### PR TITLE
Include licensed field in PluginInfo xcontent and toString

### DIFF
--- a/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/ListPluginsCommandTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/ListPluginsCommandTests.java
@@ -154,6 +154,7 @@ public class ListPluginsCommandTests extends ESTestCase {
                 "Elasticsearch Version: " + Version.CURRENT.toString(),
                 "Java Version: 1.8",
                 "Native Controller: false",
+                "Licensed: false",
                 "Type: isolated",
                 "Extended Plugins: []",
                 " * Classname: org.fake"
@@ -177,6 +178,7 @@ public class ListPluginsCommandTests extends ESTestCase {
                 "Elasticsearch Version: " + Version.CURRENT.toString(),
                 "Java Version: 1.8",
                 "Native Controller: true",
+                "Licensed: false",
                 "Type: isolated",
                 "Extended Plugins: []",
                 " * Classname: org.fake"
@@ -201,6 +203,7 @@ public class ListPluginsCommandTests extends ESTestCase {
                 "Elasticsearch Version: " + Version.CURRENT.toString(),
                 "Java Version: 1.8",
                 "Native Controller: false",
+                "Licensed: false",
                 "Type: isolated",
                 "Extended Plugins: []",
                 " * Classname: org.fake",
@@ -212,6 +215,7 @@ public class ListPluginsCommandTests extends ESTestCase {
                 "Elasticsearch Version: " + Version.CURRENT.toString(),
                 "Java Version: 1.8",
                 "Native Controller: false",
+                "Licensed: false",
                 "Type: isolated",
                 "Extended Plugins: []",
                 " * Classname: org.fake2"

--- a/server/src/main/java/org/elasticsearch/plugins/PluginInfo.java
+++ b/server/src/main/java/org/elasticsearch/plugins/PluginInfo.java
@@ -379,6 +379,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
             builder.field("classname", classname);
             builder.field("extended_plugins", extendedPlugins);
             builder.field("has_native_controller", hasNativeController);
+            builder.field("licensed", isLicensed);
             builder.field("type", type);
             if (type == PluginType.BOOTSTRAP) {
                 builder.field("java_opts", javaOpts);
@@ -422,6 +423,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
             .append(prefix).append("Elasticsearch Version: ").append(elasticsearchVersion).append("\n")
             .append(prefix).append("Java Version: ").append(javaVersion).append("\n")
             .append(prefix).append("Native Controller: ").append(hasNativeController).append("\n")
+            .append(prefix).append("Licensed: ").append(isLicensed).append("\n")
             .append(prefix).append("Type: ").append(type).append("\n");
 
         if (type == PluginType.BOOTSTRAP) {

--- a/server/src/main/java/org/elasticsearch/plugins/PluginInfo.java
+++ b/server/src/main/java/org/elasticsearch/plugins/PluginInfo.java
@@ -359,9 +359,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
     }
 
     /**
-     * Whether a license must be accepted before this plugin can be installed.
-     *
-     * @return {@code true} if a license must be accepted.
+     * Whether this plugin is subject to the Elastic License.
      */
     public boolean isLicensed() {
         return isLicensed;

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/cluster/ClusterStatsMonitoringDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/cluster/ClusterStatsMonitoringDocTests.java
@@ -544,6 +544,7 @@ public class ClusterStatsMonitoringDocTests extends BaseMonitoringDocTestCase<Cl
                 + "          \"classname\": \"_plugin_class\","
                 + "          \"extended_plugins\": [],"
                 + "          \"has_native_controller\": false,"
+                + "          \"licensed\": false,"
                 + "          \"type\": \"isolated\""
                 + "        }"
                 + "      ],"


### PR DESCRIPTION
When #65409 was merged, it didn't include the new `PluginInfo` field `licensed` in the `toString()` or `toXContent()` outputs. This PR adds them and updates the tests accordingly.