### PR TITLE
Use the build JVM for executing third party audit checks

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/ThirdPartyAuditPrecommitPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/ThirdPartyAuditPrecommitPlugin.java
@@ -27,6 +27,7 @@ import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.tasks.TaskProvider;
+import org.gradle.internal.jvm.Jvm;
 
 import java.nio.file.Path;
 
@@ -58,7 +59,7 @@ public class ThirdPartyAuditPrecommitPlugin extends PrecommitPlugin implements I
         TaskProvider<ThirdPartyAuditTask> audit = project.getTasks().register("thirdPartyAudit", ThirdPartyAuditTask.class);
         audit.configure(t -> {
             t.dependsOn(resourcesTask);
-            t.setJavaHome(BuildParams.getRuntimeJavaHome().toString());
+            t.setJavaHome(Jvm.current().getJavaHome().getPath());
             t.getTargetCompatibility().set(project.provider(BuildParams::getRuntimeJavaVersion));
             t.setSignatureFile(resourcesDir.resolve("forbidden/third-party-audit.txt").toFile());
         });


### PR DESCRIPTION
We should not be using the runtime java home for build-time precommit checks. These things have no relevance to runtime java, which should only be used for changing the JVM when executing Elasticsearch code (i.e. tests), not build code. This also causes issues which certain tools because now the available classpath changes based on build environment which we don't want.

This pull request removes the last usage of runtime java home for build checks and instead we use the current Gradle JVM.