### PR TITLE
[7.x] [DOCS] Add timeout param for rollup API (#65858)

### DIFF
--- a/docs/reference/rollup/apis/put-job.asciidoc
+++ b/docs/reference/rollup/apis/put-job.asciidoc
@@ -261,6 +261,10 @@ the indexer.
 be shared with other {rollup-jobs}. The data is stored so that it doesn't
 interfere with unrelated jobs.
 
+`timeout`::
+(Optional, <<time-units,time value>>)
+Time to wait for the request to complete. Defaults to `20s` (20 seconds).
+
 [[rollup-put-job-api-example]]
 ==== {api-example-title}
 

--- a/docs/reference/rollup/apis/rollup-api.asciidoc
+++ b/docs/reference/rollup/apis/rollup-api.asciidoc
@@ -186,3 +186,7 @@ values run faster but require more memory.
 +
 NOTE: This argument only affects the speed and memory usage of the rollup
 operation. It does not affect the rollup results.
+
+`timeout`::
+(Optional, <<time-units,time value>>)
+Time to wait for the request to complete. Defaults to `20s` (20 seconds).


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Add timeout param for rollup API (#65858)