### PR TITLE
Fix eclipse compile problem in LocalExporter

### DIFF
--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/local/LocalExporter.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/local/LocalExporter.java
@@ -6,6 +6,7 @@
 package org.elasticsearch.xpack.monitoring.exporter.local;
 
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
@@ -598,7 +599,7 @@ public class LocalExporter extends Exporter implements ClusterStateListener, Cle
             if (indexExists) {
                 logger.trace("pruning monitoring watch [{}]", uniqueWatchId);
                 asyncActions.add(() -> client.execute(DeleteWatchAction.INSTANCE, new DeleteWatchRequest(uniqueWatchId),
-                    new ErrorCapturingResponseListener<>("watch", uniqueWatchId, pendingResponses, setupListener, errors)));
+                    new ErrorCapturingResponseListener<>("watch", uniqueWatchId, pendingResponses, setupListener, errors, this.name())));
             }
         }
     }
@@ -771,10 +772,10 @@ public class LocalExporter extends Exporter implements ClusterStateListener, Cle
         private final List<Exception> errors;
 
         ErrorCapturingResponseListener(String type, String name, AtomicInteger countDown,
-                                              Consumer<ExporterResourceStatus> setupListener, List<Exception> errors) {
+                                              Consumer<ExporterResourceStatus> setupListener, List<Exception> errors, String configName) {
             super(type, name, countDown, () -> {
                 // Called on completion of all removal tasks
-                ExporterResourceStatus status = ExporterResourceStatus.determineReadiness(LocalExporter.this.name(), TYPE, errors);
+                ExporterResourceStatus status = ExporterResourceStatus.determineReadiness(configName, TYPE, errors);
                 setupListener.accept(status);
             });
             this.errors = errors;


### PR DESCRIPTION
In Eclipse IDE (Version: 2020-09, 4.17.0), I get a compilation error in some recently added code in LocalExporter.
Error is: 
```
Cannot refer to 'this' nor 'super' while explicitly invoking a constructor
LocalExporter.java	/:x-pack:plugin:monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/local	line 775
```
This doesn't show up when compiling with Gradle, so I assume its one of the many IDE specific problems and will open an issue upstream.
In the meantime, I think passing in the config name would avoid having to reference "this" in the lambda expression.


