### PR TITLE
[7.x][ML] Add search runtime_mappings to datafeed configuration (#65606)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java
@@ -29,6 +29,7 @@ import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.metrics.MaxAggregationBuilder;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.xpack.core.common.time.TimeUtils;
 import org.elasticsearch.xpack.core.ml.datafeed.extractor.ExtractorUtils;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.messages.Messages;
@@ -37,7 +38,6 @@ import org.elasticsearch.xpack.core.ml.utils.MlStrings;
 import org.elasticsearch.xpack.core.ml.utils.QueryProvider;
 import org.elasticsearch.xpack.core.ml.utils.ToXContentParams;
 import org.elasticsearch.xpack.core.ml.utils.XContentObjectTransformer;
-import org.elasticsearch.xpack.core.common.time.TimeUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -166,6 +166,7 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
         parser.declareObject(Builder::setIndicesOptions,
             (p, c) -> IndicesOptions.fromMap(p.map(), SearchRequest.DEFAULT_INDICES_OPTIONS),
             INDICES_OPTIONS);
+        parser.declareObject(Builder::setRuntimeMappings, (p, c) -> p.map(), SearchSourceBuilder.RUNTIME_MAPPINGS_FIELD);
         return parser;
     }
 
@@ -192,11 +193,13 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
     private final DelayedDataCheckConfig delayedDataCheckConfig;
     private final Integer maxEmptySearches;
     private final IndicesOptions indicesOptions;
+    private final Map<String, Object> runtimeMappings;
 
     private DatafeedConfig(String id, String jobId, TimeValue queryDelay, TimeValue frequency, List<String> indices,
                            QueryProvider queryProvider, AggProvider aggProvider, List<SearchSourceBuilder.ScriptField> scriptFields,
                            Integer scrollSize, ChunkingConfig chunkingConfig, Map<String, String> headers,
-                           DelayedDataCheckConfig delayedDataCheckConfig, Integer maxEmptySearches, IndicesOptions indicesOptions) {
+                           DelayedDataCheckConfig delayedDataCheckConfig, Integer maxEmptySearches, IndicesOptions indicesOptions,
+                           Map<String, Object> runtimeMappings) {
         this.id = id;
         this.jobId = jobId;
         this.queryDelay = queryDelay;
@@ -211,6 +214,7 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
         this.delayedDataCheckConfig = delayedDataCheckConfig;
         this.maxEmptySearches = maxEmptySearches;
         this.indicesOptions = ExceptionsHelper.requireNonNull(indicesOptions, INDICES_OPTIONS);
+        this.runtimeMappings = Collections.unmodifiableMap(runtimeMappings);
     }
 
     public DatafeedConfig(StreamInput in) throws IOException {
@@ -260,6 +264,11 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
             indicesOptions = IndicesOptions.readIndicesOptions(in);
         } else {
             indicesOptions = SearchRequest.DEFAULT_INDICES_OPTIONS;
+        }
+        if (in.getVersion().onOrAfter(Version.V_7_11_0)) {
+            runtimeMappings = in.readMap();
+        } else {
+            runtimeMappings = Collections.emptyMap();
         }
     }
 
@@ -437,6 +446,10 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
         return indicesOptions;
     }
 
+    public Map<String, Object> getRuntimeMappings() {
+        return runtimeMappings;
+    }
+
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(id);
@@ -480,6 +493,9 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
         }
         if (out.getVersion().onOrAfter(Version.V_7_7_0)) {
             indicesOptions.writeIndicesOptions(out);
+        }
+        if (out.getVersion().onOrAfter(Version.V_7_11_0)) {
+            out.writeMap(runtimeMappings);
         }
     }
 
@@ -539,6 +555,9 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
         if (maxEmptySearches != null) {
             builder.field(MAX_EMPTY_SEARCHES.getPreferredName(), maxEmptySearches);
         }
+        if (runtimeMappings.isEmpty() == false) {
+            builder.field(SearchSourceBuilder.RUNTIME_MAPPINGS_FIELD.getPreferredName(), runtimeMappings);
+        }
         builder.endObject();
         return builder;
     }
@@ -591,13 +610,14 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
                 && Objects.equals(this.headers, that.headers)
                 && Objects.equals(this.delayedDataCheckConfig, that.delayedDataCheckConfig)
                 && Objects.equals(this.maxEmptySearches, that.maxEmptySearches)
-                && Objects.equals(this.indicesOptions, that.indicesOptions);
+                && Objects.equals(this.indicesOptions, that.indicesOptions)
+                && Objects.equals(this.runtimeMappings, that.runtimeMappings);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(id, jobId, frequency, queryDelay, indices, queryProvider, scrollSize, aggProvider, scriptFields, chunkingConfig,
-                headers, delayedDataCheckConfig, maxEmptySearches, indicesOptions);
+                headers, delayedDataCheckConfig, maxEmptySearches, indicesOptions, runtimeMappings);
     }
 
     @Override
@@ -668,6 +688,7 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
         private DelayedDataCheckConfig delayedDataCheckConfig = DelayedDataCheckConfig.defaultDelayedDataCheckConfig();
         private Integer maxEmptySearches;
         private IndicesOptions indicesOptions;
+        private Map<String, Object> runtimeMappings = Collections.emptyMap();
 
         public Builder() { }
 
