### PR TITLE
Fix rest spec

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/indices.promote_data_stream.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/indices.promote_data_stream.json
@@ -5,6 +5,9 @@
       "description":"Promotes a data stream from a replicated data stream managed by CCR to a regular data stream"
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {


### PR DESCRIPTION
Add missing header section in indices.promote_data_stream that caused
a CI failure after #53979 was merged