### PR TITLE
[DOCS] Update rollup xrefs

### DIFF
--- a/docs/reference/intro.asciidoc
+++ b/docs/reference/intro.asciidoc
@@ -261,6 +261,6 @@ secondary clusters are read-only followers.
 As with any enterprise system, you need tools to secure, manage, and
 monitor your {es} clusters. Security, monitoring, and administrative features
 that are integrated into {es} enable you to use {kibana-ref}/introduction.html[{kib}]
-as a control center for managing a cluster. Features like <<rollup-overview,
+as a control center for managing a cluster. Features like <<xpack-rollup,
 data rollups>> and <<index-lifecycle-management, index lifecycle management>>
 help you intelligently manage your data over time.

--- a/docs/reference/rollup/apis/put-job.asciidoc
+++ b/docs/reference/rollup/apis/put-job.asciidoc
@@ -125,7 +125,7 @@ hourly (`60m`) intervals are configured, <<rollup-search,rollup search>>
 can execute aggregations with 60m or greater (weekly, monthly, etc) intervals.
 So define the interval as the smallest unit that you wish to later query. For
 more information about the difference between calendar and fixed time
-intervals, see <<rollup-understanding-group-intervals>>.
+intervals, see <<calendar_and_fixed_intervals>>.
 +
 --
 NOTE: Smaller, more granular intervals take up proportionally more space.


### PR DESCRIPTION
Updates a few rollup links. We plan to remove a few of these anchors as part of the docs update for the rollup refactor.