### PR TITLE
New configuration option to configure the biggest allowed size for a response.

### DIFF
--- a/server/src/main/java/org/elasticsearch/http/DefaultRestChannel.java
+++ b/server/src/main/java/org/elasticsearch/http/DefaultRestChannel.java
@@ -128,6 +128,13 @@ public class DefaultRestChannel extends AbstractRestChannel implements RestChann
             // If our response doesn't specify a content-type header, set one
             setHeaderField(httpResponse, CONTENT_TYPE, restResponse.contentType(), false);
             // If our response has no content-length, calculate and set one
+
+            //Checks if response size is larger then the clusters settings max
+            if(restResponse.content().length() < settings.getMaxResponseSize())
+            {
+                //
+            }
+
             contentLength = String.valueOf(restResponse.content().length());
             setHeaderField(httpResponse, CONTENT_LENGTH, contentLength, false);
 

--- a/server/src/main/java/org/elasticsearch/http/HttpHandlingSettings.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpHandlingSettings.java
@@ -32,6 +32,7 @@ import static org.elasticsearch.http.HttpTransportSettings.SETTING_HTTP_MAX_INIT
 import static org.elasticsearch.http.HttpTransportSettings.SETTING_HTTP_READ_TIMEOUT;
 import static org.elasticsearch.http.HttpTransportSettings.SETTING_HTTP_RESET_COOKIES;
 import static org.elasticsearch.http.HttpTransportSettings.SETTING_PIPELINING_MAX_EVENTS;
+import static org.elasticsearch.http.HttpTransportSettings.SETTING_HTTP_MAX_RESPONSE_SIZE;
 
 public class HttpHandlingSettings {
 
@@ -39,6 +40,7 @@ public class HttpHandlingSettings {
     private final int maxChunkSize;
     private final int maxHeaderSize;
     private final int maxInitialLineLength;
+    private final int maxResponseSize;
     private final boolean resetCookies;
     private final boolean compression;
     private final int compressionLevel;
@@ -47,13 +49,14 @@ public class HttpHandlingSettings {
     private final long readTimeoutMillis;
     private boolean corsEnabled;
 
-    public HttpHandlingSettings(int maxContentLength, int maxChunkSize, int maxHeaderSize, int maxInitialLineLength,
+    public HttpHandlingSettings(int maxContentLength, int maxChunkSize, int maxHeaderSize, int maxInitialLineLength, int maxResponseSize,
                                 boolean resetCookies, boolean compression, int compressionLevel, boolean detailedErrorsEnabled,
                                 int pipeliningMaxEvents, long readTimeoutMillis, boolean corsEnabled) {
         this.maxContentLength = maxContentLength;
         this.maxChunkSize = maxChunkSize;
         this.maxHeaderSize = maxHeaderSize;
         this.maxInitialLineLength = maxInitialLineLength;
+        this.maxReponseSize = maxResponseSize;
         this.resetCookies = resetCookies;
         this.compression = compression;
         this.compressionLevel = compressionLevel;
@@ -68,6 +71,7 @@ public class HttpHandlingSettings {
             Math.toIntExact(SETTING_HTTP_MAX_CHUNK_SIZE.get(settings).getBytes()),
             Math.toIntExact(SETTING_HTTP_MAX_HEADER_SIZE.get(settings).getBytes()),
             Math.toIntExact(SETTING_HTTP_MAX_INITIAL_LINE_LENGTH.get(settings).getBytes()),
+            Math.toIntExact(SETTING_HTTP_MAX_RESPONSE_SIZE.get(settings).getBytes()),
             SETTING_HTTP_RESET_COOKIES.get(settings),
             SETTING_HTTP_COMPRESSION.get(settings),
             SETTING_HTTP_COMPRESSION_LEVEL.get(settings),
@@ -91,6 +95,10 @@ public class HttpHandlingSettings {
 
     public int getMaxInitialLineLength() {
         return maxInitialLineLength;
+    }
+
+    public int getMaxResponseSize() {
+        return maxResponseSize;
     }
 
     public boolean isResetCookies() {

--- a/server/src/main/java/org/elasticsearch/http/HttpTransportSettings.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpTransportSettings.java
@@ -88,6 +88,16 @@ public final class HttpTransportSettings {
         Setting.byteSizeSetting("http.max_warning_header_size", new ByteSizeValue(-1), Property.NodeScope);
     public static final Setting<ByteSizeValue> SETTING_HTTP_MAX_INITIAL_LINE_LENGTH =
         Setting.byteSizeSetting("http.max_initial_line_length", new ByteSizeValue(4, ByteSizeUnit.KB), Property.NodeScope);
+        
+    // This is a new setting that should be used to limit the size of the elastic response
+    public static final Setting<ByteSizeValue> SETTING_HTTP_MAX_RESPONSE_SIZE =
+        Setting.bytesSizeSetting(
+                "http.max_response_size",
+                new ByteSizeValue(100, ByteSizeUnit.MB),
+                new ByteSizeValue(100, ByteSizeUnit.MB),
+                new ByteSizeValue(512, ByteSizeUnit.MB),
+                Property.NodeScope);
+    
     // don't reset cookies by default, since I don't think we really need to
     // note, parsing cookies was fixed in netty 3.5.1 regarding stack allocation, but still, currently, we don't need cookies
     public static final Setting<Boolean> SETTING_HTTP_RESET_COOKIES =


### PR DESCRIPTION
Trying to close #64879. 

Created a new ByteSetting on HttpHandlingSettings so the user can specify a maximum size for the Elastic response on that cluster. 

Currently the setting is still in development and need proper direction on where this size comparison should be made and what is the proper response when the response is larger then the max set by the user.

Since I'm new to the project, my best guess is the DefaultRestChannel class to handle this. Any feedback is appreciated.