### PR TITLE
Rename FieldsLookup to StoredFieldsLookup

### DIFF
--- a/qa/smoke-test-http/src/test/java/org/elasticsearch/http/SearchRestCancellationIT.java
+++ b/qa/smoke-test-http/src/test/java/org/elasticsearch/http/SearchRestCancellationIT.java
@@ -43,7 +43,7 @@ import org.elasticsearch.script.MockScriptPlugin;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
-import org.elasticsearch.search.lookup.LeafFieldsLookup;
+import org.elasticsearch.search.lookup.LeafStoredFieldsLookup;
 import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskId;
@@ -271,7 +271,7 @@ public class SearchRestCancellationIT extends HttpSmokeTestCase {
         @Override
         public Map<String, Function<Map<String, Object>, Object>> pluginScripts() {
             return Collections.singletonMap(SCRIPT_NAME, params -> {
-                LeafFieldsLookup fieldsLookup = (LeafFieldsLookup) params.get("_fields");
+                LeafStoredFieldsLookup fieldsLookup = (LeafStoredFieldsLookup) params.get("_fields");
                 LogManager.getLogger(SearchRestCancellationIT.class).info("Blocking on the document {}", fieldsLookup.get("_id"));
                 hits.incrementAndGet();
                 try {

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/SearchCancellationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/SearchCancellationIT.java
@@ -44,7 +44,7 @@ import org.elasticsearch.plugins.PluginsService;
 import org.elasticsearch.script.MockScriptPlugin;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptType;
-import org.elasticsearch.search.lookup.LeafFieldsLookup;
+import org.elasticsearch.search.lookup.LeafStoredFieldsLookup;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.tasks.TaskInfo;
@@ -386,7 +386,7 @@ public class SearchCancellationIT extends ESIntegTestCase {
                 if (runnable != null) {
                     runnable.run();
                 }
-                LeafFieldsLookup fieldsLookup = (LeafFieldsLookup) params.get("_fields");
+                LeafStoredFieldsLookup fieldsLookup = (LeafStoredFieldsLookup) params.get("_fields");
                 LogManager.getLogger(SearchCancellationIT.class).info("Blocking on the document {}", fieldsLookup.get("_id"));
                 hits.incrementAndGet();
                 try {

--- a/server/src/main/java/org/elasticsearch/search/lookup/LeafSearchLookup.java
+++ b/server/src/main/java/org/elasticsearch/search/lookup/LeafSearchLookup.java
@@ -31,10 +31,10 @@ public class LeafSearchLookup {
     private final LeafReaderContext ctx;
     private final LeafDocLookup docMap;
     private final SourceLookup sourceLookup;
-    private final LeafFieldsLookup fieldsLookup;
+    private final LeafStoredFieldsLookup fieldsLookup;
     private final Map<String, Object> asMap;
 
-    public LeafSearchLookup(LeafReaderContext ctx, LeafDocLookup docMap, SourceLookup sourceLookup, LeafFieldsLookup fieldsLookup) {
+    public LeafSearchLookup(LeafReaderContext ctx, LeafDocLookup docMap, SourceLookup sourceLookup, LeafStoredFieldsLookup fieldsLookup) {
         this.ctx = ctx;
         this.docMap = docMap;
         this.sourceLookup = sourceLookup;
@@ -54,7 +54,7 @@ public class LeafSearchLookup {
         return this.sourceLookup;
     }
 
-    public LeafFieldsLookup fields() {
+    public LeafStoredFieldsLookup fields() {
         return this.fieldsLookup;
     }
 

--- a/server/src/main/java/org/elasticsearch/search/lookup/LeafStoredFieldsLookup.java
+++ b/server/src/main/java/org/elasticsearch/search/lookup/LeafStoredFieldsLookup.java
@@ -35,7 +35,7 @@ import java.util.function.Function;
 import static java.util.Collections.singletonMap;
 
 @SuppressWarnings({"unchecked", "rawtypes"})
-public class LeafFieldsLookup implements Map<Object, Object> {
+public class LeafStoredFieldsLookup implements Map<Object, Object> {
 
     private final Function<String, MappedFieldType> fieldTypeLookup;
     private final LeafReader reader;
@@ -44,7 +44,7 @@ public class LeafFieldsLookup implements Map<Object, Object> {
 
     private final Map<String, FieldLookup> cachedFieldData = new HashMap<>();
 
-    LeafFieldsLookup(Function<String, MappedFieldType> fieldTypeLookup, LeafReader reader) {
+    LeafStoredFieldsLookup(Function<String, MappedFieldType> fieldTypeLookup, LeafReader reader) {
         this.fieldTypeLookup = fieldTypeLookup;
         this.reader = reader;
     }

--- a/server/src/main/java/org/elasticsearch/search/lookup/SearchLookup.java
+++ b/server/src/main/java/org/elasticsearch/search/lookup/SearchLookup.java
@@ -52,7 +52,7 @@ public class SearchLookup {
     private final Set<String> fieldChain;
     private final DocLookup docMap;
     private final SourceLookup sourceLookup;
-    private final FieldsLookup fieldsLookup;
+    private final StoredFieldsLookup storedFieldsLookup;
     private final Function<String, MappedFieldType> fieldTypeLookup;
     private final BiFunction<MappedFieldType, Supplier<SearchLookup>, IndexFieldData<?>> fieldDataLookup;
 
@@ -67,7 +67,7 @@ public class SearchLookup {
         docMap = new DocLookup(fieldTypeLookup,
             fieldType -> fieldDataLookup.apply(fieldType, () -> forkAndTrackFieldReferences(fieldType.name())));
         sourceLookup = new SourceLookup();
-        fieldsLookup = new FieldsLookup(fieldTypeLookup);
+        storedFieldsLookup = new StoredFieldsLookup(fieldTypeLookup);
         this.fieldDataLookup = fieldDataLookup;
     }
 
@@ -83,7 +83,7 @@ public class SearchLookup {
         this.docMap = new DocLookup(searchLookup.fieldTypeLookup,
             fieldType -> searchLookup.fieldDataLookup.apply(fieldType, () -> forkAndTrackFieldReferences(fieldType.name())));
         this.sourceLookup = searchLookup.sourceLookup;
-        this.fieldsLookup = searchLookup.fieldsLookup;
+        this.storedFieldsLookup = searchLookup.storedFieldsLookup;
         this.fieldTypeLookup = searchLookup.fieldTypeLookup;
         this.fieldDataLookup = searchLookup.fieldDataLookup;
     }
@@ -113,7 +113,7 @@ public class SearchLookup {
         return new LeafSearchLookup(context,
                 docMap.getLeafDocLookup(context),
                 sourceLookup,
-                fieldsLookup.getLeafFieldsLookup(context));
+                storedFieldsLookup.getLeafFieldsLookup(context));
     }
 
     public DocLookup doc() {

--- a/server/src/main/java/org/elasticsearch/search/lookup/StoredFieldsLookup.java
+++ b/server/src/main/java/org/elasticsearch/search/lookup/StoredFieldsLookup.java
@@ -23,15 +23,15 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 
 import java.util.function.Function;
 
-public class FieldsLookup {
+public class StoredFieldsLookup {
 
     private final Function<String, MappedFieldType> fieldTypeLookup;
 
-    FieldsLookup(Function<String, MappedFieldType> fieldTypeLookup) {
+    StoredFieldsLookup(Function<String, MappedFieldType> fieldTypeLookup) {
         this.fieldTypeLookup = fieldTypeLookup;
     }
 
-    LeafFieldsLookup getLeafFieldsLookup(LeafReaderContext context) {
-        return new LeafFieldsLookup(fieldTypeLookup, context.reader());
+    LeafStoredFieldsLookup getLeafFieldsLookup(LeafReaderContext context) {
+        return new LeafStoredFieldsLookup(fieldTypeLookup, context.reader());
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/lookup/LeafStoredFieldsLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/search/lookup/LeafStoredFieldsLookupTests.java
@@ -37,8 +37,8 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class LeafFieldsLookupTests extends ESTestCase {
-    private LeafFieldsLookup fieldsLookup;
+public class LeafStoredFieldsLookupTests extends ESTestCase {
+    private LeafStoredFieldsLookup fieldsLookup;
 
     @Before
     public void setUp() throws Exception {
@@ -61,7 +61,7 @@ public class LeafFieldsLookupTests extends ESTestCase {
             return null;
         }).when(leafReader).document(anyInt(), any(StoredFieldVisitor.class));
 
-        fieldsLookup = new LeafFieldsLookup(field -> field.equals("field") || field.equals("alias") ? fieldType : null, leafReader);
+        fieldsLookup = new LeafStoredFieldsLookup(field -> field.equals("field") || field.equals("alias") ? fieldType : null, leafReader);
     }
 
     public void testBasicLookup() {


### PR DESCRIPTION
FieldsLookup is used to load stored fields, so let's make that 
explicit in the naming.