### PR TITLE
[7.x] [DOCS] Fix `_doc_count` field title (#65704)

### DIFF
--- a/docs/reference/mapping/fields/doc-count-field.asciidoc
+++ b/docs/reference/mapping/fields/doc-count-field.asciidoc
@@ -1,8 +1,5 @@
 [[mapping-doc-count-field]]
-=== `_doc_count` data type
-++++
-<titleabbrev>_doc_count</titleabbrev>
-++++
+=== `_doc_count` field
 
 Bucket aggregations always return a field named `doc_count` showing the number of documents that were aggregated and partitioned
 in each bucket. Computation of the value of `doc_count` is very simple. `doc_count` is incremented by 1 for every document collected


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Fix `_doc_count` field title (#65704)