### PR TITLE
Fix composite aggregation on unsigned long

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/LongValuesSource.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/LongValuesSource.java
@@ -146,11 +146,8 @@ class LongValuesSource extends SingleDimensionValuesSource<Long> {
     void setAfter(Comparable value) {
         if (missingBucket && value == null) {
             afterValue = null;
-        } else if (value instanceof Number) {
-            afterValue = ((Number) value).longValue();
         } else {
-            // for date histogram source with "format", the after value is formatted
-            // as a string so we need to retrieve the original value in milliseconds.
+            // parse the value from a string in case it is a date or a formatted unsigned long.
             afterValue = format.parseLong(value.toString(), false, () -> {
                 throw new IllegalArgumentException("now() is not supported in [after] key");
             });

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/unsigned_long/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/unsigned_long/10_basic.yml
@@ -299,3 +299,80 @@ setup:
   - match: { hits.hits.2.fields.ul.0 : "9223372036854775808" }
   - match: { hits.hits.3.fields.ul.0 : "18446744073709551614" }
   - match: { hits.hits.4.fields.ul.0 : "18446744073709551615" }
+
+---
+"Composite aggregations":
+  - skip:
+      version: " - 7.99.99"
+      reason: "TODO: unsigned_long support for composite aggs was fixed in 7.11"
+
+  - do:
+      search:
+        index: test1
+        body:
+          size: 0
+          aggs:
+            test:
+              composite:
+                 size: 3
+                 sources: [{
+                  "ul": {
+                     "terms": {
+                       "field": "ul"
+                     }
+                   }
+                 }]
+
+  - set: { aggregations.test.after_key: after_key }
+  - length: { aggregations.test.buckets: 3 }
+  - match: { aggregations.test.buckets.0.key.ul: 0 }
+  - match: { aggregations.test.buckets.0.doc_count:  1 }
+  - match: { aggregations.test.buckets.1.key.ul: 9223372036854775807 }
+  - match: { aggregations.test.buckets.1.doc_count:  1 }
+  - match: { aggregations.test.buckets.2.key.ul: 9223372036854775808 }
+  - match: { aggregations.test.buckets.2.doc_count:  1 }
+
+  - do:
+      search:
+        index: test1
+        body:
+          size: 0
+          aggs:
+            test:
+              composite:
+                size: 3
+                after: $after_key
+                sources: [{
+                  "ul": {
+                    "terms": {
+                      "field": "ul"
+                    }
+                }
+              }]
+
+  - set: { aggregations.test.after_key: after_key }
+  - length: { aggregations.test.buckets: 2 }
+  - match: { aggregations.test.buckets.0.key.ul: 18446744073709551614 }
+  - match: { aggregations.test.buckets.0.doc_count:  1 }
+  - match: { aggregations.test.buckets.1.key.ul: 18446744073709551615 }
+  - match: { aggregations.test.buckets.1.doc_count:  1 }
+
+  - do:
+      search:
+        index: test1
+        body:
+          size: 0
+          aggs:
+            test:
+              composite:
+                size: 3
+                after: $after_key
+                sources: [{
+                  "ul": {
+                    "terms": {
+                      "field": "ul"
+                    }
+                  }
+              }]
+
+  - length: { aggregations.test.buckets: 0 }


### PR DESCRIPTION
This commit ensures that the after key is parsed with the doc value formatter.
This is needed for unsigned longs that uses shifted longs internally.

Closes #65685