### PR TITLE
Minor fix in dynamic template validation

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
@@ -426,6 +426,7 @@ public class RootObjectMapper extends ObjectMapper {
                         (name, mapping) -> typeParser.parse(name, mapping, parserContext).build(new ContentPath(1)));
                 }
                 dynamicTemplateInvalid = false;
+                break;
             } catch(Exception e) {
                 lastError = e;
             }


### PR DESCRIPTION
As part of #66156 the validation of dynamic templates has been adapted to support runtime fields. As part of that change, a `break` was forgotten, which causes needless additional validation rounds after a template has been already successfully validated against one of the field types.