### PR TITLE
Move RestClusterStateAction Response Serialization to Management Pool (#65843)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
@@ -68,6 +68,7 @@ import org.elasticsearch.test.disruption.BusyMasterServiceDisruption;
 import org.elasticsearch.test.disruption.ServiceDisruptionScheme;
 import org.elasticsearch.test.rest.FakeRestRequest;
 import org.elasticsearch.test.transport.MockTransportService;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportMessageListener;
 import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.transport.TransportRequestOptions;
@@ -443,7 +444,8 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
             throw getRepoError.get();
         }
 
-        RestClusterStateAction clusterStateAction = new RestClusterStateAction(internalCluster().getInstance(SettingsFilter.class));
+        RestClusterStateAction clusterStateAction = new RestClusterStateAction(internalCluster().getInstance(SettingsFilter.class),
+                internalCluster().getInstance(ThreadPool.class));
         RestRequest clusterStateRequest = new FakeRestRequest();
         final CountDownLatch clusterStateLatch = new CountDownLatch(1);
         final AtomicReference<AssertionError> clusterStateError = new AtomicReference<>();

--- a/server/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -652,7 +652,7 @@ public class ActionModule extends AbstractModule {
         registerHandler.accept(new RestNodesHotThreadsAction());
         registerHandler.accept(new RestClusterAllocationExplainAction());
         registerHandler.accept(new RestClusterStatsAction());
-        registerHandler.accept(new RestClusterStateAction(settingsFilter));
+        registerHandler.accept(new RestClusterStateAction(settingsFilter, threadPool));
         registerHandler.accept(new RestClusterHealthAction());
         registerHandler.accept(new RestClusterUpdateSettingsAction());
         registerHandler.accept(new RestClusterGetSettingsAction(settings, clusterSettings, settingsFilter));

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterStateAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterStateAction.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.rest.action.admin.cluster;
 
+import org.elasticsearch.ElasticsearchTimeoutException;
+import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -36,7 +38,9 @@ import org.elasticsearch.rest.BytesRestResponse;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestResponse;
 import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.rest.action.RestActionListener;
 import org.elasticsearch.rest.action.RestBuilderListener;
+import org.elasticsearch.threadpool.ThreadPool;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -54,8 +58,11 @@ public class RestClusterStateAction extends BaseRestHandler {
 
     private final SettingsFilter settingsFilter;
 
-    public RestClusterStateAction(SettingsFilter settingsFilter) {
+    private final ThreadPool threadPool;
+
+    public RestClusterStateAction(SettingsFilter settingsFilter, ThreadPool threadPool) {
         this.settingsFilter = settingsFilter;
+        this.threadPool = threadPool;
     }
 
     @Override
@@ -109,20 +116,36 @@ public class RestClusterStateAction extends BaseRestHandler {
         }
         settingsFilter.addFilterSettingParams(request);
 
-        return channel -> client.admin().cluster().state(clusterStateRequest, new RestBuilderListener<ClusterStateResponse>(channel) {
-            @Override
-            public RestResponse buildResponse(ClusterStateResponse response, XContentBuilder builder) throws Exception {
-                builder.startObject();
-                if (clusterStateRequest.waitForMetadataVersion() != null) {
-                    builder.field(Fields.WAIT_FOR_TIMED_OUT, response.isWaitForTimedOut());
-                }
-                builder.field(Fields.CLUSTER_NAME, response.getClusterName().value());
-                ToXContent.Params params = new ToXContent.DelegatingMapParams(
-                    singletonMap(Metadata.CONTEXT_MODE_PARAM, Metadata.CONTEXT_MODE_API), request);
-                response.getState().toXContent(builder, params);
-                builder.endObject();
-                return new BytesRestResponse(RestStatus.OK, builder);
-            }
+        return channel -> client.admin().cluster().state(clusterStateRequest, new RestActionListener<ClusterStateResponse>(channel) {
+
+                    @Override
+                    protected void processResponse(ClusterStateResponse response) {
+                        final long startTimeMs = threadPool.relativeTimeInMillis();
+                        // Process serialization on MANAGEMENT pool since the serialization of the cluster state to XContent
+                        // can be too slow to execute on an IO thread
+                        threadPool.executor(ThreadPool.Names.MANAGEMENT).execute(
+                                ActionRunnable.wrap(this, l -> new RestBuilderListener<ClusterStateResponse>(channel) {
+                                    @Override
+                                    public RestResponse buildResponse(final ClusterStateResponse response,
+                                                                      final XContentBuilder builder) throws Exception {
+                                        if (clusterStateRequest.local() == false &&
+                                                threadPool.relativeTimeInMillis() - startTimeMs >
+                                                        clusterStateRequest.masterNodeTimeout().millis()) {
+                                            throw new ElasticsearchTimeoutException("Timed out getting cluster state");
+                                        }
+                                        builder.startObject();
+                                        if (clusterStateRequest.waitForMetadataVersion() != null) {
+                                            builder.field(Fields.WAIT_FOR_TIMED_OUT, response.isWaitForTimedOut());
+                                        }
+                                        builder.field(Fields.CLUSTER_NAME, response.getClusterName().value());
+                                        ToXContent.Params params = new ToXContent.DelegatingMapParams(
+                                                singletonMap(Metadata.CONTEXT_MODE_PARAM, Metadata.CONTEXT_MODE_API), request);
+                                        response.getState().toXContent(builder, params);
+                                        builder.endObject();
+                                        return new BytesRestResponse(RestStatus.OK, builder);
+                                    }
+                                }.onResponse(response)));
+                    }
         });
     }
 

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetMappingAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetMappingAction.java
@@ -121,8 +121,8 @@ public class RestGetMappingAction extends BaseRestHandler {
             @Override
             protected void processResponse(GetMappingsResponse getMappingsResponse) {
                 final long startTimeMs = threadPool.relativeTimeInMillis();
-                // Process serialization on GENERIC pool since the serialization of the raw mappings to XContent can be too slow to execute
-                // on an IO thread
+                // Process serialization on MANAGEMENT pool since the serialization of the raw mappings to XContent can be too slow to
+                // execute on an IO thread
                 threadPool.executor(ThreadPool.Names.MANAGEMENT).execute(
                         ActionRunnable.wrap(this, l -> new RestBuilderListener<GetMappingsResponse>(channel) {
                             @Override


### PR DESCRIPTION
Moving the cluster state response serialization to the management thread just like we did for the mappings response in #57937 since it's a potentially very large and slow to serialize response.

backport of #65843 