### PR TITLE
EQL: Add back boxing of sub-queries

### DIFF
--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/TumblingWindow.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/TumblingWindow.java
@@ -371,6 +371,8 @@ public class TumblingWindow implements Executable {
         Criterion<BoxedQueryRequest> criterion = criteria.get(currentStage);
         BoxedQueryRequest request = criterion.queryRequest();
 
+        boxQuery(window, criterion);
+
         log.trace("Querying (secondary) stage [{}] {}", criterion.stage(), request);
 
         client.query(request, wrap(r -> {


### PR DESCRIPTION
A previous commit removed the boxing of secondary queries; this commit
reverts that.
