### PR TITLE
[ML] Reduce log noise in BaseMlIntegTestCase

### DIFF
--- a/x-pack/plugin/ml/build.gradle
+++ b/x-pack/plugin/ml/build.gradle
@@ -52,6 +52,7 @@ dependencies {
   testImplementation project(path: xpackModule('ilm'), configuration: 'default')
   compileOnly project(path: xpackModule('autoscaling'), configuration: 'default')
   testImplementation project(path: xpackModule('data-streams'), configuration: 'default')
+  testImplementation project(':modules:ingest-common')
   // This should not be here
   testImplementation project(path: xpackModule('security'), configuration: 'testArtifacts')
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/support/BaseMlIntegTestCase.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/support/BaseMlIntegTestCase.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.reindex.ReindexPlugin;
 import org.elasticsearch.indices.recovery.RecoveryState;
+import org.elasticsearch.ingest.common.IngestCommonPlugin;
 import org.elasticsearch.license.LicenseService;
 import org.elasticsearch.persistent.PersistentTasksClusterService;
 import org.elasticsearch.plugins.Plugin;
@@ -111,6 +112,7 @@ public abstract class BaseMlIntegTestCase extends ESIntegTestCase {
         return Arrays.asList(
             LocalStateMachineLearning.class,
             CommonAnalysisPlugin.class,
+            IngestCommonPlugin.class,
             ReindexPlugin.class,
             // ILM is required for .ml-state template index settings
             IndexLifecycle.class,


### PR DESCRIPTION
Tests inheriting `BaseMlIntegTestCase` have noisy
logs with the error `No processor type exists with name [...]`.
Those are caused because of loaded templates that need
the `IngestCommonPlugin` loaded.

This commit adds a test dependency to the `ingest-common` module
and loads `IngestCommonPlugin` in `BaseMlIntegTestCase` to reduce
such noise.
