### PR TITLE
[master] [DOCS] Fix typo (#65993)

### DIFF
--- a/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
+++ b/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
@@ -51,7 +51,7 @@ the `searchable snapshot` action force merge step will be a no-op.
 [NOTE]
 The `forcemerge` action is best effort. It might happen that some of
 the shards are relocating, in which case they will not be merged.
-The `searchable-snapshot` action will continue executing even if not all shards
+The `searchable_snapshot` action will continue executing even if not all shards
 are force merged.
 
 [[ilm-searchable-snapshot-ex]]


### PR DESCRIPTION
Backports the following commits to master:
 - [DOCS] Fix typo (#65993)