### PR TITLE
Fix NPE in ILMHistoryStore TRACE Loggging

### DIFF
--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/history/ILMHistoryStore.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/history/ILMHistoryStore.java
@@ -89,14 +89,10 @@ public class ILMHistoryStore implements Closeable {
                 public void afterBulk(long executionId, BulkRequest request, BulkResponse response) {
                     long items = request.numberOfActions();
                     if (logger.isTraceEnabled()) {
-                        logger.trace("indexed [{}] items into ILM history index [{}], items: {}", items,
+                        logger.trace("indexed [{}] items into ILM history index [{}]", items,
                             Arrays.stream(response.getItems())
                                 .map(BulkItemResponse::getIndex)
                                 .distinct()
-                                .collect(Collectors.joining(",")),
-                            request.requests().stream()
-                                .map(dwr -> ((IndexRequest) dwr).sourceAsMap())
-                                .map(Objects::toString)
                                 .collect(Collectors.joining(",")));
                     }
                     if (response.hasFailures()) {


### PR DESCRIPTION
We can't access the bulk request items after the bulk request was executed
because we `null` them out. This code would always throw an NPE therefore
and now started to trip assertions due to #65415.
