### PR TITLE
Fix DiskThresholdDeciderIT

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/cluster/DiskUsageIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/DiskUsageIntegTestCase.java
@@ -212,6 +212,9 @@ public class DiskUsageIntegTestCase extends ESIntegTestCase {
         }
 
         TestFileStore getTestFileStore(Path path) {
+            if (path.endsWith(path.getFileSystem().getPath("nodes", "0"))) {
+                path = path.getParent().getParent();
+            }
             final TestFileStore fileStore = trackedPaths.get(path);
             if (fileStore != null) {
                 return fileStore;


### PR DESCRIPTION
In #65540, DiskUsageIntegTestCase was extracted. Unfortunately, the 7.x
backport (#65868) removed the handling of the nodes/0 folder,
reintroduced here.

Closes #65946
