### PR TITLE
Store _doc_count field as custom term frequency

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/CustomTermFreqField.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/CustomTermFreqField.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.apache.lucene.analysis.tokenattributes.TermFrequencyAttribute;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.index.IndexOptions;
+
+/**
+ * Custom field that allow storing an integer value as a term frequency in lucene.
+ */
+public final class CustomTermFreqField extends Field {
+
+  private static final FieldType FIELD_TYPE = new FieldType();
+  static {
+    FIELD_TYPE.setTokenized(false);
+    FIELD_TYPE.setOmitNorms(true);
+    FIELD_TYPE.setIndexOptions(IndexOptions.DOCS_AND_FREQS);
+  }
+
+  private int fieldValue;
+
+  public CustomTermFreqField(String fieldName, CharSequence term, int fieldValue) {
+    super(fieldName, term, FIELD_TYPE);
+    this.fieldValue = fieldValue;
+  }
+
+  public CustomTermFreqField(String fieldName, int fieldValue) {
+    this(fieldName, fieldName, fieldValue);
+  }
+
+  public void setFieldValue(int fieldValue) {
+    this.fieldValue = fieldValue;
+  }
+
+  @Override
+  public TokenStream tokenStream(Analyzer analyzer, TokenStream reuse) {
+    CustomTermFreqTokenStream stream;
+    if (reuse instanceof CustomTermFreqTokenStream) {
+      stream = (CustomTermFreqTokenStream) reuse;
+    } else {
+      stream = new CustomTermFreqTokenStream();
+    }
+    stream.setValues((String) fieldsData, fieldValue);
+    return stream;
+  }
+
+  private static final class CustomTermFreqTokenStream extends TokenStream {
+    private final CharTermAttribute termAttribute = addAttribute(CharTermAttribute.class);
+    private final TermFrequencyAttribute freqAttribute = addAttribute(TermFrequencyAttribute.class);
+    private boolean used = true;
+    private String value = null;
+    private int freq = 0;
+
+    private CustomTermFreqTokenStream() {
+    }
+
+    /** Sets the values */
+    void setValues(String value, int freq) {
+      this.value = value;
+      this.freq = freq;
+    }
+
+    @Override
+    public boolean incrementToken() {
+      if (used) {
+        return false;
+      }
+      clearAttributes();
+      termAttribute.append(value);
+      freqAttribute.setTermFrequency(freq);
+      used = true;
+      return true;
+    }
+
+    @Override
+    public void reset() {
+      used = false;
+    }
+
+    @Override
+    public void close() {
+      value = null;
+    }
+  }
+}

