### PR TITLE
Add hidden data streams to stats endpoint

### DIFF
--- a/x-pack/plugin/data-streams/src/main/java/org/elasticsearch/xpack/datastreams/action/DataStreamsActionUtil.java
+++ b/x-pack/plugin/data-streams/src/main/java/org/elasticsearch/xpack/datastreams/action/DataStreamsActionUtil.java
@@ -27,9 +27,14 @@ public class DataStreamsActionUtil {
         String[] names,
         IndicesOptions indicesOptions
     ) {
+        indicesOptions = updateIndicesOptions(indicesOptions);
+        return indexNameExpressionResolver.dataStreamNames(currentState, indicesOptions, names);
+    }
+
+    public static IndicesOptions updateIndicesOptions(IndicesOptions indicesOptions) {
         EnumSet<IndicesOptions.WildcardStates> expandWildcards = indicesOptions.getExpandWildcards();
         expandWildcards.add(IndicesOptions.WildcardStates.OPEN);
         indicesOptions = new IndicesOptions(indicesOptions.getOptions(), expandWildcards);
-        return indexNameExpressionResolver.dataStreamNames(currentState, indicesOptions, names);
+        return indicesOptions;
     }
 }

--- a/x-pack/plugin/data-streams/src/main/java/org/elasticsearch/xpack/datastreams/action/DataStreamsStatsTransportAction.java
+++ b/x-pack/plugin/data-streams/src/main/java/org/elasticsearch/xpack/datastreams/action/DataStreamsStatsTransportAction.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.datastreams.action;
 import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.PointValues;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
 import org.elasticsearch.action.support.broadcast.node.TransportBroadcastByNodeAction;
@@ -31,6 +32,7 @@ import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardNotFoundException;
 import org.elasticsearch.index.store.StoreStats;
 import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.action.DataStreamsStatsAction;
@@ -74,6 +76,12 @@ public class DataStreamsStatsTransportAction extends TransportBroadcastByNodeAct
         this.clusterService = clusterService;
         this.indicesService = indicesService;
         this.indexNameExpressionResolver = indexNameExpressionResolver;
+    }
+
+    @Override
+    protected void doExecute(Task task, DataStreamsStatsAction.Request request, ActionListener<DataStreamsStatsAction.Response> listener) {
+        request.indicesOptions(DataStreamsActionUtil.updateIndicesOptions(request.indicesOptions()));
+        super.doExecute(task, request, listener);
     }
 
     @Override

--- a/x-pack/plugin/data-streams/src/main/java/org/elasticsearch/xpack/datastreams/rest/RestDataStreamsStatsAction.java
+++ b/x-pack/plugin/data-streams/src/main/java/org/elasticsearch/xpack/datastreams/rest/RestDataStreamsStatsAction.java
@@ -5,6 +5,7 @@
  */
 package org.elasticsearch.xpack.datastreams.rest;
 
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.rest.BaseRestHandler;
@@ -33,6 +34,7 @@ public class RestDataStreamsStatsAction extends BaseRestHandler {
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
         DataStreamsStatsAction.Request dataStreamsStatsRequest = new DataStreamsStatsAction.Request();
         dataStreamsStatsRequest.indices(Strings.splitStringByCommaToArray(request.param("name")));
+        dataStreamsStatsRequest.indicesOptions(IndicesOptions.fromRequest(request, dataStreamsStatsRequest.indicesOptions()));
         return channel -> client.execute(DataStreamsStatsAction.INSTANCE, dataStreamsStatsRequest, new RestToXContentListener<>(channel));
     }
 }

