### PR TITLE
Mark Cat Tasks API as experimental in rest-api-spec

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.tasks.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.tasks.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html",
       "description":"Returns information about the tasks currently executing on one or more nodes in the cluster."
     },
-    "stability":"stable",
+    "stability":"experimental",
     "visibility":"public",
     "headers":{
       "accept": [ "text/plain", "application/json"]


### PR DESCRIPTION
Per #51628 and the Task management API docs the tasks.* APIs are still in the experimental stage and should be marked this way in the REST API spec. This is a follow on from @sethmlarson's PR #65823

cc @elastic/clients-team

I welcome advice on the correct version labelling of this before merging.