### PR TITLE
Feature : Cumulative Sum update to work with Terms Aggregate (#46225)

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/PipelineAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/PipelineAggregationBuilder.java
@@ -29,7 +29,6 @@ import org.elasticsearch.search.aggregations.AggregatorFactories.Builder;
 import org.elasticsearch.search.aggregations.bucket.histogram.AutoDateHistogramAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.histogram.HistogramAggregationBuilder;
-import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.io.IOException;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/PipelineAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/PipelineAggregationBuilder.java
@@ -29,6 +29,7 @@ import org.elasticsearch.search.aggregations.AggregatorFactories.Builder;
 import org.elasticsearch.search.aggregations.bucket.histogram.AutoDateHistogramAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.histogram.HistogramAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.io.IOException;
@@ -179,6 +180,8 @@ public abstract class PipelineAggregationBuilder
                     }
                 } else if (parent instanceof AutoDateHistogramAggregationBuilder) {
                     // Nothing to check
+                } else if (parent instanceof TermsAggregationBuilder) {
+                    //TODO: what should be checked?
                 } else {
                     addValidationError(
                             type + " aggregation [" + name + "] must have a histogram, date_histogram or auto_date_histogram as parent");

--- a/server/src/main/java/org/elasticsearch/search/aggregations/PipelineAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/PipelineAggregationBuilder.java
@@ -184,7 +184,8 @@ public abstract class PipelineAggregationBuilder
                     //TODO: what should be checked?
                 } else {
                     addValidationError(
-                            type + " aggregation [" + name + "] must have a histogram, date_histogram, auto_date_histogram or terms as parent");
+                            type + " aggregation [" + name + "] must have a histogram, date_histogram, auto_date_histogram or terms "
+                                 + "as parent");
                 }
             }
         }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/PipelineAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/PipelineAggregationBuilder.java
@@ -137,7 +137,7 @@ public abstract class PipelineAggregationBuilder
             @Override
             public void validateParentAggSequentiallyOrdered(String type, String name) {
                 addValidationError(type + " aggregation [" + name
-                        + "] must have a histogram, date_histogram or auto_date_histogram as parent but doesn't have a parent");
+                        + "] must have a histogram, date_histogram, auto_date_histogram or terms as parent but doesn't have a parent");
             }
         }
 
@@ -184,7 +184,7 @@ public abstract class PipelineAggregationBuilder
                     //TODO: what should be checked?
                 } else {
                     addValidationError(
-                            type + " aggregation [" + name + "] must have a histogram, date_histogram or auto_date_histogram as parent");
+                            type + " aggregation [" + name + "] must have a histogram, date_histogram, auto_date_histogram or terms as parent");
                 }
             }
         }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/DoubleTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/DoubleTerms.java
