### PR TITLE
[DOCS] Minor rewording

### DIFF
--- a/docs/reference/rollup/apis/rollup-api.asciidoc
+++ b/docs/reference/rollup/apis/rollup-api.asciidoc
@@ -103,8 +103,8 @@ Time interval used to group documents. For differences between
 +
 TIP: Choose this value carefully. You won't be able to use a smaller interval
 later. For example, you can't aggregate daily rollups into hourly
-summaries. However, smaller time intervals can greatly increase the size of your
-`<rollup-index>`.
+summaries. However, smaller time intervals can greatly increase the size of the
+resulting rollup index.
 
 `time_zone`::
 (Optional, string)
@@ -146,7 +146,7 @@ Array of <<keyword,keyword family>> and <<number,numeric>> fields to store. If
 you specify a `terms` object, this property is required.
 +
 TIP: Avoid storing high-cardinality fields. High-cardinality fields can greatly
-increase the size of your `<rollup-index>`.
+increase the size of the resulting rollup index.
 =====
 ====
 


### PR DESCRIPTION
Minor wording change in the rollup API docs. This will make it easier to reuse content in the `rollup` ILM action docs.