### PR TITLE
EQL: Included all keys when filtering until

### DIFF
--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/SequenceMatcher.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/SequenceMatcher.java
@@ -239,8 +239,12 @@ public class SequenceMatcher {
         return false;
     }
 
-    Set<SequenceKey> keysFor(int stage) {
+    Set<SequenceKey> keys(int stage) {
         return stageToKeys.keys(stage);
+    }
+
+    Set<SequenceKey> keys() {
+        return stageToKeys.keys();
     }
 
     List<Sequence> completed() {

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/StageToKeys.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/StageToKeys.java
@@ -6,6 +6,8 @@
 
 package org.elasticsearch.xpack.eql.execution.sequence;
 
+import org.elasticsearch.xpack.ql.util.CollectionUtils;
+
 import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -50,6 +52,16 @@ class StageToKeys {
     Set<SequenceKey> keys(int stage) {
         Set<SequenceKey> set = stageToKey.get(stage);
         return set == null ? emptySet() : set;
+    }
+
+    Set<SequenceKey> keys() {
+        Set<SequenceKey> keys = new LinkedHashSet<>();
+        for (Set<SequenceKey> sequenceKeys : stageToKey) {
+            if (CollectionUtils.isEmpty(sequenceKeys) == false) {
+                keys.addAll(sequenceKeys);
+            }
+        }
+        return keys;
     }
 
     void clear() {

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/TumblingWindow.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/TumblingWindow.java
@@ -477,7 +477,7 @@ public class TumblingWindow implements Executable {
         }
 
         if (hasKeys) {
-            int stage = criterion == until ? 0 : window.baseStage;
+            int stage = criterion == until ? Integer.MIN_VALUE : window.baseStage;
             addKeyConstraints(stage, request);
         }
     }
@@ -515,8 +515,9 @@ public class TumblingWindow implements Executable {
 
     private void addKeyConstraints(int keyStage, BoxedQueryRequest request) {
         // add constraints if possible
-        if (keyStage >= 0) {
-            Set<SequenceKey> keys = matcher.keysFor(keyStage);
+        if (keyStage >= 0 || keyStage == Integer.MIN_VALUE) {
+            // negative means all keys and is used by until
+            Set<SequenceKey> keys = keyStage == Integer.MIN_VALUE ? matcher.keys() : matcher.keys(keyStage);
             int size = keys.size();
             if (size > 0) {
                 request.keys(keys.stream().map(SequenceKey::asList).collect(toList()));


### PR DESCRIPTION
Until queries that include key filtering need to look at all keys not
just the base query.

Fix #66737
