### PR TITLE
[DOCS] Fix timeout parameter defaults

### DIFF
--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -34,7 +34,10 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=node-filter]
 [[cluster-stats-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeout]
+`timeout`::
+(Optional, <<time-units, time units>>) Time period to wait for
+a response. If no response is received before the timeout expires, the request
+fails and returns an error. Defaults to no timeout.
 
 [role="child_attributes"]
 [[cluster-stats-api-response-body]]

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -35,9 +35,9 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=node-filter]
 ==== {api-query-parms-title}
 
 `timeout`::
-(Optional, <<time-units, time units>>) Time period to wait for
-a response. If no response is received before the timeout expires, the request
-fails and returns an error. Defaults to no timeout.
+(Optional, <<time-units, time units>>)
+Period to wait for a response. If no response is received before the timeout
+expires, the request fails and returns an error. Defaults to no timeout.
 
 [role="child_attributes"]
 [[cluster-stats-api-response-body]]

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -36,8 +36,9 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=node-filter]
 
 `timeout`::
 (Optional, <<time-units, time units>>)
-Period to wait for a response. If no response is received before the timeout
-expires, the request fails and returns an error. Defaults to no timeout.
+Period to wait for each node to respond. If a node does not respond before its
+timeout expires, its stats are excluded from the response. Timed out nodes are
+included in the response's `_nodes.failed` property. Defaults to no timeout.
 
 [role="child_attributes"]
 [[cluster-stats-api-response-body]]

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -37,8 +37,9 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=node-filter]
 `timeout`::
 (Optional, <<time-units, time units>>)
 Period to wait for each node to respond. If a node does not respond before its
-timeout expires, its stats are excluded from the response. Timed out nodes are
-included in the response's `_nodes.failed` property. Defaults to no timeout.
+timeout expires, the response does not include its stats. However, timed out
+nodes are included in the response's `_nodes.failed` property. Defaults to no
+timeout.
 
 [role="child_attributes"]
 [[cluster-stats-api-response-body]]

--- a/docs/reference/docs/bulk.asciidoc
+++ b/docs/reference/docs/bulk.asciidoc
@@ -219,7 +219,10 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=source_excludes]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=source_includes]
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeout]
+`timeout`::
+(Optional, <<time-units, time units>>) Time period to wait for
+a response. If no response is received before the timeout expires, the request
+fails and returns an error. Defaults to `1m` (one minute).
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards]
 

--- a/docs/reference/docs/bulk.asciidoc
+++ b/docs/reference/docs/bulk.asciidoc
@@ -229,7 +229,9 @@ Period each action waits for the following operations:
 * <<dynamic-mapping,Dynamic mapping>> updates
 * <<index-wait-for-active-shards,Waiting for active shards>>
 
-The timeout applies to each operation separately. Defaults to `1m` (one minute).
+Defaults to `1m` (one minute). This guarantees {es} waits for at least the
+timeout before failing. The actual wait time could be longer, particularly when
+multiple waits occur.
 --
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards]

--- a/docs/reference/docs/bulk.asciidoc
+++ b/docs/reference/docs/bulk.asciidoc
@@ -220,9 +220,17 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=source_excludes]
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=source_includes]
 
 `timeout`::
-(Optional, <<time-units, time units>>) Time period to wait for
-a response. If no response is received before the timeout expires, the request
-fails and returns an error. Defaults to `1m` (one minute).
++
+--
+(Optional, <<time-units, time units>>)
+Period each action waits for the following operations:
+
+* <<index-creation,Automatic index creation>>
+* <<dynamic-mapping,Dynamic mapping>> updates
+* <<index-wait-for-active-shards,Waiting for active shards>>
+
+The timeout applies to each operation separately. Defaults to `1m` (one minute).
+--
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards]
 

--- a/docs/reference/docs/delete-by-query.asciidoc
+++ b/docs/reference/docs/delete-by-query.asciidoc
@@ -229,7 +229,10 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=stats]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=terminate_after]
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeout]
+`timeout`::
+(Optional, <<time-units, time units>>) Time period to wait for
+a response. If no response is received before the timeout expires, the request
+fails and returns an error. Defaults to `1m` (one minute).
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=version]
 

--- a/docs/reference/docs/delete-by-query.asciidoc
+++ b/docs/reference/docs/delete-by-query.asciidoc
@@ -230,9 +230,9 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=stats]
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=terminate_after]
 
 `timeout`::
-(Optional, <<time-units, time units>>) Time period to wait for
-a response. If no response is received before the timeout expires, the request
-fails and returns an error. Defaults to `1m` (one minute).
+(Optional, <<time-units, time units>>)
+Period each deletion request <<index-wait-for-active-shards,waits for active
+shards>>. Defaults to `1m` (one minute).
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=version]
 

