### PR TITLE
Remove Lucene Precommit from PersistentCache

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/PersistentCacheTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/PersistentCacheTests.java
@@ -119,11 +119,8 @@ public class PersistentCacheTests extends AbstractSearchableSnapshotsTestCase {
 
                 boolean commit = false;
                 if (frequently()) {
-                    writer.prepareCommit();
-                    if (frequently()) {
-                        writer.commit();
-                        commit = true;
-                    }
+                    writer.commit();
+                    commit = true;
                 }
 
                 if (commit) {


### PR DESCRIPTION
Noticed this while working on the allocator:

There is nothing gained from doing the precommit step explicitly here.
Also, we can just reuse the same map entries statically.
