### PR TITLE
[ML] Unmuting tests that use old-cluster-categorization-job

### DIFF
--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/30_ml_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/30_ml_jobs_crud.yml
@@ -51,10 +51,6 @@
 
 ---
 "Test get old cluster categorization job":
-  - skip:
-      version: "all"
-      reason: "@AwaitsFix(bugUrl = https://github.com/elastic/elasticsearch/issues/65893)"
-
   - do:
       ml.get_jobs:
         job_id: old-cluster-categorization-job

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/30_ml_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/30_ml_jobs_crud.yml
@@ -8,10 +8,6 @@ setup:
 
 ---
 "Test open old jobs":
-  - skip:
-      version: "all"
-      reason: "@AwaitsFix(bugUrl = https://github.com/elastic/elasticsearch/issues/65893)"
-
   - do:
       ml.open_job:
         job_id: old-cluster-job


### PR DESCRIPTION
This reverts commit 1cf0a6e1193584cbada90b5ae6ad927c5d0b443d.

The tests should work now that #66015 is merged.

Relates #65893