### PR TITLE
[ML] Support mapped runtime fields for data frame analytics

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/MappingsMerger.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/MappingsMerger.java
@@ -46,10 +46,25 @@ public final class MappingsMerger {
         ClientHelper.executeWithHeadersAsync(headers, ML_ORIGIN, client, GetMappingsAction.INSTANCE, getMappingsRequest, mappingsListener);
     }
 
-    static MappingMetadata mergeMappings(DataFrameAnalyticsSource source,
-                                                                   GetMappingsResponse getMappingsResponse) {
-        ImmutableOpenMap<String, MappingMetadata> indexToMappings = getMappingsResponse.getMappings();
+    static MappingMetadata mergeMappings(DataFrameAnalyticsSource source, GetMappingsResponse getMappingsResponse) {
+        Map<String, Object> mappings = new HashMap<>();
+        mappings.put("dynamic", false);
 
+        ImmutableOpenMap<String, MappingMetadata> indexToMappings = getMappingsResponse.getMappings();
+        for (MappingsType mappingsType : MappingsType.values()) {
+            Map<String, IndexAndMapping> mergedMappingsForType = mergeAcrossIndices(source, indexToMappings, mappingsType);
+            if (mergedMappingsForType.isEmpty() == false) {
+                mappings.put(mappingsType.type,
+                    mergedMappingsForType.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().mapping)));
+            }
+        }
+
+        return new MappingMetadata(MapperService.SINGLE_MAPPING_NAME, mappings);
+    }
+
+    private static Map<String, IndexAndMapping> mergeAcrossIndices(DataFrameAnalyticsSource source,
+                                                                   ImmutableOpenMap<String, MappingMetadata> indexToMappings,
+                                                                   MappingsType mappingsType) {
         Map<String, IndexAndMapping> mergedMappings = new HashMap<>();
 
         Iterator<ObjectObjectCursor<String, MappingMetadata>> iterator = indexToMappings.iterator();
@@ -58,10 +73,10 @@ public final class MappingsMerger {
             MappingMetadata mapping = indexMappings.value;
             if (mapping != null) {
                 Map<String, Object> currentMappings = mapping.getSourceAsMap();
-                if (currentMappings.containsKey("properties")) {
+                if (currentMappings.containsKey(mappingsType.type)) {
 
                     @SuppressWarnings("unchecked")
-                    Map<String, Object> fieldMappings = (Map<String, Object>) currentMappings.get("properties");
+                    Map<String, Object> fieldMappings = (Map<String, Object>) currentMappings.get(mappingsType.type);
 
                     for (Map.Entry<String, Object> fieldMapping : fieldMappings.entrySet()) {
                         String field = fieldMapping.getKey();
@@ -70,9 +85,9 @@ public final class MappingsMerger {
                                 IndexAndMapping existingIndexAndMapping = mergedMappings.get(field);
                                 if (existingIndexAndMapping.mapping.equals(fieldMapping.getValue()) == false) {
                                     throw ExceptionsHelper.badRequestException(
-                                        "cannot merge mappings because of differences for field [{}]; mapped as [{}] in index [{}]; " +
-                                            "mapped as [{}] in index [{}]", field, fieldMapping.getValue(), indexMappings.key,
-                                            existingIndexAndMapping.mapping, existingIndexAndMapping.index);
+                                        "cannot merge [{}] mappings because of differences for field [{}]; mapped as [{}] in index [{}]; " +
+                                        "mapped as [{}] in index [{}]", mappingsType.type, field, fieldMapping.getValue(),
+                                        indexMappings.key, existingIndexAndMapping.mapping, existingIndexAndMapping.index);
 
                                 }
                             } else {
@@ -83,16 +98,7 @@ public final class MappingsMerger {
                 }
             }
         }
-
-        return createMappingMetadata(MapperService.SINGLE_MAPPING_NAME,
-            mergedMappings.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().mapping)));
-    }
-
-    private static MappingMetadata createMappingMetadata(String type, Map<String, Object> properties) {
-        Map<String, Object> mappings = new HashMap<>();
-        mappings.put("dynamic", false);
-        mappings.put("properties", properties);
-        return new MappingMetadata(type, mappings);
+        return mergedMappings;
     }
 
     private static class IndexAndMapping {
@@ -102,6 +108,17 @@ public final class MappingsMerger {
         private IndexAndMapping(String index, Object mapping) {
             this.index = Objects.requireNonNull(index);
             this.mapping = Objects.requireNonNull(mapping);
+        }
+    }
+
+    private enum MappingsType {
+        PROPERTIES("properties"),
+        RUNTIME("runtime");
+
+        private String type;
+
+        MappingsType(String type) {
+            this.type = type;
         }
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/MappingsMergerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/MappingsMergerTests.java
@@ -85,15 +85,12 @@ public class MappingsMergerTests extends ESTestCase {
         MappingMetadata mergedMappings = MappingsMerger.mergeMappings(newSource(), getMappingsResponse);
 
         Map<String, Object> mappingsAsMap = mergedMappings.getSourceAsMap();
-        assertThat(mappingsAsMap.size(), equalTo(2));
-        assertThat(mappingsAsMap.containsKey("dynamic"), is(true));
+        assertThat(mappingsAsMap.keySet(), containsInAnyOrder("dynamic", "properties"));
         assertThat(mappingsAsMap.get("dynamic"), equalTo(false));
-        assertThat(mappingsAsMap.containsKey("properties"), is(true));
 
         @SuppressWarnings("unchecked")
         Map<String, Object> fieldMappings = (Map<String, Object>) mappingsAsMap.get("properties");
 
-        assertThat(fieldMappings.size(), equalTo(3));
         assertThat(fieldMappings.keySet(), containsInAnyOrder("field_1", "field_2", "field_3"));
         assertThat(fieldMappings.get("field_1"), equalTo("field_1_mappings"));
         assertThat(fieldMappings.get("field_2"), equalTo("field_2_mappings"));
@@ -161,16 +158,13 @@ public class MappingsMergerTests extends ESTestCase {
         MappingMetadata mergedMappings = MappingsMerger.mergeMappings(newSource(), getMappingsResponse);
 
         Map<String, Object> mappingsAsMap = mergedMappings.getSourceAsMap();
-        assertThat(mappingsAsMap.size(), equalTo(2));
-        assertThat(mappingsAsMap.containsKey("dynamic"), is(true));
-        assertThat(mappingsAsMap.containsKey("runtime"), is(true));
+        assertThat(mappingsAsMap.keySet(), containsInAnyOrder("dynamic", "runtime"));
 
         assertThat(mappingsAsMap.get("dynamic"), is(false));
 
         @SuppressWarnings("unchecked")
         Map<String, Object> fieldMappings = (Map<String, Object>) mappingsAsMap.get("runtime");
 
-        assertThat(fieldMappings.size(), equalTo(3));
         assertThat(fieldMappings.keySet(), containsInAnyOrder("field_1", "field_2", "field_3"));
         assertThat(fieldMappings.get("field_1"), equalTo("field_1_mappings"));
         assertThat(fieldMappings.get("field_2"), equalTo("field_2_mappings"));
@@ -210,23 +204,18 @@ public class MappingsMergerTests extends ESTestCase {
         MappingMetadata mergedMappings = MappingsMerger.mergeMappings(newSource(), getMappingsResponse);
 
         Map<String, Object> mappingsAsMap = mergedMappings.getSourceAsMap();
-        assertThat(mappingsAsMap.size(), equalTo(3));
-        assertThat(mappingsAsMap.containsKey("dynamic"), is(true));
-        assertThat(mappingsAsMap.containsKey("properties"), is(true));
-        assertThat(mappingsAsMap.containsKey("runtime"), is(true));
+        assertThat(mappingsAsMap.keySet(), containsInAnyOrder("dynamic", "properties", "runtime"));
 
         assertThat(mappingsAsMap.get("dynamic"), is(false));
 
         @SuppressWarnings("unchecked")
         Map<String, Object> mergedProperties = (Map<String, Object>) mappingsAsMap.get("properties");
-        assertThat(mergedProperties.size(), equalTo(2));
         assertThat(mergedProperties.keySet(), containsInAnyOrder("p_1", "p_2"));
         assertThat(mergedProperties.get("p_1"), equalTo("p_1_mappings"));
         assertThat(mergedProperties.get("p_2"), equalTo("p_2_mappings"));
 
         @SuppressWarnings("unchecked")
         Map<String, Object> mergedRuntime = (Map<String, Object>) mappingsAsMap.get("runtime");
-        assertThat(mergedRuntime.size(), equalTo(3));
         assertThat(mergedRuntime.keySet(), containsInAnyOrder("r_1", "r_2", "p_1"));
         assertThat(mergedRuntime.get("r_1"), equalTo("r_1_mappings"));
         assertThat(mergedRuntime.get("r_2"), equalTo("r_2_mappings"));
@@ -253,13 +242,11 @@ public class MappingsMergerTests extends ESTestCase {
 
         @SuppressWarnings("unchecked")
         Map<String, Object> propertyMappings = (Map<String, Object>) mappingsAsMap.get("properties");
-        assertThat(propertyMappings.size(), equalTo(1));
-        assertThat(propertyMappings.containsKey("field_2"), is(true));
+        assertThat(propertyMappings.keySet(), containsInAnyOrder("field_2"));
 
         @SuppressWarnings("unchecked")
         Map<String, Object> runtimeMappings = (Map<String, Object>) mappingsAsMap.get("runtime");
-        assertThat(runtimeMappings.size(), equalTo(1));
-        assertThat(runtimeMappings.containsKey("runtime_field_1"), is(true));
+        assertThat(runtimeMappings.keySet(), containsInAnyOrder("runtime_field_1"));
     }
 
     private static DataFrameAnalyticsSource newSource() {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/MappingsMergerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/MappingsMergerTests.java
@@ -24,7 +24,7 @@ import static org.hamcrest.Matchers.is;
 
 public class MappingsMergerTests extends ESTestCase {
 
-    public void testMergeMappings_GivenIndicesWithIdenticalMappings() {
+    public void testMergeMappings_GivenIndicesWithIdenticalProperties() {
         Map<String, Object> index1Mappings = Map.of("properties", Map.of("field_1", "field_1_mappings", "field_2", "field_2_mappings"));
         MappingMetadata index1MappingMetadata = new MappingMetadata("_doc", index1Mappings);
 
@@ -45,7 +45,7 @@ public class MappingsMergerTests extends ESTestCase {
         assertThat(mergedMappings.getSourceAsMap(), equalTo(expectedMappings));
     }
 
-    public void testMergeMappings_GivenFieldWithDifferentMapping() {
+    public void testMergeMappings_GivenPropertyFieldWithDifferentMapping() {
         Map<String, Object> index1Mappings = Map.of("properties", Map.of("field_1", "field_1_mappings"));
         MappingMetadata index1MappingMetadata = new MappingMetadata("_doc", index1Mappings);
 
@@ -61,12 +61,13 @@ public class MappingsMergerTests extends ESTestCase {
         ElasticsearchStatusException e = expectThrows(ElasticsearchStatusException.class,
             () -> MappingsMerger.mergeMappings(newSource(), getMappingsResponse));
         assertThat(e.status(), equalTo(RestStatus.BAD_REQUEST));
-        assertThat(e.getMessage(), containsString("cannot merge mappings because of differences for field [field_1]; "));
+        assertThat(e.getMessage(),
+            containsString("cannot merge [properties] mappings because of differences for field [field_1]; "));
         assertThat(e.getMessage(), containsString("mapped as [different_field_1_mappings] in index [index_2]"));
         assertThat(e.getMessage(), containsString("mapped as [field_1_mappings] in index [index_1]"));
     }
 
-    public void testMergeMappings_GivenIndicesWithDifferentMappingsButNoConflicts() {
+    public void testMergeMappings_GivenIndicesWithDifferentPropertiesButNoConflicts() {
         Map<String, Object> index1Mappings = Map.of("properties",
             Map.of("field_1", "field_1_mappings", "field_2", "field_2_mappings"));
         MappingMetadata index1MappingMetadata = new MappingMetadata("_doc", index1Mappings);
@@ -99,8 +100,145 @@ public class MappingsMergerTests extends ESTestCase {
         assertThat(fieldMappings.get("field_3"), equalTo("field_3_mappings"));
     }
 
+    public void testMergeMappings_GivenIndicesWithIdenticalRuntimeFields() {
+        Map<String, Object> index1Mappings = Map.of("runtime", Map.of("field_1", "field_1_mappings", "field_2", "field_2_mappings"));
+        MappingMetadata index1MappingMetadata = new MappingMetadata("_doc", index1Mappings);
+
+        Map<String, Object> index2Mappings = Map.of("runtime", Map.of("field_1", "field_1_mappings", "field_2", "field_2_mappings"));
+        MappingMetadata index2MappingMetadata = new MappingMetadata("_doc", index2Mappings);
+
+        ImmutableOpenMap.Builder<String, MappingMetadata> mappings = ImmutableOpenMap.builder();
+        mappings.put("index_1", index1MappingMetadata);
+        mappings.put("index_2", index2MappingMetadata);
+
+        GetMappingsResponse getMappingsResponse = new GetMappingsResponse(mappings.build());
+
+        MappingMetadata mergedMappings = MappingsMerger.mergeMappings(newSource(), getMappingsResponse);
+
+        Map<String, Object> expectedMappings = new HashMap<>();
+        expectedMappings.put("dynamic", false);
+        expectedMappings.put("runtime", index1Mappings.get("runtime"));
+        assertThat(mergedMappings.getSourceAsMap(), equalTo(expectedMappings));
+    }
+
+    public void testMergeMappings_GivenRuntimeFieldWithDifferentMapping() {
+        Map<String, Object> index1Mappings = Map.of("runtime", Map.of("field_1", "field_1_mappings"));
+        MappingMetadata index1MappingMetadata = new MappingMetadata("_doc", index1Mappings);
+
+        Map<String, Object> index2Mappings = Map.of("runtime", Map.of("field_1", "different_field_1_mappings"));
+        MappingMetadata index2MappingMetadata = new MappingMetadata("_doc", index2Mappings);
+
+        ImmutableOpenMap.Builder<String, MappingMetadata> mappings = ImmutableOpenMap.builder();
+        mappings.put("index_1", index1MappingMetadata);
+        mappings.put("index_2", index2MappingMetadata);
+
+        GetMappingsResponse getMappingsResponse = new GetMappingsResponse(mappings.build());
+
+        ElasticsearchStatusException e = expectThrows(ElasticsearchStatusException.class,
+            () -> MappingsMerger.mergeMappings(newSource(), getMappingsResponse));
+        assertThat(e.status(), equalTo(RestStatus.BAD_REQUEST));
+        assertThat(e.getMessage(),
+            containsString("cannot merge [runtime] mappings because of differences for field [field_1]; "));
+        assertThat(e.getMessage(), containsString("mapped as [different_field_1_mappings] in index [index_2]"));
+        assertThat(e.getMessage(), containsString("mapped as [field_1_mappings] in index [index_1]"));
+    }
+
+    public void testMergeMappings_GivenIndicesWithDifferentRuntimeFieldsButNoConflicts() {
+        Map<String, Object> index1Mappings = Map.of("runtime",
+            Map.of("field_1", "field_1_mappings", "field_2", "field_2_mappings"));
+        MappingMetadata index1MappingMetadata = new MappingMetadata("_doc", index1Mappings);
+
+        Map<String, Object> index2Mappings = Map.of("runtime",
+            Map.of("field_1", "field_1_mappings", "field_3", "field_3_mappings"));
+        MappingMetadata index2MappingMetadata = new MappingMetadata("_doc", index2Mappings);
+
+        ImmutableOpenMap.Builder<String, MappingMetadata> mappings = ImmutableOpenMap.builder();
+        mappings.put("index_1", index1MappingMetadata);
+        mappings.put("index_2", index2MappingMetadata);
+
+        GetMappingsResponse getMappingsResponse = new GetMappingsResponse(mappings.build());
+
+        MappingMetadata mergedMappings = MappingsMerger.mergeMappings(newSource(), getMappingsResponse);
+
+        Map<String, Object> mappingsAsMap = mergedMappings.getSourceAsMap();
+        assertThat(mappingsAsMap.size(), equalTo(2));
+        assertThat(mappingsAsMap.containsKey("dynamic"), is(true));
+        assertThat(mappingsAsMap.containsKey("runtime"), is(true));
+
+        assertThat(mappingsAsMap.get("dynamic"), is(false));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> fieldMappings = (Map<String, Object>) mappingsAsMap.get("runtime");
+
+        assertThat(fieldMappings.size(), equalTo(3));
+        assertThat(fieldMappings.keySet(), containsInAnyOrder("field_1", "field_2", "field_3"));
+        assertThat(fieldMappings.get("field_1"), equalTo("field_1_mappings"));
+        assertThat(fieldMappings.get("field_2"), equalTo("field_2_mappings"));
+        assertThat(fieldMappings.get("field_3"), equalTo("field_3_mappings"));
+    }
+
+    public void testMergeMappings_GivenPropertyAndRuntimeFields() {
+        Map<String, Object> index1Mappings = new HashMap<>();
+        {
+            Map<String, Object> index1Properties = new HashMap<>();
+            index1Properties.put("p_1", "p_1_mappings");
+            Map<String, Object> index1Runtime = new HashMap<>();
+            index1Runtime.put("r_1", "r_1_mappings");
+            index1Mappings.put("properties", index1Properties);
+            index1Mappings.put("runtime", index1Runtime);
+        }
+        MappingMetadata index1MappingMetadata = new MappingMetadata("_doc", index1Mappings);
+
+        Map<String, Object> index2Mappings = new HashMap<>();
+        {
+            Map<String, Object> index2Properties = new HashMap<>();
+            index2Properties.put("p_2", "p_2_mappings");
+            Map<String, Object> index2Runtime = new HashMap<>();
+            index2Runtime.put("r_2", "r_2_mappings");
+            index2Runtime.put("p_1", "p_1_different_mappings"); // It is ok to have conflicting runtime/property mappings
+            index2Mappings.put("properties", index2Properties);
+            index2Mappings.put("runtime", index2Runtime);
+        }
+        MappingMetadata index2MappingMetadata = new MappingMetadata("_doc", index2Mappings);
+
+        ImmutableOpenMap.Builder<String, MappingMetadata> mappings = ImmutableOpenMap.builder();
+        mappings.put("index_1", index1MappingMetadata);
+        mappings.put("index_2", index2MappingMetadata);
+
+        GetMappingsResponse getMappingsResponse = new GetMappingsResponse(mappings.build());
+
+        MappingMetadata mergedMappings = MappingsMerger.mergeMappings(newSource(), getMappingsResponse);
+
+        Map<String, Object> mappingsAsMap = mergedMappings.getSourceAsMap();
+        assertThat(mappingsAsMap.size(), equalTo(3));
+        assertThat(mappingsAsMap.containsKey("dynamic"), is(true));
+        assertThat(mappingsAsMap.containsKey("properties"), is(true));
+        assertThat(mappingsAsMap.containsKey("runtime"), is(true));
+
+        assertThat(mappingsAsMap.get("dynamic"), is(false));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> mergedProperties = (Map<String, Object>) mappingsAsMap.get("properties");
+        assertThat(mergedProperties.size(), equalTo(2));
+        assertThat(mergedProperties.keySet(), containsInAnyOrder("p_1", "p_2"));
+        assertThat(mergedProperties.get("p_1"), equalTo("p_1_mappings"));
+        assertThat(mergedProperties.get("p_2"), equalTo("p_2_mappings"));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> mergedRuntime = (Map<String, Object>) mappingsAsMap.get("runtime");
+        assertThat(mergedRuntime.size(), equalTo(3));
+        assertThat(mergedRuntime.keySet(), containsInAnyOrder("r_1", "r_2", "p_1"));
+        assertThat(mergedRuntime.get("r_1"), equalTo("r_1_mappings"));
+        assertThat(mergedRuntime.get("r_2"), equalTo("r_2_mappings"));
+        assertThat(mergedRuntime.get("p_1"), equalTo("p_1_different_mappings"));
+    }
+
     public void testMergeMappings_GivenSourceFiltering() {
-        Map<String, Object> indexMappings = Map.of("properties", Map.of("field_1", "field_1_mappings", "field_2", "field_2_mappings"));
+        Map<String, Object> properties = Map.of("field_1", "field_1_mappings", "field_2", "field_2_mappings");
+        Map<String, Object> runtime = Map.of("runtime_field_1", "runtime_field_1_mappings", "runtime_field_2", "runtime_field_2_mappings");
+        Map<String, Object> indexMappings = new HashMap<>();
+        indexMappings.put("properties", properties);
+        indexMappings.put("runtime", runtime);
         MappingMetadata indexMappingMetadata = new MappingMetadata("_doc", indexMappings);
 
         ImmutableOpenMap.Builder<String, MappingMetadata> mappings = ImmutableOpenMap.builder();
@@ -109,14 +247,19 @@ public class MappingsMergerTests extends ESTestCase {
         GetMappingsResponse getMappingsResponse = new GetMappingsResponse(mappings.build());
 
         MappingMetadata mergedMappings = MappingsMerger.mergeMappings(
-            newSourceWithExcludes("field_1"), getMappingsResponse);
+            newSourceWithExcludes("field_1", "runtime_field_2"), getMappingsResponse);
 
         Map<String, Object> mappingsAsMap = mergedMappings.getSourceAsMap();
-        @SuppressWarnings("unchecked")
-        Map<String, Object> fieldMappings = (Map<String, Object>) mappingsAsMap.get("properties");
 
-        assertThat(fieldMappings.size(), equalTo(1));
-        assertThat(fieldMappings.containsKey("field_2"), is(true));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> propertyMappings = (Map<String, Object>) mappingsAsMap.get("properties");
+        assertThat(propertyMappings.size(), equalTo(1));
+        assertThat(propertyMappings.containsKey("field_2"), is(true));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> runtimeMappings = (Map<String, Object>) mappingsAsMap.get("runtime");
+        assertThat(runtimeMappings.size(), equalTo(1));
+        assertThat(runtimeMappings.containsKey("runtime_field_1"), is(true));
     }
 
     private static DataFrameAnalyticsSource newSource() {


### PR DESCRIPTION
When we create the destination index for a data frame analytics job,
we merge the mappings across the source indices and copy them over
to the dest index. In order to support mapped runtime fields,
this commit adds to that merging and copying over the runtime
mappings.

Fixes #65854
