### PR TITLE
QL: handle IP type fields extraction with ignore_malformed property

### DIFF
--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/execution/search/extractor/AbstractFieldHitExtractor.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/execution/search/extractor/AbstractFieldHitExtractor.java
@@ -128,16 +128,13 @@ public abstract class AbstractFieldHitExtractor implements HitExtractor {
             // if the field was ignored because it was malformed and ignore_malformed was turned on
             if (fullFieldName != null
                     && hit.getFields().containsKey(IgnoredFieldMapper.NAME)
-                    && isFromDocValuesOnly(dataType) == false
-                    && (dataType.isNumeric() || dataType == DataTypes.IP)) {
+                    && isFromDocValuesOnly(dataType) == false) {
                 /*
-                 * ignore_malformed makes sense for extraction from _source for numeric and IP fields only.
-                 * And we check here that the data type is actually a numeric or IP one to rule out
-                 * any non-numeric sub-fields (for which the "parent" field should actually be extracted from _source).
+                 * We check here the presence of the field name (fullFieldName including the parent name) in the list
+                 * of _ignored fields (due to malformed data, which was ignored).
                  * For example, in the case of a malformed number, a "byte" field with "ignore_malformed: true"
                  * with a "text" sub-field should return "null" for the "byte" parent field and the actual malformed
-                 * data for the "text" sub-field. Also, the _ignored section of the response contains the full field
-                 * name, thus the need to do the comparison with that and not only the field name.
+                 * data for the "text" sub-field.
                  */
                 if (hit.getFields().get(IgnoredFieldMapper.NAME).getValues().contains(fullFieldName)) {
                     return null;

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/execution/search/extractor/AbstractFieldHitExtractor.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/execution/search/extractor/AbstractFieldHitExtractor.java
@@ -129,10 +129,10 @@ public abstract class AbstractFieldHitExtractor implements HitExtractor {
             if (fullFieldName != null
                     && hit.getFields().containsKey(IgnoredFieldMapper.NAME)
                     && isFromDocValuesOnly(dataType) == false
-                    && dataType.isNumeric()) {
+                    && (dataType.isNumeric() || dataType == DataTypes.IP)) {
                 /*
-                 * ignore_malformed makes sense for extraction from _source for numeric fields only.
-                 * And we check here that the data type is actually a numeric one to rule out
+                 * ignore_malformed makes sense for extraction from _source for numeric and IP fields only.
+                 * And we check here that the data type is actually a numeric or IP one to rule out
                  * any non-numeric sub-fields (for which the "parent" field should actually be extracted from _source).
                  * For example, in the case of a malformed number, a "byte" field with "ignore_malformed: true"
                  * with a "text" sub-field should return "null" for the "byte" parent field and the actual malformed
@@ -201,7 +201,7 @@ public abstract class AbstractFieldHitExtractor implements HitExtractor {
                     }
                     return result;
                 }
-            } else if (DataTypes.isString(dataType)) {
+            } else if (DataTypes.isString(dataType) || dataType == DataTypes.IP) {
                 return values.toString();
             } else {
                 return values;


### PR DESCRIPTION
Fixes a bug where the field value extraction for an ip field that has `ignore_malformed=true` still happens from `_source` even though the value might be ignored because it's not a valid IP.

Fixes also https://github.com/elastic/elasticsearch/issues/66675.