### PR TITLE
RestController should not consume request content

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RollupRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RollupRequestConverters.java
@@ -90,9 +90,7 @@ final class RollupRequestConverters {
             .addPathPartAsIs("_rollup", "job")
             .addPathPart(deleteRollupJobRequest.getId())
             .build();
-        Request request = new Request(HttpDelete.METHOD_NAME, endpoint);
-        request.setEntity(createEntity(deleteRollupJobRequest, REQUEST_BODY_CONTENT_TYPE));
-        return request;
+        return new Request(HttpDelete.METHOD_NAME, endpoint);
     }
 
     static Request search(final SearchRequest request) throws IOException {
@@ -114,9 +112,7 @@ final class RollupRequestConverters {
             .addPathPartAsIs("_rollup", "data")
             .addPathPart(getRollupCapsRequest.getIndexPattern())
             .build();
-        Request request = new Request(HttpGet.METHOD_NAME, endpoint);
-        request.setEntity(createEntity(getRollupCapsRequest, REQUEST_BODY_CONTENT_TYPE));
-        return request;
+        return new Request(HttpGet.METHOD_NAME, endpoint);
     }
 
     static Request getRollupIndexCaps(final GetRollupIndexCapsRequest getRollupIndexCapsRequest) throws IOException {
@@ -124,8 +120,6 @@ final class RollupRequestConverters {
             .addCommaSeparatedPathParts(getRollupIndexCapsRequest.indices())
             .addPathPartAsIs("_rollup", "data")
             .build();
-        Request request = new Request(HttpGet.METHOD_NAME, endpoint);
-        request.setEntity(createEntity(getRollupIndexCapsRequest, REQUEST_BODY_CONTENT_TYPE));
-        return request;
+        return new Request(HttpGet.METHOD_NAME, endpoint);
     }
 }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/rollup/DeleteRollupJobRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/rollup/DeleteRollupJobRequest.java
@@ -19,21 +19,13 @@
 package org.elasticsearch.client.rollup;
 
 import org.elasticsearch.client.Validatable;
-import org.elasticsearch.common.ParseField;
-import org.elasticsearch.common.xcontent.ConstructingObjectParser;
-import org.elasticsearch.common.xcontent.ToXContentObject;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentParser;
 
-import java.io.IOException;
 import java.util.Objects;
 
 
-public class DeleteRollupJobRequest implements Validatable, ToXContentObject {
+public class DeleteRollupJobRequest implements Validatable {
 
-    private static final ParseField ID_FIELD = new ParseField("id");
     private final String id;
-
 
     public DeleteRollupJobRequest(String id) {
         this.id = Objects.requireNonNull(id, "id parameter must not be null");
@@ -41,27 +33,6 @@ public class DeleteRollupJobRequest implements Validatable, ToXContentObject {
 
     public String getId() {
         return id;
-    }
-
-    private static final ConstructingObjectParser<DeleteRollupJobRequest, Void> PARSER =
-        new ConstructingObjectParser<>("request",  a -> {
-            return new DeleteRollupJobRequest((String) a[0]);
-        });
-
-    static {
-        PARSER.declareString(ConstructingObjectParser.constructorArg(), ID_FIELD);
-    }
-
-    public static DeleteRollupJobRequest fromXContent(XContentParser parser) {
-        return PARSER.apply(parser, null);
-    }
-
-    @Override
-    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject();
-        builder.field(ID_FIELD.getPreferredName(), this.id);
-        builder.endObject();
-        return builder;
     }
 
     @Override

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/rollup/GetRollupCapsRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/rollup/GetRollupCapsRequest.java
@@ -21,14 +21,11 @@ package org.elasticsearch.client.rollup;
 import org.elasticsearch.client.Validatable;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.xcontent.ToXContentObject;
-import org.elasticsearch.common.xcontent.XContentBuilder;
 
-import java.io.IOException;
 import java.util.Objects;
 
-public class GetRollupCapsRequest implements Validatable, ToXContentObject {
-    private static final String ID = "id";
+public class GetRollupCapsRequest implements Validatable {
+
     private final String indexPattern;
 
     public GetRollupCapsRequest(final String indexPattern) {
@@ -41,14 +38,6 @@ public class GetRollupCapsRequest implements Validatable, ToXContentObject {
 
     public String getIndexPattern() {
         return indexPattern;
-    }
-
-    @Override
-    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject();
-        builder.field(ID, indexPattern);
-        builder.endObject();
-        return builder;
     }
 
     @Override

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/rollup/GetRollupIndexCapsRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/rollup/GetRollupIndexCapsRequest.java
@@ -21,16 +21,11 @@ package org.elasticsearch.client.rollup;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.Validatable;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.xcontent.ToXContentObject;
-import org.elasticsearch.common.xcontent.XContentBuilder;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Objects;
 
-public class GetRollupIndexCapsRequest implements Validatable, ToXContentObject {
-    private static final String INDICES = "indices";
-    private static final String INDICES_OPTIONS = "indices_options";
+public class GetRollupIndexCapsRequest implements Validatable {
 
     private String[] indices;
     private IndicesOptions options;
@@ -58,21 +53,6 @@ public class GetRollupIndexCapsRequest implements Validatable, ToXContentObject 
 
     public String[] indices() {
         return indices;
-    }
-
-    @Override
-    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject();
-        {
-            builder.array(INDICES, indices);
-            builder.startObject(INDICES_OPTIONS);
-            {
-                options.toXContent(builder, params);
-            }
-            builder.endObject();
-        }
-        builder.endObject();
-        return builder;
     }
 
     @Override

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/rollup/DeleteRollupJobRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/rollup/DeleteRollupJobRequestTests.java
@@ -18,39 +18,12 @@
  */
 package org.elasticsearch.client.rollup;
 
-import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.test.AbstractXContentTestCase;
-import org.junit.Before;
+import org.elasticsearch.test.ESTestCase;
 
-import java.io.IOException;
-
-public class DeleteRollupJobRequestTests extends AbstractXContentTestCase<DeleteRollupJobRequest> {
-
-    private String jobId;
-
-    @Before
-    public void setUpOptionalId() {
-        jobId = randomAlphaOfLengthBetween(1, 10);
-    }
-
-    @Override
-    protected DeleteRollupJobRequest createTestInstance() {
-        return new DeleteRollupJobRequest(jobId);
-    }
-
-    @Override
-    protected DeleteRollupJobRequest doParseInstance(final XContentParser parser) throws IOException {
-        return DeleteRollupJobRequest.fromXContent(parser);
-    }
-
-    @Override
-    protected boolean supportsUnknownFields() {
-        return false;
-    }
+public class DeleteRollupJobRequestTests extends ESTestCase {
 
     public void testRequireConfiguration() {
         final NullPointerException e = expectThrows(NullPointerException.class, ()-> new DeleteRollupJobRequest(null));
         assertEquals("id parameter must not be null", e.getMessage());
     }
-
 }

--- a/server/src/main/java/org/elasticsearch/rest/RestController.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestController.java
@@ -222,7 +222,7 @@ public class RestController implements HttpServerTransport.Dispatcher {
     }
 
     private void dispatchRequest(RestRequest request, RestChannel channel, RestHandler handler) throws Exception {
-        final int contentLength = request.content().length();
+        final int contentLength = request.contentLength();
         if (contentLength > 0) {
             final XContentType xContentType = request.getXContentType();
             if (xContentType == null) {

--- a/server/src/main/java/org/elasticsearch/rest/RestRequest.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestRequest.java
@@ -209,15 +209,15 @@ public class RestRequest implements ToXContent.Params {
     }
 
     public boolean hasContent() {
-        return content(false).length() > 0;
+        return contentLength() > 0;
+    }
+
+    public int contentLength() {
+        return httpRequest.content().length();
     }
 
     public BytesReference content() {
-        return content(true);
-    }
-
-    protected BytesReference content(final boolean contentConsumed) {
-        this.contentConsumed = this.contentConsumed | contentConsumed;
+        this.contentConsumed = true;
         return httpRequest.content();
     }
 

--- a/server/src/test/java/org/elasticsearch/rest/RestControllerTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/RestControllerTests.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.yaml.YamlXContent;
 import org.elasticsearch.core.internal.io.IOUtils;
@@ -480,6 +481,38 @@ public class RestControllerTests extends ESTestCase {
             randomBoolean() ? new IllegalStateException("bad request") : new Throwable("bad request"));
         assertTrue(channel.getSendResponseCalled());
         assertThat(channel.getRestResponse().content().utf8ToString(), containsString("bad request"));
+    }
+
+    public void testDoesNotConsumeContent() throws Exception {
+        final RestRequest.Method method = randomFrom(RestRequest.Method.values());
+        restController.registerHandler(method, "/notconsumed", new RestHandler() {
+            @Override
+            public void handleRequest(RestRequest request, RestChannel channel, NodeClient client) throws Exception {
+                channel.sendResponse(new BytesRestResponse(RestStatus.OK, BytesRestResponse.TEXT_CONTENT_TYPE, BytesArray.EMPTY));
+            }
+
+            @Override
+            public boolean canTripCircuitBreaker() {
+                return false;
+            }
+        });
+
+        final XContentBuilder content = XContentBuilder.builder(randomFrom(XContentType.values()).xContent())
+            .startObject().field("field", "value").endObject();
+        final FakeRestRequest restRequest = new FakeRestRequest.Builder(xContentRegistry())
+            .withPath("/notconsumed")
+            .withMethod(method)
+            .withContent(BytesReference.bytes(content), content.contentType())
+            .build();
+
+        final AssertingChannel channel = new AssertingChannel(restRequest, true, RestStatus.OK);
+        assertFalse(channel.getSendResponseCalled());
+        assertFalse(restRequest.isContentConsumed());
+
+        restController.dispatchRequest(restRequest, channel, new ThreadContext(Settings.EMPTY));
+
+        assertTrue(channel.getSendResponseCalled());
+        assertFalse("RestController must not consume request content", restRequest.isContentConsumed());
     }
 
     public void testDispatchBadRequestUnknownCause() {

--- a/server/src/test/java/org/elasticsearch/rest/RestRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/RestRequestTests.java
@@ -83,6 +83,10 @@ public class RestRequestTests extends ESTestCase {
         runConsumesContentTest(RestRequest::hasContent, false);
     }
 
+    public void testContentLengthDoesNotConsumesContent() {
+        runConsumesContentTest(RestRequest::contentLength, false);
+    }
+
     private <T extends Exception> void runConsumesContentTest(
             final CheckedConsumer<RestRequest, T> consumer, final boolean expected) {
         final HttpRequest httpRequest = mock(HttpRequest.class);

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/rest/RestForgetFollowerAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/rest/RestForgetFollowerAction.java
@@ -9,11 +9,10 @@ package org.elasticsearch.xpack.ccr.rest;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.rest.BaseRestHandler;
-import org.elasticsearch.rest.BytesRestResponse;
 import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.core.ccr.action.ForgetFollowerAction;
+import org.elasticsearch.xpack.core.ccr.action.ForgetFollowerAction.Request;
 
 import java.io.IOException;
 import java.util.List;
@@ -34,18 +33,14 @@ public class RestForgetFollowerAction extends BaseRestHandler {
     }
 
     @Override
-    protected RestChannelConsumer prepareRequest(final RestRequest restRequest, final NodeClient client) {
-        final String leaderIndex = restRequest.param("index");
-
-        return channel -> {
-            try (XContentParser parser = restRequest.contentOrSourceParamParser()) {
-                final ForgetFollowerAction.Request request = ForgetFollowerAction.Request.fromXContent(parser, leaderIndex);
-                client.execute(ForgetFollowerAction.INSTANCE, request, new RestToXContentListener<>(channel));
-            } catch (final IOException e) {
-                channel.sendResponse(new BytesRestResponse(channel, RestStatus.INTERNAL_SERVER_ERROR, e));
-            }
-        };
-
+    protected RestChannelConsumer prepareRequest(final RestRequest restRequest, final NodeClient client) throws IOException {
+        final Request request = createRequest(restRequest, restRequest.param("index"));
+        return channel -> client.execute(ForgetFollowerAction.INSTANCE, request, new RestToXContentListener<>(channel));
     }
 
+    private static Request createRequest(final RestRequest restRequest, final String leaderIndex) throws IOException {
+        try (XContentParser parser = restRequest.contentOrSourceParamParser()) {
+            return Request.fromXContent(parser, leaderIndex);
+        }
+    }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/user/RestChangePasswordAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/user/RestChangePasswordAction.java
@@ -7,6 +7,7 @@ package org.elasticsearch.xpack.security.rest.action.user;
 
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.license.XPackLicenseState;
@@ -79,9 +80,10 @@ public class RestChangePasswordAction extends SecurityBaseRestHandler implements
         }
 
         final String refresh = request.param("refresh");
+        final BytesReference content = request.requiredContent();
         return channel ->
                 new SecurityClient(client)
-                    .prepareChangePassword(username, request.requiredContent(), request.getXContentType(), passwordHasher)
+                    .prepareChangePassword(username, content, request.getXContentType(), passwordHasher)
                         .setRefreshPolicy(refresh)
                         .execute(new RestBuilderListener<ActionResponse.Empty>(channel) {
                             @Override


### PR DESCRIPTION
The change #37504 modifies the BaseRestHandler to make it reject all requests
that have an unconsumed body. The notion of consumed or unconsumed body
 is carried by the RestRequest object and its contentConsumed attribute, which
 is set to true when the content() or content(true) methods are used.

In our REST layer, we usually expect the RestHandlers to consume the request
content when needed, but it appears that the RestController always consumes
 the content upfront.

This commit changes the content() method used by the RestController so that it
does not mark the content as consumed.

Backport of #44902
Closes #65242

Note to reviewers: this is targeted against 7.x as this is a backport of a fix that was made on master but at the time was not backported. However, I see this as a bug that we should fix which is why I am opening this for backport to 7.x. The review request is more about whether or not we should backport this to 7.x than the actual changes to the code as they have already been approved.