### PR TITLE
[DOCS] Fix rollup V2 docs integ tests for release builds

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -52,13 +52,11 @@ testClusters.matching { it.name == "integTest"}.configureEach {
   if (singleNode().testDistribution == DEFAULT) {
     setting 'xpack.license.self_generated.type', 'trial'
     setting 'indices.lifecycle.history_index_enabled', 'false'
-    if (BuildParams.isSnapshotBuild() == true) {
-      systemProperty 'es.rollup_v2_feature_flag_enabled', 'true'
-    }
     if (BuildParams.isSnapshotBuild() == false) {
       systemProperty 'es.autoscaling_feature_flag_registered', 'true'
     }
     setting 'xpack.autoscaling.enabled', 'true'
+    systemProperty 'es.rollup_v2_feature_flag_enabled', 'true'
     keystorePassword 's3cr3t'
   }
 

--- a/docs/reference/rollup/apis/rollup-api.asciidoc
+++ b/docs/reference/rollup/apis/rollup-api.asciidoc
@@ -38,8 +38,7 @@ POST /my-index-000001/_rollup
   ]
 }
 ----
-// CONSOLE
-// TEST[skip:"AwaitsFix https://github.com/elastic/elasticsearch/issues/65544"]
+// TEST[setup:my_index]
 
 
 [[rollup-api-request]]


### PR DESCRIPTION
Enables the rollup V2 feature flag in docs tests for both snapshot and release builds. Previously, related docs tests would pass in snapshot builds but fail in release builds.

Fixes #65544

Relates to #65398