### PR TITLE
Autoscaling reactive storage decider (#65520)

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/ClusterInfo.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterInfo.java
@@ -211,7 +211,7 @@ public class ClusterInfo implements ToXContentFragment, Writeable {
      * Method that incorporates the ShardId for the shard into a string that
      * includes a 'p' or 'r' depending on whether the shard is a primary.
      */
-    static String shardIdentifierFromRouting(ShardRouting shardRouting) {
+    public static String shardIdentifierFromRouting(ShardRouting shardRouting) {
         return shardRouting.shardId().toString() + "[" + (shardRouting.primary() ? "p" : "r") + "]";
     }
 

--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageIT.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageIT.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.autoscaling.storage;
+
+import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
+import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.cluster.ClusterInfoService;
+import org.elasticsearch.cluster.DiskUsageIntegTestCase;
+import org.elasticsearch.cluster.InternalClusterInfoService;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.cluster.routing.allocation.DiskThresholdSettings;
+import org.elasticsearch.cluster.routing.allocation.decider.DiskThresholdDecider;
+import org.elasticsearch.common.collect.List;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.xpack.autoscaling.Autoscaling;
+import org.elasticsearch.xpack.autoscaling.LocalStateAutoscaling;
+import org.elasticsearch.xpack.autoscaling.action.GetAutoscalingCapacityAction;
+import org.elasticsearch.xpack.autoscaling.action.PutAutoscalingPolicyAction;
+import org.elasticsearch.xpack.core.XPackSettings;
+import org.hamcrest.Matchers;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Locale;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.elasticsearch.index.store.Store.INDEX_STORE_STATS_REFRESH_INTERVAL_SETTING;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0)
+public class ReactiveStorageIT extends DiskUsageIntegTestCase {
+
+    private static final long WATERMARK_BYTES = 10240;
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        Collection<Class<? extends Plugin>> plugins = new ArrayList<>(super.nodePlugins());
+        plugins.add(LocalStateAutoscaling.class);
+        return plugins;
+    }
+
+    @Override
+    protected Settings nodeSettings(final int nodeOrdinal) {
+        final Settings.Builder builder = Settings.builder().put(super.nodeSettings(nodeOrdinal));
+        builder.put(Autoscaling.AUTOSCALING_ENABLED_SETTING.getKey(), true)
+            .put(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK_SETTING.getKey(), (WATERMARK_BYTES * 2) + "b")
+            .put(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK_SETTING.getKey(), WATERMARK_BYTES + "b")
+            .put(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_WATERMARK_SETTING.getKey(), "0b")
+            .put(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_REROUTE_INTERVAL_SETTING.getKey(), "0ms")
+            .put(DiskThresholdDecider.ENABLE_FOR_SINGLE_DATA_NODE.getKey(), "true");
+        return builder.build();
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> transportClientPlugins() {
+        return List.of(LocalStateAutoscaling.class, getTestTransportPlugin());
+    }
+
+    @Override
+    protected Settings transportClientSettings() {
+        final Settings.Builder builder = Settings.builder().put(super.transportClientSettings());
+        builder.put(Autoscaling.AUTOSCALING_ENABLED_SETTING.getKey(), true);
+        builder.put(XPackSettings.SECURITY_ENABLED.getKey(), false);
+        return builder.build();
+    }
+
+    public void testScaleUp() throws InterruptedException {
+        internalCluster().startMasterOnlyNode();
+        final String dataNodeName = internalCluster().startDataOnlyNode();
+        final String policyName = "test";
+        putAutoscalingPolicy(policyName);
+
+        final String indexName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
+        createIndex(
+            indexName,
+            Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 6)
+                .put(INDEX_STORE_STATS_REFRESH_INTERVAL_SETTING.getKey(), "0ms")
+                .build()
+        );
+        indexRandom(
+            true,
+            IntStream.range(1, 100)
+                .mapToObj(i -> client().prepareIndex(indexName, "_doc").setSource("field", randomAlphaOfLength(50)))
+                .toArray(IndexRequestBuilder[]::new)
+        );
+        forceMerge();
+        refresh();
+
+        // just check it does not throw when not refreshed.
+        capacity();
+
+        IndicesStatsResponse stats = client().admin().indices().prepareStats(indexName).clear().setStore(true).get();
+        long used = stats.getTotal().getStore().getSizeInBytes();
+        long minShardSize = Arrays.stream(stats.getShards()).mapToLong(s -> s.getStats().getStore().sizeInBytes()).min().getAsLong();
+        long maxShardSize = Arrays.stream(stats.getShards()).mapToLong(s -> s.getStats().getStore().sizeInBytes()).max().getAsLong();
+        long enoughSpace = used + WATERMARK_BYTES + 1;
+
+        setTotalSpace(dataNodeName, enoughSpace);
+        GetAutoscalingCapacityAction.Response response = capacity();
+        assertThat(response.results().keySet(), Matchers.equalTo(org.elasticsearch.common.collect.Set.of(policyName)));
+        assertThat(response.results().get(policyName).currentCapacity().total().storage().getBytes(), Matchers.equalTo(enoughSpace));
+        assertThat(response.results().get(policyName).requiredCapacity().total().storage().getBytes(), Matchers.equalTo(enoughSpace));
+        assertThat(response.results().get(policyName).requiredCapacity().node().storage().getBytes(), Matchers.equalTo(maxShardSize));
+
+        setTotalSpace(dataNodeName, enoughSpace - 2);
+        response = capacity();
+        assertThat(response.results().keySet(), Matchers.equalTo(org.elasticsearch.common.collect.Set.of(policyName)));
+        assertThat(response.results().get(policyName).currentCapacity().total().storage().getBytes(), Matchers.equalTo(enoughSpace - 2));
+        assertThat(
+            response.results().get(policyName).requiredCapacity().total().storage().getBytes(),
+            Matchers.greaterThan(enoughSpace - 2)
+        );
+        assertThat(
+            response.results().get(policyName).requiredCapacity().total().storage().getBytes(),
+            Matchers.lessThanOrEqualTo(enoughSpace + minShardSize)
+        );
+        assertThat(response.results().get(policyName).requiredCapacity().node().storage().getBytes(), Matchers.equalTo(maxShardSize));
+    }
+
+    /**
+     * Verify that the list of roles includes all data roles to ensure we consider adding future data roles.
+     */
+    public void testRoles() {
+        // this has to be an integration test to ensure roles are available.
+        internalCluster().startMasterOnlyNode();
+        ReactiveStorageDeciderService service = new ReactiveStorageDeciderService(
+            Settings.EMPTY,
+            new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
+            null
+        );
+        assertThat(
+            service.roles().stream().sorted().collect(Collectors.toList()),
+            Matchers.equalTo(
+                DiscoveryNode.getPossibleRoles().stream().filter(DiscoveryNodeRole::canContainData).sorted().collect(Collectors.toList())
+            )
+        );
+    }
+
+    public void setTotalSpace(String dataNodeName, long totalSpace) {
+        getTestFileStore(dataNodeName).setTotalSpace(totalSpace);
+        final ClusterInfoService clusterInfoService = internalCluster().getCurrentMasterNodeInstance(ClusterInfoService.class);
+        ((InternalClusterInfoService) clusterInfoService).refresh();
+    }
+
+    public GetAutoscalingCapacityAction.Response capacity() {
+        GetAutoscalingCapacityAction.Request request = new GetAutoscalingCapacityAction.Request();
+        GetAutoscalingCapacityAction.Response response = client().execute(GetAutoscalingCapacityAction.INSTANCE, request).actionGet();
+        return response;
+    }
+
+    private void putAutoscalingPolicy(String policyName) {
+        final PutAutoscalingPolicyAction.Request request = new PutAutoscalingPolicyAction.Request(
+            policyName,
+            new TreeSet<>(org.elasticsearch.common.collect.Set.of("data")),
+            new TreeMap<>(org.elasticsearch.common.collect.Map.of("reactive_storage", Settings.EMPTY))
+        );
+        assertAcked(client().execute(PutAutoscalingPolicyAction.INSTANCE, request).actionGet());
+    }
+}

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/Autoscaling.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/Autoscaling.java
@@ -6,6 +6,7 @@
 
 package org.elasticsearch.xpack.autoscaling;
 
+import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.Build;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
@@ -14,6 +15,7 @@ import org.elasticsearch.cluster.NamedDiff;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
@@ -51,6 +53,7 @@ import org.elasticsearch.xpack.autoscaling.rest.RestDeleteAutoscalingPolicyHandl
 import org.elasticsearch.xpack.autoscaling.rest.RestGetAutoscalingCapacityHandler;
 import org.elasticsearch.xpack.autoscaling.rest.RestGetAutoscalingPolicyHandler;
 import org.elasticsearch.xpack.autoscaling.rest.RestPutAutoscalingPolicyHandler;
+import org.elasticsearch.xpack.autoscaling.storage.ReactiveStorageDeciderService;
 import org.elasticsearch.xpack.core.XPackPlugin;
 
 import java.util.ArrayList;
@@ -94,6 +97,8 @@ public class Autoscaling extends Plugin implements ActionPlugin, ExtensiblePlugi
     private final boolean enabled;
 
     private final List<AutoscalingExtension> autoscalingExtensions;
+    private final SetOnce<ClusterService> clusterService = new SetOnce<>();
+    private final SetOnce<AllocationDeciders> allocationDeciders = new SetOnce<>();
 
     public Autoscaling(final Settings settings) {
         this.enabled = AUTOSCALING_ENABLED_SETTING.get(settings);
@@ -132,6 +137,7 @@ public class Autoscaling extends Plugin implements ActionPlugin, ExtensiblePlugi
         IndexNameExpressionResolver indexNameExpressionResolver,
         Supplier<RepositoriesService> repositoriesServiceSupplier
     ) {
+        this.clusterService.set(clusterService);
         return org.elasticsearch.common.collect.List.of(new AutoscalingCalculateCapacityService.Holder(this));
     }
 
@@ -180,6 +186,11 @@ public class Autoscaling extends Plugin implements ActionPlugin, ExtensiblePlugi
                 AutoscalingDeciderResult.Reason.class,
                 FixedAutoscalingDeciderService.NAME,
                 FixedAutoscalingDeciderService.FixedReason::new
+            ),
+            new NamedWriteableRegistry.Entry(
+                AutoscalingDeciderResult.Reason.class,
+                ReactiveStorageDeciderService.NAME,
+                ReactiveStorageDeciderService.ReactiveReason::new
             )
         );
     }
