### PR TITLE
Push build scan configuration into background

### DIFF
--- a/gradle/build-scan.gradle
+++ b/gradle/build-scan.gradle
@@ -7,88 +7,90 @@ import java.util.concurrent.TimeUnit
 long startTime = project.gradle.services.get(BuildRequestMetaData).getStartTime()
 
 buildScan {
-  URL jenkinsUrl = System.getenv('JENKINS_URL') ? new URL(System.getenv('JENKINS_URL')) : null
-  String buildNumber = System.getenv('BUILD_NUMBER')
-  String buildUrl = System.getenv('BUILD_URL')
-  String jobName = System.getenv('JOB_NAME')
-  String nodeName = System.getenv('NODE_NAME')
+  background {
+    URL jenkinsUrl = System.getenv('JENKINS_URL') ? new URL(System.getenv('JENKINS_URL')) : null
+    String buildNumber = System.getenv('BUILD_NUMBER')
+    String buildUrl = System.getenv('BUILD_URL')
+    String jobName = System.getenv('JOB_NAME')
+    String nodeName = System.getenv('NODE_NAME')
 
-  tag OS.current().name()
+    tag OS.current().name()
 
-  // Tag if this build is run in FIPS mode
-  if (BuildParams.inFipsJvm) {
-    tag 'FIPS'
-  }
-
-  // Automatically publish scans from Elasticsearch CI
-  if (jenkinsUrl?.host?.endsWith('elastic.co') || jenkinsUrl?.host?.endsWith('elastic.dev')) {
-    publishAlways()
-    buildScan.server = 'https://gradle-enterprise.elastic.co'
-  }
-
-  // Link to Jenkins worker logs and system metrics
-  if (nodeName) {
-    link 'System logs', "https://infra-stats.elastic.co/app/infra#/logs?" +
-      "&logFilter=(expression:'host.name:${nodeName}',kind:kuery)"
-    buildFinished {
-      link 'System metrics', "https://infra-stats.elastic.co/app/infra#/metrics/host/" +
-        "${nodeName}?_g=()&metricTime=(autoReload:!f,refreshInterval:5000," +
-        "time:(from:${startTime - TimeUnit.MILLISECONDS.convert(5, TimeUnit.MINUTES)},interval:%3E%3D1m," +
-        "to:${System.currentTimeMillis() + TimeUnit.MILLISECONDS.convert(5, TimeUnit.MINUTES)}))"
+    // Tag if this build is run in FIPS mode
+    if (BuildParams.inFipsJvm) {
+      tag 'FIPS'
     }
-  }
 
-  // Jenkins-specific build scan metadata
-  if (jenkinsUrl) {
-    // Disable async upload in CI to ensure scan upload completes before CI agent is terminated
-    uploadInBackground = false
+    // Automatically publish scans from Elasticsearch CI
+    if (jenkinsUrl?.host?.endsWith('elastic.co') || jenkinsUrl?.host?.endsWith('elastic.dev')) {
+      publishAlways()
+      buildScan.server = 'https://gradle-enterprise.elastic.co'
+    }
 
-    // Parse job name in the case of matrix builds
-    // Matrix job names come in the form of "base-job-name/matrix_param1=value1,matrix_param2=value2"
-    def splitJobName = jobName.split('/')
-    if (splitJobName.length > 1 && splitJobName.last() ==~ /^([a-zA-Z0-9_\-]+=[a-zA-Z0-9_\-&\.]+,?)+$/) {
-      def baseJobName = splitJobName.dropRight(1).join('/')
-      tag baseJobName
-      tag splitJobName.last()
-      value 'Job Name', baseJobName
-      def matrixParams = splitJobName.last().split(',')
-      matrixParams.collect { it.split('=') }.each { param ->
-        value "MATRIX_${param[0].toUpperCase()}", param[1]
+    // Link to Jenkins worker logs and system metrics
+    if (nodeName) {
+      link 'System logs', "https://infra-stats.elastic.co/app/infra#/logs?" +
+        "&logFilter=(expression:'host.name:${nodeName}',kind:kuery)"
+      buildFinished {
+        link 'System metrics', "https://infra-stats.elastic.co/app/infra#/metrics/host/" +
+          "${nodeName}?_g=()&metricTime=(autoReload:!f,refreshInterval:5000," +
+          "time:(from:${startTime - TimeUnit.MILLISECONDS.convert(5, TimeUnit.MINUTES)},interval:%3E%3D1m," +
+          "to:${System.currentTimeMillis() + TimeUnit.MILLISECONDS.convert(5, TimeUnit.MINUTES)}))"
+      }
+    }
+
+    // Jenkins-specific build scan metadata
+    if (jenkinsUrl) {
+      // Disable async upload in CI to ensure scan upload completes before CI agent is terminated
+      uploadInBackground = false
+
+      // Parse job name in the case of matrix builds
+      // Matrix job names come in the form of "base-job-name/matrix_param1=value1,matrix_param2=value2"
+      def splitJobName = jobName.split('/')
+      if (splitJobName.length > 1 && splitJobName.last() ==~ /^([a-zA-Z0-9_\-]+=[a-zA-Z0-9_\-&\.]+,?)+$/) {
+        def baseJobName = splitJobName.dropRight(1).join('/')
+        tag baseJobName
+        tag splitJobName.last()
+        value 'Job Name', baseJobName
+        def matrixParams = splitJobName.last().split(',')
+        matrixParams.collect { it.split('=') }.each { param ->
+          value "MATRIX_${param[0].toUpperCase()}", param[1]
+        }
+      } else {
+        tag jobName
+        value 'Job Name', jobName
+      }
+
+      tag 'CI'
+      link 'CI Build', buildUrl
+      link 'GCP Upload', "https://console.cloud.google.com/storage/elasticsearch-ci-artifacts/jobs/${jobName}/build/${buildNumber}.tar.bz2"
+      value 'Job Number', buildNumber
+
+      System.getenv().getOrDefault('NODE_LABELS', '').split(' ').each {
+        value 'Jenkins Worker Label', it
+      }
+
+      // Add SCM information
+      def isPrBuild = System.getenv('ROOT_BUILD_CAUSE_GHPRBCAUSE') != null
+      if (isPrBuild) {
+        value 'Git Commit ID', System.getenv('ghprbActualCommit')
+        value 'Git Branch', System.getenv('ghprbTargetBranch')
+        tag System.getenv('ghprbTargetBranch')
+        tag "pr/${System.getenv('ghprbPullId')}"
+        tag 'pull-request'
+        link 'Source', "https://github.com/elastic/elasticsearch/tree/${System.getenv('ghprbActualCommit')}"
+        link 'Pull Request', System.getenv('ghprbPullLink')
+      } else {
+        if (System.getenv('GIT_BRANCH')) {
+          def branch = System.getenv('GIT_BRANCH').split('/').last()
+          value 'Git Branch', branch
+          tag branch
+        }
+        value 'Git Commit ID', BuildParams.gitRevision
+        link 'Source', "https://github.com/elastic/elasticsearch/tree/${BuildParams.gitRevision}"
       }
     } else {
-      tag jobName
-      value 'Job Name', jobName
+      tag 'LOCAL'
     }
-
-    tag 'CI'
-    link 'CI Build', buildUrl
-    link 'GCP Upload', "https://console.cloud.google.com/storage/elasticsearch-ci-artifacts/jobs/${jobName}/build/${buildNumber}.tar.bz2"
-    value 'Job Number', buildNumber
-
-    System.getenv().getOrDefault('NODE_LABELS', '').split(' ').each {
-      value 'Jenkins Worker Label', it
-    }
-
-    // Add SCM information
-    def isPrBuild = System.getenv('ROOT_BUILD_CAUSE_GHPRBCAUSE') != null
-    if (isPrBuild) {
-      value 'Git Commit ID', System.getenv('ghprbActualCommit')
-      value 'Git Branch', System.getenv('ghprbTargetBranch')
-      tag System.getenv('ghprbTargetBranch')
-      tag "pr/${System.getenv('ghprbPullId')}"
-      tag 'pull-request'
-      link 'Source', "https://github.com/elastic/elasticsearch/tree/${System.getenv('ghprbActualCommit')}"
-      link 'Pull Request', System.getenv('ghprbPullLink')
-    } else {
-      if (System.getenv('GIT_BRANCH')) {
-        def branch = System.getenv('GIT_BRANCH').split('/').last()
-        value 'Git Branch', branch
-        tag branch
-      }
-      value 'Git Commit ID', BuildParams.gitRevision
-      link 'Source', "https://github.com/elastic/elasticsearch/tree/${BuildParams.gitRevision}"
-    }
-  } else {
-    tag 'LOCAL'
   }
 }


### PR DESCRIPTION
- Build scans allow to be configured in a background thread which lowers the impact
of the configuration on the overall build configuration time.
- The configuration time was already quite low but as its such a low hanging fruit we
take advantage of that option in our ES build too.