### PR TITLE
Fix ML tests for autoscaling in release builds

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/build.gradle
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/build.gradle
@@ -31,11 +31,18 @@ javaRestTest {
    * other if we allow them to set the number of available processors as it's set-once in Netty.
    */
   systemProperty 'es.set.netty.runtime.available.processors', 'false'
+  if (BuildParams.isSnapshotBuild() == false) {
+    systemProperty 'es.autoscaling_feature_flag_registered', 'true'
+  }
 }
 
 testClusters.all {
   numberOfNodes = 3
   testDistribution = 'DEFAULT'
+
+  if (BuildParams.isSnapshotBuild() == false) {
+    systemProperty 'es.autoscaling_feature_flag_registered', 'true'
+  }
 
   setting 'xpack.security.enabled', 'true'
   setting 'xpack.monitoring.elasticsearch.collection.enabled', 'false'


### PR DESCRIPTION
This commit fixes test failures due to ML tests that try to test
autoscaling in a release build. In a release build a system property
is needed to enable autoscaling, which this change adds.
