### PR TITLE
Document new waiting on shards on index close

### DIFF
--- a/docs/reference/migration/migrate_8_0/indices.asciidoc
+++ b/docs/reference/migration/migrate_8_0/indices.asciidoc
@@ -102,3 +102,18 @@ Discontinue use of the `index.translog.retention.age` and
 `index.translog.retention.size` index settings. Requests that
 include these settings will return an error.
 ====
+
+.The default for the `?wait_for_active_shards` parameter on the close index API has changed from `NONE` to `DEFAULT`.
+[%collapsible]
+====
+*Details* +
+When closing an index in earlier versions, by default {es} would not wait for
+the shards of the closed index to be properly assigned before returning. From
+version 8.0 onwards the default behaviour is to wait for shards to be assigned
+according to the <<index-wait-for-active-shards,index setting
+`index.write.wait_for_active_shards`>>.
+
+*Impact* +
+Accept the new behaviour, or specify `?wait_for_active_shards=NONE` to preserve
+the old behaviour if needed.
+====


### PR DESCRIPTION
In 8.x the default for `?wait_for_active_shards` changes from `NONE` to
`DEFAULT` on calls to `POST /index/_close`. This commit adds this change
to the breaking changes docs.

Relates #66419, #66542