### PR TITLE
Fix AutoFollowIT#testRolloverAliasInFollowClusterForbidden() test.

### DIFF
--- a/x-pack/plugin/ccr/qa/multi-cluster/src/test/java/org/elasticsearch/xpack/ccr/AutoFollowIT.java
+++ b/x-pack/plugin/ccr/qa/multi-cluster/src/test/java/org/elasticsearch/xpack/ccr/AutoFollowIT.java
@@ -422,7 +422,6 @@ public class AutoFollowIT extends ESCCRRestTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/66251")
     public void testRolloverAliasInFollowClusterForbidden() throws Exception {
         if ("follow".equals(targetCluster) == false) {
             return;
@@ -499,13 +498,17 @@ public class AutoFollowIT extends ESCCRRestTestCase {
                                     String aliasName,
                                     boolean checkWriteIndex,
                                     String... otherIndices) throws IOException {
-        var getAliasRequest = new Request("GET", "/_alias/" + aliasName);
-        var responseBody = toMap(client.performRequest(getAliasRequest));
-        if (checkWriteIndex) {
-            assertThat(ObjectPath.eval(otherIndices[0] + ".aliases." + aliasName + ".is_write_index", responseBody), is(true));
-        }
-        for (String otherIndex : otherIndices) {
-            assertThat(ObjectPath.eval(otherIndex + ".aliases." + aliasName, responseBody), notNullValue());
+        try {
+            var getAliasRequest = new Request("GET", "/_alias/" + aliasName);
+            var responseBody = toMap(client.performRequest(getAliasRequest));
+            if (checkWriteIndex) {
+                assertThat(ObjectPath.eval(otherIndices[0] + ".aliases." + aliasName + ".is_write_index", responseBody), is(true));
+            }
+            for (String otherIndex : otherIndices) {
+                assertThat(ObjectPath.eval(otherIndex + ".aliases." + aliasName, responseBody), notNullValue());
+            }
+        } catch (ResponseException e) {
+            throw new AssertionError("get alias call failed", e);
         }
     }
 


### PR DESCRIPTION
If the alias is missing then wrap the error in an assertion error,
so that it can be retried by assertBusy(...) code block.

Closes #66251