### PR TITLE
[7.x] Mark EQL APIs as stable (#66184)

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/eql.delete.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/eql.delete.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/eql-search-api.html",
       "description": "Deletes an async EQL search by ID. If the search is still running, the search request will be cancelled. Otherwise, the saved search results are deleted."
     },
-    "stability":"beta",
+    "stability":"stable",
     "headers":{
       "accept": [ "application/json"]
     },

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/eql.get.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/eql.get.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/eql-search-api.html",
       "description": "Returns async results from previously executed Event Query Language (EQL) search"
     },
-    "stability": "beta",
+    "stability": "stable",
     "headers":{
       "accept": [ "application/json"]
     },

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/eql.search.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/eql.search.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/eql-search-api.html",
       "description": "Returns results matching a query expressed in Event Query Language (EQL)"
     },
-    "stability": "beta",
+    "stability": "stable",
     "headers":{
       "accept": [ "application/json"],
       "content_type": ["application/json"]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Mark EQL APIs as stable (#66184)