### PR TITLE
[7.x] [DOCS] Fix typo (#65912)

### DIFF
--- a/docs/reference/analysis/index-search-time.asciidoc
+++ b/docs/reference/analysis/index-search-time.asciidoc
@@ -81,7 +81,7 @@ indexed in the `text` field.
 |`dog`     |              | X
 |===
 
-Because the field value are query string were analyzed in the same way, they
+Because the field value and query string were analyzed in the same way, they
 created similar tokens. The tokens `quick` and `fox` are exact matches. This
 means the search matches the document containing `"The QUICK brown foxes jumped
 over the dog!"`, just as the user expects.


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Fix typo (#65912)