### PR TITLE
Mute AutoFollowIT.testRolloverAliasInFollowClusterForbidden() test.

### DIFF
--- a/x-pack/plugin/ccr/qa/multi-cluster/src/test/java/org/elasticsearch/xpack/ccr/AutoFollowIT.java
+++ b/x-pack/plugin/ccr/qa/multi-cluster/src/test/java/org/elasticsearch/xpack/ccr/AutoFollowIT.java
@@ -422,6 +422,7 @@ public class AutoFollowIT extends ESCCRRestTestCase {
         }
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/66251")
     public void testRolloverAliasInFollowClusterForbidden() throws Exception {
         if ("follow".equals(targetCluster) == false) {
             return;


### PR DESCRIPTION
backport #66363 to 7.x branch.

Relates to #66251