### PR TITLE
 Allow to create SparseFileTracker with ranges already present

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/SparseFileTrackerTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/SparseFileTrackerTests.java
@@ -18,6 +18,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Semaphore;
@@ -425,7 +426,7 @@ public class SparseFileTrackerTests extends ESTestCase {
             assertThat(sparseFileTracker.getAbsentRangeWithin(completedRange.v1(), completedRange.v2()), nullValue());
 
             final AtomicBoolean listenerCalled = new AtomicBoolean();
-            assertThat(sparseFileTracker.waitForRange(completedRange, completedRange, new ActionListener<>() {
+            assertThat(sparseFileTracker.waitForRange(completedRange, completedRange, new ActionListener<Void>() {
                 @Override
                 public void onResponse(Void aVoid) {
                     listenerCalled.set(true);

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/SparseFileTrackerTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/SparseFileTrackerTests.java
@@ -420,7 +420,10 @@ public class SparseFileTrackerTests extends ESTestCase {
         final SortedSet<Tuple<Long, Long>> completedRanges = randomRanges(fileLength);
 
         final SparseFileTracker sparseFileTracker = new SparseFileTracker("test", fileLength, completedRanges);
-        assertThat(sparseFileTracker.getCompletedRanges(), equalTo(completedRanges));
+        assertThat(
+            sparseFileTracker.getCompletedRanges().toArray(new Tuple<?, ?>[0]),
+            equalTo(completedRanges.toArray(new Tuple<?, ?>[0]))
+        );
 
         for (Tuple<Long, Long> completedRange : completedRanges) {
             assertThat(sparseFileTracker.getAbsentRangeWithin(completedRange.v1(), completedRange.v2()), nullValue());

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/SparseFileTrackerTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/SparseFileTrackerTests.java
@@ -33,6 +33,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.nullValue;
 
 public class SparseFileTrackerTests extends ESTestCase {
 
@@ -413,7 +414,33 @@ public class SparseFileTrackerTests extends ESTestCase {
         checkThread.join();
     }
 
-    public void testCompletedRanges() {
+    public void testSparseFileTrackerCreatedWithCompletedRanges() {
+        final long fileLength = between(0, 1000);
+        final SortedSet<Tuple<Long, Long>> completedRanges = randomRanges(fileLength);
+
+        final SparseFileTracker sparseFileTracker = new SparseFileTracker("test", fileLength, completedRanges);
+        assertThat(sparseFileTracker.getCompletedRanges(), equalTo(completedRanges));
+
+        for (Tuple<Long, Long> completedRange : completedRanges) {
+            assertThat(sparseFileTracker.getAbsentRangeWithin(completedRange.v1(), completedRange.v2()), nullValue());
+
+            final AtomicBoolean listenerCalled = new AtomicBoolean();
+            assertThat(sparseFileTracker.waitForRange(completedRange, completedRange, new ActionListener<>() {
+                @Override
+                public void onResponse(Void aVoid) {
+                    listenerCalled.set(true);
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    throw new AssertionError(e);
+                }
+            }), hasSize(0));
+            assertThat(listenerCalled.get(), is(true));
+        }
+    }
+
+    public void testGetCompletedRanges() {
         final byte[] fileContents = new byte[between(0, 1000)];
         final SparseFileTracker sparseFileTracker = new SparseFileTracker("test", fileContents.length);
 
@@ -560,5 +587,19 @@ public class SparseFileTrackerTests extends ESTestCase {
             gap.onCompletion();
             return true;
         }
+    }
+
+    /**
+     * Generates a sorted set of non-empty and non-contiguous random ranges that could fit into a file of a given maximum length.
+     */
+    private static SortedSet<Tuple<Long, Long>> randomRanges(long length) {
+        final SortedSet<Tuple<Long, Long>> randomRanges = new TreeSet<>(Comparator.comparingLong(Tuple::v1));
+        for (long i = 0L; i < length;) {
+            long start = randomLongBetween(i, Math.max(0L, length - 1L));
+            long end = randomLongBetween(start + 1L, length); // +1 for non empty ranges
+            randomRanges.add(Tuple.tuple(start, end));
+            i = end + 1L + randomLongBetween(0L, Math.max(0L, length - end)); // +1 for non contiguous ranges
+        }
+        return randomRanges;
     }
 }


### PR DESCRIPTION
This commit allows to create SparseFileTracker instances with 
already completed/available ranges. Creating non empty sparse 
file tracker will be required for the searchable snapshots cache 
to be initialized with existing information on cache files.

Backport of #65501 for 7.11