### PR TITLE
[7.10] [DOCS] Fix `search.max_buckets` default (#66311)

### DIFF
--- a/docs/reference/aggregations/bucket.asciidoc
+++ b/docs/reference/aggregations/bucket.asciidoc
@@ -15,8 +15,8 @@ define fixed number of multiple buckets, and others dynamically create the bucke
 
 NOTE: The maximum number of buckets allowed in a single response is limited by a
 dynamic cluster setting named
-<<search-settings-max-buckets,`search.max_buckets`>>. It defaults to 65,535,
-requests that try to return more than the limit will fail with an exception.
+<<search-settings-max-buckets,`search.max_buckets`>>. It defaults to 65,535.
+Requests that try to return more than the limit will fail with an exception.
 
 include::bucket/adjacency-matrix-aggregation.asciidoc[]
 

--- a/docs/reference/modules/indices/search-settings.asciidoc
+++ b/docs/reference/modules/indices/search-settings.asciidoc
@@ -22,6 +22,6 @@ few resources.
 `search.max_buckets`::
 (<<cluster-update-settings,Dynamic>>, integer)
 Maximum number of <<search-aggregations-bucket,aggregation buckets>> allowed in
-a single response. Defaults to `10000`.
+a single response. Defaults to 65,535.
 +
 Requests that attempt to return more than this limit will return an error.


### PR DESCRIPTION
Backports the following commits to 7.10:
 - [DOCS] Fix `search.max_buckets` default (#66311)