### PR TITLE
Clarify network interface setting

### DIFF
--- a/docs/reference/modules/network.asciidoc
+++ b/docs/reference/modules/network.asciidoc
@@ -65,9 +65,6 @@ Defaults to `9300-9400`.
 
 The following special values may be passed to `network.host`:
 
-`_[networkInterface]_`::
-  Addresses of a network interface, for example `_en0_`.
-
 `_local_`::
   Any loopback addresses on the system, for example `127.0.0.1`.
 
@@ -76,6 +73,11 @@ The following special values may be passed to `network.host`:
 
 `_global_`::
   Any globally-scoped addresses on the system, for example `8.8.8.8`.
+
+`_[networkInterface]_`::
+  Use the addresses of the network interface called `[networkInterface]`. For
+  example if you wish to use the addresses of an interface called `en0` then
+  set `network.host: _en0_`.
 
 [[network-interface-values-ipv4-vs-ipv6]]
 ===== IPv4 vs IPv6

--- a/server/src/main/java/org/elasticsearch/common/network/NetworkService.java
+++ b/server/src/main/java/org/elasticsearch/common/network/NetworkService.java
@@ -196,19 +196,19 @@ public final class NetworkService {
     }
 
     /** resolves a single host specification */
-    private InetAddress[] resolveInternal(String host) throws IOException {
+    private InetAddress[] resolveInternal(final String host) throws IOException {
         if ((host.startsWith("#") && host.endsWith("#")) || (host.startsWith("_") && host.endsWith("_"))) {
-            host = host.substring(1, host.length() - 1);
+            final String interfaceSpec = host.substring(1, host.length() - 1);
             // next check any registered custom resolvers if any
             if (customNameResolvers != null) {
                 for (CustomNameResolver customNameResolver : customNameResolvers) {
-                    InetAddress addresses[] = customNameResolver.resolveIfPossible(host);
+                    InetAddress addresses[] = customNameResolver.resolveIfPossible(interfaceSpec);
                     if (addresses != null) {
                         return addresses;
                     }
                 }
             }
-            switch (host) {
+            switch (interfaceSpec) {
                 case "local":
                     return NetworkUtils.getLoopbackAddresses();
                 case "local:ipv4":
@@ -229,14 +229,14 @@ public final class NetworkService {
                     return NetworkUtils.filterIPV6(NetworkUtils.getGlobalAddresses());
                 default:
                     /* an interface specification */
-                    if (host.endsWith(":ipv4")) {
-                        host = host.substring(0, host.length() - 5);
-                        return NetworkUtils.filterIPV4(NetworkUtils.getAddressesForInterface(host));
-                    } else if (host.endsWith(":ipv6")) {
-                        host = host.substring(0, host.length() - 5);
-                        return NetworkUtils.filterIPV6(NetworkUtils.getAddressesForInterface(host));
+                    if (interfaceSpec.endsWith(":ipv4")) {
+                        return NetworkUtils.filterIPV4(NetworkUtils.getAddressesForInterface(host, ":ipv4",
+                                interfaceSpec.substring(0, interfaceSpec.length() - 5)));
+                    } else if (interfaceSpec.endsWith(":ipv6")) {
+                        return NetworkUtils.filterIPV6(NetworkUtils.getAddressesForInterface(host, ":ipv6",
+                                interfaceSpec.substring(0, interfaceSpec.length() - 5)));
                     } else {
-                        return NetworkUtils.getAddressesForInterface(host);
+                        return NetworkUtils.getAddressesForInterface(host, "", interfaceSpec);
                     }
             }
         }

--- a/server/src/main/java/org/elasticsearch/common/network/NetworkUtils.java
+++ b/server/src/main/java/org/elasticsearch/common/network/NetworkUtils.java
@@ -35,6 +35,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 /**
  * Utilities for network interfaces / addresses binding and publishing.
@@ -210,18 +211,22 @@ public abstract class NetworkUtils {
     }
 
     /** Returns addresses for the given interface (it must be marked up) */
-    static InetAddress[] getAddressesForInterface(String name) throws SocketException {
-        Optional<NetworkInterface> networkInterface = maybeGetInterfaceByName(getInterfaces(), name);
+    static InetAddress[] getAddressesForInterface(String settingValue, String suffix, String interfaceName) throws SocketException {
+        Optional<NetworkInterface> networkInterface = maybeGetInterfaceByName(getInterfaces(), interfaceName);
 
         if (networkInterface.isPresent() == false) {
-            throw new IllegalArgumentException("No interface named '" + name + "' found, got " + getInterfaces());
+            throw new IllegalArgumentException("setting [" + settingValue + "] matched no network interfaces; valid values include [" +
+                    getInterfaces().stream().map(otherInterface -> "_" + otherInterface.getName() + suffix + "_")
+                            .collect(Collectors.joining(", ")) + "]");
         }
         if (!networkInterface.get().isUp()) {
-            throw new IllegalArgumentException("Interface '" + name + "' is not up and running");
+            throw new IllegalArgumentException("setting [" + settingValue + "] matched network interface [" +
+                    networkInterface.get().getName() + "] but this interface is not up and running");
         }
         List<InetAddress> list = Collections.list(networkInterface.get().getInetAddresses());
         if (list.isEmpty()) {
-            throw new IllegalArgumentException("Interface '" + name + "' has no internet addresses");
+            throw new IllegalArgumentException("setting [" + settingValue + "] matched network interface [" +
+                    networkInterface.get().getName() + "] but this interface has no internet addresses");
         }
         return list.toArray(new InetAddress[list.size()]);
     }

--- a/server/src/test/java/org/elasticsearch/common/network/NetworkUtilsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/network/NetworkUtilsTests.java
@@ -27,6 +27,8 @@ import java.net.NetworkInterface;
 import java.util.List;
 import java.util.Optional;
 
+import static org.elasticsearch.common.network.NetworkUtils.getInterfaces;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -84,7 +86,7 @@ public class NetworkUtilsTests extends ESTestCase {
 
     // test that selecting by name is possible
     public void testMaybeGetInterfaceByName() throws Exception {
-        final List<NetworkInterface> networkInterfaces = NetworkUtils.getInterfaces();
+        final List<NetworkInterface> networkInterfaces = getInterfaces();
         for (NetworkInterface netIf : networkInterfaces) {
             final Optional<NetworkInterface> maybeNetworkInterface =
                 NetworkUtils.maybeGetInterfaceByName(networkInterfaces, netIf.getName());
@@ -94,8 +96,11 @@ public class NetworkUtilsTests extends ESTestCase {
     }
 
     public void testNonExistingInterface() throws Exception {
-        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class,
-                () -> NetworkUtils.getAddressesForInterface("non-existing"));
-        assertThat(exception.getMessage(), containsString("No interface named 'non-existing' found"));
+        final IllegalArgumentException exception = expectThrows(IllegalArgumentException.class,
+                () -> NetworkUtils.getAddressesForInterface("settingValue", ":suffix" , "non-existing"));
+        assertThat(exception.getMessage(), containsString("setting [settingValue] matched no network interfaces; valid values include"));
+        for (NetworkInterface anInterface : getInterfaces()) {
+            assertThat(exception.getMessage(), containsString(anInterface.getName() + ":suffix"));
+        }
     }
 }

--- a/server/src/test/java/org/elasticsearch/common/network/NetworkUtilsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/network/NetworkUtilsTests.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.elasticsearch.common.network.NetworkUtils.getInterfaces;
-import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 


### PR DESCRIPTION
Today we document the use of `_[networkInterface]_` to specify the
addresses of a network interface but do not spell out which parts of
this syntax should be taken literally and which are part of the
placeholder for the interface name. If you get it wrong then the
exception message is confusing too since it uses the results of
`NetworkInterface#toString()` which contains much more than just the
name of the interface.

This commit clarifies the docs and the exception message.

Closes #65978.