### PR TITLE
Introduce dynamic runtime setting (#65489)

### DIFF
--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/CandidateQueryTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/CandidateQueryTests.java
@@ -1119,7 +1119,7 @@ public class CandidateQueryTests extends ESSingleNodeTestCase {
     }
 
     private void addQuery(Query query, List<ParseContext.Document> docs) {
-        ParseContext.InternalParseContext parseContext = new ParseContext.InternalParseContext(documentMapper, null, null, null);
+        ParseContext.InternalParseContext parseContext = new ParseContext.InternalParseContext(documentMapper, null, null, null, null);
         fieldMapper.processQuery(query, parseContext);
         ParseContext.Document queryDocument = parseContext.doc();
         // Add to string representation of the query to make debugging easier:

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorFieldMapperTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorFieldMapperTests.java
@@ -181,7 +181,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
 
         DocumentMapper documentMapper = mapperService.documentMapper("doc");
         PercolatorFieldMapper fieldMapper = (PercolatorFieldMapper) documentMapper.mappers().getMapper(fieldName);
-        ParseContext.InternalParseContext parseContext = new ParseContext.InternalParseContext(documentMapper, null, null, null);
+        ParseContext.InternalParseContext parseContext = new ParseContext.InternalParseContext(documentMapper, null, null, null, null);
         fieldMapper.processQuery(bq.build(), parseContext);
         ParseContext.Document document = parseContext.doc();
 
@@ -202,7 +202,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
         bq.add(termQuery1, Occur.MUST);
         bq.add(termQuery2, Occur.MUST);
 
-        parseContext = new ParseContext.InternalParseContext(documentMapper, null, null, null);
+        parseContext = new ParseContext.InternalParseContext(documentMapper, null, null, null, null);
         fieldMapper.processQuery(bq.build(), parseContext);
         document = parseContext.doc();
 
@@ -231,7 +231,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
 
         DocumentMapper documentMapper = mapperService.documentMapper("doc");
         PercolatorFieldMapper fieldMapper = (PercolatorFieldMapper) documentMapper.mappers().getMapper(fieldName);
-        ParseContext.InternalParseContext parseContext = new ParseContext.InternalParseContext(documentMapper, null, null, null);
+        ParseContext.InternalParseContext parseContext = new ParseContext.InternalParseContext(documentMapper, null, null, null, null);
         fieldMapper.processQuery(bq.build(), parseContext);
         ParseContext.Document document = parseContext.doc();
 
@@ -256,7 +256,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
             .rangeQuery(15, 20, true, true, null, null, null, context);
         bq.add(rangeQuery2, Occur.MUST);
 
-        parseContext = new ParseContext.InternalParseContext(documentMapper, null, null, null);
+        parseContext = new ParseContext.InternalParseContext(documentMapper, null, null, null, null);
         fieldMapper.processQuery(bq.build(), parseContext);
         document = parseContext.doc();
 
@@ -279,7 +279,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
         TermRangeQuery query = new TermRangeQuery("field1", new BytesRef("a"), new BytesRef("z"), true, true);
         DocumentMapper documentMapper = mapperService.documentMapper("doc");
         PercolatorFieldMapper fieldMapper = (PercolatorFieldMapper) documentMapper.mappers().getMapper(fieldName);
-        ParseContext.InternalParseContext parseContext = new ParseContext.InternalParseContext(documentMapper, null, null, null);
+        ParseContext.InternalParseContext parseContext = new ParseContext.InternalParseContext(documentMapper, null, null, null, null);
         fieldMapper.processQuery(query, parseContext);
         ParseContext.Document document = parseContext.doc();
 
@@ -293,7 +293,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
         PhraseQuery phraseQuery = new PhraseQuery("field", "term");
         DocumentMapper documentMapper = mapperService.documentMapper("doc");
         PercolatorFieldMapper fieldMapper = (PercolatorFieldMapper) documentMapper.mappers().getMapper(fieldName);
-        ParseContext.InternalParseContext parseContext = new ParseContext.InternalParseContext(documentMapper, null, null, null);
+        ParseContext.InternalParseContext parseContext = new ParseContext.InternalParseContext(documentMapper, null, null, null, null);
         fieldMapper.processQuery(phraseQuery, parseContext);
         ParseContext.Document document = parseContext.doc();
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -22,7 +22,6 @@ package org.elasticsearch.index.mapper;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.search.Query;
-import org.elasticsearch.Version;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.time.DateFormatter;

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -22,11 +22,9 @@ package org.elasticsearch.index.mapper;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.search.Query;
-import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.Tuple;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
@@ -34,11 +32,9 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.index.mapper.DynamicTemplate.XContentFieldType;
 import org.elasticsearch.index.query.QueryShardContext;
 
 import java.io.IOException;
-import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -47,18 +43,19 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
 
-import static org.elasticsearch.index.mapper.FieldMapper.IGNORE_MALFORMED_SETTING;
-
 /** A parser for documents, given mappings from a DocumentMapper */
 final class DocumentParser {
 
     private final NamedXContentRegistry xContentRegistry;
     private final Function<DateFormatter, Mapper.TypeParser.ParserContext> dateParserContext;
+    private final DynamicRuntimeFieldsBuilder dynamicRuntimeFieldsBuilder;
 
     DocumentParser(NamedXContentRegistry xContentRegistry,
-                   Function<DateFormatter, Mapper.TypeParser.ParserContext> dateParserContext) {
+                   Function<DateFormatter, Mapper.TypeParser.ParserContext> dateParserContext,
+                   DynamicRuntimeFieldsBuilder dynamicRuntimeFieldsBuilder) {
         this.xContentRegistry = xContentRegistry;
         this.dateParserContext = dateParserContext;
+        this.dynamicRuntimeFieldsBuilder = dynamicRuntimeFieldsBuilder;
     }
 
     ParsedDocument parseDocument(SourceToParse source,
@@ -72,7 +69,7 @@ final class DocumentParser {
 
         try (XContentParser parser = XContentHelper.createParser(xContentRegistry,
             LoggingDeprecationHandler.INSTANCE, source.source(), xContentType)) {
-            context = new ParseContext.InternalParseContext(docMapper, dateParserContext, source, parser);
+            context = new ParseContext.InternalParseContext(docMapper, dateParserContext, dynamicRuntimeFieldsBuilder, source, parser);
             validateStart(parser);
             internalParseDocument(mapping, metadataFieldsMappers, context, parser);
             validateEnd(parser);
@@ -86,7 +83,8 @@ final class DocumentParser {
 
         context.postParse();
 
-        return parsedDocument(source, context, createDynamicUpdate(mapping, docMapper, context.getDynamicMappers()));
+        return parsedDocument(source, context, createDynamicUpdate(mapping, docMapper,
+            context.getDynamicMappers(), context.getDynamicRuntimeFields()));
     }
 
     private static boolean containsDisabledObjectMapper(ObjectMapper objectMapper, String[] subfields) {
@@ -104,7 +102,7 @@ final class DocumentParser {
     }
 
     private static void internalParseDocument(Mapping mapping, MetadataFieldMapper[] metadataFieldsMappers,
-                                              ParseContext.InternalParseContext context, XContentParser parser) throws IOException {
+                                              ParseContext context, XContentParser parser) throws IOException {
         final boolean emptyDoc = isEmptyDoc(mapping, parser);
 
         for (MetadataFieldMapper metadataMapper : metadataFieldsMappers) {
@@ -221,10 +219,27 @@ final class DocumentParser {
     }
 
     /** Creates a Mapping containing any dynamically added fields, or returns null if there were no dynamic mappings. */
-    static Mapping createDynamicUpdate(Mapping mapping, DocumentMapper docMapper, List<Mapper> dynamicMappers) {
-        if (dynamicMappers.isEmpty()) {
+    static Mapping createDynamicUpdate(Mapping mapping,
+                                       DocumentMapper docMapper,
+                                       List<Mapper> dynamicMappers,
+                                       List<RuntimeFieldType> dynamicRuntimeFields) {
+        if (dynamicMappers.isEmpty() && dynamicRuntimeFields.isEmpty()) {
             return null;
         }
+        RootObjectMapper root;
+        if (dynamicMappers.isEmpty() == false) {
+            root = createDynamicUpdate(mapping.root, docMapper, dynamicMappers);
+        } else {
+            root = mapping.root.copyAndReset();
+        }
+        root.addRuntimeFields(dynamicRuntimeFields);
+        return mapping.mappingUpdate(root);
+    }
+
+    private static RootObjectMapper createDynamicUpdate(RootObjectMapper root,
+                                                        DocumentMapper docMapper,
+                                                        List<Mapper> dynamicMappers) {
+
         // We build a mapping by first sorting the mappers, so that all mappers containing a common prefix
         // will be processed in a contiguous block. When the prefix is no longer seen, we pop the extra elements
         // off the stack, merging them upwards into the existing mappers.
@@ -232,7 +247,7 @@ final class DocumentParser {
         Iterator<Mapper> dynamicMapperItr = dynamicMappers.iterator();
         List<ObjectMapper> parentMappers = new ArrayList<>();
         Mapper firstUpdate = dynamicMapperItr.next();
-        parentMappers.add(createUpdate(mapping.root(), splitAndValidatePath(firstUpdate.name()), 0, firstUpdate));
+        parentMappers.add(createUpdate(root, splitAndValidatePath(firstUpdate.name()), 0, firstUpdate));
         Mapper previousMapper = null;
         while (dynamicMapperItr.hasNext()) {
             Mapper newMapper = dynamicMapperItr.next();
@@ -268,16 +283,16 @@ final class DocumentParser {
             }
 
             if (newMapper instanceof ObjectMapper) {
-                parentMappers.add((ObjectMapper)newMapper);
+                parentMappers.add((ObjectMapper) newMapper);
             } else {
                 addToLastMapper(parentMappers, newMapper, true);
             }
         }
         popMappers(parentMappers, 1, true);
         assert parentMappers.size() == 1;
-
-        return mapping.mappingUpdate(parentMappers.get(0));
+        return (RootObjectMapper)parentMappers.get(0);
     }
+
 
     private static void popMappers(List<ObjectMapper> parentMappers, int keepBefore, boolean merge) {
         assert keepBefore >= 1; // never remove the root mapper
@@ -483,7 +498,7 @@ final class DocumentParser {
         return context;
     }
 
-    private static void parseObjectOrField(ParseContext context, Mapper mapper) throws IOException {
+    static void parseObjectOrField(ParseContext context, Mapper mapper) throws IOException {
         if (mapper instanceof ObjectMapper) {
             parseObjectOrNested(context, (ObjectMapper) mapper);
         } else if (mapper instanceof FieldMapper) {
@@ -514,20 +529,15 @@ final class DocumentParser {
             ObjectMapper.Dynamic dynamic = dynamicOrDefault(parentMapper, context);
             if (dynamic == ObjectMapper.Dynamic.STRICT) {
                 throw new StrictDynamicMappingException(mapper.fullPath(), currentFieldName);
-            } else if (dynamic == ObjectMapper.Dynamic.TRUE) {
-                Mapper.Builder builder = context.root().findTemplateBuilder(context, currentFieldName, XContentFieldType.OBJECT);
-                if (builder == null) {
-                    Version version = context.indexSettings().getIndexVersionCreated();
-                    builder = new ObjectMapper.Builder(currentFieldName, version).enabled(true);
-                }
-                objectMapper = builder.build(context.path());
-                context.addDynamicMapper(objectMapper);
-                context.path().add(currentFieldName);
-                parseObjectOrField(context, objectMapper);
-                context.path().remove();
-            } else {
+            } else if ( dynamic == ObjectMapper.Dynamic.FALSE) {
                 // not dynamic, read everything up to end object
                 context.parser().skipChildren();
+            } else {
+                Mapper dynamicObjectMapper = dynamic.getDynamicFieldsBuilder().createDynamicObjectMapper(context, currentFieldName);
+                context.addDynamicMapper(dynamicObjectMapper);
+                context.path().add(currentFieldName);
+                parseObjectOrField(context, dynamicObjectMapper);
+                context.path().remove();
             }
             for (int i = 0; i < parentMapperTuple.v1(); i++) {
                 context.path().remove();
@@ -557,25 +567,24 @@ final class DocumentParser {
             ObjectMapper.Dynamic dynamic = dynamicOrDefault(parentMapper, context);
             if (dynamic == ObjectMapper.Dynamic.STRICT) {
                 throw new StrictDynamicMappingException(parentMapper.fullPath(), arrayFieldName);
-            } else if (dynamic == ObjectMapper.Dynamic.TRUE) {
-                Mapper.Builder builder = context.root().findTemplateBuilder(context, arrayFieldName, XContentFieldType.OBJECT);
-                if (builder == null) {
+            } else if (dynamic == ObjectMapper.Dynamic.FALSE)  {
+                // TODO: shouldn't this skip, not parse?
+                parseNonDynamicArray(context, parentMapper, lastFieldName, arrayFieldName);
+            } else {
+                Mapper objectMapperFromTemplate = dynamic.getDynamicFieldsBuilder().createObjectMapperFromTemplate(context, arrayFieldName);
+                if (objectMapperFromTemplate == null) {
                     parseNonDynamicArray(context, parentMapper, lastFieldName, arrayFieldName);
                 } else {
-                    mapper = builder.build(context.path());
-                    assert mapper != null;
-                    if (parsesArrayValue(mapper)) {
-                        context.addDynamicMapper(mapper);
+                    if (parsesArrayValue(objectMapperFromTemplate)) {
+                        context.addDynamicMapper(objectMapperFromTemplate);
                         context.path().add(arrayFieldName);
-                        parseObjectOrField(context, mapper);
+                        parseObjectOrField(context, objectMapperFromTemplate);
                         context.path().remove();
                     } else {
                         parseNonDynamicArray(context, parentMapper, lastFieldName, arrayFieldName);
                     }
                 }
-            } else {
-                // TODO: shouldn't this skip, not parse?
-                parseNonDynamicArray(context, parentMapper, lastFieldName, arrayFieldName);
+
             }
             for (int i = 0; i < parentMapperTuple.v1(); i++) {
                 context.path().remove();
@@ -641,122 +650,6 @@ final class DocumentParser {
         }
     }
 
-    private static Mapper.Builder newLongBuilder(String name, Settings settings) {
-        return new NumberFieldMapper.Builder(name, NumberFieldMapper.NumberType.LONG, settings);
-    }
-
-    private static Mapper.Builder newFloatBuilder(String name, Settings settings) {
-        return new NumberFieldMapper.Builder(name, NumberFieldMapper.NumberType.FLOAT, settings);
-    }
-
-    private static Mapper.Builder createBuilderFromDynamicValue(final ParseContext context,
-                                                                     XContentParser.Token token,
-                                                                     String currentFieldName) throws IOException {
-        if (token == XContentParser.Token.VALUE_STRING) {
-            String text = context.parser().text();
-
-            boolean parseableAsLong = false;
-            try {
-                Long.parseLong(text);
-                parseableAsLong = true;
-            } catch (NumberFormatException e) {
-                // not a long number
-            }
-
-            boolean parseableAsDouble = false;
-            try {
-                Double.parseDouble(text);
-                parseableAsDouble = true;
-            } catch (NumberFormatException e) {
-                // not a double number
-            }
-
-            if (parseableAsLong && context.root().numericDetection()) {
-                Mapper.Builder builder = context.root().findTemplateBuilder(context, currentFieldName, XContentFieldType.LONG);
-                if (builder == null) {
-                    builder = newLongBuilder(currentFieldName, context.indexSettings().getSettings());
-                }
-                return builder;
-            } else if (parseableAsDouble && context.root().numericDetection()) {
-                Mapper.Builder builder = context.root().findTemplateBuilder(context, currentFieldName, XContentFieldType.DOUBLE);
-                if (builder == null) {
-                    builder = newFloatBuilder(currentFieldName, context.indexSettings().getSettings());
-                }
-                return builder;
-            } else if (parseableAsLong == false && parseableAsDouble == false && context.root().dateDetection()) {
-                // We refuse to match pure numbers, which are too likely to be
-                // false positives with date formats that include eg.
-                // `epoch_millis` or `YYYY`
-                for (DateFormatter dateTimeFormatter : context.root().dynamicDateTimeFormatters()) {
-                    try {
-                        dateTimeFormatter.parse(text);
-                    } catch (ElasticsearchParseException | DateTimeParseException | IllegalArgumentException e) {
-                        // failure to parse this, continue
-                        continue;
-                    }
-                    Mapper.Builder builder
-                        = context.root().findTemplateBuilder(context, currentFieldName, dateTimeFormatter);
-                    if (builder == null) {
-                        boolean ignoreMalformed = IGNORE_MALFORMED_SETTING.get(context.indexSettings().getSettings());
-                        builder = new DateFieldMapper.Builder(currentFieldName, DateFieldMapper.Resolution.MILLISECONDS,
-                            dateTimeFormatter, ignoreMalformed, context.indexSettings().getIndexVersionCreated());
-                    }
-                    return builder;
-
-                }
-            }
-
-            Mapper.Builder builder = context.root().findTemplateBuilder(context, currentFieldName, XContentFieldType.STRING);
-            if (builder == null) {
-                builder = new TextFieldMapper.Builder(currentFieldName, context.indexAnalyzers())
-                        .addMultiField(new KeywordFieldMapper.Builder("keyword").ignoreAbove(256));
-            }
-            return builder;
-        } else if (token == XContentParser.Token.VALUE_NUMBER) {
-            XContentParser.NumberType numberType = context.parser().numberType();
-            if (numberType == XContentParser.NumberType.INT
-                    || numberType == XContentParser.NumberType.LONG
-                    || numberType == XContentParser.NumberType.BIG_INTEGER) {
-                Mapper.Builder builder = context.root().findTemplateBuilder(context, currentFieldName, XContentFieldType.LONG);
-                if (builder == null) {
-                    builder = newLongBuilder(currentFieldName, context.indexSettings().getSettings());
-                }
-                return builder;
-            } else if (numberType == XContentParser.NumberType.FLOAT
-                    || numberType == XContentParser.NumberType.DOUBLE
-                    || numberType == XContentParser.NumberType.BIG_DECIMAL) {
-                Mapper.Builder builder = context.root().findTemplateBuilder(context, currentFieldName, XContentFieldType.DOUBLE);
-                if (builder == null) {
-                    // no templates are defined, we use float by default instead of double
-                    // since this is much more space-efficient and should be enough most of
-                    // the time
-                    builder = newFloatBuilder(currentFieldName, context.indexSettings().getSettings());
-                }
-                return builder;
-            }
-        } else if (token == XContentParser.Token.VALUE_BOOLEAN) {
-            Mapper.Builder builder = context.root().findTemplateBuilder(context, currentFieldName, XContentFieldType.BOOLEAN);
-            if (builder == null) {
-                builder = new BooleanFieldMapper.Builder(currentFieldName);
-            }
-            return builder;
-        } else if (token == XContentParser.Token.VALUE_EMBEDDED_OBJECT) {
-            Mapper.Builder builder = context.root().findTemplateBuilder(context, currentFieldName, XContentFieldType.BINARY);
-            if (builder == null) {
-                builder = new BinaryFieldMapper.Builder(currentFieldName);
-            }
-            return builder;
-        } else {
-            Mapper.Builder builder = context.root().findTemplateBuilder(context, currentFieldName, XContentFieldType.STRING);
-            if (builder != null) {
-                return builder;
-            }
-        }
-        // TODO how do we identify dynamically that its a binary value?
-        throw new IllegalStateException("Can't handle serializing a dynamic type with content token [" + token + "] and field name ["
-            + currentFieldName + "]");
-    }
-
     private static void parseDynamicValue(final ParseContext context, ObjectMapper parentMapper,
                                           String currentFieldName, XContentParser.Token token) throws IOException {
         ObjectMapper.Dynamic dynamic = dynamicOrDefault(parentMapper, context);
@@ -766,11 +659,7 @@ final class DocumentParser {
         if (dynamic == ObjectMapper.Dynamic.FALSE) {
             return;
         }
-        final Mapper.Builder builder = createBuilderFromDynamicValue(context, token, currentFieldName);
-        Mapper mapper = builder.build(context.path());
-        context.addDynamicMapper(mapper);
-
-        parseObjectOrField(context, mapper);
+        dynamic.getDynamicFieldsBuilder().createDynamicFieldFromValue(context, token, currentFieldName);
     }
 
     /** Creates instances of the fields that the current field should be copied to */
@@ -843,27 +732,19 @@ final class DocumentParser {
             if (mapper == null) {
                 // One mapping is missing, check if we are allowed to create a dynamic one.
                 ObjectMapper.Dynamic dynamic = dynamicOrDefault(parent, context);
-
-                switch (dynamic) {
-                    case STRICT:
-                        throw new StrictDynamicMappingException(parent.fullPath(), paths[i]);
-                    case TRUE:
-                        Mapper.Builder builder = context.root().findTemplateBuilder(context, paths[i], XContentFieldType.OBJECT);
-                        if (builder == null) {
-                            Version version = context.indexSettings().getIndexVersionCreated();
-                            builder = new ObjectMapper.Builder(paths[i], version).enabled(true);
-                        }
-                        mapper = (ObjectMapper) builder.build(context.path());
-                        if (mapper.nested() != ObjectMapper.Nested.NO) {
-                            throw new MapperParsingException("It is forbidden to create dynamic nested objects (["
-                                + context.path().pathAsText(paths[i]) + "]) through `copy_to` or dots in field names");
-                        }
-                        context.addDynamicMapper(mapper);
-                        break;
-                    case FALSE:
-                       // Should not dynamically create any more mappers so return the last mapper
+                if (dynamic == ObjectMapper.Dynamic.STRICT) {
+                    throw new StrictDynamicMappingException(parent.fullPath(), paths[i]);
+                } else if (dynamic == ObjectMapper.Dynamic.FALSE) {
+                    // Should not dynamically create any more mappers so return the last mapper
                     return new Tuple<>(pathsAdded, parent);
-
+                } else {
+                    //objects are created under properties even with dynamic: runtime, as the runtime section only holds leaf fields
+                    mapper = (ObjectMapper) dynamic.getDynamicFieldsBuilder().createDynamicObjectMapper(context, paths[i]);
+                    if (mapper.nested() != ObjectMapper.Nested.NO) {
+                        throw new MapperParsingException("It is forbidden to create dynamic nested objects (["
+                            + context.path().pathAsText(paths[i]) + "]) through `copy_to` or dots in field names");
+                    }
+                    context.addDynamicMapper(mapper);
                 }
             }
             context.path().add(paths[i]);
@@ -885,9 +766,12 @@ final class DocumentParser {
             String parentName = parentMapper.name().substring(0, lastDotNdx);
             parentMapper = context.docMapper().mappers().objectMappers().get(parentName);
             if (parentMapper == null) {
-                // If parentMapper is ever null, it means the parent of the current mapper was dynamically created.
-                // But in order to be created dynamically, the dynamic setting of that parent was necessarily true
-                return ObjectMapper.Dynamic.TRUE;
+                //If parentMapper is null, it means the parent of the current mapper is being dynamically created right now
+                parentMapper = context.getObjectMapper(parentName);
+                if (parentMapper == null) {
+                    //it can still happen that the path is ambiguous and we are not able to locate the parent
+                    break;
+                }
             }
             dynamic = parentMapper.dynamic();
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/DynamicFieldsBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DynamicFieldsBuilder.java
@@ -1,0 +1,322 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.CheckedBiConsumer;
+import org.elasticsearch.common.CheckedRunnable;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.time.DateFormatter;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.mapper.ObjectMapper.Dynamic;
+
+import java.io.IOException;
+import java.time.format.DateTimeParseException;
+
+/**
+ * Encapsulates the logic for dynamically creating fields as part of document parsing.
+ * Objects are always created the same, but leaf fields can be mapped under properties, as concrete fields that get indexed,
+ * or as runtime fields that are evaluated at search-time and have no indexing overhead.
+ */
+final class DynamicFieldsBuilder {
+    private static final Concrete CONCRETE = new Concrete(DocumentParser::parseObjectOrField);
+    static final DynamicFieldsBuilder DYNAMIC_TRUE = new DynamicFieldsBuilder(CONCRETE);
+    static final DynamicFieldsBuilder DYNAMIC_RUNTIME = new DynamicFieldsBuilder(new Runtime());
+
+    private final Strategy strategy;
+
+    private DynamicFieldsBuilder(Strategy strategy) {
+        this.strategy = strategy;
+    }
+
+    /**
+     * Creates a dynamic field based on the value of the current token being parsed from an incoming document.
+     * Makes decisions based on the type of the field being found, looks at matching dynamic templates and
+     * delegates to the appropriate strategy which depends on the current dynamic mode.
+     * The strategy defines if fields are going to be mapped as ordinary or runtime fields.
+     */
+    void createDynamicFieldFromValue(final ParseContext context,
+                                           XContentParser.Token token,
+                                           String name) throws IOException {
+        if (token == XContentParser.Token.VALUE_STRING) {
+            String text = context.parser().text();
+
+            boolean parseableAsLong = false;
+            try {
+                Long.parseLong(text);
+                parseableAsLong = true;
+            } catch (NumberFormatException e) {
+                // not a long number
+            }
+
+            boolean parseableAsDouble = false;
+            try {
+                Double.parseDouble(text);
+                parseableAsDouble = true;
+            } catch (NumberFormatException e) {
+                // not a double number
+            }
+
+            if (parseableAsLong && context.root().numericDetection()) {
+                createDynamicField(context, name, DynamicTemplate.XContentFieldType.LONG,
+                    () -> strategy.newDynamicLongField(context, name));
+            } else if (parseableAsDouble && context.root().numericDetection()) {
+                createDynamicField(context, name, DynamicTemplate.XContentFieldType.DOUBLE,
+                    () -> strategy.newDynamicDoubleField(context, name));
+            } else if (parseableAsLong == false && parseableAsDouble == false && context.root().dateDetection()) {
+                // We refuse to match pure numbers, which are too likely to be
+                // false positives with date formats that include eg.
+                // `epoch_millis` or `YYYY`
+                for (DateFormatter dateTimeFormatter : context.root().dynamicDateTimeFormatters()) {
+                    try {
+                        dateTimeFormatter.parse(text);
+                    } catch (ElasticsearchParseException | DateTimeParseException | IllegalArgumentException e) {
+                        // failure to parse this, continue
+                        continue;
+                    }
+                    createDynamicDateField(context, name, dateTimeFormatter,
+                        () -> strategy.newDynamicDateField(context, name, dateTimeFormatter));
+                    return;
+                }
+                createDynamicField(context, name, DynamicTemplate.XContentFieldType.STRING,
+                    () -> strategy.newDynamicStringField(context, name));
+            } else {
+                createDynamicField(context, name, DynamicTemplate.XContentFieldType.STRING,
+                    () -> strategy.newDynamicStringField(context, name));
+            }
+        } else if (token == XContentParser.Token.VALUE_NUMBER) {
+            XContentParser.NumberType numberType = context.parser().numberType();
+            if (numberType == XContentParser.NumberType.INT
+                || numberType == XContentParser.NumberType.LONG
+                || numberType == XContentParser.NumberType.BIG_INTEGER) {
+                createDynamicField(context, name, DynamicTemplate.XContentFieldType.LONG,
+                    () -> strategy.newDynamicLongField(context, name));
+            } else if (numberType == XContentParser.NumberType.FLOAT
+                || numberType == XContentParser.NumberType.DOUBLE
+                || numberType == XContentParser.NumberType.BIG_DECIMAL) {
+                createDynamicField(context, name, DynamicTemplate.XContentFieldType.DOUBLE,
+                    () -> strategy.newDynamicDoubleField(context, name));
+            } else {
+                throw new IllegalStateException("Unable to parse number of type [" + numberType + "]");
+            }
+        } else if (token == XContentParser.Token.VALUE_BOOLEAN) {
+            createDynamicField(context, name, DynamicTemplate.XContentFieldType.BOOLEAN,
+                () -> strategy.newDynamicBooleanField(context, name));
+        } else if (token == XContentParser.Token.VALUE_EMBEDDED_OBJECT) {
+            //runtime binary fields are not supported, hence binary objects always get created as concrete fields
+            createDynamicField(context, name, DynamicTemplate.XContentFieldType.BINARY,
+                () -> CONCRETE.newDynamicBinaryField(context, name));
+        } else {
+            createDynamicStringFieldFromTemplate(context, name);
+        }
+    }
+
+    /**
+     * Returns a dynamically created object mapper, eventually based on a matching dynamic template.
+     * Note that objects are always mapped under properties.
+     */
+    Mapper createDynamicObjectMapper(ParseContext context, String name) {
+        //dynamic:runtime maps objects under properties, exactly like dynamic:true
+        Mapper mapper = createObjectMapperFromTemplate(context, name);
+        return mapper != null ? mapper :
+            new ObjectMapper.Builder(name, context.indexSettings().getIndexVersionCreated()).enabled(true).build(context.path());
+    }
+
+    /**
+     * Returns a dynamically created object mapper, based exclusively on a matching dynamic template, null otherwise.
+     * Note that objects are always mapped under properties.
+     */
+    Mapper createObjectMapperFromTemplate(ParseContext context, String name) {
+        Mapper.Builder templateBuilder = findTemplateBuilder(context, name, DynamicTemplate.XContentFieldType.OBJECT, null);
+        return templateBuilder == null ? null : templateBuilder.build(context.path());
+    }
+
+    /**
+     * Creates a dynamic string field based on a matching dynamic template.
+     * No field is created in case there is no matching dynamic template.
+     */
+    void createDynamicStringFieldFromTemplate(ParseContext context, String name) throws IOException {
+        createDynamicField(context, name, DynamicTemplate.XContentFieldType.STRING, () -> {});
+    }
+
+    private static void createDynamicDateField(ParseContext context,
+                                               String name,
+                                               DateFormatter dateFormatter,
+                                               CheckedRunnable<IOException> createDynamicField) throws IOException {
+        createDynamicField(context, name, DynamicTemplate.XContentFieldType.DATE, dateFormatter, createDynamicField);
+    }
+
+    private static void createDynamicField(ParseContext context,
+                                           String name,
+                                           DynamicTemplate.XContentFieldType matchType,
+                                           CheckedRunnable<IOException> dynamicFieldStrategy) throws IOException {
+        assert matchType != DynamicTemplate.XContentFieldType.DATE;
+        createDynamicField(context, name, matchType, null, dynamicFieldStrategy);
+    }
+
+    private static void createDynamicField(ParseContext context,
+                                           String name,
+                                           DynamicTemplate.XContentFieldType matchType,
+                                           DateFormatter dateFormatter,
+                                           CheckedRunnable<IOException> dynamicFieldStrategy) throws IOException {
+        Mapper.Builder templateBuilder = findTemplateBuilder(context, name, matchType, dateFormatter);
+        if (templateBuilder == null) {
+            dynamicFieldStrategy.run();
+        } else {
+            CONCRETE.createDynamicField(templateBuilder, context);
+        }
+    }
+
+    /**
+     * Find a template. Returns {@code null} if no template could be found.
+     * @param context        the parse context for this document
+     * @param name           the current field name
+     * @param matchType      the type of the field in the json document or null if unknown
+     * @param dateFormatter  a date formatter to use if the type is a date, null if not a date or is using the default format
+     * @return a mapper builder, or null if there is no template for such a field
+     */
+    private static Mapper.Builder findTemplateBuilder(ParseContext context,
+                                                      String name,
+                                                      DynamicTemplate.XContentFieldType matchType,
+                                                      DateFormatter dateFormatter) {
+        DynamicTemplate dynamicTemplate = context.root().findTemplate(context.path(), name, matchType);
+        if (dynamicTemplate == null) {
+            return null;
+        }
+        String dynamicType = matchType.defaultMappingType();
+        Mapper.TypeParser.ParserContext parserContext = context.parserContext(dateFormatter);
+        String mappingType = dynamicTemplate.mappingType(dynamicType);
+        Mapper.TypeParser typeParser = parserContext.typeParser(mappingType);
+        if (typeParser == null) {
+            throw new MapperParsingException("failed to find type parsed [" + mappingType + "] for [" + name + "]");
+        }
+        return typeParser.parse(name, dynamicTemplate.mappingForName(name, dynamicType), parserContext);
+    }
+
+    /**
+     * Defines how leaf fields of type string, long, double, boolean and date are dynamically mapped
+     */
+    private interface Strategy {
+        void newDynamicStringField(ParseContext context, String name) throws IOException;
+        void newDynamicLongField(ParseContext context, String name) throws IOException;
+        void newDynamicDoubleField(ParseContext context, String name) throws IOException;
+        void newDynamicBooleanField(ParseContext context, String name) throws IOException;
+        void newDynamicDateField(ParseContext context, String name, DateFormatter dateFormatter) throws IOException;
+    }
+
+    /**
+     * Dynamically creates concrete fields, as part of the properties section.
+     * Use for leaf fields, when their parent object is mapped as dynamic:true
+     * @see Dynamic
+     */
+    private static final class Concrete implements Strategy {
+        private final CheckedBiConsumer<ParseContext, Mapper, IOException> parseField;
+
+        Concrete(CheckedBiConsumer<ParseContext, Mapper, IOException> parseField) {
+            this.parseField = parseField;
+        }
+
+        void createDynamicField(Mapper.Builder builder, ParseContext context) throws IOException {
+            Mapper mapper = builder.build(context.path());
+            context.addDynamicMapper(mapper);
+            parseField.accept(context, mapper);
+        }
+
+        @Override
+        public void newDynamicStringField(ParseContext context, String name) throws IOException {
+            createDynamicField(new TextFieldMapper.Builder(name, context.indexAnalyzers()).addMultiField(
+                    new KeywordFieldMapper.Builder("keyword").ignoreAbove(256)), context);
+        }
+
+        @Override
+        public void newDynamicLongField(ParseContext context, String name) throws IOException {
+            createDynamicField(
+                new NumberFieldMapper.Builder(name, NumberFieldMapper.NumberType.LONG, context.indexSettings().getSettings()), context);
+        }
+
+        @Override
+        public void newDynamicDoubleField(ParseContext context, String name) throws IOException {
+            // no templates are defined, we use float by default instead of double
+            // since this is much more space-efficient and should be enough most of
+            // the time
+            createDynamicField(new NumberFieldMapper.Builder(name,
+                NumberFieldMapper.NumberType.FLOAT, context.indexSettings().getSettings()), context);
+        }
+
+        @Override
+        public void newDynamicBooleanField(ParseContext context, String name) throws IOException {
+            createDynamicField(new BooleanFieldMapper.Builder(name), context);
+        }
+
+        @Override
+        public void newDynamicDateField(ParseContext context, String name, DateFormatter dateTimeFormatter) throws IOException {
+            Settings settings = context.indexSettings().getSettings();
+            boolean ignoreMalformed = FieldMapper.IGNORE_MALFORMED_SETTING.get(settings);
+            createDynamicField(new DateFieldMapper.Builder(name, DateFieldMapper.Resolution.MILLISECONDS,
+                dateTimeFormatter, ignoreMalformed, context.indexSettings().getIndexVersionCreated()), context);
+        }
+
+        void newDynamicBinaryField(ParseContext context, String name) throws IOException {
+            createDynamicField(new BinaryFieldMapper.Builder(name), context);
+        }
+    }
+
+    /**
+     * Dynamically creates runtime fields, in the runtime section.
+     * Used for leaf fields, when their parent object is mapped as dynamic:runtime.
+     * @see Dynamic
+     */
+    private static final class Runtime implements Strategy {
+        @Override
+        public void newDynamicStringField(ParseContext context, String name) {
+            String fullName = context.path().pathAsText(name);
+            RuntimeFieldType runtimeFieldType = context.getDynamicRuntimeFieldsBuilder().newDynamicStringField(fullName);
+            context.addDynamicRuntimeField(runtimeFieldType);
+        }
+
+        @Override
+        public void newDynamicLongField(ParseContext context, String name) {
+            String fullName = context.path().pathAsText(name);
+            RuntimeFieldType runtimeFieldType = context.getDynamicRuntimeFieldsBuilder().newDynamicLongField(fullName);
+            context.addDynamicRuntimeField(runtimeFieldType);
+        }
+
+        @Override
+        public void newDynamicDoubleField(ParseContext context, String name) {
+            String fullName = context.path().pathAsText(name);
+            RuntimeFieldType runtimeFieldType = context.getDynamicRuntimeFieldsBuilder().newDynamicDoubleField(fullName);
+            context.addDynamicRuntimeField(runtimeFieldType);
+        }
+
+        @Override
+        public void newDynamicBooleanField(ParseContext context, String name) {
+            String fullName = context.path().pathAsText(name);
+            RuntimeFieldType runtimeFieldType = context.getDynamicRuntimeFieldsBuilder().newDynamicBooleanField(fullName);
+            context.addDynamicRuntimeField(runtimeFieldType);
+        }
+
+        @Override
+        public void newDynamicDateField(ParseContext context, String name, DateFormatter dateFormatter) {
+            String fullName = context.path().pathAsText(name);
+            RuntimeFieldType runtimeFieldType = context.getDynamicRuntimeFieldsBuilder().newDynamicDateField(fullName, dateFormatter);
+            context.addDynamicRuntimeField(runtimeFieldType);
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/mapper/DynamicRuntimeFieldsBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DynamicRuntimeFieldsBuilder.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.elasticsearch.common.time.DateFormatter;
+import org.elasticsearch.plugins.MapperPlugin;
+
+import static org.elasticsearch.index.mapper.ObjectMapper.Dynamic;
+
+/**
+ * Defines how runtime fields are dynamically created. Used when objects are mapped with dynamic:runtime.
+ * Plugins that provide runtime field implementations can also plug in their implementation of this interface
+ * to define how leaf fields of each supported type can be dynamically created in dynamic runtime mode.
+ *
+ * @see MapperPlugin#getDynamicRuntimeFieldsBuilder()
+ * @see Dynamic
+ */
+public interface DynamicRuntimeFieldsBuilder {
+    /**
+     * Dynamically creates a runtime field from a parsed string value
+     */
+    RuntimeFieldType newDynamicStringField(String name);
+    /**
+     * Dynamically creates a runtime field from a parsed long value
+     */
+    RuntimeFieldType newDynamicLongField(String name);
+    /**
+     * Dynamically creates a runtime field from a parsed double value
+     */
+    RuntimeFieldType newDynamicDoubleField(String name);
+    /**
+     * Dynamically creates a runtime field from a parsed boolean value
+     */
+    RuntimeFieldType newDynamicBooleanField(String name);
+    /**
+     * Dynamically creates a runtime field from a parsed date value
+     */
+    RuntimeFieldType newDynamicDateField(String name, DateFormatter dateFormatter);
+}

--- a/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
@@ -60,6 +60,7 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
             private final Function<String, SimilarityProvider> similarityLookupService;
             private final Function<String, TypeParser> typeParsers;
             private final Function<String, RuntimeFieldType.Parser> runtimeTypeParsers;
+            private final boolean supportsDynamicRuntimeMappings;
             private final Version indexVersionCreated;
             private final Supplier<QueryShardContext> queryShardContextSupplier;
             private final DateFormatter dateFormatter;
@@ -77,7 +78,8 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
                                  ScriptService scriptService,
                                  IndexAnalyzers indexAnalyzers,
                                  IndexSettings indexSettings,
-                                 BooleanSupplier idFieldDataEnabled) {
+                                 BooleanSupplier idFieldDataEnabled,
+                                 boolean supportsDynamicRuntimeMappings) {
                 this.similarityLookupService = similarityLookupService;
                 this.typeParsers = typeParsers;
                 this.runtimeTypeParsers = runtimeTypeParsers;
@@ -88,6 +90,7 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
                 this.indexAnalyzers = indexAnalyzers;
                 this.indexSettings = indexSettings;
                 this.idFieldDataEnabled = idFieldDataEnabled;
+                this.supportsDynamicRuntimeMappings = supportsDynamicRuntimeMappings;
             }
 
             public IndexAnalyzers getIndexAnalyzers() {
@@ -116,6 +119,10 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
 
             public RuntimeFieldType.Parser runtimeFieldTypeParser(String type) {
                 return runtimeTypeParsers.apply(type);
+            }
+
+            public boolean supportsDynamicRuntimeMappings() {
+                return supportsDynamicRuntimeMappings;
             }
 
             public Version indexVersionCreated() {
@@ -154,7 +161,7 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
                 MultiFieldParserContext(ParserContext in) {
                     super(in.similarityLookupService, in.typeParsers, in.runtimeTypeParsers, in.indexVersionCreated,
                         in.queryShardContextSupplier, in.dateFormatter, in.scriptService, in.indexAnalyzers, in.indexSettings,
-                        in.idFieldDataEnabled);
+                        in.idFieldDataEnabled, in.supportsDynamicRuntimeMappings);
                 }
 
                 @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -146,8 +146,8 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
         Function<DateFormatter, Mapper.TypeParser.ParserContext> parserContextFunction =
             dateFormatter -> new Mapper.TypeParser.ParserContext(similarityService::getSimilarity, mapperRegistry.getMapperParsers()::get,
                 mapperRegistry.getRuntimeFieldTypeParsers()::get, indexVersionCreated, queryShardContextSupplier, dateFormatter,
-                scriptService, indexAnalyzers, indexSettings, idFieldDataEnabled);
-        this.documentParser = new DocumentParser(xContentRegistry, parserContextFunction);
+                scriptService, indexAnalyzers, indexSettings, idFieldDataEnabled, mapperRegistry.getDynamicRuntimeFieldsBuilder() != null);
+        this.documentParser = new DocumentParser(xContentRegistry, parserContextFunction, mapperRegistry.getDynamicRuntimeFieldsBuilder());
         Map<String, MetadataFieldMapper.TypeParser> metadataMapperParsers =
             mapperRegistry.getMetadataMapperParsers(indexSettings.getIndexVersionCreated());
         this.parserContextSupplier = () -> parserContextFunction.apply(null);

--- a/server/src/main/java/org/elasticsearch/index/mapper/Mapping.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/Mapping.java
@@ -85,8 +85,8 @@ public final class Mapping implements ToXContentFragment {
     /**
      * Generate a mapping update for the given root object mapper.
      */
-    public Mapping mappingUpdate(Mapper rootObjectMapper) {
-        return new Mapping((RootObjectMapper) rootObjectMapper, metadataMappers, meta);
+    public Mapping mappingUpdate(RootObjectMapper rootObjectMapper) {
+        return new Mapping(rootObjectMapper, metadataMappers, meta);
     }
 
     /** Get the root mapper with the given class. */

--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -53,13 +53,27 @@ public class ObjectMapper extends Mapper implements Cloneable {
     public static class Defaults {
         public static final boolean ENABLED = true;
         public static final Nested NESTED = Nested.NO;
-        public static final Dynamic DYNAMIC = null; // not set, inherited from root
     }
 
     public enum Dynamic {
-        TRUE,
+        TRUE {
+            @Override
+            DynamicFieldsBuilder getDynamicFieldsBuilder() {
+                return DynamicFieldsBuilder.DYNAMIC_TRUE;
+            }
+        },
         FALSE,
-        STRICT
+        STRICT,
+        RUNTIME {
+            @Override
+            DynamicFieldsBuilder getDynamicFieldsBuilder() {
+                return DynamicFieldsBuilder.DYNAMIC_RUNTIME;
+            }
+        };
+
+        DynamicFieldsBuilder getDynamicFieldsBuilder() {
+            throw new UnsupportedOperationException("Cannot create dynamic fields when dynamic is set to [" + this + "]");
+        };
     }
 
     public static class Nested {
@@ -139,7 +153,7 @@ public class ObjectMapper extends Mapper implements Cloneable {
 
         protected Nested nested = Defaults.NESTED;
 
-        protected Dynamic dynamic = Defaults.DYNAMIC;
+        protected Dynamic dynamic;
 
         protected final List<Mapper.Builder> mappersBuilders = new ArrayList<>();
         protected final Version indexCreatedVersion;
@@ -198,7 +212,7 @@ public class ObjectMapper extends Mapper implements Cloneable {
         @Override
         public Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
             ObjectMapper.Builder builder = new Builder(name, parserContext.indexVersionCreated());
-            parseNested(name, node, builder, parserContext);
+            parseNested(name, node, builder);
             for (Iterator<Map.Entry<String, Object>> iterator = node.entrySet().iterator(); iterator.hasNext();) {
                 Map.Entry<String, Object> entry = iterator.next();
                 String fieldName = entry.getKey();
@@ -216,6 +230,12 @@ public class ObjectMapper extends Mapper implements Cloneable {
                 String value = fieldNode.toString();
                 if (value.equalsIgnoreCase("strict")) {
                     builder.dynamic(Dynamic.STRICT);
+                }  else if (value.equalsIgnoreCase("runtime")) {
+                    if (parserContext.supportsDynamicRuntimeMappings() == false) {
+                        throw new IllegalArgumentException("unable to set dynamic:runtime as there is " +
+                            "no registered dynamic runtime fields builder");
+                    }
+                    builder.dynamic(Dynamic.RUNTIME);
                 } else {
                     boolean dynamic = XContentMapValues.nodeBooleanValue(fieldNode, fieldName + ".dynamic");
                     builder.dynamic(dynamic ? Dynamic.TRUE : Dynamic.FALSE);
@@ -241,8 +261,7 @@ public class ObjectMapper extends Mapper implements Cloneable {
             return false;
         }
 
-        protected static void parseNested(String name, Map<String, Object> node, ObjectMapper.Builder builder,
-                                          ParserContext parserContext) {
+        protected static void parseNested(String name, Map<String, Object> node, ObjectMapper.Builder builder) {
             boolean nested = false;
             Explicit<Boolean> nestedIncludeInParent = new Explicit<>(false, false);
             Explicit<Boolean> nestedIncludeInRoot = new Explicit<>(false, false);
@@ -383,13 +402,18 @@ public class ObjectMapper extends Mapper implements Cloneable {
         return clone;
     }
 
+    ObjectMapper copyAndReset() {
+        ObjectMapper copy = clone();
+        // reset the sub mappers
+        copy.mappers = new CopyOnWriteHashMap<>();
+        return copy;
+    }
+
     /**
      * Build a mapping update with the provided sub mapping update.
      */
-    public ObjectMapper mappingUpdate(Mapper mapper) {
-        ObjectMapper mappingUpdate = clone();
-        // reset the sub mappers
-        mappingUpdate.mappers = new CopyOnWriteHashMap<>();
+    final ObjectMapper mappingUpdate(Mapper mapper) {
+        ObjectMapper mappingUpdate = copyAndReset();
         mappingUpdate.putMapper(mapper);
         return mappingUpdate;
     }
@@ -566,5 +590,4 @@ public class ObjectMapper extends Mapper implements Cloneable {
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
 
     }
-
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/ParseContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ParseContext.java
@@ -29,14 +29,17 @@ import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.analysis.IndexAnalyzers;
+import org.elasticsearch.plugins.MapperPlugin;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -166,6 +169,11 @@ public abstract class ParseContext {
         }
 
         @Override
+        public ObjectMapper getObjectMapper(String name) {
+            return in.getObjectMapper(name);
+        }
+
+        @Override
         public Iterable<Document> nonRootDocuments() {
             return in.nonRootDocuments();
         }
@@ -281,6 +289,21 @@ public abstract class ParseContext {
         }
 
         @Override
+        public void addDynamicRuntimeField(RuntimeFieldType runtimeField) {
+            in.addDynamicRuntimeField(runtimeField);
+        }
+
+        @Override
+        public List<RuntimeFieldType> getDynamicRuntimeFields() {
+            return in.getDynamicRuntimeFields();
+        }
+
+        @Override
+        public DynamicRuntimeFieldsBuilder getDynamicRuntimeFieldsBuilder() {
+            return in.getDynamicRuntimeFieldsBuilder();
+        }
+
+        @Override
         public void addIgnoredField(String field) {
             in.addIgnoredField(field);
         }
@@ -294,13 +317,16 @@ public abstract class ParseContext {
     public static class InternalParseContext extends ParseContext {
         private final DocumentMapper docMapper;
         private final Function<DateFormatter, Mapper.TypeParser.ParserContext> parserContextFunction;
-        private final ContentPath path;
+        private final ContentPath path = new ContentPath(0);
         private final XContentParser parser;
         private final Document document;
-        private final List<Document> documents;
+        private final List<Document> documents = new ArrayList<>();
         private final SourceToParse sourceToParse;
         private final long maxAllowedNumNestedDocs;
-        private final List<Mapper> dynamicMappers;
+        private final List<Mapper> dynamicMappers =  new ArrayList<>();
+        private final Map<String, ObjectMapper> dynamicObjectMappers = new HashMap<>();
+        private final List<RuntimeFieldType> dynamicRuntimeFields = new ArrayList<>();
+        private final DynamicRuntimeFieldsBuilder dynamicRuntimeFieldsBuilder;
         private final Set<String> ignoredFields = new HashSet<>();
         private Field version;
         private SeqNoFieldMapper.SequenceIDFields seqID;
@@ -309,18 +335,17 @@ public abstract class ParseContext {
 
         public InternalParseContext(DocumentMapper docMapper,
                                     Function<DateFormatter, Mapper.TypeParser.ParserContext> parserContextFunction,
+                                    DynamicRuntimeFieldsBuilder dynamicRuntimeFieldsBuilder,
                                     SourceToParse source,
                                     XContentParser parser) {
             this.docMapper = docMapper;
             this.parserContextFunction = parserContextFunction;
-            this.path = new ContentPath(0);
+            this.dynamicRuntimeFieldsBuilder = dynamicRuntimeFieldsBuilder;
             this.parser = parser;
             this.document = new Document();
-            this.documents = new ArrayList<>();
             this.documents.add(document);
             this.version = null;
             this.sourceToParse = source;
-            this.dynamicMappers = new ArrayList<>();
             this.maxAllowedNumNestedDocs = docMapper.indexSettings().getMappingNestedDocsLimit();
             this.numNestedDocs = 0L;
         }
@@ -414,12 +439,35 @@ public abstract class ParseContext {
 
         @Override
         public void addDynamicMapper(Mapper mapper) {
+            if (mapper instanceof ObjectMapper) {
+                dynamicObjectMappers.put(mapper.name(), (ObjectMapper)mapper);
+            }
             dynamicMappers.add(mapper);
         }
 
         @Override
         public List<Mapper> getDynamicMappers() {
             return dynamicMappers;
+        }
+
+        @Override
+        public ObjectMapper getObjectMapper(String name) {
+            return dynamicObjectMappers.get(name);
+        }
+
+        @Override
+        public void addDynamicRuntimeField(RuntimeFieldType runtimeField) {
+            dynamicRuntimeFields.add(runtimeField);
+        }
+
+        @Override
+        public List<RuntimeFieldType> getDynamicRuntimeFields() {
+            return Collections.unmodifiableList(dynamicRuntimeFields);
+        }
+
+        @Override
+        public DynamicRuntimeFieldsBuilder getDynamicRuntimeFieldsBuilder() {
+            return dynamicRuntimeFieldsBuilder;
         }
 
         @Override
@@ -636,8 +684,26 @@ public abstract class ParseContext {
      */
     public abstract void addDynamicMapper(Mapper update);
 
+    public abstract ObjectMapper getObjectMapper(String name);
+
     /**
      * Get dynamic mappers created while parsing.
      */
     public abstract List<Mapper> getDynamicMappers();
+
+    /**
+     * Add a new runtime field dynamically created while parsing.
+     */
+    public abstract void addDynamicRuntimeField(RuntimeFieldType runtimeField);
+
+    /**
+     * Get dynamic runtime fields created while parsing.
+     */
+    public abstract List<RuntimeFieldType> getDynamicRuntimeFields();
+
+    /**
+     * Retrieve the builder for dynamically created runtime fields
+     * @see MapperPlugin#getDynamicRuntimeFieldsBuilder()
+     */
+    public abstract DynamicRuntimeFieldsBuilder getDynamicRuntimeFieldsBuilder();
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
@@ -248,18 +248,18 @@ public class RootObjectMapper extends ObjectMapper {
     }
 
     @Override
-    public ObjectMapper mappingUpdate(Mapper mapper) {
-        RootObjectMapper update = (RootObjectMapper) super.mappingUpdate(mapper);
+    RootObjectMapper copyAndReset() {
+        RootObjectMapper copy = (RootObjectMapper) super.copyAndReset();
         // for dynamic updates, no need to carry root-specific options, we just
         // set everything to their implicit default value so that they are not
         // applied at merge time
-        update.dynamicTemplates = new Explicit<>(new DynamicTemplate[0], false);
-        update.dynamicDateTimeFormatters = new Explicit<>(Defaults.DYNAMIC_DATE_TIME_FORMATTERS, false);
-        update.dateDetection = new Explicit<>(Defaults.DATE_DETECTION, false);
-        update.numericDetection = new Explicit<>(Defaults.NUMERIC_DETECTION, false);
+        copy.dynamicTemplates = new Explicit<>(new DynamicTemplate[0], false);
+        copy.dynamicDateTimeFormatters = new Explicit<>(Defaults.DYNAMIC_DATE_TIME_FORMATTERS, false);
+        copy.dateDetection = new Explicit<>(Defaults.DATE_DETECTION, false);
+        copy.numericDetection = new Explicit<>(Defaults.NUMERIC_DETECTION, false);
         //also no need to carry the already defined runtime fields, only new ones need to be added
-        update.runtimeFieldTypes.clear();
-        return update;
+        copy.runtimeFieldTypes.clear();
+        return copy;
     }
 
     boolean dateDetection() {
@@ -284,36 +284,6 @@ public class RootObjectMapper extends ObjectMapper {
 
     RuntimeFieldType getRuntimeFieldType(String name) {
         return runtimeFieldTypes.get(name);
-    }
-
-    public Mapper.Builder findTemplateBuilder(ParseContext context, String name, XContentFieldType matchType) {
-        return findTemplateBuilder(context, name, matchType, null);
-    }
-
-    public Mapper.Builder findTemplateBuilder(ParseContext context, String name, DateFormatter dateFormatter) {
-        return findTemplateBuilder(context, name, XContentFieldType.DATE, dateFormatter);
-    }
-
-    /**
-     * Find a template. Returns {@code null} if no template could be found.
-     * @param name        the field name
-     * @param matchType   the type of the field in the json document or null if unknown
-     * @param dateFormat  a dateformatter to use if the type is a date, null if not a date or is using the default format
-     * @return a mapper builder, or null if there is no template for such a field
-     */
-    private Mapper.Builder findTemplateBuilder(ParseContext context, String name, XContentFieldType matchType, DateFormatter dateFormat) {
-        DynamicTemplate dynamicTemplate = findTemplate(context.path(), name, matchType);
-        if (dynamicTemplate == null) {
-            return null;
-        }
-        String dynamicType = matchType.defaultMappingType();
-        Mapper.TypeParser.ParserContext parserContext = context.parserContext(dateFormat);
-        String mappingType = dynamicTemplate.mappingType(dynamicType);
-        Mapper.TypeParser typeParser = parserContext.typeParser(mappingType);
-        if (typeParser == null) {
-            throw new MapperParsingException("failed to find type parsed [" + mappingType + "] for [" + name + "]");
-        }
-        return typeParser.parse(name, dynamicTemplate.mappingForName(name, dynamicType), parserContext);
     }
 
     public DynamicTemplate findTemplate(ContentPath path, String name, XContentFieldType matchType) {
@@ -365,6 +335,12 @@ public class RootObjectMapper extends ObjectMapper {
         }
         assert this.runtimeFieldTypes != mergeWithObject.runtimeFieldTypes;
         this.runtimeFieldTypes.putAll(mergeWithObject.runtimeFieldTypes);
+    }
+
+    void addRuntimeFields(Collection<RuntimeFieldType> runtimeFields) {
+        for (RuntimeFieldType runtimeField : runtimeFields) {
+            this.runtimeFieldTypes.put(runtimeField.name(), runtimeField);
+        }
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/indices/IndicesModule.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesModule.java
@@ -34,6 +34,7 @@ import org.elasticsearch.index.mapper.BooleanFieldMapper;
 import org.elasticsearch.index.mapper.CompletionFieldMapper;
 import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.DocCountFieldMapper;
+import org.elasticsearch.index.mapper.DynamicRuntimeFieldsBuilder;
 import org.elasticsearch.index.mapper.FieldAliasMapper;
 import org.elasticsearch.index.mapper.FieldNamesFieldMapper;
 import org.elasticsearch.index.mapper.GeoPointFieldMapper;
@@ -85,7 +86,7 @@ public class IndicesModule extends AbstractModule {
 
     public IndicesModule(List<MapperPlugin> mapperPlugins) {
         this.mapperRegistry = new MapperRegistry(getMappers(mapperPlugins), getRuntimeFieldTypes(mapperPlugins),
-            getMetadataMappers(mapperPlugins), getFieldFilter(mapperPlugins));
+            getDynamicRuntimeFieldsBuilder(mapperPlugins), getMetadataMappers(mapperPlugins), getFieldFilter(mapperPlugins));
         registerBuiltinWritables();
     }
 
@@ -155,6 +156,19 @@ public class IndicesModule extends AbstractModule {
             }
         }
         return Collections.unmodifiableMap(runtimeParsers);
+    }
+
+    private static DynamicRuntimeFieldsBuilder getDynamicRuntimeFieldsBuilder(List<MapperPlugin> mapperPlugins) {
+        DynamicRuntimeFieldsBuilder dynamicRuntimeFieldsBuilder = null;
+        for (MapperPlugin mapperPlugin : mapperPlugins) {
+            if (mapperPlugin.getDynamicRuntimeFieldsBuilder() != null) {
+                if (dynamicRuntimeFieldsBuilder != null) {
+                    throw new IllegalArgumentException("Dynamic runtime fields builder already registered");
+                }
+                dynamicRuntimeFieldsBuilder = mapperPlugin.getDynamicRuntimeFieldsBuilder();
+            }
+        }
+        return dynamicRuntimeFieldsBuilder;
     }
 
     private static final Map<String, MetadataFieldMapper.TypeParser> builtInMetadataMappers = initBuiltInMetadataMappers();

--- a/server/src/main/java/org/elasticsearch/indices/mapper/MapperRegistry.java
+++ b/server/src/main/java/org/elasticsearch/indices/mapper/MapperRegistry.java
@@ -21,6 +21,7 @@ package org.elasticsearch.indices.mapper;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.index.mapper.AllFieldMapper;
+import org.elasticsearch.index.mapper.DynamicRuntimeFieldsBuilder;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MetadataFieldMapper;
 import org.elasticsearch.index.mapper.RuntimeFieldType;
@@ -39,15 +40,19 @@ public final class MapperRegistry {
 
     private final Map<String, Mapper.TypeParser> mapperParsers;
     private final Map<String, RuntimeFieldType.Parser> runtimeFieldTypeParsers;
+    private final DynamicRuntimeFieldsBuilder dynamicRuntimeFieldsBuilder;
     private final Map<String, MetadataFieldMapper.TypeParser> metadataMapperParsers;
     private final Map<String, MetadataFieldMapper.TypeParser> metadataMapperParsers6x;
     private final Function<String, Predicate<String>> fieldFilter;
 
 
     public MapperRegistry(Map<String, Mapper.TypeParser> mapperParsers, Map<String, RuntimeFieldType.Parser> runtimeFieldTypeParsers,
-            Map<String, MetadataFieldMapper.TypeParser> metadataMapperParsers, Function<String, Predicate<String>> fieldFilter) {
+                          DynamicRuntimeFieldsBuilder dynamicRuntimeFieldsBuilder,
+                          Map<String, MetadataFieldMapper.TypeParser> metadataMapperParsers,
+                          Function<String, Predicate<String>> fieldFilter) {
         this.mapperParsers = Collections.unmodifiableMap(new LinkedHashMap<>(mapperParsers));
         this.runtimeFieldTypeParsers = runtimeFieldTypeParsers;
+        this.dynamicRuntimeFieldsBuilder = dynamicRuntimeFieldsBuilder;
         this.metadataMapperParsers = Collections.unmodifiableMap(new LinkedHashMap<>(metadataMapperParsers));
         // add the _all field mapper for indices created in 6x
         Map<String, MetadataFieldMapper.TypeParser> metadata6x = new LinkedHashMap<>();
@@ -67,6 +72,10 @@ public final class MapperRegistry {
 
     public Map<String, RuntimeFieldType.Parser> getRuntimeFieldTypeParsers() {
         return runtimeFieldTypeParsers;
+    }
+
+    public DynamicRuntimeFieldsBuilder getDynamicRuntimeFieldsBuilder() {
+        return dynamicRuntimeFieldsBuilder;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/plugins/MapperPlugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/MapperPlugin.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.plugins;
 
+import org.elasticsearch.index.mapper.DynamicRuntimeFieldsBuilder;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MetadataFieldMapper;
 import org.elasticsearch.index.mapper.RuntimeFieldType;
@@ -44,8 +45,23 @@ public interface MapperPlugin {
         return Collections.emptyMap();
     }
 
+    /**
+     * Returss the runtime field implementations added by this plugin.
+     * <p>
+     * The key of the returned {@link Map} is the unique name for the field type which will be used
+     * as the mapping {@code type}, and the value is a {@link RuntimeFieldType.Parser} to parse the
+     * field type settings into a {@link RuntimeFieldType}.
+     */
     default Map<String, RuntimeFieldType.Parser> getRuntimeFieldTypes() {
         return Collections.emptyMap();
+    }
+
+    /**
+     * Defines how runtime fields are dynamically created when objects are mapped with dynamic:runtime.
+     * @see DynamicRuntimeFieldsBuilder
+     */
+    default DynamicRuntimeFieldsBuilder getDynamicRuntimeFieldsBuilder() {
+        return null;
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexUpgradeServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexUpgradeServiceTests.java
@@ -153,7 +153,8 @@ public class MetadataIndexUpgradeServiceTests extends ESTestCase {
         return new MetadataIndexUpgradeService(
             Settings.EMPTY,
             xContentRegistry(),
-            new MapperRegistry(Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(), MapperPlugin.NOOP_FIELD_FILTER),
+            new MapperRegistry(Collections.emptyMap(), Collections.emptyMap(), null,
+                Collections.emptyMap(), MapperPlugin.NOOP_FIELD_FILTER),
             IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
             new SystemIndices(Collections.singletonMap("system-plugin",
                 Collections.singletonList(new SystemIndexDescriptor(".system", "a system index")))),

--- a/server/src/test/java/org/elasticsearch/index/codec/CodecTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/CodecTests.java
@@ -92,7 +92,7 @@ public class CodecTests extends ESTestCase {
         IndexSettings settings = IndexSettingsModule.newIndexSettings("_na", nodeSettings);
         SimilarityService similarityService = new SimilarityService(settings, null, Collections.emptyMap());
         IndexAnalyzers indexAnalyzers = createTestAnalysis(settings, nodeSettings).indexAnalyzers;
-        MapperRegistry mapperRegistry = new MapperRegistry(Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
+        MapperRegistry mapperRegistry = new MapperRegistry(Collections.emptyMap(), Collections.emptyMap(), null, Collections.emptyMap(),
             MapperPlugin.NOOP_FIELD_FILTER);
         MapperService service = new MapperService(settings, indexAnalyzers, xContentRegistry(), similarityService, mapperRegistry,
                 () -> null, () -> false, null);

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
@@ -151,7 +151,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
             b.field("dynamic", "true");
             b.startObject("runtime");
             {
-                b.startObject("object").field("type", "test").endObject();
+                b.startObject("object").field("type", "string").endObject();
             }
             b.endObject();
         }));
@@ -186,8 +186,8 @@ public class DocumentParserTests extends MapperServiceTestCase {
             b.field("dynamic", "true");
             b.startObject("runtime");
             {
-                b.startObject("location").field("type", "test").endObject();
-                b.startObject("country").field("type", "test").endObject();
+                b.startObject("location").field("type", "string").endObject();
+                b.startObject("country").field("type", "string").endObject();
             }
             b.endObject();
             b.startObject("properties");

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
@@ -61,8 +61,16 @@ public class DocumentParserTests extends MapperServiceTestCase {
     }
 
     public void testParseWithRuntimeField() throws Exception {
-        DocumentMapper mapper = createDocumentMapper(runtimeFieldMapping(b -> b.field("type", "test")));
+        DocumentMapper mapper = createDocumentMapper(runtimeFieldMapping(b -> b.field("type", "string")));
         ParsedDocument doc = mapper.parse(source(b -> b.field("field", "value")));
+        //field defined as runtime field but not under properties: no dynamic updates, the field does not get indexed
+        assertNull(doc.dynamicMappingsUpdate());
+        assertNull(doc.rootDoc().getField("field"));
+    }
+
+    public void testParseWithRuntimeFieldArray() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(runtimeFieldMapping(b -> b.field("type", "string")));
+        ParsedDocument doc = mapper.parse(source(b -> b.array("field", "value1", "value2")));
         //field defined as runtime field but not under properties: no dynamic updates, the field does not get indexed
         assertNull(doc.dynamicMappingsUpdate());
         assertNull(doc.rootDoc().getField("field"));
@@ -71,7 +79,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
     public void testParseWithShadowedField() throws Exception {
         XContentBuilder builder = XContentFactory.jsonBuilder().startObject().startObject("_doc");
         builder.startObject("runtime");
-        builder.startObject("field").field("type", "test").endObject();
+        builder.startObject("field").field("type", "string").endObject();
         builder.endObject();
         builder.startObject("properties");
         builder.startObject("field").field("type", "keyword").endObject();
@@ -87,7 +95,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
     public void testParseWithRuntimeFieldDottedNameDisabledObject() throws Exception {
         XContentBuilder builder = XContentFactory.jsonBuilder().startObject().startObject("_doc");
         builder.startObject("runtime");
-        builder.startObject("path1.path2.path3.field").field("type", "test").endObject();
+        builder.startObject("path1.path2.path3.field").field("type", "string").endObject();
         builder.endObject();
         builder.startObject("properties");
         builder.startObject("path1").field("type", "object").field("enabled", false).endObject();
@@ -105,7 +113,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
     public void testParseWithShadowedSubField() throws Exception {
         XContentBuilder builder = XContentFactory.jsonBuilder().startObject().startObject("_doc");
         builder.startObject("runtime");
-        builder.startObject("field.keyword").field("type", "test").endObject();
+        builder.startObject("field.keyword").field("type", "string").endObject();
         builder.endObject();
         builder.startObject("properties");
         builder.startObject("field").field("type", "text");
@@ -123,7 +131,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
     public void testParseWithShadowedMultiField() throws Exception {
         XContentBuilder builder = XContentFactory.jsonBuilder().startObject().startObject("_doc");
         builder.startObject("runtime");
-        builder.startObject("field").field("type", "test").endObject();
+        builder.startObject("field").field("type", "string").endObject();
         builder.endObject();
         builder.startObject("properties");
         builder.startObject("field").field("type", "text");
@@ -408,7 +416,6 @@ public class DocumentParserTests extends MapperServiceTestCase {
     }
 
     public void testNestedHaveIdAndTypeFields() throws Exception {
-
         DocumentMapper mapper = createDocumentMapper(mapping(b -> {
             b.startObject("foo");
             {
@@ -494,6 +501,36 @@ public class DocumentParserTests extends MapperServiceTestCase {
         assertNotNull(doc.rootDoc().getField("foo.bar.baz"));
     }
 
+    public void testPropagateDynamicRuntimeWithDynamicMapper() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(topMapping(b -> {
+            b.field("dynamic", false);
+            b.startObject("properties");
+            {
+                b.startObject("foo");
+                {
+                    b.field("type", "object");
+                    b.field("dynamic", "runtime");
+                    b.startObject("properties").endObject();
+                }
+                b.endObject();
+            }
+            b.endObject();
+        }));
+        ParsedDocument doc = mapper.parse(source(b -> {
+            b.startObject("foo");
+            {
+                b.field("baz", "test");
+                b.startObject("bar").field("baz", "something").endObject();
+            }
+            b.endObject();
+        }));
+        assertNull(doc.rootDoc().getField("foo.bar.baz"));
+        assertEquals("{\"_doc\":{\"dynamic\":\"false\"," +
+            "\"runtime\":{\"foo.bar.baz\":{\"type\":\"string\"},\"foo.baz\":{\"type\":\"string\"}}," +
+            "\"properties\":{\"foo\":{\"dynamic\":\"runtime\",\"properties\":{\"bar\":{\"type\":\"object\"}}}}}}",
+            Strings.toString(doc.dynamicMappingsUpdate()));
+    }
+
     public void testDynamicRootFallback() throws Exception {
         DocumentMapper mapper = createDocumentMapper(topMapping(b -> {
             b.field("dynamic", false);
@@ -543,7 +580,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
 
     // creates an object mapper, which is about 100x harder than it should be....
     ObjectMapper createObjectMapper(MapperService mapperService, String name) {
-        ParseContext context = new ParseContext.InternalParseContext(mapperService.documentMapper(), null, null, null);
+        ParseContext context = new ParseContext.InternalParseContext(mapperService.documentMapper(), null, null, null, null);
         String[] nameParts = name.split("\\.");
         for (int i = 0; i < nameParts.length - 1; ++i) {
             context.path().add(nameParts[i]);
@@ -554,21 +591,30 @@ public class DocumentParserTests extends MapperServiceTestCase {
 
     public void testEmptyMappingUpdate() throws Exception {
         DocumentMapper docMapper = createDummyMapping();
-        assertNull(DocumentParser.createDynamicUpdate(docMapper.mapping(), docMapper, Collections.emptyList()));
+        assertNull(DocumentParser.createDynamicUpdate(docMapper.mapping(), docMapper, Collections.emptyList(), Collections.emptyList()));
     }
 
     public void testSingleMappingUpdate() throws Exception {
         DocumentMapper docMapper = createDummyMapping();
         List<Mapper> updates = Collections.singletonList(new MockFieldMapper("foo"));
-        Mapping mapping = DocumentParser.createDynamicUpdate(docMapper.mapping(), docMapper, updates);
+        Mapping mapping = DocumentParser.createDynamicUpdate(docMapper.mapping(), docMapper, updates, Collections.emptyList());
         assertNotNull(mapping);
         assertNotNull(mapping.root().getMapper("foo"));
+    }
+
+    public void testSingleRuntimeFieldMappingUpdate() throws Exception {
+        DocumentMapper docMapper = createDummyMapping();
+        List<RuntimeFieldType> updates = Collections.singletonList(new TestRuntimeField("foo", "any"));
+        Mapping mapping = DocumentParser.createDynamicUpdate(docMapper.mapping(), docMapper, Collections.emptyList(), updates);
+        assertNotNull(mapping);
+        assertNull(mapping.root().getMapper("foo"));
+        assertNotNull(mapping.root().getRuntimeFieldType("foo"));
     }
 
     public void testSubfieldMappingUpdate() throws Exception {
         DocumentMapper docMapper = createDummyMapping();
         List<Mapper> updates = Collections.singletonList(new MockFieldMapper("x.foo"));
-        Mapping mapping = DocumentParser.createDynamicUpdate(docMapper.mapping(), docMapper, updates);
+        Mapping mapping = DocumentParser.createDynamicUpdate(docMapper.mapping(), docMapper, updates, Collections.emptyList());
         assertNotNull(mapping);
         Mapper xMapper = mapping.root().getMapper("x");
         assertNotNull(xMapper);
@@ -577,12 +623,22 @@ public class DocumentParserTests extends MapperServiceTestCase {
         assertNull(((ObjectMapper) xMapper).getMapper("subx"));
     }
 
+    public void testRuntimeSubfieldMappingUpdate() throws Exception {
+        DocumentMapper docMapper = createDummyMapping();
+        List<RuntimeFieldType> updates = Collections.singletonList(new TestRuntimeField("x.foo", "any"));
+        Mapping mapping = DocumentParser.createDynamicUpdate(docMapper.mapping(), docMapper, Collections.emptyList(), updates);
+        assertNotNull(mapping);
+        Mapper xMapper = mapping.root().getMapper("x");
+        assertNull(xMapper);
+        assertNotNull(mapping.root.getRuntimeFieldType("x.foo"));
+    }
+
     public void testMultipleSubfieldMappingUpdate() throws Exception {
         DocumentMapper docMapper = createDummyMapping();
         List<Mapper> updates = new ArrayList<>();
         updates.add(new MockFieldMapper("x.foo"));
         updates.add(new MockFieldMapper("x.bar"));
-        Mapping mapping = DocumentParser.createDynamicUpdate(docMapper.mapping(), docMapper, updates);
+        Mapping mapping = DocumentParser.createDynamicUpdate(docMapper.mapping(), docMapper, updates, Collections.emptyList());
         assertNotNull(mapping);
         Mapper xMapper = mapping.root().getMapper("x");
         assertNotNull(xMapper);
@@ -595,7 +651,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
     public void testDeepSubfieldMappingUpdate() throws Exception {
         DocumentMapper docMapper = createDummyMapping();
         List<Mapper> updates = Collections.singletonList(new MockFieldMapper("x.subx.foo"));
-        Mapping mapping = DocumentParser.createDynamicUpdate(docMapper.mapping(), docMapper, updates);
+        Mapping mapping = DocumentParser.createDynamicUpdate(docMapper.mapping(), docMapper, updates, Collections.emptyList());
         assertNotNull(mapping);
         Mapper xMapper = mapping.root().getMapper("x");
         assertNotNull(xMapper);
@@ -611,7 +667,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         List<Mapper> updates = new ArrayList<>();
         updates.add(new MockFieldMapper("x.a"));
         updates.add(new MockFieldMapper("x.subx.b"));
-        Mapping mapping = DocumentParser.createDynamicUpdate(docMapper.mapping(), docMapper, updates);
+        Mapping mapping = DocumentParser.createDynamicUpdate(docMapper.mapping(), docMapper, updates, Collections.emptyList());
         assertNotNull(mapping);
         Mapper xMapper = mapping.root().getMapper("x");
         assertNotNull(xMapper);
@@ -630,7 +686,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         updates.add(createObjectMapper(mapperService, "foo.bar"));
         updates.add(new MockFieldMapper("foo.bar.baz"));
         updates.add(new MockFieldMapper("foo.field"));
-        Mapping mapping = DocumentParser.createDynamicUpdate(docMapper.mapping(), docMapper, updates);
+        Mapping mapping = DocumentParser.createDynamicUpdate(docMapper.mapping(), docMapper, updates, Collections.emptyList());
         assertNotNull(mapping);
         Mapper fooMapper = mapping.root().getMapper("foo");
         assertNotNull(fooMapper);
@@ -715,6 +771,46 @@ public class DocumentParserTests extends MapperServiceTestCase {
         StrictDynamicMappingException exception = expectThrows(StrictDynamicMappingException.class,
             () -> mapper.parse(source(b -> b.startArray("foo").value(0).value(1).endArray())));
         assertEquals("mapping set to strict, dynamic introduction of [foo] within [_doc] is not allowed", exception.getMessage());
+    }
+
+    public void testDynamicRuntimeLongArray() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(topMapping(b -> b.field("dynamic", "runtime")));
+        ParsedDocument doc = mapper.parse(source(b -> b.startArray("foo").value(0).value(1).endArray()));
+        assertEquals(0, doc.rootDoc().getFields("foo").length);
+        RuntimeFieldType foo = doc.dynamicMappingsUpdate().root.getRuntimeFieldType("foo");
+        assertEquals("long", foo.typeName());
+    }
+
+    public void testDynamicRuntimeDoubleArray() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(topMapping(b -> b.field("dynamic", "runtime")));
+        ParsedDocument doc = mapper.parse(source(b -> b.startArray("foo").value(0.25).value(1.43).endArray()));
+        assertEquals(0, doc.rootDoc().getFields("foo").length);
+        RuntimeFieldType foo = doc.dynamicMappingsUpdate().root.getRuntimeFieldType("foo");
+        assertEquals("double", foo.typeName());
+    }
+
+    public void testDynamicRuntimeStringArray() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(topMapping(b -> b.field("dynamic", "runtime")));
+        ParsedDocument doc = mapper.parse(source(b -> b.startArray("foo").value("test1").value("test2").endArray()));
+        assertEquals(0, doc.rootDoc().getFields("foo").length);
+        RuntimeFieldType foo = doc.dynamicMappingsUpdate().root.getRuntimeFieldType("foo");
+        assertEquals("string", foo.typeName());
+    }
+
+    public void testDynamicRuntimeBooleanArray() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(topMapping(b -> b.field("dynamic", "runtime")));
+        ParsedDocument doc = mapper.parse(source(b -> b.startArray("foo").value(true).value(false).endArray()));
+        assertEquals(0, doc.rootDoc().getFields("foo").length);
+        RuntimeFieldType foo = doc.dynamicMappingsUpdate().root.getRuntimeFieldType("foo");
+        assertEquals("boolean", foo.typeName());
+    }
+
+    public void testDynamicRuntimeDateArray() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(topMapping(b -> b.field("dynamic", "runtime")));
+        ParsedDocument doc = mapper.parse(source(b -> b.startArray("foo").value("2020-12-15").value("2020-12-09").endArray()));
+        assertEquals(0, doc.rootDoc().getFields("foo").length);
+        RuntimeFieldType foo = doc.dynamicMappingsUpdate().root.getRuntimeFieldType("foo");
+        assertEquals("date", foo.typeName());
     }
 
     public void testMappedGeoPointArray() throws Exception {
@@ -1472,8 +1568,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
     }
 
     public void testDynamicFieldsStartingAndEndingWithDot() throws Exception {
-        MapperService mapperService = createMapperService(mapping(b -> {
-        }));
+        MapperService mapperService = createMapperService(mapping(b -> {}));
         merge(mapperService, dynamicMapping(mapperService.documentMapper().parse(source(b -> {
             b.startArray("top.");
             {
@@ -1520,9 +1615,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
     }
 
     public void testDynamicFieldsEmptyName() throws Exception {
-
-        DocumentMapper mapper = createDocumentMapper(mapping(b -> {
-        }));
+        DocumentMapper mapper = createDocumentMapper(mapping(b -> {}));
 
         IllegalArgumentException emptyFieldNameException = expectThrows(IllegalArgumentException.class,
             () -> mapper.parse(source(b -> {
@@ -1542,9 +1635,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
     }
 
     public void testBlankFieldNames() throws Exception {
-
-        DocumentMapper mapper = createDocumentMapper(mapping(b -> {
-        }));
+        DocumentMapper mapper = createDocumentMapper(mapping(b -> {}));
         MapperParsingException err = expectThrows(MapperParsingException.class, () ->
             mapper.parse(source(b -> b.field("", "foo"))));
         assertThat(err.getCause(), notNullValue());

--- a/server/src/test/java/org/elasticsearch/index/mapper/DynamicMappingTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DynamicMappingTests.java
@@ -64,10 +64,30 @@ public class DynamicMappingTests extends MapperServiceTestCase {
 
         assertThat(doc.rootDoc().get("field1"), equalTo("value1"));
         assertThat(doc.rootDoc().get("field2"), equalTo("value2"));
+
+        assertEquals("{\"_doc\":{\"dynamic\":\"true\",\"" +
+                "properties\":{\"field2\":{\"type\":\"text\",\"fields\":{\"keyword\":{\"type\":\"keyword\",\"ignore_above\":256}}}}}}",
+            Strings.toString(doc.dynamicMappingsUpdate()));
+    }
+
+    public void testDynamicRuntime() throws IOException {
+        DocumentMapper defaultMapper = createDocumentMapper(dynamicMapping("runtime",
+            b -> b.startObject("field1").field("type", "text").endObject()));
+
+        ParsedDocument doc = defaultMapper.parse(source(b -> {
+            b.field("field1", "value1");
+            b.field("field2", "value2");
+        }));
+
+        assertThat(doc.rootDoc().get("field1"), equalTo("value1"));
+        assertNull(doc.rootDoc().get("field2"));
+
+        assertEquals("{\"_doc\":{\"dynamic\":\"runtime\"," +
+                "\"runtime\":{\"field2\":{\"type\":\"string\"}}}}",
+            Strings.toString(doc.dynamicMappingsUpdate()));
     }
 
     public void testDynamicFalse() throws IOException {
-
         DocumentMapper defaultMapper = createDocumentMapper(dynamicMapping("false",
             b -> b.startObject("field1").field("type", "text").endObject()));
 
@@ -78,11 +98,11 @@ public class DynamicMappingTests extends MapperServiceTestCase {
 
         assertThat(doc.rootDoc().get("field1"), equalTo("value1"));
         assertThat(doc.rootDoc().get("field2"), nullValue());
+
+        assertNull(doc.dynamicMappingsUpdate());
     }
 
-
     public void testDynamicStrict() throws IOException {
-
         DocumentMapper defaultMapper = createDocumentMapper(dynamicMapping("strict",
             b -> b.startObject("field1").field("type", "text").endObject()));
 
@@ -102,7 +122,6 @@ public class DynamicMappingTests extends MapperServiceTestCase {
     }
 
     public void testDynamicFalseWithInnerObjectButDynamicSetOnRoot() throws IOException {
-
         DocumentMapper defaultMapper = createDocumentMapper(dynamicMapping("false", b -> {
             b.startObject("obj1");
             {
@@ -129,7 +148,6 @@ public class DynamicMappingTests extends MapperServiceTestCase {
     }
 
     public void testDynamicStrictWithInnerObjectButDynamicSetOnRoot() throws IOException {
-
         DocumentMapper defaultMapper = createDocumentMapper(dynamicMapping("strict", b -> {
             b.startObject("obj1");
             {
@@ -157,6 +175,16 @@ public class DynamicMappingTests extends MapperServiceTestCase {
     public void testDynamicMappingOnEmptyString() throws Exception {
         MapperService mapperService = createMapperService(mapping(b -> {}));
         ParsedDocument doc = mapperService.documentMapper().parse(source(b -> b.field("empty_field", "")));
+        assertNotNull(doc.rootDoc().getField("empty_field"));
+        merge(mapperService, dynamicMapping(doc.dynamicMappingsUpdate()));
+        MappedFieldType fieldType = mapperService.fieldType("empty_field");
+        assertNotNull(fieldType);
+    }
+
+    public void testDynamicRuntimeMappingOnEmptyString() throws Exception {
+        MapperService mapperService = createMapperService(dynamicMapping("runtime", b -> {}));
+        ParsedDocument doc = mapperService.documentMapper().parse(source(b -> b.field("empty_field", "")));
+        assertNull(doc.rootDoc().getField("empty_field"));
         merge(mapperService, dynamicMapping(doc.dynamicMappingsUpdate()));
         MappedFieldType fieldType = mapperService.fieldType("empty_field");
         assertNotNull(fieldType);
@@ -170,12 +198,9 @@ public class DynamicMappingTests extends MapperServiceTestCase {
     }
 
     public void testField() throws Exception {
-
         DocumentMapper mapper = createDocumentMapper(mapping(b -> {}));
-
         ParsedDocument doc = mapper.parse(source(b -> b.field("foo", "bar")));
         assertNotNull(doc.dynamicMappingsUpdate());
-
         assertEquals(
             "{\"_doc\":{\"properties\":{\"foo\":{\"type\":\"text\",\"fields\":" +
                 "{\"keyword\":{\"type\":\"keyword\",\"ignore_above\":256}}}}}}",
@@ -183,7 +208,7 @@ public class DynamicMappingTests extends MapperServiceTestCase {
     }
 
     public void testDynamicUpdateWithRuntimeField() throws Exception {
-        MapperService mapperService = createMapperService(runtimeFieldMapping(b -> b.field("type", "test")));
+        MapperService mapperService = createMapperService(runtimeFieldMapping(b -> b.field("type", "string")));
         ParsedDocument doc = mapperService.documentMapper().parse(source(b -> b.field("test", "value")));
         assertEquals("{\"_doc\":{\"properties\":{" +
             "\"test\":{\"type\":\"text\",\"fields\":{\"keyword\":{\"type\":\"keyword\",\"ignore_above\":256}}}}}}",
@@ -197,7 +222,7 @@ public class DynamicMappingTests extends MapperServiceTestCase {
 
     public void testDynamicUpdateWithRuntimeFieldDottedName() throws Exception {
         MapperService mapperService = createMapperService(runtimeMapping(
-            b -> b.startObject("path1.path2.path3.field").field("type", "test").endObject()));
+            b -> b.startObject("path1.path2.path3.field").field("type", "string").endObject()));
         ParsedDocument doc = mapperService.documentMapper().parse(source(b -> {
             b.startObject("path1").startObject("path2").startObject("path3");
             b.field("field", "value");
@@ -232,7 +257,6 @@ public class DynamicMappingTests extends MapperServiceTestCase {
     }
 
     public void testIncremental() throws Exception {
-
         // Make sure that mapping updates are incremental, this is important for performance otherwise
         // every new field introduction runs in linear time with the total number of fields
         DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", "text")));
@@ -249,7 +273,6 @@ public class DynamicMappingTests extends MapperServiceTestCase {
     }
 
     public void testIntroduceTwoFields() throws Exception {
-
         DocumentMapper mapper = createDocumentMapper(mapping(b -> {}));
         ParsedDocument doc = mapper.parse(source(b -> {
             b.field("foo", "bar");
@@ -276,8 +299,71 @@ public class DynamicMappingTests extends MapperServiceTestCase {
             containsString("{\"foo\":{\"properties\":{\"bar\":{\"properties\":{\"baz\":{\"type\":\"text\""));
     }
 
-    public void testArray() throws Exception {
+    public void testDynamicRuntimeFieldWithinObject() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(dynamicMapping("runtime", b -> {}));
+        ParsedDocument doc = mapper.parse(source(b -> {
+            b.startObject("foo");
+            {
+                b.startObject("bar").field("baz", 1).endObject();
+            }
+            b.endObject();
+        }));
 
+        assertEquals("{\"_doc\":{\"dynamic\":\"runtime\"," +
+            "\"runtime\":{\"foo.bar.baz\":{\"type\":\"long\"}}," +
+            "\"properties\":{\"foo\":{\"properties\":{\"bar\":{\"type\":\"object\"}}}}}}",
+            Strings.toString(doc.dynamicMappingsUpdate()));
+    }
+
+    public void testDynamicRuntimeMappingDynamicObject() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(dynamicMapping("runtime",
+            b -> b.startObject("dynamic_object").field("type", "object").field("dynamic", true).endObject()));
+        ParsedDocument doc = mapper.parse(source(b -> {
+            b.startObject("dynamic_object");
+            {
+                b.startObject("foo").startObject("bar").field("baz", 1).endObject().endObject();
+            }
+            b.endObject();
+            b.startObject("object");
+            {
+                b.startObject("foo").startObject("bar").field("baz", 1).endObject().endObject();
+            }
+            b.endObject();
+        }));
+
+        assertEquals("{\"_doc\":{\"dynamic\":\"runtime\"," +
+                "\"runtime\":{\"object.foo.bar.baz\":{\"type\":\"long\"}}," +
+                "\"properties\":{\"dynamic_object\":{\"dynamic\":\"true\"," +
+                "\"properties\":{\"foo\":{" + "\"properties\":{\"bar\":{" + "\"properties\":{\"baz\":" + "{\"type\":\"long\"}}}}}}}," +
+                "\"object\":{\"properties\":{\"foo\":{\"properties\":{\"bar\":{\"type\":\"object\"}}}}}}}}",
+            Strings.toString(doc.dynamicMappingsUpdate()));
+    }
+
+    public void testDynamicMappingDynamicRuntimeObject() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(dynamicMapping("true",
+            b -> b.startObject("runtime_object").field("type", "object").field("dynamic", "runtime").endObject()));
+        ParsedDocument doc = mapper.parse(source(b -> {
+            b.startObject("runtime_object");
+            {
+                b.startObject("foo").startObject("bar").field("baz", "text").endObject().endObject();
+            }
+            b.endObject();
+            b.startObject("object");
+            {
+                b.startObject("foo").startObject("bar").field("baz", "text").endObject().endObject();
+            }
+            b.endObject();
+        }));
+
+        assertEquals("{\"_doc\":{\"dynamic\":\"true\",\"" +
+                "runtime\":{\"runtime_object.foo.bar.baz\":{\"type\":\"string\"}}," +
+                "\"properties\":{\"object\":{\"properties\":{\"foo\":{\"properties\":{\"bar\":{\"properties\":{" +
+                "\"baz\":{\"type\":\"text\",\"fields\":{\"keyword\":{\"type\":\"keyword\",\"ignore_above\":256}}}}}}}}}," +
+                "\"runtime_object\":{\"dynamic\":\"runtime\",\"properties\":{\"foo\":{\"properties\":{\"bar\":{\"type\":\"object\"}}}}}}}}",
+            Strings.toString(doc.dynamicMappingsUpdate()));
+    }
+
+    public void testArray() throws Exception {
         DocumentMapper mapper = createDocumentMapper(mapping(b -> {}));
         ParsedDocument doc = mapper.parse(source(b -> b.startArray("foo").value("bar").value("baz").endArray()));
 
@@ -287,7 +373,6 @@ public class DynamicMappingTests extends MapperServiceTestCase {
     }
 
     public void testInnerDynamicMapping() throws Exception {
-
         DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", "object")));
         ParsedDocument doc = mapper.parse(source(b -> {
             b.startObject("field");
@@ -303,7 +388,6 @@ public class DynamicMappingTests extends MapperServiceTestCase {
     }
 
     public void testComplexArray() throws Exception {
-
         DocumentMapper mapper = createDocumentMapper(mapping(b -> {}));
         ParsedDocument doc = mapper.parse(source(b -> {
             b.startArray("foo");
@@ -320,7 +404,6 @@ public class DynamicMappingTests extends MapperServiceTestCase {
     }
 
     public void testReuseExistingMappings() throws Exception {
-
         // Even if the dynamic type of our new field is long, we already have a mapping for the same field
         // of type string so it should be mapped as a string
         DocumentMapper newMapper = createDocumentMapper(mapping(b -> {
@@ -428,8 +511,21 @@ public class DynamicMappingTests extends MapperServiceTestCase {
         assertThat(mapper.typeName(), equalTo("float"));
     }
 
-    public void testNumericDetectionDefault() throws Exception {
+    public void testNumericDetectionEnabledDynamicRuntime() throws Exception {
+        MapperService mapperService = createMapperService(topMapping(b -> b.field("numeric_detection", true).field("dynamic", "runtime")));
 
+        ParsedDocument doc = mapperService.documentMapper().parse(source(b -> {
+            b.field("s_long", "100");
+            b.field("s_double", "100.0");
+        }));
+        assertNotNull(doc.dynamicMappingsUpdate());
+        merge(mapperService, dynamicMapping(doc.dynamicMappingsUpdate()));
+
+        assertThat(mapperService.fieldType("s_long").typeName(), equalTo("long"));
+        assertThat(mapperService.fieldType("s_double").typeName(), equalTo("double"));
+    }
+
+    public void testNumericDetectionDefault() throws Exception {
         MapperService mapperService = createMapperService(mapping(b -> {}));
 
         ParsedDocument doc = mapperService.documentMapper().parse(source(b -> {
@@ -446,8 +542,21 @@ public class DynamicMappingTests extends MapperServiceTestCase {
         assertThat(mapper, instanceOf(TextFieldMapper.class));
     }
 
-    public void testDateDetectionInheritsFormat() throws Exception {
+    public void testNumericDetectionDefaultDynamicRuntime() throws Exception {
+        MapperService mapperService = createMapperService(dynamicMapping("runtime", b -> {}));
 
+        ParsedDocument doc = mapperService.documentMapper().parse(source(b -> {
+            b.field("s_long", "100");
+            b.field("s_double", "100.0");
+        }));
+        assertNotNull(doc.dynamicMappingsUpdate());
+        merge(mapperService, dynamicMapping(doc.dynamicMappingsUpdate()));
+
+        assertThat(mapperService.fieldType("s_long").typeName(), equalTo("string"));
+        assertThat(mapperService.fieldType("s_double").typeName(), equalTo("string"));
+    }
+
+    public void testDateDetectionInheritsFormat() throws Exception {
         MapperService mapperService = createMapperService(topMapping(b -> {
             b.startArray("dynamic_date_formats").value("yyyy-MM-dd").endArray();
             b.startArray("dynamic_templates");

--- a/server/src/test/java/org/elasticsearch/index/mapper/FieldTypeLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FieldTypeLookupTests.java
@@ -45,7 +45,8 @@ public class FieldTypeLookupTests extends ESTestCase {
     public void testFilter() {
         Collection<FieldMapper> fieldMappers = List.of(new MockFieldMapper("field"), new MockFieldMapper("test"));
         Collection<FieldAliasMapper> fieldAliases = singletonList(new FieldAliasMapper("alias", "alias", "test"));
-        Collection<RuntimeFieldType> runtimeFields = List.of(new TestRuntimeField("runtime"), new TestRuntimeField("field"));
+        Collection<RuntimeFieldType> runtimeFields = List.of(
+            new TestRuntimeField("runtime", "type"), new TestRuntimeField("field", "type"));
         FieldTypeLookup fieldTypeLookup = new FieldTypeLookup(fieldMappers, fieldAliases, runtimeFields);
         assertEquals(3, size(fieldTypeLookup.filter(ft -> true)));
         for (MappedFieldType fieldType : fieldTypeLookup.filter(ft -> true)) {
@@ -140,7 +141,7 @@ public class FieldTypeLookupTests extends ESTestCase {
 
     public void testRuntimeFieldsLookup() {
         MockFieldMapper concrete = new MockFieldMapper("concrete");
-        TestRuntimeField runtime = new TestRuntimeField("runtime");
+        TestRuntimeField runtime = new TestRuntimeField("runtime", "type");
 
         FieldTypeLookup fieldTypeLookup = new FieldTypeLookup(List.of(concrete), emptyList(), List.of(runtime));
         assertThat(fieldTypeLookup.get("concrete"), instanceOf(MockFieldMapper.FakeFieldType.class));
@@ -152,9 +153,9 @@ public class FieldTypeLookupTests extends ESTestCase {
         MockFieldMapper field = new MockFieldMapper("field");
         MockFieldMapper subfield = new MockFieldMapper("object.subfield");
         MockFieldMapper concrete = new MockFieldMapper("concrete");
-        TestRuntimeField fieldOverride = new TestRuntimeField("field");
-        TestRuntimeField subfieldOverride = new TestRuntimeField("object.subfield");
-        TestRuntimeField runtime = new TestRuntimeField("runtime");
+        TestRuntimeField fieldOverride = new TestRuntimeField("field", "type");
+        TestRuntimeField subfieldOverride = new TestRuntimeField("object.subfield", "type");
+        TestRuntimeField runtime = new TestRuntimeField("runtime", "type");
 
         FieldTypeLookup fieldTypeLookup = new FieldTypeLookup(List.of(field, concrete, subfield), emptyList(),
             List.of(fieldOverride, runtime, subfieldOverride));
@@ -168,8 +169,8 @@ public class FieldTypeLookupTests extends ESTestCase {
     public void testRuntimeFieldsSimpleMatchToFullName() {
         MockFieldMapper field1 = new MockFieldMapper("field1");
         MockFieldMapper concrete = new MockFieldMapper("concrete");
-        TestRuntimeField field2 = new TestRuntimeField("field2");
-        TestRuntimeField subfield = new TestRuntimeField("object.subfield");
+        TestRuntimeField field2 = new TestRuntimeField("field2", "type");
+        TestRuntimeField subfield = new TestRuntimeField("object.subfield", "type");
 
         FieldTypeLookup fieldTypeLookup = new FieldTypeLookup(List.of(field1, concrete), emptyList(), List.of(field2, subfield));
         {
@@ -190,8 +191,8 @@ public class FieldTypeLookupTests extends ESTestCase {
         // should never be called for runtime fields as they are not in _source
         MockFieldMapper field1 = new MockFieldMapper("field1");
         MockFieldMapper concrete = new MockFieldMapper("concrete");
-        TestRuntimeField field2 = new TestRuntimeField("field2");
-        TestRuntimeField subfield = new TestRuntimeField("object.subfield");
+        TestRuntimeField field2 = new TestRuntimeField("field2", "type");
+        TestRuntimeField subfield = new TestRuntimeField("object.subfield", "type");
 
         FieldTypeLookup fieldTypeLookup = new FieldTypeLookup(List.of(field1, concrete), emptyList(), List.of(field2, subfield));
         {

--- a/server/src/test/java/org/elasticsearch/index/mapper/MappingLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/MappingLookupTests.java
@@ -31,7 +31,7 @@ public class MappingLookupTests extends ESTestCase {
 
     public void testOnlyRuntimeField() {
         MappingLookup mappingLookup = new MappingLookup(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-            Collections.singletonList(new TestRuntimeField("test")), 0);
+            Collections.singletonList(new TestRuntimeField("test", "type")), 0);
         assertEquals(0, size(mappingLookup.fieldMappers()));
         assertEquals(0, mappingLookup.objectMappers().size());
         assertNull(mappingLookup.getMapper("test"));
@@ -41,7 +41,7 @@ public class MappingLookupTests extends ESTestCase {
     public void testRuntimeFieldLeafOverride() {
         MockFieldMapper fieldMapper = new MockFieldMapper("test");
         MappingLookup mappingLookup = new MappingLookup(Collections.singletonList(fieldMapper), Collections.emptyList(),
-            Collections.emptyList(), Collections.singletonList(new TestRuntimeField("test")), 0);
+            Collections.emptyList(), Collections.singletonList(new TestRuntimeField("test", "type")), 0);
         assertThat(mappingLookup.getMapper("test"), instanceOf(MockFieldMapper.class));
         assertEquals(1, size(mappingLookup.fieldMappers()));
         assertEquals(0, mappingLookup.objectMappers().size());
@@ -54,7 +54,7 @@ public class MappingLookupTests extends ESTestCase {
         ObjectMapper objectMapper = new ObjectMapper("object", "object", new Explicit<>(true, true), ObjectMapper.Nested.NO,
             ObjectMapper.Dynamic.TRUE, Collections.singletonMap("object.subfield", fieldMapper), Version.CURRENT);
         MappingLookup mappingLookup = new MappingLookup(Collections.singletonList(fieldMapper), Collections.singletonList(objectMapper),
-            Collections.emptyList(), Collections.singletonList(new TestRuntimeField("object.subfield")), 0);
+            Collections.emptyList(), Collections.singletonList(new TestRuntimeField("object.subfield", "type")), 0);
         assertThat(mappingLookup.getMapper("object.subfield"), instanceOf(MockFieldMapper.class));
         assertEquals(1, size(mappingLookup.fieldMappers()));
         assertEquals(1, mappingLookup.objectMappers().size());

--- a/server/src/test/java/org/elasticsearch/index/mapper/ParametrizedMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ParametrizedMapperTests.java
@@ -217,7 +217,7 @@ public class ParametrizedMapperTests extends MapperServiceTestCase {
         }, name -> null, version, () -> null, null, null,
             mapperService.getIndexAnalyzers(), mapperService.getIndexSettings(), () -> {
             throw new UnsupportedOperationException();
-        });
+        }, false);
         return (TestMapper) new TypeParser()
             .parse("field", XContentHelper.convertToMap(JsonXContent.jsonXContent, mapping, true), pc)
             .build(new ContentPath());

--- a/server/src/test/java/org/elasticsearch/index/mapper/RootObjectMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RootObjectMapperTests.java
@@ -626,6 +626,25 @@ public class RootObjectMapperTests extends MapperServiceTestCase {
             "[unsupported : value]", e.getMessage());
     }
 
+    public void testDynamicRuntimeNotSupported() {
+        {
+            MapperParsingException e = expectThrows(MapperParsingException.class,
+                () -> createMapperService(topMapping(b -> b.field("dynamic", "runtime"))));
+            assertEquals("Failed to parse mapping: unable to set dynamic:runtime as there is no registered dynamic runtime fields builder",
+                e.getMessage());
+        }
+        {
+            MapperParsingException e = expectThrows(MapperParsingException.class,
+                () -> createMapperService(mapping(b -> {
+                    b.startObject("object");
+                    b.field("type", "object").field("dynamic", "runtime");
+                    b.endObject();
+                })));
+            assertEquals("Failed to parse mapping: unable to set dynamic:runtime as there is no registered dynamic runtime fields builder",
+                e.getMessage());
+        }
+    }
+
     private static class RuntimeFieldPlugin extends Plugin implements MapperPlugin {
         @Override
         public Map<String, RuntimeFieldType.Parser> getRuntimeFieldTypes() {
@@ -642,7 +661,7 @@ public class RootObjectMapperTests extends MapperServiceTestCase {
         private final String prop2;
 
         protected RuntimeField(String name, String prop1, String prop2) {
-            super(name);
+            super(name, "test");
             this.prop1 = prop1;
             this.prop2 = prop2;
         }

--- a/server/src/test/java/org/elasticsearch/index/mapper/RootObjectMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RootObjectMapperTests.java
@@ -630,7 +630,7 @@ public class RootObjectMapperTests extends MapperServiceTestCase {
         {
             MapperParsingException e = expectThrows(MapperParsingException.class,
                 () -> createMapperService(topMapping(b -> b.field("dynamic", "runtime"))));
-            assertEquals("Failed to parse mapping: unable to set dynamic:runtime as there is no registered dynamic runtime fields builder",
+            assertEquals("Failed to parse mapping [_doc]: unable to set dynamic:runtime as there is no registered dynamic runtime fields builder",
                 e.getMessage());
         }
         {
@@ -640,7 +640,7 @@ public class RootObjectMapperTests extends MapperServiceTestCase {
                     b.field("type", "object").field("dynamic", "runtime");
                     b.endObject();
                 })));
-            assertEquals("Failed to parse mapping: unable to set dynamic:runtime as there is no registered dynamic runtime fields builder",
+            assertEquals("Failed to parse mapping [_doc]: unable to set dynamic:runtime as there is no registered dynamic runtime fields builder",
                 e.getMessage());
         }
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/RootObjectMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RootObjectMapperTests.java
@@ -630,7 +630,8 @@ public class RootObjectMapperTests extends MapperServiceTestCase {
         {
             MapperParsingException e = expectThrows(MapperParsingException.class,
                 () -> createMapperService(topMapping(b -> b.field("dynamic", "runtime"))));
-            assertEquals("Failed to parse mapping [_doc]: unable to set dynamic:runtime as there is no registered dynamic runtime fields builder",
+            assertEquals("Failed to parse mapping [_doc]: " +
+                    "unable to set dynamic:runtime as there is no registered dynamic runtime fields builder",
                 e.getMessage());
         }
         {
@@ -640,7 +641,8 @@ public class RootObjectMapperTests extends MapperServiceTestCase {
                     b.field("type", "object").field("dynamic", "runtime");
                     b.endObject();
                 })));
-            assertEquals("Failed to parse mapping [_doc]: unable to set dynamic:runtime as there is no registered dynamic runtime fields builder",
+            assertEquals("Failed to parse mapping [_doc]: " +
+                    "unable to set dynamic:runtime as there is no registered dynamic runtime fields builder",
                 e.getMessage());
         }
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/TestRuntimeField.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TestRuntimeField.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.search.Query;
+import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.plugins.MapperPlugin;
@@ -29,8 +30,12 @@ import java.util.Collections;
 import java.util.Map;
 
 public class TestRuntimeField extends RuntimeFieldType {
-    public TestRuntimeField(String name) {
+
+    private final String type;
+
+    public TestRuntimeField(String name, String type) {
         super(name, Collections.emptyMap());
+        this.type = type;
     }
 
     @Override
@@ -44,7 +49,7 @@ public class TestRuntimeField extends RuntimeFieldType {
 
     @Override
     public String typeName() {
-        return "test";
+        return type;
     }
 
     @Override
@@ -55,7 +60,42 @@ public class TestRuntimeField extends RuntimeFieldType {
     public static class Plugin extends org.elasticsearch.plugins.Plugin implements MapperPlugin {
         @Override
         public Map<String, Parser> getRuntimeFieldTypes() {
-            return Collections.singletonMap("test", (name, node, parserContext) -> new TestRuntimeField(name));
+            return org.elasticsearch.common.collect.Map.of(
+                "string", (name, node, parserContext) -> new TestRuntimeField(name, "string"),
+                "double", (name, node, parserContext) -> new TestRuntimeField(name, "double"),
+                "long", (name, node, parserContext) -> new TestRuntimeField(name, "long"),
+                "boolean", (name, node, parserContext) -> new TestRuntimeField(name, "boolean"),
+                "date", (name, node, parserContext) -> new TestRuntimeField(name, "date"));
+        }
+
+        @Override
+        public DynamicRuntimeFieldsBuilder getDynamicRuntimeFieldsBuilder() {
+            return new DynamicRuntimeFieldsBuilder() {
+                @Override
+                public RuntimeFieldType newDynamicStringField(String name) {
+                    return new TestRuntimeField(name, "string");
+                }
+
+                @Override
+                public RuntimeFieldType newDynamicLongField(String name) {
+                    return new TestRuntimeField(name, "long");
+                }
+
+                @Override
+                public RuntimeFieldType newDynamicDoubleField(String name) {
+                    return new TestRuntimeField(name, "double");
+                }
+
+                @Override
+                public RuntimeFieldType newDynamicBooleanField(String name) {
+                    return new TestRuntimeField(name, "boolean");
+                }
+
+                @Override
+                public RuntimeFieldType newDynamicDateField(String name, DateFormatter dateFormatter) {
+                    return new TestRuntimeField(name, "date");
+                }
+            };
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/TypeParsersTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TypeParsersTests.java
@@ -80,7 +80,7 @@ public class TypeParsersTests extends ESTestCase {
         Mapper.TypeParser.ParserContext olderContext = new Mapper.TypeParser.ParserContext(null, type -> typeParser, type -> null,
             Version.CURRENT, null, null, null, mapperService.getIndexAnalyzers(), mapperService.getIndexSettings(), () -> {
             throw new UnsupportedOperationException();
-        });
+        }, false);
 
         TextFieldMapper.PARSER.parse("some-field", fieldNode, olderContext);
         assertWarnings("At least one multi-field, [sub-field], " +

--- a/server/src/test/java/org/elasticsearch/index/query/QueryShardContextTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/QueryShardContextTests.java
@@ -325,8 +325,8 @@ public class QueryShardContextTests extends ESTestCase {
          * shards are parsed on the same node.
          */
         Map<String, Object> runtimeMappings = org.elasticsearch.common.collect.Map.ofEntries(
-            org.elasticsearch.common.collect.Map.entry("cat", org.elasticsearch.common.collect.Map.of("type", "test")),
-            org.elasticsearch.common.collect.Map.entry("dog", org.elasticsearch.common.collect.Map.of("type", "test"))
+            org.elasticsearch.common.collect.Map.entry("cat", org.elasticsearch.common.collect.Map.of("type", "string")),
+            org.elasticsearch.common.collect.Map.entry("dog", org.elasticsearch.common.collect.Map.of("type", "long"))
         );
         QueryShardContext qsc = createQueryShardContext(
             "uuid",
@@ -422,7 +422,7 @@ public class QueryShardContextTests extends ESTestCase {
 
     private static Function<String, MappedFieldType> fieldTypeLookup(
         TriFunction<String, LeafSearchLookup, Integer, String> runtimeDocValues) {
-        return name -> new TestRuntimeField(name) {
+        return name -> new TestRuntimeField(name, null) {
             @Override
             public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName,
                                                            Supplier<SearchLookup> searchLookup) {

--- a/server/src/test/java/org/elasticsearch/indices/IndicesModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndicesModuleTests.java
@@ -20,8 +20,10 @@
 package org.elasticsearch.indices;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.index.mapper.DocCountFieldMapper;
 import org.elasticsearch.index.mapper.AllFieldMapper;
+import org.elasticsearch.index.mapper.DynamicRuntimeFieldsBuilder;
 import org.elasticsearch.index.mapper.FieldNamesFieldMapper;
 import org.elasticsearch.index.mapper.IdFieldMapper;
 import org.elasticsearch.index.mapper.IgnoredFieldMapper;
@@ -30,6 +32,7 @@ import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.MetadataFieldMapper;
 import org.elasticsearch.index.mapper.RoutingFieldMapper;
+import org.elasticsearch.index.mapper.RuntimeFieldType;
 import org.elasticsearch.index.mapper.SeqNoFieldMapper;
 import org.elasticsearch.index.mapper.SourceFieldMapper;
 import org.elasticsearch.index.mapper.TestRuntimeField;
@@ -197,6 +200,45 @@ public class IndicesModuleTests extends ESTestCase {
     public void testDuplicateRuntimeFieldPlugin() {
         TestRuntimeField.Plugin plugin = new TestRuntimeField.Plugin();
         List<MapperPlugin> plugins = Arrays.asList(plugin, plugin);
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+            () -> new IndicesModule(plugins));
+        assertThat(e.getMessage(), containsString("already registered"));
+    }
+
+    public void testTwoDynamicRuntimeFieldsBuilders() {
+        TestRuntimeField.Plugin plugin = new TestRuntimeField.Plugin();
+        MapperPlugin second = new MapperPlugin() {
+            @Override
+            public DynamicRuntimeFieldsBuilder getDynamicRuntimeFieldsBuilder() {
+                return new DynamicRuntimeFieldsBuilder() {
+                    @Override
+                    public RuntimeFieldType newDynamicStringField(String name) {
+                        return null;
+                    }
+
+                    @Override
+                    public RuntimeFieldType newDynamicLongField(String name) {
+                        return null;
+                    }
+
+                    @Override
+                    public RuntimeFieldType newDynamicDoubleField(String name) {
+                        return null;
+                    }
+
+                    @Override
+                    public RuntimeFieldType newDynamicBooleanField(String name) {
+                        return null;
+                    }
+
+                    @Override
+                    public RuntimeFieldType newDynamicDateField(String name, DateFormatter dateFormatter) {
+                        return null;
+                    }
+                };
+            }
+        };
+        List<MapperPlugin> plugins = Arrays.asList(plugin, second);
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
             () -> new IndicesModule(plugins));
         assertThat(e.getMessage(), containsString("already registered"));

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -819,7 +819,7 @@ public abstract class AggregatorTestCase extends ESTestCase {
 
     private static class MockParserContext extends Mapper.TypeParser.ParserContext {
         MockParserContext() {
-            super(null, null, null, Version.CURRENT, null, null, null, null, null, null);
+            super(null, null, null, Version.CURRENT, null, null, null, null, null, null, false);
         }
 
         @Override

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/RuntimeFields.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/RuntimeFields.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.runtimefields;
 import org.elasticsearch.common.inject.Module;
 import org.elasticsearch.index.mapper.BooleanFieldMapper;
 import org.elasticsearch.index.mapper.DateFieldMapper;
+import org.elasticsearch.index.mapper.DynamicRuntimeFieldsBuilder;
 import org.elasticsearch.index.mapper.GeoPointFieldMapper;
 import org.elasticsearch.index.mapper.IpFieldMapper;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
@@ -65,6 +66,11 @@ public final class RuntimeFields extends Plugin implements MapperPlugin, ScriptP
             LongFieldScript.CONTEXT,
             StringFieldScript.CONTEXT
         );
+    }
+
+    @Override
+    public DynamicRuntimeFieldsBuilder getDynamicRuntimeFieldsBuilder() {
+        return org.elasticsearch.xpack.runtimefields.mapper.DynamicRuntimeFieldsBuilder.INSTANCE;
     }
 
     public Collection<Module> createGuiceModules() {

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/BooleanScriptFieldType.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/BooleanScriptFieldType.java
@@ -27,6 +27,7 @@ import org.elasticsearch.xpack.runtimefields.query.BooleanScriptFieldTermQuery;
 
 import java.io.IOException;
 import java.time.ZoneId;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -46,6 +47,10 @@ public final class BooleanScriptFieldType extends AbstractScriptFieldType<Boolea
 
     private BooleanScriptFieldType(String name, BooleanFieldScript.Factory scriptFactory, Builder builder) {
         super(name, scriptFactory::newFactory, builder);
+    }
+
+    BooleanScriptFieldType(String name) {
+        this(name, BooleanFieldScript.PARSE_FROM_SOURCE, null, Collections.emptyMap(), (builder, includeDefaults) -> {});
     }
 
     BooleanScriptFieldType(

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/DateScriptFieldType.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/DateScriptFieldType.java
@@ -97,6 +97,14 @@ public class DateScriptFieldType extends AbstractScriptFieldType<DateFieldScript
         this.dateTimeFormatter = dateTimeFormatter;
     }
 
+    DateScriptFieldType(String name, DateFormatter dateTimeFormatter) {
+        this(name, DateFieldScript.PARSE_FROM_SOURCE, dateTimeFormatter, null, Collections.emptyMap(), (builder, includeDefaults) -> {
+            if (DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.pattern().equals(dateTimeFormatter.pattern()) == false) {
+                builder.field("format", dateTimeFormatter.pattern());
+            }
+        });
+    }
+
     DateScriptFieldType(
         String name,
         DateFieldScript.Factory scriptFactory,

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/DoubleScriptFieldType.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/DoubleScriptFieldType.java
@@ -27,6 +27,7 @@ import org.elasticsearch.xpack.runtimefields.query.DoubleScriptFieldTermsQuery;
 
 import java.io.IOException;
 import java.time.ZoneId;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -46,6 +47,10 @@ public final class DoubleScriptFieldType extends AbstractScriptFieldType<DoubleF
 
     private DoubleScriptFieldType(String name, DoubleFieldScript.Factory scriptFactory, Builder builder) {
         super(name, scriptFactory::newFactory, builder);
+    }
+
+    DoubleScriptFieldType(String name) {
+        this(name, DoubleFieldScript.PARSE_FROM_SOURCE, null, Collections.emptyMap(), (builder, includeDefaults) -> {});
     }
 
     DoubleScriptFieldType(

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/DynamicRuntimeFieldsBuilder.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/DynamicRuntimeFieldsBuilder.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.mapper;
+
+import org.elasticsearch.common.time.DateFormatter;
+import org.elasticsearch.index.mapper.RuntimeFieldType;
+
+public final class DynamicRuntimeFieldsBuilder implements org.elasticsearch.index.mapper.DynamicRuntimeFieldsBuilder {
+
+    public static final DynamicRuntimeFieldsBuilder INSTANCE = new DynamicRuntimeFieldsBuilder();
+
+    private DynamicRuntimeFieldsBuilder() {}
+
+    @Override
+    public RuntimeFieldType newDynamicStringField(String name) {
+        return new KeywordScriptFieldType(name);
+    }
+
+    @Override
+    public RuntimeFieldType newDynamicLongField(String name) {
+        return new LongScriptFieldType(name);
+    }
+
+    @Override
+    public RuntimeFieldType newDynamicDoubleField(String name) {
+        return new DoubleScriptFieldType(name);
+    }
+
+    @Override
+    public RuntimeFieldType newDynamicBooleanField(String name) {
+        return new BooleanScriptFieldType(name);
+    }
+
+    @Override
+    public RuntimeFieldType newDynamicDateField(String name, DateFormatter dateFormatter) {
+        return new DateScriptFieldType(name, dateFormatter);
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/KeywordScriptFieldType.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/KeywordScriptFieldType.java
@@ -31,6 +31,7 @@ import org.elasticsearch.xpack.runtimefields.query.StringScriptFieldWildcardQuer
 
 import java.io.IOException;
 import java.time.ZoneId;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -51,6 +52,10 @@ public final class KeywordScriptFieldType extends AbstractScriptFieldType<String
             return new KeywordScriptFieldType(name, factory, this);
         }
     });
+
+    KeywordScriptFieldType(String name) {
+        this(name, StringFieldScript.PARSE_FROM_SOURCE, null, Collections.emptyMap(), (builder, includeDefaults) -> {});
+    }
 
     private KeywordScriptFieldType(String name, StringFieldScript.Factory scriptFactory, Builder builder) {
         super(name, scriptFactory::newFactory, builder);

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/LongScriptFieldType.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/LongScriptFieldType.java
@@ -27,6 +27,7 @@ import org.elasticsearch.xpack.runtimefields.query.LongScriptFieldTermsQuery;
 
 import java.io.IOException;
 import java.time.ZoneId;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -43,6 +44,10 @@ public final class LongScriptFieldType extends AbstractScriptFieldType<LongField
             return new LongScriptFieldType(name, factory, this);
         }
     });
+
+    LongScriptFieldType(String name) {
+        this(name, LongFieldScript.PARSE_FROM_SOURCE, null, Collections.emptyMap(), (builder, includeDefaults) -> {});
+    }
 
     private LongScriptFieldType(String name, LongFieldScript.Factory scriptFactory, Builder builder) {
         super(name, scriptFactory::newFactory, builder);

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/DynamicRuntimeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/DynamicRuntimeTests.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.mapper;
+
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.index.mapper.DocumentMapper;
+import org.elasticsearch.index.mapper.MapperServiceTestCase;
+import org.elasticsearch.index.mapper.ObjectMapper;
+import org.elasticsearch.index.mapper.ParsedDocument;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.xpack.runtimefields.RuntimeFields;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+
+public class DynamicRuntimeTests extends MapperServiceTestCase {
+    @Override
+    protected Collection<? extends Plugin> getPlugins() {
+        return Collections.singletonList(new RuntimeFields());
+    }
+
+    public void testDynamicLeafFields() throws IOException {
+        DocumentMapper documentMapper = createDocumentMapper(topMapping(b -> b.field("dynamic", ObjectMapper.Dynamic.RUNTIME)));
+        ParsedDocument doc = documentMapper.parse(source(b -> {
+            b.field("long", 123);
+            b.field("double", 123.456);
+            b.field("string", "text");
+            b.field("boolean", true);
+            b.field("date", "2020-12-15");
+        }));
+        assertEquals(
+            "{\"_doc\":{\"dynamic\":\"runtime\","
+                + "\"runtime\":{\"boolean\":{\"type\":\"boolean\"},"
+                + "\"date\":{\"type\":\"date\"},"
+                + "\"double\":{\"type\":\"double\"},"
+                + "\"long\":{\"type\":\"long\"},"
+                + "\"string\":{\"type\":\"keyword\"}}}}",
+            Strings.toString(doc.dynamicMappingsUpdate())
+        );
+    }
+
+    public void testWithDynamicDateFormats() throws IOException {
+        DocumentMapper documentMapper = createDocumentMapper(topMapping(b -> {
+            b.field("dynamic", ObjectMapper.Dynamic.RUNTIME);
+            b.array("dynamic_date_formats", "dd/MM/yyyy", "dd-MM-yyyy");
+        }));
+        ParsedDocument doc = documentMapper.parse(source(b -> {
+            b.field("date1", "15/12/2020");
+            b.field("date2", "15-12-2020");
+        }));
+        assertEquals(
+            "{\"_doc\":{\"dynamic\":\"runtime\","
+                + "\"runtime\":{\"date1\":{\"type\":\"date\",\"format\":\"dd/MM/yyyy\"},"
+                + "\"date2\":{\"type\":\"date\",\"format\":\"dd-MM-yyyy\"}}}}",
+            Strings.toString(doc.dynamicMappingsUpdate())
+        );
+    }
+
+    public void testWithObjects() throws IOException {
+        DocumentMapper documentMapper = createDocumentMapper(topMapping(b -> {
+            b.field("dynamic", false);
+            b.startObject("properties");
+            b.startObject("dynamic_true").field("type", "object").field("dynamic", true).endObject();
+            b.startObject("dynamic_runtime").field("type", "object").field("dynamic", ObjectMapper.Dynamic.RUNTIME).endObject();
+            b.endObject();
+        }));
+        ParsedDocument doc = documentMapper.parse(source(b -> {
+            b.startObject("anything").field("field", "text").endObject();
+            b.startObject("dynamic_true").field("field1", "text").startObject("child").field("field2", "text").endObject().endObject();
+            b.startObject("dynamic_runtime").field("field3", "text").startObject("child").field("field4", "text").endObject().endObject();
+        }));
+        assertEquals(
+            "{\"_doc\":{\"dynamic\":\"false\","
+                + "\"runtime\":{\"dynamic_runtime.child.field4\":{\"type\":\"keyword\"},"
+                + "\"dynamic_runtime.field3\":{\"type\":\"keyword\"}},"
+                + "\"properties\":{\"dynamic_runtime\":{\"dynamic\":\"runtime\",\"properties\":{\"child\":{\"type\":\"object\"}}},"
+                + "\"dynamic_true\":{\"dynamic\":\"true\",\"properties\":{\"child\":{\"properties\":{"
+                + "\"field2\":{\"type\":\"text\",\"fields\":{\"keyword\":{\"type\":\"keyword\",\"ignore_above\":256}}}}},"
+                + "\"field1\":{\"type\":\"text\",\"fields\":{\"keyword\":{\"type\":\"keyword\",\"ignore_above\":256}}}}}}}}",
+            Strings.toString(doc.dynamicMappingsUpdate())
+        );
+    }
+
+    public void testWithDynamicTemplate() throws IOException {
+        DocumentMapper documentMapper = createDocumentMapper(topMapping(b -> {
+            b.field("dynamic", ObjectMapper.Dynamic.RUNTIME);
+            b.startArray("dynamic_templates");
+            {
+                b.startObject();
+                {
+                    b.startObject("test");
+                    {
+                        b.field("match_mapping_type", "string");
+                        b.startObject("mapping").field("type", "keyword").endObject();
+                    }
+                    b.endObject();
+                }
+                b.endObject();
+            }
+            b.endArray();
+        }));
+        ParsedDocument parsedDoc = documentMapper.parse(source(b -> {
+            b.field("s", "hello");
+            b.field("l", 1);
+        }));
+        assertEquals(
+            "{\"_doc\":{\"dynamic\":\"runtime\","
+                + "\"runtime\":{\"l\":{\"type\":\"long\"}},"
+                + "\"properties\":{\"s\":{\"type\":\"keyword\"}}}}",
+            Strings.toString(parsedDoc.dynamicMappingsUpdate())
+        );
+    }
+}


### PR DESCRIPTION
The dynamic:runtime setting is similar to dynamic:true in that it dynamically defines fields based on values parsed from incoming documents. Though instead of defining leaf fields under properties, it defines them as runtime fields under the runtime section. This is useful in scenarios where search speed can be traded for storage costs, given that runtime fields are loaded at runtime rather than indexed.

Backport of #65489