### PR TITLE
Show -Dlicense.key value in test repro info

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/junit/listeners/ReproduceInfoPrinter.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/junit/listeners/ReproduceInfoPrinter.java
@@ -180,7 +180,6 @@ public class ReproduceInfoPrinter extends RunListener {
             appendOpt("tests.timezone", TimeZone.getDefault().getID());
             appendOpt("tests.distribution", System.getProperty("tests.distribution"));
             appendOpt("runtime.java", Integer.toString(JavaVersion.current().getVersion().get(0)));
-            appendOpt("runtime.java", Integer.toString(JavaVersion.current().getVersion().get(0)));
             appendOpt("license.key", System.getProperty("licence.key"));
             appendOpt(ESTestCase.FIPS_SYSPROP, System.getProperty(ESTestCase.FIPS_SYSPROP));
             return this;

--- a/test/framework/src/main/java/org/elasticsearch/test/junit/listeners/ReproduceInfoPrinter.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/junit/listeners/ReproduceInfoPrinter.java
@@ -25,7 +25,6 @@ import org.apache.lucene.util.Constants;
 import org.elasticsearch.bootstrap.JavaVersion;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.SuppressForbidden;
-import org.elasticsearch.common.io.PathUtils;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
@@ -34,7 +33,6 @@ import org.junit.runner.Description;
 import org.junit.runner.notification.Failure;
 import org.junit.runner.notification.RunListener;
 
-import java.nio.file.Path;
 import java.util.Locale;
 import java.util.TimeZone;
 
@@ -183,29 +181,9 @@ public class ReproduceInfoPrinter extends RunListener {
             appendOpt("tests.distribution", System.getProperty("tests.distribution"));
             appendOpt("runtime.java", Integer.toString(JavaVersion.current().getVersion().get(0)));
             appendOpt("runtime.java", Integer.toString(JavaVersion.current().getVersion().get(0)));
-            appendOpt("license.key", relativePath(System.getProperty("licence.key")));
+            appendOpt("license.key", System.getProperty("licence.key"));
             appendOpt(ESTestCase.FIPS_SYSPROP, System.getProperty(ESTestCase.FIPS_SYSPROP));
             return this;
-        }
-
-        private String relativePath(String pathProperty) {
-            if(pathProperty == null) {
-                return null;
-            }
-            Path path = PathUtils.get(pathProperty);
-            if(path.isAbsolute()) {
-                // try to resolve workspace root from Jenksin WORKSPACE env variable
-                String workspace = System.getenv("WORKSPACE");
-                if(workspace == null) {
-                    // fallback to resolve workspace root from teamcity checkout dir
-                    workspace = System.getProperty("teamcity.build.workingDir");
-                }
-                if(workspace != null) {
-                    // resolve path relative to workspace root
-                    return PathUtils.get(workspace).relativize(path).toString();
-                }
-            }
-            return pathProperty;
         }
 
         public ReproduceErrorMessageBuilder appendClientYamlSuiteProperties() {

--- a/x-pack/plugin/core/build.gradle
+++ b/x-pack/plugin/core/build.gradle
@@ -84,10 +84,11 @@ tasks.named("processResources").configure {
   } else {
     throw new IllegalArgumentException('Property license.key must be set for release build')
   }
-  if (Files.exists(Paths.get(licenseKey)) == false) {
+  File licenseKeyFile = rootProject.file(licenseKey)
+  if (licenseKeyFile.exists() == false) {
     throw new IllegalArgumentException('license.key at specified path [' + licenseKey + '] does not exist')
   }
-  from(licenseKey) {
+  from(licenseKeyFile) {
     rename { String filename -> 'public.key' }
   }
 }


### PR DESCRIPTION
- When a -Dlicense.key sys property is passed to the build we want to consider
this in the test reproduction info message
- absolute Paths tried to be converted to relative paths relative to workspace
root to allow simply copy & paste
- Also fixes a inconsistency for checking license existence in x-pack plugin core build