### PR TITLE
Deprecate lack of waiting on shards on index close

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RankEvalIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RankEvalIT.java
@@ -108,7 +108,9 @@ public class RankEvalIT extends ESRestHighLevelClientTestCase {
         }
 
         // now try this when test2 is closed
-        client().performRequest(new Request("POST", "index2/_close"));
+        final Request closeRequest = new Request("POST", "index2/_close");
+        closeRequest.addParameter("wait_for_active_shards", "DEFAULT");
+        client().performRequest(closeRequest);
         rankEvalRequest.indicesOptions(IndicesOptions.fromParameters(null, "true", null, "false", SearchRequest.DEFAULT_INDICES_OPTIONS));
         response = execute(rankEvalRequest, highLevelClient()::rankEval, highLevelClient()::rankEvalAsync);
     }

--- a/distribution/archives/integ-test-zip/src/test/java/org/elasticsearch/test/rest/WaitForRefreshAndCloseIT.java
+++ b/distribution/archives/integ-test-zip/src/test/java/org/elasticsearch/test/rest/WaitForRefreshAndCloseIT.java
@@ -97,7 +97,9 @@ public class WaitForRefreshAndCloseIT extends ESRestTestCase {
         });
 
         // Close the index. That should flush the listener.
-        client().performRequest(new Request("POST", "/test/_close"));
+        final Request closeRequest = new Request("POST", "/test/_close");
+        closeRequest.addParameter("wait_for_active_shards", "DEFAULT");
+        client().performRequest(closeRequest);
 
         /*
          * The request may fail, but we really, really, really want to make

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.aliases/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.aliases/10_basic.yml
@@ -399,6 +399,7 @@
   - do:
       indices.close:
         index: test_index
+        wait_for_active_shards: DEFAULT
 
   - do:
       cat.aliases:
@@ -432,6 +433,7 @@
   - do:
       indices.close:
         index: test_index
+        wait_for_active_shards: DEFAULT
 
   - do:
       node_selector:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.indices/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.indices/10_basic.yml
@@ -66,6 +66,7 @@
   - do:
       indices.close:
         index: index-2
+        wait_for_active_shards: DEFAULT
   - is_true: acknowledged
 
   - do:
@@ -107,6 +108,7 @@
   - do:
       indices.close:
         index: index-2
+        wait_for_active_shards: DEFAULT
   - is_true: acknowledged
 
   - do:
@@ -249,6 +251,7 @@
   - do:
       indices.close:
         index: bar
+        wait_for_active_shards: DEFAULT
 
   - do:
       cat.indices:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.recovery/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.recovery/10_basic.yml
@@ -93,6 +93,7 @@
   - do:
       indices.close:
         index: index2
+        wait_for_active_shards: DEFAULT
   - is_true: acknowledged
 
   - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.segments/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.segments/10_basic.yml
@@ -95,6 +95,7 @@
   - do:
       indices.close:
         index: index1
+        wait_for_active_shards: DEFAULT
 
   - do:
       catch: bad_request

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.allocation_explain/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.allocation_explain/10_basic.yml
@@ -68,6 +68,7 @@
   - do:
       indices.close:
         index: test_closed
+        wait_for_active_shards: DEFAULT
 
   - match: { acknowledged: true }
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.health/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.health/10_basic.yml
@@ -183,6 +183,7 @@
   - do:
       indices.close:
         index: index-2
+        wait_for_active_shards: DEFAULT
   - is_true: acknowledged
 
   # closing the index-2 turns the cluster health back to green
@@ -258,6 +259,7 @@
   - do:
       indices.close:
         index: index-2
+        wait_for_active_shards: DEFAULT
   - is_true: acknowledged
 
   - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.health/30_indices_options.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.health/30_indices_options.yml
@@ -23,6 +23,7 @@ setup:
   - do:
       indices.close:
         index: index-2
+        wait_for_active_shards: DEFAULT
 
   - do:
       cluster.health:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.state/30_expand_wildcards.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.state/30_expand_wildcards.yml
@@ -25,6 +25,7 @@ setup:
   - do:
       indices.close:
         index: test_close_index
+        wait_for_active_shards: DEFAULT
 
 ---
 "Test expand_wildcards parameter on closed, open indices and both":

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get/10_basic.yml
@@ -38,6 +38,7 @@ setup:
   - do:
       indices.close:
         index: test_index_3
+        wait_for_active_shards: DEFAULT
 
   - do:
       cluster.health:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get/11_basic_with_types.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get/11_basic_with_types.yml
@@ -37,6 +37,7 @@ setup:
   - do:
       indices.close:
         index: test_index_3
+        wait_for_active_shards: DEFAULT
 
   - do:
       cluster.health:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_alias/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_alias/10_basic.yml
@@ -307,6 +307,7 @@ setup:
   - do:
       indices.close:
         index: test_index_2
+        wait_for_active_shards: DEFAULT
 
   - do:
       indices.get_alias:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_mapping/50_wildcard_expansion.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_mapping/50_wildcard_expansion.yml
@@ -52,6 +52,7 @@ setup:
   - do:
       indices.close:
         index: test-xyy
+        wait_for_active_shards: DEFAULT
 
   - do:
         cluster.health:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.open/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.open/10_basic.yml
@@ -14,6 +14,7 @@
   - do:
       indices.close:
         index: test_index
+        wait_for_active_shards: DEFAULT
   - is_true: acknowledged
 
   - do:
@@ -52,6 +53,7 @@
   - do:
       indices.close:
         index: test_index
+        wait_for_active_shards: DEFAULT
   - is_true: acknowledged
 
   - do:
@@ -83,6 +85,27 @@
   - match: { acknowledged: true }
   - match: { shards_acknowledged: true }
 ---
+"Close index without specifying wait_for_active_shards":
+  - skip:
+      version: " - 7.1.99"
+      reason:  "closed indices are replicated starting version 7.2.0"
+      features: ["warnings", "node_selector"]
+
+  - do:
+      indices.create:
+        index: test_index
+        body:
+          settings:
+            number_of_replicas: 0
+
+  - do:
+      indices.close:
+        index: test_index
+      warnings:
+        - "When closing an index in 8.0 the default behaviour will change from ?wait_for_active_shards=NONE to ?wait_for_active_shards=DEFAULT. To opt-in to the new default, set ?wait_for_active_shards=DEFAULT when closing indices."
+      node_selector:
+        version: "7.12.0 - "
+---
 "Close index response with result per index":
   - skip:
       version: " - 7.2.99"
@@ -112,6 +135,7 @@
   - do:
       indices.close:
         index: "index_*"
+        wait_for_active_shards: DEFAULT
 
   - match: { acknowledged: true }
   - match: { shards_acknowledged: true }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.open/20_multiple_indices.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.open/20_multiple_indices.yml
@@ -26,6 +26,7 @@ setup:
   - do:
       indices.close:
         index: _all
+        wait_for_active_shards: DEFAULT
   - is_true: acknowledged
 
   - do:
@@ -53,6 +54,7 @@ setup:
   - do:
       indices.close:
         index: test_*
+        wait_for_active_shards: DEFAULT
   - is_true: acknowledged
 
   - do:
@@ -80,6 +82,7 @@ setup:
   - do:
       indices.close:
         index: '*'
+        wait_for_active_shards: DEFAULT
   - is_true: acknowledged
 
   - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_settings/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_settings/10_basic.yml
@@ -89,6 +89,7 @@ setup:
   - do:
       indices.close:
         index: test-index
+        wait_for_active_shards: DEFAULT
 
   - do:
       indices.put_settings:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.recovery/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.recovery/10_basic.yml
@@ -56,6 +56,7 @@
   - do:
       indices.close:
         index: test_2
+        wait_for_active_shards: DEFAULT
   - is_true: acknowledged
 
   - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.resolve_index/10_basic_resolve_index.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.resolve_index/10_basic_resolve_index.yml
@@ -24,6 +24,7 @@ setup:
   - do:
       indices.close:
         index: test_index2
+        wait_for_active_shards: DEFAULT
 
   - do:
       indices.create:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.segments/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.segments/10_basic.yml
@@ -60,6 +60,7 @@
   - do:
       indices.close:
         index: index1
+        wait_for_active_shards: DEFAULT
 
   - do:
       catch: bad_request

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/80_indices_options.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/80_indices_options.yml
@@ -34,6 +34,7 @@
   - do:
       indices.close:
           index:  index_closed
+          wait_for_active_shards: DEFAULT
 
   - do:
       catch:  /index_closed_exception/

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.restore/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.restore/10_basic.yml
@@ -40,6 +40,7 @@ setup:
   - do:
       indices.close:
         index : test_index
+        wait_for_active_shards: DEFAULT
 
   - do:
       snapshot.restore:

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -1225,7 +1225,9 @@ public abstract class ESRestTestCase extends ESTestCase {
     }
 
     protected static void closeIndex(String index) throws IOException {
-        Response response = client().performRequest(new Request("POST", "/" + index + "/_close"));
+        final Request closeRequest = new Request("POST", "/" + index + "/_close");
+        closeRequest.addParameter("wait_for_active_shards", "DEFAULT");
+        Response response = client().performRequest(closeRequest);
         assertThat(response.getStatusLine().getStatusCode(), equalTo(RestStatus.OK.getStatus()));
     }
 

--- a/x-pack/plugin/ccr/qa/multi-cluster/src/test/java/org/elasticsearch/xpack/ccr/FollowIndexIT.java
+++ b/x-pack/plugin/ccr/qa/multi-cluster/src/test/java/org/elasticsearch/xpack/ccr/FollowIndexIT.java
@@ -81,7 +81,7 @@ public class FollowIndexIT extends ESCCRRestTestCase {
             assertBusy(() -> verifyCcrMonitoring(leaderIndexName, followIndexName), 30, TimeUnit.SECONDS);
 
             pauseFollow(followIndexName);
-            assertOK(client().performRequest(new Request("POST", "/" + followIndexName + "/_close")));
+            closeIndex(followIndexName);
             assertOK(client().performRequest(new Request("POST", "/" + followIndexName + "/_ccr/unfollow")));
             Exception e = expectThrows(ResponseException.class, () -> resumeFollow(followIndexName));
             assertThat(e.getMessage(), containsString("follow index [" + followIndexName + "] does not have ccr metadata"));

--- a/x-pack/plugin/ccr/qa/security/src/test/java/org/elasticsearch/xpack/ccr/FollowIndexSecurityIT.java
+++ b/x-pack/plugin/ccr/qa/security/src/test/java/org/elasticsearch/xpack/ccr/FollowIndexSecurityIT.java
@@ -89,7 +89,7 @@ public class FollowIndexSecurityIT extends ESCCRRestTestCase {
                 assertThat(countCcrNodeTasks(), equalTo(0));
             });
 
-            assertOK(client().performRequest(new Request("POST", "/" + allowedIndex + "/_close")));
+            closeIndex(allowedIndex);
             assertOK(client().performRequest(new Request("POST", "/" + allowedIndex + "/_ccr/unfollow")));
             Exception e = expectThrows(ResponseException.class, () -> resumeFollow(allowedIndex));
             assertThat(e.getMessage(), containsString("follow index [" + allowedIndex + "] does not have ccr metadata"));
@@ -124,7 +124,7 @@ public class FollowIndexSecurityIT extends ESCCRRestTestCase {
             e = expectThrows(ResponseException.class,
                 () -> client().performRequest(new Request("POST", "/" + unallowedIndex + "/_ccr/unfollow")));
             assertThat(e.getMessage(), containsString("action [indices:admin/xpack/ccr/unfollow] is unauthorized for user [test_ccr]"));
-            assertOK(adminClient().performRequest(new Request("POST", "/" + unallowedIndex + "/_close")));
+            closeIndex(unallowedIndex);
             assertOK(adminClient().performRequest(new Request("POST", "/" + unallowedIndex + "/_ccr/unfollow")));
             assertBusy(() -> assertThat(countCcrNodeTasks(), equalTo(0)));
         }

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsRestTestCase.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsRestTestCase.java
@@ -143,6 +143,7 @@ public abstract class AbstractSearchableSnapshotsRestTestCase extends ESRestTest
     public void testCloseAndReopen() throws Exception {
         runSearchableSnapshotsTest((restoredIndexName, numDocs) -> {
             final Request closeRequest = new Request(HttpPost.METHOD_NAME, restoredIndexName + "/_close");
+            closeRequest.addParameter("wait_for_active_shards", "DEFAULT");
             assertOK(client().performRequest(closeRequest));
             ensureGreen(restoredIndexName);
 

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/data_stream/20_unsupported_apis.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/data_stream/20_unsupported_apis.yml
@@ -45,6 +45,7 @@
   - do:
       indices.close:
         index: logs-*
+        wait_for_active_shards: DEFAULT
   - is_true: acknowledged
   - length: { indices: 0 }
 
@@ -165,6 +166,7 @@
       catch: bad_request
       indices.close:
         index: ".ds-simple-data-stream1-*000001"
+        wait_for_active_shards: DEFAULT
 
   - do:
       indices.delete_data_stream:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/data_stream/40_supported_apis.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/data_stream/40_supported_apis.yml
@@ -230,6 +230,7 @@ teardown:
   - do:
       indices.close:
         index: ".ds-simple-data-stream1-*000001,.ds-simple-data-stream1-*000002"
+        wait_for_active_shards: DEFAULT
   - is_true: acknowledged
 
   - do:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/data_stream/80_resolve_index_data_streams.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/data_stream/80_resolve_index_data_streams.yml
@@ -54,6 +54,7 @@ setup:
   - do:
       indices.close:
         index: test_index2
+        wait_for_active_shards: DEFAULT
 
   - do:
       indices.create:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/indices.freeze/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/indices.freeze/10_basic.yml
@@ -104,6 +104,7 @@
 - do:
     indices.close:
       index: test-close
+      wait_for_active_shards: DEFAULT
 
 - do:
     indices.freeze:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_crud.yml
@@ -1223,6 +1223,7 @@
   - do:
       indices.close:
         index: ".ml-anomalies-shared"
+        wait_for_active_shards: DEFAULT
 
   - do:
       catch: /Cannot create job \[closed-results-job\] as it requires closed index \[\.ml-anomalies-shared\]/
@@ -1250,6 +1251,7 @@
   - do:
       indices.close:
         index: ".ml-state-000001"
+        wait_for_active_shards: DEFAULT
 
   - do:
       catch: /Cannot create job \[closed-results-job\] as it requires closed index \[\.ml-state-000001\]/

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/monitoring/bulk/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/monitoring/bulk/10_basic.yml
@@ -206,6 +206,7 @@
   - do:
       indices.close:
         index: .monitoring-beats-*
+        wait_for_active_shards: DEFAULT
 
   - do:
       catch: /export_exception/

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/security/authz/14_cat_indices.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/security/authz/14_cat_indices.yml
@@ -55,6 +55,7 @@ setup:
   - do:
       indices.close:
         index:  index3
+        wait_for_active_shards: DEFAULT
 
 ---
 teardown:
@@ -150,6 +151,7 @@ teardown:
   - do:
       indices.close:
         index:  index_to_monitor
+        wait_for_active_shards: DEFAULT
 
   - do:
       headers: { Authorization: "Basic Y2F0X3VzZXI6Y2F0X3Bhc3N3b3Jk" } # cat_user

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/snapshot/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/snapshot/10_basic.yml
@@ -53,6 +53,7 @@ setup:
   - do:
       indices.close:
         index : test_index
+        wait_for_active_shards: DEFAULT
 
   - do:
       snapshot.restore:

--- a/x-pack/qa/rolling-upgrade-multi-cluster/src/test/java/org/elasticsearch/upgrades/CcrRollingUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade-multi-cluster/src/test/java/org/elasticsearch/upgrades/CcrRollingUpgradeIT.java
@@ -378,7 +378,7 @@ public class CcrRollingUpgradeIT extends AbstractMultiClusterUpgradeTestCase {
 
     private static void stopIndexFollowing(RestClient client, String followerIndex) throws IOException {
         pauseIndexFollowing(client, followerIndex);
-        assertOK(client.performRequest(new Request("POST", "/" + followerIndex + "/_close")));
+        closeIndex(followerIndex);
         assertOK(client.performRequest(new Request("POST", "/" + followerIndex + "/_ccr/unfollow")));
     }
 


### PR DESCRIPTION
In 8.x the default for `?wait_for_active_shards` will change from `NONE`
to `DEFAULT` on calls to `POST /index/_close`. This commit adds a
deprecation warning in 7.x if this parameter is not specified to
encourage users to adopt the new behaviour before upgrading.

Closes #66419