### PR TITLE
Properly handle resolving file paths for test classpath resource

### DIFF
--- a/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/fixtures/AbstractGitAwareGradleFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/fixtures/AbstractGitAwareGradleFuncTest.groovy
@@ -24,6 +24,8 @@ import org.gradle.testkit.runner.GradleRunner
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 
+import java.nio.file.Paths
+
 abstract class AbstractGitAwareGradleFuncTest extends AbstractGradleFuncTest {
 
     @Rule
@@ -41,7 +43,7 @@ abstract class AbstractGitAwareGradleFuncTest extends AbstractGradleFuncTest {
     File setupGitRemote() {
         URL fakeRemote = getClass().getResource("fake_git/remote")
         File workingRemoteGit = new File(remoteRepoDirs.root, 'remote')
-        FileUtils.copyDirectory(new File(fakeRemote.toURI()), workingRemoteGit)
+        FileUtils.copyDirectory(Paths.get(fakeRemote.toURI()).toFile(), workingRemoteGit)
         fakeRemote.file + "/.git"
         gradleRunner(workingRemoteGit, "wrapper").build()
 


### PR DESCRIPTION
This should sort out issues when resolving a file path to a classpath resource (URI) in edge cases like Windows file paths with spaces.

Right now this is only failing on our Teamcity instances, because the checkout dir happens to include a space.

Closes https://github.com/elastic/elasticsearch/issues/66372