### PR TITLE
Add force merge caveat for ConcurrentMergeScheduler

### DIFF
--- a/docs/reference/index-modules/merge.asciidoc
+++ b/docs/reference/index-modules/merge.asciidoc
@@ -17,7 +17,7 @@ resources between merging and other activities like search.
 The merge scheduler (ConcurrentMergeScheduler) controls the execution of merge
 operations when they are needed.  Merges run in separate threads, and when the
 maximum number of threads is reached, further merges will wait until a merge
-thread becomes available.
+thread becomes available. 
 
 The merge scheduler supports the following _dynamic_ setting:
 
@@ -29,3 +29,5 @@ The merge scheduler supports the following _dynamic_ setting:
     works well for a good solid-state-disk (SSD).  If your index is on spinning
     platter drives instead, decrease this to 1.
 
+NOTE: `index.merge.scheduler.max_thread_count` does not influence the merge threads
+used by force merge.


### PR DESCRIPTION
Per @DaveCTurner , the `index.merge.scheduler.max_thread_count` is unrelated to force merge.  This attempts to clarify in documentation :)