### PR TITLE
[ML] Fix serialization order for model_size_stats

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/ModelSizeStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/ModelSizeStats.java
@@ -226,6 +226,15 @@ public class ModelSizeStats implements ToXContentObject, Writeable {
         totalPartitionFieldCount = in.readVLong();
         bucketAllocationFailuresCount = in.readVLong();
         memoryStatus = MemoryStatus.readFromStream(in);
+        if (in.getVersion().onOrAfter(Version.V_7_11_0)) {
+            if (in.readBoolean()) {
+                assignmentMemoryBasis = AssignmentMemoryBasis.readFromStream(in);
+            } else {
+                assignmentMemoryBasis = null;
+            }
+        } else {
+            assignmentMemoryBasis = null;
+        }
         if (in.getVersion().onOrAfter(Version.V_7_7_0)) {
             categorizedDocCount = in.readVLong();
             totalCategoryCount = in.readVLong();
@@ -246,15 +255,6 @@ public class ModelSizeStats implements ToXContentObject, Writeable {
             deadCategoryCount = 0;
             failedCategoryCount = 0;
             categorizationStatus = CategorizationStatus.OK;
-        }
-        if (in.getVersion().onOrAfter(Version.V_7_11_0)) {
-            if (in.readBoolean()) {
-                assignmentMemoryBasis = AssignmentMemoryBasis.readFromStream(in);
-            } else {
-                assignmentMemoryBasis = null;
-            }
-        } else {
-            assignmentMemoryBasis = null;
         }
         logTime = new Date(in.readVLong());
         timestamp = in.readBoolean() ? new Date(in.readVLong()) : null;
@@ -286,6 +286,14 @@ public class ModelSizeStats implements ToXContentObject, Writeable {
         out.writeVLong(totalPartitionFieldCount);
         out.writeVLong(bucketAllocationFailuresCount);
         memoryStatus.writeTo(out);
+        if (out.getVersion().onOrAfter(Version.V_7_11_0)) {
+            if (assignmentMemoryBasis != null) {
+                out.writeBoolean(true);
+                assignmentMemoryBasis.writeTo(out);
+            } else {
+                out.writeBoolean(false);
+            }
+        }
         if (out.getVersion().onOrAfter(Version.V_7_7_0)) {
             out.writeVLong(categorizedDocCount);
             out.writeVLong(totalCategoryCount);
@@ -296,14 +304,6 @@ public class ModelSizeStats implements ToXContentObject, Writeable {
                 out.writeVLong(failedCategoryCount);
             }
             categorizationStatus.writeTo(out);
-        }
-        if (out.getVersion().onOrAfter(Version.V_7_11_0)) {
-            if (assignmentMemoryBasis != null) {
-                out.writeBoolean(true);
-                assignmentMemoryBasis.writeTo(out);
-            } else {
-                out.writeBoolean(false);
-            }
         }
         out.writeVLong(logTime.getTime());
         boolean hasTimestamp = timestamp != null;


### PR DESCRIPTION
Due to a backporting mistake, master and 7.x were
serializing the members of model_size_stats in
different orders.  This led to BWC test failures
on master.

This change makes the ordering in 7.x the same as
the ordering in master.  It will be tested when
the mute done in #65895 is reverted on the master
branch.

Fixes #65893