### PR TITLE
[7.x] [Monitoring] add field mappings for beats cgroups (#65997)

### DIFF
--- a/x-pack/plugin/core/src/main/resources/monitoring-beats.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-beats.json
@@ -146,6 +146,91 @@
               "properties": {
                 "beat": {
                   "properties": {
+                    "cgroup": {
+                      "properties": {
+                        "cpu": {
+                          "properties": {
+                            "id": {
+                              "type": "keyword"
+                            },
+                            "cfs": {
+                              "properties": {
+                                "period": {
+                                  "properties": {
+                                    "us": {
+                                      "type": "long"
+                                    }
+                                  }
+                                },
+                                "quota": {
+                                  "properties": {
+                                    "us": {
+                                      "type": "long"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "stats": {
+                              "properties": {
+                                "periods": {
+                                  "type": "long"
+                                },
+                                "throttled": {
+                                  "properties": {
+                                    "periods": {
+                                      "type": "long"
+                                    },
+                                    "ns": {
+                                      "type": "long"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "cpuacct": {
+                          "properties": {
+                            "id": {
+                              "type": "keyword"
+                            },
+                            "total": {
+                              "properties": {
+                                "ns": {
+                                  "type": "long"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "memory": {
+                          "properties": {
+                            "id": {
+                              "type": "keyword"
+                            },
+                            "mem": {
+                              "properties": {
+                                "limit": {
+                                  "properties": {
+                                    "bytes": {
+                                      "type": "long"
+                                    }
+                                  }
+                                },
+                                "usage": {
+                                  "properties": {
+                                    "bytes": {
+                                      "type": "long"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
                     "cpu": {
                       "properties": {
                         "system": {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Monitoring] add field mappings for beats cgroups (#65997)