### PR TITLE
QL: Verify filter's condition type (backport of #66268)

### DIFF
--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/analysis/Verifier.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/analysis/Verifier.java
@@ -51,6 +51,7 @@ import static org.elasticsearch.xpack.eql.stats.FeatureMetric.SEQUENCE_QUERIES_F
 import static org.elasticsearch.xpack.eql.stats.FeatureMetric.SEQUENCE_QUERIES_THREE;
 import static org.elasticsearch.xpack.eql.stats.FeatureMetric.SEQUENCE_QUERIES_TWO;
 import static org.elasticsearch.xpack.eql.stats.FeatureMetric.SEQUENCE_UNTIL;
+import static org.elasticsearch.xpack.ql.analyzer.VerifierChecks.checkFilterConditionType;
 import static org.elasticsearch.xpack.ql.common.Failure.fail;
 
 /**
@@ -148,6 +149,7 @@ public class Verifier {
                 Set<Failure> localFailures = new LinkedHashSet<>();
                 failures.addAll(localFailures);
 
+                checkFilterConditionType(p, localFailures);
                 // mark the plan as analyzed
                 // if everything checks out
                 if (failures.isEmpty()) {

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/analysis/Verifier.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/analysis/Verifier.java
@@ -147,9 +147,10 @@ public class Verifier {
 
             plan.forEachDown(p -> {
                 Set<Failure> localFailures = new LinkedHashSet<>();
-                failures.addAll(localFailures);
 
                 checkFilterConditionType(p, localFailures);
+
+                failures.addAll(localFailures);
                 // mark the plan as analyzed
                 // if everything checks out
                 if (failures.isEmpty()) {

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/analysis/VerifierTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/analysis/VerifierTests.java
@@ -71,6 +71,16 @@ public class VerifierTests extends ESTestCase {
         accept("foo where true");
     }
 
+    public void testQueryCondition() {
+        accept("any where bool");
+        assertEquals("1:11: Condition expression needs to be boolean, found [LONG]", error("any where pid"));
+        assertEquals("1:11: Condition expression needs to be boolean, found [DATETIME]", error("any where @timestamp"));
+        assertEquals("1:11: Condition expression needs to be boolean, found [KEYWORD]", error("any where command_line"));
+        assertEquals("1:11: Condition expression needs to be boolean, found [TEXT]", error("any where hostname"));
+        assertEquals("1:11: Condition expression needs to be boolean, found [KEYWORD]", error("any where constant_keyword"));
+        assertEquals("1:11: Condition expression needs to be boolean, found [IP]", error("any where source_address"));
+    }
+
     public void testQueryStartsWithNumber() {
         assertEquals("1:1: no viable alternative at input '42'", errorParsing("42 where true"));
     }

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/analysis/VerifierTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/analysis/VerifierTests.java
@@ -77,7 +77,7 @@ public class VerifierTests extends ESTestCase {
         assertEquals("1:11: Condition expression needs to be boolean, found [DATETIME]", error("any where @timestamp"));
         assertEquals("1:11: Condition expression needs to be boolean, found [KEYWORD]", error("any where command_line"));
         assertEquals("1:11: Condition expression needs to be boolean, found [TEXT]", error("any where hostname"));
-        assertEquals("1:11: Condition expression needs to be boolean, found [KEYWORD]", error("any where constant_keyword"));
+        assertEquals("1:11: Condition expression needs to be boolean, found [CONSTANT_KEYWORD]", error("any where constant_keyword"));
         assertEquals("1:11: Condition expression needs to be boolean, found [IP]", error("any where source_address"));
     }
 

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/analyzer/VerifierChecks.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/analyzer/VerifierChecks.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.ql.analyzer;
+
+import org.elasticsearch.xpack.ql.common.Failure;
+import org.elasticsearch.xpack.ql.expression.Expression;
+import org.elasticsearch.xpack.ql.plan.logical.Filter;
+import org.elasticsearch.xpack.ql.plan.logical.LogicalPlan;
+
+import java.util.Set;
+
+import static org.elasticsearch.xpack.ql.common.Failure.fail;
+import static org.elasticsearch.xpack.ql.type.DataTypes.BOOLEAN;
+
+public final class VerifierChecks {
+
+    public static void checkFilterConditionType(LogicalPlan p, Set<Failure> localFailures) {
+        if (p instanceof Filter) {
+            Expression condition = ((Filter) p).condition();
+            if (condition.dataType() != BOOLEAN) {
+                localFailures.add(fail(condition, "Condition expression needs to be boolean, found [{}]", condition.dataType()));
+            }
+        }
+    }
+
+}

--- a/x-pack/plugin/sql/qa/server/src/main/resources/conditionals.csv-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/conditionals.csv-spec
@@ -326,6 +326,23 @@ Pettey
 Heyers
 ;
 
+iifConditionWhere
+SELECT last_name FROM test_emp WHERE IIF(LENGTH(last_name) < 7, true, false) LIMIT 10;
+
+  last_name
+-----------
+Simmel
+Peac
+Sluis
+Terkki
+Genin
+Peha
+Erde
+Famili
+Pettey
+Heyers
+;
+
 iifOrderBy
 SELECT last_name FROM test_emp ORDER BY IIF(languages >= 3, 'first', 'second'), emp_no LIMIT 10;
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Verifier.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Verifier.java
@@ -69,6 +69,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 
 import static java.util.stream.Collectors.toMap;
+import static org.elasticsearch.xpack.ql.analyzer.VerifierChecks.checkFilterConditionType;
 import static org.elasticsearch.xpack.ql.common.Failure.fail;
 import static org.elasticsearch.xpack.ql.util.CollectionUtils.combine;
 import static org.elasticsearch.xpack.sql.stats.FeatureMetric.COMMAND;
@@ -208,6 +209,7 @@ public final class Verifier {
                     return;
                 }
 
+                checkFilterConditionType(p, localFailures);
                 checkGroupingFunctionInGroupBy(p, localFailures);
                 checkFilterOnAggs(p, localFailures, attributeRefs);
                 checkFilterOnGrouping(p, localFailures, attributeRefs);

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/VerifierErrorMessagesTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/VerifierErrorMessagesTests.java
@@ -26,9 +26,7 @@ import org.elasticsearch.xpack.sql.parser.SqlParser;
 import org.elasticsearch.xpack.sql.stats.Metrics;
 
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -98,14 +96,14 @@ public class VerifierErrorMessagesTests extends ESTestCase {
     }
 
     public void testNonBooleanFilter() {
-        Map<String, List<String>> testData = new HashMap<>();
-        testData.put("INTEGER", List.of("int", "int + 1", "ABS(int)", "ASCII(keyword)"));
-        testData.put("KEYWORD", List.of("keyword", "RTRIM(keyword)", "IIF(true, 'true', 'false')"));
-        testData.put("DATETIME", List.of("date", "date + INTERVAL 1 DAY", "NOW()"));
-        for (String typeName : testData.keySet()) {
-            for (String exp : testData.get(typeName)) {
-                assertEquals("1:26: Condition expression needs to be boolean, found [" + typeName + "]",
-                    error("SELECT * FROM test WHERE " + exp));
+        String[][] testData = new String[][]{
+            {"INTEGER", "int", "int + 1", "ABS(int)", "ASCII(keyword)"},
+            {"KEYWORD", "keyword", "RTRIM(keyword)", "IIF(true, 'true', 'false')"},
+            {"DATETIME", "date", "date + INTERVAL 1 DAY", "NOW()"}};
+        for (String[] testDatum : testData) {
+            for (int j = 1; j < testDatum.length; j++) {
+                assertEquals("1:26: Condition expression needs to be boolean, found [" + testDatum[0] + "]",
+                    error("SELECT * FROM test WHERE " + testDatum[j]));
             }
         }
     }


### PR DESCRIPTION
* Verify filter's condition type

This adds a check in the verifier to check if filter's condition is of a
boolean type and fail the request otherwise.

(cherry picked from commit 3aec1a3d99a3f4650ec8be014a97106320f0874a)
