### PR TITLE
Add CacheFile#fsync() method to ensure cached data are written on disk

### DIFF
--- a/libs/core/src/test/java/org/elasticsearch/core/internal/io/IOUtilsTests.java
+++ b/libs/core/src/test/java/org/elasticsearch/core/internal/io/IOUtilsTests.java
@@ -213,11 +213,15 @@ public class IOUtilsTests extends ESTestCase {
 
     }
 
+    private void fsync(final Path path, final boolean isDir) throws IOException {
+        IOUtils.fsync(path, isDir, randomBoolean());
+    }
+
     public void testFsyncDirectory() throws Exception {
         final Path path = createTempDir().toRealPath();
         final Path subPath = path.resolve(randomAlphaOfLength(8));
         Files.createDirectories(subPath);
-        IOUtils.fsync(subPath, true);
+        fsync(subPath, true);
         // no exception
     }
 
@@ -246,16 +250,16 @@ public class IOUtilsTests extends ESTestCase {
         final Path wrapped = new FilterPath(path, fs);
         if (Constants.WINDOWS) {
             // no exception, we early return and do not even try to open the directory
-            IOUtils.fsync(wrapped, true);
+            fsync(wrapped, true);
         } else {
-            expectThrows(AccessDeniedException.class, () -> IOUtils.fsync(wrapped, true));
+            expectThrows(AccessDeniedException.class, () -> fsync(wrapped, true));
         }
     }
 
     public void testFsyncNonExistentDirectory() throws Exception {
         final Path dir = FilterPath.unwrap(createTempDir()).toRealPath();
         final Path nonExistentDir = dir.resolve("non-existent");
-        expectThrows(NoSuchFileException.class, () -> IOUtils.fsync(nonExistentDir, true));
+        expectThrows(NoSuchFileException.class, () -> fsync(nonExistentDir, true));
     }
 
     public void testFsyncFile() throws IOException {
@@ -266,7 +270,7 @@ public class IOUtilsTests extends ESTestCase {
         try (OutputStream o = Files.newOutputStream(file)) {
             o.write("0\n".getBytes(StandardCharsets.US_ASCII));
         }
-        IOUtils.fsync(file, false);
+        fsync(file, false);
         // no exception
     }
 

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/SparseFileTracker.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/SparseFileTracker.java
@@ -49,8 +49,8 @@ public class SparseFileTracker {
         return length;
     }
 
-    public List<Tuple<Long, Long>> getCompletedRanges() {
-        List<Tuple<Long, Long>> completedRanges = null;
+    public SortedSet<Tuple<Long, Long>> getCompletedRanges() {
+        SortedSet<Tuple<Long, Long>> completedRanges = null;
         synchronized (mutex) {
             assert invariant();
             for (Range range : ranges) {
@@ -58,12 +58,12 @@ public class SparseFileTracker {
                     continue;
                 }
                 if (completedRanges == null) {
-                    completedRanges = new ArrayList<>();
+                    completedRanges = new TreeSet<>(Comparator.comparingLong(Tuple::v1));
                 }
                 completedRanges.add(Tuple.tuple(range.start, range.end));
             }
         }
-        return completedRanges == null ? Collections.emptyList() : completedRanges;
+        return completedRanges == null ? Collections.emptySortedSet() : completedRanges;
     }
 
     /**

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/CacheFileTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/CacheFileTests.java
@@ -5,25 +5,47 @@
  */
 package org.elasticsearch.index.store.cache;
 
+import org.apache.lucene.mockfile.FilterFileChannel;
+import org.apache.lucene.mockfile.FilterFileSystemProvider;
+import org.apache.lucene.mockfile.FilterPath;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.cluster.coordination.DeterministicTaskQueue;
 import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.io.PathUtils;
+import org.elasticsearch.common.io.PathUtilsForTesting;
 import org.elasticsearch.index.store.cache.CacheFile.EvictionListener;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.hamcrest.Matcher;
 
 import java.io.IOException;
 import java.nio.channels.FileChannel;
+import java.nio.file.FileSystem;
 import java.nio.file.Files;
+import java.nio.file.OpenOption;
 import java.nio.file.Path;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.spi.FileSystemProvider;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 
+import static java.util.Collections.synchronizedNavigableSet;
 import static org.elasticsearch.common.settings.Settings.builder;
+import static org.elasticsearch.index.store.cache.TestUtils.mergeContiguousRanges;
 import static org.elasticsearch.node.Node.NODE_NAME_SETTING;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -171,6 +193,104 @@ public class CacheFileTests extends ESTestCase {
         }
     }
 
+    public void testFSync() throws Exception {
+        try (FSyncTrackingFileSystemProvider fileSystem = setupFSyncCountingFileSystem()) {
+            final CacheFile cacheFile = new CacheFile("test", randomLongBetween(100, 1000), fileSystem.resolve("test"));
+            assertFalse(cacheFile.needsFsync());
+
+            final TestEvictionListener listener = new TestEvictionListener();
+            cacheFile.acquire(listener);
+
+            try {
+                if (randomBoolean()) {
+                    final SortedSet<Tuple<Long, Long>> completedRanges = cacheFile.fsync();
+                    assertNumberOfFSyncs(cacheFile.getFile(), equalTo(0L));
+                    assertThat(completedRanges, hasSize(0));
+                    assertFalse(cacheFile.needsFsync());
+                }
+
+                final SortedSet<Tuple<Long, Long>> expectedCompletedRanges = randomPopulateAndReads(cacheFile);
+                if (expectedCompletedRanges.isEmpty() == false) {
+                    assertTrue(cacheFile.needsFsync());
+                } else {
+                    assertFalse(cacheFile.needsFsync());
+                }
+
+                final SortedSet<Tuple<Long, Long>> completedRanges = cacheFile.fsync();
+                assertNumberOfFSyncs(cacheFile.getFile(), equalTo(expectedCompletedRanges.isEmpty() ? 0L : 1L));
+                assertThat(completedRanges, equalTo(expectedCompletedRanges));
+                assertFalse(cacheFile.needsFsync());
+            } finally {
+                cacheFile.release(listener);
+            }
+        }
+    }
+
+    public void testFSyncOnEvictedFile() throws Exception {
+        try (FSyncTrackingFileSystemProvider fileSystem = setupFSyncCountingFileSystem()) {
+            final CacheFile cacheFile = new CacheFile("test", randomLongBetween(1L, 1000L), fileSystem.resolve("test"));
+            assertFalse(cacheFile.needsFsync());
+
+            final TestEvictionListener listener = new TestEvictionListener();
+            cacheFile.acquire(listener);
+
+            try {
+                final SortedSet<Tuple<Long, Long>> expectedCompletedRanges = randomPopulateAndReads(cacheFile);
+                if (expectedCompletedRanges.isEmpty() == false) {
+                    assertTrue(cacheFile.needsFsync());
+                    final SortedSet<Tuple<Long, Long>> completedRanges = cacheFile.fsync();
+                    assertThat(completedRanges, equalTo(expectedCompletedRanges));
+                    assertNumberOfFSyncs(cacheFile.getFile(), equalTo(1L));
+                    assertFalse(cacheFile.needsFsync());
+                }
+                assertFalse(cacheFile.needsFsync());
+
+                cacheFile.startEviction();
+
+                final SortedSet<Tuple<Long, Long>> completedRangesAfterEviction = cacheFile.fsync();
+                assertNumberOfFSyncs(cacheFile.getFile(), equalTo(expectedCompletedRanges.isEmpty() ? 0L : 1L));
+                assertThat(completedRangesAfterEviction, hasSize(0));
+                assertFalse(cacheFile.needsFsync());
+            } finally {
+                cacheFile.release(listener);
+            }
+        }
+    }
+
+    public void testFSyncFailure() throws Exception {
+        try (FSyncTrackingFileSystemProvider fileSystem = setupFSyncCountingFileSystem()) {
+            fileSystem.failFSyncs.set(true);
+
+            final CacheFile cacheFile = new CacheFile("test", randomLongBetween(1L, 1000L), fileSystem.resolve("test"));
+            assertFalse(cacheFile.needsFsync());
+
+            final TestEvictionListener listener = new TestEvictionListener();
+            cacheFile.acquire(listener);
+
+            try {
+                final SortedSet<Tuple<Long, Long>> expectedCompletedRanges = randomPopulateAndReads(cacheFile);
+                if (expectedCompletedRanges.isEmpty() == false) {
+                    assertTrue(cacheFile.needsFsync());
+                    expectThrows(IOException.class, cacheFile::fsync);
+                } else {
+                    assertFalse(cacheFile.needsFsync());
+                    final SortedSet<Tuple<Long, Long>> completedRanges = cacheFile.fsync();
+                    assertTrue(completedRanges.isEmpty());
+                }
+                assertNumberOfFSyncs(cacheFile.getFile(), equalTo(0L));
+
+                fileSystem.failFSyncs.set(false);
+
+                final SortedSet<Tuple<Long, Long>> completedRanges = cacheFile.fsync();
+                assertThat(completedRanges, equalTo(expectedCompletedRanges));
+                assertNumberOfFSyncs(cacheFile.getFile(), equalTo(expectedCompletedRanges.isEmpty() ? 0L : 1L));
+                assertFalse(cacheFile.needsFsync());
+            } finally {
+                cacheFile.release(listener);
+            }
+        }
+    }
+
     static class TestEvictionListener implements EvictionListener {
 
         private final SetOnce<CacheFile> evicted = new SetOnce<>();
@@ -186,6 +306,87 @@ public class CacheFileTests extends ESTestCase {
         @Override
         public void onEviction(CacheFile evictedCacheFile) {
             evicted.set(Objects.requireNonNull(evictedCacheFile));
+        }
+    }
+
+    private SortedSet<Tuple<Long, Long>> randomPopulateAndReads(final CacheFile cacheFile) {
+        final SortedSet<Tuple<Long, Long>> ranges = synchronizedNavigableSet(new TreeSet<>(Comparator.comparingLong(Tuple::v1)));
+        final List<Future<Integer>> futures = new ArrayList<>();
+        final DeterministicTaskQueue deterministicTaskQueue = new DeterministicTaskQueue(
+            builder().put(NODE_NAME_SETTING.getKey(), getTestName()).build(),
+            random()
+        );
+        for (int i = 0; i < between(0, 10); i++) {
+            final long start = randomLongBetween(0L, cacheFile.getLength() - 1L);
+            final long end = randomLongBetween(start + 1L, cacheFile.getLength());
+            final Tuple<Long, Long> range = Tuple.tuple(start, end);
+            futures.add(
+                cacheFile.populateAndRead(range, range, channel -> Math.toIntExact(end - start), (channel, from, to, progressUpdater) -> {
+                    ranges.add(Tuple.tuple(from, to));
+                    progressUpdater.accept(to);
+                }, deterministicTaskQueue.getThreadPool().generic())
+            );
+        }
+        deterministicTaskQueue.runAllRunnableTasks();
+        assertTrue(futures.stream().allMatch(Future::isDone));
+        return mergeContiguousRanges(ranges);
+    }
+
+    public static void assertNumberOfFSyncs(final Path path, final Matcher<Long> matcher) {
+        final FSyncTrackingFileSystemProvider provider = (FSyncTrackingFileSystemProvider) path.getFileSystem().provider();
+        final AtomicLong fsyncCounter = provider.files.get(path);
+        assertThat("File [" + path + "] was never fsynced", notNullValue());
+        assertThat("Mismatching number of fsync for [" + path + "]", fsyncCounter.get(), matcher);
+    }
+
+    private static FSyncTrackingFileSystemProvider setupFSyncCountingFileSystem() {
+        final FileSystem defaultFileSystem = PathUtils.getDefaultFileSystem();
+        final FSyncTrackingFileSystemProvider provider = new FSyncTrackingFileSystemProvider(defaultFileSystem, createTempDir());
+        PathUtilsForTesting.installMock(provider.getFileSystem(null));
+        return provider;
+    }
+
+    /**
+     * A {@link FileSystemProvider} that counts the number of times the method {@link FileChannel#force(boolean)} is executed on every
+     * files. It reinstates the default file system when this file system provider is closed.
+     */
+    private static class FSyncTrackingFileSystemProvider extends FilterFileSystemProvider implements AutoCloseable {
+
+        private final Map<Path, AtomicLong> files = new ConcurrentHashMap<>();
+        private final AtomicBoolean failFSyncs = new AtomicBoolean();
+        private final FileSystem delegateInstance;
+        private final Path rootDir;
+
+        FSyncTrackingFileSystemProvider(FileSystem delegate, Path rootDir) {
+            super("fsynccounting://", delegate);
+            this.rootDir = new FilterPath(rootDir, this.fileSystem);
+            this.delegateInstance = delegate;
+        }
+
+        public Path resolve(String other) {
+            return rootDir.resolve(other);
+        }
+
+        @Override
+        public FileChannel newFileChannel(Path path, Set<? extends OpenOption> options, FileAttribute<?>... attrs) throws IOException {
+            return new FilterFileChannel(delegate.newFileChannel(toDelegate(path), options, attrs)) {
+
+                final AtomicLong counter = files.computeIfAbsent(path, p -> new AtomicLong(0L));
+
+                @Override
+                public void force(boolean metaData) throws IOException {
+                    if (failFSyncs.get()) {
+                        throw new IOException("simulated");
+                    }
+                    super.force(metaData);
+                    counter.incrementAndGet();
+                }
+            };
+        }
+
+        @Override
+        public void close() {
+            PathUtilsForTesting.installMock(delegateInstance);
         }
     }
 }

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/CacheFileTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/CacheFileTests.java
@@ -218,7 +218,7 @@ public class CacheFileTests extends ESTestCase {
 
                 final SortedSet<Tuple<Long, Long>> completedRanges = cacheFile.fsync();
                 assertNumberOfFSyncs(cacheFile.getFile(), equalTo(expectedCompletedRanges.isEmpty() ? 0L : 1L));
-                assertThat(completedRanges, equalTo(expectedCompletedRanges));
+                assertArrayEquals(completedRanges.toArray(new Tuple<?, ?>[0]), expectedCompletedRanges.toArray(new Tuple<?, ?>[0]));
                 assertFalse(cacheFile.needsFsync());
             } finally {
                 cacheFile.release(listener);
@@ -239,7 +239,7 @@ public class CacheFileTests extends ESTestCase {
                 if (expectedCompletedRanges.isEmpty() == false) {
                     assertTrue(cacheFile.needsFsync());
                     final SortedSet<Tuple<Long, Long>> completedRanges = cacheFile.fsync();
-                    assertThat(completedRanges, equalTo(expectedCompletedRanges));
+                    assertArrayEquals(completedRanges.toArray(new Tuple<?, ?>[0]), expectedCompletedRanges.toArray(new Tuple<?, ?>[0]));
                     assertNumberOfFSyncs(cacheFile.getFile(), equalTo(1L));
                     assertFalse(cacheFile.needsFsync());
                 }
@@ -282,7 +282,7 @@ public class CacheFileTests extends ESTestCase {
                 fileSystem.failFSyncs.set(false);
 
                 final SortedSet<Tuple<Long, Long>> completedRanges = cacheFile.fsync();
-                assertThat(completedRanges, equalTo(expectedCompletedRanges));
+                assertArrayEquals(completedRanges.toArray(new Tuple<?, ?>[0]), expectedCompletedRanges.toArray(new Tuple<?, ?>[0]));
                 assertNumberOfFSyncs(cacheFile.getFile(), equalTo(expectedCompletedRanges.isEmpty() ? 0L : 1L));
                 assertFalse(cacheFile.needsFsync());
             } finally {

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/TestUtils.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/TestUtils.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.blobstore.BlobMetadata;
 import org.elasticsearch.common.blobstore.BlobPath;
 import org.elasticsearch.common.blobstore.DeleteResult;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.store.IndexInputStats;
@@ -22,8 +23,11 @@ import java.io.ByteArrayInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsConstants.toIntBytes;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -47,6 +51,34 @@ public final class TestUtils {
             numberOfRanges++;
         }
         return numberOfRanges;
+    }
+
+    static SortedSet<Tuple<Long, Long>> mergeContiguousRanges(final SortedSet<Tuple<Long, Long>> ranges) {
+        return ranges.stream().collect(() -> new TreeSet<>(Comparator.comparingLong(Tuple::v1)), (gaps, gap) -> {
+            if (gaps.isEmpty()) {
+                gaps.add(gap);
+            } else {
+                final Tuple<Long, Long> previous = gaps.pollLast();
+                if (previous.v2().equals(gap.v1())) {
+                    gaps.add(Tuple.tuple(previous.v1(), gap.v2()));
+                } else {
+                    gaps.add(previous);
+                    gaps.add(gap);
+                }
+            }
+        }, (gaps1, gaps2) -> {
+            if (gaps1.isEmpty() == false && gaps2.isEmpty() == false) {
+                final Tuple<Long, Long> last = gaps1.pollLast();
+                final Tuple<Long, Long> first = gaps2.pollFirst();
+                if (last.v2().equals(first.v1())) {
+                    gaps1.add(Tuple.tuple(last.v1(), first.v2()));
+                } else {
+                    gaps1.add(last);
+                    gaps2.add(first);
+                }
+            }
+            gaps1.addAll(gaps2);
+        });
     }
 
     public static void assertCounter(IndexInputStats.Counter counter, long total, long count, long min, long max) {


### PR DESCRIPTION
This commit adds a new CacheFile.fsync() method to fsync the cache
file on disk. This method uses the utility method IOUtils.fsync(Path,
boolean) that executes a FileChannel.force() call under the hood.

Backport of #64201 for 7.11