### PR TITLE
Fix id field mapper stored configuration issue.

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/IdFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IdFieldMapper.java
@@ -89,7 +89,7 @@ public class IdFieldMapper extends MetadataFieldMapper {
             NESTED_FIELD_TYPE = new FieldType();
             NESTED_FIELD_TYPE.setTokenized(false);
             NESTED_FIELD_TYPE.setIndexOptions(IndexOptions.DOCS);
-            NESTED_FIELD_TYPE.setStored(true);
+            NESTED_FIELD_TYPE.setStored(false);
             NESTED_FIELD_TYPE.setOmitNorms(true);
             NESTED_FIELD_TYPE.freeze();
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/IdFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IdFieldMapper.java
@@ -91,7 +91,6 @@ public class IdFieldMapper extends MetadataFieldMapper {
             NESTED_FIELD_TYPE.setIndexOptions(IndexOptions.DOCS);
             NESTED_FIELD_TYPE.setStored(true);
             NESTED_FIELD_TYPE.setOmitNorms(true);
-            NESTED_FIELD_TYPE.setStored(false);
             NESTED_FIELD_TYPE.freeze();
         }
     }


### PR DESCRIPTION
Should be a duplicated `setStored` call, set stored as true by default for nested field type in id field mapper.