### PR TITLE
[Transform] Always apply range query in continuous mode.

### DIFF
--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
@@ -884,8 +884,11 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
 
             // Only apply extra filter if it is the subsequent run of the continuous transform
             if (nextCheckpoint.getCheckpoint() > 1 && changeCollector != null) {
-                filteredQuery
-                    .filter(changeCollector.buildFilterQuery(lastCheckpoint.getTimeUpperBound(), nextCheckpoint.getTimeUpperBound()));
+                QueryBuilder filter =
+                    changeCollector.buildFilterQuery(lastCheckpoint.getTimeUpperBound(), nextCheckpoint.getTimeUpperBound());
+                if (filter != null) {
+                    filteredQuery.filter(filter);
+                }
             }
 
             queryBuilder = filteredQuery;


### PR DESCRIPTION
This PR makes the range query from sync config applied always when the transform is continuous.

Relates https://github.com/elastic/elasticsearch/issues/65817