--- a/docs/reference/docs/delete.asciidoc
+++ b/docs/reference/docs/delete.asciidoc
@@ -155,7 +155,10 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=refresh]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=routing]
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeout]
+`timeout`::
+(Optional, <<time-units, time units>>) Time period to wait for
+a response. If no response is received before the timeout expires, the request
+fails and returns an error. Defaults to `1m` (one minute).
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=doc-version]
 

--- a/docs/reference/docs/delete.asciidoc
+++ b/docs/reference/docs/delete.asciidoc
@@ -156,9 +156,9 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=refresh]
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=routing]
 
 `timeout`::
-(Optional, <<time-units, time units>>) Time period to wait for
-a response. If no response is received before the timeout expires, the request
-fails and returns an error. Defaults to `1m` (one minute).
+(Optional, <<time-units, time units>>)
+Period to <<index-wait-for-active-shards,wait for active shards>>. Defaults to
+`1m` (one minute).
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=doc-version]
 

--- a/docs/reference/docs/index_.asciidoc
+++ b/docs/reference/docs/index_.asciidoc
@@ -86,7 +86,9 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=refresh]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=routing]
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+`timeout`::
+Period to wait for a response. If no response is received before the timeout
+expires, the request fails and returns an error. Defaults to `1m` (one minute).
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=doc-version]
 

--- a/docs/reference/docs/index_.asciidoc
+++ b/docs/reference/docs/index_.asciidoc
@@ -87,8 +87,19 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=refresh]
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=routing]
 
 `timeout`::
-Period to wait for a response. If no response is received before the timeout
-expires, the request fails and returns an error. Defaults to `1m` (one minute).
++
+--
+(Optional, <<time-units, time units>>)
+Period the request waits for the following operations:
+
+* <<index-creation,Automatic index creation>>
+* <<dynamic-mapping,Dynamic mapping>> updates
+* <<index-wait-for-active-shards,Waiting for active shards>>
+
+Defaults to `1m` (one minute). This guarantees {es} waits for at least the
+timeout before failing. The actual wait time could be longer, particularly when
+multiple waits occur.
+--
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=doc-version]
 

--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -436,7 +436,10 @@ POST _reindex
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=refresh]
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeout]
+`timeout`::
+(Optional, <<time-units, time units>>) Time period to wait for
+a response. If no response is received before the timeout expires, the request
+fails and returns an error. Defaults to `1m` (one minute).
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards]
 

--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -440,13 +440,15 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=refresh]
 +
 --
 (Optional, <<time-units, time units>>)
-Period each indexing request waits for the following operations:
+Period each indexing waits for the following operations:
 
 * <<index-creation,Automatic index creation>>
 * <<dynamic-mapping,Dynamic mapping>> updates
 * <<index-wait-for-active-shards,Waiting for active shards>>
 
-The timeout applies to each operation separately. Defaults to `1m` (one minute).
+Defaults to `1m` (one minute). This guarantees {es} waits for at least the
+timeout before failing. The actual wait time could be longer, particularly when
+multiple waits occur.
 --
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards]

--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -437,9 +437,17 @@ POST _reindex
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=refresh]
 
 `timeout`::
-(Optional, <<time-units, time units>>) Time period to wait for
-a response. If no response is received before the timeout expires, the request
-fails and returns an error. Defaults to `1m` (one minute).
++
+--
+(Optional, <<time-units, time units>>)
+Period each indexing request waits for the following operations:
+
+* <<index-creation,Automatic index creation>>
+* <<dynamic-mapping,Dynamic mapping>> updates
+* <<index-wait-for-active-shards,Waiting for active shards>>
+
+The timeout applies to each operation separately. Defaults to `1m` (one minute).
+--
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards]
 

--- a/docs/reference/docs/update-by-query.asciidoc
+++ b/docs/reference/docs/update-by-query.asciidoc
@@ -229,7 +229,10 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=stats]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=terminate_after]
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeout]
+`timeout`::
+(Optional, <<time-units, time units>>) Time period to wait for
+a response. If no response is received before the timeout expires, the request
+fails and returns an error. Defaults to `1m` (one minute).
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=version]
 

--- a/docs/reference/docs/update-by-query.asciidoc
+++ b/docs/reference/docs/update-by-query.asciidoc
@@ -238,7 +238,9 @@ Period each update request waits for the following operations:
 * Dynamic mapping updates
 * <<index-wait-for-active-shards,Waiting for active shards>>
 
-The timeout applies to each operation separately. Defaults to `1m` (one minute).
+Defaults to `1m` (one minute). This guarantees {es} waits for at least the
+timeout before failing. The actual wait time could be longer, particularly when
+multiple waits occur.
 --
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=version]

