### PR TITLE
Use Gradle-approved exception message prefix for json validation tasks

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/internal/precommit/ValidateJsonAgainstSchemaTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/internal/precommit/ValidateJsonAgainstSchemaTask.java
@@ -124,7 +124,7 @@ public class ValidateJsonAgainstSchemaTask extends DefaultTask {
             sb.append(getReport().toURI().toASCIIString());
             sb.append(System.lineSeparator());
             sb.append(
-                String.format("JSON validation failed: %d files contained %d violations", errors.keySet().size(), errors.values().size())
+                String.format("Verification failed: %d files contained %d violations", errors.keySet().size(), errors.values().size())
             );
             throw new JsonSchemaException(sb.toString());
         }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/internal/precommit/ValidateJsonNoKeywordsTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/internal/precommit/ValidateJsonNoKeywordsTask.java
@@ -171,7 +171,7 @@ public class ValidateJsonNoKeywordsTask extends DefaultTask {
             "Error validating JSON. See the report at: %s%s%s",
             getReport().toURI().toASCIIString(),
             System.lineSeparator(),
-            String.format("JSON validation failed: %d files contained %d violations", errors.keySet().size(), errors.values().size())
+            String.format("Verification failed: %d files contained %d violations", errors.keySet().size(), errors.values().size())
         );
         throw new GradleException(message);
     }


### PR DESCRIPTION
Gradle Enterprise uses a simple heuristic for categorizing "verification" failures. We consider "verification" failures to be build failures caused by some check the build performs. This could be things like compilation failing, failing tests, failing checkstyle rules, etc. This is in contrast to non-verification failures, such as errors resolving dependencies or other unexpected build exceptions. We treat these differently (non-verification failures should effectively _never_ happen) so we want to categorize them correctly for the purposes of triaging build issues.

Gradle treats [exception messages with certain prefixes](https://docs.gradle.com/enterprise/failure-classification/#verification_failures) to be verification failures. This pull request modifies the exception message produced by our JSON schema validation tasks to use one of the known prefixes so these types of errors will now get tossed into the correct bucket.