### PR TITLE
[ML] Disable dynamic mapping to DFA dest index

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/DataFrameAnalysis.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/DataFrameAnalysis.java
@@ -51,7 +51,7 @@ public interface DataFrameAnalysis extends ToXContentObject, NamedWriteable {
      * @param fieldCapabilitiesResponse field capabilities fetched for this analysis' required fields
      * @return {@link Map} containing fields for which the mappings should be handled explicitly
      */
-    Map<String, Object> getExplicitlyMappedFields(String resultsFieldName, FieldCapabilitiesResponse fieldCapabilitiesResponse);
+    Map<String, Object> getResultMappings(String resultsFieldName, FieldCapabilitiesResponse fieldCapabilitiesResponse);
 
     /**
      * @return {@code true} if this analysis supports data frame rows with missing values

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/OutlierDetection.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/OutlierDetection.java
@@ -246,7 +246,7 @@ public class OutlierDetection implements DataFrameAnalysis {
     }
 
     @Override
-    public Map<String, Object> getExplicitlyMappedFields(String resultsFieldName, FieldCapabilitiesResponse fieldCapabilitiesResponse) {
+    public Map<String, Object> getResultMappings(String resultsFieldName, FieldCapabilitiesResponse fieldCapabilitiesResponse) {
         Map<String, Object> additionalProperties = new HashMap<>();
         additionalProperties.put(resultsFieldName + ".outlier_score",
             Collections.singletonMap("type", NumberFieldMapper.NumberType.DOUBLE.typeName()));

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Regression.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Regression.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.mapper.BooleanFieldMapper;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.mapper.ObjectMapper;
@@ -285,8 +286,9 @@ public class Regression implements DataFrameAnalysis {
     }
 
     @Override
-    public Map<String, Object> getExplicitlyMappedFields(String resultsFieldName, FieldCapabilitiesResponse fieldCapabilitiesResponse) {
+    public Map<String, Object> getResultMappings(String resultsFieldName, FieldCapabilitiesResponse fieldCapabilitiesResponse) {
         Map<String, Object> additionalProperties = new HashMap<>();
+        additionalProperties.put(resultsFieldName + ".is_training", Collections.singletonMap("type", BooleanFieldMapper.CONTENT_TYPE));
         additionalProperties.put(resultsFieldName + ".feature_importance", FEATURE_IMPORTANCE_MAPPING);
         // Prediction field should be always mapped as "double" rather than "float" in order to increase precision in case of
         // high (over 10M) values of dependent variable.

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/OutlierDetectionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/OutlierDetectionTests.java
@@ -107,8 +107,8 @@ public class OutlierDetectionTests extends AbstractBWCSerializationTestCase<Outl
         assertThat(createTestInstance().getFieldCardinalityConstraints(), is(empty()));
     }
 
-    public void testGetExplicitlyMappedFields() {
-        Map<String, Object> mappedFields = createTestInstance().getExplicitlyMappedFields("test", null);
+    public void testGetResultMappings() {
+        Map<String, Object> mappedFields = createTestInstance().getResultMappings("test", null);
         assertThat(mappedFields.size(), equalTo(2));
         assertThat(mappedFields, hasKey("test.outlier_score"));
         assertThat(mappedFields.get("test.outlier_score"),

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/RegressionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/RegressionTests.java
@@ -325,6 +325,7 @@ public class RegressionTests extends AbstractBWCSerializationTestCase<Regression
         Map<String, Object> resultMappings = new Regression("foo").getResultMappings("results", null);
         assertThat(resultMappings, hasEntry("results.foo_prediction", Collections.singletonMap("type", "double")));
         assertThat(resultMappings, hasEntry("results.feature_importance", Regression.FEATURE_IMPORTANCE_MAPPING));
+        assertThat(resultMappings, hasEntry("results.is_training", Collections.singletonMap("type", "boolean")));
     }
 
     public void testGetStateDocId() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/RegressionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/RegressionTests.java
@@ -321,10 +321,10 @@ public class RegressionTests extends AbstractBWCSerializationTestCase<Regression
         assertThat(createTestInstance().getFieldCardinalityConstraints(), is(empty()));
     }
 
-    public void testGetExplicitlyMappedFields() {
-        Map<String, Object> explicitlyMappedFields = new Regression("foo").getExplicitlyMappedFields("results", null);
-        assertThat(explicitlyMappedFields, hasEntry("results.foo_prediction", Collections.singletonMap("type", "double")));
-        assertThat(explicitlyMappedFields, hasEntry("results.feature_importance", Regression.FEATURE_IMPORTANCE_MAPPING));
+    public void testGetResultMappings() {
+        Map<String, Object> resultMappings = new Regression("foo").getResultMappings("results", null);
+        assertThat(resultMappings, hasEntry("results.foo_prediction", Collections.singletonMap("type", "double")));
+        assertThat(resultMappings, hasEntry("results.feature_importance", Regression.FEATURE_IMPORTANCE_MAPPING));
     }
 
     public void testGetStateDocId() {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DestinationIndex.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DestinationIndex.java
@@ -175,7 +175,7 @@ public final class DestinationIndex {
         Map<String, Object> mappingsAsMap = mappings.sourceAsMap();
         Map<String, Object> properties = getOrPutDefault(mappingsAsMap, PROPERTIES, HashMap::new);
         checkResultsFieldIsNotPresentInProperties(config, properties);
-        properties.putAll(createAdditionalMappings(config, Collections.unmodifiableMap(properties), fieldCapabilitiesResponse));
+        properties.putAll(createAdditionalMappings(config, fieldCapabilitiesResponse));
         Map<String, Object> metadata = getOrPutDefault(mappingsAsMap, META, HashMap::new);
         metadata.putAll(createMetadata(config.getId(), clock, Version.CURRENT));
         return new CreateIndexRequest(destinationIndex, settings).mapping(mappingsAsMap);
@@ -210,12 +210,11 @@ public final class DestinationIndex {
     }
 
     private static Map<String, Object> createAdditionalMappings(DataFrameAnalyticsConfig config,
-                                                                Map<String, Object> mappingsProperties,
                                                                 FieldCapabilitiesResponse fieldCapabilitiesResponse) {
         Map<String, Object> properties = new HashMap<>();
         properties.put(INCREMENTAL_ID, Map.of("type", NumberFieldMapper.NumberType.LONG.typeName()));
         properties.putAll(
-            config.getAnalysis().getExplicitlyMappedFields(
+            config.getAnalysis().getResultMappings(
                 config.getDest().getResultsField(), fieldCapabilitiesResponse));
         return properties;
     }
@@ -259,10 +258,7 @@ public final class DestinationIndex {
         ActionListener<FieldCapabilitiesResponse> fieldCapabilitiesListener = ActionListener.wrap(
             fieldCapabilitiesResponse -> {
                 // Determine mappings to be added to the destination index
-                Map<String, Object> addedMappings =
-                    Map.of(
-                        PROPERTIES,
-                        createAdditionalMappings(config, Collections.unmodifiableMap(destPropertiesAsMap), fieldCapabilitiesResponse));
+                Map<String, Object> addedMappings = Map.of(PROPERTIES, createAdditionalMappings(config, fieldCapabilitiesResponse));
 
                 // Add the mappings to the destination index
                 PutMappingRequest putMappingRequest =

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/MappingsMerger.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/MappingsMerger.java
@@ -18,7 +18,6 @@ import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsSource;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -89,8 +88,11 @@ public final class MappingsMerger {
             mergedMappings.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().mapping)));
     }
 
-    private static MappingMetadata createMappingMetadata(String type, Map<String, Object> mappings) {
-        return new MappingMetadata(type, Collections.singletonMap("properties", mappings));
+    private static MappingMetadata createMappingMetadata(String type, Map<String, Object> properties) {
+        Map<String, Object> mappings = new HashMap<>();
+        mappings.put("dynamic", false);
+        mappings.put("properties", properties);
+        return new MappingMetadata(type, mappings);
     }
 
     private static class IndexAndMapping {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/MappingsMergerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/MappingsMergerTests.java
@@ -38,7 +38,12 @@ public class MappingsMergerTests extends ESTestCase {
 
         MappingMetadata mergedMappings = MappingsMerger.mergeMappings(newSource(), getMappingsResponse);
 
-        assertThat(mergedMappings.getSourceAsMap(), equalTo(index1Mappings));
+        Map<String, Object> mergedMappingsMap = mergedMappings.getSourceAsMap();
+        assertThat(mergedMappingsMap.size(), equalTo(2));
+        assertThat(mergedMappingsMap.containsKey("dynamic"), is(true));
+        assertThat(mergedMappingsMap.get("dynamic"), equalTo(false));
+        assertThat(mergedMappingsMap.containsKey("properties"), is(true));
+        assertThat(mergedMappingsMap.get("properties"), equalTo(index1Mappings.get("properties")));
     }
 
     public void testMergeMappings_GivenFieldWithDifferentMapping() {
@@ -80,7 +85,9 @@ public class MappingsMergerTests extends ESTestCase {
         MappingMetadata mergedMappings = MappingsMerger.mergeMappings(newSource(), getMappingsResponse);
 
         Map<String, Object> mappingsAsMap = mergedMappings.getSourceAsMap();
-        assertThat(mappingsAsMap.size(), equalTo(1));
+        assertThat(mappingsAsMap.size(), equalTo(2));
+        assertThat(mappingsAsMap.containsKey("dynamic"), is(true));
+        assertThat(mappingsAsMap.get("dynamic"), equalTo(false));
         assertThat(mappingsAsMap.containsKey("properties"), is(true));
 
         @SuppressWarnings("unchecked")

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/MappingsMergerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/MappingsMergerTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsSource;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -38,12 +39,10 @@ public class MappingsMergerTests extends ESTestCase {
 
         MappingMetadata mergedMappings = MappingsMerger.mergeMappings(newSource(), getMappingsResponse);
 
-        Map<String, Object> mergedMappingsMap = mergedMappings.getSourceAsMap();
-        assertThat(mergedMappingsMap.size(), equalTo(2));
-        assertThat(mergedMappingsMap.containsKey("dynamic"), is(true));
-        assertThat(mergedMappingsMap.get("dynamic"), equalTo(false));
-        assertThat(mergedMappingsMap.containsKey("properties"), is(true));
-        assertThat(mergedMappingsMap.get("properties"), equalTo(index1Mappings.get("properties")));
+        Map<String, Object> expectedMappings = new HashMap<>();
+        expectedMappings.put("dynamic", false);
+        expectedMappings.put("properties", index1Mappings.get("properties"));
+        assertThat(mergedMappings.getSourceAsMap(), equalTo(expectedMappings));
     }
 
     public void testMergeMappings_GivenFieldWithDifferentMapping() {


### PR DESCRIPTION
We need to disable dynamic mapping to the destination
index of data frame analytics jobs. If the source index
has dynamic mapping disabled, then after reindexing it is
possible that we add mappings for fields that were previously
unmapped, thus making them eligible features. This is
confusing to the user.

This commit disables dynamic mapping to the destination index.
It makes all result field mappings explicit.
