### PR TITLE
Fix warning when installing a plugin for different ESversion

### DIFF
--- a/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/ListPluginsCommand.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/ListPluginsCommand.java
@@ -70,7 +70,7 @@ class ListPluginsCommand extends EnvironmentAwareCommand {
                 "WARNING: plugin ["
                     + info.getName()
                     + "] was built for Elasticsearch version "
-                    + info.getVersion()
+                    + info.getElasticsearchVersion()
                     + " but version "
                     + Version.CURRENT
                     + " is required"

--- a/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/ListPluginsCommandTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/ListPluginsCommandTests.java
@@ -266,7 +266,7 @@ public class ListPluginsCommandTests extends ESTestCase {
         buildFakePlugin(env, "fake desc 2", "fake_plugin2", "org.fake2");
 
         MockTerminal terminal = listPlugins(home);
-        String message = "plugin [fake_plugin1] was built for Elasticsearch version 1.0 but version " + Version.CURRENT + " is required";
+        String message = "plugin [fake_plugin1] was built for Elasticsearch version 1.0.0 but version " + Version.CURRENT + " is required";
         assertEquals("fake_plugin1\nfake_plugin2\n", terminal.getOutput());
         assertEquals("WARNING: " + message + "\n", terminal.getErrorOutput());
 


### PR DESCRIPTION
This commit change the warn message returned by elasticsearch-plugin list. The elasticsearch version of plugin is needed for comparison with current es version rather than the plugin version.