### PR TITLE
[ML] Muting tests that use old-cluster-categorization-job

### DIFF
--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/30_ml_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/30_ml_jobs_crud.yml
@@ -51,6 +51,10 @@
 
 ---
 "Test get old cluster categorization job":
+  - skip:
+      version: "all"
+      reason: "@AwaitsFix(bugUrl = https://github.com/elastic/elasticsearch/issues/65893)"
+
   - do:
       ml.get_jobs:
         job_id: old-cluster-categorization-job

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/30_ml_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/30_ml_jobs_crud.yml
@@ -8,6 +8,10 @@ setup:
 
 ---
 "Test open old jobs":
+  - skip:
+      version: "all"
+      reason: "@AwaitsFix(bugUrl = https://github.com/elastic/elasticsearch/issues/65893)"
+
   - do:
       ml.open_job:
         job_id: old-cluster-job


### PR DESCRIPTION
Due to https://github.com/elastic/elasticsearch/issues/65893