### PR TITLE
[7.x] Watcher - ensure that rest_total_hits_as_int is persisted (#65988)

### DIFF
--- a/x-pack/plugin/watcher/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/watcher/put_watch/91_search_total_hits_as_int.yml
+++ b/x-pack/plugin/watcher/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/watcher/put_watch/91_search_total_hits_as_int.yml
@@ -110,3 +110,42 @@ setup:
 
   - match: { _source.key: "value" }
 
+---
+"Test persist rest_total_hits_as_int":
+  - do:
+      watcher.put_watch:
+        id: "my_watch1"
+        body:  >
+          {
+            "trigger": {
+              "schedule" : { "cron" : "0 0 0 1 * ? 2099" }
+            },
+            "input": {
+              "search" : {
+                "request" : {
+                  "indices" : [ "my_test_index" ],
+                  "rest_total_hits_as_int": false,
+                  "body" : {
+                    "query": {
+                      "match_all" : {}
+                    }
+                  }
+                }
+              }
+            },
+            "actions": {
+              "test_index": {
+                "index": {
+                  "index": "test"
+                }
+              }
+            }
+          }
+  - match: { _id: "my_watch1" }
+
+  - do:
+      watcher.get_watch:
+        id: "my_watch1"
+  - match: { found : true}
+  - match: { _id: "my_watch1" }
+  - match: { watch.input.search.request.rest_total_hits_as_int: false }

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/support/search/WatcherSearchTemplateRequest.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/support/search/WatcherSearchTemplateRequest.java
@@ -148,9 +148,9 @@ public class WatcherSearchTemplateRequest implements ToXContentObject {
         if (types != null) {
             builder.array(TYPES_FIELD.getPreferredName(), types);
         }
-        if (restTotalHitsAsInt) {
-            builder.field(REST_TOTAL_HITS_AS_INT_FIELD.getPreferredName(), restTotalHitsAsInt);
-        }
+
+        builder.field(REST_TOTAL_HITS_AS_INT_FIELD.getPreferredName(), restTotalHitsAsInt);
+
         if (searchSource != null && searchSource.length() > 0) {
             try (InputStream stream = searchSource.streamInput()) {
                 builder.rawField(BODY_FIELD.getPreferredName(), stream);


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Watcher - ensure that rest_total_hits_as_int is persisted (#65988)