### PR TITLE
link to HunspellStemFilter did not work in row 14

### DIFF
--- a/docs/reference/analysis/tokenfilters/hunspell-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/hunspell-tokenfilter.asciidoc
@@ -11,7 +11,7 @@ filter requires
 language-specific Hunspell dictionaries.
 
 This filter uses Lucene's
-{lucene-analysis-docs}/hunspell/HunspellStemFilter.html[HunspellStemFilter].
+{lucene-analysis-docs}!!!!!!![HunspellStemFilter].
 
 [TIP]
 ====


### PR DESCRIPTION
link to HunspellStemFilter did not work in row 14, marked place to change with "!!!!!!!"
presumably correct link:
https://lucene.apache.org/core/8_0_0/analyzers-common/org/apache/lucene/analysis/hunspell/HunspellStemFilter.html

do not merge it pls, it is just notification