### PR TITLE
Mute tests failing on Debian 8 due to memory reporting (#66648)

### DIFF
--- a/docs/reference/ml/anomaly-detection/apis/get-ml-info.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-ml-info.asciidoc
@@ -126,3 +126,4 @@ This is a possible response:
 // TESTRESPONSE[s/"build_hash": "99a07c016d5a73"/"build_hash": "$body.native_code.build_hash"/]
 // TESTRESPONSE[s/"effective_max_model_memory_limit": "28961mb"/"effective_max_model_memory_limit": "$body.limits.effective_max_model_memory_limit"/]
 // TESTRESPONSE[s/"total_ml_memory": "86883mb"/"total_ml_memory": "$body.limits.total_ml_memory"/]
+// TESTRESPONSE[skip:"AwaitsFix https://github.com/elastic/elasticsearch/issues/66629"]

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.stats/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.stats/10_basic.yml
@@ -1,5 +1,9 @@
 ---
 "cluster stats test":
+  - skip:
+      version: "all"
+      reason: "https://github.com/elastic/elasticsearch/issues/66629"
+
   - do:
       cluster.stats: {}
 
@@ -33,8 +37,10 @@
 ---
 "get cluster stats returns cluster_uuid at the top level":
   - skip:
-      version: " - 6.99.99"
-      reason:  "cluster stats including cluster_uuid at the top level is new in v6.5.0 and higher"
+      version: "all"
+      reason: "https://github.com/elastic/elasticsearch/issues/66629"
+      #version: " - 6.99.99"
+      #reason:  "cluster stats including cluster_uuid at the top level is new in v6.5.0 and higher"
 
   - do:
       cluster.stats: {}

--- a/server/src/test/java/org/elasticsearch/monitor/os/OsProbeTests.java
+++ b/server/src/test/java/org/elasticsearch/monitor/os/OsProbeTests.java
@@ -19,17 +19,6 @@
 
 package org.elasticsearch.monitor.os;
 
-import org.apache.lucene.util.Constants;
-import org.elasticsearch.test.ESTestCase;
-
-import java.io.IOException;
-import java.math.BigInteger;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Locale;
-import java.util.stream.Collectors;
-
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.both;
@@ -39,6 +28,17 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.notNullValue;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+
+import org.apache.lucene.util.Constants;
+import org.elasticsearch.test.ESTestCase;
 
 public class OsProbeTests extends ESTestCase {
 
@@ -84,6 +84,7 @@ public class OsProbeTests extends ESTestCase {
         assertThat(info.getAvailableProcessors(), equalTo(Runtime.getRuntime().availableProcessors()));
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/66629")
     public void testOsStats() {
         final OsProbe osProbe = new OsProbe();
         OsStats stats = osProbe.osStats();


### PR DESCRIPTION
Backports the following commits to 7.11:
 - Mute tests failing on Debian 8 due to memory reporting (#66648)