### PR TITLE
BACKPORT 7x Introduce new audit record for security configuration changes via API

### DIFF
--- a/x-pack/plugin/core/src/main/config/log4j2.properties
+++ b/x-pack/plugin/core/src/main/config/log4j2.properties
@@ -36,13 +36,17 @@ appender.audit_rolling.layout.pattern = {\
                 %varsNotEmpty{, "x_forwarded_for":"%enc{%map{x_forwarded_for}}{JSON}"}\
                 %varsNotEmpty{, "transport.profile":"%enc{%map{transport.profile}}{JSON}"}\
                 %varsNotEmpty{, "rule":"%enc{%map{rule}}{JSON}"}\
-                %varsNotEmpty{, "event.category":"%enc{%map{event.category}}{JSON}"}\
+                %varsNotEmpty{, "put":%map{put}}\
+                %varsNotEmpty{, "delete":%map{delete}}\
+                %varsNotEmpty{, "change":%map{change}}\
+                %varsNotEmpty{, "create":%map{create}}\
+                %varsNotEmpty{, "invalidate":%map{invalidate}}\
                 }%n
 # "node.name" node name from the `elasticsearch.yml` settings
 # "node.id" node id which should not change between cluster restarts
 # "host.name" unresolved hostname of the local node
 # "host.ip" the local bound ip (i.e. the ip listening for connections)
-# "event.type" a received REST request is translated into one or more transport requests. This indicates which processing layer generated the event "rest" or "transport" (internal)
+# "origin.type" a received REST request is translated into one or more transport requests. This indicates which processing layer generated the event "rest" or "transport" (internal)
 # "event.action" the name of the audited event, eg. "authentication_failed", "access_granted", "run_as_granted", etc.
 # "authentication.type" one of "realm", "api_key", "token", "anonymous" or "internal"
 # "user.name" the subject name as authenticated by a realm
@@ -54,7 +58,7 @@ appender.audit_rolling.layout.pattern = {\
 # "user.roles" the roles array of the user; these are the roles that are granting privileges
 # "apikey.id" this field is present if and only if the "authentication.type" is "api_key"
 # "apikey.name" this field is present if and only if the "authentication.type" is "api_key"
-# "origin.type" it is "rest" if the event is originating (is in relation to) a REST request; possible other values are "transport" and "ip_filter"
+# "event.type" informs about what internal system generated the event; possible values are "rest", "transport", "ip_filter" and "security_config_change"
 # "origin.address" the remote address and port of the first network hop, i.e. a REST proxy or another cluster node
 # "realm" name of a realm that has generated an "authentication_failed" or an "authentication_successful"; the subject is not yet authenticated
 # "url.path" the URI component between the port and the query string; it is percent (URL) encoded
@@ -69,7 +73,8 @@ appender.audit_rolling.layout.pattern = {\
 # "x_forwarded_for" the addresses from the "X-Forwarded-For" request header, as a verbatim string value (not an array)
 # "transport.profile" name of the transport profile in case this is a "connection_granted" or "connection_denied" event
 # "rule" name of the applied rule if the "origin.type" is "ip_filter"
-# "event.category" fixed value "elasticsearch-audit"
+# the "put", "delete", "change", "create", "invalidate" fields are only present
+# when the "event.type" is "security_config_change" and contain the security config change (as an object) taking effect
 
 appender.audit_rolling.filePattern = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_audit-%d{yyyy-MM-dd}.json
 appender.audit_rolling.policies.type = Policies

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/PutRoleRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/PutRoleRequest.java
@@ -122,11 +122,11 @@ public class PutRoleRequest extends ActionRequest implements WriteRequest<PutRol
         this.clusterPrivileges = clusterPrivileges;
     }
 
-    void conditionalCluster(ConfigurableClusterPrivilege... configurableClusterPrivileges) {
+    public void conditionalCluster(ConfigurableClusterPrivilege... configurableClusterPrivileges) {
         this.configurableClusterPrivileges = configurableClusterPrivileges;
     }
 
-    void addIndex(RoleDescriptor.IndicesPrivileges... privileges) {
+    public void addIndex(RoleDescriptor.IndicesPrivileges... privileges) {
         this.indicesPrivileges.addAll(Arrays.asList(privileges));
     }
 
@@ -142,7 +142,7 @@ public class PutRoleRequest extends ActionRequest implements WriteRequest<PutRol
                 .build());
     }
 
-    void addApplicationPrivileges(RoleDescriptor.ApplicationResourcePrivileges... privileges) {
+    public void addApplicationPrivileges(RoleDescriptor.ApplicationResourcePrivileges... privileges) {
         this.applicationPrivileges.addAll(Arrays.asList(privileges));
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/esnative/NativeRealmSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/esnative/NativeRealmSettings.java
@@ -14,6 +14,7 @@ import java.util.Set;
 
 public final class NativeRealmSettings {
     public static final String TYPE = "native";
+    public static final String DEFAULT_NAME = "default_native";
 
     private NativeRealmSettings() {}
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/file/FileRealmSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/file/FileRealmSettings.java
@@ -14,6 +14,7 @@ import java.util.Set;
 
 public final class FileRealmSettings {
     public static final String TYPE = "file";
+    public static final String DEFAULT_NAME = "default_file";
 
     private FileRealmSettings() {}
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/RoleDescriptor.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/RoleDescriptor.java
@@ -686,11 +686,11 @@ public class RoleDescriptor implements ToXContentObject, Writeable {
             return allowRestrictedIndices;
         }
 
-        private boolean hasDeniedFields() {
+        public boolean hasDeniedFields() {
             return deniedFields != null && deniedFields.length > 0;
         }
 
-        private boolean hasGrantedFields() {
+        public boolean hasGrantedFields() {
             if (grantedFields != null && grantedFields.length >= 0) {
                 // we treat just '*' as no FLS since that's what the UI defaults to
                 if (grantedFields.length == 1 && "*".equals(grantedFields[0])) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/AuditLevel.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/AuditLevel.java
@@ -12,7 +12,6 @@ import java.util.Locale;
 
 public enum AuditLevel {
 
-    
     ANONYMOUS_ACCESS_DENIED,
     AUTHENTICATION_FAILED,
     REALM_AUTHENTICATION_FAILED,
@@ -22,6 +21,7 @@ public enum AuditLevel {
     CONNECTION_GRANTED,
     CONNECTION_DENIED,
     SYSTEM_ACCESS_GRANTED,
+    SECURITY_CONFIG_CHANGE,
     AUTHENTICATION_SUCCESS,
     RUN_AS_GRANTED,
     RUN_AS_DENIED;
@@ -60,6 +60,9 @@ public enum AuditLevel {
                     break;
                 case "system_access_granted":
                     enumSet.add(SYSTEM_ACCESS_GRANTED);
+                    break;
+                case "security_config_change":
+                    enumSet.add(SECURITY_CONFIG_CHANGE);
                     break;
                 case "authentication_success":
                     enumSet.add(AUTHENTICATION_SUCCESS);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrail.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrail.java
@@ -191,13 +191,11 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
     public static final Setting<Boolean> INCLUDE_REQUEST_BODY = Setting.boolSetting(setting("audit.logfile.events.emit_request_body"),
             false, Property.NodeScope, Property.Dynamic);
     // actions (and their requests) that are audited as "security change" events
-    public static final Set<String> SECURITY_CHANGE_ACTIONS = new HashSet<>();
-    static {
-        SECURITY_CHANGE_ACTIONS.addAll(Arrays.asList(PutUserAction.NAME, PutRoleAction.NAME, PutRoleMappingAction.NAME,
-                SetEnabledAction.NAME, ChangePasswordAction.NAME, CreateApiKeyAction.NAME, GrantApiKeyAction.NAME, PutPrivilegesAction.NAME,
-                DeleteUserAction.NAME, DeleteRoleAction.NAME, DeleteRoleMappingAction.NAME, InvalidateApiKeyAction.NAME,
-                DeletePrivilegesAction.NAME));
-    }
+    public static final Set<String> SECURITY_CHANGE_ACTIONS = new HashSet<>(Arrays.asList(PutUserAction.NAME,
+            PutRoleAction.NAME, PutRoleMappingAction.NAME,
+            SetEnabledAction.NAME, ChangePasswordAction.NAME, CreateApiKeyAction.NAME, GrantApiKeyAction.NAME, PutPrivilegesAction.NAME,
+            DeleteUserAction.NAME, DeleteRoleAction.NAME, DeleteRoleMappingAction.NAME, InvalidateApiKeyAction.NAME,
+            DeletePrivilegesAction.NAME));
     private static final String FILTER_POLICY_PREFIX = setting("audit.logfile.events.ignore_filters.");
     // because of the default wildcard value (*) for the field filter, a policy with
     // an unspecified filter field will match events that have any value for that

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrail.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrail.java
@@ -12,6 +12,7 @@ import org.apache.logging.log4j.core.Filter.Result;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.filter.MarkerFilter;
 import org.apache.logging.log4j.message.StringMapMessage;
+import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterStateListener;
@@ -26,15 +27,47 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportRequest;
+import org.elasticsearch.xpack.core.security.action.CreateApiKeyAction;
+import org.elasticsearch.xpack.core.security.action.CreateApiKeyRequest;
+import org.elasticsearch.xpack.core.security.action.GrantApiKeyAction;
+import org.elasticsearch.xpack.core.security.action.GrantApiKeyRequest;
+import org.elasticsearch.xpack.core.security.action.InvalidateApiKeyAction;
+import org.elasticsearch.xpack.core.security.action.InvalidateApiKeyRequest;
+import org.elasticsearch.xpack.core.security.action.privilege.DeletePrivilegesAction;
+import org.elasticsearch.xpack.core.security.action.privilege.DeletePrivilegesRequest;
+import org.elasticsearch.xpack.core.security.action.privilege.PutPrivilegesAction;
+import org.elasticsearch.xpack.core.security.action.privilege.PutPrivilegesRequest;
+import org.elasticsearch.xpack.core.security.action.role.DeleteRoleAction;
+import org.elasticsearch.xpack.core.security.action.role.DeleteRoleRequest;
+import org.elasticsearch.xpack.core.security.action.role.PutRoleAction;
+import org.elasticsearch.xpack.core.security.action.role.PutRoleRequest;
+import org.elasticsearch.xpack.core.security.action.rolemapping.DeleteRoleMappingAction;
+import org.elasticsearch.xpack.core.security.action.rolemapping.DeleteRoleMappingRequest;
+import org.elasticsearch.xpack.core.security.action.rolemapping.PutRoleMappingAction;
+import org.elasticsearch.xpack.core.security.action.rolemapping.PutRoleMappingRequest;
+import org.elasticsearch.xpack.core.security.action.user.ChangePasswordAction;
+import org.elasticsearch.xpack.core.security.action.user.ChangePasswordRequest;
+import org.elasticsearch.xpack.core.security.action.user.DeleteUserAction;
+import org.elasticsearch.xpack.core.security.action.user.DeleteUserRequest;
+import org.elasticsearch.xpack.core.security.action.user.PutUserAction;
+import org.elasticsearch.xpack.core.security.action.user.PutUserRequest;
+import org.elasticsearch.xpack.core.security.action.user.SetEnabledAction;
+import org.elasticsearch.xpack.core.security.action.user.SetEnabledRequest;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationToken;
 import org.elasticsearch.xpack.core.security.authz.AuthorizationEngine.AuthorizationInfo;
+import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
+import org.elasticsearch.xpack.core.security.authz.privilege.ConfigurableClusterPrivileges;
 import org.elasticsearch.xpack.core.security.support.Automatons;
 import org.elasticsearch.xpack.core.security.user.User;
 import org.elasticsearch.xpack.security.Security;
@@ -49,6 +82,7 @@ import com.fasterxml.jackson.core.io.JsonStringEncoder;
 
 import org.apache.logging.log4j.LogManager;
 
+import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.Arrays;
@@ -60,6 +94,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -78,6 +113,7 @@ import static org.elasticsearch.xpack.security.audit.AuditLevel.CONNECTION_GRANT
 import static org.elasticsearch.xpack.security.audit.AuditLevel.REALM_AUTHENTICATION_FAILED;
 import static org.elasticsearch.xpack.security.audit.AuditLevel.RUN_AS_DENIED;
 import static org.elasticsearch.xpack.security.audit.AuditLevel.RUN_AS_GRANTED;
+import static org.elasticsearch.xpack.security.audit.AuditLevel.SECURITY_CONFIG_CHANGE;
 import static org.elasticsearch.xpack.security.audit.AuditLevel.SYSTEM_ACCESS_GRANTED;
 import static org.elasticsearch.xpack.security.audit.AuditLevel.TAMPERED_REQUEST;
 import static org.elasticsearch.xpack.security.audit.AuditLevel.parse;
@@ -89,8 +125,9 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
     public static final String LOCAL_ORIGIN_FIELD_VALUE = "local_node";
     public static final String TRANSPORT_ORIGIN_FIELD_VALUE = "transport";
     public static final String IP_FILTER_ORIGIN_FIELD_VALUE = "ip_filter";
+    public static final String SECURITY_CHANGE_ORIGIN_FIELD_VALUE = "security_config_change";
 
-    // changing any of this names requires changing the log4j2.properties file too
+    // changing any of these field names requires changing the log4j2.properties file(s) too
     public static final String LOG_TYPE = "type";
     public static final String TIMESTAMP = "timestamp";
     public static final String ORIGIN_TYPE_FIELD_NAME = "origin.type";
@@ -124,6 +161,15 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
     public static final String RULE_FIELD_NAME = "rule";
     public static final String OPAQUE_ID_FIELD_NAME = "opaque_id";
     public static final String X_FORWARDED_FOR_FIELD_NAME = "x_forwarded_for";
+    // the fields below are used exclusively for "security_config_change" type of events, and show the configuration
+    // object taking effect; it could be creating a new, or updating an existing configuration
+    // if our (REST) APIs (at least the security APIs) would make the distinction between creating a *new* resource using the POST
+    // verb and updating an *existing* resource using the PUT verb, then auditing would also be able to show the create/update distinction
+    public static final String PUT_CONFIG_FIELD_NAME = "put";
+    public static final String DELETE_CONFIG_FIELD_NAME = "delete";
+    public static final String CHANGE_CONFIG_FIELD_NAME = "change";
+    public static final String CREATE_CONFIG_FIELD_NAME = "create";
+    public static final String INVALIDATE_API_KEYS_FIELD_NAME = "invalidate";
 
     public static final String NAME = "logfile";
     public static final Setting<Boolean> EMIT_HOST_ADDRESS_SETTING = Setting.boolSetting(setting("audit.logfile.emit_node_host_address"),
@@ -136,7 +182,7 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
             Property.NodeScope, Property.Dynamic);
     private static final List<String> DEFAULT_EVENT_INCLUDES = Arrays.asList(ACCESS_DENIED.toString(), ACCESS_GRANTED.toString(),
             ANONYMOUS_ACCESS_DENIED.toString(), AUTHENTICATION_FAILED.toString(), CONNECTION_DENIED.toString(), TAMPERED_REQUEST.toString(),
-            RUN_AS_DENIED.toString(), RUN_AS_GRANTED.toString());
+            RUN_AS_DENIED.toString(), RUN_AS_GRANTED.toString(), SECURITY_CONFIG_CHANGE.toString());
     public static final Setting<List<String>> INCLUDE_EVENT_SETTINGS = Setting.listSetting(setting("audit.logfile.events.include"),
             DEFAULT_EVENT_INCLUDES, Function.identity(), value -> AuditLevel.parse(value, Collections.emptyList()),
             Property.NodeScope, Property.Dynamic);
@@ -145,6 +191,11 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
             Property.NodeScope, Property.Dynamic);
     public static final Setting<Boolean> INCLUDE_REQUEST_BODY = Setting.boolSetting(setting("audit.logfile.events.emit_request_body"),
             false, Property.NodeScope, Property.Dynamic);
+    // actions (and their requests) that are audited as "security change" events
+    public static final Set<String> SECURITY_CHANGE_ACTIONS = Set.of(PutUserAction.NAME, PutRoleAction.NAME, PutRoleMappingAction.NAME,
+            SetEnabledAction.NAME, ChangePasswordAction.NAME, CreateApiKeyAction.NAME, GrantApiKeyAction.NAME, PutPrivilegesAction.NAME,
+            DeleteUserAction.NAME, DeleteRoleAction.NAME, DeleteRoleMappingAction.NAME, InvalidateApiKeyAction.NAME,
+            DeletePrivilegesAction.NAME);
     private static final String FILTER_POLICY_PREFIX = setting("audit.logfile.events.ignore_filters.");
     // because of the default wildcard value (*) for the field filter, a policy with
     // an unspecified filter field will match events that have any value for that
@@ -245,7 +296,7 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
                         Optional.empty())) == false) {
             // this is redundant information maintained for bwc purposes
             final String authnRealm = authentication.getAuthenticatedBy().getName();
-            final StringMapMessage logEntry = new LogEntryBuilder()
+            new LogEntryBuilder()
                     .with(EVENT_TYPE_FIELD_NAME, REST_ORIGIN_FIELD_VALUE)
                     .with(EVENT_ACTION_FIELD_NAME, "authentication_success")
                     .with(REALM_FIELD_NAME, authnRealm)
@@ -257,7 +308,6 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
                     .withOpaqueId(threadContext)
                     .withXForwardedFor(threadContext)
                     .build();
-            logger.info(AUDIT_MARKER, logEntry);
         }
     }
 
@@ -272,7 +322,7 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
                             Optional.ofNullable(ApiKeyService.getCreatorRealmName(authentication)),
                             Optional.empty(),
                             indices)) == false) {
-                final StringMapMessage logEntry = new LogEntryBuilder()
+                new LogEntryBuilder()
                         .with(EVENT_TYPE_FIELD_NAME, TRANSPORT_ORIGIN_FIELD_VALUE)
                         .with(EVENT_ACTION_FIELD_NAME, "authentication_success")
                         .with(ACTION_FIELD_NAME, action)
@@ -284,7 +334,6 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
                         .withOpaqueId(threadContext)
                         .withXForwardedFor(threadContext)
                         .build();
-                logger.info(AUDIT_MARKER, logEntry);
             }
         }
     }
@@ -295,7 +344,7 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
             final Optional<String[]> indices = indices(transportRequest);
             if (eventFilterPolicyRegistry.ignorePredicate()
                     .test(new AuditEventMetaInfo(Optional.empty(), Optional.empty(), indices)) == false) {
-                final StringMapMessage logEntry = new LogEntryBuilder()
+                new LogEntryBuilder()
                         .with(EVENT_TYPE_FIELD_NAME, TRANSPORT_ORIGIN_FIELD_VALUE)
                         .with(EVENT_ACTION_FIELD_NAME, "anonymous_access_denied")
                         .with(ACTION_FIELD_NAME, action)
@@ -306,7 +355,6 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
                         .withOpaqueId(threadContext)
                         .withXForwardedFor(threadContext)
                         .build();
-                logger.info(AUDIT_MARKER, logEntry);
             }
         }
     }
