### PR TITLE
Change index removal reason when IndicesService is stopping

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -350,7 +350,7 @@ public class IndicesService extends AbstractLifecycleComponent
         for (final Index index : indices) {
             indicesStopExecutor.execute(() -> {
                 try {
-                    removeIndex(index, IndexRemovalReason.NO_LONGER_ASSIGNED, "shutdown");
+                    removeIndex(index, IndexRemovalReason.SHUTDOWN, "shutdown");
                 } finally {
                     latch.countDown();
                 }

--- a/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -950,6 +950,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
              * like the shards files, state and transaction logs are kept around in the case of a disaster recovery.
              */
             NO_LONGER_ASSIGNED,
+
             /**
              * The index is deleted. Persistent parts of the index  like the shards files, state and transaction logs are removed once
              * all resources are released.
@@ -974,6 +975,13 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
              * like the shards files, state and transaction logs are kept around in the case of a disaster recovery.
              */
             REOPENED,
+
+            /**
+             * The index is closed as part of the node shutdown process. The index should be removed and all associated resources released.
+             * Persistent parts of the index like the shards files, state and transaction logs should be kept around in the case the node
+             * restarts.
+             */
+            SHUTDOWN,
         }
     }
 }


### PR DESCRIPTION
When IndicesService is stopping on a data node, it closes every 
IndexService instances that are existing by calling the 
removeIndex(Index, IndexRemovalReason, String) method.

The IndexRemovalReason that is passed as a parameter in this 
case is NO_LONGER_ASSIGNED which is also the one passed
 in other situation like removing an index because it got assigned 
to another data node. The fact that the same reason is used in 
multiple cases make it difficult for IndexEventListener to do the
 distinction between an index closed because the node is 
shutting down and an index closed between it moved away.

This commit changes the IndexRemovalReason used when 
closing the IndicesService to be SHUTDOWN.

backport of #65816