### PR TITLE
[7.10] [DOCS] Note `tar.gz` does not include `systemd` (#66298)

### DIFF
--- a/docs/reference/setup/install/targz-daemon.asciidoc
+++ b/docs/reference/setup/install/targz-daemon.asciidoc
@@ -21,5 +21,6 @@ To shut down Elasticsearch, kill the process ID recorded in the `pid` file:
 pkill -F pid
 --------------------------------------------
 
-NOTE: The startup scripts provided in the <<rpm,RPM>> and <<deb,Debian>>
-packages take care of starting and stopping the Elasticsearch process for you.
+NOTE: The {es} `.tar.gz` package does not include the `systemd` module. To
+manage {es} as a service, use the <<start-deb,Debian>> or <<start-rpm,RPM>>
+package instead.


### PR DESCRIPTION
Backports the following commits to 7.10:
 - [DOCS] Note `tar.gz` does not include `systemd` (#66298)