### PR TITLE
[DOCS] Fix formatting

### DIFF
--- a/docs/reference/cluster/nodes-info.asciidoc
+++ b/docs/reference/cluster/nodes-info.asciidoc
@@ -28,56 +28,57 @@ the cluster nodes information. All the nodes selective options are explained
 
 By default, it returns all attributes and core settings for a node.
 
-
+[role="child_attributes"]
 [[cluster-nodes-info-api-path-params]]
 ==== {api-path-parms-title}
 
 `<metric>`::
-		(Optional, string) Limits the information returned to the specific metrics.
-		A comma-separated list of the following options:
+(Optional, string)
+Limits the information returned to the specific metrics. Supports a
+comma-separated list, such as `http,ingest`.
 +
---
-
-
+[%collapsible%open]
+.Valid values for `<metric>`
+====
 `http`::
-		HTTP connection information.
+HTTP connection information.
 
 `ingest`::
-		Statistics about ingest preprocessing.
+Statistics about ingest preprocessing.
 
 `jvm`::
-		JVM stats, memory pool information, garbage collection, buffer pools, number
-		of loaded/unloaded classes.
+JVM stats, memory pool information, garbage collection, buffer pools, number of
+loaded/unloaded classes.
 
 `os`::
-		Operating system stats, load average, mem, swap.
+Operating system stats, load average, mem, swap.
 
 `plugins`::
-		Details about the installed plugins and modules per node. The following
-		information are available for each plugin and module:
+Details about the installed plugins and modules per node. The following
+information are available for each plugin and module:
 +
 ---
-		* `name`: plugin name
-		* `version`: version of Elasticsearch the plugin was built for
-		* `description`: short description of the plugin's purpose
-		* `classname`: fully-qualified class name of the plugin's entry point
-		* `has_native_controller`: whether or not the plugin has a native controller
-		process
+* `name`: plugin name
+* `version`: version of Elasticsearch the plugin was built for
+* `description`: short description of the plugin's purpose
+* `classname`: fully-qualified class name of the plugin's entry point
+* `has_native_controller`: whether or not the plugin has a native controller
+process
 ---
 
 `process`::
-		Process statistics, memory consumption, cpu usage, open file descriptors.
+Process statistics, memory consumption, cpu usage, open file descriptors.
 
 `settings`::
-    Lists all node settings in use as defined in the `elasticsearch.yml` file.
+Lists all node settings in use as defined in the `elasticsearch.yml` file.
 
 `thread_pool`::
-		Statistics about each thread pool, including current size, queue and
-		rejected tasks
+Statistics about each thread pool, including current size, queue and rejected
+tasks
 
 `transport`::
-		Transport statistics about sent and received bytes in cluster communication.
---
+Transport statistics about sent and received bytes in cluster communication.
+====
 
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=node-id]

--- a/docs/reference/cluster/nodes-info.asciidoc
+++ b/docs/reference/cluster/nodes-info.asciidoc
@@ -57,7 +57,7 @@ Operating system stats, load average, mem, swap.
 +
 --
 Details about the installed plugins and modules per node. The following
-information are available for each plugin and module:
+information is available for each plugin and module:
 
 * `name`: plugin name
 * `version`: version of Elasticsearch the plugin was built for

--- a/docs/reference/cluster/nodes-info.asciidoc
+++ b/docs/reference/cluster/nodes-info.asciidoc
@@ -54,17 +54,18 @@ loaded/unloaded classes.
 Operating system stats, load average, mem, swap.
 
 `plugins`::
++
+--
 Details about the installed plugins and modules per node. The following
 information are available for each plugin and module:
-+
----
+
 * `name`: plugin name
 * `version`: version of Elasticsearch the plugin was built for
 * `description`: short description of the plugin's purpose
 * `classname`: fully-qualified class name of the plugin's entry point
 * `has_native_controller`: whether or not the plugin has a native controller
 process
----
+--
 
 `process`::
 Process statistics, memory consumption, cpu usage, open file descriptors.


### PR DESCRIPTION
Fixes some broken formatting in the nodes info API docs:

<img width="808" alt="Screen Shot 2020-12-16 at 10 33 47 AM" src="https://user-images.githubusercontent.com/40268737/102369709-41fbf480-3f8a-11eb-84cc-0e7f70a020a2.PNG">
