### PR TITLE
[7.x] [DOCS] EQL: Change `result_position` default to `tail` (#66550)

### DIFF
--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -235,13 +235,13 @@ Set of matching events or sequences to return.
 .Valid values for `result_position`
 [%collapsible%open]
 ====
-`head`::
+`tail`::
 (Default)
-Return the earliest matches, similar to the {wikipedia}/Head_(Unix)[Unix head
+Return the most recent matches, similar to the {wikipedia}/Tail_(Unix)[Unix tail
 command].
 
-`tail`::
-Return the most recent matches, similar to the {wikipedia}/Tail_(Unix)[Unix tail
+`head`::
+Return the earliest matches, similar to the {wikipedia}/Head_(Unix)[Unix head
 command].
 ====
 +

--- a/docs/reference/eql/eql.asciidoc
+++ b/docs/reference/eql/eql.asciidoc
@@ -59,7 +59,7 @@ GET /my-index-000001/_eql/search
 ----
 // TEST[setup:sec_logs]
 
-By default, basic EQL queries return the top 10 matching events in the
+By default, basic EQL queries return the 10 most recent matching events in the
 `hits.events` property. These hits are sorted by timestamp, converted to
 milliseconds since the {wikipedia}/Unix_time[Unix epoch], in ascending order.
 
@@ -155,7 +155,8 @@ GET /my-index-000001/_eql/search
 ----
 // TEST[setup:sec_logs]
 
-Matching sequences are returned in the `hits.sequences` property.
+The response's `hits.sequences` property contains the 10 most recent matching
+sequences.
 
 [source,console-result]
 ----


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] EQL: Change `result_position` default to `tail` (#66550)