### PR TITLE
All DateFormatters should be able to print Long.MAX_VALUE (#65945)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
+++ b/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
@@ -345,6 +345,13 @@ public class DateFormatters {
                                       .withResolverStyle(ResolverStyle.STRICT)
     );
 
+    private static final DateTimeFormatter BASIC_YEAR_MONTH_DAY_PRINTER = new DateTimeFormatterBuilder()
+        .appendValue(ChronoField.YEAR, 4, 10, SignStyle.NORMAL)
+        .appendValue(MONTH_OF_YEAR, 2, 2, SignStyle.NOT_NEGATIVE)
+        .appendValue(DAY_OF_MONTH, 2, 2, SignStyle.NOT_NEGATIVE)
+        .toFormatter(Locale.ROOT)
+        .withResolverStyle(ResolverStyle.STRICT);
+
     private static final DateTimeFormatter BASIC_YEAR_MONTH_DAY_FORMATTER = new DateTimeFormatterBuilder()
         .appendValue(ChronoField.YEAR, 4, 4, SignStyle.NORMAL)
         .appendValue(MONTH_OF_YEAR, 2, 2, SignStyle.NOT_NEGATIVE)
@@ -359,7 +366,7 @@ public class DateFormatters {
         .withResolverStyle(ResolverStyle.STRICT);
 
     private static final DateTimeFormatter BASIC_DATE_TIME_PRINTER = new DateTimeFormatterBuilder()
-        .append(BASIC_YEAR_MONTH_DAY_FORMATTER)
+        .append(BASIC_YEAR_MONTH_DAY_PRINTER)
         .append(BASIC_T_TIME_PRINTER)
         .toFormatter(Locale.ROOT)
         .withResolverStyle(ResolverStyle.STRICT);
@@ -381,12 +388,16 @@ public class DateFormatters {
         new DateTimeFormatterBuilder().append(BASIC_YEAR_MONTH_DAY_FORMATTER).appendLiteral("T").toFormatter(Locale.ROOT)
                                       .withResolverStyle(ResolverStyle.STRICT);
 
+    private static final DateTimeFormatter BASIC_DATE_T_PRINTER =
+        new DateTimeFormatterBuilder().append(BASIC_YEAR_MONTH_DAY_PRINTER).appendLiteral("T").toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT);
+
     /*
      * Returns a basic formatter that combines a basic date and time without millis,
      * separated by a 'T' (uuuuMMdd'T'HHmmssZ).
      */
     private static final DateFormatter BASIC_DATE_TIME_NO_MILLIS = new JavaDateFormatter("basic_date_time_no_millis",
-        new DateTimeFormatterBuilder().append(BASIC_DATE_T).append(BASIC_TIME_NO_MILLIS_BASE)
+        new DateTimeFormatterBuilder().append(BASIC_DATE_T_PRINTER).append(BASIC_TIME_NO_MILLIS_BASE)
                                       .appendOffset("+HH:MM", "Z").toFormatter(Locale.ROOT)
                                       .withResolverStyle(ResolverStyle.STRICT),
         new DateTimeFormatterBuilder().append(BASIC_DATE_T).append(BASIC_TIME_NO_MILLIS_BASE)
@@ -467,7 +478,7 @@ public class DateFormatters {
 
     private static final DateTimeFormatter STRICT_BASIC_WEEK_DATE_PRINTER = new DateTimeFormatterBuilder()
         .parseStrict()
-        .appendValue(IsoFields.WEEK_BASED_YEAR, 4)
+        .appendValue(IsoFields.WEEK_BASED_YEAR, 4, 10, SignStyle.NORMAL)
         .appendLiteral("W")
         .appendValue(IsoFields.WEEK_OF_WEEK_BASED_YEAR, 2, 2, SignStyle.NEVER)
         .appendValue(ChronoField.DAY_OF_WEEK)
@@ -1000,7 +1011,7 @@ public class DateFormatters {
      */
     private static final DateFormatter BASIC_DATE = new JavaDateFormatter("basic_date",
         new DateTimeFormatterBuilder()
-            .appendValue(ChronoField.YEAR, 4, 4, SignStyle.NORMAL)
+            .appendValue(ChronoField.YEAR, 4, 10, SignStyle.NORMAL)
             .appendValue(MONTH_OF_YEAR, 2, 2, SignStyle.NOT_NEGATIVE)
             .appendValue(DAY_OF_MONTH, 2, 2, SignStyle.NOT_NEGATIVE)
             .toFormatter(Locale.ROOT)

--- a/server/src/test/java/org/elasticsearch/common/time/DateFormattersTests.java
+++ b/server/src/test/java/org/elasticsearch/common/time/DateFormattersTests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.common.time;
 
 import org.elasticsearch.bootstrap.JavaVersion;
 import org.elasticsearch.common.joda.Joda;
+import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.test.ESTestCase;
 
 import java.time.Clock;
@@ -91,6 +92,19 @@ public class DateFormattersTests extends ESTestCase {
             assertThat(instant.getEpochSecond(), is(0L));
             assertThat(instant.getNano(), is(123123456));
         }
+    }
+
+    /**
+     * test that formatting a date with Long.MAX_VALUE or Long.MIN_VALUE doesn throw errors since we use these
+     * e.g. for sorting documents with `null` values first or last
+     */
+    public void testPrintersLongMinMaxValue() {
+        for (FormatNames format : FormatNames.values()) {
+            DateFormatter formatter = DateFormatters.forPattern(format.getSnakeCaseName());
+            formatter.format(DateFieldMapper.Resolution.MILLISECONDS.toInstant(Long.MIN_VALUE));
+            formatter.format(DateFieldMapper.Resolution.MILLISECONDS.toInstant(Long.MAX_VALUE));
+        }
+        assertWarnings("Format name \"week_year\" is deprecated and will be removed in a future version. Use \"weekyear\" format instead");
     }
 
     public void testInvalidEpochMilliParser() {


### PR DESCRIPTION
All date formats should allow all possible long date values to be formatted.
Currently some of the printers used by some formats are too restrictive here
(e.g. for 'basic_date_time_no_millis'), only allowing up to four digits for the
year. This PR changes this for the formatters that are otherwise failing the
added tests that tries to format Long.MAX_VALUE and Long.MIN_VALUE respectively,
as these are values we for example implicitely use when sorting missing fields.

Closes #65639