### PR TITLE
Mute TimeThrottleIntegrationTests.testTimeThrottle

### DIFF
--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/actions/TimeThrottleIntegrationTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/actions/TimeThrottleIntegrationTests.java
@@ -31,6 +31,7 @@ import static org.hamcrest.Matchers.is;
 
 public class TimeThrottleIntegrationTests extends AbstractWatcherIntegrationTestCase {
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/65176")
     public void testTimeThrottle() throws Exception {
         String id = randomAlphaOfLength(20);
         PutWatchResponse putWatchResponse = new PutWatchRequestBuilder(client())


### PR DESCRIPTION
This test is failing on master in CI occassionally. This change mutes
the test to stop the noise until it can be looked at again.

Relates #65176