### PR TITLE
[7.x][ML] Resume reassigning datafeed from loaded model snapshot (#65…

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -136,6 +136,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
 import java.util.TreeMap;
@@ -1711,6 +1712,20 @@ public final class InternalTestCluster extends TestCluster {
         if (nodeAndClient != null) {
             logger.info("Closing random node [{}] ", nodeAndClient.name);
             stopNodesAndClient(nodeAndClient);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Stops a specific node in the cluster. Returns true if the node was found to stop, false otherwise.
+     */
+    public synchronized boolean stopNode(String nodeName) throws IOException {
+        ensureOpen();
+        Optional<NodeAndClient> nodeToStop = nodes.values().stream().filter(n -> n.getName().equals(nodeName)).findFirst();
+        if (nodeToStop.isPresent()) {
+            logger.info("Closing node [{}]", nodeToStop.get().name);
+            stopNodesAndClient(nodeToStop.get());
             return true;
         }
         return false;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/RevertModelSnapshotAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/RevertModelSnapshotAction.java
@@ -42,12 +42,14 @@ public class RevertModelSnapshotAction extends ActionType<RevertModelSnapshotAct
 
         public static final ParseField SNAPSHOT_ID = new ParseField("snapshot_id");
         public static final ParseField DELETE_INTERVENING = new ParseField("delete_intervening_results");
+        private static final ParseField FORCE = new ParseField("force");
 
         private static final ObjectParser<Request, Void> PARSER = new ObjectParser<>(NAME, Request::new);
         static {
             PARSER.declareString((request, jobId) -> request.jobId = jobId, Job.ID);
             PARSER.declareString((request, snapshotId) -> request.snapshotId = snapshotId, SNAPSHOT_ID);
             PARSER.declareBoolean(Request::setDeleteInterveningResults, DELETE_INTERVENING);
+            PARSER.declareBoolean(Request::setForce, FORCE);
         }
 
         public static Request parseRequest(String jobId, String snapshotId, XContentParser parser) {
@@ -64,6 +66,7 @@ public class RevertModelSnapshotAction extends ActionType<RevertModelSnapshotAct
         private String jobId;
         private String snapshotId;
         private boolean deleteInterveningResults;
+        private boolean force;
 
         public Request() {
         }
@@ -73,6 +76,11 @@ public class RevertModelSnapshotAction extends ActionType<RevertModelSnapshotAct
             jobId = in.readString();
             snapshotId = in.readString();
             deleteInterveningResults = in.readBoolean();
+            if (in.getVersion().onOrAfter(Version.V_7_11_0)) {
+                force = in.readBoolean();
+            } else {
+                force = false;
+            }
         }
 
         public Request(String jobId, String snapshotId) {
@@ -96,6 +104,14 @@ public class RevertModelSnapshotAction extends ActionType<RevertModelSnapshotAct
             this.deleteInterveningResults = deleteInterveningResults;
         }
 
+        public boolean isForce() {
+            return force;
+        }
+
+        public void setForce(boolean force) {
+            this.force = force;
+        }
+
         @Override
         public ActionRequestValidationException validate() {
             return null;
@@ -107,6 +123,9 @@ public class RevertModelSnapshotAction extends ActionType<RevertModelSnapshotAct
             out.writeString(jobId);
             out.writeString(snapshotId);
             out.writeBoolean(deleteInterveningResults);
+            if (out.getVersion().onOrAfter(Version.V_7_11_0)) {
+                out.writeBoolean(force);
+            }
         }
 
         @Override
@@ -115,13 +134,14 @@ public class RevertModelSnapshotAction extends ActionType<RevertModelSnapshotAct
             builder.field(Job.ID.getPreferredName(), jobId);
             builder.field(SNAPSHOT_ID.getPreferredName(), snapshotId);
             builder.field(DELETE_INTERVENING.getPreferredName(), deleteInterveningResults);
+            builder.field(FORCE.getPreferredName(), force);
             builder.endObject();
             return builder;
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(jobId, snapshotId, deleteInterveningResults);
+            return Objects.hash(jobId, snapshotId, deleteInterveningResults, force);
         }
 
         @Override
@@ -133,8 +153,10 @@ public class RevertModelSnapshotAction extends ActionType<RevertModelSnapshotAct
                 return false;
             }
             Request other = (Request) obj;
-            return Objects.equals(jobId, other.jobId) && Objects.equals(snapshotId, other.snapshotId)
-                    && Objects.equals(deleteInterveningResults, other.deleteInterveningResults);
+            return Objects.equals(jobId, other.jobId)
+                    && Objects.equals(snapshotId, other.snapshotId)
+                    && Objects.equals(deleteInterveningResults, other.deleteInterveningResults)
+                    && force == other.force;
         }
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/RevertModelSnapshotActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/RevertModelSnapshotActionRequestTests.java
@@ -19,6 +19,9 @@ public class RevertModelSnapshotActionRequestTests extends AbstractSerializingTe
         if (randomBoolean()) {
             request.setDeleteInterveningResults(randomBoolean());
         }
+        if (randomBoolean()) {
+            request.setForce(randomBoolean());
+        }
         return request;
     }
 

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlDistributedFailureIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlDistributedFailureIT.java
@@ -5,10 +5,13 @@
  */
 package org.elasticsearch.xpack.ml.integration;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionFuture;
