### PR TITLE
[7.x] Mute rollup docs test (#65585)

### DIFF
--- a/docs/reference/rollup/apis/rollup-api.asciidoc
+++ b/docs/reference/rollup/apis/rollup-api.asciidoc
@@ -38,7 +38,9 @@ POST /my-index-000001/_rollup
   ]
 }
 ----
-// TEST[setup:my_index]
+// CONSOLE
+// TEST[skip:"AwaitsFix https://github.com/elastic/elasticsearch/issues/65544"]
+
 
 [[rollup-api-request]]
 ==== {api-request-title}


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Mute rollup docs test (#65585)