### PR TITLE
[7.x] [ML] fixes xcontent serialization for ML scaling reason (#66548)

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlScalingReason.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlScalingReason.java
@@ -119,7 +119,7 @@ public class MlScalingReason implements AutoscalingDeciderResult.Reason {
         builder.startObject();
         builder.field(WAITING_ANALYTICS_JOBS, waitingAnalyticsJobs);
         builder.field(WAITING_ANOMALY_JOBS, waitingAnalyticsJobs);
-        builder.field(CONFIGURATION, passedConfiguration);
+        builder.startObject(CONFIGURATION).value(passedConfiguration).endObject();
         if (largestWaitingAnalyticsJob != null) {
             builder.field(LARGEST_WAITING_ANALYTICS_JOB, largestWaitingAnalyticsJob);
         }
@@ -130,6 +130,11 @@ public class MlScalingReason implements AutoscalingDeciderResult.Reason {
         builder.field(REASON, simpleReason);
         builder.endObject();
         return builder;
+    }
+
+    @Override
+    public boolean isFragment() {
+        return false;
     }
 
     static class Builder {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlScalingReasonTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlScalingReasonTests.java
@@ -6,6 +6,7 @@
 
 package org.elasticsearch.xpack.ml.autoscaling;
 
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Settings;
@@ -15,6 +16,13 @@ import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingCapacity;
 
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static org.elasticsearch.xpack.ml.autoscaling.MlScalingReason.CONFIGURATION;
+import static org.elasticsearch.xpack.ml.autoscaling.MlScalingReason.CURRENT_CAPACITY;
+import static org.elasticsearch.xpack.ml.autoscaling.MlScalingReason.REASON;
+import static org.elasticsearch.xpack.ml.autoscaling.MlScalingReason.WAITING_ANALYTICS_JOBS;
+import static org.elasticsearch.xpack.ml.autoscaling.MlScalingReason.WAITING_ANOMALY_JOBS;
+import static org.hamcrest.Matchers.containsString;
 
 public class MlScalingReasonTests extends AbstractWireSerializingTestCase<MlScalingReason> {
 
@@ -55,4 +63,13 @@ public class MlScalingReasonTests extends AbstractWireSerializingTestCase<MlScal
         return builder.build();
     }
 
+    public void testToXContent() throws Exception {
+        MlScalingReason reason = createTestInstance();
+        String xcontentString = Strings.toString(reason);
+        assertThat(xcontentString, containsString(WAITING_ANALYTICS_JOBS));
+        assertThat(xcontentString, containsString(WAITING_ANOMALY_JOBS));
+        assertThat(xcontentString, containsString(CONFIGURATION));
+        assertThat(xcontentString, containsString(CURRENT_CAPACITY));
+        assertThat(xcontentString, containsString(REASON));
+    }
 }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ML] fixes xcontent serialization for ML scaling reason (#66548)