+import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -21,9 +24,12 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.DeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.TermsQueryBuilder;
 import org.elasticsearch.persistent.PersistentTaskResponse;
@@ -44,11 +50,15 @@ import org.elasticsearch.xpack.core.ml.action.PutDatafeedAction;
 import org.elasticsearch.xpack.core.ml.action.PutJobAction;
 import org.elasticsearch.xpack.core.ml.action.StartDatafeedAction;
 import org.elasticsearch.xpack.core.ml.action.StopDatafeedAction;
+import org.elasticsearch.xpack.core.ml.action.UpdateJobAction;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedState;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.config.JobState;
+import org.elasticsearch.xpack.core.ml.job.config.JobUpdate;
+import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.DataCounts;
+import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSnapshot;
 import org.elasticsearch.xpack.core.ml.notifications.NotificationsIndex;
 import org.elasticsearch.xpack.ml.MachineLearning;
 import org.elasticsearch.xpack.ml.job.process.autodetect.BlackHoleAutodetectProcess;
@@ -57,6 +67,7 @@ import org.elasticsearch.xpack.ml.support.BaseMlIntegTestCase;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -67,6 +78,8 @@ import static org.elasticsearch.test.NodeRoles.masterOnlyNode;
 import static org.elasticsearch.test.NodeRoles.onlyRole;
 import static org.elasticsearch.test.NodeRoles.onlyRoles;
 import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
