### PR TITLE
Fix deprecation message for synced flush

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/IndicesClientDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/IndicesClientDocumentationIT.java
@@ -1034,7 +1034,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
 
             // tag::flush-synced-execute
             SyncedFlushResponse flushSyncedResponse = client.indices().flushSynced(request, expectWarnings(
-                "Synced flush is deprecated and will be removed in 8.0. Use flush at _/flush or /{index}/_flush instead."
+                "Synced flush is deprecated and will be removed in 8.0. Use flush at /_flush or /{index}/_flush instead."
             ));
             // end::flush-synced-execute
 
@@ -1080,7 +1080,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
 
             // tag::flush-synced-execute-async
             client.indices().flushSyncedAsync(request, expectWarnings(
-                "Synced flush is deprecated and will be removed in 8.0. Use flush at _/flush or /{index}/_flush instead."
+                "Synced flush is deprecated and will be removed in 8.0. Use flush at /_flush or /{index}/_flush instead."
             ), listener); // <1>
             // end::flush-synced-execute-async
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.flush/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.flush/10_basic.yml
@@ -1,8 +1,8 @@
 ---
 "Index synced flush rest test":
   - skip:
-      version: " - 7.5.99"
-      reason: "synced flush is deprecated in 7.6"
+      version: " - 7.5.99, 7.11.0 - "
+      reason: "synced flush is deprecated in 7.6. Message changed in 7.11"
       features: "warnings"
   - do:
       indices.create:
@@ -18,6 +18,36 @@
   - do:
       warnings:
         - Synced flush is deprecated and will be removed in 8.0. Use flush at _/flush or /{index}/_flush instead.
+      indices.flush_synced:
+        index: testing
+
+  - is_false: _shards.failed
+
+  - do:
+      indices.stats: {level: shards}
+
+  - is_true: indices.testing.shards.0.0.commit.user_data.sync_id
+
+---
+"Index synced flush rest test with updated message":
+  - skip:
+      version: " - 7.10.99"
+      reason: "synced flush deprecation message changed in 7.11"
+      features: "warnings"
+  - do:
+      indices.create:
+        index: testing
+        body:
+          settings:
+            index:
+              number_of_replicas: 0
+
+  - do:
+      cluster.health:
+        wait_for_status: green
+  - do:
+      warnings:
+        - Synced flush is deprecated and will be removed in 8.0. Use flush at /_flush or /{index}/_flush instead.
       indices.flush_synced:
         index: testing
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/flush/FlushIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/flush/FlushIT.java
@@ -20,12 +20,14 @@ package org.elasticsearch.indices.flush;
 
 import org.apache.lucene.index.Term;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.LatchedActionListener;
 import org.elasticsearch.action.admin.indices.flush.FlushRequest;
 import org.elasticsearch.action.admin.indices.flush.FlushResponse;
 import org.elasticsearch.action.admin.indices.flush.SyncedFlushResponse;
 import org.elasticsearch.action.admin.indices.stats.IndexStats;
 import org.elasticsearch.action.admin.indices.stats.ShardStats;
 import org.elasticsearch.action.support.ActiveShardCount;
+import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.routing.ShardRouting;
@@ -66,6 +68,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
@@ -73,6 +76,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyArray;
 import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -231,10 +235,28 @@ public class FlushIT extends ESIntegTestCase {
             assertNull(shardStats.getCommitStats().getUserData().get(Engine.SYNC_COMMIT_ID));
         }
         logger.info("--> trying sync flush");
-        SyncedFlushResponse syncedFlushResult = client().admin().indices().prepareSyncedFlush("test").get();
+        // since we expect a warning to be returned, we need to manually capture the warning in a header
+        // as the future can be completed outside of the test thread
+        final Client client = client();
+        final CountDownLatch latch = new CountDownLatch(1);
+        final AtomicReference<SyncedFlushResponse> responseRef = new AtomicReference<>();
+        final AtomicReference<Map<String, List<String>>> headerRef = new AtomicReference<>();
+        client.admin().indices().prepareSyncedFlush("test").execute(
+            new LatchedActionListener<>(ActionListener.wrap(r -> {
+                responseRef.set(r);
+                headerRef.set(client.threadPool().getThreadContext().getResponseHeaders());
+            }, e -> fail(e.getMessage())), latch));
+        latch.await();
         logger.info("--> sync flush done");
         stop.set(true);
         indexingThread.join();
+        SyncedFlushResponse syncedFlushResult = responseRef.get();
+        Map<String, List<String>> headers = headerRef.get();
+        assertThat(headers.containsKey("Warning"), is(true));
+        assertThat(headers.get("Warning")
+            .stream()
+            .anyMatch(s -> s.contains(SyncedFlushService.SYNCED_FLUSH_DEPRECATION_MESSAGE)),
+            is(true));
         indexStats = client().admin().indices().prepareStats("test").get().getIndex("test");
         assertFlushResponseEqualsShardStats(indexStats.getShards(), syncedFlushResult.getShardsResultPerIndex().get("test"));
         refresh();

--- a/server/src/main/java/org/elasticsearch/indices/flush/SyncedFlushService.java
+++ b/server/src/main/java/org/elasticsearch/indices/flush/SyncedFlushService.java
@@ -82,7 +82,7 @@ public class SyncedFlushService implements IndexEventListener {
     private static final DeprecationLogger DEPRECATION_LOGGER = DeprecationLogger.getLogger(logger.getName());
 
     public static final String SYNCED_FLUSH_DEPRECATION_MESSAGE =
-        "Synced flush is deprecated and will be removed in 8.0. Use flush at _/flush or /{index}/_flush instead.";
+        "Synced flush is deprecated and will be removed in 8.0. Use flush at /_flush or /{index}/_flush instead.";
 
     private static final String PRE_SYNCED_FLUSH_ACTION_NAME = "internal:indices/flush/synced/pre";
     private static final String SYNCED_FLUSH_ACTION_NAME = "internal:indices/flush/synced/sync";


### PR DESCRIPTION
This commit fixes a typo for the deprecation message that synced flush
emits and also updates a test to always confirm that the deprecation
message is returned.

Relates #65235