### PR TITLE
Fix IndexFoldersDeletionListenerIT.testListenersInvokedWhenIndexIsRelocated (#66329)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/plugins/IndexFoldersDeletionListenerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/plugins/IndexFoldersDeletionListenerIT.java
@@ -25,6 +25,7 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider;
+import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.env.Environment;
@@ -45,6 +46,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.singletonList;
@@ -56,7 +58,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 
-@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST)
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0, numClientNodes = 0)
 public class IndexFoldersDeletionListenerIT extends ESIntegTestCase {
 
     @Override
@@ -67,26 +69,37 @@ public class IndexFoldersDeletionListenerIT extends ESIntegTestCase {
     }
 
     public void testListenersInvokedWhenIndexIsDeleted() throws Exception {
+        final String masterNode = internalCluster().startMasterOnlyNode();
+        internalCluster().startDataOnlyNodes(2);
+        ensureStableCluster(2 + 1, masterNode);
+
         final String indexName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
-        createIndex(indexName);
+        createIndex(indexName, Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 2 * between(1, 2))
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, between(0, 1))
+            .build());
 
         final NumShards numShards = getNumShards(indexName);
-        ensureClusterSizeConsistency(); // wait for a stable cluster
-        ensureGreen(indexName); // wait for no relocation
+        assertFalse(client().admin().cluster().prepareHealth()
+            .setIndices(indexName)
+            .setWaitForGreenStatus()
+            .setWaitForEvents(Priority.LANGUID)
+            .setWaitForNoRelocatingShards(true)
+            .setWaitForNoInitializingShards(true)
+            .get()
+            .isTimedOut());
 
-        final ClusterState clusterState = clusterService().state();
+        final ClusterState clusterState = internalCluster().clusterService(masterNode).state();
         final Index index = clusterState.metadata().index(indexName).getIndex();
         final Map<String, List<ShardRouting>> shardsByNodes = shardRoutingsByNodes(clusterState, index);
         assertThat(shardsByNodes.values().stream().mapToInt(List::size).sum(), equalTo(numShards.totalNumShards));
 
         for (Map.Entry<String, List<ShardRouting>> shardsByNode : shardsByNodes.entrySet()) {
-            final String nodeName = shardsByNode.getKey();
-            final IndexFoldersDeletionListenerPlugin plugin = plugin(nodeName);
-            assertTrue("Expecting no indices deleted on node " + nodeName, plugin.deletedIndices.isEmpty());
-            assertTrue("Expecting no shards deleted on node " + nodeName, plugin.deletedShards.isEmpty());
+            assertNoDeletions(shardsByNode.getKey());
         }
 
         assertAcked(client().admin().indices().prepareDelete(indexName));
+        assertPendingDeletesProcessed();
 
         assertBusy(() -> {
             for (Map.Entry<String, List<ShardRouting>> shardsByNode : shardsByNodes.entrySet()) {
@@ -106,30 +119,37 @@ public class IndexFoldersDeletionListenerIT extends ESIntegTestCase {
                         deletedShards.contains(shardId));
                 }
             }
-        });
+        }, 30L, TimeUnit.SECONDS);
     }
 
     public void testListenersInvokedWhenIndexIsRelocated() throws Exception {
-        internalCluster().ensureAtLeastNumDataNodes(4);
+        final String masterNode = internalCluster().startMasterOnlyNode();
+        internalCluster().startDataOnlyNodes(4);
+        ensureStableCluster(4 + 1, masterNode);
+
         final String indexName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
         createIndex(indexName, Settings.builder()
-            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, between(4, 10))
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 4 * between(1, 2))
             .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, between(0, 1))
             .build());
 
         final NumShards numShards = getNumShards(indexName);
-        ensureGreen(indexName);
+        assertFalse(client().admin().cluster().prepareHealth()
+            .setIndices(indexName)
+            .setWaitForGreenStatus()
+            .setWaitForEvents(Priority.LANGUID)
+            .setWaitForNoRelocatingShards(true)
+            .setWaitForNoInitializingShards(true)
+            .get()
+            .isTimedOut());
 
-        final ClusterState clusterState = clusterService().state();
+        final ClusterState clusterState = internalCluster().clusterService(masterNode).state();
         final Index index = clusterState.metadata().index(indexName).getIndex();
         final Map<String, List<ShardRouting>> shardsByNodes = shardRoutingsByNodes(clusterState, index);
         assertThat(shardsByNodes.values().stream().mapToInt(List::size).sum(), equalTo(numShards.totalNumShards));
 
         for (Map.Entry<String, List<ShardRouting>> shardsByNode : shardsByNodes.entrySet()) {
-            final String nodeName = shardsByNode.getKey();
-            final IndexFoldersDeletionListenerPlugin plugin = plugin(nodeName);
-            assertTrue("Expecting no indices deleted on node " + nodeName, plugin.deletedIndices.isEmpty());
-            assertTrue("Expecting no shards deleted on node " + nodeName, plugin.deletedShards.isEmpty());
+            assertNoDeletions(shardsByNode.getKey());
         }
 
         final List<String> excludedNodes = randomSubsetOf(2, shardsByNodes.keySet());
