### PR TITLE
Explain size limit for transport messages

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -742,8 +742,8 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
         }
 
         if (messageLength > THIRTY_PER_HEAP_SIZE) {
-            throw new IllegalArgumentException("transport content length received [" + new ByteSizeValue(messageLength) + "] exceeded ["
-                + new ByteSizeValue(THIRTY_PER_HEAP_SIZE) + "]");
+            throw new IllegalArgumentException("illegal transport message of size [" + new ByteSizeValue(messageLength) +
+                    "] which exceeds 30% of this node's heap size [" + new ByteSizeValue(THIRTY_PER_HEAP_SIZE) + "], closing connection");
         }
 
         return messageLength;


### PR DESCRIPTION
If a node receives an unreasonably large transport message then it
rejects it and closes the connection. This can occur if, for instance, a
rather small node tries to join a cluster with a rather oversized
cluster state. The message logged in this case says that the message is
too large but does not give any clues to the user what to do about it.

This commit adds to the message the information that the limit is 30% of
the node's heap size, to give a hint that a larger heap might help.