### PR TITLE
Mute IndicesClientIT.testDataStreams

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesClientIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesClientIT.java
@@ -2034,6 +2034,7 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
         assertThat(aliasExists(index, alias2), equalTo(true));
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/60461")
     public void testDataStreams() throws Exception {
         String dataStreamName = "data-stream";
 


### PR DESCRIPTION
This commit mutes IndicesClientIT.testDataStreams as this test is
failing in CI intermittently.

Relates #60746
Relates #60461