### PR TITLE
Make sure to execute async actions in _explain API.

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/explain/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/explain/10_basic.yml
@@ -59,3 +59,22 @@ setup:
           id:     id_1
           body:
             match_all: {}
+
+---
+"Explain with query that requires async calls":
+  - skip:
+      version: " - 7.99.99"
+      reason: "bug fix not yet backported"
+  - do:
+      explain:
+        index:  test_1
+        id:     id_1
+        body:
+          query:
+            terms:
+              foo:
+                index: test_1
+                id: placeholder
+                path: placeholder
+
+  - is_false: matched


### PR DESCRIPTION
When rewriting some queries, like `terms` with a lookup document, it's
necessary to perform an action like a client call. Previously, we wouldn't run
these actions, which caused the _explain API to fail on this type of query.