### PR TITLE
[7.x] Mute SegmentsStatsTests testFileExtensionDescriptions (#65615)

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/engine/SegmentsStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/SegmentsStatsTests.java
@@ -37,6 +37,7 @@ import org.elasticsearch.test.ESTestCase;
 
 public class SegmentsStatsTests extends ESTestCase {
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/65267")
     public void testFileExtensionDescriptions() throws Exception {
         try (Directory dir = newDirectory()) {
             try (IndexWriter w = new IndexWriter(dir, new IndexWriterConfig()


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Mute SegmentsStatsTests testFileExtensionDescriptions (#65615)