### PR TITLE
[ILM] check if delete phase has actions (#65847)

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ilm/LifecyclePolicy.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ilm/LifecyclePolicy.java
@@ -80,7 +80,10 @@ public class LifecyclePolicy implements ToXContentObject {
             if (ALLOWED_ACTIONS.containsKey(phase.getName()) == false) {
                 throw new IllegalArgumentException("Lifecycle does not support phase [" + phase.getName() + "]");
             }
-            phase.getActions().forEach((actionName, action) -> {
+           if (phase.getName().equals("delete") && phase.getActions().size() == 0) {
+               throw new IllegalArgumentException("phase [" + phase.getName() + "] must contain actions");
+           }
+           phase.getActions().forEach((actionName, action) -> {
                 if (ALLOWED_ACTIONS.get(phase.getName()).contains(actionName) == false) {
                     throw new IllegalArgumentException("invalid action [" + actionName + "] " +
                         "defined in phase [" + phase.getName() +"]");

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ilm/LifecyclePolicy.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ilm/LifecyclePolicy.java
@@ -81,7 +81,7 @@ public class LifecyclePolicy implements ToXContentObject {
                 throw new IllegalArgumentException("Lifecycle does not support phase [" + phase.getName() + "]");
             }
            if (phase.getName().equals("delete") && phase.getActions().size() == 0) {
-               throw new IllegalArgumentException("phase [" + phase.getName() + "] must contain actions");
+              throw new IllegalArgumentException("phase [" + phase.getName() + "] must define actions");
            }
            phase.getActions().forEach((actionName, action) -> {
                 if (ALLOWED_ACTIONS.get(phase.getName()).contains(actionName) == false) {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ilm/LifecyclePolicyTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ilm/LifecyclePolicyTests.java
@@ -200,7 +200,7 @@ public class LifecyclePolicyTests extends AbstractXContentTestCase<LifecyclePoli
 
         Exception e = expectThrows(IllegalArgumentException.class,
             () -> new LifecyclePolicy(lifecycleName, phases));
-        assertThat(e.getMessage(), equalTo("phase [" + delete.getName() + "] must contain actions"));
+        assertThat(e.getMessage(), equalTo("phase [" + delete.getName() + "] must define actions"));
     }
 
     public static LifecyclePolicy createRandomPolicy(String lifecycleName) {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ilm/LifecyclePolicyTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ilm/LifecyclePolicyTests.java
@@ -192,6 +192,17 @@ public class LifecyclePolicyTests extends AbstractXContentTestCase<LifecyclePoli
         }
     }
 
+    public void testValidateEmptyDeletePhase() {
+        Map<String, LifecycleAction> actions = new HashMap<>();
+
+        Phase delete = new Phase("delete", TimeValue.ZERO, actions);
+        Map<String, Phase> phases = Collections.singletonMap("delete", delete);
+
+        Exception e = expectThrows(IllegalArgumentException.class,
+            () -> new LifecyclePolicy(lifecycleName, phases));
+        assertThat(e.getMessage(), equalTo("phase [" + delete.getName() + "] must contain actions"));
+    }
+
     public static LifecyclePolicy createRandomPolicy(String lifecycleName) {
         List<String> phaseNames = randomSubsetOf(Arrays.asList("hot", "warm", "cold", "delete"));
         Map<String, Phase> phases = new HashMap<>(phaseNames.size());
@@ -205,6 +216,17 @@ public class LifecyclePolicyTests extends AbstractXContentTestCase<LifecyclePoli
                     return VALID_COLD_ACTIONS;
                 case "delete":
                     return VALID_DELETE_ACTIONS;
+                default:
+                    throw new IllegalArgumentException("invalid phase [" + phase + "]");
+            }};
+        Function<String, Boolean> allowEmptyActions = (phase) -> {
+            switch (phase) {
+                case "hot":
+                case "warm":
+                case "cold":
+                    return true;
+                case "delete":
+                    return false;
                 default:
                     throw new IllegalArgumentException("invalid phase [" + phase + "]");
             }};
@@ -238,7 +260,12 @@ public class LifecyclePolicyTests extends AbstractXContentTestCase<LifecyclePoli
         for (String phase : phaseNames) {
             TimeValue after = TimeValue.parseTimeValue(randomTimeValue(0, 1000000000, "s", "m", "h", "d"), "test_after");
             Map<String, LifecycleAction> actions = new HashMap<>();
-            List<String> actionNames = randomSubsetOf(validActions.apply(phase));
+            List<String> actionNames;
+            if (allowEmptyActions.apply(phase)) {
+                actionNames = randomSubsetOf(validActions.apply(phase));
+            } else {
+                actionNames = randomSubsetOf(randomIntBetween(1, validActions.apply(phase).size()), validActions.apply(phase));
+            }
             for (String action : actionNames) {
                 actions.put(action, randomAction.apply(action));
             }


### PR DESCRIPTION
Fixes #65847

Added validation for the Delete phase with empty actions.