### PR TITLE
[Transform] randomize integration tests using runtime fields

### DIFF
--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/ContinuousTestCase.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/ContinuousTestCase.java
@@ -46,6 +46,12 @@ public abstract class ContinuousTestCase extends ESRestTestCase {
     public static final String INGEST_PIPELINE = "transform-ingest";
     public static final String MAX_RUN_FIELD = "run.max";
     public static final String INGEST_RUN_FIELD = "run_ingest";
+    // mixture of fields to choose from, indexed and runtime
+    public static final Set<String> METRIC_FIELDS = Set.of("metric", "metric-rt-2x");
+    public static final Set<String> METRIC_TIMESTAMP_FIELDS = Set.of("metric-timestamp", "metric-timestamp-5m-earlier");
+    public static final Set<String> TERMS_FIELDS = Set.of("event", "event-upper");
+    public static final Set<String> TIMESTAMP_FIELDS = Set.of("timestamp", "timestamp-at-runtime");
+    public static final Set<String> OTHER_TIMESTAMP_FIELDS = Set.of("some-timestamp", "some-timestamp-10m-earlier");
     public static final DateTimeFormatter STRICT_DATE_OPTIONAL_TIME_PRINTER_NANOS = new DateTimeFormatterBuilder().parseCaseInsensitive()
         .append(ISO_LOCAL_DATE)
         .appendLiteral('T')

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/DateHistogramGroupByIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/DateHistogramGroupByIT.java
@@ -45,10 +45,12 @@ public class DateHistogramGroupByIT extends ContinuousTestCase {
 
     private final boolean missing;
     private final boolean datesAsEpochMillis;
+    private final String timestampField;
 
     public DateHistogramGroupByIT() {
         missing = randomBoolean();
         datesAsEpochMillis = randomBoolean();
+        timestampField = randomFrom(TIMESTAMP_FIELDS);
     }
 
     @Override
@@ -66,7 +68,7 @@ public class DateHistogramGroupByIT extends ContinuousTestCase {
         pivotConfigBuilder.setGroups(
             new GroupConfig.Builder().groupBy(
                 "second",
-                new DateHistogramGroupSource.Builder().setField("timestamp")
+                new DateHistogramGroupSource.Builder().setField(timestampField)
                     .setInterval(new DateHistogramGroupSource.FixedInterval(DateHistogramInterval.SECOND))
                     .setMissingBucket(missing)
                     .build()
@@ -90,7 +92,7 @@ public class DateHistogramGroupByIT extends ContinuousTestCase {
         SearchRequest searchRequestSource = new SearchRequest(CONTINUOUS_EVENTS_SOURCE_INDEX).allowPartialSearchResults(false)
             .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
         SearchSourceBuilder sourceBuilderSource = new SearchSourceBuilder().size(0);
-        DateHistogramAggregationBuilder bySecond = new DateHistogramAggregationBuilder("second").field("timestamp")
+        DateHistogramAggregationBuilder bySecond = new DateHistogramAggregationBuilder("second").field(timestampField)
             .fixedInterval(DateHistogramInterval.SECOND)
             .order(BucketOrder.key(true));
         if (missing) {

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/HistogramGroupByIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/HistogramGroupByIT.java
@@ -29,6 +29,12 @@ import static org.hamcrest.Matchers.equalTo;
 public class HistogramGroupByIT extends ContinuousTestCase {
     private static final String NAME = "continuous-histogram-pivot-test";
 
+    private final String metricField;
+
+    public HistogramGroupByIT() {
+        metricField = randomFrom(METRIC_FIELDS);
+    }
+
     @Override
     public String getName() {
         return NAME;
@@ -43,7 +49,7 @@ public class HistogramGroupByIT extends ContinuousTestCase {
         transformConfigBuilder.setId(NAME);
         PivotConfig.Builder pivotConfigBuilder = new PivotConfig.Builder();
         pivotConfigBuilder.setGroups(
-            new GroupConfig.Builder().groupBy("metric", new HistogramGroupSource.Builder().setField("metric").setInterval(50.0).build())
+            new GroupConfig.Builder().groupBy("metric", new HistogramGroupSource.Builder().setField(metricField).setInterval(50.0).build())
                 .build()
         );
         AggregatorFactories.Builder aggregations = new AggregatorFactories.Builder();
@@ -59,7 +65,7 @@ public class HistogramGroupByIT extends ContinuousTestCase {
         SearchRequest searchRequestSource = new SearchRequest(CONTINUOUS_EVENTS_SOURCE_INDEX).allowPartialSearchResults(false)
             .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
         SearchSourceBuilder sourceBuilderSource = new SearchSourceBuilder().size(0);
-        HistogramAggregationBuilder metricBuckets = new HistogramAggregationBuilder("metric").field("metric")
+        HistogramAggregationBuilder metricBuckets = new HistogramAggregationBuilder("metric").field(metricField)
             .interval(50.0)
             .order(BucketOrder.key(true));
         sourceBuilderSource.aggregation(metricBuckets);


### PR DESCRIPTION
this change adds coverage for runtime fields to the continuous transform integration test cases. runtime fields are configured at random.

Note: I haven't changed integration tests for latest, because of the ongoing fields API rewrite.