### PR TITLE
[DOCS] Fix `_doc_count` field title

### DIFF
--- a/docs/reference/mapping/fields/doc-count-field.asciidoc
+++ b/docs/reference/mapping/fields/doc-count-field.asciidoc
@@ -1,8 +1,5 @@
 [[mapping-doc-count-field]]
-=== `_doc_count` data type
-++++
-<titleabbrev>_doc_count</titleabbrev>
-++++
+=== `_doc_count` field
 
 Bucket aggregations always return a field named `doc_count` showing the number of documents that were aggregated and partitioned
 in each bucket. Computation of the value of `doc_count` is very simple. `doc_count` is incremented by 1 for every document collected


### PR DESCRIPTION
Corrects the title of the `_doc_count` metadata field page for consistency with other metadata fields.

**Before**

<img width="210" alt="Screen Shot 2020-12-01 at 3 07 41 PM" src="https://user-images.githubusercontent.com/40268737/100791264-fd4b5780-33e6-11eb-91b3-63df98498f44.PNG">


**After**

<img width="185" alt="Screen Shot 2020-12-01 at 3 09 52 PM" src="https://user-images.githubusercontent.com/40268737/100791458-48fe0100-33e7-11eb-9e91-1fc37c56ebb8.PNG">


### Preview

https://elasticsearch_65704.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/mapping-doc-count-field.html