### PR TITLE
Unmute TransformContinuousIT

### DIFF
--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TransformContinuousIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TransformContinuousIT.java
@@ -16,6 +16,7 @@ import org.elasticsearch.action.ingest.DeletePipelineRequest;
 import org.elasticsearch.action.ingest.PutPipelineRequest;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.client.core.AcknowledgedResponse;
 import org.elasticsearch.client.transform.DeleteTransformRequest;
@@ -39,6 +40,7 @@ import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.junit.After;
@@ -57,10 +59,12 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.hamcrest.Matchers.containsInRelativeOrder;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.core.Is.is;
 
@@ -151,7 +155,6 @@ public class TransformContinuousIT extends ESRestTestCase {
         deletePipeline(ContinuousTestCase.INGEST_PIPELINE);
     }
 
-    @AwaitsFix(bugUrl="https://github.com/elastic/elasticsearch/issues/66410")
     public void testContinousEvents() throws Exception {
         String sourceIndexName = ContinuousTestCase.CONTINUOUS_EVENTS_SOURCE_INDEX;
         DecimalFormat numberFormat = new DecimalFormat("000", new DecimalFormatSymbols(Locale.ROOT));
@@ -479,6 +482,11 @@ public class TransformContinuousIT extends ESRestTestCase {
             putPipeline(new PutPipelineRequest(ContinuousTestCase.INGEST_PIPELINE, BytesReference.bytes(pipeline), XContentType.JSON))
                 .isAcknowledged()
         );
+        // Make sure the pipeline really got created and is seen in the cluster state.
+        Map<String, Object> clusterState = entityAsMap(client().performRequest(new Request("GET", "/_cluster/state/metadata")));
+        @SuppressWarnings("unchecked")
+        List<String> pipelineIds = (List<String>) XContentMapValues.extractValue(clusterState, "metadata", "ingest", "pipeline", "id");
+        assertThat(pipelineIds, containsInRelativeOrder(ContinuousTestCase.INGEST_PIPELINE));
     }
 
     private GetTransformStatsResponse getTransformStats(String id) throws IOException {
@@ -540,19 +548,24 @@ public class TransformContinuousIT extends ESRestTestCase {
 
     private AcknowledgedResponse putTransform(TransformConfig config) throws IOException {
         try (RestHighLevelClient restClient = new TestRestHighLevelClient()) {
-            return restClient.transform().putTransform(new PutTransformRequest(config), RequestOptions.DEFAULT);
+            PutTransformRequest request = new PutTransformRequest(config);
+            logger.warn("putTransform: {}", Strings.toString(request));
+            return restClient.transform().putTransform(request, RequestOptions.DEFAULT);
         }
     }
 
-    private org.elasticsearch.action.support.master.AcknowledgedResponse putPipeline(PutPipelineRequest pipeline) throws IOException {
+    private org.elasticsearch.action.support.master.AcknowledgedResponse putPipeline(PutPipelineRequest request) throws IOException {
         try (RestHighLevelClient restClient = new TestRestHighLevelClient()) {
-            return restClient.ingest().putPipeline(pipeline, RequestOptions.DEFAULT);
+            logger.warn("putPipeline: {}", Strings.toString(request));
+            return restClient.ingest().putPipeline(request, RequestOptions.DEFAULT);
         }
     }
 
     private org.elasticsearch.action.support.master.AcknowledgedResponse deletePipeline(String id) throws IOException {
         try (RestHighLevelClient restClient = new TestRestHighLevelClient()) {
-            return restClient.ingest().deletePipeline(new DeletePipelineRequest(id), RequestOptions.DEFAULT);
+            DeletePipelineRequest request = new DeletePipelineRequest(id);
+            logger.warn("deletePipeline: {}", request.getId());
+            return restClient.ingest().deletePipeline(request, RequestOptions.DEFAULT);
         }
     }
 
@@ -564,23 +577,27 @@ public class TransformContinuousIT extends ESRestTestCase {
 
     private StartTransformResponse startTransform(String id) throws IOException {
         try (RestHighLevelClient restClient = new TestRestHighLevelClient()) {
-            return restClient.transform().startTransform(new StartTransformRequest(id), RequestOptions.DEFAULT);
+            StartTransformRequest request = new StartTransformRequest(id);
+            logger.warn("startTransform: {}", request.getId());
+            return restClient.transform().startTransform(request, RequestOptions.DEFAULT);
         }
     }
 
     private StopTransformResponse stopTransform(String id, boolean waitForCompletion, TimeValue timeout, boolean waitForCheckpoint)
         throws IOException {
         try (RestHighLevelClient restClient = new TestRestHighLevelClient()) {
-            return restClient.transform()
-                .stopTransform(new StopTransformRequest(id, waitForCompletion, timeout, waitForCheckpoint), RequestOptions.DEFAULT);
+            StopTransformRequest request = new StopTransformRequest(id, waitForCompletion, timeout, waitForCheckpoint);
+            logger.warn("stopTransform: {}", request.getId());
+            return restClient.transform().stopTransform(request, RequestOptions.DEFAULT);
         }
     }
 
     private AcknowledgedResponse deleteTransform(String id, boolean force) throws IOException {
         try (RestHighLevelClient restClient = new TestRestHighLevelClient()) {
-            DeleteTransformRequest deleteRequest = new DeleteTransformRequest(id);
-            deleteRequest.setForce(force);
-            return restClient.transform().deleteTransform(deleteRequest, RequestOptions.DEFAULT);
+            DeleteTransformRequest request = new DeleteTransformRequest(id);
+            request.setForce(force);
+            logger.warn("deleteTransform: {}", request.getId());
+            return restClient.transform().deleteTransform(request, RequestOptions.DEFAULT);
         }
     }
 

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TransformContinuousIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TransformContinuousIT.java
@@ -549,14 +549,14 @@ public class TransformContinuousIT extends ESRestTestCase {
     private AcknowledgedResponse putTransform(TransformConfig config) throws IOException {
         try (RestHighLevelClient restClient = new TestRestHighLevelClient()) {
             PutTransformRequest request = new PutTransformRequest(config);
-            logger.warn("putTransform: {}", Strings.toString(request));
+            logger.info("putTransform: {}", Strings.toString(request));
             return restClient.transform().putTransform(request, RequestOptions.DEFAULT);
         }
     }
 
     private org.elasticsearch.action.support.master.AcknowledgedResponse putPipeline(PutPipelineRequest request) throws IOException {
         try (RestHighLevelClient restClient = new TestRestHighLevelClient()) {
-            logger.warn("putPipeline: {}", Strings.toString(request));
+            logger.info("putPipeline: {}", Strings.toString(request));
             return restClient.ingest().putPipeline(request, RequestOptions.DEFAULT);
         }
     }
@@ -564,7 +564,7 @@ public class TransformContinuousIT extends ESRestTestCase {
     private org.elasticsearch.action.support.master.AcknowledgedResponse deletePipeline(String id) throws IOException {
         try (RestHighLevelClient restClient = new TestRestHighLevelClient()) {
             DeletePipelineRequest request = new DeletePipelineRequest(id);
-            logger.warn("deletePipeline: {}", request.getId());
+            logger.info("deletePipeline: {}", request.getId());
             return restClient.ingest().deletePipeline(request, RequestOptions.DEFAULT);
         }
     }
@@ -578,7 +578,7 @@ public class TransformContinuousIT extends ESRestTestCase {
     private StartTransformResponse startTransform(String id) throws IOException {
         try (RestHighLevelClient restClient = new TestRestHighLevelClient()) {
             StartTransformRequest request = new StartTransformRequest(id);
-            logger.warn("startTransform: {}", request.getId());
+            logger.info("startTransform: {}", request.getId());
             return restClient.transform().startTransform(request, RequestOptions.DEFAULT);
         }
     }
@@ -587,7 +587,7 @@ public class TransformContinuousIT extends ESRestTestCase {
         throws IOException {
         try (RestHighLevelClient restClient = new TestRestHighLevelClient()) {
             StopTransformRequest request = new StopTransformRequest(id, waitForCompletion, timeout, waitForCheckpoint);
-            logger.warn("stopTransform: {}", request.getId());
+            logger.info("stopTransform: {}", request.getId());
             return restClient.transform().stopTransform(request, RequestOptions.DEFAULT);
         }
     }
@@ -596,7 +596,7 @@ public class TransformContinuousIT extends ESRestTestCase {
         try (RestHighLevelClient restClient = new TestRestHighLevelClient()) {
             DeleteTransformRequest request = new DeleteTransformRequest(id);
             request.setForce(force);
-            logger.warn("deleteTransform: {}", request.getId());
+            logger.info("deleteTransform: {}", request.getId());
             return restClient.transform().deleteTransform(request, RequestOptions.DEFAULT);
         }
     }


### PR DESCRIPTION
Unmute `TransformContinuousIT` test.
Additionally,
- Add more logging (incl. transform config) for `TransformContinuousIT`
- Verify whether the ingest pipeline was really created after `PutPipelineRequest` is issued

Relates https://github.com/elastic/elasticsearch/issues/66410