### PR TITLE
[ML] Remove unnecessary call to get datafeed stats in preview

### DIFF
--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportPreviewDatafeedActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportPreviewDatafeedActionTests.java
@@ -52,7 +52,7 @@ public class TransportPreviewDatafeedActionTests extends ESTestCase {
 
         doAnswer(new Answer<Void>() {
             @Override
-            public Void answer(InvocationOnMock invocationOnMock) throws Throwable {
+            public Void answer(InvocationOnMock invocationOnMock) {
                 PreviewDatafeedAction.Response response = (PreviewDatafeedAction.Response) invocationOnMock.getArguments()[0];
                 capturedResponse = response.toString();
                 return null;
@@ -61,7 +61,7 @@ public class TransportPreviewDatafeedActionTests extends ESTestCase {
 
         doAnswer(new Answer<Void>() {
             @Override
-            public Void answer(InvocationOnMock invocationOnMock) throws Throwable {
+            public Void answer(InvocationOnMock invocationOnMock) {
                 capturedFailure = (Exception) invocationOnMock.getArguments()[0];
                 return null;
             }


### PR DESCRIPTION
Remove an unnecessary call to gather the datafeed timing stats in datafeed preview.

The stats are passed to a `DatafeedTimingStatsReporter` that updates but never persists the stats so there is no point getting the most up to date values first.