### PR TITLE
[DOCS] Adds empty snapshot_id description to revert snapshot API docs

### DIFF
--- a/docs/reference/ml/anomaly-detection/apis/get-snapshot.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-snapshot.asciidoc
@@ -41,8 +41,9 @@ by using a comma-separated list of `<snapshot_id>` or a wildcard expression.
 You can get all snapshots for all calendars by using `_all`,
 by specifying `*` as the `<snapshot_id>`, or by omitting the `<snapshot_id>`.
 
-NOTE: You can specify `empty` as a <snapshot_id>. Revert to `empty` results in 
-an empty model that start learning from scratch when you start the job.
+NOTE: You can specify a <snapshot_id> as `empty`. Revert to `empty` results in 
+an empty model that start learning from scratch when the {anomaly-job} is 
+started.
 --
 
 

--- a/docs/reference/ml/anomaly-detection/apis/get-snapshot.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-snapshot.asciidoc
@@ -40,9 +40,6 @@ You can multiple snapshots for a single job in a single API request
 by using a comma-separated list of `<snapshot_id>` or a wildcard expression.
 You can get all snapshots for all calendars by using `_all`,
 by specifying `*` as the `<snapshot_id>`, or by omitting the `<snapshot_id>`.
-You can also specify `empty` as the <snapshot_id>. Revert to `empty` results in 
-an empty model that start learning from scratch when the {anomaly-job} is 
-started.
 --
 
 

--- a/docs/reference/ml/anomaly-detection/apis/get-snapshot.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-snapshot.asciidoc
@@ -15,12 +15,14 @@ Retrieves information about model snapshots.
 
 `GET _ml/anomaly_detectors/<job_id>/model_snapshots/<snapshot_id>`
 
+
 [[ml-get-snapshot-prereqs]]
 == {api-prereq-title}
 
 * If the {es} {security-features} are enabled, you must have `monitor_ml`,
 `monitor`, `manage_ml`, or `manage` cluster privileges to use this API. See
 <<security-privileges>> and {ml-docs-setup-privileges}.
+
 
 [[ml-get-snapshot-path-parms]]
 == {api-path-parms-title}
@@ -38,7 +40,11 @@ You can multiple snapshots for a single job in a single API request
 by using a comma-separated list of `<snapshot_id>` or a wildcard expression.
 You can get all snapshots for all calendars by using `_all`,
 by specifying `*` as the `<snapshot_id>`, or by omitting the `<snapshot_id>`.
+
+NOTE: You can specify `empty` as a <snapshot_id>. Revert to `empty` results in 
+an empty model that start learning from scratch when you start the job.
 --
+
 
 [[ml-get-snapshot-request-body]]
 == {api-request-body-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-snapshot.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-snapshot.asciidoc
@@ -40,8 +40,7 @@ You can multiple snapshots for a single job in a single API request
 by using a comma-separated list of `<snapshot_id>` or a wildcard expression.
 You can get all snapshots for all calendars by using `_all`,
 by specifying `*` as the `<snapshot_id>`, or by omitting the `<snapshot_id>`.
-
-NOTE: You can specify a <snapshot_id> as `empty`. Revert to `empty` results in 
+You can also specify `empty` as the <snapshot_id>. Revert to `empty` results in 
 an empty model that start learning from scratch when the {anomaly-job} is 
 started.
 --

--- a/docs/reference/ml/anomaly-detection/apis/revert-snapshot.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/revert-snapshot.asciidoc
@@ -42,6 +42,11 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 `<snapshot_id>`::
 (Required, string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=snapshot-id]
++
+--
+You can specify `empty` as the <snapshot_id>. Revert to `empty` results in an 
+empty model that start learning from scratch when the {anomaly-job} is started.
+--
 
 [[ml-revert-snapshot-request-body]]
 == {api-request-body-title}

--- a/docs/reference/ml/anomaly-detection/apis/revert-snapshot.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/revert-snapshot.asciidoc
@@ -44,8 +44,9 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=snapshot-id]
 +
 --
-You can specify `empty` as the <snapshot_id>. Revert to `empty` results in an 
-empty model that start learning from scratch when the {anomaly-job} is started.
+You can specify `empty` as the <snapshot_id>. Reverting to the `empty` snapshot 
+means the {anomaly-job} starts learning a new model from scratch when it is 
+started.
 --
 
 [[ml-revert-snapshot-request-body]]


### PR DESCRIPTION
## Overview

This PR adds info to the Revert snapshot API docs about a special snapshot_id called `empty`.

### Preview

[Path parameters](https://elasticsearch_66036.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ml-get-snapshot.html#ml-get-snapshot-path-parms)