@@ -315,7 +363,7 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
     public void anonymousAccessDenied(String requestId, RestRequest request) {
         if (events.contains(ANONYMOUS_ACCESS_DENIED)
                 && eventFilterPolicyRegistry.ignorePredicate().test(AuditEventMetaInfo.EMPTY) == false) {
-            final StringMapMessage logEntry = new LogEntryBuilder()
+            new LogEntryBuilder()
                     .with(EVENT_TYPE_FIELD_NAME, REST_ORIGIN_FIELD_VALUE)
                     .with(EVENT_ACTION_FIELD_NAME, "anonymous_access_denied")
                     .withRestUriAndMethod(request)
@@ -325,7 +373,6 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
                     .withOpaqueId(threadContext)
                     .withXForwardedFor(threadContext)
                     .build();
-            logger.info(AUDIT_MARKER, logEntry);
         }
     }
 
@@ -335,7 +382,7 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
             final Optional<String[]> indices = indices(transportRequest);
             if (eventFilterPolicyRegistry.ignorePredicate()
                     .test(new AuditEventMetaInfo(Optional.of(token), Optional.empty(), indices)) == false) {
-                final StringMapMessage logEntry = new LogEntryBuilder()
+                new LogEntryBuilder()
                         .with(EVENT_TYPE_FIELD_NAME, TRANSPORT_ORIGIN_FIELD_VALUE)
                         .with(EVENT_ACTION_FIELD_NAME, "authentication_failed")
                         .with(ACTION_FIELD_NAME, action)
@@ -347,7 +394,6 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
                         .withOpaqueId(threadContext)
                         .withXForwardedFor(threadContext)
                         .build();
-                logger.info(AUDIT_MARKER, logEntry);
             }
         }
     }
@@ -355,7 +401,7 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
     @Override
     public void authenticationFailed(String requestId, RestRequest request) {
         if (events.contains(AUTHENTICATION_FAILED) && eventFilterPolicyRegistry.ignorePredicate().test(AuditEventMetaInfo.EMPTY) == false) {
-            final StringMapMessage logEntry = new LogEntryBuilder()
+            new LogEntryBuilder()
                     .with(EVENT_TYPE_FIELD_NAME, REST_ORIGIN_FIELD_VALUE)
                     .with(EVENT_ACTION_FIELD_NAME, "authentication_failed")
                     .withRestUriAndMethod(request)
@@ -365,7 +411,6 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
                     .withOpaqueId(threadContext)
                     .withXForwardedFor(threadContext)
                     .build();
-            logger.info(AUDIT_MARKER, logEntry);
         }
     }
 
@@ -375,7 +420,7 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
             final Optional<String[]> indices = indices(transportRequest);
             if (eventFilterPolicyRegistry.ignorePredicate()
                     .test(new AuditEventMetaInfo(Optional.empty(), Optional.empty(), indices)) == false) {
-                final StringMapMessage logEntry = new LogEntryBuilder()
+                new LogEntryBuilder()
                         .with(EVENT_TYPE_FIELD_NAME, TRANSPORT_ORIGIN_FIELD_VALUE)
                         .with(EVENT_ACTION_FIELD_NAME, "authentication_failed")
                         .with(ACTION_FIELD_NAME, action)
@@ -386,7 +431,6 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
                         .withOpaqueId(threadContext)
                         .withXForwardedFor(threadContext)
                         .build();
-                logger.info(AUDIT_MARKER, logEntry);
             }
         }
     }
@@ -395,7 +439,7 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
     public void authenticationFailed(String requestId, AuthenticationToken token, RestRequest request) {
         if (events.contains(AUTHENTICATION_FAILED) && eventFilterPolicyRegistry.ignorePredicate()
                 .test(new AuditEventMetaInfo(Optional.of(token), Optional.empty(), Optional.empty())) == false) {
-            final StringMapMessage logEntry = new LogEntryBuilder()
+            new LogEntryBuilder()
                     .with(EVENT_TYPE_FIELD_NAME, REST_ORIGIN_FIELD_VALUE)
                     .with(EVENT_ACTION_FIELD_NAME, "authentication_failed")
                     .with(PRINCIPAL_FIELD_NAME, token.principal())
@@ -406,7 +450,6 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
                     .withOpaqueId(threadContext)
                     .withXForwardedFor(threadContext)
                     .build();
-            logger.info(AUDIT_MARKER, logEntry);
         }
     }
 
@@ -417,7 +460,7 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
             final Optional<String[]> indices = indices(transportRequest);
             if (eventFilterPolicyRegistry.ignorePredicate()
                     .test(new AuditEventMetaInfo(Optional.of(token), Optional.of(realm), indices)) == false) {
-                final StringMapMessage logEntry = new LogEntryBuilder()
+                new LogEntryBuilder()
                         .with(EVENT_TYPE_FIELD_NAME, TRANSPORT_ORIGIN_FIELD_VALUE)
                         .with(EVENT_ACTION_FIELD_NAME, "realm_authentication_failed")
                         .with(REALM_FIELD_NAME, realm)
@@ -430,7 +473,6 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
                         .withOpaqueId(threadContext)
                         .withXForwardedFor(threadContext)
                         .build();
-                logger.info(AUDIT_MARKER, logEntry);
             }
         }
     }
@@ -439,7 +481,7 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
     public void authenticationFailed(String requestId, String realm, AuthenticationToken token, RestRequest request) {
         if (events.contains(REALM_AUTHENTICATION_FAILED) && eventFilterPolicyRegistry.ignorePredicate()
                 .test(new AuditEventMetaInfo(Optional.of(token), Optional.of(realm), Optional.empty())) == false) {
-            final StringMapMessage logEntry = new LogEntryBuilder()
+            new LogEntryBuilder()
                     .with(EVENT_TYPE_FIELD_NAME, REST_ORIGIN_FIELD_VALUE)
                     .with(EVENT_ACTION_FIELD_NAME, "realm_authentication_failed")
                     .with(REALM_FIELD_NAME, realm)
@@ -451,7 +493,6 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
                     .withOpaqueId(threadContext)
                     .withXForwardedFor(threadContext)
                     .build();
-            logger.info(AUDIT_MARKER, logEntry);
         }
     }
 
@@ -466,7 +507,7 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
                     // can be null for API keys created before version 7.7
                     Optional.ofNullable(ApiKeyService.getCreatorRealmName(authentication)),
                     Optional.of(authorizationInfo), indices)) == false) {
-                final StringMapMessage logEntry = new LogEntryBuilder()
+                new LogEntryBuilder()
                         .with(EVENT_TYPE_FIELD_NAME, TRANSPORT_ORIGIN_FIELD_VALUE)
                         .with(EVENT_ACTION_FIELD_NAME, "access_granted")
                         .with(ACTION_FIELD_NAME, action)
@@ -479,7 +520,59 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
                         .withXForwardedFor(threadContext)
                         .with(authorizationInfo.asMap())
                         .build();
-                logger.info(AUDIT_MARKER, logEntry);
+            }
+        }
+        // "Security config change" records are not filtered out by ignore policies (i.e. they are always printed).
+        // The security changes here are the consequences of *user* requests,
+        // so in a strict interpretation we should filter them out if there are ignore policies in place for the causing user,
+        // but we do NOT do that because filtering out audit records of security changes can be unexpectedly dangerous.
+        if (events.contains(SECURITY_CONFIG_CHANGE) && SECURITY_CHANGE_ACTIONS.contains(action)) {
+            try {
+                if (msg instanceof PutUserRequest) {
+                    assert PutUserAction.NAME.equals(action);
+                    securityChangeLogEntryBuilder(requestId).withRequestBody((PutUserRequest) msg).build();
+                } else if (msg instanceof PutRoleRequest) {
+                    assert PutRoleAction.NAME.equals(action);
+                    securityChangeLogEntryBuilder(requestId).withRequestBody((PutRoleRequest) msg).build();
+                } else if (msg instanceof PutRoleMappingRequest) {
+                    assert PutRoleMappingAction.NAME.equals(action);
+                    securityChangeLogEntryBuilder(requestId).withRequestBody((PutRoleMappingRequest) msg).build();
+                } else if (msg instanceof SetEnabledRequest) {
+                    assert SetEnabledAction.NAME.equals(action);
+                    securityChangeLogEntryBuilder(requestId).withRequestBody((SetEnabledRequest) msg).build();
+                } else if (msg instanceof ChangePasswordRequest) {
+                    assert ChangePasswordAction.NAME.equals(action);
+                    securityChangeLogEntryBuilder(requestId).withRequestBody((ChangePasswordRequest) msg).build();
+                } else if (msg instanceof CreateApiKeyRequest) {
+                    assert CreateApiKeyAction.NAME.equals(action);
+                    securityChangeLogEntryBuilder(requestId).withRequestBody((CreateApiKeyRequest) msg).build();
+                } else if (msg instanceof GrantApiKeyRequest) {
+                    assert GrantApiKeyAction.NAME.equals(action);
+                    securityChangeLogEntryBuilder(requestId).withRequestBody((GrantApiKeyRequest) msg).build();
+                } else if (msg instanceof PutPrivilegesRequest) {
+                    assert PutPrivilegesAction.NAME.equals(action);
+                    securityChangeLogEntryBuilder(requestId).withRequestBody((PutPrivilegesRequest) msg).build();
+                } else if (msg instanceof DeleteUserRequest) {
+                    assert DeleteUserAction.NAME.equals(action);
+                    securityChangeLogEntryBuilder(requestId).withRequestBody((DeleteUserRequest) msg).build();
+                } else if (msg instanceof DeleteRoleRequest) {
+                    assert DeleteRoleAction.NAME.equals(action);
+                    securityChangeLogEntryBuilder(requestId).withRequestBody((DeleteRoleRequest) msg).build();
+                } else if (msg instanceof DeleteRoleMappingRequest) {
+                    assert DeleteRoleMappingAction.NAME.equals(action);
+                    securityChangeLogEntryBuilder(requestId).withRequestBody((DeleteRoleMappingRequest) msg).build();
+                } else if (msg instanceof InvalidateApiKeyRequest) {
+                    assert InvalidateApiKeyAction.NAME.equals(action);
+                    securityChangeLogEntryBuilder(requestId).withRequestBody((InvalidateApiKeyRequest) msg).build();
+                } else if (msg instanceof DeletePrivilegesRequest) {
+                    assert DeletePrivilegesAction.NAME.equals(action);
+                    securityChangeLogEntryBuilder(requestId).withRequestBody((DeletePrivilegesRequest) msg).build();
+                } else {
+                    throw new IllegalStateException("Unknown message class type [" + msg.getClass().getSimpleName() +
+                            "] for the \"security change\" action [" + action + "]");
+                }
+            } catch (IOException e) {
+                throw new ElasticsearchSecurityException("Unexpected error while serializing event data", e);
             }
         }
     }
@@ -520,7 +613,7 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
                         .with(ORIGIN_TYPE_FIELD_NAME, TRANSPORT_ORIGIN_FIELD_VALUE)
                         .with(ORIGIN_ADDRESS_FIELD_NAME, NetworkAddress.format(remoteAddress.address()));
                 }
-                logger.info(AUDIT_MARKER, logEntryBuilder.build());
+                logEntryBuilder.build();
             }
         }
     }
@@ -534,7 +627,7 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
                     // can be null for API keys created before version 7.7
                     Optional.ofNullable(ApiKeyService.getCreatorRealmName(authentication)),
                     Optional.of(authorizationInfo), indices)) == false) {
-                final StringMapMessage logEntry = new LogEntryBuilder()
+                new LogEntryBuilder()
                         .with(EVENT_TYPE_FIELD_NAME, TRANSPORT_ORIGIN_FIELD_VALUE)
                         .with(EVENT_ACTION_FIELD_NAME, "access_denied")
                         .with(ACTION_FIELD_NAME, action)
@@ -547,7 +640,6 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
                         .withOpaqueId(threadContext)
                         .withXForwardedFor(threadContext)
                         .build();
-                logger.info(AUDIT_MARKER, logEntry);
             }
         }
     }
@@ -555,7 +647,7 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
     @Override
     public void tamperedRequest(String requestId, RestRequest request) {
         if (events.contains(TAMPERED_REQUEST) && eventFilterPolicyRegistry.ignorePredicate().test(AuditEventMetaInfo.EMPTY) == false) {
-            final StringMapMessage logEntry = new LogEntryBuilder()
+            new LogEntryBuilder()
                     .with(EVENT_TYPE_FIELD_NAME, REST_ORIGIN_FIELD_VALUE)
                     .with(EVENT_ACTION_FIELD_NAME, "tampered_request")
                     .withRestUriAndMethod(request)
@@ -565,7 +657,6 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
                     .withOpaqueId(threadContext)
                     .withXForwardedFor(threadContext)
                     .build();
-            logger.info(AUDIT_MARKER, logEntry);
         }
     }
 
@@ -575,7 +666,7 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
             final Optional<String[]> indices = indices(transportRequest);
             if (eventFilterPolicyRegistry.ignorePredicate()
                     .test(new AuditEventMetaInfo(Optional.empty(), Optional.empty(), indices)) == false) {
-                final StringMapMessage logEntry = new LogEntryBuilder()
+                new LogEntryBuilder()
                         .with(EVENT_TYPE_FIELD_NAME, TRANSPORT_ORIGIN_FIELD_VALUE)
                         .with(EVENT_ACTION_FIELD_NAME, "tampered_request")
                         .with(ACTION_FIELD_NAME, action)
@@ -586,7 +677,6 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
                         .withOpaqueId(threadContext)
                         .withXForwardedFor(threadContext)
                         .build();
-                logger.info(AUDIT_MARKER, logEntry);
             }
         }
     }
@@ -601,7 +691,7 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
                             Optional.ofNullable(ApiKeyService.getCreatorRealmName(authentication)),
                             Optional.empty(),
                             indices)) == false) {
-                final StringMapMessage logEntry = new LogEntryBuilder()
+                new LogEntryBuilder()
                         .with(EVENT_TYPE_FIELD_NAME, TRANSPORT_ORIGIN_FIELD_VALUE)
                         .with(EVENT_ACTION_FIELD_NAME, "tampered_request")
                         .with(ACTION_FIELD_NAME, action)
@@ -613,7 +703,6 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
                         .withOpaqueId(threadContext)
                         .withXForwardedFor(threadContext)
                         .build();
-                logger.info(AUDIT_MARKER, logEntry);
             }
         }
     }
@@ -621,7 +710,7 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
     @Override
     public void connectionGranted(InetAddress inetAddress, String profile, SecurityIpFilterRule rule) {
         if (events.contains(CONNECTION_GRANTED) && eventFilterPolicyRegistry.ignorePredicate().test(AuditEventMetaInfo.EMPTY) == false) {
-            final StringMapMessage logEntry = new LogEntryBuilder()
+            new LogEntryBuilder()
                     .with(EVENT_TYPE_FIELD_NAME, IP_FILTER_ORIGIN_FIELD_VALUE)
                     .with(EVENT_ACTION_FIELD_NAME, "connection_granted")
                     .with(ORIGIN_TYPE_FIELD_NAME,
@@ -632,14 +721,13 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
                     .withOpaqueId(threadContext)
                     .withXForwardedFor(threadContext)
                     .build();
-            logger.info(AUDIT_MARKER, logEntry);
         }
     }
 
     @Override
     public void connectionDenied(InetAddress inetAddress, String profile, SecurityIpFilterRule rule) {
         if (events.contains(CONNECTION_DENIED) && eventFilterPolicyRegistry.ignorePredicate().test(AuditEventMetaInfo.EMPTY) == false) {
-            final StringMapMessage logEntry = new LogEntryBuilder()
+            new LogEntryBuilder()
                     .with(EVENT_TYPE_FIELD_NAME, IP_FILTER_ORIGIN_FIELD_VALUE)
                     .with(EVENT_ACTION_FIELD_NAME, "connection_denied")
                     .with(ORIGIN_TYPE_FIELD_NAME,
@@ -650,7 +738,6 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
                     .withOpaqueId(threadContext)
                     .withXForwardedFor(threadContext)
                     .build();
-            logger.info(AUDIT_MARKER, logEntry);
         }
     }
 
@@ -663,7 +750,7 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
                     // can be null for API keys created before version 7.7
                     Optional.ofNullable(ApiKeyService.getCreatorRealmName(authentication)),
                     Optional.of(authorizationInfo), indices)) == false) {
-                final StringMapMessage logEntry = new LogEntryBuilder()
+                new LogEntryBuilder()
                         .with(EVENT_TYPE_FIELD_NAME, TRANSPORT_ORIGIN_FIELD_VALUE)
                         .with(EVENT_ACTION_FIELD_NAME, "run_as_granted")
                         .with(ACTION_FIELD_NAME, action)
@@ -676,7 +763,6 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
                         .withOpaqueId(threadContext)
                         .withXForwardedFor(threadContext)
                         .build();
-                logger.info(AUDIT_MARKER, logEntry);
             }
         }
     }
@@ -690,7 +776,7 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
                     // can be null for API keys created before version 7.7
                     Optional.ofNullable(ApiKeyService.getCreatorRealmName(authentication)),
                     Optional.of(authorizationInfo), indices)) == false) {
-                final StringMapMessage logEntry = new LogEntryBuilder()
+                new LogEntryBuilder()
                         .with(EVENT_TYPE_FIELD_NAME, TRANSPORT_ORIGIN_FIELD_VALUE)
                         .with(EVENT_ACTION_FIELD_NAME, "run_as_denied")
                         .with(ACTION_FIELD_NAME, action)
@@ -703,7 +789,6 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
                         .withOpaqueId(threadContext)
                         .withXForwardedFor(threadContext)
                         .build();
-                logger.info(AUDIT_MARKER, logEntry);
             }
         }
     }
@@ -715,7 +800,7 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
                         // can be null for API keys created before version 7.7
                         Optional.ofNullable(ApiKeyService.getCreatorRealmName(authentication)),
                         Optional.of(authorizationInfo), Optional.empty())) == false) {
-            final StringMapMessage logEntry = new LogEntryBuilder()
+            new LogEntryBuilder()
                     .with(EVENT_TYPE_FIELD_NAME, REST_ORIGIN_FIELD_VALUE)
                     .with(EVENT_ACTION_FIELD_NAME, "run_as_denied")
                     .with(authorizationInfo.asMap())
@@ -727,8 +812,13 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
                     .withOpaqueId(threadContext)
                     .withXForwardedFor(threadContext)
                     .build();
-            logger.info(AUDIT_MARKER, logEntry);
         }
