### PR TITLE
[7.x] [DOCS] Adds empty snapshot_id description to revert snapshot API docs (#66036)

### DIFF
--- a/docs/reference/ml/anomaly-detection/apis/get-snapshot.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-snapshot.asciidoc
@@ -15,12 +15,14 @@ Retrieves information about model snapshots.
 
 `GET _ml/anomaly_detectors/<job_id>/model_snapshots/<snapshot_id>`
 
+
 [[ml-get-snapshot-prereqs]]
 == {api-prereq-title}
 
 * If the {es} {security-features} are enabled, you must have `monitor_ml`,
 `monitor`, `manage_ml`, or `manage` cluster privileges to use this API. See
 <<security-privileges>> and {ml-docs-setup-privileges}.
+
 
 [[ml-get-snapshot-path-parms]]
 == {api-path-parms-title}
@@ -39,6 +41,7 @@ by using a comma-separated list of `<snapshot_id>` or a wildcard expression.
 You can get all snapshots for all calendars by using `_all`,
 by specifying `*` as the `<snapshot_id>`, or by omitting the `<snapshot_id>`.
 --
+
 
 [[ml-get-snapshot-request-body]]
 == {api-request-body-title}

--- a/docs/reference/ml/anomaly-detection/apis/revert-snapshot.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/revert-snapshot.asciidoc
@@ -42,6 +42,12 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 `<snapshot_id>`::
 (Required, string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=snapshot-id]
++
+--
+You can specify `empty` as the <snapshot_id>. Reverting to the `empty` snapshot 
+means the {anomaly-job} starts learning a new model from scratch when it is 
+started.
+--
 
 [[ml-revert-snapshot-request-body]]
 == {api-request-body-title}


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Adds empty snapshot_id description to revert snapshot API docs (#66036)