### PR TITLE
Mute HistoryTemplateIndexActionMappingsTests

### DIFF
--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/history/HistoryTemplateIndexActionMappingsTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/history/HistoryTemplateIndexActionMappingsTests.java
@@ -5,6 +5,7 @@
  */
 package org.elasticsearch.xpack.watcher.history;
 
+import org.apache.lucene.util.LuceneTestCase.AwaitsFix;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.protocol.xpack.watcher.PutWatchResponse;
 import org.elasticsearch.search.aggregations.Aggregations;
@@ -27,6 +28,7 @@ import static org.hamcrest.Matchers.notNullValue;
  * This test makes sure that the index action response `index` field in the watch_record action result is
  * not analyzed so it can be used in aggregations
  */
+@AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/65091")
 public class HistoryTemplateIndexActionMappingsTests extends AbstractWatcherIntegrationTestCase {
 
     public void testIndexActionFields() throws Exception {


### PR DESCRIPTION
HistoryTemplateIndexActionMappingsTests testIndexActionFields has been
failing in CI. This commit mutes the test.

Relates #65091