### PR TITLE
Adding "read ingest pipeline" cluster privilege (#66137)

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/security/user/privileges/Role.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/security/user/privileges/Role.java
@@ -312,6 +312,7 @@ public final class Role {
         public static final String MANAGE_ROLLUP = "manage_rollup";
         public static final String MANAGE_INDEX_TEMPLATES = "manage_index_templates";
         public static final String MANAGE_INGEST_PIPELINES = "manage_ingest_pipelines";
+        public static final String READ_INGEST_PIPELINES = "read_ingest_pipelines";
         public static final String TRANSPORT_CLIENT = "transport_client";
         public static final String MANAGE_SECURITY = "manage_security";
         public static final String MANAGE_SAML = "manage_saml";
@@ -326,9 +327,9 @@ public final class Role {
         public static final String MANAGE_ENRICH = "manage_enrich";
         public static final String[] ALL_ARRAY = new String[] { NONE, ALL, MONITOR, MONITOR_TRANSFORM_DEPRECATED, MONITOR_TRANSFORM,
             MONITOR_ML, MONITOR_WATCHER, MONITOR_ROLLUP, MANAGE, MANAGE_TRANSFORM_DEPRECATED, MANAGE_TRANSFORM,
-            MANAGE_ML, MANAGE_WATCHER, MANAGE_ROLLUP, MANAGE_INDEX_TEMPLATES, MANAGE_INGEST_PIPELINES, TRANSPORT_CLIENT,
-            MANAGE_SECURITY, MANAGE_SAML, MANAGE_OIDC, MANAGE_TOKEN, MANAGE_PIPELINE, MANAGE_AUTOSCALING, MANAGE_CCR, READ_CCR,
-            MANAGE_ILM, READ_ILM, MANAGE_ENRICH };
+            MANAGE_ML, MANAGE_WATCHER, MANAGE_ROLLUP, MANAGE_INDEX_TEMPLATES, MANAGE_INGEST_PIPELINES, READ_INGEST_PIPELINES,
+            TRANSPORT_CLIENT, MANAGE_SECURITY, MANAGE_SAML, MANAGE_OIDC, MANAGE_TOKEN, MANAGE_PIPELINE, MANAGE_AUTOSCALING, MANAGE_CCR,
+            READ_CCR, MANAGE_ILM, READ_ILM, MANAGE_ENRICH };
     }
 
     /**

--- a/x-pack/docs/en/rest-api/security/get-builtin-privileges.asciidoc
+++ b/x-pack/docs/en/rest-api/security/get-builtin-privileges.asciidoc
@@ -96,6 +96,7 @@ A successful call returns an object with "cluster" and "index" fields.
     "none",
     "read_ccr",
     "read_ilm",
+    "read_ingest_pipelines",
     "read_slm",
     "transport_client"
   ],

--- a/x-pack/docs/en/security/authorization/privileges.asciidoc
+++ b/x-pack/docs/en/security/authorization/privileges.asciidoc
@@ -171,7 +171,10 @@ This privilege is necessary only on clusters that contain leader indices.
 All read-only {Ilm} operations, such as getting policies and checking the
 status of {Ilm}
 
-read_slm::
+`read_ingest_pipelines`::
+Read-only access to ingest pipline (get, simulate).
+
+`read_slm`::
 All read-only {slm-init} actions, such as getting policies and checking the
 {slm-init} status.
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ClusterPrivilegeResolver.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ClusterPrivilegeResolver.java
@@ -169,6 +169,7 @@ public class ClusterPrivilegeResolver {
         MANAGE_WATCHER,
         MANAGE_IDX_TEMPLATES,
         MANAGE_INGEST_PIPELINES,
+        READ_INGEST_PIPELINES,
         TRANSPORT_CLIENT,
         MANAGE_SECURITY,
         MANAGE_SAML,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ClusterPrivilegeResolver.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ClusterPrivilegeResolver.java
@@ -15,6 +15,8 @@ import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotAct
 import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsAction;
 import org.elasticsearch.action.admin.cluster.snapshots.status.SnapshotsStatusAction;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateAction;
+import org.elasticsearch.action.ingest.GetPipelineAction;
+import org.elasticsearch.action.ingest.SimulatePipelineAction;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.xpack.core.ilm.action.GetLifecycleAction;
@@ -72,6 +74,8 @@ public class ClusterPrivilegeResolver {
     private static final Set<String> MANAGE_IDX_TEMPLATE_PATTERN = Collections.unmodifiableSet(Sets.newHashSet("indices:admin/template/*",
             "indices:admin/index_template/*"));
     private static final Set<String> MANAGE_INGEST_PIPELINE_PATTERN = Collections.singleton("cluster:admin/ingest/pipeline/*");
+    private static final Set<String> READ_INGEST_PIPELINE_PATTERN = Collections.unmodifiableSet(Sets.newHashSet(GetPipelineAction.NAME,
+        SimulatePipelineAction.NAME));
     private static final Set<String> MANAGE_ROLLUP_PATTERN = Collections.unmodifiableSet(
         Sets.newHashSet("cluster:admin/xpack/rollup/*", "cluster:monitor/xpack/rollup/*"));
     private static final Set<String> MANAGE_CCR_PATTERN =
@@ -115,6 +119,8 @@ public class ClusterPrivilegeResolver {
         new ActionClusterPrivilege("manage_index_templates", MANAGE_IDX_TEMPLATE_PATTERN);
     public static final NamedClusterPrivilege MANAGE_INGEST_PIPELINES =
         new ActionClusterPrivilege("manage_ingest_pipelines", MANAGE_INGEST_PIPELINE_PATTERN);
+    public static final NamedClusterPrivilege READ_INGEST_PIPELINES =
+        new ActionClusterPrivilege("read_ingest_pipelines", READ_INGEST_PIPELINE_PATTERN);
     public static final NamedClusterPrivilege TRANSPORT_CLIENT = new ActionClusterPrivilege("transport_client",
         TRANSPORT_CLIENT_PATTERN);
     public static final NamedClusterPrivilege MANAGE_SECURITY = new ActionClusterPrivilege("manage_security", ALL_SECURITY_PATTERN,

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/privilege/PrivilegeTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/privilege/PrivilegeTests.java
@@ -260,4 +260,24 @@ public class PrivilegeTests extends ESTestCase {
 
         }
     }
+
+    public void testIngestPipelinePrivileges() {
+        {
+            verifyClusterActionAllowed(ClusterPrivilegeResolver.MANAGE_INGEST_PIPELINES, "cluster:admin/ingest/pipeline/get",
+                "cluster:admin/ingest/pipeline/put",
+                "cluster:admin/ingest/pipeline/delete",
+                "cluster:admin/ingest/pipeline/simulate");
+            verifyClusterActionDenied(ClusterPrivilegeResolver.MANAGE_INGEST_PIPELINES, "cluster:admin/whatever");
+        }
+
+        {
+            verifyClusterActionAllowed(ClusterPrivilegeResolver.READ_INGEST_PIPELINES,
+                "cluster:admin/ingest/pipeline/get",
+                "cluster:admin/ingest/pipeline/simulate");
+            verifyClusterActionDenied(ClusterPrivilegeResolver.READ_INGEST_PIPELINES,"cluster:admin/ingest/pipeline/put",
+                "cluster:admin/ingest/pipeline/delete",
+                "cluster:admin/whatever");
+
+        }
+    }
 }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/privileges/11_builtin.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/privileges/11_builtin.yml
@@ -15,5 +15,5 @@ setup:
   # This is fragile - it needs to be updated every time we add a new cluster/index privilege
   # I would much prefer we could just check that specific entries are in the array, but we don't have
   # an assertion for that
-  - length: { "cluster" : 37 }
+  - length: { "cluster" : 38 }
   - length: { "index" : 19 }


### PR DESCRIPTION
Adding "read ingest pipeline" cluster privilege

The new privilege will allow to run ingest tools with minimal
privilege to check whether a
pipeline exists, without being able to modify it.
This privilege also support simulate pipeline too since it is a readonly
 operation.

 Resolve #48028
#backport