@@ -38,7 +38,7 @@ import java.util.Objects;
 public class DoubleTerms extends InternalMappedTerms<DoubleTerms, DoubleTerms.Bucket> {
     public static final String NAME = "dterms";
 
-    static class Bucket extends InternalTerms.Bucket<Bucket> {
+    public static class Bucket extends InternalTerms.Bucket<Bucket> {
         double term;
 
         Bucket(double term, long docCount, InternalAggregations aggregations, boolean showDocCountError, long docCountError,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/UnmappedTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/UnmappedTerms.java
@@ -43,7 +43,7 @@ public class UnmappedTerms extends InternalTerms<UnmappedTerms, UnmappedTerms.Bu
      * Concrete type that can't be built because Java needs a concrete type so {@link InternalTerms.Bucket} can have a self type but
      * {@linkplain UnmappedTerms} doesn't ever need to build it because it never returns any buckets.
      */
-    protected abstract static class Bucket extends InternalTerms.Bucket<Bucket> {
+    public abstract static class Bucket extends InternalTerms.Bucket<Bucket> {
         private Bucket(long docCount, InternalAggregations aggregations, boolean showDocCountError, long docCountError,
                 DocValueFormat formatter) {
             super(docCount, aggregations, showDocCountError, docCountError, formatter);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/CumulativeSumPipelineAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/CumulativeSumPipelineAggregationBuilder.java
@@ -24,6 +24,11 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.aggregations.AggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.histogram.AutoDateHistogramAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.histogram.HistogramAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 
 import java.io.IOException;
 import java.util.List;
@@ -104,8 +109,37 @@ public class CumulativeSumPipelineAggregationBuilder extends AbstractPipelineAgg
         if (bucketsPaths.length != 1) {
             context.addBucketPathValidationError("must contain a single entry for aggregation [" + name + "]");
         }
-        context.validateParentAggSequentiallyOrdered(NAME, name);
+
+        //FIXME: duplicated from context.validate
+        AggregationBuilder parent = context.getParent();
+        if ( parent == null ){
+            context.addValidationError(type + " aggregation [" + name
+                + "] must have a histogram, date_histogram, auto_date_histogram or terms as parent but doesn't have a parent");
+
+        } else if ( parent instanceof HistogramAggregationBuilder) {
+            HistogramAggregationBuilder histoParent = (HistogramAggregationBuilder) parent;
+            if (histoParent.minDocCount() != 0) {
+                context.addValidationError(
+                    "parent histogram of " + NAME + " aggregation [" + name + "] must have min_doc_count of 0");
+            }
+        } else if (parent instanceof DateHistogramAggregationBuilder) {
+            DateHistogramAggregationBuilder histoParent = (DateHistogramAggregationBuilder) parent;
+            if (histoParent.minDocCount() != 0) {
+                context.addValidationError(
+                    "parent histogram of " + NAME + " aggregation [" + name + "] must have min_doc_count of 0");
+            }
+        } else if (parent instanceof AutoDateHistogramAggregationBuilder) {
+            // Nothing to check
+        } else if (parent instanceof TermsAggregationBuilder) {
+            //TODO: what should be checked?
+        } else {
+            context.addValidationError(
+                NAME + " aggregation [" + name + "] must have a histogram, date_histogram, auto_date_histogram or terms"
+                    + " as parent");
+        }
     }
+
+
 
     @Override
     protected final XContentBuilder internalXContent(XContentBuilder builder, Params params) throws IOException {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/CumulativeSumPipelineAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/CumulativeSumPipelineAggregator.java
@@ -26,9 +26,7 @@ import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
 import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation.Bucket;
 import org.elasticsearch.search.aggregations.bucket.histogram.HistogramFactory;
-import org.elasticsearch.search.aggregations.bucket.terms.DoubleTerms;
-import org.elasticsearch.search.aggregations.bucket.terms.LongTerms;
-import org.elasticsearch.search.aggregations.bucket.terms.StringTerms;
+import org.elasticsearch.search.aggregations.bucket.terms.*;
 import org.elasticsearch.search.aggregations.pipeline.BucketHelpers.GapPolicy;
 
 import java.util.ArrayList;
@@ -113,9 +111,18 @@ public class CumulativeSumPipelineAggregator extends PipelineAggregator {
                 newBuckets.add(newBucket);
             }
             internalAggregation = factory.create(newBuckets);
+        } else if (parentAggregate instanceof UnmappedTerms) {
+            UnmappedTerms factory = (UnmappedTerms) parentAggregate;
+            List<UnmappedTerms.Bucket> newBuckets = new ArrayList<>(buckets.size());
+            //FIXME: is this necessary?
+            for (Map.Entry<Integer, List<InternalAggregation>> entry : aggregationMap.entrySet()) {
+                UnmappedTerms.Bucket newBucket = factory.createBucket(InternalAggregations.from(entry.getValue()),
+                    (UnmappedTerms.Bucket) buckets.get(entry.getKey()));
+                newBuckets.add(newBucket);
+            }
+            internalAggregation = factory.create(newBuckets);
         }
 
-        //FIXME: should we do a last ifblock to address null?
         return internalAggregation;
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/CumulativeSumPipelineAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/CumulativeSumPipelineAggregator.java
@@ -81,7 +81,8 @@ public class CumulativeSumPipelineAggregator extends PipelineAggregator {
             List<Bucket> newBuckets = new ArrayList<>(buckets.size());
             for (Map.Entry<Integer, List<InternalAggregation>> entry : aggregationMap.entrySet()) {
                 Bucket bucket = buckets.get(entry.getKey());
-                Bucket newBucket = factory.createBucket(factory.getKey(bucket), bucket.getDocCount(), InternalAggregations.from(entry.getValue()));
+                Bucket newBucket = factory.createBucket(factory.getKey(bucket), bucket.getDocCount(),
+                                                        InternalAggregations.from(entry.getValue()));
                 newBuckets.add(newBucket);
             }
             internalAggregation = factory.createAggregation(newBuckets);
@@ -89,7 +90,8 @@ public class CumulativeSumPipelineAggregator extends PipelineAggregator {
             LongTerms factory = (LongTerms) parentAggregate;
             List<LongTerms.Bucket> newBuckets = new ArrayList<>(buckets.size());
             for (Map.Entry<Integer, List<InternalAggregation>> entry : aggregationMap.entrySet()) {
-                LongTerms.Bucket newBucket = factory.createBucket(InternalAggregations.from(entry.getValue()), (LongTerms.Bucket) buckets.get(entry.getKey()));
+                LongTerms.Bucket newBucket = factory.createBucket(InternalAggregations.from(entry.getValue()),
+                                                                  (LongTerms.Bucket) buckets.get(entry.getKey()));
                 newBuckets.add(newBucket);
             }
             internalAggregation = factory.create(newBuckets);
@@ -97,7 +99,8 @@ public class CumulativeSumPipelineAggregator extends PipelineAggregator {
             DoubleTerms factory = (DoubleTerms) parentAggregate;
             List<DoubleTerms.Bucket> newBuckets = new ArrayList<>(buckets.size());
             for (Map.Entry<Integer, List<InternalAggregation>> entry : aggregationMap.entrySet()) {
-                DoubleTerms.Bucket newBucket = factory.createBucket(InternalAggregations.from(entry.getValue()), (DoubleTerms.Bucket) buckets.get(entry.getKey()));
+                DoubleTerms.Bucket newBucket = factory.createBucket(InternalAggregations.from(entry.getValue()),
+                                                                    (DoubleTerms.Bucket) buckets.get(entry.getKey()));
                 newBuckets.add(newBucket);
             }
             internalAggregation = factory.create(newBuckets);
@@ -105,7 +108,8 @@ public class CumulativeSumPipelineAggregator extends PipelineAggregator {
             StringTerms factory = (StringTerms) parentAggregate;
             List<StringTerms.Bucket> newBuckets = new ArrayList<>(buckets.size());
             for (Map.Entry<Integer, List<InternalAggregation>> entry : aggregationMap.entrySet()) {
-                StringTerms.Bucket newBucket = factory.createBucket(InternalAggregations.from(entry.getValue()), (StringTerms.Bucket) buckets.get(entry.getKey()));
+                StringTerms.Bucket newBucket = factory.createBucket(InternalAggregations.from(entry.getValue()),
+                                                                    (StringTerms.Bucket) buckets.get(entry.getKey()));
                 newBuckets.add(newBucket);
             }
             internalAggregation = factory.create(newBuckets);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/CumulativeSumPipelineAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/CumulativeSumPipelineAggregator.java
@@ -26,7 +26,10 @@ import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
 import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation.Bucket;
 import org.elasticsearch.search.aggregations.bucket.histogram.HistogramFactory;
-import org.elasticsearch.search.aggregations.bucket.terms.*;
+import org.elasticsearch.search.aggregations.bucket.terms.DoubleTerms;
+import org.elasticsearch.search.aggregations.bucket.terms.LongTerms;
+import org.elasticsearch.search.aggregations.bucket.terms.StringTerms;
+import org.elasticsearch.search.aggregations.bucket.terms.UnmappedTerms;
 import org.elasticsearch.search.aggregations.pipeline.BucketHelpers.GapPolicy;
 
 import java.util.ArrayList;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/CumulativeSumPipelineAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/CumulativeSumPipelineAggregator.java
@@ -26,9 +26,13 @@ import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
 import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation.Bucket;
 import org.elasticsearch.search.aggregations.bucket.histogram.HistogramFactory;
+import org.elasticsearch.search.aggregations.bucket.terms.DoubleTerms;
+import org.elasticsearch.search.aggregations.bucket.terms.LongTerms;
+import org.elasticsearch.search.aggregations.bucket.terms.StringTerms;
 import org.elasticsearch.search.aggregations.pipeline.BucketHelpers.GapPolicy;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -48,27 +52,68 @@ public class CumulativeSumPipelineAggregator extends PipelineAggregator {
     @Override
     public InternalAggregation reduce(InternalAggregation aggregation, ReduceContext reduceContext) {
         InternalMultiBucketAggregation<? extends InternalMultiBucketAggregation, ? extends InternalMultiBucketAggregation.InternalBucket>
-                histo = (InternalMultiBucketAggregation<? extends InternalMultiBucketAggregation, ? extends
-                InternalMultiBucketAggregation.InternalBucket>) aggregation;
-        List<? extends InternalMultiBucketAggregation.InternalBucket> buckets = histo.getBuckets();
-        HistogramFactory factory = (HistogramFactory) histo;
-        List<Bucket> newBuckets = new ArrayList<>(buckets.size());
-        double sum = 0;
-        for (InternalMultiBucketAggregation.InternalBucket bucket : buckets) {
-            Double thisBucketValue = resolveBucketValue(histo, bucket, bucketsPaths()[0], GapPolicy.INSERT_ZEROS);
+            parentAggregate = (InternalMultiBucketAggregation<? extends InternalMultiBucketAggregation, ? extends
+            InternalMultiBucketAggregation.InternalBucket>) aggregation;
 
-            // Only increment the sum if it's a finite value, otherwise "increment by zero" is correct
+        InternalAggregation internalAggregation = null;
+        List<? extends InternalMultiBucketAggregation.InternalBucket> buckets = parentAggregate.getBuckets();
+
+        double sum = 0;
+        Map<Integer, List<InternalAggregation>> aggregationMap = new HashMap<>();
+        for (int i = 0; i < buckets.size(); ++i) {
+            InternalMultiBucketAggregation.InternalBucket bucket = buckets.get(i);
+
+            Double thisBucketValue = resolveBucketValue(parentAggregate, bucket, bucketsPaths()[0], GapPolicy.INSERT_ZEROS);
             if (thisBucketValue != null && thisBucketValue.isInfinite() == false && thisBucketValue.isNaN() == false) {
                 sum += thisBucketValue;
             }
 
-            List<InternalAggregation> aggs = StreamSupport.stream(bucket.getAggregations().spliterator(), false)
+            List<InternalAggregation> aggregate = StreamSupport.stream(bucket.getAggregations().spliterator(), false)
                 .map((p) -> (InternalAggregation) p)
                 .collect(Collectors.toList());
-            aggs.add(new InternalSimpleValue(name(), sum, formatter, metadata()));
-            Bucket newBucket = factory.createBucket(factory.getKey(bucket), bucket.getDocCount(), InternalAggregations.from(aggs));
-            newBuckets.add(newBucket);
+            aggregate.add(new InternalSimpleValue(name(), sum, formatter, metadata()));
+            aggregationMap.put(i, aggregate);
         }
-        return factory.createAggregation(newBuckets);
+
+        //FIXME: kludgy. assess interfaces, probably create another interface/factory/helper
+        if (parentAggregate instanceof HistogramFactory) {
+            HistogramFactory factory = (HistogramFactory) parentAggregate;
+            List<Bucket> newBuckets = new ArrayList<>(buckets.size());
+            for (Map.Entry<Integer, List<InternalAggregation>> entry : aggregationMap.entrySet()) {
+                Bucket bucket = buckets.get(entry.getKey());
+                Bucket newBucket = factory.createBucket(factory.getKey(bucket), bucket.getDocCount(), InternalAggregations.from(entry.getValue()));
+                newBuckets.add(newBucket);
+            }
+            internalAggregation = factory.createAggregation(newBuckets);
+        } else if (parentAggregate instanceof LongTerms) {
+            LongTerms factory = (LongTerms) parentAggregate;
+            List<LongTerms.Bucket> newBuckets = new ArrayList<>(buckets.size());
+            for (Map.Entry<Integer, List<InternalAggregation>> entry : aggregationMap.entrySet()) {
+                LongTerms.Bucket newBucket = factory.createBucket(InternalAggregations.from(entry.getValue()), (LongTerms.Bucket) buckets.get(entry.getKey()));
+                newBuckets.add(newBucket);
+            }
+            internalAggregation = factory.create(newBuckets);
+        } else if (parentAggregate instanceof DoubleTerms) {
+            DoubleTerms factory = (DoubleTerms) parentAggregate;
+            List<DoubleTerms.Bucket> newBuckets = new ArrayList<>(buckets.size());
+            for (Map.Entry<Integer, List<InternalAggregation>> entry : aggregationMap.entrySet()) {
+                DoubleTerms.Bucket newBucket = factory.createBucket(InternalAggregations.from(entry.getValue()), (DoubleTerms.Bucket) buckets.get(entry.getKey()));
+                newBuckets.add(newBucket);
+            }
+            internalAggregation = factory.create(newBuckets);
+        } else if (parentAggregate instanceof StringTerms) {
+            StringTerms factory = (StringTerms) parentAggregate;
+            List<StringTerms.Bucket> newBuckets = new ArrayList<>(buckets.size());
+            for (Map.Entry<Integer, List<InternalAggregation>> entry : aggregationMap.entrySet()) {
+                StringTerms.Bucket newBucket = factory.createBucket(InternalAggregations.from(entry.getValue()), (StringTerms.Bucket) buckets.get(entry.getKey()));
+                newBuckets.add(newBucket);
+            }
+            internalAggregation = factory.create(newBuckets);
+        }
+
+        //FIXME: should we do a last ifblock to address null?
+        return internalAggregation;
     }
+
+
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/CumulativeSumAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/CumulativeSumAggregatorTests.java
@@ -75,6 +75,16 @@ public class CumulativeSumAggregatorTests extends AggregatorTestCase {
 
     private static final List<Integer> datasetValues = Arrays.asList(1,2,3,4,5,6,7,8,9,10);
 
+    //TODO: implement
+    public void testTermsLong() throws IOException {
+    }
+
+    public void testTermsDouble() throws IOException {
+    }
+
+    public void testTermsString() throws IOException {
+    }
+
     public void testSimple() throws IOException {
         Query query = new MatchAllDocsQuery();
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/CumulativeSumAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/CumulativeSumAggregatorTests.java
@@ -19,7 +19,11 @@
 
 package org.elasticsearch.search.aggregations.pipeline;
 
-import org.apache.lucene.document.*;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.DoubleDocValuesField;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.document.SortedNumericDocValuesField;
+import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexableField;
@@ -43,7 +47,8 @@ import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramAggre
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.histogram.HistogramAggregationBuilder;
-import org.elasticsearch.search.aggregations.bucket.terms.*;
+import org.elasticsearch.search.aggregations.bucket.terms.InternalTerms;
+import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.elasticsearch.search.aggregations.metrics.AvgAggregationBuilder;
 import org.elasticsearch.search.aggregations.metrics.InternalAvg;
 import org.elasticsearch.search.aggregations.metrics.Sum;

--- a/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/CumulativeSumAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/CumulativeSumAggregatorTests.java
@@ -19,20 +19,21 @@
 
 package org.elasticsearch.search.aggregations.pipeline;
 
-import org.apache.lucene.document.Document;
-import org.apache.lucene.document.NumericDocValuesField;
-import org.apache.lucene.document.SortedNumericDocValuesField;
+import org.apache.lucene.document.*;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.RandomIndexWriter;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.CheckedConsumer;
 import org.elasticsearch.common.time.DateFormatters;
 import org.elasticsearch.index.mapper.DateFieldMapper;
+import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
@@ -42,16 +43,19 @@ import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramAggre
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.histogram.HistogramAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.terms.*;
 import org.elasticsearch.search.aggregations.metrics.AvgAggregationBuilder;
 import org.elasticsearch.search.aggregations.metrics.InternalAvg;
 import org.elasticsearch.search.aggregations.metrics.Sum;
 import org.elasticsearch.search.aggregations.metrics.SumAggregationBuilder;
 import org.elasticsearch.search.aggregations.support.AggregationInspectionHelper;
+import org.elasticsearch.search.aggregations.support.ValueType;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.IsNull.notNullValue;
@@ -59,6 +63,7 @@ import static org.hamcrest.core.IsNull.notNullValue;
 public class CumulativeSumAggregatorTests extends AggregatorTestCase {
 
     private static final String HISTO_FIELD = "histo";
+    private static final String KEYWORD_FIELD = "keyword";
     private static final String VALUE_FIELD = "value_field";
 
     private static final List<String> datasetTimes = Arrays.asList(
@@ -75,17 +80,44 @@ public class CumulativeSumAggregatorTests extends AggregatorTestCase {
 
     private static final List<Integer> datasetValues = Arrays.asList(1,2,3,4,5,6,7,8,9,10);
 
-    //TODO: implement
-    public void testTermsLong() throws IOException {
+    private static final List<String> datasetTermsString = Arrays.asList("1","1","1","2","2","2","3","3","4","4");
+    private static final List<Double> datasetTermsDouble = Arrays.asList(1.0,1.0,1.0,2.0,2.0,2.0,3.0,3.0,4.0,4.0);
+    private static final List<Long> datasetTermsLong = Arrays.asList(1L,1L,1L,2L,2L,2L,3L,3L,4L,4L);
+    private static final List<Long> datasetTermValues = Arrays.asList(5L,5L,4L,4L,3L,3L,2L,2L,1L,1L);
+    private static final List<Double> expectedTermsMetricValues = Arrays.asList(14.0,24.0,28.0,30.0);
+    private static final List<Double> expectedTermsCountValues = Arrays.asList(3.0,6.0,8.0,10.0);
+
+    public void testTermsStringCount() throws IOException {
+        executeTestCaseTerms(ValueType.STRING, KEYWORD_FIELD, "_count", datasetTermsString, expectedTermsCountValues,
+            (val) -> new SortedSetDocValuesField(KEYWORD_FIELD, new BytesRef((String)val)),
+            new KeywordFieldMapper.KeywordFieldType(KEYWORD_FIELD));
     }
 
-    public void testTermsDouble() throws IOException {
+    public void testTermsStringMetric() throws IOException {
+        executeTestCaseTerms(ValueType.STRING, KEYWORD_FIELD, "sum", datasetTermsString, expectedTermsMetricValues,
+            (val) -> new SortedSetDocValuesField(KEYWORD_FIELD, new BytesRef((String)val)),
+            new KeywordFieldMapper.KeywordFieldType(KEYWORD_FIELD) );
     }
 
-    public void testTermsString() throws IOException {
+    public void testTermsLongMetric() throws IOException {
+        executeTestCaseTerms(ValueType.LONG, KEYWORD_FIELD, "sum", datasetTermsLong, expectedTermsMetricValues,
+            (val) -> new NumericDocValuesField(KEYWORD_FIELD, (Long)val),
+            new NumberFieldMapper.NumberFieldType(KEYWORD_FIELD, NumberFieldMapper.NumberType.LONG) );
     }
 
-    public void testSimple() throws IOException {
+    public void testTermsDoubleMetric() throws IOException {
+        executeTestCaseTerms(ValueType.DOUBLE, KEYWORD_FIELD, "sum", datasetTermsDouble, expectedTermsMetricValues,
+            (val) -> new DoubleDocValuesField(KEYWORD_FIELD, (Double)val),
+            new NumberFieldMapper.NumberFieldType(KEYWORD_FIELD, NumberFieldMapper.NumberType.DOUBLE) );
+    }
+
+    public void testTermsNoBuckets() throws IOException {
+        executeTestCaseTerms(ValueType.LONG,"unmapped","sum", datasetTermsLong, expectedTermsMetricValues,
+            (val) -> new NumericDocValuesField(KEYWORD_FIELD, (Long)val),
+            new NumberFieldMapper.NumberFieldType(KEYWORD_FIELD, NumberFieldMapper.NumberType.LONG) );
+    }
+
+    public void testHistoSimple() throws IOException {
         Query query = new MatchAllDocsQuery();
 
         DateHistogramAggregationBuilder aggBuilder = new DateHistogramAggregationBuilder("histo");
@@ -108,7 +140,7 @@ public class CumulativeSumAggregatorTests extends AggregatorTestCase {
     /**
      * First value from a derivative is null, so this makes sure the cusum can handle that
      */
-    public void testDerivative() throws IOException {
+    public void testHistoDerivative() throws IOException {
         Query query = new MatchAllDocsQuery();
 
         DateHistogramAggregationBuilder aggBuilder = new DateHistogramAggregationBuilder("histo");
@@ -136,7 +168,7 @@ public class CumulativeSumAggregatorTests extends AggregatorTestCase {
         });
     }
 
-    public void testCount() throws IOException {
+    public void testHistoCount() throws IOException {
         Query query = new MatchAllDocsQuery();
 
         DateHistogramAggregationBuilder aggBuilder = new DateHistogramAggregationBuilder("histo");
@@ -156,7 +188,7 @@ public class CumulativeSumAggregatorTests extends AggregatorTestCase {
         assertWarnings("[interval] on [date_histogram] is deprecated, use [fixed_interval] or [calendar_interval] in the future.");
     }
 
-    public void testDocCount() throws IOException {
+    public void testHistoDocCount() throws IOException {
         Query query = new MatchAllDocsQuery();
 
         int numDocs = randomIntBetween(6, 20);
@@ -206,7 +238,7 @@ public class CumulativeSumAggregatorTests extends AggregatorTestCase {
         });
     }
 
-    public void testMetric() throws IOException {
+    public void testHistoMetric() throws IOException {
         Query query = new MatchAllDocsQuery();
 
         int numDocs = randomIntBetween(6, 20);
@@ -259,7 +291,7 @@ public class CumulativeSumAggregatorTests extends AggregatorTestCase {
         });
     }
 
-    public void testNoBuckets() throws IOException {
+    public void testHistoNoBuckets() throws IOException {
         int numDocs = randomIntBetween(6, 20);
         int interval = randomIntBetween(2, 5);
 
@@ -336,6 +368,36 @@ public class CumulativeSumAggregatorTests extends AggregatorTestCase {
                 verify.accept(histogram);
             }
         }
+    }
+
+    public void executeTestCaseTerms(ValueType valueType, String termsField, String bucketPath,
+                                     List datasetKey, List expectedValues,
+                                     Function<Object, IndexableField> keyField, MappedFieldType keyFieldType) throws IOException {
+        TermsAggregationBuilder aggBuilder = new TermsAggregationBuilder("terms")
+            .userValueTypeHint(valueType)
+            .field(termsField)
+            .subAggregation(new SumAggregationBuilder("sum").field(VALUE_FIELD))
+            .subAggregation(new CumulativeSumPipelineAggregationBuilder("cusum", bucketPath));
+
+        MappedFieldType valueFieldType
+            = new NumberFieldMapper.NumberFieldType(VALUE_FIELD, NumberFieldMapper.NumberType.LONG);
+
+        testCase(aggBuilder, new MatchAllDocsQuery(), indexWriter -> {
+            Document document = new Document();
+            for (int counter = 0; counter < datasetKey.size(); ++counter) {
+                document.add(keyField.apply(datasetKey.get(counter)));
+                document.add(new NumericDocValuesField(VALUE_FIELD, datasetTermValues.get(counter).intValue()));
+
+                indexWriter.addDocument(document);
+                document.clear();
+            }
+        }, terms->{
+            List<? extends InternalTerms.Bucket> buckets = ((InternalTerms)terms).getBuckets();
+            for(int i = 0; i< buckets.size(); ++i){
+                assertThat(((InternalSimpleValue) (buckets.get(i).getAggregations().get("cusum"))).value(),
+                    equalTo(expectedValues.get(i)));
+            }
+        }, new MappedFieldType[]{keyFieldType, valueFieldType});
     }
 
     private static long asLong(String dateTime) {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/CumulativeSumTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/CumulativeSumTests.java
@@ -52,13 +52,13 @@ public class CumulativeSumTests extends BasePipelineAggregationTestCase<Cumulati
         when(parent.getName()).thenReturn("name");
 
         assertThat(validate(parent, new CumulativeSumPipelineAggregationBuilder("name", "invalid_agg>metric")), equalTo(
-                "Validation Failed: 1: cumulative_sum aggregation [name] must have a histogram, date_histogram "
-                + "or auto_date_histogram as parent;"));
+                "Validation Failed: 1: cumulative_sum aggregation [name] must have a histogram, date_histogram, "
+                + "auto_date_histogram or terms as parent;"));
     }
 
     public void testNoParent() throws IOException {
         assertThat(validate(emptyList(), new CumulativeSumPipelineAggregationBuilder("name", "invalid_agg>metric")), equalTo(
-                "Validation Failed: 1: cumulative_sum aggregation [name] must have a histogram, date_histogram "
-                + "or auto_date_histogram as parent but doesn't have a parent;"));
+                "Validation Failed: 1: cumulative_sum aggregation [name] must have a histogram, date_histogram, "
+                + "auto_date_histogram or terms as parent but doesn't have a parent;"));
     }
 }


### PR DESCRIPTION
Hi @polyfractal, please take a look 
- [x] Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- [x] Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- [x] Run `gradle precommit`. Spotless passes on OSX Catalina (JDK14) but fails on Windows 10 (JDK14). Have not investigated yet.
- [x] Run `gradle check`? (Still running, last time i ran it, it needed14h)
- [x] Pull request against master? 
- [x] Checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)? 

_Implementation_
- This allows `Term` bucket aggregate to have a `CuSum` bucket subaggregate. 
- The current implementation in `CumulativeSumPipelineAggregator.reduce` is admittedly quite inelegant. Havent really thought of a better alternative aside from introducing a new interface with a factory method specifically for pipeline aggregators.
- Had to customize the validation for `CuSumPipelineAggBuilder` by duplicating the code from `ForInsideTree` and `ForTreeRoot` and exposing the parent with a new `getParent` interface in `ValidationContext`. Admittedly this could have been solved in a different way, maybe a protected `validParents<Class, Function>` map. It is quite a redesign issue which i think does require more discussion to be done right.
- Made protected `DoubleTerms.Bucket`, `UnmappedTerms.Bucket` classes public. Might need some redesign/discussion. 
- Only added unit tests. Didnt add any `IntegrationTest` or `RestHL` tests
- Not squashed yet

_Thoughts_
- Likely `CuCardinality` and other Pipeline aggs would benefit from a similar change?
- Are there other use cases that i have missed? ie script


