### PR TITLE
[7.10] Mark Task APIs as experimental in rest-api-spec

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.cancel.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.cancel.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html",
       "description":"Cancels a task, if it can be cancelled through an API."
     },
-    "stability":"stable",
+    "stability":"experimental",
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.get.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html",
       "description":"Returns information about a task."
     },
-    "stability":"stable",
+    "stability":"experimental",
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.list.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.list.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html",
       "description":"Returns a list of tasks."
     },
-    "stability":"stable",
+    "stability":"experimental",
     "url":{
       "paths":[
         {


### PR DESCRIPTION
Backports the following commits to 7.10:
- Mark Task APIs as experimental in rest-api-spec (https://github.com/elastic/elasticsearch/commit/56a25bf08b872af52290391119e776dfed51f968)