@@ -202,10 +213,19 @@ public class Autoscaling extends Plugin implements ActionPlugin, ExtensiblePlugi
 
     @Override
     public Collection<AutoscalingDeciderService> deciders() {
-        return org.elasticsearch.common.collect.List.of(new FixedAutoscalingDeciderService());
+        assert allocationDeciders.get() != null;
+        return org.elasticsearch.common.collect.List.of(
+            new FixedAutoscalingDeciderService(),
+            new ReactiveStorageDeciderService(
+                clusterService.get().getSettings(),
+                clusterService.get().getClusterSettings(),
+                allocationDeciders.get()
+            )
+        );
     }
 
-    public Set<AutoscalingDeciderService> createDeciderServices() {
+    public Set<AutoscalingDeciderService> createDeciderServices(AllocationDeciders allocationDeciders) {
+        this.allocationDeciders.set(allocationDeciders);
         return autoscalingExtensions.stream().flatMap(p -> p.deciders().stream()).collect(Collectors.toSet());
     }
 }

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/action/GetAutoscalingCapacityAction.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/action/GetAutoscalingCapacityAction.java
@@ -83,6 +83,10 @@ public class GetAutoscalingCapacityAction extends ActionType<GetAutoscalingCapac
             out.writeMap(results, StreamOutput::writeString, (o, decision) -> decision.writeTo(o));
         }
 
+        public SortedMap<String, AutoscalingDeciderResults> results() {
+            return results;
+        }
+
         @Override
         public XContentBuilder toXContent(final XContentBuilder builder, final Params params) throws IOException {
             builder.startObject();

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/action/TransportGetAutoscalingCapacityAction.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/action/TransportGetAutoscalingCapacityAction.java
@@ -13,8 +13,10 @@ import org.elasticsearch.cluster.ClusterInfoService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.snapshots.SnapshotsInfoService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingCalculateCapacityService;
@@ -25,6 +27,7 @@ public class TransportGetAutoscalingCapacityAction extends TransportMasterNodeAc
 
     private final AutoscalingCalculateCapacityService capacityService;
     private final ClusterInfoService clusterInfoService;
+    private final SnapshotsInfoService snapshotsInfoService;
 
     @Inject
     public TransportGetAutoscalingCapacityAction(
@@ -34,7 +37,9 @@ public class TransportGetAutoscalingCapacityAction extends TransportMasterNodeAc
         final ActionFilters actionFilters,
         final IndexNameExpressionResolver indexNameExpressionResolver,
         final AutoscalingCalculateCapacityService.Holder capacityServiceHolder,
-        final ClusterInfoService clusterInfoService
+        final ClusterInfoService clusterInfoService,
+        final SnapshotsInfoService snapshotsInfoService,
+        final AllocationDeciders allocationDeciders
     ) {
         super(
             GetAutoscalingCapacityAction.NAME,
@@ -47,7 +52,8 @@ public class TransportGetAutoscalingCapacityAction extends TransportMasterNodeAc
             GetAutoscalingCapacityAction.Response::new,
             ThreadPool.Names.SAME
         );
-        this.capacityService = capacityServiceHolder.get();
+        this.snapshotsInfoService = snapshotsInfoService;
+        this.capacityService = capacityServiceHolder.get(allocationDeciders);
         this.clusterInfoService = clusterInfoService;
         assert this.capacityService != null;
     }
@@ -59,7 +65,9 @@ public class TransportGetAutoscalingCapacityAction extends TransportMasterNodeAc
         final ActionListener<GetAutoscalingCapacityAction.Response> listener
     ) {
         listener.onResponse(
-            new GetAutoscalingCapacityAction.Response(capacityService.calculate(state, clusterInfoService.getClusterInfo()))
+            new GetAutoscalingCapacityAction.Response(
+                capacityService.calculate(state, clusterInfoService.getClusterInfo(), snapshotsInfoService.snapshotShardSizes())
+            )
         );
     }
 

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/action/TransportPutAutoscalingPolicyAction.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/action/TransportPutAutoscalingPolicyAction.java
@@ -20,6 +20,7 @@ import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -50,9 +51,17 @@ public class TransportPutAutoscalingPolicyAction extends AcknowledgedTransportMa
         final ThreadPool threadPool,
         final ActionFilters actionFilters,
         final IndexNameExpressionResolver indexNameExpressionResolver,
