### PR TITLE
Allow blocking calls on futures used in TimestampFieldMapperService

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/TimestampFieldMapperService.java
+++ b/server/src/main/java/org/elasticsearch/indices/TimestampFieldMapperService.java
@@ -104,7 +104,15 @@ public class TimestampFieldMapperService extends AbstractLifecycleComponent impl
 
             if (hasUsefulTimestampField(indexMetadata) && fieldTypesByIndex.containsKey(index) == false) {
                 logger.trace("computing timestamp mapping for {}", index);
-                final PlainActionFuture<DateFieldMapper.DateFieldType> future = new PlainActionFuture<>();
+                final PlainActionFuture<DateFieldMapper.DateFieldType> future = new PlainActionFuture<>() {
+                    @Override
+                    protected boolean blockingAllowed() {
+                        // We only get the future result once it's completed
+                        // so technically we don't block the calling thread.
+                        // See #getTimestampFieldType()
+                        return true;
+                    }
+                };
                 fieldTypesByIndex.put(index, future);
 
                 final IndexService indexService = indicesService.indexService(index);

--- a/server/src/main/java/org/elasticsearch/indices/TimestampFieldMapperService.java
+++ b/server/src/main/java/org/elasticsearch/indices/TimestampFieldMapperService.java
@@ -106,15 +106,7 @@ public class TimestampFieldMapperService extends AbstractLifecycleComponent impl
 
             if (hasUsefulTimestampField(indexMetadata) && fieldTypesByIndex.containsKey(index) == false) {
                 logger.trace("computing timestamp mapping for {}", index);
-                final PlainActionFuture<DateFieldMapper.DateFieldType> future = new PlainActionFuture<>() {
-                    @Override
-                    protected boolean blockingAllowed() {
-                        // We only get the future result once it's completed
-                        // so technically we don't block the calling thread.
-                        // See #getTimestampFieldType()
-                        return true;
-                    }
-                };
+                final PlainActionFuture<DateFieldMapper.DateFieldType> future = new PlainActionFuture<>();
                 fieldTypesByIndex.put(index, future);
 
                 final IndexService indexService = indicesService.indexService(index);

--- a/server/src/main/java/org/elasticsearch/indices/TimestampFieldMapperService.java
+++ b/server/src/main/java/org/elasticsearch/indices/TimestampFieldMapperService.java
@@ -189,7 +189,6 @@ public class TimestampFieldMapperService extends AbstractLifecycleComponent impl
             assert false : "Unexpected timeout exception while getting a timestamp mapping";
             throw e;
         }
-        throw new AssertionError("Unexpected timeout exception while getting a timestamp mapping");
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/indices/TimestampFieldMapperService.java
+++ b/server/src/main/java/org/elasticsearch/indices/TimestampFieldMapperService.java
@@ -23,6 +23,7 @@ import com.carrotsearch.hppc.cursors.ObjectCursor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterStateApplier;
@@ -32,6 +33,7 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
@@ -176,7 +178,17 @@ public class TimestampFieldMapperService extends AbstractLifecycleComponent impl
         if (future == null || future.isDone() == false) {
             return null;
         }
-        return future.actionGet();
+
+        try {
+            // It's possible that callers of this class are executed
+            // in a transport thread, for that reason we request
+            // the future value with a timeout of 0. That won't
+            // trigger assertion errors.
+            return future.actionGet(TimeValue.ZERO);
+        } catch (ElasticsearchTimeoutException e) {
+            assert false : "Unexpected timeout exception while getting a timestamp mapping";
+        }
+        throw new AssertionError("Unexpected timeout exception while getting a timestamp mapping");
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/indices/TimestampFieldMapperService.java
+++ b/server/src/main/java/org/elasticsearch/indices/TimestampFieldMapperService.java
@@ -187,6 +187,7 @@ public class TimestampFieldMapperService extends AbstractLifecycleComponent impl
             return future.actionGet(TimeValue.ZERO);
         } catch (ElasticsearchTimeoutException e) {
             assert false : "Unexpected timeout exception while getting a timestamp mapping";
+            throw e;
         }
         throw new AssertionError("Unexpected timeout exception while getting a timestamp mapping");
     }


### PR DESCRIPTION
Some of the clients of TimestampFieldMapperService might be executed
in a transport thread, we only do a blocking action once the future
is completed in #getTimestampFieldType, so technically we are not
blocking the thread. To avoid triggering assertion errors, we mark
that future as non-blocking.