### PR TITLE
[7.x] [DOCS] Update rollup glossary item (#65519)

### DIFF
--- a/docs/reference/glossary.asciidoc
+++ b/docs/reference/glossary.asciidoc
@@ -418,6 +418,17 @@ See the {ref}/indices-rollover-index.html[rollover index API].
 // end::rollover-def[]
 --
 
+ifdef::permanently-unreleased-branch[]
+
+[[glossary-rollup]] rollup ::
+// tag::rollup-def[]
+Aggregates an index's time series data and stores the results in another index.
+For example, you can roll up hourly data into daily or weekly summaries.
+// end::rollup-def[]
+
+endif::[]
+ifndef::permanently-unreleased-branch[]
+
 [[glossary-rollup]] rollup ::
 // tag::rollup-def[]
 Summarize high-granularity data into a more compressed format to
@@ -436,6 +447,8 @@ A background task that runs continuously to summarize documents in an index and
 index the summaries into a separate rollup index.
 The job configuration controls what information is rolled up and how often.
 // end::rollup-job-def[]
+
+endif::[]
 
 [[glossary-routing]] routing ::
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Update rollup glossary item (#65519)