### PR TITLE
[DOCS] Adds note about data_counts values to Revert snapshot API docs

### DIFF
--- a/docs/reference/ml/anomaly-detection/apis/revert-snapshot.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/revert-snapshot.asciidoc
@@ -21,6 +21,7 @@ Reverts to a specific snapshot.
 `manage` cluster privileges to use this API. See
 <<security-privileges>> and {ml-docs-setup-privileges}.
 
+
 [[ml-revert-snapshot-desc]]
 == {api-description-title}
 
@@ -31,6 +32,10 @@ one-off event. In the case where this anomalous input is known to be a one-off,
 then it might be appropriate to reset the model state to a time before this
 event. For example, you might consider reverting to a saved snapshot after Black
 Friday or a critical system failure.
+
+NOTE: Reverting to a snapshot does not change the `data_counts` values of the 
+{anomaly-job}, these values are not reverted to the earlier state.
+
 
 [[ml-revert-snapshot-path-parms]]
 == {api-path-parms-title}
@@ -49,6 +54,7 @@ means the {anomaly-job} starts learning a new model from scratch when it is
 started.
 --
 
+
 [[ml-revert-snapshot-request-body]]
 == {api-request-body-title}
 
@@ -61,6 +67,7 @@ NOTE: If you choose not to delete intervening results when reverting a snapshot,
 the job will not accept input data that is older than the current time.
 If you want to resend data, then delete the intervening results.
 
+
 [[ml-revert-snapshot-example]]
 == {api-examples-title}
 
@@ -72,6 +79,7 @@ POST _ml/anomaly_detectors/high_sum_total_sales/model_snapshots/1575402237/_reve
 }
 --------------------------------------------------
 // TEST[skip:todo]
+
 
 When the operation is complete, you receive the following results:
 [source,js]
@@ -112,4 +120,5 @@ When the operation is complete, you receive the following results:
 }
 ----
 
-For a description of these properties, see the <<ml-get-snapshot-results,get model snapshots API>>.
+For a description of these properties, see the 
+<<ml-get-snapshot-results,get model snapshots API>>.


### PR DESCRIPTION
## Overview

This PR adds a note to the Revert snapshot API docs about the fact that `data_counts` values won't reset after reverting to a snapshot.

### Preview

[Revert snapshot API description]()