### PR TITLE
[ML] Data frame analytics _explain API should not fail when none field is included

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/explain_data_frame_analytics.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/explain_data_frame_analytics.yml
@@ -312,3 +312,35 @@
   - match: { field_selection.4.is_required: false }
   - match: { field_selection.4.feature_type: "categorical" }
   - is_false: field_selection.4.reason
+
+---
+"Test given no included field":
+
+  - do:
+      indices.create:
+        index: index-source
+        body:
+          mappings:
+            properties:
+              x:
+                type: keyword
+
+  - do:
+      index:
+        index: index-source
+        refresh: true
+        body: { x: "hello!" }
+  - match: { result: "created" }
+
+  - do:
+      ml.explain_data_frame_analytics:
+        body:
+          source: { index: "index-source" }
+          analysis: { outlier_detection: {} }
+  - match:
+      memory_estimation.expected_memory_without_disk: "0"
+  - match:
+      memory_estimation.expected_memory_with_disk: "0"
+  - length: { field_selection: 1 }
+  - match: { field_selection.0.name: "x" }
+  - match: { field_selection.0.is_included: false }


### PR DESCRIPTION
This commit fixes an issue with DFA _explain API where if it is called
and no field is included, it results to an error message coming from
the c++ process due to the data frame having no columns.

We want the _explain API not to error when no fields are included
exactly in order to explain to the user why it is that no fields
are included. Thus, we can simply fix this by not running the
memory estimation process and returning zero estimates instead.

Note that the _start API will fail with a user friendly error message
that informs there are no included fields.
