### PR TITLE
Simplify searchable snapshot CacheKey

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/SearchableSnapshotDirectory.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/SearchableSnapshotDirectory.java
@@ -344,7 +344,7 @@ public class SearchableSnapshotDirectory extends BaseDirectory {
     }
 
     public CacheKey createCacheKey(String fileName) {
-        return new CacheKey(snapshotId, indexId, shardId, fileName);
+        return new CacheKey(snapshotId.getUUID(), indexId.getName(), shardId, fileName);
     }
 
     public CacheFile getCacheFile(CacheKey cacheKey, long fileLength) throws Exception {

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/CacheKey.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/CacheKey.java
@@ -6,31 +6,29 @@
 package org.elasticsearch.index.store.cache;
 
 import org.elasticsearch.index.shard.ShardId;
-import org.elasticsearch.repositories.IndexId;
-import org.elasticsearch.snapshots.SnapshotId;
 
 import java.util.Objects;
 
 public class CacheKey {
 
-    private final SnapshotId snapshotId;
-    private final IndexId indexId;
+    private final String snapshotUUID;
+    private final String snapshotIndexName;
     private final ShardId shardId;
     private final String fileName;
 
-    public CacheKey(SnapshotId snapshotId, IndexId indexId, ShardId shardId, String fileName) {
-        this.snapshotId = Objects.requireNonNull(snapshotId);
-        this.indexId = Objects.requireNonNull(indexId);
+    public CacheKey(String snapshotUUID, String snapshotIndexName, ShardId shardId, String fileName) {
+        this.snapshotUUID = Objects.requireNonNull(snapshotUUID);
+        this.snapshotIndexName = Objects.requireNonNull(snapshotIndexName);
         this.shardId = Objects.requireNonNull(shardId);
         this.fileName = Objects.requireNonNull(fileName);
     }
 
-    public SnapshotId getSnapshotId() {
-        return snapshotId;
+    public String getSnapshotUUID() {
+        return snapshotUUID;
     }
 
-    public IndexId getIndexId() {
-        return indexId;
+    public String getSnapshotIndexName() {
+        return snapshotIndexName;
     }
 
     public ShardId getShardId() {
@@ -50,19 +48,27 @@ public class CacheKey {
             return false;
         }
         final CacheKey cacheKey = (CacheKey) o;
-        return Objects.equals(snapshotId, cacheKey.snapshotId)
-            && Objects.equals(indexId, cacheKey.indexId)
+        return Objects.equals(snapshotUUID, cacheKey.snapshotUUID)
+            && Objects.equals(snapshotIndexName, cacheKey.snapshotIndexName)
             && Objects.equals(shardId, cacheKey.shardId)
             && Objects.equals(fileName, cacheKey.fileName);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(snapshotId, indexId, shardId, fileName);
+        return Objects.hash(snapshotUUID, snapshotIndexName, shardId, fileName);
     }
 
     @Override
     public String toString() {
-        return "[" + "snapshotId=" + snapshotId + ", indexId=" + indexId + ", shardId=" + shardId + ", fileName='" + fileName + "']";
+        return "[snapshotUUID="
+            + snapshotUUID
+            + ", snapshotIndexName="
+            + snapshotIndexName
+            + ", shardId="
+            + shardId
+            + ", fileName='"
+            + fileName
+            + "']";
     }
 }

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/PersistentCache.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/PersistentCache.java
@@ -486,9 +486,7 @@ public class PersistentCache implements Closeable {
     private static final String CACHE_PATH_FIELD = "cache_path";
     private static final String CACHE_RANGES_FIELD = "cache_ranges";
     private static final String SNAPSHOT_ID_FIELD = "snapshot_id";
-    private static final String SNAPSHOT_NAME_FIELD = "snapshot_name";
-    private static final String INDEX_ID_FIELD = "index_id";
-    private static final String INDEX_NAME_FIELD = "index_name";
+    private static final String SNAPSHOT_INDEX_NAME_FIELD = "index_name";
     private static final String SHARD_INDEX_NAME_FIELD = "shard_index_name";
     private static final String SHARD_INDEX_ID_FIELD = "shard_index_id";
     private static final String SHARD_ID_FIELD = "shard_id";
@@ -501,10 +499,6 @@ public class PersistentCache implements Closeable {
 
     private static String buildId(Path path) {
         return path.getFileName().toString();
-    }
-
-    private static Term buildTerm(CacheFile cacheFile) {
-        return buildTerm(buildId(cacheFile));
     }
 
     private static Term buildTerm(String cacheFileUuid) {
@@ -530,14 +524,8 @@ public class PersistentCache implements Closeable {
         final CacheKey cacheKey = cacheFile.getCacheKey();
         document.add(new StringField(FILE_NAME_FIELD, cacheKey.getFileName(), Field.Store.YES));
         document.add(new StringField(FILE_LENGTH_FIELD, Long.toString(cacheFile.getLength()), Field.Store.YES));
-
-        final SnapshotId snapshotId = cacheKey.getSnapshotId();
-        document.add(new StringField(SNAPSHOT_NAME_FIELD, snapshotId.getName(), Field.Store.YES));
-        document.add(new StringField(SNAPSHOT_ID_FIELD, snapshotId.getUUID(), Field.Store.YES));
-
-        final IndexId indexId = cacheKey.getIndexId();
-        document.add(new StringField(INDEX_NAME_FIELD, indexId.getName(), Field.Store.YES));
-        document.add(new StringField(INDEX_ID_FIELD, indexId.getId(), Field.Store.YES));
+        document.add(new StringField(SNAPSHOT_ID_FIELD, cacheKey.getSnapshotUUID(), Field.Store.YES));
+        document.add(new StringField(SNAPSHOT_INDEX_NAME_FIELD, cacheKey.getSnapshotIndexName(), Field.Store.YES));
 
         final ShardId shardId = cacheKey.getShardId();
         document.add(new StringField(SHARD_INDEX_NAME_FIELD, shardId.getIndex().getName(), Field.Store.YES));
@@ -555,8 +543,8 @@ public class PersistentCache implements Closeable {
 
     private static CacheKey buildCacheKey(Document document) {
         return new CacheKey(
-            new SnapshotId(getValue(document, SNAPSHOT_NAME_FIELD), getValue(document, SNAPSHOT_ID_FIELD)),
-            new IndexId(getValue(document, INDEX_NAME_FIELD), getValue(document, INDEX_ID_FIELD)),
+            getValue(document, SNAPSHOT_ID_FIELD),
+            getValue(document, SNAPSHOT_INDEX_NAME_FIELD),
             new ShardId(
                 new Index(getValue(document, SHARD_INDEX_NAME_FIELD), getValue(document, SHARD_INDEX_ID_FIELD)),
                 Integer.parseInt(getValue(document, SHARD_ID_FIELD))

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/CacheFileTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/CacheFileTests.java
@@ -15,8 +15,6 @@ import org.elasticsearch.common.util.concurrent.RunOnce;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.store.cache.CacheFile.EvictionListener;
 import org.elasticsearch.index.store.cache.TestUtils.FSyncTrackingFileSystemProvider;
-import org.elasticsearch.repositories.IndexId;
-import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.hamcrest.Matcher;
@@ -49,17 +47,12 @@ import static org.hamcrest.Matchers.sameInstance;
 public class CacheFileTests extends ESTestCase {
 
     private static final Runnable NOOP = () -> {};
-    private static final CacheKey CACHE_KEY = new CacheKey(
-        new SnapshotId("_name", "_uuid"),
-        new IndexId("_name", "_uuid"),
-        new ShardId("_name", "_uuid", 0),
-        "_filename"
-    );
+    private static final CacheKey CACHE_KEY = new CacheKey("_snap_uuid", "_snap_index", new ShardId("_name", "_uuid", 0), "_filename");
 
     public void testGetCacheKey() throws Exception {
         final CacheKey cacheKey = new CacheKey(
-            new SnapshotId(randomAlphaOfLength(5).toLowerCase(Locale.ROOT), UUIDs.randomBase64UUID(random())),
-            new IndexId(randomAlphaOfLength(5).toLowerCase(Locale.ROOT), UUIDs.randomBase64UUID(random())),
+            UUIDs.randomBase64UUID(random()),
+            randomAlphaOfLength(5).toLowerCase(Locale.ROOT),
             new ShardId(randomAlphaOfLength(5).toLowerCase(Locale.ROOT), UUIDs.randomBase64UUID(random()), randomInt(5)),
             randomAlphaOfLength(105).toLowerCase(Locale.ROOT)
         );

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/CacheKeyTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/CacheKeyTests.java
@@ -5,12 +5,13 @@
  */
 package org.elasticsearch.index.store.cache;
 
+import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
-import org.elasticsearch.repositories.IndexId;
-import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.EqualsHashCodeTestUtils;
+
+import java.util.Locale;
 
 public class CacheKeyTests extends ESTestCase {
 
@@ -18,12 +19,12 @@ public class CacheKeyTests extends ESTestCase {
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(createInstance(), this::copy, this::mutate);
     }
 
-    private SnapshotId randomSnapshotId() {
-        return new SnapshotId(randomAlphaOfLengthBetween(5, 10), randomAlphaOfLengthBetween(5, 10));
+    private String randomSnapshotUUID() {
+        return UUIDs.randomBase64UUID(random());
     }
 
-    private IndexId randomIndexId() {
-        return new IndexId(randomAlphaOfLengthBetween(5, 10), randomAlphaOfLengthBetween(5, 10));
+    private String randomSnapshotIndexName() {
+        return randomAlphaOfLengthBetween(5, 10).toLowerCase(Locale.ROOT);
     }
 
     private ShardId randomShardId() {
@@ -31,37 +32,29 @@ public class CacheKeyTests extends ESTestCase {
     }
 
     private CacheKey createInstance() {
-        return new CacheKey(randomSnapshotId(), randomIndexId(), randomShardId(), randomAlphaOfLengthBetween(5, 10));
+        return new CacheKey(randomSnapshotUUID(), randomSnapshotIndexName(), randomShardId(), randomAlphaOfLengthBetween(5, 10));
     }
 
     private CacheKey copy(final CacheKey origin) {
-        SnapshotId snapshotId = origin.getSnapshotId();
-        if (randomBoolean()) {
-            snapshotId = new SnapshotId(origin.getSnapshotId().getName(), origin.getSnapshotId().getUUID());
-        }
-        IndexId indexId = origin.getIndexId();
-        if (randomBoolean()) {
-            indexId = new IndexId(origin.getIndexId().getName(), origin.getIndexId().getId());
-        }
         ShardId shardId = origin.getShardId();
         if (randomBoolean()) {
             shardId = new ShardId(new Index(shardId.getIndex().getName(), shardId.getIndex().getUUID()), shardId.id());
         }
-        return new CacheKey(snapshotId, indexId, shardId, origin.getFileName());
+        return new CacheKey(origin.getSnapshotUUID(), origin.getSnapshotIndexName(), shardId, origin.getFileName());
     }
 
     private CacheKey mutate(CacheKey origin) {
-        SnapshotId snapshotId = origin.getSnapshotId();
-        IndexId indexId = origin.getIndexId();
+        String snapshotUUID = origin.getSnapshotUUID();
+        String snapshotIndexName = origin.getSnapshotIndexName();
         ShardId shardId = origin.getShardId();
         String fileName = origin.getFileName();
 
         switch (randomInt(3)) {
             case 0:
-                snapshotId = randomValueOtherThan(origin.getSnapshotId(), this::randomSnapshotId);
+                snapshotUUID = randomValueOtherThan(snapshotUUID, this::randomSnapshotUUID);
                 break;
             case 1:
-                indexId = randomValueOtherThan(origin.getIndexId(), this::randomIndexId);
+                snapshotIndexName = randomValueOtherThan(snapshotIndexName, this::randomSnapshotIndexName);
                 break;
             case 2:
                 shardId = randomValueOtherThan(origin.getShardId(), this::randomShardId);
@@ -72,6 +65,6 @@ public class CacheKeyTests extends ESTestCase {
             default:
                 throw new AssertionError("Unsupported mutation");
         }
-        return new CacheKey(snapshotId, indexId, shardId, fileName);
+        return new CacheKey(snapshotUUID, snapshotIndexName, shardId, fileName);
     }
 }

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheServiceTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheServiceTests.java
@@ -64,8 +64,8 @@ public class CacheServiceTests extends AbstractSearchableSnapshotsTestCase {
     public void testCacheSynchronization() throws Exception {
         final int numShards = randomIntBetween(1, 3);
         final Index index = new Index(randomAlphaOfLength(5).toLowerCase(Locale.ROOT), UUIDs.randomBase64UUID(random()));
-        final SnapshotId snapshotId = new SnapshotId("_snapshot_name", UUIDs.randomBase64UUID(random()));
-        final IndexId indexId = new IndexId("_index_name", UUIDs.randomBase64UUID(random()));
+        final String snapshotUUID = UUIDs.randomBase64UUID(random());
+        final String snapshotIndexName = UUIDs.randomBase64UUID(random());
 
         logger.debug("--> creating shard cache directories on disk");
         final Path[] shardsCacheDirs = new Path[numShards];
@@ -74,7 +74,7 @@ public class CacheServiceTests extends AbstractSearchableSnapshotsTestCase {
             assertFalse(Files.exists(shardDataPath));
 
             logger.debug("--> creating directories [{}] for shard [{}]", shardDataPath.toAbsolutePath(), i);
-            shardsCacheDirs[i] = Files.createDirectories(resolveSnapshotCache(shardDataPath).resolve(snapshotId.getUUID()));
+            shardsCacheDirs[i] = Files.createDirectories(CacheService.resolveSnapshotCache(shardDataPath).resolve(snapshotUUID));
         }
 
         try (CacheService cacheService = defaultCacheService()) {
@@ -110,7 +110,7 @@ public class CacheServiceTests extends AbstractSearchableSnapshotsTestCase {
                 for (int i = 0; i < between(1, 25); i++) {
                     final ShardId shardId = new ShardId(index, randomIntBetween(0, numShards - 1));
                     final String fileName = String.format(Locale.ROOT, "file_%d_%d", iteration, i);
-                    final CacheKey cacheKey = new CacheKey(snapshotId, indexId, shardId, fileName);
+                    final CacheKey cacheKey = new CacheKey(snapshotUUID, snapshotIndexName, shardId, fileName);
                     final CacheFile cacheFile = cacheService.get(cacheKey, randomIntBetween(0, 10_000), shardsCacheDirs[shardId.id()]);
 
                     final CacheFile.EvictionListener listener = evictedCacheFile -> {};
@@ -178,14 +178,14 @@ public class CacheServiceTests extends AbstractSearchableSnapshotsTestCase {
         try (CacheService cacheService = defaultCacheService()) {
             final long fileLength = randomLongBetween(0L, 1000L);
             final CacheKey cacheKey = new CacheKey(
-                new SnapshotId(randomAlphaOfLength(5).toLowerCase(Locale.ROOT), UUIDs.randomBase64UUID(random())),
-                new IndexId(randomAlphaOfLength(5).toLowerCase(Locale.ROOT), UUIDs.randomBase64UUID(random())),
+                UUIDs.randomBase64UUID(random()),
+                randomAlphaOfLength(5).toLowerCase(Locale.ROOT),
                 new ShardId(randomAlphaOfLength(5).toLowerCase(Locale.ROOT), UUIDs.randomBase64UUID(random()), randomInt(5)),
                 randomAlphaOfLength(105).toLowerCase(Locale.ROOT)
             );
 
             final Path cacheDir = Files.createDirectories(
-                resolveSnapshotCache(randomShardPath(cacheKey.getShardId())).resolve(cacheKey.getSnapshotId().getUUID())
+                resolveSnapshotCache(randomShardPath(cacheKey.getShardId())).resolve(cacheKey.getSnapshotUUID())
             );
             final String cacheFileUuid = UUIDs.randomBase64UUID(random());
             final SortedSet<Tuple<Long, Long>> cacheFileRanges = randomBoolean() ? randomRanges(fileLength) : emptySortedSet();
@@ -238,7 +238,8 @@ public class CacheServiceTests extends AbstractSearchableSnapshotsTestCase {
         final PlainActionFuture<Void> waitForEviction = PlainActionFuture.newFuture();
         final CacheFile.EvictionListener evictionListener = evicted -> waitForEviction.onResponse(null);
 
-        final CacheFile cacheFile = cacheService.get(new CacheKey(snapshotId, indexId, shardId, "_0.dvd"), 100, cacheDir);
+        final CacheKey cacheKey = new CacheKey(snapshotId.getUUID(), indexId.getName(), shardId, "_0.dvd");
+        final CacheFile cacheFile = cacheService.get(cacheKey, 100, cacheDir);
         cacheFile.acquire(evictionListener);
 
         cacheService.markShardAsEvictedInCache(snapshotId, indexId, shardId);

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/PersistentCacheTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/PersistentCacheTests.java
@@ -20,7 +20,6 @@ import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.store.cache.CacheFile;
 import org.elasticsearch.index.store.cache.CacheKey;
 import org.elasticsearch.repositories.IndexId;
-import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.xpack.searchablesnapshots.AbstractSearchableSnapshotsTestCase;
 
 import java.io.IOException;
@@ -200,18 +199,18 @@ public class PersistentCacheTests extends AbstractSearchableSnapshotsTestCase {
 
         final List<CacheFile> cacheFiles = new ArrayList<>();
         for (int snapshots = 0; snapshots < between(1, 2); snapshots++) {
-            SnapshotId snapshotId = new SnapshotId(randomAlphaOfLength(5).toLowerCase(Locale.ROOT), UUIDs.randomBase64UUID(random()));
+            final String snapshotUUID = UUIDs.randomBase64UUID(random());
             for (int indices = 0; indices < between(1, 2); indices++) {
                 IndexId indexId = new IndexId(randomAlphaOfLength(5).toLowerCase(Locale.ROOT), UUIDs.randomBase64UUID(random()));
                 for (int shards = 0; shards < between(1, 2); shards++) {
                     ShardId shardId = new ShardId(indexId.getName(), indexId.getId(), shards);
 
                     final Path cacheDir = Files.createDirectories(
-                        CacheService.resolveSnapshotCache(randomShardPath(shardId)).resolve(snapshotId.getUUID())
+                        CacheService.resolveSnapshotCache(randomShardPath(shardId)).resolve(snapshotUUID)
                     );
 
                     for (int files = 0; files < between(1, 2); files++) {
-                        final CacheKey cacheKey = new CacheKey(snapshotId, indexId, shardId, "file_" + files);
+                        final CacheKey cacheKey = new CacheKey(snapshotUUID, indexId.getName(), shardId, "file_" + files);
                         final CacheFile cacheFile = cacheService.get(cacheKey, randomLongBetween(0L, buffer.length), cacheDir);
 
                         final CacheFile.EvictionListener listener = evictedCacheFile -> {};


### PR DESCRIPTION
This commit simplifies the CacheKey object 
as suggested in #65725.

Backport of  #66263 for 7.11