### PR TITLE
[TEST] Ensure `InvalidateApiKeyRequest` has at least one key in test

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/security/InvalidateApiKeyRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/security/InvalidateApiKeyRequestTests.java
@@ -39,7 +39,7 @@ public class InvalidateApiKeyRequestTests extends ESTestCase {
             request = InvalidateApiKeyRequest.usingApiKeyId(randomAlphaOfLength(5), randomBoolean());
         } else {
             request = InvalidateApiKeyRequest.usingApiKeyIds(
-                IntStream.range(1, randomIntBetween(1, 5)).mapToObj(ignored -> randomAlphaOfLength(5)).collect(Collectors.toList()),
+                IntStream.range(1, randomIntBetween(2, 5)).mapToObj(ignored -> randomAlphaOfLength(5)).collect(Collectors.toList()),
                 randomBoolean());
         }
         Optional<ValidationException> ve = request.validate();


### PR DESCRIPTION
Fixes potential failure in `InvalidateApiKeyRequestTests` where
a request is constructed with empty keys.

Relates #66317