@@ -692,6 +713,7 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
             this.delayedDataCheckConfig = config.getDelayedDataCheckConfig();
             this.maxEmptySearches = config.getMaxEmptySearches();
             this.indicesOptions = config.indicesOptions;
+            this.runtimeMappings = new HashMap<>(config.runtimeMappings);
         }
 
         public Builder setId(String datafeedId) {
@@ -819,6 +841,11 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
             return this.indicesOptions;
         }
 
+        public void setRuntimeMappings(Map<String, Object> runtimeMappings) {
+            this.runtimeMappings = ExceptionsHelper.requireNonNull(runtimeMappings,
+                SearchSourceBuilder.RUNTIME_MAPPINGS_FIELD.getPreferredName());
+        }
+
         public DatafeedConfig build() {
             ExceptionsHelper.requireNonNull(id, ID.getPreferredName());
             ExceptionsHelper.requireNonNull(jobId, Job.ID.getPreferredName());
@@ -830,6 +857,7 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
             }
 
             validateScriptFields();
+            validateRuntimeMappings();
             setDefaultChunkingConfig();
 
             setDefaultQueryDelay();
@@ -837,7 +865,7 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
                 indicesOptions = SearchRequest.DEFAULT_INDICES_OPTIONS;
             }
             return new DatafeedConfig(id, jobId, queryDelay, frequency, indices, queryProvider, aggProvider, scriptFields, scrollSize,
-                    chunkingConfig, headers, delayedDataCheckConfig, maxEmptySearches, indicesOptions);
+                    chunkingConfig, headers, delayedDataCheckConfig, maxEmptySearches, indicesOptions, runtimeMappings);
         }
 
         void validateScriptFields() {
@@ -847,6 +875,28 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
             if (scriptFields != null && !scriptFields.isEmpty()) {
                 throw ExceptionsHelper.badRequestException(
                     Messages.getMessage(Messages.DATAFEED_CONFIG_CANNOT_USE_SCRIPT_FIELDS_WITH_AGGS));
+            }
+        }
+
+        /**
+         * Perform a light check that the structure resembles runtime_mappings.
+         * The full check cannot happen until search
+         */
+        void validateRuntimeMappings() {
+            for (Map.Entry<String, Object> entry : runtimeMappings.entrySet()) {
+                // top level objects are fields
+                String fieldName = entry.getKey();
+                if (entry.getValue() instanceof Map) {
+                    @SuppressWarnings("unchecked")
+                    Map<String, Object> propNode = new HashMap<>(((Map<String, Object>) entry.getValue()));
+                    Object typeNode = propNode.get("type");
+                    if (typeNode == null) {
+                        throw ExceptionsHelper.badRequestException("No type specified for runtime field [" + fieldName + "]");
+                    }
+                } else {
+                    throw ExceptionsHelper.badRequestException("Expected map for runtime field [" + fieldName + "] " +
+                        "definition but got a " + fieldName.getClass().getSimpleName());
+                }
             }
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
@@ -222,6 +222,8 @@ public final class Messages {
             "This job would cause a mapping clash with existing field [{0}] - avoid the clash by assigning a dedicated results index";
     public static final String JOB_CONFIG_TIME_FIELD_NOT_ALLOWED_IN_ANALYSIS_CONFIG =
             "data_description.time_field may not be used in the analysis_config";
+    public static final String JOB_CONFIG_TIME_FIELD_CANNOT_BE_RUNTIME =
+        "data_description.time_field [{0}] cannot be a runtime field";
     public static final String JOB_CONFIG_MODEL_SNAPSHOT_RETENTION_SETTINGS_INCONSISTENT =
             "The value of '" + Job.DAILY_MODEL_SNAPSHOT_RETENTION_AFTER_DAYS + "' [{0}] cannot be greater than '" +
                 Job.MODEL_SNAPSHOT_RETENTION_DAYS + "' [{1}]";

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/core/ml/config_index_mappings.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/core/ml/config_index_mappings.json
@@ -375,6 +375,10 @@
       "results_retention_days" : {
         "type" : "long"
       },
+      "runtime_mappings" : {
+        "type" : "object",
+        "enabled" : false
+      },
       "script_fields" : {
         "type" : "object",
         "enabled" : false

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfigTests.java
@@ -168,6 +168,14 @@ public class DatafeedConfigTests extends AbstractSerializingTestCase<DatafeedCon
             Boolean.toString(randomBoolean()),
             Boolean.toString(randomBoolean()),
             SearchRequest.DEFAULT_INDICES_OPTIONS));
+        if (randomBoolean()) {
+            Map<String, Object> settings = new HashMap<>();
+            settings.put("type", "keyword");
+            settings.put("script", "");
+            Map<String, Object> field = new HashMap<>();
+            field.put("runtime_field_foo", settings);
+            builder.setRuntimeMappings(field);
+        }
         return builder;
     }
 
@@ -502,6 +510,29 @@ public class DatafeedConfigTests extends AbstractSerializingTestCase<DatafeedCon
         ElasticsearchException e = expectThrows(ElasticsearchException.class, datafeed::build);
 
         assertThat(e.getMessage(), equalTo("script_fields cannot be used in combination with aggregations"));
