### PR TITLE
[7.10] [DOCS] Changes wording of pivot parameter in PUT transforms API docs. (#65731)

### DIFF
--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -671,8 +671,8 @@ The method for transforming the data. These objects define the pivot function
 end::pivot[]
 
 tag::pivot-aggs[]
-Defines how to aggregate the grouped data. The following aggregations are
-supported:
+Defines how to aggregate the grouped data. The following aggregations are 
+currently supported:
 +
 --
 * <<search-aggregations-metrics-avg-aggregation,Average>>
@@ -692,16 +692,12 @@ supported:
 * <<search-aggregations-metrics-valuecount-aggregation,Value count>>
 * <<search-aggregations-metrics-weight-avg-aggregation,Weighted average>>
 
-
-IMPORTANT: {transforms-cap} support a subset of the functionality in
-aggregations. See <<transform-limitations>>.
-
 --
 end::pivot-aggs[]
 
 tag::pivot-group-by[]
-Defines how to group the data. More than one grouping can be defined
-  per pivot. The following groupings are supported:
+Defines how to group the data. More than one grouping can be defined per pivot. 
+The following groupings are currently supported:
 +
 --
 * <<_date_histogram,Date histogram>>


### PR DESCRIPTION
Backports the following commits to 7.10:
 - [DOCS] Changes wording of pivot parameter in PUT transforms API docs. (#65731)