+        final AllocationDeciders allocationDeciders,
         final AutoscalingCalculateCapacityService.Holder policyValidatorHolder
     ) {
-        this(transportService, clusterService, threadPool, actionFilters, indexNameExpressionResolver, policyValidatorHolder.get());
+        this(
+            transportService,
+            clusterService,
+            threadPool,
+            actionFilters,
+            indexNameExpressionResolver,
+            policyValidatorHolder.get(allocationDeciders)
+        );
     }
 
     TransportPutAutoscalingPolicyAction(

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingDeciderContext.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingDeciderContext.java
@@ -6,12 +6,17 @@
 
 package org.elasticsearch.xpack.autoscaling.capacity;
 
+import org.elasticsearch.cluster.ClusterInfo;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.snapshots.SnapshotShardSizeInfo;
 
 import java.util.Set;
 
 public interface AutoscalingDeciderContext {
+    /**
+     * The cluster state to use when calculation a capacity.
+     */
     ClusterState state();
 
     /**
@@ -24,4 +29,15 @@ public interface AutoscalingDeciderContext {
      * Return the nodes governed by the policy.
      */
     Set<DiscoveryNode> nodes();
+
+    /**
+     * The cluster info to use when calculating a capacity. This represents the storage use on nodes including per shard usage.
+     */
+    ClusterInfo info();
+
+    /**
+     * The snapshot shard size info to use when calculating decider capacity. This represents shard sizes of unallocated restores of
+     * shards
+     */
+    SnapshotShardSizeInfo snapshotShardSizeInfo();
 }

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderService.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderService.java
@@ -1,0 +1,379 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.autoscaling.storage;
+
+import org.elasticsearch.cluster.ClusterInfo;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.DiskUsage;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.cluster.routing.RoutingNode;
+import org.elasticsearch.cluster.routing.RoutingNodes;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.routing.ShardRoutingState;
+import org.elasticsearch.cluster.routing.allocation.DiskThresholdSettings;
+import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
+import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
+import org.elasticsearch.cluster.routing.allocation.decider.Decision;
+import org.elasticsearch.cluster.routing.allocation.decider.DiskThresholdDecider;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.snapshots.SnapshotShardSizeInfo;
+import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingCapacity;
+import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingDeciderContext;
+import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingDeciderResult;
+import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingDeciderService;
+import org.elasticsearch.xpack.core.DataTier;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+public class ReactiveStorageDeciderService implements AutoscalingDeciderService {
+    public static final String NAME = "reactive_storage";
+
+    private final DiskThresholdSettings diskThresholdSettings;
+    private final AllocationDeciders allocationDeciders;
+
+    public ReactiveStorageDeciderService(Settings settings, ClusterSettings clusterSettings, AllocationDeciders allocationDeciders) {
+        this.diskThresholdSettings = new DiskThresholdSettings(settings, clusterSettings);
+        this.allocationDeciders = allocationDeciders;
+    }
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public List<Setting<?>> deciderSettings() {
+        return org.elasticsearch.common.collect.List.of();
+    }
+
+    @Override
+    public List<DiscoveryNodeRole> roles() {
+        return org.elasticsearch.common.collect.List.of(
+            DiscoveryNodeRole.DATA_ROLE,
+            DataTier.DATA_CONTENT_NODE_ROLE,
+            DataTier.DATA_HOT_NODE_ROLE,
+            DataTier.DATA_WARM_NODE_ROLE,
+            DataTier.DATA_COLD_NODE_ROLE
+        );
+    }
+
+    @Override
+    public AutoscalingDeciderResult scale(Settings configuration, AutoscalingDeciderContext context) {
+        AutoscalingCapacity autoscalingCapacity = context.currentCapacity();
+        if (autoscalingCapacity == null || autoscalingCapacity.total().storage() == null) {
+            return new AutoscalingDeciderResult(null, new ReactiveReason("current capacity not available", -1, -1));
+        }
+
+        AllocationState allocationState = new AllocationState(context, diskThresholdSettings, allocationDeciders);
+        long unassignedBytes = allocationState.storagePreventsAllocation();
+        long assignedBytes = allocationState.storagePreventsRemainOrMove();
+        long maxShardSize = allocationState.maxShardSize();
+        assert assignedBytes >= 0;
+        assert unassignedBytes >= 0;
+        assert maxShardSize >= 0;
+        String message = message(unassignedBytes, assignedBytes);
+        AutoscalingCapacity requiredCapacity = AutoscalingCapacity.builder()
+            .total(autoscalingCapacity.total().storage().getBytes() + unassignedBytes + assignedBytes, null)
+            .node(maxShardSize, null)
+            .build();
+        return new AutoscalingDeciderResult(requiredCapacity, new ReactiveReason(message, unassignedBytes, assignedBytes));
+    }
+
+    static String message(long unassignedBytes, long assignedBytes) {
+        return unassignedBytes > 0 || assignedBytes > 0
+            ? "not enough storage available, needs " + new ByteSizeValue(unassignedBytes + assignedBytes)
+            : "storage ok";
+    }
+
+    static boolean isDiskOnlyNoDecision(Decision decision) {
+        // we consider throttling==yes, throttling should be temporary.
+        List<Decision> nos = decision.getDecisions()
+            .stream()
+            .filter(single -> single.type() == Decision.Type.NO)
+            .collect(Collectors.toList());
+        return nos.size() == 1 && DiskThresholdDecider.NAME.equals(nos.get(0).label());
+    }
+
+    static class AllocationState {
+        private final ClusterState state;
+        private final AllocationDeciders allocationDeciders;
+        private final DiskThresholdSettings diskThresholdSettings;
+        private final ClusterInfo info;
+        private final SnapshotShardSizeInfo shardSizeInfo;
+        private final Predicate<DiscoveryNode> nodeTierPredicate;
+        private final Set<DiscoveryNode> nodes;
+
+        AllocationState(
+            AutoscalingDeciderContext context,
+            DiskThresholdSettings diskThresholdSettings,
+            AllocationDeciders allocationDeciders
+        ) {
+            this(
+                context.state(),
+                allocationDeciders,
+                diskThresholdSettings,
+                context.info(),
+                context.snapshotShardSizeInfo(),
+                context.nodes()
+            );
+        }
+
+        AllocationState(
+            ClusterState state,
+            AllocationDeciders allocationDeciders,
+            DiskThresholdSettings diskThresholdSettings,
+            ClusterInfo info,
+            SnapshotShardSizeInfo shardSizeInfo,
+            Set<DiscoveryNode> nodes
+        ) {
+            this.state = state;
+            this.allocationDeciders = allocationDeciders;
+            this.diskThresholdSettings = diskThresholdSettings;
+            this.info = info;
+            this.shardSizeInfo = shardSizeInfo;
+            this.nodes = nodes;
+            this.nodeTierPredicate = nodes::contains;
+        }
+
+        public long storagePreventsAllocation() {
+            RoutingNodes routingNodes = new RoutingNodes(state, false);
+            RoutingAllocation allocation = new RoutingAllocation(
+                allocationDeciders,
+                routingNodes,
+                state,
+                info,
+                shardSizeInfo,
+                System.nanoTime()
+            );
+            return StreamSupport.stream(state.getRoutingNodes().unassigned().spliterator(), false)
+                .filter(shard -> canAllocate(shard, allocation) == false)
+                .filter(shard -> cannotAllocateDueToStorage(shard, allocation))
+                .mapToLong(this::sizeOf)
+                .sum();
+        }
+
+        public long storagePreventsRemainOrMove() {
+            RoutingNodes routingNodes = new RoutingNodes(state, false);
+            RoutingAllocation allocation = new RoutingAllocation(
+                allocationDeciders,
+                routingNodes,
+                state,
+                info,
+                shardSizeInfo,
+                System.nanoTime()
+            );
+            List<ShardRouting> candidates = state.getRoutingNodes()
+                .shardsWithState(ShardRoutingState.STARTED)
+                .stream()
+                .filter(shard -> allocationDeciders.canRemain(shard, routingNodes.node(shard.currentNodeId()), allocation) == Decision.NO)
+                .filter(shard -> canAllocate(shard, allocation) == false)
+                .collect(Collectors.toList());
+
+            // track these to ensure we do not double account if they both cannot remain and allocated due to storage.
+            Set<ShardRouting> unmovableShards = candidates.stream()
+                .filter(s -> allocatedToTier(s, allocation))
+                .filter(s -> cannotRemainDueToStorage(s, allocation))
+                .collect(Collectors.toSet());
+            long unmovableBytes = unmovableShards.stream()
+                .collect(Collectors.groupingBy(ShardRouting::currentNodeId))
+                .entrySet()
+                .stream()
+                .mapToLong(e -> unmovableSize(e.getKey(), e.getValue()))
+                .sum();
+
+            long unallocatableBytes = candidates.stream()
+                .filter(not(unmovableShards::contains))
+                .filter(s1 -> cannotAllocateDueToStorage(s1, allocation))
+                .mapToLong(this::sizeOf)
+                .sum();
+
+            return unallocatableBytes + unmovableBytes;
+        }
+
+        private boolean allocatedToTier(ShardRouting s, RoutingAllocation allocation) {
+            return nodeTierPredicate.test(allocation.routingNodes().node(s.currentNodeId()).node());
+        }
+
+        /**
+         * Check that disk decider is only decider for a node preventing allocation of the shard.
+         * @return true if and only if a node exists in the tier where only disk decider prevents allocation
+         */
+        private boolean cannotAllocateDueToStorage(ShardRouting shard, RoutingAllocation allocation) {
+            assert allocation.debugDecision() == false;
+            // enable debug decisions to see all decisions and preserve the allocation decision label
+            allocation.debugDecision(true);
+            try {
+                return nodesInTier(allocation.routingNodes()).map(node -> allocationDeciders.canAllocate(shard, node, allocation))
+                    .anyMatch(ReactiveStorageDeciderService::isDiskOnlyNoDecision);
+            } finally {
+                allocation.debugDecision(false);
+            }
+        }
+
+        /**
+         * Check that the disk decider is only decider that says NO to let shard remain on current node.
+         * @return true if and only if disk decider is only decider that says NO to canRemain.
+         */
+        private boolean cannotRemainDueToStorage(ShardRouting shard, RoutingAllocation allocation) {
+            assert allocation.debugDecision() == false;
+            // enable debug decisions to see all decisions and preserve the allocation decision label
+            allocation.debugDecision(true);
+            try {
+                return isDiskOnlyNoDecision(
+                    allocationDeciders.canRemain(shard, allocation.routingNodes().node(shard.currentNodeId()), allocation)
+                );
+            } finally {
+                allocation.debugDecision(false);
+            }
+        }
+
+        private boolean canAllocate(ShardRouting shard, RoutingAllocation allocation) {
+            return nodesInTier(allocation.routingNodes()).anyMatch(
+                node -> allocationDeciders.canAllocate(shard, node, allocation) != Decision.NO
+            );
+        }
+
+        public long maxShardSize() {
+            return nodesInTier(state.getRoutingNodes()).flatMap(rn -> StreamSupport.stream(rn.spliterator(), false))
+                .mapToLong(this::sizeOf)
+                .max()
+                .orElse(0L);
+        }
+
+        long sizeOf(ShardRouting shard) {
+            long expectedShardSize = getExpectedShardSize(shard);
+            if (expectedShardSize == 0L && shard.primary() == false) {
+                ShardRouting primary = state.getRoutingNodes().activePrimary(shard.shardId());
+                if (primary != null) {
+                    expectedShardSize = getExpectedShardSize(primary);
+                }
+            }
+            assert expectedShardSize >= 0;
+            // todo: we should ideally not have the level of uncertainty we have here.
+            return expectedShardSize == 0L ? ByteSizeUnit.KB.toBytes(1) : expectedShardSize;
+        }
+
+        private long getExpectedShardSize(ShardRouting shard) {
+            return DiskThresholdDecider.getExpectedShardSize(shard, 0L, info, shardSizeInfo, state.metadata(), state.routingTable());
+        }
+
+        long unmovableSize(String nodeId, Collection<ShardRouting> shards) {
+            ClusterInfo info = this.info;
+            DiskUsage diskUsage = info.getNodeMostAvailableDiskUsages().get(nodeId);
+            if (diskUsage == null) {
+                // do not want to scale up then, since this should only happen when node has just joined (clearly edge case).
+                return 0;
+            }
+
+            long threshold = Math.max(
+                diskThresholdSettings.getFreeBytesThresholdHigh().getBytes(),
+                thresholdFromPercentage(diskThresholdSettings.getFreeDiskThresholdHigh(), diskUsage)
+            );
+            long missing = threshold - diskUsage.getFreeBytes();
+            return Math.max(missing, shards.stream().mapToLong(this::sizeOf).min().getAsLong());
+        }
+
+        private long thresholdFromPercentage(Double percentage, DiskUsage diskUsage) {
+            if (percentage == null) {
+                return 0L;
+            }
+
+            return (long) Math.ceil(diskUsage.getTotalBytes() * percentage / 100);
+        }
+
+        Stream<RoutingNode> nodesInTier(RoutingNodes routingNodes) {
+            return nodes.stream().map(n -> routingNodes.node(n.getId()));
+        }
+    }
+
+    public static class ReactiveReason implements AutoscalingDeciderResult.Reason {
+        private final String reason;
+        private final long unassigned;
+        private final long assigned;
+
+        public ReactiveReason(String reason, long unassigned, long assigned) {
+            this.reason = reason;
+            this.unassigned = unassigned;
+            this.assigned = assigned;
+        }
+
+        public ReactiveReason(StreamInput in) throws IOException {
+            this.reason = in.readString();
+            this.unassigned = in.readLong();
+            this.assigned = in.readLong();
+        }
+
+        @Override
+        public String summary() {
+            return reason;
+        }
+
+        public long unassigned() {
+            return unassigned;
+        }
+
+        public long assigned() {
+            return assigned;
+        }
+
+        @Override
+        public String getWriteableName() {
+            return ReactiveStorageDeciderService.NAME;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeString(reason);
+            out.writeLong(unassigned);
+            out.writeLong(assigned);
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            builder.field("reason", reason);
+            builder.field("unassigned", unassigned);
+            builder.field("assigned", assigned);
+            builder.endObject();
+            return builder;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            ReactiveReason that = (ReactiveReason) o;
+            return unassigned == that.unassigned && assigned == that.assigned && reason.equals(that.reason);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(reason, unassigned, assigned);
+        }
+    }
+
+    // java 11 forward compatibility
+    static <T> Predicate<T> not(Predicate<T> predicate) {
+        return predicate.negate();
+    }
+}

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingCalculateCapacityServiceTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingCalculateCapacityServiceTests.java
@@ -19,6 +19,8 @@ import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.snapshots.InternalSnapshotsInfoService;
+import org.elasticsearch.snapshots.SnapshotShardSizeInfo;
 import org.elasticsearch.xpack.autoscaling.AutoscalingMetadata;
 import org.elasticsearch.xpack.autoscaling.AutoscalingTestCase;
 import org.elasticsearch.xpack.autoscaling.policy.AutoscalingPolicy;
@@ -39,6 +41,9 @@ import java.util.stream.StreamSupport;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
 
 public class AutoscalingCalculateCapacityServiceTests extends AutoscalingTestCase {
     public void testMultiplePoliciesFixedCapacity() {
@@ -57,8 +62,7 @@ public class AutoscalingCalculateCapacityServiceTests extends AutoscalingTestCas
         ClusterState state = ClusterState.builder(ClusterName.DEFAULT)
             .metadata(Metadata.builder().putCustom(AutoscalingMetadata.NAME, new AutoscalingMetadata(policies)))
             .build();
-        SortedMap<String, AutoscalingDeciderResults> resultsMap = service.calculate(state, new ClusterInfo() {
-        });
+        SortedMap<String, AutoscalingDeciderResults> resultsMap = service.calculate(state, ClusterInfo.EMPTY, null);
         assertThat(resultsMap.keySet(), equalTo(policyNames));
         for (Map.Entry<String, AutoscalingDeciderResults> entry : resultsMap.entrySet()) {
             AutoscalingDeciderResults results = entry.getValue();
@@ -122,7 +126,7 @@ public class AutoscalingCalculateCapacityServiceTests extends AutoscalingTestCas
             .build();
 
         assertThat(
-            service.calculate(state, ClusterInfo.EMPTY).get("test").results().keySet(),
+            service.calculate(state, ClusterInfo.EMPTY, SnapshotShardSizeInfo.EMPTY).get("test").results().keySet(),
             equalTo(org.elasticsearch.common.collect.Set.of(defaultOn.name()))
         );
     }
@@ -160,13 +164,20 @@ public class AutoscalingCalculateCapacityServiceTests extends AutoscalingTestCas
         ClusterState state = ClusterState.builder(ClusterName.DEFAULT).build();
         ClusterInfo info = ClusterInfo.EMPTY;
         SortedSet<String> roleNames = randomRoles();
-        AutoscalingCalculateCapacityService.DefaultAutoscalingDeciderContext context =
-            new AutoscalingCalculateCapacityService.DefaultAutoscalingDeciderContext(roleNames, state, info);
+
+        AutoscalingCalculateCapacityService service = new AutoscalingCalculateCapacityService(
+            org.elasticsearch.common.collect.Set.of(new FixedAutoscalingDeciderService())
+        );
+        SnapshotShardSizeInfo snapshotShardSizeInfo = new SnapshotShardSizeInfo(
+            ImmutableOpenMap.<InternalSnapshotsInfoService.SnapshotShard, Long>builder().build()
+        );
+        AutoscalingDeciderContext context = service.createContext(roleNames, state, info, snapshotShardSizeInfo);
 
         assertSame(state, context.state());
-
         assertThat(context.nodes(), equalTo(org.elasticsearch.common.collect.Set.of()));
         assertThat(context.currentCapacity(), equalTo(AutoscalingCapacity.ZERO));
+        assertThat(context.info(), sameInstance(info));
+        assertThat(context.snapshotShardSizeInfo(), sameInstance(snapshotShardSizeInfo));
 
         Set<DiscoveryNodeRole> roles = roleNames.stream().map(DiscoveryNode::getRoleFromRoleName).collect(Collectors.toSet());
         Set<DiscoveryNodeRole> otherRoles = mutateRoles(roleNames).stream()
@@ -186,14 +197,14 @@ public class AutoscalingCalculateCapacityServiceTests extends AutoscalingTestCas
                     )
             )
             .build();
-        context = new AutoscalingCalculateCapacityService.DefaultAutoscalingDeciderContext(roleNames, state, info);
+        context = new AutoscalingCalculateCapacityService.DefaultAutoscalingDeciderContext(roleNames, state, info, null);
 
         assertThat(context.nodes().size(), equalTo(1));
         assertThat(context.nodes(), equalTo(StreamSupport.stream(state.nodes().spliterator(), false).collect(Collectors.toSet())));
         assertNull(context.currentCapacity());
 
-        ImmutableOpenMap.Builder<String, DiskUsage> leastUsages = ImmutableOpenMap.<String, DiskUsage>builder();
-        ImmutableOpenMap.Builder<String, DiskUsage> mostUsages = ImmutableOpenMap.<String, DiskUsage>builder();
+        ImmutableOpenMap.Builder<String, DiskUsage> leastUsagesBuilder = ImmutableOpenMap.builder();
+        ImmutableOpenMap.Builder<String, DiskUsage> mostUsagesBuilder = ImmutableOpenMap.builder();
         DiscoveryNodes.Builder nodes = DiscoveryNodes.builder();
         Set<DiscoveryNode> expectedNodes = new HashSet<>();
         long sumTotal = 0;
@@ -210,20 +221,29 @@ public class AutoscalingCalculateCapacityServiceTests extends AutoscalingTestCas
             );
             nodes.add(node);
 
