### PR TITLE
[7.x][ML] Disable dynamic mapping to DFA dest index (#65972)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Classification.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Classification.java
@@ -16,6 +16,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.mapper.BooleanFieldMapper;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.mapper.ObjectMapper;
@@ -141,7 +142,6 @@ public class Classification implements DataFrameAnalysis {
 
         Map<String, Object> properties = new HashMap<>();
         properties.put("feature_name", Collections.singletonMap("type", KeywordFieldMapper.CONTENT_TYPE));
-        properties.put("importance", Collections.singletonMap("type", NumberFieldMapper.NumberType.DOUBLE.typeName()));
         properties.put("classes", classesMapping);
 
         Map<String, Object> mapping = new HashMap<>();
@@ -376,15 +376,18 @@ public class Classification implements DataFrameAnalysis {
 
     @SuppressWarnings("unchecked")
     @Override
-    public Map<String, Object> getExplicitlyMappedFields(String resultsFieldName, FieldCapabilitiesResponse fieldCapabilitiesResponse) {
+    public Map<String, Object> getResultMappings(String resultsFieldName, FieldCapabilitiesResponse fieldCapabilitiesResponse) {
         Map<String, Object> additionalProperties = new HashMap<>();
+        additionalProperties.put(resultsFieldName + ".is_training", Collections.singletonMap("type", BooleanFieldMapper.CONTENT_TYPE));
+        additionalProperties.put(resultsFieldName + ".prediction_probability",
+            Collections.singletonMap("type", NumberFieldMapper.NumberType.DOUBLE.typeName()));
+        additionalProperties.put(resultsFieldName + ".prediction_score",
+            Collections.singletonMap("type", NumberFieldMapper.NumberType.DOUBLE.typeName()));
         additionalProperties.put(resultsFieldName + ".feature_importance", FEATURE_IMPORTANCE_MAPPING);
-        if (fieldCapabilitiesResponse == null) {
-            return additionalProperties;
-        }
+
         Map<String, FieldCapabilities> dependentVariableFieldCaps = fieldCapabilitiesResponse.getField(dependentVariable);
         if (dependentVariableFieldCaps == null || dependentVariableFieldCaps.isEmpty()) {
-            return additionalProperties;
+            throw ExceptionsHelper.badRequestException("no mappings could be found for required field [{}]", DEPENDENT_VARIABLE);
         }
         Object dependentVariableMappingType = dependentVariableFieldCaps.values().iterator().next().getType();
         additionalProperties.put(
@@ -393,6 +396,7 @@ public class Classification implements DataFrameAnalysis {
         Map<String, Object> topClassesProperties = new HashMap<>();
         topClassesProperties.put("class_name", Collections.singletonMap("type", dependentVariableMappingType));
         topClassesProperties.put("class_probability", Collections.singletonMap("type", NumberFieldMapper.NumberType.DOUBLE.typeName()));
+        topClassesProperties.put("class_score", Collections.singletonMap("type", NumberFieldMapper.NumberType.DOUBLE.typeName()));
 
         Map<String, Object> topClassesMapping = new HashMap<>();
         topClassesMapping.put("type", ObjectMapper.NESTED_CONTENT_TYPE);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/DataFrameAnalysis.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/DataFrameAnalysis.java
@@ -51,7 +51,7 @@ public interface DataFrameAnalysis extends ToXContentObject, NamedWriteable {
      * @param fieldCapabilitiesResponse field capabilities fetched for this analysis' required fields
      * @return {@link Map} containing fields for which the mappings should be handled explicitly
      */
-    Map<String, Object> getExplicitlyMappedFields(String resultsFieldName, FieldCapabilitiesResponse fieldCapabilitiesResponse);
+    Map<String, Object> getResultMappings(String resultsFieldName, FieldCapabilitiesResponse fieldCapabilitiesResponse);
 
     /**
      * @return {@code true} if this analysis supports data frame rows with missing values

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/OutlierDetection.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/OutlierDetection.java
@@ -246,7 +246,7 @@ public class OutlierDetection implements DataFrameAnalysis {
     }
 
     @Override
-    public Map<String, Object> getExplicitlyMappedFields(String resultsFieldName, FieldCapabilitiesResponse fieldCapabilitiesResponse) {
+    public Map<String, Object> getResultMappings(String resultsFieldName, FieldCapabilitiesResponse fieldCapabilitiesResponse) {
         Map<String, Object> additionalProperties = new HashMap<>();
         additionalProperties.put(resultsFieldName + ".outlier_score",
             Collections.singletonMap("type", NumberFieldMapper.NumberType.DOUBLE.typeName()));

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Regression.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Regression.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.mapper.BooleanFieldMapper;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.mapper.ObjectMapper;
@@ -299,8 +300,9 @@ public class Regression implements DataFrameAnalysis {
     }
 
     @Override
-    public Map<String, Object> getExplicitlyMappedFields(String resultsFieldName, FieldCapabilitiesResponse fieldCapabilitiesResponse) {
+    public Map<String, Object> getResultMappings(String resultsFieldName, FieldCapabilitiesResponse fieldCapabilitiesResponse) {
         Map<String, Object> additionalProperties = new HashMap<>();
+        additionalProperties.put(resultsFieldName + ".is_training", Collections.singletonMap("type", BooleanFieldMapper.CONTENT_TYPE));
         additionalProperties.put(resultsFieldName + ".feature_importance", FEATURE_IMPORTANCE_MAPPING);
         // Prediction field should be always mapped as "double" rather than "float" in order to increase precision in case of
         // high (over 10M) values of dependent variable.

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/ClassificationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/ClassificationTests.java
@@ -364,43 +364,42 @@ public class ClassificationTests extends AbstractBWCSerializationTestCase<Classi
         assertThat(constraints.get(0).getUpperBound(), equalTo(30L));
     }
 
-    public void testGetExplicitlyMappedFields_FieldCapabilitiesResponseIsNull() {
-        Map<String, Object> explicitlyMappedFields = new Classification("foo").getExplicitlyMappedFields("results", null);
-        assertThat(explicitlyMappedFields, equalTo(singletonMap("results.feature_importance", Classification.FEATURE_IMPORTANCE_MAPPING)));
-    }
-
-    public void testGetExplicitlyMappedFields_DependentVariableMappingIsAbsent() {
+    public void testGetResultMappings_DependentVariableMappingIsAbsent() {
         FieldCapabilitiesResponse fieldCapabilitiesResponse = new FieldCapabilitiesResponse(new String[0], Collections.emptyMap());
-        Map<String, Object> explicitlyMappedFields =
-            new Classification("foo").getExplicitlyMappedFields("results", fieldCapabilitiesResponse);
-        assertThat(explicitlyMappedFields, equalTo(singletonMap("results.feature_importance", Classification.FEATURE_IMPORTANCE_MAPPING)));
+        expectThrows(ElasticsearchStatusException.class,
+            () -> new Classification("foo").getResultMappings("results", fieldCapabilitiesResponse));
     }
 
-    public void testGetExplicitlyMappedFields_DependentVariableMappingHasNoTypes() {
+    public void testGetResultMappings_DependentVariableMappingHasNoTypes() {
         FieldCapabilitiesResponse fieldCapabilitiesResponse =
             new FieldCapabilitiesResponse(new String[0], Collections.singletonMap("foo", Collections.emptyMap()));
-        Map<String, Object> explicitlyMappedFields =
-            new Classification("foo").getExplicitlyMappedFields("results", fieldCapabilitiesResponse);
-        assertThat(explicitlyMappedFields, equalTo(singletonMap("results.feature_importance", Classification.FEATURE_IMPORTANCE_MAPPING)));
+        expectThrows(ElasticsearchStatusException.class,
+            () -> new Classification("foo").getResultMappings("results", fieldCapabilitiesResponse));
     }
 
-    public void testGetExplicitlyMappedFields_DependentVariableMappingIsPresent() {
+    public void testGetResultMappings_DependentVariableMappingIsPresent() {
         Map<String, Object> expectedTopClassesMapping = new HashMap<String, Object>() {{
             put("type", "nested");
             put("properties", new HashMap<String, Object>() {{
                 put("class_name", singletonMap("type", "dummy"));
                 put("class_probability", singletonMap("type", "double"));
+                put("class_score", singletonMap("type", "double"));
             }});
         }};
         FieldCapabilitiesResponse fieldCapabilitiesResponse =
             new FieldCapabilitiesResponse(
                 new String[0],
                 Collections.singletonMap("foo", Collections.singletonMap("dummy", createFieldCapabilities("foo", "dummy"))));
-        Map<String, Object> explicitlyMappedFields =
-            new Classification("foo").getExplicitlyMappedFields("results", fieldCapabilitiesResponse);
-        assertThat(explicitlyMappedFields, hasEntry("results.foo_prediction", singletonMap("type", "dummy")));
-        assertThat(explicitlyMappedFields, hasEntry("results.top_classes", expectedTopClassesMapping));
-        assertThat(explicitlyMappedFields, hasEntry("results.feature_importance", Classification.FEATURE_IMPORTANCE_MAPPING));
+
+        Map<String, Object> resultMappings =
+            new Classification("foo").getResultMappings("results", fieldCapabilitiesResponse);
+
+        assertThat(resultMappings, hasEntry("results.foo_prediction", singletonMap("type", "dummy")));
+        assertThat(resultMappings, hasEntry("results.prediction_probability", singletonMap("type", "double")));
+        assertThat(resultMappings, hasEntry("results.prediction_score", singletonMap("type", "double")));
+        assertThat(resultMappings, hasEntry("results.is_training", singletonMap("type", "boolean")));
+        assertThat(resultMappings, hasEntry("results.top_classes", expectedTopClassesMapping));
+        assertThat(resultMappings, hasEntry("results.feature_importance", Classification.FEATURE_IMPORTANCE_MAPPING));
     }
 
     public void testToXContent_GivenVersionBeforeRandomizeSeedWasIntroduced() throws IOException {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/OutlierDetectionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/OutlierDetectionTests.java
@@ -107,8 +107,8 @@ public class OutlierDetectionTests extends AbstractBWCSerializationTestCase<Outl
         assertThat(createTestInstance().getFieldCardinalityConstraints(), is(empty()));
     }
 
-    public void testGetExplicitlyMappedFields() {
-        Map<String, Object> mappedFields = createTestInstance().getExplicitlyMappedFields("test", null);
+    public void testGetResultMappings() {
+        Map<String, Object> mappedFields = createTestInstance().getResultMappings("test", null);
         assertThat(mappedFields.size(), equalTo(2));
         assertThat(mappedFields, hasKey("test.outlier_score"));
         assertThat(mappedFields.get("test.outlier_score"),

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/RegressionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/RegressionTests.java
@@ -321,10 +321,11 @@ public class RegressionTests extends AbstractBWCSerializationTestCase<Regression
         assertThat(createTestInstance().getFieldCardinalityConstraints(), is(empty()));
     }
 
-    public void testGetExplicitlyMappedFields() {
-        Map<String, Object> explicitlyMappedFields = new Regression("foo").getExplicitlyMappedFields("results", null);
-        assertThat(explicitlyMappedFields, hasEntry("results.foo_prediction", Collections.singletonMap("type", "double")));
-        assertThat(explicitlyMappedFields, hasEntry("results.feature_importance", Regression.FEATURE_IMPORTANCE_MAPPING));
+    public void testGetResultMappings() {
+        Map<String, Object> resultMappings = new Regression("foo").getResultMappings("results", null);
+        assertThat(resultMappings, hasEntry("results.foo_prediction", Collections.singletonMap("type", "double")));
+        assertThat(resultMappings, hasEntry("results.feature_importance", Regression.FEATURE_IMPORTANCE_MAPPING));
+        assertThat(resultMappings, hasEntry("results.is_training", Collections.singletonMap("type", "boolean")));
     }
 
     public void testGetStateDocId() {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DestinationIndex.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DestinationIndex.java
@@ -222,7 +222,7 @@ public final class DestinationIndex {
         incrementalIdMapping.put("type", NumberFieldMapper.NumberType.LONG.typeName());
         properties.put(INCREMENTAL_ID, incrementalIdMapping);
 
-        properties.putAll(config.getAnalysis().getExplicitlyMappedFields(config.getDest().getResultsField(), fieldCapabilitiesResponse));
+        properties.putAll(config.getAnalysis().getResultMappings(config.getDest().getResultsField(), fieldCapabilitiesResponse));
         return properties;
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/MappingsMerger.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/MappingsMerger.java
@@ -18,7 +18,6 @@ import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsSource;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -102,9 +101,12 @@ public final class MappingsMerger {
         return result.build();
     }
 
-    private static MappingMetadata createMappingMetadata(String type, Map<String, Object> mappings) {
+    private static MappingMetadata createMappingMetadata(String type, Map<String, Object> properties) {
+        Map<String, Object> mappings = new HashMap<>();
+        mappings.put("dynamic", false);
+        mappings.put("properties", properties);
         try {
-            return new MappingMetadata(type, Collections.singletonMap("properties", mappings));
+            return new MappingMetadata(type, mappings);
         } catch (IOException e) {
             throw ExceptionsHelper.serverError("Failed to parse mappings: " + mappings);
         }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/MappingsMergerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/MappingsMergerTests.java
@@ -52,9 +52,13 @@ public class MappingsMergerTests extends ESTestCase {
 
         ImmutableOpenMap<String, MappingMetadata> mergedMappings = MappingsMerger.mergeMappings(newSource(), getMappingsResponse);
 
+        Map<String, Object> expectedMappings = new HashMap<>();
+        expectedMappings.put("dynamic", false);
+        expectedMappings.put("properties", index1Mappings.get("properties"));
+
         assertThat(mergedMappings.size(), equalTo(1));
         assertThat(mergedMappings.containsKey("_doc"), is(true));
-        assertThat(mergedMappings.valuesIt().next().getSourceAsMap(), equalTo(index1Mappings));
+        assertThat(mergedMappings.valuesIt().next().getSourceAsMap(), equalTo(expectedMappings));
     }
 
     public void testMergeMappings_GivenIndicesWithDifferentTypes() throws IOException {
@@ -142,7 +146,9 @@ public class MappingsMergerTests extends ESTestCase {
         assertThat(mergedMappings.size(), equalTo(1));
         assertThat(mergedMappings.containsKey("_doc"), is(true));
         Map<String, Object> mappingsAsMap = mergedMappings.valuesIt().next().getSourceAsMap();
-        assertThat(mappingsAsMap.size(), equalTo(1));
+        assertThat(mappingsAsMap.size(), equalTo(2));
+        assertThat(mappingsAsMap.containsKey("dynamic"), is(true));
+        assertThat(mappingsAsMap.get("dynamic"), equalTo(false));
         assertThat(mappingsAsMap.containsKey("properties"), is(true));
 
         @SuppressWarnings("unchecked")


### PR DESCRIPTION
We need to disable dynamic mapping to the destination
index of data frame analytics jobs. If the source index
has dynamic mapping disabled, then after reindexing it is
possible that we add mappings for fields that were previously
unmapped, thus making them eligible features. This is
confusing to the user.

This commit disables dynamic mapping to the destination index.
It makes all result field mappings explicit.

Backport of #65972
