### PR TITLE
[DOCS] Add `timeout` param for rollup APIs

### DIFF
--- a/docs/reference/rollup/apis/put-job.asciidoc
+++ b/docs/reference/rollup/apis/put-job.asciidoc
@@ -261,6 +261,10 @@ the indexer.
 be shared with other {rollup-jobs}. The data is stored so that it doesn't
 interfere with unrelated jobs.
 
+`timeout`::
+(Optional, <<time-units,time value>>)
+Time to wait for the request to complete. Defaults to `20s` (20 seconds).
+
 [[rollup-put-job-api-example]]
 ==== {api-example-title}
 

--- a/docs/reference/rollup/apis/rollup-api.asciidoc
+++ b/docs/reference/rollup/apis/rollup-api.asciidoc
@@ -186,3 +186,7 @@ values run faster but require more memory.
 +
 NOTE: This argument only affects the speed and memory usage of the rollup
 operation. It does not affect the rollup results.
+
+`timeout`::
+(Optional, <<time-units,time value>>)
+Time to wait for the request to complete. Defaults to `20s` (20 seconds).


### PR DESCRIPTION
Adds the `timeout` parameter to the V2 rollup API docs. I overlooked this param in #65398.

Also documents the `timeout` param for the create legacy rollup job API. Looks like that one's been missing for a while.


### Previews

Rollup V2 API: https://elasticsearch_65858.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/rollup-api.html#rollup-api-request-body

Create legacy rollup job API: https://elasticsearch_65858.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/rollup-api.html#rollup-api-request-body