### PR TITLE
[7.11] Fix MANAGE_IDX_TEMPLATE privilege to allow `component_template/*` (#66514)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ClusterPrivilegeResolver.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ClusterPrivilegeResolver.java
@@ -72,7 +72,7 @@ public class ClusterPrivilegeResolver {
     private static final Set<String> TRANSPORT_CLIENT_PATTERN = Collections.unmodifiableSet(
         Sets.newHashSet("cluster:monitor/nodes/liveness", "cluster:monitor/state"));
     private static final Set<String> MANAGE_IDX_TEMPLATE_PATTERN = Collections.unmodifiableSet(Sets.newHashSet("indices:admin/template/*",
-            "indices:admin/index_template/*"));
+            "indices:admin/index_template/*", "cluster:admin/component_template/*"));
     private static final Set<String> MANAGE_INGEST_PIPELINE_PATTERN = Collections.singleton("cluster:admin/ingest/pipeline/*");
     private static final Set<String> READ_PIPELINE_PATTERN = Collections.unmodifiableSet(Sets.newHashSet(GetPipelineAction.NAME,
         SimulatePipelineAction.NAME));


### PR DESCRIPTION
(cherry picked from commit bcc28e0ab8e6883e14b23f93f428dee03b377a1d)
Signed-off-by: Andrei Dan <andrei.dan@elastic.co>

Backport of #66514 