### PR TITLE
[7.x][ML] Support mapped runtime fields for data frame analytics (#66…

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RunDataFrameAnalyticsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RunDataFrameAnalyticsIT.java
@@ -9,6 +9,8 @@ import org.elasticsearch.action.admin.indices.settings.get.GetSettingsRequest;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.fieldcaps.FieldCapabilitiesRequest;
+import org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponse;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.search.SearchResponse;
@@ -29,6 +31,7 @@ import org.elasticsearch.xpack.core.ml.dataframe.analyses.OutlierDetection;
 import org.junit.After;
 import org.junit.Before;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.allOf;
@@ -731,6 +734,102 @@ public class RunDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsIntegTest
             "Creating destination index [test-outlier-detection-with-custom-params-results]",
             "Started reindexing to destination index [test-outlier-detection-with-custom-params-results]",
             "Finished reindexing to destination index [test-outlier-detection-with-custom-params-results]",
+            "Started loading data",
+            "Started analyzing",
+            "Started writing results",
+            "Finished analysis");
+    }
+
+    public void testOutlierDetection_GivenIndexWithRuntimeFields() throws Exception {
+        String sourceIndex = "test-outlier-detection-with-index-with-runtime-fields";
+
+        String mappings = "{\"dynamic\":false, \"runtime\": { \"runtime_numeric\": " +
+            "{ \"type\": \"double\", \"script\": { \"source\": \"emit(params._source.numeric)\", \"lang\": \"painless\" } } }}";
+
+        client().admin().indices().prepareCreate(sourceIndex)
+            .addMapping("_doc", mappings, XContentType.JSON)
+            .get();
+
+        BulkRequestBuilder bulkRequestBuilder = client().prepareBulk();
+        bulkRequestBuilder.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+
+        for (int i = 0; i < 5; i++) {
+            IndexRequest indexRequest = new IndexRequest(sourceIndex);
+
+            // We insert one odd value out of 5 for one feature
+            String docId = i == 0 ? "outlier" : "normal" + i;
+            indexRequest.id(docId);
+            indexRequest.source("numeric", i == 0 ? 100.0 : 1.0);
+            bulkRequestBuilder.add(indexRequest);
+        }
+        BulkResponse bulkResponse = bulkRequestBuilder.get();
+        if (bulkResponse.hasFailures()) {
+            fail("Failed to index data: " + bulkResponse.buildFailureMessage());
+        }
+
+        String id = "test_outlier_detection_with_index_with_runtime_mappings";
+        DataFrameAnalyticsConfig config = buildAnalytics(id, sourceIndex, sourceIndex + "-results", null,
+            new OutlierDetection.Builder().build());
+        putAnalytics(config);
+
+        assertIsStopped(id);
+        assertProgressIsZero(id);
+
+        startAnalytics(id);
+        waitUntilAnalyticsIsStopped(id);
+        GetDataFrameAnalyticsStatsAction.Response.Stats stats = getAnalyticsStats(id);
+        assertThat(stats.getDataCounts().getJobId(), equalTo(id));
+        assertThat(stats.getDataCounts().getTrainingDocsCount(), equalTo(5L));
+        assertThat(stats.getDataCounts().getTestDocsCount(), equalTo(0L));
+        assertThat(stats.getDataCounts().getSkippedDocsCount(), equalTo(0L));
+
+        SearchResponse sourceData = client().prepareSearch(sourceIndex).get();
+        double scoreOfOutlier = 0.0;
+        double scoreOfNonOutlier = -1.0;
+        for (SearchHit hit : sourceData.getHits()) {
+            GetResponse destDocGetResponse = client().prepareGet().setIndex(config.getDest().getIndex()).setId(hit.getId()).get();
+            assertThat(destDocGetResponse.isExists(), is(true));
+            Map<String, Object> sourceDoc = hit.getSourceAsMap();
+            Map<String, Object> destDoc = destDocGetResponse.getSource();
+            for (String field : sourceDoc.keySet()) {
+                assertThat(destDoc.containsKey(field), is(true));
+                assertThat(destDoc.get(field), equalTo(sourceDoc.get(field)));
+            }
+            assertThat(destDoc.containsKey("ml"), is(true));
+
+            @SuppressWarnings("unchecked")
+            Map<String, Object> resultsObject = (Map<String, Object>) destDoc.get("ml");
+
+            assertThat(resultsObject.containsKey("outlier_score"), is(true));
+            double outlierScore = (double) resultsObject.get("outlier_score");
+            assertThat(outlierScore, allOf(greaterThanOrEqualTo(0.0), lessThanOrEqualTo(1.0)));
+            if (hit.getId().equals("outlier")) {
+                scoreOfOutlier = outlierScore;
+
+                @SuppressWarnings("unchecked")
+                List<Map<String, Object>> featureInfluence = (List<Map<String, Object>>) resultsObject.get("feature_influence");
+                assertThat(featureInfluence.size(), equalTo(1));
+                assertThat(featureInfluence.get(0).get("feature_name"), equalTo("runtime_numeric"));
+            } else {
+                if (scoreOfNonOutlier < 0) {
+                    scoreOfNonOutlier = outlierScore;
+                } else {
+                    assertThat(outlierScore, equalTo(scoreOfNonOutlier));
+                }
+            }
+        }
+        assertThat(scoreOfOutlier, is(greaterThan(scoreOfNonOutlier)));
+
+        assertProgressComplete(id);
+        assertThat(searchStoredProgress(id).getHits().getTotalHits().value, equalTo(1L));
+        assertThatAuditMessagesMatch(id,
+            "Created analytics with analysis type [outlier_detection]",
+            "Estimated memory usage for this analytics to be",
+            "Starting analytics on node",
+            "Started analytics",
+            "Creating destination index [" + sourceIndex + "-results]",
+            "Started reindexing to destination index [" + sourceIndex + "-results]",
+            "Finished reindexing to destination index [" + sourceIndex + "-results]",
             "Started loading data",
             "Started analyzing",
             "Started writing results",

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/MappingsMerger.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/MappingsMerger.java
@@ -13,6 +13,7 @@ import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsSource;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
@@ -48,9 +49,32 @@ public final class MappingsMerger {
 
     static ImmutableOpenMap<String, MappingMetadata> mergeMappings(DataFrameAnalyticsSource source,
                                                                    GetMappingsResponse getMappingsResponse) {
-        ImmutableOpenMap<String, ImmutableOpenMap<String, MappingMetadata>> indexToMappings = getMappingsResponse.getMappings();
+        Map<String, Object> mappings = new HashMap<>();
+        mappings.put("dynamic", false);
 
-        String type = null;
+        ImmutableOpenMap<String, ImmutableOpenMap<String, MappingMetadata>> indexToMappings = getMappingsResponse.getMappings();
+        for (MappingsType mappingsType : MappingsType.values()) {
+            Map<String, IndexAndMapping> mergedMappingsForType = mergeAcrossIndices(source, indexToMappings, mappingsType);
+            if (mergedMappingsForType.isEmpty() == false) {
+                mappings.put(mappingsType.type,
+                    mergedMappingsForType.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().mapping)));
+            }
+        }
+
+        ImmutableOpenMap.Builder<String, MappingMetadata> result = ImmutableOpenMap.builder();
+        try {
+            result.put(MapperService.SINGLE_MAPPING_NAME, new MappingMetadata(MapperService.SINGLE_MAPPING_NAME, mappings));
+        } catch (IOException e) {
+            throw ExceptionsHelper.serverError("Failed to parse mappings: " + mappings);
+        }
+        return result.build();
+    }
+
+    private static Map<String, IndexAndMapping> mergeAcrossIndices(
+            DataFrameAnalyticsSource source,
+            ImmutableOpenMap<String, ImmutableOpenMap<String, MappingMetadata>> indexToMappings,
+            MappingsType mappingsType) {
+
         Map<String, IndexAndMapping> mergedMappings = new HashMap<>();
 
         Iterator<ObjectObjectCursor<String, ImmutableOpenMap<String, MappingMetadata>>> iterator = indexToMappings.iterator();
@@ -59,19 +83,11 @@ public final class MappingsMerger {
             Iterator<ObjectObjectCursor<String, MappingMetadata>> typeIterator = indexMappings.value.iterator();
             while (typeIterator.hasNext()) {
                 ObjectObjectCursor<String, MappingMetadata> typeMapping = typeIterator.next();
-                if (type == null) {
-                    type = typeMapping.key;
-                } else {
-                    if (type.equals(typeMapping.key) == false) {
-                        throw ExceptionsHelper.badRequestException("source indices contain mappings for different types: [{}, {}]",
-                            type, typeMapping.key);
-                    }
-                }
                 Map<String, Object> currentMappings = typeMapping.value.getSourceAsMap();
-                if (currentMappings.containsKey("properties")) {
+                if (currentMappings.containsKey(mappingsType.type)) {
 
                     @SuppressWarnings("unchecked")
-                    Map<String, Object> fieldMappings = (Map<String, Object>) currentMappings.get("properties");
+                    Map<String, Object> fieldMappings = (Map<String, Object>) currentMappings.get(mappingsType.type);
 
                     for (Map.Entry<String, Object> fieldMapping : fieldMappings.entrySet()) {
                         String field = fieldMapping.getKey();
@@ -80,9 +96,9 @@ public final class MappingsMerger {
                                 IndexAndMapping existingIndexAndMapping = mergedMappings.get(field);
                                 if (existingIndexAndMapping.mapping.equals(fieldMapping.getValue()) == false) {
                                     throw ExceptionsHelper.badRequestException(
-                                        "cannot merge mappings because of differences for field [{}]; mapped as [{}] in index [{}]; " +
-                                            "mapped as [{}] in index [{}]", field, fieldMapping.getValue(), indexMappings.key,
-                                            existingIndexAndMapping.mapping, existingIndexAndMapping.index);
+                                        "cannot merge [{}] mappings because of differences for field [{}]; mapped as [{}] in index [{}]; " +
+                                        "mapped as [{}] in index [{}]", mappingsType.type, field, fieldMapping.getValue(),
+                                        indexMappings.key, existingIndexAndMapping.mapping, existingIndexAndMapping.index);
 
                                 }
                             } else {
@@ -94,22 +110,7 @@ public final class MappingsMerger {
             }
         }
 
-        MappingMetadata mappingMetadata = createMappingMetadata(type,
-            mergedMappings.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().mapping)));
-        ImmutableOpenMap.Builder<String, MappingMetadata> result = ImmutableOpenMap.builder();
-        result.put(type, mappingMetadata);
-        return result.build();
-    }
-
-    private static MappingMetadata createMappingMetadata(String type, Map<String, Object> properties) {
-        Map<String, Object> mappings = new HashMap<>();
-        mappings.put("dynamic", false);
-        mappings.put("properties", properties);
-        try {
-            return new MappingMetadata(type, mappings);
-        } catch (IOException e) {
-            throw ExceptionsHelper.serverError("Failed to parse mappings: " + mappings);
-        }
+        return mergedMappings;
     }
 
     private static class IndexAndMapping {
@@ -119,6 +120,17 @@ public final class MappingsMerger {
         private IndexAndMapping(String index, Object mapping) {
             this.index = Objects.requireNonNull(index);
             this.mapping = Objects.requireNonNull(mapping);
+        }
+    }
+
+    private enum MappingsType {
+        PROPERTIES("properties"),
+        RUNTIME("runtime");
+
+        private String type;
+
+        MappingsType(String type) {
+            this.type = type;
         }
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/MappingsMergerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/MappingsMergerTests.java
@@ -26,7 +26,7 @@ import static org.hamcrest.Matchers.is;
 
 public class MappingsMergerTests extends ESTestCase {
 
-    public void testMergeMappings_GivenIndicesWithIdenticalMappings() throws IOException {
+    public void testMergeMappings_GivenIndicesWithIdenticalProperties() throws IOException {
         Map<String, Object> index1Properties = new HashMap<>();
         index1Properties.put("field_1", "field_1_mappings");
         index1Properties.put("field_2", "field_2_mappings");
@@ -61,37 +61,9 @@ public class MappingsMergerTests extends ESTestCase {
         assertThat(mergedMappings.valuesIt().next().getSourceAsMap(), equalTo(expectedMappings));
     }
 
-    public void testMergeMappings_GivenIndicesWithDifferentTypes() throws IOException {
-        Map<String, Object> index1Mappings = Collections.singletonMap("properties",
-            Collections.singletonMap("field_1", "field_1_mappings"));
-        MappingMetadata index1MappingMetadata = new MappingMetadata("type_1", index1Mappings);
-
-        Map<String, Object> index2Mappings = Collections.singletonMap("properties",
-            Collections.singletonMap("field_1", "field_1_mappings"));
-        MappingMetadata index2MappingMetadata = new MappingMetadata("type_2", index2Mappings);
-
-        ImmutableOpenMap.Builder<String, MappingMetadata> index1MappingsMap = ImmutableOpenMap.builder();
-        index1MappingsMap.put("type_1", index1MappingMetadata);
-        ImmutableOpenMap.Builder<String, MappingMetadata> index2MappingsMap = ImmutableOpenMap.builder();
-        index2MappingsMap.put("type_2", index2MappingMetadata);
-
-        ImmutableOpenMap.Builder<String, ImmutableOpenMap<String, MappingMetadata>> mappings = ImmutableOpenMap.builder();
-        mappings.put("index_1", index1MappingsMap.build());
-        mappings.put("index_2", index2MappingsMap.build());
-
-        GetMappingsResponse getMappingsResponse = new GetMappingsResponse(mappings.build());
-
-        ElasticsearchStatusException e = expectThrows(ElasticsearchStatusException.class,
-            () -> MappingsMerger.mergeMappings(newSource(), getMappingsResponse));
-        assertThat(e.status(), equalTo(RestStatus.BAD_REQUEST));
-        assertThat(e.getMessage(), containsString("source indices contain mappings for different types:"));
-        assertThat(e.getMessage(), containsString("type_1"));
-        assertThat(e.getMessage(), containsString("type_2"));
-    }
-
-    public void testMergeMappings_GivenFieldWithDifferentMapping() throws IOException {
-        Map<String, Object> index1Mappings = Collections.singletonMap("properties",
-            Collections.singletonMap("field_1", "field_1_mappings"));
+    public void testMergeMappings_GivenPropertyFieldWithDifferentMapping() throws IOException {
+            Map<String, Object> index1Mappings = Collections.singletonMap("properties",
+                Collections.singletonMap("field_1", "field_1_mappings"));
         MappingMetadata index1MappingMetadata = new MappingMetadata("_doc", index1Mappings);
 
         Map<String, Object> index2Mappings = Collections.singletonMap("properties",
@@ -112,12 +84,13 @@ public class MappingsMergerTests extends ESTestCase {
         ElasticsearchStatusException e = expectThrows(ElasticsearchStatusException.class,
             () -> MappingsMerger.mergeMappings(newSource(), getMappingsResponse));
         assertThat(e.status(), equalTo(RestStatus.BAD_REQUEST));
-        assertThat(e.getMessage(), containsString("cannot merge mappings because of differences for field [field_1]; "));
+        assertThat(e.getMessage(),
+            containsString("cannot merge [properties] mappings because of differences for field [field_1]; "));
         assertThat(e.getMessage(), containsString("mapped as [different_field_1_mappings] in index [index_2]"));
         assertThat(e.getMessage(), containsString("mapped as [field_1_mappings] in index [index_1]"));
     }
 
-    public void testMergeMappings_GivenIndicesWithDifferentMappingsButNoConflicts() throws IOException {
+    public void testMergeMappings_GivenIndicesWithDifferentPropertiesButNoConflicts() throws IOException {
         Map<String, Object> index1Properties = new HashMap<>();
         index1Properties.put("field_1", "field_1_mappings");
         index1Properties.put("field_2", "field_2_mappings");
@@ -146,47 +119,217 @@ public class MappingsMergerTests extends ESTestCase {
         assertThat(mergedMappings.size(), equalTo(1));
         assertThat(mergedMappings.containsKey("_doc"), is(true));
         Map<String, Object> mappingsAsMap = mergedMappings.valuesIt().next().getSourceAsMap();
-        assertThat(mappingsAsMap.size(), equalTo(2));
-        assertThat(mappingsAsMap.containsKey("dynamic"), is(true));
+        assertThat(mappingsAsMap.keySet(), containsInAnyOrder("dynamic", "properties"));
         assertThat(mappingsAsMap.get("dynamic"), equalTo(false));
-        assertThat(mappingsAsMap.containsKey("properties"), is(true));
 
         @SuppressWarnings("unchecked")
         Map<String, Object> fieldMappings = (Map<String, Object>) mappingsAsMap.get("properties");
 
-        assertThat(fieldMappings.size(), equalTo(3));
         assertThat(fieldMappings.keySet(), containsInAnyOrder("field_1", "field_2", "field_3"));
         assertThat(fieldMappings.get("field_1"), equalTo("field_1_mappings"));
         assertThat(fieldMappings.get("field_2"), equalTo("field_2_mappings"));
         assertThat(fieldMappings.get("field_3"), equalTo("field_3_mappings"));
     }
 
+    public void testMergeMappings_GivenIndicesWithIdenticalRuntimeFields() throws IOException {
+        Map<String, Object> index1Runtime = new HashMap<>();
+        index1Runtime.put("field_1", "field_1_mappings");
+        index1Runtime.put("field_2", "field_2_mappings");
+        Map<String, Object> index1Mappings = Collections.singletonMap("runtime", index1Runtime);
+        MappingMetadata index1MappingMetadata = new MappingMetadata("_doc", index1Mappings);
+
+        Map<String, Object> index2Runtime = new HashMap<>();
+        index2Runtime.put("field_1", "field_1_mappings");
+        index2Runtime.put("field_2", "field_2_mappings");
+        Map<String, Object> index2Mappings = Collections.singletonMap("runtime", index2Runtime);
+        MappingMetadata index2MappingMetadata = new MappingMetadata("_doc", index2Mappings);
+
+        ImmutableOpenMap.Builder<String, MappingMetadata> index1MappingsMap = ImmutableOpenMap.builder();
+        index1MappingsMap.put("_doc", index1MappingMetadata);
+        ImmutableOpenMap.Builder<String, MappingMetadata> index2MappingsMap = ImmutableOpenMap.builder();
+        index2MappingsMap.put("_doc", index2MappingMetadata);
+
+        ImmutableOpenMap.Builder<String, ImmutableOpenMap<String, MappingMetadata>> mappings = ImmutableOpenMap.builder();
+        mappings.put("index_1", index1MappingsMap.build());
+        mappings.put("index_2", index2MappingsMap.build());
+
+        GetMappingsResponse getMappingsResponse = new GetMappingsResponse(mappings.build());
+
+        ImmutableOpenMap<String, MappingMetadata> mergedMappings = MappingsMerger.mergeMappings(newSource(), getMappingsResponse);
+
+        Map<String, Object> expectedMappings = new HashMap<>();
+        expectedMappings.put("dynamic", false);
+        expectedMappings.put("runtime", index1Mappings.get("runtime"));
+
+        assertThat(mergedMappings.size(), equalTo(1));
+        assertThat(mergedMappings.containsKey("_doc"), is(true));
+        assertThat(mergedMappings.valuesIt().next().getSourceAsMap(), equalTo(expectedMappings));
+    }
+
+    public void testMergeMappings_GivenRuntimeFieldWithDifferentMapping() throws IOException {
+        Map<String, Object> index1Runtime = new HashMap<>();
+        index1Runtime.put("field_1", "field_1_mappings");
+        Map<String, Object> index1Mappings = Collections.singletonMap("runtime", index1Runtime);
+        MappingMetadata index1MappingMetadata = new MappingMetadata("_doc", index1Mappings);
+
+        Map<String, Object> index2Runtime = new HashMap<>();
+        index2Runtime.put("field_1", "different_field_1_mappings");
+        Map<String, Object> index2Mappings = Collections.singletonMap("runtime", index2Runtime);
+        MappingMetadata index2MappingMetadata = new MappingMetadata("_doc", index2Mappings);
+
+        ImmutableOpenMap.Builder<String, MappingMetadata> index1MappingsMap = ImmutableOpenMap.builder();
+        index1MappingsMap.put("_doc", index1MappingMetadata);
+        ImmutableOpenMap.Builder<String, MappingMetadata> index2MappingsMap = ImmutableOpenMap.builder();
+        index2MappingsMap.put("_doc", index2MappingMetadata);
+
+        ImmutableOpenMap.Builder<String, ImmutableOpenMap<String, MappingMetadata>> mappings = ImmutableOpenMap.builder();
+        mappings.put("index_1", index1MappingsMap.build());
+        mappings.put("index_2", index2MappingsMap.build());
+
+        GetMappingsResponse getMappingsResponse = new GetMappingsResponse(mappings.build());
+
+        ElasticsearchStatusException e = expectThrows(ElasticsearchStatusException.class,
+            () -> MappingsMerger.mergeMappings(newSource(), getMappingsResponse));
+        assertThat(e.status(), equalTo(RestStatus.BAD_REQUEST));
+        assertThat(e.getMessage(),
+            containsString("cannot merge [runtime] mappings because of differences for field [field_1]; "));
+        assertThat(e.getMessage(), containsString("mapped as [different_field_1_mappings] in index [index_2]"));
+        assertThat(e.getMessage(), containsString("mapped as [field_1_mappings] in index [index_1]"));
+    }
+
+    public void testMergeMappings_GivenIndicesWithDifferentRuntimeFieldsButNoConflicts() throws IOException {
+        Map<String, Object> index1Runtime = new HashMap<>();
+        index1Runtime.put("field_1", "field_1_mappings");
+        index1Runtime.put("field_2", "field_2_mappings");
+        Map<String, Object> index1Mappings = Collections.singletonMap("runtime", index1Runtime);
+        MappingMetadata index1MappingMetadata = new MappingMetadata("_doc", index1Mappings);
+
+        Map<String, Object> index2Runtime = new HashMap<>();
+        index2Runtime.put("field_1", "field_1_mappings");
+        index2Runtime.put("field_3", "field_3_mappings");
+        Map<String, Object> index2Mappings = Collections.singletonMap("runtime", index2Runtime);
+        MappingMetadata index2MappingMetadata = new MappingMetadata("_doc", index2Mappings);
+
+        ImmutableOpenMap.Builder<String, MappingMetadata> index1MappingsMap = ImmutableOpenMap.builder();
+        index1MappingsMap.put("_doc", index1MappingMetadata);
+        ImmutableOpenMap.Builder<String, MappingMetadata> index2MappingsMap = ImmutableOpenMap.builder();
+        index2MappingsMap.put("_doc", index2MappingMetadata);
+
+        ImmutableOpenMap.Builder<String, ImmutableOpenMap<String, MappingMetadata>> mappings = ImmutableOpenMap.builder();
+        mappings.put("index_1", index1MappingsMap.build());
+        mappings.put("index_2", index2MappingsMap.build());
+
+        GetMappingsResponse getMappingsResponse = new GetMappingsResponse(mappings.build());
+
+        ImmutableOpenMap<String, MappingMetadata> mergedMappings = MappingsMerger.mergeMappings(newSource(), getMappingsResponse);
+
+        assertThat(mergedMappings.size(), equalTo(1));
+        assertThat(mergedMappings.containsKey("_doc"), is(true));
+        Map<String, Object> mappingsAsMap = mergedMappings.valuesIt().next().getSourceAsMap();
+        assertThat(mappingsAsMap.keySet(), containsInAnyOrder("dynamic", "runtime"));
+        assertThat(mappingsAsMap.get("dynamic"), equalTo(false));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> runtimeFields = (Map<String, Object>) mappingsAsMap.get("runtime");
+
+        assertThat(runtimeFields.keySet(), containsInAnyOrder("field_1", "field_2", "field_3"));
+        assertThat(runtimeFields.get("field_1"), equalTo("field_1_mappings"));
+        assertThat(runtimeFields.get("field_2"), equalTo("field_2_mappings"));
+        assertThat(runtimeFields.get("field_3"), equalTo("field_3_mappings"));
+    }
+
+    public void testMergeMappings_GivenPropertyAndRuntimeFields() throws IOException {
+        Map<String, Object> index1Mappings = new HashMap<>();
+        {
+            Map<String, Object> index1Properties = new HashMap<>();
+            index1Properties.put("p_1", "p_1_mappings");
+            Map<String, Object> index1Runtime = new HashMap<>();
+            index1Runtime.put("r_1", "r_1_mappings");
+            index1Mappings.put("properties", index1Properties);
+            index1Mappings.put("runtime", index1Runtime);
+        }
+        MappingMetadata index1MappingMetadata = new MappingMetadata("_doc", index1Mappings);
+
+        Map<String, Object> index2Mappings = new HashMap<>();
+        {
+            Map<String, Object> index2Properties = new HashMap<>();
+            index2Properties.put("p_2", "p_2_mappings");
+            Map<String, Object> index2Runtime = new HashMap<>();
+            index2Runtime.put("r_2", "r_2_mappings");
+            index2Runtime.put("p_1", "p_1_different_mappings"); // It is ok to have conflicting runtime/property mappings
+            index2Mappings.put("properties", index2Properties);
+            index2Mappings.put("runtime", index2Runtime);
+        }
+        MappingMetadata index2MappingMetadata = new MappingMetadata("_doc", index2Mappings);
+
+        ImmutableOpenMap.Builder<String, MappingMetadata> index1MappingsMap = ImmutableOpenMap.builder();
+        index1MappingsMap.put("_doc", index1MappingMetadata);
+        ImmutableOpenMap.Builder<String, MappingMetadata> index2MappingsMap = ImmutableOpenMap.builder();
+        index2MappingsMap.put("_doc", index2MappingMetadata);
+
+        ImmutableOpenMap.Builder<String, ImmutableOpenMap<String, MappingMetadata>> mappings = ImmutableOpenMap.builder();
+        mappings.put("index_1", index1MappingsMap.build());
+        mappings.put("index_2", index2MappingsMap.build());
+
+        GetMappingsResponse getMappingsResponse = new GetMappingsResponse(mappings.build());
+
+        ImmutableOpenMap<String, MappingMetadata> mergedMappings = MappingsMerger.mergeMappings(newSource(), getMappingsResponse);
+
+        assertThat(mergedMappings.size(), equalTo(1));
+        assertThat(mergedMappings.containsKey("_doc"), is(true));
+        Map<String, Object> mappingsAsMap = mergedMappings.valuesIt().next().getSourceAsMap();
+        assertThat(mappingsAsMap.keySet(), containsInAnyOrder("dynamic", "properties", "runtime"));
+        assertThat(mappingsAsMap.get("dynamic"), equalTo(false));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> mergedProperties = (Map<String, Object>) mappingsAsMap.get("properties");
+        assertThat(mergedProperties.keySet(), containsInAnyOrder("p_1", "p_2"));
+        assertThat(mergedProperties.get("p_1"), equalTo("p_1_mappings"));
+        assertThat(mergedProperties.get("p_2"), equalTo("p_2_mappings"));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> mergedRuntime = (Map<String, Object>) mappingsAsMap.get("runtime");
+        assertThat(mergedRuntime.keySet(), containsInAnyOrder("r_1", "r_2", "p_1"));
+        assertThat(mergedRuntime.get("r_1"), equalTo("r_1_mappings"));
+        assertThat(mergedRuntime.get("r_2"), equalTo("r_2_mappings"));
+        assertThat(mergedRuntime.get("p_1"), equalTo("p_1_different_mappings"));
+    }
+
     public void testMergeMappings_GivenSourceFiltering() throws IOException {
-        Map<String, Object> indexProperties = new HashMap<>();
-        indexProperties.put("field_1", "field_1_mappings");
-        indexProperties.put("field_2", "field_2_mappings");
-        Map<String, Object> index1Mappings = Collections.singletonMap("properties", indexProperties);
-        MappingMetadata indexMappingMetadata = new MappingMetadata("_doc", index1Mappings);
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("field_1", "field_1_mappings");
+        properties.put("field_2", "field_2_mappings");
+
+        Map<String, Object> runtime = new HashMap<>();
+        runtime.put("runtime_field_1", "runtime_field_1_mappings");
+        runtime.put("runtime_field_2", "runtime_field_2_mappings");
+
+        Map<String, Object> indexMappings = new HashMap<>();
+        indexMappings.put("properties", properties);
+        indexMappings.put("runtime", runtime);
+        MappingMetadata indexMappingMetadata = new MappingMetadata("_doc", indexMappings);
 
         ImmutableOpenMap.Builder<String, MappingMetadata> indexMappingsMap = ImmutableOpenMap.builder();
         indexMappingsMap.put("_doc", indexMappingMetadata);
-
         ImmutableOpenMap.Builder<String, ImmutableOpenMap<String, MappingMetadata>> mappings = ImmutableOpenMap.builder();
         mappings.put("index_1", indexMappingsMap.build());
 
         GetMappingsResponse getMappingsResponse = new GetMappingsResponse(mappings.build());
 
         ImmutableOpenMap<String, MappingMetadata> mergedMappings = MappingsMerger.mergeMappings(
-            newSourceWithExcludes("field_1"), getMappingsResponse);
+            newSourceWithExcludes("field_1", "runtime_field_2"), getMappingsResponse);
 
         assertThat(mergedMappings.size(), equalTo(1));
         assertThat(mergedMappings.containsKey("_doc"), is(true));
         Map<String, Object> mappingsAsMap = mergedMappings.valuesIt().next().getSourceAsMap();
-        @SuppressWarnings("unchecked")
-        Map<String, Object> fieldMappings = (Map<String, Object>) mappingsAsMap.get("properties");
 
-        assertThat(fieldMappings.size(), equalTo(1));
-        assertThat(fieldMappings.containsKey("field_2"), is(true));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> propertyMappings = (Map<String, Object>) mappingsAsMap.get("properties");
+        assertThat(propertyMappings.keySet(), containsInAnyOrder("field_2"));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> runtimeMappings = (Map<String, Object>) mappingsAsMap.get("runtime");
+        assertThat(runtimeMappings.keySet(), containsInAnyOrder("runtime_field_1"));
     }
 
     private static DataFrameAnalyticsSource newSource() {


### PR DESCRIPTION
…014)

When we create the destination index for a data frame analytics job,
we merge the mappings across the source indices and copy them over
to the dest index. In order to support mapped runtime fields,
this commit adds to that merging and copying over the runtime
mappings.

Fixes #65854

Backport of #66014
