### PR TITLE
Do not restore autoscaling policy from snapshots (#66023)

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -133,6 +133,9 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
         EnumSet<XContentContext> context();
     }
 
+    public interface NonRestorableCustom extends Custom {
+    }
+
     public static final Setting<Boolean> SETTING_READ_ONLY_SETTING =
         Setting.boolSetting("cluster.blocks.read_only", false, Property.Dynamic, Property.NodeScope);
 

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -470,7 +470,8 @@ public class RestoreService implements ClusterStateApplier {
                             if (metadata.customs() != null) {
                                 for (ObjectObjectCursor<String, Metadata.Custom> cursor : metadata.customs()) {
                                     if (RepositoriesMetadata.TYPE.equals(cursor.key) == false
-                                            && DataStreamMetadata.TYPE.equals(cursor.key) == false) {
+                                            && DataStreamMetadata.TYPE.equals(cursor.key) == false
+                                            && cursor.value instanceof Metadata.NonRestorableCustom == false) {
                                         // Don't restore repositories while we are working with them
                                         // TODO: Should we restore them at the end?
                                         // Also, don't restore data streams here, we already added them to the metadata builder above

--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/AutoscalingSnapshotsIT.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/AutoscalingSnapshotsIT.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.autoscaling;
+
+import org.elasticsearch.ResourceNotFoundException;
+import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
+import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.xpack.autoscaling.action.DeleteAutoscalingPolicyAction;
+import org.elasticsearch.xpack.autoscaling.action.GetAutoscalingPolicyAction;
+import org.elasticsearch.xpack.autoscaling.action.PutAutoscalingPolicyAction;
+import org.elasticsearch.xpack.autoscaling.policy.AutoscalingPolicy;
+import org.junit.Before;
+
+import java.nio.file.Path;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.xpack.autoscaling.AutoscalingTestCase.randomAutoscalingPolicy;
+import static org.elasticsearch.xpack.autoscaling.AutoscalingTestCase.randomAutoscalingPolicyOfName;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+public class AutoscalingSnapshotsIT extends AutoscalingIntegTestCase {
+
+    public static final String REPO = "repo";
+    public static final String SNAPSHOT = "snap";
+
+    @Before
+    public void setup() throws Exception {
+        Path location = randomRepoPath();
+        logger.info("--> creating repository [{}] [{}]", REPO, "fs");
+        assertAcked(clusterAdmin().preparePutRepository(REPO).setType("fs").setSettings(Settings.builder().put("location", location)));
+    }
+
+    public void testAutoscalingPolicyWillNotBeRestored() {
+        final Client client = client();
+
+        AutoscalingPolicy policy = randomAutoscalingPolicy();
+        putPolicy(policy);
+
+        CreateSnapshotResponse createSnapshotResponse = client.admin()
+            .cluster()
+            .prepareCreateSnapshot(REPO, SNAPSHOT)
+            .setWaitForCompletion(true)
+            .setIncludeGlobalState(true)
+            .get();
+        assertEquals(RestStatus.OK, createSnapshotResponse.status());
+
+        final boolean deletePolicy = randomBoolean();
+        if (deletePolicy) {
+            final DeleteAutoscalingPolicyAction.Request deleteRequest = new DeleteAutoscalingPolicyAction.Request(policy.name());
+            assertAcked(client.execute(DeleteAutoscalingPolicyAction.INSTANCE, deleteRequest).actionGet());
+        } else {
+            // Update the policy
+            policy = randomAutoscalingPolicyOfName(policy.name());
+            putPolicy(policy);
+        }
+        final AutoscalingPolicy anotherPolicy = randomAutoscalingPolicy();
+        putPolicy(anotherPolicy);
+
+        RestoreSnapshotResponse restoreSnapshotResponse = client.admin()
+            .cluster()
+            .prepareRestoreSnapshot(REPO, SNAPSHOT)
+            .setWaitForCompletion(true)
+            .setRestoreGlobalState(true)
+            .get();
+        assertEquals(RestStatus.OK, restoreSnapshotResponse.status());
+
+        if (deletePolicy) {
+            assertPolicyNotFound(policy);
+        } else {
+            assertPolicy(policy);
+        }
+        assertPolicy(anotherPolicy);
+    }
+
+    private void putPolicy(AutoscalingPolicy policy) {
+        final PutAutoscalingPolicyAction.Request request = new PutAutoscalingPolicyAction.Request(
+            policy.name(),
+            policy.roles(),
+            policy.deciders()
+        );
+        assertAcked(client().execute(PutAutoscalingPolicyAction.INSTANCE, request).actionGet());
+    }
+
+    private void assertPolicy(AutoscalingPolicy policy) {
+        final GetAutoscalingPolicyAction.Request getRequest = new GetAutoscalingPolicyAction.Request(policy.name());
+        final AutoscalingPolicy actualPolicy = client().execute(GetAutoscalingPolicyAction.INSTANCE, getRequest).actionGet().policy();
+        assertThat(actualPolicy, equalTo(policy));
+    }
+
+    private void assertPolicyNotFound(AutoscalingPolicy policy) {
+        final GetAutoscalingPolicyAction.Request getRequest = new GetAutoscalingPolicyAction.Request(policy.name());
+        final ResourceNotFoundException e = expectThrows(
+            ResourceNotFoundException.class,
+            () -> client().execute(GetAutoscalingPolicyAction.INSTANCE, getRequest).actionGet().policy()
+        );
+        assertThat(e.getMessage(), containsString("autoscaling policy with name [" + policy.name() + "] does not exist"));
+    }
+}

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/AutoscalingMetadata.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/AutoscalingMetadata.java
@@ -32,7 +32,7 @@ import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-public class AutoscalingMetadata implements XPackPlugin.XPackMetadataCustom {
+public class AutoscalingMetadata implements XPackPlugin.XPackMetadataCustom, Metadata.NonRestorableCustom {
 
     public static final String NAME = "autoscaling";
 


### PR DESCRIPTION
Autoscaling policies (custom metadata) are marked as non-restorable and hence
they are never restored from a snapshot.
