### PR TITLE
[ML] update snapshot upgrader bwc test to check for latest min_version 7.11

### DIFF
--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlJobSnapshotUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlJobSnapshotUpgradeIT.java
@@ -85,7 +85,6 @@ public class MlJobSnapshotUpgradeIT extends AbstractUpgradeTestCase {
      * The purpose of this test is to ensure that when a job is open through a rolling upgrade we upgrade the results
      * index mappings when it is assigned to an upgraded node even if no other ML endpoint is called after the upgrade
      */
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/66161")
     public void testSnapshotUpgrader() throws Exception {
         hlrc = new HLRC(client()).machineLearning();
         Request adjustLoggingLevels = new Request("PUT", "/_cluster/settings");
@@ -137,8 +136,8 @@ public class MlJobSnapshotUpgradeIT extends AbstractUpgradeTestCase {
         assertThat(snapshots, hasSize(1));
         snapshot = snapshots.get(0);
         assertThat(snapshot.getLatestRecordTimeStamp(), equalTo(snapshots.get(0).getLatestRecordTimeStamp()));
-        // min version in upgraded 7.series is 7.9.0
-        assertThat(snapshot.getMinVersion(), equalTo(Version.V_7_9_0));
+        // min version in upgraded 7.series is 7.11.0
+        assertThat(snapshot.getMinVersion(), equalTo(Version.V_7_11_0));
 
         // Does the snapshot still work?
         assertThat(hlrc.getJobStats(new GetJobStatsRequest(JOB_ID), RequestOptions.DEFAULT)

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlJobSnapshotUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlJobSnapshotUpgradeIT.java
@@ -62,6 +62,8 @@ import static org.hamcrest.Matchers.is;
 public class MlJobSnapshotUpgradeIT extends AbstractUpgradeTestCase {
 
     private static final String JOB_ID = "ml-snapshots-upgrade-job";
+    // min version in upgraded 7.series is 7.11.0
+    private static final Version CPP_COMPATIBILTIY_VERSION = Version.V_7_11_0;
 
     private static class HLRC extends RestHighLevelClient {
         HLRC(RestClient restClient) {
@@ -136,8 +138,7 @@ public class MlJobSnapshotUpgradeIT extends AbstractUpgradeTestCase {
         assertThat(snapshots, hasSize(1));
         snapshot = snapshots.get(0);
         assertThat(snapshot.getLatestRecordTimeStamp(), equalTo(snapshots.get(0).getLatestRecordTimeStamp()));
-        // min version in upgraded 7.series is 7.11.0
-        assertThat(snapshot.getMinVersion(), equalTo(Version.V_7_11_0));
+        assertThat(snapshot.getMinVersion(), equalTo(CPP_COMPATIBILTIY_VERSION));
 
         // Does the snapshot still work?
         assertThat(hlrc.getJobStats(new GetJobStatsRequest(JOB_ID), RequestOptions.DEFAULT)


### PR DESCRIPTION
closes https://github.com/elastic/elasticsearch/issues/66161