### PR TITLE
[ML] Deprecate anomaly detection post data endpoint

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/MachineLearningIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/MachineLearningIT.java
@@ -232,6 +232,10 @@ import static org.hamcrest.Matchers.nullValue;
 
 public class MachineLearningIT extends ESRestHighLevelClientTestCase {
 
+    private static final RequestOptions POST_DATA_OPTIONS = RequestOptions.DEFAULT.toBuilder()
+        .setWarningsHandler(warnings -> Collections.singletonList("Posting data directly to anomaly detection jobs is deprecated, " +
+            "in a future major version it will be compulsory to use a datafeed").equals(warnings) == false).build();
+
     @After
     public void cleanUp() throws IOException {
         new MlTestStateCleaner(logger, highLevelClient().machineLearning()).clearMlMetadata();
@@ -436,10 +440,7 @@ public class MachineLearningIT extends ESRestHighLevelClientTestCase {
         }
         PostDataRequest postDataRequest = new PostDataRequest(jobId, builder);
         // Post data is deprecated, so expect a deprecation warning
-        RequestOptions requestOptions = RequestOptions.DEFAULT.toBuilder()
-            .setWarningsHandler(warnings -> Collections.singletonList("Posting data directly to anomaly detection jobs is deprecated, " +
-                "in a future major version it will be compulsory to use a datafeed").equals(warnings) == false).build();
-        machineLearningClient.postData(postDataRequest, requestOptions);
+        machineLearningClient.postData(postDataRequest, POST_DATA_OPTIONS);
         machineLearningClient.flushJob(new FlushJobRequest(jobId), RequestOptions.DEFAULT);
 
         ForecastJobRequest request = new ForecastJobRequest(jobId);
@@ -466,11 +467,8 @@ public class MachineLearningIT extends ESRestHighLevelClientTestCase {
         PostDataRequest postDataRequest = new PostDataRequest(jobId, builder);
 
         // Post data is deprecated, so expect a deprecation warning
-        RequestOptions requestOptions = RequestOptions.DEFAULT.toBuilder()
-            .setWarningsHandler(warnings -> Collections.singletonList("Posting data directly to anomaly detection jobs is deprecated, " +
-                "in a future major version it will be compulsory to use a datafeed").equals(warnings) == false).build();
         PostDataResponse response = execute(postDataRequest, machineLearningClient::postData, machineLearningClient::postDataAsync,
-            requestOptions);
+            POST_DATA_OPTIONS);
         assertEquals(10, response.getDataCounts().getInputRecordCount());
         assertEquals(0, response.getDataCounts().getOutOfOrderTimeStampCount());
     }
@@ -1048,10 +1046,7 @@ public class MachineLearningIT extends ESRestHighLevelClientTestCase {
 
         PostDataRequest postDataRequest = new PostDataRequest(jobId, builder);
         // Post data is deprecated, so expect a deprecation warning
-        RequestOptions requestOptions = RequestOptions.DEFAULT.toBuilder()
-            .setWarningsHandler(warnings -> Collections.singletonList("Posting data directly to anomaly detection jobs is deprecated, " +
-                "in a future major version it will be compulsory to use a datafeed").equals(warnings) == false).build();
-        machineLearningClient.postData(postDataRequest, requestOptions);
+        machineLearningClient.postData(postDataRequest, POST_DATA_OPTIONS);
         machineLearningClient.flushJob(new FlushJobRequest(jobId), RequestOptions.DEFAULT);
         ForecastJobResponse forecastJobResponse1 = machineLearningClient.forecastJob(new ForecastJobRequest(jobId), RequestOptions.DEFAULT);
         ForecastJobResponse forecastJobResponse2 = machineLearningClient.forecastJob(new ForecastJobRequest(jobId), RequestOptions.DEFAULT);

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/MachineLearningIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/MachineLearningIT.java
@@ -435,7 +435,11 @@ public class MachineLearningIT extends ESRestHighLevelClientTestCase {
             builder.addDoc(hashMap);
         }
         PostDataRequest postDataRequest = new PostDataRequest(jobId, builder);
-        machineLearningClient.postData(postDataRequest, RequestOptions.DEFAULT);
+        // Post data is deprecated, so expect a deprecation warning
+        RequestOptions requestOptions = RequestOptions.DEFAULT.toBuilder()
+            .setWarningsHandler(warnings -> Collections.singletonList("Posting data directly to anomaly detection jobs is deprecated, " +
+                "in a future major version it will be compulsory to use a datafeed").equals(warnings) == false).build();
+        machineLearningClient.postData(postDataRequest, requestOptions);
         machineLearningClient.flushJob(new FlushJobRequest(jobId), RequestOptions.DEFAULT);
 
         ForecastJobRequest request = new ForecastJobRequest(jobId);
@@ -461,7 +465,12 @@ public class MachineLearningIT extends ESRestHighLevelClientTestCase {
         }
         PostDataRequest postDataRequest = new PostDataRequest(jobId, builder);
 
-        PostDataResponse response = execute(postDataRequest, machineLearningClient::postData, machineLearningClient::postDataAsync);
+        // Post data is deprecated, so expect a deprecation warning
+        RequestOptions requestOptions = RequestOptions.DEFAULT.toBuilder()
+            .setWarningsHandler(warnings -> Collections.singletonList("Posting data directly to anomaly detection jobs is deprecated, " +
+                "in a future major version it will be compulsory to use a datafeed").equals(warnings) == false).build();
+        PostDataResponse response = execute(postDataRequest, machineLearningClient::postData, machineLearningClient::postDataAsync,
+            requestOptions);
         assertEquals(10, response.getDataCounts().getInputRecordCount());
         assertEquals(0, response.getDataCounts().getOutOfOrderTimeStampCount());
     }
@@ -1038,7 +1047,11 @@ public class MachineLearningIT extends ESRestHighLevelClientTestCase {
         }
 
         PostDataRequest postDataRequest = new PostDataRequest(jobId, builder);
-        machineLearningClient.postData(postDataRequest, RequestOptions.DEFAULT);
+        // Post data is deprecated, so expect a deprecation warning
+        RequestOptions requestOptions = RequestOptions.DEFAULT.toBuilder()
+            .setWarningsHandler(warnings -> Collections.singletonList("Posting data directly to anomaly detection jobs is deprecated, " +
+                "in a future major version it will be compulsory to use a datafeed").equals(warnings) == false).build();
+        machineLearningClient.postData(postDataRequest, requestOptions);
         machineLearningClient.flushJob(new FlushJobRequest(jobId), RequestOptions.DEFAULT);
         ForecastJobResponse forecastJobResponse1 = machineLearningClient.forecastJob(new ForecastJobRequest(jobId), RequestOptions.DEFAULT);
         ForecastJobResponse forecastJobResponse2 = machineLearningClient.forecastJob(new ForecastJobRequest(jobId), RequestOptions.DEFAULT);

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/MlClientDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/MlClientDocumentationIT.java
@@ -33,6 +33,7 @@ import org.elasticsearch.client.MachineLearningIT;
 import org.elasticsearch.client.MlTestStateCleaner;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.WarningsHandler;
 import org.elasticsearch.client.core.PageParams;
 import org.elasticsearch.client.indices.CreateIndexRequest;
 import org.elasticsearch.client.ml.CloseJobRequest;
@@ -1382,7 +1383,11 @@ public class MlClientDocumentationIT extends ESRestHighLevelClientTestCase {
         }
 
         PostDataRequest postDataRequest = new PostDataRequest(job.getId(), builder);
-        client.machineLearning().postData(postDataRequest, RequestOptions.DEFAULT);
+        // Post data is deprecated, so expect a deprecation warning
+        RequestOptions requestOptions = RequestOptions.DEFAULT.toBuilder()
+            .setWarningsHandler(warnings -> Collections.singletonList("Posting data directly to anomaly detection jobs is deprecated, " +
+                "in a future major version it will be compulsory to use a datafeed").equals(warnings) == false).build();
+        client.machineLearning().postData(postDataRequest, requestOptions);
         client.machineLearning().flushJob(new FlushJobRequest(job.getId()), RequestOptions.DEFAULT);
 
         ForecastJobResponse forecastJobResponse = client.machineLearning().
@@ -1519,7 +1524,11 @@ public class MlClientDocumentationIT extends ESRestHighLevelClientTestCase {
             builder.addDoc(hashMap);
         }
         PostDataRequest postDataRequest = new PostDataRequest(job.getId(), builder);
-        client.machineLearning().postData(postDataRequest, RequestOptions.DEFAULT);
+        // Post data is deprecated, so expect a deprecation warning
+        RequestOptions requestOptions = RequestOptions.DEFAULT.toBuilder()
+            .setWarningsHandler(warnings -> Collections.singletonList("Posting data directly to anomaly detection jobs is deprecated, " +
+                "in a future major version it will be compulsory to use a datafeed").equals(warnings) == false).build();
+        client.machineLearning().postData(postDataRequest, requestOptions);
         client.machineLearning().flushJob(new FlushJobRequest(job.getId()), RequestOptions.DEFAULT);
 
         {
@@ -1789,7 +1798,10 @@ public class MlClientDocumentationIT extends ESRestHighLevelClientTestCase {
             postDataRequest.setResetStart(null);
 
             // tag::post-data-execute
-            PostDataResponse postDataResponse = client.machineLearning().postData(postDataRequest, RequestOptions.DEFAULT);
+            RequestOptions ignoreDeprecationsWarningsOptions = RequestOptions.DEFAULT.toBuilder()
+                .setWarningsHandler(WarningsHandler.PERMISSIVE).build();
+            PostDataResponse postDataResponse =
+                client.machineLearning().postData(postDataRequest, ignoreDeprecationsWarningsOptions);
             // end::post-data-execute
 
             // tag::post-data-response
@@ -1823,7 +1835,9 @@ public class MlClientDocumentationIT extends ESRestHighLevelClientTestCase {
             listener = new LatchedActionListener<>(listener, latch);
 
             // tag::post-data-execute-async
-            client.machineLearning().postDataAsync(postDataRequest, RequestOptions.DEFAULT, listener); // <1>
+            RequestOptions ignoreDeprecationsWarningsOptions = RequestOptions.DEFAULT.toBuilder()
+                .setWarningsHandler(WarningsHandler.PERMISSIVE).build();
+            client.machineLearning().postDataAsync(postDataRequest, ignoreDeprecationsWarningsOptions, listener); // <1>
             // end::post-data-execute-async
 
             assertTrue(latch.await(30L, TimeUnit.SECONDS));

--- a/docs/reference/migration/migrate_8_0/api.asciidoc
+++ b/docs/reference/migration/migrate_8_0/api.asciidoc
@@ -69,3 +69,15 @@ Discontinue use of the `local` query parameter.
 {ref}/indices-get-field-mapping.html[get field mapping API] requests that
 include this parameter will return an error.
 ====
+
+.Post data to jobs API is deprecated.
+[%collapsible]
+====
+*Details* +
+The {ml} <<ml-post-data,post data to jobs API>> is deprecated starting in 7.11.0
+and will be removed in a future major version.
+
+*Impact* +
+Use <<ml-api-datafeed-endpoint,{dfeeds}>> instead.
+
+====

--- a/docs/reference/ml/anomaly-detection/apis/post-data.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/post-data.asciidoc
@@ -6,7 +6,8 @@
 <titleabbrev>Post data to jobs</titleabbrev>
 ++++
 
-deprecated:[7.11.0, "Posting data directly to anomaly detection jobs is deprecated, in a future major version a <<ml-put-datafeed-request-body,{dfeed}>> will be required."]
+deprecated::[7.11.0, "Posting data directly to anomaly detection jobs is deprecated, in a future major version a <<ml-api-datafeed-endpoint,{dfeed}>> will be required."]
+
 Sends data to an anomaly detection job for analysis.
 
 [[ml-post-data-request]]

--- a/docs/reference/ml/anomaly-detection/apis/post-data.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/post-data.asciidoc
@@ -6,7 +6,7 @@
 <titleabbrev>Post data to jobs</titleabbrev>
 ++++
 
-deprecated:[7.11.0, "This API will be removed in a future major version, where it will be compulsory to use a <<ml-put-datafeed-request-body,{dfeed}>> instead."]
+deprecated:[7.11.0, "Posting data directly to anomaly detection jobs is deprecated, in a future major version a <<ml-put-datafeed-request-body,{dfeed}>> will be required."]
 Sends data to an anomaly detection job for analysis.
 
 [[ml-post-data-request]]

--- a/docs/reference/ml/anomaly-detection/apis/post-data.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/post-data.asciidoc
@@ -6,6 +6,7 @@
 <titleabbrev>Post data to jobs</titleabbrev>
 ++++
 
+deprecated:[7.11.0, "This API will be removed in a future major version, where it will be compulsory to use a <<ml-put-datafeed-request-body,{dfeed}>> instead."]
 Sends data to an anomaly detection job for analysis.
 
 [[ml-post-data-request]]

--- a/x-pack/plugin/ml/qa/basic-multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlBasicMultiNodeIT.java
+++ b/x-pack/plugin/ml/qa/basic-multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlBasicMultiNodeIT.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.ml.integration;
 import org.apache.http.entity.ContentType;
 import org.apache.http.nio.entity.NStringEntity;
 import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.common.Strings;
@@ -15,7 +16,6 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.yaml.snakeyaml.util.UriEncoder;
 
-import javax.print.attribute.standard.JobStateReason;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Collections;
@@ -31,6 +31,10 @@ import static org.hamcrest.Matchers.is;
 public class MlBasicMultiNodeIT extends ESRestTestCase {
 
     private static final String BASE_PATH = "/_ml/";
+
+    private static final RequestOptions POST_DATA_OPTIONS = RequestOptions.DEFAULT.toBuilder()
+        .setWarningsHandler(warnings -> Collections.singletonList("Posting data directly to anomaly detection jobs is deprecated, " +
+            "in a future major version it will be compulsory to use a datafeed").equals(warnings) == false).build();
 
     public void testMachineLearningInstalled() throws Exception {
         Response response = client().performRequest(new Request("GET", "/_xpack"));
@@ -66,6 +70,7 @@ public class MlBasicMultiNodeIT extends ESRestTestCase {
                 "{\"airline\":\"AAL\",\"responsetime\":\"132.2046\",\"sourcetype\":\"farequote\",\"time\":\"1403481600\"}\n" +
                 "{\"airline\":\"JZA\",\"responsetime\":\"990.4628\",\"sourcetype\":\"farequote\",\"time\":\"1403481700\"}",
                 randomFrom(ContentType.APPLICATION_JSON, ContentType.create("application/x-ndjson"))));
+        addData.setOptions(POST_DATA_OPTIONS);
         Response addDataResponse = client().performRequest(addData);
         assertEquals(202, addDataResponse.getStatusLine().getStatusCode());
         Map<String, Object> responseBody = entityAsMap(addDataResponse);
@@ -165,6 +170,8 @@ public class MlBasicMultiNodeIT extends ESRestTestCase {
                 "{\"airline\":\"KLM\",\"responsetime\":\"1355.4812\",\"sourcetype\":\"farequote\",\"time\":\"1403481900\"}\n" +
                 "{\"airline\":\"NKS\",\"responsetime\":\"9991.3981\",\"sourcetype\":\"farequote\",\"time\":\"1403482000\"}",
                 randomFrom(ContentType.APPLICATION_JSON, ContentType.create("application/x-ndjson"))));
+        // Post data is deprecated, so expect a deprecation warning
+        addDataRequest.setOptions(POST_DATA_OPTIONS);
         Response addDataResponse = client().performRequest(addDataRequest);
         assertEquals(202, addDataResponse.getStatusLine().getStatusCode());
         Map<String, Object> responseBody = entityAsMap(addDataResponse);
@@ -205,6 +212,8 @@ public class MlBasicMultiNodeIT extends ESRestTestCase {
                 "{\"airline\":\"UAL\",\"responsetime\":\"8.4275\",\"sourcetype\":\"farequote\",\"time\":\"1407081900\"}\n" +
                 "{\"airline\":\"FFT\",\"responsetime\":\"221.8693\",\"sourcetype\":\"farequote\",\"time\":\"1407082000\"}",
                 randomFrom(ContentType.APPLICATION_JSON, ContentType.create("application/x-ndjson"))));
+        // Post data is deprecated, so expect a deprecation warning
+        addDataRequest2.setOptions(POST_DATA_OPTIONS);
         Response addDataResponse2 = client().performRequest(addDataRequest2);
         assertEquals(202, addDataResponse2.getStatusLine().getStatusCode());
         Map<String, Object> responseBody2 = entityAsMap(addDataResponse2);

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlJobIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlJobIT.java
@@ -28,6 +28,7 @@ import org.elasticsearch.xpack.ml.MachineLearning;
 import org.junit.After;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -475,6 +476,10 @@ public class MlJobIT extends ESRestTestCase {
         assertThat(entityAsMap(openResponse), hasEntry("opened", true));
 
         Request postDataRequest = new Request("POST", MachineLearning.BASE_PATH + "anomaly_detectors/" + jobId + "/_data");
+        // Post data is deprecated, so expect a deprecation warning
+        postDataRequest.setOptions(RequestOptions.DEFAULT.toBuilder()
+            .setWarningsHandler(warnings -> Collections.singletonList("Posting data directly to anomaly detection jobs is deprecated, " +
+                "in a future major version it will be compulsory to use a datafeed").equals(warnings) == false));
         postDataRequest.setJsonEntity("{ \"airline\":\"LOT\", \"response_time\":100, \"time\":\"2019-07-01 00:00:00Z\" }");
         client().performRequest(postDataRequest);
         postDataRequest.setJsonEntity("{ \"airline\":\"LOT\", \"response_time\":100, \"time\":\"2019-07-01 02:00:00Z\" }");

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/job/RestPostDataAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/job/RestPostDataAction.java
@@ -26,9 +26,15 @@ public class RestPostDataAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<DeprecatedRoute> deprecatedRoutes() {
         return Collections.singletonList(
-            new Route(POST, MachineLearning.BASE_PATH + "anomaly_detectors/{" + Job.ID.getPreferredName() + "}/_data")
-        );
+            new DeprecatedRoute(POST, MachineLearning.BASE_PATH + "anomaly_detectors/{" + Job.ID.getPreferredName() + "}/_data",
+            "Posting data directly to anomaly detection jobs is deprecated, " +
+                "in a future major version it will be compulsory to use a datafeed"));
     }
 
     @Override

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/index_layout.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/index_layout.yml
@@ -4,6 +4,10 @@ setup:
 ---
 "Test CRUD on two jobs in shared index":
 
+  - skip:
+      features:
+        - "warnings"
+
   - do:
       ml.put_job:
         job_id: index-layout-job
@@ -58,6 +62,8 @@ setup:
         job_id: index-layout-job2
 
   - do:
+      warnings:
+        - 'Posting data directly to anomaly detection jobs is deprecated, in a future major version it will be compulsory to use a datafeed'
       ml.post_data:
         job_id: index-layout-job
         body: >
@@ -65,6 +71,8 @@ setup:
           {"airline":"JZA","responsetime":"990.4628","sourcetype":"farequote","time":"1403481700"}
 
   - do:
+      warnings:
+        - 'Posting data directly to anomaly detection jobs is deprecated, in a future major version it will be compulsory to use a datafeed'
       ml.post_data:
         job_id: index-layout-job2
         body: >
@@ -341,6 +349,10 @@ setup:
 ---
 "Test unrelated index":
 
+  - skip:
+      features:
+        - "warnings"
+
   - do:
       ml.put_job:
         job_id: index-layout-job
@@ -368,6 +380,8 @@ setup:
         job_id: index-layout-job
 
   - do:
+      warnings:
+        - 'Posting data directly to anomaly detection jobs is deprecated, in a future major version it will be compulsory to use a datafeed'
       ml.post_data:
         job_id: index-layout-job
         body: >
@@ -649,6 +663,10 @@ setup:
 ---
 "Test force close does not create state":
 
+  - skip:
+      features:
+        - "warnings"
+
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
@@ -680,6 +698,8 @@ setup:
         job_id: index-layout-force-close-job
 
   - do:
+      warnings:
+        - 'Posting data directly to anomaly detection jobs is deprecated, in a future major version it will be compulsory to use a datafeed'
       ml.post_data:
         job_id: index-layout-force-close-job
         body: >

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/job_cat_apis.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/job_cat_apis.yml
@@ -72,7 +72,13 @@ setup:
 ---
 "Test cat anomaly detector jobs":
 
+  - skip:
+      features:
+        - "warnings"
+
   - do:
+      warnings:
+        - 'Posting data directly to anomaly detection jobs is deprecated, in a future major version it will be compulsory to use a datafeed'
       ml.post_data:
         job_id: job-stats-test
         body: >

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_crud.yml
@@ -657,7 +657,9 @@
 ---
 "Test close job":
   - skip:
-      features: headers
+      features:
+        - "headers"
+        - "warnings"
   - do:
       ml.put_job:
         job_id: jobs-crud-close-job
@@ -682,6 +684,8 @@
         job_id: jobs-crud-close-job
 
   - do:
+      warnings:
+        - 'Posting data directly to anomaly detection jobs is deprecated, in a future major version it will be compulsory to use a datafeed'
       ml.post_data:
         job_id: jobs-crud-close-job
         body: >
@@ -915,7 +919,9 @@
 ---
 "Test force close job":
   - skip:
-      features: headers
+      features:
+        - "headers"
+        - "warnings"
   - do:
       ml.put_job:
         job_id: jobs-crud-force-close-job
@@ -943,6 +949,8 @@
         job_id: jobs-crud-force-close-job
 
   - do:
+      warnings:
+        - 'Posting data directly to anomaly detection jobs is deprecated, in a future major version it will be compulsory to use a datafeed'
       ml.post_data:
         job_id: jobs-crud-force-close-job
         body: >

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_get_stats.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_get_stats.yml
@@ -72,7 +72,13 @@ setup:
 ---
 "Test get job stats after uploading data prompting the creation of some stats":
 
+  - skip:
+      features:
+        - "warnings"
+
   - do:
+      warnings:
+        - 'Posting data directly to anomaly detection jobs is deprecated, in a future major version it will be compulsory to use a datafeed'
       ml.post_data:
         job_id: job-stats-test
         body: >
@@ -110,7 +116,13 @@ setup:
 ---
 "Test get job stats for closed job":
 
+  - skip:
+      features:
+        - "warnings"
+
   - do:
+      warnings:
+        - 'Posting data directly to anomaly detection jobs is deprecated, in a future major version it will be compulsory to use a datafeed'
       ml.post_data:
         job_id: job-stats-test
         body: >
@@ -341,7 +353,13 @@ setup:
 ---
 "Test no exception on get job stats with missing index":
 
+  - skip:
+      features:
+        - "warnings"
+
   - do:
+      warnings:
+        - 'Posting data directly to anomaly detection jobs is deprecated, in a future major version it will be compulsory to use a datafeed'
       ml.post_data:
         job_id: job-stats-test
         body: >

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/post_data.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/post_data.yml
@@ -46,7 +46,13 @@ setup:
 
 ---
 "Test POST data job api, flush, close and verify DataCounts doc":
+  - skip:
+      features:
+        - "warnings"
+
   - do:
+      warnings:
+        - 'Posting data directly to anomaly detection jobs is deprecated, in a future major version it will be compulsory to use a datafeed'
       ml.post_data:
         job_id: post-data-job
         body:
@@ -123,7 +129,13 @@ setup:
 ---
 "Test flush with skip_time":
 
+  - skip:
+      features:
+        - "warnings"
+
   - do:
+      warnings:
+        - 'Posting data directly to anomaly detection jobs is deprecated, in a future major version it will be compulsory to use a datafeed'
       ml.post_data:
         job_id: post-data-job
         body:
@@ -146,6 +158,8 @@ setup:
 
   # Send some data that should be ignored
   - do:
+      warnings:
+        - 'Posting data directly to anomaly detection jobs is deprecated, in a future major version it will be compulsory to use a datafeed'
       ml.post_data:
         job_id: post-data-job
         body:
@@ -160,6 +174,8 @@ setup:
 
   # Send data that will create results for the bucket after the skipped one
   - do:
+      warnings:
+        - 'Posting data directly to anomaly detection jobs is deprecated, in a future major version it will be compulsory to use a datafeed'
       ml.post_data:
         job_id: post-data-job
         body:
@@ -191,8 +207,12 @@ setup:
   - skip:
       reason: "https://github.com/elastic/elasticsearch/issues/34747"
       version: "6.5.0 - "
+      features:
+        - "warnings"
 
   - do:
+      warnings:
+        - 'Posting data directly to anomaly detection jobs is deprecated, in a future major version it will be compulsory to use a datafeed'
       catch: missing
       ml.post_data:
         job_id: not_a_job
@@ -207,6 +227,8 @@ setup:
             time: 1403481700
 
   - do:
+      warnings:
+        - 'Posting data directly to anomaly detection jobs is deprecated, in a future major version it will be compulsory to use a datafeed'
       catch: /parse_exception/
       ml.post_data:
         job_id: post-data-job
@@ -222,6 +244,8 @@ setup:
             time: 1403481700
 
   - do:
+      warnings:
+        - 'Posting data directly to anomaly detection jobs is deprecated, in a future major version it will be compulsory to use a datafeed'
       catch: /parse_exception/
       ml.post_data:
         job_id: post-data-job
@@ -280,12 +304,18 @@ setup:
 ---
 "Test flushing and posting a closed job":
 
+  - skip:
+      features:
+        - "warnings"
+
   - do:
       catch: /status_exception/
       ml.flush_job:
         job_id: post-data-closed-job
 
   - do:
+      warnings:
+        - 'Posting data directly to anomaly detection jobs is deprecated, in a future major version it will be compulsory to use a datafeed'
       catch: /status_exception/
       ml.post_data:
         job_id: post-data-closed-job

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/30_ml_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/30_ml_jobs_crud.yml
@@ -88,6 +88,10 @@
 
 ---
 "Create a job in the mixed cluster and write some data":
+
+  - skip:
+      features: allowed_warnings
+
   - do:
       ml.put_job:
         job_id: mixed-cluster-job
@@ -114,6 +118,8 @@
         job_id: mixed-cluster-job
 
   - do:
+      allowed_warnings:
+        - 'Posting data directly to anomaly detection jobs is deprecated, in a future major version it will be compulsory to use a datafeed'
       ml.post_data:
         job_id: mixed-cluster-job
         body:

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/30_ml_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/30_ml_jobs_crud.yml
@@ -15,6 +15,9 @@ setup:
 ---
 "Put job on the old cluster and post some data":
 
+  - skip:
+      features: allowed_warnings
+
   - do:
       ml.put_job:
         job_id: old-cluster-job
@@ -41,6 +44,8 @@ setup:
         job_id: old-cluster-job
 
   - do:
+      allowed_warnings:
+        - 'Posting data directly to anomaly detection jobs is deprecated, in a future major version it will be compulsory to use a datafeed'
       ml.post_data:
         job_id: old-cluster-job
         body:
@@ -73,6 +78,9 @@ setup:
 ---
 "Put categorization job on the old cluster and post some data":
 
+  - skip:
+      features: allowed_warnings
+
   - do:
       ml.put_job:
         job_id: old-cluster-categorization-job
@@ -104,6 +112,8 @@ setup:
         job_id: old-cluster-categorization-job
 
   - do:
+      allowed_warnings:
+        - 'Posting data directly to anomaly detection jobs is deprecated, in a future major version it will be compulsory to use a datafeed'
       ml.post_data:
         job_id: old-cluster-categorization-job
         body:
@@ -131,6 +141,10 @@ setup:
 
 ---
 "Put job on the old cluster with the default model memory limit and post some data":
+
+  - skip:
+      features: allowed_warnings
+
   - do:
       ml.put_job:
         job_id: no-model-memory-limit-job
@@ -152,6 +166,8 @@ setup:
         job_id: no-model-memory-limit-job
 
   - do:
+      allowed_warnings:
+        - 'Posting data directly to anomaly detection jobs is deprecated, in a future major version it will be compulsory to use a datafeed'
       ml.post_data:
         job_id: no-model-memory-limit-job
         body:
@@ -186,6 +202,9 @@ setup:
 ---
 "Put job with timing stats checking on the old cluster and post some data":
 
+  - skip:
+      features: allowed_warnings
+
   - do:
       ml.put_job:
         job_id: old-cluster-job-with-ts
@@ -212,6 +231,8 @@ setup:
         job_id: old-cluster-job-with-ts
 
   - do:
+      allowed_warnings:
+        - 'Posting data directly to anomaly detection jobs is deprecated, in a future major version it will be compulsory to use a datafeed'
       ml.post_data:
         job_id: old-cluster-job-with-ts
         body:


### PR DESCRIPTION
There is little evidence of this endpoint being used
and there is quite a lot of code complexity associated
with the various formats that can be used to upload
data and the different errors that can occur when direct
data upload is open to end users.

In a future release we can make this endpoint internal
so that only datafeeds can use it, and remove all the
options and formats that are not used by datafeeds.

End users will have to store their input data for
anomaly detection in Elasticsearch indices (which we
believe all do today) and use a datafeed to feed it
to anomaly detection jobs.