### PR TITLE
Avoid Needless Cache Status Fetches in SearchableSnapshotAllocator

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteResponse.java
@@ -44,7 +44,7 @@ public class ClusterRerouteResponse extends AcknowledgedResponse implements ToXC
         explanations = RoutingExplanations.readFrom(in);
     }
 
-    public ClusterRerouteResponse(boolean acknowledged, ClusterState state, RoutingExplanations explanations) {
+    ClusterRerouteResponse(boolean acknowledged, ClusterState state, RoutingExplanations explanations) {
         super(acknowledged);
         this.state = state;
         this.explanations = explanations;

--- a/server/src/main/java/org/elasticsearch/gateway/ReplicaShardAllocator.java
+++ b/server/src/main/java/org/elasticsearch/gateway/ReplicaShardAllocator.java
@@ -241,8 +241,8 @@ public abstract class ReplicaShardAllocator extends BaseGatewayShardAllocator {
      * YES or THROTTLE).  If in explain mode, also returns the node-level explanations as the second element
      * in the returned tuple.
      */
-    private static Tuple<Decision, Map<String, NodeAllocationResult>> canBeAllocatedToAtLeastOneNode(ShardRouting shard,
-                                                                                                     RoutingAllocation allocation) {
+    public static Tuple<Decision, Map<String, NodeAllocationResult>> canBeAllocatedToAtLeastOneNode(ShardRouting shard,
+                                                                                                    RoutingAllocation allocation) {
         Decision madeDecision = Decision.NO;
         final boolean explain = allocation.debugDecision();
         Map<String, NodeAllocationResult> nodeDecisions = explain ? new HashMap<>() : null;

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
@@ -172,8 +172,8 @@ public class SearchableSnapshots extends Plugin implements IndexStorePlugin, Eng
     private final SetOnce<BlobStoreCacheService> blobStoreCacheService = new SetOnce<>();
     private final SetOnce<CacheService> cacheService = new SetOnce<>();
     private final SetOnce<ThreadPool> threadPool = new SetOnce<>();
-    private final SetOnce<Client> client = new SetOnce<>();
     private final SetOnce<FailShardsOnInvalidLicenseClusterListener> failShardsListener = new SetOnce<>();
+    private final SetOnce<SearchableSnapshotAllocator> allocator = new SetOnce<>();
     private final Settings settings;
 
     public SearchableSnapshots(final Settings settings) {
@@ -235,7 +235,7 @@ public class SearchableSnapshots extends Plugin implements IndexStorePlugin, Eng
         } else {
             PersistentCache.cleanUp(settings, nodeEnvironment);
         }
-        this.client.set(client);
+        this.allocator.set(new SearchableSnapshotAllocator(client, clusterService.getRerouteService()));
         components.add(new CacheServiceSupplier(cacheService.get()));
         return Collections.unmodifiableList(components);
     }
@@ -344,7 +344,7 @@ public class SearchableSnapshots extends Plugin implements IndexStorePlugin, Eng
 
     @Override
     public Map<String, ExistingShardsAllocator> getExistingShardsAllocators() {
-        return Map.of(SearchableSnapshotAllocator.ALLOCATOR_NAME, new SearchableSnapshotAllocator(client.get()));
+        return Map.of(SearchableSnapshotAllocator.ALLOCATOR_NAME, allocator.get());
     }
 
     // overridable by tests

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotAllocatorTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotAllocatorTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.allocation.ExistingShardsAllocator;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
+import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
@@ -47,6 +48,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.node.Node.NODE_NAME_SETTING;
+import static org.hamcrest.Matchers.empty;
 
 public class SearchableSnapshotAllocatorTests extends ESAllocationTestCase {
 
@@ -56,51 +58,14 @@ public class SearchableSnapshotAllocatorTests extends ESAllocationTestCase {
         final DiscoveryNode localNode = randomFrom(nodes);
         final Settings localNodeSettings = Settings.builder().put(NODE_NAME_SETTING.getKey(), localNode.getName()).build();
 
-        final ClusterName clusterName = org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY);
-
         final DeterministicTaskQueue deterministicTaskQueue = new DeterministicTaskQueue(localNodeSettings, random());
 
-        final Metadata metadata = Metadata.builder()
-            .put(
-                IndexMetadata.builder(shardId.getIndexName())
-                    .settings(
-                        settings(Version.CURRENT).put(
-                            ExistingShardsAllocator.EXISTING_SHARDS_ALLOCATOR_SETTING.getKey(),
-                            SearchableSnapshotAllocator.ALLOCATOR_NAME
-                        ).put(IndexModule.INDEX_STORE_TYPE_SETTING.getKey(), SearchableSnapshotsConstants.SNAPSHOT_DIRECTORY_FACTORY_KEY)
-                    )
-                    .numberOfShards(1)
-                    .numberOfReplicas(0)
-                    .putInSyncAllocationIds(shardId.id(), Collections.emptySet())
-            )
-            .build();
+        final Metadata metadata = buildSingleShardIndexMetadata(shardId);
         final RoutingTable.Builder routingTableBuilder = RoutingTable.builder();
         routingTableBuilder.addAsRestore(metadata.index(shardId.getIndex()), randomSnapshotSource(shardId));
 
-        final DiscoveryNodes.Builder nodesBuilder = DiscoveryNodes.builder();
-        for (DiscoveryNode node : nodes) {
-            nodesBuilder.add(node);
-        }
-        final DiscoveryNodes discoveryNodes = nodesBuilder.build();
-        final ClusterState state = ClusterState.builder(clusterName)
-            .metadata(metadata)
-            .routingTable(routingTableBuilder.build())
-            .nodes(discoveryNodes)
-            .build();
+        final ClusterState state = buildClusterState(nodes, metadata, routingTableBuilder);
         final long shardSize = randomNonNegativeLong();
-        final RoutingAllocation allocation = new RoutingAllocation(
-            yesAllocationDeciders(),
-            new RoutingNodes(state, false),
-            state,
-            null,
-            new SnapshotShardSizeInfo(ImmutableOpenMap.of()) {
-                @Override
-                public Long getShardSize(ShardRouting shardRouting) {
-                    return shardSize;
-                }
-            },
-            TimeUnit.MILLISECONDS.toNanos(deterministicTaskQueue.getCurrentTimeMillis())
-        );
 
         final AtomicInteger reroutesTriggered = new AtomicInteger(0);
 
@@ -119,7 +84,7 @@ public class SearchableSnapshotAllocatorTests extends ESAllocationTestCase {
                 if (action == TransportSearchableSnapshotCacheStoresAction.TYPE) {
                     listener.onResponse(
                         (Response) new TransportSearchableSnapshotCacheStoresAction.NodesCacheFilesMetadata(
-                            clusterName,
+                            state.getClusterName(),
                             existingCacheSizes.entrySet()
                                 .stream()
                                 .map(
@@ -142,6 +107,8 @@ public class SearchableSnapshotAllocatorTests extends ESAllocationTestCase {
             reroutesTriggered.incrementAndGet();
             listener.onResponse(null);
         });
+
+        final RoutingAllocation allocation = buildAllocation(deterministicTaskQueue, state, shardSize, yesAllocationDeciders());
         allocateAllUnassigned(allocation, allocator);
 
         assertEquals(1, reroutesTriggered.get());
@@ -153,9 +120,100 @@ public class SearchableSnapshotAllocatorTests extends ESAllocationTestCase {
 
             final ShardRouting primaryRouting = allocation.routingNodes().assignedShards(shardId).get(0);
             final String primaryNodeId = primaryRouting.currentNodeId();
-            final DiscoveryNode primaryNode = discoveryNodes.get(primaryNodeId);
+            final DiscoveryNode primaryNode = state.nodes().get(primaryNodeId);
             assertEquals(bestCacheSize, (long) existingCacheSizes.get(primaryNode));
         }
+    }
+
+    public void testNoFetchesOnDeciderNo() {
+        final ShardId shardId = new ShardId("test", "_na_", 0);
+        final List<DiscoveryNode> nodes = randomList(1, 10, () -> newNode("node-" + UUIDs.randomBase64UUID(random())));
+        final DiscoveryNode localNode = randomFrom(nodes);
+        final Settings localNodeSettings = Settings.builder().put(NODE_NAME_SETTING.getKey(), localNode.getName()).build();
+
+        final DeterministicTaskQueue deterministicTaskQueue = new DeterministicTaskQueue(localNodeSettings, random());
+
+        final Metadata metadata = buildSingleShardIndexMetadata(shardId);
+        final RoutingTable.Builder routingTableBuilder = RoutingTable.builder();
+        routingTableBuilder.addAsRestore(metadata.index(shardId.getIndex()), randomSnapshotSource(shardId));
+
+        final ClusterState state = buildClusterState(nodes, metadata, routingTableBuilder);
+        final RoutingAllocation allocation = buildAllocation(
+            deterministicTaskQueue,
+            state,
+            randomNonNegativeLong(),
+            noAllocationDeciders()
+        );
+
+        final Client client = new NoOpNodeClient(deterministicTaskQueue.getThreadPool()) {
+            @Override
+            public <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
+                ActionType<Response> action,
+                Request request,
+                ActionListener<Response> listener
+            ) {
+                throw new AssertionError("Expecting no requests but received [" + action + "]");
+            }
+        };
+
+        final SearchableSnapshotAllocator allocator = new SearchableSnapshotAllocator(
+            client,
+            (reason, priority, listener) -> { throw new AssertionError("Expecting no reroutes"); }
+        );
+        allocateAllUnassigned(allocation, allocator);
+        assertTrue(allocation.routingNodesChanged());
+        assertThat(allocation.routingNodes().assignedShards(shardId), empty());
+        assertTrue(allocation.routingTable().index(shardId.getIndex()).allPrimaryShardsUnassigned());
+    }
+
+    private static Metadata buildSingleShardIndexMetadata(ShardId shardId) {
+        return Metadata.builder()
+            .put(
+                IndexMetadata.builder(shardId.getIndexName())
+                    .settings(
+                        settings(Version.CURRENT).put(
+                            ExistingShardsAllocator.EXISTING_SHARDS_ALLOCATOR_SETTING.getKey(),
+                            SearchableSnapshotAllocator.ALLOCATOR_NAME
+                        ).put(IndexModule.INDEX_STORE_TYPE_SETTING.getKey(), SearchableSnapshotsConstants.SNAPSHOT_DIRECTORY_FACTORY_KEY)
+                    )
+                    .numberOfShards(1)
+                    .numberOfReplicas(0)
+                    .putInSyncAllocationIds(shardId.id(), Collections.emptySet())
+            )
+            .build();
+    }
+
+    private ClusterState buildClusterState(List<DiscoveryNode> nodes, Metadata metadata, RoutingTable.Builder routingTableBuilder) {
+        final DiscoveryNodes.Builder nodesBuilder = DiscoveryNodes.builder();
+        for (DiscoveryNode node : nodes) {
+            nodesBuilder.add(node);
+        }
+        return ClusterState.builder(ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))
+            .metadata(metadata)
+            .routingTable(routingTableBuilder.build())
+            .nodes(nodesBuilder)
+            .build();
+    }
+
+    private static RoutingAllocation buildAllocation(
+        DeterministicTaskQueue deterministicTaskQueue,
+        ClusterState state,
+        long shardSize,
+        AllocationDeciders allocationDeciders
+    ) {
+        return new RoutingAllocation(
+            allocationDeciders,
+            new RoutingNodes(state, false),
+            state,
+            null,
+            new SnapshotShardSizeInfo(ImmutableOpenMap.of()) {
+                @Override
+                public Long getShardSize(ShardRouting shardRouting) {
+                    return shardSize;
+                }
+            },
+            TimeUnit.MILLISECONDS.toNanos(deterministicTaskQueue.getCurrentTimeMillis())
+        );
     }
 
     private static void allocateAllUnassigned(RoutingAllocation allocation, ExistingShardsAllocator allocator) {


### PR DESCRIPTION
We shouldn't fetch cache status if no allocation is possible to begin with.
Also, this surfaced an issue with using the `Client` to `reroute` since that
won't retry stale shards (failed the invalid license IT for example) so I moved
to using the `RerouteService` like we do in the `GatewayAllocator`.
(Plus, dried up one method that was 100% the same as in the replica allocator)
