### PR TITLE
[DOCS] Rollup V2: Fix rollup index def

### DIFF
--- a/docs/reference/glossary.asciidoc
+++ b/docs/reference/glossary.asciidoc
@@ -451,7 +451,7 @@ ifdef::permanently-unreleased-branch[]
 
 [[glossary-rollup]] rollup ::
 // tag::rollup-def[]
-Aggregates an index's time series data and stores the results in another index.
+Aggregates an index's time series data and stores the results in a new index.
 For example, you can roll up hourly data into daily or weekly summaries.
 // end::rollup-def[]
 

--- a/docs/reference/rollup/apis/rollup-api.asciidoc
+++ b/docs/reference/rollup/apis/rollup-api.asciidoc
@@ -68,7 +68,7 @@ syntax>> or wildcards (`*`).
 `rollup_index`::
 (Required, string)
 New index that stores the rollup results. Cannot be an existing index,
-<<data-streams,data stream>>, or <<indices-aliases,index alias>>.
+a <<data-streams,data stream>>, or a <<indices-aliases,index alias>>.
 +
 The request creates this index with
 <<index-modules-blocks,`index.blocks.write`>> set to `true`.  If the `<index>`

--- a/docs/reference/rollup/apis/rollup-api.asciidoc
+++ b/docs/reference/rollup/apis/rollup-api.asciidoc
@@ -71,9 +71,9 @@ New index that stores the rollup results. Cannot be an existing index,
 a <<data-streams,data stream>>, or an <<indices-aliases,index alias>>.
 +
 The request creates this index with
-<<index-modules-blocks,`index.blocks.write`>> set to `true`.  If the `<index>`
-is a backing index for a data stream, this index is a backing index for the
-same stream.
+<<index-modules-blocks,`index.blocks.write`>> set to `true`.  If the original
+`<index>` is a backing index for a data stream, this index is a backing index
+for the same stream.
 
 `groups`::
 (Required, object)

--- a/docs/reference/rollup/apis/rollup-api.asciidoc
+++ b/docs/reference/rollup/apis/rollup-api.asciidoc
@@ -71,7 +71,7 @@ New index that stores the rollup results. Cannot be an existing index,
 a <<data-streams,data stream>>, or an <<indices-aliases,index alias>>.
 +
 The request creates this index with
-<<index-modules-blocks,`index.blocks.write`>> set to `true`.  If the original
+<<index-modules-blocks,`index.blocks.write`>> set to `true`. If the original
 `<index>` is a backing index for a data stream, this index is a backing index
 for the same stream.
 

--- a/docs/reference/rollup/apis/rollup-api.asciidoc
+++ b/docs/reference/rollup/apis/rollup-api.asciidoc
@@ -68,7 +68,7 @@ syntax>> or wildcards (`*`).
 `rollup_index`::
 (Required, string)
 New index that stores the rollup results. Cannot be an existing index,
-a <<data-streams,data stream>>, or a <<indices-aliases,index alias>>.
+a <<data-streams,data stream>>, or an <<indices-aliases,index alias>>.
 +
 The request creates this index with
 <<index-modules-blocks,`index.blocks.write`>> set to `true`.  If the `<index>`

--- a/docs/reference/rollup/apis/rollup-api.asciidoc
+++ b/docs/reference/rollup/apis/rollup-api.asciidoc
@@ -72,7 +72,7 @@ a <<data-streams,data stream>>, or an <<indices-aliases,index alias>>.
 +
 The request creates this index with
 <<index-modules-blocks,`index.blocks.write`>> set to `true`.  If the `<index>`
-is a backing index for a data stream, this new index is a backing index for the
+is a backing index for a data stream, this index is a backing index for the
 same stream.
 
 `groups`::

--- a/docs/reference/rollup/apis/rollup-api.asciidoc
+++ b/docs/reference/rollup/apis/rollup-api.asciidoc
@@ -6,7 +6,7 @@
 <titleabbrev>Rollup</titleabbrev>
 ++++
 
-Aggregates an index's time series data and stores the results in another index.
+Aggregates an index's time series data and stores the results in a new index.
 For example, you can roll up hourly data into daily or weekly summaries.
 
 [source,console]
@@ -67,12 +67,13 @@ syntax>> or wildcards (`*`).
 
 `rollup_index`::
 (Required, string)
-Index that stores the rollup results. Cannot be a <<data-streams,data stream>>
-or <<indices-aliases,index alias>>.
+New index that stores the rollup results. Cannot be an existing index,
+<<data-streams,data stream>>, or <<indices-aliases,index alias>>.
 +
-If this index does not exist, the request creates it. If the `<index>` is a
-backing index for a data stream, this new index is a backing index for the same
-stream.
+The request creates this index with
+<<index-modules-blocks,`index.blocks.write`>> set to `true`.  If the `<index>`
+is a backing index for a data stream, this new index is a backing index for the
+same stream.
 
 `groups`::
 (Required, object)

--- a/docs/reference/rollup/rollup-apis.asciidoc
+++ b/docs/reference/rollup/rollup-apis.asciidoc
@@ -6,7 +6,7 @@
 ifdef::permanently-unreleased-branch[]
 
 A rollup aggregates an index's time series data and stores the results in
-another index. For example, you can roll up hourly data into daily or weekly
+a new index. For example, you can roll up hourly data into daily or weekly
 summaries.
 
 * <<rollup-api,Rollup API>>


### PR DESCRIPTION
Clarifies that a rollup index cannot be an existing index. Also notes that rollup indices have `index.blocks.write` set to `true`.