### PR TITLE
Fix eclipse compilation (backport of #66047)

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/persistence/ResultsPersisterService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/persistence/ResultsPersisterService.java
@@ -171,6 +171,7 @@ public class ResultsPersisterService {
         SearchRetryableAction mlRetryableAction = new SearchRetryableAction(
             jobId,
             searchRequest,
+            client,
             shouldRetry,
             retryMsgHandler,
             getResponse);
@@ -273,6 +274,8 @@ public class ResultsPersisterService {
         private final SearchRequest searchRequest;
         SearchRetryableAction(String jobId,
                               SearchRequest searchRequest,
+                              // Pass the client to work around https://bugs.eclipse.org/bugs/show_bug.cgi?id=569557
+                              OriginSettingClient client,
                               Supplier<Boolean> shouldRetry,
                               Consumer<String> msgHandler,
                               ActionListener<SearchResponse> listener) {


### PR DESCRIPTION
Looks like we've hit another "funny" eclipse compiler error. I filed
https://bugs.eclipse.org/bugs/show_bug.cgi?id=569557 , but short version
is that the following code compiles with javac and not eclipse:
```
package test;

import java.util.function.Supplier;

public class Test {
	private final Object o = new Object();

	private class Inner {
		public Inner() {
			this(() -> o);
		}

		private Inner(Supplier<Object> o) {}
	}
}
```

Specifically the outer class's `o` can't be refered to in the lambda.
This stops us from doing that in ML so eclipse can be happy again.
