### PR TITLE
Fix `lucene_version_path` in docs

### DIFF
--- a/docs/Versions.asciidoc
+++ b/docs/Versions.asciidoc
@@ -2,7 +2,7 @@
 include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
 
 :lucene_version:        8.7.0
-:lucene_version_path:   8.7.0
+:lucene_version_path:   8_7_0
 :jdk:                   1.8.0_131
 :jdk_major:             8
 :build_flavor:          default


### PR DESCRIPTION
The `lucene_version_path` variable is used in urls pointing to the Lucene docs.
They use underscore separators for the major and minor versions there.
Correcting this since this has been lost in the latest update on the 7.x branch.