### PR TITLE
Add OpenJDK 16 to our java testing matrix

### DIFF
--- a/.ci/matrix-runtime-javas.yml
+++ b/.ci/matrix-runtime-javas.yml
@@ -9,6 +9,7 @@ ES_RUNTIME_JAVA:
   - java11
   - openjdk14
   - openjdk15
+  - openjdk16
   - zulu11
   - corretto11
   - adoptopenjdk11


### PR DESCRIPTION
The PR adds the openjdk 16 EA builds to our periodic java testing matrix.

Closes https://github.com/elastic/elasticsearch/issues/66274