### PR TITLE
[7.x] Skip REST YAML tests in FIPS 140 mode (#65735)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/README.asciidoc
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/README.asciidoc
@@ -121,6 +121,9 @@ temporarily skip it, and avoid having lots of test failures in the meantime.
 Once all runners have implemented the feature, it can be declared supported
 by default, thus the related skip sections can be removed from the tests.
 
+The skip section can also be used to selectively mute tests in certain
+cases where they would otherwise fail, see `default_shards` and `fips_140`.
+
 ....
     "Parent":
      - skip:
@@ -235,6 +238,10 @@ Allows you to stash an arbitrary key from a returned map e.g:
 ....
 
 This means: Stash any of the keys returned under `nodes` as `$node_id`
+
+=== `fips_140`
+
+This test should not be run when the test cluster is set in FIPS 140 mode.
 
 Required operators:
 -------------------

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCase.java
@@ -375,6 +375,8 @@ public abstract class ESClientYamlSuiteTestCase extends ESRestTestCase {
             request.setOptions(builder.build());
             adminClient().performRequest(request);
         }
+        assumeFalse("[" + testCandidate.getTestPath() + "] skipped, reason: in fips 140 mode",
+            inFipsJvm() && testCandidate.getTestSection().getSkipSection().getFeatures().contains("fips_140"));
 
         if (!testCandidate.getSetupSection().isEmpty()) {
             logger.debug("start setup test [{}]", testCandidate.getTestPath());


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Skip REST YAML tests in FIPS 140 mode (#65735)