### PR TITLE
Remove suggest reference in some API specs

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.stats.json
@@ -40,7 +40,6 @@
                 "segments",
                 "store",
                 "warmer",
-                "suggest",
                 "bulk"
               ],
               "description":"Limit the information returned the specific metrics."
@@ -87,7 +86,6 @@
                 "segments",
                 "store",
                 "warmer",
-                "suggest",
                 "bulk"
               ],
               "description":"Limit the information returned the specific metrics."
@@ -99,11 +97,11 @@
     "params":{
       "completion_fields":{
         "type":"list",
-        "description":"A comma-separated list of fields for `fielddata` and `suggest` index metric (supports wildcards)"
+        "description":"A comma-separated list of fields for the `completion` index metric (supports wildcards)"
       },
       "fielddata_fields":{
         "type":"list",
-        "description":"A comma-separated list of fields for `fielddata` index metric (supports wildcards)"
+        "description":"A comma-separated list of fields for the `fielddata` index metric (supports wildcards)"
       },
       "fields":{
         "type":"list",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.stats.json
@@ -126,7 +126,6 @@
                 "segments",
                 "store",
                 "warmer",
-                "suggest",
                 "bulk"
               ],
               "description":"Limit the information returned for `indices` metric to the specific index metrics. Isn't used if `indices` (or `all`) metric isn't specified."
@@ -175,7 +174,6 @@
                 "segments",
                 "store",
                 "warmer",
-                "suggest",
                 "bulk"
               ],
               "description":"Limit the information returned for `indices` metric to the specific index metrics. Isn't used if `indices` (or `all`) metric isn't specified."
@@ -191,11 +189,11 @@
     "params":{
       "completion_fields":{
         "type":"list",
-        "description":"A comma-separated list of fields for `fielddata` and `suggest` index metric (supports wildcards)"
+        "description":"A comma-separated list of fields for the `completion` index metric (supports wildcards)"
       },
       "fielddata_fields":{
         "type":"list",
-        "description":"A comma-separated list of fields for `fielddata` index metric (supports wildcards)"
+        "description":"A comma-separated list of fields for the `fielddata` index metric (supports wildcards)"
       },
       "fields":{
         "type":"list",


### PR DESCRIPTION
This commit removes the reference to the suggest index metric in the
nodes stats and indices stats rest api spec files. Suggest has been
removed so it is no longer correct to have it in these files.

Closes #43407