### PR TITLE
[Transform] Fix casting in ExceptionRootCauseFinder

### DIFF
--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/utils/ExceptionRootCauseFinder.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/utils/ExceptionRootCauseFinder.java
@@ -49,7 +49,7 @@ public final class ExceptionRootCauseFinder {
         Throwable unwrappedThrowable = org.elasticsearch.ExceptionsHelper.unwrapCause(t);
 
         if (unwrappedThrowable instanceof SearchPhaseExecutionException) {
-            SearchPhaseExecutionException searchPhaseException = (SearchPhaseExecutionException) t;
+            SearchPhaseExecutionException searchPhaseException = (SearchPhaseExecutionException) unwrappedThrowable;
             for (ShardSearchFailure shardFailure : searchPhaseException.shardFailures()) {
                 Throwable unwrappedShardFailure = org.elasticsearch.ExceptionsHelper.unwrapCause(shardFailure.getCause());
 

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/utils/ExceptionRootCauseFinderTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/utils/ExceptionRootCauseFinderTests.java
@@ -6,14 +6,18 @@
 
 package org.elasticsearch.xpack.transform.utils;
 
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.DocWriteRequest.OpType;
 import org.elasticsearch.action.bulk.BulkItemResponse;
+import org.elasticsearch.action.search.SearchPhaseExecutionException;
+import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.translog.TranslogException;
+import org.elasticsearch.indices.IndexCreationException;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
 
@@ -21,7 +25,10 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.hamcrest.Matchers.equalTo;
+
 public class ExceptionRootCauseFinderTests extends ESTestCase {
+
     public void testFetFirstIrrecoverableExceptionFromBulkResponses() {
         Map<Integer, BulkItemResponse> bulkItemResponses = new HashMap<>();
 
@@ -142,10 +149,21 @@ public class ExceptionRootCauseFinderTests extends ESTestCase {
         assertNull(ExceptionRootCauseFinder.getFirstIrrecoverableExceptionFromBulkResponses(bulkItemResponses.values()));
     }
 
+    public void testGetRootCauseException_GivenWrappedSearchPhaseException() {
+        SearchPhaseExecutionException searchPhaseExecutionException = new SearchPhaseExecutionException("test-phase",
+            "partial shards failure", new ShardSearchFailure[] { new ShardSearchFailure(new ElasticsearchException("for the cause!")) });
+
+        Throwable rootCauseException = ExceptionRootCauseFinder.getRootCauseException(
+            new IndexCreationException("test-index", searchPhaseExecutionException));
+
+        assertThat(rootCauseException.getMessage(), equalTo("for the cause!"));
+    }
+
     private static void assertFirstException(Collection<BulkItemResponse> bulkItemResponses, Class<?> expectedClass, String message) {
         Throwable t = ExceptionRootCauseFinder.getFirstIrrecoverableExceptionFromBulkResponses(bulkItemResponses);
         assertNotNull(t);
         assertEquals(t.getClass(), expectedClass);
         assertEquals(t.getMessage(), message);
     }
+
 }


### PR DESCRIPTION
Method `getRootCauseException` is checking whether the unwrapped
exception is an instance of `SearchPhaseExecutionException` but then
proceeds to cast the parent exception. This would lead to a casting
error. This commit fixes this and adds a unit test to guard it.
