### PR TITLE
[Transform] Do not deduce mappings in latest transform function

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/transform/preview_transforms.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/transform/preview_transforms.yml
@@ -101,8 +101,8 @@ setup:
   - match: { generated_dest_index.mappings.properties.airline.type: "keyword" }
   - match: { generated_dest_index.mappings.properties.by-hour.type: "date" }
   - match: { generated_dest_index.mappings.properties.avg_response.type: "double" }
-  - match: { generated_dest_index.mappings.properties.time.properties.max.type: "date" }
-  - match: { generated_dest_index.mappings.properties.time.properties.min.type: "date" }
+  - match: { generated_dest_index.mappings.properties.time\.max.type: "date" }
+  - match: { generated_dest_index.mappings.properties.time\.min.type: "date" }
 
   - do:
       ingest.put_pipeline:

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/latest/Latest.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/latest/Latest.java
@@ -11,8 +11,6 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.fieldcaps.FieldCapabilitiesAction;
-import org.elasticsearch.action.fieldcaps.FieldCapabilitiesRequest;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.search.SearchAction;
 import org.elasticsearch.action.search.SearchRequest;
@@ -47,6 +45,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
+import static java.util.Collections.emptyMap;
 import static java.util.stream.Collectors.toList;
 
 public class Latest implements Function {
@@ -187,20 +186,7 @@ public class Latest implements Function {
 
     @Override
     public void deduceMappings(Client client, SourceConfig sourceConfig, ActionListener<Map<String, String>> listener) {
-        FieldCapabilitiesRequest fieldCapabilitiesRequest =
-            new FieldCapabilitiesRequest().indices(sourceConfig.getIndex())
-                .fields("*")
-                .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
-        client.execute(
-            FieldCapabilitiesAction.INSTANCE,
-            fieldCapabilitiesRequest,
-            ActionListener.wrap(
-                response -> {
-                    listener.onResponse(
-                        DocumentConversionUtils.removeInternalFields(DocumentConversionUtils.extractFieldMappings(response)));
-                },
-                listener::onFailure)
-        );
+        listener.onResponse(emptyMap());
     }
 
     @Override

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/persistence/TransformIndexTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/persistence/TransformIndexTests.java
@@ -95,10 +95,8 @@ public class TransformIndexTests extends ESTestCase {
                 put("a.b", "keyword");
             }}),
             is(equalTo(new HashMap<>() {{
-                put("a", new HashMap<>() {{
-                    put("type", "long");
-                    put("fields", singletonMap("b", singletonMap("type", "keyword")));
-                }});
+                put("a", singletonMap("type", "long"));
+                put("a.b", singletonMap("type", "keyword"));
             }}))
         );
         assertThat(
@@ -108,17 +106,9 @@ public class TransformIndexTests extends ESTestCase {
                 put("a.b.c", "keyword");
             }}),
             is(equalTo(new HashMap<>() {{
-                put("a", new HashMap<>() {{
-                    put("type", "long");
-                    put("fields", new HashMap<>() {{
-                        put("b", new HashMap<>() {{
-                            put("type", "text");
-                            put("fields", new HashMap<>() {{
-                                put("c", singletonMap("type", "keyword"));
-                            }});
-                        }});
-                    }});
-                }});
+                put("a", singletonMap("type", "long"));
+                put("a.b", singletonMap("type", "text"));
+                put("a.b.c", singletonMap("type", "keyword"));
             }}))
         );
         assertThat(
@@ -133,38 +123,14 @@ public class TransformIndexTests extends ESTestCase {
                 put("f.g.h.i", "text");
             }}),
             is(equalTo(new HashMap<>() {{
-                put("a", new HashMap<>() {{
-                    put("type", "object");
-                    put("properties", new HashMap<>() {{
-                        put("b", new HashMap<>() {{
-                            put("type", "long");
-                        }});
-                    }});
-                }});
-                put("c", new HashMap<>() {{
-                    put("type", "nested");
-                    put("properties", new HashMap<>() {{
-                        put("d", new HashMap<>() {{
-                            put("type", "boolean");
-                        }});
-                    }});
-                }});
-                put("f", new HashMap<>() {{
-                    put("type", "object");
-                    put("properties", new HashMap<>() {{
-                        put("g", new HashMap<>() {{
-                            put("type", "object");
-                            put("properties", new HashMap<>() {{
-                                put("h", new HashMap<>() {{
-                                    put("type", "text");
-                                    put("fields", new HashMap<>() {{
-                                        put("i", singletonMap("type", "text"));
-                                    }});
-                                }});
-                            }});
-                        }});
-                    }});
-                }});
+                put("a", singletonMap("type", "object"));
+                put("a.b", singletonMap("type", "long"));
+                put("c", singletonMap("type", "nested"));
+                put("c.d", singletonMap("type", "boolean"));
+                put("f", singletonMap("type", "object"));
+                put("f.g", singletonMap("type", "object"));
+                put("f.g.h", singletonMap("type", "text"));
+                put("f.g.h.i", singletonMap("type", "text"));
             }}))
         );
     }


### PR DESCRIPTION
This PR disables mapping deduction in case of `latest` transform function. The reason is we cannot deduce the mappings reliably anyway (think of various settings like text's analyzer).
In most cases we expect the users providing index templates from which destination index mappings will be taken (the user can even create the destination index with custom mappings at their will).
For the case when there is no template, the transform will still create the destination index, but with no mappings. This will result in documents from source index being indexed into destination index with dynamic mappings.

Additionally, this PR makes `LatestContinuousIT` test use runtime fields to verify that `latest` handles runtime fields correctly.

Relates #65869