### PR TITLE
Wraps timestamp values in quotes in preview_transforms YAML test

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/transform/preview_transforms.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/transform/preview_transforms.yml
@@ -84,17 +84,17 @@ setup:
             }
           }
   - match: { preview.0.airline: foo }
-  - match: { preview.0.by-hour: 2017-02-18T00:00:00.000Z }
+  - match: { preview.0.by-hour: "2017-02-18T00:00:00.000Z" }
   - match: { preview.0.avg_response: 1.0 }
   - match: { preview.0.time.max: "2017-02-18T00:30:00.000Z" }
   - match: { preview.0.time.min: "2017-02-18T00:00:00.000Z" }
   - match: { preview.1.airline: bar }
-  - match: { preview.1.by-hour: 2017-02-18T01:00:00.000Z }
+  - match: { preview.1.by-hour: "2017-02-18T01:00:00.000Z" }
   - match: { preview.1.avg_response: 42.0 }
   - match: { preview.1.time.max: "2017-02-18T01:00:00.000Z" }
   - match: { preview.1.time.min: "2017-02-18T01:00:00.000Z" }
   - match: { preview.2.airline: foo }
-  - match: { preview.2.by-hour: 2017-02-18T01:00:00.000Z }
+  - match: { preview.2.by-hour: "2017-02-18T01:00:00.000Z" }
   - match: { preview.2.avg_response: 42.0 }
   - match: { preview.2.time.max: "2017-02-18T01:01:00.000Z" }
   - match: { preview.2.time.min: "2017-02-18T01:01:00.000Z" }
@@ -135,15 +135,15 @@ setup:
             }
           }
   - match: { preview.0.airline: foo }
-  - match: { preview.0.by-hour: 2017-02-18T00:00:00.000Z }
+  - match: { preview.0.by-hour: "2017-02-18T00:00:00.000Z" }
   - match: { preview.0.avg_response: 1.0 }
   - match: { preview.0.my_field: 42 }
   - match: { preview.1.airline: bar }
-  - match: { preview.1.by-hour: 2017-02-18T01:00:00.000Z }
+  - match: { preview.1.by-hour: "2017-02-18T01:00:00.000Z" }
   - match: { preview.1.avg_response: 42.0 }
   - match: { preview.1.my_field: 42 }
   - match: { preview.2.airline: foo }
-  - match: { preview.2.by-hour: 2017-02-18T01:00:00.000Z }
+  - match: { preview.2.by-hour: "2017-02-18T01:00:00.000Z" }
   - match: { preview.2.avg_response: 42.0 }
   - match: { preview.2.my_field: 42 }
   - match: { generated_dest_index.mappings.properties.airline.type: "keyword" }


### PR DESCRIPTION
When timestamp values are not wrapped in quotes, the Ruby YAML parser errors when trying to parse this test. It would be great to find a way to validate these values in advance.

Related: #62153 #62468 #63543 #63661