### PR TITLE
Migrate async search to use an auto-created system index

### DIFF
--- a/x-pack/plugin/async/src/main/java/org/elasticsearch/xpack/async/AsyncResultsIndexPlugin.java
+++ b/x-pack/plugin/async/src/main/java/org/elasticsearch/xpack/async/AsyncResultsIndexPlugin.java
@@ -13,7 +13,6 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
-import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.indices.SystemIndexDescriptor;
@@ -28,8 +27,6 @@ import org.elasticsearch.xpack.core.async.AsyncTaskIndexService;
 import org.elasticsearch.xpack.core.async.AsyncTaskMaintenanceService;
 import org.elasticsearch.xpack.core.search.action.AsyncSearchResponse;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;

--- a/x-pack/plugin/async/src/main/java/org/elasticsearch/xpack/async/AsyncResultsIndexPlugin.java
+++ b/x-pack/plugin/async/src/main/java/org/elasticsearch/xpack/async/AsyncResultsIndexPlugin.java
@@ -36,7 +36,6 @@ import java.util.List;
 import java.util.function.Supplier;
 
 import static org.elasticsearch.xpack.core.ClientHelper.ASYNC_SEARCH_ORIGIN;
-import static org.elasticsearch.xpack.core.ClientHelper.LOGSTASH_MANAGEMENT_ORIGIN;
 
 public class AsyncResultsIndexPlugin extends Plugin implements SystemIndexPlugin {
 
@@ -48,24 +47,7 @@ public class AsyncResultsIndexPlugin extends Plugin implements SystemIndexPlugin
 
     @Override
     public Collection<SystemIndexDescriptor> getSystemIndexDescriptors(Settings settings) {
-        final XContentBuilder mappings;
-        try {
-            mappings = AsyncTaskIndexService.mappings();
-        } catch (IOException e) {
-            throw new UncheckedIOException("Failed to build " + XPackPlugin.ASYNC_RESULTS_INDEX + " index mappings", e);
-        }
-
-        return List.of(
-            SystemIndexDescriptor.builder()
-                .setIndexPattern(XPackPlugin.ASYNC_RESULTS_INDEX)
-                .setDescription(this.getClass().getSimpleName())
-                .setPrimaryIndex(XPackPlugin.ASYNC_RESULTS_INDEX)
-                .setMappings(mappings)
-                .setSettings(AsyncTaskIndexService.settings())
-                .setVersionMetaKey("version")
-                .setOrigin(LOGSTASH_MANAGEMENT_ORIGIN)
-                .build()
-        );
+        return List.of(AsyncTaskIndexService.getSystemIndexDescriptor());
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncTaskIndexService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncTaskIndexService.java
@@ -5,10 +5,6 @@
  */
 package org.elasticsearch.xpack.core.async;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.elasticsearch.ExceptionsHelper;
-import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
@@ -60,14 +56,17 @@ import static org.elasticsearch.xpack.core.security.authc.AuthenticationField.AU
  * A service that exposes the CRUD operations for the async task-specific index.
  */
 public final class AsyncTaskIndexService<R extends AsyncResponse<R>> {
-    private static final Logger logger = LogManager.getLogger(AsyncTaskIndexService.class);
 
     public static final String HEADERS_FIELD = "headers";
     public static final String RESPONSE_HEADERS_FIELD = "response_headers";
     public static final String EXPIRATION_TIME_FIELD = "expiration_time";
     public static final String RESULT_FIELD = "result";
 
-    static Settings settings() {
+    // Usually the settings and mappings below would be co-located with the SystemIndexPlugin implementation,
+    // however in this case this service is in a different project to AsyncResultsIndexPlugin, as are tests
+    // that need access to #settings().
+
+    public static Settings settings() {
         return Settings.builder()
             .put("index.codec", "best_compression")
             .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
@@ -76,7 +75,7 @@ public final class AsyncTaskIndexService<R extends AsyncResponse<R>> {
             .build();
     }
 
-    static XContentBuilder mappings() throws IOException {
+    public static XContentBuilder mappings() throws IOException {
         XContentBuilder builder = jsonBuilder()
             .startObject()
                 .startObject(SINGLE_MAPPING_NAME)
@@ -107,12 +106,10 @@ public final class AsyncTaskIndexService<R extends AsyncResponse<R>> {
     }
 
     private final String index;
-    private final ClusterService clusterService;
     private final Client client;
     private final SecurityContext securityContext;
     private final NamedWriteableRegistry registry;
     private final Writeable.Reader<R> reader;
-
 
     public AsyncTaskIndexService(String index,
                                  ClusterService clusterService,
@@ -122,7 +119,6 @@ public final class AsyncTaskIndexService<R extends AsyncResponse<R>> {
                                  Writeable.Reader<R> reader,
                                  NamedWriteableRegistry registry) {
         this.index = index;
-        this.clusterService = clusterService;
         this.securityContext = new SecurityContext(clusterService.getSettings(), threadContext);
         this.client = new OriginSettingClient(client, origin);
         this.registry = registry;
@@ -134,34 +130,6 @@ public final class AsyncTaskIndexService<R extends AsyncResponse<R>> {
      */
     public Client getClient() {
         return client;
-    }
-
-    /**
-     * Creates the index with the expected settings and mappings if it doesn't exist.
-     */
-    void createIndexIfNecessary(ActionListener<Void> listener) {
-        if (clusterService.state().routingTable().hasIndex(index) == false) {
-            try {
-                client.admin().indices().prepareCreate(index)
-                    .setSettings(settings())
-                    .setMapping(mappings())
-                    .execute(ActionListener.wrap(
-                        resp -> listener.onResponse(null),
-                        exc -> {
-                            if (ExceptionsHelper.unwrapCause(exc) instanceof ResourceAlreadyExistsException) {
-                                listener.onResponse(null);
-                            } else {
-                                logger.error("failed to create " + index + " index", exc);
-                                listener.onFailure(exc);
-                            }
-                        }));
-            } catch (Exception exc) {
-                logger.error("failed to create " + index + " index", exc);
-                listener.onFailure(exc);
-            }
-        } else {
-            listener.onResponse(null);
-        }
     }
 
     /**
@@ -180,7 +148,7 @@ public final class AsyncTaskIndexService<R extends AsyncResponse<R>> {
             .create(true)
             .id(docId)
             .source(source, XContentType.JSON);
-        createIndexIfNecessary(ActionListener.wrap(v -> client.index(indexRequest, listener), listener::onFailure));
+        client.index(indexRequest, listener);
     }
 
     /**
@@ -199,9 +167,7 @@ public final class AsyncTaskIndexService<R extends AsyncResponse<R>> {
                 .id(docId)
                 .doc(source, XContentType.JSON)
                 .retryOnConflict(5);
-            // updates create the index automatically if it doesn't exist so we force the creation
-            // preemptively.
-            createIndexIfNecessary(ActionListener.wrap(v -> client.update(request, listener), listener::onFailure));
+            client.update(request, listener);
         } catch(Exception e) {
             listener.onFailure(e);
         }
@@ -219,9 +185,7 @@ public final class AsyncTaskIndexService<R extends AsyncResponse<R>> {
             .id(docId)
             .doc(source, XContentType.JSON)
             .retryOnConflict(5);
-        // updates create the index automatically if it doesn't exist so we force the creation
-        // preemptively.
-        createIndexIfNecessary(ActionListener.wrap(v -> client.update(request, listener), listener::onFailure));
+        client.update(request, listener);
     }
 
     /**
@@ -231,9 +195,7 @@ public final class AsyncTaskIndexService<R extends AsyncResponse<R>> {
                                ActionListener<DeleteResponse> listener) {
         try {
             DeleteRequest request = new DeleteRequest(index).id(asyncExecutionId.getDocId());
-            // deletes create the index automatically if it doesn't exist so we force the creation
-            // preemptively.
-            createIndexIfNecessary(ActionListener.wrap(v -> client.delete(request, listener), listener::onFailure));
+            client.delete(request, listener);
         } catch(Exception e) {
             listener.onFailure(e);
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/async/AsyncTaskServiceTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/async/AsyncTaskServiceTests.java
@@ -15,6 +15,9 @@ import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.indices.SystemIndexDescriptor;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.plugins.SystemIndexPlugin;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.elasticsearch.transport.TransportService;
@@ -24,7 +27,10 @@ import org.elasticsearch.xpack.core.security.user.User;
 import org.junit.Before;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 // TODO: test CRUD operations
 public class AsyncTaskServiceTests extends ESSingleNodeTestCase {
@@ -39,6 +45,23 @@ public class AsyncTaskServiceTests extends ESSingleNodeTestCase {
         indexService = new AsyncTaskIndexService<>(index, clusterService,
             transportService.getThreadPool().getThreadContext(),
             client(), "test_origin", AsyncSearchResponse::new, writableRegistry());
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        List<Class<? extends Plugin>> plugins = new ArrayList<>(super.getPlugins());
+        plugins.add(TestPlugin.class);
+        return plugins;
+    }
+
+    /**
+     * This class exists because AsyncResultsIndexPlugin exists in a different x-pack module.
+     */
+    public static class TestPlugin extends Plugin implements SystemIndexPlugin {
+        @Override
+        public Collection<SystemIndexDescriptor> getSystemIndexDescriptors(Settings settings) {
+            return List.of(AsyncTaskIndexService.getSystemIndexDescriptor());
+        }
     }
 
     public void testEnsuredAuthenticatedUserIsSame() throws IOException {
@@ -99,16 +122,7 @@ public class AsyncTaskServiceTests extends ESSingleNodeTestCase {
     }
 
     public void testAutoCreateIndex() throws Exception {
-        // TODO
-//        {
-//            PlainActionFuture<Void> future = PlainActionFuture.newFuture();
-//            indexService.createIndexIfNecessary(future);
-//            future.get();
-//            assertSettings();
-//        }
-//        AcknowledgedResponse ack = client().admin().indices().prepareDelete(index).get();
-//        assertTrue(ack.isAcknowledged());
-
+        // To begin with, the results index should be auto-created.
         AsyncExecutionId id = new AsyncExecutionId("0", new TaskId("N/A", 0));
         AsyncSearchResponse resp = new AsyncSearchResponse(id.getEncoded(), true, true, 0L, 0L);
         {
@@ -117,37 +131,48 @@ public class AsyncTaskServiceTests extends ESSingleNodeTestCase {
             future.get();
             assertSettings();
         }
+
+        // Delete the index, so we can test subsequent auto-create behaviour
         AcknowledgedResponse ack = client().admin().indices().prepareDelete(index).get();
         assertTrue(ack.isAcknowledged());
+
+        // Subsequent response deletes throw a (wrapped) index not found exception
         {
             PlainActionFuture<DeleteResponse> future = PlainActionFuture.newFuture();
             indexService.deleteResponse(id, future);
-            future.get();
-            assertSettings();
+            expectThrows(Exception.class, future::get);
         }
-        ack = client().admin().indices().prepareDelete(index).get();
-        assertTrue(ack.isAcknowledged());
+
+        // So do updates
         {
             PlainActionFuture<UpdateResponse> future = PlainActionFuture.newFuture();
             indexService.updateResponse(id.getDocId(), Collections.emptyMap(), resp, future);
-            expectThrows(Exception.class, () -> future.get());
+            expectThrows(Exception.class, future::get);
             assertSettings();
         }
-        ack = client().admin().indices().prepareDelete(index).get();
-        assertTrue(ack.isAcknowledged());
+
+        // And so does updating the expiration time
         {
             PlainActionFuture<UpdateResponse> future = PlainActionFuture.newFuture();
             indexService.updateExpirationTime("0", 10L, future);
-            expectThrows(Exception.class, () -> future.get());
+            expectThrows(Exception.class, future::get);
+            assertSettings();
+        }
+
+        // But the index is still auto-created
+        {
+            PlainActionFuture<IndexResponse> future = PlainActionFuture.newFuture();
+            indexService.createResponse(id.getDocId(), Collections.emptyMap(), resp, future);
+            future.get();
             assertSettings();
         }
     }
 
-    private void assertSettings() throws IOException {
+    private void assertSettings() {
         GetIndexResponse getIndexResponse = client().admin().indices().getIndex(
             new GetIndexRequest().indices(index)).actionGet();
         Settings settings = getIndexResponse.getSettings().get(index);
         Settings expected = AsyncTaskIndexService.settings();
-        assertEquals(expected, settings.filter(key -> expected.hasValue(key)));
+        assertEquals(expected, settings.filter(expected::hasValue));
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/async/AsyncTaskServiceTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/async/AsyncTaskServiceTests.java
@@ -99,14 +99,15 @@ public class AsyncTaskServiceTests extends ESSingleNodeTestCase {
     }
 
     public void testAutoCreateIndex() throws Exception {
-        {
-            PlainActionFuture<Void> future = PlainActionFuture.newFuture();
-            indexService.createIndexIfNecessary(future);
-            future.get();
-            assertSettings();
-        }
-        AcknowledgedResponse ack = client().admin().indices().prepareDelete(index).get();
-        assertTrue(ack.isAcknowledged());
+        // TODO
+//        {
+//            PlainActionFuture<Void> future = PlainActionFuture.newFuture();
+//            indexService.createIndexIfNecessary(future);
+//            future.get();
+//            assertSettings();
+//        }
+//        AcknowledgedResponse ack = client().admin().indices().prepareDelete(index).get();
+//        assertTrue(ack.isAcknowledged());
 
         AsyncExecutionId id = new AsyncExecutionId("0", new TaskId("N/A", 0));
         AsyncSearchResponse resp = new AsyncSearchResponse(id.getEncoded(), true, true, 0L, 0L);
@@ -116,7 +117,7 @@ public class AsyncTaskServiceTests extends ESSingleNodeTestCase {
             future.get();
             assertSettings();
         }
-        ack = client().admin().indices().prepareDelete(index).get();
+        AcknowledgedResponse ack = client().admin().indices().prepareDelete(index).get();
         assertTrue(ack.isAcknowledged());
         {
             PlainActionFuture<DeleteResponse> future = PlainActionFuture.newFuture();


### PR DESCRIPTION
Part of #61656.

Migrate async search to use an auto-created system index. This does change the behaviour of `AsyncTaskIndexService` - previously, it would ensure the index existed before carrying out any operation, whereas now the index is only created when a document is created. For any other operation, the wrapped `IndexNotFoundException` will be allowed to bubble up.