### PR TITLE
EQL: Fix early trimming of in-flight data

### DIFF
--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/KeyToSequences.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/KeyToSequences.java
@@ -95,27 +95,30 @@ class KeyToSequences {
     }
 
     /**
-     * Remove all matches expect the latest.
+     * Remove all matches except the latest occurring _before_ the given ordinal.
      */
-    void trimToTail() {
+    void trimToTail(Ordinal ordinal) {
         for (Iterator<SequenceEntry> it = keyToSequences.values().iterator(); it.hasNext(); ) {
             SequenceEntry seqs =  it.next();
-            // first remove the sequences
-            // and remember the last item from the first
-            // initialized stage to be used with until
+            // remember the last item found (will be ascending)
+            // to trim unneeded until that occur before it
             Sequence firstTail = null;
+            // remove any empty keys
+            boolean keyIsEmpty = true;
             for (SequenceGroup group : seqs.groups) {
                 if (group != null) {
-                    Sequence sequence = group.trimToLast();
+                    Sequence sequence = group.trimBeforeLast(ordinal);
                     if (firstTail == null) {
                         firstTail = sequence;
                     }
+                    keyIsEmpty &= group.isEmpty();
                 }
             }
             // there are no sequences on any stage for this key, drop it
-            if (firstTail == null) {
+            if (keyIsEmpty) {
                 it.remove();
-            } else {
+            }
+            if (firstTail != null) {
                 // drop any possible UNTIL that occurs before the last tail
                 UntilGroup until = seqs.until;
                 if (until != null) {

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/OrdinalGroup.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/OrdinalGroup.java
@@ -52,11 +52,27 @@ abstract class OrdinalGroup<E> implements Iterable<Ordinal> {
      * The element and everything before it is removed.
      */
     E trimBefore(Ordinal ordinal) {
+        return trimBefore(ordinal, true);
+    }
+
+    /**
+     * Returns the latest element from the group that has its timestamp
+     * less than the given argument alongside its position in the list.
+     * Everything before the element it is removed. The element is kept.
+     */
+    E trimBeforeLast(Ordinal ordinal) {
+        return trimBefore(ordinal, false);
+    }
+
+    private E trimBefore(Ordinal ordinal, boolean removeMatch) {
         Tuple<E, Integer> match = findBefore(ordinal);
 
         // trim
         if (match != null) {
-            int pos = match.v2() + 1;
+            int pos = match.v2();
+            if (removeMatch) {
+                pos = pos + 1;
+            }
             elements.subList(0, pos).clear();
 
             // update min time
@@ -74,17 +90,6 @@ abstract class OrdinalGroup<E> implements Iterable<Ordinal> {
     E before(Ordinal ordinal) {
         Tuple<E, Integer> match = findBefore(ordinal);
         return match != null ? match.v1() : null;
-    }
-
-    E trimToLast() {
-        E last = elements.peekLast();
-        if (last != null) {
-            elements.clear();
-            start = null;
-            stop = null;
-            add(last);
-        }
-        return last;
     }
 
     private Tuple<E, Integer> findBefore(Ordinal ordinal) {

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/SequenceMatcher.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/SequenceMatcher.java
@@ -253,19 +253,15 @@ public class SequenceMatcher {
      * This allows the matcher to keep only the last match per stage
      * and adjust insertion positions.
      */
-    void trim(boolean everything) {
+    void trim(Ordinal ordinal) {
         // for descending sequences, remove all in-flight sequences
         // since the windows moves head and thus there is no chance
         // of new results coming in
-
-        // however this needs to be indicated from outside since
-        // the same window can be only ASC trimmed during a loop
-        // and fully once the DESC query moves
-        if (everything) {
+        if (ordinal == null) {
             keyToSequences.clear();
         } else {
             // keep only the tail
-            keyToSequences.trimToTail();
+            keyToSequences.trimToTail(ordinal);
         }
     }
 


### PR DESCRIPTION
Rework trimToLast to take into account an ordinal for last trimming so
instead of keeping the last entry in a stage, it keeps the last entry
before the given ordinal.
This takes care of the case where a dense stage that requires several
passes does not discard valid data from a previous sparse stage that go
beyond the current stage point.