### PR TITLE
Unmute and adjust IndicesClientIT.testDataStreams() test

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesClientIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesClientIT.java
@@ -2034,7 +2034,6 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
         assertThat(aliasExists(index, alias2), equalTo(true));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/60461")
     public void testDataStreams() throws Exception {
         String dataStreamName = "data-stream";
 
@@ -2085,7 +2084,6 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
         assertThat(backingIndices, equalTo(1));
         ByteSizeValue byteSizeValue = dataStreamsStatsResponse.getTotalStoreSize();
         assertThat(byteSizeValue, notNullValue());
-        assertThat(byteSizeValue.getBytes(), not(equalTo(0L)));
         Map<String, DataStreamStats> dataStreamsStats = dataStreamsStatsResponse.getDataStreams();
         assertThat(dataStreamsStats, notNullValue());
         assertThat(dataStreamsStats.size(), equalTo(1));


### PR DESCRIPTION
Backport #65879 to 7.x branch.

Removed assertion that is flaky in CI and not really necessary to test HLRC integration.

Relates to #60461
