### PR TITLE
Reduce memory usage on Azure repository implementation

### DIFF
--- a/plugins/repository-azure/src/internalClusterTest/java/org/elasticsearch/repositories/azure/AzureBlobStoreRepositoryTests.java
+++ b/plugins/repository-azure/src/internalClusterTest/java/org/elasticsearch/repositories/azure/AzureBlobStoreRepositoryTests.java
@@ -24,7 +24,6 @@ import com.sun.net.httpserver.Headers;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import fixture.azure.AzureHttpHandler;
-import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.common.SuppressForbidden;
 import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.common.blobstore.BlobPath;
@@ -50,7 +49,6 @@ import java.util.regex.Pattern;
 
 import static org.hamcrest.Matchers.equalTo;
 
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/66385")
 @SuppressForbidden(reason = "this test uses a HttpServer to emulate an Azure endpoint")
 public class AzureBlobStoreRepositoryTests extends ESMockAPIBasedRepositoryIntegTestCase {
 

--- a/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureClientProvider.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureClientProvider.java
@@ -68,7 +68,7 @@ class AzureClientProvider extends AbstractLifecycleComponent {
     private static final TimeValue DEFAULT_CONNECTION_TIMEOUT = TimeValue.timeValueSeconds(30);
     private static final TimeValue DEFAULT_MAX_CONNECTION_IDLE_TIME = TimeValue.timeValueSeconds(60);
     private static final int DEFAULT_MAX_CONNECTIONS = 50;
-    private static final int DEFAULT_EVENT_LOOP_THREAD_COUNT = Math.min(Runtime.getRuntime().availableProcessors(), 8) * 2;
+    private static final int DEFAULT_EVENT_LOOP_THREAD_COUNT = 1;
     private static final int PENDING_CONNECTION_QUEUE_SIZE = -1; // see ConnectionProvider.ConnectionPoolSpec.pendingAcquireMaxCount
 
     static final Setting<Integer> EVENT_LOOP_THREAD_COUNT = Setting.intSetting(
@@ -150,7 +150,6 @@ class AzureClientProvider extends AbstractLifecycleComponent {
         int tinyCacheSize = PooledByteBufAllocator.defaultTinyCacheSize();
         int smallCacheSize = PooledByteBufAllocator.defaultSmallCacheSize();
         int normalCacheSize = PooledByteBufAllocator.defaultNormalCacheSize();
-        boolean useCacheForAllThreads = PooledByteBufAllocator.defaultUseCacheForAllThreads();
 
         return new PooledByteBufAllocator(false,
             nHeapArena,
@@ -160,7 +159,7 @@ class AzureClientProvider extends AbstractLifecycleComponent {
             tinyCacheSize,
             smallCacheSize,
             normalCacheSize,
-            useCacheForAllThreads);
+            false);
     }
 
     AzureBlobServiceClient createClient(AzureStorageSettings settings,

--- a/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureClientProvider.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureClientProvider.java
@@ -144,7 +144,7 @@ class AzureClientProvider extends AbstractLifecycleComponent {
     }
 
     private static ByteBufAllocator createByteBufAllocator() {
-        int nHeapArena = PooledByteBufAllocator.defaultNumHeapArena();
+        int nHeapArena = 1;
         int pageSize = PooledByteBufAllocator.defaultPageSize();
         int maxOrder = PooledByteBufAllocator.defaultMaxOrder();
         int tinyCacheSize = PooledByteBufAllocator.defaultTinyCacheSize();

--- a/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureStorageService.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureStorageService.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.settings.SettingsException;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.monitor.jvm.JvmInfo;
 
 import java.net.InetSocketAddress;
 import java.net.Proxy;
@@ -36,8 +37,6 @@ import java.net.URL;
 import java.util.Map;
 import java.util.function.BiConsumer;
 
-import static com.azure.storage.blob.BlobAsyncClient.BLOB_DEFAULT_NUMBER_OF_BUFFERS;
-import static com.azure.storage.blob.BlobClient.BLOB_DEFAULT_UPLOAD_BLOCK_SIZE;
 import static java.util.Collections.emptyMap;
 
 public class AzureStorageService {
@@ -56,10 +55,22 @@ public class AzureStorageService {
     public static final long MAX_BLOCK_NUMBER = 50000;
 
     /**
+     * Default block size for multi-block uploads. The Azure repository will use the Put block and Put block list APIs to split the
+     * stream into several part, each of block_size length, and will upload each part in its own request.
+     */
+    private static final ByteSizeValue DEFAULT_BLOCK_SIZE = new ByteSizeValue(
+        Math.max(
+            ByteSizeUnit.MB.toBytes(5), // minimum value
+            Math.min(
+                MAX_BLOCK_SIZE.getBytes(),
+                JvmInfo.jvmInfo().getMem().getHeapMax().getBytes() / 20)),
+        ByteSizeUnit.BYTES);
+
+    /**
      * The maximum size of a Block Blob.
      * See https://docs.microsoft.com/en-us/rest/api/storageservices/understanding-block-blobs--append-blobs--and-page-blobs
      */
-    public static final long MAX_BLOB_SIZE = MAX_BLOCK_NUMBER * MAX_BLOCK_SIZE.getBytes();
+    public static final long MAX_BLOB_SIZE = MAX_BLOCK_NUMBER * DEFAULT_BLOCK_SIZE.getBytes();
 
     /**
      * Maximum allowed blob size in Azure blob store.
@@ -68,8 +79,7 @@ public class AzureStorageService {
 
     // see ModelHelper.BLOB_DEFAULT_MAX_SINGLE_UPLOAD_SIZE
     private static final long DEFAULT_MAX_SINGLE_UPLOAD_SIZE = new ByteSizeValue(256, ByteSizeUnit.MB).getBytes();
-    private static final long DEFAULT_UPLOAD_BLOCK_SIZE = BLOB_DEFAULT_UPLOAD_BLOCK_SIZE;
-    private static final int DEFAULT_MAX_PARALLELISM = BLOB_DEFAULT_NUMBER_OF_BUFFERS;
+    private static final long DEFAULT_UPLOAD_BLOCK_SIZE = DEFAULT_BLOCK_SIZE.getBytes();
 
     // 'package' for testing
     volatile Map<String, AzureStorageSettings> storageSettings = emptyMap();
@@ -127,11 +137,6 @@ public class AzureStorageService {
     // non-static, package private for testing
     long getSizeThresholdForMultiBlockUpload() {
         return DEFAULT_MAX_SINGLE_UPLOAD_SIZE;
-    }
-
-    // non-static, package private for testing
-    int getMaxUploadParallelism() {
-        return DEFAULT_MAX_PARALLELISM;
     }
 
     int getMaxReadRetries(String clientName) {

--- a/plugins/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureBlobContainerRetriesTests.java
+++ b/plugins/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureBlobContainerRetriesTests.java
@@ -174,11 +174,6 @@ public class AzureBlobContainerRetriesTests extends ESTestCase {
             }
 
             @Override
-            int getMaxUploadParallelism() {
-                return 1;
-            }
-
-            @Override
             int getMaxReadRetries(String clientName) {
                 return maxRetries;
             }
@@ -415,6 +410,9 @@ public class AzureBlobContainerRetriesTests extends ESTestCase {
                 if (requestReceived.compareAndSet(false, true)) {
                     throw new AssertionError("Should not receive two requests");
                 } else {
+                    // We have to try to read the body since the netty async http client sends the request
+                    // lazily
+                    Streams.readFully(exchange.getRequestBody());
                     exchange.sendResponseHeaders(RestStatus.CREATED.getStatus(), -1);
                 }
             } finally {


### PR DESCRIPTION
This commit moves the upload logic to the repository itself
instead of delegating into the SDK.
Multi-block uploads are done sequentially instead of in parallel
that allows to bound the outstanding memory.
Additionally the number of i/o threads have been reduced to 1,
to reduce the memory overhead.

Closes #66385