### PR TITLE
[DOCS] Add `require_alias` query param to reindex API

### DIFF
--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -444,6 +444,8 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=wait_for_completion]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=requests_per_second]
 
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=require-alias]
+
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=scroll]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=slices]

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -582,8 +582,9 @@ end::memory[]
 
 tag::require-alias[]
 `require_alias`::
-(Optional, Boolean) When true, this requires the destination to be an alias.
-Defaults to false.
+(Optional, Boolean)
+If `true`, the destination must be an <<indices-aliases,index alias>>. Defaults to
+`false`.
 end::require-alias[]
 
 tag::node-filter[]


### PR DESCRIPTION
Adds the `require_alias` query parameter to the reindex API docs.

Relates to #58917

Closes #65537