### PR TITLE
Make sure shared source always represents the top-level root document.

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.inner_hits/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.inner_hits/10_basic.yml
@@ -82,3 +82,69 @@ setup:
     - match: { hits.hits.0.fields._seq_no: [1] }
     - match: { hits.hits.0.inner_hits.nested_field.hits.hits.0._version: 2 }
     - match: { hits.hits.0.inner_hits.nested_field.hits.hits.0.fields._seq_no: [1] }
+
+---
+"Inner hits with disabled _source":
+  - do:
+      indices.create:
+        index: disabled_source
+        body:
+          mappings:
+            _source:
+              enabled: false
+            properties:
+              nested_field:
+                type: nested
+                properties:
+                  sub_nested_field:
+                    type: nested
+
+  - do:
+      index:
+        index: disabled_source
+        id:    1
+        body:
+          nested_field:
+            field: value
+            sub_nested_field:
+              field: value
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      search:
+        index: disabled_source
+        rest_total_hits_as_int: true
+        body:
+          query:
+            nested:
+              path: "nested_field.sub_nested_field"
+              query: { match_all: {}}
+              inner_hits: {}
+  - match: { hits.total: 1 }
+  - match: { hits.hits.0._id: "1" }
+  - match: { hits.hits.0.inner_hits.nested_field\.sub_nested_field.hits.hits.0._id: "1" }
+  - is_false: hits.hits.0.inner_hits.nested_field\.sub_nested_field.hits.hits.0._source
+
+  - do:
+      search:
+        index: disabled_source
+        rest_total_hits_as_int: true
+        body:
+          query:
+            nested:
+              path: "nested_field"
+              inner_hits: {}
+              query:
+                nested:
+                  path: "nested_field.sub_nested_field"
+                  query: { match_all: {}}
+                  inner_hits: {}
+
+  - match: { hits.total: 1 }
+  - match: { hits.hits.0._id: "1" }
+  - match: { hits.hits.0.inner_hits.nested_field.hits.hits.0._id: "1" }
+  - is_false: hits.hits.0.inner_hits.nested_field.hits.hits.0._source
+  - match: { hits.hits.0.inner_hits.nested_field.hits.hits.0.inner_hits.nested_field\.sub_nested_field.hits.hits.0._id: "1" }
+  - is_false: hits.hits.0.inner_hits.nested_field.hits.hits.0.inner_hits.nested_field\.sub_nested_field.hits.hits.0._source

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fetch/subphase/InnerHitsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fetch/subphase/InnerHitsIT.java
@@ -279,10 +279,14 @@ public class InnerHitsIT extends ESIntegTestCase {
         requests.add(client().prepareIndex("articles").setId("1").setSource(jsonBuilder().startObject()
                 .field("title", "quick brown fox")
                 .startArray("comments")
-                .startObject()
-                .field("message", "fox eat quick")
-                .startArray("remarks").startObject().field("message", "good").endObject().endArray()
-                .endObject()
+                    .startObject()
+                        .field("message", "fox eat quick")
+                        .startArray("remarks").startObject().field("message", "good").endObject().endArray()
+                    .endObject()
+                    .startObject()
+                        .field("message", "hippo is hungry")
+                        .startArray("remarks").startObject().field("message", "neutral").endObject().endArray()
+                    .endObject()
                 .endArray()
                 .endObject()));
         requests.add(client().prepareIndex("articles").setId("2").setSource(jsonBuilder().startObject()
@@ -296,6 +300,7 @@ public class InnerHitsIT extends ESIntegTestCase {
                 .endObject()));
         indexRandom(true, requests);
 
+        // Check we can load the first doubly-nested document.
         SearchResponse response = client().prepareSearch("articles")
                 .setQuery(
                         nestedQuery("comments",
@@ -319,6 +324,33 @@ public class InnerHitsIT extends ESIntegTestCase {
         assertThat(innerHits.getAt(0).getId(), equalTo("1"));
         assertThat(innerHits.getAt(0).getNestedIdentity().getField().string(), equalTo("comments"));
         assertThat(innerHits.getAt(0).getNestedIdentity().getOffset(), equalTo(0));
+        assertThat(innerHits.getAt(0).getNestedIdentity().getChild().getField().string(), equalTo("remarks"));
+        assertThat(innerHits.getAt(0).getNestedIdentity().getChild().getOffset(), equalTo(0));
+
+        // Check we can load the second doubly-nested document.
+        response = client().prepareSearch("articles")
+            .setQuery(
+                nestedQuery("comments",
+                    nestedQuery("comments.remarks", matchQuery("comments.remarks.message", "neutral"), ScoreMode.Avg)
+                        .innerHit(new InnerHitBuilder("remark")),
+                    ScoreMode.Avg).innerHit(new InnerHitBuilder())
+            ).get();
+        assertNoFailures(response);
+        assertHitCount(response, 1);
+        assertSearchHit(response, 1, hasId("1"));
+        assertThat(response.getHits().getAt(0).getInnerHits().size(), equalTo(1));
+        innerHits = response.getHits().getAt(0).getInnerHits().get("comments");
+        assertThat(innerHits.getTotalHits().value, equalTo(1L));
+        assertThat(innerHits.getHits().length, equalTo(1));
+        assertThat(innerHits.getAt(0).getId(), equalTo("1"));
+        assertThat(innerHits.getAt(0).getNestedIdentity().getField().string(), equalTo("comments"));
+        assertThat(innerHits.getAt(0).getNestedIdentity().getOffset(), equalTo(1));
+        innerHits = innerHits.getAt(0).getInnerHits().get("remark");
+        assertThat(innerHits.getTotalHits().value, equalTo(1L));
+        assertThat(innerHits.getHits().length, equalTo(1));
+        assertThat(innerHits.getAt(0).getId(), equalTo("1"));
+        assertThat(innerHits.getAt(0).getNestedIdentity().getField().string(), equalTo("comments"));
+        assertThat(innerHits.getAt(0).getNestedIdentity().getOffset(), equalTo(1));
         assertThat(innerHits.getAt(0).getNestedIdentity().getChild().getField().string(), equalTo("remarks"));
         assertThat(innerHits.getAt(0).getNestedIdentity().getChild().getOffset(), equalTo(0));
 

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/InnerHitsPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/InnerHitsPhase.java
@@ -58,16 +58,16 @@ public final class InnerHitsPhase implements FetchSubPhase {
 
             @Override
             public void process(HitContext hitContext) throws IOException {
-                hitExecute(innerHits, hitContext);
+                SearchHit hit = hitContext.hit();
+                SourceLookup rootLookup = searchContext.getRootSourceLookup(hitContext);
+                hitExecute(innerHits, hit, rootLookup);
             }
         };
     }
 
-    private void hitExecute(Map<String, InnerHitsContext.InnerHitSubContext> innerHits, HitContext hitContext) throws IOException {
-
-        SearchHit hit = hitContext.hit();
-        SourceLookup sourceLookup = hitContext.sourceLookup();
-
+    private void hitExecute(Map<String, InnerHitsContext.InnerHitSubContext> innerHits,
+                            SearchHit hit,
+                            SourceLookup rootLookup) throws IOException {
         for (Map.Entry<String, InnerHitsContext.InnerHitSubContext> entry : innerHits.entrySet()) {
             InnerHitsContext.InnerHitSubContext innerHitsContext = entry.getValue();
             TopDocsAndMaxScore topDoc = innerHitsContext.topDocs(hit);
@@ -83,7 +83,7 @@ public final class InnerHitsPhase implements FetchSubPhase {
             }
             innerHitsContext.docIdsToLoad(docIdsToLoad, docIdsToLoad.length);
             innerHitsContext.setRootId(hit.getId());
-            innerHitsContext.setRootLookup(sourceLookup);
+            innerHitsContext.setRootLookup(rootLookup);
 
             fetchPhase.execute(innerHitsContext);
             FetchSearchResult fetchResult = innerHitsContext.fetchResult();


### PR DESCRIPTION
In #60494 we started passing down the root document's _source when processing
nested hits, to avoid reloading and reparsing the root source for each hit.
Unfortunately the approach did not work when there are multiple layers of
`inner_hits`. In this case, the second-layer inner hit received its immediate
parent's source instead of the root source. This parent source is filtered to
just contain the parts corresponding to the nested document, but the source
parsing logic is designed to always operate on the top-level root source. This
caused failures when loading the second-layer inner hits.

This PR makes sure to always pass the root document's _source when processing
inner hits, even if there are multiple layers.

Fixes #66577.