### PR TITLE
[ML] change to only calculate model size on initial load to prevent slow cache promotions

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModel.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModel.java
@@ -56,7 +56,7 @@ public class LocalModel implements Closeable {
     private final License.OperationMode licenseLevel;
     private final CircuitBreaker trainedModelCircuitBreaker;
     private final AtomicLong referenceCount;
-    private final long modelSize;
+    private final long cachedRamBytesUsed;
 
     LocalModel(String modelId,
                String nodeId,
@@ -68,7 +68,7 @@ public class LocalModel implements Closeable {
                TrainedModelStatsService trainedModelStatsService,
                CircuitBreaker trainedModelCircuitBreaker) {
         this.trainedModelDefinition = trainedModelDefinition;
-        this.modelSize = trainedModelDefinition.ramBytesUsed();
+        this.cachedRamBytesUsed = trainedModelDefinition.ramBytesUsed();
         this.modelId = modelId;
         this.fieldNames = new HashSet<>(input.getFieldNames());
         // the ctor being called means a new instance was created.
@@ -84,7 +84,10 @@ public class LocalModel implements Closeable {
     }
 
     long ramBytesUsed() {
-        return modelSize;
+        // This should always be cached and not calculated on call. 
+        // This is because the caching system calls this method on every promotion call that changes the LRU head
+        // Consequently, recalculating can cause serious throughput issues due to LRU changes in the cache
+        return cachedRamBytesUsed;
     }
 
     public String getModelId() {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModel.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModel.java
@@ -56,6 +56,7 @@ public class LocalModel implements Closeable {
     private final License.OperationMode licenseLevel;
     private final CircuitBreaker trainedModelCircuitBreaker;
     private final AtomicLong referenceCount;
+    private final long modelSize;
 
     LocalModel(String modelId,
                String nodeId,
@@ -67,6 +68,7 @@ public class LocalModel implements Closeable {
                TrainedModelStatsService trainedModelStatsService,
                CircuitBreaker trainedModelCircuitBreaker) {
         this.trainedModelDefinition = trainedModelDefinition;
+        this.modelSize = trainedModelDefinition.ramBytesUsed();
         this.modelId = modelId;
         this.fieldNames = new HashSet<>(input.getFieldNames());
         // the ctor being called means a new instance was created.
@@ -82,7 +84,7 @@ public class LocalModel implements Closeable {
     }
 
     long ramBytesUsed() {
-        return trainedModelDefinition.ramBytesUsed();
+        return modelSize;
     }
 
     public String getModelId() {


### PR DESCRIPTION
When a value is promoted in the LRU cache, its weight is removed and added. 

The LocalModel object was recalculating the model size for ever weight check, which caused a polynomial runtime.

This commit changes the model size to only be calculated in the LocalModel ctor. 