### PR TITLE
[7.x] [DOCS] Fix URL in rollup API JSON spec (#65683)

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.rollup.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.rollup.json
@@ -1,7 +1,7 @@
 {
   "rollup.rollup":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/xpack-rollup.html",
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-api.html",
       "description":"Rollup an index"
     },
     "stability":"stable",


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Fix URL in rollup API JSON spec (#65683)