--- a/docs/reference/docs/update-by-query.asciidoc
+++ b/docs/reference/docs/update-by-query.asciidoc
@@ -230,9 +230,16 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=stats]
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=terminate_after]
 
 `timeout`::
-(Optional, <<time-units, time units>>) Time period to wait for
-a response. If no response is received before the timeout expires, the request
-fails and returns an error. Defaults to `1m` (one minute).
++
+--
+(Optional, <<time-units, time units>>)
+Period each update request waits for the following operations:
+
+* Dynamic mapping updates
+* <<index-wait-for-active-shards,Waiting for active shards>>
+
+The timeout applies to each operation separately. Defaults to `1m` (one minute).
+--
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=version]
 

--- a/docs/reference/docs/update.asciidoc
+++ b/docs/reference/docs/update.asciidoc
@@ -73,7 +73,17 @@ You can also specify a comma-separated list of the fields you want to retrieve.
 `_source_includes`::
 (Optional, list) Specify the source fields you want to retrieve.
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+`timeout`::
++
+--
+(Optional, <<time-units, time units>>)
+Period to wait for the following operations:
+
+* <<dynamic-mapping,Dynamic mapping>> updates
+* <<index-wait-for-active-shards,Waiting for active shards>>
+
+The timeout applies to each operation separately. Defaults to `1m` (one minute).
+--
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards]
 

--- a/docs/reference/docs/update.asciidoc
+++ b/docs/reference/docs/update.asciidoc
@@ -82,7 +82,9 @@ Period to wait for the following operations:
 * <<dynamic-mapping,Dynamic mapping>> updates
 * <<index-wait-for-active-shards,Waiting for active shards>>
 
-The timeout applies to each operation separately. Defaults to `1m` (one minute).
+Defaults to `1m` (one minute). This guarantees {es} waits for at least the
+timeout before failing. The actual wait time could be longer, particularly when
+multiple waits occur.
 --
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards]

--- a/docs/reference/indices/dangling-index-delete.asciidoc
+++ b/docs/reference/indices/dangling-index-delete.asciidoc
@@ -41,4 +41,4 @@ UUID of the index to delete. You can find this using the
 This field must be set to `true` in order to carry out the import, since it will
 no longer be possible to recover the data from the dangling index.
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeout]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]

--- a/docs/reference/indices/dangling-index-import.asciidoc
+++ b/docs/reference/indices/dangling-index-import.asciidoc
@@ -42,7 +42,7 @@ cannot know where the dangling index data came from or determine which shard
 copies are fresh and which are stale, it cannot guarantee that the imported data
 represents the latest state of the index when it was last in the cluster.
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeout]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
 [[dangling-index-import-api-example]]
 ==== {api-examples-title}

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -1005,17 +1005,16 @@ Unit used to display time values.
 end::time[]
 
 tag::timeoutparms[]
-
-tag::timeout[]
 tag::master-timeout[]
 `master_timeout`::
-(Optional, <<time-units, time units>>) Specifies the period of time to wait for
+(Optional, <<time-units, time units>>) Time period to wait for
 a connection to the master node. If no response is received before the timeout
 expires, the request fails and returns an error. Defaults to `30s`.
 end::master-timeout[]
 
+tag::timeout[]
 `timeout`::
-(Optional, <<time-units, time units>>) Specifies the period of time to wait for
+(Optional, <<time-units, time units>>) Time period to wait for
 a response. If no response is received before the timeout expires, the request
 fails and returns an error. Defaults to `30s`.
 end::timeout[]

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -1007,16 +1007,17 @@ end::time[]
 tag::timeoutparms[]
 tag::master-timeout[]
 `master_timeout`::
-(Optional, <<time-units, time units>>) Time period to wait for
-a connection to the master node. If no response is received before the timeout
-expires, the request fails and returns an error. Defaults to `30s`.
+(Optional, <<time-units, time units>>)
+Period to wait for a connection to the master node. If no response is received
+before the timeout expires, the request fails and returns an error. Defaults to
+`30s`.
 end::master-timeout[]
 
 tag::timeout[]
 `timeout`::
-(Optional, <<time-units, time units>>) Time period to wait for
-a response. If no response is received before the timeout expires, the request
-fails and returns an error. Defaults to `30s`.
+(Optional, <<time-units, time units>>)
+Period to wait for a response. If no response is received before the timeout
+expires, the request fails and returns an error. Defaults to `30s`.
 end::timeout[]
 end::timeoutparms[]
 


### PR DESCRIPTION
Corrects the default `timeout` argument for several APIs.

Closes #66077.