### PR TITLE
Add searchable snapshot cache folder to NodeEnvironment

### DIFF
--- a/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -181,6 +181,11 @@ public final class NodeEnvironment  implements Closeable {
     public static final String INDICES_FOLDER = "indices";
     public static final String NODE_LOCK_FILENAME = "node.lock";
 
+    /**
+     * Searchable snapshot's Lucene index directory.
+     */
+    private static final String SNAPSHOT_CACHE_FOLDER = "snapshot_cache";
+
     public static class NodeLock implements Releasable {
 
         private final Lock[] locks;
@@ -381,7 +386,11 @@ public final class NodeEnvironment  implements Closeable {
                     MetadataStateFormat.STATE_DIR_NAME,
 
                     // indices
-                    INDICES_FOLDER));
+                    INDICES_FOLDER,
+
+                    // searchable snapshot cache Lucene index
+                    SNAPSHOT_CACHE_FOLDER
+                ));
 
                 try (DirectoryStream<Path> stream = Files.newDirectoryStream(legacyNodePath.path)) {
                     for (Path subFolderPath : stream) {


### PR DESCRIPTION
The change in #65725 introduced a new directory named `snapshot_cache` at the root of data node paths (at the same level as the `_state` and the `indices` folders).

Sadly this makes some BWC tests to fail as `NodeEnvironment` checks for extra/unknown directories at startup. Here are some CI failures:
- https://gradle-enterprise.elastic.co/s/qerw7f4o6d3cq
- https://gradle-enterprise.elastic.co/s/v6iuvamvcsq2w

This pull request changes `NodeEnvironment` so that it now autorizes `snapshot_cache` in root data paths.