@@ -159,48 +179,58 @@ public class IndexFoldersDeletionListenerIT extends ESIntegTestCase {
                             deletedShards.contains(shardId));
                     }
                 } else {
-                    assertTrue("Expecting no indices deleted on node " + nodeName, plugin.deletedIndices.isEmpty());
-                    assertTrue("Expecting no shards deleted on node " + nodeName, plugin.deletedShards.isEmpty());
+                    assertNoDeletions(nodeName);
                 }
             }
-        });
+        }, 30L, TimeUnit.SECONDS);
     }
 
     public void testListenersInvokedWhenIndexIsDangling() throws Exception {
-        internalCluster().ensureAtLeastNumDataNodes(4);
+        final String masterNode = internalCluster().startMasterOnlyNode();
+        internalCluster().startDataOnlyNodes(4);
+        ensureStableCluster(4 + 1, masterNode);
+
         final String indexName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
         createIndex(indexName, Settings.builder()
-            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, between(4, 10))
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 4 * between(1, 2))
             .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, between(0, 1))
             .build());
 
         final NumShards numShards = getNumShards(indexName);
-        ensureGreen(indexName);
+        assertFalse(client().admin().cluster().prepareHealth()
+            .setIndices(indexName)
+            .setWaitForGreenStatus()
+            .setWaitForEvents(Priority.LANGUID)
+            .setWaitForNoRelocatingShards(true)
+            .setWaitForNoInitializingShards(true)
+            .get()
+            .isTimedOut());
 
-        final ClusterState clusterState = clusterService().state();
+        final ClusterState clusterState = internalCluster().clusterService(masterNode).state();
         final Index index = clusterState.metadata().index(indexName).getIndex();
         final Map<String, List<ShardRouting>> shardsByNodes = shardRoutingsByNodes(clusterState, index);
         assertThat(shardsByNodes.values().stream().mapToInt(List::size).sum(), equalTo(numShards.totalNumShards));
 
         for (Map.Entry<String, List<ShardRouting>> shardsByNode : shardsByNodes.entrySet()) {
-            final String nodeName = shardsByNode.getKey();
-            final IndexFoldersDeletionListenerPlugin plugin = plugin(nodeName);
-            assertTrue("Expecting no indices deleted on node " + nodeName, plugin.deletedIndices.isEmpty());
-            assertTrue("Expecting no shards deleted on node " + nodeName, plugin.deletedShards.isEmpty());
+            assertNoDeletions(shardsByNode.getKey());
         }
 
         final String stoppedNode = randomFrom(shardsByNodes.keySet());
         final Settings stoppedNodeDataPathSettings = internalCluster().dataPathSettings(stoppedNode);
         internalCluster().stopRandomNode(InternalTestCluster.nameFilter(stoppedNode));
+        ensureStableCluster(3 + 1, masterNode);
 
         assertAcked(client().admin().indices().prepareDelete(indexName));
 
         final String restartedNode = internalCluster().startNode(stoppedNodeDataPathSettings);
+        ensureStableCluster(4 + 1, masterNode);
+        assertPendingDeletesProcessed();
+
         assertBusy(() -> {
             final IndexFoldersDeletionListenerPlugin plugin = plugin(restartedNode);
             assertTrue("Listener should have been notified of deletion of index " + index + " on node " + restartedNode,
                 plugin.deletedIndices.contains(index));
-        });
+        }, 30L, TimeUnit.SECONDS);
     }
 
     public void testListenersInvokedWhenIndexHasLeftOverShard() throws Exception {
@@ -229,6 +259,7 @@ public class IndexFoldersDeletionListenerIT extends ESIntegTestCase {
 
         logger.debug("--> stopping data node [{}], the data left on disk will be injected as left-overs in a newer data node", dataNode);
         internalCluster().stopRandomNode(InternalTestCluster.nameFilter(dataNode));
+        ensureStableCluster(1, masterNode);
 
         logger.debug("--> deleting leftover indices");
         assertAcked(client().admin().indices().prepareDelete("index-*"));
@@ -266,6 +297,7 @@ public class IndexFoldersDeletionListenerIT extends ESIntegTestCase {
                     dataPaths.stream().map(p -> p.toAbsolutePath().toString()).collect(Collectors.toList()))
                 .putNull(Environment.PATH_SHARED_DATA_SETTING.getKey())
                 .build());
+        ensureStableCluster(1 + 1, masterNode);
 
         final IndexFoldersDeletionListenerPlugin plugin = plugin(dataNode);
         assertTrue("Expecting no shards deleted on node " + dataNode, plugin.deletedShards.isEmpty());
@@ -329,5 +361,13 @@ public class IndexFoldersDeletionListenerIT extends ESIntegTestCase {
             final Iterable<IndicesService> services = internalCluster().getDataNodeInstances(IndicesService.class);
             services.forEach(indicesService -> assertFalse(indicesService.hasUncompletedPendingDeletes()));
         });
