### PR TITLE
[DOCS] Replace "time-series" with "time series"

### DIFF
--- a/docs/reference/rollup/apis/rollup-api.asciidoc
+++ b/docs/reference/rollup/apis/rollup-api.asciidoc
@@ -6,7 +6,7 @@
 <titleabbrev>Rollup</titleabbrev>
 ++++
 
-Aggregates an index's time-series data and stores the results in another index.
+Aggregates an index's time series data and stores the results in another index.
 For example, you can roll up hourly data into daily or weekly summaries.
 
 [source,console]

--- a/docs/reference/rollup/rollup-apis.asciidoc
+++ b/docs/reference/rollup/rollup-apis.asciidoc
@@ -5,7 +5,7 @@
 
 ifdef::permanently-unreleased-branch[]
 
-A rollup aggregates an index's time-series data and stores the results in
+A rollup aggregates an index's time series data and stores the results in
 another index. For example, you can roll up hourly data into daily or weekly
 summaries.
 


### PR DESCRIPTION
Changes a few instances of "time-series" to "time series." Per our style guide, this should never be hyphenated.