### PR TITLE
Shadowed mappers need to skip their children

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -939,7 +939,8 @@ final class DocumentParser {
 
         @Override
         protected void parseCreateField(ParseContext context) throws IOException {
-            //field defined as runtime field, don't index anything
+            //field defined as runtime field, don't index anything but skip over any possible children
+            context.parser().skipChildren();
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/index/mapper/DynamicMappingTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DynamicMappingTests.java
@@ -74,10 +74,12 @@ public class DynamicMappingTests extends MapperServiceTestCase {
         ParsedDocument doc = defaultMapper.parse(source(b -> {
             b.field("field1", "value1");
             b.field("field2", "value2");
+            b.startObject("object").field("field3", "value3").endObject();
         }));
 
         assertThat(doc.rootDoc().get("field1"), equalTo("value1"));
         assertThat(doc.rootDoc().get("field2"), nullValue());
+        assertThat(doc.rootDoc().get("object.field3"), nullValue());
     }
 
 

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/RuntimeFieldIndexShadowTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/RuntimeFieldIndexShadowTests.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.mapper;
+
+import org.elasticsearch.index.mapper.DocumentMapper;
+import org.elasticsearch.index.mapper.MapperServiceTestCase;
+import org.elasticsearch.index.mapper.ParsedDocument;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.xpack.runtimefields.RuntimeFields;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+
+public class RuntimeFieldIndexShadowTests extends MapperServiceTestCase {
+
+    @Override
+    protected Collection<? extends Plugin> getPlugins() {
+        return Collections.singleton(new RuntimeFields());
+    }
+
+    public void testRuntimeFieldShadowsObject() throws IOException {
+
+        // A runtime field defined in the mappings should automatically
+        // stop an identically named field in a document from being indexed
+
+        DocumentMapper mapper = createDocumentMapper(topMapping(b -> {
+            b.field("dynamic", "true");
+            b.startObject("runtime");
+            {
+                b.startObject("location").field("type", "geo_point").endObject();
+                b.startObject("country").field("type", "keyword").endObject();
+            }
+            b.endObject();
+            b.startObject("properties");
+            {
+                b.startObject("timestamp").field("type", "date").endObject();
+                b.startObject("concrete").field("type", "keyword").endObject();
+            }
+            b.endObject();
+        }));
+
+        ParsedDocument doc = mapper.parse(source(b -> {
+            b.field("timestamp", "1998-04-30T14:30:17-05:00");
+            b.startObject("location");
+            {
+                b.field("lat", 13.5);
+                b.field("lon", 34.89);
+            }
+            b.endObject();
+            b.field("country", "de");
+            b.field("concrete", "foo");
+        }));
+
+        assertNotNull(doc.rootDoc().getField("timestamp"));
+        assertNotNull(doc.rootDoc().getField("_source"));
+        assertNull(doc.rootDoc().getField("location.lat"));
+        assertNotNull(doc.rootDoc().getField("concrete"));
+        assertNull(doc.rootDoc().getField("country"));
+
+    }
+
+}

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/101_geo_point_from_source.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/101_geo_point_from_source.yml
@@ -14,9 +14,6 @@ setup:
             properties:
               timestamp:
                 type: date
-              location:
-                type: object
-                enabled: false
 
   - do:
       bulk:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/11_keyword_from_source.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/11_keyword_from_source.yml
@@ -8,6 +8,7 @@ setup:
             number_of_shards: 1
             number_of_replicas: 0
           mappings:
+            dynamic: false
             runtime:
               status.active:
                 type: keyword
@@ -20,9 +21,6 @@ setup:
                 type: double
               node:
                 type: keyword
-              status:
-                type: object
-                enabled: false
 
 
   - do:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/21_long_from_source.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/21_long_from_source.yml
@@ -8,6 +8,7 @@ setup:
             number_of_shards: 1
             number_of_replicas: 0
           mappings:
+            dynamic: false
             runtime:
               history.count:
                 type: long
@@ -20,9 +21,6 @@ setup:
                 type: double
               node:
                 type: keyword
-              history:
-                type: object
-                enabled: false
 
   - do:
       bulk:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/31_double_from_source.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/31_double_from_source.yml
@@ -8,6 +8,7 @@ setup:
             number_of_shards: 1
             number_of_replicas: 0
           mappings:
+            dynamic: false
             runtime:
               history.count:
                 type: double
@@ -20,9 +21,6 @@ setup:
                 type: double
               node:
                 type: keyword
-              history:
-                type: object
-                enabled: false
 
   - do:
       bulk:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/41_date_from_source.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/41_date_from_source.yml
@@ -8,6 +8,7 @@ setup:
             number_of_shards: 1
             number_of_replicas: 0
           mappings:
+            dynamic: false
             runtime:
               history.installed:
                 type: date
@@ -21,9 +22,6 @@ setup:
                 type: double
               node:
                 type: keyword
-              history:
-                type: object
-                enabled: false
 
   - do:
       bulk:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/51_ip_from_source.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/51_ip_from_source.yml
@@ -8,6 +8,7 @@ setup:
             number_of_shards: 1
             number_of_replicas: 0
           mappings:
+            dynamic: false
             runtime:
               host.ip:
                 type: ip
@@ -20,9 +21,6 @@ setup:
                 type: double
               node:
                 type: keyword
-              host:
-                type: object
-                enabled: false
 
   - do:
       bulk:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/61_boolean_from_source.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/61_boolean_from_source.yml
@@ -8,6 +8,7 @@ setup:
             number_of_shards: 1
             number_of_replicas: 0
           mappings:
+            dynamic: false
             runtime:
               state.active:
                 type: boolean
@@ -20,9 +21,6 @@ setup:
                 type: double
               node:
                 type: keyword
-              state:
-                type: object
-                enabled: false
 
   - do:
       bulk:


### PR DESCRIPTION
When a runtime field is defined in mappings, it automatically shadows any
corresponding fields that might be dynamically created.  If a document is
added with an object that matches a runtime field, we need to make sure
that all of the object's children are skipped during parsing.