### PR TITLE
[DOCS] Clarify use of CCS on ML nodes

### DIFF
--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -15,7 +15,7 @@ All nodes know about all the other nodes in the cluster and can forward client
 requests to the appropriate node.
 
 By default, a node is all of the following types: master-eligible, data, ingest,
-{transform} and (if available) {ml}.
+{transform}, remote_cluster_client and (if available) {ml}.
 // end::modules-node-description-tag[]
 
 TIP: As the cluster grows and in particular if you have large {ml} jobs or

--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -340,6 +340,9 @@ xpack.ml.enabled: true <1>
 ----
 <1> The `xpack.ml.enabled` setting is enabled by default.
 
+If you want the node to use {ccs}, add `remote_cluster_client` to the list of
+roles. See <<remote-node>>.
+
 [[transform-node]]
 ==== [xpack]#{transform-cap} node#
 
@@ -353,6 +356,9 @@ To create a dedicated {transform} node in the {default-dist}, set:
 ----
 node.roles: [ transform ]
 ----
+
+If you want the node to use {ccs}, add `remote_cluster_client` to the list of
+roles. See <<remote-node>>.
 
 [[change-node-role]]
 ==== Changing the role of a node

--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -335,13 +335,12 @@ To create a dedicated {ml} node in the {default-dist}, set:
 
 [source,yaml]
 ----
-node.roles: [ ml ]
-xpack.ml.enabled: true <1>
+node.roles: [ ml, remote_cluster_client] <1>
+xpack.ml.enabled: true <2>
 ----
-<1> The `xpack.ml.enabled` setting is enabled by default.
-
-If you want the node to use {ccs}, add `remote_cluster_client` to the list of
-roles. See <<remote-node>>.
+<1> The `remote_cluster_client` role is optional but strongly recommended.
+Otherwise, {ccs} fails when used in {ml} jobs or {dfeeds}. See <<remote-node>>.
+<2> The `xpack.ml.enabled` setting is enabled by default.
 
 [[transform-node]]
 ==== [xpack]#{transform-cap} node#
@@ -354,11 +353,10 @@ To create a dedicated {transform} node in the {default-dist}, set:
 
 [source,yaml]
 ----
-node.roles: [ transform ]
+node.roles: [ transform, remote_cluster_client ] <1>
 ----
-
-If you want the node to use {ccs}, add `remote_cluster_client` to the list of
-roles. See <<remote-node>>.
+<1> The `remote_cluster_client` role is optional but strongly recommended.
+Otherwise, {ccs} fails when used in {transforms}. See <<remote-node>>.
 
 [[change-node-role]]
 ==== Changing the role of a node

--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -15,7 +15,7 @@ All nodes know about all the other nodes in the cluster and can forward client
 requests to the appropriate node.
 
 By default, a node is all of the following types: master-eligible, data, ingest,
-and (if available) machine learning. All data nodes are also transform nodes.
+{transform} and (if available) {ml}.
 // end::modules-node-description-tag[]
 
 TIP: As the cluster grows and in particular if you have large {ml} jobs or

--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -13,20 +13,13 @@ clients.
 // tag::modules-node-description-tag[]
 All nodes know about all the other nodes in the cluster and can forward client
 requests to the appropriate node.
-
-By default, a node is all of the following types: master-eligible, data, ingest,
-{transform}, remote_cluster_client and (if available) {ml}.
 // end::modules-node-description-tag[]
-
-TIP: As the cluster grows and in particular if you have large {ml} jobs or
-{ctransforms}, consider separating dedicated master-eligible nodes from
-dedicated data nodes, {ml} nodes, and {transform} nodes.
 
 [[node-roles]]
 ==== Node roles
 
 You can define the roles of a node by setting `node.roles`. If you don't
-configure this setting, then the node has the following roles by default:
+configure this setting, the node has the following roles by default:
 
 * `master`
 * `data`
@@ -37,8 +30,13 @@ configure this setting, then the node has the following roles by default:
 * `ingest`
 * `ml`
 * `remote_cluster_client`
+* `transform`
 
 NOTE: If you set `node.roles`, the node is assigned only the roles you specify.
+
+As the cluster grows and in particular if you have large {ml} jobs or
+{ctransforms}, consider separating dedicated master-eligible nodes from
+dedicated data nodes, {ml} nodes, and {transform} nodes.
 
 <<master-node,Master-eligible node>>::
 

--- a/docs/reference/settings/ml-settings.asciidoc
+++ b/docs/reference/settings/ml-settings.asciidoc
@@ -22,11 +22,12 @@ hardware, you must disable {ml} (by setting `xpack.ml.enabled` to `false`).
 
 `node.roles: [ ml ]`::
 (<<static-cluster-setting,Static>>) Set `node.roles` to contain `ml` to identify
