### PR TITLE
Move TokenService to Standard license

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
@@ -54,7 +54,7 @@ public class XPackLicenseState {
         SECURITY_ALL_REALMS(OperationMode.PLATINUM, false),
         SECURITY_STANDARD_REALMS(OperationMode.GOLD, false),
         SECURITY_CUSTOM_ROLE_PROVIDERS(OperationMode.PLATINUM, true),
-        SECURITY_TOKEN_SERVICE(OperationMode.GOLD, false),
+        SECURITY_TOKEN_SERVICE(OperationMode.STANDARD, false),
         SECURITY_API_KEY_SERVICE(OperationMode.MISSING, false),
         SECURITY_AUTHORIZATION_REALM(OperationMode.PLATINUM, true),
         SECURITY_AUTHORIZATION_ENGINE(OperationMode.PLATINUM, true),

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/XPackLicenseStateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/XPackLicenseStateTests.java
@@ -176,6 +176,7 @@ public class XPackLicenseStateTests extends ESTestCase {
         assertThat(licenseState.checkFeature(Feature.SECURITY_STATS_AND_HEALTH), is(true));
         assertThat(licenseState.checkFeature(Feature.SECURITY_DLS_FLS), is(false));
         assertThat(licenseState.checkFeature(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(false));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_TOKEN_SERVICE), is(true));
     }
 
     public void testSecurityStandardExpired() {
@@ -190,6 +191,7 @@ public class XPackLicenseStateTests extends ESTestCase {
         assertThat(licenseState.checkFeature(Feature.SECURITY_STATS_AND_HEALTH), is(false));
         assertThat(licenseState.checkFeature(Feature.SECURITY_DLS_FLS), is(false));
         assertThat(licenseState.checkFeature(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(false));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_TOKEN_SERVICE), is(true));
     }
 
     public void testSecurityGold() {


### PR DESCRIPTION
The token service was part of the Gold license, but due to its use as
part of Cloud SSO, we are moving it down to Standard instead.
