### PR TITLE
[DOCS] Fix some typos in docs

### DIFF
--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -13,9 +13,9 @@ Returns cluster nodes statistics.
 
 `GET /_nodes/<node_id>/stats` +
 
-`GET/_nodes/stats/<metric>` +
+`GET /_nodes/stats/<metric>` +
 
-`GET/_nodes/<node_id>/stats/<metric>` +
+`GET /_nodes/<node_id>/stats/<metric>` +
 
 `GET /_nodes/stats/<metric>/<index_metric>` +
 

--- a/docs/reference/docs/delete-by-query.asciidoc
+++ b/docs/reference/docs/delete-by-query.asciidoc
@@ -561,7 +561,7 @@ sub-request proportionally.
 portion of the documents. All documents will be addressed, but some slices may
 be larger than others. Expect larger slices to have a more even distribution.
 * Parameters like `requests_per_second` and `max_docs` on a request with
-slices` are distributed proportionally to each sub-request. Combine that with
+`slices` are distributed proportionally to each sub-request. Combine that with
 the point above about distribution being uneven and you should conclude that
 using `max_docs` with `slices` might not result in exactly `max_docs` documents
 being deleted.

--- a/docs/reference/index-modules/allocation/filtering.asciidoc
+++ b/docs/reference/index-modules/allocation/filtering.asciidoc
@@ -41,7 +41,7 @@ You can also set custom attributes when you start a node:
 +
 [source,sh]
 --------------------------------------------------------
-`./bin/elasticsearch -Enode.attr.size=medium
+./bin/elasticsearch -Enode.attr.size=medium
 --------------------------------------------------------
 
 . Add a routing allocation filter to the index. The `index.routing.allocation`


### PR DESCRIPTION
There are some typos in [node-stats api doc](https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-stats.html), [delete-by-query api doc](https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html) and [index level shard allocation filtering doc](https://www.elastic.co/guide/en/elasticsearch/reference/master/shard-allocation-filtering.html).