### PR TITLE
Register a test cluster so plugin project "run" tasks continue to work

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/RunTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/RunTask.java
@@ -147,6 +147,11 @@ public class RunTask extends DefaultTestClustersTask {
     public void runAndWait() throws IOException {
         List<BufferedReader> toRead = new ArrayList<>();
         List<BooleanSupplier> aliveChecks = new ArrayList<>();
+
+        if (getClusters().isEmpty()) {
+            throw new GradleException("Task " + getPath() + " is not configured to use any clusters. Be sure to call useCluster().");
+        }
+
         try {
             for (ElasticsearchCluster cluster : getClusters()) {
                 for (ElasticsearchNode node : cluster.getNodes()) {

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/util/GradleUtils.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/util/GradleUtils.java
@@ -226,4 +226,10 @@ public abstract class GradleUtils {
         int lastDelimiterIndex = taskPath.lastIndexOf(":");
         return lastDelimiterIndex == 0 ? ":" : taskPath.substring(0, lastDelimiterIndex);
     }
+
+    public static boolean isModuleProject(String projectPath) {
+        return projectPath.contains("modules:")
+            || projectPath.startsWith(":x-pack:plugin")
+            || projectPath.startsWith(":x-pack:quota-aware-fs");
+    }
 }


### PR DESCRIPTION
At some point some refactoring we did broke the ability to call `:run` on a particular plugin or module project to simply spin up a quick Elasticsearch node with that given plugin/module installed. This pull request simply returns this functionality by explicitly registering a test cluster on these project specifically for that purpose.

Also found an instance where we might mistakenly be realizing the `bundle` task early and replaced that usage with a `TaskProvider`.

Closes #66361