### PR TITLE
Optimize date_histogram's hard_bounds

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogram.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogram.java
@@ -367,7 +367,7 @@ public final class InternalDateHistogram extends InternalMultiBucketAggregation<
         LongBounds bounds = emptyBucketInfo.bounds;
         ListIterator<Bucket> iter = list.listIterator();
 
-        // first adding all the empty buckets *before* the actual data (based on th extended_bounds.min the user requested)
+        // first adding all the empty buckets *before* the actual data (based on the extended_bounds.min the user requested)
         InternalAggregations reducedEmptySubAggs = InternalAggregations.reduce(Collections.singletonList(emptyBucketInfo.subAggregations),
                 reduceContext);
         if (bounds != null) {


### PR DESCRIPTION
This allows `date_histogram`s with `hard_bounds` and `extended_bounds`
to use the "as range" style optimizations introducedin #63643. There
isn't any work to do for `exended_bounds` besides add a test. For
`hard_bounds` we have to be careful when constructing the ranges that to
filter.
