### PR TITLE
Fix Log4J config example in docs

### DIFF
--- a/docs/reference/setup/logging-config.asciidoc
+++ b/docs/reference/setup/logging-config.asciidoc
@@ -179,7 +179,8 @@ This is most appropriate when debugging a problem on a single node.
 --
 [source,properties]
 ----
-logger.org.elasticsearch.discovery.level = debug
+logger.discovery.name = org.elasticsearch.discovery
+logger.discovery.level = debug
 ----
 
 This is most appropriate when you already need to change your Log4j 2


### PR DESCRIPTION
We lost the `logger.transport.name` line in #65169 and I incorrectly
extrapolated from what was left and mangled it further in #66318. This
commit fixes things.