### PR TITLE
fix: Version CURRENT is V_7_10_0

### DIFF
--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -151,7 +151,7 @@ public class Version implements Comparable<Version>, ToXContentFragment {
     public static final Version V_7_10_0 = new Version(7100099, org.apache.lucene.util.Version.LUCENE_8_7_0);
     public static final Version V_7_10_1 = new Version(7100199, org.apache.lucene.util.Version.LUCENE_8_7_0);
     public static final Version V_7_10_2 = new Version(7100299, org.apache.lucene.util.Version.LUCENE_8_7_0);
-    public static final Version CURRENT = V_7_10_2;
+    public static final Version CURRENT = V_7_10_0;
 
     private static final ImmutableOpenIntMap<Version> idToVersion;
     private static final ImmutableOpenMap<String, Version> stringToVersion;


### PR DESCRIPTION
If Version.java CURRENT is 7_10_2 may cause version compatibility problems.
such as:Plugin [repository-url] was built for Elasticsearch version 7.10.0 but version 7.10.2 is running.