### PR TITLE
[7.x] [ML] add default inference config to lang ident model (#65986)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
@@ -104,8 +104,8 @@ public final class Messages {
         "Configuration [{0}] requires minimum node version [{1}] (current minimum node version [{2}]";
     public static final String MODEL_DEFINITION_NOT_FOUND = "Could not find trained model definition [{0}]";
     public static final String MODEL_METADATA_NOT_FOUND = "Could not find trained model metadata {0}";
-    public static final String INFERENCE_CANNOT_DELETE_MODEL =
-        "Unable to delete model [{0}]";
+    public static final String INFERENCE_CANNOT_DELETE_ML_MANAGED_MODEL =
+        "Unable to delete model [{0}] as it is required by machine learning";
     public static final String MODEL_DEFINITION_TRUNCATED =
         "Model definition truncated. Unable to deserialize trained model definition [{0}]";
     public static final String INFERENCE_FAILED_TO_DESERIALIZE = "Could not deserialize trained model [{0}]";

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/persistence/TrainedModelProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/persistence/TrainedModelProvider.java
@@ -686,7 +686,10 @@ public class TrainedModelProvider {
 
     public void deleteTrainedModel(String modelId, ActionListener<Boolean> listener) {
         if (MODELS_STORED_AS_RESOURCE.contains(modelId)) {
-            listener.onFailure(ExceptionsHelper.badRequestException(Messages.getMessage(Messages.INFERENCE_CANNOT_DELETE_MODEL, modelId)));
+            listener.onFailure(ExceptionsHelper.badRequestException(Messages.getMessage(
+                Messages.INFERENCE_CANNOT_DELETE_ML_MANAGED_MODEL,
+                modelId
+            )));
             return;
         }
         DeleteByQueryRequest request = new DeleteByQueryRequest().setAbortOnVersionConflict(false);

--- a/x-pack/plugin/ml/src/main/resources/org/elasticsearch/xpack/ml/inference/persistence/lang_ident_model_1.json
+++ b/x-pack/plugin/ml/src/main/resources/org/elasticsearch/xpack/ml/inference/persistence/lang_ident_model_1.json
@@ -14,6 +14,7 @@
       "text"
     ]
   },
+  "inference_config" : {"classification" : {}},
   "estimated_heap_memory_usage_bytes" : 1053992,
   "estimated_operations" : 39629,
   "license_level" : "basic"

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/persistence/TrainedModelProviderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/persistence/TrainedModelProviderTests.java
@@ -42,7 +42,10 @@ public class TrainedModelProviderTests extends ESTestCase {
         // Should be OK as we don't make any client calls
         trainedModelProvider.deleteTrainedModel("lang_ident_model_1", future);
         ElasticsearchException ex = expectThrows(ElasticsearchException.class, future::actionGet);
-        assertThat(ex.getMessage(), equalTo(Messages.getMessage(Messages.INFERENCE_CANNOT_DELETE_MODEL, "lang_ident_model_1")));
+        assertThat(ex.getMessage(), equalTo(Messages.getMessage(
+            Messages.INFERENCE_CANNOT_DELETE_ML_MANAGED_MODEL,
+            "lang_ident_model_1"
+        )));
     }
 
     public void testPutModelThatExistsAsResource() {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ML] add default inference config to lang ident model (#65986)