-            long total = randomLongBetween(1, 1L << 40);
-            long total1 = randomBoolean() ? total : randomLongBetween(0, total);
-            long total2 = total1 != total ? total : randomLongBetween(0, total);
-            leastUsages.fPut(nodeId, new DiskUsage(nodeId, null, null, total1, randomLongBetween(0, total)));
-            mostUsages.fPut(nodeId, new DiskUsage(nodeId, null, null, total2, randomLongBetween(0, total)));
             if (useOtherRoles == false) {
+                long total = randomLongBetween(1, 1L << 40);
+                DiskUsage diskUsage = new DiskUsage(nodeId, null, randomAlphaOfLength(5), total, randomLongBetween(0, total));
+                leastUsagesBuilder.put(nodeId, diskUsage);
+                if (randomBoolean()) {
+                    diskUsage = new DiskUsage(nodeId, null, diskUsage.getPath(), total, diskUsage.getFreeBytes());
+                }
+                mostUsagesBuilder.put(nodeId, diskUsage);
                 sumTotal += total;
                 maxTotal = Math.max(total, maxTotal);
                 expectedNodes.add(node);
+            } else {
+                long total1 = randomLongBetween(0, 1L << 40);
+                leastUsagesBuilder.put(nodeId, new DiskUsage(nodeId, null, randomAlphaOfLength(5), total1, randomLongBetween(0, total1)));
+                long total2 = randomLongBetween(0, 1L << 40);
+                mostUsagesBuilder.put(nodeId, new DiskUsage(nodeId, null, randomAlphaOfLength(5), total2, randomLongBetween(0, total2)));
             }
         }
         state = ClusterState.builder(ClusterName.DEFAULT).nodes(nodes).build();
-        info = new ClusterInfo(leastUsages.build(), mostUsages.build(), null, null, null);
-        context = new AutoscalingCalculateCapacityService.DefaultAutoscalingDeciderContext(roleNames, state, info);
+        ImmutableOpenMap<String, DiskUsage> leastUsages = leastUsagesBuilder.build();
+        ImmutableOpenMap<String, DiskUsage> mostUsages = mostUsagesBuilder.build();
+        info = new ClusterInfo(leastUsages, mostUsages, null, null, null);
+        context = new AutoscalingCalculateCapacityService.DefaultAutoscalingDeciderContext(roleNames, state, info, null);
 
         assertThat(context.nodes(), equalTo(expectedNodes));
         AutoscalingCapacity capacity = context.currentCapacity();
@@ -232,6 +252,27 @@ public class AutoscalingCalculateCapacityServiceTests extends AutoscalingTestCas
         // todo: fix these once we know memory of all nodes on master.
         assertThat(capacity.node().memory(), equalTo(ByteSizeValue.ZERO));
         assertThat(capacity.total().memory(), equalTo(ByteSizeValue.ZERO));
