### PR TITLE
Stricter Check for Snapshot Restore Version Compatibility (#65580)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/RestoreSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/RestoreSnapshotIT.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.snapshots;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResponse;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
@@ -34,6 +35,7 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.indices.InvalidIndexNameException;
 import org.elasticsearch.repositories.RepositoriesService;
+import org.elasticsearch.repositories.fs.FsRepository;
 import org.elasticsearch.rest.RestStatus;
 
 import java.nio.file.Path;
@@ -685,5 +687,18 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
                         .setRenamePattern("test-index").setRenameReplacement("new-index")
                         .get());
         assertThat(restoreError.getMessage(), containsString("cannot disable setting [index.soft_deletes.enabled] on restore"));
+    }
+
+    public void testFailOnAncientVersion() throws Exception {
+        final String repoName = "test-repo";
+        final Path repoPath = randomRepoPath();
+        createRepository(repoName, FsRepository.TYPE, repoPath);
+        final Version oldVersion = Version.CURRENT.minimumIndexCompatibilityVersion().minimumCompatibilityVersion();
+        final String oldSnapshot = initWithSnapshotVersion(repoName, repoPath, oldVersion);
+        final SnapshotRestoreException snapshotRestoreException = expectThrows(SnapshotRestoreException.class,
+                () -> client().admin().cluster().prepareRestoreSnapshot(repoName, oldSnapshot).execute().actionGet());
+        assertThat(snapshotRestoreException.getMessage(), containsString( "the snapshot was created with Elasticsearch version ["
+                + oldVersion + "] which is below the current versions minimum index compatibility version [" +
+                Version.CURRENT.minimumIndexCompatibilityVersion() + "]"));
     }
 }

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/ChecksumBlobStoreFormat.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/ChecksumBlobStoreFormat.java
@@ -63,7 +63,7 @@ import java.util.Map;
 public final class ChecksumBlobStoreFormat<T extends ToXContent> {
 
     // Serialization parameters to specify correct context for metadata serialization
-    private static final ToXContent.Params SNAPSHOT_ONLY_FORMAT_PARAMS;
+    public static final ToXContent.Params SNAPSHOT_ONLY_FORMAT_PARAMS;
 
     static {
         Map<String, String> snapshotOnlyParams = new HashMap<>();

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -943,6 +943,12 @@ public class RestoreService implements ClusterStateApplier {
                                                "the snapshot was created with Elasticsearch version [" + snapshotInfo.version() +
                                                    "] which is higher than the version of this node [" + Version.CURRENT + "]");
         }
+        if (snapshotInfo.version().before(Version.CURRENT.minimumIndexCompatibilityVersion())) {
+            throw new SnapshotRestoreException(new Snapshot(repository, snapshotInfo.snapshotId()),
+                    "the snapshot was created with Elasticsearch version [" + snapshotInfo.version() +
+                            "] which is below the current versions minimum index compatibility version [" +
+                            Version.CURRENT.minimumIndexCompatibilityVersion() + "]");
+        }
     }
 
     public static boolean failed(SnapshotInfo snapshot, String index) {


### PR DESCRIPTION
We can add a pre-flight check for version compatibility that uses the
version in `SnapshotInfo` so that we don't need to load the `INdexMetadata`
for this which may not be readable 2 major versions back to begin with.

Note: this still technically leaves the option where a snapshot of major N contains
indices of major `N - 1` but sine we don't have any way of reading the index meta version
other than reading the actual `IndexMetadata` there isn't much we can do about this without
investing non-trivial efforts -> I think this is a good enough enhancement to the checks
for now.

Closes #65567

backport of #65580 