### PR TITLE
[7.x] [DOCS] Fix type exists API request example  (#65574)

### DIFF
--- a/docs/reference/indices/types-exists.asciidoc
+++ b/docs/reference/indices/types-exists.asciidoc
@@ -19,7 +19,7 @@ HEAD my-index-000001/_mapping/message
 [[indices-types-exists-api-request]]
 ==== {api-request-title}
 
-`HEAD /<index>/mapping/<type>`
+`HEAD /<index>/_mapping/<type>`
 
 
 [[indices-types-exists-api-path-params]]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Fix type exists API request example  (#65574)