+    }
+
+    public void testBuild_GivenRuntimeMappingMissingType() {
+        DatafeedConfig.Builder builder = new DatafeedConfig.Builder("datafeed1", "job1");
+        builder.setIndices(Collections.singletonList("my_index"));
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("type_field_is_missing", "");
+        Map<String, Object> fields = new HashMap<>();
+        fields.put("runtime_field_foo", properties);
+        builder.setRuntimeMappings(fields);
+
+        ElasticsearchException e = expectThrows(ElasticsearchException.class, builder::build);
+        assertThat(e.getMessage(), equalTo("No type specified for runtime field [runtime_field_foo]"));
+    }
+
+    public void testBuild_GivenInvalidRuntimeMapping() {
+        DatafeedConfig.Builder builder = new DatafeedConfig.Builder("datafeed1", "job1");
+        builder.setIndices(Collections.singletonList("my_index"));
+        Map<String, Object> fields = new HashMap<>();
+        fields.put("field_is_not_an_object", "");
+        builder.setRuntimeMappings(fields);
+        ElasticsearchException e = expectThrows(ElasticsearchException.class, builder::build);
+        assertThat(e.getMessage(), equalTo("Expected map for runtime field [field_is_not_an_object] definition but got a String"));
     }
 
     public void testHasAggregations_GivenNull() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappingsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappingsTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.index.get.GetResult;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.VersionUtils;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -67,7 +68,7 @@ public class ElasticsearchMappingsTests extends ESTestCase {
 
     // These are not reserved because they're Elasticsearch keywords, not
     // field names
-    private static List<String> KEYWORDS = Arrays.asList(
+    private static final List<String> KEYWORDS = Arrays.asList(
             ElasticsearchMappings.ANALYZER,
             ElasticsearchMappings.COPY_TO,
             ElasticsearchMappings.DYNAMIC,
@@ -75,10 +76,11 @@ public class ElasticsearchMappingsTests extends ESTestCase {
             ElasticsearchMappings.NESTED,
             ElasticsearchMappings.PROPERTIES,
             ElasticsearchMappings.TYPE,
-            ElasticsearchMappings.WHITESPACE
+            ElasticsearchMappings.WHITESPACE,
+            SearchSourceBuilder.RUNTIME_MAPPINGS_FIELD.getPreferredName()
     );
 
-    private static List<String> INTERNAL_FIELDS = Arrays.asList(
+    private static final List<String> INTERNAL_FIELDS = Arrays.asList(
             GetResult._ID,
             GetResult._INDEX,
             GetResult._TYPE
@@ -195,6 +197,7 @@ public class ElasticsearchMappingsTests extends ESTestCase {
             ElasticsearchMappings.mappingRequiresUpdate(cs, indices, VersionUtils.getPreviousMinorVersion()));
     }
 
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public void testAddDocMappingIfMissing() throws IOException {
         ThreadPool threadPool = mock(ThreadPool.class);
         when(threadPool.getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DatafeedJobsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DatafeedJobsIT.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.admin.cluster.node.hotthreads.NodesHotThreadsRes
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.common.CheckedConsumer;
 import org.elasticsearch.common.CheckedRunnable;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.common.util.concurrent.ConcurrentMapLong;
@@ -25,17 +26,23 @@ import org.elasticsearch.xpack.core.ml.datafeed.ChunkingConfig;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedState;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedUpdate;
+import org.elasticsearch.xpack.core.ml.job.config.AnalysisConfig;
+import org.elasticsearch.xpack.core.ml.job.config.DataDescription;
+import org.elasticsearch.xpack.core.ml.job.config.Detector;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.config.JobState;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.DataCounts;
 import org.hamcrest.Matcher;
 import org.junit.After;
+import org.junit.Before;
 
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -144,6 +151,67 @@ public class DatafeedJobsIT extends MlNativeAutodetectIntegTestCase {
         }, 60, TimeUnit.SECONDS);
 
         waitUntilJobIsClosed(job.getId());
+    }
+
+    public void testLookbackOnlyRuntimeMapping() throws Exception {
+        client().admin().indices().prepareCreate("data-1")
+            .addMapping("type", "time", "type=date")
+            .get();
+        long numDocs = randomIntBetween(32, 2048);
+        long now = System.currentTimeMillis();
+        long oneWeekAgo = now - 604800000;
+        long twoWeeksAgo = oneWeekAgo - 604800000;
+        indexDocs(logger, "data-1", numDocs, twoWeeksAgo, oneWeekAgo);
+
+        DataDescription.Builder dataDescription = new DataDescription.Builder();
+
+        Detector.Builder d = new Detector.Builder("count", null);
+        // day_of_week is a runtime field.
+        // count by day of week does not make much sense but is good enough for this test
+        d.setByFieldName("day_of_week");
+        AnalysisConfig.Builder analysisConfig = new AnalysisConfig.Builder(Collections.singletonList(d.build()));
+        analysisConfig.setBucketSpan(TimeValue.timeValueHours(1));
+
+        Job.Builder jobBuilder = new Job.Builder();
+        jobBuilder.setId("lookback-job-with-rt-fields");
+        jobBuilder.setAnalysisConfig(analysisConfig);
+        jobBuilder.setDataDescription(dataDescription);
+
+        registerJob(jobBuilder);
+        putJob(jobBuilder);
+        openJob(jobBuilder.getId());
+        assertBusy(() -> assertEquals(getJobStats(jobBuilder.getId()).get(0).getState(), JobState.OPENED));
+
+        DatafeedConfig.Builder dfBuilder = new DatafeedConfig.Builder(jobBuilder.getId() + "-datafeed", jobBuilder.getId());
+        dfBuilder.setQueryDelay(TimeValue.timeValueSeconds(1));
+        dfBuilder.setFrequency(TimeValue.timeValueSeconds(1));
+        dfBuilder.setIndices(Collections.singletonList("data-1"));
+
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("type", "long");
+        properties.put("script", "emit(doc['time'].value.getDayOfWeekEnum().value)");
+        Map<String, Object> fields = new HashMap<>();
+        fields.put("day_of_week", properties);
+        dfBuilder.setRuntimeMappings(fields);
+
+        DatafeedConfig datafeedConfig = dfBuilder.build();
+
+        registerDatafeed(datafeedConfig);
+        putDatafeed(datafeedConfig);
+
+        startDatafeed(datafeedConfig.getId(), 0L, now);
+        assertBusy(() -> {
+            DataCounts dataCounts = getDataCounts(jobBuilder.getId());
+            assertThat(dataCounts.getProcessedRecordCount(), equalTo(numDocs));
+            assertThat(dataCounts.getOutOfOrderTimeStampCount(), equalTo(0L));
+            assertThat(dataCounts.getMissingFieldCount(), equalTo(0L));
+
+            GetDatafeedsStatsAction.Request request = new GetDatafeedsStatsAction.Request(datafeedConfig.getId());
+            GetDatafeedsStatsAction.Response response = client().execute(GetDatafeedsStatsAction.INSTANCE, request).actionGet();
+            assertThat(response.getResponse().results().get(0).getDatafeedState(), equalTo(DatafeedState.STOPPED));
+        }, 60, TimeUnit.SECONDS);
+
+        waitUntilJobIsClosed(jobBuilder.getId());
     }
 
     @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/63973")

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPreviewDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPreviewDatafeedAction.java
@@ -125,7 +125,7 @@ public class TransportPreviewDatafeedAction extends HandledTransportAction<Previ
         try {
             Optional<InputStream> inputStream = dataExtractor.next();
             // DataExtractor returns single-line JSON but without newline characters between objects.
-            // Instead, it has a space between objects due to how JSON XContenetBuilder works.
+            // Instead, it has a space between objects due to how JSON XContentBuilder works.
             // In order to return a proper JSON array from preview, we surround with square brackets and
             // we stick in a comma between objects.
             // Also, the stream is expected to be a single line but in case it is not, we join lines

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/delayeddatacheck/DatafeedDelayedDataDetector.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/delayeddatacheck/DatafeedDelayedDataDetector.java
@@ -49,9 +49,11 @@ public class DatafeedDelayedDataDetector implements DelayedDataDetector {
     private final QueryBuilder datafeedQuery;
     private final String[] datafeedIndices;
     private final IndicesOptions indicesOptions;
+    private final Map<String, Object> runtimeMappings;
 
     DatafeedDelayedDataDetector(long bucketSpan, long window, String jobId, String timeField, QueryBuilder datafeedQuery,
-                                String[] datafeedIndices, IndicesOptions indicesOptions, Client client) {
+                                String[] datafeedIndices, IndicesOptions indicesOptions, Map<String, Object> runtimeMappings,
+                                Client client) {
         this.bucketSpan = bucketSpan;
         this.window = window;
         this.jobId = jobId;
@@ -59,6 +61,7 @@ public class DatafeedDelayedDataDetector implements DelayedDataDetector {
         this.datafeedQuery = datafeedQuery;
         this.datafeedIndices = datafeedIndices;
         this.indicesOptions = Objects.requireNonNull(indicesOptions);
+        this.runtimeMappings = Objects.requireNonNull(runtimeMappings);
         this.client = client;
     }
 
@@ -117,7 +120,8 @@ public class DatafeedDelayedDataDetector implements DelayedDataDetector {
             .size(0)
             .aggregation(new DateHistogramAggregationBuilder(DATE_BUCKETS)
                 .fixedInterval(new DateHistogramInterval(bucketSpan + "ms")).field(timeField))
-            .query(ExtractorUtils.wrapInTimeRangeQuery(datafeedQuery, timeField, start, end));
+            .query(ExtractorUtils.wrapInTimeRangeQuery(datafeedQuery, timeField, start, end))
+            .runtimeMappings(runtimeMappings);
 
         SearchRequest searchRequest = new SearchRequest(datafeedIndices).source(searchSourceBuilder).indicesOptions(indicesOptions);
         try (ThreadContext.StoredContext ignore = client.threadPool().getThreadContext().stashWithOrigin(ML_ORIGIN)) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/delayeddatacheck/DelayedDataDetectorFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/delayeddatacheck/DelayedDataDetectorFactory.java
@@ -52,6 +52,7 @@ public class DelayedDataDetectorFactory {
                 datafeedConfig.getParsedQuery(xContentRegistry),
                 datafeedConfig.getIndices().toArray(new String[0]),
                 datafeedConfig.getIndicesOptions(),
+                datafeedConfig.getRuntimeMappings(),
                 client);
         } else {
             return new NullDelayedDataDetector();

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AbstractAggregationDataExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AbstractAggregationDataExtractor.java
@@ -47,7 +47,7 @@ abstract class AbstractAggregationDataExtractor<T extends ActionRequestBuilder<S
      * post data action too often. The value of 1000 was determined via
      * such testing.
      */
-    private static int BATCH_KEY_VALUE_PAIRS = 1000;
+    private static final int BATCH_KEY_VALUE_PAIRS = 1000;
 
     protected final Client client;
     protected final AggregationDataExtractorContext context;
@@ -55,7 +55,7 @@ abstract class AbstractAggregationDataExtractor<T extends ActionRequestBuilder<S
     private boolean hasNext;
     private boolean isCancelled;
     private AggregationToJsonProcessor aggregationToJsonProcessor;
-    private ByteArrayOutputStream outputStream;
+    private final ByteArrayOutputStream outputStream;
 
     AbstractAggregationDataExtractor(
             Client client, AggregationDataExtractorContext dataExtractorContext, DatafeedTimingStatsReporter timingStatsReporter) {
@@ -104,7 +104,7 @@ abstract class AbstractAggregationDataExtractor<T extends ActionRequestBuilder<S
             initAggregationProcessor(aggs);
         }
 
-        return Optional.ofNullable(processNextBatch());
+        return Optional.of(processNextBatch());
     }
 
     private Aggregations search() {
@@ -137,6 +137,9 @@ abstract class AbstractAggregationDataExtractor<T extends ActionRequestBuilder<S
             .size(0)
             .query(ExtractorUtils.wrapInTimeRangeQuery(context.query, context.timeField, histogramSearchStartTime, context.end));
 
+        if (context.runtimeMappings.isEmpty() == false) {
+            searchSourceBuilder.runtimeMappings(context.runtimeMappings);
+        }
         context.aggs.getAggregatorFactories().forEach(searchSourceBuilder::aggregation);
         context.aggs.getPipelineAggregatorFactories().forEach(searchSourceBuilder::aggregation);
         return searchSourceBuilder;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationDataExtractorContext.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationDataExtractorContext.java
@@ -27,10 +27,11 @@ class AggregationDataExtractorContext {
     final boolean includeDocCount;
     final Map<String, String> headers;
     final IndicesOptions indicesOptions;
+    final Map<String, Object> runtimeMappings;
 
     AggregationDataExtractorContext(String jobId, String timeField, Set<String> fields, List<String> indices, QueryBuilder query,
                                     AggregatorFactories.Builder aggs, long start, long end, boolean includeDocCount,
-                                    Map<String, String> headers, IndicesOptions indicesOptions) {
+                                    Map<String, String> headers, IndicesOptions indicesOptions, Map<String, Object> runtimeMappings) {
         this.jobId = Objects.requireNonNull(jobId);
         this.timeField = Objects.requireNonNull(timeField);
         this.fields = Objects.requireNonNull(fields);
@@ -42,5 +43,6 @@ class AggregationDataExtractorContext {
         this.includeDocCount = includeDocCount;
         this.headers = headers;
         this.indicesOptions = Objects.requireNonNull(indicesOptions);
+        this.runtimeMappings = Objects.requireNonNull(runtimeMappings);
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationDataExtractorFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationDataExtractorFactory.java
@@ -51,7 +51,8 @@ public class AggregationDataExtractorFactory implements DataExtractorFactory {
                 Intervals.alignToFloor(end, histogramInterval),
                 job.getAnalysisConfig().getSummaryCountFieldName().equals(DatafeedConfig.DOC_COUNT),
                 datafeedConfig.getHeaders(),
-                datafeedConfig.getIndicesOptions());
+                datafeedConfig.getIndicesOptions(),
+                datafeedConfig.getRuntimeMappings());
         return new AggregationDataExtractor(client, dataExtractorContext, timingStatsReporter);
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/RollupDataExtractorFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/RollupDataExtractorFactory.java
@@ -75,7 +75,8 @@ public class RollupDataExtractorFactory implements DataExtractorFactory {
             Intervals.alignToFloor(end, histogramInterval),
             job.getAnalysisConfig().getSummaryCountFieldName().equals(DatafeedConfig.DOC_COUNT),
             datafeedConfig.getHeaders(),
-            datafeedConfig.getIndicesOptions());
+            datafeedConfig.getIndicesOptions(),
+            datafeedConfig.getRuntimeMappings());
         return new RollupDataExtractor(client, dataExtractorContext, timingStatsReporter);
     }
 
@@ -86,6 +87,13 @@ public class RollupDataExtractorFactory implements DataExtractorFactory {
                               NamedXContentRegistry xContentRegistry,
                               DatafeedTimingStatsReporter timingStatsReporter,
                               ActionListener<DataExtractorFactory> listener) {
+
+        if (datafeed.getRuntimeMappings().isEmpty() == false) {
+            // TODO Rollup V2 will support runtime fields
+            listener.onFailure(new IllegalArgumentException("The datafeed has runtime_mappings defined, "
+                + "runtime fields are not supported in rollup searches"));
+            return;
+        }
 
         final AggregationBuilder datafeedHistogramAggregation = getHistogramAggregation(
             datafeed.getParsedAggregations(xContentRegistry).getAggregatorFactories());

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/chunked/ChunkedDataExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/chunked/ChunkedDataExtractor.java
@@ -239,6 +239,7 @@ public class ChunkedDataExtractor implements DataExtractor {
             return new SearchSourceBuilder()
                 .size(0)
                 .query(ExtractorUtils.wrapInTimeRangeQuery(context.query, context.timeField, currentStart, context.end))
+                .runtimeMappings(context.runtimeMappings)
                 .aggregation(AggregationBuilders.min(EARLIEST_TIME).field(context.timeField))
                 .aggregation(AggregationBuilders.max(LATEST_TIME).field(context.timeField));
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/chunked/ChunkedDataExtractorContext.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/chunked/ChunkedDataExtractorContext.java
@@ -34,10 +34,12 @@ class ChunkedDataExtractorContext {
     final boolean hasAggregations;
     final Long histogramInterval;
     final IndicesOptions indicesOptions;
+    final Map<String, Object> runtimeMappings;
 
     ChunkedDataExtractorContext(String jobId, String timeField, List<String> indices, QueryBuilder query, int scrollSize, long start,
                                 long end, @Nullable TimeValue chunkSpan, TimeAligner timeAligner, Map<String, String> headers,
-                                boolean hasAggregations, @Nullable Long histogramInterval, IndicesOptions indicesOptions) {
+                                boolean hasAggregations, @Nullable Long histogramInterval, IndicesOptions indicesOptions,
+                                Map<String, Object> runtimeMappings) {
         this.jobId = Objects.requireNonNull(jobId);
         this.timeField = Objects.requireNonNull(timeField);
         this.indices = indices.toArray(new String[indices.size()]);
@@ -51,5 +53,6 @@ class ChunkedDataExtractorContext {
         this.hasAggregations = hasAggregations;
         this.histogramInterval = histogramInterval;
         this.indicesOptions = Objects.requireNonNull(indicesOptions);
+        this.runtimeMappings = Objects.requireNonNull(runtimeMappings);
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/chunked/ChunkedDataExtractorFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/chunked/ChunkedDataExtractorFactory.java
@@ -55,7 +55,8 @@ public class ChunkedDataExtractorFactory implements DataExtractorFactory {
                 datafeedConfig.getHeaders(),
                 datafeedConfig.hasAggregations(),
                 datafeedConfig.hasAggregations() ? datafeedConfig.getHistogramIntervalMillis(xContentRegistry) : null,
-                datafeedConfig.getIndicesOptions()
+                datafeedConfig.getIndicesOptions(),
+                datafeedConfig.getRuntimeMappings()
             );
         return new ChunkedDataExtractor(client, dataExtractorFactory, dataExtractorContext, timingStatsReporter);
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractorContext.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractorContext.java
@@ -25,10 +25,11 @@ class ScrollDataExtractorContext {
     final long end;
     final Map<String, String> headers;
     final IndicesOptions indicesOptions;
+    final Map<String, Object> runtimeMappings;
 
     ScrollDataExtractorContext(String jobId, TimeBasedExtractedFields extractedFields, List<String> indices, QueryBuilder query,
                                List<SearchSourceBuilder.ScriptField> scriptFields, int scrollSize, long start, long end,
-                               Map<String, String> headers, IndicesOptions indicesOptions) {
+                               Map<String, String> headers, IndicesOptions indicesOptions, Map<String, Object> runtimeMappings) {
         this.jobId = Objects.requireNonNull(jobId);
         this.extractedFields = Objects.requireNonNull(extractedFields);
         this.indices = indices.toArray(new String[indices.size()]);
@@ -39,5 +40,6 @@ class ScrollDataExtractorContext {
         this.end = end;
         this.headers = headers;
         this.indicesOptions = Objects.requireNonNull(indicesOptions);
+        this.runtimeMappings = Objects.requireNonNull(runtimeMappings);
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractorFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractorFactory.java
@@ -23,6 +23,7 @@ import org.elasticsearch.xpack.ml.datafeed.DatafeedTimingStatsReporter;
 import org.elasticsearch.xpack.ml.datafeed.extractor.DataExtractorFactory;
 
 import java.util.Objects;
+import java.util.Set;
 
 public class ScrollDataExtractorFactory implements DataExtractorFactory {
     private final Client client;
@@ -54,7 +55,8 @@ public class ScrollDataExtractorFactory implements DataExtractorFactory {
                 start,
                 end,
                 datafeedConfig.getHeaders(),
-                datafeedConfig.getIndicesOptions()
+                datafeedConfig.getIndicesOptions(),
+                datafeedConfig.getRuntimeMappings()
         );
         return new ScrollDataExtractor(client, dataExtractorContext, timingStatsReporter);
     }
@@ -89,11 +91,16 @@ public class ScrollDataExtractorFactory implements DataExtractorFactory {
         // Step 1. Get field capabilities necessary to build the information of how to extract fields
         FieldCapabilitiesRequest fieldCapabilitiesRequest = new FieldCapabilitiesRequest();
         fieldCapabilitiesRequest.indices(datafeed.getIndices().toArray(new String[0])).indicesOptions(datafeed.getIndicesOptions());
+
+        // Cannot get field caps on RT fields defined at search
+        Set<String> runtimefields = datafeed.getRuntimeMappings().keySet();
+
         // We need capabilities for all fields matching the requested fields' parents so that we can work around
         // multi-fields that are not in source.
         String[] requestFields = job.allInputFields()
             .stream()
             .map(f -> MlStrings.getParentField(f) + "*")
+            .filter(f -> runtimefields.contains(f) == false)
             .toArray(String[]::new);
         fieldCapabilitiesRequest.fields(requestFields);
         ClientHelper.<FieldCapabilitiesResponse> executeWithHeaders(datafeed.getHeaders(), ClientHelper.ML_ORIGIN, client, () -> {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/TimeBasedExtractedFields.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/TimeBasedExtractedFields.java
@@ -55,7 +55,10 @@ public class TimeBasedExtractedFields extends ExtractedFields {
 
     public static TimeBasedExtractedFields build(Job job, DatafeedConfig datafeed, FieldCapabilitiesResponse fieldsCapabilities) {
         Set<String> scriptFields = datafeed.getScriptFields().stream().map(sf -> sf.fieldName()).collect(Collectors.toSet());
-        ExtractionMethodDetector extractionMethodDetector = new ExtractionMethodDetector(scriptFields, fieldsCapabilities);
+        Set<String> searchRuntimeFields = datafeed.getRuntimeMappings().keySet();
+
+        ExtractionMethodDetector extractionMethodDetector =
+            new ExtractionMethodDetector(scriptFields, fieldsCapabilities, searchRuntimeFields);
         String timeField = job.getDataDescription().getTimeField();
         if (scriptFields.contains(timeField) == false && extractionMethodDetector.isAggregatable(timeField) == false) {
             throw new IllegalArgumentException("cannot retrieve time field [" + timeField + "] because it is not aggregatable");

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetector.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetector.java
@@ -368,6 +368,7 @@ public class ExtractedFieldsDetector {
                                                   List<ProcessedField> processedFields) {
         ExtractedFields extractedFields = ExtractedFields.build(fields,
             Collections.emptySet(),
+            Collections.emptySet(),
             fieldCapabilitiesResponse,
             cardinalitiesForFieldsWithConstraints,
             processedFields);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationDataExtractorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationDataExtractorTests.java
@@ -36,6 +36,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -61,6 +62,7 @@ public class AggregationDataExtractorTests extends ESTestCase {
     private QueryBuilder query;
     private AggregatorFactories.Builder aggs;
     private DatafeedTimingStatsReporter timingStatsReporter;
+    private Map<String, Object> runtimeMappings;
 
     private class TestDataExtractor extends AggregationDataExtractor {
 
@@ -103,6 +105,7 @@ public class AggregationDataExtractorTests extends ESTestCase {
                 .addAggregator(AggregationBuilders.histogram("time").field("time").interval(1000).subAggregation(
                         AggregationBuilders.terms("airline").field("airline").subAggregation(
                                 AggregationBuilders.avg("responsetime").field("responsetime"))));
+        runtimeMappings = Collections.emptyMap();
         timingStatsReporter = new DatafeedTimingStatsReporter(new DatafeedTimingStats(jobId), mock(DatafeedTimingStatsPersister.class));
     }
 
@@ -265,7 +268,7 @@ public class AggregationDataExtractorTests extends ESTestCase {
 
     private AggregationDataExtractorContext createContext(long start, long end) {
         return new AggregationDataExtractorContext(jobId, timeField, fields, indices, query, aggs, start, end, true,
-            Collections.emptyMap(), SearchRequest.DEFAULT_INDICES_OPTIONS);
+            Collections.emptyMap(), SearchRequest.DEFAULT_INDICES_OPTIONS, runtimeMappings);
     }
 
     @SuppressWarnings("unchecked")

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/RollupDataExtractorFactoryTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/RollupDataExtractorFactoryTests.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.ml.datafeed.extractor.aggregation;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
+import org.elasticsearch.xpack.core.ml.job.config.AnalysisConfig;
+import org.elasticsearch.xpack.core.ml.job.config.DataDescription;
+import org.elasticsearch.xpack.core.ml.job.config.Detector;
+import org.elasticsearch.xpack.core.ml.job.config.Job;
+import org.elasticsearch.xpack.ml.datafeed.DatafeedTimingStatsReporter;
+import org.elasticsearch.xpack.ml.datafeed.extractor.DataExtractorFactory;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.Mockito.mock;
+
+public class RollupDataExtractorFactoryTests extends ESTestCase {
+
+    public void testCreateWithRuntimeFields() {
+        String jobId = "foojob";
+
+        Detector.Builder detectorBuilder = new Detector.Builder();
+        detectorBuilder.setFunction("sum");
+        detectorBuilder.setFieldName("value");
+        AnalysisConfig.Builder analysisConfig = new AnalysisConfig.Builder(Collections.singletonList(detectorBuilder.build()));
+        Job.Builder jobBuilder = new Job.Builder(jobId);
+        jobBuilder.setDataDescription(new DataDescription.Builder());
+        jobBuilder.setAnalysisConfig(analysisConfig);
+
+        DatafeedConfig.Builder datafeedConfigBuilder = new DatafeedConfig.Builder("foo-feed", jobId);
+        datafeedConfigBuilder.setIndices(Collections.singletonList("my_index"));
+
+        Map<String, Object> settings = new HashMap<>();
+        settings.put("type", "keyword");
+        settings.put("script", "");
+        Map<String, Object> field = new HashMap<>();
+        field.put("runtime_field_bar", settings);
+        datafeedConfigBuilder.setRuntimeMappings(field);
+
+        AtomicReference<Exception> exceptionRef = new AtomicReference<>();
+        ActionListener<DataExtractorFactory> listener = ActionListener.wrap(
+            r -> fail("unexpected response"),
+            exceptionRef::set
+        );
+
+        RollupDataExtractorFactory.create(mock(Client.class), datafeedConfigBuilder.build(), jobBuilder.build(new Date()),
+            Collections.emptyMap(), xContentRegistry(), mock(DatafeedTimingStatsReporter.class), listener);
+
+        assertNotNull(exceptionRef.get());
+        Exception e = exceptionRef.get();
+        assertThat(e, instanceOf(IllegalArgumentException.class));
+        assertThat(e.getMessage(), equalTo("The datafeed has runtime_mappings defined, " +
+            "runtime fields are not supported in rollup searches"));
+    }
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/chunked/ChunkedDataExtractorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/chunked/ChunkedDataExtractorTests.java
@@ -552,7 +552,7 @@ public class ChunkedDataExtractorTests extends ESTestCase {
     private ChunkedDataExtractorContext createContext(long start, long end, boolean hasAggregations, Long histogramInterval) {
         return new ChunkedDataExtractorContext(jobId, timeField, indices, query, scrollSize, start, end, chunkSpan,
             ChunkedDataExtractorFactory.newIdentityTimeAligner(), Collections.emptyMap(), hasAggregations, histogramInterval,
-            SearchRequest.DEFAULT_INDICES_OPTIONS);
+            SearchRequest.DEFAULT_INDICES_OPTIONS, Collections.emptyMap());
     }
 
     private static class StubSubExtractor implements DataExtractor {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractorTests.java
@@ -446,7 +446,8 @@ public class ScrollDataExtractorTests extends ESTestCase {
 
         List<SearchSourceBuilder.ScriptField> sFields = Arrays.asList(withoutSplit, withSplit);
         ScrollDataExtractorContext context = new ScrollDataExtractorContext(jobId, extractedFields, indices,
-                query, sFields, scrollSize, 1000, 2000, Collections.emptyMap(), SearchRequest.DEFAULT_INDICES_OPTIONS);
+                query, sFields, scrollSize, 1000, 2000, Collections.emptyMap(), SearchRequest.DEFAULT_INDICES_OPTIONS,
+            Collections.emptyMap());
 
         TestDataExtractor extractor = new TestDataExtractor(context);
 
@@ -492,7 +493,7 @@ public class ScrollDataExtractorTests extends ESTestCase {
 
     private ScrollDataExtractorContext createContext(long start, long end) {
         return new ScrollDataExtractorContext(jobId, extractedFields, indices, query, scriptFields, scrollSize, start, end,
-            Collections.emptyMap(), SearchRequest.DEFAULT_INDICES_OPTIONS);
+            Collections.emptyMap(), SearchRequest.DEFAULT_INDICES_OPTIONS, Collections.emptyMap());
     }
 
     private SearchResponse createEmptySearchResponse() {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/preview_datafeed.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/preview_datafeed.yml
@@ -390,3 +390,82 @@ setup:
       ml.preview_datafeed:
         datafeed_id: empty-feed
   - length: { $body: 0 }
+
+
+---
+"Test preview aggregation with runtime fields":
+
+  - do:
+      ml.put_job:
+        job_id: runtime-field-aggregation-job
+        body:  >
+          {
+            "analysis_config" : {
+                "bucket_span": "3600s",
+                "summary_count_field_name": "doc_count",
+                "detectors" :[{"function":"mean","field_name":"responsetime_x_2","by_field_name":"airline"}]
+            },
+            "data_description" : {
+                "time_field":"time"
+            }
+          }
+
+  - do:
+      ml.put_datafeed:
+        datafeed_id: aggregation-doc-count-feed
+        body:  >
+          {
+            "job_id":"runtime-field-aggregation-job",
+            "indexes":"airline-data",
+            "runtime_mappings" : {
+              "responsetime_x_2": {
+                "type": "double",
+                "script": "emit(doc['responsetime'].value * 2.0)"
+              }
+            },
+            "aggregations": {
+              "buckets": {
+                "histogram": {
+                  "field": "time",
+                  "interval": 3600000
+                },
+                "aggregations": {
+                  "time": {
+                    "max": {
+                      "field": "time"
+                    }
+                  },
+                  "airline": {
+                    "terms": {
+                      "field": "airline",
+                      "size": 100
+                    },
+                    "aggregations": {
+                      "responsetime_x_2": {
+                        "sum": {
+                           "field": "responsetime_x_2"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+
+  - do:
+      ml.preview_datafeed:
+        datafeed_id: aggregation-doc-count-feed
+  - length: { $body: 3 }
+  - match: { 0.time: 1487377800000 }
+  - match: { 0.airline: foo }
+  - match: { 0.responsetime_x_2: 4.0 }
+  - match: { 0.doc_count: 2 }
+  - match: { 1.time: 1487379660000 }
+  - match: { 1.airline: bar }
+  - match: { 1.responsetime_x_2: 84.0 }
+  - match: { 1.doc_count: 1 }
+  - match: { 1.time: 1487379660000 }
+  - match: { 2.airline: foo }
+  - match: { 2.responsetime_x_2: 84.0 }
+  - match: { 2.doc_count: 1 }


### PR DESCRIPTION
Adds the runtime_mappings section to DatafeedConfig to define runtime fields.
The runtime fields are then passed through to datafeed searches

Backport of #65606