### PR TITLE
[ML] Improve integration test robustness to perturbations in the ml-cpp results

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DetectionRulesIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DetectionRulesIT.java
@@ -118,7 +118,7 @@ public class DetectionRulesIT extends MlNativeAutodetectIntegTestCase {
         GetRecordsAction.Request recordsAfterFirstHalf = new GetRecordsAction.Request(job.getId());
         recordsAfterFirstHalf.setStart(String.valueOf(firstRecordTimestamp + 1));
         records = getRecords(recordsAfterFirstHalf);
-        assertThat(records.size(), equalTo(1));
+        assertThat("records were " + records, (int)(records.stream().filter(r -> r.getProbability() < 0.01).count()), equalTo(1));
         assertThat(records.get(0).getByFieldValue(), equalTo("low"));
     }
 


### PR DESCRIPTION
This test should check the count of *low* probability results. This is sufficient to test the rule condition is applied and is more stable to perturbations of results.