### PR TITLE
Try to make DeprecationHttpIT more robust

### DIFF
--- a/x-pack/plugin/deprecation/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/deprecation/DeprecationHttpIT.java
+++ b/x-pack/plugin/deprecation/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/deprecation/DeprecationHttpIT.java
@@ -33,6 +33,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.test.hamcrest.RegexMatcher.matches;
@@ -238,7 +239,8 @@ public class DeprecationHttpIT extends ESRestTestCase {
             assertBusy(() -> {
                 Response response;
                 try {
-                    response = client().performRequest(new Request("GET", ".logs-deprecation-elasticsearch/_search"));
+                    client().performRequest(new Request("POST", "/.logs-deprecation-elasticsearch/_refresh?ignore_unavailable=true"));
+                    response = client().performRequest(new Request("GET", "/.logs-deprecation-elasticsearch/_search"));
                 } catch (Exception e) {
                     // It can take a moment for the index to be created. If it doesn't exist then the client
                     // throws an exception. Translate it into an assertion error so that assertBusy() will
@@ -304,7 +306,7 @@ public class DeprecationHttpIT extends ESRestTestCase {
                         )
                     )
                 );
-            });
+            }, 30, TimeUnit.SECONDS);
         } finally {
             configureWriteDeprecationLogsToIndex(null);
             client().performRequest(new Request("DELETE", "_data_stream/.logs-deprecation-elasticsearch"));


### PR DESCRIPTION
Closes #65589 hopefully. There is a test case that checks whether
deprecation logs have been indexed. It uses `assertBusy` so that it
keeps checking for a period, since it may take some time for the data to
become available. However, the test nonetheless occasionally still
fails, with no shards being available to search.

In an attempt to address this, add a `_refresh` call on the deprecation
data stream, and increase the `assertBusy` timeout to 30s.