### PR TITLE
Update version constants in DataStreams BWC Test

### DIFF
--- a/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
@@ -719,7 +719,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
         List<Map<String, String>> indices = (List<Map<String, String>>) ds.get("indices");
         assertEquals("ds", ds.get("name"));
         assertEquals(1, indices.size());
-        assertEquals(getOldClusterVersion().onOrAfter(Version.V_8_0_0)
+        assertEquals(getOldClusterVersion().onOrAfter(Version.V_7_11_0)
             ? DataStream.getDefaultBackingIndexName("ds", 1)
             : DataStreamTestHelper.getLegacyDefaultBackingIndexName("ds", 1),
             indices.get(0).get("index_name"));


### PR DESCRIPTION
This change updates version constants in
`FullClusterRestartIT.testDataStreams` to reflect the fact that
#65205 was backported to v7.11 (as #66307)
