### PR TITLE
Preprocess polygon rings before processing it for decomposition. (#59501)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/geo/builders/ShapeBuilder.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/builders/ShapeBuilder.java
@@ -280,6 +280,7 @@ public abstract class ShapeBuilder<T extends Shape, G extends org.elasticsearch.
     protected static int intersections(double dateline, Edge[] edges) {
         int numIntersections = 0;
         assert !Double.isNaN(dateline);
+        int maxComponent = 0;
         for (int i = 0; i < edges.length; i++) {
             Coordinate p1 = edges[i].coordinate;
             Coordinate p2 = edges[i].next.coordinate;
@@ -290,10 +291,46 @@ public abstract class ShapeBuilder<T extends Shape, G extends org.elasticsearch.
             if (!Double.isNaN(position)) {
                 edges[i].intersection(position);
                 numIntersections++;
+                maxComponent = Math.max(maxComponent, edges[i].component);
             }
         }
+        if (maxComponent > 0) {
+            // we might detect polygons touching the dateline as intersections
+            // Here we clean them up
+            for (int i = 0; i < maxComponent; i++) {
+                if (clearComponentTouchingDateline(edges, i + 1)) {
+                    numIntersections--;
+                }
+            }
+        }
+
         Arrays.sort(edges, INTERSECTION_ORDER);
         return numIntersections;
+    }
+
+    /**
+     * Checks the number of dateline intersections detected for a component. If there is only
+     * one, it clears it as it means that the component just touches the dateline.
+     *
+     * @param edges    set of edges that may intersect with the dateline
+     * @param component    The component to check
+     * @return true if the component touches the dateline.
+     */
+    private static boolean clearComponentTouchingDateline(Edge[] edges, int component) {
+        Edge intersection = null;
+        for (Edge edge : edges) {
+            if (edge.intersect != Edge.MAX_COORDINATE && edge.component == component) {
+                if (intersection == null) {
+                    intersection = edge;
+                } else {
+                    return false;
+                }
+            }
+        }
+        if (intersection != null) {
+            intersection.intersect = Edge.MAX_COORDINATE;
+        }
+        return intersection != null;
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/common/geo/ShapeBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/ShapeBuilderTests.java
@@ -566,6 +566,27 @@ public class ShapeBuilderTests extends ESTestCase {
         assertMultiPolygon(buildGeometry(builder.close()), false);
     }
 
+    public void testShapeWithHoleTouchingAtDateline() throws Exception {
+        PolygonBuilder builder = new PolygonBuilder(new CoordinatesBuilder()
+            .coordinate(-180, 90)
+            .coordinate(-180, -90)
+            .coordinate(180, -90)
+            .coordinate(180, 90)
+            .coordinate(-180, 90)
+        );
+        builder.hole(new LineStringBuilder(new CoordinatesBuilder()
+            .coordinate(180.0, -16.14)
+            .coordinate(178.53, -16.64)
+            .coordinate(178.49, -16.82)
+            .coordinate(178.73, -17.02)
+            .coordinate(178.86, -16.86)
+            .coordinate(180.0, -16.14)
+        ));
+
+        assertPolygon(builder.close().buildS4J(), true);
+        assertPolygon(buildGeometry(builder.close()), false);
+    }
+
     public void testShapeWithTangentialHole() {
         // test a shape with one tangential (shared) vertex (should pass)
         PolygonBuilder builder = new PolygonBuilder(new CoordinatesBuilder()
@@ -703,7 +724,7 @@ public class ShapeBuilderTests extends ESTestCase {
         assertMultiPolygon(buildGeometry(builder.close()), false);
      }
 
-    public void testInvalidShapeWithConsecutiveDuplicatePoints() {
+    public void testShapeWithConsecutiveDuplicatePoints() {
         PolygonBuilder builder = new PolygonBuilder(new CoordinatesBuilder()
                 .coordinate(180, 0)
                 .coordinate(176, 4)
@@ -712,10 +733,56 @@ public class ShapeBuilderTests extends ESTestCase {
                 .coordinate(180, 0)
                 );
 
-        Exception e = expectThrows(InvalidShapeException.class, () -> builder.close().buildS4J());
-        assertThat(e.getMessage(), containsString("duplicate consecutive coordinates at: ("));
-        e = expectThrows(InvalidShapeException.class, () -> buildGeometry(builder.close()));
-        assertThat(e.getMessage(), containsString("duplicate consecutive coordinates at: ("));
+        // duplicated points are removed
+        PolygonBuilder expected = new PolygonBuilder(new CoordinatesBuilder()
+            .coordinate(180, 0)
+            .coordinate(176, 4)
+            .coordinate(-176, 4)
+            .coordinate(180, 0)
+        );
+
+        assertEquals(buildGeometry(expected.close()), buildGeometry(builder.close()));
+        assertEquals(expected.close().buildS4J(), builder.close().buildS4J());
+    }
+
+    public void testShapeWithCoplanarVerticalPoints() throws Exception {
+        PolygonBuilder builder = new PolygonBuilder(new CoordinatesBuilder()
+            .coordinate(180, -36)
+            .coordinate(180, 90)
+            .coordinate(-180, 90)
+            .coordinate(-180, 79)
+            .coordinate(16, 58)
+            .coordinate(8, 13)
+            .coordinate(-180, 74)
+            .coordinate(-180, -85)
+            .coordinate(-180, -90)
+            .coordinate(180,  -90)
+            .coordinate(180, -85)
+            .coordinate(26, 6)
+            .coordinate(33, 62)
+            .coordinate(180, -36)
+        );
+
+        //coplanar points on vertical edge are removed.
+        PolygonBuilder expected = new PolygonBuilder(new CoordinatesBuilder()
+            .coordinate(180, -36)
+            .coordinate(180, 90)
+            .coordinate(-180, 90)
+            .coordinate(-180, 79)
+            .coordinate(16, 58)
+            .coordinate(8, 13)
+            .coordinate(-180, 74)
+            .coordinate(-180, -90)
+            .coordinate(180,  -90)
+            .coordinate(180, -85)
+            .coordinate(26, 6)
+            .coordinate(33, 62)
+            .coordinate(180, -36)
+        );
+
+        assertEquals(buildGeometry(expected.close()), buildGeometry(builder.close()));
+        assertEquals(expected.close().buildS4J(), builder.close().buildS4J());
+
     }
 
     public void testPolygon3D() {


### PR DESCRIPTION
Adds a preprocess step for polygon rings before they go over the code for decomposition. The process removes from the polygon ring consecutive duplicate points as well as coplanar points that exist in vertical lines.

backport #59501