### PR TITLE
[7.11] Mute JDBC client tests with SSL in FIPS mode (#66566)

### DIFF
--- a/x-pack/plugin/sql/qa/jdbc/security/with-ssl/build.gradle
+++ b/x-pack/plugin/sql/qa/jdbc/security/with-ssl/build.gradle
@@ -1,3 +1,5 @@
+import org.elasticsearch.gradle.info.BuildParams
+
 apply plugin: 'elasticsearch.test-with-ssl'
 
 testClusters.all {
@@ -5,4 +7,9 @@ testClusters.all {
   setting 'xpack.license.self_generated.type', 'trial'
   setting 'xpack.security.http.ssl.enabled', 'true'
   setting 'xpack.security.transport.ssl.enabled', 'true'
+}
+
+// JDBC client can only be configured for SSL with keystores, but we can't use JKS/PKCS12 keystores in FIPS 140-2 mode.
+tasks.withType(Test).configureEach {
+  onlyIf { BuildParams.inFipsJvm == false}
 }


### PR DESCRIPTION
Backports the following commits to 7.11:
 - Mute JDBC client tests with SSL in FIPS mode (#66566)