### PR TITLE
[ML] Fix model snapshot upgrade test

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/upgrade_job_snapshot.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/upgrade_job_snapshot.yml
@@ -30,7 +30,7 @@ setup:
             "timestamp": "2016-06-02T00:00:00Z",
             "snapshot_id": "snapshot-1",
             "snapshot_doc_count": 3,
-            "min_version": "7.11.0",
+            "min_version": "7.12.0",
             "retain": false
           }
 


### PR DESCRIPTION
The test that asserts that a model snapshot doesn't get upgraded
requires that the model snapshot be on the current version.

This PR contains a quick fix.

A better long term fix is needed otherwise this test will need
changing on every version bump.