### PR TITLE
[7.11] Do not deduce mappings in latest transform function (#66523)

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/transform/preview_transforms.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/transform/preview_transforms.yml
@@ -101,8 +101,8 @@ setup:
   - match: { generated_dest_index.mappings.properties.airline.type: "keyword" }
   - match: { generated_dest_index.mappings.properties.by-hour.type: "date" }
   - match: { generated_dest_index.mappings.properties.avg_response.type: "double" }
-  - match: { generated_dest_index.mappings.properties.time.properties.max.type: "date" }
-  - match: { generated_dest_index.mappings.properties.time.properties.min.type: "date" }
+  - match: { generated_dest_index.mappings.properties.time\.max.type: "date" }
+  - match: { generated_dest_index.mappings.properties.time\.min.type: "date" }
 
   - do:
       ingest.put_pipeline:

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/TransformIndex.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/TransformIndex.java
@@ -15,39 +15,26 @@ import org.elasticsearch.action.admin.indices.create.CreateIndexAction;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.mapper.MapperService;
-import org.elasticsearch.index.mapper.ObjectMapper;
 import org.elasticsearch.xpack.core.transform.TransformField;
 import org.elasticsearch.xpack.core.transform.TransformMessages;
 import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
 import org.elasticsearch.xpack.core.transform.transforms.TransformDestIndexSettings;
 
 import java.time.Clock;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static java.util.Map.Entry.comparingByKey;
+import static java.util.Collections.singletonMap;
+import static java.util.stream.Collectors.toMap;
 
 public final class TransformIndex {
     private static final Logger logger = LogManager.getLogger(TransformIndex.class);
 
     public static final String DOC_TYPE = "_doc";
-    /**
-     * The list of object types used in the mappings.
-     * We include {@code null} as an alternative for "object", which is the default.
-     */
-    private static final Set<String> OBJECT_TYPES =
-        new HashSet<>(Arrays.asList(null, ObjectMapper.CONTENT_TYPE, ObjectMapper.NESTED_CONTENT_TYPE));
     private static final String PROPERTIES = "properties";
-    private static final String FIELDS = "fields";
     private static final String META = "_meta";
 
     private TransformIndex() {}
@@ -114,7 +101,7 @@ public final class TransformIndex {
 
         Map<String, Object> transformMetadata = new HashMap<>();
         transformMetadata.put(TransformField.CREATION_DATE_MILLIS, clock.millis());
-        transformMetadata.put(TransformField.VERSION.getPreferredName(), Collections.singletonMap(TransformField.CREATED, Version.CURRENT));
+        transformMetadata.put(TransformField.VERSION.getPreferredName(), singletonMap(TransformField.CREATED, Version.CURRENT));
         transformMetadata.put(TransformField.TRANSFORM, id);
 
         metadata.put(TransformField.META_FIELDNAME, transformMetadata);
@@ -153,27 +140,7 @@ public final class TransformIndex {
      * @param mappings A Map of the form {"fieldName": "fieldType"}
      */
     static Map<String, Object> createMappingsFromStringMap(Map<String, String> mappings) {
-        List<Map.Entry<String, String>> sortedMappingsEntries = new ArrayList<>(mappings.entrySet());
-        // We sort the entry list to make sure that for each (parent, parent.child) pair, parent entry will be processed before child entry.
-        sortedMappingsEntries.sort(comparingByKey());
-        Map<String, Object> fieldMappings = new HashMap<>();
-        for (Map.Entry<String, String> entry : sortedMappingsEntries) {
-            String[] parts = Strings.tokenizeToStringArray(entry.getKey(), ".");
-            String type = entry.getValue();
-            Map<String, Object> current = fieldMappings;
-            current = diveInto(current, parts[0]);
-            for (int j = 1; j < parts.length; ++j) {
-                // Here we decide whether a dot ('.') means inner object or a multi-field.
-                current = diveInto(current, OBJECT_TYPES.contains(current.get("type")) ? PROPERTIES : FIELDS);
-                current = diveInto(current, parts[j]);
-            }
-            current.put("type", type);
-        }
-        return fieldMappings;
-    }
-
-    @SuppressWarnings("unchecked")
-    private static Map<String, Object> diveInto(Map<String, Object> map, String key) {
-        return (Map<String, Object>) map.computeIfAbsent(key, k -> new HashMap<>());
+        return mappings.entrySet().stream()
+            .collect(toMap(e -> e.getKey(), e -> singletonMap("type", e.getValue())));
     }
 }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/latest/Latest.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/latest/Latest.java
@@ -11,8 +11,6 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.fieldcaps.FieldCapabilitiesAction;
-import org.elasticsearch.action.fieldcaps.FieldCapabilitiesRequest;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.search.SearchAction;
 import org.elasticsearch.action.search.SearchRequest;
@@ -47,6 +45,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
+import static java.util.Collections.emptyMap;
 import static java.util.stream.Collectors.toList;
 
 public class Latest implements Function {
@@ -187,20 +186,7 @@ public class Latest implements Function {
 
     @Override
     public void deduceMappings(Client client, SourceConfig sourceConfig, ActionListener<Map<String, String>> listener) {
-        FieldCapabilitiesRequest fieldCapabilitiesRequest =
-            new FieldCapabilitiesRequest().indices(sourceConfig.getIndex())
-                .fields("*")
-                .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
-        client.execute(
-            FieldCapabilitiesAction.INSTANCE,
-            fieldCapabilitiesRequest,
-            ActionListener.wrap(
-                response -> {
-                    listener.onResponse(
-                        DocumentConversionUtils.removeInternalFields(DocumentConversionUtils.extractFieldMappings(response)));
-                },
-                listener::onFailure)
-        );
+        listener.onResponse(emptyMap());
     }
 
     @Override

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/persistence/TransformIndexTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/persistence/TransformIndexTests.java
@@ -95,10 +95,8 @@ public class TransformIndexTests extends ESTestCase {
                 put("a.b", "keyword");
             }}),
             is(equalTo(new HashMap<String, Object>() {{
-                put("a", new HashMap<String, Object>() {{
-                    put("type", "long");
-                    put("fields", singletonMap("b", singletonMap("type", "keyword")));
-                }});
+                put("a", singletonMap("type", "long"));
+                put("a.b", singletonMap("type", "keyword"));
             }}))
         );
         assertThat(
@@ -108,17 +106,9 @@ public class TransformIndexTests extends ESTestCase {
                 put("a.b.c", "keyword");
             }}),
             is(equalTo(new HashMap<String, Object>() {{
-                put("a", new HashMap<String, Object>() {{
-                    put("type", "long");
-                    put("fields", new HashMap<String, Object>() {{
-                        put("b", new HashMap<String, Object>() {{
-                            put("type", "text");
-                            put("fields", new HashMap<String, Object>() {{
-                                put("c", singletonMap("type", "keyword"));
-                            }});
-                        }});
-                    }});
-                }});
+                put("a", singletonMap("type", "long"));
+                put("a.b", singletonMap("type", "text"));
+                put("a.b.c", singletonMap("type", "keyword"));
             }}))
         );
         assertThat(
@@ -133,38 +123,14 @@ public class TransformIndexTests extends ESTestCase {
                 put("f.g.h.i", "text");
             }}),
             is(equalTo(new HashMap<String, Object>() {{
-                put("a", new HashMap<String, Object>() {{
-                    put("type", "object");
-                    put("properties", new HashMap<String, Object>() {{
-                        put("b", new HashMap<String, Object>() {{
-                            put("type", "long");
-                        }});
-                    }});
-                }});
-                put("c", new HashMap<String, Object>() {{
-                    put("type", "nested");
-                    put("properties", new HashMap<String, Object>() {{
-                        put("d", new HashMap<String, Object>() {{
-                            put("type", "boolean");
-                        }});
-                    }});
-                }});
-                put("f", new HashMap<String, Object>() {{
-                    put("type", "object");
-                    put("properties", new HashMap<String, Object>() {{
-                        put("g", new HashMap<String, Object>() {{
-                            put("type", "object");
-                            put("properties", new HashMap<String, Object>() {{
-                                put("h", new HashMap<String, Object>() {{
-                                    put("type", "text");
-                                    put("fields", new HashMap<String, Object>() {{
-                                        put("i", singletonMap("type", "text"));
-                                    }});
-                                }});
-                            }});
-                        }});
-                    }});
-                }});
+                put("a", singletonMap("type", "object"));
+                put("a.b", singletonMap("type", "long"));
+                put("c", singletonMap("type", "nested"));
+                put("c.d", singletonMap("type", "boolean"));
+                put("f", singletonMap("type", "object"));
+                put("f.g", singletonMap("type", "object"));
+                put("f.g.h", singletonMap("type", "text"));
+                put("f.g.h.i", singletonMap("type", "text"));
             }}))
         );
     }


### PR DESCRIPTION
Backports the following commits to 7.11:
 - Do not deduce mappings in latest transform function  (#66523)