### PR TITLE
Autoscaling rename tier to total (#65552)

### DIFF
--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingCalculateCapacityService.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingCalculateCapacityService.java
@@ -193,7 +193,7 @@ public class AutoscalingCalculateCapacityService implements PolicyValidator {
                 .map(c -> new AutoscalingCapacity(c, c))
                 .reduce(
                     (c1, c2) -> new AutoscalingCapacity(
-                        AutoscalingCapacity.AutoscalingResources.sum(c1.tier(), c2.tier()),
+                        AutoscalingCapacity.AutoscalingResources.sum(c1.total(), c2.total()),
                         AutoscalingCapacity.AutoscalingResources.max(c1.node(), c2.node())
                     )
                 )

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingCapacity.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingCapacity.java
@@ -140,13 +140,13 @@ public class AutoscalingCapacity implements ToXContent, Writeable {
     public static final AutoscalingCapacity ZERO = new AutoscalingCapacity(AutoscalingResources.ZERO, AutoscalingResources.ZERO);
 
     public AutoscalingCapacity(AutoscalingResources total, AutoscalingResources node) {
-        assert total != null : "Cannot provide capacity without specifying tier level capacity";
+        assert total != null : "Cannot provide capacity without specifying total capacity";
         assert node == null || node.memory == null
         // implies
-            || total.memory != null : "Cannot provide node memory without tier memory";
+            || total.memory != null : "Cannot provide node memory without total memory";
         assert node == null || node.storage == null
         // implies
-            || total.storage != null : "Cannot provide node storage without tier memory";
+            || total.storage != null : "Cannot provide node storage without total memory";
 
         this.total = total;
         this.node = node;
@@ -157,7 +157,7 @@ public class AutoscalingCapacity implements ToXContent, Writeable {
         this.node = in.readOptionalWriteable(AutoscalingResources::new);
     }
 
-    public AutoscalingResources tier() {
+    public AutoscalingResources total() {
         return total;
     }
 
@@ -233,8 +233,8 @@ public class AutoscalingCapacity implements ToXContent, Writeable {
             return total(new AutoscalingResources(storage, memory));
         }
 
-        public Builder total(AutoscalingResources tier) {
-            this.total = tier;
+        public Builder total(AutoscalingResources total) {
+            this.total = total;
             return this;
         }
 

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/FixedAutoscalingDeciderService.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/FixedAutoscalingDeciderService.java
@@ -42,7 +42,7 @@ public class FixedAutoscalingDeciderService implements AutoscalingDeciderService
         ByteSizeValue memory = MEMORY.exists(configuration) ? MEMORY.get(configuration) : null;
         if (storage != null || memory != null) {
             requiredCapacity = AutoscalingCapacity.builder()
-                .total(tierCapacity(storage, nodes), tierCapacity(memory, nodes))
+                .total(totalCapacity(storage, nodes), totalCapacity(memory, nodes))
                 .node(storage, memory)
                 .build();
         } else {
@@ -52,7 +52,7 @@ public class FixedAutoscalingDeciderService implements AutoscalingDeciderService
         return new AutoscalingDeciderResult(requiredCapacity, new FixedReason(storage, memory, nodes));
     }
 
-    private static ByteSizeValue tierCapacity(ByteSizeValue nodeCapacity, int nodes) {
+    private static ByteSizeValue totalCapacity(ByteSizeValue nodeCapacity, int nodes) {
         if (nodeCapacity != null) {
             return new ByteSizeValue(nodeCapacity.getBytes() * nodes);
         } else {

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/AutoscalingTestCase.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/AutoscalingTestCase.java
@@ -55,10 +55,10 @@ public abstract class AutoscalingTestCase extends ESTestCase {
     }
 
     public static AutoscalingCapacity randomAutoscalingCapacity() {
-        AutoscalingCapacity.AutoscalingResources tier = randomNullValueAutoscalingResources();
+        AutoscalingCapacity.AutoscalingResources total = randomNullValueAutoscalingResources();
         return new AutoscalingCapacity(
-            tier,
-            randomBoolean() ? randomNullValueAutoscalingResources(tier.storage() != null, tier.memory() != null) : null
+            total,
+            randomBoolean() ? randomNullValueAutoscalingResources(total.storage() != null, total.memory() != null) : null
         );
     }
 

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingCalculateCapacityServiceTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingCalculateCapacityServiceTests.java
@@ -185,10 +185,10 @@ public class AutoscalingCalculateCapacityServiceTests extends AutoscalingTestCas
         assertThat(context.nodes(), equalTo(expectedNodes));
         AutoscalingCapacity capacity = context.currentCapacity();
         assertThat(capacity.node().storage(), equalTo(new ByteSizeValue(maxTotal)));
-        assertThat(capacity.tier().storage(), equalTo(new ByteSizeValue(sumTotal)));
+        assertThat(capacity.total().storage(), equalTo(new ByteSizeValue(sumTotal)));
         // todo: fix these once we know memory of all nodes on master.
         assertThat(capacity.node().memory(), equalTo(ByteSizeValue.ZERO));
-        assertThat(capacity.tier().memory(), equalTo(ByteSizeValue.ZERO));
+        assertThat(capacity.total().memory(), equalTo(ByteSizeValue.ZERO));
     }
 
     public void testValidateDeciderName() {

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingCapacityWireSerializationTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingCapacityWireSerializationTests.java
@@ -29,22 +29,22 @@ public class AutoscalingCapacityWireSerializationTests extends AbstractWireSeria
         AutoscalingCapacity.Builder builder = AutoscalingCapacity.builder().capacity(instance);
 
         if (randomBoolean()) {
-            // mutate tier
-            boolean hasBothStorageAndMemory = instance.tier().memory() != null && instance.tier().storage() != null;
+            // mutate total
+            boolean hasBothStorageAndMemory = instance.total().memory() != null && instance.total().storage() != null;
             if (randomBoolean()) {
                 builder.total(
                     randomByteSize(
                         hasBothStorageAndMemory && (instance.node() == null || instance.node().storage() == null),
-                        instance.tier().storage()
+                        instance.total().storage()
                     ),
-                    instance.tier().memory()
+                    instance.total().memory()
                 );
             } else {
                 builder.total(
-                    instance.tier().storage(),
+                    instance.total().storage(),
                     randomByteSize(
                         hasBothStorageAndMemory && (instance.node() == null || instance.node().memory() == null),
-                        instance.tier().memory()
+                        instance.total().memory()
                     )
                 );
             }
@@ -53,11 +53,11 @@ public class AutoscalingCapacityWireSerializationTests extends AbstractWireSeria
             if (instance.node() == null) {
                 builder.node(
                     AutoscalingTestCase.randomNullValueAutoscalingResources(
-                        instance.tier().storage() != null,
-                        instance.tier().memory() != null
+                        instance.total().storage() != null,
+                        instance.total().memory() != null
                     )
                 );
-            } else if (randomBoolean() && instance.tier().storage() != null || instance.tier().memory() == null) {
+            } else if (randomBoolean() && instance.total().storage() != null || instance.total().memory() == null) {
                 builder.node(randomByteSize(instance.node().memory() != null, instance.node().storage()), instance.node().memory());
             } else {
                 builder.node(instance.node().storage(), randomByteSize(instance.node().storage() != null, instance.node().memory()));

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingDeciderResultsTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingDeciderResultsTests.java
@@ -129,7 +129,7 @@ public class AutoscalingDeciderResultsTests extends AutoscalingTestCase {
         autoscalingCapacities.add(larger);
         Randomness.shuffle(autoscalingCapacities);
         AutoscalingCapacity.Builder expectedBuilder = AutoscalingCapacity.builder()
-            .total(expectedStorage.tier().storage(), expectedMemory.tier().memory());
+            .total(expectedStorage.total().storage(), expectedMemory.total().memory());
         if (node) {
             expectedBuilder.node(expectedStorage.node().storage(), expectedMemory.node().memory());
         }

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/AutoscalingIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/AutoscalingIT.java
@@ -150,7 +150,7 @@ public class AutoscalingIT extends MlNativeAutodetectIntegTestCase {
 
         AutoscalingDeciderResult autoscalingDeciderResult = autoscalingDeciderResults.results().get("ml");
         assertThat(autoscalingDeciderResult.reason().summary(), containsString(reason));
-        assertThat(autoscalingDeciderResult.requiredCapacity().tier().memory().getBytes(), equalTo(tierBytes));
+        assertThat(autoscalingDeciderResult.requiredCapacity().total().memory().getBytes(), equalTo(tierBytes));
         assertThat(autoscalingDeciderResult.requiredCapacity().node().memory().getBytes(), equalTo(nodeBytes));
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingDeciderServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingDeciderServiceTests.java
@@ -110,7 +110,7 @@ public class MlAutoscalingDeciderServiceTests extends ESTestCase {
                 reasonBuilder);
             assertTrue(decision.isPresent());
             assertThat(decision.get().requiredCapacity().node().memory().getBytes(), equalTo((DEFAULT_JOB_SIZE + OVERHEAD) * 4));
-            assertThat(decision.get().requiredCapacity().tier().memory().getBytes(), equalTo(12 * DEFAULT_JOB_SIZE));
+            assertThat(decision.get().requiredCapacity().total().memory().getBytes(), equalTo(12 * DEFAULT_JOB_SIZE));
         }
         { // we allow one job in the analytics queue
             Optional<AutoscalingDeciderResult> decision = service.checkForScaleUp(0, 1,
@@ -121,7 +121,7 @@ public class MlAutoscalingDeciderServiceTests extends ESTestCase {
                 reasonBuilder);
             assertTrue(decision.isPresent());
             assertThat(decision.get().requiredCapacity().node().memory().getBytes(), equalTo(4 * (DEFAULT_JOB_SIZE + OVERHEAD)));
-            assertThat(decision.get().requiredCapacity().tier().memory().getBytes(), equalTo(8 * DEFAULT_JOB_SIZE));
+            assertThat(decision.get().requiredCapacity().total().memory().getBytes(), equalTo(8 * DEFAULT_JOB_SIZE));
         }
         { // we allow one job in the anomaly queue and analytics queue
             Optional<AutoscalingDeciderResult> decision = service.checkForScaleUp(1, 1,
@@ -132,7 +132,7 @@ public class MlAutoscalingDeciderServiceTests extends ESTestCase {
                 reasonBuilder);
             assertTrue(decision.isPresent());
             assertThat(decision.get().requiredCapacity().node().memory().getBytes(), equalTo(4 * (DEFAULT_JOB_SIZE + OVERHEAD)));
-            assertThat(decision.get().requiredCapacity().tier().memory().getBytes(), equalTo(4 * DEFAULT_JOB_SIZE));
+            assertThat(decision.get().requiredCapacity().total().memory().getBytes(), equalTo(4 * DEFAULT_JOB_SIZE));
         }
     }
 
@@ -153,7 +153,7 @@ public class MlAutoscalingDeciderServiceTests extends ESTestCase {
                 reasonBuilder);
             assertTrue(decision.isPresent());
             assertThat(decision.get().requiredCapacity().node().memory().getBytes(), equalTo(DEFAULT_JOB_SIZE * 4));
-            assertThat(decision.get().requiredCapacity().tier().memory().getBytes(), equalTo(DEFAULT_JOB_SIZE * 4));
+            assertThat(decision.get().requiredCapacity().total().memory().getBytes(), equalTo(DEFAULT_JOB_SIZE * 4));
         }
         {
             Optional<AutoscalingDeciderResult> decision = service.checkForScaleUp(2, 1,
@@ -173,7 +173,7 @@ public class MlAutoscalingDeciderServiceTests extends ESTestCase {
                 reasonBuilder);
             assertTrue(decision.isPresent());
             assertThat(decision.get().requiredCapacity().node().memory().getBytes(), equalTo(ByteSizeValue.ofGb(8).getBytes()));
-            assertThat(decision.get().requiredCapacity().tier().memory().getBytes(), equalTo(ByteSizeValue.ofMb(8992).getBytes()));
+            assertThat(decision.get().requiredCapacity().total().memory().getBytes(), equalTo(ByteSizeValue.ofMb(8992).getBytes()));
         }
     }
 
@@ -235,7 +235,7 @@ public class MlAutoscalingDeciderServiceTests extends ESTestCase {
             AutoscalingDeciderResult autoscalingDeciderResult = result.get();
             assertThat(autoscalingDeciderResult.requiredCapacity().node().memory().getBytes(),
                 equalTo((ByteSizeValue.ofMb(100).getBytes() + OVERHEAD) * 4));
-            assertThat(autoscalingDeciderResult.requiredCapacity().tier().memory().getBytes(),
+            assertThat(autoscalingDeciderResult.requiredCapacity().total().memory().getBytes(),
                 equalTo(ByteSizeValue.ofGb(12).getBytes()));
         }
         {// Current capacity allows for smaller tier
@@ -248,7 +248,7 @@ public class MlAutoscalingDeciderServiceTests extends ESTestCase {
             AutoscalingDeciderResult autoscalingDeciderResult = result.get();
             assertThat(autoscalingDeciderResult.requiredCapacity().node().memory().getBytes(),
                 equalTo((ByteSizeValue.ofMb(100).getBytes() + OVERHEAD) * 4));
-            assertThat(autoscalingDeciderResult.requiredCapacity().tier().memory().getBytes(),
+            assertThat(autoscalingDeciderResult.requiredCapacity().total().memory().getBytes(),
                 equalTo(ByteSizeValue.ofGb(12).getBytes()));
         }
         {// Scale down is not really possible

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/NativeMemoryCapacityTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/NativeMemoryCapacityTests.java
@@ -47,12 +47,12 @@ public class NativeMemoryCapacityTests extends ESTestCase {
         { // auto is false
             AutoscalingCapacity autoscalingCapacity = capacity.autoscalingCapacity(25, false);
             assertThat(autoscalingCapacity.node().memory().getBytes(), equalTo(ByteSizeValue.ofGb(1).getBytes() * 4L));
-            assertThat(autoscalingCapacity.tier().memory().getBytes(), equalTo(ByteSizeValue.ofGb(4).getBytes() * 4L));
+            assertThat(autoscalingCapacity.total().memory().getBytes(), equalTo(ByteSizeValue.ofGb(4).getBytes() * 4L));
         }
         { // auto is true
             AutoscalingCapacity autoscalingCapacity = capacity.autoscalingCapacity(25, true);
             assertThat(autoscalingCapacity.node().memory().getBytes(), equalTo(1412818190L));
-            assertThat(autoscalingCapacity.tier().memory().getBytes(), equalTo(5651272758L));
+            assertThat(autoscalingCapacity.total().memory().getBytes(), equalTo(5651272758L));
         }
         { // auto is true with unknown jvm size
             capacity = new NativeMemoryCapacity(
@@ -61,7 +61,7 @@ public class NativeMemoryCapacityTests extends ESTestCase {
             );
             AutoscalingCapacity autoscalingCapacity = capacity.autoscalingCapacity(25, true);
             assertThat(autoscalingCapacity.node().memory().getBytes(), equalTo(2618882498L));
-            assertThat(autoscalingCapacity.tier().memory().getBytes(), equalTo(10475529991L));
+            assertThat(autoscalingCapacity.total().memory().getBytes(), equalTo(10475529991L));
         }
 
     }


### PR DESCRIPTION
Fixed a few remaining places where tier was still used, renamed to total
like in most other places.