### PR TITLE
Do not mmap() or preload files just for the footer

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/server/src/main/java/org/elasticsearch/index/store/Store.java
@@ -136,7 +136,7 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
         Setting.timeSetting("index.store.stats_refresh_interval", TimeValue.timeValueSeconds(10), Property.IndexScope);
 
     /**
-     * Specific {@link IOContext} used to verify Lucene files footer checksums.
+     * Specific {@link IOContext} indicating that we will read only the Lucene file footer (containing the file checksum)
      * See {@link MetadataSnapshot#checksumFromLuceneFile(Directory, String, Map, Logger, Version, boolean)}
      */
     public static final IOContext READONCE_CHECKSUM = new IOContext(IOContext.READONCE.context);

--- a/server/src/test/java/org/elasticsearch/index/store/FsDirectoryFactoryTests.java
+++ b/server/src/test/java/org/elasticsearch/index/store/FsDirectoryFactoryTests.java
@@ -58,15 +58,16 @@ public class FsDirectoryFactoryTests extends ESTestCase {
         try (Directory directory = newDirectory(build)) {
             assertTrue(FsDirectoryFactory.isHybridFs(directory));
             FsDirectoryFactory.HybridDirectory hybridDirectory = (FsDirectoryFactory.HybridDirectory) directory;
-            assertTrue(hybridDirectory.useDelegate("foo.dvd"));
-            assertTrue(hybridDirectory.useDelegate("foo.nvd"));
-            assertTrue(hybridDirectory.useDelegate("foo.tim"));
-            assertTrue(hybridDirectory.useDelegate("foo.tip"));
-            assertTrue(hybridDirectory.useDelegate("foo.cfs"));
-            assertTrue(hybridDirectory.useDelegate("foo.dim"));
-            assertTrue(hybridDirectory.useDelegate("foo.kdd"));
-            assertTrue(hybridDirectory.useDelegate("foo.kdi"));
-            assertFalse(hybridDirectory.useDelegate("foo.bar"));
+            assertTrue(hybridDirectory.useDelegate("foo.dvd", newIOContext(random())));
+            assertTrue(hybridDirectory.useDelegate("foo.nvd", newIOContext(random())));
+            assertTrue(hybridDirectory.useDelegate("foo.tim", newIOContext(random())));
+            assertTrue(hybridDirectory.useDelegate("foo.tip", newIOContext(random())));
+            assertTrue(hybridDirectory.useDelegate("foo.cfs", newIOContext(random())));
+            assertTrue(hybridDirectory.useDelegate("foo.dim", newIOContext(random())));
+            assertTrue(hybridDirectory.useDelegate("foo.kdd", newIOContext(random())));
+            assertTrue(hybridDirectory.useDelegate("foo.kdi", newIOContext(random())));
+            assertFalse(hybridDirectory.useDelegate("foo.kdi", Store.READONCE_CHECKSUM));
+            assertFalse(hybridDirectory.useDelegate("foo.bar", newIOContext(random())));
             MMapDirectory delegate = hybridDirectory.getDelegate();
             assertThat(delegate, Matchers.instanceOf(FsDirectoryFactory.PreLoadMMapDirectory.class));
             FsDirectoryFactory.PreLoadMMapDirectory preLoadMMapDirectory = (FsDirectoryFactory.PreLoadMMapDirectory) delegate;


### PR DESCRIPTION
Today during replica shard allocation we read the checksum footer for
every file (#56933). By default some of these files are opened using
`mmap()` and are subject to preloading if preloading is configured. This
is rather wasteful.

This commit switches these open-and-read-footer operations to use
`NIOFSDirectory` avoiding the unnecessary preloading step even if it is
configured. This somewhat mitigates #56933, but does not resolve it
fully since even after this change we still open many more files than we
really need to.