### PR TITLE
Expose security clear cache paths explicitly

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/apikey/RestClearApiKeyCacheAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/apikey/RestClearApiKeyCacheAction.java
@@ -15,7 +15,6 @@ import org.elasticsearch.xpack.core.security.action.ClearSecurityCacheAction;
 import org.elasticsearch.xpack.core.security.action.ClearSecurityCacheRequest;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 
 import static org.elasticsearch.rest.RestRequest.Method.POST;

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/apikey/RestClearApiKeyCacheAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/apikey/RestClearApiKeyCacheAction.java
@@ -33,8 +33,10 @@ public class RestClearApiKeyCacheAction extends ApiKeyBaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return Collections.singletonList(
-            new Route(POST, "/_security/api_key/{ids}/_clear_cache"));
+        return List.of(
+            new Route(POST, "/_security/api_key/_clear_cache"),
+            new Route(POST, "/_security/api_key/{ids}/_clear_cache")
+        );
     }
 
     @Override

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/privilege/RestClearPrivilegesCacheAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/privilege/RestClearPrivilegesCacheAction.java
@@ -34,7 +34,10 @@ public class RestClearPrivilegesCacheAction extends SecurityBaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return Collections.singletonList(new Route(POST, "/_security/privilege/{application}/_clear_cache"));
+        return List.of(
+            new Route(POST, "/_security/privilege/_clear_cache"),
+            new Route(POST, "/_security/privilege/{application}/_clear_cache")
+        );
     }
 
     @Override

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/privilege/RestClearPrivilegesCacheAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/privilege/RestClearPrivilegesCacheAction.java
@@ -16,7 +16,6 @@ import org.elasticsearch.xpack.core.security.action.privilege.ClearPrivilegesCac
 import org.elasticsearch.xpack.security.rest.action.SecurityBaseRestHandler;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 
 import static org.elasticsearch.rest.RestRequest.Method.POST;

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/realm/RestClearRealmCacheAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/realm/RestClearRealmCacheAction.java
@@ -27,7 +27,7 @@ public final class RestClearRealmCacheAction extends SecurityBaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return Collections.emptyList();
+        return Collections.singletonList(new Route(POST, "/_security/realm/_clear_cache"));
     }
 
     @Override

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/role/RestClearRolesCacheAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/role/RestClearRolesCacheAction.java
@@ -27,7 +27,7 @@ public final class RestClearRolesCacheAction extends SecurityBaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return Collections.emptyList();
+        return Collections.singletonList(new Route(POST, "/_security/role/_clear_cache"));
     }
 
     @Override

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.clear_api_key_cache.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.clear_api_key_cache.json
@@ -21,6 +21,12 @@
               "description":"A comma-separated list of IDs of API keys to clear from the cache"
             }
           }
+        },
+        {
+          "path":"/_security/api_key/_clear_cache",
+          "methods":[
+            "POST"
+          ]
         }
       ]
     },

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.clear_cached_privileges.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.clear_cached_privileges.json
@@ -21,6 +21,12 @@
               "description":"A comma-separated list of application names"
             }
           }
+        },
+        {
+          "path":"/_security/privilege/_clear_cache",
+          "methods":[
+            "POST"
+          ]
         }
       ]
     },

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.clear_cached_realms.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.clear_cached_realms.json
@@ -21,6 +21,12 @@
               "description":"Comma-separated list of realms to clear"
             }
           }
+        },
+        {
+          "path":"/_security/realm/_clear_cache",
+          "methods":[
+            "POST"
+          ]
         }
       ]
     },

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.clear_cached_roles.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.clear_cached_roles.json
@@ -21,6 +21,12 @@
               "description":"Role name"
             }
           }
+        },
+        {
+          "path":"/_security/role/_clear_cache",
+          "methods":[
+            "POST"
+          ]
         }
       ]
     },

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/privileges/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/privileges/10_basic.yml
@@ -337,5 +337,5 @@ teardown:
   - match: { _nodes.failed: 0 }
 
   - do:
-      security.clear_cached_privileges:
+      security.clear_cached_privileges: {}
   - match: { _nodes.failed: 0 }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/privileges/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/privileges/10_basic.yml
@@ -338,5 +338,4 @@ teardown:
 
   - do:
       security.clear_cached_privileges:
-        application: "*"
   - match: { _nodes.failed: 0 }


### PR DESCRIPTION
This PR adds explicit routes for the optional path parameters for the
various security clear cache api's.

This follows an already established pattern of other api's taking
optional path parameters.

cc @stevejgordon continuation of: https://github.com/elastic/elasticsearch/pull/65924