### PR TITLE
[DOCS] EQL: Remove outdated wildcard ref

### DIFF
--- a/docs/reference/eql/functions.asciidoc
+++ b/docs/reference/eql/functions.asciidoc
@@ -1015,10 +1015,6 @@ expressions. Matching is case-sensitive.
 *Example*
 [source,eql]
 ----
-// The two following expressions are equivalent.
-process.name == "*regsvr32*" or process.name == "*explorer*"
-wildcard(process.name, "*regsvr32*", "*explorer*")
-
 // process.name = "regsvr32.exe"
 wildcard(process.name, "*regsvr32*")                // returns true
 wildcard(process.name, "*regsvr32*", "*explorer*")  // returns true


### PR DESCRIPTION
Removes an outdated wildcard reference overlooked in #63195