+
+        if (expectedNodes.isEmpty() == false) {
+            String multiPathNodeId = randomFrom(expectedNodes).getId();
+            mostUsagesBuilder = ImmutableOpenMap.builder(mostUsages);
+            DiskUsage original = mostUsagesBuilder.get(multiPathNodeId);
+            mostUsagesBuilder.put(
+                multiPathNodeId,
+                new DiskUsage(
+                    multiPathNodeId,
+                    null,
+                    randomValueOtherThan(original.getPath(), () -> randomAlphaOfLength(5)),
+                    original.getTotalBytes(),
+                    original.getFreeBytes()
+                )
+            );
+
+            info = new ClusterInfo(leastUsages, mostUsagesBuilder.build(), null, null, null);
+            context = new AutoscalingCalculateCapacityService.DefaultAutoscalingDeciderContext(roleNames, state, info, null);
+            assertThat(context.nodes(), equalTo(expectedNodes));
+            assertThat(context.currentCapacity(), is(nullValue()));
+        }
     }
 
     public void testValidateDeciderName() {

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderDecisionTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderDecisionTests.java
@@ -1,0 +1,573 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.autoscaling.storage;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterInfo;
+import org.elasticsearch.cluster.ClusterModule;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.DiskUsage;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.routing.RoutingNode;
+import org.elasticsearch.cluster.routing.RoutingNodes;
+import org.elasticsearch.cluster.routing.RoutingTable;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.routing.ShardRoutingState;
+import org.elasticsearch.cluster.routing.allocation.DiskThresholdSettings;
+import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
+import org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator;
+import org.elasticsearch.cluster.routing.allocation.decider.AllocationDecider;
+import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
+import org.elasticsearch.cluster.routing.allocation.decider.Decision;
+import org.elasticsearch.cluster.routing.allocation.decider.DiskThresholdDecider;
+import org.elasticsearch.cluster.routing.allocation.decider.ThrottlingAllocationDecider;
+import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.snapshots.SnapshotShardSizeInfo;
+import org.elasticsearch.xpack.autoscaling.AutoscalingTestCase;
+import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingCapacity;
+import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingDeciderContext;
+import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingDeciderResult;
+import org.elasticsearch.xpack.cluster.routing.allocation.DataTierAllocationDecider;
+import org.elasticsearch.xpack.core.DataTier;
+import org.junit.Before;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import static org.elasticsearch.xpack.core.DataTier.DATA_HOT_NODE_ROLE;
+import static org.elasticsearch.xpack.core.DataTier.DATA_WARM_NODE_ROLE;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
+
+/**
+ * Test the higher level parts of {@link ReactiveStorageDeciderService} that all require a similar setup.
+ */
+public class ReactiveStorageDeciderDecisionTests extends AutoscalingTestCase {
+    private static final Logger logger = LogManager.getLogger(ReactiveStorageDeciderDecisionTests.class);
+
+    private static final AllocationDecider CAN_ALLOCATE_NO_DECIDER = new AllocationDecider() {
+        @Override
+        public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
+            return Decision.NO;
+        }
+    };
+    private static final AllocationDecider CAN_REMAIN_NO_DECIDER = new AllocationDecider() {
+        @Override
+        public Decision canRemain(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
+            return Decision.NO;
+        }
+    };
+    private static final BalancedShardsAllocator SHARDS_ALLOCATOR = new BalancedShardsAllocator(Settings.EMPTY);
+    private static final DiskThresholdSettings DISK_THRESHOLD_SETTINGS = new DiskThresholdSettings(
+        Settings.EMPTY,
+        new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+    );
+
+    private ClusterState state;
+    private final int hotNodes = randomIntBetween(1, 8);
+    private final int warmNodes = randomIntBetween(1, 3);
+    // these are the shards that the decider tests work on
+    private Set<ShardId> subjectShards;
+    // say NO with disk label for subject shards
+    private final AllocationDecider mockCanAllocateDiskDecider = new AllocationDecider() {
+        @Override
+        public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
+            if (subjectShards.contains(shardRouting.shardId()) && node.node().getName().startsWith("hot")) {
+                return allocation.decision(Decision.NO, DiskThresholdDecider.NAME, "test");
+            }
+            return super.canAllocate(shardRouting, node, allocation);
+        }
+    };
+    // say NO with disk label for subject shards
+    private final AllocationDecider mockCanRemainDiskDecider = new AllocationDecider() {
+        @Override
+        public Decision canRemain(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
+            if (subjectShards.contains(shardRouting.shardId()) && node.node().getName().startsWith("hot")) return allocation.decision(
+                Decision.NO,
+                DiskThresholdDecider.NAME,
+                "test"
+            );
+            return super.canRemain(shardRouting, node, allocation);
+        }
+    };
+
+    @Before
+    public void setup() {
+        DiscoveryNode.setAdditionalRoles(
+            org.elasticsearch.common.collect.Set.of(
+                DataTier.DATA_CONTENT_NODE_ROLE,
+                DataTier.DATA_HOT_NODE_ROLE,
+                DataTier.DATA_WARM_NODE_ROLE,
+                DataTier.DATA_COLD_NODE_ROLE
+            )
+        );
+        ClusterState state = ClusterState.builder(new ClusterName("test")).build();
+        state = addRandomIndices(hotNodes, hotNodes, state);
+        state = addDataNodes(DATA_HOT_NODE_ROLE, "hot", state, hotNodes);
+        state = addDataNodes(DATA_WARM_NODE_ROLE, "warm", state, warmNodes);
+        this.state = state;
+
+        Set<ShardId> shardIds = shardIds(state.getRoutingNodes().unassigned());
+        this.subjectShards = new HashSet<>(randomSubsetOf(randomIntBetween(1, shardIds.size()), shardIds));
+    }
+
+    public void testStoragePreventsAllocation() {
+        ClusterState lastState = null;
+        int maxRounds = state.getRoutingNodes().unassigned().size() + 3; // (allocated + start + detect-same)
+        int round = 0;
+        while (lastState != state && round < maxRounds) {
+            long numPrevents = numAllocatableSubjectShards();
+            assert round != 0 || numPrevents > 0 : "must have shards that can be allocated on first round";
+
+            verify(ReactiveStorageDeciderService.AllocationState::storagePreventsAllocation, numPrevents, mockCanAllocateDiskDecider);
+            verify(
+                ReactiveStorageDeciderService.AllocationState::storagePreventsAllocation,
+                0,
+                mockCanAllocateDiskDecider,
+                CAN_ALLOCATE_NO_DECIDER
+            );
+            verify(ReactiveStorageDeciderService.AllocationState::storagePreventsAllocation, 0);
+            if (numPrevents > 0) {
+                verifyScale(numPrevents, "not enough storage available, needs " + numPrevents + "b", mockCanAllocateDiskDecider);
+            } else {
+                verifyScale(0, "storage ok", mockCanAllocateDiskDecider);
+            }
+            verifyScale(0, "storage ok", mockCanAllocateDiskDecider, CAN_ALLOCATE_NO_DECIDER);
+            verifyScale(0, "storage ok");
+            verifyScale(addDataNodes(DATA_HOT_NODE_ROLE, "additional", state, hotNodes), 0, "storage ok", mockCanAllocateDiskDecider);
+            lastState = state;
+            startRandomShards();
+            ++round;
+        }
+        assert round > 0;
+        assertThat(state, sameInstance(lastState));
+    }
+
+    public void testStoragePreventsMove() {
+        // this test moves shards to warm nodes and then checks that the reactive decider can calculate the storage necessary to move them
+        // back to hot nodes.
+
+        // allocate all primary shards
+        allocate();
+
+        // set of shards to force on to warm nodes.
+        Set<ShardId> warmShards = Sets.union(new HashSet<>(randomSubsetOf(shardIds(state.getRoutingNodes().unassigned()))), subjectShards);
+
+        // start (to be) warm shards. Only use primary shards for simplicity.
+        withRoutingAllocation(
+            allocation -> allocation.routingNodes()
+                .shardsWithState(ShardRoutingState.INITIALIZING)
+                .stream()
+                .filter(ShardRouting::primary)
+                .filter(s -> warmShards.contains(s.shardId()))
+                .forEach(shard -> allocation.routingNodes().startShard(logger, shard, allocation.changes()))
+        );
+
+        do {
+            startRandomShards();
+            // all of the relevant replicas are assigned too.
+        } while (StreamSupport.stream(state.getRoutingNodes().unassigned().spliterator(), false)
+            .map(ShardRouting::shardId)
+            .anyMatch(warmShards::contains));
+
+        // relocate warm shards to warm nodes and start them
+        withRoutingAllocation(
+            allocation -> allocation.routingNodes()
+                .shardsWithState(ShardRoutingState.STARTED)
+                .stream()
+                .filter(ShardRouting::primary)
+                .filter(s -> warmShards.contains(s.shardId()))
+                .forEach(
+                    shard -> allocation.routingNodes()
+                        .startShard(
+                            logger,
+                            allocation.routingNodes()
+                                .relocateShard(
+                                    shard,
+                                    randomNodeId(allocation.routingNodes(), DATA_WARM_NODE_ROLE),
+                                    0L,
+                                    allocation.changes()
+                                )
+                                .v2(),
+                            allocation.changes()
+                        )
+                )
+        );
+
+        verify(
+            ReactiveStorageDeciderService.AllocationState::storagePreventsRemainOrMove,
+            subjectShards.size(),
+            mockCanAllocateDiskDecider
+        );
+        verify(
+            ReactiveStorageDeciderService.AllocationState::storagePreventsRemainOrMove,
+            0,
+            mockCanAllocateDiskDecider,
+            CAN_ALLOCATE_NO_DECIDER
+        );
+        verify(ReactiveStorageDeciderService.AllocationState::storagePreventsRemainOrMove, 0);
+
+        verifyScale(subjectShards.size(), "not enough storage available, needs " + subjectShards.size() + "b", mockCanAllocateDiskDecider);
+        verifyScale(0, "storage ok", mockCanAllocateDiskDecider, CAN_ALLOCATE_NO_DECIDER);
+        verifyScale(0, "storage ok");
+        verifyScale(addDataNodes(DATA_HOT_NODE_ROLE, "additional", state, hotNodes), 0, "storage ok", mockCanAllocateDiskDecider);
+    }
+
+    public void testStoragePreventsRemain() {
+        allocate();
+        // we can only decide on a move for started shards (due to for instance ThrottlingAllocationDecider assertion).
+        for (int i = 0; i < randomIntBetween(1, 4) || hasStartedSubjectShard() == false; ++i) {
+            startRandomShards();
+        }
+
+        // the remain check only assumes the smallest shard need to move off. More detailed testing of AllocationState.unmovableSize in
+        // {@link ReactiveStorageDeciderServiceTests#testUnmovableSize}
+        long nodes = state.routingTable()
+            .shardsWithState(ShardRoutingState.STARTED)
+            .stream()
+            .filter(s -> subjectShards.contains(s.shardId()))
+            .map(ShardRouting::currentNodeId)
+            .distinct()
+            .count();
+
+        verify(
+            ReactiveStorageDeciderService.AllocationState::storagePreventsRemainOrMove,
+            nodes,
+            mockCanRemainDiskDecider,
+            CAN_ALLOCATE_NO_DECIDER
+        );
+        verify(
+            ReactiveStorageDeciderService.AllocationState::storagePreventsRemainOrMove,
+            0,
+            mockCanRemainDiskDecider,
+            CAN_REMAIN_NO_DECIDER,
+            CAN_ALLOCATE_NO_DECIDER
+        );
+        verify(ReactiveStorageDeciderService.AllocationState::storagePreventsRemainOrMove, 0);
+
+        // only consider it once (move case) if both cannot remain and cannot allocate.
+        verify(
+            ReactiveStorageDeciderService.AllocationState::storagePreventsRemainOrMove,
+            nodes,
+            mockCanAllocateDiskDecider,
+            mockCanRemainDiskDecider
+        );
+
+        verifyScale(nodes, "not enough storage available, needs " + nodes + "b", mockCanRemainDiskDecider, CAN_ALLOCATE_NO_DECIDER);
+        verifyScale(0, "storage ok", mockCanRemainDiskDecider, CAN_REMAIN_NO_DECIDER, CAN_ALLOCATE_NO_DECIDER);
+        verifyScale(0, "storage ok");
+    }
+
+    private interface VerificationSubject {
+        long invoke(ReactiveStorageDeciderService.AllocationState state);
+    }
+
+    private void verify(VerificationSubject subject, long expected, AllocationDecider... allocationDeciders) {
+        ReactiveStorageDeciderService.AllocationState allocationState = new ReactiveStorageDeciderService.AllocationState(
+            createContext(DataTier.DATA_HOT_NODE_ROLE),
+            DISK_THRESHOLD_SETTINGS,
+            createAllocationDeciders(allocationDeciders)
+        );
+        assertThat(subject.invoke(allocationState), equalTo(expected));
+    }
+
+    private void verifyScale(long expectedDifference, String reason, AllocationDecider... allocationDeciders) {
+        verifyScale(state, expectedDifference, reason, allocationDeciders);
+    }
+
+    private static void verifyScale(ClusterState state, long expectedDifference, String reason, AllocationDecider... allocationDeciders) {
+        ReactiveStorageDeciderService decider = new ReactiveStorageDeciderService(
+            Settings.EMPTY,
+            new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
+            createAllocationDeciders(allocationDeciders)
+        );
+        TestAutoscalingDeciderContext context = createContext(state, org.elasticsearch.common.collect.Set.of(DataTier.DATA_HOT_NODE_ROLE));
+        AutoscalingDeciderResult result = decider.scale(Settings.EMPTY, context);
+        if (context.currentCapacity != null) {
+            assertThat(
+                result.requiredCapacity().total().storage().getBytes() - context.currentCapacity.total().storage().getBytes(),
+                equalTo(expectedDifference)
+            );
+            assertThat(result.reason().summary(), equalTo(reason));
+        } else {
+            assertThat(result.requiredCapacity(), is(nullValue()));
+            assertThat(result.reason().summary(), equalTo("current capacity not available"));
+        }
+    }
+
+    private long numAllocatableSubjectShards() {
+        AllocationDeciders deciders = createAllocationDeciders();
+        RoutingAllocation allocation = createRoutingAllocation(state, deciders);
+        return StreamSupport.stream(state.getRoutingNodes().unassigned().spliterator(), false)
+            .filter(shard -> subjectShards.contains(shard.shardId()))
+            .filter(
+                shard -> StreamSupport.stream(allocation.routingNodes().spliterator(), false)
+                    .anyMatch(node -> deciders.canAllocate(shard, node, allocation) != Decision.NO)
+            )
+            .count();
+    }
+
+    private boolean hasStartedSubjectShard() {
+        return state.getRoutingNodes()
+            .shardsWithState(ShardRoutingState.STARTED)
+            .stream()
+            .filter(ShardRouting::primary)
+            .map(ShardRouting::shardId)
+            .anyMatch(subjectShards::contains);
+    }
+
+    private static AllocationDeciders createAllocationDeciders(AllocationDecider... extraDeciders) {
+        Set<Setting<?>> allSettings = Stream.concat(
+            ClusterSettings.BUILT_IN_CLUSTER_SETTINGS.stream(),
+            Stream.of(
+                DataTierAllocationDecider.CLUSTER_ROUTING_REQUIRE_SETTING,
+                DataTierAllocationDecider.CLUSTER_ROUTING_INCLUDE_SETTING,
+                DataTierAllocationDecider.CLUSTER_ROUTING_EXCLUDE_SETTING
+            )
+        ).collect(Collectors.toSet());
+
+        ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, allSettings);
+        Collection<AllocationDecider> systemAllocationDeciders = ClusterModule.createAllocationDeciders(
+            Settings.builder()
+                .put(
+                    ThrottlingAllocationDecider.CLUSTER_ROUTING_ALLOCATION_NODE_INITIAL_PRIMARIES_RECOVERIES_SETTING.getKey(),
+                    Integer.MAX_VALUE
+                )
+                .build(),
+            clusterSettings,
+            Collections.emptyList()
+        );
+        return new AllocationDeciders(
+            Stream.of(
+                Stream.of(extraDeciders),
+                Stream.of(new DataTierAllocationDecider(clusterSettings)),
+                systemAllocationDeciders.stream()
+            ).flatMap(s -> s).collect(Collectors.toList())
+        );
+    }
+
+    private static RoutingAllocation createRoutingAllocation(ClusterState state, AllocationDeciders allocationDeciders) {
+        RoutingNodes routingNodes = new RoutingNodes(state, false);
+        return new RoutingAllocation(allocationDeciders, routingNodes, state, createClusterInfo(state), null, System.nanoTime());
+    }
+
+    private void withRoutingAllocation(Consumer<RoutingAllocation> block) {
+        RoutingAllocation allocation = createRoutingAllocation(state, createAllocationDeciders());
+        block.accept(allocation);
+        state = ReactiveStorageDeciderServiceTests.updateClusterState(state, allocation);
+    }
+
+    private void allocate() {
+        withRoutingAllocation(SHARDS_ALLOCATOR::allocate);
+    }
+
+    private void startRandomShards() {
+        withRoutingAllocation(allocation -> {
+            List<ShardRouting> initializingShards = allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING);
+            initializingShards.sort(Comparator.comparing(ShardRouting::shardId).thenComparing(ShardRouting::primary, Boolean::compare));
+            List<ShardRouting> shards = randomSubsetOf(Math.min(randomIntBetween(1, 100), initializingShards.size()), initializingShards);
+
+            // replicas before primaries, since replicas can be reinit'ed, resulting in a new ShardRouting instance.
+            shards.stream()
+                .filter(ReactiveStorageDeciderService.not(ShardRouting::primary))
+                .forEach(s -> allocation.routingNodes().startShard(logger, s, allocation.changes()));
+            shards.stream()
+                .filter(ShardRouting::primary)
+                .forEach(s -> allocation.routingNodes().startShard(logger, s, allocation.changes()));
+            SHARDS_ALLOCATOR.allocate(allocation);
+
+            // ensure progress by only relocating a shard if we started more than one shard.
+            if (shards.size() > 1 && randomBoolean()) {
+                List<ShardRouting> started = allocation.routingNodes().shardsWithState(ShardRoutingState.STARTED);
+                if (started.isEmpty() == false) {
+                    ShardRouting toMove = randomFrom(started);
+                    Set<RoutingNode> candidates = StreamSupport.stream(allocation.routingNodes().spliterator(), false)
+                        .filter(n -> allocation.deciders().canAllocate(toMove, n, allocation) == Decision.YES)
+                        .collect(Collectors.toSet());
+                    if (candidates.isEmpty() == false) {
+                        allocation.routingNodes().relocateShard(toMove, randomFrom(candidates).nodeId(), 0L, allocation.changes());
+                    }
+                }
+            }
+        });
+    }
+
+    private TestAutoscalingDeciderContext createContext(DiscoveryNodeRole role) {
+        return createContext(state, org.elasticsearch.common.collect.Set.of(role));
+    }
+
+    private static TestAutoscalingDeciderContext createContext(ClusterState state, Set<DiscoveryNodeRole> roles) {
+        return new TestAutoscalingDeciderContext(state, roles, randomCurrentCapacity());
+    }
+
+    private static AutoscalingCapacity randomCurrentCapacity() {
+        if (randomInt(4) > 0) {
+            // we only rely on storage.
+            boolean includeMemory = randomBoolean();
+            return AutoscalingCapacity.builder()
+                .total(randomByteSizeValue(), includeMemory ? randomByteSizeValue() : null)
+                .node(randomByteSizeValue(), includeMemory ? randomByteSizeValue() : null)
+                .build();
+        } else {
+            return null;
+        }
+    }
+
+    private static class TestAutoscalingDeciderContext implements AutoscalingDeciderContext {
+        private final ClusterState state;
+        private final AutoscalingCapacity currentCapacity;
+        private final Set<DiscoveryNode> nodes;
+        private final ClusterInfo info;
+
+        private TestAutoscalingDeciderContext(ClusterState state, Set<DiscoveryNodeRole> roles, AutoscalingCapacity currentCapacity) {
+            this.state = state;
+            this.currentCapacity = currentCapacity;
+            this.nodes = StreamSupport.stream(state.nodes().spliterator(), false)
+                .filter(n -> roles.stream().anyMatch(n.getRoles()::contains))
+                .collect(Collectors.toSet());
+            this.info = createClusterInfo(state);
+        }
+
+        @Override
+        public ClusterState state() {
+            return state;
+        }
+
+        @Override
+        public AutoscalingCapacity currentCapacity() {
+            return currentCapacity;
+        }
+
+        @Override
+        public Set<DiscoveryNode> nodes() {
+            return nodes;
+        }
+
+        @Override
+        public ClusterInfo info() {
+            return info;
+        }
+
+        @Override
+        public SnapshotShardSizeInfo snapshotShardSizeInfo() {
+            return null;
+        }
+    }
+
+    private static ClusterInfo createClusterInfo(ClusterState state) {
+        // we make a simple setup to detect the right decisions are made. The unmovable calculation is tested in more detail elsewhere.
+        // the diskusage is set such that the disk threshold decider never rejects an allocation.
+        Map<String, DiskUsage> diskUsages = StreamSupport.stream(state.nodes().spliterator(), false)
+            .collect(Collectors.toMap(DiscoveryNode::getId, node -> new DiskUsage(node.getId(), null, "the_path", 1000, 1000)));
+        ImmutableOpenMap<String, DiskUsage> immutableDiskUsages = ImmutableOpenMap.<String, DiskUsage>builder().putAll(diskUsages).build();
+
+        return new ClusterInfo() {
+            @Override
+            public ImmutableOpenMap<String, DiskUsage> getNodeLeastAvailableDiskUsages() {
+                return immutableDiskUsages;
+            }
+
+            @Override
+            public ImmutableOpenMap<String, DiskUsage> getNodeMostAvailableDiskUsages() {
+                return immutableDiskUsages;
+            }
+
+            @Override
+            public String getDataPath(ShardRouting shardRouting) {
+                return "the_path";
+            }
+
+            @Override
+            public long getShardSize(ShardRouting shardRouting, long defaultValue) {
+                return 1L;
+            }
+
+            @Override
+            public Long getShardSize(ShardRouting shardRouting) {
+                return 1L;
+            }
+        };
+    }
+
+    private static ClusterState addRandomIndices(int minShards, int maxShardCopies, ClusterState state) {
+        String[] tierSettingNames = new String[] {
+            DataTierAllocationDecider.INDEX_ROUTING_REQUIRE,
+            DataTierAllocationDecider.INDEX_ROUTING_INCLUDE,
+            DataTierAllocationDecider.INDEX_ROUTING_PREFER };
+        int shards = randomIntBetween(minShards, 20);
+        Metadata.Builder builder = Metadata.builder();
+        RoutingTable.Builder routingTableBuilder = RoutingTable.builder();
+        while (shards > 0) {
+            IndexMetadata indexMetadata = IndexMetadata.builder("test" + "-" + shards)
+                .settings(settings(Version.CURRENT).put(randomFrom(tierSettingNames), "data_hot"))
+                .numberOfShards(randomIntBetween(1, 5))
+                .numberOfReplicas(randomIntBetween(0, maxShardCopies - 1))
+                .build();
+
+            builder.put(indexMetadata, false);
+            routingTableBuilder.addAsNew(indexMetadata);
+            shards -= indexMetadata.getNumberOfShards() * (indexMetadata.getNumberOfReplicas() + 1);
+        }
+
+        return ClusterState.builder(state).metadata(builder).routingTable(routingTableBuilder.build()).build();
+    }
+
+    private static ClusterState addDataNodes(DiscoveryNodeRole role, String prefix, ClusterState state, int nodes) {
+        DiscoveryNodes.Builder builder = DiscoveryNodes.builder(state.nodes());
+        IntStream.range(0, nodes).mapToObj(i -> newDataNode(role, prefix + "_" + i)).forEach(builder::add);
+        return ClusterState.builder(state).nodes(builder).build();
+    }
+
+    private static DiscoveryNode newDataNode(DiscoveryNodeRole role, String nodeName) {
+        return new DiscoveryNode(
+            nodeName,
+            UUIDs.randomBase64UUID(),
+            buildNewFakeTransportAddress(),
+            org.elasticsearch.common.collect.Map.of(),
+            org.elasticsearch.common.collect.Set.of(role),
+            Version.CURRENT
+        );
+    }
+
+    private static String randomNodeId(RoutingNodes routingNodes, DiscoveryNodeRole role) {
+        return randomFrom(
+            StreamSupport.stream(routingNodes.spliterator(), false)
+                .map(RoutingNode::node)
+                .filter(n -> n.getRoles().contains(role))
+                .collect(Collectors.toSet())
+        ).getId();
+    }
+
+    private static Set<ShardId> shardIds(Iterable<ShardRouting> candidateShards) {
+        return StreamSupport.stream(candidateShards.spliterator(), false).map(ShardRouting::shardId).collect(Collectors.toSet());
+    }
+}

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderReasonWireSerializationTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderReasonWireSerializationTests.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.autoscaling.storage;
+
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.test.ESTestCase;
+
+public class ReactiveStorageDeciderReasonWireSerializationTests extends AbstractWireSerializingTestCase<
+    ReactiveStorageDeciderService.ReactiveReason> {
+    @Override
+    protected Writeable.Reader<ReactiveStorageDeciderService.ReactiveReason> instanceReader() {
+        return ReactiveStorageDeciderService.ReactiveReason::new;
+    }
+
+    @Override
+    protected ReactiveStorageDeciderService.ReactiveReason mutateInstance(ReactiveStorageDeciderService.ReactiveReason instance) {
+        switch (between(0, 2)) {
+            case 0:
+                return new ReactiveStorageDeciderService.ReactiveReason(
+                    randomValueOtherThan(instance.summary(), () -> randomAlphaOfLength(10)),
+                    instance.unassigned(),
+                    instance.assigned()
+                );
+            case 1:
+                return new ReactiveStorageDeciderService.ReactiveReason(
+                    instance.summary(),
+                    randomValueOtherThan(instance.unassigned(), ESTestCase::randomNonNegativeLong),
+                    instance.assigned()
+                );
+            case 2:
+                return new ReactiveStorageDeciderService.ReactiveReason(
+                    instance.summary(),
+                    instance.unassigned(),
+                    randomValueOtherThan(instance.assigned(), ESTestCase::randomNonNegativeLong)
+                );
+            default:
+                fail("unexpected");
+        }
+        return randomValueOtherThan(instance, this::createTestInstance);
+    }
+
+    @Override
+    protected ReactiveStorageDeciderService.ReactiveReason createTestInstance() {
+        return new ReactiveStorageDeciderService.ReactiveReason(randomAlphaOfLength(10), randomNonNegativeLong(), randomNonNegativeLong());
+    }
+}

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderServiceTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderServiceTests.java
@@ -1,0 +1,386 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.autoscaling.storage;
+
+import com.carrotsearch.hppc.IntHashSet;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterInfo;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.DiskUsage;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
+import org.elasticsearch.cluster.routing.RecoverySource;
+import org.elasticsearch.cluster.routing.RoutingNodes;
+import org.elasticsearch.cluster.routing.RoutingTable;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.routing.ShardRoutingState;
+import org.elasticsearch.cluster.routing.TestShardRouting;
+import org.elasticsearch.cluster.routing.allocation.DiskThresholdSettings;
+import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
+import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
+import org.elasticsearch.cluster.routing.allocation.decider.AwarenessAllocationDecider;
+import org.elasticsearch.cluster.routing.allocation.decider.Decision;
+import org.elasticsearch.cluster.routing.allocation.decider.DiskThresholdDecider;
+import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider;
+import org.elasticsearch.cluster.routing.allocation.decider.SameShardAllocationDecider;
+import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.common.collect.Map;
+import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.repositories.IndexId;
+import org.elasticsearch.snapshots.InternalSnapshotsInfoService;
+import org.elasticsearch.snapshots.Snapshot;
+import org.elasticsearch.snapshots.SnapshotId;
+import org.elasticsearch.snapshots.SnapshotShardSizeInfo;
+import org.elasticsearch.xpack.autoscaling.AutoscalingTestCase;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.StreamSupport;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Tests the primitive methods in {@link ReactiveStorageDeciderService}. Tests of higher level methods are in
+ * {@link ReactiveStorageDeciderDecisionTests}
+ */
+public class ReactiveStorageDeciderServiceTests extends AutoscalingTestCase {
+    private static final List<String> SOME_ALLOCATION_DECIDERS = Arrays.asList(
+        SameShardAllocationDecider.NAME,
+        AwarenessAllocationDecider.NAME,
+        EnableAllocationDecider.NAME
+    );
+
+    public void testIsDiskOnlyDecision() {
+        Decision.Multi decision = new Decision.Multi();
+        if (randomBoolean()) {
+            decision.add(randomFrom(Decision.YES, Decision.ALWAYS, Decision.THROTTLE));
+        }
+        decision.add(new Decision.Single(Decision.Type.NO, DiskThresholdDecider.NAME, "test"));
+        randomSubsetOf(SOME_ALLOCATION_DECIDERS).stream()
+            .map(
+                label -> new Decision.Single(
+                    randomValueOtherThan(Decision.Type.NO, () -> randomFrom(Decision.Type.values())),
+                    label,
+                    "test " + label
+                )
+            )
+            .forEach(decision::add);
+
+        assertThat(ReactiveStorageDeciderService.isDiskOnlyNoDecision(decision), is(true));
+    }
+
+    public void testIsNotDiskOnlyDecision() {
+        Decision.Multi decision = new Decision.Multi();
+        if (randomBoolean()) {
+            decision.add(randomFrom(Decision.YES, Decision.ALWAYS, Decision.THROTTLE, Decision.NO));
+        }
+        if (randomBoolean()) {
+            decision.add(new Decision.Single(Decision.Type.NO, DiskThresholdDecider.NAME, "test"));
+            if (randomBoolean()) {
+                decision.add(Decision.NO);
+            } else {
+                decision.add(new Decision.Single(Decision.Type.NO, randomFrom(SOME_ALLOCATION_DECIDERS), "test"));
+            }
+        } else if (randomBoolean()) {
+            decision.add(new Decision.Single(Decision.Type.YES, DiskThresholdDecider.NAME, "test"));
+        }
+        randomSubsetOf(SOME_ALLOCATION_DECIDERS).stream()
+            .map(label -> new Decision.Single(randomFrom(Decision.Type.values()), label, "test " + label))
+            .forEach(decision::add);
+
+        assertThat(ReactiveStorageDeciderService.isDiskOnlyNoDecision(decision), is(false));
+    }
+
+    public void testSizeOf() {
+        ClusterState.Builder stateBuilder = ClusterState.builder(ClusterName.DEFAULT);
+        Metadata.Builder metaBuilder = Metadata.builder();
+        IndexMetadata indexMetadata = IndexMetadata.builder(randomAlphaOfLength(5))
+            .settings(settings(Version.CURRENT))
+            .numberOfShards(randomIntBetween(1, 10))
+            .numberOfReplicas(randomIntBetween(1, 10))
+            .build();
+        metaBuilder.put(indexMetadata, true);
+        stateBuilder.metadata(metaBuilder);
+        stateBuilder.routingTable(RoutingTable.builder().addAsNew(indexMetadata).build());
+        addNode(stateBuilder);
+        addNode(stateBuilder);
+        ClusterState initialClusterState = stateBuilder.build();
+
+        int shardId = randomInt(indexMetadata.getNumberOfShards() - 1);
+        IndexShardRoutingTable subjectRoutings = initialClusterState.routingTable()
+            .shardRoutingTable(indexMetadata.getIndex().getName(), shardId);
+        RoutingAllocation allocation = new RoutingAllocation(
+            new AllocationDeciders(org.elasticsearch.common.collect.List.of()),
+            new RoutingNodes(initialClusterState, false),
+            initialClusterState,
+            null,
+            null,
+            System.nanoTime()
+        );
+        ShardRouting primaryShard = subjectRoutings.primaryShard();
+        ShardRouting replicaShard = subjectRoutings.replicaShards().get(0);
+        DiscoveryNode[] nodes = StreamSupport.stream(initialClusterState.nodes().spliterator(), false).toArray(DiscoveryNode[]::new);
+        boolean useReplica = randomBoolean();
+        if (useReplica || randomBoolean()) {
+            startShard(allocation, primaryShard, nodes[0].getId());
+            if (randomBoolean()) {
+                startShard(allocation, replicaShard, nodes[1].getId());
+            }
+        }
+
+        final ClusterState clusterState = updateClusterState(initialClusterState, allocation);
+
+        ImmutableOpenMap.Builder<String, Long> shardSizeBuilder = ImmutableOpenMap.builder();
+        IntStream.range(0, randomInt(10))
+            .mapToObj(i -> randomFrom(clusterState.routingTable().allShards()))
+            .filter(s -> s.shardId().getId() != shardId)
+            .forEach(s -> shardSizeBuilder.put(shardIdentifier(s), randomNonNegativeLong()));
+
+        long expected = randomLongBetween(1, Long.MAX_VALUE);
+        if (useReplica == false || randomBoolean()) {
+            shardSizeBuilder.put(shardIdentifier(primaryShard), expected);
+        } else {
+            shardSizeBuilder.put(shardIdentifier(replicaShard), expected);
+        }
+
+        ShardRouting subjectShard = useReplica ? replicaShard : primaryShard;
+        validateSizeOf(clusterState, subjectShard, shardSizeBuilder, expected);
+        validateSizeOf(clusterState, subjectShard, ImmutableOpenMap.builder(), ByteSizeUnit.KB.toBytes(1));
+    }
+
+    public void validateSizeOf(
+        ClusterState clusterState,
+        ShardRouting subjectShard,
+        ImmutableOpenMap.Builder<String, Long> shardSizeBuilder,
+        long expected
+    ) {
+        ClusterInfo info = new ClusterInfo(null, null, shardSizeBuilder.build(), null, null);
+        ReactiveStorageDeciderService.AllocationState allocationState = new ReactiveStorageDeciderService.AllocationState(
+            clusterState,
+            null,
+            null,
+            info,
+            null,
+            org.elasticsearch.common.collect.Set.of()
+        );
+
+        assertThat(allocationState.sizeOf(subjectShard), equalTo(expected));
+    }
+
+    private void startShard(RoutingAllocation allocation, ShardRouting unassignedShard, String nodeId) {
+        for (RoutingNodes.UnassignedShards.UnassignedIterator iterator = allocation.routingNodes().unassigned().iterator(); iterator
+            .hasNext();) {
+            ShardRouting candidate = iterator.next();
+            if (candidate == unassignedShard) {
+                ShardRouting initialized = iterator.initialize(
+                    nodeId,
+                    null,
+                    ShardRouting.UNAVAILABLE_EXPECTED_SHARD_SIZE,
+                    allocation.changes()
+                );
+                allocation.routingNodes().startShard(logger, initialized, allocation.changes());
+                return;
+            }
+        }
+
+        fail("must find shard: " + unassignedShard);
+    }
+
+    public void testSizeOfSnapshot() {
+        ClusterState.Builder stateBuilder = ClusterState.builder(ClusterName.DEFAULT);
+        Metadata.Builder metaBuilder = Metadata.builder();
+        RecoverySource.SnapshotRecoverySource recoverySource = new RecoverySource.SnapshotRecoverySource(
+            UUIDs.randomBase64UUID(),
+            new Snapshot(randomAlphaOfLength(5), new SnapshotId(randomAlphaOfLength(5), UUIDs.randomBase64UUID())),
+            Version.CURRENT,
+            new IndexId(randomAlphaOfLength(5), UUIDs.randomBase64UUID())
+        );
+        IndexMetadata indexMetadata = IndexMetadata.builder(randomAlphaOfLength(5))
+            .settings(settings(Version.CURRENT))
+            .numberOfShards(randomIntBetween(1, 10))
+            .numberOfReplicas(randomIntBetween(0, 10))
+            .build();
+        metaBuilder.put(indexMetadata, true);
+        stateBuilder.metadata(metaBuilder);
+        stateBuilder.routingTable(RoutingTable.builder().addAsNewRestore(indexMetadata, recoverySource, new IntHashSet()).build());
+        ClusterState clusterState = stateBuilder.build();
+
+        int shardId = randomInt(indexMetadata.getNumberOfShards() - 1);
+        ShardRouting primaryShard = clusterState.routingTable()
+            .shardRoutingTable(indexMetadata.getIndex().getName(), shardId)
+            .primaryShard();
+
+        ImmutableOpenMap.Builder<InternalSnapshotsInfoService.SnapshotShard, Long> shardSizeBuilder = ImmutableOpenMap.builder();
+        IntStream.range(0, randomInt(10))
+            .mapToObj(i -> randomFrom(clusterState.routingTable().allShards()))
+            .filter(s -> s.shardId().getId() != shardId)
+            .forEach(s -> shardSizeBuilder.put(snapshotShardSizeKey(recoverySource, s), randomNonNegativeLong()));
+
+        long expected = randomLongBetween(1, Long.MAX_VALUE);
+        shardSizeBuilder.put(snapshotShardSizeKey(recoverySource, primaryShard), expected);
+
+        validateSizeOfSnapshotShard(clusterState, primaryShard, shardSizeBuilder, expected);
+        validateSizeOfSnapshotShard(clusterState, primaryShard, ImmutableOpenMap.builder(), ByteSizeUnit.KB.toBytes(1));
+    }
+
+    private void validateSizeOfSnapshotShard(
+        ClusterState clusterState,
+        ShardRouting primaryShard,
+        ImmutableOpenMap.Builder<InternalSnapshotsInfoService.SnapshotShard, Long> shardSizeBuilder,
+        long expected
+    ) {
+        SnapshotShardSizeInfo shardSizeInfo = new SnapshotShardSizeInfo(shardSizeBuilder.build());
+        ReactiveStorageDeciderService.AllocationState allocationState = new ReactiveStorageDeciderService.AllocationState(
+            clusterState,
+            null,
+            null,
+            null,
+            shardSizeInfo,
+            org.elasticsearch.common.collect.Set.of()
+        );
+
+        assertThat(allocationState.sizeOf(primaryShard), equalTo(expected));
+    }
+
+    private InternalSnapshotsInfoService.SnapshotShard snapshotShardSizeKey(
+        RecoverySource.SnapshotRecoverySource recoverySource,
+        ShardRouting primaryShard
+    ) {
+        return new InternalSnapshotsInfoService.SnapshotShard(recoverySource.snapshot(), recoverySource.index(), primaryShard.shardId());
+    }
+
+    private void addNode(ClusterState.Builder stateBuilder) {
+        stateBuilder.nodes(
+            DiscoveryNodes.builder(stateBuilder.nodes())
+                .add(
+                    new DiscoveryNode(
+                        "test",
+                        UUIDs.randomBase64UUID(),
+                        buildNewFakeTransportAddress(),
+                        Map.of(),
+                        org.elasticsearch.common.collect.Set.of(DiscoveryNodeRole.DATA_ROLE),
+                        Version.CURRENT
+                    )
+                )
+        );
+    }
+
+    public void testUnmovableSize() {
+        Settings.Builder settingsBuilder = Settings.builder();
+        if (randomBoolean()) {
+            // disk is 100 kb. Default is 90 percent. 10KB free is equivalent to default.
+            String tenKb = ByteSizeValue.ofKb(10).toString();
+            settingsBuilder.put(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK_SETTING.getKey(), tenKb);
+            // also set these to pass validation
+            settingsBuilder.put(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK_SETTING.getKey(), tenKb);
+            settingsBuilder.put(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_WATERMARK_SETTING.getKey(), tenKb);
+        }
+        Settings settings = settingsBuilder.build();
+        DiskThresholdSettings thresholdSettings = new DiskThresholdSettings(
+            settings,
+            new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+        );
+
+        String nodeId = randomAlphaOfLength(5);
+
+        ClusterState.Builder stateBuilder = ClusterState.builder(ClusterName.DEFAULT);
+        Metadata.Builder metaBuilder = Metadata.builder();
+        IndexMetadata indexMetadata = IndexMetadata.builder(randomAlphaOfLength(5))
+            .settings(settings(Version.CURRENT))
+            .numberOfShards(1)
+            .numberOfReplicas(10)
+            .build();
+        metaBuilder.put(indexMetadata, true);
+        stateBuilder.metadata(metaBuilder);
+        ClusterState clusterState = stateBuilder.build();
+
+        Set<ShardRouting> shards = IntStream.range(0, between(1, 10))
+            .mapToObj(i -> Tuple.tuple(new ShardId(indexMetadata.getIndex(), randomInt(10)), randomBoolean()))
+            .distinct()
+            .map(t -> TestShardRouting.newShardRouting(t.v1(), nodeId, t.v2(), ShardRoutingState.STARTED))
+            .collect(Collectors.toSet());
+
+        long minShardSize = randomLongBetween(1, 10);
+
+        ImmutableOpenMap.Builder<String, DiskUsage> diskUsagesBuilder = ImmutableOpenMap.builder();
+        diskUsagesBuilder.put(nodeId, new DiskUsage(nodeId, null, null, ByteSizeUnit.KB.toBytes(100), ByteSizeUnit.KB.toBytes(5)));
+        ImmutableOpenMap<String, DiskUsage> diskUsages = diskUsagesBuilder.build();
+        ImmutableOpenMap.Builder<String, Long> shardSizeBuilder = ImmutableOpenMap.builder();
+        ShardRouting missingShard = randomBoolean() ? randomFrom(shards) : null;
+        Collection<ShardRouting> shardsWithSizes = shards.stream().filter(s -> s != missingShard).collect(Collectors.toSet());
+        for (ShardRouting shard : shardsWithSizes) {
+            shardSizeBuilder.put(shardIdentifier(shard), ByteSizeUnit.KB.toBytes(randomLongBetween(minShardSize, 100)));
+        }
+        if (shardsWithSizes.isEmpty() == false) {
+            shardSizeBuilder.put(shardIdentifier(randomFrom(shardsWithSizes)), ByteSizeUnit.KB.toBytes(minShardSize));
+        }
+        ClusterInfo info = new ClusterInfo(diskUsages, diskUsages, shardSizeBuilder.build(), null, null);
+
+        ReactiveStorageDeciderService.AllocationState allocationState = new ReactiveStorageDeciderService.AllocationState(
+            clusterState,
+            null,
+            thresholdSettings,
+            info,
+            null,
+            org.elasticsearch.common.collect.Set.of()
+        );
+
+        long result = allocationState.unmovableSize(nodeId, shards);
+        if (missingShard != null
+            && (missingShard.primary()
+                || clusterState.getRoutingNodes().activePrimary(missingShard.shardId()) == null
+                || info.getShardSize(clusterState.getRoutingNodes().activePrimary(missingShard.shardId())) == null)
+            || minShardSize < 5) {
+            // the diff between used and high watermark is 5 KB.
+            assertThat(result, equalTo(ByteSizeUnit.KB.toBytes(5)));
+        } else {
+            assertThat(result, equalTo(ByteSizeUnit.KB.toBytes(minShardSize)));
+        }
+    }
+
+    public void testMessage() {
+        assertThat(ReactiveStorageDeciderService.message(0, 0), equalTo("storage ok"));
+        assertThat(ReactiveStorageDeciderService.message(0, 1023), equalTo("not enough storage available, needs 1023b"));
+        assertThat(ReactiveStorageDeciderService.message(1024, 0), equalTo("not enough storage available, needs 1kb"));
+        assertThat(ReactiveStorageDeciderService.message(0, 1024), equalTo("not enough storage available, needs 1kb"));
+        assertThat(ReactiveStorageDeciderService.message(1023, 1), equalTo("not enough storage available, needs 1kb"));
+    }
+
+    private String shardIdentifier(ShardRouting s) {
+        return ClusterInfo.shardIdentifierFromRouting(s);
+    }
+
+    public static ClusterState updateClusterState(ClusterState oldState, RoutingAllocation allocation) {
+        assert allocation.metadata() == oldState.metadata();
+        if (allocation.routingNodesChanged() == false) {
+            return oldState;
+        }
+        final RoutingTable oldRoutingTable = oldState.routingTable();
+        final RoutingNodes newRoutingNodes = allocation.routingNodes();
+        final RoutingTable newRoutingTable = new RoutingTable.Builder().updateNodes(oldRoutingTable.version(), newRoutingNodes).build();
+        final Metadata newMetadata = allocation.updateMetadataWithRoutingChanges(newRoutingTable);
+        assert newRoutingTable.validate(newMetadata); // validates the routing table is coherent with the cluster state metadata
+
+        return ClusterState.builder(oldState).routingTable(newRoutingTable).metadata(newMetadata).build();
+    }
+}


### PR DESCRIPTION
Backport of #65520 

The reactive storage decider will request additional capacity
proportional to the size of shards that are either:
* unassigned and unable to be allocated with only reason being storage
on a node
* shards that cannot remain where they are with only reason being
storage and cannot be allocated anywhere else
* shards that cannot remain where they are and cannot be allocated
on any node and at least one node has storage as the only reason for
unable to allocate.

The reactive storage decider does not try to look into the future, thus
at the time the reactive decider asks to scale up, the cluster is
already in a need for more storage.