### PR TITLE
Improve FieldFetcher retrieval of fields (#66160)

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/FieldFetcherTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/FieldFetcherTests.java
@@ -36,6 +36,7 @@ import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.lookup.SourceLookup;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -657,6 +658,32 @@ public class FieldFetcherTests extends MapperServiceTestCase {
         fields = fetchFields(mapperService, source, fieldAndFormatList("unmapped_object.b", null, true), null);
         assertThat(fields.size(), equalTo(1));
         assertThat(fields.get("unmapped_object.b").getValue(), equalTo("bar"));
+    }
+
+    public void testLastFormatWins() throws IOException {
+        MapperService mapperService = createMapperService();
+
+        XContentBuilder source = XContentFactory.jsonBuilder().startObject()
+            .startArray("date_field")
+                .value("2011-11-11T11:11:11")
+                .value("2012-12-12T12:12:12")
+            .endArray()
+            .endObject();
+
+        List<FieldAndFormat> ff = new ArrayList<>();
+        ff.add(new FieldAndFormat("date_field", "year", false));
+        Map<String, DocumentField> fields = fetchFields(mapperService, source, ff, null);
+        assertThat(fields.size(), equalTo(1));
+        assertThat(fields.get("date_field").getValues().size(), equalTo(2));
+        assertThat(fields.get("date_field").getValues().get(0), equalTo("2011"));
+        assertThat(fields.get("date_field").getValues().get(1), equalTo("2012"));
+
+        ff.add(new FieldAndFormat("date_field", "hour", false));
+        fields = fetchFields(mapperService, source, ff, null);
+        assertThat(fields.size(), equalTo(1));
+        assertThat(fields.get("date_field").getValues().size(), equalTo(2));
+        assertThat(fields.get("date_field").getValues().get(0), equalTo("11"));
+        assertThat(fields.get("date_field").getValues().get(1), equalTo("12"));
     }
 
     private List<FieldAndFormat> fieldAndFormatList(String name, String format, boolean includeUnmapped) {


### PR DESCRIPTION
Currently FieldFetcher stores all the FieldContexts that are later used to
retrieve the fields in a List. This has the disadvantage that the same field
path can be retrieved several times (e.g. if multiple patterns match the same
path or if similar paths are defined several times e.g. with different formats).
Currently the last value to be retrieved "wins" and gets returned. We might as
well de-duplicate the FieldContexts by using a map internally, keyed by the
field path that is going to be retrieved, to avoid more work later.

Backport of #66160