### PR TITLE
Default to testing against oss distribution

### DIFF
--- a/qa/wildfly/build.gradle
+++ b/qa/wildfly/build.gradle
@@ -57,7 +57,7 @@ elasticsearch_distributions {
   docker {
     type = 'docker'
     architecture = Architecture.current()
-    flavor = System.getProperty('tests.distribution', 'default')
+    flavor = System.getProperty('tests.distribution', 'oss')
     version = VersionProperties.getElasticsearch()
     failIfUnavailable = false // This ensures we skip this testing if Docker is unavailable
   }
@@ -68,7 +68,7 @@ tasks.named("preProcessFixture").configure {
 }
 
 dockerCompose {
-  if ('default'.equalsIgnoreCase(System.getProperty('tests.distribution', 'default'))) {
+  if ('default'.equalsIgnoreCase(System.getProperty('tests.distribution', 'oss'))) {
     useComposeFiles = ['docker-compose.yml']
   } else {
     useComposeFiles = ['docker-compose-oss.yml']


### PR DESCRIPTION
We should default to testing wildfly compatibility using the OSS distribution. The reason here is that we have explicit CI jobs that run our full test suite using the default distro, but not the other way around. As it is we are not testing this using the OSS distro at all.