### PR TITLE
Clarify update scripts docs on doc vs ctx use

### DIFF
--- a/docs/reference/scripting/fields.asciidoc
+++ b/docs/reference/scripting/fields.asciidoc
@@ -16,6 +16,8 @@ API will have access to the `ctx` variable which exposes:
 `ctx.op`::          The operation that should be applied to the document: `index` or `delete`.
 `ctx._index` etc::  Access to <<mapping-fields,document metadata fields>>, some of which may be read-only.
 
+These scripts do not have access to the `doc` variable and have to use `ctx` to access the documents they operate on.
+
 [discrete]
 == Search and aggregation scripts
 


### PR DESCRIPTION
`doc` vs `ctx`. [one of the most popular Discuss forum questions on Painless](https://discuss.elastic.co/t/checking-for-missing-date-fields-in-painless-script/161743) explains that `doc` is not accessible in certain contexts. The [contexts overview](https://www.elastic.co/guide/en/elasticsearch/painless/7.10/painless-contexts.html) is an excellent reference-style section, but neither it nor [the page that shows ctx and doc in action](https://www.elastic.co/guide/en/elasticsearch/reference/7.10/modules-scripting-fields.html) can currently easily answer a q like "painless doc [values] not working". This adds a sentence to the page explaining the situation.

Feel free to correct me if wrong, it seems to still be the case :)!