### PR TITLE
Coerce blank fields to null in ApiKey requests

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/GetApiKeyRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/GetApiKeyRequest.java
@@ -36,10 +36,10 @@ public final class GetApiKeyRequest extends ActionRequest {
 
     public GetApiKeyRequest(StreamInput in) throws IOException {
         super(in);
-        realmName = in.readOptionalString();
-        userName = in.readOptionalString();
-        apiKeyId = in.readOptionalString();
-        apiKeyName = in.readOptionalString();
+        realmName = textOrNull(in.readOptionalString());
+        userName = textOrNull(in.readOptionalString());
+        apiKeyId = textOrNull(in.readOptionalString());
+        apiKeyName = textOrNull(in.readOptionalString());
         if (in.getVersion().onOrAfter(Version.V_7_4_0)) {
             ownedByAuthenticatedUser = in.readOptionalBoolean();
         } else {
@@ -49,11 +49,15 @@ public final class GetApiKeyRequest extends ActionRequest {
 
     public GetApiKeyRequest(@Nullable String realmName, @Nullable String userName, @Nullable String apiKeyId,
                             @Nullable String apiKeyName, boolean ownedByAuthenticatedUser) {
-        this.realmName = realmName;
-        this.userName = userName;
-        this.apiKeyId = apiKeyId;
-        this.apiKeyName = apiKeyName;
+        this.realmName = textOrNull(realmName);
+        this.userName = textOrNull(userName);
+        this.apiKeyId = textOrNull(apiKeyId);
+        this.apiKeyName = textOrNull(apiKeyName);
         this.ownedByAuthenticatedUser = ownedByAuthenticatedUser;
+    }
+
+    private static String textOrNull(@Nullable String arg) {
+        return Strings.hasText(arg) ? arg : null;
     }
 
     public String getRealmName() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/InvalidateApiKeyRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/InvalidateApiKeyRequest.java
@@ -38,15 +38,15 @@ public final class InvalidateApiKeyRequest extends ActionRequest {
 
     public InvalidateApiKeyRequest(StreamInput in) throws IOException {
         super(in);
-        realmName = in.readOptionalString();
-        userName = in.readOptionalString();
+        realmName = textOrNull(in.readOptionalString());
+        userName = textOrNull(in.readOptionalString());
         if (in.getVersion().onOrAfter(Version.V_7_10_0)) {
             ids = in.readOptionalStringArray();
         } else {
             final String id = in.readOptionalString();
             ids = Strings.hasText(id) == false ? null : new String[] { id };
         }
-        name = in.readOptionalString();
+        name = textOrNull(in.readOptionalString());
         if (in.getVersion().onOrAfter(Version.V_7_4_0)) {
             ownedByAuthenticatedUser = in.readOptionalBoolean();
         } else {
@@ -65,15 +65,19 @@ public final class InvalidateApiKeyRequest extends ActionRequest {
             throw new IllegalArgumentException("Must use either [id] or [ids], not both at the same time");
         }
 
-        this.realmName = realmName;
-        this.userName = userName;
-        if (id != null) {
-            this.ids = new String[] {id};
+        this.realmName = textOrNull(realmName);
+        this.userName = textOrNull(userName);
+        if (Strings.hasText(id)) {
+            this.ids = new String[]{id};
         } else {
             this.ids = ids;
         }
-        this.name = name;
+        this.name = textOrNull(name);
         this.ownedByAuthenticatedUser = ownedByAuthenticatedUser;
+    }
+
+    private static String textOrNull(@Nullable String arg) {
+        return Strings.hasText(arg) ? arg : null;
     }
 
     public String getRealmName() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/GetApiKeyRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/GetApiKeyRequestTests.java
@@ -17,11 +17,13 @@ import org.elasticsearch.test.ESTestCase;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.function.Supplier;
 
 import static org.elasticsearch.test.VersionUtils.randomVersionBetween;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 public class GetApiKeyRequestTests extends ESTestCase {
 
@@ -142,6 +144,21 @@ public class GetApiKeyRequestTests extends ESTestCase {
 
             assertThat(requestFromInputStream, equalTo(getApiKeyRequest));
         }
+    }
+
+    public void testEmptyStringsAreCoercedToNull() {
+        Supplier<String> randomBlankString = () -> " ".repeat(randomIntBetween(0, 5));
+        final GetApiKeyRequest request = new GetApiKeyRequest(
+            randomBlankString.get(), // realm name
+            randomBlankString.get(), // user name
+            randomBlankString.get(), // key id
+            randomBlankString.get(), // key name
+            randomBoolean() // owned by user
+        );
+        assertThat(request.getRealmName(), nullValue());
+        assertThat(request.getUserName(), nullValue());
+        assertThat(request.getApiKeyId(), nullValue());
+        assertThat(request.getApiKeyName(), nullValue());
     }
 
     private static String randomNullOrEmptyString() {


### PR DESCRIPTION
API Key request objects (`InvalidateApiKeyRequest` and
`GetApiKeyRequest`) support multiple key-selection parameters such as
realm-name, user-name, key-id and key-name.

The specified behaviour is that if any of these are _blank_ then they
act as a wildcard and do not restrict the search criteria.

This change moves the "is blank" logic into the constructor for these
requests so that there is a single consistent way to determine blank
(`Strings.hasText(arg) == false`) and all usage of these fields can
rely on the getter returning either `null` or a _real value_, and
never a non-null blank.

Relates: #62916