### PR TITLE
[7.x] [ML] fix running AutoscaleIT when build isn't a snapshot build (#65848)

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/build.gradle
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/build.gradle
@@ -1,3 +1,4 @@
+import org.elasticsearch.gradle.info.BuildParams
 apply plugin: 'elasticsearch.java-rest-test'
 
 dependencies {
@@ -37,6 +38,9 @@ testClusters.all {
   numberOfNodes = 3
   testDistribution = 'DEFAULT'
 
+  if (BuildParams.isSnapshotBuild() == false) {
+    systemProperty 'es.autoscaling_feature_flag_registered', 'true'
+  }
   setting 'xpack.security.enabled', 'true'
   setting 'xpack.monitoring.elasticsearch.collection.enabled', 'false'
   setting 'xpack.ml.enabled', 'true'

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/AutoscalingIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/AutoscalingIT.java
@@ -11,7 +11,6 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.xpack.autoscaling.Autoscaling;
 import org.elasticsearch.xpack.autoscaling.action.GetAutoscalingCapacityAction;
 import org.elasticsearch.xpack.autoscaling.action.PutAutoscalingPolicyAction;
 import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingDeciderResult;


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ML] fix running AutoscaleIT when build isn't a snapshot build (#65848)