### PR TITLE
[DOCS] Fix S3 bucket names in S3 repo plugin docs

### DIFF
--- a/docs/plugins/repository-s3.asciidoc
+++ b/docs/plugins/repository-s3.asciidoc
@@ -33,6 +33,10 @@ PUT _snapshot/my_s3_repository
 ----
 // TEST[skip:we don't have s3 setup while testing this]
 
+*bucket:*  The name of the bucket to be used for snapshots. (Mandatory)
+Note that the bucket name can be between 3 and 63 characters long, and can contain only lower-case characters, numbers, periods, and dashes it cannot contain underscores, end with a dash, have consecutive periods, or use dashes adjacent to periods
+
+The bucket naming convention is outlines in AWS [here](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-s3-bucket-naming-requirements.html)
 
 [[repository-s3-client]]
 ==== Client Settings

--- a/docs/plugins/repository-s3.asciidoc
+++ b/docs/plugins/repository-s3.asciidoc
@@ -254,9 +254,9 @@ The following settings are supported:
 (Required)
 Name of the S3 bucket to use for snapshots.
 +
-The bucket name must adhere to the
-https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-s3-bucket-naming-requirements.html[Amazon
-S3 Bucket Naming Requirements].
+The bucket name must adhere to Amazon's
+https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html#bucketnamingrules[S3
+bucket naming rules].
 
 `client`::
 

--- a/docs/plugins/repository-s3.asciidoc
+++ b/docs/plugins/repository-s3.asciidoc
@@ -27,7 +27,7 @@ PUT _snapshot/my_s3_repository
 {
   "type": "s3",
   "settings": {
-    "bucket": "my_bucket"
+    "bucket": "my-bucket"
   }
 }
 ----
@@ -48,8 +48,8 @@ PUT _snapshot/my_s3_repository
 {
   "type": "s3",
   "settings": {
-    "bucket": "my_bucket",
-    "client": "my_alternate_client"
+    "bucket": "my-bucket",
+    "client": "my-alternate-client"
   }
 }
 ----
@@ -241,7 +241,7 @@ PUT _snapshot/my_s3_repository
 {
   "type": "s3",
   "settings": {
-    "bucket": "my-bucket-name",
+    "bucket": "my-bucket",
     "another_setting": "setting-value"
   }
 }
@@ -344,8 +344,8 @@ PUT _snapshot/my_s3_repository
 {
   "type": "s3",
   "settings": {
-    "client": "my-client-name",
-    "bucket": "my-bucket-name",
+    "client": "my-client",
+    "bucket": "my-bucket",
     "endpoint": "my.s3.endpoint"
   }
 }

--- a/docs/plugins/repository-s3.asciidoc
+++ b/docs/plugins/repository-s3.asciidoc
@@ -252,7 +252,7 @@ The following settings are supported:
 
 `bucket`::
 (Required)
-Name of the bucket to use for snapshots.
+Name of the S3 bucket to use for snapshots.
 +
 The bucket name must adhere to the
 https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-s3-bucket-naming-requirements.html[Amazon

--- a/docs/plugins/repository-s3.asciidoc
+++ b/docs/plugins/repository-s3.asciidoc
@@ -33,6 +33,7 @@ PUT _snapshot/my_s3_repository
 ----
 // TEST[skip:we don't have s3 setup while testing this]
 
+
 [[repository-s3-client]]
 ==== Client Settings
 
@@ -241,7 +242,7 @@ PUT _snapshot/my_s3_repository
   "type": "s3",
   "settings": {
     "bucket": "my-bucket-name",
-    "another_setting": "setting_value"
+    "another_setting": "setting-value"
   }
 }
 ----
@@ -250,7 +251,8 @@ PUT _snapshot/my_s3_repository
 The following settings are supported:
 
 `bucket`::
-The name of the bucket to be used for snapshots. (Mandatory)
+(Required)
+Name of the bucket to use for snapshots.
 +
 The bucket name must adhere to the
 https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-s3-bucket-naming-requirements.html[Amazon

--- a/docs/plugins/repository-s3.asciidoc
+++ b/docs/plugins/repository-s3.asciidoc
@@ -33,11 +33,6 @@ PUT _snapshot/my_s3_repository
 ----
 // TEST[skip:we don't have s3 setup while testing this]
 
-*bucket:*  The name of the bucket to be used for snapshots. (Mandatory)
-Note that the bucket name can be between 3 and 63 characters long, and can contain only lower-case characters, numbers, periods, and dashes it cannot contain underscores, end with a dash, have consecutive periods, or use dashes adjacent to periods
-
-The bucket naming convention is outlines in AWS [here](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-s3-bucket-naming-requirements.html)
-
 [[repository-s3-client]]
 ==== Client Settings
 
@@ -245,7 +240,7 @@ PUT _snapshot/my_s3_repository
 {
   "type": "s3",
   "settings": {
-    "bucket": "my_bucket_name",
+    "bucket": "my-bucket-name",
     "another_setting": "setting_value"
   }
 }
@@ -255,8 +250,11 @@ PUT _snapshot/my_s3_repository
 The following settings are supported:
 
 `bucket`::
-
-    The name of the bucket to be used for snapshots. (Mandatory)
+The name of the bucket to be used for snapshots. (Mandatory)
++
+The bucket name must adhere to the
+https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-s3-bucket-naming-requirements.html[Amazon
+S3 Bucket Naming Requirements].
 
 `client`::
 
@@ -344,8 +342,8 @@ PUT _snapshot/my_s3_repository
 {
   "type": "s3",
   "settings": {
-    "client": "my_client_name",
-    "bucket": "my_bucket_name",
+    "client": "my-client-name",
+    "bucket": "my-bucket-name",
     "endpoint": "my.s3.endpoint"
   }
 }


### PR DESCRIPTION
Opening this PR on behalf of @InbarShimshon. Contains reverted changes from https://github.com/elastic/elasticsearch/commit/77a54aa722d2d5288ca2dc96a447d55b53b2dac4 and https://github.com/elastic/elasticsearch/commit/c40c29e2e4eb93cca01ea1f0c3e45b291e1fa2da

@InbarShimshon treat this PR as your own. Please feel to edit the description, push changes, etc. Thanks!

---

### Summary

* Clarifies that buckets in the S3 repo config must adhere to the [S3 bucket naming requirements](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-s3-bucket-naming-requirements.html).
* Fixes several example snippets that don't adhere to those requirements

### Preview
- S3 plugin getting started: https://elasticsearch_66521.docs-preview.app.elstc.co/guide/en/elasticsearch/plugins/master/repository-s3-usage.html

- S3 plugin client settings: https://elasticsearch_66521.docs-preview.app.elstc.co/guide/en/elasticsearch/plugins/master/repository-s3-client.html

- S3 plugin repo settings: https://elasticsearch_66521.docs-preview.app.elstc.co/guide/en/elasticsearch/plugins/master/repository-s3-repository.html
