### PR TITLE
Mark Task APIs as experimental in rest-api-spec

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.cancel.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.cancel.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html",
       "description":"Cancels a task, if it can be cancelled through an API."
     },
-    "stability":"stable",
+    "stability":"experimental",
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.get.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html",
       "description":"Returns information about a task."
     },
-    "stability":"stable",
+    "stability":"experimental",
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.list.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.list.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html",
       "description":"Returns a list of tasks."
     },
-    "stability":"stable",
+    "stability":"experimental",
     "url":{
       "paths":[
         {


### PR DESCRIPTION
Per https://github.com/elastic/elasticsearch/issues/51628 and [the Task management API docs](https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html) the `tasks.*` APIs are still in the experimental stage and should be marked this way in the REST API spec.

cc @elastic/clients-team 