### PR TITLE
move rollup_index param out of RollupActionConfig

### DIFF
--- a/docs/reference/rollup/apis/rollup-api.asciidoc
+++ b/docs/reference/rollup/apis/rollup-api.asciidoc
@@ -11,9 +11,8 @@ For example, you can roll up hourly data into daily or weekly summaries.
 
 [source,console]
 ----
-POST /my-index-000001/_rollup
+POST /my-index-000001/_rollup/my-rollup-index
 {
-  "rollup_index": "my-rollup-index",
   "groups": {
     "date_histogram": {
       "field": "@timestamp",
@@ -61,15 +60,15 @@ Index to roll up. Cannot be a <<data-streams,data stream>> or
 <<indices-aliases,index alias>>. Does not support <<multi-index,multi-target
 syntax>> or wildcards (`*`).
 
-[role="child_attributes"]
-[[rollup-api-request-body]]
-==== {api-request-body-title}
-
 `rollup_index`::
 (Required, string)
 New index that stores the rollup results. Cannot be an existing index,
 a <<data-streams,data stream>>, or an <<indices-aliases,index alias>>.
-+
+
+[role="child_attributes"]
+[[rollup-api-request-body]]
+==== {api-request-body-title}
+
 The request creates this index with
 <<index-modules-blocks,`index.blocks.write`>> set to `true`. If the original
 `<index>` is a backing index for a data stream, this index is a backing index

--- a/docs/reference/rollup/apis/rollup-api.asciidoc
+++ b/docs/reference/rollup/apis/rollup-api.asciidoc
@@ -43,7 +43,7 @@ POST /my-index-000001/_rollup/my-rollup-index
 [[rollup-api-request]]
 ==== {api-request-title}
 
-`PUT /<index>/_rollup/<rollup_index>`
+`PUT /<index>/_rollup/<rollup-index>`
 
 [[rollup-api-prereqs]]
 ==== {api-prereq-title}
@@ -60,7 +60,7 @@ Index to roll up. Cannot be a <<data-streams,data stream>> or
 <<indices-aliases,index alias>>. Does not support <<multi-index,multi-target
 syntax>> or wildcards (`*`).
 
-`<rollup_index>`::
+`<rollup-index>`::
 (Required, string)
 New index that stores the rollup results. Cannot be an existing index,
 a <<data-streams,data stream>>, or an <<indices-aliases,index alias>>.
@@ -104,7 +104,7 @@ Time interval used to group documents. For differences between
 TIP: Choose this value carefully. You won't be able to use a smaller interval
 later. For example, you can't aggregate daily rollups into hourly
 summaries. However, smaller time intervals can greatly increase the size of your
-`<rollup_index>`.
+`<rollup-index>`.
 
 `time_zone`::
 (Optional, string)
@@ -146,7 +146,7 @@ Array of <<keyword,keyword family>> and <<number,numeric>> fields to store. If
 you specify a `terms` object, this property is required.
 +
 TIP: Avoid storing high-cardinality fields. High-cardinality fields can greatly
-increase the size of your `<rollup_index>`.
+increase the size of your `<rollup-index>`.
 =====
 ====
 

--- a/docs/reference/rollup/apis/rollup-api.asciidoc
+++ b/docs/reference/rollup/apis/rollup-api.asciidoc
@@ -43,7 +43,7 @@ POST /my-index-000001/_rollup/my-rollup-index
 [[rollup-api-request]]
 ==== {api-request-title}
 
-`PUT /<index>/_rollup`
+`PUT /<index>/_rollup/<rollup_index>`
 
 [[rollup-api-prereqs]]
 ==== {api-prereq-title}
@@ -60,19 +60,19 @@ Index to roll up. Cannot be a <<data-streams,data stream>> or
 <<indices-aliases,index alias>>. Does not support <<multi-index,multi-target
 syntax>> or wildcards (`*`).
 
-`rollup_index`::
+`<rollup_index>`::
 (Required, string)
 New index that stores the rollup results. Cannot be an existing index,
 a <<data-streams,data stream>>, or an <<indices-aliases,index alias>>.
-
-[role="child_attributes"]
-[[rollup-api-request-body]]
-==== {api-request-body-title}
-
++
 The request creates this index with
 <<index-modules-blocks,`index.blocks.write`>> set to `true`. If the original
 `<index>` is a backing index for a data stream, this index is a backing index
 for the same stream.
+
+[role="child_attributes"]
+[[rollup-api-request-body]]
+==== {api-request-body-title}
 
 `groups`::
 (Required, object)

--- a/docs/reference/rollup/apis/rollup-api.asciidoc
+++ b/docs/reference/rollup/apis/rollup-api.asciidoc
@@ -104,7 +104,7 @@ Time interval used to group documents. For differences between
 TIP: Choose this value carefully. You won't be able to use a smaller interval
 later. For example, you can't aggregate daily rollups into hourly
 summaries. However, smaller time intervals can greatly increase the size of your
-`rollup_index`.
+`<rollup_index>`.
 
 `time_zone`::
 (Optional, string)
@@ -146,7 +146,7 @@ Array of <<keyword,keyword family>> and <<number,numeric>> fields to store. If
 you specify a `terms` object, this property is required.
 +
 TIP: Avoid storing high-cardinality fields. High-cardinality fields can greatly
-increase the size of your `rollup_index`.
+increase the size of your `<rollup_index>`.
 =====
 ====
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/v2/RollupAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/v2/RollupAction.java
@@ -35,10 +35,12 @@ public class RollupAction extends ActionType<RollupAction.Response> {
 
     public static class Request extends ActionRequest implements ToXContentObject {
         private String sourceIndex;
+        private String rollupIndex;
         private RollupActionConfig rollupConfig;
 
-        public Request(String sourceIndex, RollupActionConfig rollupConfig) {
+        public Request(String sourceIndex, String rollupIndex, RollupActionConfig rollupConfig) {
             this.sourceIndex = sourceIndex;
+            this.rollupIndex = rollupIndex;
             this.rollupConfig = rollupConfig;
         }
 
@@ -47,23 +49,29 @@ public class RollupAction extends ActionType<RollupAction.Response> {
         public Request(StreamInput in) throws IOException {
             super(in);
             sourceIndex = in.readString();
+            rollupIndex = in.readString();
             rollupConfig = new RollupActionConfig(in);
         }
 
         @Override
         public Task createTask(long id, String type, String action, TaskId parentTaskId, Map<String, String> headers) {
-            return new RollupTask(id, type, action, parentTaskId, rollupConfig, headers);
+            return new RollupTask(id, type, action, parentTaskId, rollupIndex, rollupConfig, headers);
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
             out.writeString(sourceIndex);
+            out.writeString(rollupIndex);
             rollupConfig.writeTo(out);
         }
 
         public String getSourceIndex() {
             return sourceIndex;
+        }
+
+        public String getRollupIndex() {
+            return rollupIndex;
         }
 
         public RollupActionConfig getRollupConfig() {
@@ -79,6 +87,7 @@ public class RollupAction extends ActionType<RollupAction.Response> {
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject();
             builder.field("source_index", sourceIndex);
+            builder.field("rollup_index", rollupIndex);
             rollupConfig.toXContent(builder, params);
             builder.endObject();
             return builder;
@@ -86,7 +95,7 @@ public class RollupAction extends ActionType<RollupAction.Response> {
 
         @Override
         public int hashCode() {
-            return Objects.hash(sourceIndex, rollupConfig);
+            return Objects.hash(sourceIndex, rollupIndex, rollupConfig);
         }
 
         @Override
@@ -99,6 +108,7 @@ public class RollupAction extends ActionType<RollupAction.Response> {
             }
             Request other = (Request) obj;
             return Objects.equals(sourceIndex, other.sourceIndex)
+                && Objects.equals(rollupIndex, other.rollupIndex)
                 && Objects.equals(rollupConfig, other.rollupConfig);
         }
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/v2/RollupTask.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/v2/RollupTask.java
@@ -5,8 +5,6 @@
  */
 package org.elasticsearch.xpack.core.rollup.v2;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.xpack.core.rollup.RollupField;
@@ -19,14 +17,19 @@ import java.util.Map;
  * which drives the indexing, and periodically updates it's parent PersistentTask with the indexing's current position.
  */
 public class RollupTask extends CancellableTask {
-    private static final Logger logger = LogManager.getLogger(RollupTask.class.getName());
-
+    private String rollupIndex;
     private RollupActionConfig config;
     private RollupJobStatus status;
 
-    RollupTask(long id, String type, String action, TaskId parentTask, RollupActionConfig config, Map<String, String> headers) {
-        super(id, type, action, RollupField.NAME + "_" + config.getRollupIndex(), parentTask, headers);
+    RollupTask(long id, String type, String action, TaskId parentTask, String rollupIndex, RollupActionConfig config,
+               Map<String, String> headers) {
+        super(id, type, action, RollupField.NAME + "_" + rollupIndex, parentTask, headers);
+        this.rollupIndex = rollupIndex;
         this.config = config;
+    }
+
+    public String getRollupIndex() {
+        return rollupIndex;
     }
 
     public RollupActionConfig config() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/rollup/v2/RollupActionConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/rollup/v2/RollupActionConfigTests.java
@@ -29,11 +29,10 @@ public class RollupActionConfigTests extends AbstractSerializingTestCase<RollupA
     }
 
     public static RollupActionConfig randomConfig(Random random) {
-        final String rollupIndex = randomAlphaOfLength(5);
         final TimeValue timeout = random.nextBoolean() ? null : ConfigTestHelpers.randomTimeout(random);
         final GroupConfig groupConfig = ConfigTestHelpers.randomGroupConfig(random);
         final List<MetricConfig> metricConfigs = ConfigTestHelpers.randomMetricsConfigs(random);
-        return new RollupActionConfig(groupConfig, metricConfigs, timeout, rollupIndex);
+        return new RollupActionConfig(groupConfig, metricConfigs, timeout);
     }
 
     @Override
@@ -46,19 +45,10 @@ public class RollupActionConfigTests extends AbstractSerializingTestCase<RollupA
         return RollupActionConfig.fromXContent(parser);
     }
 
-    public void testEmptyRollupIndex() {
-        final RollupActionConfig sample = createTestInstance();
-        Exception e = expectThrows(IllegalArgumentException.class, () ->
-            new RollupActionConfig(sample.getGroupConfig(), sample.getMetricsConfig(), sample.getTimeout(),
-                randomBoolean() ? null : ""));
-        assertThat(e.getMessage(), equalTo("Rollup index must be a non-null, non-empty string"));
-    }
-
     public void testEmptyGroupAndMetrics() {
         final RollupActionConfig sample = createTestInstance();
         Exception e = expectThrows(IllegalArgumentException.class, () ->
-            new RollupActionConfig(null, randomBoolean() ? null : emptyList(), sample.getTimeout(),
-                sample.getRollupIndex()));
+            new RollupActionConfig(null, randomBoolean() ? null : emptyList(), sample.getTimeout()));
         assertThat(e.getMessage(), equalTo("At least one grouping or metric must be configured"));
     }
 }

--- a/x-pack/plugin/rollup/qa/rest/src/test/resources/rest-api-spec/test/rollup/10_basic.yml
+++ b/x-pack/plugin/rollup/qa/rest/src/test/resources/rest-api-spec/test/rollup/10_basic.yml
@@ -54,9 +54,9 @@ setup:
   - do:
       rollup.rollup:
         index: docs
+        rollup_index: rollup_docs
         body:  >
           {
-            "rollup_index": "rollup_docs",
             "groups" : {
               "date_histogram": {
                 "field": "timestamp",

--- a/x-pack/plugin/rollup/qa/rest/src/test/resources/rest-api-spec/test/rollup/10_basic.yml
+++ b/x-pack/plugin/rollup/qa/rest/src/test/resources/rest-api-spec/test/rollup/10_basic.yml
@@ -54,7 +54,7 @@ setup:
   - do:
       rollup.rollup:
         index: docs
-        rollup-index: rollup_docs
+        rollup_index: rollup_docs
         body:  >
           {
             "groups" : {

--- a/x-pack/plugin/rollup/qa/rest/src/test/resources/rest-api-spec/test/rollup/10_basic.yml
+++ b/x-pack/plugin/rollup/qa/rest/src/test/resources/rest-api-spec/test/rollup/10_basic.yml
@@ -54,7 +54,7 @@ setup:
   - do:
       rollup.rollup:
         index: docs
-        rollup_index: rollup_docs
+        rollup-index: rollup_docs
         body:  >
           {
             "groups" : {

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/v2/RestRollupAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/v2/RestRollupAction.java
@@ -22,14 +22,15 @@ public class RestRollupAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return List.of(new Route(POST, "/{index}/_rollup"));
+        return List.of(new Route(POST, "/{index}/_rollup/{rollup_index}"));
     }
 
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
         String index = restRequest.param("index");
+        String rollupIndex = restRequest.param("rollup_index");
         RollupActionConfig config = RollupActionConfig.fromXContent(restRequest.contentParser());
-        RollupAction.Request request = new RollupAction.Request(index, config);
+        RollupAction.Request request = new RollupAction.Request(index, rollupIndex, config);
         return channel -> client.execute(RollupAction.INSTANCE, request, new RestToXContentListener<>(channel));
     }
 

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/v2/RestRollupAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/v2/RestRollupAction.java
@@ -22,13 +22,13 @@ public class RestRollupAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return List.of(new Route(POST, "/{index}/_rollup/{rollup_index}"));
+        return List.of(new Route(POST, "/{index}/_rollup/{rollup-index}"));
     }
 
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
         String index = restRequest.param("index");
-        String rollupIndex = restRequest.param("rollup_index");
+        String rollupIndex = restRequest.param("rollup-index");
         RollupActionConfig config = RollupActionConfig.fromXContent(restRequest.contentParser());
         RollupAction.Request request = new RollupAction.Request(index, rollupIndex, config);
         return channel -> client.execute(RollupAction.INSTANCE, request, new RestToXContentListener<>(channel));

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/v2/RestRollupAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/v2/RestRollupAction.java
@@ -22,13 +22,13 @@ public class RestRollupAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return List.of(new Route(POST, "/{index}/_rollup/{rollup-index}"));
+        return List.of(new Route(POST, "/{index}/_rollup/{rollup_index}"));
     }
 
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
         String index = restRequest.param("index");
-        String rollupIndex = restRequest.param("rollup-index");
+        String rollupIndex = restRequest.param("rollup_index");
         RollupActionConfig config = RollupActionConfig.fromXContent(restRequest.contentParser());
         RollupAction.Request request = new RollupAction.Request(index, rollupIndex, config);
         return channel -> client.execute(RollupAction.INSTANCE, request, new RestToXContentListener<>(channel));

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/v2/RollupV2Indexer.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/v2/RollupV2Indexer.java
@@ -106,13 +106,13 @@ public class RollupV2Indexer extends AsyncTwoPhaseIndexer<Map<String, Object>, R
         this.request = request;
         this.headers = headers;
         this.compositeBuilder = createCompositeBuilder(this.request.getRollupConfig());
-        this.tmpIndex = ".rolluptmp-" + this.request.getRollupConfig().getRollupIndex();
+        this.tmpIndex = ".rolluptmp-" + this.request.getRollupIndex();
         this.completionListener = completionListener;
     }
 
     @Override
     protected String getJobId() {
-        return request.getRollupConfig().getId();
+        return "rollup_" + request.getRollupIndex();
     }
 
     @Override
@@ -196,7 +196,7 @@ public class RollupV2Indexer extends AsyncTwoPhaseIndexer<Map<String, Object>, R
     @Override
     protected void onFinish(ActionListener<Void> listener) {
         // "shrink index"
-        ResizeRequest resizeRequest = new ResizeRequest(request.getRollupConfig().getRollupIndex(), tmpIndex);
+        ResizeRequest resizeRequest = new ResizeRequest(request.getRollupIndex(), tmpIndex);
         resizeRequest.setResizeType(ResizeType.CLONE);
         resizeRequest.getTargetIndexRequest()
             .settings(Settings.builder().put(IndexMetadata.SETTING_INDEX_HIDDEN, false).build());

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/v2/TransportRollupAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/v2/TransportRollupAction.java
@@ -71,7 +71,7 @@ public class TransportRollupAction extends HandledTransportAction<RollupAction.R
 
                 @Override
                 public ClusterState execute(ClusterState currentState) throws Exception {
-                    String rollupIndexName = rollupTask.config().getRollupIndex();
+                    String rollupIndexName = rollupTask.getRollupIndex();
                     IndexMetadata rollupIndexMetadata = currentState.getMetadata().index(rollupIndexName);
                     Index rollupIndex = rollupIndexMetadata.getIndex();
                     // TODO(talevy): find better spot to get the original index name

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.rollup.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.rollup.json
@@ -13,7 +13,7 @@
     "url": {
       "paths": [
         {
-          "path": "/{index}/_rollup",
+          "path": "/{index}/_rollup/{rollup_index}",
           "methods": [
             "POST"
           ],
@@ -21,6 +21,11 @@
             "index": {
               "type": "string",
               "description": "The index to roll up",
+              "required": true
+            },
+            "rollup_index": {
+              "type": "string",
+              "description": "The name of the rollup index to create",
               "required": true
             }
           }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.rollup.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.rollup.json
@@ -13,7 +13,7 @@
     "url": {
       "paths": [
         {
-          "path": "/{index}/_rollup/{rollup_index}",
+          "path": "/{index}/_rollup/{rollup-index}",
           "methods": [
             "POST"
           ],
@@ -23,7 +23,7 @@
               "description": "The index to roll up",
               "required": true
             },
-            "rollup_index": {
+            "rollup-index": {
               "type": "string",
               "description": "The name of the rollup index to create",
               "required": true

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.rollup.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.rollup.json
@@ -13,7 +13,7 @@
     "url": {
       "paths": [
         {
-          "path": "/{index}/_rollup/{rollup-index}",
+          "path": "/{index}/_rollup/{rollup_index}",
           "methods": [
             "POST"
           ],
@@ -23,7 +23,7 @@
               "description": "The index to roll up",
               "required": true
             },
-            "rollup-index": {
+            "rollup_index": {
               "type": "string",
               "description": "The name of the rollup index to create",
               "required": true


### PR DESCRIPTION
This commit moves the ownership of tracking the rollup_index from
the RollupActionConfig to the RollupAction.Request.

This is cleaner since the config should not be concerned with the
source and rollup indices.

relates #42720.