### PR TITLE
Port all task definitions to task avoidance api

### DIFF
--- a/libs/secure-sm/build.gradle
+++ b/libs/secure-sm/build.gradle
@@ -37,7 +37,7 @@ tasks.named('forbiddenApisMain').configure {
 // JAR hell is part of core which we do not want to add as a dependency
 tasks.named("jarHell").configure { enabled = false }
 
-testingConventions {
+tasks.named("testingConventions").configure {
   naming.clear()
   naming {
     Tests {

--- a/modules/reindex/build.gradle
+++ b/modules/reindex/build.gradle
@@ -129,7 +129,7 @@ if (Os.isFamily(Os.FAMILY_WINDOWS)) {
     // see: https://github.com/elastic/elasticsearch/issues/51202
     versions = ['2', '1']
   }
-  for (String version : versions) {
+  versions.each { version ->
     // TODO Rene: we should be able to replace these unzip tasks with gradle artifact transforms
     TaskProvider<Sync> unzip = tasks.register("unzipEs${version}", Sync) {
       Configuration oldEsDependency = configurations['es' + version]

--- a/modules/reindex/build.gradle
+++ b/modules/reindex/build.gradle
@@ -21,6 +21,7 @@ import org.apache.tools.ant.taskdefs.condition.Os
 import org.elasticsearch.gradle.Architecture
 import org.elasticsearch.gradle.OS
 import org.elasticsearch.gradle.info.BuildParams
+import org.elasticsearch.gradle.test.AntFixture
 
 apply plugin: 'elasticsearch.test-with-dependencies'
 apply plugin: 'elasticsearch.jdk-download'
@@ -111,12 +112,12 @@ jdks {
 
 if (Os.isFamily(Os.FAMILY_WINDOWS)) {
   logger.warn("Disabling reindex-from-old tests because we can't get the pid file on windows")
-  javaRestTest {
+  tasks.named("javaRestTest").configure {
     systemProperty "tests.fromOld", "false"
   }
 } else if (rootProject.rootDir.toString().contains(" ")) {
   logger.warn("Disabling reindex-from-old tests because Elasticsearch 1.7 won't start with spaces in the path")
-  javaRestTest {
+  tasks.named("javaRestTest").configure {
     systemProperty "tests.fromOld", "false"
   }
 } else {
@@ -141,7 +142,7 @@ if (Os.isFamily(Os.FAMILY_WINDOWS)) {
       into temporaryDir
     }
 
-    Task fixture = task("oldEs${version}Fixture", type: org.elasticsearch.gradle.test.AntFixture) {
+    TaskProvider<AntFixture> fixture = tasks.register("oldEs${version}Fixture", AntFixture) {
       dependsOn project.configurations.oldesFixture, jdks.legacy
       dependsOn unzip
       executable = "${BuildParams.runtimeJavaHome}/bin/java"
@@ -158,13 +159,13 @@ if (Os.isFamily(Os.FAMILY_WINDOWS)) {
       }
     }
 
-    javaRestTest {
+    tasks.named("javaRestTest").configure {
       dependsOn fixture
         systemProperty "tests.fromOld", "true"
         /* Use a closure on the string to delay evaluation until right before we
          * run the integration tests so that we can be sure that the file is
          * ready. */
-        nonInputProperties.systemProperty "es${version}.port", "${-> fixture.addressAndPort}"
+        nonInputProperties.systemProperty "es${version}.port", "${-> fixture.get().addressAndPort}"
     }
   }
 }

--- a/plugins/discovery-gce/build.gradle
+++ b/plugins/discovery-gce/build.gradle
@@ -34,12 +34,12 @@ tasks.named("dependencyLicenses").configure {
   mapping from: /google-.*/, to: 'google'
 }
 
-check {
+tasks.named("check").configure {
   // also execute the QA tests when testing the plugin
   dependsOn 'qa:gce:check'
 }
 
-test {
+tasks.named("test").configure {
   // this is needed for insecure plugins, remove if possible!
   systemProperty 'tests.artifact', project.name
 }

--- a/plugins/repository-azure/azure-storage-blob/build.gradle
+++ b/plugins/repository-azure/azure-storage-blob/build.gradle
@@ -29,7 +29,7 @@ List<String> classesToRewrite = ['com/azure/storage/blob/implementation/AppendBl
                                  'com/azure/storage/blob/implementation/PageBlobsImpl$PageBlobsService.class',
                                  'com/azure/storage/blob/implementation/ServicesImpl$ServicesService.class']
 
-tasks.create('extractClientClasses', Copy).configure {
+tasks.register('extractClientClasses', Copy).configure {
   from({ zipTree(configurations.originalJar.singleFile) }) {
     include "com/azure/storage/blob/implementation/**"
   }
@@ -37,8 +37,7 @@ tasks.create('extractClientClasses', Copy).configure {
 }
 
 def modifiedOutput = project.layout.buildDirectory.dir('modified')
-def makePublic = tasks.create('makeClientClassesPublic', JavaClassPublicifier)
-makePublic.configure {
+def makePublic = tasks.register('makeClientClassesPublic', JavaClassPublicifier) {
   dependsOn 'extractClientClasses'
   classFiles = classesToRewrite
   inputDir = project.layout.buildDirectory.dir('original')

--- a/plugins/repository-azure/build.gradle
+++ b/plugins/repository-azure/build.gradle
@@ -335,13 +335,12 @@ tasks.named("processYamlRestTestResources").configure {
   MavenFilteringHack.filter(it, expansions)
 }
 
-internalClusterTest {
+tasks.named("internalClusterTest").configure {
   // this is tested explicitly in a separate test task
   exclude '**/AzureStorageCleanupThirdPartyTests.class'
 }
 
-testClusters {
-  yamlRestTest {
+testClusters.matching { it.name == "yamlRestTest" }.configureEach {
     keystore 'azure.client.integration_test.account', azureAccount
     if (azureKey != null && azureKey.isEmpty() == false) {
       keystore 'azure.client.integration_test.key', azureKey
@@ -354,15 +353,14 @@ testClusters {
       String firstPartOfSeed = BuildParams.testSeed.tokenize(':').get(0)
       setting 'thread_pool.repository_azure.max', (Math.abs(Long.parseUnsignedLong(firstPartOfSeed, 16) % 10) + 1).toString(), System.getProperty('ignore.tests.seed') == null ? DEFAULT : IGNORE_VALUE
     }
-  }
 }
 
-task azureThirdPartyTest(type: Test) {
+tasks.register("azureThirdPartyTest", Test) {
   SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
   SourceSet internalTestSourceSet = sourceSets.getByName(InternalClusterTestPlugin.SOURCE_SET_NAME)
   setTestClassesDirs(internalTestSourceSet.getOutput().getClassesDirs())
   setClasspath(internalTestSourceSet.getRuntimeClasspath())
-  dependsOn tasks.internalClusterTest
+  dependsOn "internalClusterTest"
   include '**/AzureStorageCleanupThirdPartyTests.class'
   systemProperty 'test.azure.account', azureAccount ? azureAccount : ""
   systemProperty 'test.azure.key', azureKey ? azureKey : ""

--- a/qa/smoke-test-http/build.gradle
+++ b/qa/smoke-test-http/build.gradle
@@ -28,7 +28,7 @@ dependencies {
   testImplementation project(':plugins:transport-nio') // for http
 }
 
-integTest {
+tasks.named("integTest").configure {
   /*
    * We have to disable setting the number of available processors as tests in the same JVM randomize processors and will step on each
    * other if we allow them to set the number of available processors as it's set-once in Netty.

--- a/test/fixtures/gcs-fixture/build.gradle
+++ b/test/fixtures/gcs-fixture/build.gradle
@@ -26,8 +26,10 @@ dependencies {
   api project(':server')
 }
 
+def jarTask = tasks.named("jar")
 tasks.named("preProcessFixture").configure {
-  dependsOn tasks.named("jar"), configurations.runtimeClasspath
+  dependsOn jarTask, configurations.runtimeClasspath
+  inputs.files(jarTask, configurations.runtimeClasspath)
   doLast {
     file("${testFixturesDir}/shared").mkdirs()
     project.copy {

--- a/test/fixtures/gcs-fixture/build.gradle
+++ b/test/fixtures/gcs-fixture/build.gradle
@@ -26,8 +26,8 @@ dependencies {
   api project(':server')
 }
 
-preProcessFixture {
-  dependsOn jar, configurations.runtimeClasspath
+tasks.named("preProcessFixture").configure {
+  dependsOn tasks.named("jar"), configurations.runtimeClasspath
   doLast {
     file("${testFixturesDir}/shared").mkdirs()
     project.copy {

--- a/x-pack/docs/build.gradle
+++ b/x-pack/docs/build.gradle
@@ -5,14 +5,16 @@ apply plugin: 'elasticsearch.rest-resources'
  * `// CONSOLE` and `// TESTRESPONSE` but have yet to be converted. Try and
  * only remove entries from this list. When it is empty we'll remove it
  * entirely and have a party! There will be cake and everything.... */
-buildRestTests.expectedUnconvertedCandidates = [
-  'en/rest-api/watcher/put-watch.asciidoc',
-  'en/security/authentication/user-cache.asciidoc',
-  'en/security/authorization/run-as-privilege.asciidoc',
-  'en/security/ccs-clients-integrations/http.asciidoc',
-  'en/rest-api/watcher/stats.asciidoc',
-  'en/watcher/example-watches/watching-time-series-data.asciidoc',
-]
+tasks.named("buildRestTests").configure {
+  expectedUnconvertedCandidates = [
+          'en/rest-api/watcher/put-watch.asciidoc',
+          'en/security/authentication/user-cache.asciidoc',
+          'en/security/authorization/run-as-privilege.asciidoc',
+          'en/security/ccs-clients-integrations/http.asciidoc',
+          'en/rest-api/watcher/stats.asciidoc',
+          'en/watcher/example-watches/watching-time-series-data.asciidoc',
+  ]
+}
 
 dependencies {
   testImplementation project(path: xpackModule('core'), configuration: 'default')

--- a/x-pack/plugin/async/build.gradle
+++ b/x-pack/plugin/async/build.gradle
@@ -13,7 +13,7 @@ dependencies {
   compileOnly project(path: xpackModule('core'), configuration: 'default')
 }
 
-dependencyLicenses {
+tasks.named("dependencyLicenses").configure {
   ignoreSha 'x-pack-core'
 }
 

--- a/x-pack/plugin/ccr/build.gradle
+++ b/x-pack/plugin/ccr/build.gradle
@@ -19,7 +19,7 @@ tasks.register('internalClusterTestNoSecurityManager', Test) {
   include noSecurityManagerITClasses
   systemProperty 'tests.security.manager', 'false'
 }
-check.dependsOn 'internalClusterTestNoSecurityManager'
+tasks.named("check").configure { dependsOn 'internalClusterTestNoSecurityManager' }
 
 tasks.named('internalClusterTest').configure {
   exclude noSecurityManagerITClasses
@@ -35,8 +35,10 @@ dependencies {
   testImplementation project(path: xpackModule('monitoring'), configuration: 'testArtifacts')
 }
 
-testingConventions.naming {
-  IT {
-    baseClass "org.elasticsearch.xpack.CcrIntegTestCase"
+tasks.named("testingConventions").configure {
+  naming {
+    IT {
+      baseClass "org.elasticsearch.xpack.CcrIntegTestCase"
+    }
   }
 }

--- a/x-pack/plugin/ccr/qa/downgrade-to-basic-license/build.gradle
+++ b/x-pack/plugin/ccr/qa/downgrade-to-basic-license/build.gradle
@@ -10,13 +10,24 @@ dependencies {
   testImplementation project(':x-pack:plugin:ccr:qa')
 }
 
-task "leader-cluster"(type: RestIntegTestTask) {
+
+testClusters {
+  "leader-cluster" {
+    testDistribution = 'DEFAULT'
+    setting 'xpack.license.self_generated.type', 'trial'
+  }
+
+  "follow-cluster" {
+    testDistribution = 'DEFAULT'
+    setting 'xpack.monitoring.collection.enabled', 'true'
+    setting 'xpack.license.self_generated.type', 'trial'
+    setting 'cluster.remote.leader_cluster.seeds', { "\"${testClusters."leader-cluster".getAllTransportPortURI().join(",")}\"" }
+  }
+}
+
+tasks.register("leader-cluster", RestIntegTestTask) {
   mustRunAfter("precommit")
   systemProperty 'tests.target_cluster', 'leader'
-}
-testClusters."leader-cluster" {
-  testDistribution = 'DEFAULT'
-  setting 'xpack.license.self_generated.type', 'trial'
 }
 
 File policyFile = file("${buildDir}/tmp/java.policy")
@@ -57,7 +68,7 @@ tasks.register("writeJavaPolicy") {
   }
 }
 
-task "follow-cluster"(type: RestIntegTestTask) {
+tasks.register("follow-cluster", RestIntegTestTask) {
   dependsOn 'writeJavaPolicy', "leader-cluster"
     useCluster testClusters."leader-cluster"
     if (BuildParams.inFipsJvm){
@@ -69,14 +80,6 @@ task "follow-cluster"(type: RestIntegTestTask) {
     nonInputProperties.systemProperty 'tests.leader_host', "${-> testClusters."leader-cluster".getAllHttpSocketURI().get(0)}"
     nonInputProperties.systemProperty 'log', "${-> testClusters."follow-cluster".getFirstNode().getServerLog()}"
 }
-
-testClusters."follow-cluster" {
-  testDistribution = 'DEFAULT'
-  setting 'xpack.monitoring.collection.enabled', 'true'
-  setting 'xpack.license.self_generated.type', 'trial'
-  setting 'cluster.remote.leader_cluster.seeds', { "\"${testClusters."leader-cluster".getAllTransportPortURI().join(",")}\"" }
-}
-
 
 tasks.named("check").configure { dependsOn "follow-cluster" }
 // no unit tests for multi-cluster-search, only the rest integration test

--- a/x-pack/plugin/ccr/qa/multi-cluster/build.gradle
+++ b/x-pack/plugin/ccr/qa/multi-cluster/build.gradle
@@ -9,51 +9,53 @@ dependencies {
   testImplementation project(':x-pack:plugin:ccr:qa')
 }
 
-task "leader-cluster"(type: RestIntegTestTask) {
+testClusters {
+  'leader-cluster' {
+    testDistribution = 'DEFAULT'
+    setting 'xpack.license.self_generated.type', 'trial'
+  }
+  'middle-cluster' {
+    testDistribution = 'DEFAULT'
+    setting 'xpack.license.self_generated.type', 'trial'
+    setting 'cluster.remote.leader_cluster.seeds',
+            { "\"${testClusters.named('leader-cluster').get().getAllTransportPortURI().join(",")}\"" }
+  }
+}
+
+tasks.register("leader-cluster", RestIntegTestTask) {
   mustRunAfter("precommit")
   systemProperty 'tests.target_cluster', 'leader'
 }
 
-testClusters."leader-cluster" {
-  testDistribution = 'DEFAULT'
-  setting 'xpack.license.self_generated.type', 'trial'
-}
-
-
-task "middle-cluster"(type: RestIntegTestTask) {
+tasks.register("middle-cluster", RestIntegTestTask) {
   dependsOn "leader-cluster"
   useCluster testClusters."leader-cluster"
   systemProperty 'tests.target_cluster', 'middle'
   nonInputProperties.systemProperty 'tests.leader_host',
-    "${-> testClusters."leader-cluster".getAllHttpSocketURI().get(0)}"
-}
-testClusters."middle-cluster" {
-  testDistribution = 'DEFAULT'
-  setting 'xpack.license.self_generated.type', 'trial'
-  setting 'cluster.remote.leader_cluster.seeds',
-    { "\"${testClusters."leader-cluster".getAllTransportPortURI().join(",")}\"" }
+    "${-> testClusters.named('leader-cluster').get().getAllHttpSocketURI().get(0)}"
 }
 
-task 'follow-cluster'(type: RestIntegTestTask) {
+
+tasks.register('follow-cluster', RestIntegTestTask) {
   dependsOn "leader-cluster", "middle-cluster"
     useCluster testClusters."leader-cluster"
     useCluster testClusters."middle-cluster"
     systemProperty 'tests.target_cluster', 'follow'
     nonInputProperties.systemProperty 'tests.leader_host',
-      "${-> testClusters."leader-cluster".getAllHttpSocketURI().get(0)}"
+      "${-> testClusters.named('leader-cluster').get().getAllHttpSocketURI().get(0)}"
     nonInputProperties.systemProperty 'tests.middle_host',
-      "${-> testClusters."middle-cluster".getAllHttpSocketURI().get(0)}"
+      "${-> testClusters.named('middle-cluster').get().getAllHttpSocketURI().get(0)}"
 }
 
-testClusters."follow-cluster" {
+testClusters.matching { it.name == "follow-cluster" }.configureEach {
   testDistribution = 'DEFAULT'
   setting 'xpack.monitoring.collection.enabled', 'true'
   setting 'xpack.license.self_generated.type', 'trial'
   setting 'cluster.remote.leader_cluster.seeds',
-    { "\"${testClusters."leader-cluster".getAllTransportPortURI().join(",")}\"" }
+    { "\"${testClusters.named('leader-cluster').get().getAllTransportPortURI().join(",")}\"" }
   setting 'cluster.remote.middle_cluster.seeds',
-    { "\"${testClusters."middle-cluster".getAllTransportPortURI().join(",")}\"" }
+    { "\"${testClusters.named('middle-cluster').get().getAllTransportPortURI().join(",")}\"" }
 }
 
-check.dependsOn "follow-cluster"
+tasks.named("check").configure { dependsOn "follow-cluster" }
 tasks.named("test").configure { enabled = false } // no unit tests for multi-cluster-search, only the rest integration test

--- a/x-pack/plugin/ccr/qa/non-compliant-license/build.gradle
+++ b/x-pack/plugin/ccr/qa/non-compliant-license/build.gradle
@@ -9,26 +9,30 @@ dependencies {
   testImplementation project(':x-pack:plugin:ccr:qa:')
 }
 
-task 'leader-cluster'(type: RestIntegTestTask) {
+testClusters {
+  'leader-cluster' {
+    testDistribution = 'DEFAULT'
+  }
+
+  'follow-cluster' {
+    testDistribution = 'DEFAULT'
+    setting 'xpack.license.self_generated.type', 'trial'
+    setting 'cluster.remote.leader_cluster.seeds',
+            { "\"${testClusters.'leader-cluster'.getAllTransportPortURI().join(",")}\"" }
+  }
+}
+
+tasks.register('leader-cluster', RestIntegTestTask) {
   mustRunAfter("precommit")
   systemProperty 'tests.target_cluster', 'leader'
 }
-testClusters.'leader-cluster' {
-  testDistribution = 'DEFAULT'
-}
 
-task 'follow-cluster'(type: RestIntegTestTask) {
+tasks.register('follow-cluster', RestIntegTestTask) {
   dependsOn 'leader-cluster'
   useCluster testClusters.'leader-cluster'
   systemProperty 'tests.target_cluster', 'follow'
   nonInputProperties.systemProperty 'tests.leader_host',
     { "${testClusters.'follow-cluster'.getAllHttpSocketURI().get(0)}" }
-}
-testClusters.'follow-cluster' {
-  testDistribution = 'DEFAULT'
-  setting 'xpack.license.self_generated.type', 'trial'
-  setting 'cluster.remote.leader_cluster.seeds',
-    { "\"${testClusters.'leader-cluster'.getAllTransportPortURI().join(",")}\"" }
 }
 
 tasks.named("check").configure { dependsOn "follow-cluster" }

--- a/x-pack/plugin/ccr/qa/restart/build.gradle
+++ b/x-pack/plugin/ccr/qa/restart/build.gradle
@@ -8,33 +8,37 @@ dependencies {
   testImplementation project(':x-pack:plugin:ccr:qa')
 }
 
-task 'leader-cluster'(type: RestIntegTestTask) {
+testClusters {
+  'leader-cluster' {
+    testDistribution = 'DEFAULT'
+    setting 'xpack.license.self_generated.type', 'trial'
+  }
+
+  'follow-cluster' {
+    testDistribution = 'DEFAULT'
+    setting 'xpack.monitoring.collection.enabled', 'true'
+    setting 'xpack.license.self_generated.type', 'trial'
+    setting 'cluster.remote.leader_cluster.seeds',
+            { "\"${testClusters.'leader-cluster'.getAllTransportPortURI().get(0)}\"" }
+    nameCustomization = { 'follow' }
+  }
+}
+
+tasks.register('leader-cluster', RestIntegTestTask) {
   mustRunAfter("precommit")
   systemProperty 'tests.target_cluster', 'leader'
 }
-testClusters.'leader-cluster' {
-  testDistribution = 'DEFAULT'
-  setting 'xpack.license.self_generated.type', 'trial'
-}
 
-task 'follow-cluster'(type: RestIntegTestTask) {
+tasks.register('follow-cluster', RestIntegTestTask) {
   dependsOn 'leader-cluster'
-    useCluster testClusters.'leader-cluster'
-    systemProperty 'tests.target_cluster', 'follow'
-    nonInputProperties.systemProperty 'tests.leader_host',
-      "${-> testClusters.'leader-cluster'.getAllHttpSocketURI().get(0)}"
-}
-testClusters.'follow-cluster' {
-  testDistribution = 'DEFAULT'
-  setting 'xpack.monitoring.collection.enabled', 'true'
-  setting 'xpack.license.self_generated.type', 'trial'
-  setting 'cluster.remote.leader_cluster.seeds',
-    { "\"${testClusters.'leader-cluster'.getAllTransportPortURI().get(0)}\"" }
-  nameCustomization = { 'follow' }
+  useCluster testClusters.'leader-cluster'
+  systemProperty 'tests.target_cluster', 'follow'
+  nonInputProperties.systemProperty 'tests.leader_host',
+          "${-> testClusters.'leader-cluster'.getAllHttpSocketURI().get(0)}"
 }
 
-task followClusterRestartTest(type: StandaloneRestIntegTestTask) {
-  dependsOn tasks.'follow-cluster'
+tasks.register("followClusterRestartTest", StandaloneRestIntegTestTask) {
+  dependsOn 'follow-cluster'
   useCluster testClusters.'leader-cluster'
   useCluster testClusters.'follow-cluster'
 
@@ -47,5 +51,5 @@ task followClusterRestartTest(type: StandaloneRestIntegTestTask) {
   }
 }
 
-check.dependsOn followClusterRestartTest
+tasks.named("check").configure { dependsOn "followClusterRestartTest" }
 tasks.named("test").configure { enabled = false }

--- a/x-pack/plugin/ccr/qa/security/build.gradle
+++ b/x-pack/plugin/ccr/qa/security/build.gradle
@@ -17,38 +17,41 @@ tasks.register("resolve") {
     println "configurations.testCompileClasspath.files " + configurations.testCompileClasspath.files.size()
   }
 }
-task 'leader-cluster'(type: RestIntegTestTask) {
+
+testClusters {
+  'leader-cluster' {
+    testDistribution = 'DEFAULT'
+    setting 'xpack.license.self_generated.type', 'trial'
+    setting 'xpack.security.enabled', 'true'
+    extraConfigFile 'roles.yml', file('leader-roles.yml')
+    user username: "test_admin", role: "superuser"
+    user username: "test_ccr", role: "ccruser"
+  }
+
+  'follow-cluster' {
+    testDistribution = 'DEFAULT'
+    setting 'cluster.remote.leader_cluster.seeds', {
+      "\"${testClusters.'leader-cluster'.getAllTransportPortURI().join(",")}\""
+    }
+    setting 'xpack.license.self_generated.type', 'trial'
+    setting 'xpack.security.enabled', 'true'
+    setting 'xpack.monitoring.collection.enabled', 'true'
+    extraConfigFile 'roles.yml', file('follower-roles.yml')
+    user username: "test_admin", role: "superuser"
+    user username: "test_ccr", role: "ccruser"
+  }
+}
+
+tasks.register('leader-cluster', RestIntegTestTask) {
   mustRunAfter("precommit")
   systemProperty 'tests.target_cluster', 'leader'
 }
 
-testClusters.'leader-cluster' {
-  testDistribution = 'DEFAULT'
-  setting 'xpack.license.self_generated.type', 'trial'
-  setting 'xpack.security.enabled', 'true'
-  extraConfigFile 'roles.yml', file('leader-roles.yml')
-  user username: "test_admin", role: "superuser"
-  user username: "test_ccr", role: "ccruser"
-}
-
-task 'follow-cluster'(type: RestIntegTestTask) {
+tasks.register('follow-cluster', RestIntegTestTask) {
   dependsOn 'leader-cluster'
   useCluster testClusters.'leader-cluster'
   systemProperty 'tests.target_cluster', 'follow'
   nonInputProperties.systemProperty 'tests.leader_host', "${-> testClusters.'leader-cluster'.getAllHttpSocketURI().get(0)}"
-}
-
-testClusters.'follow-cluster' {
-  testDistribution = 'DEFAULT'
-  setting 'cluster.remote.leader_cluster.seeds', {
-    "\"${testClusters.'leader-cluster'.getAllTransportPortURI().join(",")}\""
-  }
-  setting 'xpack.license.self_generated.type', 'trial'
-  setting 'xpack.security.enabled', 'true'
-  setting 'xpack.monitoring.collection.enabled', 'true'
-  extraConfigFile 'roles.yml', file('follower-roles.yml')
-  user username: "test_admin", role: "superuser"
-  user username: "test_ccr", role: "ccruser"
 }
 
 tasks.named("check").configure { dependsOn('follow-cluster') }

--- a/x-pack/plugin/identity-provider/build.gradle
+++ b/x-pack/plugin/identity-provider/build.gradle
@@ -354,7 +354,7 @@ tasks.named("test").configure {
   systemProperty 'es.set.netty.runtime.available.processors', 'false'
 }
 
-internalClusterTest {
+tasks.named("internalClusterTest").configure {
   systemProperty 'es.set.netty.runtime.available.processors', 'false'
 }
 

--- a/x-pack/plugin/ilm/qa/rest/build.gradle
+++ b/x-pack/plugin/ilm/qa/rest/build.gradle
@@ -14,7 +14,7 @@ restResources {
 def clusterCredentials = [username: System.getProperty('tests.rest.cluster.username', 'test_admin'),
                           password: System.getProperty('tests.rest.cluster.password', 'x-pack-test-password')]
 
-yamlRestTest {
+tasks.named("yamlRestTest").configure {
   systemProperty 'tests.rest.cluster.username', clusterCredentials.username
   systemProperty 'tests.rest.cluster.password', clusterCredentials.password
 }

--- a/x-pack/plugin/watcher/build.gradle
+++ b/x-pack/plugin/watcher/build.gradle
@@ -82,7 +82,7 @@ tasks.named("forbiddenPatterns").configure {
   exclude '**/*.p12'
 }
 
-internalClusterTest {
+tasks.named("internalClusterTest").configure {
   /*
    * We have to disable setting the number of available processors as tests in the same JVM randomize processors and will step on each
    * other if we allow them to set the number of available processors as it's set-once in Netty.

--- a/x-pack/qa/multi-cluster-search-security/build.gradle
+++ b/x-pack/qa/multi-cluster-search-security/build.gradle
@@ -14,41 +14,43 @@ restResources {
   }
 }
 
-task 'remote-cluster'(type: RestIntegTestTask) {
+tasks.register('remote-cluster', RestIntegTestTask) {
   mustRunAfter("precommit")
   systemProperty 'tests.rest.suite', 'remote_cluster'
 }
 
-testClusters.'remote-cluster' {
-  testDistribution = 'DEFAULT'
-  numberOfNodes = 2
-  setting 'node.roles', '[data,ingest,master]'
-  setting 'xpack.security.enabled', 'true'
-  setting 'xpack.watcher.enabled', 'false'
-  setting 'xpack.ml.enabled', 'false'
-  setting 'xpack.license.self_generated.type', 'trial'
+testClusters {
+  'remote-cluster' {
+    testDistribution = 'DEFAULT'
+    numberOfNodes = 2
+    setting 'node.roles', '[data,ingest,master]'
+    setting 'xpack.security.enabled', 'true'
+    setting 'xpack.watcher.enabled', 'false'
+    setting 'xpack.ml.enabled', 'false'
+    setting 'xpack.license.self_generated.type', 'trial'
 
-  user username: "test_user", password: "x-pack-test-password"
+    user username: "test_user", password: "x-pack-test-password"
+  }
+
+  'mixed-cluster' {
+    testDistribution = 'DEFAULT'
+    setting 'xpack.security.enabled', 'true'
+    setting 'xpack.watcher.enabled', 'false'
+    setting 'xpack.ml.enabled', 'false'
+    setting 'xpack.license.self_generated.type', 'trial'
+    setting 'cluster.remote.my_remote_cluster.seeds', {
+      testClusters.'remote-cluster'.getAllTransportPortURI().collect { "\"$it\"" }.toString()
+    }
+    setting 'cluster.remote.connections_per_cluster', "1"
+
+    user username: "test_user", password: "x-pack-test-password"
+  }
 }
 
-task 'mixed-cluster'(type: RestIntegTestTask) {
+tasks.register('mixed-cluster', RestIntegTestTask) {
   dependsOn 'remote-cluster'
   useCluster testClusters.'remote-cluster'
   systemProperty 'tests.rest.suite', 'multi_cluster'
-}
-
-testClusters.'mixed-cluster' {
-  testDistribution = 'DEFAULT'
-  setting 'xpack.security.enabled', 'true'
-  setting 'xpack.watcher.enabled', 'false'
-  setting 'xpack.ml.enabled', 'false'
-  setting 'xpack.license.self_generated.type', 'trial'
-  setting 'cluster.remote.my_remote_cluster.seeds', {
-    testClusters.'remote-cluster'.getAllTransportPortURI().collect { "\"$it\"" }.toString()
-  }
-  setting 'cluster.remote.connections_per_cluster', "1"
-
-  user username: "test_user", password: "x-pack-test-password"
 }
 
 tasks.register("integTest") {

--- a/x-pack/qa/multi-cluster-tests-with-security/build.gradle
+++ b/x-pack/qa/multi-cluster-tests-with-security/build.gradle
@@ -15,39 +15,43 @@ restResources {
   }
 }
 
-task 'remote-cluster'(type: RestIntegTestTask) {
+
+testClusters {
+  'remote-cluster' {
+    testDistribution = 'DEFAULT'
+    numberOfNodes = 2
+    setting 'node.roles', '[data,ingest,master]'
+    setting 'xpack.security.enabled', 'true'
+    setting 'xpack.watcher.enabled', 'false'
+    setting 'xpack.license.self_generated.type', 'trial'
+
+    user username: "test_user", password: "x-pack-test-password"
+  }
+
+  'mixed-cluster' {
+    testDistribution = 'DEFAULT'
+    setting 'xpack.security.enabled', 'true'
+    setting 'xpack.watcher.enabled', 'false'
+    setting 'xpack.license.self_generated.type', 'trial'
+    setting 'cluster.remote.my_remote_cluster.seeds', {
+      testClusters.'remote-cluster'.getAllTransportPortURI().collect { "\"$it\"" }.toString()
+    }
+    setting 'cluster.remote.connections_per_cluster', "1"
+
+    user username: "test_user", password: "x-pack-test-password"
+  }
+}
+
+tasks.register('remote-cluster', RestIntegTestTask) {
   mustRunAfter("precommit")
   systemProperty 'tests.rest.suite', 'remote_cluster'
 }
 
-testClusters.'remote-cluster' {
-  testDistribution = 'DEFAULT'
-  numberOfNodes = 2
-  setting 'node.roles', '[data,ingest,master]'
-  setting 'xpack.security.enabled', 'true'
-  setting 'xpack.watcher.enabled', 'false'
-  setting 'xpack.license.self_generated.type', 'trial'
 
-  user username: "test_user", password: "x-pack-test-password"
-}
-
-task 'mixed-cluster'(type: RestIntegTestTask) {
+tasks.register('mixed-cluster', RestIntegTestTask) {
   dependsOn 'remote-cluster'
   useCluster testClusters.'remote-cluster'
   systemProperty 'tests.rest.suite', 'multi_cluster'
-}
-
-testClusters.'mixed-cluster' {
-  testDistribution = 'DEFAULT'
-  setting 'xpack.security.enabled', 'true'
-  setting 'xpack.watcher.enabled', 'false'
-  setting 'xpack.license.self_generated.type', 'trial'
-  setting 'cluster.remote.my_remote_cluster.seeds', {
-    testClusters.'remote-cluster'.getAllTransportPortURI().collect { "\"$it\"" }.toString()
-  }
-  setting 'cluster.remote.connections_per_cluster', "1"
-
-  user username: "test_user", password: "x-pack-test-password"
 }
 
 tasks.register("integTest") {

--- a/x-pack/qa/rolling-upgrade-multi-cluster/build.gradle
+++ b/x-pack/qa/rolling-upgrade-multi-cluster/build.gradle
@@ -32,7 +32,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
     setting 'xpack.license.self_generated.type', 'trial'
   }
 
-  tasks.withType(StandaloneRestIntegTestTask).matching { it.name.startsWith("${baseName}#") }.all {
+  tasks.withType(StandaloneRestIntegTestTask).matching { it.name.startsWith("${baseName}#") }.configureEach {
     useCluster testClusters."${baseName}-leader"
     useCluster testClusters."${baseName}-follower"
     systemProperty 'tests.upgrade_from_version', bwcVersion.toString().replace('-SNAPSHOT', '')
@@ -51,9 +51,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
     }
   }
 
-  for (kind in ["follower", "leader"]) {
-    // Attention!! Groovy trap: do not pass `kind` to a closure
-
+  ["follower", "leader"].each { kind ->
     tasks.register("${baseName}#${kind}#clusterTest", StandaloneRestIntegTestTask) {
       systemProperty 'tests.rest.upgrade_state', 'none'
       systemProperty 'tests.rest.cluster_name', kind

--- a/x-pack/qa/saml-idp-tests/build.gradle
+++ b/x-pack/qa/saml-idp-tests/build.gradle
@@ -39,7 +39,7 @@ tasks.register("setupPorts") {
   }
 }
 
-integTest.dependsOn "setupPorts"
+tasks.named("integTest").configure {dependsOn "setupPorts" }
 
 testClusters.matching { it.name == "integTest" }.configureEach {
   testDistribution = 'DEFAULT'

--- a/x-pack/qa/smoke-test-plugins/build.gradle
+++ b/x-pack/qa/smoke-test-plugins/build.gradle
@@ -24,7 +24,7 @@ ext.expansions = [
         'expected.plugins.count': pluginPaths.size()
 ]
 
-processTestResources {
+tasks.named("processTestResources").configure {
   inputs.properties(project.expansions)
   MavenFilteringHack.filter(it, expansions)
 }

--- a/x-pack/test/idp-fixture/build.gradle
+++ b/x-pack/test/idp-fixture/build.gradle
@@ -4,7 +4,7 @@ import org.elasticsearch.gradle.Architecture
 apply plugin: 'elasticsearch.test.fixtures'
 apply plugin: 'elasticsearch.internal-distribution-download'
 
-task copyKeystore(type: Sync) {
+tasks.register("copyKeystore", Sync) {
   from project(':x-pack:plugin:core')
     .file('src/test/resources/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.jks')
   into "${buildDir}/certs"
@@ -24,8 +24,8 @@ elasticsearch_distributions {
   }
 }
 
-preProcessFixture {
-  dependsOn copyKeystore, elasticsearch_distributions.docker
+tasks.named("preProcessFixture").configure {
+  dependsOn "copyKeystore", elasticsearch_distributions.docker
   doLast {
     File file = file("${buildDir}/logs/node1")
     file.mkdirs()


### PR DESCRIPTION
This finishes porting all tasks created in gradle build scripts and plugins to use the task avoidance api (see https://github.com/elastic/elasticsearch/issues/56610) 

<img width="732" alt="Screenshot 2020-12-22 at 13 39 35" src="https://user-images.githubusercontent.com/77300/102889923-cb646880-445b-11eb-96e6-6069ca46c7ec.png">

As a next step I'll look into enforcing this api in favour of immediate task creation . At the moment this is not provided by gradle and requires a custom solution 

Fixes #56610