### PR TITLE
Autoscaling capacity should be in bytes

### DIFF
--- a/x-pack/plugin/autoscaling/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/autoscaling/get_autoscaling_capacity.yml
+++ b/x-pack/plugin/autoscaling/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/autoscaling/get_autoscaling_capacity.yml
@@ -24,14 +24,14 @@
   - do:
       autoscaling.get_autoscaling_capacity: {}
 
-  - match: { policies.my_autoscaling_policy.required_capacity.total.storage: 13370b }
-  - match: { policies.my_autoscaling_policy.required_capacity.total.memory: 73310b }
-  - match: { policies.my_autoscaling_policy.required_capacity.node.storage: 1337b }
-  - match: { policies.my_autoscaling_policy.required_capacity.node.memory: 7331b }
-  - match: { policies.my_autoscaling_policy.deciders.fixed.required_capacity.total.storage: 13370b }
-  - match: { policies.my_autoscaling_policy.deciders.fixed.required_capacity.total.memory: 73310b }
-  - match: { policies.my_autoscaling_policy.deciders.fixed.required_capacity.node.storage: 1337b }
-  - match: { policies.my_autoscaling_policy.deciders.fixed.required_capacity.node.memory: 7331b }
+  - match: { policies.my_autoscaling_policy.required_capacity.total.storage: 13370 }
+  - match: { policies.my_autoscaling_policy.required_capacity.total.memory: 73310 }
+  - match: { policies.my_autoscaling_policy.required_capacity.node.storage: 1337 }
+  - match: { policies.my_autoscaling_policy.required_capacity.node.memory: 7331 }
+  - match: { policies.my_autoscaling_policy.deciders.fixed.required_capacity.total.storage: 13370 }
+  - match: { policies.my_autoscaling_policy.deciders.fixed.required_capacity.total.memory: 73310 }
+  - match: { policies.my_autoscaling_policy.deciders.fixed.required_capacity.node.storage: 1337 }
+  - match: { policies.my_autoscaling_policy.deciders.fixed.required_capacity.node.memory: 7331 }
   - match: { policies.my_autoscaling_policy.deciders.fixed.reason_summary: "fixed storage [1.3kb] memory [7.1kb] nodes [10]" }
   - length: { policies.my_autoscaling_policy.current_nodes: 0 }
 

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingCapacity.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingCapacity.java
@@ -54,10 +54,10 @@ public class AutoscalingCapacity implements ToXContent, Writeable {
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject();
             if (storage != null) {
-                builder.field("storage", storage.getStringRep());
+                builder.field("storage", storage.getBytes());
             }
             if (memory != null) {
-                builder.field("memory", memory.getStringRep());
+                builder.field("memory", memory.getBytes());
             }
             builder.endObject();
             return builder;


### PR DESCRIPTION
The autoscaling storage and memory capacities returned were
inadvertently returned as capacities with units. This imposes a burden
on the caller to be able to parse ES byte-size units. Fixed this to
just return the bytes as numbers.