### PR TITLE
Fail force-merges on read-only engines (#64756)

### DIFF
--- a/docs/reference/migration/index.asciidoc
+++ b/docs/reference/migration/index.asciidoc
@@ -9,6 +9,8 @@ release, see the <<release-highlights>> and <<es-release-notes>>.
 
 For information about how to upgrade your cluster, see <<setup-upgrade>>.
 
+* <<breaking-changes-7.12,Breaking changes in 7.12>>
+* <<breaking-changes-7.11,Breaking changes in 7.11>>
 * <<breaking-changes-7.10,Breaking changes in 7.10>>
 * <<breaking-changes-7.9,Breaking changes in 7.9>>
 * <<breaking-changes-7.8,Breaking changes in 7.8>>
@@ -23,6 +25,8 @@ For information about how to upgrade your cluster, see <<setup-upgrade>>.
 
 --
 
+include::migrate_7_12.asciidoc[]
+include::migrate_7_11.asciidoc[]
 include::migrate_7_10.asciidoc[]
 include::migrate_7_9.asciidoc[]
 include::migrate_7_8.asciidoc[]

--- a/docs/reference/migration/migrate_7_12.asciidoc
+++ b/docs/reference/migration/migrate_7_12.asciidoc
@@ -1,0 +1,33 @@
+[[breaking-changes-7.12]]
+== Breaking changes in 7.12
+++++
+<titleabbrev>7.12</titleabbrev>
+++++
+
+This section discusses the changes that you need to be aware of when migrating
+your application to {es} 7.12.
+
+See also <<release-highlights>> and <<es-release-notes>>.
+
+// * <<breaking_711_blah_changes>>
+// * <<breaking_711_blah_changes>>
+
+//NOTE: The notable-breaking-changes tagged regions are re-used in the
+//Installation and Upgrade Guide
+
+//tag::notable-breaking-changes[]
+
+[discrete]
+[[breaking_712_engine_changes]]
+=== Engine changes
+
+[[breaking_712_engine_forcemerge_change]]
+.Force-merges on frozen and searchable snapshot indices will fail if merging is required
+[%collapsible]
+====
+*Details* +
+In earlier versions a force-merge on a frozen index or a searchable snapshot
+index would yield a successful response without performing the requested merge.
+From version 7.12 onwards a force-merge on these kinds of index will fail
+unless the requested merge is a no-op.
+====

--- a/docs/reference/migration/migrate_7_12.asciidoc
+++ b/docs/reference/migration/migrate_7_12.asciidoc
@@ -27,7 +27,8 @@ See also <<release-highlights>> and <<es-release-notes>>.
 ====
 *Details* +
 In earlier versions a force-merge on a frozen index or a searchable snapshot
-index would yield a successful response without performing the requested merge.
-From version 7.12 onwards a force-merge on these kinds of index will fail
-unless the requested merge is a no-op.
+index would incorrectly yield a successful response without performing the
+requested merge. This bug is fixed in version 7.12: from this version onwards a
+force-merge on these immutable indices will fail if the requested merge is not
+a no-op.
 ====

--- a/docs/reference/migration/migrate_7_12.asciidoc
+++ b/docs/reference/migration/migrate_7_12.asciidoc
@@ -9,8 +9,8 @@ your application to {es} 7.12.
 
 See also <<release-highlights>> and <<es-release-notes>>.
 
-// * <<breaking_711_blah_changes>>
-// * <<breaking_711_blah_changes>>
+// * <<breaking_712_blah_changes>>
+// * <<breaking_712_blah_changes>>
 
 //NOTE: The notable-breaking-changes tagged regions are re-used in the
 //Installation and Upgrade Guide

--- a/server/src/main/java/org/elasticsearch/index/engine/ReadOnlyEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/ReadOnlyEngine.java
@@ -29,6 +29,7 @@ import org.apache.lucene.search.ReferenceManager;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.Lock;
 import org.elasticsearch.Version;
+import org.elasticsearch.action.admin.indices.forcemerge.ForceMergeRequest;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.lucene.index.ElasticsearchDirectoryReader;
 import org.elasticsearch.common.util.concurrent.ReleasableLock;
@@ -404,6 +405,16 @@ public class ReadOnlyEngine extends Engine {
     @Override
     public void forceMerge(boolean flush, int maxNumSegments, boolean onlyExpungeDeletes,
                            boolean upgrade, boolean upgradeOnlyAncientSegments, String forceMergeUUID) {
+        if (maxNumSegments == ForceMergeRequest.Defaults.MAX_NUM_SEGMENTS) {
+            // noop
+        } else if (maxNumSegments < lastCommittedSegmentInfos.size()) {
+            throw new UnsupportedOperationException("force merge is not supported on a read-only engine, " +
+                "target max number of segments[" + maxNumSegments + "], " +
+                "current number of segments[" + lastCommittedSegmentInfos.size() + "].");
+        } else {
+            logger.debug("current number of segments[{}] is not greater than target max number of segments[{}].",
+                lastCommittedSegmentInfos.size(), maxNumSegments);
+        }
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/engine/ReadOnlyEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/ReadOnlyEngineTests.java
@@ -21,6 +21,8 @@ package org.elasticsearch.index.engine;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.util.LuceneTestCase;
+import org.elasticsearch.action.admin.indices.forcemerge.ForceMergeRequest;
+import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.lucene.index.ElasticsearchDirectoryReader;
 import org.elasticsearch.core.internal.io.IOUtils;
@@ -212,6 +214,43 @@ public class ReadOnlyEngineTests extends EngineTestCase {
                 } catch (final IllegalStateException e) {
                     fail("Read-only engine pre-closing verifications failed");
                 }
+            }
+        }
+    }
+
+    public void testForceMergeOnReadOnlyEngine() throws IOException {
+        IOUtils.close(engine, store);
+        final AtomicLong globalCheckpoint = new AtomicLong(SequenceNumbers.NO_OPS_PERFORMED);
+        try (Store store = createStore()) {
+            EngineConfig config = config(defaultSettings, store, createTempDir(), newMergePolicy(), null, null, globalCheckpoint::get);
+            int numDocs = scaledRandomIntBetween(10, 100);
+            int numSegments;
+            try (InternalEngine engine = createEngine(config)) {
+                for (int i = 0; i < numDocs; i++) {
+                    ParsedDocument doc = testParsedDocument(Integer.toString(i), null, testDocument(), new BytesArray("{}"), null);
+                    engine.index(new Engine.Index(newUid(doc), doc, i, primaryTerm.get(), 1, null, Engine.Operation.Origin.REPLICA,
+                        System.nanoTime(), -1, false, SequenceNumbers.UNASSIGNED_SEQ_NO, 0));
+                    engine.flush();
+                    globalCheckpoint.set(i);
+                }
+                engine.syncTranslog();
+                engine.flushAndClose();
+                numSegments = engine.getLastCommittedSegmentInfos().size();
+                assertTrue( numSegments > 1);
+            }
+
+            try (ReadOnlyEngine readOnlyEngine = new ReadOnlyEngine(config, null , null, true, Function.identity(), true)) {
+                UnsupportedOperationException exception = expectThrows(UnsupportedOperationException.class,
+                    () -> readOnlyEngine.forceMerge(
+                        true, numSegments-1, false, false, false, UUIDs.randomBase64UUID()));
+                assertThat(exception.getMessage(), equalTo("force merge is not supported on a read-only engine, " +
+                    "target max number of segments[" + (numSegments-1) + "], current number of segments[" + numSegments + "]."));
+
+                readOnlyEngine.forceMerge(true, ForceMergeRequest.Defaults.MAX_NUM_SEGMENTS,
+                    false, false, false, UUIDs.randomBase64UUID());
+                readOnlyEngine.forceMerge(true, numSegments, false, false, false, UUIDs.randomBase64UUID());
+                readOnlyEngine.forceMerge(true, numSegments+1, false, false, false, UUIDs.randomBase64UUID());
+                assertEquals(readOnlyEngine.getLastCommittedSegmentInfos().size(), numSegments);
             }
         }
     }


### PR DESCRIPTION
Today we treat all force-merges on a read-only (e.g. frozen) engine as
no-ops, indicating to the client that they succeeded even if they had no
effect. This commit corrects that behaviour, resolving the resulting
confusion, by rejecting force-merges on read-only engines that are
definitely not no-ops.