### PR TITLE
Add Ability to Write a BytesReference to Azure BlobContainer

### DIFF
--- a/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureBlobContainer.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureBlobContainer.java
@@ -107,6 +107,11 @@ public class AzureBlobContainer extends AbstractBlobContainer {
     }
 
     @Override
+    public void writeBlob(String blobName, BytesReference bytes, boolean failIfAlreadyExists) throws IOException {
+        blobStore.writeBlob(buildKey(blobName), bytes, failIfAlreadyExists);
+    }
+
+    @Override
     public DeleteResult delete() throws IOException {
         return blobStore.deleteBlobDirectory(keyPath);
     }


### PR DESCRIPTION
This pull request adds the ability to write a BytesReference to Azure and GCP BlobContainers.
This is a continuation of #66501