### PR TITLE
Use single backslash for nested paths in YAML integration tests

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.highlight/20_fvh.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.highlight/20_fvh.yml
@@ -112,5 +112,5 @@ setup:
                     nested.title:
                       type: fvh
 
-  - match: {hits.hits.0.inner_hits.nested_hits.hits.hits.0.highlight.nested\\.title.0: "<em>purple</em> octopus"}
-  - match: {hits.hits.0.inner_hits.nested_hits.hits.hits.1.highlight.nested\\.title.0: "<em>purple</em> fish"}
+  - match: {hits.hits.0.inner_hits.nested_hits.hits.hits.0.highlight.nested\.title.0: "<em>purple</em> octopus"}
+  - match: {hits.hits.0.inner_hits.nested_hits.hits.hits.1.highlight.nested\.title.0: "<em>purple</em> fish"}


### PR DESCRIPTION
This integration test is causing failures in a few clients repositories due to the double backslash. It seems like a single backslash is what is used elsewhere. The change was introduced in https://github.com/elastic/elasticsearch/pull/65641.

cc @elastic/clients-team 