### PR TITLE
BACKPORT 7.x Log warn when license does not permit auditing (#65498)

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/AuditTrailServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/AuditTrailServiceTests.java
@@ -5,10 +5,16 @@
  */
 package org.elasticsearch.xpack.security.audit;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.license.License;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.license.XPackLicenseState.Feature;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockLogAppender;
 import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.Authentication.RealmRef;
@@ -20,6 +26,8 @@ import org.elasticsearch.xpack.security.transport.filter.SecurityIpFilterRule;
 import org.junit.Before;
 
 import java.net.InetAddress;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -56,6 +64,55 @@ public class AuditTrailServiceTests extends ESTestCase {
         token = mock(AuthenticationToken.class);
         request = mock(TransportRequest.class);
         restRequest = mock(RestRequest.class);
+    }
+
+    public void testLogWhenLicenseProhibitsAuditing() throws Exception {
+        MockLogAppender mockLogAppender = new MockLogAppender();
+        mockLogAppender.start();
+        Logger auditTrailServiceLogger = LogManager.getLogger(AuditTrailService.class);
+        Loggers.addAppender(auditTrailServiceLogger, mockLogAppender);
+        when(licenseState.getOperationMode()).thenReturn(randomFrom(License.OperationMode.values()));
+        if (isAuditingAllowed) {
+            mockLogAppender.addExpectation(new MockLogAppender.UnseenEventExpectation(
+                    "audit disabled because of license",
+                    AuditTrailService.class.getName(),
+                    Level.WARN,
+                    "Security auditing is DISABLED because the currently active license [" +
+                            licenseState.getOperationMode() + "] does not permit it"
+            ));
+        } else {
+            mockLogAppender.addExpectation(new MockLogAppender.SeenEventExpectation(
+                    "audit disabled because of license",
+                    AuditTrailService.class.getName(),
+                    Level.WARN,
+                    "Security auditing is DISABLED because the currently active license [" +
+                            licenseState.getOperationMode() + "] does not permit it"
+            ));
+        }
+        for (int i = 1; i <= randomIntBetween(2, 6); i++) {
+            service.get();
+        }
+        mockLogAppender.assertAllExpectationsMatched();
+        Loggers.removeAppender(auditTrailServiceLogger, mockLogAppender);
+    }
+
+    public void testNoLogRecentlyWhenLicenseProhibitsAuditing() throws Exception {
+        MockLogAppender mockLogAppender = new MockLogAppender();
+        mockLogAppender.start();
+        Logger auditTrailServiceLogger = LogManager.getLogger(AuditTrailService.class);
+        Loggers.addAppender(auditTrailServiceLogger, mockLogAppender);
+        service.nextLogInstantAtomic.set(randomFrom(Instant.now().minus(Duration.ofMinutes(5)), Instant.now()));
+        mockLogAppender.addExpectation(new MockLogAppender.UnseenEventExpectation(
+                "audit disabled because of license",
+                AuditTrailService.class.getName(),
+                Level.WARN,
+                "Security auditing is DISABLED because the currently active license [*] does not permit it"
+        ));
+        for (int i = 1; i <= randomIntBetween(2, 6); i++) {
+            service.get();
+        }
+        mockLogAppender.assertAllExpectationsMatched();
+        Loggers.removeAppender(auditTrailServiceLogger, mockLogAppender);
     }
 
     public void testAuthenticationFailed() throws Exception {


### PR DESCRIPTION
Backport of https://github.com/elastic/elasticsearch/pull/65498

Security auditing only works on license levels GOLD or higher.
The license level can dynamically change while the node is running.
This PR logs a WARN message when license does not permit auditing,
but the static settings xpack.security.enabled and xpack.security.audit.enabled
are true. The log warn message is outputed at most every 30 mins.