### PR TITLE
[7.11] Add extra steps to ensure that watch indices are created before test starts (#66416) (#66422)

### DIFF
--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/test/MonitoringIntegTestCase.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/test/MonitoringIntegTestCase.java
@@ -200,7 +200,7 @@ public abstract class MonitoringIntegTestCase extends ESIntegTestCase {
         assertBusy(this::ensureMonitoringIndicesYellow);
     }
 
-    private void awaitIndexExists(final String index) throws Exception {
+    protected void awaitIndexExists(final String index) throws Exception {
         assertBusy(() -> assertIndicesExists(index), 30, TimeUnit.SECONDS);
     }
 


### PR DESCRIPTION
Backports the following commits to 7.11:
 - Add extra steps to ensure that watch indices are created before test starts (#66416) (#66422)