### PR TITLE
[Transform] report last search time in transform stats

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/transform/transforms/TransformCheckpointingInfo.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/transform/transforms/TransformCheckpointingInfo.java
@@ -43,43 +43,56 @@ public class TransformCheckpointingInfo {
     private final Instant changesLastDetectedAt;
     private final Instant changesLastSearchedAt;
 
-    private static final ConstructingObjectParser<TransformCheckpointingInfo, Void> LENIENT_PARSER =
-            new ConstructingObjectParser<>(
-                "transform_checkpointing_info",
-                true,
-                a -> {
-                        long behind = a[2] == null ? 0L : (Long) a[2];
-                        Instant changesLastDetectedAt = (Instant)a[3];
-                        Instant changesLastSearchedAt = (Instant)a[4];
-                        return new TransformCheckpointingInfo(
-                            a[0] == null ? TransformCheckpointStats.EMPTY : (TransformCheckpointStats) a[0],
-                            a[1] == null ? TransformCheckpointStats.EMPTY : (TransformCheckpointStats) a[1],
-                            behind,
-                            changesLastDetectedAt,
-                            changesLastSearchedAt);
-                    });
+    private static final ConstructingObjectParser<TransformCheckpointingInfo, Void> LENIENT_PARSER = new ConstructingObjectParser<>(
+        "transform_checkpointing_info",
+        true,
+        a -> {
+            long behind = a[2] == null ? 0L : (Long) a[2];
+            Instant changesLastDetectedAt = (Instant) a[3];
+            Instant changesLastSearchedAt = (Instant) a[4];
+            return new TransformCheckpointingInfo(
+                a[0] == null ? TransformCheckpointStats.EMPTY : (TransformCheckpointStats) a[0],
+                a[1] == null ? TransformCheckpointStats.EMPTY : (TransformCheckpointStats) a[1],
+                behind,
+                changesLastDetectedAt,
+                changesLastSearchedAt
+            );
+        }
+    );
 
     static {
-        LENIENT_PARSER.declareObject(ConstructingObjectParser.optionalConstructorArg(),
-                (p, c) -> TransformCheckpointStats.fromXContent(p), LAST_CHECKPOINT);
-        LENIENT_PARSER.declareObject(ConstructingObjectParser.optionalConstructorArg(),
-                (p, c) -> TransformCheckpointStats.fromXContent(p), NEXT_CHECKPOINT);
+        LENIENT_PARSER.declareObject(
+            ConstructingObjectParser.optionalConstructorArg(),
+            (p, c) -> TransformCheckpointStats.fromXContent(p),
+            LAST_CHECKPOINT
+        );
+        LENIENT_PARSER.declareObject(
+            ConstructingObjectParser.optionalConstructorArg(),
+            (p, c) -> TransformCheckpointStats.fromXContent(p),
+            NEXT_CHECKPOINT
+        );
         LENIENT_PARSER.declareLong(ConstructingObjectParser.optionalConstructorArg(), OPERATIONS_BEHIND);
-        LENIENT_PARSER.declareField(ConstructingObjectParser.optionalConstructorArg(),
+        LENIENT_PARSER.declareField(
+            ConstructingObjectParser.optionalConstructorArg(),
             p -> TimeUtil.parseTimeFieldToInstant(p, CHANGES_LAST_DETECTED_AT.getPreferredName()),
             CHANGES_LAST_DETECTED_AT,
-            ObjectParser.ValueType.VALUE);
-        LENIENT_PARSER.declareField(ConstructingObjectParser.optionalConstructorArg(),
+            ObjectParser.ValueType.VALUE
+        );
+        LENIENT_PARSER.declareField(
+            ConstructingObjectParser.optionalConstructorArg(),
             p -> TimeUtil.parseTimeFieldToInstant(p, CHANGES_LAST_SEARCHED_AT.getPreferredName()),
             CHANGES_LAST_SEARCHED_AT,
-            ObjectParser.ValueType.VALUE);
+            ObjectParser.ValueType.VALUE
+        );
     }
 
-    public TransformCheckpointingInfo(TransformCheckpointStats last,
-                                      TransformCheckpointStats next,
-                                      long operationsBehind,
-                                      Instant changesLastDetectedAt,
-                                      Instant changesLastSearchedAt) {
+    public TransformCheckpointingInfo(
+        TransformCheckpointStats last,
+        TransformCheckpointStats next,
+        long operationsBehind,
+        Instant changesLastDetectedAt,
+        Instant changesLastSearchedAt
+    ) {
         this.last = Objects.requireNonNull(last);
         this.next = Objects.requireNonNull(next);
         this.operationsBehind = operationsBehind;
@@ -130,11 +143,11 @@ public class TransformCheckpointingInfo {
 
         TransformCheckpointingInfo that = (TransformCheckpointingInfo) other;
 
-        return Objects.equals(this.last, that.last) &&
-            Objects.equals(this.next, that.next) &&
-            this.operationsBehind == that.operationsBehind &&
-            Objects.equals(this.changesLastDetectedAt, that.changesLastDetectedAt) &&
-            Objects.equals(this.changesLastSearchedAt, that.changesLastSearchedAt);
+        return Objects.equals(this.last, that.last)
+            && Objects.equals(this.next, that.next)
+            && this.operationsBehind == that.operationsBehind
+            && Objects.equals(this.changesLastDetectedAt, that.changesLastDetectedAt)
+            && Objects.equals(this.changesLastSearchedAt, that.changesLastSearchedAt);
     }
 
 }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/transform/transforms/TransformCheckpointingInfo.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/transform/transforms/TransformCheckpointingInfo.java
@@ -49,13 +49,13 @@ public class TransformCheckpointingInfo {
         a -> {
             long behind = a[2] == null ? 0L : (Long) a[2];
             Instant changesLastDetectedAt = (Instant) a[3];
-            Instant changesLastSearchedAt = (Instant) a[4];
+            Instant lastSearchTime = (Instant) a[4];
             return new TransformCheckpointingInfo(
                 a[0] == null ? TransformCheckpointStats.EMPTY : (TransformCheckpointStats) a[0],
                 a[1] == null ? TransformCheckpointStats.EMPTY : (TransformCheckpointStats) a[1],
                 behind,
                 changesLastDetectedAt,
-                changesLastSearchedAt
+                lastSearchTime
             );
         }
     );

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/transform/transforms/TransformCheckpointingInfo.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/transform/transforms/TransformCheckpointingInfo.java
@@ -35,13 +35,13 @@ public class TransformCheckpointingInfo {
     public static final ParseField NEXT_CHECKPOINT = new ParseField("next", "in_progress");
     public static final ParseField OPERATIONS_BEHIND = new ParseField("operations_behind");
     public static final ParseField CHANGES_LAST_DETECTED_AT = new ParseField("changes_last_detected_at");
-    public static final ParseField CHANGES_LAST_SEARCHED_AT = new ParseField("changes_last_searched_at");
+    public static final ParseField LAST_SEARCH_TIME = new ParseField("last_search_time");
 
     private final TransformCheckpointStats last;
     private final TransformCheckpointStats next;
     private final long operationsBehind;
     private final Instant changesLastDetectedAt;
-    private final Instant changesLastSearchedAt;
+    private final Instant lastSearchTime;
 
     private static final ConstructingObjectParser<TransformCheckpointingInfo, Void> LENIENT_PARSER = new ConstructingObjectParser<>(
         "transform_checkpointing_info",
@@ -80,8 +80,8 @@ public class TransformCheckpointingInfo {
         );
         LENIENT_PARSER.declareField(
             ConstructingObjectParser.optionalConstructorArg(),
-            p -> TimeUtil.parseTimeFieldToInstant(p, CHANGES_LAST_SEARCHED_AT.getPreferredName()),
-            CHANGES_LAST_SEARCHED_AT,
+            p -> TimeUtil.parseTimeFieldToInstant(p, LAST_SEARCH_TIME.getPreferredName()),
+            LAST_SEARCH_TIME,
             ObjectParser.ValueType.VALUE
         );
     }
@@ -91,13 +91,13 @@ public class TransformCheckpointingInfo {
         TransformCheckpointStats next,
         long operationsBehind,
         Instant changesLastDetectedAt,
-        Instant changesLastSearchedAt
+        Instant lastSearchTime
     ) {
         this.last = Objects.requireNonNull(last);
         this.next = Objects.requireNonNull(next);
         this.operationsBehind = operationsBehind;
         this.changesLastDetectedAt = changesLastDetectedAt;
-        this.changesLastSearchedAt = changesLastSearchedAt;
+        this.lastSearchTime = lastSearchTime;
     }
 
     public TransformCheckpointStats getLast() {
@@ -118,8 +118,8 @@ public class TransformCheckpointingInfo {
     }
 
     @Nullable
-    public Instant getChangesLastSearchedAt() {
-        return changesLastSearchedAt;
+    public Instant getLastSearchTime() {
+        return lastSearchTime;
     }
 
     public static TransformCheckpointingInfo fromXContent(XContentParser p) {
@@ -128,7 +128,7 @@ public class TransformCheckpointingInfo {
 
     @Override
     public int hashCode() {
-        return Objects.hash(last, next, operationsBehind, changesLastDetectedAt, changesLastSearchedAt);
+        return Objects.hash(last, next, operationsBehind, changesLastDetectedAt, lastSearchTime);
     }
 
     @Override
@@ -147,7 +147,7 @@ public class TransformCheckpointingInfo {
             && Objects.equals(this.next, that.next)
             && this.operationsBehind == that.operationsBehind
             && Objects.equals(this.changesLastDetectedAt, that.changesLastDetectedAt)
-            && Objects.equals(this.changesLastSearchedAt, that.changesLastSearchedAt);
+            && Objects.equals(this.lastSearchTime, that.lastSearchTime);
     }
 
 }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/transform/transforms/TransformCheckpointingInfo.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/transform/transforms/TransformCheckpointingInfo.java
@@ -35,11 +35,13 @@ public class TransformCheckpointingInfo {
     public static final ParseField NEXT_CHECKPOINT = new ParseField("next", "in_progress");
     public static final ParseField OPERATIONS_BEHIND = new ParseField("operations_behind");
     public static final ParseField CHANGES_LAST_DETECTED_AT = new ParseField("changes_last_detected_at");
+    public static final ParseField CHANGES_LAST_SEARCHED_AT = new ParseField("changes_last_searched_at");
 
     private final TransformCheckpointStats last;
     private final TransformCheckpointStats next;
     private final long operationsBehind;
     private final Instant changesLastDetectedAt;
+    private final Instant changesLastSearchedAt;
 
     private static final ConstructingObjectParser<TransformCheckpointingInfo, Void> LENIENT_PARSER =
             new ConstructingObjectParser<>(
@@ -48,11 +50,13 @@ public class TransformCheckpointingInfo {
                 a -> {
                         long behind = a[2] == null ? 0L : (Long) a[2];
                         Instant changesLastDetectedAt = (Instant)a[3];
+                        Instant changesLastSearchedAt = (Instant)a[4];
                         return new TransformCheckpointingInfo(
                             a[0] == null ? TransformCheckpointStats.EMPTY : (TransformCheckpointStats) a[0],
                             a[1] == null ? TransformCheckpointStats.EMPTY : (TransformCheckpointStats) a[1],
                             behind,
-                            changesLastDetectedAt);
+                            changesLastDetectedAt,
+                            changesLastSearchedAt);
                     });
 
     static {
@@ -65,16 +69,22 @@ public class TransformCheckpointingInfo {
             p -> TimeUtil.parseTimeFieldToInstant(p, CHANGES_LAST_DETECTED_AT.getPreferredName()),
             CHANGES_LAST_DETECTED_AT,
             ObjectParser.ValueType.VALUE);
+        LENIENT_PARSER.declareField(ConstructingObjectParser.optionalConstructorArg(),
+            p -> TimeUtil.parseTimeFieldToInstant(p, CHANGES_LAST_SEARCHED_AT.getPreferredName()),
+            CHANGES_LAST_SEARCHED_AT,
+            ObjectParser.ValueType.VALUE);
     }
 
     public TransformCheckpointingInfo(TransformCheckpointStats last,
                                       TransformCheckpointStats next,
                                       long operationsBehind,
-                                      Instant changesLastDetectedAt) {
+                                      Instant changesLastDetectedAt,
+                                      Instant changesLastSearchedAt) {
         this.last = Objects.requireNonNull(last);
         this.next = Objects.requireNonNull(next);
         this.operationsBehind = operationsBehind;
         this.changesLastDetectedAt = changesLastDetectedAt;
+        this.changesLastSearchedAt = changesLastSearchedAt;
     }
 
     public TransformCheckpointStats getLast() {
@@ -94,13 +104,18 @@ public class TransformCheckpointingInfo {
         return changesLastDetectedAt;
     }
 
+    @Nullable
+    public Instant getChangesLastSearchedAt() {
+        return changesLastSearchedAt;
+    }
+
     public static TransformCheckpointingInfo fromXContent(XContentParser p) {
         return LENIENT_PARSER.apply(p, null);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(last, next, operationsBehind, changesLastDetectedAt);
+        return Objects.hash(last, next, operationsBehind, changesLastDetectedAt, changesLastSearchedAt);
     }
 
     @Override
@@ -118,7 +133,8 @@ public class TransformCheckpointingInfo {
         return Objects.equals(this.last, that.last) &&
             Objects.equals(this.next, that.next) &&
             this.operationsBehind == that.operationsBehind &&
-            Objects.equals(this.changesLastDetectedAt, that.changesLastDetectedAt);
+            Objects.equals(this.changesLastDetectedAt, that.changesLastDetectedAt) &&
+            Objects.equals(this.changesLastSearchedAt, that.changesLastSearchedAt);
     }
 
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/transform/transforms/TransformCheckpointingInfoTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/transform/transforms/TransformCheckpointingInfoTests.java
@@ -62,6 +62,9 @@ public class TransformCheckpointingInfoTests extends ESTestCase {
         if (info.getChangesLastDetectedAt() != null) {
             builder.field(TransformCheckpointingInfo.CHANGES_LAST_DETECTED_AT.getPreferredName(), info.getChangesLastDetectedAt());
         }
+        if (info.getChangesLastSearchedAt() != null) {
+            builder.field(TransformCheckpointingInfo.CHANGES_LAST_SEARCHED_AT.getPreferredName(), info.getChangesLastSearchedAt());
+        }
         builder.endObject();
     }
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/transform/transforms/TransformCheckpointingInfoTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/transform/transforms/TransformCheckpointingInfoTests.java
@@ -30,12 +30,12 @@ import static org.elasticsearch.test.AbstractXContentTestCase.xContentTester;
 public class TransformCheckpointingInfoTests extends ESTestCase {
 
     public void testFromXContent() throws IOException {
-        xContentTester(this::createParser,
+        xContentTester(
+            this::createParser,
             TransformCheckpointingInfoTests::randomTransformCheckpointingInfo,
             TransformCheckpointingInfoTests::toXContent,
-            TransformCheckpointingInfo::fromXContent)
-                .supportsUnknownFields(false)
-                .test();
+            TransformCheckpointingInfo::fromXContent
+        ).supportsUnknownFields(false).test();
     }
 
     public static TransformCheckpointingInfo randomTransformCheckpointingInfo() {
@@ -44,7 +44,8 @@ public class TransformCheckpointingInfoTests extends ESTestCase {
             TransformCheckpointStatsTests.randomTransformCheckpointStats(),
             randomLongBetween(0, 10000),
             randomBoolean() ? null : Instant.ofEpochMilli(randomNonNegativeLong()),
-            randomBoolean() ? null : Instant.ofEpochMilli(randomNonNegativeLong()));
+            randomBoolean() ? null : Instant.ofEpochMilli(randomNonNegativeLong())
+        );
     }
 
     public static void toXContent(TransformCheckpointingInfo info, XContentBuilder builder) throws IOException {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/transform/transforms/TransformCheckpointingInfoTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/transform/transforms/TransformCheckpointingInfoTests.java
@@ -43,6 +43,7 @@ public class TransformCheckpointingInfoTests extends ESTestCase {
             TransformCheckpointStatsTests.randomTransformCheckpointStats(),
             TransformCheckpointStatsTests.randomTransformCheckpointStats(),
             randomLongBetween(0, 10000),
+            randomBoolean() ? null : Instant.ofEpochMilli(randomNonNegativeLong()),
             randomBoolean() ? null : Instant.ofEpochMilli(randomNonNegativeLong()));
     }
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/transform/transforms/TransformCheckpointingInfoTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/transform/transforms/TransformCheckpointingInfoTests.java
@@ -62,8 +62,8 @@ public class TransformCheckpointingInfoTests extends ESTestCase {
         if (info.getChangesLastDetectedAt() != null) {
             builder.field(TransformCheckpointingInfo.CHANGES_LAST_DETECTED_AT.getPreferredName(), info.getChangesLastDetectedAt());
         }
-        if (info.getChangesLastSearchedAt() != null) {
-            builder.field(TransformCheckpointingInfo.CHANGES_LAST_SEARCHED_AT.getPreferredName(), info.getChangesLastSearchedAt());
+        if (info.getLastSearchTime() != null) {
+            builder.field(TransformCheckpointingInfo.LAST_SEARCH_TIME.getPreferredName(), info.getLastSearchTime());
         }
         builder.endObject();
     }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/transform/transforms/hlrc/TransformCheckpointingInfoTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/transform/transforms/hlrc/TransformCheckpointingInfoTests.java
@@ -38,6 +38,7 @@ public class TransformCheckpointingInfoTests extends AbstractResponseTestCase<
             TransformCheckpointStatsTests.randomTransformCheckpointStats(),
             TransformCheckpointStatsTests.randomTransformCheckpointStats(),
             randomNonNegativeLong(),
+            randomBoolean() ? null : Instant.ofEpochMilli(randomNonNegativeLong()),
             randomBoolean() ? null : Instant.ofEpochMilli(randomNonNegativeLong()));
     }
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/transform/transforms/hlrc/TransformCheckpointingInfoTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/transform/transforms/hlrc/TransformCheckpointingInfoTests.java
@@ -31,7 +31,7 @@ import static org.elasticsearch.client.transform.transforms.hlrc.TransformStatsT
 
 public class TransformCheckpointingInfoTests extends AbstractResponseTestCase<
     org.elasticsearch.xpack.core.transform.transforms.TransformCheckpointingInfo,
-        TransformCheckpointingInfo> {
+    TransformCheckpointingInfo> {
 
     public static org.elasticsearch.xpack.core.transform.transforms.TransformCheckpointingInfo randomTransformCheckpointingInfo() {
         return new org.elasticsearch.xpack.core.transform.transforms.TransformCheckpointingInfo(
@@ -39,12 +39,14 @@ public class TransformCheckpointingInfoTests extends AbstractResponseTestCase<
             TransformCheckpointStatsTests.randomTransformCheckpointStats(),
             randomNonNegativeLong(),
             randomBoolean() ? null : Instant.ofEpochMilli(randomNonNegativeLong()),
-            randomBoolean() ? null : Instant.ofEpochMilli(randomNonNegativeLong()));
+            randomBoolean() ? null : Instant.ofEpochMilli(randomNonNegativeLong())
+        );
     }
 
     @Override
-    protected org.elasticsearch.xpack.core.transform.transforms.TransformCheckpointingInfo
-    createServerTestInstance(XContentType xContentType) {
+    protected org.elasticsearch.xpack.core.transform.transforms.TransformCheckpointingInfo createServerTestInstance(
+        XContentType xContentType
+    ) {
         return randomTransformCheckpointingInfo();
     }
 
@@ -54,8 +56,10 @@ public class TransformCheckpointingInfoTests extends AbstractResponseTestCase<
     }
 
     @Override
-    protected void assertInstances(org.elasticsearch.xpack.core.transform.transforms.TransformCheckpointingInfo serverTestInstance,
-                                   TransformCheckpointingInfo clientInstance) {
+    protected void assertInstances(
+        org.elasticsearch.xpack.core.transform.transforms.TransformCheckpointingInfo serverTestInstance,
+        TransformCheckpointingInfo clientInstance
+    ) {
         assertTransformCheckpointInfo(serverTestInstance, clientInstance);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformCheckpointingInfo.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformCheckpointingInfo.java
@@ -41,6 +41,7 @@ public class TransformCheckpointingInfo implements Writeable, ToXContentObject {
         private TransformCheckpoint nextCheckpoint;
         private TransformCheckpoint sourceCheckpoint;
         private Instant changesLastDetectedAt;
+        private Instant changesLastSearchedAt;
         private long operationsBehind;
 
         public TransformCheckpointingInfoBuilder() {}
@@ -76,7 +77,8 @@ public class TransformCheckpointingInfo implements Writeable, ToXContentObject {
                     nextCheckpoint.getTimeUpperBound()
                 ),
                 operationsBehind,
-                changesLastDetectedAt
+                changesLastDetectedAt,
+                changesLastSearchedAt
             );
         }
 
@@ -122,6 +124,11 @@ public class TransformCheckpointingInfo implements Writeable, ToXContentObject {
             return this;
         }
 
+        public TransformCheckpointingInfoBuilder setChangesLastSearchedAt(Instant changesLastSearchedAt) {
+            this.changesLastSearchedAt = changesLastSearchedAt;
+            return this;
+        }
+        
         public TransformCheckpointingInfoBuilder setOperationsBehind(long operationsBehind) {
             this.operationsBehind = operationsBehind;
             return this;
@@ -133,6 +140,7 @@ public class TransformCheckpointingInfo implements Writeable, ToXContentObject {
         TransformCheckpointStats.EMPTY,
         TransformCheckpointStats.EMPTY,
         0L,
+        null,
         null
     );
 
@@ -140,10 +148,12 @@ public class TransformCheckpointingInfo implements Writeable, ToXContentObject {
     public static final ParseField NEXT_CHECKPOINT = new ParseField("next");
     public static final ParseField OPERATIONS_BEHIND = new ParseField("operations_behind");
     public static final ParseField CHANGES_LAST_DETECTED_AT = new ParseField("changes_last_detected_at");
+    public static final ParseField CHANGES_LAST_SEARCHED_AT = new ParseField("changes_last_searched_at");
     private final TransformCheckpointStats last;
     private final TransformCheckpointStats next;
     private final long operationsBehind;
     private final Instant changesLastDetectedAt;
+    private final Instant changesLastSearchedAt;
 
     private static final ConstructingObjectParser<TransformCheckpointingInfo, Void> LENIENT_PARSER = new ConstructingObjectParser<>(
         "data_frame_transform_checkpointing_info",
@@ -151,11 +161,13 @@ public class TransformCheckpointingInfo implements Writeable, ToXContentObject {
         a -> {
             long behind = a[2] == null ? 0L : (Long) a[2];
             Instant changesLastDetectedAt = (Instant) a[3];
+            Instant changesLastSearchedAt = (Instant) a[4];
             return new TransformCheckpointingInfo(
                 a[0] == null ? TransformCheckpointStats.EMPTY : (TransformCheckpointStats) a[0],
                 a[1] == null ? TransformCheckpointStats.EMPTY : (TransformCheckpointStats) a[1],
                 behind,
-                changesLastDetectedAt
+                changesLastDetectedAt,
+                changesLastSearchedAt
             );
         }
     );
@@ -178,6 +190,12 @@ public class TransformCheckpointingInfo implements Writeable, ToXContentObject {
             CHANGES_LAST_DETECTED_AT,
             ObjectParser.ValueType.VALUE
         );
+        LENIENT_PARSER.declareField(
+            ConstructingObjectParser.optionalConstructorArg(),
+            p -> TimeUtils.parseTimeFieldToInstant(p, CHANGES_LAST_SEARCHED_AT.getPreferredName()),
+            CHANGES_LAST_SEARCHED_AT,
+            ObjectParser.ValueType.VALUE
+        );
     }
 
     /**
@@ -187,18 +205,22 @@ public class TransformCheckpointingInfo implements Writeable, ToXContentObject {
      * @param last stats of the last checkpoint
      * @param next stats of the next checkpoint
      * @param operationsBehind counter of operations the current checkpoint is behind source
-     * @param changesLastDetectedAt the last time the source indices were checked for changes
+     * @param changesLastDetectedAt the last time the source indices changes have been found
+     * @param changesLastSearchedAt the last time the source indices were checked for changes
      */
     public TransformCheckpointingInfo(
         TransformCheckpointStats last,
         TransformCheckpointStats next,
         long operationsBehind,
-        Instant changesLastDetectedAt
+        Instant changesLastDetectedAt,
+        Instant changesLastSearchedAt
     ) {
         this.last = Objects.requireNonNull(last);
         this.next = Objects.requireNonNull(next);
         this.operationsBehind = operationsBehind;
+        // todo: Instant is immutable, so a copy does not seem necessary
         this.changesLastDetectedAt = changesLastDetectedAt == null ? null : Instant.ofEpochMilli(changesLastDetectedAt.toEpochMilli());
+        this.changesLastSearchedAt = changesLastSearchedAt == null ? null : Instant.ofEpochMilli(changesLastSearchedAt.toEpochMilli());
     }
 
     public TransformCheckpointingInfo(StreamInput in) throws IOException {
@@ -209,6 +231,11 @@ public class TransformCheckpointingInfo implements Writeable, ToXContentObject {
             changesLastDetectedAt = in.readOptionalInstant();
         } else {
             changesLastDetectedAt = null;
+        }
+        if (in.getVersion().onOrAfter(Version.V_8_0_0)) { // todo: V_7_12_0
+            changesLastSearchedAt = in.readOptionalInstant();
+        } else {
+            changesLastSearchedAt = null;
         }
     }
 
@@ -226,6 +253,10 @@ public class TransformCheckpointingInfo implements Writeable, ToXContentObject {
 
     public Instant getChangesLastDetectedAt() {
         return changesLastDetectedAt;
+    }
+    
+    public Instant getChangesLastSearchedAt() {
+        return changesLastSearchedAt;
     }
 
     @Override
@@ -245,6 +276,13 @@ public class TransformCheckpointingInfo implements Writeable, ToXContentObject {
                 changesLastDetectedAt.toEpochMilli()
             );
         }
+        if (changesLastSearchedAt != null) {
+            builder.timeField(
+                CHANGES_LAST_SEARCHED_AT.getPreferredName(),
+                CHANGES_LAST_SEARCHED_AT.getPreferredName() + "_string",
+                changesLastSearchedAt.toEpochMilli()
+            );
+        }
         builder.endObject();
         return builder;
     }
@@ -257,6 +295,9 @@ public class TransformCheckpointingInfo implements Writeable, ToXContentObject {
         if (out.getVersion().onOrAfter(Version.V_7_4_0)) {
             out.writeOptionalInstant(changesLastDetectedAt);
         }
+        if (out.getVersion().onOrAfter(Version.V_8_0_0)) { // todo: V_7_12_0
+            out.writeOptionalInstant(changesLastSearchedAt);
+        }
     }
 
     public static TransformCheckpointingInfo fromXContent(XContentParser p) {
@@ -265,7 +306,7 @@ public class TransformCheckpointingInfo implements Writeable, ToXContentObject {
 
     @Override
     public int hashCode() {
-        return Objects.hash(last, next, operationsBehind, changesLastDetectedAt);
+        return Objects.hash(last, next, operationsBehind, changesLastDetectedAt, changesLastSearchedAt);
     }
 
     @Override
@@ -283,7 +324,8 @@ public class TransformCheckpointingInfo implements Writeable, ToXContentObject {
         return Objects.equals(this.last, that.last)
             && Objects.equals(this.next, that.next)
             && this.operationsBehind == that.operationsBehind
-            && Objects.equals(this.changesLastDetectedAt, that.changesLastDetectedAt);
+            && Objects.equals(this.changesLastDetectedAt, that.changesLastDetectedAt)
+            && Objects.equals(this.changesLastSearchedAt, that.changesLastSearchedAt);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformCheckpointingInfo.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformCheckpointingInfo.java
@@ -128,7 +128,7 @@ public class TransformCheckpointingInfo implements Writeable, ToXContentObject {
             this.changesLastSearchedAt = changesLastSearchedAt;
             return this;
         }
-        
+
         public TransformCheckpointingInfoBuilder setOperationsBehind(long operationsBehind) {
             this.operationsBehind = operationsBehind;
             return this;
@@ -254,7 +254,7 @@ public class TransformCheckpointingInfo implements Writeable, ToXContentObject {
     public Instant getChangesLastDetectedAt() {
         return changesLastDetectedAt;
     }
-    
+
     public Instant getChangesLastSearchedAt() {
         return changesLastSearchedAt;
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformCheckpointingInfo.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformCheckpointingInfo.java
@@ -161,13 +161,13 @@ public class TransformCheckpointingInfo implements Writeable, ToXContentObject {
         a -> {
             long behind = a[2] == null ? 0L : (Long) a[2];
             Instant changesLastDetectedAt = (Instant) a[3];
-            Instant changesLastSearchedAt = (Instant) a[4];
+            Instant lastSearchedTime = (Instant) a[4];
             return new TransformCheckpointingInfo(
                 a[0] == null ? TransformCheckpointStats.EMPTY : (TransformCheckpointStats) a[0],
                 a[1] == null ? TransformCheckpointStats.EMPTY : (TransformCheckpointStats) a[1],
                 behind,
                 changesLastDetectedAt,
-                changesLastSearchedAt
+                lastSearchedTime
             );
         }
     );

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformCheckpointingInfo.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformCheckpointingInfo.java
@@ -161,13 +161,13 @@ public class TransformCheckpointingInfo implements Writeable, ToXContentObject {
         a -> {
             long behind = a[2] == null ? 0L : (Long) a[2];
             Instant changesLastDetectedAt = (Instant) a[3];
-            Instant lastSearchedTime = (Instant) a[4];
+            Instant lastSearchTime = (Instant) a[4];
             return new TransformCheckpointingInfo(
                 a[0] == null ? TransformCheckpointStats.EMPTY : (TransformCheckpointStats) a[0],
                 a[1] == null ? TransformCheckpointStats.EMPTY : (TransformCheckpointStats) a[1],
                 behind,
                 changesLastDetectedAt,
-                lastSearchedTime
+                lastSearchTime
             );
         }
     );

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformCheckpointingInfoTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformCheckpointingInfoTests.java
@@ -47,7 +47,7 @@ public class TransformCheckpointingInfoTests extends AbstractSerializingTransfor
             TransformCheckpointStats.EMPTY,
             TransformCheckpointStats.EMPTY,
             randomNonNegativeLong(),
-            // changesLastDetectedAt, changesLastSearchedAt is not serialized to past values, so when it is pulled back in, it will be null
+            // changesLastDetectedAt, lastSearchTime is not serialized to past values, so when it is pulled back in, it will be null
             null,
             null
         );

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformCheckpointingInfoTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformCheckpointingInfoTests.java
@@ -22,6 +22,7 @@ public class TransformCheckpointingInfoTests extends AbstractSerializingTransfor
             TransformCheckpointStatsTests.randomTransformCheckpointStats(),
             TransformCheckpointStatsTests.randomTransformCheckpointStats(),
             randomNonNegativeLong(),
+            randomBoolean() ? null : Instant.ofEpochMilli(randomLongBetween(1, 100000)),
             randomBoolean() ? null : Instant.ofEpochMilli(randomLongBetween(1, 100000))
         );
     }
@@ -46,7 +47,8 @@ public class TransformCheckpointingInfoTests extends AbstractSerializingTransfor
             TransformCheckpointStats.EMPTY,
             TransformCheckpointStats.EMPTY,
             randomNonNegativeLong(),
-            // changesLastDetectedAt is not serialized to past values, so when it is pulled back in, it will be null
+            // changesLastDetectedAt, changesLastSearchedAt is not serialized to past values, so when it is pulled back in, it will be null
+            null,
             null
         );
         try (BytesStreamOutput output = new BytesStreamOutput()) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformStatsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformStatsTests.java
@@ -75,6 +75,7 @@ public class TransformStatsTests extends AbstractSerializingTestCase<TransformSt
                     new TransformCheckpointStats(0, null, null, 100, 1000),
                     // changesLastDetectedAt aren't serialized back
                     100,
+                    null,
                     null
                 )
             );
@@ -103,6 +104,7 @@ public class TransformStatsTests extends AbstractSerializingTestCase<TransformSt
                     new TransformCheckpointStats(0, null, null, 100, 1000),
                     // changesLastDetectedAt aren't serialized back
                     100,
+                    null,
                     null
                 )
             );

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/ContinuousTestCase.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/ContinuousTestCase.java
@@ -42,6 +42,7 @@ import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
 
 public abstract class ContinuousTestCase extends ESRestTestCase {
 
+    public static final TimeValue SYNC_DELAY = new TimeValue(1, TimeUnit.SECONDS);
     public static final String CONTINUOUS_EVENTS_SOURCE_INDEX = "test-transform-continuous-events";
     public static final String INGEST_PIPELINE = "transform-ingest";
     public static final String MAX_RUN_FIELD = "run.max";
@@ -89,7 +90,7 @@ public abstract class ContinuousTestCase extends ESRestTestCase {
     protected TransformConfig.Builder addCommonBuilderParameters(TransformConfig.Builder builder) {
         return builder.setSyncConfig(getSyncConfig())
             .setSettings(addCommonSetings(new SettingsConfig.Builder()).build())
-            .setFrequency(new TimeValue(1, TimeUnit.SECONDS));
+            .setFrequency(SYNC_DELAY);
     }
 
     protected AggregatorFactories.Builder addCommonAggregations(AggregatorFactories.Builder builder) {
@@ -131,6 +132,6 @@ public abstract class ContinuousTestCase extends ESRestTestCase {
     }
 
     private SyncConfig getSyncConfig() {
-        return new TimeSyncConfig("timestamp", new TimeValue(1, TimeUnit.SECONDS));
+        return new TimeSyncConfig("timestamp", SYNC_DELAY);
     }
 }

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/HistogramGroupByIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/HistogramGroupByIT.java
@@ -1,6 +1,5 @@
 package org.elasticsearch.xpack.transform.integration.continuous;
 
-import org.apache.lucene.util.LuceneTestCase.AwaitsFix;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -27,7 +26,6 @@ import java.util.Set;
 
 import static org.hamcrest.Matchers.equalTo;
 
-@AwaitsFix(bugUrl="https://github.com/elastic/elasticsearch/issues/66410")
 public class HistogramGroupByIT extends ContinuousTestCase {
     private static final String NAME = "continuous-histogram-pivot-test";
 

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TransformContinuousIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TransformContinuousIT.java
@@ -16,7 +16,6 @@ import org.elasticsearch.action.ingest.DeletePipelineRequest;
 import org.elasticsearch.action.ingest.PutPipelineRequest;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
-import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.client.core.AcknowledgedResponse;
 import org.elasticsearch.client.transform.DeleteTransformRequest;

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TransformContinuousIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TransformContinuousIT.java
@@ -273,8 +273,6 @@ public class TransformContinuousIT extends ESRestTestCase {
             // start all transforms, wait until the processed all data and stop them
             startTransforms();
 
-            // at random we added between 0 and 999_999ns == (1ms - 1ns) to every data point, so we add 1ms, so every data point is before
-            // the checkpoint
             waitUntilTransformsProcessedNewData(ContinuousTestCase.SYNC_DELAY, run);
             stopTransforms();
 

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TransformContinuousIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TransformContinuousIT.java
@@ -512,7 +512,7 @@ public class TransformContinuousIT extends ESRestTestCase {
                         + stats.getState()
                         + ", reason: "
                         + stats.getReason(),
-                    stats.getCheckpointingInfo().getChangesLastSearchedAt(),
+                    stats.getCheckpointingInfo().getLastSearchTime(),
                     greaterThan(waitUntil)
                 );
             }, 20, TimeUnit.SECONDS);

--- a/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/checkpoint/TransformCheckpointServiceNodeTests.java
+++ b/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/checkpoint/TransformCheckpointServiceNodeTests.java
@@ -266,7 +266,8 @@ public class TransformCheckpointServiceNodeTests extends TransformSingleNodeTest
             new TransformCheckpointStats(1, null, null, timestamp, 0L),
             new TransformCheckpointStats(2, position, progress, timestamp + 100L, 0L),
             30L,
-            Instant.ofEpochMilli(timestamp)
+            Instant.ofEpochMilli(timestamp),
+            null
         );
 
         assertAsync(
@@ -281,7 +282,8 @@ public class TransformCheckpointServiceNodeTests extends TransformSingleNodeTest
             new TransformCheckpointStats(1, null, null, timestamp, 0L),
             new TransformCheckpointStats(2, position, progress, timestamp + 100L, 0L),
             63L,
-            Instant.ofEpochMilli(timestamp)
+            Instant.ofEpochMilli(timestamp),
+            null
         );
         assertAsync(
             listener -> getCheckpoint(transformCheckpointService, transformId, 1, position, progress, listener),
@@ -296,7 +298,8 @@ public class TransformCheckpointServiceNodeTests extends TransformSingleNodeTest
             new TransformCheckpointStats(1, null, null, timestamp, 0L),
             new TransformCheckpointStats(2, position, progress, timestamp + 100L, 0L),
             0L,
-            Instant.ofEpochMilli(timestamp)
+            Instant.ofEpochMilli(timestamp),
+            null
         );
         assertAsync(
             listener -> getCheckpoint(transformCheckpointService, transformId, 1, position, progress, listener),

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformContext.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformContext.java
@@ -29,7 +29,7 @@ class TransformContext {
     private volatile int numFailureRetries = Transform.DEFAULT_FAILURE_RETRIES;
     private final AtomicInteger failureCount;
     private volatile Instant changesLastDetectedAt;
-    private volatile Instant lastSearchedTime;
+    private volatile Instant lastSearchTime;
     private volatile boolean shouldStopAtCheckpoint;
 
     // the checkpoint of this transform, storing the checkpoint until data indexing from source to dest is _complete_
@@ -108,12 +108,12 @@ class TransformContext {
         return changesLastDetectedAt;
     }
 
-    void setLastSearchedTime(Instant time) {
-        lastSearchedTime = time;
+    void setLastSearchTime(Instant time) {
+        lastSearchTime = time;
     }
 
-    Instant getLastSearchedTime() {
-        return lastSearchedTime;
+    Instant getLastSearchTime() {
+        return lastSearchTime;
     }
 
     public boolean shouldStopAtCheckpoint() {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformContext.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformContext.java
@@ -107,15 +107,15 @@ class TransformContext {
     Instant getChangesLastDetectedAt() {
         return changesLastDetectedAt;
     }
-    
+
     void setChangesLastSearchedAt(Instant time) {
         changesLastSearchedAt = time;
-    }   
+    }
 
     Instant getChangesLastSearchedAt() {
         return changesLastSearchedAt;
     }
-    
+
     public boolean shouldStopAtCheckpoint() {
         return shouldStopAtCheckpoint;
     }
@@ -129,18 +129,16 @@ class TransformContext {
     }
 
     void markAsFailed(String failureMessage) {
-        taskListener
-            .fail(
-                failureMessage,
-                ActionListener
-                    .wrap(
-                        r -> {
-                            // Successfully marked as failed, reset counter so that task can be restarted
-                            failureCount.set(0);
-                        },
-                        e -> {}
-                    )
-            );
+        taskListener.fail(
+            failureMessage,
+            ActionListener.wrap(
+                r -> {
+                    // Successfully marked as failed, reset counter so that task can be restarted
+                    failureCount.set(0);
+                },
+                e -> {}
+            )
+        );
     }
 
 }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformContext.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformContext.java
@@ -29,6 +29,7 @@ class TransformContext {
     private volatile int numFailureRetries = Transform.DEFAULT_FAILURE_RETRIES;
     private final AtomicInteger failureCount;
     private volatile Instant changesLastDetectedAt;
+    private volatile Instant changesLastSearchedAt;
     private volatile boolean shouldStopAtCheckpoint;
 
     // the checkpoint of this transform, storing the checkpoint until data indexing from source to dest is _complete_
@@ -106,7 +107,15 @@ class TransformContext {
     Instant getChangesLastDetectedAt() {
         return changesLastDetectedAt;
     }
+    
+    void setChangesLastSearchedAt(Instant time) {
+        changesLastSearchedAt = time;
+    }   
 
+    Instant getChangesLastSearchedAt() {
+        return changesLastSearchedAt;
+    }
+    
     public boolean shouldStopAtCheckpoint() {
         return shouldStopAtCheckpoint;
     }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformContext.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformContext.java
@@ -29,7 +29,7 @@ class TransformContext {
     private volatile int numFailureRetries = Transform.DEFAULT_FAILURE_RETRIES;
     private final AtomicInteger failureCount;
     private volatile Instant changesLastDetectedAt;
-    private volatile Instant changesLastSearchedAt;
+    private volatile Instant lastSearchedTime;
     private volatile boolean shouldStopAtCheckpoint;
 
     // the checkpoint of this transform, storing the checkpoint until data indexing from source to dest is _complete_
@@ -108,12 +108,12 @@ class TransformContext {
         return changesLastDetectedAt;
     }
 
-    void setChangesLastSearchedAt(Instant time) {
-        changesLastSearchedAt = time;
+    void setLastSearchedTime(Instant time) {
+        lastSearchedTime = time;
     }
 
-    Instant getChangesLastSearchedAt() {
-        return changesLastSearchedAt;
+    Instant getLastSearchedTime() {
+        return lastSearchedTime;
     }
 
     public boolean shouldStopAtCheckpoint() {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
@@ -338,7 +338,7 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
         // we should verify if there are local changes based on the sync config. If not, do not proceed further and exit.
         if (context.getCheckpoint() > 0 && initialRun()) {
             sourceHasChanged(ActionListener.wrap(hasChanged -> {
-                context.setChangesLastSearchedAt(instantOfTrigger);
+                context.setLastSearchedTime(instantOfTrigger);
                 hasSourceChanged = hasChanged;
                 if (hasChanged) {
                     context.setChangesLastDetectedAt(instantOfTrigger);
@@ -357,7 +357,7 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
             }));
         } else {
             hasSourceChanged = true;
-            context.setChangesLastSearchedAt(instantOfTrigger);
+            context.setLastSearchedTime(instantOfTrigger);
             context.setChangesLastDetectedAt(instantOfTrigger);
             changedSourceListener.onResponse(null);
         }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
@@ -880,15 +880,15 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
         QueryBuilder queryBuilder = config.getSource().getQueryConfig().getQuery();
 
         if (isContinuous()) {
-            BoolQueryBuilder filteredQuery =
-                new BoolQueryBuilder()
-                    .filter(queryBuilder)
-                    .filter(config.getSyncConfig().getRangeQuery(nextCheckpoint));
+            BoolQueryBuilder filteredQuery = new BoolQueryBuilder().filter(queryBuilder)
+                .filter(config.getSyncConfig().getRangeQuery(nextCheckpoint));
 
             // Only apply extra filter if it is the subsequent run of the continuous transform
             if (nextCheckpoint.getCheckpoint() > 1 && changeCollector != null) {
-                QueryBuilder filter =
-                    changeCollector.buildFilterQuery(lastCheckpoint.getTimeUpperBound(), nextCheckpoint.getTimeUpperBound());
+                QueryBuilder filter = changeCollector.buildFilterQuery(
+                    lastCheckpoint.getTimeUpperBound(),
+                    nextCheckpoint.getTimeUpperBound()
+                );
                 if (filter != null) {
                     filteredQuery.filter(filter);
                 }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
@@ -338,7 +338,7 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
         // we should verify if there are local changes based on the sync config. If not, do not proceed further and exit.
         if (context.getCheckpoint() > 0 && initialRun()) {
             sourceHasChanged(ActionListener.wrap(hasChanged -> {
-                context.setLastSearchedTime(instantOfTrigger);
+                context.setLastSearchTime(instantOfTrigger);
                 hasSourceChanged = hasChanged;
                 if (hasChanged) {
                     context.setChangesLastDetectedAt(instantOfTrigger);
@@ -357,7 +357,7 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
             }));
         } else {
             hasSourceChanged = true;
-            context.setLastSearchedTime(instantOfTrigger);
+            context.setLastSearchTime(instantOfTrigger);
             context.setChangesLastDetectedAt(instantOfTrigger);
             changedSourceListener.onResponse(null);
         }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
@@ -174,6 +174,9 @@ public class TransformTask extends AllocatedPersistentTask implements SchedulerE
             if (context.getChangesLastDetectedAt() != null) {
                 infoBuilder.setChangesLastDetectedAt(context.getChangesLastDetectedAt());
             }
+            if (context.getChangesLastSearchedAt() != null) {
+                infoBuilder.setChangesLastSearchedAt(context.getChangesLastSearchedAt());
+            }
             listener.onResponse(infoBuilder.build());
         }, listener::onFailure);
 

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
@@ -174,8 +174,8 @@ public class TransformTask extends AllocatedPersistentTask implements SchedulerE
             if (context.getChangesLastDetectedAt() != null) {
                 infoBuilder.setChangesLastDetectedAt(context.getChangesLastDetectedAt());
             }
-            if (context.getChangesLastSearchedAt() != null) {
-                infoBuilder.setLastSearchTime(context.getChangesLastSearchedAt());
+            if (context.getLastSearchedTime() != null) {
+                infoBuilder.setLastSearchTime(context.getLastSearchedTime());
             }
             listener.onResponse(infoBuilder.build());
         }, listener::onFailure);

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
@@ -174,8 +174,8 @@ public class TransformTask extends AllocatedPersistentTask implements SchedulerE
             if (context.getChangesLastDetectedAt() != null) {
                 infoBuilder.setChangesLastDetectedAt(context.getChangesLastDetectedAt());
             }
-            if (context.getLastSearchedTime() != null) {
-                infoBuilder.setLastSearchTime(context.getLastSearchedTime());
+            if (context.getLastSearchTime() != null) {
+                infoBuilder.setLastSearchTime(context.getLastSearchTime());
             }
             listener.onResponse(infoBuilder.build());
         }, listener::onFailure);

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
@@ -175,7 +175,7 @@ public class TransformTask extends AllocatedPersistentTask implements SchedulerE
                 infoBuilder.setChangesLastDetectedAt(context.getChangesLastDetectedAt());
             }
             if (context.getChangesLastSearchedAt() != null) {
-                infoBuilder.setChangesLastSearchedAt(context.getChangesLastSearchedAt());
+                infoBuilder.setLastSearchTime(context.getChangesLastSearchedAt());
             }
             listener.onResponse(infoBuilder.build());
         }, listener::onFailure);

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransportGetTransformStatsActionTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransportGetTransformStatsActionTests.java
@@ -45,6 +45,7 @@ public class TransportGetTransformStatsActionTests extends ESTestCase {
             new TransformCheckpointStats(1, null, null, 1, 1),
             new TransformCheckpointStats(2, null, null, 2, 5),
             2,
+            Instant.now(),
             Instant.now()
         );
 
@@ -81,6 +82,7 @@ public class TransportGetTransformStatsActionTests extends ESTestCase {
             new TransformCheckpointStats(1, null, null, 1, 1),
             new TransformCheckpointStats(2, null, null, 2, 5),
             2,
+            Instant.now(),
             Instant.now()
         );
 
@@ -126,6 +128,7 @@ public class TransportGetTransformStatsActionTests extends ESTestCase {
             new TransformCheckpointStats(1, null, null, 1, 1),
             new TransformCheckpointStats(2, null, null, 2, 5),
             2,
+            Instant.now(),
             Instant.now()
         );
 


### PR DESCRIPTION
transforms reports the the last time changes where detected with `changes_last_detected_at`, however that doesn't tell a user it searched for changes, this PR adds a field `last_search_time` to report when transform searched for changes the last time.

fixes #66410
relates #66367

### Notes
 - should be super useful for support cases
 - cat transforms should report `last_search_time` (#66367)
 - makes testing more reliable (#66410)
 - not reported for stopped transforms

### Review

the main changes are part of [`bd59629` (#66718)](https://github.com/elastic/elasticsearch/pull/66718/commits/bd596295acaec91ab4d66e0ab484b2a9cddbad0a), the rest are style and test fixes