### PR TITLE
Add missing path to API spec

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.clear_api_key_cache.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.clear_api_key_cache.json
@@ -18,6 +18,12 @@
               "description":"A comma-separated list of IDs of API keys to clear from the cache"
             }
           }
+        },
+        {
+          "path":"/_security/api_key/*/_clear_cache",
+          "methods":[
+            "POST"
+          ]
         }
       ]
     },

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.clear_api_key_cache.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.clear_api_key_cache.json
@@ -20,7 +20,7 @@
           }
         },
         {
-          "path":"/_security/api_key/*/_clear_cache",
+          "path":"/_security/api_key/_clear_cache",
           "methods":[
             "POST"
           ]


### PR DESCRIPTION
The clear API key cache documentation and discussions in #63885 and #63907 suggest that to clear all API keys from the cache, an asterisk can be used in the URL.

We have patched the API spec when implementing this API in elasticsearch-net, https://github.com/elastic/elasticsearch-net/pull/5147 and this PR introduces this path to the main specification so that future code generation does not require manual patching.

Ideally this will backport to 7.10 branch so that 7.10 clients pick up the additional path from the spec.

cc @Mpdreamz 