@@ -154,7 +167,7 @@ public class MlDistributedFailureIT extends BaseMlIntegTestCase {
         String jobId = "test-lose-ml-node";
         String datafeedId = jobId + "-datafeed";
         setupJobAndDatafeed(jobId, datafeedId, TimeValue.timeValueHours(1));
-        waitForDatafeed(jobId, numDocs1);
+        waitForJobToHaveProcessedExactly(jobId, numDocs1);
 
         // stop the only ML node
         ensureGreen(); // replicas must be assigned, otherwise we could lose a whole index
@@ -233,7 +246,7 @@ public class MlDistributedFailureIT extends BaseMlIntegTestCase {
         String jobId = "test-stop-unassigned-datafeed-for-failed-job";
         String datafeedId = jobId + "-datafeed";
         setupJobAndDatafeed(jobId, datafeedId, TimeValue.timeValueHours(1));
-        waitForDatafeed(jobId, numDocs1);
+        waitForJobToHaveProcessedExactly(jobId, numDocs1);
 
         // Job state should be opened here
         GetJobsStatsAction.Request jobStatsRequest = new GetJobsStatsAction.Request(jobId);
@@ -342,7 +355,7 @@ public class MlDistributedFailureIT extends BaseMlIntegTestCase {
         String jobId = "test-stop-and-force-stop";
         String datafeedId = jobId + "-datafeed";
         setupJobAndDatafeed(jobId, datafeedId, TimeValue.timeValueHours(1));
-        waitForDatafeed(jobId, numDocs1);
+        waitForJobToHaveProcessedExactly(jobId, numDocs1);
 
         GetDatafeedsStatsAction.Request datafeedStatsRequest = new GetDatafeedsStatsAction.Request(datafeedId);
         GetDatafeedsStatsAction.Response datafeedStatsResponse =
@@ -427,6 +440,69 @@ public class MlDistributedFailureIT extends BaseMlIntegTestCase {
         });
     }
 
+    public void testClusterWithTwoMlNodes_RunsDatafeed_GivenOriginalNodeGoesDown() throws Exception {
+        internalCluster().ensureAtMostNumDataNodes(0);
+        logger.info("Starting dedicated master node...");
+        internalCluster().startMasterOnlyNode();
+        logger.info("Starting ml and data node...");
+        internalCluster().startNode(onlyRoles(
+            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(DiscoveryNodeRole.DATA_ROLE, MachineLearning.ML_ROLE)))
+        ));
+        logger.info("Starting another ml and data node...");
+        internalCluster().startNode(onlyRoles(
+            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(DiscoveryNodeRole.DATA_ROLE, MachineLearning.ML_ROLE)))
+        ));
+        ensureStableCluster();
+
+        // index some datafeed data
+        client().admin().indices().prepareCreate("data")
+            .addMapping("type", "time", "type=date")
+            .get();
+        long numDocs = 80000;
+        long now = System.currentTimeMillis();
+        long weekAgo = now - 604800000;
+        long twoWeeksAgo = weekAgo - 604800000;
+        indexDocs(logger, "data", numDocs, twoWeeksAgo, weekAgo);
+
+        String jobId = "test-node-goes-down-while-running-job";
+        String datafeedId = jobId + "-datafeed";
+
+        Job.Builder job = createScheduledJob(jobId);
+        PutJobAction.Request putJobRequest = new PutJobAction.Request(job);
+        client().execute(PutJobAction.INSTANCE, putJobRequest).actionGet();
+
+        DatafeedConfig config = createDatafeed(datafeedId, job.getId(), Collections.singletonList("data"), TimeValue.timeValueHours(1));
+        PutDatafeedAction.Request putDatafeedRequest = new PutDatafeedAction.Request(config);
+        client().execute(PutDatafeedAction.INSTANCE, putDatafeedRequest).actionGet();
+
+        client().execute(OpenJobAction.INSTANCE, new OpenJobAction.Request(job.getId()));
+
+        assertBusy(() -> {
+            GetJobsStatsAction.Response statsResponse =
+                client().execute(GetJobsStatsAction.INSTANCE, new GetJobsStatsAction.Request(job.getId())).actionGet();
+            assertEquals(JobState.OPENED, statsResponse.getResponse().results().get(0).getState());
+        }, 30, TimeUnit.SECONDS);
+
+        DiscoveryNode nodeRunningJob = client().execute(GetJobsStatsAction.INSTANCE, new GetJobsStatsAction.Request(job.getId()))
+            .actionGet().getResponse().results().get(0).getNode();
+
+        setMlIndicesDelayedNodeLeftTimeoutToZero();
+
+        StartDatafeedAction.Request startDatafeedRequest = new StartDatafeedAction.Request(config.getId(), 0L);
+        startDatafeedRequest.getParams().setEndTime("now");
+        client().execute(StartDatafeedAction.INSTANCE, startDatafeedRequest).get();
+
+        waitForJobToHaveProcessedAtLeast(jobId, 1000);
+
+        internalCluster().stopNode(nodeRunningJob.getName());
+
+        waitForJobClosed(jobId);
+
+        DataCounts dataCounts = getJobStats(jobId).getDataCounts();
+        assertThat(dataCounts.getProcessedRecordCount(), greaterThanOrEqualTo(numDocs));
+        assertThat(dataCounts.getOutOfOrderTimeStampCount(), equalTo(0L));
+    }
+
     private void setupJobWithoutDatafeed(String jobId, ByteSizeValue modelMemoryLimit) throws Exception {
         Job.Builder job = createFareQuoteJob(jobId, modelMemoryLimit);
         PutJobAction.Request putJobRequest = new PutJobAction.Request(job);
@@ -473,7 +549,12 @@ public class MlDistributedFailureIT extends BaseMlIntegTestCase {
         indexDocs(logger, "data", numDocs1, twoWeeksAgo, weekAgo);
 
         setupJobAndDatafeed(jobId, "data_feed_id", TimeValue.timeValueSeconds(1));
-        waitForDatafeed(jobId, numDocs1);
+        waitForJobToHaveProcessedExactly(jobId, numDocs1);
+
+        // At this point the lookback has completed and normally there would be a model snapshot persisted.
+        // We manually index a model snapshot document to imitate this behaviour and to avoid the job
+        // having to recover after reassignment.
+        indexModelSnapshotFromCurrentJobStats(jobId);
 
         client().admin().indices().prepareSyncedFlush().get();
 
@@ -518,7 +599,7 @@ public class MlDistributedFailureIT extends BaseMlIntegTestCase {
         long numDocs2 = randomIntBetween(2, 64);
         long now2 = System.currentTimeMillis();
         indexDocs(logger, "data", numDocs2, now2 + 5000, now2 + 6000);
-        waitForDatafeed(jobId, numDocs1 + numDocs2);
+        waitForJobToHaveProcessedExactly(jobId, numDocs1 + numDocs2);
     }
 
     // Get datacounts from index instead of via job stats api,
@@ -543,7 +624,7 @@ public class MlDistributedFailureIT extends BaseMlIntegTestCase {
         }
     }
 
-    private void waitForDatafeed(String jobId, long numDocs) throws Exception {
+    private void waitForJobToHaveProcessedExactly(String jobId, long numDocs) throws Exception {
         assertBusy(() -> {
             DataCounts dataCounts = getDataCountsFromIndex(jobId);
             assertEquals(numDocs, dataCounts.getProcessedRecordCount());
@@ -551,7 +632,46 @@ public class MlDistributedFailureIT extends BaseMlIntegTestCase {
         }, 30, TimeUnit.SECONDS);
     }
 
+    private void waitForJobToHaveProcessedAtLeast(String jobId, long numDocs) throws Exception {
+        assertBusy(() -> {
+            DataCounts dataCounts = getDataCountsFromIndex(jobId);
+            assertThat(dataCounts.getProcessedRecordCount(), greaterThanOrEqualTo(numDocs));
+            assertEquals(0L, dataCounts.getOutOfOrderTimeStampCount());
+        }, 30, TimeUnit.SECONDS);
+    }
+
+    private void waitForJobClosed(String jobId) throws Exception {
+        assertBusy(() -> {
+            JobStats jobStats = getJobStats(jobId);
+            assertEquals(jobStats.getState(), JobState.CLOSED);
+        }, 30, TimeUnit.SECONDS);
+    }
+
     private void ensureStableCluster() {
         ensureStableCluster(internalCluster().getNodeNames().length, TimeValue.timeValueSeconds(60));
+    }
+
+    private void indexModelSnapshotFromCurrentJobStats(String jobId) throws IOException {
+        JobStats jobStats = getJobStats(jobId);
+        DataCounts dataCounts = jobStats.getDataCounts();
+
+        ModelSnapshot modelSnapshot = new ModelSnapshot.Builder(jobId)
+            .setLatestRecordTimeStamp(dataCounts.getLatestRecordTimeStamp())
+            .setMinVersion(Version.CURRENT)
+            .setSnapshotId(jobId + "_mock_snapshot")
+            .setTimestamp(new Date())
+            .build();
+
+        try (XContentBuilder xContentBuilder = JsonXContent.contentBuilder()) {
+            modelSnapshot.toXContent(xContentBuilder, ToXContent.EMPTY_PARAMS);
+            IndexRequest indexRequest = new IndexRequest(AnomalyDetectorsIndex.jobResultsAliasedName(jobId));
+            indexRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+            indexRequest.id(ModelSnapshot.documentId(modelSnapshot));
+            indexRequest.source(xContentBuilder);
+            client().index(indexRequest).actionGet();
+        }
+
+        JobUpdate jobUpdate = new JobUpdate.Builder(jobId).setModelSnapshotId(modelSnapshot.getSnapshotId()).build();
+        client().execute(UpdateJobAction.INSTANCE, new UpdateJobAction.Request(jobId, jobUpdate)).actionGet();
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -215,6 +215,7 @@ import org.elasticsearch.xpack.ml.action.TransportValidateJobConfigAction;
 import org.elasticsearch.xpack.ml.annotations.AnnotationPersister;
 import org.elasticsearch.xpack.ml.autoscaling.MlAutoscalingDeciderService;
 import org.elasticsearch.xpack.ml.autoscaling.MlAutoscalingNamedWritableProvider;
+import org.elasticsearch.xpack.ml.datafeed.DatafeedContextProvider;
 import org.elasticsearch.xpack.ml.datafeed.DatafeedJobBuilder;
 import org.elasticsearch.xpack.ml.datafeed.DatafeedManager;
 import org.elasticsearch.xpack.ml.datafeed.persistence.DatafeedConfigProvider;
@@ -314,11 +315,11 @@ import org.elasticsearch.xpack.ml.rest.job.RestOpenJobAction;
 import org.elasticsearch.xpack.ml.rest.job.RestPostDataAction;
 import org.elasticsearch.xpack.ml.rest.job.RestPostJobUpdateAction;
 import org.elasticsearch.xpack.ml.rest.job.RestPutJobAction;
-import org.elasticsearch.xpack.ml.rest.modelsnapshots.RestUpgradeJobModelSnapshotAction;
 import org.elasticsearch.xpack.ml.rest.modelsnapshots.RestDeleteModelSnapshotAction;
 import org.elasticsearch.xpack.ml.rest.modelsnapshots.RestGetModelSnapshotsAction;
 import org.elasticsearch.xpack.ml.rest.modelsnapshots.RestRevertModelSnapshotAction;
 import org.elasticsearch.xpack.ml.rest.modelsnapshots.RestUpdateModelSnapshotAction;
+import org.elasticsearch.xpack.ml.rest.modelsnapshots.RestUpgradeJobModelSnapshotAction;
 import org.elasticsearch.xpack.ml.rest.results.RestGetBucketsAction;
 import org.elasticsearch.xpack.ml.rest.results.RestGetCategoriesAction;
 import org.elasticsearch.xpack.ml.rest.results.RestGetInfluencersAction;
@@ -490,6 +491,7 @@ public class MachineLearning extends Plugin implements SystemIndexPlugin,
     private final boolean transportClientMode;
 
     private final SetOnce<AutodetectProcessManager> autodetectProcessManager = new SetOnce<>();
+    private final SetOnce<DatafeedContextProvider> datafeedContextProvider = new SetOnce<>();
     private final SetOnce<DatafeedManager> datafeedManager = new SetOnce<>();
     private final SetOnce<DataFrameAnalyticsManager> dataFrameAnalyticsManager = new SetOnce<>();
     private final SetOnce<DataFrameAnalyticsAuditor> dataFrameAnalyticsAuditor = new SetOnce<>();
@@ -709,9 +711,11 @@ public class MachineLearning extends Plugin implements SystemIndexPlugin,
                 jobResultsPersister,
                 settings,
                 clusterService.getNodeName());
+        DatafeedContextProvider datafeedContextProvider = new DatafeedContextProvider(jobConfigProvider, datafeedConfigProvider,
+            jobResultsProvider);
+        this.datafeedContextProvider.set(datafeedContextProvider);
         DatafeedManager datafeedManager = new DatafeedManager(threadPool, client, clusterService, datafeedJobBuilder,
-                System::currentTimeMillis, anomalyDetectionAuditor, autodetectProcessManager, jobConfigProvider, datafeedConfigProvider,
-                jobResultsProvider);
+                System::currentTimeMillis, anomalyDetectionAuditor, autodetectProcessManager, datafeedContextProvider);
         this.datafeedManager.set(datafeedManager);
 
         // Inference components
@@ -812,6 +816,7 @@ public class MachineLearning extends Plugin implements SystemIndexPlugin,
                 new OpenJobPersistentTasksExecutor(settings,
                     clusterService,
                     autodetectProcessManager.get(),
+                    datafeedContextProvider.get(),
                     memoryTracker.get(),
                     client,
                     expressionResolver),

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportRevertModelSnapshotAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportRevertModelSnapshotAction.java
@@ -85,7 +85,7 @@ public class TransportRevertModelSnapshotAction extends TransportMasterNodeActio
                 PersistentTasksCustomMetadata tasks = state.getMetadata().custom(PersistentTasksCustomMetadata.TYPE);
                 JobState jobState = MlTasks.getJobState(request.getJobId(), tasks);
 
-                if (jobState.equals(JobState.CLOSED) == false) {
+                if (request.isForce() == false && jobState.equals(JobState.CLOSED) == false) {
                     listener.onFailure(ExceptionsHelper.conflictStatusException(Messages.getMessage(Messages.REST_JOB_NOT_CLOSED_REVERT)));
                     return;
                 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedContext.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedContext.java
@@ -6,50 +6,100 @@
 
 package org.elasticsearch.xpack.ml.datafeed;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedTimingStats;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
+import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSnapshot;
 import org.elasticsearch.xpack.ml.job.persistence.RestartTimeInfo;
 
 import java.util.Objects;
 
-class DatafeedContext {
+public class DatafeedContext {
 
+    private static final Logger logger = LogManager.getLogger(DatafeedContext.class);
+
+    private final long datafeedStartTimeMs;
     private final DatafeedConfig datafeedConfig;
     private final Job job;
     private final RestartTimeInfo restartTimeInfo;
     private final DatafeedTimingStats timingStats;
+    @Nullable
+    private final ModelSnapshot modelSnapshot;
 
-    DatafeedContext(DatafeedConfig datafeedConfig, Job job, RestartTimeInfo restartTimeInfo,
-                           DatafeedTimingStats timingStats) {
+    private DatafeedContext(long datafeedStartTimeMs, DatafeedConfig datafeedConfig, Job job, RestartTimeInfo restartTimeInfo,
+                           DatafeedTimingStats timingStats, ModelSnapshot modelSnapshot) {
+        this.datafeedStartTimeMs = datafeedStartTimeMs;
         this.datafeedConfig = Objects.requireNonNull(datafeedConfig);
         this.job = Objects.requireNonNull(job);
         this.restartTimeInfo = Objects.requireNonNull(restartTimeInfo);
         this.timingStats = Objects.requireNonNull(timingStats);
+        this.modelSnapshot = modelSnapshot;
     }
 
-
-    DatafeedConfig getDatafeedConfig() {
+    public DatafeedConfig getDatafeedConfig() {
         return datafeedConfig;
     }
 
-    Job getJob() {
+    public Job getJob() {
         return job;
     }
 
-    RestartTimeInfo getRestartTimeInfo() {
+    public RestartTimeInfo getRestartTimeInfo() {
         return restartTimeInfo;
     }
 
-    DatafeedTimingStats getTimingStats() {
+    public DatafeedTimingStats getTimingStats() {
         return timingStats;
     }
 
+    @Nullable
+    public ModelSnapshot getModelSnapshot() {
+        return modelSnapshot;
+    }
+
+    public boolean shouldRecoverFromCurrentSnapshot() {
+        if (modelSnapshot == null) {
+            logger.debug("[{}] checking whether recovery is required; job latest result timestamp [{}]; " +
+                    "job latest record timestamp [{}]; snapshot is [null]; datafeed start time [{}]", datafeedConfig.getJobId(),
+                restartTimeInfo.getLatestFinalBucketTimeMs(), restartTimeInfo.getLatestRecordTimeMs(), datafeedStartTimeMs);
+        } else {
+            logger.debug("[{}] checking whether recovery is required; job latest result timestamp [{}]; " +
+                    "job latest record timestamp [{}]; snapshot latest result timestamp [{}]; snapshot latest record timestamp [{}]; " +
+                    "datafeed start time [{}]",
+                datafeedConfig.getJobId(),
+                restartTimeInfo.getLatestFinalBucketTimeMs(),
+                restartTimeInfo.getLatestRecordTimeMs(),
+                modelSnapshot.getLatestResultTimeStamp() == null ? null : modelSnapshot.getLatestResultTimeStamp().getTime(),
+                modelSnapshot.getLatestRecordTimeStamp() == null ? null : modelSnapshot.getLatestRecordTimeStamp().getTime(),
+                datafeedStartTimeMs);
+        }
+
+        if (restartTimeInfo.isAfter(datafeedStartTimeMs)) {
+            return restartTimeInfo.haveSeenDataPreviously() &&
+                (modelSnapshot == null || restartTimeInfo.isAfterModelSnapshot(modelSnapshot));
+        }
+        // If the datafeed start time is past the job checkpoint we should not attempt to recover
+        return false;
+    }
+
+    static Builder builder(long datafeedStartTimeMs) {
+        return new Builder(datafeedStartTimeMs);
+    }
+
     static class Builder {
+        private final long datafeedStartTimeMs;
         private volatile DatafeedConfig datafeedConfig;
         private volatile Job job;
         private volatile RestartTimeInfo restartTimeInfo;
         private volatile DatafeedTimingStats timingStats;
+        private volatile ModelSnapshot modelSnapshot;
+
+        Builder(long datafeedStartTimeMs) {
+            this.datafeedStartTimeMs = datafeedStartTimeMs;
+        }
 
         Builder setDatafeedConfig(DatafeedConfig datafeedConfig) {
             this.datafeedConfig = datafeedConfig;
@@ -75,8 +125,13 @@ class DatafeedContext {
             return this;
         }
 
+        Builder setModelSnapshot(ModelSnapshot modelSnapshot) {
+            this.modelSnapshot = modelSnapshot;
+            return this;
+        }
+
         DatafeedContext build() {
-            return new DatafeedContext(datafeedConfig, job, restartTimeInfo, timingStats);
+            return new DatafeedContext(datafeedStartTimeMs, datafeedConfig, job, restartTimeInfo, timingStats, modelSnapshot);
         }
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedContextProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedContextProvider.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.ml.datafeed;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
+import org.elasticsearch.xpack.core.ml.MlTasks;
+import org.elasticsearch.xpack.core.ml.action.StartDatafeedAction;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedTimingStats;
+import org.elasticsearch.xpack.core.ml.job.config.Job;
+import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSnapshot;
+import org.elasticsearch.xpack.core.ml.job.results.Result;
+import org.elasticsearch.xpack.ml.datafeed.persistence.DatafeedConfigProvider;
+import org.elasticsearch.xpack.ml.job.persistence.JobConfigProvider;
+import org.elasticsearch.xpack.ml.job.persistence.JobResultsProvider;
+import org.elasticsearch.xpack.ml.job.persistence.RestartTimeInfo;
+
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Consumer;
+
+public class DatafeedContextProvider {
+
+    private final JobConfigProvider jobConfigProvider;
+    private final DatafeedConfigProvider datafeedConfigProvider;
+    private final JobResultsProvider resultsProvider;
+
+    public DatafeedContextProvider(JobConfigProvider jobConfigProvider, DatafeedConfigProvider datafeedConfigProvider,
+                                   JobResultsProvider jobResultsProvider) {
+        this.jobConfigProvider = Objects.requireNonNull(jobConfigProvider);
+        this.datafeedConfigProvider = Objects.requireNonNull(datafeedConfigProvider);
+        this.resultsProvider = Objects.requireNonNull(jobResultsProvider);
+    }
+
+    public void buildDatafeedContext(String datafeedId, long datafeedStartTimeMs, ActionListener<DatafeedContext> listener) {
+        DatafeedContext.Builder context = DatafeedContext.builder(datafeedStartTimeMs);
+
+        Consumer<Result<ModelSnapshot>> modelSnapshotListener = resultSnapshot -> {
+            context.setModelSnapshot(resultSnapshot == null ? null : resultSnapshot.result);
+            listener.onResponse(context.build());
+        };
+
+        Consumer<DatafeedTimingStats> timingStatsListener = timingStats -> {
+            context.setTimingStats(timingStats);
+            resultsProvider.getModelSnapshot(
+                context.getJob().getId(),
+                context.getJob().getModelSnapshotId(),
+                modelSnapshotListener,
+                listener::onFailure);
+        };
+
+        ActionListener<RestartTimeInfo> restartTimeInfoListener = ActionListener.wrap(
+            restartTimeInfo -> {
+                context.setRestartTimeInfo(restartTimeInfo);
+                resultsProvider.datafeedTimingStats(context.getJob().getId(), timingStatsListener, listener::onFailure);
+            },
+            listener::onFailure
+        );
+
+        ActionListener<Job.Builder> jobConfigListener = ActionListener.wrap(
+            jobBuilder -> {
+                context.setJob(jobBuilder.build());
+                resultsProvider.getRestartTimeInfo(jobBuilder.getId(), restartTimeInfoListener);
+            },
+            listener::onFailure
+        );
+
+        ActionListener<DatafeedConfig.Builder> datafeedListener = ActionListener.wrap(
+            datafeedConfigBuilder -> {
+                DatafeedConfig datafeedConfig = datafeedConfigBuilder.build();
+                context.setDatafeedConfig(datafeedConfig);
+                jobConfigProvider.getJob(datafeedConfig.getJobId(), jobConfigListener);
+            },
+            listener::onFailure
+        );
+
+        datafeedConfigProvider.getDatafeedConfig(datafeedId, datafeedListener);
+    }
+
+    public void buildDatafeedContextForJob(String jobId, ClusterState clusterState,  ActionListener<DatafeedContext> listener) {
+        ActionListener<Set<String>> datafeedListener = ActionListener.wrap(
+            datafeeds -> {
+                assert datafeeds.size() <= 1;
+                if (datafeeds.isEmpty()) {
+                    // This job has no datafeed attached to it
+                    listener.onResponse(null);
+                    return;
+                }
+
+                String datafeedId = datafeeds.iterator().next();
+                PersistentTasksCustomMetadata tasks = clusterState.getMetadata().custom(PersistentTasksCustomMetadata.TYPE);
+                PersistentTasksCustomMetadata.PersistentTask<?> datafeedTask = MlTasks.getDatafeedTask(datafeedId, tasks);
+                if (datafeedTask == null) {
+                    // This datafeed is not started
+                    listener.onResponse(null);
+                    return;
+                }
+
+                @SuppressWarnings("unchecked")
+                StartDatafeedAction.DatafeedParams taskParams = (StartDatafeedAction.DatafeedParams) datafeedTask.getParams();
+                buildDatafeedContext(datafeedId, taskParams.getStartTime(), listener);
+            },
+            listener::onFailure
+        );
+
+        datafeedConfigProvider.findDatafeedsForJobIds(Collections.singleton(jobId), datafeedListener);
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobDataCountsPersister.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobDataCountsPersister.java
@@ -91,6 +91,7 @@ public class JobDataCountsPersister {
             final IndexRequest request = new IndexRequest(AnomalyDetectorsIndex.resultsWriteAlias(jobId))
                 .id(DataCounts.documentId(jobId))
                 .setRequireAlias(true)
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
                 .source(content);
             executeAsyncWithOrigin(client, ML_ORIGIN, IndexAction.INSTANCE, request, new ActionListener<IndexResponse>() {
                 @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/RestartTimeInfo.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/RestartTimeInfo.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.ml.job.persistence;
 
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSnapshot;
 
 public class RestartTimeInfo {
 
@@ -32,5 +33,22 @@ public class RestartTimeInfo {
 
     public boolean haveSeenDataPreviously() {
         return haveSeenDataPreviously;
+    }
+
+    public boolean isAfter(long timestampMs) {
+        long jobLatestResultTime = latestFinalBucketTimeMs == null ? 0 : latestFinalBucketTimeMs;
+        long jobLatestRecordTime = latestRecordTimeMs == null ? 0 : latestRecordTimeMs;
+        return Math.max(jobLatestResultTime, jobLatestRecordTime) > timestampMs;
+    }
+
+    public boolean isAfterModelSnapshot(ModelSnapshot modelSnapshot) {
+        assert modelSnapshot != null;
+        long jobLatestResultTime = latestFinalBucketTimeMs == null ? 0 : latestFinalBucketTimeMs;
+        long jobLatestRecordTime = latestRecordTimeMs == null ? 0 : latestRecordTimeMs;
+        long modelLatestResultTime = modelSnapshot.getLatestResultTimeStamp() == null ?
+                0 : modelSnapshot.getLatestResultTimeStamp().getTime();
+        long modelLatestRecordTime = modelSnapshot.getLatestRecordTimeStamp() == null ?
+                0 : modelSnapshot.getLatestRecordTimeStamp().getTime();
+        return jobLatestResultTime > modelLatestResultTime || jobLatestRecordTime > modelLatestRecordTime;
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManager.java
@@ -603,7 +603,7 @@ public class AutodetectProcessManager implements ClusterStateListener {
         String jobId = jobTask.getJobId();
         notifyLoadingSnapshot(jobId, autodetectParams);
 
-        if (autodetectParams.dataCounts().getProcessedRecordCount() > 0) {
+        if (autodetectParams.dataCounts().getLatestRecordTimeStamp() != null) {
             if (autodetectParams.modelSnapshot() == null) {
                 String msg = "No model snapshot could be found for a job with processed records";
                 logger.warn("[{}] {}", jobId, msg);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobBuilderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobBuilderTests.java
@@ -89,12 +89,12 @@ public class DatafeedJobBuilderTests extends ESTestCase {
                 }, e -> fail()
         );
 
-        DatafeedContext datafeedContext = new DatafeedContext(
-            datafeed.build(),
-            jobBuilder.build(),
-            new RestartTimeInfo(null, null, false),
-            new DatafeedTimingStats(jobBuilder.getId())
-        );
+        DatafeedContext datafeedContext = DatafeedContext.builder(0L)
+            .setDatafeedConfig(datafeed.build())
+            .setJob(jobBuilder.build())
+            .setRestartTimeInfo(new RestartTimeInfo(null, null, false))
+            .setTimingStats(new DatafeedTimingStats(jobBuilder.getId()))
+            .build();
 
         TransportStartDatafeedAction.DatafeedTask datafeedTask = newDatafeedTask("datafeed1");
 
@@ -121,12 +121,12 @@ public class DatafeedJobBuilderTests extends ESTestCase {
                 }, e -> fail()
         );
 
-        DatafeedContext datafeedContext = new DatafeedContext(
-            datafeed.build(),
-            jobBuilder.build(),
-            new RestartTimeInfo(3_600_000L, 7_200_000L, false),
-            new DatafeedTimingStats(jobBuilder.getId())
-        );
+        DatafeedContext datafeedContext = DatafeedContext.builder(0L)
+            .setDatafeedConfig(datafeed.build())
+            .setJob(jobBuilder.build())
+            .setRestartTimeInfo(new RestartTimeInfo(3_600_000L, 7_200_000L, false))
+            .setTimingStats(new DatafeedTimingStats(jobBuilder.getId()))
+            .build();
 
         TransportStartDatafeedAction.DatafeedTask datafeedTask = newDatafeedTask("datafeed1");
 
@@ -153,12 +153,12 @@ public class DatafeedJobBuilderTests extends ESTestCase {
                 }, e -> fail()
         );
 
-        DatafeedContext datafeedContext = new DatafeedContext(
-            datafeed.build(),
-            jobBuilder.build(),
-            new RestartTimeInfo(3_800_000L, 3_600_000L, false),
-            new DatafeedTimingStats(jobBuilder.getId())
-        );
+        DatafeedContext datafeedContext = DatafeedContext.builder(0L)
+            .setDatafeedConfig(datafeed.build())
+            .setJob(jobBuilder.build())
+            .setRestartTimeInfo(new RestartTimeInfo(3_800_000L, 3_600_000L, false))
+            .setTimingStats(new DatafeedTimingStats(jobBuilder.getId()))
+            .build();
 
         TransportStartDatafeedAction.DatafeedTask datafeedTask = newDatafeedTask("datafeed1");
 
@@ -198,12 +198,12 @@ public class DatafeedJobBuilderTests extends ESTestCase {
             }
         );
 
-        DatafeedContext datafeedContext = new DatafeedContext(
-            datafeed.build(),
-            jobBuilder.build(),
-            new RestartTimeInfo(null, null, false),
-            new DatafeedTimingStats(jobBuilder.getId())
-        );
+        DatafeedContext datafeedContext = DatafeedContext.builder(0L)
+            .setDatafeedConfig(datafeed.build())
+            .setJob(jobBuilder.build())
+            .setRestartTimeInfo(new RestartTimeInfo(null, null, false))
+            .setTimingStats(new DatafeedTimingStats(jobBuilder.getId()))
+            .build();
 
         TransportStartDatafeedAction.DatafeedTask datafeedTask = newDatafeedTask("datafeed1");
 


### PR DESCRIPTION
…630)

This fixes a long outstanding issue with the resume behaviour
of a datafeed that has been reassigned on a node.

When we resume a datafeed, we start from the latest result time
or the latest record time, whichever is greater. This makes sense
when a job had been closed gracefully previously.

In the scenario when a job is being reassigned, it is highly likely
that the job has seen data after the latest snapshot was persisted.
This means that with the current behaviour, we load that snapshot and
then we resume sending data from the point the job had reached previously.
This results to the model having a knowledge gap.

This commit addresses this by checking whether a reassining datafeed
has gone past its job's model snapshot and reverting the job to
that snapshot while deleting intervening results. Then we resume
the datafeed from the latest result or latest record of the snapshot.

Fixes #63400

Backport of #65630
