### PR TITLE
skip degenerated line in CentroidCalculatorTests#testAddDifferentDimensionalType

### DIFF
--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/CentroidCalculatorTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/CentroidCalculatorTests.java
@@ -356,9 +356,11 @@ public class CentroidCalculatorTests extends ESTestCase {
             CentroidCalculator calculator = new CentroidCalculator();
             calculator.add(point);
             calculator.add(line);
-            assertThat(calculator.getX(), equalTo(lineCalculator.getX()));
-            assertThat(calculator.getY(), equalTo(lineCalculator.getY()));
-            assertThat(calculator.sumWeight(), equalTo(lineCalculator.sumWeight()));
+            if (lineCalculator.getDimensionalShapeType() == LINE) {  // skip degenerated line
+                assertThat(calculator.getX(), equalTo(lineCalculator.getX()));
+                assertThat(calculator.getY(), equalTo(lineCalculator.getY()));
+                assertThat(calculator.sumWeight(), equalTo(lineCalculator.sumWeight()));
+            }
         }
 
         // line add point
@@ -368,9 +370,11 @@ public class CentroidCalculatorTests extends ESTestCase {
             CentroidCalculator calculator = new CentroidCalculator();
             calculator.add(line);
             calculator.add(point);
-            assertThat(calculator.getX(), equalTo(lineCalculator.getX()));
-            assertThat(calculator.getY(), equalTo(lineCalculator.getY()));
-            assertThat(calculator.sumWeight(), equalTo(lineCalculator.sumWeight()));
+            if (lineCalculator.getDimensionalShapeType() == LINE) { // skip degenerated line
+                assertThat(calculator.getX(), equalTo(lineCalculator.getX()));
+                assertThat(calculator.getY(), equalTo(lineCalculator.getY()));
+                assertThat(calculator.sumWeight(), equalTo(lineCalculator.sumWeight()));
+            }
         }
 
         // line add line


### PR DESCRIPTION
Fixes a test failure due to the generation of degenerated line.

closes  #66300