### PR TITLE
Always use "elasticsearch" as Gradle project name

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -2,8 +2,7 @@ plugins {
   id "com.gradle.enterprise" version "3.5"
 }
 
-String dirName = rootProject.projectDir.name
-rootProject.name = dirName
+rootProject.name = "elasticsearch"
 
 List projects = [
   'build-tools',
@@ -135,7 +134,7 @@ project(":test:external-modules").children.each { testProject ->
 }
 
 // look for extra plugins for elasticsearch
-File extraProjects = new File(rootProject.projectDir.parentFile, "${dirName}-extra")
+File extraProjects = new File(rootProject.projectDir.parentFile, "${rootProject.projectDir.name}-extra")
 if (extraProjects.exists()) {
   for (File extraProjectDir : extraProjects.listFiles()) {
     addSubProjects('', extraProjectDir)


### PR DESCRIPTION
We currently set the Gradle root project name to the current directory name. This is actually Gradle's default behavior, although we also explicitly do this in our `settings.gradle` file. We want to standardize on this for a few reasons:

1. It makes filtering in Gradle Enterprise a lot simpler. Right now, since the project names are all over the place it's hard to get a picture of _just_ Elasticsearch builds as usage of Gradle Enterprise extends beyond the ES team to include others, like Cloud.
2. Often times the project name doesn't make a lot of sense, or is too verbose to grok as CI systems like Jenkins use the entire job name as the checkout dir, or in Teamcity we truncate this to just the internal build id. In either case, we don't want to have to think about implementation details like that. What the checkout folder is named shouldn't have any impact on the build scan, and if we want that information (job name) we have other mechanisms like tags to capture and filter builds on that criteria.
3. While "project name" is a loose concept, Gradle Enterprise actually considers unique project names as distinctly different projects, which has some consequences. For example, the project name is part of the unique id created for tests/tasks. So for any given test/task execution, a unique id is created for every project name. This has had the side effect of causing performance issues for us in Gradle Enterprise when querying test failures as internally Gradle Enterprise is capturing 100s of millions of unique tests because the project name is constantly changing.

This is a mostly transparent change, as the root project name is really just decorative. There are places where this is displayed to developers though, such as in the IDE. I took some time to experiment here to see what will happen if you have multiple IDEs open with the same project name, as is often the case when working with git worktrees across multiple branches. At least in IntelliJ, if you have multiple windows open of the same "project" it simply will display the workspace directory instead, which sorts out any possibly ambiguity. 