+    }
+
+    private LogEntryBuilder securityChangeLogEntryBuilder(String requestId) {
+        return new LogEntryBuilder(false)
+                .with(EVENT_TYPE_FIELD_NAME, SECURITY_CHANGE_ORIGIN_FIELD_VALUE)
+                .withRequestId(requestId);
     }
 
     private class LogEntryBuilder {
@@ -736,7 +826,308 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
         private final StringMapMessage logEntry;
 
         LogEntryBuilder() {
+            this(true);
+        }
+
+        LogEntryBuilder(boolean showOrigin) {
             logEntry = new StringMapMessage(LoggingAuditTrail.this.entryCommonFields.commonFields);
+            if (false == showOrigin) {
+                logEntry.remove(ORIGIN_ADDRESS_FIELD_NAME);
+                logEntry.remove(ORIGIN_TYPE_FIELD_NAME);
+            }
+        }
+
+        LogEntryBuilder withRequestBody(PutUserRequest putUserRequest) throws IOException {
+            logEntry.with(EVENT_ACTION_FIELD_NAME, "put_user");
+            XContentBuilder builder = JsonXContent.contentBuilder().humanReadable(true);
+            builder.startObject()
+                    .startObject("user")
+                    .field("name", putUserRequest.username())
+                    .field("enabled", putUserRequest.enabled())
+                    .array("roles", putUserRequest.roles());
+                    if (putUserRequest.fullName() != null) {
+                        builder.field("full_name", putUserRequest.fullName());
+                    }
+                    if (putUserRequest.email() != null) {
+                        builder.field("email", putUserRequest.email());
+                    }
+                    // password and password hashes are not exposed in the audit log
+                    builder.field("has_password", putUserRequest.passwordHash() != null);
+                    if (putUserRequest.metadata() != null && false == putUserRequest.metadata().isEmpty()) {
+                        // JSON building for the metadata might fail when encountering unknown class types.
+                        // This is NOT a problem because such metadata (eg containing GeoPoint) will most probably
+                        // cause troubles in downstream code (eg storing the metadata), so this simply introduces a new failure mode.
+                        // Also the malevolent metadata can only be produced by the transport client.
+                        builder.field("metadata", putUserRequest.metadata());
+                    }
+                    builder.endObject() // user
+                    .endObject();
+            logEntry.with(PUT_CONFIG_FIELD_NAME, Strings.toString(builder));
+            return this;
+        }
+
+        LogEntryBuilder withRequestBody(ChangePasswordRequest changePasswordRequest) throws IOException {
+            logEntry.with(EVENT_ACTION_FIELD_NAME, "change_password");
+            XContentBuilder builder = JsonXContent.contentBuilder().humanReadable(true);
+            builder.startObject()
+                    .startObject("password")
+                    .startObject("user")
+                    .field("name", changePasswordRequest.username())
+                    .endObject() // user
+                    .endObject() // password
+                    .endObject();
+            logEntry.with(CHANGE_CONFIG_FIELD_NAME, Strings.toString(builder));
+            return this;
+        }
+
+        LogEntryBuilder withRequestBody(PutRoleRequest putRoleRequest) throws IOException {
+            logEntry.with(EVENT_ACTION_FIELD_NAME, "put_role");
+            XContentBuilder builder = JsonXContent.contentBuilder().humanReadable(true);
+            builder.startObject()
+                    .startObject("role")
+                    .field("name", putRoleRequest.name())
+                    // the "role_descriptor" nested structure, where the "name" is left out, is closer to the event structure
+                    // for creating API Keys
+                    .field("role_descriptor");
+            withRoleDescriptor(builder, putRoleRequest.roleDescriptor());
+            builder.endObject() // role
+                    .endObject();
+            logEntry.with(PUT_CONFIG_FIELD_NAME, Strings.toString(builder));
+            return this;
+        }
+
+        LogEntryBuilder withRequestBody(PutRoleMappingRequest putRoleMappingRequest) throws IOException {
+            logEntry.with(EVENT_ACTION_FIELD_NAME, "put_role_mapping");
+            XContentBuilder builder = JsonXContent.contentBuilder().humanReadable(true);
+            builder.startObject()
+                    .startObject("role_mapping")
+                    .field("name", putRoleMappingRequest.getName());
+                    if (putRoleMappingRequest.getRoles() != null && false == putRoleMappingRequest.getRoles().isEmpty()) {
+                        builder.field("roles", putRoleMappingRequest.getRoles());
+                    }
+                    if (putRoleMappingRequest.getRoleTemplates() != null && false == putRoleMappingRequest.getRoleTemplates().isEmpty()) {
+                        // the toXContent method of the {@code TemplateRoleName} does a good job
+                        builder.field("role_templates", putRoleMappingRequest.getRoleTemplates());
+                    }
+                    // the toXContent methods of the {@code RoleMapperExpression} instances do a good job
+                    builder.field("rules", putRoleMappingRequest.getRules())
+                    .field("enabled", putRoleMappingRequest.isEnabled());
+                    if (putRoleMappingRequest.getMetadata() != null && false == putRoleMappingRequest.getMetadata().isEmpty()) {
+                        builder.field("metadata", putRoleMappingRequest.getMetadata());
+                    }
+                    builder.endObject() // role_mapping
+                    .endObject();
+            logEntry.with(PUT_CONFIG_FIELD_NAME, Strings.toString(builder));
+            return this;
+        }
+
+        LogEntryBuilder withRequestBody(SetEnabledRequest setEnabledRequest) throws IOException {
+            XContentBuilder builder = JsonXContent.contentBuilder().humanReadable(true);
+            // setEnabledRequest#enabled cannot be `null`, but nevertheless we should not assume it at this layer
+            if (setEnabledRequest.enabled() != null && setEnabledRequest.enabled()) {
+                builder.startObject()
+                        .startObject("enable")
+                        .startObject("user")
+                        .field("name", setEnabledRequest.username())
+                        .endObject() // user
+                        .endObject() // enable
+                        .endObject();
+                logEntry.with(EVENT_ACTION_FIELD_NAME, "change_enable_user");
+            } else {
+                builder.startObject()
+                        .startObject("disable")
+                        .startObject("user")
+                        .field("name", setEnabledRequest.username())
+                        .endObject() // user
+                        .endObject() // disable
+                        .endObject();
+                logEntry.with(EVENT_ACTION_FIELD_NAME, "change_disable_user");
+            }
+            logEntry.with(CHANGE_CONFIG_FIELD_NAME, Strings.toString(builder));
+            return this;
+        }
+
+        LogEntryBuilder withRequestBody(PutPrivilegesRequest putPrivilegesRequest) throws IOException {
+            logEntry.with(EVENT_ACTION_FIELD_NAME, "put_privileges");
+            XContentBuilder builder = JsonXContent.contentBuilder().humanReadable(true);
+            builder.startObject()
+                    // toXContent of {@code ApplicationPrivilegeDescriptor} does a good job
+                    .field("privileges", putPrivilegesRequest.getPrivileges())
+                    .endObject();
+            logEntry.with(PUT_CONFIG_FIELD_NAME, Strings.toString(builder));
+            return this;
+        }
+
+        LogEntryBuilder withRequestBody(CreateApiKeyRequest createApiKeyRequest) throws IOException {
+            logEntry.with(EVENT_ACTION_FIELD_NAME, "create_apikey");
+            XContentBuilder builder = JsonXContent.contentBuilder().humanReadable(true);
+            builder.startObject();
+            withRequestBody(builder, createApiKeyRequest);
+            builder.endObject();
+            logEntry.with(CREATE_CONFIG_FIELD_NAME, Strings.toString(builder));
+            return this;
+        }
+
+        LogEntryBuilder withRequestBody(GrantApiKeyRequest grantApiKeyRequest) throws IOException {
+            logEntry.with(EVENT_ACTION_FIELD_NAME, "create_apikey");
+            XContentBuilder builder = JsonXContent.contentBuilder().humanReadable(true);
+            builder.startObject();
+            withRequestBody(builder, grantApiKeyRequest.getApiKeyRequest());
+            GrantApiKeyRequest.Grant grant = grantApiKeyRequest.getGrant();
+            builder.startObject("grant")
+                        .field("type", grant.getType());
+                        if (grant.getUsername() != null) {
+                            builder.startObject("user")
+                                    .field("name", grant.getUsername())
+                                    .field("has_password", grant.getPassword() != null)
+                                    .endObject(); // user
+                        }
+                        if (grant.getAccessToken() != null) {
+                            builder.field("has_access_token", grant.getAccessToken() != null);
+                        }
+                    builder.endObject(); // grant
+            builder.endObject();
+            logEntry.with(CREATE_CONFIG_FIELD_NAME, Strings.toString(builder));
+            return this;
+        }
+
+        private void withRequestBody(XContentBuilder builder, CreateApiKeyRequest createApiKeyRequest) throws IOException {
+            TimeValue expiration = createApiKeyRequest.getExpiration();
+            builder.startObject("apikey")
+                    .field("name", createApiKeyRequest.getName())
+                    .field("expiration", expiration != null ? expiration.toString() : null)
+                    .startArray("role_descriptors");
+            for (RoleDescriptor roleDescriptor : createApiKeyRequest.getRoleDescriptors()) {
+                withRoleDescriptor(builder, roleDescriptor);
+            }
+            builder.endArray() // role_descriptors
+            .endObject(); // apikey
+        }
+
+        private void withRoleDescriptor(XContentBuilder builder, RoleDescriptor roleDescriptor) throws IOException {
+            builder.startObject()
+                .array(RoleDescriptor.Fields.CLUSTER.getPreferredName(), roleDescriptor.getClusterPrivileges());
+            if (roleDescriptor.getConditionalClusterPrivileges() != null && roleDescriptor.getConditionalClusterPrivileges().length > 0) {
+                // This fails if this list contains multiple instances of the {@code ManageApplicationPrivileges}
+                // Again, only the transport client can produce this, and this only introduces a different failure mode and
+                // not a new one (i.e. without auditing it would fail differently, but it would still fail)
+                builder.field(RoleDescriptor.Fields.GLOBAL.getPreferredName());
+                ConfigurableClusterPrivileges.toXContent(builder, ToXContent.EMPTY_PARAMS,
+                        Arrays.asList(roleDescriptor.getConditionalClusterPrivileges()));
+            }
+            builder.startArray(RoleDescriptor.Fields.INDICES.getPreferredName());
+            for (RoleDescriptor.IndicesPrivileges indicesPrivileges : roleDescriptor.getIndicesPrivileges()) {
+                withIndicesPrivileges(builder, indicesPrivileges);
+            }
+            builder.endArray();
+            // the toXContent method of the {@code RoleDescriptor.ApplicationResourcePrivileges) does a good job
+            builder.array(RoleDescriptor.Fields.APPLICATIONS.getPreferredName(), (Object[]) roleDescriptor.getApplicationPrivileges());
+            builder.array(RoleDescriptor.Fields.RUN_AS.getPreferredName(), roleDescriptor.getRunAs());
+            if (roleDescriptor.getMetadata() != null && false == roleDescriptor.getMetadata().isEmpty()) {
+                // JSON building for the metadata might fail when encountering unknown class types.
+                // This is NOT a problem because such metadata (eg containing GeoPoint) will most probably
+                // cause troubles in downstream code (eg storing the metadata), so this simply introduces a new failure mode.
+                // Also the malevolent metadata can only be produced by the transport client.
+                builder.field(RoleDescriptor.Fields.METADATA.getPreferredName(), roleDescriptor.getMetadata());
+            }
+            builder.endObject();
+        }
+
+        private void withIndicesPrivileges(XContentBuilder builder, RoleDescriptor.IndicesPrivileges indicesPrivileges) throws IOException {
+            builder.startObject();
+            builder.array("names", indicesPrivileges.getIndices());
+            builder.array("privileges", indicesPrivileges.getPrivileges());
+            if (indicesPrivileges.isUsingFieldLevelSecurity()) {
+                builder.startObject(RoleDescriptor.Fields.FIELD_PERMISSIONS.getPreferredName());
+                // always print the "grant" fields (even if the placeholder for all) because it looks better when avoiding the sole
+                // "except" field
+                builder.array(RoleDescriptor.Fields.GRANT_FIELDS.getPreferredName(), indicesPrivileges.getGrantedFields());
+                if (indicesPrivileges.hasDeniedFields()) {
+                    builder.array(RoleDescriptor.Fields.EXCEPT_FIELDS.getPreferredName(), indicesPrivileges.getDeniedFields());
+                }
+                builder.endObject();
+            }
+            if (indicesPrivileges.isUsingDocumentLevelSecurity()) {
+                builder.field("query", indicesPrivileges.getQuery().utf8ToString());
+            }
+            // default for "allow_restricted_indices" is false, and it's very common to stay that way, so don't show it unless true
+            if (indicesPrivileges.allowRestrictedIndices()) {
+                builder.field("allow_restricted_indices", indicesPrivileges.allowRestrictedIndices());
+            }
+            builder.endObject();
+        }
+
+        LogEntryBuilder withRequestBody(DeleteUserRequest deleteUserRequest) throws IOException {
+            logEntry.with(EVENT_ACTION_FIELD_NAME, "delete_user");
+            XContentBuilder builder = JsonXContent.contentBuilder().humanReadable(true);
+            builder.startObject()
+                    .startObject("user")
+                        .field("name", deleteUserRequest.username())
+                    .endObject() // user
+                    .endObject();
+            logEntry.with(DELETE_CONFIG_FIELD_NAME, Strings.toString(builder));
+            return this;
+        }
+
+        LogEntryBuilder withRequestBody(DeleteRoleRequest deleteRoleRequest) throws IOException {
+            logEntry.with(EVENT_ACTION_FIELD_NAME, "delete_role");
+            XContentBuilder builder = JsonXContent.contentBuilder().humanReadable(true);
+            builder.startObject()
+                    .startObject("role")
+                    .field("name", deleteRoleRequest.name())
+                    .endObject() // role
+                    .endObject();
+            logEntry.with(DELETE_CONFIG_FIELD_NAME, Strings.toString(builder));
+            return this;
+        }
+
+        LogEntryBuilder withRequestBody(DeleteRoleMappingRequest deleteRoleMappingRequest) throws IOException {
+            logEntry.with(EVENT_ACTION_FIELD_NAME, "delete_role_mapping");
+            XContentBuilder builder = JsonXContent.contentBuilder().humanReadable(true);
+            builder.startObject()
+                    .startObject("role_mapping")
+                    .field("name", deleteRoleMappingRequest.getName())
+                    .endObject() // role_mapping
+                    .endObject();
+            logEntry.with(DELETE_CONFIG_FIELD_NAME, Strings.toString(builder));
+            return this;
+        }
+
+        LogEntryBuilder withRequestBody(InvalidateApiKeyRequest invalidateApiKeyRequest) throws IOException {
+            logEntry.with(EVENT_ACTION_FIELD_NAME, "invalidate_apikeys");
+            XContentBuilder builder = JsonXContent.contentBuilder().humanReadable(true);
+            builder.startObject()
+                    .startObject("apikeys");
+                if (invalidateApiKeyRequest.getIds() != null && invalidateApiKeyRequest.getIds().length > 0) {
+                    builder.array("ids", invalidateApiKeyRequest.getIds());
+                }
+                if (Strings.hasLength(invalidateApiKeyRequest.getName())) {
+                    builder.field("name", invalidateApiKeyRequest.getName());
+                }
+                builder.field("owned_by_authenticated_user", invalidateApiKeyRequest.ownedByAuthenticatedUser());
+                if (Strings.hasLength(invalidateApiKeyRequest.getUserName()) || Strings.hasLength(invalidateApiKeyRequest.getRealmName())) {
+                    builder.startObject("user")
+                            .field("name", invalidateApiKeyRequest.getUserName())
+                            .field("realm", invalidateApiKeyRequest.getRealmName())
+                            .endObject(); // user
+                }
+            builder.endObject() // apikeys
+                    .endObject();
+            logEntry.with(INVALIDATE_API_KEYS_FIELD_NAME, Strings.toString(builder));
+            return this;
+        }
+
+        LogEntryBuilder withRequestBody(DeletePrivilegesRequest deletePrivilegesRequest) throws IOException {
+            logEntry.with(EVENT_ACTION_FIELD_NAME, "delete_privileges");
+            XContentBuilder builder = JsonXContent.contentBuilder().humanReadable(true);
+            builder.startObject()
+                    .startObject("privileges")
+                        .field("application", deletePrivilegesRequest.application())
+                        .array("privileges", deletePrivilegesRequest.privileges())
+                    .endObject() // privileges
+                    .endObject();
+            logEntry.with(DELETE_CONFIG_FIELD_NAME, Strings.toString(builder));
+            return this;
         }
 
         LogEntryBuilder withRestUriAndMethod(RestRequest request) {
@@ -880,8 +1271,8 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
             return this;
         }
 
-        StringMapMessage build() {
-            return logEntry;
+        void build() {
+            logger.info(AUDIT_MARKER, logEntry);
         }
 
         String toQuotedJsonArray(Object[] values) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrail.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrail.java
@@ -5,6 +5,8 @@
  */
 package org.elasticsearch.xpack.security.audit.logfile;
 
+import com.fasterxml.jackson.core.io.JsonStringEncoder;
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.MarkerManager;
@@ -78,10 +80,6 @@ import org.elasticsearch.xpack.security.rest.RemoteHostHeader;
 import org.elasticsearch.xpack.security.transport.filter.IPFilter;
 import org.elasticsearch.xpack.security.transport.filter.SecurityIpFilterRule;
 
-import com.fasterxml.jackson.core.io.JsonStringEncoder;
-
-import org.apache.logging.log4j.LogManager;
-
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -89,6 +87,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -192,10 +191,13 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
     public static final Setting<Boolean> INCLUDE_REQUEST_BODY = Setting.boolSetting(setting("audit.logfile.events.emit_request_body"),
             false, Property.NodeScope, Property.Dynamic);
     // actions (and their requests) that are audited as "security change" events
-    public static final Set<String> SECURITY_CHANGE_ACTIONS = Set.of(PutUserAction.NAME, PutRoleAction.NAME, PutRoleMappingAction.NAME,
-            SetEnabledAction.NAME, ChangePasswordAction.NAME, CreateApiKeyAction.NAME, GrantApiKeyAction.NAME, PutPrivilegesAction.NAME,
-            DeleteUserAction.NAME, DeleteRoleAction.NAME, DeleteRoleMappingAction.NAME, InvalidateApiKeyAction.NAME,
-            DeletePrivilegesAction.NAME);
+    public static final Set<String> SECURITY_CHANGE_ACTIONS = new HashSet<>();
+    static {
+        SECURITY_CHANGE_ACTIONS.addAll(Arrays.asList(PutUserAction.NAME, PutRoleAction.NAME, PutRoleMappingAction.NAME,
+                SetEnabledAction.NAME, ChangePasswordAction.NAME, CreateApiKeyAction.NAME, GrantApiKeyAction.NAME, PutPrivilegesAction.NAME,
+                DeleteUserAction.NAME, DeleteRoleAction.NAME, DeleteRoleMappingAction.NAME, InvalidateApiKeyAction.NAME,
+                DeletePrivilegesAction.NAME));
+    }
     private static final String FILTER_POLICY_PREFIX = setting("audit.logfile.events.ignore_filters.");
     // because of the default wildcard value (*) for the field filter, a policy with
     // an unspecified filter field will match events that have any value for that

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/Realms.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/Realms.java
@@ -302,12 +302,14 @@ public class Realms implements Iterable<Realm> {
     private void addNativeRealms(List<Realm> realms) throws Exception {
         Realm.Factory fileRealm = factories.get(FileRealmSettings.TYPE);
         if (fileRealm != null) {
-            var realmIdentifier = new RealmConfig.RealmIdentifier(FileRealmSettings.TYPE, FileRealmSettings.DEFAULT_NAME);
+            RealmConfig.RealmIdentifier realmIdentifier =
+                new RealmConfig.RealmIdentifier(FileRealmSettings.TYPE, FileRealmSettings.DEFAULT_NAME);
             realms.add(fileRealm.create(new RealmConfig(realmIdentifier, settings, env, threadContext)));
         }
         Realm.Factory indexRealmFactory = factories.get(NativeRealmSettings.TYPE);
         if (indexRealmFactory != null) {
-            var realmIdentifier = new RealmConfig.RealmIdentifier(NativeRealmSettings.TYPE, NativeRealmSettings.DEFAULT_NAME);
+            RealmConfig.RealmIdentifier realmIdentifier =
+                new RealmConfig.RealmIdentifier(NativeRealmSettings.TYPE, NativeRealmSettings.DEFAULT_NAME);
             realms.add(indexRealmFactory.create(new RealmConfig(realmIdentifier, settings, env, threadContext)));
         }
     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/Realms.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/Realms.java
@@ -302,15 +302,13 @@ public class Realms implements Iterable<Realm> {
     private void addNativeRealms(List<Realm> realms) throws Exception {
         Realm.Factory fileRealm = factories.get(FileRealmSettings.TYPE);
         if (fileRealm != null) {
-            realms.add(fileRealm.create(new RealmConfig(
-                    new RealmConfig.RealmIdentifier(FileRealmSettings.TYPE, "default_" + FileRealmSettings.TYPE),
-                    settings, env, threadContext)));
+            var realmIdentifier = new RealmConfig.RealmIdentifier(FileRealmSettings.TYPE, FileRealmSettings.DEFAULT_NAME);
+            realms.add(fileRealm.create(new RealmConfig(realmIdentifier, settings, env, threadContext)));
         }
         Realm.Factory indexRealmFactory = factories.get(NativeRealmSettings.TYPE);
         if (indexRealmFactory != null) {
-            realms.add(indexRealmFactory.create(new RealmConfig(
-                    new RealmConfig.RealmIdentifier(NativeRealmSettings.TYPE, "default_" + NativeRealmSettings.TYPE),
-                    settings, env, threadContext)));
+            var realmIdentifier = new RealmConfig.RealmIdentifier(NativeRealmSettings.TYPE, NativeRealmSettings.DEFAULT_NAME);
+            realms.add(indexRealmFactory.create(new RealmConfig(realmIdentifier, settings, env, threadContext)));
         }
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/esnative/ReservedRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/esnative/ReservedRealm.java
@@ -53,6 +53,7 @@ import java.util.Map;
 public class ReservedRealm extends CachingUsernamePasswordRealm {
 
     public static final String TYPE = "reserved";
+    public static final String NAME = "reserved";
 
     private final ReservedUserInfo bootstrapUserInfo;
     public static final Setting<Boolean> ACCEPT_DEFAULT_PASSWORD_SETTING = Setting.boolSetting(
@@ -71,7 +72,7 @@ public class ReservedRealm extends CachingUsernamePasswordRealm {
 
     public ReservedRealm(Environment env, Settings settings, NativeUsersStore nativeUsersStore, AnonymousUser anonymousUser,
                          SecurityIndexManager securityIndex, ThreadPool threadPool) {
-        super(new RealmConfig(new RealmConfig.RealmIdentifier(TYPE, TYPE), settings, env, threadPool.getThreadContext()), threadPool);
+        super(new RealmConfig(new RealmConfig.RealmIdentifier(TYPE, NAME), settings, env, threadPool.getThreadContext()), threadPool);
         this.nativeUsersStore = nativeUsersStore;
         this.realmEnabled = XPackSettings.RESERVED_REALM_ENABLED_SETTING.get(settings);
         this.anonymousUser = anonymousUser;

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
@@ -252,7 +252,7 @@ public class LoggingAuditTrailTests extends ESTestCase {
                 .put(LoggingAuditTrail.INCLUDE_REQUEST_BODY.getKey(), includeRequestBody)
                 .put(XPackSettings.RESERVED_REALM_ENABLED_SETTING.getKey(), reservedRealmEnabled)
                 .put(AnonymousUser.USERNAME_SETTING.getKey(), customAnonymousUsername)
-                .putList(AnonymousUser.ROLES_SETTING.getKey(), (List<String>) randomFrom(Collections.singleton(
+                .putList(AnonymousUser.ROLES_SETTING.getKey(), randomFrom(Collections.singletonList(
                         "smth"), Collections.<String>emptyList()))
                 .build();
         localNode = mock(DiscoveryNode.class);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.bulk.BulkItemRequest;
 import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -21,13 +22,17 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.network.NetworkAddress;
 import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.mock.orig.Mockito;
@@ -38,15 +43,51 @@ import org.elasticsearch.test.rest.FakeRestRequest;
 import org.elasticsearch.test.rest.FakeRestRequest.Builder;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportRequest;
+import org.elasticsearch.xpack.core.XPackSettings;
+import org.elasticsearch.xpack.core.security.action.CreateApiKeyAction;
+import org.elasticsearch.xpack.core.security.action.CreateApiKeyRequest;
+import org.elasticsearch.xpack.core.security.action.GrantApiKeyAction;
+import org.elasticsearch.xpack.core.security.action.GrantApiKeyRequest;
+import org.elasticsearch.xpack.core.security.action.InvalidateApiKeyAction;
+import org.elasticsearch.xpack.core.security.action.InvalidateApiKeyRequest;
+import org.elasticsearch.xpack.core.security.action.privilege.DeletePrivilegesAction;
+import org.elasticsearch.xpack.core.security.action.privilege.DeletePrivilegesRequest;
+import org.elasticsearch.xpack.core.security.action.privilege.PutPrivilegesAction;
+import org.elasticsearch.xpack.core.security.action.privilege.PutPrivilegesRequest;
+import org.elasticsearch.xpack.core.security.action.role.DeleteRoleAction;
+import org.elasticsearch.xpack.core.security.action.role.DeleteRoleRequest;
+import org.elasticsearch.xpack.core.security.action.role.PutRoleAction;
+import org.elasticsearch.xpack.core.security.action.role.PutRoleRequest;
+import org.elasticsearch.xpack.core.security.action.rolemapping.DeleteRoleMappingAction;
+import org.elasticsearch.xpack.core.security.action.rolemapping.DeleteRoleMappingRequest;
+import org.elasticsearch.xpack.core.security.action.rolemapping.PutRoleMappingAction;
+import org.elasticsearch.xpack.core.security.action.rolemapping.PutRoleMappingRequest;
+import org.elasticsearch.xpack.core.security.action.user.ChangePasswordAction;
+import org.elasticsearch.xpack.core.security.action.user.ChangePasswordRequest;
+import org.elasticsearch.xpack.core.security.action.user.DeleteUserAction;
+import org.elasticsearch.xpack.core.security.action.user.DeleteUserRequest;
+import org.elasticsearch.xpack.core.security.action.user.PutUserAction;
+import org.elasticsearch.xpack.core.security.action.user.PutUserRequest;
+import org.elasticsearch.xpack.core.security.action.user.SetEnabledAction;
+import org.elasticsearch.xpack.core.security.action.user.SetEnabledRequest;
 import org.elasticsearch.xpack.core.security.audit.logfile.CapturingLogger;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.Authentication.AuthenticationType;
 import org.elasticsearch.xpack.core.security.authc.Authentication.RealmRef;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationToken;
+import org.elasticsearch.xpack.core.security.authc.support.mapper.TemplateRoleName;
+import org.elasticsearch.xpack.core.security.authc.support.mapper.expressiondsl.ExpressionModel;
+import org.elasticsearch.xpack.core.security.authc.support.mapper.expressiondsl.RoleMapperExpression;
 import org.elasticsearch.xpack.core.security.authz.AuthorizationEngine.AuthorizationInfo;
+import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
+import org.elasticsearch.xpack.core.security.authz.privilege.ApplicationPrivilegeDescriptor;
+import org.elasticsearch.xpack.core.security.authz.privilege.ConfigurableClusterPrivilege;
+import org.elasticsearch.xpack.core.security.authz.privilege.ConfigurableClusterPrivileges;
+import org.elasticsearch.xpack.core.security.user.AnonymousUser;
 import org.elasticsearch.xpack.core.security.user.AsyncSearchUser;
 import org.elasticsearch.xpack.core.security.user.SystemUser;
 import org.elasticsearch.xpack.core.security.user.User;
+import org.elasticsearch.xpack.core.security.user.UsernamesField;
 import org.elasticsearch.xpack.core.security.user.XPackSecurityUser;
 import org.elasticsearch.xpack.core.security.user.XPackUser;
 import org.elasticsearch.xpack.security.audit.AuditLevel;
@@ -64,11 +105,16 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.mockito.stubbing.Answer;
 
+import java.io.BufferedInputStream;
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -76,9 +122,14 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.xpack.security.audit.logfile.LoggingAuditTrail.PRINCIPAL_ROLES_FIELD_NAME;
 import static org.elasticsearch.xpack.security.authc.ApiKeyServiceTests.Utils.createApiKeyAuthentication;
@@ -152,6 +203,8 @@ public class LoggingAuditTrailTests extends ESTestCase {
     }
 
     private static PatternLayout patternLayout;
+    private static String customAnonymousUsername;
+    private static boolean reservedRealmEnabled;
     private Settings settings;
     private DiscoveryNode localNode;
     private ClusterService clusterService;
@@ -180,6 +233,8 @@ public class LoggingAuditTrailTests extends ESTestCase {
         final String patternLayoutFormat = properties.getProperty("appender.audit_rolling.layout.pattern");
         assertThat(patternLayoutFormat, is(notNullValue()));
         patternLayout = PatternLayout.newBuilder().withPattern(patternLayoutFormat).withCharset(StandardCharsets.UTF_8).build();
+        customAnonymousUsername = randomAlphaOfLength(8);
+        reservedRealmEnabled = randomBoolean();
     }
 
     @AfterClass
@@ -195,7 +250,10 @@ public class LoggingAuditTrailTests extends ESTestCase {
                 .put(LoggingAuditTrail.EMIT_HOST_NAME_SETTING.getKey(), randomBoolean())
                 .put(LoggingAuditTrail.EMIT_NODE_NAME_SETTING.getKey(), randomBoolean())
                 .put(LoggingAuditTrail.EMIT_NODE_ID_SETTING.getKey(), randomBoolean())
-                .put("xpack.security.audit.logfile.events.emit_request_body", includeRequestBody)
+                .put(LoggingAuditTrail.INCLUDE_REQUEST_BODY.getKey(), includeRequestBody)
+                .put(XPackSettings.RESERVED_REALM_ENABLED_SETTING.getKey(), reservedRealmEnabled)
+                .put(AnonymousUser.USERNAME_SETTING.getKey(), customAnonymousUsername)
+                .putList(AnonymousUser.ROLES_SETTING.getKey(), randomFrom(List.of(), List.of("smth")))
                 .build();
         localNode = mock(DiscoveryNode.class);
         when(localNode.getAddress()).thenReturn(buildNewFakeTransportAddress());
@@ -208,7 +266,13 @@ public class LoggingAuditTrailTests extends ESTestCase {
             arg0.updateLocalNodeInfo(localNode);
             return null;
         }).when(clusterService).addListener(Mockito.isA(LoggingAuditTrail.class));
-        final ClusterSettings clusterSettings = mockClusterSettings();
+        final ClusterSettings clusterSettings = new ClusterSettings(settings,
+                Set.of(LoggingAuditTrail.EMIT_HOST_ADDRESS_SETTING, LoggingAuditTrail.EMIT_HOST_NAME_SETTING,
+                        LoggingAuditTrail.EMIT_NODE_NAME_SETTING, LoggingAuditTrail.EMIT_NODE_ID_SETTING,
+                        LoggingAuditTrail.INCLUDE_EVENT_SETTINGS, LoggingAuditTrail.EXCLUDE_EVENT_SETTINGS,
+                        LoggingAuditTrail.INCLUDE_REQUEST_BODY, LoggingAuditTrail.FILTER_POLICY_IGNORE_PRINCIPALS,
+                        LoggingAuditTrail.FILTER_POLICY_IGNORE_REALMS, LoggingAuditTrail.FILTER_POLICY_IGNORE_ROLES,
+                        LoggingAuditTrail.FILTER_POLICY_IGNORE_INDICES, Loggers.LOG_LEVEL_SETTING));
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
         commonFields = new LoggingAuditTrail.EntryCommonFields(settings, localNode).commonFields;
         threadContext = new ThreadContext(Settings.EMPTY);
@@ -279,6 +343,738 @@ public class LoggingAuditTrailTests extends ESTestCase {
         assertThat(e, hasToString(containsString("invalid pattern [/no-inspiration]")));
     }
 
+    public void testSecurityConfigChangeEventFormattingForRoles() throws IOException {
+        final Path path = getDataPath("/org/elasticsearch/xpack/security/audit/logfile/audited_roles.txt");
+        final Map<String, String> auditedRolesMap = new HashMap<>();
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(new BufferedInputStream(Files.newInputStream(path)),
+                StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                // even number of lines
+                auditedRolesMap.put(line, reader.readLine());
+            }
+        }
+
+        RoleDescriptor nullRoleDescriptor = new RoleDescriptor("null_role", randomFrom((String[]) null, new String[0]),
+                randomFrom((RoleDescriptor.IndicesPrivileges[]) null, new RoleDescriptor.IndicesPrivileges[0]),
+                randomFrom((RoleDescriptor.ApplicationResourcePrivileges[])null, new RoleDescriptor.ApplicationResourcePrivileges[0]),
+                randomFrom((ConfigurableClusterPrivilege[])null, new ConfigurableClusterPrivilege[0]),
+                randomFrom((String[])null, new String[0]),
+                randomFrom((Map<String, Object>)null, Map.of()),
+                Map.of("transient", "meta", "is", "ignored"));
+        RoleDescriptor roleDescriptor1 = new RoleDescriptor("role_descriptor1", new String[]{"monitor"},
+                new RoleDescriptor.IndicesPrivileges[]{RoleDescriptor.IndicesPrivileges.builder()
+                        .indices("test*")
+                        .privileges("read", "create_index")
+                        .grantedFields("grantedField1")
+                        .query("{\"match_all\":{}}")
+                        .allowRestrictedIndices(true)
+                        .build()},
+                randomFrom((RoleDescriptor.ApplicationResourcePrivileges[]) null, new RoleDescriptor.ApplicationResourcePrivileges[0]),
+                randomFrom((ConfigurableClusterPrivilege[]) null, new ConfigurableClusterPrivilege[0]),
+                randomFrom((String[]) null, new String[0]),
+                randomFrom((Map<String, Object>) null, Map.of()),
+                Map.of()
+        );
+        RoleDescriptor roleDescriptor2 = new RoleDescriptor("role_descriptor2", randomFrom((String[]) null, new String[0]),
+                new RoleDescriptor.IndicesPrivileges[]{
+                        RoleDescriptor.IndicesPrivileges.builder()
+                                .indices("na\"me", "*")
+                                .privileges("manage_ilm")
+                                .deniedFields("denied*")
+                                .query("{\"match\": {\"category\": \"click\"}}")
+                                .build(),
+                        RoleDescriptor.IndicesPrivileges.builder()
+                                .indices("/@&~(\\.security.*)/")
+                                .privileges("all", "cluster:a_wrong_*_one")
+                                .build()},
+                new RoleDescriptor.ApplicationResourcePrivileges[] {
+                        RoleDescriptor.ApplicationResourcePrivileges.builder()
+                                .application("maps")
+                                .resources("raster:*")
+                                .privileges("coming", "up", "with", "random", "names", "is", "hard")
+                                .build()},
+                randomFrom((ConfigurableClusterPrivilege[]) null, new ConfigurableClusterPrivilege[0]),
+                new String[] {"impersonated???"},
+                randomFrom((Map<String, Object>) null, Map.of()),
+                Map.of()
+        );
+        RoleDescriptor roleDescriptor3 = new RoleDescriptor("role_descriptor3", randomFrom((String[]) null, new String[0]),
+                randomFrom((RoleDescriptor.IndicesPrivileges[]) null, new RoleDescriptor.IndicesPrivileges[0]),
+                new RoleDescriptor.ApplicationResourcePrivileges[] {
+                        RoleDescriptor.ApplicationResourcePrivileges.builder()
+                                .application("maps")
+                                .resources("raster:*")
+                                .privileges("{", "}", "\n", "\\", "\"")
+                                .build(),
+                        RoleDescriptor.ApplicationResourcePrivileges.builder()
+                                .application("maps")
+                                .resources("noooooo!!\n\n\f\\\\r", "{")
+                                .privileges("*:*")
+                                .build()},
+                randomFrom((ConfigurableClusterPrivilege[]) null, new ConfigurableClusterPrivilege[0]),
+                new String[] {"jack", "nich*", "//\""},
+                Map.of("some meta", 42),
+                Map.of()
+        );
+        Map<String, Object> metaMap = new TreeMap<>();
+        metaMap.put("?list", List.of("e1", "e2", "*"));
+        metaMap.put("some other meta", Map.of("r", "t"));
+        RoleDescriptor roleDescriptor4 = new RoleDescriptor("role_descriptor4", new String[] {"manage_ml", "grant_api_key",
+                "manage_rollup"},
+                new RoleDescriptor.IndicesPrivileges[]{
+                        RoleDescriptor.IndicesPrivileges.builder()
+                                .indices("/. ? + * | { } [ ] ( ) \" \\/", "*")
+                                .privileges("read", "read_cross_cluster")
+                                .grantedFields("almost", "all*")
+                                .deniedFields("denied*")
+                                .build()},
+                randomFrom((RoleDescriptor.ApplicationResourcePrivileges[]) null, new RoleDescriptor.ApplicationResourcePrivileges[0]),
+                new ConfigurableClusterPrivilege[] {
+                        new ConfigurableClusterPrivileges.ManageApplicationPrivileges(Set.of("a+b+|b+a+"))
+                },
+                new String[] {"//+a+\"[a]/"},
+                metaMap,
+                Map.of("ignored", 2)
+        );
+        String keyName = randomAlphaOfLength(4);
+        TimeValue expiration = randomFrom(new TimeValue(randomNonNegativeLong(), randomFrom(TimeUnit.values())), null);
+        List<RoleDescriptor> allTestRoleDescriptors = List.of(nullRoleDescriptor, roleDescriptor1, roleDescriptor2, roleDescriptor3,
+                roleDescriptor4);
+        List<RoleDescriptor> keyRoleDescriptors = randomSubsetOf(allTestRoleDescriptors);
+        StringBuilder roleDescriptorsStringBuilder = new StringBuilder();
+        roleDescriptorsStringBuilder.append("\"role_descriptors\":[");
+        keyRoleDescriptors.forEach(roleDescriptor -> {
+            roleDescriptorsStringBuilder.append(auditedRolesMap.get(roleDescriptor.getName()));
+            roleDescriptorsStringBuilder.append(',');
+        });
+        if (false == keyRoleDescriptors.isEmpty()) {
+            // delete last comma
+            roleDescriptorsStringBuilder.deleteCharAt(roleDescriptorsStringBuilder.length() - 1);
+        }
+        roleDescriptorsStringBuilder.append("]");
+        final String requestId = randomRequestId();
+        final String[] expectedRoles = randomArray(0, 4, String[]::new, () -> randomBoolean() ? null : randomAlphaOfLengthBetween(1, 4));
+        final AuthorizationInfo authorizationInfo = () -> Collections.singletonMap(PRINCIPAL_ROLES_FIELD_NAME, expectedRoles);
+        final Authentication authentication = createAuthentication();
+
+        CreateApiKeyRequest createApiKeyRequest = new CreateApiKeyRequest(keyName, keyRoleDescriptors, expiration);
+        createApiKeyRequest.setRefreshPolicy(randomFrom(WriteRequest.RefreshPolicy.values()));
+        auditTrail.accessGranted(requestId, authentication, CreateApiKeyAction.NAME, createApiKeyRequest, authorizationInfo);
+        StringBuilder createKeyAuditEventStringBuilder = new StringBuilder();
+        createKeyAuditEventStringBuilder.append("\"create\":{\"apikey\":{\"name\":\"" + keyName + "\",\"expiration\":" +
+                (expiration != null ? "\"" + expiration.toString() + "\"" : "null") + ",");
+        createKeyAuditEventStringBuilder.append(roleDescriptorsStringBuilder.toString());
+        createKeyAuditEventStringBuilder.append("}}");
+        String expectedCreateKeyAuditEventString = createKeyAuditEventStringBuilder.toString();
+        List<String> output = CapturingLogger.output(logger.getName(), Level.INFO);
+        assertThat(output.size(), is(2));
+        String generatedCreateKeyAuditEventString = output.get(1);
+        assertThat(generatedCreateKeyAuditEventString, containsString(expectedCreateKeyAuditEventString));
+        generatedCreateKeyAuditEventString = generatedCreateKeyAuditEventString.replace(", " + expectedCreateKeyAuditEventString, "");
+        MapBuilder<String, String> checkedFields = new MapBuilder<>(commonFields);
+        checkedFields.remove(LoggingAuditTrail.ORIGIN_ADDRESS_FIELD_NAME);
+        checkedFields.remove(LoggingAuditTrail.ORIGIN_TYPE_FIELD_NAME);
+        checkedFields.put("type", "audit")
+                .put(LoggingAuditTrail.EVENT_TYPE_FIELD_NAME, "security_config_change")
+                .put(LoggingAuditTrail.EVENT_ACTION_FIELD_NAME, "create_apikey")
+                .put(LoggingAuditTrail.REQUEST_ID_FIELD_NAME, requestId);
+        assertMsg(generatedCreateKeyAuditEventString, checkedFields.immutableMap());
+        // clear log
+        CapturingLogger.output(logger.getName(), Level.INFO).clear();
+
+        GrantApiKeyRequest grantApiKeyRequest = new GrantApiKeyRequest();
+        grantApiKeyRequest.setRefreshPolicy(randomFrom(WriteRequest.RefreshPolicy.values()));
+        grantApiKeyRequest.getGrant().setType(randomFrom(randomAlphaOfLength(8), null));
+        grantApiKeyRequest.getGrant().setUsername(randomFrom(randomAlphaOfLength(8), null));
+        grantApiKeyRequest.getGrant().setPassword(randomFrom(new SecureString("password not exposed"), null));
+        grantApiKeyRequest.getGrant().setAccessToken(randomFrom(new SecureString("access token not exposed"), null));
+        grantApiKeyRequest.setApiKeyRequest(createApiKeyRequest);
+        auditTrail.accessGranted(requestId, authentication, GrantApiKeyAction.NAME, grantApiKeyRequest, authorizationInfo);
+        output = CapturingLogger.output(logger.getName(), Level.INFO);
+        assertThat(output.size(), is(2));
+        String generatedGrantKeyAuditEventString = output.get(1);
+        StringBuilder grantKeyAuditEventStringBuilder = new StringBuilder();
+        grantKeyAuditEventStringBuilder.append("\"create\":{\"apikey\":{\"name\":\"" + keyName + "\",\"expiration\":" +
+                (expiration != null ? "\"" + expiration.toString() + "\"" : "null") + ",");
+        grantKeyAuditEventStringBuilder.append(roleDescriptorsStringBuilder.toString());
+        grantKeyAuditEventStringBuilder.append("},\"grant\":{\"type\":");
+        if (grantApiKeyRequest.getGrant().getType() != null) {
+            grantKeyAuditEventStringBuilder.append("\"").append(grantApiKeyRequest.getGrant().getType()).append("\"");
+        } else {
+            grantKeyAuditEventStringBuilder.append("null");
+        }
+        if (grantApiKeyRequest.getGrant().getUsername() != null) {
+            grantKeyAuditEventStringBuilder.append(",\"user\":{\"name\":\"").append(grantApiKeyRequest.getGrant().getUsername())
+                    .append("\",\"has_password\":").append(grantApiKeyRequest.getGrant().getPassword() != null).append("}");
+        }
+        if (grantApiKeyRequest.getGrant().getAccessToken() != null) {
+            grantKeyAuditEventStringBuilder.append(",\"has_access_token\":").append(true);
+        }
+        grantKeyAuditEventStringBuilder.append("}}");
+        String expectedGrantKeyAuditEventString = grantKeyAuditEventStringBuilder.toString();
+        assertThat(generatedGrantKeyAuditEventString, containsString(expectedGrantKeyAuditEventString));
+        generatedGrantKeyAuditEventString = generatedGrantKeyAuditEventString.replace(", " + expectedGrantKeyAuditEventString, "");
+        checkedFields = new MapBuilder<>(commonFields);
+        checkedFields.remove(LoggingAuditTrail.ORIGIN_ADDRESS_FIELD_NAME);
+        checkedFields.remove(LoggingAuditTrail.ORIGIN_TYPE_FIELD_NAME);
+        checkedFields.put("type", "audit")
+                .put(LoggingAuditTrail.EVENT_TYPE_FIELD_NAME, "security_config_change")
+                .put(LoggingAuditTrail.EVENT_ACTION_FIELD_NAME, "create_apikey")
+                .put(LoggingAuditTrail.REQUEST_ID_FIELD_NAME, requestId);
+        assertMsg(generatedGrantKeyAuditEventString, checkedFields.immutableMap());
+        // clear log
+        CapturingLogger.output(logger.getName(), Level.INFO).clear();
+
+        PutRoleRequest putRoleRequest = new PutRoleRequest();
+        putRoleRequest.setRefreshPolicy(randomFrom(WriteRequest.RefreshPolicy.values()));
+        RoleDescriptor roleDescriptor = randomFrom(allTestRoleDescriptors);
+        putRoleRequest.name(roleDescriptor.getName());
+        putRoleRequest.cluster(roleDescriptor.getClusterPrivileges());
+        putRoleRequest.addIndex(roleDescriptor.getIndicesPrivileges());
+        putRoleRequest.runAs(roleDescriptor.getRunAs());
+        putRoleRequest.conditionalCluster(roleDescriptor.getConditionalClusterPrivileges());
+        putRoleRequest.addApplicationPrivileges(roleDescriptor.getApplicationPrivileges());
+        putRoleRequest.metadata(roleDescriptor.getMetadata());
+        auditTrail.accessGranted(requestId, authentication, PutRoleAction.NAME, putRoleRequest, authorizationInfo);
+        output = CapturingLogger.output(logger.getName(), Level.INFO);
+        assertThat(output.size(), is(2));
+        String generatedPutRoleAuditEventString = output.get(1);
+        StringBuilder putRoleAuditEventStringBuilder = new StringBuilder();
+        putRoleAuditEventStringBuilder.append("\"put\":{\"role\":{\"name\":\"" + putRoleRequest.name() + "\",")
+                .append("\"role_descriptor\":")
+                .append(auditedRolesMap.get(putRoleRequest.name()))
+                .append("}}");
+        String expectedPutRoleAuditEventString = putRoleAuditEventStringBuilder.toString();
+        assertThat(generatedPutRoleAuditEventString, containsString(expectedPutRoleAuditEventString));
+        generatedPutRoleAuditEventString = generatedPutRoleAuditEventString.replace(", " + expectedPutRoleAuditEventString, "");
+        checkedFields = new MapBuilder<>(commonFields);
+        checkedFields.remove(LoggingAuditTrail.ORIGIN_ADDRESS_FIELD_NAME);
+        checkedFields.remove(LoggingAuditTrail.ORIGIN_TYPE_FIELD_NAME);
+        checkedFields.put("type", "audit")
+                .put(LoggingAuditTrail.EVENT_TYPE_FIELD_NAME, "security_config_change")
+                .put(LoggingAuditTrail.EVENT_ACTION_FIELD_NAME, "put_role")
+                .put(LoggingAuditTrail.REQUEST_ID_FIELD_NAME, requestId);
+        assertMsg(generatedPutRoleAuditEventString, checkedFields.immutableMap());
+        // clear log
+        CapturingLogger.output(logger.getName(), Level.INFO).clear();
+
+        DeleteRoleRequest deleteRoleRequest = new DeleteRoleRequest();
+        deleteRoleRequest.setRefreshPolicy(randomFrom(WriteRequest.RefreshPolicy.values()));
+        deleteRoleRequest.name(putRoleRequest.name());
+        auditTrail.accessGranted(requestId, authentication, DeleteRoleAction.NAME, deleteRoleRequest, authorizationInfo);
+        output = CapturingLogger.output(logger.getName(), Level.INFO);
+        assertThat(output.size(), is(2));
+        String generatedDeleteRoleAuditEventString = output.get(1);
+        StringBuilder deleteRoleStringBuilder = new StringBuilder();
+        deleteRoleStringBuilder.append("\"delete\":{\"role\":{\"name\":");
+        if (deleteRoleRequest.name() == null) {
+            deleteRoleStringBuilder.append("null");
+        } else {
+            deleteRoleStringBuilder.append("\"").append(deleteRoleRequest.name()).append("\"");
+        }
+        deleteRoleStringBuilder.append("}}");
+        String expectedDeleteRoleAuditEventString = deleteRoleStringBuilder.toString();
+        assertThat(generatedDeleteRoleAuditEventString, containsString(expectedDeleteRoleAuditEventString));
+        generatedDeleteRoleAuditEventString =
+                generatedDeleteRoleAuditEventString.replace(", " + expectedDeleteRoleAuditEventString,"");
+        checkedFields = new MapBuilder<>(commonFields);
+        checkedFields.remove(LoggingAuditTrail.ORIGIN_ADDRESS_FIELD_NAME);
+        checkedFields.remove(LoggingAuditTrail.ORIGIN_TYPE_FIELD_NAME);
+        checkedFields.put("type", "audit")
+                .put(LoggingAuditTrail.EVENT_TYPE_FIELD_NAME, "security_config_change")
+                .put(LoggingAuditTrail.EVENT_ACTION_FIELD_NAME, "delete_role")
+                .put(LoggingAuditTrail.REQUEST_ID_FIELD_NAME, requestId);
+        assertMsg(generatedDeleteRoleAuditEventString, checkedFields.immutableMap());
+    }
+
+    public void testSecurityConfigChangeEventFormattingForApiKeyInvalidation() throws IOException {
+        final String requestId = randomRequestId();
+        final String[] expectedRoles = randomArray(0, 4, String[]::new, () -> randomBoolean() ? null : randomAlphaOfLengthBetween(1, 4));
+        final AuthorizationInfo authorizationInfo = () -> Collections.singletonMap(PRINCIPAL_ROLES_FIELD_NAME, expectedRoles);
+        final Authentication authentication = createAuthentication();
+
+        final InvalidateApiKeyRequest invalidateApiKeyRequest;
+        if (randomBoolean()) {
+            invalidateApiKeyRequest = new InvalidateApiKeyRequest(randomFrom(randomAlphaOfLength(8), null),
+                    randomFrom(randomAlphaOfLength(8), null), null, randomFrom(randomAlphaOfLength(8), null), randomBoolean(),
+                    randomFrom(randomArray(3, String[]::new, () -> randomAlphaOfLength(8)), null));
+        } else {
+            invalidateApiKeyRequest = new InvalidateApiKeyRequest(randomFrom(randomAlphaOfLength(8), null),
+                    randomFrom(randomAlphaOfLength(8), null), randomAlphaOfLength(8), randomFrom(randomAlphaOfLength(8), null),
+                    randomBoolean());
+        }
+        auditTrail.accessGranted(requestId, authentication, InvalidateApiKeyAction.NAME, invalidateApiKeyRequest, authorizationInfo);
+        List<String> output = CapturingLogger.output(logger.getName(), Level.INFO);
+        assertThat(output.size(), is(2));
+        String generatedInvalidateKeyAuditEventString = output.get(1);
+        StringBuilder invalidateKeyEventStringBuilder = new StringBuilder();
+        invalidateKeyEventStringBuilder.append("\"invalidate\":{\"apikeys\":{");
+        if (invalidateApiKeyRequest.getIds() != null && invalidateApiKeyRequest.getIds().length > 0) {
+            invalidateKeyEventStringBuilder.append("\"ids\":[");
+            for (String apiKeyId : invalidateApiKeyRequest.getIds()) {
+                invalidateKeyEventStringBuilder.append("\"").append(apiKeyId).append("\",");
+            }
+            // delete last comma
+            invalidateKeyEventStringBuilder.deleteCharAt(invalidateKeyEventStringBuilder.length() - 1);
+            invalidateKeyEventStringBuilder.append("],");
+        }
+        if (Strings.hasLength(invalidateApiKeyRequest.getName())) {
+            invalidateKeyEventStringBuilder.append("\"name\":\"").append(invalidateApiKeyRequest.getName()).append("\",");
+        }
+        invalidateKeyEventStringBuilder.append("\"owned_by_authenticated_user\":")
+                .append(invalidateApiKeyRequest.ownedByAuthenticatedUser());
+        if (Strings.hasLength(invalidateApiKeyRequest.getUserName()) || Strings.hasLength(invalidateApiKeyRequest.getRealmName())) {
+            invalidateKeyEventStringBuilder.append(",\"user\":{\"name\":");
+            if (Strings.hasLength(invalidateApiKeyRequest.getUserName())) {
+                invalidateKeyEventStringBuilder.append("\"").append(invalidateApiKeyRequest.getUserName()).append("\"");
+            } else {
+                invalidateKeyEventStringBuilder.append("null");
+            }
+            invalidateKeyEventStringBuilder.append(",\"realm\":");
+            if (Strings.hasLength(invalidateApiKeyRequest.getRealmName())) {
+                invalidateKeyEventStringBuilder.append("\"").append(invalidateApiKeyRequest.getRealmName()).append("\"");
+            } else {
+                invalidateKeyEventStringBuilder.append("null");
+            }
+            invalidateKeyEventStringBuilder.append("}");
+        }
+        invalidateKeyEventStringBuilder.append("}}");
+        String expectedInvalidateKeyEventString = invalidateKeyEventStringBuilder.toString();
+        assertThat(generatedInvalidateKeyAuditEventString, containsString(expectedInvalidateKeyEventString));
+        generatedInvalidateKeyAuditEventString = generatedInvalidateKeyAuditEventString
+                .replace(", " + expectedInvalidateKeyEventString, "");
+        MapBuilder<String, String> checkedFields = new MapBuilder<>(commonFields);
+        checkedFields.remove(LoggingAuditTrail.ORIGIN_ADDRESS_FIELD_NAME);
+        checkedFields.remove(LoggingAuditTrail.ORIGIN_TYPE_FIELD_NAME);
+        checkedFields.put("type", "audit")
+                .put(LoggingAuditTrail.EVENT_TYPE_FIELD_NAME, "security_config_change")
+                .put(LoggingAuditTrail.EVENT_ACTION_FIELD_NAME, "invalidate_apikeys")
+                .put(LoggingAuditTrail.REQUEST_ID_FIELD_NAME, requestId);
+        assertMsg(generatedInvalidateKeyAuditEventString, checkedFields.immutableMap());
+    }
+
+    public void testSecurityConfigChangeEventFormattingForApplicationPrivileges() throws IOException {
+        final String requestId = randomRequestId();
+        final String[] expectedRoles = randomArray(0, 4, String[]::new, () -> randomBoolean() ? null : randomAlphaOfLengthBetween(1, 4));
+        final AuthorizationInfo authorizationInfo = () -> Collections.singletonMap(PRINCIPAL_ROLES_FIELD_NAME, expectedRoles);
+        final Authentication authentication = createAuthentication();
+        final Map<String, Object> metadata = new TreeMap<>();
+        final String serializedMetadata;
+        if (randomBoolean()) {
+            metadata.put("test", true);
+            metadata.put("ans", 42);
+            serializedMetadata = ",\"metadata\":{\"ans\":42,\"test\":true}";
+        } else {
+            metadata.put("ans", List.of(42, true));
+            metadata.put("other", Map.of("42", true));
+            serializedMetadata = ",\"metadata\":{\"ans\":[42,true],\"other\":{\"42\":true}}";
+        }
+
+        PutPrivilegesRequest putPrivilegesRequest = new PutPrivilegesRequest();
+        putPrivilegesRequest.setRefreshPolicy(randomFrom(WriteRequest.RefreshPolicy.values()));
+        putPrivilegesRequest.setPrivileges(Arrays.asList(randomArray(4, ApplicationPrivilegeDescriptor[]::new, () -> {
+            Set<String> actions = Arrays.stream(generateRandomStringArray(4, 4, false)).collect(Collectors.toSet());
+            return new ApplicationPrivilegeDescriptor(randomAlphaOfLength(4), randomAlphaOfLength(4), actions, metadata);
+        })));
+        auditTrail.accessGranted(requestId, authentication, PutPrivilegesAction.NAME, putPrivilegesRequest, authorizationInfo);
+        List<String> output = CapturingLogger.output(logger.getName(), Level.INFO);
+        assertThat(output.size(), is(2));
+        String generatedPutPrivilegesAuditEventString = output.get(1);
+        StringBuilder putPrivilegesAuditEventStringBuilder = new StringBuilder();
+        putPrivilegesAuditEventStringBuilder.append("\"put\":{\"privileges\":[");
+        if (false == putPrivilegesRequest.getPrivileges().isEmpty()) {
+            for (ApplicationPrivilegeDescriptor appPriv : putPrivilegesRequest.getPrivileges()) {
+                putPrivilegesAuditEventStringBuilder.append("{\"application\":\"").append(appPriv.getApplication()).append("\"")
+                        .append(",\"name\":\"").append(appPriv.getName()).append("\"")
+                        .append(",\"actions\":[");
+                if (appPriv.getActions().isEmpty()) {
+                    putPrivilegesAuditEventStringBuilder.append("]");
+                } else {
+                    for (String action : appPriv.getActions()) {
+                        putPrivilegesAuditEventStringBuilder.append("\"").append(action).append("\",");
+                    }
+                    // delete last comma
+                    putPrivilegesAuditEventStringBuilder.deleteCharAt(putPrivilegesAuditEventStringBuilder.length() - 1);
+                    putPrivilegesAuditEventStringBuilder.append("]");
+                }
+                putPrivilegesAuditEventStringBuilder.append(serializedMetadata).append("},");
+            }
+            // delete last comma
+            putPrivilegesAuditEventStringBuilder.deleteCharAt(putPrivilegesAuditEventStringBuilder.length() - 1);
+        }
+        putPrivilegesAuditEventStringBuilder.append("]}");
+        String expectedPutPrivilegesEventString = putPrivilegesAuditEventStringBuilder.toString();
+        assertThat(generatedPutPrivilegesAuditEventString, containsString(expectedPutPrivilegesEventString));
+        generatedPutPrivilegesAuditEventString = generatedPutPrivilegesAuditEventString
+                .replace(", " + expectedPutPrivilegesEventString, "");
+        MapBuilder<String, String> checkedFields = new MapBuilder<>(commonFields);
+        checkedFields.remove(LoggingAuditTrail.ORIGIN_ADDRESS_FIELD_NAME);
+        checkedFields.remove(LoggingAuditTrail.ORIGIN_TYPE_FIELD_NAME);
+        checkedFields.put("type", "audit")
+                .put(LoggingAuditTrail.EVENT_TYPE_FIELD_NAME, "security_config_change")
+                .put(LoggingAuditTrail.EVENT_ACTION_FIELD_NAME, "put_privileges")
+                .put(LoggingAuditTrail.REQUEST_ID_FIELD_NAME, requestId);
+        assertMsg(generatedPutPrivilegesAuditEventString, checkedFields.immutableMap());
+        // clear log
+        CapturingLogger.output(logger.getName(), Level.INFO).clear();
+        DeletePrivilegesRequest deletePrivilegesRequest = new DeletePrivilegesRequest(randomFrom(randomAlphaOfLength(8), null),
+                generateRandomStringArray(4, 4, true));
+        deletePrivilegesRequest.setRefreshPolicy(randomFrom(WriteRequest.RefreshPolicy.values()));
+        auditTrail.accessGranted(requestId, authentication, DeletePrivilegesAction.NAME, deletePrivilegesRequest, authorizationInfo);
+        output = CapturingLogger.output(logger.getName(), Level.INFO);
+        assertThat(output.size(), is(2));
+        String generatedDeletePrivilegesAuditEventString = output.get(1);
+        StringBuilder deletePrivilegesAuditEventStringBuilder = new StringBuilder();
+        deletePrivilegesAuditEventStringBuilder.append("\"delete\":{\"privileges\":{\"application\":");
+        if (deletePrivilegesRequest.application() != null) {
+            deletePrivilegesAuditEventStringBuilder.append("\"").append(deletePrivilegesRequest.application()).append("\"");
+        } else {
+            deletePrivilegesAuditEventStringBuilder.append("null");
+        }
+        deletePrivilegesAuditEventStringBuilder.append(",\"privileges\":");
+        if (deletePrivilegesRequest.privileges() == null) {
+            deletePrivilegesAuditEventStringBuilder.append("null");
+        } else if (deletePrivilegesRequest.privileges().length == 0) {
+            deletePrivilegesAuditEventStringBuilder.append("[]");
+        } else {
+            deletePrivilegesAuditEventStringBuilder.append("[");
+            for (String privilege : deletePrivilegesRequest.privileges()) {
+                if (privilege == null) {
+                    deletePrivilegesAuditEventStringBuilder.append("null,");
+                } else {
+                    deletePrivilegesAuditEventStringBuilder.append("\"").append(privilege).append("\",");
+                }
+            }
+            // delete last comma
+            deletePrivilegesAuditEventStringBuilder.deleteCharAt(deletePrivilegesAuditEventStringBuilder.length() - 1);
+            deletePrivilegesAuditEventStringBuilder.append("]");
+        }
+        deletePrivilegesAuditEventStringBuilder.append("}}");
+        String expectedDeletePrivilegesEventString = deletePrivilegesAuditEventStringBuilder.toString();
+        assertThat(generatedDeletePrivilegesAuditEventString, containsString(expectedDeletePrivilegesEventString));
+        generatedDeletePrivilegesAuditEventString = generatedDeletePrivilegesAuditEventString
+                .replace(", " + expectedDeletePrivilegesEventString, "");
+        checkedFields = new MapBuilder<>(commonFields);
+        checkedFields.remove(LoggingAuditTrail.ORIGIN_ADDRESS_FIELD_NAME);
+        checkedFields.remove(LoggingAuditTrail.ORIGIN_TYPE_FIELD_NAME);
+        checkedFields.put("type", "audit")
+                .put(LoggingAuditTrail.EVENT_TYPE_FIELD_NAME, "security_config_change")
+                .put(LoggingAuditTrail.EVENT_ACTION_FIELD_NAME, "delete_privileges")
+                .put(LoggingAuditTrail.REQUEST_ID_FIELD_NAME, requestId);
+        assertMsg(generatedDeletePrivilegesAuditEventString, checkedFields.immutableMap());
+    }
+
+    public void testSecurityConfigChangeEventFormattingForRoleMapping() throws IOException {
+        final String requestId = randomRequestId();
+        final String[] expectedRoles = randomArray(0, 4, String[]::new, () -> randomBoolean() ? null : randomAlphaOfLengthBetween(1, 4));
+        final AuthorizationInfo authorizationInfo = () -> Collections.singletonMap(PRINCIPAL_ROLES_FIELD_NAME, expectedRoles);
+        final Authentication authentication = createAuthentication();
+
+        PutRoleMappingRequest putRoleMappingRequest = new PutRoleMappingRequest();
+        putRoleMappingRequest.setRefreshPolicy(randomFrom(WriteRequest.RefreshPolicy.values()));
+        putRoleMappingRequest.setName(randomFrom(randomAlphaOfLength(8), null));
+        putRoleMappingRequest.setEnabled(randomBoolean());
+        putRoleMappingRequest.setRoles(Arrays.asList(randomArray(4, String[]::new, () -> randomAlphaOfLength(4))));
+        putRoleMappingRequest.setRoleTemplates(Arrays.asList(randomArray(4, TemplateRoleName[]::new,
+                () -> new TemplateRoleName(new BytesArray(randomAlphaOfLengthBetween(0, 8)),
+                        randomFrom(TemplateRoleName.Format.values())))));
+        RoleMapperExpression mockRoleMapperExpression = new RoleMapperExpression() {
+            @Override
+            public boolean match(ExpressionModel model) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public String getWriteableName() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void writeTo(StreamOutput out) throws IOException {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+                builder.startObject();
+                builder.field("mock", "A mock role mapper expression");
+                builder.endObject();
+                return builder;
+            }
+        };
+        boolean hasRules = randomBoolean();
+        if (hasRules) {
+            putRoleMappingRequest.setRules(mockRoleMapperExpression);
+        }
+        boolean hasMetadata = randomBoolean();
+        if (hasMetadata) {
+            Map<String, Object> metadata = new TreeMap<>();
+            metadata.put("list", List.of("42", 13));
+            metadata.put("smth", 42);
+            putRoleMappingRequest.setMetadata(metadata);
+        }
+        auditTrail.accessGranted(requestId, authentication, PutRoleMappingAction.NAME, putRoleMappingRequest, authorizationInfo);
+        List<String> output = CapturingLogger.output(logger.getName(), Level.INFO);
+        assertThat(output.size(), is(2));
+        String generatedPutRoleMappingAuditEventString = output.get(1);
+        StringBuilder putRoleMappingAuditEventStringBuilder = new StringBuilder();
+        putRoleMappingAuditEventStringBuilder.append("\"put\":{\"role_mapping\":{\"name\":");
+        if (putRoleMappingRequest.getName() != null) {
+            putRoleMappingAuditEventStringBuilder.append("\"").append(putRoleMappingRequest.getName()).append("\"");
+        } else {
+            putRoleMappingAuditEventStringBuilder.append("null");
+        }
+        if (putRoleMappingRequest.getRoles() != null && false == putRoleMappingRequest.getRoles().isEmpty()) {
+            putRoleMappingAuditEventStringBuilder.append(",\"roles\":[");
+            for (String roleName : putRoleMappingRequest.getRoles()) {
+                putRoleMappingAuditEventStringBuilder.append("\"").append(roleName).append("\",");
+            }
+            // delete last comma
+            putRoleMappingAuditEventStringBuilder.deleteCharAt(putRoleMappingAuditEventStringBuilder.length() - 1);
+            putRoleMappingAuditEventStringBuilder.append("]");
+        }
+        if (putRoleMappingRequest.getRoleTemplates() != null && false == putRoleMappingRequest.getRoleTemplates().isEmpty()) {
+            putRoleMappingAuditEventStringBuilder.append(",\"role_templates\":[");
+            for (TemplateRoleName templateRoleName : putRoleMappingRequest.getRoleTemplates()) {
+                putRoleMappingAuditEventStringBuilder.append("{\"template\":\"")
+                        .append(templateRoleName.getTemplate().utf8ToString())
+                        .append("\",\"format\":\"")
+                        .append(templateRoleName.getFormat().toString().toLowerCase(Locale.ROOT))
+                        .append("\"},");
+            }
+            // delete last comma
+            putRoleMappingAuditEventStringBuilder.deleteCharAt(putRoleMappingAuditEventStringBuilder.length() - 1);
+            putRoleMappingAuditEventStringBuilder.append("]");
+        }
+        if (hasRules) {
+            putRoleMappingAuditEventStringBuilder.append(",\"rules\":{\"mock\":\"A mock role mapper expression\"}");
+        } else {
+            putRoleMappingAuditEventStringBuilder.append(",\"rules\":null");
+        }
+        putRoleMappingAuditEventStringBuilder.append(",\"enabled\":").append(putRoleMappingRequest.isEnabled());
+        if (hasMetadata) {
+            putRoleMappingAuditEventStringBuilder.append(",\"metadata\":{\"list\":[\"42\",13],\"smth\":42}}}");
+        } else {
+            putRoleMappingAuditEventStringBuilder.append("}}");
+        }
+        String expectedPutRoleMappingAuditEventString = putRoleMappingAuditEventStringBuilder.toString();
+        assertThat(generatedPutRoleMappingAuditEventString, containsString(expectedPutRoleMappingAuditEventString));
+        generatedPutRoleMappingAuditEventString = generatedPutRoleMappingAuditEventString
+                .replace(", " + expectedPutRoleMappingAuditEventString, "");
+        MapBuilder<String, String> checkedFields = new MapBuilder<>(commonFields);
+        checkedFields.remove(LoggingAuditTrail.ORIGIN_ADDRESS_FIELD_NAME);
+        checkedFields.remove(LoggingAuditTrail.ORIGIN_TYPE_FIELD_NAME);
+        checkedFields.put("type", "audit")
+                .put(LoggingAuditTrail.EVENT_TYPE_FIELD_NAME, "security_config_change")
+                .put(LoggingAuditTrail.EVENT_ACTION_FIELD_NAME, "put_role_mapping")
+                .put(LoggingAuditTrail.REQUEST_ID_FIELD_NAME, requestId);
+        assertMsg(generatedPutRoleMappingAuditEventString, checkedFields.immutableMap());
+        // clear log
+        CapturingLogger.output(logger.getName(), Level.INFO).clear();
+
+        DeleteRoleMappingRequest deleteRoleMappingRequest = new DeleteRoleMappingRequest();
+        deleteRoleMappingRequest.setRefreshPolicy(randomFrom(WriteRequest.RefreshPolicy.values()));
+        deleteRoleMappingRequest.setName(putRoleMappingRequest.getName());
+        auditTrail.accessGranted(requestId, authentication, DeleteRoleMappingAction.NAME, deleteRoleMappingRequest, authorizationInfo);
+        output = CapturingLogger.output(logger.getName(), Level.INFO);
+        assertThat(output.size(), is(2));
+        String generatedDeleteRoleMappingAuditEventString = output.get(1);
+        StringBuilder deleteRoleMappingStringBuilder = new StringBuilder();
+        deleteRoleMappingStringBuilder.append("\"delete\":{\"role_mapping\":{\"name\":");
+        if (deleteRoleMappingRequest.getName() == null) {
+            deleteRoleMappingStringBuilder.append("null");
+        } else {
+            deleteRoleMappingStringBuilder.append("\"").append(deleteRoleMappingRequest.getName()).append("\"");
+        }
+        deleteRoleMappingStringBuilder.append("}}");
+        String expectedDeleteRoleMappingAuditEventString = deleteRoleMappingStringBuilder.toString();
+        assertThat(generatedDeleteRoleMappingAuditEventString, containsString(expectedDeleteRoleMappingAuditEventString));
+        generatedDeleteRoleMappingAuditEventString =
+                generatedDeleteRoleMappingAuditEventString.replace(", " + expectedDeleteRoleMappingAuditEventString,"");
+        checkedFields = new MapBuilder<>(commonFields);
+        checkedFields.remove(LoggingAuditTrail.ORIGIN_ADDRESS_FIELD_NAME);
+        checkedFields.remove(LoggingAuditTrail.ORIGIN_TYPE_FIELD_NAME);
+        checkedFields.put("type", "audit")
+                .put(LoggingAuditTrail.EVENT_TYPE_FIELD_NAME, "security_config_change")
+                .put(LoggingAuditTrail.EVENT_ACTION_FIELD_NAME, "delete_role_mapping")
+                .put(LoggingAuditTrail.REQUEST_ID_FIELD_NAME, requestId);
+        assertMsg(generatedDeleteRoleMappingAuditEventString, checkedFields.immutableMap());
+    }
+
+    public void testSecurityConfigChangeEventFormattingForUsers() throws IOException {
+        final String requestId = randomRequestId();
+        final String[] expectedRoles = randomArray(0, 4, String[]::new, () -> randomBoolean() ? null : randomAlphaOfLengthBetween(1, 4));
+        final AuthorizationInfo authorizationInfo = () -> Collections.singletonMap(PRINCIPAL_ROLES_FIELD_NAME, expectedRoles);
+        final Authentication authentication = createAuthentication();
+
+        PutUserRequest putUserRequest = new PutUserRequest();
+        String username = randomFrom(randomAlphaOfLength(3), customAnonymousUsername, AnonymousUser.DEFAULT_ANONYMOUS_USERNAME,
+                UsernamesField.ELASTIC_NAME, UsernamesField.KIBANA_NAME);
+        putUserRequest.username(username);
+        putUserRequest.roles(randomFrom(randomArray(4, String[]::new, () -> randomAlphaOfLength(8)), null));
+        putUserRequest.fullName(randomFrom(randomAlphaOfLength(8), null));
+        putUserRequest.email(randomFrom(randomAlphaOfLength(8), null));
+        putUserRequest.setRefreshPolicy(randomFrom(WriteRequest.RefreshPolicy.values()));
+        putUserRequest.enabled(randomBoolean());
+        putUserRequest.passwordHash(randomFrom(randomAlphaOfLengthBetween(0, 8).toCharArray(), null));
+        boolean hasMetadata = randomBoolean();
+        if (hasMetadata) {
+            Map<String, Object> metadata = new TreeMap<>();
+            metadata.put("smth", 42);
+            metadata.put("list", List.of("42", 13));
+            putUserRequest.metadata(metadata);
+        }
+
+        auditTrail.accessGranted(requestId, authentication, PutUserAction.NAME, putUserRequest, authorizationInfo);
+        List<String> output = CapturingLogger.output(logger.getName(), Level.INFO);
+        assertThat(output.size(), is(2));
+        String generatedPutUserAuditEventString = output.get(1);
+
+        StringBuilder putUserAuditEventStringBuilder = new StringBuilder();
+        putUserAuditEventStringBuilder.append("\"put\":{\"user\":{\"name\":");
+        putUserAuditEventStringBuilder.append("\"" + putUserRequest.username() + "\"");
+        putUserAuditEventStringBuilder.append(",\"enabled\":");
+        putUserAuditEventStringBuilder.append(putUserRequest.enabled());
+        putUserAuditEventStringBuilder.append(",\"roles\":");
+        if (putUserRequest.roles() == null) {
+            putUserAuditEventStringBuilder.append("null");
+        } else if (putUserRequest.roles().length == 0) {
+            putUserAuditEventStringBuilder.append("[]");
+        } else {
+            putUserAuditEventStringBuilder.append("[");
+            for (String roleName : putUserRequest.roles()) {
+                putUserAuditEventStringBuilder.append("\"").append(roleName).append("\",");
+            }
+            // delete last comma
+            putUserAuditEventStringBuilder.deleteCharAt(putUserAuditEventStringBuilder.length() - 1);
+            putUserAuditEventStringBuilder.append("]");
+        }
+        if (putUserRequest.fullName() != null) {
+            putUserAuditEventStringBuilder.append(",\"full_name\":\"").append(putUserRequest.fullName()).append("\"");
+        }
+        if (putUserRequest.email() != null) {
+            putUserAuditEventStringBuilder.append(",\"email\":\"").append(putUserRequest.email()).append("\"");
+        }
+        putUserAuditEventStringBuilder.append(",\"has_password\":").append(putUserRequest.passwordHash() != null);
+        if (hasMetadata) {
+            putUserAuditEventStringBuilder.append(",\"metadata\":{\"list\":[\"42\",13],\"smth\":42}}}");
+        } else {
+            putUserAuditEventStringBuilder.append("}}");
+        }
+        String expectedPutUserAuditEventString = putUserAuditEventStringBuilder.toString();
+        assertThat(generatedPutUserAuditEventString, containsString(expectedPutUserAuditEventString));
+        generatedPutUserAuditEventString = generatedPutUserAuditEventString.replace(", " + expectedPutUserAuditEventString, "");
+        MapBuilder<String, String> checkedFields = new MapBuilder<>(commonFields);
+        checkedFields.remove(LoggingAuditTrail.ORIGIN_ADDRESS_FIELD_NAME);
+        checkedFields.remove(LoggingAuditTrail.ORIGIN_TYPE_FIELD_NAME);
+        checkedFields.put("type", "audit")
+                .put(LoggingAuditTrail.EVENT_TYPE_FIELD_NAME, "security_config_change")
+                .put(LoggingAuditTrail.EVENT_ACTION_FIELD_NAME, "put_user")
+                .put(LoggingAuditTrail.REQUEST_ID_FIELD_NAME, requestId);
+        assertMsg(generatedPutUserAuditEventString, checkedFields.immutableMap());
+        // clear log
+        CapturingLogger.output(logger.getName(), Level.INFO).clear();
+
+        SetEnabledRequest setEnabledRequest = new SetEnabledRequest();
+        setEnabledRequest.setRefreshPolicy(randomFrom(WriteRequest.RefreshPolicy.values()));
+        // enable user
+        setEnabledRequest.enabled(true);
+        setEnabledRequest.username(username);
+        auditTrail.accessGranted(requestId, authentication, SetEnabledAction.NAME, setEnabledRequest, authorizationInfo);
+        output = CapturingLogger.output(logger.getName(), Level.INFO);
+        assertThat(output.size(), is(2));
+        String generatedEnableUserAuditEventString = output.get(1);
+        StringBuilder enableUserStringBuilder = new StringBuilder();
+        enableUserStringBuilder.append("\"change\":{\"enable\":{\"user\":{\"name\":\"").append(username).append("\"}}}");
+        String expectedEnableUserAuditEventString = enableUserStringBuilder.toString();
+        assertThat(generatedEnableUserAuditEventString, containsString(expectedEnableUserAuditEventString));
+        generatedEnableUserAuditEventString = generatedEnableUserAuditEventString.replace(", " + expectedEnableUserAuditEventString, "");
+        checkedFields = new MapBuilder<>(commonFields);
+        checkedFields.remove(LoggingAuditTrail.ORIGIN_ADDRESS_FIELD_NAME);
+        checkedFields.remove(LoggingAuditTrail.ORIGIN_TYPE_FIELD_NAME);
+        checkedFields.put("type", "audit")
+                .put(LoggingAuditTrail.EVENT_TYPE_FIELD_NAME, "security_config_change")
+                .put(LoggingAuditTrail.EVENT_ACTION_FIELD_NAME, "change_enable_user")
+                .put(LoggingAuditTrail.REQUEST_ID_FIELD_NAME, requestId);
+        assertMsg(generatedEnableUserAuditEventString, checkedFields.immutableMap());
+        // clear log
+        CapturingLogger.output(logger.getName(), Level.INFO).clear();
+
+        setEnabledRequest = new SetEnabledRequest();
+        setEnabledRequest.setRefreshPolicy(randomFrom(WriteRequest.RefreshPolicy.values()));
+        // disable user
+        setEnabledRequest.enabled(false);
+        setEnabledRequest.username(username);
+        auditTrail.accessGranted(requestId, authentication, SetEnabledAction.NAME, setEnabledRequest, authorizationInfo);
+        output = CapturingLogger.output(logger.getName(), Level.INFO);
+        assertThat(output.size(), is(2));
+        String generatedDisableUserAuditEventString = output.get(1);
+        StringBuilder disableUserStringBuilder = new StringBuilder();
+        disableUserStringBuilder.append("\"change\":{\"disable\":{\"user\":{\"name\":\"").append(username).append("\"}}}");
+        String expectedDisableUserAuditEventString = disableUserStringBuilder.toString();
+        assertThat(generatedDisableUserAuditEventString, containsString(expectedDisableUserAuditEventString));
+        generatedDisableUserAuditEventString = generatedDisableUserAuditEventString.replace(", " + expectedDisableUserAuditEventString, "");
+        checkedFields = new MapBuilder<>(commonFields);
+        checkedFields.remove(LoggingAuditTrail.ORIGIN_ADDRESS_FIELD_NAME);
+        checkedFields.remove(LoggingAuditTrail.ORIGIN_TYPE_FIELD_NAME);
+        checkedFields.put("type", "audit")
+                .put(LoggingAuditTrail.EVENT_TYPE_FIELD_NAME, "security_config_change")
+                .put(LoggingAuditTrail.EVENT_ACTION_FIELD_NAME, "change_disable_user")
+                .put(LoggingAuditTrail.REQUEST_ID_FIELD_NAME, requestId);
+        assertMsg(generatedDisableUserAuditEventString, checkedFields.immutableMap());
+        // clear log
+        CapturingLogger.output(logger.getName(), Level.INFO).clear();
+
+        ChangePasswordRequest changePasswordRequest = new ChangePasswordRequest();
+        changePasswordRequest.setRefreshPolicy(randomFrom(WriteRequest.RefreshPolicy.values()));
+        changePasswordRequest.username(username);
+        changePasswordRequest.passwordHash(randomFrom(randomAlphaOfLengthBetween(0, 8).toCharArray(), null));
+        auditTrail.accessGranted(requestId, authentication, ChangePasswordAction.NAME, changePasswordRequest, authorizationInfo);
+        output = CapturingLogger.output(logger.getName(), Level.INFO);
+        assertThat(output.size(), is(2));
+        String generatedChangePasswordAuditEventString = output.get(1);
+        StringBuilder changePasswordStringBuilder = new StringBuilder();
+        changePasswordStringBuilder.append("\"change\":{\"password\":{\"user\":{\"name\":\"").append(username).append("\"}}}");
+        String expectedChangePasswordAuditEventString = changePasswordStringBuilder.toString();
+        assertThat(generatedChangePasswordAuditEventString, containsString(expectedChangePasswordAuditEventString));
+        generatedChangePasswordAuditEventString =
+                generatedChangePasswordAuditEventString.replace(", " + expectedChangePasswordAuditEventString,
+                "");
+        checkedFields = new MapBuilder<>(commonFields);
+        checkedFields.remove(LoggingAuditTrail.ORIGIN_ADDRESS_FIELD_NAME);
+        checkedFields.remove(LoggingAuditTrail.ORIGIN_TYPE_FIELD_NAME);
+        checkedFields.put("type", "audit")
+                .put(LoggingAuditTrail.EVENT_TYPE_FIELD_NAME, "security_config_change")
+                .put(LoggingAuditTrail.EVENT_ACTION_FIELD_NAME, "change_password")
+                .put(LoggingAuditTrail.REQUEST_ID_FIELD_NAME, requestId);
+        assertMsg(generatedChangePasswordAuditEventString, checkedFields.immutableMap());
+        // clear log
+        CapturingLogger.output(logger.getName(), Level.INFO).clear();
+
+        DeleteUserRequest deleteUserRequest = new DeleteUserRequest();
+        deleteUserRequest.setRefreshPolicy(randomFrom(WriteRequest.RefreshPolicy.values()));
+        deleteUserRequest.username(username);
+        auditTrail.accessGranted(requestId, authentication, DeleteUserAction.NAME, deleteUserRequest, authorizationInfo);
+        output = CapturingLogger.output(logger.getName(), Level.INFO);
+        assertThat(output.size(), is(2));
+        String generatedDeleteUserAuditEventString = output.get(1);
+        StringBuilder deleteUserStringBuilder = new StringBuilder();
+        deleteUserStringBuilder.append("\"delete\":{\"user\":{\"name\":\"").append(username).append("\"}}");
+        String expectedDeleteUserAuditEventString = deleteUserStringBuilder.toString();
+        assertThat(generatedDeleteUserAuditEventString, containsString(expectedDeleteUserAuditEventString));
+        generatedDeleteUserAuditEventString =
+                generatedDeleteUserAuditEventString.replace(", " + expectedDeleteUserAuditEventString,"");
+        checkedFields = new MapBuilder<>(commonFields);
+        checkedFields.remove(LoggingAuditTrail.ORIGIN_ADDRESS_FIELD_NAME);
+        checkedFields.remove(LoggingAuditTrail.ORIGIN_TYPE_FIELD_NAME);
+        checkedFields.put("type", "audit")
+                .put(LoggingAuditTrail.EVENT_TYPE_FIELD_NAME, "security_config_change")
+                .put(LoggingAuditTrail.EVENT_ACTION_FIELD_NAME, "delete_user")
+                .put(LoggingAuditTrail.REQUEST_ID_FIELD_NAME, requestId);
+        assertMsg(generatedDeleteUserAuditEventString, checkedFields.immutableMap());
+    }
+
     public void testAnonymousAccessDeniedTransport() throws Exception {
         final TransportRequest request = randomBoolean() ? new MockRequest(threadContext) : new MockIndicesRequest(threadContext);
 
@@ -298,11 +1094,10 @@ public class LoggingAuditTrailTests extends ESTestCase {
 
         // test disabled
         CapturingLogger.output(logger.getName(), Level.INFO).clear();
-        settings = Settings.builder()
+        updateLoggerSettings(Settings.builder()
                 .put(settings)
                 .put("xpack.security.audit.logfile.events.exclude", "anonymous_access_denied")
-                .build();
-        auditTrail = new LoggingAuditTrail(settings, clusterService, logger, threadContext);
+                .build());
         auditTrail.anonymousAccessDenied(requestId, "_action", request);
         assertEmptyLog(logger);
     }
@@ -333,11 +1128,10 @@ public class LoggingAuditTrailTests extends ESTestCase {
 
         // test disabled
         CapturingLogger.output(logger.getName(), Level.INFO).clear();
-        settings = Settings.builder()
+        updateLoggerSettings(Settings.builder()
                 .put(settings)
                 .put("xpack.security.audit.logfile.events.exclude", "anonymous_access_denied")
-                .build();
-        auditTrail = new LoggingAuditTrail(settings, clusterService, logger, threadContext);
+                .build());
         auditTrail.anonymousAccessDenied(requestId, request);
         assertEmptyLog(logger);
     }
@@ -364,11 +1158,10 @@ public class LoggingAuditTrailTests extends ESTestCase {
 
         // test disabled
         CapturingLogger.output(logger.getName(), Level.INFO).clear();
-        settings = Settings.builder()
+        updateLoggerSettings(Settings.builder()
                 .put(settings)
                 .put("xpack.security.audit.logfile.events.exclude", "authentication_failed")
-                .build();
-        auditTrail = new LoggingAuditTrail(settings, clusterService, logger, threadContext);
+                .build());
         auditTrail.authenticationFailed(requestId, new MockToken(), "_action", request);
         assertEmptyLog(logger);
     }
@@ -393,11 +1186,10 @@ public class LoggingAuditTrailTests extends ESTestCase {
 
         // test disabled
         CapturingLogger.output(logger.getName(), Level.INFO).clear();
-        settings = Settings.builder()
+        updateLoggerSettings(Settings.builder()
                 .put(settings)
                 .put("xpack.security.audit.logfile.events.exclude", "authentication_failed")
-                .build();
-        auditTrail = new LoggingAuditTrail(settings, clusterService, logger, threadContext);
+                .build());
         auditTrail.authenticationFailed(requestId, "_action", request);
         assertEmptyLog(logger);
     }
@@ -435,11 +1227,10 @@ public class LoggingAuditTrailTests extends ESTestCase {
 
         // test disabled
         CapturingLogger.output(logger.getName(), Level.INFO).clear();
-        settings = Settings.builder()
+        updateLoggerSettings(Settings.builder()
                 .put(settings)
                 .put("xpack.security.audit.logfile.events.exclude", "authentication_failed")
-                .build();
-        auditTrail = new LoggingAuditTrail(settings, clusterService, logger, threadContext);
+                .build());
         auditTrail.authenticationFailed(requestId, new MockToken(), request);
         assertEmptyLog(logger);
     }
@@ -476,11 +1267,10 @@ public class LoggingAuditTrailTests extends ESTestCase {
 
         // test disabled
         CapturingLogger.output(logger.getName(), Level.INFO).clear();
-        settings = Settings.builder()
+        updateLoggerSettings(Settings.builder()
                 .put(settings)
                 .put("xpack.security.audit.logfile.events.exclude", "authentication_failed")
-                .build();
-        auditTrail = new LoggingAuditTrail(settings, clusterService, logger, threadContext);
+                .build());
         auditTrail.authenticationFailed(requestId, request);
         assertEmptyLog(logger);
     }
@@ -494,11 +1284,10 @@ public class LoggingAuditTrailTests extends ESTestCase {
         assertEmptyLog(logger);
 
         // test enabled
-        settings = Settings.builder()
+        updateLoggerSettings(Settings.builder()
                        .put(settings)
                        .put("xpack.security.audit.logfile.events.include", "realm_authentication_failed")
-                       .build();
-        auditTrail = new LoggingAuditTrail(settings, clusterService, logger, threadContext);
+                       .build());
         auditTrail.authenticationFailed(requestId, realm, mockToken, "_action", request);
         final MapBuilder<String, String> checkedFields = new MapBuilder<>(commonFields);
         final MapBuilder<String, String[]> checkedArrayFields = new MapBuilder<>();
@@ -533,11 +1322,10 @@ public class LoggingAuditTrailTests extends ESTestCase {
         assertEmptyLog(logger);
 
         // test enabled
-        settings = Settings.builder()
+        updateLoggerSettings(Settings.builder()
                 .put(settings)
                 .put("xpack.security.audit.logfile.events.include", "realm_authentication_failed")
-                .build();
-        auditTrail = new LoggingAuditTrail(settings, clusterService, logger, threadContext);
+                .build());
         auditTrail.authenticationFailed(requestId, realm, mockToken, request);
         final MapBuilder<String, String> checkedFields = new MapBuilder<>(commonFields);
         checkedFields.put(LoggingAuditTrail.EVENT_TYPE_FIELD_NAME, LoggingAuditTrail.REST_ORIGIN_FIELD_VALUE)
@@ -603,13 +1391,56 @@ public class LoggingAuditTrailTests extends ESTestCase {
 
         // test disabled
         CapturingLogger.output(logger.getName(), Level.INFO).clear();
-        settings = Settings.builder()
+        updateLoggerSettings(Settings.builder()
                 .put(settings)
                 .put("xpack.security.audit.logfile.events.exclude", "access_granted")
-                .build();
-        auditTrail = new LoggingAuditTrail(settings, clusterService, logger, threadContext);
+                .build());
         auditTrail.accessGranted(requestId, authentication, "_action", request, authorizationInfo);
         assertEmptyLog(logger);
+    }
+
+    public void testSecurityConfigChangedEventSelection() {
+        final String requestId = randomRequestId();
+        final String[] expectedRoles = randomArray(0, 4, String[]::new, () -> randomBoolean() ? null : randomAlphaOfLengthBetween(1, 4));
+        final AuthorizationInfo authorizationInfo = () -> Collections.singletonMap(PRINCIPAL_ROLES_FIELD_NAME, expectedRoles);
+        final Authentication authentication = createAuthentication();
+        Tuple<String, TransportRequest> actionAndRequest = randomFrom(new Tuple<>(PutUserAction.NAME, new PutUserRequest()),
+                new Tuple<>(PutRoleAction.NAME, new PutRoleRequest()),
+                new Tuple<>(PutRoleMappingAction.NAME, new PutRoleMappingRequest()),
+                new Tuple<>(SetEnabledAction.NAME, new SetEnabledRequest()),
+                new Tuple<>(ChangePasswordAction.NAME, new ChangePasswordRequest()),
+                new Tuple<>(CreateApiKeyAction.NAME, new CreateApiKeyRequest()),
+                new Tuple<>(GrantApiKeyAction.NAME, new GrantApiKeyRequest()),
+                new Tuple<>(PutPrivilegesAction.NAME, new PutPrivilegesRequest()),
+                new Tuple<>(DeleteUserAction.NAME, new DeleteUserRequest()),
+                new Tuple<>(DeleteRoleAction.NAME, new DeleteRoleRequest()),
+                new Tuple<>(DeleteRoleMappingAction.NAME, new DeleteRoleMappingRequest()),
+                new Tuple<>(InvalidateApiKeyAction.NAME, new InvalidateApiKeyRequest()),
+                new Tuple<>(DeletePrivilegesAction.NAME, new DeletePrivilegesRequest())
+        );
+        auditTrail.accessGranted(requestId, authentication, actionAndRequest.v1(), actionAndRequest.v2(), authorizationInfo);
+        List<String> output = CapturingLogger.output(logger.getName(), Level.INFO);
+        assertThat(output.size(), is(2));
+        assertThat(output.get(1), containsString("security_config_change"));
+        CapturingLogger.output(logger.getName(), Level.INFO).clear();
+        updateLoggerSettings(Settings.builder()
+                .put(settings)
+                .put("xpack.security.audit.logfile.events.exclude", "security_config_change")
+                .build());
+        auditTrail.accessGranted(requestId, authentication, actionAndRequest.v1(), actionAndRequest.v2(), authorizationInfo);
+        output = CapturingLogger.output(logger.getName(), Level.INFO);
+        assertThat(output.size(), is(1));
+        assertThat(output.get(0), not(containsString("security_config_change")));
+        CapturingLogger.output(logger.getName(), Level.INFO).clear();
+        updateLoggerSettings(Settings.builder()
+                .put(settings)
+                .put("xpack.security.audit.logfile.events.include", "security_config_change")
+                .put("xpack.security.audit.logfile.events.exclude", "access_granted")
+                .build());
+        auditTrail.accessGranted(requestId, authentication, actionAndRequest.v1(), actionAndRequest.v2(), authorizationInfo);
+        output = CapturingLogger.output(logger.getName(), Level.INFO);
+        assertThat(output.size(), is(1));
+        assertThat(output.get(0), containsString("security_config_change"));
     }
 
     public void testSystemAccessGranted() throws Exception {
@@ -632,11 +1463,10 @@ public class LoggingAuditTrailTests extends ESTestCase {
         assertEmptyLog(logger);
 
         // enable system user for access granted events
-        settings = Settings.builder()
+        updateLoggerSettings(Settings.builder()
                 .put(settings)
                 .put("xpack.security.audit.logfile.events.include", "system_access_granted")
-                .build();
-        auditTrail = new LoggingAuditTrail(settings, clusterService, logger, threadContext);
+                .build());
 
         auditTrail.accessGranted(requestId, authentication, "_action", request, authorizationInfo);
 
@@ -689,11 +1519,10 @@ public class LoggingAuditTrailTests extends ESTestCase {
         assertEmptyLog(logger);
 
         // test enabled
-        settings = Settings.builder()
+        updateLoggerSettings(Settings.builder()
                 .put(settings)
                 .put("xpack.security.audit.logfile.events.include", "system_access_granted")
-                .build();
-        auditTrail = new LoggingAuditTrail(settings, clusterService, logger, threadContext);
+                .build());
         auditTrail.accessGranted(requestId, authentication, "internal:_action", request, authorizationInfo);
         final MapBuilder<String, String> checkedFields = new MapBuilder<>(commonFields);
         final MapBuilder<String, String[]> checkedArrayFields = new MapBuilder<>();
@@ -758,11 +1587,10 @@ public class LoggingAuditTrailTests extends ESTestCase {
 
         // test disabled
         CapturingLogger.output(logger.getName(), Level.INFO).clear();
-        settings = Settings.builder()
-                    .put(settings)
-                    .put("xpack.security.audit.logfile.events.exclude", "access_granted")
-                    .build();
-        auditTrail = new LoggingAuditTrail(settings, clusterService, logger, threadContext);
+        updateLoggerSettings(Settings.builder()
+                .put(settings)
+                .put("xpack.security.audit.logfile.events.exclude", "access_granted")
+                .build());
         auditTrail.accessGranted(requestId, authentication, "internal:_action", request, authorizationInfo);
         assertEmptyLog(logger);
     }
@@ -812,11 +1640,10 @@ public class LoggingAuditTrailTests extends ESTestCase {
 
         // test disabled
         CapturingLogger.output(logger.getName(), Level.INFO).clear();
-        settings = Settings.builder()
+        updateLoggerSettings(Settings.builder()
                 .put(settings)
                 .put("xpack.security.audit.logfile.events.exclude", "access_denied")
-                .build();
-        auditTrail = new LoggingAuditTrail(settings, clusterService, logger, threadContext);
+                .build());
         auditTrail.accessDenied(requestId, authentication, "_action", request, authorizationInfo);
         assertEmptyLog(logger);
     }
@@ -850,11 +1677,10 @@ public class LoggingAuditTrailTests extends ESTestCase {
 
         // test disabled
         CapturingLogger.output(logger.getName(), Level.INFO).clear();
-        settings = Settings.builder()
+        updateLoggerSettings(Settings.builder()
                 .put(settings)
                 .put("xpack.security.audit.logfile.events.exclude", "tampered_request")
-                .build();
-        auditTrail = new LoggingAuditTrail(settings, clusterService, logger, threadContext);
+                .build());
         auditTrail.tamperedRequest(requestId, request);
         assertEmptyLog(logger);
     }
@@ -879,11 +1705,10 @@ public class LoggingAuditTrailTests extends ESTestCase {
 
         // test disabled
         CapturingLogger.output(logger.getName(), Level.INFO).clear();
-        settings = Settings.builder()
+        updateLoggerSettings(Settings.builder()
                 .put(settings)
                 .put("xpack.security.audit.logfile.events.exclude", "tampered_request")
-                .build();
-        auditTrail = new LoggingAuditTrail(settings, clusterService, logger, threadContext);
+                .build());
         auditTrail.tamperedRequest(requestId, "_action", request);
         assertEmptyLog(logger);
     }
@@ -929,11 +1754,10 @@ public class LoggingAuditTrailTests extends ESTestCase {
 
         // test disabled
         CapturingLogger.output(logger.getName(), Level.INFO).clear();
-        settings = Settings.builder()
+        updateLoggerSettings(Settings.builder()
                 .put(settings)
                 .put("xpack.security.audit.logfile.events.exclude", "tampered_request")
-                .build();
-        auditTrail = new LoggingAuditTrail(settings, clusterService, logger, threadContext);
+                .build());
         auditTrail.tamperedRequest(requestId, authentication, "_action", request);
         assertEmptyLog(logger);
     }
@@ -959,11 +1783,10 @@ public class LoggingAuditTrailTests extends ESTestCase {
 
         // test disabled
         CapturingLogger.output(logger.getName(), Level.INFO).clear();
-        settings = Settings.builder()
+        updateLoggerSettings(Settings.builder()
                 .put(settings)
                 .put("xpack.security.audit.logfile.events.exclude", "connection_denied")
-                .build();
-        auditTrail = new LoggingAuditTrail(settings, clusterService, logger, threadContext);
+                .build());
         auditTrail.connectionDenied(inetAddress, profile, rule);
         assertEmptyLog(logger);
     }
@@ -977,11 +1800,10 @@ public class LoggingAuditTrailTests extends ESTestCase {
         assertEmptyLog(logger);
 
         // test enabled
-        settings = Settings.builder()
+        updateLoggerSettings(Settings.builder()
                 .put(settings)
                 .put("xpack.security.audit.logfile.events.include", "connection_granted")
-                .build();
-        auditTrail = new LoggingAuditTrail(settings, clusterService, logger, threadContext);
+                .build());
         auditTrail.connectionGranted(inetAddress, profile, rule);
         final MapBuilder<String, String> checkedFields = new MapBuilder<>(commonFields);
         checkedFields.put(LoggingAuditTrail.EVENT_TYPE_FIELD_NAME, LoggingAuditTrail.IP_FILTER_ORIGIN_FIELD_VALUE)
@@ -1028,11 +1850,10 @@ public class LoggingAuditTrailTests extends ESTestCase {
 
         // test disabled
         CapturingLogger.output(logger.getName(), Level.INFO).clear();
-        settings = Settings.builder()
+        updateLoggerSettings(Settings.builder()
                 .put(settings)
                 .put("xpack.security.audit.logfile.events.exclude", "run_as_granted")
-                .build();
-        auditTrail = new LoggingAuditTrail(settings, clusterService, logger, threadContext);
+                .build());
         auditTrail.runAsGranted(requestId, authentication, "_action", request, authorizationInfo);
         assertEmptyLog(logger);
     }
@@ -1068,11 +1889,10 @@ public class LoggingAuditTrailTests extends ESTestCase {
 
         // test disabled
         CapturingLogger.output(logger.getName(), Level.INFO).clear();
-        settings = Settings.builder()
+        updateLoggerSettings(Settings.builder()
                 .put(settings)
                 .put("xpack.security.audit.logfile.events.exclude", "run_as_denied")
-                .build();
-        auditTrail = new LoggingAuditTrail(settings, clusterService, logger, threadContext);
+                .build());
         auditTrail.runAsDenied(requestId, authentication, "_action", request, authorizationInfo);
         assertEmptyLog(logger);
     }
@@ -1096,11 +1916,10 @@ public class LoggingAuditTrailTests extends ESTestCase {
         auditTrail.authenticationSuccess(requestId, authentication, request);
         assertEmptyLog(logger);
 
-        settings = Settings.builder()
+        updateLoggerSettings(Settings.builder()
                 .put(this.settings)
                 .put("xpack.security.audit.logfile.events.include", "authentication_success")
-                .build();
-        auditTrail = new LoggingAuditTrail(settings, clusterService, logger, threadContext);
+                .build());
         auditTrail.authenticationSuccess(requestId, authentication, request);
         checkedFields.put(LoggingAuditTrail.EVENT_TYPE_FIELD_NAME, LoggingAuditTrail.REST_ORIGIN_FIELD_VALUE)
                      .put(LoggingAuditTrail.EVENT_ACTION_FIELD_NAME, "authentication_success")
@@ -1160,11 +1979,10 @@ public class LoggingAuditTrailTests extends ESTestCase {
         auditTrail.authenticationSuccess(requestId, authentication, "_action", request);
         assertEmptyLog(logger);
 
-        settings = Settings.builder()
+        updateLoggerSettings(Settings.builder()
                 .put(this.settings)
                 .put("xpack.security.audit.logfile.events.include", "authentication_success")
-                .build();
-        auditTrail = new LoggingAuditTrail(settings, clusterService, logger, threadContext);
+                .build());
         auditTrail.authenticationSuccess(requestId, authentication, "_action", request);
         checkedFields.put(LoggingAuditTrail.EVENT_TYPE_FIELD_NAME, LoggingAuditTrail.TRANSPORT_ORIGIN_FIELD_VALUE)
                 .put(LoggingAuditTrail.EVENT_ACTION_FIELD_NAME, "authentication_success")
@@ -1258,8 +2076,22 @@ public class LoggingAuditTrailTests extends ESTestCase {
         }
     }
 
+    private void updateLoggerSettings(Settings settings) {
+        this.settings = settings;
+        // either create a new audit trail or update the settings on the existing one
+        if (randomBoolean()) {
+            this.auditTrail = new LoggingAuditTrail(settings, clusterService, logger, threadContext);
+        } else {
+            this.clusterService.getClusterSettings().applySettings(settings);
+        }
+    }
+
     private void assertMsg(Logger logger, Map<String, String> checkFields) {
         assertMsg(logger, checkFields, Collections.emptyMap());
+    }
+
+    private void assertMsg(String logLine, Map<String, String> checkFields) {
+        assertMsg(logLine, checkFields, Collections.emptyMap());
     }
 
     private void assertMsg(Logger logger, Map<String, String> checkFields, Map<String, String[]> checkArrayFields) {
@@ -1270,7 +2102,11 @@ public class LoggingAuditTrailTests extends ESTestCase {
             return;
         }
         String logLine = output.get(0);
-        // check each field
+        assertMsg(logLine, checkFields, checkArrayFields);
+    }
+
+    private void assertMsg(String logLine, Map<String, String> checkFields, Map<String, String[]> checkArrayFields) {
+        // check each string-valued field
         for (final Map.Entry<String, String> checkField : checkFields.entrySet()) {
             if (null == checkField.getValue()) {
                 // null checkField means that the field does not exist
@@ -1285,6 +2121,7 @@ public class LoggingAuditTrailTests extends ESTestCase {
                 logLine = logEntryFieldPattern.matcher(logLine).replaceFirst("");
             }
         }
+        // check each array-valued field
         for (final Map.Entry<String, String[]> checkArrayField : checkArrayFields.entrySet()) {
             if (null == checkArrayField.getValue()) {
                 // null checkField means that the field does not exist
@@ -1305,8 +2142,8 @@ public class LoggingAuditTrailTests extends ESTestCase {
             }
         }
         logLine = logLine.replaceFirst("\"" + LoggingAuditTrail.LOG_TYPE + "\":\"audit\", ", "")
-                         .replaceFirst("\"" + LoggingAuditTrail.TIMESTAMP + "\":\"[^\"]*\"", "")
-                         .replaceAll("[{},]", "");
+                .replaceFirst("\"" + LoggingAuditTrail.TIMESTAMP + "\":\"[^\"]*\"", "")
+                .replaceAll("[{},]", "");
         // check no extra fields
         assertThat("Log event has extra unexpected content: " + logLine, Strings.hasText(logLine), is(false));
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
@@ -141,6 +141,7 @@ import org.elasticsearch.xpack.security.audit.AuditLevel;
 import org.elasticsearch.xpack.security.audit.AuditTrail;
 import org.elasticsearch.xpack.security.audit.AuditTrailService;
 import org.elasticsearch.xpack.security.audit.AuditUtil;
+import org.elasticsearch.xpack.security.audit.logfile.LoggingAuditTrail;
 import org.elasticsearch.xpack.security.authz.store.CompositeRolesStore;
 import org.elasticsearch.xpack.security.authz.store.NativePrivilegeStore;
 import org.elasticsearch.xpack.security.operator.OperatorPrivileges;
@@ -379,6 +380,21 @@ public class AuthorizationServiceTests extends ESTestCase {
                 authzInfoRoles(new String[] { SystemUser.ROLE_NAME }));
         }
 
+        verifyNoMoreInteractions(auditTrail);
+    }
+
+    public void testAuthorizationForSecurityChange() {
+        final Authentication authentication = createAuthentication(new User("user", "manage_security_role"));
+        final String requestId = AuditUtil.getOrGenerateRequestId(threadContext);
+        RoleDescriptor role = new RoleDescriptor("manage_security_role", new String[]{ClusterPrivilegeResolver.MANAGE_SECURITY.name()},
+                null,null, null, null, null, null);
+        roleMap.put("manage_security_role", role);
+        for (String action : LoggingAuditTrail.SECURITY_CHANGE_ACTIONS) {
+            TransportRequest request = mock(TransportRequest.class);
+            authorize(authentication, action, request);
+            verify(auditTrail).accessGranted(eq(requestId), eq(authentication), eq(action), eq(request),
+                    authzInfoRoles(new String[]{role.getName()}));
+        }
         verifyNoMoreInteractions(auditTrail);
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/RoleDescriptorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/RoleDescriptorTests.java
@@ -60,6 +60,17 @@ public class RoleDescriptorTests extends ESTestCase {
         assertEquals("{\"names\":[\"idx\"],\"privileges\":[\"priv\"],\"allow_restricted_indices\":true}", Strings.toString(b));
     }
 
+    public void testEqualsOnEmptyRoles() {
+        RoleDescriptor nullRoleDescriptor = new RoleDescriptor("null_role", randomFrom((String[]) null, new String[0]),
+                randomFrom((RoleDescriptor.IndicesPrivileges[]) null, new RoleDescriptor.IndicesPrivileges[0]),
+                randomFrom((RoleDescriptor.ApplicationResourcePrivileges[])null, new RoleDescriptor.ApplicationResourcePrivileges[0]),
+                randomFrom((ConfigurableClusterPrivilege[])null, new ConfigurableClusterPrivilege[0]),
+                randomFrom((String[])null, new String[0]),
+                randomFrom((Map<String, Object>)null, Map.of()),
+                Map.of("transient", "meta", "is", "ignored"));
+        assertTrue(nullRoleDescriptor.equals(new RoleDescriptor("null_role", null, null, null, null, null, null, null)));
+    }
+
     public void testToString() {
         RoleDescriptor.IndicesPrivileges[] groups = new RoleDescriptor.IndicesPrivileges[] {
                 RoleDescriptor.IndicesPrivileges.builder()

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/RoleDescriptorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/RoleDescriptorTests.java
@@ -61,13 +61,16 @@ public class RoleDescriptorTests extends ESTestCase {
     }
 
     public void testEqualsOnEmptyRoles() {
+        Map<String, Object> transientMetadata = new HashMap<>();
+        transientMetadata.put("transient", "meta");
+        transientMetadata.put("is", "ignored");
         RoleDescriptor nullRoleDescriptor = new RoleDescriptor("null_role", randomFrom((String[]) null, new String[0]),
                 randomFrom((RoleDescriptor.IndicesPrivileges[]) null, new RoleDescriptor.IndicesPrivileges[0]),
                 randomFrom((RoleDescriptor.ApplicationResourcePrivileges[])null, new RoleDescriptor.ApplicationResourcePrivileges[0]),
                 randomFrom((ConfigurableClusterPrivilege[])null, new ConfigurableClusterPrivilege[0]),
                 randomFrom((String[])null, new String[0]),
-                randomFrom((Map<String, Object>)null, Map.of()),
-                Map.of("transient", "meta", "is", "ignored"));
+                randomFrom((Map<String, Object>)null, new HashMap<>()),
+                transientMetadata);
         assertTrue(nullRoleDescriptor.equals(new RoleDescriptor("null_role", null, null, null, null, null, null, null)));
     }
 

--- a/x-pack/plugin/security/src/test/resources/org/elasticsearch/xpack/security/audit/logfile/audited_roles.txt
+++ b/x-pack/plugin/security/src/test/resources/org/elasticsearch/xpack/security/audit/logfile/audited_roles.txt
@@ -1,0 +1,10 @@
+null_role
+{"cluster":[],"indices":[],"applications":[],"run_as":[]}
+role_descriptor1
+{"cluster":["monitor"],"indices":[{"names":["test*"],"privileges":["read","create_index"],"field_security":{"grant":["grantedField1"]},"query":"{\"match_all\":{}}","allow_restricted_indices":true}],"applications":[],"run_as":[]}
+role_descriptor2
+{"cluster":[],"indices":[{"names":["na\"me","*"],"privileges":["manage_ilm"],"field_security":{"grant":null,"except":["denied*"]},"query":"{\"match\": {\"category\": \"click\"}}"},{"names":["/@&~(\\.security.*)/"],"privileges":["all","cluster:a_wrong_*_one"]}],"applications":[{"application":"maps","privileges":["coming","up","with","random","names","is","hard"],"resources":["raster:*"]}],"run_as":["impersonated???"]}
+role_descriptor3
+{"cluster":[],"indices":[],"applications":[{"application":"maps","privileges":["{","}","\n","\\","\""],"resources":["raster:*"]},{"application":"maps","privileges":["*:*"],"resources":["noooooo!!\n\n\f\\\\r","{"]}],"run_as":["jack","nich*","//\""],"metadata":{"some meta":42}}
+role_descriptor4
+{"cluster":["manage_ml","grant_api_key","manage_rollup"],"global":{"application":{"manage":{"applications":["a+b+|b+a+"]}}},"indices":[{"names":["/. ? + * | { } [ ] ( ) \" \\/","*"],"privileges":["read","read_cross_cluster"],"field_security":{"grant":["almost","all*"],"except":["denied*"]}}],"applications":[],"run_as":["//+a+\"[a]/"],"metadata":{"?list":["e1","e2","*"],"some other meta":{"r":"t"}}}


### PR DESCRIPTION
Backport of https://github.com/elastic/elasticsearch/pull/62916

This PR introduces a new event.type category for audit records,
namely the `security_config_change`, in the existing audit trail.
Events in this category record that a security configuration has been
set (eg user/role created/updated) or cleared (eg user/role deleted).
The events are emitted by default, but can be explicitly toggled by
the `security_config_changed` handler. The record contains all the
change details, (e.g. the rules of the particular role mapping that
has been created or updated), but all credentials are redacted out.
The change details are formatted as a JSON object are are part of
audit record structure (i.e. they are not JSON-escaped and put
in a string field).

Co-authored-by: Yang Wang <ywangd@gmail.com>
Co-authored-by: Tim Vernum <tim@adjective.org>