### PR TITLE
[DOCS] Document cat allocation API response properties

### DIFF
--- a/docs/reference/cat/allocation.asciidoc
+++ b/docs/reference/cat/allocation.asciidoc
@@ -58,9 +58,7 @@ those created when <<indices-shrink-index,shrinking>>,
 +
 --
 Total disk space in use. {es} retrieves this metric from the node's operating
-system (OS).
-+
-This metric includes disk space for:
+system (OS). The metric includes disk space for:
 
 - {es}, including the <<index-modules-translog,translog>> and unassigned shards
 - The node's OS

--- a/docs/reference/cat/allocation.asciidoc
+++ b/docs/reference/cat/allocation.asciidoc
@@ -49,20 +49,37 @@ Number of primary and replica shards assigned to the node.
 `disk.indices`::
 Disk space used by the node's shards. Does not include disk space for the
 <<index-modules-translog,translog>> or unassigned shards.
++
+IMPORTANT: This metric double-counts disk space for hard-linked files, such as
+those created when <<indices-shrink-index,shrinking>>,
+<<indices-split-index,splitting>>, or <<indices-clone-index,cloning>> an index.
 
 `disk.used`::
-Total disk space in use. Includes {es}, the node's OS, and any other
-applications or files on the node.
++
+--
+Total disk space in use. {es} retrieves this metric from the node's operating
+system (OS).
++
+This metric includes disk space for:
+
+- {es}, including the <<index-modules-translog,translog>> and unassigned shards
+- The node's OS
+- Any other applications or files on the node
+
+Unlike `disk.indices`, this metric does not double-count disk space for
+hard-linked files.
+--
 
 `disk.avail`::
-Free disk space available to {es}.
+Free disk space available to {es}. {es} retrieves this metric from the node's
+OS. <<disk-allocator,Disk-based shard allocation>> uses this metric to assign
+shards to nodes based on available disk space.
 
 `disk.total`::
 Total disk space for the node, including in-use and available space.
 
 `disk.percent`::
-Total percentage of disk space in use. Includes {es}, the node's OS, and any
-applications or files on the node.
+Total percentage of disk space in use. Calculated as `disk.used` / `disk.total`.
 
 `host`::
 Network host for the node. Set using <<network.host,`network.host`>>.

--- a/docs/reference/cat/allocation.asciidoc
+++ b/docs/reference/cat/allocation.asciidoc
@@ -51,8 +51,8 @@ Disk space used by the node's shards. Does not include disk space for the
 <<index-modules-translog,translog>> or unassigned shards.
 
 `disk.used`::
-Total disk space in use. Includes {es}, the node's OS, and any other files
-stored on the node.
+Total disk space in use. Includes {es}, the node's OS, and any other
+applications or files on the node.
 
 `disk.avail`::
 Free disk space available to {es}.
@@ -62,7 +62,7 @@ Total disk space for the node.
 
 `disk.percent`::
 Total percentage of disk space in use. Includes {es}, the node's OS, and any
-other files stored on the node.
+applications or files on the node.
 
 `host`::
 Network host for the node. Set using <<network.host,`network.host`>>.

--- a/docs/reference/cat/allocation.asciidoc
+++ b/docs/reference/cat/allocation.asciidoc
@@ -40,6 +40,40 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-s]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-v]
 
+[[cat-allocation-api-response-body]]
+==== {api-response-body-title}
+
+`shards`::
+Number of primary and replica shards assigned to the node.
+
+`disk.indices`::
+Disk space used by the node's shards. Does not include disk space for the
+<<index-modules-translog,translog>> or unassigned shards.
+
+`disk.used`::
+Total disk space in use. Includes {es}, the node's OS, and any other files
+stored on the node.
+
+`disk.avail`::
+Free disk space available to {es}.
+
+`disk.total`::
+Total disk space for the node.
+
+`disk.percent`::
+Total percentage of disk space in use. Includes {es}, the node's OS, and any
+other files stored on the node.
+
+`host`::
+Network host for the node. Set using <<network.host,`network.host`>>.
+
+`ip`::
+IP address and port for the node.
+
+`node`::
+Name for the node. Set using <<node-name,`node.name`>>.
+
+
 [[cat-allocation-api-example]]
 ==== {api-examples-title}
 

--- a/docs/reference/cat/allocation.asciidoc
+++ b/docs/reference/cat/allocation.asciidoc
@@ -58,7 +58,7 @@ applications or files on the node.
 Free disk space available to {es}.
 
 `disk.total`::
-Total disk space for the node.
+Total disk space for the node, including in-use and available space.
 
 `disk.percent`::
 Total percentage of disk space in use. Includes {es}, the node's OS, and any


### PR DESCRIPTION
Documents the response properties for the cat allocation API.

Closes #65523

### Preview

https://elasticsearch_65635.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/cat-allocation.html#cat-allocation-api-response-body