### PR TITLE
[7.x] ILM: make the rest of the forcemerge action steps retryable (#66352)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ForceMergeStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ForceMergeStep.java
@@ -26,6 +26,11 @@ public class ForceMergeStep extends AsyncActionStep {
         this.maxNumSegments = maxNumSegments;
     }
 
+    @Override
+    public boolean isRetryable() {
+        return true;
+    }
+
     public int getMaxNumSegments() {
         return maxNumSegments;
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/SegmentCountStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/SegmentCountStep.java
@@ -45,6 +45,11 @@ public class SegmentCountStep extends AsyncWaitStep {
         this.maxNumSegments = maxNumSegments;
     }
 
+    @Override
+    public boolean isRetryable() {
+        return true;
+    }
+
     public int getMaxNumSegments() {
         return maxNumSegments;
     }


### PR DESCRIPTION
(cherry picked from commit 6d83da05b5b8a2daf6787b2d9fa70a03b53f71d1)
Signed-off-by: Andrei Dan <andrei.dan@elastic.co>

Backport of #66352
