### PR TITLE
Mute tests failing on Debian 8 due to memory reporting (#66648)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.stats/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.stats/10_basic.yml
@@ -1,5 +1,9 @@
 ---
 "cluster stats test":
+  - skip:
+      version: "all"
+      reason: "https://github.com/elastic/elasticsearch/issues/66629"
+
   - do:
       cluster.stats: {}
 
@@ -33,8 +37,10 @@
 ---
 "get cluster stats returns cluster_uuid at the top level":
   - skip:
-      version: " - 6.4.99"
-      reason:  "cluster stats including cluster_uuid at the top level is new in v6.5.0 and higher"
+      version: "all"
+      reason: "https://github.com/elastic/elasticsearch/issues/66629"
+      #version: " - 6.4.99"
+      #reason:  "cluster stats including cluster_uuid at the top level is new in v6.5.0 and higher"
 
   - do:
       cluster.stats: {}

--- a/server/src/test/java/org/elasticsearch/monitor/os/OsProbeTests.java
+++ b/server/src/test/java/org/elasticsearch/monitor/os/OsProbeTests.java
@@ -83,6 +83,7 @@ public class OsProbeTests extends ESTestCase {
         assertThat(info.getAvailableProcessors(), equalTo(Runtime.getRuntime().availableProcessors()));
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/66629")
     public void testOsStats() {
         final OsProbe osProbe = new OsProbe();
         OsStats stats = osProbe.osStats();


### PR DESCRIPTION
Backports the following commits to 6.8:
 - Mute tests failing on Debian 8 due to memory reporting (#66648)