### PR TITLE
Add search runtime_mappings to datafeed configuration

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java
@@ -855,21 +855,19 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
          * The full check cannot happen until search
          */
         void validateRuntimeMappings() {
-            if (runtimeMappings != null && runtimeMappings.isEmpty() == false) {
-                for (Map.Entry<String, Object> entry : runtimeMappings.entrySet()) {
-                    // top level objects are fields
-                    String fieldName = entry.getKey();
-                    if (entry.getValue() instanceof Map) {
-                        @SuppressWarnings("unchecked")
-                        Map<String, Object> propNode = new HashMap<>(((Map<String, Object>) entry.getValue()));
-                        Object typeNode = propNode.get("type");
-                        if (typeNode == null) {
-                            throw ExceptionsHelper.badRequestException("No type specified for runtime field [" + fieldName + "]");
-                        }
-                    } else {
-                        throw ExceptionsHelper.badRequestException("Expected map for runtime field [" + fieldName + "] " +
-                            "definition but got a " + fieldName.getClass().getSimpleName());
+            for (Map.Entry<String, Object> entry : runtimeMappings.entrySet()) {
+                // top level objects are fields
+                String fieldName = entry.getKey();
+                if (entry.getValue() instanceof Map) {
+                    @SuppressWarnings("unchecked")
+                    Map<String, Object> propNode = new HashMap<>(((Map<String, Object>) entry.getValue()));
+                    Object typeNode = propNode.get("type");
+                    if (typeNode == null) {
+                        throw ExceptionsHelper.badRequestException("No type specified for runtime field [" + fieldName + "]");
                     }
+                } else {
+                    throw ExceptionsHelper.badRequestException("Expected map for runtime field [" + fieldName + "] " +
+                        "definition but got a " + fieldName.getClass().getSimpleName());
                 }
             }
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.core.ml.datafeed;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.AbstractDiffable;
@@ -28,6 +29,7 @@ import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.metrics.MaxAggregationBuilder;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.xpack.core.common.time.TimeUtils;
 import org.elasticsearch.xpack.core.ml.datafeed.extractor.ExtractorUtils;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.messages.Messages;
@@ -36,7 +38,6 @@ import org.elasticsearch.xpack.core.ml.utils.MlStrings;
 import org.elasticsearch.xpack.core.ml.utils.QueryProvider;
 import org.elasticsearch.xpack.core.ml.utils.ToXContentParams;
 import org.elasticsearch.xpack.core.ml.utils.XContentObjectTransformer;
-import org.elasticsearch.xpack.core.common.time.TimeUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -165,6 +166,7 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
         parser.declareObject(Builder::setIndicesOptions,
             (p, c) -> IndicesOptions.fromMap(p.map(), SearchRequest.DEFAULT_INDICES_OPTIONS),
             INDICES_OPTIONS);
+        parser.declareObject(Builder::setRuntimeMappings, (p, c) -> p.map(), SearchSourceBuilder.RUNTIME_MAPPINGS_FIELD);
         return parser;
     }
 
@@ -191,11 +193,13 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
     private final DelayedDataCheckConfig delayedDataCheckConfig;
     private final Integer maxEmptySearches;
     private final IndicesOptions indicesOptions;
+    private final Map<String, Object> runtimeMappings;
 
     private DatafeedConfig(String id, String jobId, TimeValue queryDelay, TimeValue frequency, List<String> indices,
                            QueryProvider queryProvider, AggProvider aggProvider, List<SearchSourceBuilder.ScriptField> scriptFields,
                            Integer scrollSize, ChunkingConfig chunkingConfig, Map<String, String> headers,
-                           DelayedDataCheckConfig delayedDataCheckConfig, Integer maxEmptySearches, IndicesOptions indicesOptions) {
+                           DelayedDataCheckConfig delayedDataCheckConfig, Integer maxEmptySearches, IndicesOptions indicesOptions,
+                           Map<String, Object> runtimeMappings) {
         this.id = id;
         this.jobId = jobId;
         this.queryDelay = queryDelay;
@@ -210,6 +214,7 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
         this.delayedDataCheckConfig = delayedDataCheckConfig;
         this.maxEmptySearches = maxEmptySearches;
         this.indicesOptions = ExceptionsHelper.requireNonNull(indicesOptions, INDICES_OPTIONS);
+        this.runtimeMappings = runtimeMappings;
     }
 
     public DatafeedConfig(StreamInput in) throws IOException {
@@ -238,6 +243,11 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
         delayedDataCheckConfig = in.readOptionalWriteable(DelayedDataCheckConfig::new);
         maxEmptySearches = in.readOptionalVInt();
         indicesOptions = IndicesOptions.readIndicesOptions(in);
+        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+            runtimeMappings = in.readBoolean() ?  in.readMap() : null;
+        } else {
+            runtimeMappings = null;
+        }
     }
 
     /**
@@ -422,6 +432,10 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
         return indicesOptions;
     }
 
+    public Map<String, Object> getRuntimeMappings() {
+        return runtimeMappings;
+    }
+
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(id);
@@ -452,6 +466,13 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
         out.writeOptionalWriteable(delayedDataCheckConfig);
         out.writeOptionalVInt(maxEmptySearches);
         indicesOptions.writeIndicesOptions(out);
+        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+            boolean hasRuntimeMappings = runtimeMappings != null;
+            out.writeBoolean(hasRuntimeMappings);
+            if (hasRuntimeMappings) {
+                out.writeMap(runtimeMappings);
+            }
+        }
     }
 
     @Override
@@ -510,6 +531,9 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
         if (maxEmptySearches != null) {
             builder.field(MAX_EMPTY_SEARCHES.getPreferredName(), maxEmptySearches);
         }
+        if (runtimeMappings != null && runtimeMappings.isEmpty() == false) {
+            builder.field(SearchSourceBuilder.RUNTIME_MAPPINGS_FIELD.getPreferredName(), runtimeMappings);
+        }
         builder.endObject();
         return builder;
     }
@@ -562,13 +586,14 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
                 && Objects.equals(this.headers, that.headers)
                 && Objects.equals(this.delayedDataCheckConfig, that.delayedDataCheckConfig)
                 && Objects.equals(this.maxEmptySearches, that.maxEmptySearches)
-                && Objects.equals(this.indicesOptions, that.indicesOptions);
+                && Objects.equals(this.indicesOptions, that.indicesOptions)
+                && Objects.equals(this.runtimeMappings, that.runtimeMappings);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(id, jobId, frequency, queryDelay, indices, queryProvider, scrollSize, aggProvider, scriptFields, chunkingConfig,
-                headers, delayedDataCheckConfig, maxEmptySearches, indicesOptions);
+                headers, delayedDataCheckConfig, maxEmptySearches, indicesOptions, runtimeMappings);
     }
 
     @Override
@@ -639,6 +664,7 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
         private DelayedDataCheckConfig delayedDataCheckConfig = DelayedDataCheckConfig.defaultDelayedDataCheckConfig();
         private Integer maxEmptySearches;
         private IndicesOptions indicesOptions;
+        private Map<String, Object> runtimeMappings;
 
         public Builder() { }
 
@@ -663,6 +689,7 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
             this.delayedDataCheckConfig = config.getDelayedDataCheckConfig();
             this.maxEmptySearches = config.getMaxEmptySearches();
             this.indicesOptions = config.indicesOptions;
+            this.runtimeMappings = config.runtimeMappings == null ? null : new HashMap<>(config.runtimeMappings);
         }
 
         public Builder setId(String datafeedId) {
@@ -790,6 +817,10 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
             return this.indicesOptions;
         }
 
+        public void setRuntimeMappings(Map<String, Object> runtimeMappings) {
+            this.runtimeMappings = runtimeMappings;
+        }
+
         public DatafeedConfig build() {
             ExceptionsHelper.requireNonNull(id, ID.getPreferredName());
             ExceptionsHelper.requireNonNull(jobId, Job.ID.getPreferredName());
@@ -801,6 +832,7 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
             }
 
             validateScriptFields();
+            validateRuntimeMappings();
             setDefaultChunkingConfig();
 
             setDefaultQueryDelay();
@@ -808,7 +840,7 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
                 indicesOptions = SearchRequest.DEFAULT_INDICES_OPTIONS;
             }
             return new DatafeedConfig(id, jobId, queryDelay, frequency, indices, queryProvider, aggProvider, scriptFields, scrollSize,
-                    chunkingConfig, headers, delayedDataCheckConfig, maxEmptySearches, indicesOptions);
+                    chunkingConfig, headers, delayedDataCheckConfig, maxEmptySearches, indicesOptions, runtimeMappings);
         }
 
         void validateScriptFields() {
@@ -818,6 +850,30 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
             if (scriptFields != null && !scriptFields.isEmpty()) {
                 throw ExceptionsHelper.badRequestException(
                     Messages.getMessage(Messages.DATAFEED_CONFIG_CANNOT_USE_SCRIPT_FIELDS_WITH_AGGS));
+            }
+        }
+
+        /**
+         * Perform a light check that the structure resembles runtime_mappings.
+         * The full check cannot happen until search
+         */
+        void validateRuntimeMappings() {
+            if (runtimeMappings != null && runtimeMappings.isEmpty() == false) {
+                for (Map.Entry<String, Object> entry : runtimeMappings.entrySet()) {
+                    // top level objects are fields
+                    String fieldName = entry.getKey();
+                    if (entry.getValue() instanceof Map) {
+                        @SuppressWarnings("unchecked")
+                        Map<String, Object> propNode = new HashMap<>(((Map<String, Object>) entry.getValue()));
+                        Object typeNode = propNode.get("type");
+                        if (typeNode == null) {
+                            throw ExceptionsHelper.badRequestException("No type specified for runtime field [" + fieldName + "]");
+                        }
+                    } else {
+                        throw ExceptionsHelper.badRequestException("Expected map for runtime field [" + fieldName + "] " +
+                            "definition but got a " + fieldName.getClass().getSimpleName());
+                    }
+                }
             }
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedJobValidator.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedJobValidator.java
@@ -104,14 +104,12 @@ public final class DatafeedJobValidator {
 
     private static void checkTimeFieldIsNotARuntimeField(DatafeedConfig datafeedConfig, String timeField) {
         Map<String, Object> runtimeMappings = datafeedConfig.getRuntimeMappings();
-        if (runtimeMappings != null) {
-            for (Map.Entry<String, Object> entry : runtimeMappings.entrySet()) {
-                // top level objects are fields
-                String fieldName = entry.getKey();
-                if (timeField.equals(fieldName)) {
-                    throw ExceptionsHelper.badRequestException(Messages.getMessage(
-                        Messages.JOB_CONFIG_TIME_FIELD_CANNOT_BE_RUNTIME, timeField));
-                }
+        for (Map.Entry<String, Object> entry : runtimeMappings.entrySet()) {
+            // top level objects are fields
+            String fieldName = entry.getKey();
+            if (timeField.equals(fieldName)) {
+                throw ExceptionsHelper.badRequestException(Messages.getMessage(
+                    Messages.JOB_CONFIG_TIME_FIELD_CANNOT_BE_RUNTIME, timeField));
             }
         }
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedJobValidator.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedJobValidator.java
@@ -13,6 +13,8 @@ import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.messages.Messages;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 
+import java.util.Map;
+
 public final class DatafeedJobValidator {
 
     private DatafeedJobValidator() {}
@@ -38,6 +40,8 @@ public final class DatafeedJobValidator {
         if (delayedDataCheckConfig.isEnabled()) {
             checkValidDelayedDataCheckConfig(bucketSpan, delayedDataCheckConfig);
         }
+
+        checkTimeFieldIsNotARuntimeField(datafeedConfig, job.getDataDescription().getTimeField());
     }
 
     private static void checkValidDelayedDataCheckConfig(TimeValue bucketSpan, DelayedDataCheckConfig delayedDataCheckConfig) {
@@ -94,6 +98,20 @@ public final class DatafeedJobValidator {
                 throw ExceptionsHelper.badRequestException(Messages.getMessage(
                         Messages.DATAFEED_FREQUENCY_MUST_BE_MULTIPLE_OF_AGGREGATIONS_INTERVAL,
                         frequency, TimeValue.timeValueMillis(histogramIntervalMillis).getStringRep()));
+            }
+        }
+    }
+
+    private static void checkTimeFieldIsNotARuntimeField(DatafeedConfig datafeedConfig, String timeField) {
+        Map<String, Object> runtimeMappings = datafeedConfig.getRuntimeMappings();
+        if (runtimeMappings != null) {
+            for (Map.Entry<String, Object> entry : runtimeMappings.entrySet()) {
+                // top level objects are fields
+                String fieldName = entry.getKey();
+                if (timeField.equals(fieldName)) {
+                    throw ExceptionsHelper.badRequestException(Messages.getMessage(
+                        Messages.JOB_CONFIG_TIME_FIELD_CANNOT_BE_RUNTIME, timeField));
+                }
             }
         }
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedJobValidator.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedJobValidator.java
@@ -41,7 +41,7 @@ public final class DatafeedJobValidator {
             checkValidDelayedDataCheckConfig(bucketSpan, delayedDataCheckConfig);
         }
 
-        checkTimeFieldIsNotARuntimeField(datafeedConfig, job.getDataDescription().getTimeField());
+        checkTimeFieldIsNotASearchRuntimeField(datafeedConfig, job.getDataDescription().getTimeField());
     }
 
     private static void checkValidDelayedDataCheckConfig(TimeValue bucketSpan, DelayedDataCheckConfig delayedDataCheckConfig) {
@@ -102,7 +102,8 @@ public final class DatafeedJobValidator {
         }
     }
 
-    private static void checkTimeFieldIsNotARuntimeField(DatafeedConfig datafeedConfig, String timeField) {
+    private static void checkTimeFieldIsNotASearchRuntimeField(DatafeedConfig datafeedConfig, String timeField) {
+        // check the search RT mappings defined in the datafeed
         Map<String, Object> runtimeMappings = datafeedConfig.getRuntimeMappings();
         for (Map.Entry<String, Object> entry : runtimeMappings.entrySet()) {
             // top level objects are fields

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
@@ -222,6 +222,8 @@ public final class Messages {
             "This job would cause a mapping clash with existing field [{0}] - avoid the clash by assigning a dedicated results index";
     public static final String JOB_CONFIG_TIME_FIELD_NOT_ALLOWED_IN_ANALYSIS_CONFIG =
             "data_description.time_field may not be used in the analysis_config";
+    public static final String JOB_CONFIG_TIME_FIELD_CANNOT_BE_RUNTIME =
+        "data_description.time_field [{0}] cannot be a runtime field";
     public static final String JOB_CONFIG_MODEL_SNAPSHOT_RETENTION_SETTINGS_INCONSISTENT =
             "The value of '" + Job.DAILY_MODEL_SNAPSHOT_RETENTION_AFTER_DAYS + "' [{0}] cannot be greater than '" +
                 Job.MODEL_SNAPSHOT_RETENTION_DAYS + "' [{1}]";

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/core/ml/config_index_mappings.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/core/ml/config_index_mappings.json
@@ -375,6 +375,10 @@
       "results_retention_days" : {
         "type" : "long"
       },
+      "runtime_mappings" : {
+        "type" : "object",
+        "enabled" : false
+      },
       "script_fields" : {
         "type" : "object",
         "enabled" : false

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappingsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappingsTests.java
@@ -75,7 +75,8 @@ public class ElasticsearchMappingsTests extends ESTestCase {
             ElasticsearchMappings.NESTED,
             ElasticsearchMappings.PROPERTIES,
             ElasticsearchMappings.TYPE,
-            ElasticsearchMappings.WHITESPACE
+            ElasticsearchMappings.WHITESPACE,
+            "runtime_mappings"
     );
 
     private static List<String> INTERNAL_FIELDS = Arrays.asList(

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappingsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappingsTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.index.get.GetResult;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.VersionUtils;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -67,7 +68,7 @@ public class ElasticsearchMappingsTests extends ESTestCase {
 
     // These are not reserved because they're Elasticsearch keywords, not
     // field names
-    private static List<String> KEYWORDS = Arrays.asList(
+    private static final List<String> KEYWORDS = Arrays.asList(
             ElasticsearchMappings.ANALYZER,
             ElasticsearchMappings.COPY_TO,
             ElasticsearchMappings.DYNAMIC,
@@ -76,10 +77,10 @@ public class ElasticsearchMappingsTests extends ESTestCase {
             ElasticsearchMappings.PROPERTIES,
             ElasticsearchMappings.TYPE,
             ElasticsearchMappings.WHITESPACE,
-            "runtime_mappings"
+            SearchSourceBuilder.RUNTIME_MAPPINGS_FIELD.getPreferredName()
     );
 
-    private static List<String> INTERNAL_FIELDS = Arrays.asList(
+    private static final List<String> INTERNAL_FIELDS = Arrays.asList(
             GetResult._ID,
             GetResult._INDEX
     );
@@ -195,6 +196,7 @@ public class ElasticsearchMappingsTests extends ESTestCase {
             ElasticsearchMappings.mappingRequiresUpdate(cs, indices, VersionUtils.getPreviousMinorVersion()));
     }
 
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public void testAddDocMappingIfMissing() {
         ThreadPool threadPool = mock(ThreadPool.class);
         when(threadPool.getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DatafeedJobsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DatafeedJobsIT.java
@@ -163,7 +163,6 @@ public class DatafeedJobsIT extends MlNativeAutodetectIntegTestCase {
         indexDocs(logger, "data-1", numDocs, twoWeeksAgo, oneWeekAgo);
 
         DataDescription.Builder dataDescription = new DataDescription.Builder();
-        dataDescription.setTimeFormat("yyyy-MM-dd HH:mm:ss");
 
         Detector.Builder d = new Detector.Builder("count", null);
         // day_of_week is a runtime field.

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DatafeedJobsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DatafeedJobsIT.java
@@ -11,15 +11,14 @@ import org.elasticsearch.action.admin.cluster.node.hotthreads.NodeHotThreads;
 import org.elasticsearch.action.admin.cluster.node.hotthreads.NodesHotThreadsResponse;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.common.CheckedRunnable;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.common.util.concurrent.ConcurrentMapLong;
 import org.elasticsearch.xpack.core.ml.action.DeleteDatafeedAction;
-import org.elasticsearch.xpack.core.ml.action.GetDatafeedsAction;
 import org.elasticsearch.xpack.core.ml.action.GetDatafeedsStatsAction;
 import org.elasticsearch.xpack.core.ml.action.GetJobsStatsAction;
 import org.elasticsearch.xpack.core.ml.action.KillProcessAction;
-import org.elasticsearch.xpack.core.ml.action.PutDatafeedAction;
 import org.elasticsearch.xpack.core.ml.action.PutJobAction;
 import org.elasticsearch.xpack.core.ml.action.StopDatafeedAction;
 import org.elasticsearch.xpack.core.ml.datafeed.ChunkingConfig;
@@ -34,6 +33,7 @@ import org.elasticsearch.xpack.core.ml.job.config.JobState;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.DataCounts;
 import org.hamcrest.Matcher;
 import org.junit.After;
+import org.junit.Before;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -189,7 +189,7 @@ public class DatafeedJobsIT extends MlNativeAutodetectIntegTestCase {
 
         Map<String, Object> properties = new HashMap<>();
         properties.put("type", "long");
-        properties.put("script", "emit(doc['date_of_birth'].value.getDayOfWeekEnum().value)");
+        properties.put("script", "emit(doc['time'].value.getDayOfWeekEnum().value)");
         Map<String, Object> fields = new HashMap<>();
         fields.put("day_of_week", properties);
         dfBuilder.setRuntimeMappings(fields);
@@ -199,16 +199,6 @@ public class DatafeedJobsIT extends MlNativeAutodetectIntegTestCase {
         registerDatafeed(datafeedConfig);
         putDatafeed(datafeedConfig);
 
-
-
-        GetDatafeedsAction.Request request = new GetDatafeedsAction.Request(datafeedConfig.getId());
-        GetDatafeedsAction.Response response = client().execute(GetDatafeedsAction.INSTANCE, request).actionGet();
-        System.out.println(response.getResponse().results().get(0));
-        fail(response.getResponse().results().get(0).toString());
-
-
-
-        /*
         startDatafeed(datafeedConfig.getId(), 0L, now);
         assertBusy(() -> {
             DataCounts dataCounts = getDataCounts(jobBuilder.getId());
@@ -222,8 +212,6 @@ public class DatafeedJobsIT extends MlNativeAutodetectIntegTestCase {
         }, 60, TimeUnit.SECONDS);
 
         waitUntilJobIsClosed(jobBuilder.getId());
-
-         */
     }
 
     @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/63973")

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DatafeedWithAggsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DatafeedWithAggsIT.java
@@ -5,10 +5,13 @@
  */
 package org.elasticsearch.xpack.ml.integration;
 
+import org.elasticsearch.action.DocWriteRequest;
+import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
@@ -22,13 +25,20 @@ import org.elasticsearch.xpack.core.ml.job.config.AnalysisConfig;
 import org.elasticsearch.xpack.core.ml.job.config.DataDescription;
 import org.elasticsearch.xpack.core.ml.job.config.Detector;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
+import org.elasticsearch.xpack.core.ml.job.config.JobState;
+import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.DataCounts;
 import org.elasticsearch.xpack.core.ml.job.results.Bucket;
 import org.junit.After;
 
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import static org.elasticsearch.xpack.ml.support.BaseMlIntegTestCase.getDataCounts;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -137,5 +147,113 @@ public class DatafeedWithAggsIT extends MlNativeAutodetectIntegTestCase {
                 fail("Bucket [" + bucket.getTimestamp().getTime() + "] has [" + bucket.getEventCount() + "] when 2 were expected");
             }
         }
+    }
+
+    public void testLookbackOnly_WithRuntimeMapping() throws Exception {
+        String indexName = "df-data";
+        client().admin().indices().prepareCreate(indexName)
+            .setMapping("time", "type=date", "metric", "type=double")
+            .get();
+
+        ZonedDateTime startOfDay = ZonedDateTime.now().toLocalDate().atStartOfDay(ZonedDateTime.now().getZone());
+        long endTime = startOfDay.toEpochSecond() * 1000;
+        long startTime = startOfDay.minus(2, ChronoUnit.DAYS).toEpochSecond() * 1000L;
+        long bucketSize = 3600000;
+        long numDocsPerBucket = 2L;
+        indexDocs(indexName, numDocsPerBucket, startTime,  endTime, bucketSize);
+
+        DataDescription.Builder dataDescription = new DataDescription.Builder();
+        dataDescription.setTimeFormat("yyyy-MM-dd HH:mm:ss");
+
+        Detector.Builder d = new Detector.Builder("sum", "metric_sum");
+        AnalysisConfig.Builder analysisConfig = new AnalysisConfig.Builder(Collections.singletonList(d.build()));
+        analysisConfig.setBucketSpan(TimeValue.timeValueHours(1));
+        analysisConfig.setSummaryCountFieldName("doc_count");
+
+        Job.Builder jobBuilder = new Job.Builder();
+        jobBuilder.setId("lookback-job-with-rt-fields-agg");
+        jobBuilder.setAnalysisConfig(analysisConfig);
+        jobBuilder.setDataDescription(dataDescription);
+
+        registerJob(jobBuilder);
+        putJob(jobBuilder);
+        openJob(jobBuilder.getId());
+        assertBusy(() -> assertEquals(getJobStats(jobBuilder.getId()).get(0).getState(), JobState.OPENED));
+
+        DatafeedConfig.Builder dfBuilder = new DatafeedConfig.Builder(jobBuilder.getId() + "-datafeed", jobBuilder.getId());
+        dfBuilder.setIndices(Collections.singletonList(indexName));
+
+        // aggregate on a runtime field
+        AggregatorFactories.Builder aggs = new AggregatorFactories.Builder();
+        aggs.addAggregator(AggregationBuilders.dateHistogram("time").field("time")
+            .fixedInterval(new DateHistogramInterval("1h"))
+            .subAggregation(AggregationBuilders.max("time").field("time"))
+            .subAggregation(AggregationBuilders.sum("metric_sum").field("metric_percent"))
+        );
+
+        dfBuilder.setParsedAggregations(aggs);
+
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("type", "double");
+        properties.put("script", "emit(doc['metric'].value * 100.0)");
+        Map<String, Object> fields = new HashMap<>();
+        fields.put("metric_percent", properties);
+        dfBuilder.setRuntimeMappings(fields);
+
+        DatafeedConfig datafeedConfig = dfBuilder.build();
+
+        registerDatafeed(datafeedConfig);
+        putDatafeed(datafeedConfig);
+
+        startDatafeed(datafeedConfig.getId(), 0L, endTime);
+        long expectedNumberOfHistoBuckets = ((endTime - startTime) / bucketSize);
+        assertBusy(() -> {
+            GetDatafeedsStatsAction.Request request = new GetDatafeedsStatsAction.Request(datafeedConfig.getId());
+            GetDatafeedsStatsAction.Response response = client().execute(GetDatafeedsStatsAction.INSTANCE, request).actionGet();
+            assertThat(response.getResponse().results().get(0).getDatafeedState(), equalTo(DatafeedState.STOPPED));
+
+            DataCounts dataCounts = getDataCounts(jobBuilder.getId());
+            System.out.println(Strings.toString(dataCounts));
+            assertThat(dataCounts.getProcessedRecordCount(), equalTo(expectedNumberOfHistoBuckets));
+            assertThat(dataCounts.getBucketCount(), equalTo(expectedNumberOfHistoBuckets -1));
+            assertThat(dataCounts.getInputFieldCount(), equalTo(expectedNumberOfHistoBuckets * 2));
+            assertThat(dataCounts.getMissingFieldCount(), equalTo(0L));
+            assertThat(dataCounts.getEmptyBucketCount(), equalTo(0L));
+        }, 60, TimeUnit.SECONDS);
+
+        waitUntilJobIsClosed(jobBuilder.getId());
+    }
+
+    private void indexDocs(String index, long numDocs, long start, long end, long bucketSize) {
+        BulkRequestBuilder bulkRequestBuilder = client().prepareBulk();
+        long numBuckets = (end - start) / bucketSize;
+        for (long i = 0; i < numBuckets; i++) {
+            for (long j = 0; j < numDocs; j++) {
+                IndexRequest indexRequest = new IndexRequest(index);
+                long timestamp = start + randomLongBetween(1, bucketSize - 1);
+                double value = randomDoubleBetween(0.0, 1.0, true);
+                indexRequest.source("time", timestamp, "metric", value).opType(DocWriteRequest.OpType.CREATE);
+                bulkRequestBuilder.add(indexRequest);
+            }
+
+            start += bucketSize;
+        }
+        assertThat(start, equalTo(end));
+
+        BulkResponse bulkResponse = bulkRequestBuilder
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+            .get();
+
+        if (bulkResponse.hasFailures()) {
+            int failures = 0;
+            for (BulkItemResponse itemResponse : bulkResponse) {
+                if (itemResponse.isFailed()) {
+                    failures++;
+                    logger.error("Item response failure [{}]", itemResponse.getFailureMessage());
+                }
+            }
+            fail("Bulk response contained " + failures + " failures");
+        }
+        logger.info("Indexed [{}] documents", bulkRequestBuilder.numberOfActions());
     }
 }

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DatafeedWithAggsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DatafeedWithAggsIT.java
@@ -5,13 +5,10 @@
  */
 package org.elasticsearch.xpack.ml.integration;
 
-import org.elasticsearch.action.DocWriteRequest;
-import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.support.WriteRequest;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
@@ -25,20 +22,13 @@ import org.elasticsearch.xpack.core.ml.job.config.AnalysisConfig;
 import org.elasticsearch.xpack.core.ml.job.config.DataDescription;
 import org.elasticsearch.xpack.core.ml.job.config.Detector;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
-import org.elasticsearch.xpack.core.ml.job.config.JobState;
-import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.DataCounts;
 import org.elasticsearch.xpack.core.ml.job.results.Bucket;
 import org.junit.After;
 
-import java.time.ZonedDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import static org.elasticsearch.xpack.ml.support.BaseMlIntegTestCase.getDataCounts;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -147,113 +137,5 @@ public class DatafeedWithAggsIT extends MlNativeAutodetectIntegTestCase {
                 fail("Bucket [" + bucket.getTimestamp().getTime() + "] has [" + bucket.getEventCount() + "] when 2 were expected");
             }
         }
-    }
-
-    public void testLookbackOnly_WithRuntimeMapping() throws Exception {
-        String indexName = "df-data";
-        client().admin().indices().prepareCreate(indexName)
-            .setMapping("time", "type=date", "metric", "type=double")
-            .get();
-
-        ZonedDateTime startOfDay = ZonedDateTime.now().toLocalDate().atStartOfDay(ZonedDateTime.now().getZone());
-        long endTime = startOfDay.toEpochSecond() * 1000;
-        long startTime = startOfDay.minus(2, ChronoUnit.DAYS).toEpochSecond() * 1000L;
-        long bucketSize = 3600000;
-        long numDocsPerBucket = 2L;
-        indexDocs(indexName, numDocsPerBucket, startTime,  endTime, bucketSize);
-
-        DataDescription.Builder dataDescription = new DataDescription.Builder();
-        dataDescription.setTimeFormat("yyyy-MM-dd HH:mm:ss");
-
-        Detector.Builder d = new Detector.Builder("sum", "metric_sum");
-        AnalysisConfig.Builder analysisConfig = new AnalysisConfig.Builder(Collections.singletonList(d.build()));
-        analysisConfig.setBucketSpan(TimeValue.timeValueHours(1));
-        analysisConfig.setSummaryCountFieldName("doc_count");
-
-        Job.Builder jobBuilder = new Job.Builder();
-        jobBuilder.setId("lookback-job-with-rt-fields-agg");
-        jobBuilder.setAnalysisConfig(analysisConfig);
-        jobBuilder.setDataDescription(dataDescription);
-
-        registerJob(jobBuilder);
-        putJob(jobBuilder);
-        openJob(jobBuilder.getId());
-        assertBusy(() -> assertEquals(getJobStats(jobBuilder.getId()).get(0).getState(), JobState.OPENED));
-
-        DatafeedConfig.Builder dfBuilder = new DatafeedConfig.Builder(jobBuilder.getId() + "-datafeed", jobBuilder.getId());
-        dfBuilder.setIndices(Collections.singletonList(indexName));
-
-        // aggregate on a runtime field
-        AggregatorFactories.Builder aggs = new AggregatorFactories.Builder();
-        aggs.addAggregator(AggregationBuilders.dateHistogram("time").field("time")
-            .fixedInterval(new DateHistogramInterval("1h"))
-            .subAggregation(AggregationBuilders.max("time").field("time"))
-            .subAggregation(AggregationBuilders.sum("metric_sum").field("metric_percent"))
-        );
-
-        dfBuilder.setParsedAggregations(aggs);
-
-        Map<String, Object> properties = new HashMap<>();
-        properties.put("type", "double");
-        properties.put("script", "emit(doc['metric'].value * 100.0)");
-        Map<String, Object> fields = new HashMap<>();
-        fields.put("metric_percent", properties);
-        dfBuilder.setRuntimeMappings(fields);
-
-        DatafeedConfig datafeedConfig = dfBuilder.build();
-
-        registerDatafeed(datafeedConfig);
-        putDatafeed(datafeedConfig);
-
-        startDatafeed(datafeedConfig.getId(), 0L, endTime);
-        long expectedNumberOfHistoBuckets = ((endTime - startTime) / bucketSize);
-        assertBusy(() -> {
-            GetDatafeedsStatsAction.Request request = new GetDatafeedsStatsAction.Request(datafeedConfig.getId());
-            GetDatafeedsStatsAction.Response response = client().execute(GetDatafeedsStatsAction.INSTANCE, request).actionGet();
-            assertThat(response.getResponse().results().get(0).getDatafeedState(), equalTo(DatafeedState.STOPPED));
-
-            DataCounts dataCounts = getDataCounts(jobBuilder.getId());
-            System.out.println(Strings.toString(dataCounts));
-            assertThat(dataCounts.getProcessedRecordCount(), equalTo(expectedNumberOfHistoBuckets));
-            assertThat(dataCounts.getBucketCount(), equalTo(expectedNumberOfHistoBuckets -1));
-            assertThat(dataCounts.getInputFieldCount(), equalTo(expectedNumberOfHistoBuckets * 2));
-            assertThat(dataCounts.getMissingFieldCount(), equalTo(0L));
-            assertThat(dataCounts.getEmptyBucketCount(), equalTo(0L));
-        }, 60, TimeUnit.SECONDS);
-
-        waitUntilJobIsClosed(jobBuilder.getId());
-    }
-
-    private void indexDocs(String index, long numDocs, long start, long end, long bucketSize) {
-        BulkRequestBuilder bulkRequestBuilder = client().prepareBulk();
-        long numBuckets = (end - start) / bucketSize;
-        for (long i = 0; i < numBuckets; i++) {
-            for (long j = 0; j < numDocs; j++) {
-                IndexRequest indexRequest = new IndexRequest(index);
-                long timestamp = start + randomLongBetween(1, bucketSize - 1);
-                double value = randomDoubleBetween(0.0, 1.0, true);
-                indexRequest.source("time", timestamp, "metric", value).opType(DocWriteRequest.OpType.CREATE);
-                bulkRequestBuilder.add(indexRequest);
-            }
-
-            start += bucketSize;
-        }
-        assertThat(start, equalTo(end));
-
-        BulkResponse bulkResponse = bulkRequestBuilder
-            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
-            .get();
-
-        if (bulkResponse.hasFailures()) {
-            int failures = 0;
-            for (BulkItemResponse itemResponse : bulkResponse) {
-                if (itemResponse.isFailed()) {
-                    failures++;
-                    logger.error("Item response failure [{}]", itemResponse.getFailureMessage());
-                }
-            }
-            fail("Bulk response contained " + failures + " failures");
-        }
-        logger.info("Indexed [{}] documents", bulkRequestBuilder.numberOfActions());
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPreviewDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPreviewDatafeedAction.java
@@ -69,6 +69,7 @@ public class TransportPreviewDatafeedAction extends HandledTransportAction<Previ
                 DatafeedConfig datafeedConfig = datafeedConfigBuilder.build();
                 jobConfigProvider.getJob(datafeedConfig.getJobId(), ActionListener.wrap(
                     jobBuilder -> {
+                        // TODO should we use DatafeedJobValidator here
                         DatafeedConfig.Builder previewDatafeed = buildPreviewDatafeed(datafeedConfig);
                         useSecondaryAuthIfAvailable(securityContext, () -> {
                             previewDatafeed.setHeaders(filterSecurityHeaders(threadPool.getThreadContext().getHeaders()));

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPreviewDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPreviewDatafeedAction.java
@@ -69,7 +69,6 @@ public class TransportPreviewDatafeedAction extends HandledTransportAction<Previ
                 DatafeedConfig datafeedConfig = datafeedConfigBuilder.build();
                 jobConfigProvider.getJob(datafeedConfig.getJobId(), ActionListener.wrap(
                     jobBuilder -> {
-                        // TODO should we use DatafeedJobValidator here
                         DatafeedConfig.Builder previewDatafeed = buildPreviewDatafeed(datafeedConfig);
                         useSecondaryAuthIfAvailable(securityContext, () -> {
                             previewDatafeed.setHeaders(filterSecurityHeaders(threadPool.getThreadContext().getHeaders()));
@@ -125,7 +124,7 @@ public class TransportPreviewDatafeedAction extends HandledTransportAction<Previ
         try {
             Optional<InputStream> inputStream = dataExtractor.next();
             // DataExtractor returns single-line JSON but without newline characters between objects.
-            // Instead, it has a space between objects due to how JSON XContenetBuilder works.
+            // Instead, it has a space between objects due to how JSON XContentBuilder works.
             // In order to return a proper JSON array from preview, we surround with square brackets and
             // we stick in a comma between objects.
             // Also, the stream is expected to be a single line but in case it is not, we join lines

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobBuilder.java
@@ -69,6 +69,7 @@ public class DatafeedJobBuilder {
         // Validate remote indices are available and get the job
         try {
             checkRemoteIndicesAreAvailable(datafeedConfig);
+            // TODO validate Runtime fields with cross cluster search
         } catch (Exception e) {
             listener.onFailure(e);
             return;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobBuilder.java
@@ -69,7 +69,6 @@ public class DatafeedJobBuilder {
         // Validate remote indices are available and get the job
         try {
             checkRemoteIndicesAreAvailable(datafeedConfig);
-            // TODO validate Runtime fields with cross cluster search
         } catch (Exception e) {
             listener.onFailure(e);
             return;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/delayeddatacheck/DatafeedDelayedDataDetector.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/delayeddatacheck/DatafeedDelayedDataDetector.java
@@ -49,9 +49,11 @@ public class DatafeedDelayedDataDetector implements DelayedDataDetector {
     private final QueryBuilder datafeedQuery;
     private final String[] datafeedIndices;
     private final IndicesOptions indicesOptions;
+    private final Map<String, Object> runtimeMappings;
 
     DatafeedDelayedDataDetector(long bucketSpan, long window, String jobId, String timeField, QueryBuilder datafeedQuery,
-                                String[] datafeedIndices, IndicesOptions indicesOptions, Client client) {
+                                String[] datafeedIndices, IndicesOptions indicesOptions, Map<String, Object> runtimeMappings,
+                                Client client) {
         this.bucketSpan = bucketSpan;
         this.window = window;
         this.jobId = jobId;
@@ -59,6 +61,7 @@ public class DatafeedDelayedDataDetector implements DelayedDataDetector {
         this.datafeedQuery = datafeedQuery;
         this.datafeedIndices = datafeedIndices;
         this.indicesOptions = Objects.requireNonNull(indicesOptions);
+        this.runtimeMappings = Objects.requireNonNull(runtimeMappings);
         this.client = client;
     }
 
@@ -117,8 +120,8 @@ public class DatafeedDelayedDataDetector implements DelayedDataDetector {
             .size(0)
             .aggregation(new DateHistogramAggregationBuilder(DATE_BUCKETS)
                 .fixedInterval(new DateHistogramInterval(bucketSpan + "ms")).field(timeField))
-            .query(ExtractorUtils.wrapInTimeRangeQuery(datafeedQuery, timeField, start, end));
-        // TODO runtime search here.
+            .query(ExtractorUtils.wrapInTimeRangeQuery(datafeedQuery, timeField, start, end))
+            .runtimeMappings(runtimeMappings);
 
         SearchRequest searchRequest = new SearchRequest(datafeedIndices).source(searchSourceBuilder).indicesOptions(indicesOptions);
         try (ThreadContext.StoredContext ignore = client.threadPool().getThreadContext().stashWithOrigin(ML_ORIGIN)) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/delayeddatacheck/DatafeedDelayedDataDetector.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/delayeddatacheck/DatafeedDelayedDataDetector.java
@@ -118,6 +118,7 @@ public class DatafeedDelayedDataDetector implements DelayedDataDetector {
             .aggregation(new DateHistogramAggregationBuilder(DATE_BUCKETS)
                 .fixedInterval(new DateHistogramInterval(bucketSpan + "ms")).field(timeField))
             .query(ExtractorUtils.wrapInTimeRangeQuery(datafeedQuery, timeField, start, end));
+        // TODO runtime search here.
 
         SearchRequest searchRequest = new SearchRequest(datafeedIndices).source(searchSourceBuilder).indicesOptions(indicesOptions);
         try (ThreadContext.StoredContext ignore = client.threadPool().getThreadContext().stashWithOrigin(ML_ORIGIN)) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/delayeddatacheck/DelayedDataDetectorFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/delayeddatacheck/DelayedDataDetectorFactory.java
@@ -52,6 +52,7 @@ public class DelayedDataDetectorFactory {
                 datafeedConfig.getParsedQuery(xContentRegistry),
                 datafeedConfig.getIndices().toArray(new String[0]),
                 datafeedConfig.getIndicesOptions(),
+                datafeedConfig.getRuntimeMappings(),
                 client);
         } else {
             return new NullDelayedDataDetector();

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AbstractAggregationDataExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AbstractAggregationDataExtractor.java
@@ -47,7 +47,7 @@ abstract class AbstractAggregationDataExtractor<T extends ActionRequestBuilder<S
      * post data action too often. The value of 1000 was determined via
      * such testing.
      */
-    private static int BATCH_KEY_VALUE_PAIRS = 1000;
+    private static final int BATCH_KEY_VALUE_PAIRS = 1000;
 
     protected final Client client;
     protected final AggregationDataExtractorContext context;
@@ -55,7 +55,7 @@ abstract class AbstractAggregationDataExtractor<T extends ActionRequestBuilder<S
     private boolean hasNext;
     private boolean isCancelled;
     private AggregationToJsonProcessor aggregationToJsonProcessor;
-    private ByteArrayOutputStream outputStream;
+    private final ByteArrayOutputStream outputStream;
 
     AbstractAggregationDataExtractor(
             Client client, AggregationDataExtractorContext dataExtractorContext, DatafeedTimingStatsReporter timingStatsReporter) {
@@ -104,7 +104,7 @@ abstract class AbstractAggregationDataExtractor<T extends ActionRequestBuilder<S
             initAggregationProcessor(aggs);
         }
 
-        return Optional.ofNullable(processNextBatch());
+        return Optional.of(processNextBatch());
     }
 
     private Aggregations search() {
@@ -137,6 +137,9 @@ abstract class AbstractAggregationDataExtractor<T extends ActionRequestBuilder<S
             .size(0)
             .query(ExtractorUtils.wrapInTimeRangeQuery(context.query, context.timeField, histogramSearchStartTime, context.end));
 
+        if (context.runtimeMappings != null && context.runtimeMappings.isEmpty() == false) {
+            searchSourceBuilder.runtimeMappings(context.runtimeMappings);
+        }
         context.aggs.getAggregatorFactories().forEach(searchSourceBuilder::aggregation);
         context.aggs.getPipelineAggregatorFactories().forEach(searchSourceBuilder::aggregation);
         return searchSourceBuilder;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AbstractAggregationDataExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AbstractAggregationDataExtractor.java
@@ -137,7 +137,7 @@ abstract class AbstractAggregationDataExtractor<T extends ActionRequestBuilder<S
             .size(0)
             .query(ExtractorUtils.wrapInTimeRangeQuery(context.query, context.timeField, histogramSearchStartTime, context.end));
 
-        if (context.runtimeMappings != null && context.runtimeMappings.isEmpty() == false) {
+        if (context.runtimeMappings.isEmpty() == false) {
             searchSourceBuilder.runtimeMappings(context.runtimeMappings);
         }
         context.aggs.getAggregatorFactories().forEach(searchSourceBuilder::aggregation);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationDataExtractorContext.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationDataExtractorContext.java
@@ -27,10 +27,11 @@ class AggregationDataExtractorContext {
     final boolean includeDocCount;
     final Map<String, String> headers;
     final IndicesOptions indicesOptions;
+    final Map<String, Object> runtimeMappings;
 
     AggregationDataExtractorContext(String jobId, String timeField, Set<String> fields, List<String> indices, QueryBuilder query,
                                     AggregatorFactories.Builder aggs, long start, long end, boolean includeDocCount,
-                                    Map<String, String> headers, IndicesOptions indicesOptions) {
+                                    Map<String, String> headers, IndicesOptions indicesOptions, Map<String, Object> runtimeMappings) {
         this.jobId = Objects.requireNonNull(jobId);
         this.timeField = Objects.requireNonNull(timeField);
         this.fields = Objects.requireNonNull(fields);
@@ -42,5 +43,6 @@ class AggregationDataExtractorContext {
         this.includeDocCount = includeDocCount;
         this.headers = headers;
         this.indicesOptions = Objects.requireNonNull(indicesOptions);
+        this.runtimeMappings = runtimeMappings;
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationDataExtractorContext.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationDataExtractorContext.java
@@ -43,6 +43,6 @@ class AggregationDataExtractorContext {
         this.includeDocCount = includeDocCount;
         this.headers = headers;
         this.indicesOptions = Objects.requireNonNull(indicesOptions);
-        this.runtimeMappings = runtimeMappings;
+        this.runtimeMappings = Objects.requireNonNull(runtimeMappings);
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationDataExtractorFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationDataExtractorFactory.java
@@ -51,7 +51,8 @@ public class AggregationDataExtractorFactory implements DataExtractorFactory {
                 Intervals.alignToFloor(end, histogramInterval),
                 job.getAnalysisConfig().getSummaryCountFieldName().equals(DatafeedConfig.DOC_COUNT),
                 datafeedConfig.getHeaders(),
-                datafeedConfig.getIndicesOptions());
+                datafeedConfig.getIndicesOptions(),
+                datafeedConfig.getRuntimeMappings());
         return new AggregationDataExtractor(client, dataExtractorContext, timingStatsReporter);
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/RollupDataExtractorFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/RollupDataExtractorFactory.java
@@ -88,7 +88,7 @@ public class RollupDataExtractorFactory implements DataExtractorFactory {
                               DatafeedTimingStatsReporter timingStatsReporter,
                               ActionListener<DataExtractorFactory> listener) {
 
-        if (datafeed.getRuntimeMappings() != null && datafeed.getRuntimeMappings().isEmpty() == false) {
+        if (datafeed.getRuntimeMappings().isEmpty() == false) {
             // TODO Rollup V2 will support runtime fields
             listener.onFailure(new IllegalArgumentException("The datafeed has runtime_mappings defined, "
                 + "runtime fields are not supported in rollup searches"));

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/RollupDataExtractorFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/RollupDataExtractorFactory.java
@@ -88,6 +88,13 @@ public class RollupDataExtractorFactory implements DataExtractorFactory {
                               DatafeedTimingStatsReporter timingStatsReporter,
                               ActionListener<DataExtractorFactory> listener) {
 
+        if (datafeed.getRuntimeMappings() != null && datafeed.getRuntimeMappings().isEmpty() == false) {
+            // TODO Rollup V2 will support runtime fields
+            listener.onFailure(new IllegalArgumentException("The datafeed has runtime_mappings defined, "
+                + "runtime fields are not supported in rollup searches"));
+            return;
+        }
+
         final AggregationBuilder datafeedHistogramAggregation = getHistogramAggregation(
             datafeed.getParsedAggregations(xContentRegistry).getAggregatorFactories());
         if ((datafeedHistogramAggregation instanceof DateHistogramAggregationBuilder) == false) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/RollupDataExtractorFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/RollupDataExtractorFactory.java
@@ -75,7 +75,8 @@ public class RollupDataExtractorFactory implements DataExtractorFactory {
             Intervals.alignToFloor(end, histogramInterval),
             job.getAnalysisConfig().getSummaryCountFieldName().equals(DatafeedConfig.DOC_COUNT),
             datafeedConfig.getHeaders(),
-            datafeedConfig.getIndicesOptions());
+            datafeedConfig.getIndicesOptions(),
+            datafeedConfig.getRuntimeMappings());
         return new RollupDataExtractor(client, dataExtractorContext, timingStatsReporter);
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/chunked/ChunkedDataExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/chunked/ChunkedDataExtractor.java
@@ -239,6 +239,8 @@ public class ChunkedDataExtractor implements DataExtractor {
             return new SearchSourceBuilder()
                 .size(0)
                 .query(ExtractorUtils.wrapInTimeRangeQuery(context.query, context.timeField, currentStart, context.end))
+                // TODO only need runtime mappings if context.timeField is a RT field?
+                .runtimeMappings(context.runtimeMappings)
                 .aggregation(AggregationBuilders.min(EARLIEST_TIME).field(context.timeField))
                 .aggregation(AggregationBuilders.max(LATEST_TIME).field(context.timeField));
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/chunked/ChunkedDataExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/chunked/ChunkedDataExtractor.java
@@ -239,7 +239,6 @@ public class ChunkedDataExtractor implements DataExtractor {
             return new SearchSourceBuilder()
                 .size(0)
                 .query(ExtractorUtils.wrapInTimeRangeQuery(context.query, context.timeField, currentStart, context.end))
-                // TODO only need runtime mappings if context.timeField is a RT field?
                 .runtimeMappings(context.runtimeMappings)
                 .aggregation(AggregationBuilders.min(EARLIEST_TIME).field(context.timeField))
                 .aggregation(AggregationBuilders.max(LATEST_TIME).field(context.timeField));

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/chunked/ChunkedDataExtractorContext.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/chunked/ChunkedDataExtractorContext.java
@@ -34,10 +34,12 @@ class ChunkedDataExtractorContext {
     final boolean hasAggregations;
     final Long histogramInterval;
     final IndicesOptions indicesOptions;
+    final Map<String, Object> runtimeMappings;
 
     ChunkedDataExtractorContext(String jobId, String timeField, List<String> indices, QueryBuilder query, int scrollSize, long start,
                                 long end, @Nullable TimeValue chunkSpan, TimeAligner timeAligner, Map<String, String> headers,
-                                boolean hasAggregations, @Nullable Long histogramInterval, IndicesOptions indicesOptions) {
+                                boolean hasAggregations, @Nullable Long histogramInterval, IndicesOptions indicesOptions,
+                                @Nullable Map<String, Object> runtimeMappings) {
         this.jobId = Objects.requireNonNull(jobId);
         this.timeField = Objects.requireNonNull(timeField);
         this.indices = indices.toArray(new String[indices.size()]);
@@ -51,5 +53,6 @@ class ChunkedDataExtractorContext {
         this.hasAggregations = hasAggregations;
         this.histogramInterval = histogramInterval;
         this.indicesOptions = Objects.requireNonNull(indicesOptions);
+        this.runtimeMappings = runtimeMappings;
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/chunked/ChunkedDataExtractorContext.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/chunked/ChunkedDataExtractorContext.java
@@ -39,7 +39,7 @@ class ChunkedDataExtractorContext {
     ChunkedDataExtractorContext(String jobId, String timeField, List<String> indices, QueryBuilder query, int scrollSize, long start,
                                 long end, @Nullable TimeValue chunkSpan, TimeAligner timeAligner, Map<String, String> headers,
                                 boolean hasAggregations, @Nullable Long histogramInterval, IndicesOptions indicesOptions,
-                                @Nullable Map<String, Object> runtimeMappings) {
+                                Map<String, Object> runtimeMappings) {
         this.jobId = Objects.requireNonNull(jobId);
         this.timeField = Objects.requireNonNull(timeField);
         this.indices = indices.toArray(new String[indices.size()]);
@@ -53,6 +53,6 @@ class ChunkedDataExtractorContext {
         this.hasAggregations = hasAggregations;
         this.histogramInterval = histogramInterval;
         this.indicesOptions = Objects.requireNonNull(indicesOptions);
-        this.runtimeMappings = runtimeMappings;
+        this.runtimeMappings = Objects.requireNonNull(runtimeMappings);
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/chunked/ChunkedDataExtractorFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/chunked/ChunkedDataExtractorFactory.java
@@ -55,7 +55,8 @@ public class ChunkedDataExtractorFactory implements DataExtractorFactory {
                 datafeedConfig.getHeaders(),
                 datafeedConfig.hasAggregations(),
                 datafeedConfig.hasAggregations() ? datafeedConfig.getHistogramIntervalMillis(xContentRegistry) : null,
-                datafeedConfig.getIndicesOptions()
+                datafeedConfig.getIndicesOptions(),
+                datafeedConfig.getRuntimeMappings()
             );
         return new ChunkedDataExtractor(client, dataExtractorFactory, dataExtractorContext, timingStatsReporter);
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractorContext.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractorContext.java
@@ -25,10 +25,11 @@ class ScrollDataExtractorContext {
     final long end;
     final Map<String, String> headers;
     final IndicesOptions indicesOptions;
+    final Map<String, Object> runtimeMappings;
 
     ScrollDataExtractorContext(String jobId, TimeBasedExtractedFields extractedFields, List<String> indices, QueryBuilder query,
                                List<SearchSourceBuilder.ScriptField> scriptFields, int scrollSize, long start, long end,
-                               Map<String, String> headers, IndicesOptions indicesOptions) {
+                               Map<String, String> headers, IndicesOptions indicesOptions, Map<String, Object> runtimeMappings) {
         this.jobId = Objects.requireNonNull(jobId);
         this.extractedFields = Objects.requireNonNull(extractedFields);
         this.indices = indices.toArray(new String[indices.size()]);
@@ -39,5 +40,6 @@ class ScrollDataExtractorContext {
         this.end = end;
         this.headers = headers;
         this.indicesOptions = Objects.requireNonNull(indicesOptions);
+        this.runtimeMappings = runtimeMappings;
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractorContext.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractorContext.java
@@ -40,6 +40,6 @@ class ScrollDataExtractorContext {
         this.end = end;
         this.headers = headers;
         this.indicesOptions = Objects.requireNonNull(indicesOptions);
-        this.runtimeMappings = runtimeMappings;
+        this.runtimeMappings = Objects.requireNonNull(runtimeMappings);
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractorFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractorFactory.java
@@ -23,6 +23,7 @@ import org.elasticsearch.xpack.ml.datafeed.DatafeedTimingStatsReporter;
 import org.elasticsearch.xpack.ml.datafeed.extractor.DataExtractorFactory;
 
 import java.util.Objects;
+import java.util.Set;
 
 public class ScrollDataExtractorFactory implements DataExtractorFactory {
     private final Client client;
@@ -90,11 +91,16 @@ public class ScrollDataExtractorFactory implements DataExtractorFactory {
         // Step 1. Get field capabilities necessary to build the information of how to extract fields
         FieldCapabilitiesRequest fieldCapabilitiesRequest = new FieldCapabilitiesRequest();
         fieldCapabilitiesRequest.indices(datafeed.getIndices().toArray(new String[0])).indicesOptions(datafeed.getIndicesOptions());
+
+        // Cannot get field caps on RT fields defined at search
+        Set<String> runtimefields = datafeed.getRuntimeMappings().keySet();
+
         // We need capabilities for all fields matching the requested fields' parents so that we can work around
         // multi-fields that are not in source.
         String[] requestFields = job.allInputFields()
             .stream()
             .map(f -> MlStrings.getParentField(f) + "*")
+            .filter(f -> runtimefields.contains(f) == false)
             .toArray(String[]::new);
         fieldCapabilitiesRequest.fields(requestFields);
         ClientHelper.<FieldCapabilitiesResponse> executeWithHeaders(datafeed.getHeaders(), ClientHelper.ML_ORIGIN, client, () -> {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractorFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractorFactory.java
@@ -54,7 +54,8 @@ public class ScrollDataExtractorFactory implements DataExtractorFactory {
                 start,
                 end,
                 datafeedConfig.getHeaders(),
-                datafeedConfig.getIndicesOptions()
+                datafeedConfig.getIndicesOptions(),
+                datafeedConfig.getRuntimeMappings()
         );
         return new ScrollDataExtractor(client, dataExtractorContext, timingStatsReporter);
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/TimeBasedExtractedFields.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/TimeBasedExtractedFields.java
@@ -55,7 +55,10 @@ public class TimeBasedExtractedFields extends ExtractedFields {
 
     public static TimeBasedExtractedFields build(Job job, DatafeedConfig datafeed, FieldCapabilitiesResponse fieldsCapabilities) {
         Set<String> scriptFields = datafeed.getScriptFields().stream().map(sf -> sf.fieldName()).collect(Collectors.toSet());
-        ExtractionMethodDetector extractionMethodDetector = new ExtractionMethodDetector(scriptFields, fieldsCapabilities);
+        Set<String> searchRuntimeFields = datafeed.getRuntimeMappings().keySet();
+
+        ExtractionMethodDetector extractionMethodDetector =
+            new ExtractionMethodDetector(scriptFields, fieldsCapabilities, searchRuntimeFields);
         String timeField = job.getDataDescription().getTimeField();
         if (scriptFields.contains(timeField) == false && extractionMethodDetector.isAggregatable(timeField) == false) {
             throw new IllegalArgumentException("cannot retrieve time field [" + timeField + "] because it is not aggregatable");

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetector.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetector.java
@@ -368,6 +368,7 @@ public class ExtractedFieldsDetector {
                                                   List<ProcessedField> processedFields) {
         ExtractedFields extractedFields = ExtractedFields.build(fields,
             Collections.emptySet(),
+            Collections.emptySet(),
             fieldCapabilitiesResponse,
             cardinalitiesForFieldsWithConstraints,
             processedFields);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/extractor/ExtractedFields.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/extractor/ExtractedFields.java
@@ -101,18 +101,13 @@ public class ExtractedFields {
             cardinalitiesForFieldsWithConstraints);
     }
 
-    // without search runtime fields
     public static ExtractedFields build(Set<String> allFields,
                                         Set<String> scriptFields,
                                         FieldCapabilitiesResponse fieldsCapabilities,
                                         Map<String, Long> cardinalitiesForFieldsWithConstraints,
                                         List<ProcessedField> processedFields) {
-        ExtractionMethodDetector extractionMethodDetector =
-            new ExtractionMethodDetector(scriptFields, fieldsCapabilities, Collections.emptySet());
-        return new ExtractedFields(
-            allFields.stream().map(extractionMethodDetector::detect).collect(Collectors.toList()),
-            processedFields,
-            cardinalitiesForFieldsWithConstraints);
+        return build(allFields, scriptFields, Collections.emptySet(), fieldsCapabilities,
+            cardinalitiesForFieldsWithConstraints, processedFields);
     }
 
     public static TimeField newTimeField(String name, ExtractedField.Method method) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationDataExtractorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationDataExtractorTests.java
@@ -36,6 +36,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -61,6 +62,7 @@ public class AggregationDataExtractorTests extends ESTestCase {
     private QueryBuilder query;
     private AggregatorFactories.Builder aggs;
     private DatafeedTimingStatsReporter timingStatsReporter;
+    private Map<String, Object> runtimeMappings;
 
     private class TestDataExtractor extends AggregationDataExtractor {
 
@@ -103,6 +105,7 @@ public class AggregationDataExtractorTests extends ESTestCase {
                 .addAggregator(AggregationBuilders.histogram("time").field("time").interval(1000).subAggregation(
                         AggregationBuilders.terms("airline").field("airline").subAggregation(
                                 AggregationBuilders.avg("responsetime").field("responsetime"))));
+        runtimeMappings = Collections.emptyMap();
         timingStatsReporter = new DatafeedTimingStatsReporter(new DatafeedTimingStats(jobId), mock(DatafeedTimingStatsPersister.class));
     }
 
@@ -265,7 +268,7 @@ public class AggregationDataExtractorTests extends ESTestCase {
 
     private AggregationDataExtractorContext createContext(long start, long end) {
         return new AggregationDataExtractorContext(jobId, timeField, fields, indices, query, aggs, start, end, true,
-            Collections.emptyMap(), SearchRequest.DEFAULT_INDICES_OPTIONS);
+            Collections.emptyMap(), SearchRequest.DEFAULT_INDICES_OPTIONS, runtimeMappings);
     }
 
     @SuppressWarnings("unchecked")

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/RollupDataExtractorFactoryTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/RollupDataExtractorFactoryTests.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.ml.datafeed.extractor.aggregation;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
+import org.elasticsearch.xpack.core.ml.job.config.AnalysisConfig;
+import org.elasticsearch.xpack.core.ml.job.config.DataDescription;
+import org.elasticsearch.xpack.core.ml.job.config.Detector;
+import org.elasticsearch.xpack.core.ml.job.config.Job;
+import org.elasticsearch.xpack.ml.datafeed.DatafeedTimingStatsReporter;
+import org.elasticsearch.xpack.ml.datafeed.extractor.DataExtractorFactory;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.Mockito.mock;
+
+public class RollupDataExtractorFactoryTests extends ESTestCase {
+
+    public void testCreateWithRuntimeFields() {
+        String jobId = "foojob";
+
+        Detector.Builder detectorBuilder = new Detector.Builder();
+        detectorBuilder.setFunction("sum");
+        detectorBuilder.setFieldName("value");
+        AnalysisConfig.Builder analysisConfig = new AnalysisConfig.Builder(Collections.singletonList(detectorBuilder.build()));
+        Job.Builder jobBuilder = new Job.Builder(jobId);
+        jobBuilder.setDataDescription(new DataDescription.Builder());
+        jobBuilder.setAnalysisConfig(analysisConfig);
+
+        DatafeedConfig.Builder datafeedConfigBuilder = new DatafeedConfig.Builder("foo-feed", jobId);
+        datafeedConfigBuilder.setIndices(Collections.singletonList("my_index"));
+
+        Map<String, Object> settings = new HashMap<>();
+        settings.put("type", "keyword");
+        settings.put("script", "");
+        Map<String, Object> field = new HashMap<>();
+        field.put("runtime_field_bar", settings);
+        datafeedConfigBuilder.setRuntimeMappings(field);
+
+        AtomicReference<Exception> exceptionRef = new AtomicReference<>();
+        ActionListener<DataExtractorFactory> listener = ActionListener.wrap(
+            r -> fail("unexpected response"),
+            exceptionRef::set
+        );
+
+        RollupDataExtractorFactory.create(mock(Client.class), datafeedConfigBuilder.build(), jobBuilder.build(new Date()),
+            Collections.emptyMap(), xContentRegistry(), mock(DatafeedTimingStatsReporter.class), listener);
+
+        assertNotNull(exceptionRef.get());
+        Exception e = exceptionRef.get();
+        assertThat(e, instanceOf(IllegalArgumentException.class));
+        assertThat(e.getMessage(), equalTo("The datafeed has runtime_mappings defined, " +
+            "runtime fields are not supported in rollup searches"));
+    }
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/RollupDataExtractorFactoryTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/RollupDataExtractorFactoryTests.java
@@ -17,7 +17,6 @@ import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.ml.datafeed.DatafeedTimingStatsReporter;
 import org.elasticsearch.xpack.ml.datafeed.extractor.DataExtractorFactory;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/chunked/ChunkedDataExtractorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/chunked/ChunkedDataExtractorTests.java
@@ -552,7 +552,7 @@ public class ChunkedDataExtractorTests extends ESTestCase {
     private ChunkedDataExtractorContext createContext(long start, long end, boolean hasAggregations, Long histogramInterval) {
         return new ChunkedDataExtractorContext(jobId, timeField, indices, query, scrollSize, start, end, chunkSpan,
             ChunkedDataExtractorFactory.newIdentityTimeAligner(), Collections.emptyMap(), hasAggregations, histogramInterval,
-            SearchRequest.DEFAULT_INDICES_OPTIONS);
+            SearchRequest.DEFAULT_INDICES_OPTIONS, Collections.emptyMap());
     }
 
     private static class StubSubExtractor implements DataExtractor {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractorTests.java
@@ -446,7 +446,8 @@ public class ScrollDataExtractorTests extends ESTestCase {
 
         List<SearchSourceBuilder.ScriptField> sFields = Arrays.asList(withoutSplit, withSplit);
         ScrollDataExtractorContext context = new ScrollDataExtractorContext(jobId, extractedFields, indices,
-                query, sFields, scrollSize, 1000, 2000, Collections.emptyMap(), SearchRequest.DEFAULT_INDICES_OPTIONS);
+                query, sFields, scrollSize, 1000, 2000, Collections.emptyMap(), SearchRequest.DEFAULT_INDICES_OPTIONS,
+            Collections.emptyMap());
 
         TestDataExtractor extractor = new TestDataExtractor(context);
 
@@ -492,7 +493,7 @@ public class ScrollDataExtractorTests extends ESTestCase {
 
     private ScrollDataExtractorContext createContext(long start, long end) {
         return new ScrollDataExtractorContext(jobId, extractedFields, indices, query, scriptFields, scrollSize, start, end,
-            Collections.emptyMap(), SearchRequest.DEFAULT_INDICES_OPTIONS);
+            Collections.emptyMap(), SearchRequest.DEFAULT_INDICES_OPTIONS, Collections.emptyMap());
     }
 
     private SearchResponse createEmptySearchResponse() {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/preview_datafeed.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/preview_datafeed.yml
@@ -390,3 +390,76 @@ setup:
       ml.preview_datafeed:
         datafeed_id: empty-feed
   - length: { $body: 0 }
+
+
+---
+"Test preview aggregation with runtime fields":
+
+  - do:
+      ml.put_job:
+        job_id: runtime-field-aggregation-job
+        body:  >
+          {
+            "analysis_config" : {
+                "bucket_span": "3600s",
+                "summary_count_field_name": "doc_count",
+                "detectors" :[{"function":"mean","field_name":"responsetime_x_2","by_field_name":"airline"}]
+            },
+            "data_description" : {
+                "time_field":"time"
+            }
+          }
+
+  - do:
+      ml.put_datafeed:
+        datafeed_id: aggregation-doc-count-feed
+        body:  >
+          {
+            "job_id":"runtime-field-aggregation-job",
+            "indexes":"airline-data",
+            "runtime_mappings" : {
+              "type": "double",
+              "script": "emit(doc['responsetime'].value * 2.0)"
+            },
+            "aggregations": {
+              "buckets": {
+                "histogram": {
+                  "field": "time",
+                  "interval": 3600000
+                },
+                "aggregations": {
+                  "time": {
+                    "max": {
+                      "field": "time"
+                    }
+                  },
+                  "airline": {
+                    "terms": {
+                      "field": "airline",
+                      "size": 100
+                    },
+                    "aggregations": {
+                      "responsetime_x_2": {
+                        "sum": {
+                           "field": "responsetime_x_2"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+  - length: { $body: 30 }
+  - match: { 0.time: 1487377800000 }
+  - match: { 0.airline: foo }
+  - match: { 0.responsetime_x_2: 4.0 }
+  - match: { 0.doc_count: 2 }
+  - match: { 1.time: 1487379660000 }
+  - match: { 1.airline: bar }
+  - match: { 1.responsetime_x_2: 84.0 }
+  - match: { 1.doc_count: 1 }
+  - match: { 1.time: 1487379660000 }
+  - match: { 2.airline: foo }
+  - match: { 2.responsetime_x_2: 84.0 }
+  - match: { 2.doc_count: 1 }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/preview_datafeed.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/preview_datafeed.yml
@@ -418,8 +418,10 @@ setup:
             "job_id":"runtime-field-aggregation-job",
             "indexes":"airline-data",
             "runtime_mappings" : {
-              "type": "double",
-              "script": "emit(doc['responsetime'].value * 2.0)"
+              "responsetime_x_2": {
+                "type": "double",
+                "script": "emit(doc['responsetime'].value * 2.0)"
+              }
             },
             "aggregations": {
               "buckets": {
@@ -450,7 +452,11 @@ setup:
               }
             }
           }
-  - length: { $body: 30 }
+
+  - do:
+      ml.preview_datafeed:
+        datafeed_id: aggregation-doc-count-feed
+  - length: { $body: 3 }
   - match: { 0.time: 1487377800000 }
   - match: { 0.airline: foo }
   - match: { 0.responsetime_x_2: 4.0 }


### PR DESCRIPTION
This change adds runtime fields in search to the datafeed.

The DatafeedConfig has an optional section to defined search runtime fields
```
            "runtime_mappings" : {
                "rt_field_1": {
                    "type": "double",
                    "script": "emit(doc['some_field'].value * 100.0)"
                },
                "rt_field_2": {
                    "type": "double",
                    "script": "emit(doc['another_field'].value)"
                },
```

The actual configuration is just a loose `Map<String, Object>` as this is what `SearchSourceBuilder` uses. There is some validation on PUT that the map contents resemble a runtime_mappings configuration.

Datafeed preview and running a datafeed are not exactly the same. The checks in `DatafeedJobValidator` are not run in preview which means the check that the time field is not an RT field will not happen. We should discuss changing preview to exactly match the behaviour or running a datafeed. 

There are some design decisions that the reviewer should know about:

1. Configurations of jobs/datafeeds that use `runtime_mappings` to create the job time field will be rejected.
2. RT fields do no work with v1 Rollup searches. If the datafeed is querying a rollup index it will not start if RT fields are used.
3. RT fields in Cross Cluster Search require the remote cluster to be v7.11 or above. The datafeed will start and the search will fail in this case. It is not possible to check prior to starting the datafeed. 


HLRC to follow, this change is big enough.