### PR TITLE
 Allow to add existing cache files in searchable snapshots cache service

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheService.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheService.java
@@ -29,6 +29,7 @@ import org.elasticsearch.index.store.cache.CacheFile;
 import org.elasticsearch.index.store.cache.CacheKey;
 import org.elasticsearch.threadpool.ThreadPool;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -178,6 +179,14 @@ public class CacheService extends AbstractLifecycleComponent {
     @Override
     protected void doClose() {}
 
+    private void ensureLifecycleInitializing() {
+        final Lifecycle.State state = lifecycleState();
+        assert state == Lifecycle.State.INITIALIZED : state;
+        if (state != Lifecycle.State.INITIALIZED) {
+            throw new IllegalStateException("Failed to read data from cache: cache service is not initializing [" + state + "]");
+        }
+    }
+
     private void ensureLifecycleStarted() {
         final Lifecycle.State state = lifecycleState();
         assert state != Lifecycle.State.INITIALIZED : state;
@@ -200,6 +209,16 @@ public class CacheService extends AbstractLifecycleComponent {
         return toIntBytes(rangeSize.getBytes());
     }
 
+    /**
+     * Retrieves the {@link CacheFile} instance associated with the specified {@link CacheKey} in the cache. If the key is not already
+     * associated with a {@link CacheFile}, this method creates a new instance using the given file length and cache directory.
+     *
+     * @param cacheKey   the cache key whose associated {@link CacheFile} instance is to be returned or computed for if non-existent
+     * @param fileLength the length of the cache file (required to compute a new instance)
+     * @param cacheDir   the cache directory where the cache file on disk is created  (required to compute a new instance)
+     * @return the current  {@link CacheFile} instance (existing or computed)
+     * @throws Exception if this method is used when the {@link CacheService} is not started
+     */
     public CacheFile get(final CacheKey cacheKey, final long fileLength, final Path cacheDir) throws Exception {
         ensureLifecycleStarted();
         return cache.computeIfAbsent(cacheKey, key -> {
@@ -211,9 +230,42 @@ public class CacheService extends AbstractLifecycleComponent {
             assert Files.notExists(path) : "cache file already exists " + path;
 
             final SetOnce<CacheFile> cacheFile = new SetOnce<>();
-            cacheFile.set(new CacheFile(key.toString(), fileLength, path, () -> onCacheFileUpdate(cacheFile.get())));
+            cacheFile.set(new CacheFile(key, fileLength, path, () -> onCacheFileUpdate(cacheFile.get())));
             return cacheFile.get();
         });
+    }
+
+    /**
+     * Computes a new {@link CacheFile} instance using the specified cache file information (file length, file name, parent directory and
+     * already available cache ranges) and associates it with the specified {@link CacheKey} in the cache. If the key is already
+     * associated with a {@link CacheFile}, the previous instance is replaced by a new one.
+     *
+     * This method can only be used before the {@link CacheService} is started.
+     *
+     * @param cacheKey        the cache key with which the new {@link CacheFile} instance is to be associated
+     * @param fileLength      the length of the cache file
+     * @param cacheDir        the cache directory where the cache file on disk is located
+     * @param cacheFileUuid   the name of the cache file on disk (should be a UUID)
+     * @param cacheFileRanges the set of ranges that are known to be already available/completed for this cache file
+     * @throws Exception if this method is used when the {@link CacheService} is not initializing
+     */
+    void put(
+        final CacheKey cacheKey,
+        final long fileLength,
+        final Path cacheDir,
+        final String cacheFileUuid,
+        final SortedSet<Tuple<Long, Long>> cacheFileRanges
+    ) throws Exception {
+
+        ensureLifecycleInitializing();
+        final Path path = cacheDir.resolve(cacheFileUuid);
+        if (Files.exists(path) == false) {
+            throw new FileNotFoundException("Cache file [" + path + "] not found");
+        }
+
+        final SetOnce<CacheFile> cacheFile = new SetOnce<>();
+        cacheFile.set(new CacheFile(cacheKey, fileLength, path, cacheFileRanges, () -> onCacheFileUpdate(cacheFile.get())));
+        cache.put(cacheKey, cacheFile.get());
     }
 
     /**

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/SparseFileTrackerTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/SparseFileTrackerTests.java
@@ -26,6 +26,7 @@ import java.util.function.Consumer;
 
 import static org.elasticsearch.common.util.concurrent.ConcurrentCollections.newConcurrentSet;
 import static org.elasticsearch.index.store.cache.TestUtils.mergeContiguousRanges;
+import static org.elasticsearch.index.store.cache.TestUtils.randomRanges;
 import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsConstants.toIntBytes;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
@@ -565,19 +566,5 @@ public class SparseFileTrackerTests extends ESTestCase {
             gap.onCompletion();
             return true;
         }
-    }
-
-    /**
-     * Generates a sorted set of non-empty and non-contiguous random ranges that could fit into a file of a given maximum length.
-     */
-    private static SortedSet<Tuple<Long, Long>> randomRanges(long length) {
-        final SortedSet<Tuple<Long, Long>> randomRanges = new TreeSet<>(Comparator.comparingLong(Tuple::v1));
-        for (long i = 0L; i < length;) {
-            long start = randomLongBetween(i, Math.max(0L, length - 1L));
-            long end = randomLongBetween(start + 1L, length); // +1 for non empty ranges
-            randomRanges.add(Tuple.tuple(start, end));
-            i = end + 1L + randomLongBetween(0L, Math.max(0L, length - end)); // +1 for non contiguous ranges
-        }
-        return randomRanges;
     }
 }

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/TestUtils.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/TestUtils.java
@@ -101,6 +101,20 @@ public final class TestUtils {
         return numberOfRanges;
     }
 
+    /**
+     * Generates a sorted set of non-empty and non-contiguous random ranges that could fit into a file of a given maximum length.
+     */
+    public static SortedSet<Tuple<Long, Long>> randomRanges(long length) {
+        final SortedSet<Tuple<Long, Long>> randomRanges = new TreeSet<>(Comparator.comparingLong(Tuple::v1));
+        for (long i = 0L; i < length;) {
+            long start = randomLongBetween(i, Math.max(0L, length - 1L));
+            long end = randomLongBetween(start + 1L, length); // +1 for non empty ranges
+            randomRanges.add(Tuple.tuple(start, end));
+            i = end + 1L + randomLongBetween(0L, Math.max(0L, length - end)); // +1 for non contiguous ranges
+        }
+        return randomRanges;
+    }
+
     public static SortedSet<Tuple<Long, Long>> mergeContiguousRanges(final SortedSet<Tuple<Long, Long>> ranges) {
         // Eclipse needs the TreeSet type to be explicit (see https://bugs.eclipse.org/bugs/show_bug.cgi?id=568600)
         return ranges.stream().collect(() -> new TreeSet<Tuple<Long, Long>>(Comparator.comparingLong(Tuple::v1)), (gaps, gap) -> {

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheServiceTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheServiceTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.xpack.searchablesnapshots.AbstractSearchableSnapshotsTe
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
+import java.io.FileNotFoundException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
@@ -30,9 +31,14 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.SortedSet;
 
+import static java.util.Collections.emptySortedSet;
 import static org.elasticsearch.index.store.cache.TestUtils.randomPopulateAndReads;
+import static org.elasticsearch.index.store.cache.TestUtils.randomRanges;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 
 public class CacheServiceTests extends AbstractSearchableSnapshotsTestCase {
 
@@ -159,6 +165,45 @@ public class CacheServiceTests extends AbstractSearchableSnapshotsTestCase {
                     assertThat(cacheService.isCacheFileToSync(cacheFile), is(false));
                     assertThat(fileSystemProvider.getNumberOfFSyncs(cacheFile.getFile()), equalTo(cacheFileAndExpectedNumberOfFSyncs.v2()));
                 });
+            }
+        }
+    }
+
+    public void testPut() throws Exception {
+        final Path cacheDir = createTempDir();
+        try (CacheService cacheService = defaultCacheService()) {
+            final long fileLength = randomLongBetween(0L, 1000L);
+            final CacheKey cacheKey = new CacheKey(
+                new SnapshotId(randomAlphaOfLength(5).toLowerCase(Locale.ROOT), UUIDs.randomBase64UUID(random())),
+                new IndexId(randomAlphaOfLength(5).toLowerCase(Locale.ROOT), UUIDs.randomBase64UUID(random())),
+                new ShardId(randomAlphaOfLength(5).toLowerCase(Locale.ROOT), UUIDs.randomBase64UUID(random()), randomInt(5)),
+                randomAlphaOfLength(105).toLowerCase(Locale.ROOT)
+            );
+            final String cacheFileUuid = UUIDs.randomBase64UUID(random());
+            final SortedSet<Tuple<Long, Long>> cacheFileRanges = randomBoolean() ? randomRanges(fileLength) : emptySortedSet();
+
+            if (randomBoolean()) {
+                final Path cacheFilePath = cacheDir.resolve(cacheFileUuid);
+                Files.createFile(cacheFilePath);
+
+                cacheService.put(cacheKey, fileLength, cacheDir, cacheFileUuid, cacheFileRanges);
+
+                cacheService.start();
+                final CacheFile cacheFile = cacheService.get(cacheKey, fileLength, cacheDir);
+                assertThat(cacheFile, notNullValue());
+                assertThat(cacheFile.getFile(), equalTo(cacheFilePath));
+                assertThat(cacheFile.getCacheKey(), equalTo(cacheKey));
+                assertThat(cacheFile.getLength(), equalTo(fileLength));
+
+                for (Tuple<Long, Long> cacheFileRange : cacheFileRanges) {
+                    assertThat(cacheFile.getAbsentRangeWithin(cacheFileRange.v1(), cacheFileRange.v2()), nullValue());
+                }
+            } else {
+                final FileNotFoundException exception = expectThrows(
+                    FileNotFoundException.class,
+                    () -> cacheService.put(cacheKey, fileLength, cacheDir, cacheFileUuid, cacheFileRanges)
+                );
+                assertThat(exception.getMessage(), containsString(cacheFileUuid));
             }
         }
     }


### PR DESCRIPTION
This commit adds a new put() method to the CacheService
that allows to add existing cache files to the searchable
snapshot cache before the service is effectively started.
This method will be used in the future to fill the cache at
node start-up time with information retrieved from a
Lucene index.

Backport of #65538 
