### PR TITLE
Clarify snapshot incrementality

### DIFF
--- a/docs/reference/snapshot-restore/index.asciidoc
+++ b/docs/reference/snapshot-restore/index.asciidoc
@@ -19,12 +19,12 @@ Remote repositories can reside on Amazon S3, HDFS, Microsoft Azure,
 Google Cloud Storage,
 and other platforms supported by a {plugins}/repository.html[repository plugin].
 
-{es} takes snapshots incrementally in the sense that the snapshotting process
-only copies data to the repository that was not already copied there by an
-earlier snapshot. This avoids unnecessary duplication of work or storage space
-and means you can safely take snapshots very frequently with minimal overhead.
-However, snapshots are also logically independent in the sense that deleting a
-snapshot does not affect the integrity of any other snapshot.
+Snapshots are taken incrementally: the snapshotting process only copies data to
+the repository that was not already copied there by an earlier snapshot,
+avoiding unnecessary duplication of work or storage space. This means you can
+safely take snapshots very frequently with minimal overhead. However, snapshots
+are also logically independent: deleting a snapshot does not affect the
+integrity of any other snapshot.
 // end::snapshot-intro[]
 
 // tag::restore-intro[]

--- a/docs/reference/snapshot-restore/index.asciidoc
+++ b/docs/reference/snapshot-restore/index.asciidoc
@@ -19,9 +19,12 @@ Remote repositories can reside on Amazon S3, HDFS, Microsoft Azure,
 Google Cloud Storage,
 and other platforms supported by a {plugins}/repository.html[repository plugin].
 
-Snapshots are incremental: each snapshot only stores data that
-is not part of an earlier snapshot.
-This enables you to take frequent snapshots with minimal overhead.
+Snapshots are taken incrementally: the snapshotting process only copies data to
+the repository that was not already copied there by an earlier snapshot,
+avoiding unnecessary duplication of work or storage space. This means you can
+safely take snapshots very frequently with minimal overhead. However, snapshots
+are also logically independent: deleting a snapshot does not affect the
+integrity of any other snapshot.
 // end::snapshot-intro[]
 
 // tag::restore-intro[]

--- a/docs/reference/snapshot-restore/index.asciidoc
+++ b/docs/reference/snapshot-restore/index.asciidoc
@@ -19,12 +19,12 @@ Remote repositories can reside on Amazon S3, HDFS, Microsoft Azure,
 Google Cloud Storage,
 and other platforms supported by a {plugins}/repository.html[repository plugin].
 
-Snapshots are taken incrementally: the snapshotting process only copies data to
-the repository that was not already copied there by an earlier snapshot,
-avoiding unnecessary duplication of work or storage space. This means you can
-safely take snapshots very frequently with minimal overhead. However, snapshots
-are also logically independent: deleting a snapshot does not affect the
-integrity of any other snapshot.
+{es} takes snapshots incrementally in the sense that the snapshotting process
+only copies data to the repository that was not already copied there by an
+earlier snapshot. This avoids unnecessary duplication of work or storage space
+and means you can safely take snapshots very frequently with minimal overhead.
+However, snapshots are also logically independent in the sense that deleting a
+snapshot does not affect the integrity of any other snapshot.
 // end::snapshot-intro[]
 
 // tag::restore-intro[]

--- a/docs/reference/snapshot-restore/index.asciidoc
+++ b/docs/reference/snapshot-restore/index.asciidoc
@@ -19,8 +19,8 @@ Remote repositories can reside on Amazon S3, HDFS, Microsoft Azure,
 Google Cloud Storage,
 and other platforms supported by a {plugins}/repository.html[repository plugin].
 
-Snapshots are taken incrementally: the snapshotting process only copies data to
-the repository that was not already copied there by an earlier snapshot,
+{es} takes snapshots incrementally: the snapshotting process only copies data
+to the repository that was not already copied there by an earlier snapshot,
 avoiding unnecessary duplication of work or storage space. This means you can
 safely take snapshots very frequently with minimal overhead. However, snapshots
 are also logically independent: deleting a snapshot does not affect the


### PR DESCRIPTION
Today we describe snapshots as "incremental" but their incrementality is
rather different beast from e.g. incremental filesystem backups. With
traditional backups you take a large and relatively infrequent "full"
backup and then a sequence of smaller "incremental" ones, and this whole
sequence of backups is required for a restore so it must be kept around
until at least the next full backup. In contrast, Elasticsearch
snapshots are logically independent and each can be deleted without
affecting the integrity of the others.

This distinction frequently causes confusion amongst newer users, so
this commit clarifies what we mean by "incremental" in the docs.