### PR TITLE
[7.x] [DOCS] Fix docs integ tests for release builds (#65761)

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -52,13 +52,11 @@ testClusters.integTest {
   if (singleNode().testDistribution == DEFAULT) {
     setting 'xpack.license.self_generated.type', 'trial'
     setting 'indices.lifecycle.history_index_enabled', 'false'
-    if (BuildParams.isSnapshotBuild() == true) {
-      systemProperty 'es.rollup_v2_feature_flag_enabled', 'true'
-    }
     if (BuildParams.isSnapshotBuild() == false) {
       systemProperty 'es.autoscaling_feature_flag_registered', 'true'
     }
     setting 'xpack.autoscaling.enabled', 'true'
+    systemProperty 'es.rollup_v2_feature_flag_enabled', 'true'
     keystorePassword 's3cr3t'
   }
 

--- a/docs/reference/rollup/apis/rollup-api.asciidoc
+++ b/docs/reference/rollup/apis/rollup-api.asciidoc
@@ -38,8 +38,7 @@ POST /my-index-000001/_rollup
   ]
 }
 ----
-// CONSOLE
-// TEST[skip:"AwaitsFix https://github.com/elastic/elasticsearch/issues/65544"]
+// TEST[setup:my_index]
 
 
 [[rollup-api-request]]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Fix docs integ tests for release builds (#65761)