### PR TITLE
ILM: make the rest of the forcemerge action steps retryable

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ForceMergeStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ForceMergeStep.java
@@ -26,6 +26,11 @@ public class ForceMergeStep extends AsyncActionStep {
         this.maxNumSegments = maxNumSegments;
     }
 
+    @Override
+    public boolean isRetryable() {
+        return true;
+    }
+
     public int getMaxNumSegments() {
         return maxNumSegments;
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/SegmentCountStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/SegmentCountStep.java
@@ -45,6 +45,11 @@ public class SegmentCountStep extends AsyncWaitStep {
         this.maxNumSegments = maxNumSegments;
     }
 
+    @Override
+    public boolean isRetryable() {
+        return true;
+    }
+
     public int getMaxNumSegments() {
         return maxNumSegments;
     }


### PR DESCRIPTION
This makes the force merge and segment count steps
retryable.

We already test the retryability infrastructure in several integration tests 
in TimeseriesLifecycleIT (ie. testILMRolloverOnManuallyRolledIndex, 
testILMRolloverRetriesOnReadOnlyBlock, testRolloverStepRetriesUntilRolledOverIndexIsDeleted,
testSetSingleNodeAllocationRetriesUntilItSucceeds etc.) so this PR doesn't
contain additional tests.

Relates to #48183