### PR TITLE
[7.x] [DOCS] EQL: Document ? wildcard (#65698)

### DIFF
--- a/docs/reference/eql/functions.asciidoc
+++ b/docs/reference/eql/functions.asciidoc
@@ -1015,15 +1015,25 @@ expressions. Matching is case-sensitive.
 *Example*
 [source,eql]
 ----
+// The * wildcard matches zero or more characters.
 // process.name = "regsvr32.exe"
 wildcard(process.name, "*regsvr32*")                // returns true
 wildcard(process.name, "*regsvr32*", "*explorer*")  // returns true
 wildcard(process.name, "*explorer*")                // returns false
 wildcard(process.name, "*explorer*", "*scrobj*")    // returns false
 
+// The ? wildcard matches exactly one character.
+// process.name = "regsvr32.exe"
+wildcard(process.name, "regsvr32.e?e")                  // returns true
+wildcard(process.name, "regsvr32.e?e", "e?plorer.exe")  // returns true
+wildcard(process.name, "regsvr32.exe?")                 // returns false
+wildcard(process.name, "e?plorer.exe")                  // returns false
+wildcard(process.name, "e?plorer.exe", "scrob?.dll")    // returns false
+
 // empty strings
 wildcard("", "*start*")                             // returns false
 wildcard("", "*")                                   // returns true
+wildcard("", "?")                                   // returns false
 wildcard("", "")                                    // returns true
 
 // null handling
@@ -1056,8 +1066,10 @@ field data types:
 +
 --
 (Required{multi-arg-ref}, string)
-Wildcard expression used to match the source string. If `null`, the function
-returns `null`. Fields are not supported as arguments.
+Wildcard expression used to match the source string. The `*` wildcard matches
+zero or more characters. The `?` wildcard matches exactly one character.
+
+If `null`, the function returns `null`. Fields are not supported as arguments.
 --
 
 *Returns:* boolean

--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -382,14 +382,24 @@ use a regular string with the `\"` escape sequence.
 [[eql-syntax-wildcards]]
 === Wildcards
 
-For string comparisons using the `:` operator, you can use wildcards (`*`) to
-match specific patterns:
+For string comparisons using the `:` operator, you can use the `*` and `?`
+wildcards to match specific patterns. The `*` wildcard matches zero or more
+characters:
 
 [source,eql]
 ----
-field : "f*o"
-field : "*foo"
-field : "foo*"
+my_field : "doc*"  // Matches "doc", "docs", or "document" but not "dos"
+my_field : "*doc"  // Matches "adoc" or "asciidoc"
+my_field : "d*c"   // Matches "doc" or "disc"
+----
+
+The `?` wildcard matches exactly one character:
+
+[source,eql]
+----
+my_field : "doc?"  // Matches "docs" but not "doc", "document", or "dos"
+my_field : "?doc"  // Matches "adoc" but not "asciidoc"
+my_field : "d?c"   // Matches "doc" but not "disc"
 ----
 
 The `:` operator also supports wildcards in <<eql-syntax-lookup-operators,list
@@ -397,7 +407,7 @@ lookups>>:
 
 [source,eql]
 ----
-field : ("f*o", "*bar", "baz*", "qux")
+my_field : ("doc*", "f*o", "ba?", "qux")
 ----
 
 [discrete]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] EQL: Document ? wildcard (#65698)