### PR TITLE
[7.x] [DOCS] Remove erroneous `flat_settings` query param (#65670)

### DIFF
--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -34,8 +34,6 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=node-filter]
 [[cluster-stats-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=flat-settings]
-
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeout]
 
 [role="child_attributes"]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Remove erroneous `flat_settings` query param (#65670)