### PR TITLE
Stricter Check for Snapshot Restore Version Compatibility

### DIFF
--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/ChecksumBlobStoreFormat.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/ChecksumBlobStoreFormat.java
@@ -63,7 +63,7 @@ import java.util.Map;
 public final class ChecksumBlobStoreFormat<T extends ToXContent> {
 
     // Serialization parameters to specify correct context for metadata serialization
-    private static final ToXContent.Params SNAPSHOT_ONLY_FORMAT_PARAMS;
+    public static final ToXContent.Params SNAPSHOT_ONLY_FORMAT_PARAMS;
 
     static {
         Map<String, String> snapshotOnlyParams = new HashMap<>();

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -927,6 +927,12 @@ public class RestoreService implements ClusterStateApplier {
                                                "the snapshot was created with Elasticsearch version [" + snapshotInfo.version() +
                                                    "] which is higher than the version of this node [" + Version.CURRENT + "]");
         }
+        if (snapshotInfo.version().before(Version.CURRENT.minimumIndexCompatibilityVersion())) {
+            throw new SnapshotRestoreException(new Snapshot(repository, snapshotInfo.snapshotId()),
+                    "the snapshot was created with Elasticsearch version [" + snapshotInfo.version() +
+                            "] which is below the current versions minimum index compatibility version [" +
+                            Version.CURRENT.minimumIndexCompatibilityVersion() + "]");
+        }
     }
 
     public static boolean failed(SnapshotInfo snapshot, String index) {


### PR DESCRIPTION
We can add a pre-flight check for version compatibility that uses the
version in `SnapshotInfo` so that we don't need to load the `INdexMetadata`
for this which may not be readable 2 major versions back to begin with.

Note: this still technically leaves the option where a snapshot of major N contains
indices of major `N - 1` but sine we don't have any way of reading the index meta version
other than reading the actual `IndexMetadata` there isn't much we can do about this without
investing non-trivial efforts -> I think this is a good enough enhancement to the checks
for now.

Closes #65567
