### PR TITLE
System indices auto-create for searchable-snapshots

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
@@ -6,10 +6,12 @@
 package org.elasticsearch.xpack.searchablesnapshots;
 
 import org.apache.lucene.util.SetOnce;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.blobstore.cache.BlobStoreCacheService;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
@@ -26,6 +28,7 @@ import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.index.IndexModule;
@@ -52,6 +55,7 @@ import org.elasticsearch.threadpool.ExecutorBuilder;
 import org.elasticsearch.threadpool.ScalingExecutorBuilder;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.watcher.ResourceWatcherService;
+import org.elasticsearch.xpack.cluster.routing.allocation.DataTierAllocationDecider;
 import org.elasticsearch.xpack.core.DataTier;
 import org.elasticsearch.xpack.core.XPackPlugin;
 import org.elasticsearch.xpack.core.action.XPackInfoFeatureAction;
@@ -68,6 +72,8 @@ import org.elasticsearch.xpack.searchablesnapshots.rest.RestClearSearchableSnaps
 import org.elasticsearch.xpack.searchablesnapshots.rest.RestMountSearchableSnapshotAction;
 import org.elasticsearch.xpack.searchablesnapshots.rest.RestSearchableSnapshotsStatsAction;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -77,6 +83,9 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.index.mapper.MapperService.SINGLE_MAPPING_NAME;
+import static org.elasticsearch.xpack.core.ClientHelper.SEARCHABLE_SNAPSHOTS_ORIGIN;
 import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsConstants.CACHE_FETCH_ASYNC_THREAD_POOL_NAME;
 import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsConstants.CACHE_FETCH_ASYNC_THREAD_POOL_SETTING;
 import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsConstants.CACHE_PREWARMING_THREAD_POOL_NAME;
@@ -218,12 +227,7 @@ public class SearchableSnapshots extends Plugin implements IndexStorePlugin, Eng
             );
             this.cacheService.set(cacheService);
             components.add(cacheService);
-            final BlobStoreCacheService blobStoreCacheService = new BlobStoreCacheService(
-                clusterService,
-                threadPool,
-                client,
-                SNAPSHOT_BLOB_CACHE_INDEX
-            );
+            final BlobStoreCacheService blobStoreCacheService = new BlobStoreCacheService(threadPool, client, SNAPSHOT_BLOB_CACHE_INDEX);
             this.blobStoreCacheService.set(blobStoreCacheService);
             components.add(blobStoreCacheService);
         }
@@ -248,7 +252,17 @@ public class SearchableSnapshots extends Plugin implements IndexStorePlugin, Eng
 
     @Override
     public Collection<SystemIndexDescriptor> getSystemIndexDescriptors(Settings settings) {
-        return List.of(new SystemIndexDescriptor(SNAPSHOT_BLOB_CACHE_INDEX, "Contains cached data of blob store repositories"));
+        return List.of(
+            SystemIndexDescriptor.builder()
+                .setIndexPattern(SNAPSHOT_BLOB_CACHE_INDEX)
+                .setDescription("Contains cached data of blob store repositories")
+                .setPrimaryIndex(SNAPSHOT_BLOB_CACHE_INDEX)
+                .setMappings(getIndexMappings())
+                .setSettings(getIndexSettings())
+                .setOrigin(SEARCHABLE_SNAPSHOTS_ORIGIN)
+                .setVersionMetaKey("version")
+                .build()
+        );
     }
 
     @Override
@@ -354,5 +368,108 @@ public class SearchableSnapshots extends Plugin implements IndexStorePlugin, Eng
                 TimeValue.timeValueSeconds(30L),
                 CACHE_PREWARMING_THREAD_POOL_SETTING
             ) };
+    }
+
+    private Settings getIndexSettings() {
+        return Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-1")
+            .put(IndexMetadata.SETTING_PRIORITY, "900")
+            .put(DataTierAllocationDecider.INDEX_ROUTING_PREFER, DATA_TIERS_PREFERENCE)
+            .build();
+    }
+
+    private XContentBuilder getIndexMappings() {
+        try {
+            final XContentBuilder builder = jsonBuilder();
+            {
+                builder.startObject();
+                {
+                    builder.startObject(SINGLE_MAPPING_NAME);
+                    builder.field("dynamic", "strict");
+                    {
+                        builder.startObject("_meta");
+                        builder.field("version", Version.CURRENT);
+                        builder.endObject();
+                    }
+                    {
+                        builder.startObject("properties");
+                        {
+                            builder.startObject("type");
+                            builder.field("type", "keyword");
+                            builder.endObject();
+                        }
+                        {
+                            builder.startObject("creation_time");
+                            builder.field("type", "date");
+                            builder.field("format", "epoch_millis");
+                            builder.endObject();
+                        }
+                        {
+                            builder.startObject("version");
+                            builder.field("type", "integer");
+                            builder.endObject();
+                        }
+                        {
+                            builder.startObject("repository");
+                            builder.field("type", "keyword");
+                            builder.endObject();
+                        }
+                        {
+                            builder.startObject("blob");
+                            builder.field("type", "object");
+                            {
+                                builder.startObject("properties");
+                                {
+                                    builder.startObject("name");
+                                    builder.field("type", "keyword");
+                                    builder.endObject();
+                                    builder.startObject("path");
+                                    builder.field("type", "keyword");
+                                    builder.endObject();
+                                }
+                                builder.endObject();
+                            }
+                            builder.endObject();
+                        }
+                        {
+                            builder.startObject("data");
+                            builder.field("type", "object");
+                            {
+                                builder.startObject("properties");
+                                {
+                                    builder.startObject("content");
+                                    builder.field("type", "binary");
+                                    builder.endObject();
+                                }
+                                {
+                                    builder.startObject("length");
+                                    builder.field("type", "long");
+                                    builder.endObject();
+                                }
+                                {
+                                    builder.startObject("from");
+                                    builder.field("type", "long");
+                                    builder.endObject();
+                                }
+                                {
+                                    builder.startObject("to");
+                                    builder.field("type", "long");
+                                    builder.endObject();
+                                }
+                                builder.endObject();
+                            }
+                            builder.endObject();
+                        }
+                        builder.endObject();
+                    }
+                    builder.endObject();
+                }
+                builder.endObject();
+            }
+            return builder;
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to build " + SNAPSHOT_BLOB_CACHE_INDEX + " index mappings", e);
+        }
     }
 }

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/TestUtils.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/TestUtils.java
@@ -287,7 +287,7 @@ public final class TestUtils {
     public static class NoopBlobStoreCacheService extends BlobStoreCacheService {
 
         public NoopBlobStoreCacheService() {
-            super(null, null, mock(Client.class), null);
+            super(null, mock(Client.class), null);
         }
 
         @Override


### PR DESCRIPTION
Part of #61656.

Use the system indices auto-creation infrastructure for the searchable
snapshots plugin.
