### PR TITLE
[DOCS] Add description for node info settings.

### DIFF
--- a/docs/reference/cluster/nodes-info.asciidoc
+++ b/docs/reference/cluster/nodes-info.asciidoc
@@ -69,7 +69,7 @@ By default, it returns all attributes and core settings for a node.
 		Process statistics, memory consumption, cpu usage, open file descriptors.
 
 `settings`::
-
+    Lists all node settings in use as defined in the `elasticsearch.yml` file.
 
 `thread_pool`::
 		Statistics about each thread pool, including current size, queue and


### PR DESCRIPTION
Adds a description for the `settings` parameter on the node info page.

Closes #62725