### PR TITLE
Fix SearchableSnapshot Relocation Test (#66322)

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsRelocationIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsRelocationIntegTests.java
@@ -123,7 +123,9 @@ public class SearchableSnapshotsRelocationIntegTests extends BaseSearchableSnaps
             .shardRecoveryStates()
             .get(restoredIndex)
             .stream()
-            .filter(recoveryState -> recoveryState.getSourceNode() != null)
+            // filter for relocations that are not in stage FINALIZE (they could end up in this stage without progress for good if the
+            // target node does not have enough cache space available to hold the primary completely
+            .filter(recoveryState -> recoveryState.getSourceNode() != null && recoveryState.getStage() != RecoveryState.Stage.FINALIZE)
             .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
Follow-up to #66234 to also handle the case where the relocation target can't hold
the full shard in its cache and gets stuck in `FINALIZE` for the relocation recovery
entry.

backport of #66322