### PR TITLE
Make SLM Run Snapshot Deletes in Parallel (#62284)

### DIFF
--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotRetentionTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotRetentionTask.java
@@ -9,18 +9,12 @@ package org.elasticsearch.xpack.slm;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.LatchedActionListener;
+import org.elasticsearch.action.support.GroupedActionListener;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.OriginSettingClient;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateObserver;
-import org.elasticsearch.cluster.RepositoryCleanupInProgress;
-import org.elasticsearch.cluster.RestoreInProgress;
-import org.elasticsearch.cluster.SnapshotDeletionsInProgress;
-import org.elasticsearch.cluster.SnapshotsInProgress;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.CountDown;
@@ -29,7 +23,6 @@ import org.elasticsearch.snapshots.SnapshotInfo;
 import org.elasticsearch.snapshots.SnapshotState;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.ClientHelper;
-import org.elasticsearch.xpack.core.ilm.LifecycleSettings;
 import org.elasticsearch.xpack.core.scheduler.SchedulerEngine;
 import org.elasticsearch.xpack.core.slm.SnapshotLifecycleMetadata;
 import org.elasticsearch.xpack.core.slm.SnapshotLifecyclePolicy;
@@ -49,9 +42,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.LongSupplier;
@@ -68,13 +58,17 @@ import static org.elasticsearch.xpack.core.slm.SnapshotLifecyclePolicy.POLICY_ID
 public class SnapshotRetentionTask implements SchedulerEngine.Listener {
 
     private static final Logger logger = LogManager.getLogger(SnapshotRetentionTask.class);
-    private static final AtomicBoolean running = new AtomicBoolean(false);
 
     private final Client client;
     private final ClusterService clusterService;
     private final LongSupplier nowNanoSupplier;
     private final ThreadPool threadPool;
     private final SnapshotHistoryStore historyStore;
+
+    /**
+     * Set of all currently deleting {@link SnapshotId} used to prevent starting multiple deletes for the same snapshot.
+     */
+    private final Set<SnapshotId> runningDeletions = Collections.synchronizedSet(new HashSet<>());
 
     public SnapshotRetentionTask(Client client, ClusterService clusterService, LongSupplier nowNanoSupplier,
                                  SnapshotHistoryStore historyStore, ThreadPool threadPool) {
@@ -111,83 +105,71 @@ public class SnapshotRetentionTask implements SchedulerEngine.Listener {
             return;
         }
 
-        if (running.compareAndSet(false, true)) {
-            final SnapshotLifecycleStats slmStats = new SnapshotLifecycleStats();
+        final SnapshotLifecycleStats slmStats = new SnapshotLifecycleStats();
 
-            // Defined here so it can be re-used without having to repeat it
-            final Consumer<Exception> failureHandler = e -> {
-                try {
-                    logger.error("error during snapshot retention task", e);
-                    slmStats.retentionFailed();
-                    updateStateWithStats(slmStats);
-                } finally {
-                    logger.info("SLM retention snapshot cleanup task completed with error");
-                    running.set(false);
-                }
-            };
-
+        // Defined here so it can be re-used without having to repeat it
+        final Consumer<Exception> failureHandler = e -> {
             try {
-                final TimeValue maxDeletionTime = LifecycleSettings.SLM_RETENTION_DURATION_SETTING.get(state.metadata().settings());
+                logger.error("error during snapshot retention task", e);
+                slmStats.retentionFailed();
+                updateStateWithStats(slmStats);
+            } finally {
+                logger.info("SLM retention snapshot cleanup task completed with error");
+            }
+        };
 
-                logger.info("starting SLM retention snapshot cleanup task");
-                slmStats.retentionRun();
-                // Find all SLM policies that have retention enabled
-                final Map<String, SnapshotLifecyclePolicy> policiesWithRetention = getAllPoliciesWithRetentionEnabled(state);
-                logger.trace("policies with retention enabled: {}", policiesWithRetention.keySet());
+        try {
+            logger.info("starting SLM retention snapshot cleanup task");
+            slmStats.retentionRun();
+            // Find all SLM policies that have retention enabled
+            final Map<String, SnapshotLifecyclePolicy> policiesWithRetention = getAllPoliciesWithRetentionEnabled(state);
+            logger.trace("policies with retention enabled: {}", policiesWithRetention.keySet());
 
-                // For those policies (there may be more than one for the same repo),
-                // return the repos that we need to get the snapshots for
-                final Set<String> repositioriesToFetch = policiesWithRetention.values().stream()
+            // For those policies (there may be more than one for the same repo),
+            // return the repos that we need to get the snapshots for
+            final Set<String> repositioriesToFetch = policiesWithRetention.values().stream()
                     .map(SnapshotLifecyclePolicy::getRepository)
                     .collect(Collectors.toSet());
-                logger.trace("fetching snapshots from repositories: {}", repositioriesToFetch);
+            logger.trace("fetching snapshots from repositories: {}", repositioriesToFetch);
 
-                if (repositioriesToFetch.isEmpty()) {
-                    running.set(false);
-                    logger.info("there are no repositories to fetch, SLM retention snapshot cleanup task complete");
-                    return;
-                }
-                // Finally, asynchronously retrieve all the snapshots, deleting them serially,
-                // before updating the cluster state with the new metrics and setting 'running'
-                // back to false
-                getAllRetainableSnapshots(repositioriesToFetch, new ActionListener<Map<String, List<SnapshotInfo>>>() {
-                    @Override
-                    public void onResponse(Map<String, List<SnapshotInfo>> allSnapshots) {
-                        try {
-                            if (logger.isTraceEnabled()) {
-                                logger.trace("retrieved snapshots: [{}]", formatSnapshots(allSnapshots));
-                            }
-                            // Find all the snapshots that are past their retention date
-                            final Map<String, List<SnapshotInfo>> snapshotsToBeDeleted = allSnapshots.entrySet().stream()
-                                .collect(Collectors.toMap(Map.Entry::getKey,
-                                    e -> e.getValue().stream()
-                                        .filter(snapshot -> snapshotEligibleForDeletion(snapshot, allSnapshots, policiesWithRetention))
-                                        .collect(Collectors.toList())));
-
-                            if (logger.isTraceEnabled()) {
-                                logger.trace("snapshots eligible for deletion: [{}]", formatSnapshots(snapshotsToBeDeleted));
-                            }
-
-                            // Finally, delete the snapshots that need to be deleted
-                            maybeDeleteSnapshots(snapshotsToBeDeleted, maxDeletionTime, slmStats);
-
-                            updateStateWithStats(slmStats);
-                        } finally {
-                            logger.info("SLM retention snapshot cleanup task complete");
-                            running.set(false);
-                        }
-                    }
-
-                    @Override
-                    public void onFailure(Exception e) {
-                        failureHandler.accept(e);
-                    }
-                }, failureHandler);
-            } catch (Exception e) {
-                failureHandler.accept(e);
+            if (repositioriesToFetch.isEmpty()) {
+                logger.info("there are no repositories to fetch, SLM retention snapshot cleanup task complete");
+                return;
             }
-        } else {
-            logger.trace("snapshot lifecycle retention task started, but a task is already running, skipping");
+            // Finally, asynchronously retrieve all the snapshots, deleting them serially,
+            // before updating the cluster state with the new metrics and setting 'running'
+            // back to false
+            getAllRetainableSnapshots(repositioriesToFetch, new ActionListener<Map<String, List<SnapshotInfo>>>() {
+                @Override
+                public void onResponse(Map<String, List<SnapshotInfo>> allSnapshots) {
+                    if (logger.isTraceEnabled()) {
+                        logger.trace("retrieved snapshots: [{}]", formatSnapshots(allSnapshots));
+                    }
+                    // Find all the snapshots that are past their retention date
+                    final Map<String, List<SnapshotInfo>> snapshotsToBeDeleted = allSnapshots.entrySet().stream()
+                            .collect(Collectors.toMap(Map.Entry::getKey,
+                                    e -> e.getValue().stream()
+                                            .filter(snapshot -> snapshotEligibleForDeletion(snapshot, allSnapshots, policiesWithRetention))
+                                            .collect(Collectors.toList())));
+
+                    if (logger.isTraceEnabled()) {
+                        logger.trace("snapshots eligible for deletion: [{}]", formatSnapshots(snapshotsToBeDeleted));
+                    }
+
+                    // Finally, delete the snapshots that need to be deleted
+                    deleteSnapshots(snapshotsToBeDeleted, slmStats, ActionListener.wrap(() -> {
+                        updateStateWithStats(slmStats);
+                        logger.info("SLM retention snapshot cleanup task complete");
+                    }));
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    failureHandler.accept(e);
+                }
+            }, failureHandler);
+        } catch (Exception e) {
+            failureHandler.accept(e);
         }
     }
 
@@ -309,117 +291,87 @@ public class SnapshotRetentionTask implements SchedulerEngine.Listener {
                 " to have a policy in its metadata, but it did not"));
     }
 
-    /**
-     * Maybe delete the given snapshots. If a snapshot is currently running according to the cluster
-     * state, this waits (using a {@link ClusterStateObserver} until a cluster state with no running
-     * snapshots before executing the blocking
-     * {@link #deleteSnapshots(Map, TimeValue, SnapshotLifecycleStats)} request. At most, we wait
-     * for the maximum allowed deletion time before timing out waiting for a state with no
-     * running snapshots.
-     *
-     * It's possible the task may still run into a SnapshotInProgressException, if a snapshot is
-     * started between the state retrieved here and the actual deletion. Since is is expected to be
-     * a rare case, no special handling is present.
-     */
-    private void maybeDeleteSnapshots(Map<String, List<SnapshotInfo>> snapshotsToDelete,
-                                      TimeValue maximumTime,
-                                      SnapshotLifecycleStats slmStats) {
+    void deleteSnapshots(Map<String, List<SnapshotInfo>> snapshotsToDelete,
+                         SnapshotLifecycleStats slmStats,
+                         ActionListener<Void> listener) {
         int count = snapshotsToDelete.values().stream().mapToInt(List::size).sum();
         if (count == 0) {
+            listener.onResponse(null);
             logger.debug("no snapshots are eligible for deletion");
             return;
         }
 
-        ClusterState state = clusterService.state();
-        if (okayToDeleteSnapshots(state)) {
-            logger.trace("there are no snapshots currently running, proceeding with snapshot deletion of [{}]",
-                formatSnapshots(snapshotsToDelete));
-            deleteSnapshots(snapshotsToDelete, maximumTime, slmStats);
-        } else {
-            logger.debug("a snapshot is currently running, rescheduling SLM retention for after snapshot has completed");
-            ClusterStateObserver observer = new ClusterStateObserver(clusterService, maximumTime, logger, threadPool.getThreadContext());
-            CountDownLatch latch = new CountDownLatch(1);
-            observer.waitForNextChange(
-                new NoSnapshotRunningListener(observer,
-                    newState -> threadPool.executor(ThreadPool.Names.MANAGEMENT).execute(() -> {
-                        try {
-                            logger.trace("received cluster state without running snapshots, proceeding with snapshot deletion of [{}]",
-                                formatSnapshots(snapshotsToDelete));
-                            deleteSnapshots(snapshotsToDelete, maximumTime, slmStats);
-                        } finally {
-                            latch.countDown();
-                        }
-                    }),
-                    e -> {
-                        latch.countDown();
-                        throw new ElasticsearchException(e);
-                    }));
-            try {
-                logger.trace("waiting for snapshot deletion to complete");
-                // Wait until we find a cluster state not running a snapshot operation.
-                // If we can't find one within a day, give up and throw an error.
-                latch.await(1, TimeUnit.DAYS);
-                logger.trace("deletion complete");
-            } catch (InterruptedException e) {
-                throw new ElasticsearchException(e);
-            }
-        }
-    }
-
-    void deleteSnapshots(Map<String, List<SnapshotInfo>> snapshotsToDelete,
-                         TimeValue maximumTime,
-                         SnapshotLifecycleStats slmStats) {
-        int count = snapshotsToDelete.values().stream().mapToInt(List::size).sum();
-
         logger.info("starting snapshot retention deletion for [{}] snapshots", count);
         long startTime = nowNanoSupplier.getAsLong();
-        final AtomicInteger deleted =  new AtomicInteger(0);
+        final AtomicInteger deleted = new AtomicInteger(0);
         final AtomicInteger failed = new AtomicInteger(0);
+        final GroupedActionListener<Void> allDeletesListener =
+                new GroupedActionListener<>(ActionListener.runAfter(listener.map(v -> null),
+                        () -> {
+                            TimeValue totalElapsedTime = TimeValue.timeValueNanos(nowNanoSupplier.getAsLong() - startTime);
+                            logger.debug("total elapsed time for deletion of [{}] snapshots: {}", deleted, totalElapsedTime);
+                            slmStats.deletionTime(totalElapsedTime);
+                        }), snapshotsToDelete.size());
         for (Map.Entry<String, List<SnapshotInfo>> entry : snapshotsToDelete.entrySet()) {
             String repo = entry.getKey();
             List<SnapshotInfo> snapshots = entry.getValue();
-            for (SnapshotInfo info : snapshots) {
+            deleteSnapshots(slmStats, deleted, failed, repo, snapshots, allDeletesListener);
+        }
+    }
+
+    private void deleteSnapshots(SnapshotLifecycleStats slmStats, AtomicInteger deleted, AtomicInteger failed, String repo,
+                                 List<SnapshotInfo> snapshots, ActionListener<Void> listener) {
+
+        final ActionListener<Void> allDeletesListener =
+                new GroupedActionListener<>(listener.map(v -> null), snapshots.size());
+        for (SnapshotInfo info : snapshots) {
+            if (runningDeletions.add(info.snapshotId()) == false) {
+                // snapshot is already being deleted, no need to start another delete job for it
+                allDeletesListener.onResponse(null);
+                continue;
+            }
+            boolean success = false;
+            try {
                 final String policyId = getPolicyId(info);
                 final long deleteStartTime = nowNanoSupplier.getAsLong();
                 // TODO: Use snapshot multi-delete instead of this loop if all nodes in the cluster support it
                 //       i.e are newer or equal to SnapshotsService#MULTI_DELETE_VERSION
-                deleteSnapshot(policyId, repo, info.snapshotId(), slmStats, ActionListener.wrap(acknowledgedResponse -> {
-                    deleted.incrementAndGet();
-                    assert acknowledgedResponse.isAcknowledged();
-                    historyStore.putAsync(SnapshotHistoryItem.deletionSuccessRecord(Instant.now().toEpochMilli(),
-                            info.snapshotId().getName(), policyId, repo));
-                }, e -> {
-                    failed.incrementAndGet();
-                    try {
-                        final SnapshotHistoryItem result = SnapshotHistoryItem.deletionFailureRecord(Instant.now().toEpochMilli(),
-                            info.snapshotId().getName(), policyId, repo, e);
-                        historyStore.putAsync(result);
-                    } catch (IOException ex) {
-                        // This shouldn't happen unless there's an issue with serializing the original exception
-                        logger.error(new ParameterizedMessage(
-                            "failed to record snapshot deletion failure for snapshot lifecycle policy [{}]",
-                            policyId), ex);
-                    }
-                }));
-                // Check whether we have exceeded the maximum time allowed to spend deleting
-                // snapshots, if we have, short-circuit the rest of the deletions
-                long finishTime = nowNanoSupplier.getAsLong();
-                TimeValue deletionTime = TimeValue.timeValueNanos(finishTime - deleteStartTime);
-                logger.debug("elapsed time for deletion of [{}] snapshot: {}", info.snapshotId(), deletionTime);
-                TimeValue totalDeletionTime = TimeValue.timeValueNanos(finishTime - startTime);
-                if (totalDeletionTime.compareTo(maximumTime) > 0) {
-                    logger.info("maximum snapshot retention deletion time reached, time spent: [{}]," +
-                            " maximum allowed time: [{}], deleted [{}] out of [{}] snapshots scheduled for deletion, failed to delete [{}]",
-                        totalDeletionTime, maximumTime, deleted, count, failed);
-                    slmStats.deletionTime(totalDeletionTime);
-                    slmStats.retentionTimedOut();
-                    return;
+                deleteSnapshot(policyId, repo, info.snapshotId(), slmStats, ActionListener.runAfter(
+                        ActionListener.wrap(acknowledgedResponse -> {
+                            deleted.incrementAndGet();
+                            assert acknowledgedResponse.isAcknowledged();
+                            historyStore.putAsync(SnapshotHistoryItem.deletionSuccessRecord(Instant.now().toEpochMilli(),
+                                    info.snapshotId().getName(), policyId, repo));
+                            allDeletesListener.onResponse(null);
+                        }, e -> {
+                            failed.incrementAndGet();
+                            try {
+                                final SnapshotHistoryItem result = SnapshotHistoryItem.deletionFailureRecord(Instant.now().toEpochMilli(),
+                                        info.snapshotId().getName(), policyId, repo, e);
+                                historyStore.putAsync(result);
+                            } catch (IOException ex) {
+                                // This shouldn't happen unless there's an issue with serializing the original exception
+                                logger.error(new ParameterizedMessage(
+                                        "failed to record snapshot deletion failure for snapshot lifecycle policy [{}]",
+                                        policyId), ex);
+                            } finally {
+                                allDeletesListener.onFailure(e);
+                            }
+                        }), () -> {
+                            runningDeletions.remove(info.snapshotId());
+                            long finishTime = nowNanoSupplier.getAsLong();
+                            TimeValue deletionTime = TimeValue.timeValueNanos(finishTime - deleteStartTime);
+                            logger.debug("elapsed time for deletion of [{}] snapshot: {}", info.snapshotId(), deletionTime);
+                        }));
+                success = true;
+            } catch (Exception e) {
+                listener.onFailure(e);
+            } finally {
+                if (success == false) {
+                    runningDeletions.remove(info.snapshotId());
                 }
             }
         }
-        TimeValue totalElapsedTime = TimeValue.timeValueNanos(nowNanoSupplier.getAsLong() - startTime);
-        logger.debug("total elapsed time for deletion of [{}] snapshots: {}", deleted, totalElapsedTime);
-        slmStats.deletionTime(totalElapsedTime);
     }
 
     /**
@@ -433,111 +385,22 @@ public class SnapshotRetentionTask implements SchedulerEngine.Listener {
     void deleteSnapshot(String slmPolicy, String repo, SnapshotId snapshot, SnapshotLifecycleStats slmStats,
                         ActionListener<AcknowledgedResponse> listener) {
         logger.info("[{}] snapshot retention deleting snapshot [{}]", repo, snapshot);
-        CountDownLatch latch = new CountDownLatch(1);
-        client.admin().cluster().prepareDeleteSnapshot(repo, snapshot.getName())
-            .execute(new LatchedActionListener<>(ActionListener.wrap(acknowledgedResponse -> {
-                    if (acknowledgedResponse.isAcknowledged()) {
-                        logger.debug("[{}] snapshot [{}] deleted successfully", repo, snapshot);
-                    } else {
-                        logger.warn("[{}] snapshot [{}] delete issued but the request was not acknowledged", repo, snapshot);
-                    }
+        client.admin().cluster().prepareDeleteSnapshot(repo, snapshot.getName()).execute(ActionListener.wrap(acknowledgedResponse -> {
                     slmStats.snapshotDeleted(slmPolicy);
                     listener.onResponse(acknowledgedResponse);
                 },
                 e -> {
-                    logger.warn(new ParameterizedMessage("[{}] failed to delete snapshot [{}] for retention",
-                        repo, snapshot), e);
-                    slmStats.snapshotDeleteFailure(slmPolicy);
-                    listener.onFailure(e);
-                }), latch));
-        try {
-            // Deletes cannot occur simultaneously, so wait for this
-            // deletion to complete before attempting the next one
-            latch.await();
-        } catch (InterruptedException e) {
-            logger.error(new ParameterizedMessage("[{}] deletion of snapshot [{}] interrupted",
-                repo, snapshot), e);
-            listener.onFailure(e);
-            slmStats.snapshotDeleteFailure(slmPolicy);
-        }
+                    try {
+                        logger.warn(new ParameterizedMessage("[{}] failed to delete snapshot [{}] for retention",
+                                repo, snapshot), e);
+                        slmStats.snapshotDeleteFailure(slmPolicy);
+                    } finally {
+                        listener.onFailure(e);
+                    }
+                }));
     }
 
     void updateStateWithStats(SnapshotLifecycleStats newStats) {
         clusterService.submitStateUpdateTask("update_slm_stats", new UpdateSnapshotLifecycleStatsTask(newStats));
-    }
-
-    public static boolean okayToDeleteSnapshots(ClusterState state) {
-        // Cannot delete during a snapshot
-        if (state.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY).entries().size() > 0) {
-            logger.trace("deletion cannot proceed as there are snapshots in progress");
-            return false;
-        }
-
-        // Cannot delete during an existing delete
-        if (state.custom(SnapshotDeletionsInProgress.TYPE, SnapshotDeletionsInProgress.EMPTY).hasDeletionsInProgress()) {
-            logger.trace("deletion cannot proceed as there are snapshot deletions in progress");
-            return false;
-        }
-
-        // Cannot delete while a repository is being cleaned
-        if (state.custom(RepositoryCleanupInProgress.TYPE, RepositoryCleanupInProgress.EMPTY).hasCleanupInProgress()) {
-            logger.trace("deletion cannot proceed as there are repository cleanups in progress");
-            return false;
-        }
-
-        // Cannot delete during a restore
-        if (state.custom(RestoreInProgress.TYPE, RestoreInProgress.EMPTY).isEmpty() == false) {
-            logger.trace("deletion cannot proceed as there are snapshot restores in progress");
-            return false;
-        }
-
-        // It's okay to delete snapshots
-        return true;
-    }
-
-    /**
-     * A {@link ClusterStateObserver.Listener} that invokes the given function with the new state,
-     * once no snapshots are running. If a snapshot is still running it registers a new listener
-     * and tries again. Passes any exceptions to the original exception listener if they occur.
-     */
-    class NoSnapshotRunningListener implements ClusterStateObserver.Listener {
-
-        private final Consumer<ClusterState> reRun;
-        private final Consumer<Exception> exceptionConsumer;
-        private final ClusterStateObserver observer;
-
-        NoSnapshotRunningListener(ClusterStateObserver observer,
-                                  Consumer<ClusterState> reRun,
-                                  Consumer<Exception> exceptionConsumer) {
-            this.observer = observer;
-            this.reRun = reRun;
-            this.exceptionConsumer = exceptionConsumer;
-        }
-
-        @Override
-        public void onNewClusterState(ClusterState state) {
-            try {
-                if (okayToDeleteSnapshots(state)) {
-                    logger.debug("retrying SLM snapshot retention deletion after snapshot operation has completed");
-                    reRun.accept(state);
-                } else {
-                    logger.trace("received new cluster state but a snapshot operation is still running");
-                    observer.waitForNextChange(this);
-                }
-            } catch (Exception e) {
-                exceptionConsumer.accept(e);
-            }
-        }
-
-        @Override
-        public void onClusterServiceClose() {
-            // This means the cluster is being shut down, so nothing to do here
-        }
-
-        @Override
-        public void onTimeout(TimeValue timeout) {
-            exceptionConsumer.accept(
-                new IllegalStateException("slm retention snapshot deletion out while waiting for ongoing snapshot operations to complete"));
-        }
     }
 }

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SnapshotRetentionTaskTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SnapshotRetentionTaskTests.java
@@ -18,27 +18,16 @@ import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.RepositoryCleanupInProgress;
-import org.elasticsearch.cluster.RestoreInProgress;
-import org.elasticsearch.cluster.SnapshotDeletionsInProgress;
-import org.elasticsearch.cluster.SnapshotsInProgress;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.index.shard.ShardId;
-import org.elasticsearch.repositories.IndexId;
-import org.elasticsearch.snapshots.Snapshot;
 import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.snapshots.SnapshotInfo;
 import org.elasticsearch.test.ClusterServiceUtils;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.VersionUtils;
 import org.elasticsearch.test.client.NoOpClient;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.xpack.core.ilm.LifecycleSettings;
 import org.elasticsearch.xpack.core.ilm.OperationMode;
 import org.elasticsearch.xpack.core.scheduler.SchedulerEngine;
 import org.elasticsearch.xpack.core.slm.SnapshotLifecycleMetadata;
@@ -61,7 +50,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -71,14 +59,11 @@ import java.util.stream.Collectors;
 
 import static org.elasticsearch.xpack.core.slm.history.SnapshotHistoryItem.DELETE_OPERATION;
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class SnapshotRetentionTaskTests extends ESTestCase {
 
@@ -238,154 +223,6 @@ public class SnapshotRetentionTaskTests extends ESTestCase {
             threadPool.shutdownNow();
             threadPool.awaitTermination(10, TimeUnit.SECONDS);
         }
-    }
-
-    public void testSuccessfulTimeBoundedDeletion() throws Exception {
-        timeBoundedDeletion(true);
-    }
-
-    public void testFailureTimeBoundedDeletion() throws Exception {
-        timeBoundedDeletion(false);
-    }
-
-    private void timeBoundedDeletion(final boolean deletionSuccess) throws Exception {
-        ThreadPool threadPool = new TestThreadPool("slm-test");
-        try (ClusterService clusterService = ClusterServiceUtils.createClusterService(threadPool);
-             Client noOpClient = new NoOpClient("slm-test")) {
-
-            final String policyId = "policy";
-            final String repoId = "repo";
-            SnapshotLifecyclePolicy policy = new SnapshotLifecyclePolicy(policyId, "snap", "1 * * * * ?",
-                repoId, null, new SnapshotRetentionConfiguration(null, null, 1));
-
-            ClusterState state = createState(policy);
-            state = ClusterState.builder(state)
-                .metadata(Metadata.builder(state.metadata())
-                    .transientSettings(Settings.builder()
-                        .put(LifecycleSettings.SLM_RETENTION_DURATION, "500ms")
-                        .build())).build();
-            ClusterServiceUtils.setState(clusterService, state);
-
-            final SnapshotInfo snap1 = new SnapshotInfo(new SnapshotId("name1", "uuid1"), Collections.singletonList("index"),
-                Collections.emptyList(), 0L, null, 1L, 1, Collections.emptyList(), true, Collections.singletonMap("policy", policyId));
-            final SnapshotInfo snap2 = new SnapshotInfo(new SnapshotId("name2", "uuid2"), Collections.singletonList("index"),
-                Collections.emptyList(), 1L, null, 2L, 1, Collections.emptyList(), true, Collections.singletonMap("policy", policyId));
-            final SnapshotInfo snap3 = new SnapshotInfo(new SnapshotId("name3", "uuid3"), Collections.singletonList("index"),
-                Collections.emptyList(), 2L, null, 3L, 1, Collections.emptyList(), true, Collections.singletonMap("policy", policyId));
-            final SnapshotInfo snap4 = new SnapshotInfo(new SnapshotId("name4", "uuid4"), Collections.singletonList("index"),
-                Collections.emptyList(), 3L, null, 4L, 1, Collections.emptyList(), true, Collections.singletonMap("policy", policyId));
-            final SnapshotInfo snap5 = new SnapshotInfo(new SnapshotId("name5", "uuid5"), Collections.singletonList("index"),
-                Collections.emptyList(), 4L, null, 5L, 1, Collections.emptyList(), true, Collections.singletonMap("policy", policyId));
-
-            final Set<SnapshotId> deleted = ConcurrentHashMap.newKeySet();
-            // We're expected two deletions before they hit the "taken too long" test, so have a latch of 2
-            CountDownLatch deletionLatch = new CountDownLatch(2);
-            CountDownLatch historyLatch = new CountDownLatch(2);
-            Set<String> deletedSnapshotsInHistory = ConcurrentHashMap.newKeySet();
-            AtomicLong nanos = new AtomicLong(System.nanoTime());
-            MockSnapshotRetentionTask retentionTask = new MockSnapshotRetentionTask(noOpClient, clusterService,
-                new SnapshotLifecycleTaskTests.VerifyingHistoryStore(noOpClient, ZoneOffset.UTC,
-                    (historyItem) -> {
-                        assertEquals(deletionSuccess, historyItem.isSuccess());
-                        if (historyItem.isSuccess() == false) {
-                            assertThat(historyItem.getErrorDetails(), containsString("deletion_failed"));
-                        }
-                        assertEquals(policyId, historyItem.getPolicyId());
-                        assertEquals(repoId, historyItem.getRepository());
-                        assertEquals(DELETE_OPERATION, historyItem.getOperation());
-                        deletedSnapshotsInHistory.add(historyItem.getSnapshotName());
-                        historyLatch.countDown();
-                    }),
-                threadPool,
-                () -> {
-                    List<SnapshotInfo> snaps = Arrays.asList(snap1, snap2, snap3, snap4, snap5);
-                    logger.info("--> retrieving snapshots [{}]", snaps);
-                    return Collections.singletonMap(repoId, snaps);
-                },
-                (deletionPolicyId, repo, snapId, slmStats, listener) -> {
-                    logger.info("--> deleting {}", snapId);
-                    // Don't pause until snapshot 2
-                    if (snapId.equals(snap2.snapshotId())) {
-                        logger.info("--> pausing for 501ms while deleting snap2 to simulate deletion past a threshold");
-                        nanos.addAndGet(TimeValue.timeValueMillis(501).nanos());
-                    }
-                    deleted.add(snapId);
-                    if (deletionSuccess) {
-                        listener.onResponse(AcknowledgedResponse.TRUE);
-                    } else {
-                        listener.onFailure(new RuntimeException("deletion_failed"));
-                    }
-                    deletionLatch.countDown();
-                },
-                nanos::get);
-
-            long time = System.currentTimeMillis();
-            retentionTask.triggered(new SchedulerEngine.Event(SnapshotRetentionService.SLM_RETENTION_JOB_ID, time, time));
-
-            boolean success = deletionLatch.await(10, TimeUnit.SECONDS);
-
-            assertThat("expected 2 snapshot deletions within 10 seconds, deleted: " + deleted, success, equalTo(true));
-
-            assertNotNull("something should have been deleted", deleted);
-            assertThat("two snapshots should have been deleted", deleted.size(), equalTo(2));
-            assertThat(deleted, containsInAnyOrder(snap1.snapshotId(), snap2.snapshotId()));
-
-            boolean historySuccess = historyLatch.await(10, TimeUnit.SECONDS);
-            assertThat("expected history entries for 2 snapshot deletions", historySuccess, equalTo(true));
-            assertThat(deletedSnapshotsInHistory, containsInAnyOrder(snap1.snapshotId().getName(), snap2.snapshotId().getName()));
-        } finally {
-            threadPool.shutdownNow();
-            threadPool.awaitTermination(10, TimeUnit.SECONDS);
-        }
-    }
-
-    public void testOkToDeleteSnapshots() {
-        final Snapshot snapshot = new Snapshot("repo", new SnapshotId("name", "uuid"));
-
-        SnapshotsInProgress inProgress = SnapshotsInProgress.of(
-            Collections.singletonList(new SnapshotsInProgress.Entry(
-                snapshot, true, false, SnapshotsInProgress.State.INIT,
-                Collections.singletonList(new IndexId("name", "id")), Collections.emptyList(), 0, 0,
-                ImmutableOpenMap.<ShardId, SnapshotsInProgress.ShardSnapshotStatus>builder().build(), null, Collections.emptyMap(),
-                VersionUtils.randomVersion(random()))));
-        ClusterState state = ClusterState.builder(new ClusterName("cluster"))
-            .putCustom(SnapshotsInProgress.TYPE, inProgress)
-            .build();
-
-        assertThat(SnapshotRetentionTask.okayToDeleteSnapshots(state), equalTo(false));
-
-        SnapshotDeletionsInProgress delInProgress = SnapshotDeletionsInProgress.of(
-                Collections.singletonList(new SnapshotDeletionsInProgress.Entry(
-                        Collections.singletonList(snapshot.getSnapshotId()), snapshot.getRepository(), 0, 0,
-                        SnapshotDeletionsInProgress.State.STARTED)));
-        state = ClusterState.builder(new ClusterName("cluster"))
-            .putCustom(SnapshotDeletionsInProgress.TYPE, delInProgress)
-            .build();
-
-        assertThat(SnapshotRetentionTask.okayToDeleteSnapshots(state), equalTo(false));
-
-        RepositoryCleanupInProgress cleanupInProgress =
-            new RepositoryCleanupInProgress(Collections.singletonList(new RepositoryCleanupInProgress.Entry("repo", 0)));
-        state = ClusterState.builder(new ClusterName("cluster"))
-            .putCustom(RepositoryCleanupInProgress.TYPE, cleanupInProgress)
-            .build();
-
-        assertThat(SnapshotRetentionTask.okayToDeleteSnapshots(state), equalTo(false));
-
-        RestoreInProgress restoreInProgress = mock(RestoreInProgress.class);
-        state = ClusterState.builder(new ClusterName("cluster"))
-            .putCustom(RestoreInProgress.TYPE, restoreInProgress)
-            .build();
-
-        assertThat(SnapshotRetentionTask.okayToDeleteSnapshots(state), equalTo(false));
-
-        restoreInProgress = mock(RestoreInProgress.class);
-        when(restoreInProgress.isEmpty()).thenReturn(true);
-        state = ClusterState.builder(new ClusterName("cluster"))
-            .putCustom(RestoreInProgress.TYPE, restoreInProgress)
-            .build();
-
-        assertThat(SnapshotRetentionTask.okayToDeleteSnapshots(state), equalTo(true));
     }
 
     public void testErrStillRunsFailureHandlerWhenRetrieving() throws Exception {


### PR DESCRIPTION
Now that we support parallel snapshot and delete operations, there
is no reason for SLM to wait for any snapshots to finish before starting
a delete. Deletes themselves can also be executed in parallel and in arbitrary
order.
This commit makes use of parallel snapshot operations by removing all waits on
other operations to finish. I tried to keep the changecount limited here so the
following follow ups were not included in this PR:
* Use snapshot multi-delete instead of looping over individual deletes
  * This isn't super important now as the deletes are internally batched into
one or two deletes anyway but requires a number of changes with the way
stats are tracked currently)
* Deprecate and remove the time bound setting for the retention run.
  * This setting doesn't really make sense when all deletes run in parallel.
For one, there is no actual point at which to check for stopping the delete operation
any longer. Also, multiple deletes in parallel tend to (in most cases) run about as
fast as a single delete internally making the limit irrelevant sine we would always try
and run at least one delete.

Relates #59655

backport of #62284 
