### PR TITLE
[ML] Resume reassigning datafeed from loaded model snapshot

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -36,15 +36,13 @@ import org.elasticsearch.action.admin.cluster.configuration.ClearVotingConfigExc
 import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
 import org.elasticsearch.action.admin.indices.stats.CommonStatsFlags;
 import org.elasticsearch.action.admin.indices.stats.CommonStatsFlags.Flag;
-import org.elasticsearch.cluster.coordination.NoMasterBlockService;
-import org.elasticsearch.discovery.Discovery;
-import org.elasticsearch.index.IndexingPressure;
 import org.elasticsearch.action.support.replication.TransportReplicationAction;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.action.index.MappingUpdatedAction;
 import org.elasticsearch.cluster.coordination.ClusterBootstrapService;
+import org.elasticsearch.cluster.coordination.NoMasterBlockService;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
@@ -83,6 +81,7 @@ import org.elasticsearch.env.ShardLockObtainFailedException;
 import org.elasticsearch.http.HttpServerTransport;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexService;
+import org.elasticsearch.index.IndexingPressure;
 import org.elasticsearch.index.engine.DocIdSeqNoAndSource;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.engine.EngineTestCase;
@@ -1529,9 +1528,9 @@ public final class InternalTestCluster extends TestCluster {
     /**
      * Stops a specific node in the cluster. Returns true if the node was found to stop, false otherwise.
      */
-    public synchronized boolean stopNode(DiscoveryNode node) throws IOException {
+    public synchronized boolean stopNode(String nodeName) throws IOException {
         ensureOpen();
-        Optional<NodeAndClient> nodeToStop = nodes.values().stream().filter(n -> n.getName().equals(node.getName())).findFirst();
+        Optional<NodeAndClient> nodeToStop = nodes.values().stream().filter(n -> n.getName().equals(nodeName)).findFirst();
         if (nodeToStop.isPresent()) {
             logger.info("Closing node [{}]", nodeToStop.get().name);
             stopNodesAndClient(nodeToStop.get());

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -37,6 +37,7 @@ import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
 import org.elasticsearch.action.admin.indices.stats.CommonStatsFlags;
 import org.elasticsearch.action.admin.indices.stats.CommonStatsFlags.Flag;
 import org.elasticsearch.cluster.coordination.NoMasterBlockService;
+import org.elasticsearch.discovery.Discovery;
 import org.elasticsearch.index.IndexingPressure;
 import org.elasticsearch.action.support.replication.TransportReplicationAction;
 import org.elasticsearch.client.Client;
@@ -126,6 +127,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
 import java.util.TreeMap;
@@ -1519,6 +1521,20 @@ public final class InternalTestCluster extends TestCluster {
         if (nodeAndClient != null) {
             logger.info("Closing random node [{}] ", nodeAndClient.name);
             stopNodesAndClient(nodeAndClient);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Stops a specific node in the cluster. Returns true if the node was found to stop, false otherwise.
+     */
+    public synchronized boolean stopNode(DiscoveryNode node) throws IOException {
+        ensureOpen();
+        Optional<NodeAndClient> nodeToStop = nodes.values().stream().filter(n -> n.getName().equals(node.getName())).findFirst();
+        if (nodeToStop.isPresent()) {
+            logger.info("Closing node [{}]", nodeToStop.get().name);
+            stopNodesAndClient(nodeToStop.get());
             return true;
         }
         return false;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/RevertModelSnapshotActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/RevertModelSnapshotActionRequestTests.java
@@ -19,6 +19,9 @@ public class RevertModelSnapshotActionRequestTests extends AbstractSerializingTe
         if (randomBoolean()) {
             request.setDeleteInterveningResults(randomBoolean());
         }
+        if (randomBoolean()) {
+            request.setForce(randomBoolean());
+        }
         return request;
     }
 

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlDistributedFailureIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlDistributedFailureIT.java
@@ -468,7 +468,7 @@ public class MlDistributedFailureIT extends BaseMlIntegTestCase {
 
         waitForJobToHaveProcessedAtLeast(jobId, 1000);
 
-        internalCluster().stopNode(nodeRunningJob);
+        internalCluster().stopNode(nodeRunningJob.getName());
 
         waitForJobClosed(jobId);
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -228,6 +228,7 @@ import org.elasticsearch.xpack.ml.annotations.AnnotationPersister;
 import org.elasticsearch.xpack.ml.autoscaling.MlAutoscalingDeciderService;
 import org.elasticsearch.xpack.ml.autoscaling.MlAutoscalingNamedWritableProvider;
 import org.elasticsearch.xpack.ml.datafeed.DatafeedConfigAutoUpdater;
+import org.elasticsearch.xpack.ml.datafeed.DatafeedContextProvider;
 import org.elasticsearch.xpack.ml.datafeed.DatafeedJobBuilder;
 import org.elasticsearch.xpack.ml.datafeed.DatafeedManager;
 import org.elasticsearch.xpack.ml.datafeed.persistence.DatafeedConfigProvider;
@@ -330,11 +331,11 @@ import org.elasticsearch.xpack.ml.rest.job.RestOpenJobAction;
 import org.elasticsearch.xpack.ml.rest.job.RestPostDataAction;
 import org.elasticsearch.xpack.ml.rest.job.RestPostJobUpdateAction;
 import org.elasticsearch.xpack.ml.rest.job.RestPutJobAction;
-import org.elasticsearch.xpack.ml.rest.modelsnapshots.RestUpgradeJobModelSnapshotAction;
 import org.elasticsearch.xpack.ml.rest.modelsnapshots.RestDeleteModelSnapshotAction;
 import org.elasticsearch.xpack.ml.rest.modelsnapshots.RestGetModelSnapshotsAction;
 import org.elasticsearch.xpack.ml.rest.modelsnapshots.RestRevertModelSnapshotAction;
 import org.elasticsearch.xpack.ml.rest.modelsnapshots.RestUpdateModelSnapshotAction;
+import org.elasticsearch.xpack.ml.rest.modelsnapshots.RestUpgradeJobModelSnapshotAction;
 import org.elasticsearch.xpack.ml.rest.results.RestGetBucketsAction;
 import org.elasticsearch.xpack.ml.rest.results.RestGetCategoriesAction;
 import org.elasticsearch.xpack.ml.rest.results.RestGetInfluencersAction;
@@ -504,6 +505,7 @@ public class MachineLearning extends Plugin implements SystemIndexPlugin,
     private final boolean enabled;
 
     private final SetOnce<AutodetectProcessManager> autodetectProcessManager = new SetOnce<>();
+    private final SetOnce<DatafeedContextProvider> datafeedContextProvider = new SetOnce<>();
     private final SetOnce<DatafeedManager> datafeedManager = new SetOnce<>();
     private final SetOnce<DataFrameAnalyticsManager> dataFrameAnalyticsManager = new SetOnce<>();
     private final SetOnce<DataFrameAnalyticsAuditor> dataFrameAnalyticsAuditor = new SetOnce<>();
@@ -723,9 +725,11 @@ public class MachineLearning extends Plugin implements SystemIndexPlugin,
                 jobResultsPersister,
                 settings,
                 clusterService.getNodeName());
+        DatafeedContextProvider datafeedContextProvider = new DatafeedContextProvider(jobConfigProvider, datafeedConfigProvider,
+            jobResultsProvider);
+        this.datafeedContextProvider.set(datafeedContextProvider);
         DatafeedManager datafeedManager = new DatafeedManager(threadPool, client, clusterService, datafeedJobBuilder,
-                System::currentTimeMillis, anomalyDetectionAuditor, autodetectProcessManager, jobConfigProvider, datafeedConfigProvider,
-                jobResultsProvider);
+                System::currentTimeMillis, anomalyDetectionAuditor, autodetectProcessManager, datafeedContextProvider);
         this.datafeedManager.set(datafeedManager);
 
         // Inference components
@@ -831,6 +835,7 @@ public class MachineLearning extends Plugin implements SystemIndexPlugin,
                 new OpenJobPersistentTasksExecutor(settings,
                     clusterService,
                     autodetectProcessManager.get(),
+                    datafeedContextProvider.get(),
                     memoryTracker.get(),
                     client,
                     expressionResolver),

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportRevertModelSnapshotAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportRevertModelSnapshotAction.java
@@ -85,7 +85,7 @@ public class TransportRevertModelSnapshotAction extends TransportMasterNodeActio
                 PersistentTasksCustomMetadata tasks = state.getMetadata().custom(PersistentTasksCustomMetadata.TYPE);
                 JobState jobState = MlTasks.getJobState(request.getJobId(), tasks);
 
-                if (jobState.equals(JobState.CLOSED) == false) {
+                if (request.isForce() == false && jobState.equals(JobState.CLOSED) == false) {
                     listener.onFailure(ExceptionsHelper.conflictStatusException(Messages.getMessage(Messages.REST_JOB_NOT_CLOSED_REVERT)));
                     return;
                 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedContext.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedContext.java
@@ -6,50 +6,100 @@
 
 package org.elasticsearch.xpack.ml.datafeed;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedTimingStats;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
+import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSnapshot;
 import org.elasticsearch.xpack.ml.job.persistence.RestartTimeInfo;
 
 import java.util.Objects;
 
-class DatafeedContext {
+public class DatafeedContext {
 
+    private static final Logger logger = LogManager.getLogger(DatafeedContext.class);
+
+    private final long datafeedStartTimeMs;
     private final DatafeedConfig datafeedConfig;
     private final Job job;
     private final RestartTimeInfo restartTimeInfo;
     private final DatafeedTimingStats timingStats;
+    @Nullable
+    private final ModelSnapshot modelSnapshot;
 
-    DatafeedContext(DatafeedConfig datafeedConfig, Job job, RestartTimeInfo restartTimeInfo,
-                           DatafeedTimingStats timingStats) {
+    private DatafeedContext(long datafeedStartTimeMs, DatafeedConfig datafeedConfig, Job job, RestartTimeInfo restartTimeInfo,
+                           DatafeedTimingStats timingStats, ModelSnapshot modelSnapshot) {
+        this.datafeedStartTimeMs = datafeedStartTimeMs;
         this.datafeedConfig = Objects.requireNonNull(datafeedConfig);
         this.job = Objects.requireNonNull(job);
         this.restartTimeInfo = Objects.requireNonNull(restartTimeInfo);
         this.timingStats = Objects.requireNonNull(timingStats);
+        this.modelSnapshot = modelSnapshot;
     }
 
-
-    DatafeedConfig getDatafeedConfig() {
+    public DatafeedConfig getDatafeedConfig() {
         return datafeedConfig;
     }
 
-    Job getJob() {
+    public Job getJob() {
         return job;
     }
 
-    RestartTimeInfo getRestartTimeInfo() {
+    public RestartTimeInfo getRestartTimeInfo() {
         return restartTimeInfo;
     }
 
-    DatafeedTimingStats getTimingStats() {
+    public DatafeedTimingStats getTimingStats() {
         return timingStats;
     }
 
+    @Nullable
+    public ModelSnapshot getModelSnapshot() {
+        return modelSnapshot;
+    }
+
+    public boolean shouldRecoverFromCurrentSnapshot() {
+        if (modelSnapshot == null) {
+            logger.debug("[{}] checking whether recovery is required; job latest result timestamp [{}]; " +
+                    "job latest record timestamp [{}]; snapshot is [null]; datafeed start time [{}]", datafeedConfig.getJobId(),
+                restartTimeInfo.getLatestFinalBucketTimeMs(), restartTimeInfo.getLatestRecordTimeMs(), datafeedStartTimeMs);
+        } else {
+            logger.debug("[{}] checking whether recovery is required; job latest result timestamp [{}]; " +
+                    "job latest record timestamp [{}]; snapshot latest result timestamp [{}]; snapshot latest record timestamp [{}]; " +
+                    "datafeed start time [{}]",
+                datafeedConfig.getJobId(),
+                restartTimeInfo.getLatestFinalBucketTimeMs(),
+                restartTimeInfo.getLatestRecordTimeMs(),
+                modelSnapshot.getLatestResultTimeStamp() == null ? null : modelSnapshot.getLatestResultTimeStamp().getTime(),
+                modelSnapshot.getLatestRecordTimeStamp() == null ? null : modelSnapshot.getLatestRecordTimeStamp().getTime(),
+                datafeedStartTimeMs);
+        }
+
+        if (restartTimeInfo.isAfter(datafeedStartTimeMs)) {
+            return restartTimeInfo.haveSeenDataPreviously() &&
+                (modelSnapshot == null || restartTimeInfo.isAfterModelSnapshot(modelSnapshot));
+        }
+        // If the datafeed start time is past the job checkpoint we should not attempt to recover
+        return false;
+    }
+
+    static Builder builder(long datafeedStartTimeMs) {
+        return new Builder(datafeedStartTimeMs);
+    }
+
     static class Builder {
+        private final long datafeedStartTimeMs;
         private volatile DatafeedConfig datafeedConfig;
         private volatile Job job;
         private volatile RestartTimeInfo restartTimeInfo;
         private volatile DatafeedTimingStats timingStats;
+        private volatile ModelSnapshot modelSnapshot;
+
+        Builder(long datafeedStartTimeMs) {
+            this.datafeedStartTimeMs = datafeedStartTimeMs;
+        }
 
         Builder setDatafeedConfig(DatafeedConfig datafeedConfig) {
             this.datafeedConfig = datafeedConfig;
@@ -75,8 +125,13 @@ class DatafeedContext {
             return this;
         }
 
+        Builder setModelSnapshot(ModelSnapshot modelSnapshot) {
+            this.modelSnapshot = modelSnapshot;
+            return this;
+        }
+
         DatafeedContext build() {
-            return new DatafeedContext(datafeedConfig, job, restartTimeInfo, timingStats);
+            return new DatafeedContext(datafeedStartTimeMs, datafeedConfig, job, restartTimeInfo, timingStats, modelSnapshot);
         }
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedContextProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedContextProvider.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.ml.datafeed;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
+import org.elasticsearch.xpack.core.ml.MlTasks;
+import org.elasticsearch.xpack.core.ml.action.StartDatafeedAction;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedTimingStats;
+import org.elasticsearch.xpack.core.ml.job.config.Job;
+import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSnapshot;
+import org.elasticsearch.xpack.core.ml.job.results.Result;
+import org.elasticsearch.xpack.ml.datafeed.persistence.DatafeedConfigProvider;
+import org.elasticsearch.xpack.ml.job.persistence.JobConfigProvider;
+import org.elasticsearch.xpack.ml.job.persistence.JobResultsProvider;
+import org.elasticsearch.xpack.ml.job.persistence.RestartTimeInfo;
+
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Consumer;
+
+public class DatafeedContextProvider {
+
+    private final JobConfigProvider jobConfigProvider;
+    private final DatafeedConfigProvider datafeedConfigProvider;
+    private final JobResultsProvider resultsProvider;
+
+    public DatafeedContextProvider(JobConfigProvider jobConfigProvider, DatafeedConfigProvider datafeedConfigProvider,
+                                   JobResultsProvider jobResultsProvider) {
+        this.jobConfigProvider = Objects.requireNonNull(jobConfigProvider);
+        this.datafeedConfigProvider = Objects.requireNonNull(datafeedConfigProvider);
+        this.resultsProvider = Objects.requireNonNull(jobResultsProvider);
+    }
+
+    public void buildDatafeedContext(String datafeedId, long datafeedStartTimeMs, ActionListener<DatafeedContext> listener) {
+        DatafeedContext.Builder context = DatafeedContext.builder(datafeedStartTimeMs);
+
+        Consumer<Result<ModelSnapshot>> modelSnapshotListener = resultSnapshot -> {
+            context.setModelSnapshot(resultSnapshot == null ? null : resultSnapshot.result);
+            listener.onResponse(context.build());
+        };
+
+        Consumer<DatafeedTimingStats> timingStatsListener = timingStats -> {
+            context.setTimingStats(timingStats);
+            resultsProvider.getModelSnapshot(
+                context.getJob().getId(),
+                context.getJob().getModelSnapshotId(),
+                modelSnapshotListener,
+                listener::onFailure);
+        };
+
+        ActionListener<RestartTimeInfo> restartTimeInfoListener = ActionListener.wrap(
+            restartTimeInfo -> {
+                context.setRestartTimeInfo(restartTimeInfo);
+                resultsProvider.datafeedTimingStats(context.getJob().getId(), timingStatsListener, listener::onFailure);
+            },
+            listener::onFailure
+        );
+
+        ActionListener<Job.Builder> jobConfigListener = ActionListener.wrap(
+            jobBuilder -> {
+                context.setJob(jobBuilder.build());
+                resultsProvider.getRestartTimeInfo(jobBuilder.getId(), restartTimeInfoListener);
+            },
+            listener::onFailure
+        );
+
+        ActionListener<DatafeedConfig.Builder> datafeedListener = ActionListener.wrap(
+            datafeedConfigBuilder -> {
+                DatafeedConfig datafeedConfig = datafeedConfigBuilder.build();
+                context.setDatafeedConfig(datafeedConfig);
+                jobConfigProvider.getJob(datafeedConfig.getJobId(), jobConfigListener);
+            },
+            listener::onFailure
+        );
+
+        datafeedConfigProvider.getDatafeedConfig(datafeedId, datafeedListener);
+    }
+
+    public void buildDatafeedContextForJob(String jobId, ClusterState clusterState,  ActionListener<DatafeedContext> listener) {
+        ActionListener<Set<String>> datafeedListener = ActionListener.wrap(
+            datafeeds -> {
+                assert datafeeds.size() <= 1;
+                if (datafeeds.isEmpty()) {
+                    // This job has no datafeed attached to it
+                    listener.onResponse(null);
+                    return;
+                }
+
+                String datafeedId = datafeeds.iterator().next();
+                PersistentTasksCustomMetadata tasks = clusterState.getMetadata().custom(PersistentTasksCustomMetadata.TYPE);
+                PersistentTasksCustomMetadata.PersistentTask<?> datafeedTask = MlTasks.getDatafeedTask(datafeedId, tasks);
+                if (datafeedTask == null) {
+                    // This datafeed is not started
+                    listener.onResponse(null);
+                    return;
+                }
+
+                @SuppressWarnings("unchecked")
+                StartDatafeedAction.DatafeedParams taskParams = (StartDatafeedAction.DatafeedParams) datafeedTask.getParams();
+                buildDatafeedContext(datafeedId, taskParams.getStartTime(), listener);
+            },
+            listener::onFailure
+        );
+
+        datafeedConfigProvider.findDatafeedsForJobIds(Collections.singleton(jobId), datafeedListener);
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobDataCountsPersister.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobDataCountsPersister.java
@@ -91,6 +91,7 @@ public class JobDataCountsPersister {
             final IndexRequest request = new IndexRequest(AnomalyDetectorsIndex.resultsWriteAlias(jobId))
                 .id(DataCounts.documentId(jobId))
                 .setRequireAlias(true)
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
                 .source(content);
             executeAsyncWithOrigin(client, ML_ORIGIN, IndexAction.INSTANCE, request, new ActionListener<>() {
                 @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/RestartTimeInfo.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/RestartTimeInfo.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.ml.job.persistence;
 
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSnapshot;
 
 public class RestartTimeInfo {
 
@@ -32,5 +33,22 @@ public class RestartTimeInfo {
 
     public boolean haveSeenDataPreviously() {
         return haveSeenDataPreviously;
+    }
+
+    public boolean isAfter(long timestampMs) {
+        long jobLatestResultTime = latestFinalBucketTimeMs == null ? 0 : latestFinalBucketTimeMs;
+        long jobLatestRecordTime = latestRecordTimeMs == null ? 0 : latestRecordTimeMs;
+        return Math.max(jobLatestResultTime, jobLatestRecordTime) > timestampMs;
+    }
+
+    public boolean isAfterModelSnapshot(ModelSnapshot modelSnapshot) {
+        assert modelSnapshot != null;
+        long jobLatestResultTime = latestFinalBucketTimeMs == null ? 0 : latestFinalBucketTimeMs;
+        long jobLatestRecordTime = latestRecordTimeMs == null ? 0 : latestRecordTimeMs;
+        long modelLatestResultTime = modelSnapshot.getLatestResultTimeStamp() == null ?
+                0 : modelSnapshot.getLatestResultTimeStamp().getTime();
+        long modelLatestRecordTime = modelSnapshot.getLatestRecordTimeStamp() == null ?
+                0 : modelSnapshot.getLatestRecordTimeStamp().getTime();
+        return jobLatestResultTime > modelLatestResultTime || jobLatestRecordTime > modelLatestRecordTime;
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManager.java
@@ -603,7 +603,7 @@ public class AutodetectProcessManager implements ClusterStateListener {
         String jobId = jobTask.getJobId();
         notifyLoadingSnapshot(jobId, autodetectParams);
 
-        if (autodetectParams.dataCounts().getProcessedRecordCount() > 0) {
+        if (autodetectParams.dataCounts().getLatestRecordTimeStamp() != null) {
             if (autodetectParams.modelSnapshot() == null) {
                 String msg = "No model snapshot could be found for a job with processed records";
                 logger.warn("[{}] {}", jobId, msg);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobBuilderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobBuilderTests.java
@@ -89,12 +89,12 @@ public class DatafeedJobBuilderTests extends ESTestCase {
                 }, e -> fail()
         );
 
-        DatafeedContext datafeedContext = new DatafeedContext(
-            datafeed.build(),
-            jobBuilder.build(),
-            new RestartTimeInfo(null, null, false),
-            new DatafeedTimingStats(jobBuilder.getId())
-        );
+        DatafeedContext datafeedContext = DatafeedContext.builder(0L)
+            .setDatafeedConfig(datafeed.build())
+            .setJob(jobBuilder.build())
+            .setRestartTimeInfo(new RestartTimeInfo(null, null, false))
+            .setTimingStats(new DatafeedTimingStats(jobBuilder.getId()))
+            .build();
 
         TransportStartDatafeedAction.DatafeedTask datafeedTask = newDatafeedTask("datafeed1");
 
@@ -121,12 +121,12 @@ public class DatafeedJobBuilderTests extends ESTestCase {
                 }, e -> fail()
         );
 
-        DatafeedContext datafeedContext = new DatafeedContext(
-            datafeed.build(),
-            jobBuilder.build(),
-            new RestartTimeInfo(3_600_000L, 7_200_000L, false),
-            new DatafeedTimingStats(jobBuilder.getId())
-        );
+        DatafeedContext datafeedContext = DatafeedContext.builder(0L)
+            .setDatafeedConfig(datafeed.build())
+            .setJob(jobBuilder.build())
+            .setRestartTimeInfo(new RestartTimeInfo(3_600_000L, 7_200_000L, false))
+            .setTimingStats(new DatafeedTimingStats(jobBuilder.getId()))
+            .build();
 
         TransportStartDatafeedAction.DatafeedTask datafeedTask = newDatafeedTask("datafeed1");
 
@@ -153,12 +153,12 @@ public class DatafeedJobBuilderTests extends ESTestCase {
                 }, e -> fail()
         );
 
-        DatafeedContext datafeedContext = new DatafeedContext(
-            datafeed.build(),
-            jobBuilder.build(),
-            new RestartTimeInfo(3_800_000L, 3_600_000L, false),
-            new DatafeedTimingStats(jobBuilder.getId())
-        );
+        DatafeedContext datafeedContext = DatafeedContext.builder(0L)
+            .setDatafeedConfig(datafeed.build())
+            .setJob(jobBuilder.build())
+            .setRestartTimeInfo(new RestartTimeInfo(3_800_000L, 3_600_000L, false))
+            .setTimingStats(new DatafeedTimingStats(jobBuilder.getId()))
+            .build();
 
         TransportStartDatafeedAction.DatafeedTask datafeedTask = newDatafeedTask("datafeed1");
 
@@ -198,12 +198,12 @@ public class DatafeedJobBuilderTests extends ESTestCase {
             }
         );
 
-        DatafeedContext datafeedContext = new DatafeedContext(
-            datafeed.build(),
-            jobBuilder.build(),
-            new RestartTimeInfo(null, null, false),
-            new DatafeedTimingStats(jobBuilder.getId())
-        );
+        DatafeedContext datafeedContext = DatafeedContext.builder(0L)
+            .setDatafeedConfig(datafeed.build())
+            .setJob(jobBuilder.build())
+            .setRestartTimeInfo(new RestartTimeInfo(null, null, false))
+            .setTimingStats(new DatafeedTimingStats(jobBuilder.getId()))
+            .build();
 
         TransportStartDatafeedAction.DatafeedTask datafeedTask = newDatafeedTask("datafeed1");
 


### PR DESCRIPTION
This fixes a long outstanding issue with the resume behaviour
of a datafeed that has been reassigned on a node.

When we resume a datafeed, we start from the latest result time
or the latest record time, whichever is greater. This makes sense
when a job had been closed gracefully previously.

In the scenario when a job is being reassigned, it is highly likely
that the job has seen data after the latest snapshot was persisted.
This means that with the current behaviour, we load that snapshot and
then we resume sending data from the point the job had reached previously.
This results to the model having a knowledge gap.

This commit addresses this by checking whether a reassigning datafeed
has gone past its job's model snapshot and reverting the job to
that snapshot while deleting intervening results. Then we resume
the datafeed from the latest result or latest record of the snapshot.

Fixes #63400
