### PR TITLE
Mute HistogramGroupByIT

### DIFF
--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/HistogramGroupByIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/HistogramGroupByIT.java
@@ -1,5 +1,6 @@
 package org.elasticsearch.xpack.transform.integration.continuous;
 
+import org.apache.lucene.util.LuceneTestCase.AwaitsFix;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -26,6 +27,7 @@ import java.util.Set;
 
 import static org.hamcrest.Matchers.equalTo;
 
+@AwaitsFix(bugUrl="https://github.com/elastic/elasticsearch/issues/66410")
 public class HistogramGroupByIT extends ContinuousTestCase {
     private static final String NAME = "continuous-histogram-pivot-test";
 


### PR DESCRIPTION
As all of the CI failures claim that `transform [continuous-histogram-pivot-test] does not progress`, let's verify if this is `HistogramGroupByIT` test's fault.

Relates #66410