### PR TITLE
SearchableSnapshotsIntegTests.testSnapshotOfSearchableSnapshotIncludesNoDataButCanBeRestored()

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
@@ -794,6 +794,7 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
         }
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/66411")
     public void testSnapshotOfSearchableSnapshotIncludesNoDataButCanBeRestored() throws Exception {
         final String indexName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
         createAndPopulateIndex(


### PR DESCRIPTION
Mute test SearchableSnapshotsIntegTests.testSnapshotOfSearchableSnapshotIncludesNoDataButCanBeRestored()

Relates to #66411