-the node as a _{ml} node_ that is capable of running jobs. Every node is a {ml}
-node by default.
+the node as a _{ml} node_. If you want to run {ml} jobs, there must be at least
+one {ml} node in your cluster. 
 +
-If you use the `node.roles` setting, then all required roles must be explicitly
-set. Consult <<modules-node>> to learn more.
+By default, every node is a {ml} node. If you set `node.roles`, however,
+you must explicitly specify all the required roles for the node. To learn more, 
+refer to <<modules-node>>.
 +
 [IMPORTANT]
 ====

--- a/docs/reference/settings/ml-settings.asciidoc
+++ b/docs/reference/settings/ml-settings.asciidoc
@@ -28,9 +28,12 @@ node by default.
 If you use the `node.roles` setting, then all required roles must be explicitly
 set. Consult <<modules-node>> to learn more.
 +
-IMPORTANT: On dedicated coordinating nodes or dedicated master nodes, do not set
+[IMPORTANT]
+====
+* On dedicated coordinating nodes or dedicated master nodes, do not set
 the `ml` role.
-
+* It is strongly recommended that dedicated {ml} nodes also have the `remote_cluster_client` role; otherwise, {ccs} fails when used in {ml} jobs or {dfeeds}. See <<remote-node>>.
+====
 
 `xpack.ml.enabled`::
 (<<static-cluster-setting,Static>>) Set to `true` (default) to enable {ml} APIs

--- a/docs/reference/settings/transform-settings.asciidoc
+++ b/docs/reference/settings/transform-settings.asciidoc
@@ -19,7 +19,7 @@ default.
 identify the node as a _transform node_. If you want to run {transforms}, there 
 must be at least one {transform} node in your cluster.
 +
-By default, every node is a {tranform} node. If you set `node.roles`, however,
+By default, every node is a {transform} node. If you set `node.roles`, however,
 you must explicitly specify all the required roles for the node. To learn more, 
 refer to <<modules-node>>.
 + 

--- a/docs/reference/settings/transform-settings.asciidoc
+++ b/docs/reference/settings/transform-settings.asciidoc
@@ -17,13 +17,18 @@ default.
 `node.roles: [ transform ]`::
 (<<static-cluster-setting,Static>>) Set `node.roles` to contain `transform` to
 identify the node as a _transform node_. If you use the default settings for a
-node, it does not have the `transform` role.
+node, it does not have the `transform` role. However, by default all generic
+data nodes are also {transform} nodes.
 +
 If a node doesn't have this role, the node cannot run transforms. If you want to 
 run transforms, there must be at least one transform node in your cluster.
 +
 If you use the `node.roles` setting, all required roles must be explicitly set.
 Consult <<modules-node>> to learn more.
++ 
+IMPORTANT: It is strongly recommended that dedicated {transform} nodes also have 
+the `remote_cluster_client` role; otherwise, {ccs} fails when used in 
+{transforms}. See <<remote-node>>.
 
 `xpack.transform.enabled`::
 deprecated:[7.8.0,Basic License features should always be enabled]

--- a/docs/reference/settings/transform-settings.asciidoc
+++ b/docs/reference/settings/transform-settings.asciidoc
@@ -16,15 +16,12 @@ default.
 
 `node.roles: [ transform ]`::
 (<<static-cluster-setting,Static>>) Set `node.roles` to contain `transform` to
-identify the node as a _transform node_. If you use the default settings for a
-node, it does not have the `transform` role. However, by default all generic
-data nodes are also {transform} nodes.
+identify the node as a _transform node_. If you want to run {transforms}, there 
+must be at least one {transform} node in your cluster.
 +
-If a node doesn't have this role, the node cannot run transforms. If you want to 
-run transforms, there must be at least one transform node in your cluster.
-+
-If you use the `node.roles` setting, all required roles must be explicitly set.
-Consult <<modules-node>> to learn more.
+By default, every node is a {tranform} node. If you set `node.roles`, however,
+you must explicitly specify all the required roles for the node. To learn more, 
+refer to <<modules-node>>.
 + 
 IMPORTANT: It is strongly recommended that dedicated {transform} nodes also have 
 the `remote_cluster_client` role; otherwise, {ccs} fails when used in 


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/66533

This PR updates https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-node.html to suggest adding the remote_cluster_client role to dedicated machine learning and transform nodes.

### Preview

* https://elasticsearch_66616.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/modules-node.html#ml-node
* https://elasticsearch_66616.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ml-settings.html
* https://elasticsearch_66616.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/transform-settings.html