### PR TITLE
[7.x] REST endpoint and tests for data stream migration

### DIFF
--- a/x-pack/plugin/data-streams/src/main/java/org/elasticsearch/xpack/datastreams/DataStreamsPlugin.java
+++ b/x-pack/plugin/data-streams/src/main/java/org/elasticsearch/xpack/datastreams/DataStreamsPlugin.java
@@ -39,6 +39,7 @@ import org.elasticsearch.xpack.datastreams.action.DeleteDataStreamTransportActio
 import org.elasticsearch.xpack.datastreams.action.GetDataStreamsTransportAction;
 import org.elasticsearch.xpack.datastreams.mapper.DataStreamTimestampFieldMapper;
 import org.elasticsearch.xpack.datastreams.rest.RestPromoteDataStreamAction;
+import org.elasticsearch.xpack.datastreams.rest.RestMigrateToDataStreamAction;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -87,8 +88,9 @@ public class DataStreamsPlugin extends Plugin implements ActionPlugin, MapperPlu
         RestHandler deleteDsAction = new RestDeleteDataStreamAction();
         RestHandler getDsAction = new RestGetDataStreamsAction();
         RestHandler dsStatsAction = new RestDataStreamsStatsAction();
+        RestHandler migrateAction = new RestMigrateToDataStreamAction();
         RestHandler promoteAction = new RestPromoteDataStreamAction();
-        return Arrays.asList(createDsAction, deleteDsAction, getDsAction, dsStatsAction, promoteAction);
+        return Arrays.asList(createDsAction, deleteDsAction, getDsAction, dsStatsAction, migrateAction, promoteAction);
     }
 
     public Collection<Module> createGuiceModules() {

--- a/x-pack/plugin/data-streams/src/main/java/org/elasticsearch/xpack/datastreams/rest/RestMigrateToDataStreamAction.java
+++ b/x-pack/plugin/data-streams/src/main/java/org/elasticsearch/xpack/datastreams/rest/RestMigrateToDataStreamAction.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.datastreams.rest;
+
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.xpack.core.MigrateToDataStreamAction;
+
+import java.io.IOException;
+import java.util.List;
+
+public class RestMigrateToDataStreamAction extends BaseRestHandler {
+
+    @Override
+    public String getName() {
+        return "migrate_to_data_stream_action";
+    }
+
+    @Override
+    public List<Route> routes() {
+        return List.of(new Route(RestRequest.Method.POST, "/_data_stream/_migrate/{name}"));
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+        MigrateToDataStreamAction.Request req = new MigrateToDataStreamAction.Request(request.param("name"));
+        return channel -> client.execute(MigrateToDataStreamAction.INSTANCE, req, new RestToXContentListener<>(channel));
+    }
+}

--- a/x-pack/plugin/data-streams/src/main/java/org/elasticsearch/xpack/datastreams/rest/RestMigrateToDataStreamAction.java
+++ b/x-pack/plugin/data-streams/src/main/java/org/elasticsearch/xpack/datastreams/rest/RestMigrateToDataStreamAction.java
@@ -7,13 +7,13 @@
 package org.elasticsearch.xpack.datastreams.rest;
 
 import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.collect.List;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.core.MigrateToDataStreamAction;
 
 import java.io.IOException;
-import java.util.List;
 
 public class RestMigrateToDataStreamAction extends BaseRestHandler {
 
@@ -23,7 +23,7 @@ public class RestMigrateToDataStreamAction extends BaseRestHandler {
     }
 
     @Override
-    public List<Route> routes() {
+    public java.util.List<Route> routes() {
         return List.of(new Route(RestRequest.Method.POST, "/_data_stream/_migrate/{name}"));
     }
 

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/indices.migrate_to_data_stream.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/indices.migrate_to_data_stream.json
@@ -5,6 +5,9 @@
       "description":"Migrates an alias to a data stream"
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/indices.migrate_to_data_stream.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/indices.migrate_to_data_stream.json
@@ -1,0 +1,27 @@
+{
+  "indices.migrate_to_data_stream":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html",
+      "description":"Migrates an alias to a data stream"
+    },
+    "stability":"stable",
+    "url":{
+      "paths":[
+        {
+          "path":"/_data_stream/_migrate/{name}",
+          "methods":[
+            "POST"
+          ],
+          "parts":{
+            "name":{
+              "type":"string",
+              "description":"The name of the alias to migrate"
+            }
+          }
+        }
+      ]
+    },
+    "params":{
+    }
+  }
+}

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/data_stream/130_migrate_to_data_stream.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/data_stream/130_migrate_to_data_stream.yml
@@ -1,0 +1,69 @@
+---
+"Migrate to data stream":
+  - skip:
+      version: " - 7.99.99"
+      reason: "change to 7.10.99 after backport"
+      features: allowed_warnings
+
+  - do:
+      allowed_warnings:
+        - "index template [my-template1] has index patterns [migrate-me-to-data-stream] matching patterns from existing older templates [global] with patterns (global => [*]); this template [my-template1] will take precedence during new index creation"
+      indices.put_index_template:
+        name: my-template1
+        body:
+          index_patterns: [migrate-me-to-data-stream]
+          data_stream: {}
+
+  - do:
+      indices.create:
+        index: test_index1
+        body:
+          aliases:
+            migrate-me-to-data-stream:
+              is_write_index: true
+
+  - do:
+      index:
+        index:  test_index1
+        body:   { "foo": "bar1", "@timestamp": "2009-11-15T14:12:12" }
+
+  - do:
+      indices.create:
+        index: test_index2
+        body:
+          aliases:
+            migrate-me-to-data-stream: {}
+
+  - do:
+      index:
+        index:  test_index2
+        body:   { "foo": "bar2", "@timestamp": "2009-11-15T14:12:13" }
+
+  - do:
+      indices.migrate_to_data_stream:
+        name: migrate-me-to-data-stream
+  - is_true: acknowledged
+
+  - do:
+      indices.resolve_index:
+        name: ['test_index*','migrate-me-to-data-stream*']
+        expand_wildcards: [all]
+
+  - match: {indices.0.name: test_index1}
+  - match: {indices.0.attributes.0: hidden}
+  - match: {indices.0.attributes.1: open}
+  - match: {indices.0.data_stream: migrate-me-to-data-stream}
+  - match: {indices.1.name: test_index2}
+  - match: {indices.1.attributes.0: hidden}
+  - match: {indices.1.attributes.1: open}
+  - match: {indices.1.data_stream: migrate-me-to-data-stream}
+  - length: {aliases: 0}
+  - match: {data_streams.0.name: migrate-me-to-data-stream}
+  - match: {data_streams.0.backing_indices.0: test_index2}
+  - match: {data_streams.0.backing_indices.1: test_index1}
+  - match: {data_streams.0.timestamp_field: "@timestamp"}
+
+  - do:
+      indices.delete_data_stream:
+        name: migrate-me-to-data-stream
+  - is_true: acknowledged

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/data_stream/130_migrate_to_data_stream.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/data_stream/130_migrate_to_data_stream.yml
@@ -1,8 +1,8 @@
 ---
 "Migrate to data stream":
   - skip:
-      version: " - 7.99.99"
-      reason: "change to 7.10.99 after backport"
+      version: " - 7.10.99"
+      reason: "migrate API introduced in 7.11.0"
       features: allowed_warnings
 
   - do:


### PR DESCRIPTION
Provides the REST endpoint for migrating existing indices to data streams.

Relates to #61046

Backport of #64415
