### PR TITLE
[DOCS] Adds xpack.ml.max_ml_node_size

### DIFF
--- a/docs/reference/settings/ml-settings.asciidoc
+++ b/docs/reference/settings/ml-settings.asciidoc
@@ -145,7 +145,7 @@ nodes to the cluster. This setting is only useful when used in conjunction with
 such an external process.
 
 `xpack.ml.max_ml_node_size`::
-(<<static-cluster-setting,Static>>)
+(<<cluster-update-settings,Dynamic>>)
 The maximum node size for {ml} nodes in a deployment that supports automatic
 cluster scaling. Defaults to `0b`, which means this value is ignored. If you set
 it to the maximum possible size of future {ml} nodes, when a {ml} job is

--- a/docs/reference/settings/ml-settings.asciidoc
+++ b/docs/reference/settings/ml-settings.asciidoc
@@ -80,6 +80,11 @@ total memory of the machine, not current free memory. Jobs are not allocated to
 a node if doing so would cause the estimated memory use of {ml} jobs to exceed
 the limit.
 
+`xpack.ml.max_ml_node_size`::
+(<<static-cluster-setting,Static>>)
+The maximum node size for {ml} nodes. Defaults to `0b`, which means this value
+is ignored.
+
 `xpack.ml.max_model_memory_limit`::
 (<<cluster-update-settings,Dynamic>>) The maximum `model_memory_limit` property
 value that can be set for any job on this node. If you try to create a job with

--- a/docs/reference/settings/ml-settings.asciidoc
+++ b/docs/reference/settings/ml-settings.asciidoc
@@ -80,11 +80,6 @@ total memory of the machine, not current free memory. Jobs are not allocated to
 a node if doing so would cause the estimated memory use of {ml} jobs to exceed
 the limit.
 
-`xpack.ml.max_ml_node_size`::
-(<<static-cluster-setting,Static>>)
-The maximum node size for {ml} nodes. Defaults to `0b`, which means this value
-is ignored.
-
 `xpack.ml.max_model_memory_limit`::
 (<<cluster-update-settings,Dynamic>>) The maximum `model_memory_limit` property
 value that can be set for any job on this node. If you try to create a job with
@@ -148,6 +143,14 @@ and the job is assigned to run on that node.
 IMPORTANT: This setting assumes some external process is capable of adding {ml}
 nodes to the cluster. This setting is only useful when used in conjunction with
 such an external process.
+
+`xpack.ml.max_ml_node_size`::
+(<<static-cluster-setting,Static>>)
+The maximum node size for {ml} nodes in a deployment that supports automatic
+cluster scaling. Defaults to `0b`, which means this value is ignored. If you set
+it to the maximum possible size of future {ml} nodes, when a {ml} job is
+assigned to a lazy node it can check (and fail quickly) when scaling cannot 
+support the size of the job. 
 
 `xpack.ml.process_connect_timeout`::
 (<<cluster-update-settings,Dynamic>>) The connection timeout for {ml} processes


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/59309 and https://github.com/elastic/elasticsearch/pull/66132

Adds xpack.ml.max_ml_node_size to the machine learning settings documentation