--- a/x-pack/plugin/data-streams/src/test/java/org/elasticsearch/xpack/datastreams/DataStreamsStatsTests.java
+++ b/x-pack/plugin/data-streams/src/test/java/org/elasticsearch/xpack/datastreams/DataStreamsStatsTests.java
@@ -28,6 +28,7 @@ import org.elasticsearch.xpack.core.action.DeleteDataStreamAction;
 import org.junit.After;
 
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -92,6 +93,24 @@ public class DataStreamsStatsTests extends ESSingleNodeTestCase {
         long timestamp = createDocument(dataStreamName);
 
         DataStreamsStatsAction.Response stats = getDataStreamsStats();
+        assertEquals(1, stats.getSuccessfulShards());
+        assertEquals(0, stats.getFailedShards());
+        assertEquals(1, stats.getDataStreamCount());
+        assertEquals(1, stats.getBackingIndices());
+        assertNotEquals(0L, stats.getTotalStoreSize().getBytes());
+        assertEquals(1, stats.getDataStreams().length);
+        assertEquals(dataStreamName, stats.getDataStreams()[0].getDataStream());
+        assertEquals(1, stats.getDataStreams()[0].getBackingIndices());
+        assertEquals(timestamp, stats.getDataStreams()[0].getMaximumTimestamp());
+        assertNotEquals(0L, stats.getDataStreams()[0].getStoreSize().getBytes());
+        assertEquals(stats.getTotalStoreSize().getBytes(), stats.getDataStreams()[0].getStoreSize().getBytes());
+    }
+
+    public void testStatsExistingHiddenDataStream() throws Exception {
+        String dataStreamName = createDataStream(true);
+        long timestamp = createDocument(dataStreamName);
+
+        DataStreamsStatsAction.Response stats = getDataStreamsStats(true);
         assertEquals(1, stats.getSuccessfulShards());
         assertEquals(0, stats.getFailedShards());
         assertEquals(1, stats.getDataStreamCount());
@@ -205,6 +224,10 @@ public class DataStreamsStatsTests extends ESSingleNodeTestCase {
     }
 
     private String createDataStream() throws Exception {
+        return createDataStream(false);
+    }
+
+    private String createDataStream(boolean hidden) throws Exception {
         String dataStreamName = randomAlphaOfLength(10).toLowerCase(Locale.getDefault());
         Template idxTemplate = new Template(
             null,
@@ -218,7 +241,7 @@ public class DataStreamsStatsTests extends ESSingleNodeTestCase {
             null,
             null,
             null,
-            new ComposableIndexTemplate.DataStreamTemplate(),
+            new ComposableIndexTemplate.DataStreamTemplate(hidden),
             null
         );
         assertTrue(
@@ -256,7 +279,16 @@ public class DataStreamsStatsTests extends ESSingleNodeTestCase {
     }
 
     private DataStreamsStatsAction.Response getDataStreamsStats() throws Exception {
-        return client().execute(DataStreamsStatsAction.INSTANCE, new DataStreamsStatsAction.Request()).get();
+        return getDataStreamsStats(false);
+    }
+
+    private DataStreamsStatsAction.Response getDataStreamsStats(boolean includeHidden) throws Exception {
+        DataStreamsStatsAction.Request request = new DataStreamsStatsAction.Request();
+        if (includeHidden) {
+            request.indicesOptions(new IndicesOptions(EnumSet.of(IndicesOptions.Option.ALLOW_NO_INDICES),
+                EnumSet.of(IndicesOptions.WildcardStates.HIDDEN)));
+        }
+        return client().execute(DataStreamsStatsAction.INSTANCE, request).get();
     }
 
     private void deleteDataStream(String dataStreamName) throws InterruptedException, java.util.concurrent.ExecutionException {

--- a/x-pack/plugin/data-streams/src/test/java/org/elasticsearch/xpack/datastreams/DataStreamsStatsTests.java
+++ b/x-pack/plugin/data-streams/src/test/java/org/elasticsearch/xpack/datastreams/DataStreamsStatsTests.java
@@ -285,8 +285,9 @@ public class DataStreamsStatsTests extends ESSingleNodeTestCase {
     private DataStreamsStatsAction.Response getDataStreamsStats(boolean includeHidden) throws Exception {
         DataStreamsStatsAction.Request request = new DataStreamsStatsAction.Request();
         if (includeHidden) {
-            request.indicesOptions(new IndicesOptions(EnumSet.of(IndicesOptions.Option.ALLOW_NO_INDICES),
-                EnumSet.of(IndicesOptions.WildcardStates.HIDDEN)));
+            request.indicesOptions(
+                new IndicesOptions(EnumSet.of(IndicesOptions.Option.ALLOW_NO_INDICES), EnumSet.of(IndicesOptions.WildcardStates.HIDDEN))
+            );
         }
         return client().execute(DataStreamsStatsAction.INSTANCE, request).get();
     }


### PR DESCRIPTION
This change adds support for hidden data streams in stats endpoint with usual `_data_stream/<index>/_stats?expand_wildcards=hidden` syntax.

Closes https://github.com/elastic/elasticsearch/issues/65323
