### PR TITLE
Forbid assertons in production mode

### DIFF
--- a/server/src/main/java/org/elasticsearch/bootstrap/BootstrapChecks.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/BootstrapChecks.java
@@ -208,9 +208,7 @@ final class BootstrapChecks {
             checks.add(new MaxMapCountCheck());
         }
         checks.add(new ClientJvmCheck());
-        if (Boolean.parseBoolean(System.getProperty("forbid.assertions", "false"))) {
-            checks.add(new AssertionsEnabledCheck());
-        }
+        checks.add(new AssertionsEnabledCheck());
         checks.add(new UseSerialGCCheck());
         checks.add(new SystemCallFilterCheck());
         checks.add(new OnErrorCheck());
@@ -508,12 +506,22 @@ final class BootstrapChecks {
 
     }
 
+    /**
+     * Checks whether assertions are enabled in the JVM. This incurs a performance penalty and should not
+     * be enabled under normal circumstances. The system property {@code es.assertions.allowed} offers
+     * an escape hatch in the event there are edge cases where enabling assertions in a production (or
+     * production-like) setting would be useful.
+     */
     static class AssertionsEnabledCheck implements BootstrapCheck {
+
+        boolean isOverrideEnabled() {
+            return Boolean.parseBoolean(System.getProperty("es.assertions.allowed", "false"));
+        }
 
         @Override
         public BootstrapCheckResult check(BootstrapContext context) {
             try {
-                assert false;
+                assert isOverrideEnabled();
             } catch (AssertionError e) {
                 return BootstrapCheckResult.failure("Assertions should not be enabled for the best performance");
             }


### PR DESCRIPTION
Assertions should not be enabled in the JVM when Elasticsearch is
executing in "production" mode. Add a bootstrap check that prohibits
this.

There is an undocumented escape hatch, when the system property
"es.assertions.allowed" is true, to cover edge cases. If we don't want
this, I can easily strip it out.