--- a/server/src/main/java/org/elasticsearch/index/mapper/CustomTermFreqField.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/CustomTermFreqField.java
@@ -28,7 +28,7 @@ import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.IndexOptions;
 
 /**
- * Custom field that allow storing an integer value as a term frequency in lucene.
+ * Custom field that allows storing an integer value as a term frequency in lucene.
  */
 public final class CustomTermFreqField extends Field {
 
@@ -44,10 +44,6 @@ public final class CustomTermFreqField extends Field {
   public CustomTermFreqField(String fieldName, CharSequence term, int fieldValue) {
     super(fieldName, term, FIELD_TYPE);
     this.fieldValue = fieldValue;
-  }
-
-  public CustomTermFreqField(String fieldName, int fieldValue) {
-    this(fieldName, fieldName, fieldValue);
   }
 
   public void setFieldValue(int fieldValue) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocCountFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocCountFieldMapper.java
@@ -93,6 +93,11 @@ public class DocCountFieldMapper extends MetadataFieldMapper {
         XContentParser parser = context.parser();
         XContentParserUtils.ensureExpectedToken(XContentParser.Token.VALUE_NUMBER, parser.currentToken(), parser);
 
+        // Check that _doc_count is a single value and not an array
+        if (context.doc().getField(NAME) != null) {
+            throw new IllegalArgumentException("Arrays are not allowed for field [" + fieldType().name() + "].");
+        }
+
         int value = parser.intValue(false);
         if (value <= 0) {
             throw new IllegalArgumentException("Field [" + fieldType().name() + "] must be a positive integer. Value ["

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocCountFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocCountFieldMapper.java
@@ -94,7 +94,7 @@ public class DocCountFieldMapper extends MetadataFieldMapper {
         XContentParserUtils.ensureExpectedToken(XContentParser.Token.VALUE_NUMBER, parser.currentToken(), parser);
 
         // Check that _doc_count is a single value and not an array
-        if (context.doc().getField(NAME) != null) {
+        if (context.doc().getByKey(NAME) != null) {
             throw new IllegalArgumentException("Arrays are not allowed for field [" + fieldType().name() + "].");
         }
 
@@ -103,7 +103,7 @@ public class DocCountFieldMapper extends MetadataFieldMapper {
             throw new IllegalArgumentException("Field [" + fieldType().name() + "] must be a positive integer. Value ["
                 + value + "] is not allowed.");
         }
-        context.doc().add(new CustomTermFreqField(NAME, value));
+        context.doc().addWithKey(NAME, new CustomTermFreqField(NAME, NAME, value));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocCountFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocCountFieldMapper.java
@@ -39,7 +39,7 @@ public class DocCountFieldMapper extends MetadataFieldMapper {
 
         public static final DocCountFieldType INSTANCE = new DocCountFieldType();
 
-        public static final int defaultValue = 1;
+        public static final int DEFAULT_VALUE = 1;
 
         public DocCountFieldType() {
             super(NAME, false, false, false, TextSearchInfo.NONE,  Collections.emptyMap());
@@ -71,11 +71,11 @@ public class DocCountFieldMapper extends MetadataFieldMapper {
                 throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
             }
 
-            return new SourceValueFetcher(name(), context, defaultValue) {
+            return new SourceValueFetcher(name(), context, DEFAULT_VALUE) {
                 @Override
                 protected Object parseSourceValue(Object value) {
                     if ("".equals(value)) {
-                        return defaultValue;
+                        return DEFAULT_VALUE;
                     } else {
                         return NumberFieldMapper.NumberType.INTEGER.parse(value, false);
                     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocCountFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocCountFieldMapper.java
@@ -39,7 +39,7 @@ public class DocCountFieldMapper extends MetadataFieldMapper {
 
         public static final DocCountFieldType INSTANCE = new DocCountFieldType();
 
-        private static final int defaultValue = 1;
+        public static final int defaultValue = 1;
 
         public DocCountFieldType() {
             super(NAME, false, false, false, TextSearchInfo.NONE,  Collections.emptyMap());

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocCountFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocCountFieldMapper.java
@@ -57,7 +57,7 @@ public class DocCountFieldMapper extends MetadataFieldMapper {
 
         @Override
         public Query existsQuery(QueryShardContext context) {
-            throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] does not support exists queries");
+            throw new QueryShardException(context, "Field [" + name() + "] of type [" + typeName() + "] does not support exists queries");
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/BucketsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/BucketsAggregator.java
@@ -87,7 +87,7 @@ public abstract class BucketsAggregator extends AggregatorBase {
      * Same as {@link #collectBucket(LeafBucketCollector, int, long)}, but doesn't check if the docCounts needs to be re-sized.
      */
     public final void collectExistingBucket(LeafBucketCollector subCollector, int doc, long bucketOrd) throws IOException {
-        long docCount = docCountProvider.getDocCount(doc);
+        int docCount = docCountProvider.getDocCount(doc);
         if (docCounts.increment(bucketOrd, docCount) == docCount) {
             // We calculate the final number of buckets only during the reduce phase. But we still need to
             // trigger bucket consumer from time to time in order to give it a chance to check available memory and break

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/DocCountProvider.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/DocCountProvider.java
@@ -33,13 +33,13 @@ import java.io.IOException;
  */
 public class DocCountProvider {
 
-    public static final int defaultValue = DocCountFieldMapper.DocCountFieldType.defaultValue;
+    public static final int DEFAULT_VALUE = DocCountFieldMapper.DocCountFieldType.DEFAULT_VALUE;
 
     private PostingsEnum docCountPostings;
 
     public int getDocCount(int doc) throws IOException {
         if (docCountPostings == null) {
-            return defaultValue;
+            return DEFAULT_VALUE;
         }
         if (docCountPostings.docID() < doc) {
             docCountPostings.advance(doc);
@@ -47,7 +47,7 @@ public class DocCountProvider {
         if (docCountPostings.docID() == doc) {
             return docCountPostings.freq();
         } else {
-            return defaultValue;
+            return DEFAULT_VALUE;
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/DocCountProvider.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/DocCountProvider.java
@@ -33,12 +33,13 @@ import java.io.IOException;
  */
 public class DocCountProvider {
 
-    public static final int DEFAULT_DOC_COUNT = 1;
+    public static final int defaultValue = DocCountFieldMapper.DocCountFieldType.defaultValue;
+
     private PostingsEnum docCountPostings;
 
     public int getDocCount(int doc) throws IOException {
         if (docCountPostings == null) {
-            return DEFAULT_DOC_COUNT;
+            return defaultValue;
         }
         if (docCountPostings.docID() < doc) {
             docCountPostings.advance(doc);
@@ -46,7 +47,7 @@ public class DocCountProvider {
         if (docCountPostings.docID() == doc) {
             return docCountPostings.freq();
         } else {
-            return DEFAULT_DOC_COUNT;
+            return defaultValue;
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregator.java
@@ -430,7 +430,7 @@ final class CompositeAggregator extends BucketsAggregator {
             @Override
             public void collect(int doc, long bucket) throws IOException {
                 try {
-                    long docCount = docCountProvider.getDocCount(doc);
+                    int docCount = docCountProvider.getDocCount(doc);
                     if (queue.addIfCompetitive(indexSortPrefix, docCount)) {
                         if (builder != null && lastDoc != doc) {
                             builder.add(doc);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/SortedDocsProducer.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/SortedDocsProducer.java
@@ -69,7 +69,7 @@ abstract class SortedDocsProducer {
             @Override
             public void collect(int doc, long bucket) throws IOException {
                 hasCollected[0] = true;
-                long docCount = docCountProvider.getDocCount(doc);
+                int docCount = docCountProvider.getDocCount(doc);
                 if (queue.addIfCompetitive(docCount)) {
                     topCompositeCollected[0]++;
                     if (adder != null && doc != lastDoc) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/GlobalOrdinalsStringTermsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/GlobalOrdinalsStringTermsAggregator.java
@@ -315,7 +315,7 @@ public class GlobalOrdinalsStringTermsAggregator extends AbstractStringTermsAggr
                             return;
                         }
                         int ord = singleValues.ordValue();
-                        long docCount = docCountProvider.getDocCount(doc);
+                        int docCount = docCountProvider.getDocCount(doc);
                         segmentDocCounts.increment(ord + 1, docCount);
                     }
                 });
@@ -329,7 +329,7 @@ public class GlobalOrdinalsStringTermsAggregator extends AbstractStringTermsAggr
                         return;
                     }
                     for (long segmentOrd = segmentOrds.nextOrd(); segmentOrd != NO_MORE_ORDS; segmentOrd = segmentOrds.nextOrd()) {
-                        long docCount = docCountProvider.getDocCount(doc);
+                        int docCount = docCountProvider.getDocCount(doc);
                         segmentDocCounts.increment(segmentOrd + 1, docCount);
                     }
                 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocCountFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocCountFieldMapperTests.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.index.mapper;
 
-import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.IndexableField;
 
 import static org.hamcrest.Matchers.containsString;
@@ -39,8 +38,7 @@ public class DocCountFieldMapperTests extends MapperServiceTestCase {
         ));
 
         IndexableField field = doc.rootDoc().getField(DOC_COUNT_FIELD);
-        assertEquals(100L, field.numericValue());
-        assertEquals(DocValuesType.NUMERIC, field.fieldType().docValuesType());
+        assertEquals(DOC_COUNT_FIELD, field.stringValue());
         assertEquals(1, doc.rootDoc().getFields(DOC_COUNT_FIELD).length);
     }
 
@@ -66,6 +64,6 @@ public class DocCountFieldMapperTests extends MapperServiceTestCase {
     public void testInvalidDocument_FractionalDocCount() throws Exception {
         DocumentMapper mapper = createDocumentMapper(mapping(b -> {}));
         Exception e = expectThrows(MapperParsingException.class, () -> mapper.parse(source(b -> b.field(CONTENT_TYPE, 100.23))));
-        assertThat(e.getCause().getMessage(), containsString("100.23 cannot be converted to Long without data loss"));
+        assertThat(e.getCause().getMessage(), containsString("100.23 cannot be converted to Integer without data loss"));
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocCountFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocCountFieldMapperTests.java
@@ -27,9 +27,6 @@ public class DocCountFieldMapperTests extends MapperServiceTestCase {
     private static final String CONTENT_TYPE = DocCountFieldMapper.CONTENT_TYPE;
     private static final String DOC_COUNT_FIELD = DocCountFieldMapper.NAME;
 
-    /**
-     * Test parsing field mapping and adding simple field
-     */
     public void testParseValue() throws Exception {
         DocumentMapper mapper = createDocumentMapper(mapping(b -> {}));
         ParsedDocument doc = mapper.parse(source(b ->
@@ -69,7 +66,8 @@ public class DocCountFieldMapperTests extends MapperServiceTestCase {
 
     public void testInvalidDocument_ArrayDocCount() throws Exception {
         DocumentMapper mapper = createDocumentMapper(mapping(b -> {}));
-        Exception e = expectThrows(MapperParsingException.class, () -> mapper.parse(source(b -> b.array(CONTENT_TYPE, 10, 20, 30))));
-        assertThat(e.getCause().getMessage(), containsString("100.23 cannot be converted to Integer without data loss"));
+        Exception e = expectThrows(MapperParsingException.class,
+            () -> mapper.parse(source(b -> b.array(CONTENT_TYPE, 10, 20, 30))));
+        assertThat(e.getCause().getMessage(), containsString("Arrays are not allowed for field [_doc_count]."));
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocCountFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocCountFieldMapperTests.java
@@ -66,4 +66,10 @@ public class DocCountFieldMapperTests extends MapperServiceTestCase {
         Exception e = expectThrows(MapperParsingException.class, () -> mapper.parse(source(b -> b.field(CONTENT_TYPE, 100.23))));
         assertThat(e.getCause().getMessage(), containsString("100.23 cannot be converted to Integer without data loss"));
     }
+
+    public void testInvalidDocument_ArrayDocCount() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(mapping(b -> {}));
+        Exception e = expectThrows(MapperParsingException.class, () -> mapper.parse(source(b -> b.array(CONTENT_TYPE, 10, 20, 30))));
+        assertThat(e.getCause().getMessage(), containsString("100.23 cannot be converted to Integer without data loss"));
+    }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocCountFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocCountFieldTypeTests.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.index.mapper;
 
-import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.elasticsearch.index.query.QueryShardException;
 
 import java.io.IOException;
@@ -42,14 +41,15 @@ public class DocCountFieldTypeTests extends FieldTypeTestCase {
 
     public void testExistsQuery() {
         MappedFieldType ft = new DocCountFieldMapper.DocCountFieldType();
-        assertTrue(ft.existsQuery(randomMockShardContext()) instanceof DocValuesFieldExistsQuery);
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> ft.existsQuery(randomMockShardContext()));
+        assertEquals("Field [_doc_count] of type [_doc_count] does not support exists queries", e.getMessage());
     }
 
     public void testFetchSourceValue() throws IOException {
         MappedFieldType fieldType = new DocCountFieldMapper.DocCountFieldType();
-        assertEquals(Arrays.asList(14L), fetchSourceValue(fieldType, 14));
-        assertEquals(Arrays.asList(14L), fetchSourceValue(fieldType, "14"));
-        assertEquals(Arrays.asList(1L), fetchSourceValue(fieldType, ""));
-        assertEquals(Arrays.asList(1L), fetchSourceValue(fieldType, null));
+        assertEquals(Arrays.asList(14), fetchSourceValue(fieldType, 14));
+        assertEquals(Arrays.asList(14), fetchSourceValue(fieldType, "14"));
+        assertEquals(Arrays.asList(1), fetchSourceValue(fieldType, ""));
+        assertEquals(Arrays.asList(1), fetchSourceValue(fieldType, null));
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocCountFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocCountFieldTypeTests.java
@@ -41,7 +41,7 @@ public class DocCountFieldTypeTests extends FieldTypeTestCase {
 
     public void testExistsQuery() {
         MappedFieldType ft = new DocCountFieldMapper.DocCountFieldType();
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> ft.existsQuery(randomMockShardContext()));
+        QueryShardException e = expectThrows(QueryShardException.class, () -> ft.existsQuery(randomMockShardContext()));
         assertEquals("Field [_doc_count] of type [_doc_count] does not support exists queries", e.getMessage());
     }
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/DocCountProviderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/DocCountProviderTests.java
@@ -48,11 +48,11 @@ public class DocCountProviderTests extends AggregatorTestCase {
     public void testDocsWithDocCount() throws IOException {
         testAggregation(new MatchAllDocsQuery(), iw -> {
             iw.addDocument(List.of(
-                new CustomTermFreqField(DOC_COUNT_FIELD, 4),
+                new CustomTermFreqField(DOC_COUNT_FIELD, DOC_COUNT_FIELD, 4),
                 new SortedNumericDocValuesField(NUMBER_FIELD, 1)
             ));
             iw.addDocument(List.of(
-                new CustomTermFreqField(DOC_COUNT_FIELD, 5),
+                new CustomTermFreqField(DOC_COUNT_FIELD, DOC_COUNT_FIELD, 5),
                 new SortedNumericDocValuesField(NUMBER_FIELD, 7)
             ));
             iw.addDocument(List.of(
@@ -77,11 +77,11 @@ public class DocCountProviderTests extends AggregatorTestCase {
     public void testQueryFiltering() throws IOException {
         testAggregation(IntPoint.newRangeQuery(NUMBER_FIELD, 4, 5), iw -> {
             iw.addDocument(List.of(
-                new CustomTermFreqField(DOC_COUNT_FIELD, 4),
+                new CustomTermFreqField(DOC_COUNT_FIELD, DOC_COUNT_FIELD, 4),
                 new IntPoint(NUMBER_FIELD, 6)
             ));
             iw.addDocument(List.of(
-                new CustomTermFreqField(DOC_COUNT_FIELD, 2),
+                new CustomTermFreqField(DOC_COUNT_FIELD, DOC_COUNT_FIELD, 2),
                 new IntPoint(NUMBER_FIELD, 5)
             ));
             iw.addDocument(List.of(

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/DocCountProviderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/DocCountProviderTests.java
@@ -20,12 +20,12 @@
 package org.elasticsearch.search.aggregations.bucket;
 
 import org.apache.lucene.document.IntPoint;
-import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.index.RandomIndexWriter;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.CheckedConsumer;
+import org.elasticsearch.index.mapper.CustomTermFreqField;
 import org.elasticsearch.index.mapper.DocCountFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
@@ -48,11 +48,11 @@ public class DocCountProviderTests extends AggregatorTestCase {
     public void testDocsWithDocCount() throws IOException {
         testAggregation(new MatchAllDocsQuery(), iw -> {
             iw.addDocument(List.of(
-                new NumericDocValuesField(DOC_COUNT_FIELD, 4),
+                new CustomTermFreqField(DOC_COUNT_FIELD, 4),
                 new SortedNumericDocValuesField(NUMBER_FIELD, 1)
             ));
             iw.addDocument(List.of(
-                new NumericDocValuesField(DOC_COUNT_FIELD, 5),
+                new CustomTermFreqField(DOC_COUNT_FIELD, 5),
                 new SortedNumericDocValuesField(NUMBER_FIELD, 7)
             ));
             iw.addDocument(List.of(
@@ -77,11 +77,11 @@ public class DocCountProviderTests extends AggregatorTestCase {
     public void testQueryFiltering() throws IOException {
         testAggregation(IntPoint.newRangeQuery(NUMBER_FIELD, 4, 5), iw -> {
             iw.addDocument(List.of(
-                new NumericDocValuesField(DOC_COUNT_FIELD, 4),
+                new CustomTermFreqField(DOC_COUNT_FIELD, 4),
                 new IntPoint(NUMBER_FIELD, 6)
             ));
             iw.addDocument(List.of(
-                new NumericDocValuesField(DOC_COUNT_FIELD, 2),
+                new CustomTermFreqField(DOC_COUNT_FIELD, 2),
                 new IntPoint(NUMBER_FIELD, 5)
             ));
             iw.addDocument(List.of(


### PR DESCRIPTION
A while back, Lucene introduced the ability to index [custom term frequencies](https://issues.apache.org/jira/browse/LUCENE-7854), ie. giving users the ability to provide a numeric value that should be indexed as a term frequency rather than letting Lucene compute the term frequency by itself based on the number of occurrences of a term.

This PR modifies the `_doc_count` field so that it is stored as Lucene custom term frequency.

A benefit of moving to custom term frequencies is that Lucene will automatically compute global term statistics like [`totalTermFreq`](https://lucene.apache.org/core/8_7_0/core/org/apache/lucene/index/TermsEnum.html#totalTermFreq--) which will let us know the sum of the values of the `_doc_count` field across an entire shard. This could in-turn be useful to generalize optimizations to rollup indices, e.g. buckets aggregations where all documents fall into the same bucket.

Relates to #64503 
