### PR TITLE
EQL: Add key constraints to sequence mechanism

### DIFF
--- a/x-pack/plugin/eql/qa/common/src/main/resources/data/endgame-140.mapping
+++ b/x-pack/plugin/eql/qa/common/src/main/resources/data/endgame-140.mapping
@@ -80,6 +80,9 @@
                 }
             }
         },
+        "file_path" : {
+          "type" : "[runtime_random_keyword_type]"
+        },
         "serial_event_id" : {
             "type" : "long"
         },

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/assembler/BoxedQueryRequest.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/assembler/BoxedQueryRequest.java
@@ -6,13 +6,25 @@
 
 package org.elasticsearch.xpack.eql.execution.assembler;
 
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.xpack.eql.execution.search.Ordinal;
 import org.elasticsearch.xpack.eql.execution.search.QueryRequest;
 import org.elasticsearch.xpack.eql.execution.search.RuntimeUtils;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static java.util.Collections.emptyList;
+import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
+import static org.elasticsearch.index.query.QueryBuilders.existsQuery;
 import static org.elasticsearch.index.query.QueryBuilders.rangeQuery;
+import static org.elasticsearch.index.query.QueryBuilders.termQuery;
+import static org.elasticsearch.index.query.QueryBuilders.termsQuery;
 
 /**
  * Ranged or boxed query. Provides a beginning or end to the current query.
@@ -25,16 +37,24 @@ import static org.elasticsearch.index.query.QueryBuilders.rangeQuery;
  */
 public class BoxedQueryRequest implements QueryRequest {
 
+    // arbitrary low number
+    // TODO: performance testing to find the sweet spot
+    public static final int MAX_TERMS = 128;
+
     private final RangeQueryBuilder timestampRange;
     private final SearchSourceBuilder searchSource;
+
+    private final List<String> keys;
+    private List<QueryBuilder> keyFilters;
 
     private Ordinal from, to;
     private Ordinal after;
 
-    public BoxedQueryRequest(QueryRequest original, String timestamp) {
+    public BoxedQueryRequest(QueryRequest original, String timestamp, List<String> keyNames) {
         searchSource = original.searchSource();
         // setup range queries and preserve their reference to simplify the update
         timestampRange = rangeQuery(timestamp).timeZone("UTC").format("epoch_millis");
+        keys = keyNames;
         RuntimeUtils.addFilter(timestampRange, searchSource);
     }
 
@@ -67,6 +87,78 @@ public class BoxedQueryRequest implements QueryRequest {
     public BoxedQueryRequest to(Ordinal end) {
         to = end;
         timestampRange.lte(end != null ? end.timestamp() : null);
+        return this;
+    }
+
+    /**
+     * Sets keys / terms to filter on.
+     * Accepts the unwrapped SequenceKey as a list of values matching an instance of a given
+     * event.
+     * Can be removed through null.
+     */
+    public BoxedQueryRequest keys(List<List<Object>> values) {
+        List<QueryBuilder> newFilters;
+
+        if (values == null || values.isEmpty()) {
+            // no keys have been specified and none have been set
+            if (keyFilters == null || keyFilters.isEmpty()) {
+                return this;
+            }
+            newFilters = emptyList();
+        }
+        else {
+            // iterate on all possible values for a given key
+            newFilters = new ArrayList<>(values.size());
+            for (int keyIndex = 0; keyIndex < keys.size(); keyIndex++) {
+                String key = keys.get(keyIndex);
+
+                boolean hasNullValue = false;
+                Set<Object> keyValues = new HashSet<>(MAX_TERMS);
+                // check the given keys but make sure to double check for
+                // null as it translates to a different query (missing/not exists)
+                for (List<Object> value : values) {
+                    Object keyValue = value.get(keyIndex);
+                    if (keyValue == null) {
+                        hasNullValue = true;
+                    } else {
+                        keyValues.add(keyValue);
+                    }
+                }
+
+                // too many unique terms, don't filter on the keys
+                if (keyValues.size() > MAX_TERMS) {
+                    newFilters = emptyList();
+                    break;
+                }
+
+                QueryBuilder query = null;
+
+                if (keyValues.size() == 1) {
+                    query = termQuery(key, keyValues.iterator().next());
+                } else if (keyValues.size() > 1) {
+                    query = termsQuery(key, keyValues);
+                }
+
+                // if null values are present
+                // make an OR call - either terms or null/missing values
+                if (hasNullValue) {
+                    BoolQueryBuilder isMissing = boolQuery().mustNot(existsQuery(key));
+                    if (query != null) {
+                        query = boolQuery()
+                            // terms query
+                            .should(query)
+                            // is missing
+                            .should(isMissing);
+                    } else {
+                        query = isMissing;
+                    }
+                }
+                newFilters.add(query);
+            }
+        }
+
+        RuntimeUtils.replaceFilter(keyFilters, newFilters, searchSource);
+        keyFilters = newFilters;
         return this;
     }
 

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/assembler/Criterion.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/assembler/Criterion.java
@@ -42,6 +42,10 @@ public class Criterion<Q extends QueryRequest> {
         this.keySize = keys.size();
     }
 
+    public int keySize() {
+        return keySize;
+    }
+
     public int stage() {
         return stage;
     }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/assembler/ExecutionManager.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/assembler/ExecutionManager.java
@@ -78,8 +78,7 @@ public class ExecutionManager {
                     // no nested fields
                     if (hitExtractor.hitName() == null) {
                         keyFields.add(hitExtractor.fieldName());
-                    }
-                    else {
+                    } else {
                         keyFields = emptyList();
                         break;
                     }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/assembler/ExecutionManager.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/assembler/ExecutionManager.java
@@ -22,6 +22,7 @@ import org.elasticsearch.xpack.eql.plan.physical.PhysicalPlan;
 import org.elasticsearch.xpack.eql.querydsl.container.FieldExtractorRegistry;
 import org.elasticsearch.xpack.eql.session.EqlConfiguration;
 import org.elasticsearch.xpack.eql.session.EqlSession;
+import org.elasticsearch.xpack.ql.execution.search.extractor.AbstractFieldHitExtractor;
 import org.elasticsearch.xpack.ql.execution.search.extractor.HitExtractor;
 import org.elasticsearch.xpack.ql.expression.Attribute;
 import org.elasticsearch.xpack.ql.expression.Expression;
@@ -30,6 +31,8 @@ import org.elasticsearch.xpack.ql.expression.Order.OrderDirection;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import static java.util.Collections.emptyList;
 
 public class ExecutionManager {
 
@@ -65,13 +68,30 @@ public class ExecutionManager {
         for (int i = 0; i < plans.size(); i++) {
             List<Attribute> keys = listOfKeys.get(i);
             List<HitExtractor> keyExtractors = hitExtractors(keys, extractorRegistry);
+            List<String> keyFields = new ArrayList<>(keyExtractors.size());
+
+            // extract top-level fields used as keys to optimize query lookups
+            // this process gets skipped for nested fields
+            for (HitExtractor extractor : keyExtractors) {
+                if (extractor instanceof AbstractFieldHitExtractor) {
+                    AbstractFieldHitExtractor hitExtractor = (AbstractFieldHitExtractor) extractor;
+                    // no nested fields
+                    if (hitExtractor.hitName() == null) {
+                        keyFields.add(hitExtractor.fieldName());
+                    }
+                    else {
+                        keyFields = emptyList();
+                        break;
+                    }
+                }
+            }
 
             PhysicalPlan query = plans.get(i);
             // search query
             if (query instanceof EsQueryExec) {
                 SearchSourceBuilder source = ((EsQueryExec) query).source(session);
                 QueryRequest original = () -> source;
-                BoxedQueryRequest boxedRequest = new BoxedQueryRequest(original, timestampName);
+                BoxedQueryRequest boxedRequest = new BoxedQueryRequest(original, timestampName, keyFields);
                 Criterion<BoxedQueryRequest> criterion =
                         new Criterion<>(i, boxedRequest, keyExtractors, tsExtractor, tbExtractor, i == 0 && descending);
                 criteria.add(criterion);

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/PITAwareQueryClient.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/PITAwareQueryClient.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.index.get.GetResult;
+import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.builder.PointInTimeBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.xpack.core.search.action.ClosePointInTimeAction;
@@ -28,6 +29,7 @@ import org.elasticsearch.xpack.ql.index.IndexResolver;
 import java.util.function.Function;
 
 import static org.elasticsearch.action.ActionListener.wrap;
+import static org.elasticsearch.index.query.QueryBuilders.termQuery;
 import static org.elasticsearch.index.query.QueryBuilders.termsQuery;
 import static org.elasticsearch.xpack.ql.util.ActionListeners.map;
 
@@ -102,7 +104,8 @@ public class PITAwareQueryClient extends BasicQueryClient {
         String[] indices = request.indices();
         if (CollectionUtils.isEmpty(indices) == false) {
             request.indices(Strings.EMPTY_ARRAY);
-            RuntimeUtils.addFilter(termsQuery(GetResult._INDEX, indices), source);
+            QueryBuilder indexQuery = indices.length == 1 ? termQuery(GetResult._INDEX, indices[0]) : termsQuery(GetResult._INDEX, indices);
+            RuntimeUtils.addFilter(indexQuery, source);
         }
     }
 

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/RuntimeUtils.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/RuntimeUtils.java
@@ -185,4 +185,35 @@ public final class RuntimeUtils {
         }
         return source;
     }
+
+    public static SearchSourceBuilder replaceFilter(List<QueryBuilder> oldFilters,
+                                                    List<QueryBuilder> newFilters,
+                                                    SearchSourceBuilder source) {
+        BoolQueryBuilder bool = null;
+        QueryBuilder query = source.query();
+
+        if (query instanceof BoolQueryBuilder) {
+            bool = (BoolQueryBuilder) query;
+            if (oldFilters != null) {
+                bool.filter().removeAll(oldFilters);
+            }
+
+            if (newFilters != null) {
+                bool.filter().addAll(newFilters);
+            }
+        }
+        // no bool query means no old filters
+        else {
+            bool = boolQuery();
+            if (query != null) {
+                bool.filter(query);
+            }
+            if (newFilters != null) {
+                bool.filter().addAll(newFilters);
+            }
+
+            source.query(bool);
+        }
+        return source;
+    }
 }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/OrdinalGroup.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/OrdinalGroup.java
@@ -47,7 +47,7 @@ abstract class OrdinalGroup<E> implements Iterable<Ordinal> {
     }
 
     /**
-     * Returns the latest element from the group that has its timestamp
+     * Returns the latest element from the group that has its ordinal
      * less than the given argument alongside its position in the list.
      * The element and everything before it is removed.
      */
@@ -56,9 +56,9 @@ abstract class OrdinalGroup<E> implements Iterable<Ordinal> {
     }
 
     /**
-     * Returns the latest element from the group that has its timestamp
+     * Returns the latest element from the group that has its ordinal
      * less than the given argument alongside its position in the list.
-     * Everything before the element it is removed. The element is kept.
+     * Everything before the found element is removed. The element is kept.
      */
     E trimBeforeLast(Ordinal ordinal) {
         return trimBefore(ordinal, false);

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/SequenceMatcher.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/SequenceMatcher.java
@@ -239,6 +239,10 @@ public class SequenceMatcher {
         return false;
     }
 
+    Set<SequenceKey> keysFor(int stage) {
+        return stageToKeys.keys(stage);
+    }
+
     List<Sequence> completed() {
         List<Sequence> asList = new ArrayList<>(completed);
         return limit != null ? limit.view(asList) : asList;

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/StageToKeys.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/StageToKeys.java
@@ -12,6 +12,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.StringJoiner;
 
+import static java.util.Collections.emptySet;
+
 /** Dedicated collection for mapping a stage (represented by the index collection) to a set of keys */
 class StageToKeys {
 
@@ -43,6 +45,11 @@ class StageToKeys {
     boolean isEmpty(int stage) {
         Set<SequenceKey> set = stageToKey.get(stage);
         return set == null || set.isEmpty();
+    }
+
+    Set<SequenceKey> keys(int stage) {
+        Set<SequenceKey> set = stageToKey.get(stage);
+        return set == null ? emptySet() : set;
     }
 
     void clear() {

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/querydsl/container/FieldExtractorRegistry.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/querydsl/container/FieldExtractorRegistry.java
@@ -24,14 +24,14 @@ import java.util.Map;
 public class FieldExtractorRegistry {
 
     private final Map<String, FieldExtraction> cache = new HashMap<>();
-    
+
     public FieldExtraction fieldExtraction(Expression expression) {
         return cache.computeIfAbsent(Expressions.id(expression), k -> createFieldExtractionFor(expression));
     }
 
     private FieldExtraction createFieldExtractionFor(Expression expression) {
         if (expression instanceof FieldAttribute) {
-            FieldAttribute fa = (FieldAttribute) expression;
+            FieldAttribute fa = ((FieldAttribute) expression).exactAttribute();
             if (fa.isNested()) {
                 throw new UnsupportedOperationException("Nested not yet supported");
             }
@@ -43,12 +43,12 @@ public class FieldExtractorRegistry {
 
         throw new EqlIllegalArgumentException("Unsupported expression [{}]", expression);
     }
-    
+
     private FieldExtraction topHitFieldExtractor(FieldAttribute fieldAttr) {
         FieldAttribute actualField = fieldAttr;
         FieldAttribute rootField = fieldAttr;
         StringBuilder fullFieldName = new StringBuilder(fieldAttr.field().getName());
-        
+
         // Only if the field is not an alias (in which case it will be taken out from docvalue_fields if it's isAggregatable()),
         // go up the tree of parents until a non-object (and non-nested) type of field is found and use that specific parent
         // as the field to extract data from, from _source. We do it like this because sub-fields are not in the _source, only

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/assembler/SequenceSpecTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/assembler/SequenceSpecTests.java
@@ -99,7 +99,7 @@ public class SequenceSpecTests extends ESTestCase {
                       .size(10)
                       .query(matchAllQuery())
                       // pass the ordinal through terminate after
-                      .terminateAfter(ordinal), "timestamp"),
+                      .terminateAfter(ordinal), "timestamp", emptyList()),
                   keyExtractors,
                   tsExtractor, tbExtractor, false);
             this.ordinal = ordinal;


### PR DESCRIPTION
If possible, improve search by looking for the already determined keys.
Change field extraction to use exact fields to handle text fields.
