### PR TITLE
[7.x] [DOCS] EQL: Move to GA (#65955)

### DIFF
--- a/docs/reference/eql/delete-async-eql-search-api.asciidoc
+++ b/docs/reference/eql/delete-async-eql-search-api.asciidoc
@@ -7,8 +7,6 @@
 <titleabbrev>Delete async EQL search</titleabbrev>
 ++++
 
-beta::[]
-
 Deletes an <<eql-search-async,async EQL search>> or a
 <<eql-search-store-sync-eql-search,stored synchronous EQL search>>. The API also
 deletes results for the search.

--- a/docs/reference/eql/detect-threats-with-eql.asciidoc
+++ b/docs/reference/eql/detect-threats-with-eql.asciidoc
@@ -3,8 +3,6 @@
 [[eql-ex-threat-detection]]
 == Example: Detect threats with EQL
 
-beta::[]
-
 This example tutorial shows how you can use EQL to detect security threats and
 other suspicious behavior. In the scenario, you're tasked with detecting
 https://attack.mitre.org/techniques/T1218/010/[regsvr32 misuse] in Windows event

--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -7,8 +7,6 @@
 <titleabbrev>EQL search</titleabbrev>
 ++++
 
-beta::[]
-
 Returns search results for an <<eql,Event Query Language (EQL)>> query.
 
 EQL assumes each document in a data stream or index corresponds to an

--- a/docs/reference/eql/eql.asciidoc
+++ b/docs/reference/eql/eql.asciidoc
@@ -6,8 +6,6 @@
 <titleabbrev>EQL</titleabbrev>
 ++++
 
-beta::[]
-
 Event Query Language (EQL) is a query language for event-based time series
 data, such as logs, metrics, and traces.
 

--- a/docs/reference/eql/functions.asciidoc
+++ b/docs/reference/eql/functions.asciidoc
@@ -6,8 +6,6 @@
 <titleabbrev>Function reference</titleabbrev>
 ++++
 
-beta::[]
-
 {es} supports the following <<eql-functions,EQL functions>>. Most EQL functions
 are case-sensitive by default.
 

--- a/docs/reference/eql/get-async-eql-search-api.asciidoc
+++ b/docs/reference/eql/get-async-eql-search-api.asciidoc
@@ -7,8 +7,6 @@
 <titleabbrev>Get async EQL search</titleabbrev>
 ++++
 
-beta::[]
-
 Returns the current status and available results for an <<eql-search-async,async
 EQL search>> or a <<eql-search-store-sync-eql-search,stored synchronous EQL
 search>>.

--- a/docs/reference/eql/pipes.asciidoc
+++ b/docs/reference/eql/pipes.asciidoc
@@ -6,8 +6,6 @@
 <titleabbrev>Pipe reference</titleabbrev>
 ++++
 
-beta::[]
-
 {es} supports the following <<eql-pipes,EQL pipes>>.
 
 [discrete]

--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -6,8 +6,6 @@
 <titleabbrev>Syntax reference</titleabbrev>
 ++++
 
-beta::[]
-
 [discrete]
 [[eql-basic-syntax]]
 === Basic syntax


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] EQL: Move to GA (#65955)