### PR TITLE
[DOCS] Improves inference processor linking and docs

### DIFF
--- a/docs/reference/ingest/processors/inference.asciidoc
+++ b/docs/reference/ingest/processors/inference.asciidoc
@@ -88,7 +88,8 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-classification
 
 [source,js]
 --------------------------------------------------
-{
+"inference":{
+  "model_id":"my_model_id"
   "inference_config": {
     "regression": {
       "results_field": "my_regression"
@@ -105,7 +106,8 @@ object.
 
 [source,js]
 --------------------------------------------------
-{
+"inference":{
+  "model_id":"my_model_id"
   "inference_config": {
     "classification": {
       "num_top_classes": 2,
@@ -123,14 +125,18 @@ categories for which the predicted probabilities are reported is 2
 classes to the `probabilities` field. Both fields are contained in the
 `target_field` results object.
 
+Refer to the 
+{ml-docs}/ml-lang-ident.html#ml-lang-ident-example[language identification] 
+trained model documentation for a full example.
+
 
 [discrete]
 [[inference-processor-feature-importance]]
 ==== {feat-imp-cap} object mapping
 
-Update your index mapping of the {feat-imp} result field as you can see below to
-get the full benefit of aggregating and searching for
-{ml-docs}/ml-feature-importance.html[{feat-imp}].
+To get the full benefit of aggregating and searching for
+{ml-docs}/ml-feature-importance.html[{feat-imp}], update your index mapping of 
+the {feat-imp} result field as you can see below:
 
 [source,js]
 --------------------------------------------------
@@ -149,14 +155,16 @@ get the full benefit of aggregating and searching for
 --------------------------------------------------
 // NOTCONSOLE
 
-The mapping field name for {feat-imp} is compounded as follows:
+The mapping field name for {feat-imp} (in the example above, it is 
+`ml.inference.feature_importance`) is compounded as follows:
 
 `<ml.inference.target_field>`.`<inference.tag>`.`feature_importance`
 
-If `inference.tag` is not provided in the processor definition, it is not part
-of the field path. The `<ml.inference.target_field>` defaults to `ml.inference`.
+* `<ml.inference.target_field>`: defaults to `ml.inference`.
+* `<inference.tag>`: if is not provided in the processor definition, then it is 
+not part of the field path.
 
-For example, you provide a tag `foo` in the definition as you can see below:
+For example, if you provide a tag `foo` in the definition as you can see below:
 
 [source,js]
 --------------------------------------------------
@@ -168,10 +176,10 @@ For example, you provide a tag `foo` in the definition as you can see below:
 // NOTCONSOLE
 
 
-The {feat-imp} value is written to the `ml.inference.foo.feature_importance`
-field.
+Then, the {feat-imp} value is written to the 
+`ml.inference.foo.feature_importance` field.
 
-You can also specify a target field as follows:
+You can also specify the target field as follows:
 
 [source,js]
 --------------------------------------------------

--- a/docs/reference/ml/df-analytics/apis/ml-df-analytics-apis.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/ml-df-analytics-apis.asciidoc
@@ -23,5 +23,11 @@ You can use the following APIs to perform {infer} operations.
 * <<get-trained-models-stats>>
 * <<delete-trained-models>>
 
+You can deploy a trained model to make predictions in an ingest pipeline or in 
+an aggregation. Refer to the following documentation to learn more.
+
+* <<inference-processor>>
+* <<search-aggregations-pipeline-inference-bucket-aggregation>>
+
 
 See also <<ml-apis>>.

--- a/docs/reference/ml/df-analytics/apis/ml-df-analytics-apis.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/ml-df-analytics-apis.asciidoc
@@ -26,8 +26,8 @@ You can use the following APIs to perform {infer} operations.
 You can deploy a trained model to make predictions in an ingest pipeline or in 
 an aggregation. Refer to the following documentation to learn more.
 
-* <<inference-processor>>
-* <<search-aggregations-pipeline-inference-bucket-aggregation>>
+* <<inference-processor,{infer-cap} processor>>
+* <<search-aggregations-pipeline-inference-bucket-aggregation,{infer-cap} bucket aggregation>>
 
 
 See also <<ml-apis>>.


### PR DESCRIPTION
## Overview

This PR:
* adds links to the DFA API page that point to the inference processor and inference aggregation docs,
* expands the `inference_config` snippets in inference processor docs to include the `inference` object,
* adds a link to the inference processor docs that points to the language identification trained model full example,
* makes the Feature importance object mapping section clearer.

### Preview

[ML DFA API overview](https://elasticsearch_66119.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ml-df-analytics-apis.html)
[Inference processor](https://elasticsearch_66119.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/inference-processor.html)