### PR TITLE
[7.x] [DOCS] Correct the default value of `wait_for_completion` query param (#65800)

### DIFF
--- a/docs/reference/cluster/tasks.asciidoc
+++ b/docs/reference/cluster/tasks.asciidoc
@@ -45,8 +45,9 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=parent-task-id]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=wait_for_completion]
-
+`wait_for_completion`::
+(Optional, Boolean) If `true`, the request blocks until the operation is complete.
+Defaults to `false`.
     
 [[tasks-api-response-codes]]
 ==== {api-response-codes-title}

--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -440,7 +440,9 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeout]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards]
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=wait_for_completion]
+`wait_for_completion`::
+(Optional, Boolean) If `true`, the request blocks until the operation is complete.
+Defaults to `true`.
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=requests_per_second]
 

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -1102,9 +1102,3 @@ Default: 1, the primary shard.
 See <<index-wait-for-active-shards>>.
 --
 end::wait_for_active_shards[]
-
-tag::wait_for_completion[]
-`wait_for_completion`::
-(Optional, Boolean) If `true`, the request blocks until the operation is complete.
-Defaults to `true`.
-end::wait_for_completion[]

--- a/docs/reference/searchable-snapshots/apis/mount-snapshot.asciidoc
+++ b/docs/reference/searchable-snapshots/apis/mount-snapshot.asciidoc
@@ -45,7 +45,9 @@ to mount.
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=wait_for_completion]
+`wait_for_completion`::
+(Optional, Boolean) If `true`, the request blocks until the operation is complete.
+Defaults to `false`.
 
 [[searchable-snapshots-api-mount-request-body]]
 ==== {api-request-body-title}


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Correct the default value of `wait_for_completion` query param (#65800)