### PR TITLE
[DOCS] Note `tar.gz` does not include `systemd`

### DIFF
--- a/docs/reference/setup/install/targz-daemon.asciidoc
+++ b/docs/reference/setup/install/targz-daemon.asciidoc
@@ -21,5 +21,6 @@ To shut down Elasticsearch, kill the process ID recorded in the `pid` file:
 pkill -F pid
 --------------------------------------------
 
-NOTE: The startup scripts provided in the <<rpm,RPM>> and <<deb,Debian>>
-packages take care of starting and stopping the Elasticsearch process for you.
+NOTE: {es}'s `.tar.gz` package do not include `systemd`. To automatically start
+{es} when the system boots up, use the <<start-deb,Debian>> or <<start-rpm,RPM>>
+package instead.

--- a/docs/reference/setup/install/targz-daemon.asciidoc
+++ b/docs/reference/setup/install/targz-daemon.asciidoc
@@ -21,6 +21,6 @@ To shut down Elasticsearch, kill the process ID recorded in the `pid` file:
 pkill -F pid
 --------------------------------------------
 
-NOTE: {es}'s `.tar.gz` package do not include `systemd`. To automatically start
-{es} when the system boots up, use the <<start-deb,Debian>> or <<start-rpm,RPM>>
+NOTE: The {es} `.tar.gz` package does not include the `systemd` module. To
+manage {es} as a service, use the <<start-deb,Debian>> or <<start-rpm,RPM>>
 package instead.


### PR DESCRIPTION
Closes #55477.

### Preview
https://elasticsearch_66298.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/starting-elasticsearch.html#_running_as_a_daemon
