### PR TITLE
Fix NPE in ClusterInfoService

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/InternalClusterInfoService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/InternalClusterInfoService.java
@@ -331,6 +331,9 @@ public class InternalClusterInfoService implements ClusterInfoService, ClusterSt
             newShardRoutingToDataPath.put(shardRouting, s.getDataPath());
 
             final StoreStats storeStats = s.getStats().getStore();
+            if (storeStats == null) {
+                continue;
+            }
             final long size = storeStats.sizeInBytes();
             final long reserved = storeStats.getReservedSize().getBytes();
 


### PR DESCRIPTION
Store stats can be `null` if e.g. the shard was already closed
when the stats where retrieved. Don't record those shards in the
sizes map to fix an NPE in this case that became visible as a result of #65415 now.
