### PR TITLE
Add logic to ensure that watch indices exist before test starts

### DIFF
--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/test/MonitoringIntegTestCase.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/test/MonitoringIntegTestCase.java
@@ -176,7 +176,7 @@ public abstract class MonitoringIntegTestCase extends ESIntegTestCase {
         assertBusy(this::ensureMonitoringIndicesYellow);
     }
 
-    private void awaitIndexExists(final String index) throws Exception {
+    protected void awaitIndexExists(final String index) throws Exception {
         assertBusy(() -> assertIndicesExists(index), 30, TimeUnit.SECONDS);
     }
 


### PR DESCRIPTION
This PR updates the initialization logic in `TransportMonitoringMigrateAlertsActionTests` to wait for the watch indices separately from the rest of the initialization logic in order to allow for the `.watches` index to be available before the test begins.

relates #66391