### PR TITLE
[ML] make InferenceIngestIT more lenient when checking cache miss counts

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/InferenceIngestIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/InferenceIngestIT.java
@@ -192,7 +192,7 @@ public class InferenceIngestIT extends ESRestTestCase {
         assertBusy(() -> {
             try {
                 assertStatsWithCacheMisses(classificationModelId, 10L);
-                assertStatsWithCacheMisses(regressionModelId, 10L);
+                assertStatsWithCacheMisses(regressionModelId, 15L);
             } catch (ResponseException ex) {
                 //this could just mean shard failures.
                 fail(ex.getMessage());

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/InferenceIngestIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/InferenceIngestIT.java
@@ -42,8 +42,11 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 
 /**
  * This is a {@link ESRestTestCase} because the cleanup code in {@link ExternalTestCluster#ensureEstimatedStats()} causes problems
@@ -142,13 +145,19 @@ public class InferenceIngestIT extends ESRestTestCase {
                 Response statsResponse = client().performRequest(new Request("GET",
                     "_ml/trained_models/" + classificationModelId + "/_stats"));
                 try (XContentParser parser = createParser(JsonXContent.jsonXContent, statsResponse.getEntity().getContent())) {
-                    TrainedModelStats trainedModelStats = GetTrainedModelsStatsResponse.fromXContent(parser).getTrainedModelStats().get(0);
+                    GetTrainedModelsStatsResponse response = GetTrainedModelsStatsResponse.fromXContent(parser);
+                    assertThat(response.getTrainedModelStats(), hasSize(1));
+                    TrainedModelStats trainedModelStats = response.getTrainedModelStats().get(0);
+                    assertThat(trainedModelStats.getInferenceStats(), is(notNullValue()));
                     assertThat(trainedModelStats.getInferenceStats().getInferenceCount(), equalTo(10L));
                     assertThat(trainedModelStats.getInferenceStats().getCacheMissCount(), greaterThan(0L));
                 }
                 statsResponse = client().performRequest(new Request("GET", "_ml/trained_models/" + regressionModelId + "/_stats"));
                 try (XContentParser parser = createParser(JsonXContent.jsonXContent, statsResponse.getEntity().getContent())) {
-                    TrainedModelStats trainedModelStats = GetTrainedModelsStatsResponse.fromXContent(parser).getTrainedModelStats().get(0);
+                    GetTrainedModelsStatsResponse response = GetTrainedModelsStatsResponse.fromXContent(parser);
+                    assertThat(response.getTrainedModelStats(), hasSize(1));
+                    TrainedModelStats trainedModelStats = response.getTrainedModelStats().get(0);
+                    assertThat(trainedModelStats.getInferenceStats(), is(notNullValue()));
                     assertThat(trainedModelStats.getInferenceStats().getInferenceCount(), equalTo(10L));
                     assertThat(trainedModelStats.getInferenceStats().getCacheMissCount(), greaterThan(0L));
                 }
@@ -202,13 +211,19 @@ public class InferenceIngestIT extends ESRestTestCase {
                 Response statsResponse = client().performRequest(new Request("GET",
                     "_ml/trained_models/" + classificationModelId + "/_stats"));
                 try (XContentParser parser = createParser(JsonXContent.jsonXContent, statsResponse.getEntity().getContent())) {
-                    TrainedModelStats trainedModelStats = GetTrainedModelsStatsResponse.fromXContent(parser).getTrainedModelStats().get(0);
+                    GetTrainedModelsStatsResponse response = GetTrainedModelsStatsResponse.fromXContent(parser);
+                    assertThat(response.getTrainedModelStats(), hasSize(1));
+                    TrainedModelStats trainedModelStats = response.getTrainedModelStats().get(0);
+                    assertThat(trainedModelStats.getInferenceStats(), is(notNullValue()));
                     assertThat(trainedModelStats.getInferenceStats().getInferenceCount(), equalTo(10L));
                     assertThat(trainedModelStats.getInferenceStats().getCacheMissCount(), greaterThan(0L));
                 }
                 statsResponse = client().performRequest(new Request("GET", "_ml/trained_models/" + regressionModelId + "/_stats"));
                 try (XContentParser parser = createParser(JsonXContent.jsonXContent, statsResponse.getEntity().getContent())) {
-                    TrainedModelStats trainedModelStats = GetTrainedModelsStatsResponse.fromXContent(parser).getTrainedModelStats().get(0);
+                    GetTrainedModelsStatsResponse response = GetTrainedModelsStatsResponse.fromXContent(parser);
+                    assertThat(response.getTrainedModelStats(), hasSize(1));
+                    TrainedModelStats trainedModelStats = response.getTrainedModelStats().get(0);
+                    assertThat(trainedModelStats.getInferenceStats(), is(notNullValue()));
                     assertThat(trainedModelStats.getInferenceStats().getInferenceCount(), equalTo(15L));
                     assertThat(trainedModelStats.getInferenceStats().getCacheMissCount(), greaterThan(0L));
                 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModel.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModel.java
@@ -58,14 +58,14 @@ public class LocalModel implements Closeable {
     private final AtomicLong referenceCount;
 
     LocalModel(String modelId,
-                      String nodeId,
-                      InferenceDefinition trainedModelDefinition,
-                      TrainedModelInput input,
-                      Map<String, String> defaultFieldMap,
-                      InferenceConfig modelInferenceConfig,
-                      License.OperationMode licenseLevel,
-                      TrainedModelStatsService trainedModelStatsService,
-                      CircuitBreaker trainedModelCircuitBreaker) {
+               String nodeId,
+               InferenceDefinition trainedModelDefinition,
+               TrainedModelInput input,
+               Map<String, String> defaultFieldMap,
+               InferenceConfig modelInferenceConfig,
+               License.OperationMode licenseLevel,
+               TrainedModelStatsService trainedModelStatsService,
+               CircuitBreaker trainedModelCircuitBreaker) {
         this.trainedModelDefinition = trainedModelDefinition;
         this.modelId = modelId;
         this.fieldNames = new HashSet<>(input.getFieldNames());


### PR DESCRIPTION
Looking over the failure history, it is always the cache miss count that is off. This is mostly ok as all the failures had indicated that there were indeed cache failures and every one of them were fence-post errors. 

Opting to make the cache miss count check lenient as other stats checked verify consistency.

closes https://github.com/elastic/elasticsearch/issues/61564