### PR TITLE
Supporting max_doc_count: 0 for RareTerms

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/RareTermsAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/RareTermsAggregationBuilder.java
@@ -117,9 +117,9 @@ public class RareTermsAggregationBuilder extends ValuesSourceAggregationBuilder<
      * the response.
      */
     public RareTermsAggregationBuilder maxDocCount(long maxDocCount) {
-        if (maxDocCount <= 0) {
+        if (maxDocCount < 0) {
             throw new IllegalArgumentException(
-                "[" + MAX_DOC_COUNT_FIELD_NAME.getPreferredName() + "] must be greater than 0. Found ["
+                "[" + MAX_DOC_COUNT_FIELD_NAME.getPreferredName() + "] must be greater or equal to 0. Found ["
                     + maxDocCount + "] in [" + name + "]");
         }
         //TODO review: what size cap should we put on this?

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringRareTermsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringRareTermsAggregator.java
@@ -127,6 +127,16 @@ public class StringRareTermsAggregator extends AbstractRareTermsAggregator {
          */
         StringRareTerms.Bucket[][] rarestPerOrd = new StringRareTerms.Bucket[owningBucketOrds.length][];
         SetBackedScalingCuckooFilter[] filters = new SetBackedScalingCuckooFilter[owningBucketOrds.length];
+
+        /*
+        * Collecting entries with zero DocCount when maxDocCount is zero.
+         */
+        if(maxDocCount == 0) {
+            for (int owningOrdIdx = 0; owningOrdIdx < owningBucketOrds.length; owningOrdIdx++) {
+                collectZeroDocEntries(owningOrdIdx);
+            }
+        }
+
         long keepCount = 0;
         long[] mergeMap = new long[(int) bucketOrds.size()];
         Arrays.fill(mergeMap, -1);
@@ -191,6 +201,24 @@ public class StringRareTermsAggregator extends AbstractRareTermsAggregator {
     @Override
     public InternalAggregation buildEmptyAggregation() {
         return new StringRareTerms(name, LongRareTermsAggregator.ORDER, metadata(), format, emptyList(), 0, newFilter());
+    }
+
+    void collectZeroDocEntries(long owningBucketOrd) throws IOException {
+        for (LeafReaderContext ctx : searcher().getTopReaderContext().leaves()) {
+            SortedBinaryDocValues values = valuesSource.bytesValues(ctx);
+
+            for (int docId = 0; docId < ctx.reader().maxDoc(); ++docId) {
+                if (values.advanceExact(docId)) {
+                    int valueCount = values.docValueCount();
+                    for (int i = 0; i < valueCount; ++i) {
+                        BytesRef term = values.nextValue();
+                        if (filter == null || filter.accept(term)) {
+                            bucketOrds.add(owningBucketOrd, term);
+                        }
+                    }
+                }
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
Closes #46787

Adding support for max_doc_count: 0 for RareTerms aggregation. When maxDocCount is zero docs with zero doc count will be collected and presented in the aggregation with doc_count:  0. The funcionality and its usefulness is better explained in the related issue.

This is my first submission to Elasticsearch that actually presents a new feature so please tell me if anything I did requires better documentation and if I need to make any test cases that cover the added functionality. I am also open to any other feedback about this Pull Request and will try to make any suggested changes.
