### PR TITLE
[7.10] [DOCS] Add `require_alias` to Bulk API (#66259)

### DIFF
--- a/docs/reference/docs/bulk.asciidoc
+++ b/docs/reference/docs/bulk.asciidoc
@@ -211,6 +211,11 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=pipeline]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=refresh]
 
+`require_alias`::
+(Optional, Boolean)
+If `true`, the request's actions must target an <<indices-aliases,index alias>>.
+Defaults to `false`.
+
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=routing]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=source]
@@ -237,6 +242,8 @@ The following line must contain the source data to be indexed.
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=bulk-index]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=bulk-id]
+
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=bulk-require-alias]
 --
 
 `delete`::
@@ -249,6 +256,8 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=bulk-index]
 `_id`::
 (Required, string) 
 The document ID.
+
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=bulk-require-alias]
 --
 
 `index`::
@@ -261,6 +270,8 @@ The following line must contain the source data to be indexed.
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=bulk-index]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=bulk-id]
+
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=bulk-require-alias]
 --
 
 `update`::
@@ -272,6 +283,8 @@ The following line must contain the partial document and update options.
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=bulk-index]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=bulk-id]
+
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=bulk-require-alias]
 --
 
 `doc`::

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -602,6 +602,13 @@ such as `1264`.
 A value of `-1` indicates {es} was unable to compute this number.
 end::memory[]
 
+tag::bulk-require-alias[]
+`require_alias`::
+(Optional, Boolean)
+If `true`, the action must target an <<indices-aliases,index alias>>. Defaults
+to `false`.
+end::bulk-require-alias[]
+
 tag::require-alias[]
 `require_alias`::
 (Optional, Boolean)


### PR DESCRIPTION
Backports the following commits to 7.10:
 - [DOCS] Add `require_alias` to Bulk API (#66259)