### PR TITLE
A node with roles [ml, remote_cluster_client] is still dedicated ML

### DIFF
--- a/distribution/tools/launchers/src/main/java/org/elasticsearch/tools/launchers/MachineDependentHeap.java
+++ b/distribution/tools/launchers/src/main/java/org/elasticsearch/tools/launchers/MachineDependentHeap.java
@@ -142,7 +142,7 @@ public final class MachineDependentHeap {
                         return MachineNodeRole.DATA;
                     } else if (containsOnly(roles, "master")) {
                         return MachineNodeRole.MASTER_ONLY;
-                    } else if (containsOnly(roles, "ml")) {
+                    } else if (containsOnly(roles, "ml") || containsOnly(roles, "ml", "remote_cluster_client")) {
                         return MachineNodeRole.ML_ONLY;
                     } else {
                         return MachineNodeRole.DATA;

--- a/distribution/tools/launchers/src/main/java/org/elasticsearch/tools/launchers/MachineDependentHeap.java
+++ b/distribution/tools/launchers/src/main/java/org/elasticsearch/tools/launchers/MachineDependentHeap.java
@@ -142,7 +142,7 @@ public final class MachineDependentHeap {
                         return MachineNodeRole.DATA;
                     } else if (containsOnly(roles, "master")) {
                         return MachineNodeRole.MASTER_ONLY;
-                    } else if (containsOnly(roles, "ml") || containsOnly(roles, "ml", "remote_cluster_client")) {
+                    } else if (roles.contains("ml") && containsOnly(roles, "ml", "remote_cluster_client")) {
                         return MachineNodeRole.ML_ONLY;
                     } else {
                         return MachineNodeRole.DATA;

--- a/distribution/tools/launchers/src/test/java/org/elasticsearch/tools/launchers/NodeRoleParserTests.java
+++ b/distribution/tools/launchers/src/test/java/org/elasticsearch/tools/launchers/NodeRoleParserTests.java
@@ -47,6 +47,12 @@ public class NodeRoleParserTests extends LaunchersTestCase {
         MachineDependentHeap.MachineNodeRole nodeRole = parseConfig(sb -> sb.append("node.roles: [ml]"));
         assertThat(nodeRole, equalTo(ML_ONLY));
 
+        nodeRole = parseConfig(sb -> sb.append("node.roles: [ml, remote_cluster_client]"));
+        assertThat(nodeRole, equalTo(ML_ONLY));
+
+        nodeRole = parseConfig(sb -> sb.append("node.roles: [remote_cluster_client, ml]"));
+        assertThat(nodeRole, equalTo(ML_ONLY));
+
         nodeRole = parseConfig(sb -> sb.append("node.roles: [ml, some_other_role]"));
         assertThat(nodeRole, not(equalTo(ML_ONLY)));
     }

--- a/distribution/tools/launchers/src/test/java/org/elasticsearch/tools/launchers/NodeRoleParserTests.java
+++ b/distribution/tools/launchers/src/test/java/org/elasticsearch/tools/launchers/NodeRoleParserTests.java
@@ -53,6 +53,9 @@ public class NodeRoleParserTests extends LaunchersTestCase {
         nodeRole = parseConfig(sb -> sb.append("node.roles: [remote_cluster_client, ml]"));
         assertThat(nodeRole, equalTo(ML_ONLY));
 
+        nodeRole = parseConfig(sb -> sb.append("node.roles: [remote_cluster_client]"));
+        assertThat(nodeRole, not(equalTo(ML_ONLY)));
+
         nodeRole = parseConfig(sb -> sb.append("node.roles: [ml, some_other_role]"));
         assertThat(nodeRole, not(equalTo(ML_ONLY)));
     }


### PR DESCRIPTION
Where CCS is being used it makes sense for ML nodes to have the
remote_cluster_client role.  This single extra role is not
significant enough to stop an ML node being considered a
"dedicated ML node".