### PR TITLE
[DOCS] Fix repetitive timeout query params in delete-by-query and update-by-query doc

### DIFF
--- a/docs/reference/docs/delete-by-query.asciidoc
+++ b/docs/reference/docs/delete-by-query.asciidoc
@@ -213,7 +213,10 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=scroll_size]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=search_type]
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=search_timeout]
+`search_timeout`::
+(Optional, <<time-units, time units>>)
+Explicit timeout for each search request.
+Defaults to no timeout.
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=slices]
 

--- a/docs/reference/docs/update-by-query.asciidoc
+++ b/docs/reference/docs/update-by-query.asciidoc
@@ -213,7 +213,10 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=scroll_size]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=search_type]
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=search_timeout]
+`search_timeout`::
+(Optional, <<time-units, time units>>)
+Explicit timeout for each search request.
+Defaults to no timeout.
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=slices]
 

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -783,13 +783,6 @@ tag::search-time-ms[]
 The amount of time spent searching, in milliseconds.
 end::search-time-ms[]
 
-tag::search_timeout[]
-`timeout`::
-(Optional, <<time-units, time units>>)
-Explicit timeout for each search request.
-Defaults to no timeout.
-end::search_timeout[]
-
 tag::search-total[]
 The number of search operations on the source index for the {transform}.
 end::search-total[]


### PR DESCRIPTION
There are two `timeout` query paramters in the [delete-by-query doc](https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html) and [update-by-query doc](https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html), which is confused.

After checking the code, I found that the first `timeout` means `search_timeout` actually.  Both the two `timeout` reference the parameters in the common-params doc, so they are repetitive.

https://github.com/elastic/elasticsearch/blob/07aec1b7d60388e533bb7644a4ba738f621bfcaa/modules/reindex/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByQueryRestHandler.java#L66