### PR TITLE
[7.10] [DOCS] Add cluster get settings API example (#65754)

### DIFF
--- a/docs/reference/cluster/get-settings.asciidoc
+++ b/docs/reference/cluster/get-settings.asciidoc
@@ -6,6 +6,14 @@
 
 Returns cluster-wide settings.
 
+[source,console]
+----
+GET /_cluster/settings
+----
+
+[[cluster-get-settings-api-request]]
+==== {api-request-title}
+
 `GET /_cluster/settings`
 
 [[cluster-get-settings-api-desc]]


### PR DESCRIPTION
Backports the following commits to 7.10:
 - [DOCS] Add cluster get settings API example (#65754)