### PR TITLE
[7.x] [DOCS] Make data stream names consistent (#65920)

### DIFF
--- a/docs/reference/data-streams/set-up-a-data-stream.asciidoc
+++ b/docs/reference/data-streams/set-up-a-data-stream.asciidoc
@@ -149,9 +149,10 @@ template's index patterns.
 
 [source,console]
 ----
-PUT /_data_stream/my-data-stream-alt
+PUT /_data_stream/my-data-stream
 ----
 // TEST[continued]
+// TEST[s/my-data-stream/my-data-stream-alt/]
 
 [discrete]
 [[secure-a-data-stream]]

--- a/docs/reference/data-streams/use-a-data-stream.asciidoc
+++ b/docs/reference/data-streams/use-a-data-stream.asciidoc
@@ -38,8 +38,6 @@ PUT /my-data-stream/_create/bfspvnIBr7VVZlfp2lqX?refresh=wait_for
   },
   "message": "Login successful"
 }
-
-PUT /_data_stream/my-data-stream-alt
 ----
 // TESTSETUP
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Make data stream names consistent (#65920)