### PR TITLE
Make WildFlyIT extend from ESTestCase

### DIFF
--- a/qa/wildfly/build.gradle
+++ b/qa/wildfly/build.gradle
@@ -79,6 +79,7 @@ tasks.register("integTest", Test) {
   outputs.doNotCacheIf('Build cache is disabled for Docker tests') { true }
   maxParallelForks = '1'
   include '**/*IT.class'
+  systemProperty 'tests.security.manager', 'false'
 }
 
 tasks.named("check").configure {

--- a/qa/wildfly/docker-compose-oss.yml
+++ b/qa/wildfly/docker-compose-oss.yml
@@ -19,7 +19,8 @@ services:
   elasticsearch:
     image: elasticsearch-oss:test
     environment:
-      discovery.type: single-node
+      - discovery.type=single-node
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
     ulimits:
       memlock:
         soft: -1

--- a/qa/wildfly/docker-compose.yml
+++ b/qa/wildfly/docker-compose.yml
@@ -19,7 +19,8 @@ services:
   elasticsearch:
     image: elasticsearch:test
     environment:
-      discovery.type: single-node
+      - discovery.type=single-node
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
     ulimits:
       memlock:
         soft: -1

--- a/qa/wildfly/src/test/java/org/elasticsearch/wildfly/WildflyIT.java
+++ b/qa/wildfly/src/test/java/org/elasticsearch/wildfly/WildflyIT.java
@@ -29,13 +29,13 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.lucene.util.LuceneTestCase;
 import org.apache.lucene.util.TestRuleLimitSysouts;
 import org.elasticsearch.cluster.ClusterModule;
 import org.elasticsearch.common.xcontent.DeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
 import java.net.URI;
@@ -48,7 +48,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 
 @TestRuleLimitSysouts.Limit(bytes = 14000)
-public class WildflyIT extends LuceneTestCase {
+public class WildflyIT extends ESTestCase {
 
     private Logger logger = LogManager.getLogger(WildflyIT.class);
 


### PR DESCRIPTION
Extending from `ESTestCase` introduces many standard conventions, not least of which is our reproduce line printer which is Gradle-aware.

Closes https://github.com/elastic/elasticsearch/issues/32572