+    }
+
+    private static void assertNoDeletions(String nodeName) {
+        final IndexFoldersDeletionListenerPlugin plugin = plugin(nodeName);
+        assertTrue("Expecting no indices deleted on node [" + nodeName + "] but got: " + plugin.deletedIndices,
+            plugin.deletedIndices.isEmpty());
+        assertTrue("Expecting no shards deleted on node [" + nodeName + "] but got: " + plugin.deletedShards,
+            plugin.deletedShards.isEmpty());
     }
 }

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/SearchableSnapshotsPersistentCacheIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/SearchableSnapshotsPersistentCacheIntegTests.java
@@ -7,13 +7,13 @@
 package org.elasticsearch.xpack.searchablesnapshots.cache;
 
 import org.apache.lucene.document.Document;
-import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.shard.ShardPath;
@@ -39,7 +39,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.notNullValue;
 
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/66278")
 public class SearchableSnapshotsPersistentCacheIntegTests extends BaseSearchableSnapshotsIntegTestCase {
 
     @Override
@@ -48,6 +47,8 @@ public class SearchableSnapshotsPersistentCacheIntegTests extends BaseSearchable
             .put(super.nodeSettings(nodeOrdinal))
             // ensure the cache is definitely used
             .put(CacheService.SNAPSHOT_CACHE_SIZE_SETTING.getKey(), new ByteSizeValue(1L, ByteSizeUnit.GB))
+            // to make cache synchronization predictable
+            .put(CacheService.SNAPSHOT_CACHE_SYNC_INTERVAL_SETTING.getKey(), TimeValue.timeValueHours(1L))
             .build();
     }
 
@@ -141,19 +142,21 @@ public class SearchableSnapshotsPersistentCacheIntegTests extends BaseSearchable
             }
         });
 
-        persistentCache = internalCluster().getInstance(CacheService.class, dataNode).getPersistentCache();
-        assertThat(persistentCache.getNumDocs(), equalTo((long) cacheFiles.size()));
+        cacheService = internalCluster().getInstance(CacheService.class, dataNode);
+        persistentCache = cacheService.getPersistentCache();
         ensureGreen(restoredIndexName);
 
         cacheFiles.forEach(cacheFile -> assertTrue(cacheFile + " should have survived node restart", Files.exists(cacheFile)));
+        assertThat("Cache files should be repopulated in cache", persistentCache.getNumDocs(), equalTo((long) cacheFiles.size()));
 
         assertAcked(client().admin().indices().prepareDelete(restoredIndexName));
 
-        assertBusy(() -> cacheFiles.forEach(cacheFile -> assertFalse(cacheFile + " should have been cleaned up", Files.exists(cacheFile))));
-        cacheService = internalCluster().getInstance(CacheService.class, dataNode);
+        assertBusy(() -> {
+            cacheFiles.forEach(cacheFile -> assertFalse(cacheFile + " should have been cleaned up", Files.exists(cacheFile)));
+            assertTrue(internalCluster().getInstance(CacheService.class, dataNode).getPersistentCache().hasDeletions());
+        });
         cacheService.synchronizeCache();
 
-        persistentCache = cacheService.getPersistentCache();
         assertThat(persistentCache.getNumDocs(), equalTo(0L));
     }
 }


### PR DESCRIPTION
The tests testListenersInvokedWhenIndexIsRelocated and
testListenersInvokedWhenIndexIsDangling fail on CI with
errors like:

java.lang.AssertionError: Expecting no shards deleted on node node_t4
at __randomizedtesting.SeedInfo.seed(...)
at org.junit.Assert.fail(Assert.java:88)
at org.junit.Assert.assertTrue(Assert.java:41)
at org.elasticsearch.plugins.IndexFoldersDeletionListenerIT.
testListenersInvokedWhenIndexIsDangling
(IndexFoldersDeletionListenerIT.java:189)

This commit tries to make those tests more stable by
starting all nodes upfront, by waiting for no rebalancing/
relocations before checking the previous assertions
and by extending a bit the time of some assertBusy()
as on CI it can take more than 10 sec for pending
deletes to be processed.