### PR TITLE
Ensure CI is run in FIPS 140 approved only mode

### DIFF
--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -584,6 +584,81 @@ repository without fetching latest. For these use cases, you can set the system
 property `tests.bwc.git_fetch_latest` to `false` and the BWC builds will skip
 fetching the latest from the remote.
 
+== Testing in FIPS 140-2 mode
+
+We have a CI matrix job that periodically runs all our tests with the JVM  configured
+to be FIPS 140-2 compliant with the use of the BouncyCastle FIPS approved Security Provider.
+FIPS 140-2 imposes certain requirements that affect how our tests should be set up or what
+can be tested. This section summarizes what one needs to take into consideration so that
+tests won't fail when run in fips mode.
+
+=== Muting tests in FIPS 140-2 mode
+
+If the following limitations cannot be observed, or there is a need to actually test some use
+case that is not available/allowed in fips mode, the test can be muted. For unit tests or Java
+rest tests one can use
+
+------------------------------------------------
+assumeFalse("Justification why this cannot be run in FIPS mode", inFipsJvm());
+------------------------------------------------
+
+For specific YAML rest tests one can use
+
+------------------------------------------------
+- skip:
+    features: fips_140
+    reason: "Justification why this cannot be run in FIPS mode"
+------------------------------------------------
+
+For disabling entire types of tests for subprojects, one can use for example:
+
+------------------------------------------------
+if (BuildParams.inFipsJvm){
+  // This test cluster is using a BASIC license and FIPS 140 mode is not supported in BASIC
+  tasks.named("javaRestTest").configure{enabled = false }
+}
+------------------------------------------------
+
+in `build.gradle`.
+
+=== Limitations
+
+The following should be taken into consideration when writing new tests or adjusting existing ones:
+
+==== TLS
+
+`JKS` and `PKCS#12` keystores cannot be used in FIPS mode. If the test depends on being able to use
+a keystore, it can be muted when needed ( see `ESTestCase#inFipsJvm` ). Alternatively, one can use
+PEM encoded files for keys and certificates for the tests or for setting up TLS in a test cluster.
+Also, when in FIPS 140 mode, hostname verification for TLS cannot be turned off so if you are using
+`*.verification_mode: none` , you'd need to mute the test in fips mode.
+
+When using TLS, ensure that private keys used are longer than 2048 bits, or mute the test in fips mode.
+
+==== Password hashing algorithm
+
+Test clusters are configured with `xpack.security.fips_mode.enabled` set to true. This means that
+FIPS 140-2 related bootstrap checks are enabled and the test cluster will fail to form if the
+password hashing algorithm is set to something else than a PBKDF2 based one. You can delegate the choice
+of algorithm to i.e. `SecurityIntegTestCase#getFastStoredHashAlgoForTests` if you don't mind the
+actual algorithm used, or depend on default values for the test cluster nodes.
+
+==== Password length
+
+While using `pbkdf2` as the password hashing algorithm, FIPS 140-2 imposes a requirement that
+passwords are longer than 14 characters. You can either ensure that all test user passwords in
+your test are longer than 14 characters and use i.e. `SecurityIntegTestCase#getFastStoredHashAlgoForTests`
+to randomly select a hashing algorithm, or use `pbkdf2_stretch` that doesn't have the same
+limitation.
+
+==== Keystore Password
+
+In FIPS 140-2 mode, the elasticsearch keystore needs to be password protected with a password
+of appropriate length. This is handled automatically in `fips.gradle` and the keystore is unlocked
+on startup by the test clusters tooling in order to have secure settings available. However, you
+might need to take into consideration that the keystore is password-protected with `keystore-password`
+if you need to interact with it in a test.
+
 == How to write good tests?
 
 === Base classes for test cases

--- a/build.gradle
+++ b/build.gradle
@@ -184,7 +184,17 @@ tasks.register("verifyVersions") {
  */
 
 boolean bwc_tests_enabled = true
-final String bwc_tests_disabled_issue = "" /* place a PR link here when committing bwc changes */
+String bwc_tests_disabled_issue = "" /* place a PR link here when committing bwc changes */
+/*
+ * FIPS 140-2 behavior was fixed in 7.11.0. Before that there is no way to run elasticsearch in a
+ * JVM that is properly configured to be in fips mode with BCFIPS. For now we need to disable
+ * all bwc testing in fips mode.
+ */
+
+if ( BuildParams.inFipsJvm ) {
+  bwc_tests_enabled = false
+  bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/issues/66772"
+}
 if (bwc_tests_enabled == false) {
   if (bwc_tests_disabled_issue.isEmpty()) {
     throw new GradleException("bwc_tests_disabled_issue must be set when bwc_tests_enabled == false")

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -523,7 +523,7 @@ public class ElasticsearchNode implements TestClusterConfiguration {
         if (keystoreSettings.isEmpty() == false || keystoreFiles.isEmpty() == false) {
             logToProcessStdout("Adding " + keystoreSettings.size() + " keystore settings and " + keystoreFiles.size() + " keystore files");
 
-            keystoreSettings.forEach((key, value) -> runKeystoreCommandWithPassword(keystorePassword, value.toString(), "add", "-x", key));
+            keystoreSettings.forEach((key, value) -> runKeystoreCommandWithPassword(keystorePassword, value.toString(), "add", key));
 
             for (Map.Entry<String, File> entry : keystoreFiles.entrySet()) {
                 File file = entry.getValue();

--- a/client/rest-high-level/build.gradle
+++ b/client/rest-high-level/build.gradle
@@ -72,14 +72,14 @@ File pkiTrustCert = file("./src/test/resources/org/elasticsearch/client/security
 tasks.named("integTest").configure {
   systemProperty 'tests.rest.async', 'false'
   systemProperty 'tests.rest.cluster.username', System.getProperty('tests.rest.cluster.username', 'test_user')
-  systemProperty 'tests.rest.cluster.password', System.getProperty('tests.rest.cluster.password', 'test-password')
+  systemProperty 'tests.rest.cluster.password', System.getProperty('tests.rest.cluster.password', 'test-user-password')
 }
 
 // Requires https://github.com/elastic/elasticsearch/pull/64403 to have this moved to task avoidance api.
 TaskProvider<RestIntegTestTask> asyncIntegTest = tasks.register("asyncIntegTest", RestIntegTestTask) {
     systemProperty 'tests.rest.async', 'true'
     systemProperty 'tests.rest.cluster.username', System.getProperty('tests.rest.cluster.username', 'test_user')
-    systemProperty 'tests.rest.cluster.password', System.getProperty('tests.rest.cluster.password', 'test-password')
+    systemProperty 'tests.rest.cluster.password', System.getProperty('tests.rest.cluster.password', 'test-user-password')
 }
 
 tasks.named("check").configure {
@@ -110,7 +110,7 @@ testClusters.all {
   keystore 'xpack.security.transport.ssl.truststore.secure_password', 'testnode'
   extraConfigFile 'roles.yml', file('roles.yml')
   user username: System.getProperty('tests.rest.cluster.username', 'test_user'),
-    password: System.getProperty('tests.rest.cluster.password', 'test-password'),
+    password: System.getProperty('tests.rest.cluster.password', 'test-user-password'),
     role: System.getProperty('tests.rest.cluster.role', 'admin')
   user username: 'admin_user', password: 'admin-password'
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/SecurityIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/SecurityIT.java
@@ -222,7 +222,7 @@ public class SecurityIT extends ESRestHighLevelClientTestCase {
     }
 
     private static PutUserRequest randomPutUserRequest(User user, boolean enabled) {
-        final char[] password = randomAlphaOfLengthBetween(6, 10).toCharArray();
+        final char[] password = randomAlphaOfLengthBetween(14, 19).toCharArray();
         return new PutUserRequest(user, password, enabled, RefreshPolicy.IMMEDIATE);
     }
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/CRUDDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/CRUDDocumentationIT.java
@@ -845,7 +845,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
             Integer remotePort = host.getPort();
             String remoteHost = host.getHostName();
             String user = "test_user";
-            String password = "test-password";
+            String password = "test-user-password";
 
             // tag::reindex-request-remote
             request.setRemoteInfo(

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SecurityDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SecurityDocumentationIT.java
@@ -157,9 +157,9 @@ public class SecurityDocumentationIT extends ESRestHighLevelClientTestCase {
     public void testGetUsers() throws Exception {
         final RestHighLevelClient client = highLevelClient();
         String[] usernames = new String[] {"user1", "user2", "user3"};
-        addUser(client, usernames[0], randomAlphaOfLengthBetween(6, 10));
-        addUser(client, usernames[1], randomAlphaOfLengthBetween(6, 10));
-        addUser(client, usernames[2], randomAlphaOfLengthBetween(6, 10));
+        addUser(client, usernames[0], randomAlphaOfLengthBetween(14, 18));
+        addUser(client, usernames[1], randomAlphaOfLengthBetween(14, 18));
+        addUser(client, usernames[2], randomAlphaOfLengthBetween(14, 18));
         {
             //tag::get-users-request
             GetUsersRequest request = new GetUsersRequest(usernames[0]);
@@ -251,7 +251,7 @@ public class SecurityDocumentationIT extends ESRestHighLevelClientTestCase {
 
         {
             //tag::put-user-password-request
-            char[] password = new char[]{'p', 'a', 's', 's', 'w', 'o', 'r', 'd'};
+            char[] password = new char[]{'t', 'e', 's', 't', '-', 'u','s','e','r','-','p', 'a', 's', 's', 'w', 'o', 'r', 'd'};
             User user = new User("example", Collections.singletonList("superuser"));
             PutUserRequest request = PutUserRequest.withPassword(user, password, true, RefreshPolicy.NONE);
             //end::put-user-password-request
@@ -270,7 +270,7 @@ public class SecurityDocumentationIT extends ESRestHighLevelClientTestCase {
             byte[] salt = new byte[32];
             // no need for secure random in a test; it could block and would not be reproducible anyway
             random().nextBytes(salt);
-            char[] password = new char[]{'p', 'a', 's', 's', 'w', 'o', 'r', 'd'};
+            char[] password = new char[]{'t', 'e', 's', 't', '-', 'u','s','e','r','-','p', 'a', 's', 's', 'w', 'o', 'r', 'd'};
             User user = new User("example2", Collections.singletonList("superuser"));
 
             //tag::put-user-hash-request
@@ -326,7 +326,7 @@ public class SecurityDocumentationIT extends ESRestHighLevelClientTestCase {
 
     public void testDeleteUser() throws Exception {
         RestHighLevelClient client = highLevelClient();
-        addUser(client, "testUser", "testPassword");
+        addUser(client, "testUser", "testUserPassword");
 
         {
             // tag::delete-user-request
@@ -566,7 +566,7 @@ public class SecurityDocumentationIT extends ESRestHighLevelClientTestCase {
 
     public void testEnableUser() throws Exception {
         RestHighLevelClient client = highLevelClient();
-        char[] password = new char[]{'p', 'a', 's', 's', 'w', 'o', 'r', 'd'};
+        char[] password = new char[]{'t', 'e', 's', 't', '-', 'u','s','e','r','-','p', 'a', 's', 's', 'w', 'o', 'r', 'd'};
         User enable_user = new User("enable_user", Collections.singletonList("superuser"));
         PutUserRequest putUserRequest = PutUserRequest.withPassword(enable_user, password, true, RefreshPolicy.IMMEDIATE);
         PutUserResponse putUserResponse = client.security().putUser(putUserRequest, RequestOptions.DEFAULT);
@@ -611,7 +611,7 @@ public class SecurityDocumentationIT extends ESRestHighLevelClientTestCase {
 
     public void testDisableUser() throws Exception {
         RestHighLevelClient client = highLevelClient();
-        char[] password = new char[]{'p', 'a', 's', 's', 'w', 'o', 'r', 'd'};
+        char[] password = new char[]{'t', 'e', 's', 't', '-', 'u','s','e','r','-','p', 'a', 's', 's', 'w', 'o', 'r', 'd'};
         User disable_user = new User("disable_user", Collections.singletonList("superuser"));
         PutUserRequest putUserRequest = PutUserRequest.withPassword(disable_user, password, true, RefreshPolicy.IMMEDIATE);
         PutUserResponse putUserResponse = client.security().putUser(putUserRequest, RequestOptions.DEFAULT);
@@ -1183,8 +1183,9 @@ public class SecurityDocumentationIT extends ESRestHighLevelClientTestCase {
 
     public void testChangePassword() throws Exception {
         RestHighLevelClient client = highLevelClient();
-        char[] password = new char[]{'p', 'a', 's', 's', 'w', 'o', 'r', 'd'};
-        char[] newPassword = new char[]{'n', 'e', 'w', 'p', 'a', 's', 's', 'w', 'o', 'r', 'd'};
+        char[] password = new char[]{'t', 'e', 's', 't', '-', 'u','s','e','r','-','p', 'a', 's', 's', 'w', 'o', 'r', 'd'};
+        char[] newPassword =
+            new char[]{'n', 'e', 'w', '-', 't', 'e', 's', 't', '-', 'u','s','e','r','-','p', 'a', 's', 's', 'w', 'o', 'r', 'd'};
         User user = new User("change_password_user", Collections.singletonList("superuser"), Collections.emptyMap(), null, null);
         PutUserRequest putUserRequest = PutUserRequest.withPassword(user, password, true, RefreshPolicy.NONE);
         PutUserResponse putUserResponse = client.security().putUser(putUserRequest, RequestOptions.DEFAULT);
@@ -1403,14 +1404,14 @@ public class SecurityDocumentationIT extends ESRestHighLevelClientTestCase {
         {
             // Setup user
             User token_user = new User("token_user", Collections.singletonList("kibana_user"));
-            PutUserRequest putUserRequest = PutUserRequest.withPassword(token_user, "password".toCharArray(), true,
+            PutUserRequest putUserRequest = PutUserRequest.withPassword(token_user, "test-user-password".toCharArray(), true,
                     RefreshPolicy.IMMEDIATE);
             PutUserResponse putUserResponse = client.security().putUser(putUserRequest, RequestOptions.DEFAULT);
             assertTrue(putUserResponse.isCreated());
         }
         {
             // tag::create-token-password-request
-            final char[] password = new char[]{'p', 'a', 's', 's', 'w', 'o', 'r', 'd'};
+            final char[] password = new char[]{'t', 'e', 's', 't', '-', 'u','s','e','r','-','p', 'a', 's', 's', 'w', 'o', 'r', 'd'};
             CreateTokenRequest createTokenRequest = CreateTokenRequest.passwordGrant("token_user", password);
             // end::create-token-password-request
 
@@ -1480,7 +1481,7 @@ public class SecurityDocumentationIT extends ESRestHighLevelClientTestCase {
         String refreshToken;
         {
             // Setup users
-            final char[] password = "password".toCharArray();
+            final char[] password = "test-user-password".toCharArray();
             User user = new User("user", Collections.singletonList("kibana_user"));
             PutUserRequest putUserRequest = PutUserRequest.withPassword(user, password, true, RefreshPolicy.IMMEDIATE);
             PutUserResponse putUserResponse = client.security().putUser(putUserRequest, RequestOptions.DEFAULT);

--- a/client/rest/src/test/java/org/elasticsearch/client/documentation/RestClientDocumentation.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/documentation/RestClientDocumentation.java
@@ -359,7 +359,7 @@ public class RestClientDocumentation {
             final CredentialsProvider credentialsProvider =
                 new BasicCredentialsProvider();
             credentialsProvider.setCredentials(AuthScope.ANY,
-                new UsernamePasswordCredentials("user", "password"));
+                new UsernamePasswordCredentials("user", "test-user-password"));
 
             RestClientBuilder builder = RestClient.builder(
                 new HttpHost("localhost", 9200))
@@ -378,7 +378,7 @@ public class RestClientDocumentation {
             final CredentialsProvider credentialsProvider =
                 new BasicCredentialsProvider();
             credentialsProvider.setCredentials(AuthScope.ANY,
-                new UsernamePasswordCredentials("user", "password"));
+                new UsernamePasswordCredentials("user", "test-user-password"));
 
             RestClientBuilder builder = RestClient.builder(
                 new HttpHost("localhost", 9200))

--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -215,13 +215,17 @@ def createAndSetWritable(Object... locations) {
   }
 }
 
-tasks.register("copyKeystore", Sync) {
+tasks.register("copyNodeKeyMaterial", Sync) {
   from project(':x-pack:plugin:core')
-    .file('src/test/resources/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.jks')
+    .files(
+      'src/test/resources/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.pem',
+      'src/test/resources/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.crt'
+    )
   into "${buildDir}/certs"
   doLast {
     file("${buildDir}/certs").setReadable(true, false)
-    file("${buildDir}/certs/testnode.jks").setReadable(true, false)
+    file("${buildDir}/certs/testnode.pem").setReadable(true, false)
+    file("${buildDir}/certs/testnode.crt").setReadable(true, false)
   }
 }
 
@@ -241,7 +245,7 @@ elasticsearch_distributions {
 
 tasks.named("preProcessFixture").configure {
   dependsOn elasticsearch_distributions.docker_default, elasticsearch_distributions.docker_oss
-  dependsOn "copyKeystore"
+  dependsOn "copyNodeKeyMaterial"
   doLast {
     // tests expect to have an empty repo
     project.delete(
@@ -261,7 +265,10 @@ tasks.named("preProcessFixture").configure {
 
 tasks.named("processTestResources").configure {
   from project(':x-pack:plugin:core')
-    .file('src/test/resources/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.jks')
+    .files(
+      'src/test/resources/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.pem',
+      'src/test/resources/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.crt'
+    )
 }
 
 tasks.register("integTest", Test) {

--- a/distribution/docker/docker-compose.yml
+++ b/distribution/docker/docker-compose.yml
@@ -3,10 +3,10 @@ version: '3'
 services:
   elasticsearch-default-1:
     image: elasticsearch:test
-    environment:  
-       - node.name=elasticsearch-default-1 
+    environment:
+       - node.name=elasticsearch-default-1
        - cluster.initial_master_nodes=elasticsearch-default-1,elasticsearch-default-2
-       - discovery.seed_hosts=elasticsearch-default-2:9300 
+       - discovery.seed_hosts=elasticsearch-default-2:9300
        - cluster.name=elasticsearch-default
        - bootstrap.memory_lock=true
        - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
@@ -15,22 +15,25 @@ services:
        - cluster.routing.allocation.disk.watermark.low=1b
        - cluster.routing.allocation.disk.watermark.high=1b
        - cluster.routing.allocation.disk.watermark.flood_stage=1b
-       - node.store.allow_mmap=false  
+       - node.store.allow_mmap=false
        - xpack.security.enabled=true
        - xpack.security.transport.ssl.enabled=true
        - xpack.security.http.ssl.enabled=true
        - xpack.security.authc.token.enabled=true
        - xpack.security.audit.enabled=true
-       - xpack.security.authc.realms.file.file1.order=0   
+       - xpack.security.authc.realms.file.file1.order=0
        - xpack.security.authc.realms.native.native1.order=1
-       - xpack.security.transport.ssl.keystore.path=/usr/share/elasticsearch/config/testnode.jks
-       - xpack.security.http.ssl.keystore.path=/usr/share/elasticsearch/config/testnode.jks
-       - xpack.http.ssl.verification_mode=certificate  
-       - xpack.security.transport.ssl.verification_mode=certificate  
+       - xpack.security.transport.ssl.key=/usr/share/elasticsearch/config/testnode.pem
+       - xpack.security.transport.ssl.certificate=/usr/share/elasticsearch/config/testnode.crt
+       - xpack.security.http.ssl.key=/usr/share/elasticsearch/config/testnode.pem
+       - xpack.security.http.ssl.certificate=/usr/share/elasticsearch/config/testnode.crt
+       - xpack.http.ssl.verification_mode=certificate
+       - xpack.security.transport.ssl.verification_mode=certificate
        - xpack.license.self_generated.type=trial
-    volumes: 
+    volumes:
        - ./build/repo:/tmp/es-repo
-       - ./build/certs/testnode.jks:/usr/share/elasticsearch/config/testnode.jks
+       - ./build/certs/testnode.pem:/usr/share/elasticsearch/config/testnode.pem
+       - ./build/certs/testnode.crt:/usr/share/elasticsearch/config/testnode.crt
        - ./build/logs/default-1:/usr/share/elasticsearch/logs
        - ./docker-test-entrypoint.sh:/docker-test-entrypoint.sh
     ports:
@@ -42,10 +45,10 @@ services:
     entrypoint: /docker-test-entrypoint.sh
   elasticsearch-default-2:
     image: elasticsearch:test
-    environment:  
+    environment:
        - node.name=elasticsearch-default-2
        - cluster.initial_master_nodes=elasticsearch-default-1,elasticsearch-default-2
-       - discovery.seed_hosts=elasticsearch-default-1:9300 
+       - discovery.seed_hosts=elasticsearch-default-1:9300
        - cluster.name=elasticsearch-default
        - bootstrap.memory_lock=true
        - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
@@ -54,22 +57,25 @@ services:
        - cluster.routing.allocation.disk.watermark.low=1b
        - cluster.routing.allocation.disk.watermark.high=1b
        - cluster.routing.allocation.disk.watermark.flood_stage=1b
-       - node.store.allow_mmap=false  
+       - node.store.allow_mmap=false
        - xpack.security.enabled=true
        - xpack.security.transport.ssl.enabled=true
        - xpack.security.http.ssl.enabled=true
        - xpack.security.authc.token.enabled=true
        - xpack.security.audit.enabled=true
-       - xpack.security.authc.realms.file.file1.order=0   
-       - xpack.security.authc.realms.native.native1.order=1  
-       - xpack.security.transport.ssl.keystore.path=/usr/share/elasticsearch/config/testnode.jks
-       - xpack.security.http.ssl.keystore.path=/usr/share/elasticsearch/config/testnode.jks
-       - xpack.http.ssl.verification_mode=certificate  
-       - xpack.security.transport.ssl.verification_mode=certificate  
+       - xpack.security.authc.realms.file.file1.order=0
+       - xpack.security.authc.realms.native.native1.order=1
+       - xpack.security.transport.ssl.key=/usr/share/elasticsearch/config/testnode.pem
+       - xpack.security.transport.ssl.certificate=/usr/share/elasticsearch/config/testnode.crt
+       - xpack.security.http.ssl.key=/usr/share/elasticsearch/config/testnode.pem
+       - xpack.security.http.ssl.certificate=/usr/share/elasticsearch/config/testnode.crt
+       - xpack.http.ssl.verification_mode=certificate
+       - xpack.security.transport.ssl.verification_mode=certificate
        - xpack.license.self_generated.type=trial
-    volumes: 
+    volumes:
        - ./build/repo:/tmp/es-repo
-       - ./build/certs/testnode.jks:/usr/share/elasticsearch/config/testnode.jks
+       - ./build/certs/testnode.pem:/usr/share/elasticsearch/config/testnode.pem
+       - ./build/certs/testnode.crt:/usr/share/elasticsearch/config/testnode.crt
        - ./build/logs/default-2:/usr/share/elasticsearch/logs
        - ./docker-test-entrypoint.sh:/docker-test-entrypoint.sh
     ports:
@@ -81,10 +87,10 @@ services:
     entrypoint: /docker-test-entrypoint.sh
   elasticsearch-oss-1:
     image: elasticsearch:test
-    environment:  
-       - node.name=elasticsearch-oss-1 
+    environment:
+       - node.name=elasticsearch-oss-1
        - cluster.initial_master_nodes=elasticsearch-oss-1,elasticsearch-oss-2
-       - discovery.seed_hosts=elasticsearch-oss-2:9300 
+       - discovery.seed_hosts=elasticsearch-oss-2:9300
        - cluster.name=elasticsearch-oss
        - bootstrap.memory_lock=true
        - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
@@ -93,8 +99,8 @@ services:
        - cluster.routing.allocation.disk.watermark.low=1b
        - cluster.routing.allocation.disk.watermark.high=1b
        - cluster.routing.allocation.disk.watermark.flood_stage=1b
-       - node.store.allow_mmap=false  
-    volumes: 
+       - node.store.allow_mmap=false
+    volumes:
        - ./build/oss-repo:/tmp/es-repo
        - ./build/logs/oss-1:/usr/share/elasticsearch/logs
     ports:
@@ -105,10 +111,10 @@ services:
         hard: -1
   elasticsearch-oss-2:
     image: elasticsearch:test
-    environment:  
+    environment:
        - node.name=elasticsearch-oss-2
        - cluster.initial_master_nodes=elasticsearch-oss-1,elasticsearch-oss-2
-       - discovery.seed_hosts=elasticsearch-oss-1:9300 
+       - discovery.seed_hosts=elasticsearch-oss-1:9300
        - cluster.name=elasticsearch-oss
        - bootstrap.memory_lock=true
        - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
@@ -117,8 +123,8 @@ services:
        - cluster.routing.allocation.disk.watermark.low=1b
        - cluster.routing.allocation.disk.watermark.high=1b
        - cluster.routing.allocation.disk.watermark.flood_stage=1b
-       - node.store.allow_mmap=false  
-    volumes: 
+       - node.store.allow_mmap=false
+    volumes:
        - ./build/oss-repo:/tmp/es-repo
        - ./build/logs/oss-2:/usr/share/elasticsearch/logs
     ports:

--- a/distribution/docker/docker-test-entrypoint.sh
+++ b/distribution/docker/docker-test-entrypoint.sh
@@ -2,6 +2,6 @@
 cd /usr/share/elasticsearch/bin/
 ./elasticsearch-users useradd x_pack_rest_user -p x-pack-test-password -r superuser || true
 echo "testnode" > /tmp/password
-cat /tmp/password  | ./elasticsearch-keystore add -x -f -v 'xpack.security.transport.ssl.keystore.secure_password'
-cat /tmp/password  | ./elasticsearch-keystore add -x -f -v 'xpack.security.http.ssl.keystore.secure_password'
-/usr/local/bin/docker-entrypoint.sh | tee > /usr/share/elasticsearch/logs/console.log
+cat /tmp/password  | ./elasticsearch-keystore add -x -f -v 'xpack.security.transport.ssl.secure_key_passphrase'
+cat /tmp/password  | ./elasticsearch-keystore add -x -f -v 'xpack.security.http.ssl.secure_key_passphrase'
+/usr/local/bin/docker-entrypoint.sh | tee /usr/share/elasticsearch/logs/console.log

--- a/distribution/docker/src/test/java/org/elasticsearch/docker/test/DockerYmlTestSuiteIT.java
+++ b/distribution/docker/src/test/java/org/elasticsearch/docker/test/DockerYmlTestSuiteIT.java
@@ -45,7 +45,6 @@ public class DockerYmlTestSuiteIT extends ESClientYamlSuiteTestCase {
 
     private static final String USER = "x_pack_rest_user";
     private static final String PASS = "x-pack-test-password";
-    private static final String KEYSTORE_PASS = "testnode";
 
     public DockerYmlTestSuiteIT(ClientYamlTestCandidate testCandidate) {
         super(testCandidate);
@@ -103,23 +102,24 @@ public class DockerYmlTestSuiteIT extends ESClientYamlSuiteTestCase {
         client().performRequest(health);
     }
 
-    static Path keyStore;
+    static Path trustedCertFile;
 
     @BeforeClass
-    public static void getKeyStore() {
+    public static void getTrustedCert() {
         try {
-            keyStore = PathUtils.get(DockerYmlTestSuiteIT.class.getResource("/testnode.jks").toURI());
+            trustedCertFile = PathUtils.get(DockerYmlTestSuiteIT.class.getResource("/testnode.crt").toURI());
         } catch (URISyntaxException e) {
-            throw new ElasticsearchException("exception while reading the store", e);
+            throw new ElasticsearchException("exception while reading the certificate", e);
         }
-        if (Files.exists(keyStore) == false) {
-            throw new IllegalStateException("Keystore file [" + keyStore + "] does not exist.");
+
+        if (Files.exists(trustedCertFile) == false) {
+            throw new IllegalStateException("Certificate file [" + trustedCertFile + "] does not exist.");
         }
     }
 
     @AfterClass
-    public static void clearKeyStore() {
-        keyStore = null;
+    public static void clearTrustedCert() {
+        trustedCertFile  = null;
     }
 
     @Override
@@ -130,8 +130,7 @@ public class DockerYmlTestSuiteIT extends ESClientYamlSuiteTestCase {
         String token = basicAuthHeaderValue(USER, new SecureString(PASS.toCharArray()));
         return Settings.builder()
             .put(ThreadContext.PREFIX + ".Authorization", token)
-            .put(ESRestTestCase.TRUSTSTORE_PATH, keyStore)
-            .put(ESRestTestCase.TRUSTSTORE_PASSWORD, KEYSTORE_PASS)
+            .put(ESRestTestCase.CERTIFICATE_AUTHORITIES, trustedCertFile)
             .build();
     }
 

--- a/distribution/tools/keystore-cli/src/test/java/org/elasticsearch/common/settings/HasPasswordKeyStoreCommandTests.java
+++ b/distribution/tools/keystore-cli/src/test/java/org/elasticsearch/common/settings/HasPasswordKeyStoreCommandTests.java
@@ -55,13 +55,13 @@ public class HasPasswordKeyStoreCommandTests extends KeyStoreCommandTestCase {
     }
 
     public void testSucceedsWhenKeystoreHasPassword() throws Exception {
-        createKeystore("password");
+        createKeystore("keystore-password");
         String output = execute();
         assertThat(output, containsString("Keystore is password-protected"));
     }
 
     public void testSilentSucceedsWhenKeystoreHasPassword() throws Exception {
-        createKeystore("password");
+        createKeystore("keystre-password");
         String output = execute("--silent");
         assertThat(output, is(emptyString()));
     }

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -55,7 +55,7 @@ testClusters.integTest {
     setting 'xpack.license.self_generated.type', 'trial'
     setting 'indices.lifecycle.history_index_enabled', 'false'
     systemProperty 'es.rollup_v2_feature_flag_enabled', 'true'
-    keystorePassword 's3cr3t'
+    keystorePassword 'keystore-password'
   }
 
   // enable regexes in painless so our tests don't complain about example snippets that use them
@@ -104,7 +104,7 @@ ext.docsFileTree = fileTree(projectDir) {
   exclude 'README.asciidoc'
   // Broken code snippet tests
   exclude 'reference/graph/explore.asciidoc'
-  if (Boolean.parseBoolean(System.getProperty("tests.fips.enabled"))) {
+  if (BuildParams.inFipsJvm) {
     // We don't install/support this plugin in FIPS 140
     exclude 'plugins/ingest-attachment.asciidoc'
     // We can't conditionally control output, this would be missing the ingest-attachment plugin

--- a/docs/reference/cluster/nodes-reload-secure-settings.asciidoc
+++ b/docs/reference/cluster/nodes-reload-secure-settings.asciidoc
@@ -57,11 +57,11 @@ node of the cluster:
 --------------------------------------------------
 POST _nodes/reload_secure_settings
 {
-  "secure_settings_password":"s3cr3t"
+  "secure_settings_password":"keystore-password"
 }
 POST _nodes/nodeId1,nodeId2/reload_secure_settings
 {
-  "secure_settings_password":"s3cr3t"
+  "secure_settings_password":"keystore-password"
 }
 --------------------------------------------------
 // TEST[setup:node]

--- a/docs/reference/setup/secure-settings.asciidoc
+++ b/docs/reference/setup/secure-settings.asciidoc
@@ -35,7 +35,7 @@ using the `bin/elasticsearch-keystore add` command, call:
 ----
 POST _nodes/reload_secure_settings
 {
-  "secure_settings_password": "s3cr3t" <1>
+  "secure_settings_password": "keystore-password" <1>
 }
 ----
 // NOTCONSOLE

--- a/gradle/fips.gradle
+++ b/gradle/fips.gradle
@@ -1,5 +1,6 @@
 import org.elasticsearch.gradle.ExportElasticsearchBuildResourcesTask
 import org.elasticsearch.gradle.info.BuildParams
+import org.elasticsearch.gradle.testclusters.TestDistribution
 import org.elasticsearch.gradle.testclusters.ElasticsearchCluster
 
 // Common config when running with a FIPS-140 runtime JVM
@@ -58,6 +59,7 @@ if (BuildParams.inFipsJvm) {
           }
         }
         testClusters.all {
+          setTestDistribution(TestDistribution.DEFAULT)
           extraConfigFile "fips_java.security", fipsSecurity
           extraConfigFile "fips_java.policy", fipsPolicy
           extraConfigFile "cacerts.bcfks", fipsTrustStore
@@ -67,6 +69,10 @@ if (BuildParams.inFipsJvm) {
           systemProperty 'javax.net.ssl.trustStorePassword', 'password'
           systemProperty 'javax.net.ssl.keyStorePassword', 'password'
           systemProperty 'javax.net.ssl.keyStoreType', 'BCFKS'
+          systemProperty 'org.bouncycastle.fips.approved_only', 'true'
+          setting 'xpack.security.fips_mode.enabled', 'true'
+          setting 'xpack.license.self_generated.type', 'trial'
+          keystorePassword 'keystore-password'
         }
       }
       project.tasks.withType(Test).configureEach { Test task ->
@@ -79,6 +85,7 @@ if (BuildParams.inFipsJvm) {
         task.systemProperty('java.security.properties', String.format(Locale.ROOT, "=%s", fipsSecurity))
         task.systemProperty('java.security.policy', String.format(Locale.ROOT, "=%s", fipsPolicy))
         task.systemProperty('javax.net.ssl.trustStore', fipsTrustStore)
+        task.systemProperty('org.bouncycastle.fips.approved_only', 'true')
       }
     }
   }

--- a/libs/ssl-config/src/test/java/org/elasticsearch/common/ssl/SslConfigurationLoaderTests.java
+++ b/libs/ssl-config/src/test/java/org/elasticsearch/common/ssl/SslConfigurationLoaderTests.java
@@ -100,6 +100,7 @@ public class SslConfigurationLoaderTests extends ESTestCase {
     }
 
     public void testLoadTrustFromPkcs12() {
+        assumeFalse("Can't use JKS/PKCS12 keystores in a FIPS JVM", inFipsJvm());
         final Settings.Builder builder = Settings.builder().put("test.ssl.truststore.path", "ca-all/ca.p12");
         if (randomBoolean()) {
             builder.put("test.ssl.truststore.password", "p12-pass");
@@ -122,6 +123,7 @@ public class SslConfigurationLoaderTests extends ESTestCase {
     }
 
     public void testLoadTrustFromJKS() {
+        assumeFalse("Can't use JKS/PKCS12 keystores in a FIPS JVM", inFipsJvm());
         final Settings.Builder builder = Settings.builder().put("test.ssl.truststore.path", "ca-all/ca.jks");
         if (randomBoolean()) {
             builder.put("test.ssl.truststore.password", "jks-pass");
@@ -167,6 +169,7 @@ public class SslConfigurationLoaderTests extends ESTestCase {
     }
 
     public void testLoadKeysFromPKCS12() {
+        assumeFalse("Can't use JKS/PKCS12 keystores in a FIPS JVM", inFipsJvm());
         final Settings.Builder builder = Settings.builder()
             .put("test.ssl.keystore.path", "cert-all/certs.p12");
         if (randomBoolean()) {

--- a/libs/ssl-config/src/test/java/org/elasticsearch/common/ssl/StoreTrustConfigTests.java
+++ b/libs/ssl-config/src/test/java/org/elasticsearch/common/ssl/StoreTrustConfigTests.java
@@ -78,6 +78,7 @@ public class StoreTrustConfigTests extends ESTestCase {
     }
 
     public void testIncorrectPasswordFailsWithMeaningfulMessage() throws Exception {
+        assumeFalse("Can't use JKS/PKCS12 keystores in a FIPS JVM", inFipsJvm());
         final Path ks = getDataPath("/certs/ca1/ca.p12");
         final StoreTrustConfig trustConfig = new StoreTrustConfig(ks, new char[0], "PKCS12", DEFAULT_ALGORITHM);
         assertThat(trustConfig.getDependentFiles(), Matchers.containsInAnyOrder(ks));

--- a/modules/geo/build.gradle
+++ b/modules/geo/build.gradle
@@ -18,6 +18,8 @@
  */
 apply plugin: 'elasticsearch.yaml-rest-test'
 
+import org.elasticsearch.gradle.info.BuildParams
+
 esplugin {
   description 'Placeholder plugin for geospatial features in ES. only registers geo_shape field mapper for now'
   classname 'org.elasticsearch.geo.GeoPlugin'
@@ -32,3 +34,9 @@ artifacts {
   restTests(project.file('src/yamlRestTest/resources/rest-api-spec/test'))
 }
 tasks.named("test").configure { enabled = false }
+
+if (BuildParams.inFipsJvm){
+  // The geo module is replaced by spatial in the default distribution and in FIPS 140 mode, we set the testclusters to
+  // use the default distribution, so there is no need to run these tests
+  tasks.named("yamlRestTest").configure{enabled = false }
+}

--- a/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/71_context_api.yml
+++ b/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/71_context_api.yml
@@ -1,4 +1,7 @@
 "Action to list contexts":
+    - skip:
+        features: fips_140
+        reason: "The tests expect to be run with OSS distribution"
     - do:
         scripts_painless_context: {}
     - match: { contexts.0: aggregation_selector}
@@ -6,6 +9,9 @@
 ---
 
 "Action to get all API values for score context":
+    - skip:
+        features: fips_140
+        reason: "The tests expect to be run with OSS distribution"
     - do:
         scripts_painless_context:
             context: score

--- a/modules/transport-netty4/src/javaRestTest/java/org/elasticsearch/rest/Netty4HeadBodyIsEmptyIT.java
+++ b/modules/transport-netty4/src/javaRestTest/java/org/elasticsearch/rest/Netty4HeadBodyIsEmptyIT.java
@@ -139,6 +139,16 @@ public class Netty4HeadBodyIsEmptyIT extends ESRestTestCase {
             builder.endObject();
 
             Request request = new Request("PUT", "/_template/template");
+            if (inFipsJvm()) {
+                request.setOptions(expectWarnings(
+                    "legacy template [template] has index patterns [*] matching patterns from existing composable templates " +
+                    "[ilm-history,.triggered_watches,.watch-history-14,.slm-history,synthetics,metrics,.deprecation-indexing-template," +
+                    ".watches,logs] with patterns (ilm-history => [ilm-history-5*],.triggered_watches => [.triggered_watches*]," +
+                    ".watch-history-14 => [.watcher-history-14*],.slm-history => [.slm-history-5*],synthetics => [synthetics-*-*]" +
+                    ",metrics => [metrics-*-*],.deprecation-indexing-template => [.logs-deprecation-elasticsearch]," +
+                    ".watches => [.watches*],logs => [logs-*-*]); this template [template] may be ignored in favor " +
+                    "of a composable template at index creation time"));
+                }
             request.setJsonEntity(Strings.toString(builder));
             client().performRequest(request);
             headTestCase("/_template/template", emptyMap(), greaterThan(0));

--- a/plugins/discovery-ec2/qa/amazon-ec2/src/yamlRestTest/java/org/elasticsearch/discovery/ec2/AmazonEC2Fixture.java
+++ b/plugins/discovery-ec2/qa/amazon-ec2/src/yamlRestTest/java/org/elasticsearch/discovery/ec2/AmazonEC2Fixture.java
@@ -124,7 +124,7 @@ public class AmazonEC2Fixture extends AbstractHttpFixture {
                 + "\"AccessKeyId\": \"" + "ec2_integration_test_access_key" + "\","
                 + "\"Expiration\": \"" + DateUtils.formatISO8601Date(expiration) + "\","
                 + "\"RoleArn\": \"" + "test" + "\","
-                + "\"SecretAccessKey\": \"" + "test" + "\","
+                + "\"SecretAccessKey\": \"" + "ec2_integration_test_secret_key" + "\","
                 + "\"Token\": \"" + "test" + "\""
                 + "}";
 

--- a/plugins/discovery-ec2/src/test/java/org/elasticsearch/discovery/ec2/AbstractEC2MockAPITestCase.java
+++ b/plugins/discovery-ec2/src/test/java/org/elasticsearch/discovery/ec2/AbstractEC2MockAPITestCase.java
@@ -75,7 +75,7 @@ public abstract class AbstractEC2MockAPITestCase extends ESTestCase {
         final String endpoint = "http://" + InetAddresses.toUriString(address.getAddress()) + ":" + address.getPort();
         final MockSecureSettings mockSecure = new MockSecureSettings();
         mockSecure.setString(Ec2ClientSettings.ACCESS_KEY_SETTING.getKey(), accessKey);
-        mockSecure.setString(Ec2ClientSettings.SECRET_KEY_SETTING.getKey(), "ec2_secret");
+        mockSecure.setString(Ec2ClientSettings.SECRET_KEY_SETTING.getKey(), "ec2_secret_key");
         return Settings.builder().put(Ec2ClientSettings.ENDPOINT_SETTING.getKey(), endpoint).setSecureSettings(mockSecure).build();
     }
 

--- a/plugins/discovery-ec2/src/test/java/org/elasticsearch/discovery/ec2/Ec2DiscoveryPluginTests.java
+++ b/plugins/discovery-ec2/src/test/java/org/elasticsearch/discovery/ec2/Ec2DiscoveryPluginTests.java
@@ -110,7 +110,7 @@ public class Ec2DiscoveryPluginTests extends ESTestCase {
     public void testClientSettingsReInit() throws IOException {
         final MockSecureSettings mockSecure1 = new MockSecureSettings();
         mockSecure1.setString(Ec2ClientSettings.ACCESS_KEY_SETTING.getKey(), "ec2_access_1");
-        mockSecure1.setString(Ec2ClientSettings.SECRET_KEY_SETTING.getKey(), "ec2_secret_1");
+        mockSecure1.setString(Ec2ClientSettings.SECRET_KEY_SETTING.getKey(), "ec2_secret_key_1");
         final boolean mockSecure1HasSessionToken = randomBoolean();
         if (mockSecure1HasSessionToken) {
             mockSecure1.setString(Ec2ClientSettings.SESSION_TOKEN_SETTING.getKey(), "ec2_session_token_1");
@@ -125,7 +125,7 @@ public class Ec2DiscoveryPluginTests extends ESTestCase {
                 .build();
         final MockSecureSettings mockSecure2 = new MockSecureSettings();
         mockSecure2.setString(Ec2ClientSettings.ACCESS_KEY_SETTING.getKey(), "ec2_access_2");
-        mockSecure2.setString(Ec2ClientSettings.SECRET_KEY_SETTING.getKey(), "ec2_secret_2");
+        mockSecure2.setString(Ec2ClientSettings.SECRET_KEY_SETTING.getKey(), "ec2_secret_key_2");
         final boolean mockSecure2HasSessionToken = randomBoolean();
         if (mockSecure2HasSessionToken) {
             mockSecure2.setString(Ec2ClientSettings.SESSION_TOKEN_SETTING.getKey(), "ec2_session_token_2");
@@ -143,7 +143,7 @@ public class Ec2DiscoveryPluginTests extends ESTestCase {
                 {
                     final AWSCredentials credentials = ((AmazonEC2Mock) clientReference.client()).credentials.getCredentials();
                     assertThat(credentials.getAWSAccessKeyId(), is("ec2_access_1"));
-                    assertThat(credentials.getAWSSecretKey(), is("ec2_secret_1"));
+                    assertThat(credentials.getAWSSecretKey(), is("ec2_secret_key_1"));
                     if (mockSecure1HasSessionToken) {
                         assertThat(credentials, instanceOf(BasicSessionCredentials.class));
                         assertThat(((BasicSessionCredentials)credentials).getSessionToken(), is("ec2_session_token_1"));
@@ -177,7 +177,7 @@ public class Ec2DiscoveryPluginTests extends ESTestCase {
             try (AmazonEc2Reference clientReference = plugin.ec2Service.client()) {
                 final AWSCredentials credentials = ((AmazonEC2Mock) clientReference.client()).credentials.getCredentials();
                 assertThat(credentials.getAWSAccessKeyId(), is("ec2_access_2"));
-                assertThat(credentials.getAWSSecretKey(), is("ec2_secret_2"));
+                assertThat(credentials.getAWSSecretKey(), is("ec2_secret_key_2"));
                 if (mockSecure2HasSessionToken) {
                     assertThat(credentials, instanceOf(BasicSessionCredentials.class));
                     assertThat(((BasicSessionCredentials)credentials).getSessionToken(), is("ec2_session_token_2"));

--- a/plugins/examples/build.gradle
+++ b/plugins/examples/build.gradle
@@ -6,7 +6,6 @@ gradle.projectsEvaluated {
     project.tasks.matching { it.name.equals('assemble') }.configureEach {
       enabled = false
     }
-
     // Disable example project testing with FIPS JVM
     tasks.withType(Test) {
       onlyIf {

--- a/plugins/repository-azure/src/internalClusterTest/java/org/elasticsearch/repositories/azure/AzureBlobStoreRepositoryTests.java
+++ b/plugins/repository-azure/src/internalClusterTest/java/org/elasticsearch/repositories/azure/AzureBlobStoreRepositoryTests.java
@@ -85,7 +85,7 @@ public class AzureBlobStoreRepositoryTests extends ESMockAPIBasedRepositoryInteg
 
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {
-        final String key = Base64.getEncoder().encodeToString(randomAlphaOfLength(10).getBytes(StandardCharsets.UTF_8));
+        final String key = Base64.getEncoder().encodeToString(randomAlphaOfLength(14).getBytes(StandardCharsets.UTF_8));
         final MockSecureSettings secureSettings = new MockSecureSettings();
         String accountName = DEFAULT_ACCOUNT_NAME;
         secureSettings.setString(AzureStorageSettings.ACCOUNT_SETTING.getConcreteSettingForNamespace("test").getKey(), accountName);

--- a/plugins/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureBlobContainerRetriesTests.java
+++ b/plugins/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureBlobContainerRetriesTests.java
@@ -144,7 +144,7 @@ public class AzureBlobContainerRetriesTests extends ESTestCase {
 
         final MockSecureSettings secureSettings = new MockSecureSettings();
         secureSettings.setString(ACCOUNT_SETTING.getConcreteSettingForNamespace(clientName).getKey(), "account");
-        final String key = Base64.getEncoder().encodeToString(randomAlphaOfLength(10).getBytes(UTF_8));
+        final String key = Base64.getEncoder().encodeToString(randomAlphaOfLength(14).getBytes(UTF_8));
         secureSettings.setString(KEY_SETTING.getConcreteSettingForNamespace(clientName).getKey(), key);
         clientSettings.setSecureSettings(secureSettings);
 

--- a/plugins/repository-gcs/build.gradle
+++ b/plugins/repository-gcs/build.gradle
@@ -236,7 +236,7 @@ def encodedCredentials = {
 tasks.register("createServiceAccountFile") {
   doLast {
     KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA")
-    keyPairGenerator.initialize(1024)
+    keyPairGenerator.initialize(2048)
     KeyPair keyPair = keyPairGenerator.generateKeyPair()
     String encodedKey = Base64.getEncoder().encodeToString(keyPair.private.getEncoded())
 

--- a/plugins/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageServiceTests.java
+++ b/plugins/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageServiceTests.java
@@ -143,7 +143,7 @@ public class GoogleCloudStorageServiceTests extends ESTestCase {
 
     private byte[] serviceAccountFileContent(String projectId) throws Exception {
         final KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
-        keyPairGenerator.initialize(1024);
+        keyPairGenerator.initialize(2048);
         final KeyPair keyPair = keyPairGenerator.generateKeyPair();
         final String encodedKey = Base64.getEncoder().encodeToString(keyPair.getPrivate().getEncoded());
         final XContentBuilder serviceAccountBuilder = jsonBuilder().startObject()

--- a/plugins/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/TestUtils.java
+++ b/plugins/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/TestUtils.java
@@ -37,7 +37,7 @@ final class TestUtils {
     static byte[] createServiceAccount(final Random random) {
         try {
             final KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
-            keyPairGenerator.initialize(1024);
+            keyPairGenerator.initialize(2048);
             final String privateKey = Base64.getEncoder().encodeToString(keyPairGenerator.generateKeyPair().getPrivate().getEncoded());
 
             final ByteArrayOutputStream out = new ByteArrayOutputStream();

--- a/plugins/repository-s3/build.gradle
+++ b/plugins/repository-s3/build.gradle
@@ -124,8 +124,8 @@ boolean s3DisableChunkedEncoding = (new Random(Long.parseUnsignedLong(BuildParam
 // credentials hard-coded in.
 
 if (!s3PermanentAccessKey && !s3PermanentSecretKey && !s3PermanentBucket && !s3PermanentBasePath) {
-  s3PermanentAccessKey = 'access_key'
-  s3PermanentSecretKey = 'secret_key'
+  s3PermanentAccessKey = 's3_test_access_key'
+  s3PermanentSecretKey = 's3_test_secret_key'
   s3PermanentBucket = 'bucket'
   s3PermanentBasePath = 'base_path'
 

--- a/plugins/repository-s3/src/internalClusterTest/java/org/elasticsearch/repositories/s3/S3BlobStoreRepositoryTests.java
+++ b/plugins/repository-s3/src/internalClusterTest/java/org/elasticsearch/repositories/s3/S3BlobStoreRepositoryTests.java
@@ -123,8 +123,8 @@ public class S3BlobStoreRepositoryTests extends ESMockAPIBasedRepositoryIntegTes
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {
         final MockSecureSettings secureSettings = new MockSecureSettings();
-        secureSettings.setString(S3ClientSettings.ACCESS_KEY_SETTING.getConcreteSettingForNamespace("test").getKey(), "access");
-        secureSettings.setString(S3ClientSettings.SECRET_KEY_SETTING.getConcreteSettingForNamespace("test").getKey(), "secret");
+        secureSettings.setString(S3ClientSettings.ACCESS_KEY_SETTING.getConcreteSettingForNamespace("test").getKey(), "test_access_key");
+        secureSettings.setString(S3ClientSettings.SECRET_KEY_SETTING.getConcreteSettingForNamespace("test").getKey(), "test_secret_key");
 
         final Settings.Builder builder = Settings.builder()
             .put(ThreadPool.ESTIMATED_TIME_INTERVAL_SETTING.getKey(), 0) // We have tests that verify an exact wait time

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobContainerRetriesTests.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobContainerRetriesTests.java
@@ -122,8 +122,10 @@ public class S3BlobContainerRetriesTests extends AbstractBlobContainerRetriesTes
         }
 
         final MockSecureSettings secureSettings = new MockSecureSettings();
-        secureSettings.setString(S3ClientSettings.ACCESS_KEY_SETTING.getConcreteSettingForNamespace(clientName).getKey(), "access");
-        secureSettings.setString(S3ClientSettings.SECRET_KEY_SETTING.getConcreteSettingForNamespace(clientName).getKey(), "secret");
+        secureSettings.setString(S3ClientSettings.ACCESS_KEY_SETTING.getConcreteSettingForNamespace(clientName).getKey(),
+            "test_access_key");
+        secureSettings.setString(S3ClientSettings.SECRET_KEY_SETTING.getConcreteSettingForNamespace(clientName).getKey(),
+            "test_secret_key");
         clientSettings.setSecureSettings(secureSettings);
         service.refreshAndClearCache(S3ClientSettings.load(clientSettings.build()));
 

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/KeystoreManagementTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/KeystoreManagementTests.java
@@ -304,7 +304,7 @@ public class KeystoreManagementTests extends PackagingTestCase {
      */
     public void test60DockerEnvironmentVariablePassword() throws Exception {
         assumeTrue(distribution().isDocker());
-        String password = "password";
+        String password = "keystore-password";
         Path dockerKeystore = installation.config("elasticsearch.keystore");
 
         Path localKeystoreFile = getKeystoreFileFromDockerContainer(password, dockerKeystore);
@@ -328,7 +328,7 @@ public class KeystoreManagementTests extends PackagingTestCase {
         try {
             tempDir = createTempDir(DockerTests.class.getSimpleName());
 
-            String password = "password";
+            String password = "keystore-password";
             String passwordFilename = "password.txt";
             Files.write(tempDir.resolve(passwordFilename), singletonList(password));
             Files.setPosixFilePermissions(tempDir.resolve(passwordFilename), p600);
@@ -362,7 +362,7 @@ public class KeystoreManagementTests extends PackagingTestCase {
      */
     public void test62DockerEnvironmentVariableBadPassword() throws Exception {
         assumeTrue(distribution().isDocker());
-        String password = "password";
+        String password = "keystore-password";
         Path dockerKeystore = installation.config("elasticsearch.keystore");
 
         Path localKeystoreFile = getKeystoreFileFromDockerContainer(password, dockerKeystore);

--- a/qa/remote-clusters/build.gradle
+++ b/qa/remote-clusters/build.gradle
@@ -31,13 +31,17 @@ dependencies {
   testImplementation project(':client:rest-high-level')
 }
 
-tasks.register("copyKeystore", Sync) {
+tasks.register("copyNodeKeyMaterial", Sync) {
   from project(':x-pack:plugin:core')
-    .file('src/test/resources/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.jks')
+    .files(
+      'src/test/resources/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.pem',
+      'src/test/resources/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.crt'
+    )
   into "${buildDir}/certs"
   doLast {
     file("${buildDir}/certs").setReadable(true, false)
-    file("${buildDir}/certs/testnode.jks").setReadable(true, false)
+    file("${buildDir}/certs/testnode.pem").setReadable(true, false)
+    file("${buildDir}/certs/testnode.crt").setReadable(true, false)
   }
 }
 
@@ -52,7 +56,7 @@ elasticsearch_distributions {
 }
 
 tasks.named("preProcessFixture").configure {
-  dependsOn "copyKeystore", elasticsearch_distributions.docker
+  dependsOn "copyNodeKeyMaterial", elasticsearch_distributions.docker
   doLast {
     // tests expect to have an empty repo
     project.delete(
@@ -89,7 +93,10 @@ def createAndSetWritable(Object... locations) {
 
 tasks.named("processTestResources").configure {
   from project(':x-pack:plugin:core')
-    .file('src/test/resources/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.jks')
+    .files(
+      'src/test/resources/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.pem',
+      'src/test/resources/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.crt'
+    )
 }
 
 tasks.register("integTest", Test) {

--- a/qa/remote-clusters/docker-compose.yml
+++ b/qa/remote-clusters/docker-compose.yml
@@ -23,14 +23,17 @@ services:
        - xpack.security.audit.enabled=true
        - xpack.security.authc.realms.file.file1.order=0
        - xpack.security.authc.realms.native.native1.order=1
-       - xpack.security.transport.ssl.keystore.path=/usr/share/elasticsearch/config/testnode.jks
-       - xpack.security.http.ssl.keystore.path=/usr/share/elasticsearch/config/testnode.jks
+       - xpack.security.transport.ssl.key=/usr/share/elasticsearch/config/testnode.pem
+       - xpack.security.transport.ssl.certificate=/usr/share/elasticsearch/config/testnode.crt
+       - xpack.security.http.ssl.key=/usr/share/elasticsearch/config/testnode.pem
+       - xpack.security.http.ssl.certificate=/usr/share/elasticsearch/config/testnode.crt
        - xpack.http.ssl.verification_mode=certificate
        - xpack.security.transport.ssl.verification_mode=certificate
        - xpack.license.self_generated.type=trial
     volumes:
        - ./build/repo:/tmp/es-repo
-       - ./build/certs/testnode.jks:/usr/share/elasticsearch/config/testnode.jks
+       - ./build/certs/testnode.pem:/usr/share/elasticsearch/config/testnode.pem
+       - ./build/certs/testnode.crt:/usr/share/elasticsearch/config/testnode.crt
        - ./build/logs/default-1:/usr/share/elasticsearch/logs
        - ./docker-test-entrypoint.sh:/docker-test-entrypoint.sh
     ports:
@@ -72,14 +75,17 @@ services:
        - xpack.security.audit.enabled=true
        - xpack.security.authc.realms.file.file1.order=0
        - xpack.security.authc.realms.native.native1.order=1
-       - xpack.security.transport.ssl.keystore.path=/usr/share/elasticsearch/config/testnode.jks
-       - xpack.security.http.ssl.keystore.path=/usr/share/elasticsearch/config/testnode.jks
+       - xpack.security.transport.ssl.key=/usr/share/elasticsearch/config/testnode.pem
+       - xpack.security.transport.ssl.certificate=/usr/share/elasticsearch/config/testnode.crt
+       - xpack.security.http.ssl.key=/usr/share/elasticsearch/config/testnode.pem
+       - xpack.security.http.ssl.certificate=/usr/share/elasticsearch/config/testnode.crt
        - xpack.http.ssl.verification_mode=certificate
        - xpack.security.transport.ssl.verification_mode=certificate
        - xpack.license.self_generated.type=trial
     volumes:
        - ./build/repo:/tmp/es-repo
-       - ./build/certs/testnode.jks:/usr/share/elasticsearch/config/testnode.jks
+       - ./build/certs/testnode.pem:/usr/share/elasticsearch/config/testnode.pem
+       - ./build/certs/testnode.crt:/usr/share/elasticsearch/config/testnode.crt
        - ./build/logs/default-2:/usr/share/elasticsearch/logs
        - ./docker-test-entrypoint.sh:/docker-test-entrypoint.sh
     ports:

--- a/qa/remote-clusters/docker-test-entrypoint.sh
+++ b/qa/remote-clusters/docker-test-entrypoint.sh
@@ -2,6 +2,6 @@
 cd /usr/share/elasticsearch/bin/
 ./elasticsearch-users useradd x_pack_rest_user -p x-pack-test-password -r superuser || true
 echo "testnode" > /tmp/password
-cat /tmp/password  | ./elasticsearch-keystore add -x -f -v 'xpack.security.transport.ssl.keystore.secure_password'
-cat /tmp/password  | ./elasticsearch-keystore add -x -f -v 'xpack.security.http.ssl.keystore.secure_password'
-/usr/local/bin/docker-entrypoint.sh | tee > /usr/share/elasticsearch/logs/console.log
+cat /tmp/password  | ./elasticsearch-keystore add -x -f -v 'xpack.security.transport.ssl.secure_key_passphrase'
+cat /tmp/password  | ./elasticsearch-keystore add -x -f -v 'xpack.security.http.ssl.secure_key_passphrase'
+/usr/local/bin/docker-entrypoint.sh | tee /usr/share/elasticsearch/logs/console.log

--- a/qa/remote-clusters/src/test/java/org/elasticsearch/cluster/remote/test/AbstractMultiClusterRemoteTestCase.java
+++ b/qa/remote-clusters/src/test/java/org/elasticsearch/cluster/remote/test/AbstractMultiClusterRemoteTestCase.java
@@ -48,7 +48,6 @@ public abstract class AbstractMultiClusterRemoteTestCase extends ESRestTestCase 
 
     private static final String USER = "x_pack_rest_user";
     private static final String PASS = "x-pack-test-password";
-    private static final String KEYSTORE_PASS = "testnode";
 
     @Override
     protected boolean preserveClusterUponCompletion() {
@@ -123,23 +122,23 @@ public abstract class AbstractMultiClusterRemoteTestCase extends ESRestTestCase 
         return getDistribution().equals("oss");
     }
 
-    static Path keyStore;
+    static Path trustedCertFile;
 
     @BeforeClass
-    public static void getKeyStore() {
+    public static void getTrustedCert() {
         try {
-            keyStore = PathUtils.get(AbstractMultiClusterRemoteTestCase.class.getResource("/testnode.jks").toURI());
+            trustedCertFile = PathUtils.get(AbstractMultiClusterRemoteTestCase.class.getResource("/testnode.crt").toURI());
         } catch (URISyntaxException e) {
-            throw new ElasticsearchException("exception while reading the store", e);
+            throw new ElasticsearchException("exception while reading the certificate file", e);
         }
-        if (Files.exists(keyStore) == false) {
-            throw new IllegalStateException("Keystore file [" + keyStore + "] does not exist.");
+        if (Files.exists(trustedCertFile) == false) {
+            throw new IllegalStateException("Certificate file [" + trustedCertFile + "] does not exist.");
         }
     }
 
     @AfterClass
-    public static void clearKeyStore() {
-        keyStore = null;
+    public static void clearTrustedCert() {
+        trustedCertFile = null;
     }
 
     @Override
@@ -150,8 +149,7 @@ public abstract class AbstractMultiClusterRemoteTestCase extends ESRestTestCase 
         String token = basicAuthHeaderValue(USER, new SecureString(PASS.toCharArray()));
         return Settings.builder()
             .put(ThreadContext.PREFIX + ".Authorization", token)
-            .put(ESRestTestCase.TRUSTSTORE_PATH, keyStore)
-            .put(ESRestTestCase.TRUSTSTORE_PASSWORD, KEYSTORE_PASS)
+            .put(ESRestTestCase.CERTIFICATE_AUTHORITIES, trustedCertFile)
             .build();
     }
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/nodes.reload_secure_settings/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/nodes.reload_secure_settings/10_basic.yml
@@ -24,7 +24,9 @@ setup:
 
 ---
 "node_reload_secure_settings test correct(empty) password":
-
+  - skip:
+      features: fips_140
+      reason: "In FIPS 140 mode, we use a password protected elasticsearch keystore"
   - do:
       nodes.reload_secure_settings: {}
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/ReloadSecureSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/ReloadSecureSettingsIT.java
@@ -33,6 +33,7 @@ import org.elasticsearch.plugins.PluginsService;
 import org.elasticsearch.plugins.ReloadablePlugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.transport.RemoteTransportException;
+import org.junit.BeforeClass;
 
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -54,6 +55,13 @@ import static org.hamcrest.Matchers.nullValue;
 
 @ESIntegTestCase.ClusterScope(minNumDataNodes = 2)
 public class ReloadSecureSettingsIT extends ESIntegTestCase {
+
+    @BeforeClass
+    public static void disableInFips() {
+        // Reload secure settings with a password protected keystore is tested in ReloadSecureSettingsWithPasswordProtectedKeystoreRestIT
+        assumeFalse("Cannot run in FIPS mode since the keystore will be password protected and sending a password in the reload" +
+            "settings api call, require TLS to be configured for the transport layer", inFipsJvm());
+    }
 
     public void testMissingKeystoreFile() throws Exception {
         final PluginsService pluginsService = internalCluster().getInstance(PluginsService.class);

--- a/test/fixtures/krb5kdc-fixture/src/main/resources/provision/kdc.conf.template
+++ b/test/fixtures/krb5kdc-fixture/src/main/resources/provision/kdc.conf.template
@@ -24,9 +24,9 @@
         kadmind_port = 749
         max_life = 12h 0m 0s
         max_renewable_life = 7d 0h 0m 0s
-        master_key_type = aes256-cts
-        # remove aes256-cts:normal since unlimited strength policy needs installed for java to use it.
-        supported_enctypes = aes128-cts:normal des3-hmac-sha1:normal arcfour-hmac:normal des-hmac-sha1:normal des-cbc-md5:normal des-cbc-crc:normal
+        master_key_type = des3-cbc-sha1-kd
+        # This is the only supported enctype for fips 140-2
+        supported_enctypes = des3-cbc-sha1-kd:normal
     }
 
 [logging]

--- a/test/fixtures/krb5kdc-fixture/src/main/resources/provision/krb5.conf.template
+++ b/test/fixtures/krb5kdc-fixture/src/main/resources/provision/krb5.conf.template
@@ -24,12 +24,14 @@
     forwardable = true
     ignore_acceptor_hostname = true
     rdns = false
-    default_tgs_enctypes = rc4-hmac
-    default_tkt_enctypes = rc4-hmac
-    permitted_enctypes = rc4-hmac
+    # des3-cbc-sha1-kd is the only enctype available in fips 140-2
+    default_tgs_enctypes = des3-cbc-sha1-kd
+    default_tkt_enctypes = des3-cbc-sha1-kd
+    permitted_enctypes = des3-cbc-sha1-kd
     # udp_preference_limit = 1
     kdc_timeout = 3000
     canonicalize = true
+    allow_weak_enctypes = false
 
 [realms]
     ${REALM_NAME} = {

--- a/test/fixtures/minio-fixture/docker-compose.yml
+++ b/test/fixtures/minio-fixture/docker-compose.yml
@@ -5,8 +5,8 @@ services:
       context: .
       args:
         bucket: "bucket"
-        accessKey: "access_key"
-        secretKey: "secret_key"
+        accessKey: "s3_test_access_key"
+        secretKey: "s3_test_secret_key"
       dockerfile: Dockerfile
     ports:
       - "9000"
@@ -16,8 +16,8 @@ services:
       context: .
       args:
         bucket: "bucket"
-        accessKey: "access_key"
-        secretKey: "secret_key"
+        accessKey: "s3_test_access_key"
+        secretKey: "s3_test_secret_key"
       dockerfile: Dockerfile
     ports:
       - "9000"

--- a/test/fixtures/s3-fixture/docker-compose.yml
+++ b/test/fixtures/s3-fixture/docker-compose.yml
@@ -8,7 +8,7 @@ services:
         port: 80
         bucket: "bucket"
         basePath: "base_path_integration_tests"
-        accessKey: "access_key"
+        accessKey: "s3_test_access_key"
       dockerfile: Dockerfile
     volumes:
       - ./testfixtures_shared/shared:/fixture/shared
@@ -23,7 +23,7 @@ services:
         port: 80
         bucket: "bucket"
         basePath: "base_path"
-        accessKey: "access_key"
+        accessKey: "s3_test_access_key"
       dockerfile: Dockerfile
     volumes:
       - ./testfixtures_shared/shared:/fixture/shared
@@ -38,7 +38,7 @@ services:
         port: 80
         bucket: "bucket"
         basePath: "base_path"
-        accessKey: "access_key"
+        accessKey: "s3_test_access_key"
       dockerfile: Dockerfile
     volumes:
       - ./testfixtures_shared/shared:/fixture/shared

--- a/test/fixtures/s3-fixture/src/main/java/fixture/s3/S3HttpFixtureWithEC2.java
+++ b/test/fixtures/s3-fixture/src/main/java/fixture/s3/S3HttpFixtureWithEC2.java
@@ -79,7 +79,7 @@ public class S3HttpFixtureWithEC2 extends S3HttpFixtureWithSessionToken {
             + "\"AccessKeyId\": \"" + ec2AccessKey + "\","
             + "\"Expiration\": \"" + ZonedDateTime.now().plusDays(1L).format(DateTimeFormatter.ISO_DATE_TIME) + "\","
             + "\"RoleArn\": \"arn\","
-            + "\"SecretAccessKey\": \"secret\","
+            + "\"SecretAccessKey\": \"secret_access_key\","
             + "\"Token\": \"" + ec2SessionToken + "\""
             + "}";
     }

--- a/x-pack/docs/build.gradle
+++ b/x-pack/docs/build.gradle
@@ -706,7 +706,7 @@ tasks.named("buildRestTests").configure { buildRestTests ->
         username: "jacknich"
         body:  >
           {
-            "password" : "test-password",
+            "password" : "l0ng-r4nd0m-p@ssw0rd",
             "roles" : [ "admin", "other_role1" ],
             "full_name" : "Jack Nicholson",
             "email" : "jacknich@example.com",

--- a/x-pack/docs/en/rest-api/security/change-password.asciidoc
+++ b/x-pack/docs/en/rest-api/security/change-password.asciidoc
@@ -24,11 +24,11 @@ privilege can change passwords of other users.
 [[security-api-change-password-desc]]
 ==== {api-description-title}
 
-You can use the <<security-api-put-user,create user API>> to update everything 
+You can use the <<security-api-put-user,create user API>> to update everything
 but a user's `username` and `password`. This API changes a user's password.
 
-For more information about the native realm, see 
-<<realms>> and <<native-realm>>. 
+For more information about the native realm, see
+<<realms>> and <<native-realm>>.
 
 
 [[security-api-change-password-path-params]]
@@ -55,7 +55,7 @@ The following example updates the password for the `jacknich` user:
 --------------------------------------------------
 POST /_security/user/jacknich/_password
 {
-  "password" : "s3cr3t"
+  "password" : "new-test-password"
 }
 --------------------------------------------------
 // TEST[setup:jacknich_user]

--- a/x-pack/docs/en/rest-api/security/create-users.asciidoc
+++ b/x-pack/docs/en/rest-api/security/create-users.asciidoc
@@ -112,7 +112,7 @@ The following example creates a user `jacknich`:
 --------------------------------------------------
 POST /_security/user/jacknich
 {
-  "password" : "j@rV1s",
+  "password" : "l0ng-r4nd0m-p@ssw0rd",
   "roles" : [ "admin", "other_role1" ],
   "full_name" : "Jack Nicholson",
   "email" : "jacknich@example.com",
@@ -138,6 +138,6 @@ After you add a user, requests from that user can be authenticated. For example:
 
 [source,shell]
 --------------------------------------------------
-curl -u jacknich:j@rV1s http://localhost:9200/_cluster/health
+curl -u jacknich:l0ng-r4nd0m-p@ssw0rd http://localhost:9200/_cluster/health
 --------------------------------------------------
 // NOTCONSOLE

--- a/x-pack/docs/en/security/ccs-clients-integrations/cross-cluster.asciidoc
+++ b/x-pack/docs/en/security/ccs-clients-integrations/cross-cluster.asciidoc
@@ -131,7 +131,7 @@ Finally, create a user on cluster `one` and apply the `cluster_two_logs` role:
 -----------------------------------------------------------
 POST /_security/user/alice
 {
-  "password" : "somepassword",
+  "password" : "somepasswordhere",
   "roles" : [ "cluster_two_logs" ],
   "full_name" : "Alice",
   "email" : "alice@example.com",

--- a/x-pack/plugin/async-search/qa/rest/build.gradle
+++ b/x-pack/plugin/async-search/qa/rest/build.gradle
@@ -1,3 +1,5 @@
+import org.elasticsearch.gradle.info.BuildParams
+
 apply plugin: 'elasticsearch.esplugin'
 apply plugin: 'elasticsearch.yaml-rest-test'
 
@@ -20,3 +22,8 @@ testClusters.all {
 }
 
 tasks.named("test").configure { enabled = false }
+
+if (BuildParams.inFipsJvm){
+  // Test clusters run with security disabled
+  tasks.named("yamlRestTest").configure{enabled = false }
+}

--- a/x-pack/plugin/ccr/qa/build.gradle
+++ b/x-pack/plugin/ccr/qa/build.gradle
@@ -1,6 +1,17 @@
+import org.elasticsearch.gradle.info.BuildParams
+
 apply plugin: 'elasticsearch.build'
 tasks.named("test").configure { enabled = false }
 
 dependencies {
   api project(':test:framework')
+}
+gradle.projectsEvaluated {
+  subprojects {
+    tasks.withType(Test).configureEach {
+      // These fail in CI but only when run as part of checkPart2 and not individually.
+      // Tracked in : https://github.com/elastic/elasticsearch/issues/66661
+      onlyIf { BuildParams.inFipsJvm == false}
+    }
+  }
 }

--- a/x-pack/plugin/ccr/qa/downgrade-to-basic-license/build.gradle
+++ b/x-pack/plugin/ccr/qa/downgrade-to-basic-license/build.gradle
@@ -25,46 +25,20 @@ tasks.register("writeJavaPolicy") {
     if (policyFile.parentFile.exists() == false && policyFile.parentFile.mkdirs() == false) {
       throw new GradleException("failed to create temporary directory [${tmp}]")
     }
-    if (BuildParams.inFipsJvm) {
-      policyFile.write(
-        [
-          "grant {",
-          "permission java.security.SecurityPermission \"putProviderProperty.BCFIPS\";",
-          "permission java.security.SecurityPermission \"putProviderProperty.BCJSSE\";",
-          "permission java.lang.RuntimePermission \"getProtectionDomain\";",
-          "permission java.util.PropertyPermission \"java.runtime.name\", \"read\";",
-          "permission org.bouncycastle.crypto.CryptoServicesPermission \"tlsAlgorithmsEnabled\";",
-          "permission java.lang.RuntimePermission \"accessClassInPackage.sun.security.internal.spec\";",
-          "permission java.lang.RuntimePermission \"accessDeclaredMembers\";",
-          "permission java.util.PropertyPermission \"intellij.debug.agent\", \"read\";",
-          "permission java.util.PropertyPermission \"intellij.debug.agent\", \"write\";",
-          "permission org.bouncycastle.crypto.CryptoServicesPermission \"exportSecretKey\";",
-          "permission org.bouncycastle.crypto.CryptoServicesPermission \"exportPrivateKey\";",
-          "permission java.io.FilePermission \"\${javax.net.ssl.trustStore}\", \"read\";",
-          "permission java.io.FilePermission \"${-> testClusters."follow-cluster".getFirstNode().getServerLog()}\", \"read\";",
-          "};"
-        ].join("\n")
-      )
-    } else {
-      policyFile.write(
-        [
-          "grant {",
-          "  permission java.io.FilePermission \"${-> testClusters."follow-cluster".getFirstNode().getServerLog()}\", \"read\";",
-          "};"
-        ].join("\n")
-      )
-    }
+    policyFile.write(
+      [
+        "grant {",
+        "  permission java.io.FilePermission \"${-> testClusters."follow-cluster".getFirstNode().getServerLog()}\", \"read\";",
+        "};"
+      ].join("\n")
+    )
   }
 }
 
 task "follow-cluster"(type: RestIntegTestTask) {
   dependsOn 'writeJavaPolicy', "leader-cluster"
     useCluster testClusters."leader-cluster"
-    if (BuildParams.inFipsJvm){
-      systemProperty 'java.security.policy', "=file://${policyFile}"
-    } else {
-      systemProperty 'java.security.policy', "file://${policyFile}"
-    }
+    systemProperty 'java.security.policy', "file://${policyFile}"
     systemProperty 'tests.target_cluster', 'follow'
     nonInputProperties.systemProperty 'tests.leader_host', "${-> testClusters."leader-cluster".getAllHttpSocketURI().get(0)}"
     nonInputProperties.systemProperty 'log', "${-> testClusters."follow-cluster".getFirstNode().getServerLog()}"
@@ -81,3 +55,8 @@ testClusters."follow-cluster" {
 tasks.named("check").configure { dependsOn "follow-cluster" }
 // no unit tests for multi-cluster-search, only the rest integration test
 tasks.named("test").configure { enabled = false }
+
+// We can't run in FIPS mode with a basic license
+tasks.withType(Test).configureEach {
+  onlyIf { BuildParams.inFipsJvm == false}
+}

--- a/x-pack/plugin/core/build.gradle
+++ b/x-pack/plugin/core/build.gradle
@@ -53,6 +53,8 @@ dependencies {
   testImplementation project(path: ':modules:lang-mustache')
   testImplementation project(path: ':modules:analysis-common')
   testImplementation project(":client:rest-high-level")
+  // Needed for Fips140ProviderVerificationTests
+  testCompileOnly('org.bouncycastle:bc-fips:1.0.2')
 
   testImplementation(project(':x-pack:license-tools')) {
     transitive = false

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/Fips140ProviderVerificationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/Fips140ProviderVerificationTests.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.core;
+
+import org.bouncycastle.crypto.CryptoServicesRegistrar;
+import org.elasticsearch.test.ESTestCase;
+
+import java.security.Security;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+public class Fips140ProviderVerificationTests extends ESTestCase {
+
+    public void testBcFipsProviderInUse() {
+        if (inFipsJvm()) {
+            assertThat(Security.getProviders().length > 0, equalTo(true));
+            assertThat(Security.getProviders()[0].getName(), containsString("BCFIPS"));
+        }
+    }
+
+    public void testInApprovedOnlyMode() {
+        if (inFipsJvm()) {
+            assertThat(CryptoServicesRegistrar.isInApprovedOnlyMode(), equalTo(true));
+        }
+    }
+
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/transport/ProfileConfigurationsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/transport/ProfileConfigurationsTests.java
@@ -22,6 +22,7 @@ import java.util.Map;
 public class ProfileConfigurationsTests extends ESTestCase {
 
     public void testGetSecureTransportProfileConfigurations() {
+        assumeFalse("Can't run in a FIPS JVM, uses JKS/PKCS12 keystores", inFipsJvm());
         final Settings settings = getBaseSettings()
             .put("path.home", createTempDir())
             .put("xpack.security.transport.ssl.verification_mode", VerificationMode.CERTIFICATE.name())

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ssl/RestrictedTrustManagerTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ssl/RestrictedTrustManagerTests.java
@@ -35,7 +35,6 @@ import java.util.Objects;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import static org.elasticsearch.test.ESIntegTestCase.inFipsJvm;
 
 public class RestrictedTrustManagerTests extends ESTestCase {
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ssl/SSLServiceTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ssl/SSLServiceTests.java
@@ -321,6 +321,7 @@ public class SSLServiceTests extends ESTestCase {
     }
 
     public void testThatHttpClientAuthDefaultsToNone() throws Exception {
+        assumeFalse("Can't run in a FIPS JVM, uses JKS/PKCS12 keystores", inFipsJvm());
         MockSecureSettings secureSettings = new MockSecureSettings();
         secureSettings.setString("xpack.security.transport.ssl.keystore.secure_password", "testnode");
         secureSettings.setString("xpack.security.http.ssl.keystore.secure_password", "testnode");
@@ -344,6 +345,7 @@ public class SSLServiceTests extends ESTestCase {
     }
 
     public void testThatTruststorePasswordIsRequired() throws Exception {
+        assumeFalse("Can't run in a FIPS JVM, uses JKS/PKCS12 keystores", inFipsJvm());
         MockSecureSettings secureSettings = new MockSecureSettings();
         secureSettings.setString("xpack.security.transport.ssl.keystore.secure_password", "testnode");
         Settings settings = Settings.builder()
@@ -360,6 +362,7 @@ public class SSLServiceTests extends ESTestCase {
     }
 
     public void testThatKeystorePasswordIsRequired() throws Exception {
+        assumeFalse("Can't run in a FIPS JVM, uses JKS/PKCS12 keystores", inFipsJvm());
         Settings settings = Settings.builder()
             .put("xpack.security.transport.ssl.keystore.path", testnodeStore)
             .put("xpack.security.transport.ssl.keystore.type", testnodeStoreType)

--- a/x-pack/plugin/data-streams/qa/multi-node/build.gradle
+++ b/x-pack/plugin/data-streams/qa/multi-node/build.gradle
@@ -1,3 +1,5 @@
+import org.elasticsearch.gradle.info.BuildParams
+
 apply plugin: 'elasticsearch.java-rest-test'
 
 File repoDir = file("$buildDir/testclusters/repo")
@@ -18,4 +20,9 @@ testClusters.matching { it.name == "javaRestTest" }.configureEach {
   setting 'xpack.license.self_generated.type', 'trial'
   //disabling ILM history as it disturbs testDSXpackUsage test
   setting 'indices.lifecycle.history_index_enabled', 'false'
+}
+
+if (BuildParams.inFipsJvm){
+  // Test clusters run with security disabled
+  tasks.named("javaRestTest").configure{enabled = false }
 }

--- a/x-pack/plugin/data-streams/qa/rest/build.gradle
+++ b/x-pack/plugin/data-streams/qa/rest/build.gradle
@@ -1,3 +1,5 @@
+import org.elasticsearch.gradle.info.BuildParams
+
 apply plugin: 'elasticsearch.yaml-rest-test'
 apply plugin: 'elasticsearch.java-rest-test'
 
@@ -17,4 +19,10 @@ testClusters.all {
   setting 'xpack.license.self_generated.type', 'trial'
   // disable ILM history, since it disturbs tests using _all
   setting 'indices.lifecycle.history_index_enabled', 'false'
+}
+if (BuildParams.inFipsJvm){
+  // These fail in CI but only when run as part of checkPart2 and not individually.
+  // Tracked in :
+  tasks.named("javaRestTest").configure{enabled = false }
+  tasks.named("yamlRestTest").configure{enabled = false }
 }

--- a/x-pack/plugin/deprecation/qa/rest/build.gradle
+++ b/x-pack/plugin/deprecation/qa/rest/build.gradle
@@ -1,4 +1,5 @@
 import org.elasticsearch.gradle.util.GradleUtils
+import org.elasticsearch.gradle.info.BuildParams
 
 apply plugin: 'elasticsearch.esplugin'
 apply plugin: 'elasticsearch.java-rest-test'
@@ -28,3 +29,8 @@ testClusters.all {
 }
 
 tasks.named("test").configure { enabled = false }
+
+if (BuildParams.inFipsJvm){
+  // Test clusters run with security disabled
+  tasks.named("javaRestTest").configure{enabled = false }
+}

--- a/x-pack/plugin/enrich/qa/rest-with-security/build.gradle
+++ b/x-pack/plugin/enrich/qa/rest-with-security/build.gradle
@@ -1,8 +1,14 @@
 apply plugin: 'elasticsearch.java-rest-test'
 
+import org.elasticsearch.gradle.info.BuildParams
+
 dependencies {
   javaRestTestImplementation project(path: xpackModule('core'))
   javaRestTestImplementation project(path: xpackModule('enrich:qa:common'))
+}
+if (BuildParams.inFipsJvm){
+  // This test cluster is using a BASIC license and FIPS 140 mode is not supported in BASIC
+  tasks.named("javaRestTest").configure{enabled = false }
 }
 
 testClusters.all {

--- a/x-pack/plugin/enrich/qa/rest/build.gradle
+++ b/x-pack/plugin/enrich/qa/rest/build.gradle
@@ -1,6 +1,8 @@
 apply plugin: 'elasticsearch.java-rest-test'
 apply plugin: 'elasticsearch.yaml-rest-test'
 
+import org.elasticsearch.gradle.info.BuildParams
+
 restResources {
   restApi {
     includeCore '_common', 'indices', 'index'
@@ -10,6 +12,12 @@ restResources {
 
 dependencies {
   javaRestTestImplementation project(path: xpackModule('enrich:qa:common'))
+}
+
+if (BuildParams.inFipsJvm){
+  // This test cluster is using a BASIC license and FIPS 140 mode is not supported in BASIC
+  tasks.named("javaRestTest").configure{enabled = false }
+  tasks.named("yamlRestTest").configure{enabled = false }
 }
 
 testClusters.all {

--- a/x-pack/plugin/eql/qa/correctness/build.gradle
+++ b/x-pack/plugin/eql/qa/correctness/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'elasticsearch.testclusters'
 tasks.named("test").configure { enabled = false }
 
 import org.elasticsearch.gradle.testclusters.RunTask
+import org.elasticsearch.gradle.info.BuildParams
 
 restResources {
   restApi {
@@ -31,6 +32,10 @@ Boolean preserveData = providers.systemProperty('eql.test.preserve.data')
   .map { s -> Boolean.parseBoolean(s) }
   .getOrElse(false)
 
+if (BuildParams.inFipsJvm){
+  // This test cluster is using a BASIC license and FIPS 140 mode is not supported in BASIC
+  tasks.named("javaRestTest").configure{enabled = false }
+}
 testClusters {
   all {
     plugin ':plugins:repository-gcs'

--- a/x-pack/plugin/eql/qa/rest/build.gradle
+++ b/x-pack/plugin/eql/qa/rest/build.gradle
@@ -1,6 +1,8 @@
 apply plugin: 'elasticsearch.java-rest-test'
 apply plugin: 'elasticsearch.yaml-rest-test'
 
+import org.elasticsearch.gradle.info.BuildParams
+
 restResources {
   restApi {
     includeCore '_common', 'bulk', 'indices'
@@ -12,6 +14,11 @@ dependencies {
   javaRestTestImplementation project(path: xpackModule('eql:qa:common'))
 }
 
+if (BuildParams.inFipsJvm){
+  // This test cluster is using a BASIC license and FIPS 140 mode is not supported in BASIC
+  tasks.named("javaRestTest").configure{enabled = false }
+  tasks.named("yamlRestTest").configure{enabled = false }
+}
 testClusters.all {
   testDistribution = 'DEFAULT'
   setting 'xpack.license.self_generated.type', 'basic'

--- a/x-pack/plugin/eql/qa/security/build.gradle
+++ b/x-pack/plugin/eql/qa/security/build.gradle
@@ -1,7 +1,14 @@
 apply plugin: 'elasticsearch.java-rest-test'
 
+import org.elasticsearch.gradle.info.BuildParams
+
 dependencies {
   javaRestTestImplementation project(path: xpackModule('eql:qa:common'))
+}
+
+if (BuildParams.inFipsJvm){
+  // This test cluster is using a BASIC license and FIPS 140 mode is not supported in BASIC
+  tasks.named("javaRestTest").configure{enabled = false }
 }
 
 testClusters.all {

--- a/x-pack/plugin/identity-provider/qa/idp-rest-tests/build.gradle
+++ b/x-pack/plugin/identity-provider/qa/idp-rest-tests/build.gradle
@@ -1,3 +1,4 @@
+import org.elasticsearch.gradle.info.BuildParams
 apply plugin: 'elasticsearch.java-rest-test'
 
 dependencies {
@@ -45,3 +46,9 @@ testClusters.all {
   user username: "idp_admin", password: "idp-password", role: "idp_admin"
   user username: "idp_user", password: "idp-password", role: "idp_user"
 }
+
+// We don't support the IDP in FIPS-140 mode, so no need to run java rest tests
+tasks.named("javaRestTest").configure {
+  onlyIf { BuildParams.inFipsJvm == false }
+}
+

--- a/x-pack/plugin/ilm/qa/multi-cluster/build.gradle
+++ b/x-pack/plugin/ilm/qa/multi-cluster/build.gradle
@@ -11,14 +11,14 @@ dependencies {
 
 File repoDir = file("$buildDir/testclusters/repo")
 
-task 'leader-cluster'(type: RestIntegTestTask) {
+tasks.register('leader-cluster', RestIntegTestTask) {
   mustRunAfter("precommit")
     systemProperty 'tests.target_cluster', 'leader'
     /* To support taking index snapshots, we have to set path.repo setting */
     systemProperty 'tests.path.repo', repoDir.absolutePath
 }
 
-testClusters.'leader-cluster' {
+testClusters.matching { it.name == 'leader-cluster' }.configureEach {
   testDistribution = 'DEFAULT'
   setting 'path.repo', repoDir.absolutePath
   setting 'xpack.ccr.enabled', 'true'
@@ -29,19 +29,19 @@ testClusters.'leader-cluster' {
   setting 'indices.lifecycle.poll_interval', '1000ms'
 }
 
-task 'follow-cluster'(type: RestIntegTestTask) {
-  dependsOn 'leader-cluster'
-    useCluster testClusters.'leader-cluster'
-    systemProperty 'tests.target_cluster', 'follow'
-    nonInputProperties.systemProperty 'tests.leader_host',
-      "${-> testClusters."leader-cluster".getAllHttpSocketURI().get(0)}"
-    nonInputProperties.systemProperty 'tests.leader_remote_cluster_seed',
-      "${-> testClusters.'leader-cluster'.getAllTransportPortURI().get(0)}"
-    /* To support taking index snapshots, we have to set path.repo setting */
-    systemProperty 'tests.path.repo', repoDir.absolutePath
+tasks.register('follow-cluster', RestIntegTestTask) {
+  dependsOn tasks.findByName('leader-cluster')
+  useCluster testClusters.'leader-cluster'
+  systemProperty 'tests.target_cluster', 'follow'
+  nonInputProperties.systemProperty 'tests.leader_host',
+    "${-> testClusters."leader-cluster".getAllHttpSocketURI().get(0)}"
+  nonInputProperties.systemProperty 'tests.leader_remote_cluster_seed',
+    "${-> testClusters.'leader-cluster'.getAllTransportPortURI().get(0)}"
+  /* To support taking index snapshots, we have to set path.repo setting */
+  systemProperty 'tests.path.repo', repoDir.absolutePath
 }
 
-testClusters.'follow-cluster' {
+testClusters.matching{ it.name == 'follow-cluster' }.configureEach {
   testDistribution = 'DEFAULT'
   setting 'path.repo', repoDir.absolutePath
   setting 'xpack.ccr.enabled', 'true'
@@ -54,5 +54,11 @@ testClusters.'follow-cluster' {
     { "\"${testClusters.'leader-cluster'.getAllTransportPortURI().get(0)}\"" }
 }
 
-check.dependsOn 'follow-cluster'
-test.enabled = false // no unit tests for this module, only the rest integration test
+tasks.named("check").configure { dependsOn 'follow-cluster' }
+// no unit tests for this module, only the rest integration test
+tasks.named("test").configure { enabled = false }
+// Security is explicitly disabled for follow-cluster and leader-cluster, do not run these in FIPS mode
+tasks.withType(Test).configureEach {
+  onlyIf { BuildParams.inFipsJvm == false}
+}
+

--- a/x-pack/plugin/ilm/qa/multi-cluster/build.gradle
+++ b/x-pack/plugin/ilm/qa/multi-cluster/build.gradle
@@ -1,4 +1,5 @@
 import org.elasticsearch.gradle.test.RestIntegTestTask
+import org.elasticsearch.gradle.info.BuildParams
 
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-test'

--- a/x-pack/plugin/ilm/qa/multi-node/build.gradle
+++ b/x-pack/plugin/ilm/qa/multi-node/build.gradle
@@ -1,4 +1,5 @@
 import org.elasticsearch.gradle.util.GradleUtils
+import org.elasticsearch.gradle.info.BuildParams
 
 apply plugin: 'elasticsearch.java-rest-test'
 
@@ -29,4 +30,9 @@ testClusters.all {
   setting 'indices.lifecycle.poll_interval', '1000ms'
   setting 'logger.org.elasticsearch.xpack.core.ilm', 'TRACE'
   setting 'logger.org.elasticsearch.xpack.ilm', 'TRACE'
+}
+
+if (BuildParams.inFipsJvm){
+  // Test clusters run with security disabled
+  tasks.named("javaRestTest").configure{enabled = false }
 }

--- a/x-pack/plugin/ilm/qa/with-security/src/javaRestTest/java/org/elasticsearch/xpack/security/PermissionsIT.java
+++ b/x-pack/plugin/ilm/qa/with-security/src/javaRestTest/java/org/elasticsearch/xpack/security/PermissionsIT.java
@@ -161,14 +161,14 @@ public class PermissionsIT extends ESRestTestCase {
             "\"indices\": [{ \"names\": [\".slm-history*\"],\"privileges\": [\"all\"] }] }");
         assertOK(adminClient().performRequest(roleRequest));
 
-        createUser("slm_admin", "slm-pass", "slm-manage");
-        createUser("slm_user", "slm-user-pass", "slm-read");
+        createUser("slm_admin", "slm-admin-password", "slm-manage");
+        createUser("slm_user", "slm-user-password", "slm-read");
 
         final HighLevelClient hlAdminClient = new HighLevelClient(adminClient());
 
         // Build two high level clients, each using a different user
         final RestClientBuilder adminBuilder = RestClient.builder(adminClient().getNodes().toArray(new Node[0]));
-        final String adminToken = basicAuthHeaderValue("slm_admin", new SecureString("slm-pass".toCharArray()));
+        final String adminToken = basicAuthHeaderValue("slm_admin", new SecureString("slm-admin-password".toCharArray()));
         configureClient(adminBuilder, Settings.builder()
             .put(ThreadContext.PREFIX + ".Authorization", adminToken)
             .build());
@@ -176,7 +176,7 @@ public class PermissionsIT extends ESRestTestCase {
         final RestHighLevelClient adminHLRC = new RestHighLevelClient(adminBuilder);
 
         final RestClientBuilder userBuilder = RestClient.builder(adminClient().getNodes().toArray(new Node[0]));
-        final String userToken = basicAuthHeaderValue("slm_user", new SecureString("slm-user-pass".toCharArray()));
+        final String userToken = basicAuthHeaderValue("slm_user", new SecureString("slm-user-password".toCharArray()));
         configureClient(userBuilder, Settings.builder()
             .put(ThreadContext.PREFIX + ".Authorization", userToken)
             .build());

--- a/x-pack/plugin/ml/qa/basic-multi-node/build.gradle
+++ b/x-pack/plugin/ml/qa/basic-multi-node/build.gradle
@@ -1,3 +1,5 @@
+import org.elasticsearch.gradle.info.BuildParams
+
 apply plugin: 'elasticsearch.java-rest-test'
 
 testClusters.all {
@@ -10,4 +12,9 @@ testClusters.all {
   setting 'xpack.license.self_generated.type', 'trial'
   setting 'indices.lifecycle.history_index_enabled', 'false'
   setting 'slm.history_index_enabled', 'false'
+}
+
+if (BuildParams.inFipsJvm){
+  // Test clusters run with security disabled
+  tasks.named("javaRestTest").configure{enabled = false }
 }

--- a/x-pack/plugin/ml/qa/disabled/build.gradle
+++ b/x-pack/plugin/ml/qa/disabled/build.gradle
@@ -1,3 +1,5 @@
+import org.elasticsearch.gradle.info.BuildParams
+
 apply plugin: 'elasticsearch.java-rest-test'
 
 //dependencies {
@@ -9,4 +11,9 @@ testClusters.all {
   testDistribution = 'DEFAULT'
   setting 'xpack.security.enabled', 'false'
   setting 'xpack.ml.enabled', 'false'
+}
+
+if (BuildParams.inFipsJvm){
+  // Test clusters run with security disabled
+  tasks.named("javaRestTest").configure{enabled = false }
 }

--- a/x-pack/plugin/ml/qa/single-node-tests/build.gradle
+++ b/x-pack/plugin/ml/qa/single-node-tests/build.gradle
@@ -1,7 +1,14 @@
+import org.elasticsearch.gradle.info.BuildParams
+
 apply plugin: 'elasticsearch.java-rest-test'
 
 testClusters.all {
   testDistribution = 'DEFAULT'
   setting 'xpack.security.enabled', 'false'
   setting 'xpack.license.self_generated.type', 'trial'
+}
+
+if (BuildParams.inFipsJvm){
+  // Test clusters run with security disabled
+  tasks.named("javaRestTest").configure{enabled = false }
 }

--- a/x-pack/plugin/repositories-metering-api/qa/gcs/build.gradle
+++ b/x-pack/plugin/repositories-metering-api/qa/gcs/build.gradle
@@ -66,7 +66,7 @@ if (!gcsServiceAccount && !gcsBucket && !gcsBasePath) {
 tasks.register("createServiceAccountFile") {
   doLast {
     KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA")
-    keyPairGenerator.initialize(1024)
+    keyPairGenerator.initialize(2048)
     KeyPair keyPair = keyPairGenerator.generateKeyPair()
     String encodedKey = Base64.getEncoder().encodeToString(keyPair.private.getEncoded())
 

--- a/x-pack/plugin/repositories-metering-api/qa/s3/build.gradle
+++ b/x-pack/plugin/repositories-metering-api/qa/s3/build.gradle
@@ -27,8 +27,8 @@ String s3Bucket = System.getenv("amazon_s3_bucket")
 String s3BasePath = System.getenv("amazon_s3_base_path")
 
 if (!s3AccessKey && !s3SecretKey && !s3Bucket && !s3BasePath) {
-  s3AccessKey = 'access_key'
-  s3SecretKey = 'secret_key'
+  s3AccessKey = 's3_test_access_key'
+  s3SecretKey = 's3_test_secret_key'
   s3Bucket = 'bucket'
   s3BasePath = null
   useFixture = true

--- a/x-pack/plugin/rollup/qa/rest/build.gradle
+++ b/x-pack/plugin/rollup/qa/rest/build.gradle
@@ -9,20 +9,25 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 apply plugin: 'elasticsearch.rest-resources'
 
+import org.elasticsearch.gradle.info.BuildParams
+
 dependencies {
-  testImplementation project(path: xpackModule('rollup'))
+    testImplementation project(path: xpackModule('rollup'))
 }
 
 restResources {
-  restApi {
-    includeCore '_common', 'bulk', 'cluster', 'indices', 'search'
-    includeXpack 'rollup'
-  }
+    restApi {
+        includeCore '_common', 'bulk', 'cluster', 'indices', 'search'
+        includeXpack 'rollup'
+    }
 }
-
-testClusters.integTest {
-  testDistribution = 'DEFAULT'
-  setting 'xpack.license.self_generated.type', 'basic'
-  systemProperty 'es.rollup_v2_feature_flag_enabled', 'true'
+if (BuildParams.inFipsJvm){
+  // This test cluster is using a BASIC license and FIPS 140 mode is not supported in BASIC
+  tasks.named("integTest").configure{enabled = false }
+  tasks.named("testingConventions").configure{enabled = false }
 }
-
+testClusters.matching { it.name == "integTest" }.configureEach {
+    testDistribution = 'DEFAULT'
+    setting 'xpack.license.self_generated.type', 'basic'
+    systemProperty 'es.rollup_v2_feature_flag_enabled', 'true'
+}

--- a/x-pack/plugin/searchable-snapshots/qa/gcs/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/qa/gcs/build.gradle
@@ -48,7 +48,7 @@ if (!gcsServiceAccount && !gcsBucket && !gcsBasePath) {
 tasks.register("createServiceAccountFile") {
   doLast {
     KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA")
-    keyPairGenerator.initialize(1024)
+    keyPairGenerator.initialize(2048)
     KeyPair keyPair = keyPairGenerator.generateKeyPair()
     String encodedKey = Base64.getEncoder().encodeToString(keyPair.private.getEncoded())
 

--- a/x-pack/plugin/searchable-snapshots/qa/minio/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/qa/minio/build.gradle
@@ -36,8 +36,8 @@ testClusters.integTest {
   testDistribution = 'DEFAULT'
   plugin repositoryPlugin.path
 
-  keystore 's3.client.searchable_snapshots.access_key', 'access_key'
-  keystore 's3.client.searchable_snapshots.secret_key', 'secret_key'
+  keystore 's3.client.searchable_snapshots.access_key', 's3_test_access_key'
+  keystore 's3.client.searchable_snapshots.secret_key', 's3_test_secret_key'
   setting 'xpack.license.self_generated.type', 'trial'
   setting 's3.client.searchable_snapshots.protocol', 'http'
   setting 's3.client.searchable_snapshots.endpoint', { "${-> fixtureAddress()}" }, IGNORE_VALUE

--- a/x-pack/plugin/searchable-snapshots/qa/s3/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/qa/s3/build.gradle
@@ -27,8 +27,8 @@ String s3Bucket = System.getenv("amazon_s3_bucket")
 String s3BasePath = System.getenv("amazon_s3_base_path")
 
 if (!s3AccessKey && !s3SecretKey && !s3Bucket && !s3BasePath) {
-  s3AccessKey = 'access_key'
-  s3SecretKey = 'secret_key'
+  s3AccessKey = 's3_test_access_key'
+  s3SecretKey = 's3_test_secret_key'
   s3Bucket = 'bucket'
   s3BasePath = null
   useFixture = true

--- a/x-pack/plugin/security/qa/basic-enable-security/build.gradle
+++ b/x-pack/plugin/security/qa/basic-enable-security/build.gradle
@@ -1,5 +1,6 @@
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 import org.elasticsearch.gradle.test.rest.JavaRestTestPlugin
+import org.elasticsearch.gradle.info.BuildParams
 
 apply plugin: 'elasticsearch.java-rest-test'
 
@@ -12,6 +13,11 @@ dependencies {
 tasks.named("javaRestTest").configure {
   description = "Run tests against a cluster that doesn't have security"
   systemProperty 'tests.has_security', 'false'
+}
+
+if (BuildParams.inFipsJvm){
+  // This test cluster is using a BASIC license and FIPS 140 mode is not supported in BASIC
+  tasks.named("javaRestTest").configure{enabled = false }
 }
 
 testClusters {
@@ -31,6 +37,9 @@ tasks.register("javaRestTestWithSecurity", StandaloneRestIntegTestTask) {
   systemProperty 'tests.has_security', 'true'
   testClassesDirs = sourceSets.javaRestTest.output.classesDirs
   classpath = sourceSets.javaRestTest.runtimeClasspath
+  onlyIf {
+    BuildParams.inFipsJvm == false
+  }
   doFirst {
     testClusters.javaRestTest {
       // TODO Rene: revisit if using dedicated new cluster definitions would be more efficient.

--- a/x-pack/plugin/security/qa/security-basic/build.gradle
+++ b/x-pack/plugin/security/qa/security-basic/build.gradle
@@ -1,10 +1,17 @@
 
 apply plugin: 'elasticsearch.java-rest-test'
 
+import org.elasticsearch.gradle.info.BuildParams
+
 dependencies {
   javaRestTestImplementation project(path: xpackModule('core'), configuration: 'default')
   javaRestTestImplementation project(path: xpackModule('security'), configuration: 'testArtifacts')
   javaRestTestImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
+}
+
+if (BuildParams.inFipsJvm){
+  // This test cluster is using a BASIC license and FIPS 140 mode is not supported in BASIC
+  tasks.named("javaRestTest").configure{enabled = false }
 }
 
 testClusters.all {

--- a/x-pack/plugin/security/qa/security-disabled/build.gradle
+++ b/x-pack/plugin/security/qa/security-disabled/build.gradle
@@ -5,6 +5,7 @@
  * For example: If a cluster has a pipeline with the set_security_user processor
  *              defined, it should be not fail
  */
+import org.elasticsearch.gradle.info.BuildParams
 
 apply plugin: 'elasticsearch.java-rest-test'
 
@@ -23,4 +24,9 @@ testClusters.all {
   // This means the security plugin is loaded and all feature are permitted, but they are not enabled
   setting 'xpack.license.self_generated.type', 'trial'
   setting 'xpack.security.enabled', 'false'
+}
+
+if (BuildParams.inFipsJvm){
+  // Test clusters run with security disabled
+  tasks.named("javaRestTest").configure{enabled = false }
 }

--- a/x-pack/plugin/security/qa/security-trial/src/javaRestTest/java/org/elasticsearch/xpack/security/apikey/ApiKeyRestIT.java
+++ b/x-pack/plugin/security/qa/security-trial/src/javaRestTest/java/org/elasticsearch/xpack/security/apikey/ApiKeyRestIT.java
@@ -42,9 +42,9 @@ import static org.hamcrest.Matchers.notNullValue;
 public class ApiKeyRestIT extends SecurityOnTrialLicenseRestTestCase {
 
     private static final String SYSTEM_USER = "system_user";
-    private static final SecureString SYSTEM_USER_PASSWORD = new SecureString("sys-pass".toCharArray());
+    private static final SecureString SYSTEM_USER_PASSWORD = new SecureString("system-user-password".toCharArray());
     private static final String END_USER = "end_user";
-    private static final SecureString END_USER_PASSWORD = new SecureString("user-pass".toCharArray());
+    private static final SecureString END_USER_PASSWORD = new SecureString("end-user-password".toCharArray());
 
     @Before
     public void createUsers() throws IOException {

--- a/x-pack/plugin/security/qa/tls-basic/build.gradle
+++ b/x-pack/plugin/security/qa/tls-basic/build.gradle
@@ -1,9 +1,16 @@
 apply plugin: 'elasticsearch.java-rest-test'
 
+import org.elasticsearch.gradle.info.BuildParams
+
 dependencies {
   testImplementation project(path: xpackModule('core'), configuration: 'default')
   testImplementation project(path: xpackModule('security'), configuration: 'testArtifacts')
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
+}
+
+if (BuildParams.inFipsJvm){
+  // This test cluster is using a BASIC license and FIPS 140 mode is not supported in BASIC
+  tasks.named("javaRestTest").configure{enabled = false }
 }
 
 testClusters.javaRestTest {

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/AbstractPrivilegeTestCase.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/AbstractPrivilegeTestCase.java
@@ -12,7 +12,7 @@ import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
-import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.test.SecuritySettingsSourceField;
 import org.elasticsearch.test.SecuritySingleNodeTestCase;
 import org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken;
 
@@ -94,7 +94,8 @@ public abstract class AbstractPrivilegeTestCase extends SecuritySingleNodeTestCa
 
     private void setUser(Request request, String user) {
         RequestOptions.Builder options = RequestOptions.DEFAULT.toBuilder();
-        options.addHeader("Authorization", UsernamePasswordToken.basicAuthHeaderValue(user, new SecureString("passwd".toCharArray())));
+        options.addHeader("Authorization",
+            UsernamePasswordToken.basicAuthHeaderValue(user, SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING));
         request.setOptions(options);
     }
 }

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/ClearRealmsCacheTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/ClearRealmsCacheTests.java
@@ -190,8 +190,8 @@ public class ClearRealmsCacheTests extends SecurityIntegTestCase {
     @Override
     protected String configUsers() {
         StringBuilder builder = new StringBuilder(SecuritySettingsSource.CONFIG_STANDARD_USER);
-        final String usersPasswdHashed = new String(getFastStoredHashAlgoForTests().hash(new SecureString
-            ("passwd".toCharArray())));
+        final String usersPasswdHashed =
+            new String(getFastStoredHashAlgoForTests().hash(SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING));
         for (String username : usernames) {
             builder.append(username).append(":").append(usersPasswdHashed).append("\n");
         }
@@ -223,7 +223,7 @@ public class ClearRealmsCacheTests extends SecurityIntegTestCase {
     private void testScenario(Scenario scenario) throws Exception {
         Map<String, UsernamePasswordToken> tokens = new HashMap<>();
         for (String user : usernames) {
-            tokens.put(user, new UsernamePasswordToken(user, new SecureString("passwd")));
+            tokens.put(user, new UsernamePasswordToken(user, SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING));
         }
 
         List<Realm> realms = new ArrayList<>();

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/ClusterPrivilegeIntegrationTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/ClusterPrivilegeIntegrationTests.java
@@ -10,8 +10,8 @@ import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.cluster.SnapshotsInProgress;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.SecuritySettingsSourceField;
 import org.elasticsearch.xpack.core.security.authc.support.Hasher;
 import org.hamcrest.Matchers;
 import org.junit.AfterClass;
@@ -79,8 +79,8 @@ public class ClusterPrivilegeIntegrationTests extends AbstractPrivilegeTestCase 
 
     @Override
     protected String configUsers() {
-        final String usersPasswdHashed = new String(Hasher.resolve(
-            randomFrom("pbkdf2", "pbkdf2_1000", "bcrypt", "bcrypt9")).hash(new SecureString("passwd".toCharArray())));
+        final Hasher passwdHasher = getFastStoredHashAlgoForTests();
+        final String usersPasswdHashed = new String(passwdHasher.hash(SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING));
         return super.configUsers() +
             "user_a:" + usersPasswdHashed + "\n" +
             "user_b:" + usersPasswdHashed + "\n" +

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/CreateDocsIndexPrivilegeTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/CreateDocsIndexPrivilegeTests.java
@@ -7,7 +7,7 @@
 package org.elasticsearch.integration;
 
 import org.elasticsearch.client.Request;
-import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.test.SecuritySettingsSourceField;
 import org.elasticsearch.xpack.core.security.authc.support.Hasher;
 import org.junit.Before;
 
@@ -22,7 +22,7 @@ public class CreateDocsIndexPrivilegeTests extends AbstractPrivilegeTestCase {
             "  indices:\n" +
             "    - names: '*'\n" +
             "      privileges: [ all ]\n" +
-        "create_doc_role:\n" +
+            "create_doc_role:\n" +
             "  indices:\n" +
             "    - names: '*'\n" +
             "      privileges: [ create_doc ]\n";
@@ -43,8 +43,8 @@ public class CreateDocsIndexPrivilegeTests extends AbstractPrivilegeTestCase {
 
     @Override
     protected String configUsers() {
-        final String usersPasswdHashed = new String(Hasher.resolve(
-            randomFrom("pbkdf2", "pbkdf2_1000", "bcrypt", "bcrypt9")).hash(new SecureString("passwd".toCharArray())));
+        final Hasher passwdHasher = getFastStoredHashAlgoForTests();
+        final String usersPasswdHashed = new String(passwdHasher.hash(SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING));
 
         return super.configUsers() +
             "admin:" + usersPasswdHashed + "\n" +

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DateMathExpressionIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DateMathExpressionIntegTests.java
@@ -22,6 +22,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.test.SecurityIntegTestCase;
+import org.elasticsearch.test.SecuritySettingsSourceField;
 
 import java.util.Collections;
 
@@ -33,7 +34,7 @@ import static org.hamcrest.Matchers.is;
 
 public class DateMathExpressionIntegTests extends SecurityIntegTestCase {
 
-    protected static final SecureString USERS_PASSWD = new SecureString("change_me".toCharArray());
+    protected static final SecureString USERS_PASSWD = SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING;
 
     @Override
     protected String configUsers() {

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DocumentAndFieldLevelSecurityTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DocumentAndFieldLevelSecurityTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.indices.IndicesModule;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.test.SecurityIntegTestCase;
+import org.elasticsearch.test.SecuritySettingsSourceField;
 import org.elasticsearch.xpack.core.XPackSettings;
 
 import java.util.Arrays;
@@ -44,7 +45,7 @@ import static org.hamcrest.Matchers.is;
 
 public class DocumentAndFieldLevelSecurityTests extends SecurityIntegTestCase {
 
-    protected static final SecureString USERS_PASSWD = new SecureString("change_me".toCharArray());
+    protected static final SecureString USERS_PASSWD = SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING;
 
     @Override
     protected String configUsers() {

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DocumentLevelSecurityRandomTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DocumentLevelSecurityRandomTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.test.SecuritySettingsSourceField;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.test.SecurityIntegTestCase;
 
@@ -25,7 +26,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class DocumentLevelSecurityRandomTests extends SecurityIntegTestCase {
 
-    protected static final SecureString USERS_PASSWD = new SecureString("change_me".toCharArray());
+    protected static final SecureString USERS_PASSWD = SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING;
 
     // can't add a second test method, because each test run creates a new instance of this class and that will will result
     // in a new random value:

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DocumentLevelSecurityTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DocumentLevelSecurityTests.java
@@ -60,6 +60,7 @@ import org.elasticsearch.search.suggest.term.TermSuggestion;
 import org.elasticsearch.search.suggest.term.TermSuggestionBuilder;
 import org.elasticsearch.test.InternalSettingsPlugin;
 import org.elasticsearch.test.SecurityIntegTestCase;
+import org.elasticsearch.test.SecuritySettingsSourceField;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.search.action.ClosePointInTimeAction;
 import org.elasticsearch.xpack.core.search.action.ClosePointInTimeRequest;
@@ -97,7 +98,7 @@ import static org.hamcrest.Matchers.notNullValue;
 @LuceneTestCase.SuppressCodecs("*") // suppress test codecs otherwise test using completion suggester fails
 public class DocumentLevelSecurityTests extends SecurityIntegTestCase {
 
-    protected static final SecureString USERS_PASSWD = new SecureString("change_me".toCharArray());
+    protected static final SecureString USERS_PASSWD = SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING;
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/FieldLevelSecurityRandomTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/FieldLevelSecurityRandomTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.sort.SortOrder;
+import org.elasticsearch.test.SecuritySettingsSourceField;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.test.SecurityIntegTestCase;
 
@@ -32,7 +33,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class FieldLevelSecurityRandomTests extends SecurityIntegTestCase {
 
-    protected static final SecureString USERS_PASSWD = new SecureString("change_me".toCharArray());
+    protected static final SecureString USERS_PASSWD = SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING;
 
     private static Set<String> allowedFields;
     private static Set<String> disAllowedFields;

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/FieldLevelSecurityTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/FieldLevelSecurityTests.java
@@ -47,6 +47,7 @@ import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.InternalSettingsPlugin;
 import org.elasticsearch.test.SecurityIntegTestCase;
+import org.elasticsearch.test.SecuritySettingsSourceField;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.search.action.ClosePointInTimeAction;
 import org.elasticsearch.xpack.core.search.action.ClosePointInTimeRequest;
@@ -87,7 +88,7 @@ import static org.hamcrest.Matchers.nullValue;
 @ESIntegTestCase.ClusterScope
 public class FieldLevelSecurityTests extends SecurityIntegTestCase {
 
-    protected static final SecureString USERS_PASSWD = new SecureString("change_me".toCharArray());
+    protected static final SecureString USERS_PASSWD = SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING;
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/IndexPrivilegeTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/IndexPrivilegeTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.test.SecuritySettingsSourceField;
 import org.elasticsearch.xpack.core.security.authc.support.Hasher;
 import org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken;
 import org.junit.Before;
@@ -120,8 +121,8 @@ public class IndexPrivilegeTests extends AbstractPrivilegeTestCase {
 
     @Override
     protected String configUsers() {
-        final String usersPasswdHashed = new String(Hasher.resolve(
-            randomFrom("pbkdf2", "pbkdf2_1000", "bcrypt", "bcrypt9")).hash(new SecureString("passwd".toCharArray())));
+        final Hasher passwdHasher = getFastStoredHashAlgoForTests();
+        final String usersPasswdHashed = new String(passwdHasher.hash(SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING));
 
         return super.configUsers() +
             "admin:" + usersPasswdHashed + "\n" +

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/IndicesPermissionsWithAliasesWildcardsAndRegexsTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/IndicesPermissionsWithAliasesWildcardsAndRegexsTests.java
@@ -9,6 +9,7 @@ import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.SecuritySettingsSourceField;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.test.SecurityIntegTestCase;
 
@@ -22,7 +23,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class IndicesPermissionsWithAliasesWildcardsAndRegexsTests extends SecurityIntegTestCase {
 
-    protected static final SecureString USERS_PASSWD = new SecureString("change_me".toCharArray());
+    protected static final SecureString USERS_PASSWD = SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING;
 
     @Override
     protected String configUsers() {

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/KibanaSystemRoleIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/KibanaSystemRoleIntegTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.test.SecurityIntegTestCase;
+import org.elasticsearch.test.SecuritySettingsSourceField;
 import org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken;
 
 import java.util.Locale;
@@ -21,7 +22,7 @@ import static org.hamcrest.Matchers.is;
 
 public class KibanaSystemRoleIntegTests extends SecurityIntegTestCase {
 
-    protected static final SecureString USERS_PASSWD = new SecureString("change_me".toCharArray());
+    protected static final SecureString USERS_PASSWD = SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING;
 
     @Override
     public String configUsers() {

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/KibanaUserRoleIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/KibanaUserRoleIntegTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.test.NativeRealmIntegTestCase;
+import org.elasticsearch.test.SecuritySettingsSourceField;
 import org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken;
 
 import java.util.Map;
@@ -32,7 +33,7 @@ import static org.hamcrest.Matchers.notNullValue;
 
 public class KibanaUserRoleIntegTests extends NativeRealmIntegTestCase {
 
-    protected static final SecureString USERS_PASSWD = new SecureString("change_me".toCharArray());
+    protected static final SecureString USERS_PASSWD = SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING;
 
     @Override
     public String configRoles() {

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/MultipleIndicesPermissionsTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/MultipleIndicesPermissionsTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.SecurityIntegTestCase;
 import org.elasticsearch.test.SecuritySettingsSource;
+import org.elasticsearch.test.SecuritySettingsSourceField;
 import org.elasticsearch.xpack.core.security.authc.support.Hasher;
 import org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken;
 import org.junit.After;
@@ -42,12 +43,12 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 
 public class MultipleIndicesPermissionsTests extends SecurityIntegTestCase {
 
-    protected static final SecureString USERS_PASSWD = new SecureString("passwd".toCharArray());
+    protected static final SecureString USERS_PASSWD = SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING;
 
     @Before
     public void waitForSecurityIndexWritable() throws Exception {
         // adds a dummy user to the native realm to force .security index creation
-        securityClient().preparePutUser("dummy_user", "password".toCharArray(), Hasher.BCRYPT, "missing_role").get();
+        securityClient().preparePutUser("dummy_user", "dummy_user_password".toCharArray(), Hasher.BCRYPT, "missing_role").get();
         assertSecurityIndexActive();
     }
 
@@ -221,7 +222,7 @@ public class MultipleIndicesPermissionsTests extends SecurityIntegTestCase {
         assertThat(indicesRecoveryResponse.shardRecoveryStates().size(), is(3));
         assertThat(indicesRecoveryResponse.shardRecoveryStates().keySet(), containsInAnyOrder("foo", "foobar", "foobarfoo"));
 
-        // test _cat/indices with wildcards that cover unauthorized indices (".security" in this case)  
+        // test _cat/indices with wildcards that cover unauthorized indices (".security" in this case)
         RequestOptions.Builder optionsBuilder = RequestOptions.DEFAULT.toBuilder();
         optionsBuilder.addHeader("Authorization", UsernamePasswordToken.basicAuthHeaderValue("user_monitor", USERS_PASSWD));
         RequestOptions options = optionsBuilder.build();

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/PermissionPrecedenceTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/PermissionPrecedenceTests.java
@@ -81,7 +81,7 @@ public class PermissionPrecedenceTests extends SecurityIntegTestCase {
 
     @Override
     protected SecureString transportClientPassword() {
-        return new SecureString("test123".toCharArray());
+        return SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING;
     }
 
     public void testDifferentCombinationsOfIndices() throws Exception {

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/PermissionPrecedenceTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/PermissionPrecedenceTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.test.SecurityIntegTestCase;
+import org.elasticsearch.test.SecuritySettingsSourceField;
 import org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken;
 
 import java.util.Collections;
@@ -49,7 +50,8 @@ public class PermissionPrecedenceTests extends SecurityIntegTestCase {
 
     @Override
     protected String configUsers() {
-        final String usersPasswdHashed = new String(getFastStoredHashAlgoForTests().hash(new SecureString("test123".toCharArray())));
+        final String usersPasswdHashed =
+            new String(getFastStoredHashAlgoForTests().hash(SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING));
         return "admin:" + usersPasswdHashed + "\n" +
             "client:" + usersPasswdHashed + "\n" +
             "user:" + usersPasswdHashed + "\n";
@@ -69,7 +71,7 @@ public class PermissionPrecedenceTests extends SecurityIntegTestCase {
 
     @Override
     protected SecureString nodeClientPassword() {
-        return new SecureString("test123".toCharArray());
+        return SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING;
     }
 
     @Override
@@ -108,7 +110,7 @@ public class PermissionPrecedenceTests extends SecurityIntegTestCase {
                 .setPatterns(Collections.singletonList("test_*"))::get, PutIndexTemplateAction.NAME, "user");
 
         Map<String, String> headers = Collections.singletonMap(UsernamePasswordToken.BASIC_AUTH_HEADER, basicAuthHeaderValue("user",
-                new SecureString("test123")));
+            SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING));
         assertThrowsAuthorizationException(client.filterWithHeader(headers).admin().indices().prepareGetTemplates("template1")::get,
                 GetIndexTemplatesAction.NAME, "user");
     }

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/SecurityClearScrollTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/SecurityClearScrollTests.java
@@ -12,10 +12,10 @@ import org.elasticsearch.action.search.ClearScrollResponse;
 import org.elasticsearch.action.search.MultiSearchRequestBuilder;
 import org.elasticsearch.action.search.MultiSearchResponse;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
-import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.xpack.core.security.SecurityField;
 import org.elasticsearch.test.SecurityIntegTestCase;
+import org.elasticsearch.test.SecuritySettingsSourceField;
+import org.elasticsearch.xpack.core.security.SecurityField;
 import org.junit.After;
 import org.junit.Before;
 
@@ -37,7 +37,8 @@ public class SecurityClearScrollTests extends SecurityIntegTestCase {
 
     @Override
     protected String configUsers() {
-        final String usersPasswdHashed = new String(getFastStoredHashAlgoForTests().hash(new SecureString("change_me".toCharArray())));
+        final String usersPasswdHashed =
+            new String(getFastStoredHashAlgoForTests().hash(SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING));
         return super.configUsers() +
             "allowed_user:" + usersPasswdHashed + "\n" +
             "denied_user:" + usersPasswdHashed + "\n";
@@ -88,8 +89,8 @@ public class SecurityClearScrollTests extends SecurityIntegTestCase {
     }
 
     public void testThatClearingAllScrollIdsWorks() throws Exception {
-        String user = "allowed_user:change_me";
-        String basicAuth = basicAuthHeaderValue("allowed_user", new SecureString("change_me".toCharArray()));
+        String user = "allowed_user:"+SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING;
+        String basicAuth = basicAuthHeaderValue("allowed_user", SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING);
         Map<String, String> headers = new HashMap<>();
         headers.put(SecurityField.USER_SETTING.getKey(), user);
         headers.put(BASIC_AUTH_HEADER, basicAuth);
@@ -102,8 +103,8 @@ public class SecurityClearScrollTests extends SecurityIntegTestCase {
     }
 
     public void testThatClearingAllScrollIdsRequirePermissions() throws Exception {
-        String user = "denied_user:change_me";
-        String basicAuth = basicAuthHeaderValue("denied_user", new SecureString("change_me".toCharArray()));
+        String user = "denied_user:"+SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING;
+        String basicAuth = basicAuthHeaderValue("denied_user", SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING);
         Map<String, String> headers = new HashMap<>();
         headers.put(SecurityField.USER_SETTING.getKey(), user);
         headers.put(BASIC_AUTH_HEADER, basicAuth);

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/test/SecuritySingleNodeTestCase.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/test/SecuritySingleNodeTestCase.java
@@ -24,6 +24,7 @@ import org.elasticsearch.http.HttpInfo;
 import org.elasticsearch.license.LicenseService;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.PluginInfo;
+import org.elasticsearch.xpack.core.security.authc.support.Hasher;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.security.LocalStateSecurity;
 import org.junit.AfterClass;
@@ -308,6 +309,11 @@ public abstract class SecuritySingleNodeTestCase extends ESSingleNodeTestCase {
 
     protected RestClient createRestClient(RestClientBuilder.HttpClientConfigCallback httpClientConfigCallback, String protocol) {
         return createRestClient(client(), httpClientConfigCallback, protocol);
+    }
+
+    protected static Hasher getFastStoredHashAlgoForTests() {
+        return inFipsJvm() ? Hasher.resolve(randomFrom("pbkdf2", "pbkdf2_1000", "pbkdf2_stretch_1000", "pbkdf2_stretch"))
+            : Hasher.resolve(randomFrom("pbkdf2", "pbkdf2_1000", "pbkdf2_stretch_1000", "pbkdf2_stretch", "bcrypt", "bcrypt9"));
     }
 
     private static synchronized RestClient getRestClient(Client client) {

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/esnative/NativeRealmIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/esnative/NativeRealmIntegTests.java
@@ -125,7 +125,7 @@ public class NativeRealmIntegTests extends NativeRealmIntegTestCase {
     public void testDeletingNonexistingUserAndRole() throws Exception {
         SecurityClient c = securityClient();
         // first create the index so it exists
-        c.preparePutUser("joe", new SecureString("s3krit".toCharArray()), hasher, "role1", "user").get();
+        c.preparePutUser("joe", new SecureString("s3krit-password".toCharArray()), hasher, "role1", "user").get();
         DeleteUserResponse resp = c.prepareDeleteUser("missing").get();
         assertFalse("user shouldn't be found", resp.found());
         DeleteRoleResponse resp2 = c.prepareDeleteRole("role").get();
@@ -145,7 +145,7 @@ public class NativeRealmIntegTests extends NativeRealmIntegTestCase {
         final List<User> existingUsers = Arrays.asList(c.prepareGetUsers().get().users());
         final int existing = existingUsers.size();
         logger.error("--> creating user");
-        c.preparePutUser("joe", new SecureString("s3kirt".toCharArray()), hasher, "role1", "user").get();
+        c.preparePutUser("joe", new SecureString("s3krit-password".toCharArray()), hasher, "role1", "user").get();
         logger.error("--> waiting for .security index");
         ensureGreen(SECURITY_MAIN_ALIAS);
         logger.info("--> retrieving user");
@@ -156,8 +156,8 @@ public class NativeRealmIntegTests extends NativeRealmIntegTestCase {
         assertArrayEquals(joe.roles(), new String[]{"role1", "user"});
 
         logger.info("--> adding two more users");
-        c.preparePutUser("joe2", new SecureString("s3kirt2".toCharArray()), hasher, "role2", "user").get();
-        c.preparePutUser("joe3", new SecureString("s3kirt3".toCharArray()), hasher, "role3", "user").get();
+        c.preparePutUser("joe2", new SecureString("s3krit-password2".toCharArray()), hasher, "role2", "user").get();
+        c.preparePutUser("joe3", new SecureString("s3krit-password3".toCharArray()), hasher, "role3", "user").get();
         GetUsersResponse allUsersResp = c.prepareGetUsers().get();
         assertTrue("users should exist", allUsersResp.hasUsers());
         assertEquals("should be " + (3 + existing) + " users total", 3 + existing, allUsersResp.users().length);
@@ -251,7 +251,7 @@ public class NativeRealmIntegTests extends NativeRealmIntegTestCase {
                         new BytesArray("{\"match_all\": {}}"), randomBoolean())
                 .get();
         logger.error("--> creating user");
-        c.preparePutUser("joe", new SecureString("s3krit".toCharArray()), hasher, "test_role").get();
+        c.preparePutUser("joe", new SecureString("s3krit-password".toCharArray()), hasher, "test_role").get();
         logger.error("--> waiting for .security index");
         ensureGreen(SECURITY_MAIN_ALIAS);
         logger.info("--> retrieving user");
@@ -263,7 +263,7 @@ public class NativeRealmIntegTests extends NativeRealmIntegTestCase {
         // Index a document with the default test user
         client().prepareIndex("idx", "doc", "1").setSource("body", "foo").setRefreshPolicy(IMMEDIATE).get();
 
-        String token = basicAuthHeaderValue("joe", new SecureString("s3krit"));
+        String token = basicAuthHeaderValue("joe", new SecureString("s3krit-password"));
         SearchResponse searchResp = client().filterWithHeader(Collections.singletonMap("Authorization", token)).prepareSearch("idx").get();
 
         assertEquals(1L, searchResp.getHits().getTotalHits().value);
@@ -272,7 +272,7 @@ public class NativeRealmIntegTests extends NativeRealmIntegTestCase {
     public void testUpdatingUserAndAuthentication() throws Exception {
         SecurityClient c = securityClient();
         logger.error("--> creating user");
-        c.preparePutUser("joe", new SecureString("s3krit".toCharArray()), hasher, SecuritySettingsSource.TEST_ROLE).get();
+        c.preparePutUser("joe", new SecureString("s3krit-password".toCharArray()), hasher, SecuritySettingsSource.TEST_ROLE).get();
         logger.error("--> waiting for .security index");
         ensureGreen(SECURITY_MAIN_ALIAS);
         logger.info("--> retrieving user");
@@ -284,12 +284,12 @@ public class NativeRealmIntegTests extends NativeRealmIntegTestCase {
         ensureGreen("idx");
         // Index a document with the default test user
         client().prepareIndex("idx", "doc", "1").setSource("body", "foo").setRefreshPolicy(IMMEDIATE).get();
-        String token = basicAuthHeaderValue("joe", new SecureString("s3krit"));
+        String token = basicAuthHeaderValue("joe", new SecureString("s3krit-password"));
         SearchResponse searchResp = client().filterWithHeader(Collections.singletonMap("Authorization", token)).prepareSearch("idx").get();
 
         assertEquals(1L, searchResp.getHits().getTotalHits().value);
 
-        c.preparePutUser("joe", new SecureString("s3krit2".toCharArray()), hasher, SecuritySettingsSource.TEST_ROLE).get();
+        c.preparePutUser("joe", new SecureString("s3krit-password2".toCharArray()), hasher, SecuritySettingsSource.TEST_ROLE).get();
 
         try {
             client().filterWithHeader(Collections.singletonMap("Authorization", token)).prepareSearch("idx").get();
@@ -299,7 +299,7 @@ public class NativeRealmIntegTests extends NativeRealmIntegTestCase {
             assertThat(e.status(), is(RestStatus.UNAUTHORIZED));
         }
 
-        token = basicAuthHeaderValue("joe", new SecureString("s3krit2"));
+        token = basicAuthHeaderValue("joe", new SecureString("s3krit-password2"));
         searchResp = client().filterWithHeader(Collections.singletonMap("Authorization", token)).prepareSearch("idx").get();
         assertEquals(1L, searchResp.getHits().getTotalHits().value);
     }
@@ -307,7 +307,7 @@ public class NativeRealmIntegTests extends NativeRealmIntegTestCase {
     public void testCreateDeleteAuthenticate() {
         SecurityClient c = securityClient();
         logger.error("--> creating user");
-        c.preparePutUser("joe", new SecureString("s3krit".toCharArray()), hasher,
+        c.preparePutUser("joe", new SecureString("s3krit-password".toCharArray()), hasher,
             SecuritySettingsSource.TEST_ROLE).get();
         logger.error("--> waiting for .security index");
         ensureGreen(SECURITY_MAIN_ALIAS);
@@ -320,7 +320,7 @@ public class NativeRealmIntegTests extends NativeRealmIntegTestCase {
         ensureGreen("idx");
         // Index a document with the default test user
         client().prepareIndex("idx", "doc", "1").setSource("body", "foo").setRefreshPolicy(IMMEDIATE).get();
-        String token = basicAuthHeaderValue("joe", new SecureString("s3krit"));
+        String token = basicAuthHeaderValue("joe", new SecureString("s3krit-password"));
         SearchResponse searchResp = client().filterWithHeader(Collections.singletonMap("Authorization", token)).prepareSearch("idx").get();
 
         assertEquals(1L, searchResp.getHits().getTotalHits().value);
@@ -346,12 +346,12 @@ public class NativeRealmIntegTests extends NativeRealmIntegTestCase {
                         new BytesArray("{\"match_all\": {}}"), randomBoolean())
                 .get();
         logger.error("--> creating user");
-        c.preparePutUser("joe", new SecureString("s3krit".toCharArray()), hasher, "test_role").get();
+        c.preparePutUser("joe", new SecureString("s3krit-password".toCharArray()), hasher, "test_role").get();
         logger.error("--> waiting for .security index");
         ensureGreen(SECURITY_MAIN_ALIAS);
 
         if (authenticate) {
-            final String token = basicAuthHeaderValue("joe", new SecureString("s3krit"));
+            final String token = basicAuthHeaderValue("joe", new SecureString("s3krit-password"));
             ClusterHealthResponse response = client().filterWithHeader(Collections.singletonMap("Authorization", token)).admin().cluster()
                     .prepareHealth().get();
             assertFalse(response.isTimedOut());
@@ -396,7 +396,8 @@ public class NativeRealmIntegTests extends NativeRealmIntegTestCase {
                 .addIndices(new String[]{"*"}, new String[]{"create_index"}, null, null, null, true)
                 .get();
         logger.error("--> creating user");
-        securityClient().preparePutUser("joe", new SecureString("s3krit".toCharArray()), hasher, "test_role", "snapshot_user").get();
+        securityClient()
+            .preparePutUser("joe", new SecureString("s3krit-password".toCharArray()), hasher, "test_role", "snapshot_user").get();
         logger.error("--> waiting for .security index");
         ensureGreen(SECURITY_MAIN_ALIAS);
         logger.info("-->  creating repository");
@@ -406,7 +407,7 @@ public class NativeRealmIntegTests extends NativeRealmIntegTestCase {
                             .put("location", randomRepoPath())
                             .put("compress", randomBoolean())
                             .put("chunk_size", randomIntBetween(100, 1000), ByteSizeUnit.BYTES)));
-        final String token = basicAuthHeaderValue("joe", new SecureString("s3krit"));
+        final String token = basicAuthHeaderValue("joe", new SecureString("s3krit-password"));
         // joe can snapshot all indices, including '.security'
         SnapshotInfo snapshotInfo = client().filterWithHeader(Collections.singletonMap("Authorization", token)).admin().cluster()
                 .prepareCreateSnapshot("test-repo", "test-snap-1")
@@ -460,11 +461,11 @@ public class NativeRealmIntegTests extends NativeRealmIntegTestCase {
                 .addIndices(new String[]{"*"}, new String[]{"read"}, new String[]{"body", "title"}, null,
                         new BytesArray("{\"match_all\": {}}"), randomBoolean())
                 .get();
-        c.preparePutUser("joe", new SecureString("s3krit".toCharArray()), hasher, "test_role").get();
+        c.preparePutUser("joe", new SecureString("s3krit-password".toCharArray()), hasher, "test_role").get();
         logger.error("--> waiting for .security index");
         ensureGreen(SECURITY_MAIN_ALIAS);
 
-        final String token = basicAuthHeaderValue("joe", new SecureString("s3krit"));
+        final String token = basicAuthHeaderValue("joe", new SecureString("s3krit-password"));
         ClusterHealthResponse response = client().filterWithHeader(Collections.singletonMap("Authorization", token)).admin().cluster()
                 .prepareHealth().get();
         assertFalse(response.isTimedOut());
@@ -581,7 +582,7 @@ public class NativeRealmIntegTests extends NativeRealmIntegTestCase {
 
         SecurityClient client = securityClient();
         if (randomBoolean()) {
-            client.preparePutUser("joe", new SecureString("s3krit".toCharArray()), hasher,
+            client.preparePutUser("joe", new SecureString("s3krit-password".toCharArray()), hasher,
                 SecuritySettingsSource.TEST_ROLE).get();
         } else {
             client.preparePutRole("read_role")
@@ -613,7 +614,7 @@ public class NativeRealmIntegTests extends NativeRealmIntegTestCase {
                 () -> securityClient().prepareDeleteUser(AnonymousUser.DEFAULT_ANONYMOUS_USERNAME).get());
         assertThat(exception.getMessage(), containsString("user [" + AnonymousUser.DEFAULT_ANONYMOUS_USERNAME + "] is anonymous"));
 
-        final char[] foobar = "foobar".toCharArray();
+        final char[] foobar = "foobar-password".toCharArray();
         exception = expectThrows(IllegalArgumentException.class,
             () -> securityClient().prepareChangePassword(AnonymousUser.DEFAULT_ANONYMOUS_USERNAME, foobar, hasher).get());
         assertThat(exception.getMessage(), containsString("user [" + AnonymousUser.DEFAULT_ANONYMOUS_USERNAME + "] is anonymous"));
@@ -668,9 +669,9 @@ public class NativeRealmIntegTests extends NativeRealmIntegTestCase {
     }
 
     public void testCreateAndChangePassword() throws Exception {
-        securityClient().preparePutUser("joe", new SecureString("s3krit".toCharArray()), hasher,
+        securityClient().preparePutUser("joe", new SecureString("s3krit-password".toCharArray()), hasher,
             SecuritySettingsSource.TEST_ROLE).get();
-        final String token = basicAuthHeaderValue("joe", new SecureString("s3krit"));
+        final String token = basicAuthHeaderValue("joe", new SecureString("s3krit-password"));
         ClusterHealthResponse response = client().filterWithHeader(Collections.singletonMap("Authorization", token))
                 .admin().cluster().prepareHealth().get();
         assertThat(response.isTimedOut(), is(false));
@@ -758,7 +759,7 @@ public class NativeRealmIntegTests extends NativeRealmIntegTestCase {
         final int numNativeUsers = scaledRandomIntBetween(1, 32);
         SecurityClient securityClient = new SecurityClient(client());
         for (int i = 0; i < numNativeUsers; i++) {
-            securityClient.preparePutUser("joe" + i, new SecureString("s3krit".toCharArray()), hasher, "superuser").get();
+            securityClient.preparePutUser("joe" + i, new SecureString("s3krit-password".toCharArray()), hasher, "superuser").get();
         }
 
         XPackUsageResponse response = new XPackUsageRequestBuilder(client()).get();
@@ -777,9 +778,9 @@ public class NativeRealmIntegTests extends NativeRealmIntegTestCase {
     }
 
     public void testSetEnabled() throws Exception {
-        securityClient().preparePutUser("joe", new SecureString("s3krit".toCharArray()), hasher,
+        securityClient().preparePutUser("joe", new SecureString("s3krit-password".toCharArray()), hasher,
             SecuritySettingsSource.TEST_ROLE).get();
-        final String token = basicAuthHeaderValue("joe", new SecureString("s3krit"));
+        final String token = basicAuthHeaderValue("joe", new SecureString("s3krit-password"));
         ClusterHealthResponse response = client().filterWithHeader(Collections.singletonMap("Authorization", token))
                 .admin().cluster().prepareHealth().get();
         assertThat(response.isTimedOut(), is(false));
@@ -802,20 +803,20 @@ public class NativeRealmIntegTests extends NativeRealmIntegTestCase {
 
     public void testNegativeLookupsThenCreateRole() throws Exception {
         SecurityClient securityClient = new SecurityClient(client());
-        securityClient.preparePutUser("joe", new SecureString("s3krit".toCharArray()), hasher, "unknown_role").get();
+        securityClient.preparePutUser("joe", new SecureString("s3krit-password".toCharArray()), hasher, "unknown_role").get();
 
         final int negativeLookups = scaledRandomIntBetween(1, 10);
         for (int i = 0; i < negativeLookups; i++) {
             if (anonymousEnabled && roleExists) {
                 ClusterHealthResponse response = client()
                         .filterWithHeader(Collections.singletonMap("Authorization",
-                                basicAuthHeaderValue("joe", new SecureString("s3krit"))))
+                                basicAuthHeaderValue("joe", new SecureString("s3krit-password"))))
                         .admin().cluster().prepareHealth().get();
                 assertNoTimeout(response);
             } else {
                 ElasticsearchSecurityException e = expectThrows(ElasticsearchSecurityException.class, () -> client()
                         .filterWithHeader(Collections.singletonMap("Authorization",
-                                basicAuthHeaderValue("joe", new SecureString("s3krit"))))
+                                basicAuthHeaderValue("joe", new SecureString("s3krit-password"))))
                         .admin().cluster().prepareHealth().get());
                 assertThat(e.status(), is(RestStatus.FORBIDDEN));
             }
@@ -824,7 +825,7 @@ public class NativeRealmIntegTests extends NativeRealmIntegTestCase {
         securityClient.preparePutRole("unknown_role").cluster("all").get();
         ClusterHealthResponse response = client()
                 .filterWithHeader(Collections.singletonMap("Authorization",
-                        basicAuthHeaderValue("joe", new SecureString("s3krit"))))
+                        basicAuthHeaderValue("joe", new SecureString("s3krit-password"))))
                 .admin().cluster().prepareHealth().get();
         assertNoTimeout(response);
     }
@@ -838,9 +839,10 @@ public class NativeRealmIntegTests extends NativeRealmIntegTestCase {
      * the loader returned a null value, while the other caller(s) would get a null value unexpectedly
      */
     public void testConcurrentRunAs() throws Exception {
-        securityClient().preparePutUser("joe", new SecureString("s3krit".toCharArray()), hasher, SecuritySettingsSource.TEST_ROLE).get();
-        securityClient().preparePutUser("executor", new SecureString("s3krit".toCharArray()), hasher, "superuser").get();
-        final String token = basicAuthHeaderValue("executor", new SecureString("s3krit"));
+        securityClient()
+            .preparePutUser("joe", new SecureString("s3krit-password".toCharArray()), hasher, SecuritySettingsSource.TEST_ROLE).get();
+        securityClient().preparePutUser("executor", new SecureString("s3krit-password".toCharArray()), hasher, "superuser").get();
+        final String token = basicAuthHeaderValue("executor", new SecureString("s3krit-password"));
         final Client client = client().filterWithHeader(MapBuilder.<String, String>newMapBuilder()
                 .put("Authorization", token)
                 .put("es-security-runas-user", "joe")

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/pki/PkiAuthDelegationIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/pki/PkiAuthDelegationIntegTests.java
@@ -76,8 +76,8 @@ public class PkiAuthDelegationIntegTests extends SecurityIntegTestCase {
 
     @Override
     protected String configUsers() {
-        final String usersPasswdHashed = new String(Hasher.resolve(
-            randomFrom("pbkdf2", "pbkdf2_1000", "bcrypt", "bcrypt9")).hash(SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING));
+        final Hasher passwdHasher = getFastStoredHashAlgoForTests();
+        final String usersPasswdHashed = new String(passwdHasher.hash(SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING));
         return super.configUsers() +
             "user_manage:" + usersPasswdHashed + "\n" +
             "user_manage_security:" + usersPasswdHashed + "\n" +

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authz/AnalyzeTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authz/AnalyzeTests.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.security.authz;
 import org.elasticsearch.action.admin.indices.analyze.AnalyzeAction;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.test.SecurityIntegTestCase;
+import org.elasticsearch.test.SecuritySettingsSourceField;
 
 import java.util.Collections;
 
@@ -19,8 +20,8 @@ public class AnalyzeTests extends SecurityIntegTestCase {
 
     @Override
     protected String configUsers() {
-        final String usersPasswdHashed = new String(getFastStoredHashAlgoForTests().hash(new SecureString
-            ("test123".toCharArray())));
+        final String usersPasswdHashed =
+            new String(getFastStoredHashAlgoForTests().hash(SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING));
         return super.configUsers() +
             "analyze_indices:" + usersPasswdHashed + "\n" +
             "analyze_cluster:" + usersPasswdHashed + "\n";
@@ -54,7 +55,7 @@ public class AnalyzeTests extends SecurityIntegTestCase {
         ensureGreen();
 
         //ok: user has permissions for analyze on test_*
-        SecureString passwd = new SecureString("test123".toCharArray());
+        SecureString passwd = SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING;
         client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("analyze_indices", passwd)))
                 .admin().indices().prepareAnalyze("this is my text").setIndex("test_1").setAnalyzer("standard").get();
 
@@ -74,7 +75,7 @@ public class AnalyzeTests extends SecurityIntegTestCase {
     public void testAnalyzeWithoutIndices() {
         //this test tries to execute different analyze api variants from a user that has analyze privileges only at cluster level
 
-        SecureString passwd = new SecureString("test123".toCharArray());
+        SecureString passwd = SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING;
         //fails: user doesn't have permissions for analyze on index test_1
         assertThrowsAuthorizationException(client().filterWithHeader(
                 Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("analyze_cluster", passwd)))

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authz/IndexAliasesTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authz/IndexAliasesTests.java
@@ -14,11 +14,11 @@ import org.elasticsearch.action.admin.indices.alias.get.GetAliasesResponse;
 import org.elasticsearch.action.admin.indices.create.CreateIndexAction;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.Client;
-import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.rest.action.admin.indices.AliasesNotFoundException;
 import org.elasticsearch.test.SecurityIntegTestCase;
+import org.elasticsearch.test.SecuritySettingsSourceField;
 import org.hamcrest.Matchers;
 import org.junit.Before;
 
@@ -38,8 +38,8 @@ public class IndexAliasesTests extends SecurityIntegTestCase {
 
     @Override
     protected String configUsers() {
-        final String usersPasswdHashed = new String(getFastStoredHashAlgoForTests().hash(new SecureString
-            ("test123".toCharArray())));
+        final String usersPasswdHashed =
+            new String(getFastStoredHashAlgoForTests().hash(SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING));
         return super.configUsers() +
             "create_only:" + usersPasswdHashed + "\n" +
             "all_on_test:" + usersPasswdHashed + "\n" +
@@ -108,7 +108,7 @@ public class IndexAliasesTests extends SecurityIntegTestCase {
     public void testCreateIndexThenAliasesCreateOnlyPermission() {
         //user has create permission only: allows to create indices, manage_aliases is required to add/remove aliases
         Map<String, String> headers = Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("create_only",
-                new SecureString("test123".toCharArray())));
+            SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING));
         final Client client = client().filterWithHeader(headers);
         assertAcked(client.admin().indices().prepareCreate("test_1").get());
 
@@ -124,7 +124,7 @@ public class IndexAliasesTests extends SecurityIntegTestCase {
         //user has create permission only: allows to create indices, manage_aliases is required to add aliases although they are part of
         // the same create index request
         Map<String, String> headers = Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("create_only",
-                new SecureString("test123".toCharArray())));
+            SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING));
 
         assertThrowsAuthorizationException(
                 client(headers).admin().indices().prepareCreate("test_1").addAlias(new Alias("test_2"))::get,
@@ -134,7 +134,7 @@ public class IndexAliasesTests extends SecurityIntegTestCase {
     public void testDeleteAliasesCreateOnlyPermission() {
         //user has create permission only: allows to create indices, manage_aliases is required to add/remove aliases
         Map<String, String> headers = Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("create_only",
-                new SecureString("test123".toCharArray())));
+            SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING));
         final Client client = client().filterWithHeader(headers);
 
         assertThrowsAuthorizationException(
@@ -151,7 +151,7 @@ public class IndexAliasesTests extends SecurityIntegTestCase {
     public void testGetAliasesCreateOnlyPermissionStrict() {
         //user has create permission only: allows to create indices, manage_aliases is required to retrieve aliases though
         Map<String, String> headers = Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("create_only",
-                new SecureString("test123".toCharArray())));
+            SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING));
         final Client client = client().filterWithHeader(headers);
 
         assertThrowsAuthorizationException(client.admin().indices().prepareGetAliases("test_1")
@@ -177,7 +177,7 @@ public class IndexAliasesTests extends SecurityIntegTestCase {
     public void testGetAliasesCreateOnlyPermissionIgnoreUnavailable() {
         //user has create permission only: allows to create indices, manage_aliases is required to retrieve aliases though
         Map<String, String> headers = Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("create_only",
-                new SecureString("test123".toCharArray())));
+            SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING));
         final Client client = client().filterWithHeader(headers);
 
         assertThrowsAuthorizationException(client.admin().indices().prepareGetAliases("test_1")
@@ -209,7 +209,7 @@ public class IndexAliasesTests extends SecurityIntegTestCase {
         //user has create and manage_aliases permission on test_*. manage_aliases is required to add/remove aliases on both aliases and
         // indices
         Map<String, String> headers = Collections.singletonMap(BASIC_AUTH_HEADER,
-                basicAuthHeaderValue("create_test_aliases_test", new SecureString("test123".toCharArray())));
+            basicAuthHeaderValue("create_test_aliases_test", SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING));
         final Client client = client().filterWithHeader(headers);
 
         assertAcked(client.admin().indices().prepareCreate("test_1").get());
@@ -231,7 +231,7 @@ public class IndexAliasesTests extends SecurityIntegTestCase {
         // indices
         //ok: user has manage_aliases on test_*
         Map<String, String> headers = Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("create_test_aliases_test",
-                new SecureString("test123".toCharArray())));
+            SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING));
         final Client client = client(headers);
 
         assertAcked(client.admin().indices().prepareCreate("test_1").addAlias(new Alias("test_alias")).get());
@@ -247,7 +247,7 @@ public class IndexAliasesTests extends SecurityIntegTestCase {
         // indices
         //ok: user has manage_aliases on test_*
         Map<String, String> headers = Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("create_test_aliases_test",
-                new SecureString("test123".toCharArray())));
+            SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING));
         final Client client = client(headers);
 
         assertAcked(client.admin().indices().prepareCreate("test_1").addAlias(new Alias("test_alias_1"))
@@ -297,7 +297,7 @@ public class IndexAliasesTests extends SecurityIntegTestCase {
         //user has create and manage_aliases permission on test_*. manage_aliases is required to retrieve aliases on both aliases and
         // indices
         Map<String, String> headers = Collections.singletonMap(BASIC_AUTH_HEADER,
-                basicAuthHeaderValue("create_test_aliases_test", new SecureString("test123".toCharArray())));
+            basicAuthHeaderValue("create_test_aliases_test", SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING));
         final Client client = client(headers);
         assertAcked(client.admin().indices().prepareCreate("test_1").addAlias(new Alias("test_alias")).get());
 
@@ -348,7 +348,7 @@ public class IndexAliasesTests extends SecurityIntegTestCase {
 
     public void testCreateIndexThenAliasesCreateAndAliasesPermission2() {
         Map<String, String> headers = Collections.singletonMap(BASIC_AUTH_HEADER,
-                basicAuthHeaderValue("create_test_aliases_alias", new SecureString("test123".toCharArray())));
+            basicAuthHeaderValue("create_test_aliases_alias", SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING));
         final Client client = client(headers);
 
         //user has create permission on test_* and manage_aliases permission on alias_*. manage_aliases is required to add/remove aliases
@@ -371,8 +371,7 @@ public class IndexAliasesTests extends SecurityIntegTestCase {
 
     public void testCreateIndexAndAliasesCreateAndAliasesPermission2() {
         Map<String, String> headers = Collections.singletonMap(BASIC_AUTH_HEADER,
-                basicAuthHeaderValue("create_test_aliases_alias", new
-                SecureString("test123".toCharArray())));
+            basicAuthHeaderValue("create_test_aliases_alias", SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING));
         final Client client = client(headers);
 
         //user has create permission on test_* and manage_aliases permission on alias_*. manage_aliases is required to add/remove aliases
@@ -385,7 +384,7 @@ public class IndexAliasesTests extends SecurityIntegTestCase {
 
     public void testDeleteAliasesCreateAndAliasesPermission2() {
         Map<String, String> headers = Collections.singletonMap(BASIC_AUTH_HEADER,
-                basicAuthHeaderValue("create_test_aliases_alias", new SecureString("test123".toCharArray())));
+            basicAuthHeaderValue("create_test_aliases_alias", SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING));
         final Client client = client(headers);
 
         //user has create permission on test_* and manage_aliases permission on alias_*. manage_aliases is required to add/remove aliases
@@ -401,7 +400,7 @@ public class IndexAliasesTests extends SecurityIntegTestCase {
 
     public void testGetAliasesCreateAndAliasesPermission2() {
         Map<String, String> headers = Collections.singletonMap(BASIC_AUTH_HEADER,
-                basicAuthHeaderValue("create_test_aliases_alias", new SecureString("test123".toCharArray())));
+            basicAuthHeaderValue("create_test_aliases_alias", SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING));
         final Client client = client(headers);
 
         //user has create permission on test_* and manage_aliases permission on alias_*. manage_aliases is required to retrieve aliases
@@ -446,7 +445,7 @@ public class IndexAliasesTests extends SecurityIntegTestCase {
 
     public void testCreateIndexThenAliasesCreateAndAliasesPermission3() {
         Map<String, String> headers = Collections.singletonMap(BASIC_AUTH_HEADER,
-                basicAuthHeaderValue("create_test_aliases_test_alias", new SecureString("test123".toCharArray())));
+            basicAuthHeaderValue("create_test_aliases_test_alias", SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING));
         final Client client = client(headers);
 
         //user has create permission on test_* and manage_aliases permission on test_*,alias_*. All good.
@@ -461,7 +460,7 @@ public class IndexAliasesTests extends SecurityIntegTestCase {
 
     public void testCreateIndexAndAliasesCreateAndAliasesPermission3() {
         Map<String, String> headers = Collections.singletonMap(BASIC_AUTH_HEADER,
-                basicAuthHeaderValue("create_test_aliases_test_alias", new SecureString("test123".toCharArray())));
+            basicAuthHeaderValue("create_test_aliases_test_alias", SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING));
         final Client client = client(headers);
 
         //user has create permission on test_* and manage_aliases permission on test_*,alias_*. All good.
@@ -472,7 +471,7 @@ public class IndexAliasesTests extends SecurityIntegTestCase {
 
     public void testDeleteAliasesCreateAndAliasesPermission3() {
         Map<String, String> headers = Collections.singletonMap(BASIC_AUTH_HEADER,
-                basicAuthHeaderValue("create_test_aliases_test_alias", new SecureString("test123".toCharArray())));
+            basicAuthHeaderValue("create_test_aliases_test_alias", SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING));
         final Client client = client(headers);
 
         //user has create permission on test_* and manage_aliases permission on test_*,alias_*. All good.
@@ -495,7 +494,7 @@ public class IndexAliasesTests extends SecurityIntegTestCase {
 
     public void testGetAliasesCreateAndAliasesPermission3() {
         Map<String, String> headers = Collections.singletonMap(BASIC_AUTH_HEADER,
-                basicAuthHeaderValue("create_test_aliases_test_alias", new SecureString("test123".toCharArray())));
+            basicAuthHeaderValue("create_test_aliases_test_alias", SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING));
         final Client client = client(headers);
 
         //user has create permission on test_* and manage_aliases permission on test_*,alias_*. All good.
@@ -530,13 +529,13 @@ public class IndexAliasesTests extends SecurityIntegTestCase {
 
     public void testCreateIndexAliasesOnlyPermission() {
         assertThrowsAuthorizationException(client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER,
-                basicAuthHeaderValue("aliases_only", new SecureString("test123".toCharArray()))))
+            basicAuthHeaderValue("aliases_only", SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING)))
                 .admin().indices().prepareCreate("test_1")::get, CreateIndexAction.NAME, "aliases_only");
     }
 
     public void testGetAliasesAliasesOnlyPermissionStrict() {
         Map<String, String> headers = Collections.singletonMap(BASIC_AUTH_HEADER,
-                basicAuthHeaderValue("aliases_only", new SecureString("test123".toCharArray())));
+            basicAuthHeaderValue("aliases_only", SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING));
         final Client client = client(headers);
         //user has manage_aliases only permissions on both alias_* and test_*
 
@@ -556,7 +555,7 @@ public class IndexAliasesTests extends SecurityIntegTestCase {
 
     public void testGetAliasesAliasesOnlyPermissionIgnoreUnavailable() {
         Map<String, String> headers = Collections.singletonMap(BASIC_AUTH_HEADER,
-                basicAuthHeaderValue("aliases_only", new SecureString("test123".toCharArray())));
+            basicAuthHeaderValue("aliases_only", SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING));
         final Client client = client(headers);
         //user has manage_aliases only permissions on both alias_* and test_*
 
@@ -579,7 +578,7 @@ public class IndexAliasesTests extends SecurityIntegTestCase {
     public void testRemoveIndex() {
         final Map<String, String> headers = Collections.singletonMap(
             BASIC_AUTH_HEADER,
-            basicAuthHeaderValue("all_on_test", new SecureString("test123".toCharArray())));
+            basicAuthHeaderValue("all_on_test", SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING));
         final Client client = client(headers);
 
         assertAcked(client.admin().indices().prepareCreate("test_delete_1").get());
@@ -601,11 +600,11 @@ public class IndexAliasesTests extends SecurityIntegTestCase {
         final String hiddenAlias = "alias_hidden";
 
         final Map<String, String> createHeaders = Collections.singletonMap(
-            BASIC_AUTH_HEADER, basicAuthHeaderValue("all_on_test", new SecureString("test123".toCharArray())));
+            BASIC_AUTH_HEADER, basicAuthHeaderValue("all_on_test", SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING));
         final Client createClient = client(createHeaders);
 
         final Map<String, String> aliasHeaders = Collections.singletonMap(
-            BASIC_AUTH_HEADER, basicAuthHeaderValue("aliases_only", new SecureString("test123".toCharArray())));
+            BASIC_AUTH_HEADER, basicAuthHeaderValue("aliases_only", SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING));
         final Client aliasesClient = client(aliasHeaders);
 
         assertAcked(createClient.admin().indices().prepareCreate(hiddenIndex)

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authz/store/NativePrivilegeStoreCacheTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authz/store/NativePrivilegeStoreCacheTests.java
@@ -266,18 +266,17 @@ public class NativePrivilegeStoreCacheTests extends SecuritySingleNodeTestCase {
             .addIndices(new String[] { "*" }, new String[] { "read" }, null, null, null, false)
             .get();
         assertTrue(putRoleResponse.isCreated());
-
+        final Hasher hasher = getFastStoredHashAlgoForTests();
         final PutUserResponse putUserResponse = new PutUserRequestBuilder(client)
             .username(testRoleCacheUser)
             .roles(testRole)
-            .password(new SecureString("password".toCharArray()),
-                Hasher.resolve(randomFrom("pbkdf2", "pbkdf2_1000", "bcrypt9", "bcrypt8", "bcrypt")))
+            .password(new SecureString("longerpassword".toCharArray()), hasher)
             .get();
         assertTrue(putUserResponse.created());
 
         // The created user can access cluster health because its role grants access
         final Client testRoleCacheUserClient = client.filterWithHeader(singletonMap("Authorization",
-                "Basic " + Base64.getEncoder().encodeToString((testRoleCacheUser + ":password").getBytes(StandardCharsets.UTF_8))));
+            "Basic " + Base64.getEncoder().encodeToString((testRoleCacheUser + ":longerpassword").getBytes(StandardCharsets.UTF_8))));
         new ClusterHealthRequestBuilder(testRoleCacheUserClient, ClusterHealthAction.INSTANCE).get();
 
         // Directly deleted the role document

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/support/SecurityIndexManagerIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/support/SecurityIndexManagerIntegTests.java
@@ -46,7 +46,7 @@ public class SecurityIndexManagerIntegTests extends SecurityIntegTestCase {
                 @Override
                 protected void doRun() throws Exception {
                     final List<PutUserRequest> requests = new ArrayList<>(numRequests);
-                    final SecureString password = new SecureString("password".toCharArray());
+                    final SecureString password = new SecureString("test-user-password".toCharArray());
                     for (int i = 0; i < numRequests; i++) {
                         requests.add(securityClient()
                                 .preparePutUser("user" + userNumber.getAndIncrement(), password,

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/test/SecurityIntegTestCase.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/test/SecurityIntegTestCase.java
@@ -538,8 +538,9 @@ public abstract class SecurityIntegTestCase extends ESIntegTestCase {
         return customSecuritySettingsSource.isSslEnabled();
     }
 
-    protected static Hasher getFastStoredHashAlgoForTests() {
-        return Hasher.resolve(randomFrom("pbkdf2", "pbkdf2_1000", "bcrypt", "bcrypt9"));
+    public static Hasher getFastStoredHashAlgoForTests() {
+        return inFipsJvm() ? Hasher.resolve(randomFrom("pbkdf2", "pbkdf2_1000", "pbkdf2_stretch_1000", "pbkdf2_stretch"))
+            : Hasher.resolve(randomFrom("pbkdf2", "pbkdf2_1000", "pbkdf2_stretch_1000", "pbkdf2_stretch", "bcrypt", "bcrypt9"));
     }
 
     protected class TestRestHighLevelClient extends RestHighLevelClient {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/test/SecuritySettingsSource.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/test/SecuritySettingsSource.java
@@ -46,7 +46,8 @@ import java.util.function.Consumer;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.randomBoolean;
 import static org.apache.lucene.util.LuceneTestCase.createTempFile;
 import static org.elasticsearch.test.ESTestCase.inFipsJvm;
-import static org.elasticsearch.test.ESTestCase.randomFrom;
+import static org.elasticsearch.test.SecurityIntegTestCase.getFastStoredHashAlgoForTests;
+import static org.elasticsearch.test.SecuritySettingsSourceField.TEST_PASSWORD;
 import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.basicAuthHeaderValue;
 import static org.elasticsearch.xpack.security.test.SecurityTestUtils.writeFile;
 
@@ -58,9 +59,9 @@ import static org.elasticsearch.xpack.security.test.SecurityTestUtils.writeFile;
 public class SecuritySettingsSource extends NodeConfigurationSource {
 
     public static final String TEST_USER_NAME = "test_user";
+    public static final Hasher HASHER = getFastStoredHashAlgoForTests();
     public static final String TEST_PASSWORD_HASHED =
-        new String(Hasher.resolve(randomFrom("pbkdf2", "pbkdf2_1000", "bcrypt9", "bcrypt8", "bcrypt")).
-            hash(new SecureString(SecuritySettingsSourceField.TEST_PASSWORD.toCharArray())));
+        new String(HASHER.hash(new SecureString(TEST_PASSWORD.toCharArray())));
     public static final RequestOptions SECURITY_REQUEST_OPTIONS = RequestOptions.DEFAULT.toBuilder()
         .addHeader("Authorization",
             "Basic " + Base64.getEncoder().encodeToString(

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/user/PutUserRequestBuilderTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/user/PutUserRequestBuilderTests.java
@@ -23,6 +23,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 
+import static org.elasticsearch.test.SecurityIntegTestCase.getFastStoredHashAlgoForTests;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -144,8 +145,8 @@ public class PutUserRequestBuilderTests extends ESTestCase {
     }
 
     public void testWithValidPasswordHash() throws IOException {
-        final Hasher hasher = Hasher.BCRYPT4; // this is the fastest hasher we officially support
-        final char[] hash = hasher.hash(new SecureString("secret".toCharArray()));
+        final Hasher hasher = getFastStoredHashAlgoForTests();
+        final char[] hash = hasher.hash(new SecureString("secretpassword".toCharArray()));
         final String json = "{\n" +
             "    \"password_hash\": \"" + new String(hash) + "\"," +
             "    \"roles\": []\n" +
@@ -158,10 +159,13 @@ public class PutUserRequestBuilderTests extends ESTestCase {
         assertThat(request.username(), equalTo("hash_user"));
     }
 
-    public void testWithMismatchedPasswordHash() throws IOException {
-        final Hasher systemHasher = Hasher.BCRYPT8;
-        final Hasher userHasher = Hasher.BCRYPT4; // this is the fastest hasher we officially support
-        final char[] hash = userHasher.hash(new SecureString("secret".toCharArray()));
+    public void testWithMismatchedPasswordHashingAlgorithm() throws IOException {
+        final Hasher systemHasher = getFastStoredHashAlgoForTests();
+        Hasher userHasher = getFastStoredHashAlgoForTests();
+        while (userHasher.name().equals(systemHasher.name())){
+            userHasher = getFastStoredHashAlgoForTests();
+        }
+        final char[] hash = userHasher.hash(new SecureString("secretpassword".toCharArray()));
         final String json = "{\n" +
             "    \"password_hash\": \"" + new String(hash) + "\"," +
             "    \"roles\": []\n" +
@@ -191,8 +195,8 @@ public class PutUserRequestBuilderTests extends ESTestCase {
     }
 
     public void testWithBothPasswordAndHash() throws IOException {
-        final Hasher hasher = randomFrom(Hasher.BCRYPT4, Hasher.PBKDF2_1000);
-        final String password = randomAlphaOfLength(12);
+        final Hasher hasher = getFastStoredHashAlgoForTests();
+        final String password = randomAlphaOfLength(14);
         final char[] hash = hasher.hash(new SecureString(password.toCharArray()));
         final LinkedHashMap<String, Object> fields = new LinkedHashMap<>();
         fields.put("password", password);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/user/TransportPutUserActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/user/TransportPutUserActionTests.java
@@ -38,6 +38,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.elasticsearch.test.SecurityIntegTestCase.getFastStoredHashAlgoForTests;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
@@ -167,9 +168,9 @@ public class TransportPutUserActionTests extends ESTestCase {
         final boolean isCreate = randomBoolean();
         final PutUserRequest request = new PutUserRequest();
         request.username(user.principal());
+        final Hasher hasher = getFastStoredHashAlgoForTests();
         if (isCreate) {
-            request.passwordHash(Hasher.resolve(
-                randomFrom("pbkdf2", "pbkdf2_1000", "bcrypt", "bcrypt9")).hash(SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING));
+            request.passwordHash(hasher.hash(SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING));
         }
         final boolean created = isCreate ? randomBoolean() : false; // updates should always return false for create
         doAnswer(new Answer() {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
@@ -86,6 +86,7 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.test.SecurityIntegTestCase.getFastStoredHashAlgoForTests;
 import static org.elasticsearch.test.TestMatchers.throwableWithMessage;
 import static org.elasticsearch.xpack.core.security.authc.AuthenticationField.API_KEY_LIMITED_ROLE_DESCRIPTORS_KEY;
 import static org.elasticsearch.xpack.core.security.authc.AuthenticationField.API_KEY_ROLE_DESCRIPTORS_KEY;
@@ -393,7 +394,7 @@ public class ApiKeyServiceTests extends ESTestCase {
 
     public void testValidateApiKey() throws Exception {
         final String apiKey = randomAlphaOfLength(16);
-        Hasher hasher = randomFrom(Hasher.PBKDF2, Hasher.BCRYPT4, Hasher.BCRYPT);
+        Hasher hasher = getFastStoredHashAlgoForTests();
         final char[] hash = hasher.hash(new SecureString(apiKey.toCharArray()));
 
         ApiKeyDoc apiKeyDoc = buildApiKeyDoc(hash, -1, false);
@@ -602,7 +603,7 @@ public class ApiKeyServiceTests extends ESTestCase {
 
     public void testApiKeyCache() {
         final String apiKey = randomAlphaOfLength(16);
-        Hasher hasher = randomFrom(Hasher.PBKDF2, Hasher.BCRYPT4, Hasher.BCRYPT);
+        Hasher hasher = getFastStoredHashAlgoForTests();
         final char[] hash = hasher.hash(new SecureString(apiKey.toCharArray()));
 
         ApiKeyDoc apiKeyDoc = buildApiKeyDoc(hash, -1, false);
@@ -617,7 +618,7 @@ public class ApiKeyServiceTests extends ESTestCase {
         assertNotNull(cachedApiKeyHashResult);
         assertThat(cachedApiKeyHashResult.success, is(true));
 
-        creds = new ApiKeyCredentials(creds.getId(), new SecureString("foobar".toCharArray()));
+        creds = new ApiKeyCredentials(creds.getId(), new SecureString("somelongenoughrandomstring".toCharArray()));
         future = new PlainActionFuture<>();
         service.validateApiKeyCredentials(creds.getId(), apiKeyDoc, creds, Clock.systemUTC(), future);
         result = future.actionGet();
@@ -626,8 +627,8 @@ public class ApiKeyServiceTests extends ESTestCase {
         assertNotNull(shouldBeSame);
         assertThat(shouldBeSame, sameInstance(cachedApiKeyHashResult));
 
-        apiKeyDoc = buildApiKeyDoc(hasher.hash(new SecureString("foobar".toCharArray())), -1, false);
-        creds = new ApiKeyCredentials(randomAlphaOfLength(12), new SecureString("foobar1".toCharArray()));
+        apiKeyDoc = buildApiKeyDoc(hasher.hash(new SecureString("somelongenoughrandomstring".toCharArray())), -1, false);
+        creds = new ApiKeyCredentials(randomAlphaOfLength(12), new SecureString("otherlongenoughrandomstring".toCharArray()));
         future = new PlainActionFuture<>();
         service.validateApiKeyCredentials(creds.getId(), apiKeyDoc, creds, Clock.systemUTC(), future);
         result = future.actionGet();
@@ -636,7 +637,7 @@ public class ApiKeyServiceTests extends ESTestCase {
         assertNotNull(cachedApiKeyHashResult);
         assertThat(cachedApiKeyHashResult.success, is(false));
 
-        creds = new ApiKeyCredentials(creds.getId(), new SecureString("foobar2".toCharArray()));
+        creds = new ApiKeyCredentials(creds.getId(), new SecureString("otherlongenoughrandomstring2".toCharArray()));
         future = new PlainActionFuture<>();
         service.validateApiKeyCredentials(creds.getId(), apiKeyDoc, creds, Clock.systemUTC(), future);
         result = future.actionGet();
@@ -644,7 +645,7 @@ public class ApiKeyServiceTests extends ESTestCase {
         assertThat(service.getFromCache(creds.getId()), not(sameInstance(cachedApiKeyHashResult)));
         assertThat(service.getFromCache(creds.getId()).success, is(false));
 
-        creds = new ApiKeyCredentials(creds.getId(), new SecureString("foobar".toCharArray()));
+        creds = new ApiKeyCredentials(creds.getId(), new SecureString("somelongenoughrandomstring".toCharArray()));
         future = new PlainActionFuture<>();
         service.validateApiKeyCredentials(creds.getId(), apiKeyDoc, creds, Clock.systemUTC(), future);
         result = future.actionGet();
@@ -655,7 +656,7 @@ public class ApiKeyServiceTests extends ESTestCase {
 
     public void testAuthenticateWhileCacheBeingPopulated() throws Exception {
         final String apiKey = randomAlphaOfLength(16);
-        Hasher hasher = randomFrom(Hasher.PBKDF2, Hasher.BCRYPT4, Hasher.BCRYPT);
+        Hasher hasher = getFastStoredHashAlgoForTests();
         final char[] hash = hasher.hash(new SecureString(apiKey.toCharArray()));
 
         Map<String, Object> sourceMap = buildApiKeySourceDoc(hash);
@@ -713,7 +714,7 @@ public class ApiKeyServiceTests extends ESTestCase {
 
     public void testApiKeyCacheDisabled() {
         final String apiKey = randomAlphaOfLength(16);
-        Hasher hasher = randomFrom(Hasher.PBKDF2, Hasher.BCRYPT4, Hasher.BCRYPT);
+        Hasher hasher = getFastStoredHashAlgoForTests();
         final char[] hash = hasher.hash(new SecureString(apiKey.toCharArray()));
         final Settings settings = Settings.builder()
             .put(ApiKeyService.CACHE_TTL_SETTING.getKey(), "0s")
@@ -735,7 +736,7 @@ public class ApiKeyServiceTests extends ESTestCase {
 
     public void testApiKeyDocCacheCanBeDisabledSeparately() {
         final String apiKey = randomAlphaOfLength(16);
-        Hasher hasher = randomFrom(Hasher.PBKDF2, Hasher.BCRYPT4, Hasher.BCRYPT);
+        Hasher hasher = getFastStoredHashAlgoForTests();
         final char[] hash = hasher.hash(new SecureString(apiKey.toCharArray()));
         final Settings settings = Settings.builder()
             .put(ApiKeyService.DOC_CACHE_TTL_SETTING.getKey(), "0s")
@@ -873,7 +874,7 @@ public class ApiKeyServiceTests extends ESTestCase {
         final ApiKeyCredentials creds = new ApiKeyCredentials(randomAlphaOfLength(12), new SecureString(apiKey.toCharArray()));
         writeCredentialsToThreadContext(creds);
 
-        Hasher hasher = randomFrom(Hasher.PBKDF2, Hasher.BCRYPT4, Hasher.BCRYPT);
+        Hasher hasher = getFastStoredHashAlgoForTests();
         final char[] hash = hasher.hash(new SecureString(apiKey.toCharArray()));
         Map<String, Object> sourceMap = buildApiKeySourceDoc(hash);
         mockSourceDocument(creds.getId(), sourceMap);
@@ -898,7 +899,7 @@ public class ApiKeyServiceTests extends ESTestCase {
         final ApiKeyCredentials creds = new ApiKeyCredentials(randomAlphaOfLength(12), new SecureString(apiKey1.toCharArray()));
         writeCredentialsToThreadContext(creds);
 
-        Hasher hasher = randomFrom(Hasher.PBKDF2, Hasher.BCRYPT4, Hasher.BCRYPT);
+        Hasher hasher = getFastStoredHashAlgoForTests();
         final char[] hash = hasher.hash(new SecureString(apiKey1.toCharArray()));
         Map<String, Object> sourceMap = buildApiKeySourceDoc(hash);
         mockSourceDocument(creds.getId(), sourceMap);
@@ -995,15 +996,16 @@ public class ApiKeyServiceTests extends ESTestCase {
                                                                 Set<RoleDescriptor> userRoles,
                                                                 List<RoleDescriptor> keyRoles,
                                                                 Version version) throws Exception {
-            XContentBuilder keyDocSource = apiKeyService.newDocument(new SecureString("secret".toCharArray()), "test", authentication,
-                    userRoles, Instant.now(), Instant.now().plus(Duration.ofSeconds(3600)), keyRoles, Version.CURRENT);
+            XContentBuilder keyDocSource = apiKeyService.newDocument(
+                new SecureString(randomAlphaOfLength(16).toCharArray()), "test", authentication,
+                userRoles, Instant.now(), Instant.now().plus(Duration.ofSeconds(3600)), keyRoles, Version.CURRENT);
             final ApiKeyDoc apiKeyDoc = ApiKeyDoc.fromXContent(
                 XContentHelper.createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE,
                     BytesReference.bytes(keyDocSource), XContentType.JSON));
             PlainActionFuture<AuthenticationResult> authenticationResultFuture = PlainActionFuture.newFuture();
             apiKeyService.validateApiKeyExpiration(apiKeyDoc, new ApiKeyService.ApiKeyCredentials("id",
-                            new SecureString("pass".toCharArray())),
-                    Clock.systemUTC(), authenticationResultFuture);
+                    new SecureString(randomAlphaOfLength(16).toCharArray())),
+                Clock.systemUTC(), authenticationResultFuture);
 
             AuthenticationResult authenticationResult = authenticationResultFuture.get();
             if (randomBoolean()) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/file/FileRealmTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/file/FileRealmTests.java
@@ -25,6 +25,7 @@ import org.mockito.stubbing.Answer;
 import java.util.Map;
 import java.util.function.Supplier;
 
+import static org.elasticsearch.test.SecurityIntegTestCase.getFastStoredHashAlgoForTests;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
@@ -60,21 +61,23 @@ public class FileRealmTests extends ESTestCase {
     public void init() throws Exception {
         userPasswdStore = mock(FileUserPasswdStore.class);
         userRolesStore = mock(FileUserRolesStore.class);
-        globalSettings = Settings.builder().put("path.home", createTempDir()).put("xpack.security.authc.password_hashing.algorithm",
-            randomFrom("bcrypt9", "pbkdf2")).build();
+        globalSettings = Settings.builder()
+            .put("path.home", createTempDir())
+            .put("xpack.security.authc.password_hashing.algorithm", getFastStoredHashAlgoForTests().name())
+            .build();
         threadPool = mock(ThreadPool.class);
         threadContext = new ThreadContext(globalSettings);
         when(threadPool.getThreadContext()).thenReturn(threadContext);
     }
 
     public void testAuthenticate() throws Exception {
-        when(userPasswdStore.verifyPassword(eq("user1"), eq(new SecureString("test123")), any(Supplier.class)))
+        when(userPasswdStore.verifyPassword(eq("user1"), eq(new SecureString("longtestpassword")), any(Supplier.class)))
                 .thenAnswer(VERIFY_PASSWORD_ANSWER);
         when(userRolesStore.roles("user1")).thenReturn(new String[] { "role1", "role2" });
         RealmConfig config = getRealmConfig(globalSettings);
         FileRealm realm = new FileRealm(config, userPasswdStore, userRolesStore, threadPool);
         PlainActionFuture<AuthenticationResult> future = new PlainActionFuture<>();
-        realm.authenticate(new UsernamePasswordToken("user1", new SecureString("test123")), future);
+        realm.authenticate(new UsernamePasswordToken("user1", new SecureString("longtestpassword")), future);
         final AuthenticationResult result = future.actionGet();
         assertThat(result.getStatus(), is(AuthenticationResult.Status.SUCCESS));
         User user = result.getUser();
@@ -96,15 +99,15 @@ public class FileRealmTests extends ESTestCase {
             .put(globalSettings)
             .build();
         RealmConfig config = getRealmConfig(settings);
-        when(userPasswdStore.verifyPassword(eq("user1"), eq(new SecureString("test123")), any(Supplier.class)))
+        when(userPasswdStore.verifyPassword(eq("user1"), eq(new SecureString("longtestpassword")), any(Supplier.class)))
                 .thenAnswer(VERIFY_PASSWORD_ANSWER);
         when(userRolesStore.roles("user1")).thenReturn(new String[]{"role1", "role2"});
         FileRealm realm = new FileRealm(config, userPasswdStore, userRolesStore, threadPool);
         PlainActionFuture<AuthenticationResult> future = new PlainActionFuture<>();
-        realm.authenticate(new UsernamePasswordToken("user1", new SecureString("test123")), future);
+        realm.authenticate(new UsernamePasswordToken("user1", new SecureString("longtestpassword")), future);
         User user1 = future.actionGet().getUser();
         future = new PlainActionFuture<>();
-        realm.authenticate(new UsernamePasswordToken("user1", new SecureString("test123")), future);
+        realm.authenticate(new UsernamePasswordToken("user1", new SecureString("longtestpassword")), future);
         User user2 = future.actionGet().getUser();
         assertThat(user1, sameInstance(user2));
     }
@@ -113,56 +116,57 @@ public class FileRealmTests extends ESTestCase {
         RealmConfig config = getRealmConfig(globalSettings);
         userPasswdStore = spy(new UserPasswdStore(config));
         userRolesStore = spy(new UserRolesStore(config));
-        when(userPasswdStore.verifyPassword(eq("user1"), eq(new SecureString("test123")), any(Supplier.class)))
+        when(userPasswdStore.verifyPassword(eq("user1"), eq(new SecureString("longtestpassword")), any(Supplier.class)))
                 .thenAnswer(VERIFY_PASSWORD_ANSWER);
         doReturn(new String[] { "role1", "role2" }).when(userRolesStore).roles("user1");
         FileRealm realm = new FileRealm(config, userPasswdStore, userRolesStore, threadPool);
         PlainActionFuture<AuthenticationResult> future = new PlainActionFuture<>();
-        realm.authenticate(new UsernamePasswordToken("user1", new SecureString("test123")), future);
+        realm.authenticate(new UsernamePasswordToken("user1", new SecureString("longtestpassword")), future);
         User user1 = future.actionGet().getUser();
         future = new PlainActionFuture<>();
-        realm.authenticate(new UsernamePasswordToken("user1", new SecureString("test123")), future);
+        realm.authenticate(new UsernamePasswordToken("user1", new SecureString("longtestpassword")), future);
         User user2 = future.actionGet().getUser();
         assertThat(user1, sameInstance(user2));
 
         userPasswdStore.notifyRefresh();
 
         future = new PlainActionFuture<>();
-        realm.authenticate(new UsernamePasswordToken("user1", new SecureString("test123")), future);
+        realm.authenticate(new UsernamePasswordToken("user1", new SecureString("longtestpassword")), future);
         User user3 = future.actionGet().getUser();
         assertThat(user2, not(sameInstance(user3)));
         future = new PlainActionFuture<>();
-        realm.authenticate(new UsernamePasswordToken("user1", new SecureString("test123")), future);
+        realm.authenticate(new UsernamePasswordToken("user1", new SecureString("longtestpassword")), future);
         User user4 = future.actionGet().getUser();
         assertThat(user3, sameInstance(user4));
 
         userRolesStore.notifyRefresh();
 
         future = new PlainActionFuture<>();
-        realm.authenticate(new UsernamePasswordToken("user1", new SecureString("test123")), future);
+        realm.authenticate(new UsernamePasswordToken("user1", new SecureString("longtestpassword")), future);
         User user5 = future.actionGet().getUser();
         assertThat(user4, not(sameInstance(user5)));
         future = new PlainActionFuture<>();
-        realm.authenticate(new UsernamePasswordToken("user1", new SecureString("test123")), future);
+        realm.authenticate(new UsernamePasswordToken("user1", new SecureString("longtestpassword")), future);
         User user6 = future.actionGet().getUser();
         assertThat(user5, sameInstance(user6));
     }
 
     public void testToken() throws Exception {
         RealmConfig config = getRealmConfig(globalSettings);
-        when(userPasswdStore.verifyPassword(eq("user1"), eq(new SecureString("test123")), any(Supplier.class)))
-                .thenAnswer(VERIFY_PASSWORD_ANSWER);
+        when(userPasswdStore.verifyPassword(eq("user1"), eq(new SecureString("longtestpassword")), any(Supplier.class)))
+            .thenAnswer(VERIFY_PASSWORD_ANSWER);
         when(userRolesStore.roles("user1")).thenReturn(new String[]{"role1", "role2"});
         FileRealm realm = new FileRealm(config, userPasswdStore, userRolesStore, threadPool);
 
         ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
-        UsernamePasswordToken.putTokenHeader(threadContext, new UsernamePasswordToken("user1", new SecureString("test123")));
+        UsernamePasswordToken.putTokenHeader(threadContext,
+            new UsernamePasswordToken("user1", new SecureString("longtestpassword")));
 
         UsernamePasswordToken token = realm.token(threadContext);
         assertThat(token, notNullValue());
         assertThat(token.principal(), equalTo("user1"));
         assertThat(token.credentials(), notNullValue());
-        assertThat(new String(token.credentials().getChars()), equalTo("test123"));
+        assertThat(new String(token.credentials().getChars()), equalTo("longtestpassword"));
     }
 
     public void testLookup() throws Exception {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/file/FileUserPasswdStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/file/FileUserPasswdStoreTests.java
@@ -52,11 +52,12 @@ public class FileUserPasswdStoreTests extends ESTestCase {
 
     @Before
     public void init() {
+        final String hashingAlgorithm = inFipsJvm() ? randomFrom("pbkdf2", "pbkdf2_1000", "pbkdf2_50000", "pbkdf2_stretch") :
+            randomFrom("bcrypt", "bcrypt11", "pbkdf2", "pbkdf2_1000", "pbkdf2_50000", "pbkdf2_stretch");
         settings = Settings.builder()
             .put("resource.reload.interval.high", "100ms")
             .put("path.home", createTempDir())
-            .put("xpack.security.authc.password_hashing.algorithm", randomFrom("bcrypt", "bcrypt11", "pbkdf2", "pbkdf2_1000",
-                "pbkdf2_50000"))
+            .put("xpack.security.authc.password_hashing.algorithm", hashingAlgorithm)
             .build();
         env = TestEnvironment.newEnvironment(settings);
         threadPool = new TestThreadPool("test");
@@ -98,7 +99,8 @@ public class FileUserPasswdStoreTests extends ESTestCase {
             String username = settings.get("xpack.security.authc.password_hashing.algorithm");
             User user = new User(username);
             assertThat(store.userExists(username), is(true));
-            AuthenticationResult result = store.verifyPassword(username, new SecureString("test123"), () -> user);
+            final String password = username.startsWith("pbkdf2") ? "longertestpassword" : "test123";
+            AuthenticationResult result = store.verifyPassword(username, new SecureString(password), () -> user);
             assertThat(result.getStatus(), is(AuthenticationResult.Status.SUCCESS));
             assertThat(result.getUser(), is(user));
 
@@ -112,13 +114,13 @@ public class FileUserPasswdStoreTests extends ESTestCase {
             }
 
             assertThat(store.userExists(username), is(true));
-            result = store.verifyPassword(username, new SecureString("test123"), () -> user);
+            result = store.verifyPassword(username, new SecureString(password), () -> user);
             assertThat(result.getStatus(), is(AuthenticationResult.Status.SUCCESS));
             assertThat(result.getUser(), is(user));
 
             try (BufferedWriter writer = Files.newBufferedWriter(file, StandardCharsets.UTF_8, StandardOpenOption.APPEND)) {
                 writer.newLine();
-                writer.append("foobar:").append(new String(hasher.hash(new SecureString("barfoo"))));
+                writer.append("foobar:").append(new String(hasher.hash(new SecureString("longtestpassword"))));
             }
 
             if (!latch.await(5, TimeUnit.SECONDS)) {
@@ -126,7 +128,7 @@ public class FileUserPasswdStoreTests extends ESTestCase {
             }
 
             assertThat(store.userExists("foobar"), is(true));
-            result = store.verifyPassword("foobar", new SecureString("barfoo"), () -> user);
+            result = store.verifyPassword("foobar", new SecureString("longtestpassword"), () -> user);
             assertThat(result.getStatus(), is(AuthenticationResult.Status.SUCCESS));
             assertThat(result.getUser(), is(user));
         }
@@ -152,7 +154,8 @@ public class FileUserPasswdStoreTests extends ESTestCase {
             //Test users share the hashing algorithm name for convenience
             String username = settings.get("xpack.security.authc.password_hashing.algorithm");
             User user = new User(username);
-            final AuthenticationResult result = store.verifyPassword(username, new SecureString("test123"), () -> user);
+            final String password = username.startsWith("pbkdf2") ? "longertestpassword" : "test123";
+            final AuthenticationResult result = store.verifyPassword(username, new SecureString(password), () -> user);
             assertThat(result.getStatus(), is(AuthenticationResult.Status.SUCCESS));
             assertThat(result.getUser(), is(user));
 
@@ -171,7 +174,7 @@ public class FileUserPasswdStoreTests extends ESTestCase {
         Path path = getDataPath("users");
         Map<String, char[]> users = FileUserPasswdStore.parseFile(path, null, Settings.EMPTY);
         assertThat(users, notNullValue());
-        assertThat(users.size(), is(11));
+        assertThat(users.size(), is(12));
         assertThat(users.get("bcrypt"), notNullValue());
         assertThat(new String(users.get("bcrypt")), equalTo("$2a$05$zxnP0vdREMxnEpkLCDI2OuSaSk/QEKA2.A42iOpI6U2u.RLLOWm1e"));
         assertThat(users.get("bcrypt10"), notNullValue());
@@ -186,13 +189,15 @@ public class FileUserPasswdStoreTests extends ESTestCase {
         assertThat(new String(users.get("sha")), equalTo("{SHA}cojt0Pw//L6ToM8G41aOKFIWh7w="));
         assertThat(users.get("pbkdf2"), notNullValue());
         assertThat(new String(users.get("pbkdf2")),
-            equalTo("{PBKDF2}10000$ekcItXk4jtK2bBjbVk0rZuWRjT0DoQqQJOIfyMeLIxg=$RA2/Nn1jRi8QskRS5IVotCV0FBO6M8DlNXC37GKa/8c="));
+            equalTo("{PBKDF2}10000$NB6kwTrIPrwJJTu+KXiPUkW5bMf1oG2BMzDJLA479Bk=$CvCgHb5UkalUiNPicqMDOzIsnh3ppyz3SZOp+Gjv+hc="));
         assertThat(users.get("pbkdf2_1000"), notNullValue());
         assertThat(new String(users.get("pbkdf2_1000")),
-            equalTo("{PBKDF2}1000$32yPZSShxuKYAl47ip0g6VwbFrD8tvFJuQCoRPGhXC8=$cXAE1BkBXRmkv7pQA7fw4TZ1+rFWS2/nZGeA3kL1Eu8="));
+            equalTo("{PBKDF2}1000$cofpEhehEObS+tNtS8/t9Zpf6UgwqkgkQFct2hhmGWA=$9Qb0S04fkF+Ebz1sGIaB9S6huZAXDihopPc6Z748f3E="));
         assertThat(users.get("pbkdf2_50000"), notNullValue());
         assertThat(new String(users.get("pbkdf2_50000")),
-            equalTo("{PBKDF2}50000$z1CLJt0MEFjkIK5iEfgvfnA6xq7lF25uasspsTKSo5Q=$XxCVLbaKDimOdyWgLCLJiyoiWpA/XDMe/xtVgn1r5Sg="));
+            equalTo("{PBKDF2}50000$riPhBgfrNIpsN91QmF5mQNCwxHfJm0q2XtGt0x5+PRM=$v2j/DD+aFIRrusEeSDUO+eX3IrBPiG+ysgc9y0RDmhs="));
+        assertThat(new String(users.get("pbkdf2_stretch")),
+            equalTo("{PBKDF2_STRETCH}10000$s1y/xv1T1iJxS9BKQ1FkZpSO19dSs6vsGgOb14d+KkU=$PtdgZoRGCSaim033lz/RcEoyhXQ/3WU4E6hfeKGsGes="));
     }
 
     public void testParseFile_Empty() throws Exception {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlMetadataCommandTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlMetadataCommandTests.java
@@ -565,6 +565,7 @@ public class SamlMetadataCommandTests extends SamlTestCase {
     }
 
     public void testDefaultOptionsWithSigningAndMultipleEncryptionKeys() throws Exception {
+        assumeFalse("Can't run in a FIPS JVM, PKCS12 keystores are not usable", inFipsJvm());
         final KeyStoreWrapper usedKeyStore = randomFrom(keyStore, passwordProtectedKeystore);
         final Path dir = createTempDir();
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlRealmTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlRealmTests.java
@@ -433,6 +433,7 @@ public class SamlRealmTests extends SamlTestCase {
     }
 
     public void testCreateEncryptionCredentialFromKeyStore() throws Exception {
+        assumeFalse("Can't run in a FIPS JVM, PKCS12 keystores are not usable", inFipsJvm());
         final Path dir = createTempDir();
         final Settings.Builder builder = Settings.builder()
                 .put(REALM_SETTINGS_PREFIX + ".type", "saml")
@@ -481,6 +482,7 @@ public class SamlRealmTests extends SamlTestCase {
     }
 
     public void testCreateSigningCredentialFromKeyStoreSuccessScenarios() throws Exception {
+        assumeFalse("Can't run in a FIPS JVM, PKCS12 keystores are not usable", inFipsJvm());
         final Path dir = createTempDir();
         final Settings.Builder builder = Settings.builder().put(REALM_SETTINGS_PREFIX + ".type", "saml").put("path.home", dir);
         final Path ksFile = dir.resolve("cred.p12");
@@ -520,6 +522,7 @@ public class SamlRealmTests extends SamlTestCase {
     }
 
     public void testCreateSigningCredentialFromKeyStoreFailureScenarios() throws Exception {
+        assumeFalse("Can't run in a FIPS JVM, PKCS12 keystores are not usable", inFipsJvm());
         final Path dir = createTempDir();
         final Settings.Builder builder = Settings.builder().put(REALM_SETTINGS_PREFIX + ".type", "saml").put("path.home", dir);
         final Path ksFile = dir.resolve("cred.p12");

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlTestCase.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlTestCase.java
@@ -85,13 +85,21 @@ public abstract class SamlTestCase extends ESTestCase {
                 keySize = randomFrom(256, 384);
                 break;
             case "RSA":
-                keySize = randomFrom(1024, 2048, 4096);
+                if (inFipsJvm()) {
+                    keySize = randomFrom(2048, 4096);
+                } else {
+                    keySize = randomFrom(1024, 2048, 4096);
+                }
                 break;
             case "DSA":
-                keySize = randomFrom(1024, 2048, 3072);
+                if (inFipsJvm()) {
+                    keySize = randomFrom(2048, 3072);
+                } else {
+                    keySize = randomFrom(1024, 2048, 3072);
+                }
                 break;
             default:
-                keySize = randomFrom(1024, 2048);
+                keySize = 2048;
         }
         Path keyPath = PathUtils.get(SamlTestCase.class.getResource
                 ("/org/elasticsearch/xpack/security/authc/saml/saml_" + algorithm + "_" + keySize + ".key").toURI());

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/CachingUsernamePasswordRealmTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/CachingUsernamePasswordRealmTests.java
@@ -33,8 +33,10 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyMap;
+import static org.elasticsearch.test.SecurityIntegTestCase.getFastStoredHashAlgoForTests;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -64,7 +66,11 @@ public class CachingUsernamePasswordRealmTests extends ESTestCase {
     }
 
     public void testCacheSettings() {
-        String cachingHashAlgo = randomFrom(Hasher.getAvailableAlgoCacheHash());
+        List<String> availableCacheAlgos = Hasher.getAvailableAlgoCacheHash();
+        if (inFipsJvm()) {
+            availableCacheAlgos = availableCacheAlgos.stream().filter(name -> (name.startsWith("pbkdf2"))).collect(Collectors.toList());
+        }
+        String cachingHashAlgo = randomFrom(availableCacheAlgos);
         int maxUsers = randomIntBetween(10, 100);
         TimeValue ttl = TimeValue.timeValueMinutes(randomIntBetween(10, 20));
         final RealmConfig.RealmIdentifier identifier = new RealmConfig.RealmIdentifier("caching", "test_realm");
@@ -410,7 +416,7 @@ public class CachingUsernamePasswordRealmTests extends ESTestCase {
         final String username = "username";
         final SecureString password = SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING;
         final AtomicInteger authCounter = new AtomicInteger(0);
-        final Hasher pwdHasher = Hasher.resolve(randomFrom("pbkdf2", "pbkdf2_1000", "bcrypt", "bcrypt9"));
+        final Hasher pwdHasher = getFastStoredHashAlgoForTests();
         final String passwordHash = new String(pwdHasher.hash(password));
         RealmConfig config = new RealmConfig(new RealmConfig.RealmIdentifier("caching", "test_realm"), globalSettings,
             TestEnvironment.newEnvironment(globalSettings), new ThreadContext(Settings.EMPTY));
@@ -476,7 +482,7 @@ public class CachingUsernamePasswordRealmTests extends ESTestCase {
         final String username = "username";
         final SecureString password = SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING;
         final AtomicInteger authCounter = new AtomicInteger(0);
-        final Hasher pwdHasher = Hasher.resolve(randomFrom("pbkdf2", "pbkdf2_1000", "bcrypt", "bcrypt9"));
+        final Hasher pwdHasher = getFastStoredHashAlgoForTests();
         final String passwordHash = new String(pwdHasher.hash(password));
         RealmConfig config = new RealmConfig(new RealmConfig.RealmIdentifier("caching", "test_realm"), globalSettings,
             TestEnvironment.newEnvironment(globalSettings), new ThreadContext(Settings.EMPTY));
@@ -484,7 +490,7 @@ public class CachingUsernamePasswordRealmTests extends ESTestCase {
         final int numberOfProcessors = Runtime.getRuntime().availableProcessors();
         final int numberOfThreads = scaledRandomIntBetween((numberOfProcessors + 1) / 2, numberOfProcessors * 3);
         List<Thread> threads = new ArrayList<>(numberOfThreads);
-        final SecureString credsToUse = new SecureString(randomAlphaOfLength(12).toCharArray());
+        final SecureString credsToUse = new SecureString(randomAlphaOfLength(14).toCharArray());
 
         // we use a bunch of different latches here, the first `latch` is used to ensure all threads have been started
         // before they start to execute. The `authWaitLatch` is there to ensure we have all threads waiting on the
@@ -559,7 +565,7 @@ public class CachingUsernamePasswordRealmTests extends ESTestCase {
         final String username = "username";
         final SecureString password = SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING;
         final SecureString randomPassword = new SecureString(randomAlphaOfLength(password.length()).toCharArray());
-        final Hasher localHasher = Hasher.resolve(randomFrom("pbkdf2", "pbkdf2_1000", "bcrypt", "bcrypt9"));
+        final Hasher localHasher = getFastStoredHashAlgoForTests();
         final String passwordHash = new String(localHasher.hash(password));
         RealmConfig config = new RealmConfig(new RealmConfig.RealmIdentifier("caching", "test_realm"), globalSettings,
                 TestEnvironment.newEnvironment(globalSettings), new ThreadContext(Settings.EMPTY));

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/HasherTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/HasherTests.java
@@ -174,7 +174,8 @@ public class HasherTests extends ESTestCase {
     }
 
     private static void testHasherSelfGenerated(Hasher hasher) {
-        SecureString passwd = new SecureString(randomAlphaOfLength(between(6, 15)).toCharArray());
+        //In FIPS 140 mode, passwords for PBKDF2 need to be at least 14 chars
+        SecureString passwd = new SecureString(randomAlphaOfLength(between(14, 18)).toCharArray());
         char[] hash = hasher.hash(passwd);
         assertTrue(hasher.verify(passwd, hash));
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/ssl/SSLErrorMessageFileTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/ssl/SSLErrorMessageFileTests.java
@@ -133,7 +133,11 @@ public class SSLErrorMessageFileTests extends ESTestCase {
         final String prefix = "xpack.security.transport.ssl";
         final Settings.Builder settings = getSettingsBuilder();
         settings.put(prefix + ".enabled", true);
-        configureWorkingTruststore(prefix, settings);
+        if (inFipsJvm()) {
+            configureWorkingTrustedAuthorities(prefix, settings);
+        } else {
+            configureWorkingTruststore(prefix, settings);
+        }
 
         expectSuccess(settings);
         assertWarnings("invalid SSL configuration for " + prefix +
@@ -145,29 +149,37 @@ public class SSLErrorMessageFileTests extends ESTestCase {
         final String prefix = "xpack.security.transport.ssl";
         final Settings.Builder settings = getSettingsBuilder();
         settings.put(prefix + ".enabled", false);
-        configureWorkingTruststore(prefix, settings);
+        if (inFipsJvm()) {
+            configureWorkingTrustedAuthorities(prefix, settings);
+        } else {
+            configureWorkingTruststore(prefix, settings);
+        }
         expectSuccess(settings);
     }
 
     public void testMessageForTransportNotEnabledButKeystoreConfigured() throws Exception {
+        assumeFalse("Cannot run in a FIPS JVM since it uses a PKCS12 keystore", inFipsJvm());
         final String prefix = "xpack.security.transport.ssl";
         checkUnusedConfiguration(prefix, prefix + ".keystore.path," + prefix + ".keystore.secure_password",
             this::configureWorkingKeystore);
     }
 
     public void testMessageForTransportNotEnabledButTruststoreConfigured() throws Exception {
+        assumeFalse("Cannot run in a FIPS JVM since it uses a PKCS12 keystore", inFipsJvm());
         final String prefix = "xpack.security.transport.ssl";
         checkUnusedConfiguration(prefix, prefix + ".truststore.path," + prefix + ".truststore.secure_password",
             this::configureWorkingTruststore);
     }
 
     public void testMessageForHttpsNotEnabledButKeystoreConfigured() throws Exception {
+        assumeFalse("Cannot run in a FIPS JVM since it uses a PKCS12 keystore", inFipsJvm());
         final String prefix = "xpack.security.http.ssl";
         checkUnusedConfiguration(prefix, prefix + ".keystore.path," + prefix + ".keystore.secure_password",
             this::configureWorkingKeystore);
     }
 
     public void testMessageForHttpsNotEnabledButTruststoreConfigured() throws Exception {
+        assumeFalse("Cannot run in a FIPS JVM since it uses a PKCS12 keystore", inFipsJvm());
         final String prefix = "xpack.security.http.ssl";
         checkUnusedConfiguration(prefix, prefix + ".truststore.path," + prefix + ".truststore.secure_password",
             this::configureWorkingTruststore);
@@ -179,7 +191,11 @@ public class SSLErrorMessageFileTests extends ESTestCase {
     }
 
     private void buildKeyConfigSettings(@Nullable Settings.Builder additionalSettings, String prefix, Settings.Builder builder) {
-        configureWorkingTruststore(prefix, builder);
+        if (inFipsJvm()) {
+            configureWorkingTrustedAuthorities(prefix, builder);
+        } else {
+            configureWorkingTruststore(prefix, builder);
+        }
         if (additionalSettings != null) {
             builder.put(additionalSettings.normalizePrefix(prefix + ".").build());
         }
@@ -335,6 +351,11 @@ public class SSLErrorMessageFileTests extends ESTestCase {
     private Settings.Builder configureWorkingTruststore(String prefix, Settings.Builder settings) {
         settings.put(prefix + ".truststore.path", resource("cert1a.p12"));
         addSecureSettings(settings, secure -> secure.setString(prefix + ".truststore.secure_password", "cert1a-p12-password"));
+        return settings;
+    }
+
+    private Settings.Builder configureWorkingTrustedAuthorities(String prefix, Settings.Builder settings) {
+        settings.putList(prefix + ".certificate_authorities", resource("ca1.crt"));
         return settings;
     }
 

--- a/x-pack/plugin/security/src/test/resources/org/elasticsearch/xpack/security/authc/file/users
+++ b/x-pack/plugin/security/src/test/resources/org/elasticsearch/xpack/security/authc/file/users
@@ -5,9 +5,10 @@ plain:{plain}test123
 sha:{SHA}cojt0Pw//L6ToM8G41aOKFIWh7w=
 # this is a comment line
 # another comment line
-pbkdf2:{PBKDF2}10000$ekcItXk4jtK2bBjbVk0rZuWRjT0DoQqQJOIfyMeLIxg=$RA2/Nn1jRi8QskRS5IVotCV0FBO6M8DlNXC37GKa/8c=
-pbkdf2_1000:{PBKDF2}1000$32yPZSShxuKYAl47ip0g6VwbFrD8tvFJuQCoRPGhXC8=$cXAE1BkBXRmkv7pQA7fw4TZ1+rFWS2/nZGeA3kL1Eu8=
-pbkdf2_50000:{PBKDF2}50000$z1CLJt0MEFjkIK5iEfgvfnA6xq7lF25uasspsTKSo5Q=$XxCVLbaKDimOdyWgLCLJiyoiWpA/XDMe/xtVgn1r5Sg=
+pbkdf2:{PBKDF2}10000$NB6kwTrIPrwJJTu+KXiPUkW5bMf1oG2BMzDJLA479Bk=$CvCgHb5UkalUiNPicqMDOzIsnh3ppyz3SZOp+Gjv+hc=
+pbkdf2_1000:{PBKDF2}1000$cofpEhehEObS+tNtS8/t9Zpf6UgwqkgkQFct2hhmGWA=$9Qb0S04fkF+Ebz1sGIaB9S6huZAXDihopPc6Z748f3E=
+pbkdf2_50000:{PBKDF2}50000$riPhBgfrNIpsN91QmF5mQNCwxHfJm0q2XtGt0x5+PRM=$v2j/DD+aFIRrusEeSDUO+eX3IrBPiG+ysgc9y0RDmhs=
+pbkdf2_stretch:{PBKDF2_STRETCH}10000$s1y/xv1T1iJxS9BKQ1FkZpSO19dSs6vsGgOb14d+KkU=$PtdgZoRGCSaim033lz/RcEoyhXQ/3WU4E6hfeKGsGes=
 bcrypt9:$2a$09$YhstxoAjO7M5MtAIFv7dVO70/pElJAYrzyumeCpLpZV2Gcz4J2/F.
 bcrypt10:$2a$10$cFxpMx6YDrH/PXwLpTlux.KVykN1TG2Pgdl5oJX5/G/KYp3G6jbFG
 bcrypt11:$2a$11$uxr7b0qgCrLV9VIz9XS7M.Eoc0gJRR60oV48UK5DKfLOp.9HjfYF2

--- a/x-pack/plugin/sql/build.gradle
+++ b/x-pack/plugin/sql/build.gradle
@@ -1,5 +1,8 @@
 apply plugin: 'elasticsearch.esplugin'
 apply plugin: 'elasticsearch.internal-cluster-test'
+
+import org.elasticsearch.gradle.info.BuildParams
+
 esplugin {
   name 'x-pack-sql'
   description 'The Elasticsearch plugin that powers SQL for Elasticsearch'
@@ -130,4 +133,9 @@ allprojects {
   tasks.register("checkNoBwc") {
     dependsOn tasks.withType(Test).matching { it.name.contains('bwc') == false }
   }
+}
+
+if (BuildParams.inFipsJvm){
+  // Test clusters run with security disabled
+  tasks.named("internalClusterTest").configure{enabled = false }
 }

--- a/x-pack/plugin/sql/qa/server/security/src/test/java/org/elasticsearch/xpack/sql/qa/security/CliSecurityIT.java
+++ b/x-pack/plugin/sql/qa/server/security/src/test/java/org/elasticsearch/xpack/sql/qa/security/CliSecurityIT.java
@@ -61,7 +61,13 @@ public class CliSecurityIT extends SqlSecurityTestCase {
             if (user == null) {
                 return admin;
             }
-            return new SecurityConfig(RestSqlIT.SSL_ENABLED, user, "testpass", admin.keystoreLocation(), admin.keystorePassword());
+            return new SecurityConfig(
+                RestSqlIT.SSL_ENABLED,
+                user,
+                "test-user-password",
+                admin.keystoreLocation(),
+                admin.keystorePassword()
+            );
         }
 
         @Override

--- a/x-pack/plugin/sql/qa/server/security/src/test/java/org/elasticsearch/xpack/sql/qa/security/JdbcSecurityIT.java
+++ b/x-pack/plugin/sql/qa/server/security/src/test/java/org/elasticsearch/xpack/sql/qa/security/JdbcSecurityIT.java
@@ -55,7 +55,7 @@ public class JdbcSecurityIT extends SqlSecurityTestCase {
         }
         Properties prop = new Properties();
         prop.put("user", user);
-        prop.put("password", "testpass");
+        prop.put("password", "test-user-password");
         addSslPropertiesIfNeeded(prop);
         return prop;
     }

--- a/x-pack/plugin/sql/qa/server/security/src/test/java/org/elasticsearch/xpack/sql/qa/security/SqlSecurityTestCase.java
+++ b/x-pack/plugin/sql/qa/server/security/src/test/java/org/elasticsearch/xpack/sql/qa/security/SqlSecurityTestCase.java
@@ -483,7 +483,7 @@ public abstract class SqlSecurityTestCase extends ESRestTestCase {
         XContentBuilder user = JsonXContent.contentBuilder().prettyPrint();
         user.startObject();
         {
-            user.field("password", "testpass");
+            user.field("password", "test-user-password");
             user.field("roles", role);
         }
         user.endObject();

--- a/x-pack/plugin/sql/qa/server/security/src/test/java/org/elasticsearch/xpack/sql/qa/security/UserFunctionIT.java
+++ b/x-pack/plugin/sql/qa/server/security/src/test/java/org/elasticsearch/xpack/sql/qa/security/UserFunctionIT.java
@@ -143,7 +143,7 @@ public class UserFunctionIT extends ESRestTestCase {
         XContentBuilder user = JsonXContent.contentBuilder().prettyPrint();
         user.startObject();
         {
-            user.field("password", "testpass");
+            user.field("password", "test-user-password");
             user.field("roles", role);
         }
         user.endObject();

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/change_password/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/change_password/10_basic.yml
@@ -10,7 +10,7 @@ setup:
         username: "joe"
         body:  >
           {
-            "password": "s3krit",
+            "password": "s3krit-password",
             "roles" : [ "superuser" ]
           }
   - do:
@@ -31,7 +31,7 @@ setup:
         username: "unprivileged_user"
         body:  >
           {
-            "password": "s3krit",
+            "password": "s3krit-password",
             "roles" : [ "user" ]
           }
 
@@ -56,7 +56,7 @@ teardown:
       features: catch_unauthorized
   - do:
       headers:
-        Authorization: "Basic am9lOnMza3JpdA=="
+        Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA=="
       cluster.health: {}
   - match: { timed_out: false }
 
@@ -66,20 +66,20 @@ teardown:
         username: "joe"
         body:  >
             {
-              "password" : "s3krit2"
+              "password" : "s3krit-password2"
             }
 
 # attempt to login with invalid credentials
   - do:
       catch: unauthorized
       headers:
-        Authorization: "Basic am9lOnMza3JpdA=="
+        Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA=="
       cluster.health: {}
 
 # login with new credentials
   - do:
       headers:
-        Authorization: "Basic am9lOnMza3JpdDI="
+        Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZDI="
       cluster.health: {}
   - match: { timed_out: false }
 
@@ -90,31 +90,31 @@ teardown:
 # test that the role actually works
   - do:
       headers:
-        Authorization: "Basic dW5wcml2aWxlZ2VkX3VzZXI6czNrcml0"
+        Authorization: "Basic dW5wcml2aWxlZ2VkX3VzZXI6czNrcml0LXBhc3N3b3Jk"
       cluster.health: {}
   - match: { timed_out: false }
 
 # change password as the current user. the user role only grants the ability to change their own password
   - do:
       headers:
-        Authorization: "Basic dW5wcml2aWxlZ2VkX3VzZXI6czNrcml0"
+        Authorization: "Basic dW5wcml2aWxlZ2VkX3VzZXI6czNrcml0LXBhc3N3b3Jk"
       security.change_password:
         body:  >
             {
-              "password" : "s3krit2"
+              "password" : "s3krit-password2"
             }
 
 # attempt to login with invalid credentials
   - do:
       catch: unauthorized
       headers:
-        Authorization: "Basic dW5wcml2aWxlZ2VkX3VzZXI6czNrcml0"
+        Authorization: "Basic dW5wcml2aWxlZ2VkX3VzZXI6czNrcml0LXBhc3N3b3Jk"
       cluster.health: {}
 
 # login with new credentials
   - do:
       headers:
-        Authorization: "Basic dW5wcml2aWxlZ2VkX3VzZXI6czNrcml0Mg=="
+        Authorization: "Basic dW5wcml2aWxlZ2VkX3VzZXI6czNrcml0LXBhc3N3b3JkMg=="
       cluster.health: {}
   - match: { timed_out: false }
 
@@ -123,18 +123,18 @@ teardown:
 # test that the role actually works
   - do:
       headers:
-        Authorization: "Basic dW5wcml2aWxlZ2VkX3VzZXI6czNrcml0"
+        Authorization: "Basic dW5wcml2aWxlZ2VkX3VzZXI6czNrcml0LXBhc3N3b3Jk"
       cluster.health: {}
   - match: { timed_out: false }
 
 # attempt to change another users password
   - do:
       headers:
-        Authorization: "Basic dW5wcml2aWxlZ2VkX3VzZXI6czNrcml0"
+        Authorization: "Basic dW5wcml2aWxlZ2VkX3VzZXI6czNrcml0LXBhc3N3b3Jk"
       catch: forbidden
       security.change_password:
         username: "anotheruser"
         body:  >
             {
-              "password" : "s3krit2"
+              "password" : "s3krit-password2"
             }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/change_password/11_token.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/change_password/11_token.yml
@@ -10,7 +10,7 @@ setup:
         username: "token_joe"
         body:  >
           {
-            "password": "s3krit",
+            "password": "s3krit-password",
             "roles" : [ "token_admin" ]
           }
   - do:
@@ -42,12 +42,12 @@ teardown:
 
   - do:
       headers:
-        Authorization: "Basic dG9rZW5fam9lOnMza3JpdA=="
+        Authorization: "Basic dG9rZW5fam9lOnMza3JpdC1wYXNzd29yZA=="
       security.get_token:
         body:
           grant_type: "password"
           username: "token_joe"
-          password: "s3krit"
+          password: "s3krit-password"
 
   - match: { type: "Bearer" }
   - is_true: access_token
@@ -63,5 +63,5 @@ teardown:
         username: "joe"
         body:  >
           {
-            "password" : "s3krit2"
+            "password" : "s3krit-password2"
           }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/license/20_put_license.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/license/20_put_license.yml
@@ -7,7 +7,9 @@ teardown:
           {"licenses":[{"uid":"3aa62ffe-36e1-4fad-bfdc-9dff8301eb22","type":"trial","issue_date_in_millis":1523456691721,"expiry_date_in_millis":1838816691721,"max_nodes":5,"issued_to":"customer","issuer":"elasticsearch","signature":"AAAABAAAAA2kWNcuc+DT0lrlmYZKAAAAIAo5/x6hrsGh1GqqrJmy4qgmEC7gK0U4zQ6q5ZEMhm4jAAABAEn6fG9y2VxKBu2T3D5hffh56kzOQODCOdhr0y2d17ZSIJMZRqO7ZywPCWNS1aR33GhfIHkTER0ysML0xMH/gXavhyRvMBndJj0UBKzuwpTawSlnxYtcqN8mSBIvJC7Ki+uJ1SpAILC2ZP9fnkRlqwXqBlTwfYn7xnZgu9DKrOWru/ipTPObo7jcePl8VTK6nWFen7/hCFDQTUFZ0jQvd+nq7A1PAcHGNxGfdbMVmAXCXgGWkRfT3clo9/vadgo+isNyh1sPq9mN7gwsvBAKtA1FrpH2EXYYbfOsSpBvUmhYMgErLg1k3/CbS0pCWLKOaX1xTMayosdZOjagU3auZXY=","start_date_in_millis":-1}]}
 ---
 "Installing and getting license works":
-
+  - skip:
+      features: fips_140
+      reason: "Cannot install a GOLD license in a cluster in FIPS 140 mode"
   ## current license version
   - do:
       license.post:
@@ -86,7 +88,9 @@ teardown:
 
 ---
 "Should install a feature type license":
-
+  - skip:
+      features: fips_140
+      reason: "Cannot install a GOLD license in a cluster in FIPS 140 mode"
     # VERSION_NO_FEATURE_TYPE license version
   - do:
       license.post:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/monitoring/bulk/20_privileges.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/monitoring/bulk/20_privileges.yml
@@ -26,7 +26,7 @@ setup:
         username: "logstash_agent"
         body:  >
           {
-            "password": "s3krit",
+            "password": "s3krit-password",
             "roles" : [ "logstash_agent_role" ]
           }
 
@@ -50,7 +50,7 @@ setup:
         username: "unknown_agent"
         body:  >
           {
-            "password": "s3krit",
+            "password": "s3krit-password",
             "roles" : [ "unknown_agent_role" ]
           }
 
@@ -83,7 +83,7 @@ teardown:
   - do:
       headers:
         # Authorization: logstash_agent
-        Authorization: "Basic bG9nc3Rhc2hfYWdlbnQ6czNrcml0"
+        Authorization: "Basic bG9nc3Rhc2hfYWdlbnQ6czNrcml0LXBhc3N3b3Jk"
       monitoring.bulk:
         system_id:          "logstash"
         system_api_version: "6"
@@ -121,7 +121,7 @@ teardown:
       catch: forbidden
       headers:
         # Authorization: unknown_agent
-        Authorization: "Basic dW5rbm93bl9hZ2VudDpzM2tyaXQ="
+        Authorization: "Basic dW5rbm93bl9hZ2VudDpzM2tyaXQtcGFzc3dvcmQ="
       monitoring.bulk:
         system_id:          "logstash"
         system_api_version: "6"

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/privileges/20_has_application_privs.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/privileges/20_has_application_privs.yml
@@ -136,7 +136,7 @@ setup:
           username: "eng_read"
           body:  >
               {
-                "password": "p@ssw0rd",
+                "password": "s3cr3t-p@ssw0rd",
                 "roles" : [ "myapp_engineering_read" ]
               }
   - do:
@@ -144,7 +144,7 @@ setup:
           username: "eng_write"
           body:  >
               {
-                "password": "p@ssw0rd",
+                "password": "s3cr3t-p@ssw0rd",
                 "roles" : [ "myapp_engineering_write" ]
               }
   - do:
@@ -152,7 +152,7 @@ setup:
           username: "your_read"
           body:  >
               {
-                "password": "p@ssw0rd",
+                "password": "s3cr3t-p@ssw0rd",
                 "roles" : [ "yourapp_read_config" ]
               }
   - do:
@@ -160,7 +160,7 @@ setup:
         username: "myapp_yourapp_wildard_role_user"
         body:  >
           {
-            "password": "p@ssw0rd",
+            "password": "s3cr3t-p@ssw0rd",
             "roles" : [ "role_containing_wildcard_app_name_and_plain_app_name" ]
           }
 
@@ -225,7 +225,7 @@ teardown:
 ---
 "Test has_privileges with application-privileges":
   - do:
-      headers: { Authorization: "Basic ZW5nX3JlYWQ6cEBzc3cwcmQ=" } # eng_read
+      headers: { Authorization: "Basic ZW5nX3JlYWQ6czNjcjN0LXBAc3N3MHJk" } # eng_read
       security.has_privileges:
         user: null
         body: >
@@ -282,7 +282,7 @@ teardown:
     } }
 
   - do:
-      headers: { Authorization: "Basic eW91cl9yZWFkOnBAc3N3MHJk" } # your_read
+      headers: { Authorization: "Basic eW91cl9yZWFkOnMzY3IzdC1wQHNzdzByZA==" } # your_read
       security.has_privileges:
         user: null
         body: >
@@ -333,7 +333,7 @@ teardown:
     } }
 
   - do:
-      headers: { Authorization: "Basic bXlhcHBfeW91cmFwcF93aWxkYXJkX3JvbGVfdXNlcjpwQHNzdzByZA==" } # myapp_yourapp_wildard_role_user
+      headers: { Authorization: "Basic bXlhcHBfeW91cmFwcF93aWxkYXJkX3JvbGVfdXNlcjpzM2NyM3QtcEBzc3cwcmQ=" } # myapp_yourapp_wildard_role_user
       security.has_privileges:
         user: null
         body: >

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/privileges/30_superuser.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/privileges/30_superuser.yml
@@ -54,7 +54,7 @@ setup:
           username: "my_admin"
           body:  >
               {
-                "password": "admin01",
+                "password": "admin01-password",
                 "roles" : [ "superuser" ]
               }
   - do:
@@ -62,7 +62,7 @@ setup:
           username: "eng_write"
           body:  >
               {
-                "password": "p@ssw0rd",
+                "password": "s3cr3t-p@ssw0rd",
                 "roles" : [ "myapp_engineering_write" ]
               }
 
@@ -87,7 +87,7 @@ teardown:
 ---
 "Test superuser has all application-privileges":
   - do:
-      headers: { Authorization: "Basic bXlfYWRtaW46YWRtaW4wMQ==" } # my_admin
+      headers: { Authorization: "Basic bXlfYWRtaW46YWRtaW4wMS1wYXNzd29yZA==" } # my_admin
       security.has_privileges:
         user: null
         body: >

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/privileges/40_get_user_privs.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/privileges/40_get_user_privs.yml
@@ -146,7 +146,7 @@ setup:
           username: "test-1"
           body:  >
               {
-                "password": "12345678",
+                "password": "test-user-password",
                 "roles" : [ "test-role-1" ]
               }
   - do:
@@ -154,7 +154,7 @@ setup:
           username: "test-2"
           body:  >
               {
-                "password": "12345678",
+                "password": "test-user-password",
                 "roles" : [ "test-role-2" ]
               }
   - do:
@@ -162,7 +162,7 @@ setup:
           username: "test-3"
           body:  >
               {
-                "password": "12345678",
+                "password": "test-user-password",
                 "roles" : [ "test-role-1", "test-role-2" ]
               }
 
@@ -206,7 +206,7 @@ teardown:
           reason: "contains is a newly added assertion"
           features: contains
   - do:
-      headers: { Authorization: "Basic dGVzdC0xOjEyMzQ1Njc4" } # test-1
+      headers: { Authorization: "Basic dGVzdC0xOnRlc3QtdXNlci1wYXNzd29yZA==" } # test-1
       security.get_user_privileges: {}
 
   - match: { "cluster" : [ "monitor" ] }
@@ -234,7 +234,7 @@ teardown:
   - match: { "run_as" : [ "test-*" ] }
 
   - do:
-      headers: { Authorization: "Basic dGVzdC0yOjEyMzQ1Njc4" } # test-2
+      headers: { Authorization: "Basic dGVzdC0yOnRlc3QtdXNlci1wYXNzd29yZA==" } # test-2
       security.get_user_privileges:
         username: null
 
@@ -268,7 +268,7 @@ teardown:
       reason: "contains is a newly added assertion"
       features: contains
   - do:
-      headers: { Authorization: "Basic dGVzdC0zOjEyMzQ1Njc4" } # test-3
+      headers: { Authorization: "Basic dGVzdC0zOnRlc3QtdXNlci1wYXNzd29yZA==" } # test-3
       security.get_user_privileges: {}
 
   - match: { "cluster" : [ "manage", "manage_security", "monitor" ] }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/roles/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/roles/10_basic.yml
@@ -11,7 +11,7 @@ setup:
         username: "joe"
         body:  >
             {
-              "password": "s3krit",
+              "password": "s3krit-password",
               "roles" : [ "admin_role" ]
             }
 
@@ -68,7 +68,7 @@ teardown:
 
   - do:
       headers:
-        Authorization: "Basic am9lOnMza3JpdA=="
+        Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA=="
       cluster.health: {}
   - match: { timed_out: false }
 

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/roles/11_idx_arrays.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/roles/11_idx_arrays.yml
@@ -48,7 +48,7 @@ teardown:
         username: "joe"
         body:  >
             {
-              "password": "s3krit",
+              "password": "s3krit-password",
               "roles" : [ "admin_role2" ]
             }
   - match: { created: true }
@@ -62,7 +62,7 @@ teardown:
 
   - do:
       headers:
-        Authorization: "Basic am9lOnMza3JpdA=="
+        Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA=="
       get:
         index: foo
         type: doc
@@ -75,7 +75,7 @@ teardown:
 # test that the role works on the cluster level
   - do:
       headers:
-        Authorization: "Basic am9lOnMza3JpdA=="
+        Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA=="
       cluster.health: {}
   - match: { timed_out: false }
 

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/roles/40_global_privileges.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/roles/40_global_privileges.yml
@@ -11,7 +11,7 @@ setup:
         username: "joe"
         body:  >
             {
-              "password": "s3krit",
+              "password": "s3krit-password",
               "roles" : [ "with_global" ]
             }
 

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/security/authz/14_cat_indices.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/security/authz/14_cat_indices.yml
@@ -23,7 +23,7 @@ setup:
         username: "cat_user"
         body:  >
           {
-            "password" : "cat_password",
+            "password" : "cat_secret_password",
             "roles" : [ "cat_some_indices_role" ],
             "full_name" : "Meow"
           }
@@ -77,7 +77,7 @@ teardown:
 "Test empty request while no-authorized index":
 
   - do:
-      headers: { Authorization: "Basic Y2F0X3VzZXI6Y2F0X3Bhc3N3b3Jk" } # cat_user
+      headers: { Authorization: "Basic Y2F0X3VzZXI6Y2F0X3NlY3JldF9wYXNzd29yZA==" } # cat_user
       cat.indices: {}
 
   - match:
@@ -96,7 +96,7 @@ teardown:
             number_of_replicas: "0"
 
   - do:
-      headers: { Authorization: "Basic Y2F0X3VzZXI6Y2F0X3Bhc3N3b3Jk" } # cat_user
+      headers: { Authorization: "Basic Y2F0X3VzZXI6Y2F0X3NlY3JldF9wYXNzd29yZA==" } # cat_user
       cat.indices: {}
 
   - match:
@@ -152,7 +152,7 @@ teardown:
         index:  index_to_monitor
 
   - do:
-      headers: { Authorization: "Basic Y2F0X3VzZXI6Y2F0X3Bhc3N3b3Jk" } # cat_user
+      headers: { Authorization: "Basic Y2F0X3VzZXI6Y2F0X3NlY3JldF9wYXNzd29yZA==" } # cat_user
       cat.indices: {}
 
   - match:
@@ -190,7 +190,7 @@ teardown:
             number_of_replicas: "0"
 
   - do:
-      headers: { Authorization: "Basic Y2F0X3VzZXI6Y2F0X3Bhc3N3b3Jk" } # cat_user
+      headers: { Authorization: "Basic Y2F0X3VzZXI6Y2F0X3NlY3JldF9wYXNzd29yZA==" } # cat_user
       cat.indices:
         index: "this_index,index_to_monitor"
         v: false
@@ -203,13 +203,13 @@ teardown:
 
   - do:
       catch: forbidden
-      headers: { Authorization: "Basic Y2F0X3VzZXI6Y2F0X3Bhc3N3b3Jk" } # cat_user
+      headers: { Authorization: "Basic Y2F0X3VzZXI6Y2F0X3NlY3JldF9wYXNzd29yZA==" } # cat_user
       cat.indices:
         index: "index1,index_to_monitor"
 
   - do:
       catch: forbidden
-      headers: { Authorization: "Basic Y2F0X3VzZXI6Y2F0X3Bhc3N3b3Jk" } # cat_user
+      headers: { Authorization: "Basic Y2F0X3VzZXI6Y2F0X3NlY3JldF9wYXNzd29yZA==" } # cat_user
       cat.indices:
         index: "this_*,index2"
 
@@ -241,7 +241,7 @@ teardown:
             number_of_replicas: "0"
 
   - do:
-      headers: { Authorization: "Basic Y2F0X3VzZXI6Y2F0X3Bhc3N3b3Jk" } # cat_user
+      headers: { Authorization: "Basic Y2F0X3VzZXI6Y2F0X3NlY3JldF9wYXNzd29yZA==" } # cat_user
       cat.indices:
         index: "this_index,index_to_monitor,this_index_is_closed"
         v: false
@@ -258,19 +258,19 @@ teardown:
 
   - do:
       catch: forbidden
-      headers: { Authorization: "Basic Y2F0X3VzZXI6Y2F0X3Bhc3N3b3Jk" } # cat_user
+      headers: { Authorization: "Basic Y2F0X3VzZXI6Y2F0X3NlY3JldF9wYXNzd29yZA==" } # cat_user
       cat.indices:
         index: "index1,index_to_monitor"
 
   - do:
       catch: forbidden
-      headers: { Authorization: "Basic Y2F0X3VzZXI6Y2F0X3Bhc3N3b3Jk" } # cat_user
+      headers: { Authorization: "Basic Y2F0X3VzZXI6Y2F0X3NlY3JldF9wYXNzd29yZA==" } # cat_user
       cat.indices:
         index: "this_*,index2"
 
   - do:
       catch: forbidden
-      headers: { Authorization: "Basic Y2F0X3VzZXI6Y2F0X3Bhc3N3b3Jk" } # cat_user
+      headers: { Authorization: "Basic Y2F0X3VzZXI6Y2F0X3NlY3JldF9wYXNzd29yZA==" } # cat_user
       cat.indices:
         index: "this_index_is_closed,index2"
 
@@ -310,7 +310,7 @@ teardown:
             number_of_replicas: "0"
 
   - do:
-      headers: { Authorization: "Basic Y2F0X3VzZXI6Y2F0X3Bhc3N3b3Jk" } # cat_user
+      headers: { Authorization: "Basic Y2F0X3VzZXI6Y2F0X3NlY3JldF9wYXNzd29yZA==" } # cat_user
       cat.indices:
         index: "t*,i*"
         v: false

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/users/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/users/10_basic.yml
@@ -25,7 +25,7 @@ teardown:
         username: "joe"
         body:  >
             {
-              "password" : "s3krit",
+              "password" : "s3krit-password",
               "roles" : [ "superuser" ],
               "full_name" : "Bazooka Joe",
               "email" : "joe@bazooka.gum",
@@ -38,7 +38,7 @@ teardown:
 
   - do:
       headers:
-        Authorization: "Basic am9lOnMza3JpdA=="
+        Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA=="
       cluster.health: {}
   - match: { timed_out: false }
 
@@ -60,7 +60,7 @@ teardown:
         body:  >
             {
               "username": "joe",
-              "password" : "s3krit",
+              "password" : "s3krit-password",
               "roles" : [ "superuser" ],
               "full_name" : "Bazooka Joe",
               "email" : "joe@bazooka.gum",
@@ -73,7 +73,7 @@ teardown:
 
   - do:
       headers:
-        Authorization: "Basic am9lOnMza3JpdA=="
+        Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA=="
       cluster.health: {}
   - match: { timed_out: false }
 
@@ -96,7 +96,7 @@ teardown:
         body:  >
             {
               "username": "joey",
-              "password" : "s3krit",
+              "password" : "s3krit-password",
               "roles" : [ "superuser" ],
               "full_name" : "Bazooka Joe",
               "email" : "joe@bazooka.gum",
@@ -150,5 +150,5 @@ teardown:
   - do:
       catch: unauthorized
       headers:
-        Authorization: "Basic am9lOnMza3JpdA=="
+        Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA=="
       security.authenticate: {}

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/users/15_overwrite_user.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/users/15_overwrite_user.yml
@@ -12,7 +12,7 @@ setup:
         username: "joe"
         body:  >
           {
-            "password": "s3krit",
+            "password": "s3krit-password",
             "roles" : [ "superuser" ]
           }
 
@@ -33,7 +33,7 @@ teardown:
 
   - do:
       headers:
-        Authorization: "Basic am9lOnMza3JpdA=="
+        Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA=="
       cluster.health: {}
   - match: { timed_out: false }
 
@@ -42,7 +42,7 @@ teardown:
         username: "joe"
         body:  >
             {
-              "password" : "s3krit2",
+              "password" : "s3krit-password2",
               "roles" : [ "superuser", "foo" ],
               "full_name" : "Bazooka Joe",
               "email" : "joe@bazooka.gum",
@@ -66,6 +66,6 @@ teardown:
 
   - do:
       headers:
-        Authorization: "Basic am9lOnMza3JpdDI="
+        Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZDI="
       cluster.health: {}
   - match: { timed_out: false }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/users/16_update_user.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/users/16_update_user.yml
@@ -9,7 +9,7 @@ setup:
         username: "joe"
         body:  >
             {
-              "password": "s3krit",
+              "password": "s3krit-password",
               "roles" : [ "superuser" ]
             }
 
@@ -39,7 +39,7 @@ teardown:
 
   - do:
       headers:
-        Authorization: "Basic am9lOnMza3JpdA=="
+        Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA=="
       cluster.health: {}
   - match: { timed_out: false }
 
@@ -71,7 +71,7 @@ teardown:
 # validate existing password works
   - do:
       headers:
-        Authorization: "Basic am9lOnMza3JpdA=="
+        Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA=="
       cluster.health: {}
   - match: { timed_out: false }
 
@@ -93,7 +93,7 @@ teardown:
         username: "joe"
         body:  >
             {
-              "password" : "s3krit2",
+              "password" : "s3krit-password2",
               "roles" : [ "superuser" ],
               "full_name" : "Bazooka Joe",
               "email" : "joe@bazooka.gum",
@@ -109,13 +109,13 @@ teardown:
   - do:
       catch: unauthorized
       headers:
-        Authorization: "Basic am9lOnMza3JpdA=="
+        Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA=="
       cluster.health: {}
 
 # validate new password works
   - do:
       headers:
-        Authorization: "Basic am9lOnMza3JpdDI="
+        Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZDI="
       cluster.health: {}
   - match: { timed_out: false }
 

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/users/30_enable_disable.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/users/30_enable_disable.yml
@@ -11,7 +11,7 @@ setup:
         username: "joe"
         body:  >
             {
-              "password": "s3krit",
+              "password": "s3krit-password",
               "roles" : [ "superuser" ]
             }
 
@@ -26,7 +26,7 @@ teardown:
 "Test disable then enable user":
   - do:
       headers:
-        Authorization: "Basic am9lOnMza3JpdA=="
+        Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA=="
       cluster.health: {}
   - match: { timed_out: false }
 
@@ -39,7 +39,7 @@ teardown:
   - do:
       catch: unauthorized
       headers:
-        Authorization: "Basic am9lOnMza3JpdA=="
+        Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA=="
       cluster.health: {}
 
 # enable the user
@@ -50,7 +50,7 @@ teardown:
 # validate that the user can login again
   - do:
       headers:
-        Authorization: "Basic am9lOnMza3JpdA=="
+        Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA=="
       cluster.health: {}
   - match: { timed_out: false }
 
@@ -59,7 +59,7 @@ teardown:
 # check that the user works
   - do:
       headers:
-        Authorization: "Basic am9lOnMza3JpdA=="
+        Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA=="
       cluster.health: {}
   - match: { timed_out: false }
 
@@ -71,7 +71,7 @@ teardown:
 # validate that the user still works
   - do:
       headers:
-        Authorization: "Basic am9lOnMza3JpdA=="
+        Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA=="
       cluster.health: {}
   - match: { timed_out: false }
 
@@ -80,7 +80,7 @@ teardown:
 # check that the user works
   - do:
       headers:
-        Authorization: "Basic am9lOnMza3JpdA=="
+        Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA=="
       cluster.health: {}
   - match: { timed_out: false }
 
@@ -93,7 +93,7 @@ teardown:
   - do:
       catch: unauthorized
       headers:
-        Authorization: "Basic am9lOnMza3JpdA=="
+        Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA=="
       cluster.health: {}
 
 # disable again
@@ -110,7 +110,7 @@ teardown:
 # check that the user works
   - do:
       headers:
-        Authorization: "Basic am9lOnMza3JpdA=="
+        Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA=="
       cluster.health: {}
   - match: { timed_out: false }
 
@@ -118,6 +118,6 @@ teardown:
   - do:
       catch: '/users may not update the enabled status of their own account/'
       headers:
-        Authorization: "Basic am9lOnMza3JpdA=="
+        Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA=="
       security.disable_user:
         username: "joe"

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/users/31_create_disabled.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/users/31_create_disabled.yml
@@ -11,7 +11,7 @@ setup:
         username: "joe"
         body:  >
             {
-              "password": "s3krit",
+              "password": "s3krit-password",
               "roles" : [ "superuser" ],
               "enabled": false
             }
@@ -27,7 +27,7 @@ teardown:
   - do:
       catch: unauthorized
       headers:
-        Authorization: "Basic am9lOnMza3JpdA=="
+        Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA=="
       cluster.health: {}
 
 # enable
@@ -38,6 +38,6 @@ teardown:
 # validate user can login
   - do:
       headers:
-        Authorization: "Basic am9lOnMza3JpdA=="
+        Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA=="
       cluster.health: {}
   - match: { timed_out: false }

--- a/x-pack/plugin/watcher/qa/rest/build.gradle
+++ b/x-pack/plugin/watcher/qa/rest/build.gradle
@@ -1,3 +1,5 @@
+import org.elasticsearch.gradle.info.BuildParams
+
 apply plugin: 'elasticsearch.yaml-rest-test'
 apply plugin: 'elasticsearch.java-rest-test'
 
@@ -25,4 +27,10 @@ testClusters.all {
   setting 'xpack.ml.enabled', 'false'
   setting 'xpack.license.self_generated.type', 'trial'
   setting 'logger.org.elasticsearch.xpack.watcher', 'DEBUG'
+}
+
+if (BuildParams.inFipsJvm){
+  // Test clusters run with security disabled
+  tasks.named("javaRestTest").configure{enabled = false }
+  tasks.named("yamlRestTest").configure{enabled = false }
 }

--- a/x-pack/plugin/watcher/qa/with-monitoring/build.gradle
+++ b/x-pack/plugin/watcher/qa/with-monitoring/build.gradle
@@ -1,3 +1,5 @@
+import org.elasticsearch.gradle.info.BuildParams
+
 apply plugin: 'elasticsearch.java-rest-test'
 
 dependencies {
@@ -13,4 +15,9 @@ testClusters.all {
   setting 'xpack.security.enabled', 'false'
   setting 'xpack.ml.enabled', 'false'
   setting 'xpack.license.self_generated.type', 'trial'
+}
+
+if (BuildParams.inFipsJvm){
+  // Test clusters run with security disabled
+  tasks.named("javaRestTest").configure{enabled = false }
 }

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/actions/email/EmailSslTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/actions/email/EmailSslTests.java
@@ -88,6 +88,7 @@ public class EmailSslTests extends ESTestCase {
     }
 
     public void testCanSendMessageToSmtpServerUsingTrustStore() throws Exception {
+        assumeFalse("Can't use PKCS12 keystores in fips mode", inFipsJvm());
         List<MimeMessage> messages = new ArrayList<>();
         server.addListener(messages::add);
         try {

--- a/x-pack/qa/evil-tests/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosTestCase.java
+++ b/x-pack/qa/evil-tests/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosTestCase.java
@@ -128,7 +128,7 @@ public abstract class KerberosTestCase extends ESTestCase {
             String clientUserName = "client-" + randomAlphaOfLength(8);
             clientUserNames.add(clientUserName);
             try {
-                createPrincipal(clientUserName, "pwd".toCharArray());
+                createPrincipal(clientUserName, "spnego-test-password".toCharArray());
             } catch (Exception e) {
                 throw ExceptionsHelper.convertToRuntime(e);
             }

--- a/x-pack/qa/evil-tests/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosTicketValidatorTests.java
+++ b/x-pack/qa/evil-tests/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosTicketValidatorTests.java
@@ -37,8 +37,9 @@ public class KerberosTicketValidatorTests extends KerberosTestCase {
 
         // Client login and init token preparation
         final String clientUserName = randomFrom(clientUserNames);
-        try (SpnegoClient spnegoClient = new SpnegoClient(principalName(clientUserName), new SecureString("pwd".toCharArray()),
-                principalName("differentServer"), randomFrom(KerberosTicketValidator.SUPPORTED_OIDS))) {
+        try (SpnegoClient spnegoClient = new SpnegoClient(principalName(clientUserName),
+            new SecureString("spnego-test-password".toCharArray()), principalName("differentServer"),
+            randomFrom(KerberosTicketValidator.SUPPORTED_OIDS))) {
             final String base64KerbToken = spnegoClient.getBase64EncodedTokenForSpnegoHeader();
             assertThat(base64KerbToken, is(notNullValue()));
 
@@ -79,8 +80,9 @@ public class KerberosTicketValidatorTests extends KerberosTestCase {
             throws LoginException, GSSException, IOException, PrivilegedActionException {
         // Client login and init token preparation
         final String clientUserName = randomFrom(clientUserNames);
-        try (SpnegoClient spnegoClient = new SpnegoClient(principalName(clientUserName), new SecureString("pwd".toCharArray()),
-                principalName(randomFrom(serviceUserNames)), randomFrom(KerberosTicketValidator.SUPPORTED_OIDS));) {
+        try (SpnegoClient spnegoClient = new SpnegoClient(principalName(clientUserName),
+            new SecureString("spnego-test-password".toCharArray()), principalName(randomFrom(serviceUserNames)),
+            randomFrom(KerberosTicketValidator.SUPPORTED_OIDS));) {
             final String base64KerbToken = spnegoClient.getBase64EncodedTokenForSpnegoHeader();
             assertThat(base64KerbToken, is(notNullValue()));
 
@@ -98,7 +100,7 @@ public class KerberosTicketValidatorTests extends KerberosTestCase {
     public void testValidKebrerosTicket() throws PrivilegedActionException, GSSException, LoginException {
         // Client login and init token preparation
         final String clientUserName = randomFrom(clientUserNames);
-        final SecureString password = new SecureString("pwd".toCharArray());
+        final SecureString password = new SecureString("spnego-test-password".toCharArray());
         final String servicePrincipalName = principalName(randomFrom(serviceUserNames));
         try (SpnegoClient spnegoClient = new SpnegoClient(principalName(clientUserName), password, servicePrincipalName,
                 randomFrom(KerberosTicketValidator.SUPPORTED_OIDS))) {

--- a/x-pack/qa/evil-tests/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/SimpleKdcLdapServerTests.java
+++ b/x-pack/qa/evil-tests/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/SimpleKdcLdapServerTests.java
@@ -50,8 +50,9 @@ public class SimpleKdcLdapServerTests extends KerberosTestCase {
         final String serviceUserName = randomFrom(serviceUserNames);
         // Client login and init token preparation
         final String clientUserName = randomFrom(clientUserNames);
-        try (SpnegoClient spnegoClient = new SpnegoClient(principalName(clientUserName), new SecureString("pwd".toCharArray()),
-                principalName(serviceUserName), randomFrom(KerberosTicketValidator.SUPPORTED_OIDS));) {
+        try (SpnegoClient spnegoClient = new SpnegoClient(principalName(clientUserName),
+            new SecureString("spnego-test-password".toCharArray()), principalName(serviceUserName),
+            randomFrom(KerberosTicketValidator.SUPPORTED_OIDS));) {
             final String base64KerbToken = spnegoClient.getBase64EncodedTokenForSpnegoHeader();
             assertThat(base64KerbToken, is(notNullValue()));
             final KerberosAuthenticationToken kerbAuthnToken = new KerberosAuthenticationToken(Base64.getDecoder().decode(base64KerbToken));

--- a/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
@@ -739,7 +739,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
         Request request = new Request("PUT", getSecurityEndpoint() + "/user/" + id);
         request.setJsonEntity(
             "{\n" +
-            "   \"password\" : \"j@rV1s\",\n" +
+            "   \"password\" : \"l0ng-r4nd0m-p@ssw0rd\",\n" +
             "   \"roles\" : [ \"admin\", \"other_role1\" ],\n" +
             "   \"full_name\" : \"" + randomAlphaOfLength(5) + "\",\n" +
             "   \"email\" : \"" + id + "@example.com\",\n" +

--- a/x-pack/qa/mixed-tier-cluster/build.gradle
+++ b/x-pack/qa/mixed-tier-cluster/build.gradle
@@ -59,3 +59,9 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible.findAll { it.on
     dependsOn "${baseName}#mixedClusterTest"
   }
 }
+
+
+// Security is explicitly disabled, do not run tests in FIPS mode
+tasks.withType(Test).configureEach {
+  onlyIf { BuildParams.inFipsJvm == false}
+}

--- a/x-pack/qa/multi-cluster-search-security/src/test/resources/rest-api-spec/test/multi_cluster/10_basic.yml
+++ b/x-pack/qa/multi-cluster-search-security/src/test/resources/rest-api-spec/test/multi_cluster/10_basic.yml
@@ -11,7 +11,7 @@ setup:
         username: "joe"
         body:  >
             {
-              "password": "s3krit",
+              "password": "s3krit-password",
               "roles" : [ "x_cluster_role" ]
             }
   - do:
@@ -33,7 +33,7 @@ setup:
         username: "remote"
         body:  >
             {
-              "password": "s3krit",
+              "password": "s3krit-password",
               "roles" : [ "remote_ccs" ]
             }
   - do:
@@ -80,7 +80,7 @@ teardown:
             - '{"f1": "local_cluster", "filter_field": 0}'
 
   - do:
-      headers: { Authorization: "Basic am9lOnMza3JpdA==" }
+      headers: { Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA==" }
       search:
         rest_total_hits_as_int: true
         index: local_index,my_remote_cluster:test_index
@@ -99,7 +99,7 @@ teardown:
   - match: { aggregations.cluster.buckets.1.doc_count: 5 }
 
   - do:
-      headers: { Authorization: "Basic am9lOnMza3JpdA==" }
+      headers: { Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA==" }
       search:
         rest_total_hits_as_int: true
         index: local_index,my_remote_cluster:test_index
@@ -123,7 +123,7 @@ teardown:
   - match: { aggregations.cluster.buckets.0.doc_count: 6 }
 
   - do:
-      headers: { Authorization: "Basic am9lOnMza3JpdA==" }
+      headers: { Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA==" }
       async_search.submit:
         index: local_index,my_remote_cluster:test_index
         wait_for_completion_timeout: 10s
@@ -151,7 +151,7 @@ teardown:
   - match: { response.aggregations.cluster.buckets.0.doc_count: 6 }
 
   - do:
-      headers: { Authorization: "Basic am9lOnMza3JpdA==" }
+      headers: { Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA==" }
       async_search.get:
         id: "$id"
 
@@ -168,14 +168,14 @@ teardown:
   - match: { response.aggregations.cluster.buckets.0.doc_count: 6 }
 
   - do:
-      headers: { Authorization: "Basic am9lOnMza3JpdA==" }
+      headers: { Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA==" }
       async_search.delete:
         id: "$id"
 
   - match: { acknowledged:   true }
 
   - do:
-      headers: { Authorization: "Basic am9lOnMza3JpdA==" }
+      headers: { Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA==" }
       search:
         rest_total_hits_as_int: true
         index: my_remote_cluster:test_index
@@ -197,7 +197,7 @@ teardown:
 
   # Test wildcard in cluster name
   - do:
-      headers: { Authorization: "Basic cmVtb3RlOnMza3JpdA==" }
+      headers: { Authorization: "Basic cmVtb3RlOnMza3JpdC1wYXNzd29yZA==" }
       search:
         rest_total_hits_as_int: true
         index: "my_*:test_index"
@@ -218,7 +218,7 @@ teardown:
   - match: { aggregations.cluster.buckets.0.doc_count: 6 }
 
   - do:
-      headers: { Authorization: "Basic am9lOnMza3JpdA==" }
+      headers: { Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA==" }
       search:
         rest_total_hits_as_int: true
         index: local_index
@@ -254,7 +254,7 @@ teardown:
   - match: {transient: {cluster.remote.test_remote_cluster.seeds: $remote_ip}}
 
   - do:
-      headers: { Authorization: "Basic am9lOnMza3JpdA==" }
+      headers: { Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA==" }
       search:
         rest_total_hits_as_int: true
         index: test_remote_cluster:test_index
@@ -268,7 +268,7 @@ teardown:
 
   # Test wildcard that matches multiple (two) cluster names
   - do:
-      headers: { Authorization: "Basic cmVtb3RlOnMza3JpdA==" }
+      headers: { Authorization: "Basic cmVtb3RlOnMza3JpdC1wYXNzd29yZA==" }
       search:
         rest_total_hits_as_int: true
         index: "*_remote_cluster:test_ind*"
@@ -283,7 +283,7 @@ teardown:
 "Search an filtered alias on the remote cluster":
 
   - do:
-      headers: { Authorization: "Basic cmVtb3RlOnMza3JpdA==" }
+      headers: { Authorization: "Basic cmVtb3RlOnMza3JpdC1wYXNzd29yZA==" }
       search:
         rest_total_hits_as_int: true
         index: my_remote_cluster:aliased_test_index
@@ -300,7 +300,7 @@ teardown:
 "Search across clusters via a secured alias":
 
   - do:
-      headers: { Authorization: "Basic cmVtb3RlOnMza3JpdA==" }
+      headers: { Authorization: "Basic cmVtb3RlOnMza3JpdC1wYXNzd29yZA==" }
       search:
         rest_total_hits_as_int: true
         index: my_remote_cluster:secure_alias # TODO make this a wildcard once
@@ -317,7 +317,7 @@ teardown:
 "Async search against filtered alias on the remote cluster":
 
   - do:
-      headers: { Authorization: "Basic cmVtb3RlOnMza3JpdA==" }
+      headers: { Authorization: "Basic cmVtb3RlOnMza3JpdC1wYXNzd29yZA==" }
       async_search.submit:
         index: my_remote_cluster:aliased_test_index
         wait_for_completion_timeout: 10s
@@ -333,7 +333,7 @@ teardown:
   - match: { response.hits.hits.0._index: "my_remote_cluster:test_index" }
 
   - do:
-      headers: { Authorization: "Basic cmVtb3RlOnMza3JpdA==" }
+      headers: { Authorization: "Basic cmVtb3RlOnMza3JpdC1wYXNzd29yZA==" }
       async_search.get:
         id: "$id"
 
@@ -345,7 +345,7 @@ teardown:
   - match: { response.hits.hits.0._index: "my_remote_cluster:test_index" }
 
   - do:
-      headers: { Authorization: "Basic cmVtb3RlOnMza3JpdA==" }
+      headers: { Authorization: "Basic cmVtb3RlOnMza3JpdC1wYXNzd29yZA==" }
       async_search.delete:
         id: "$id"
 

--- a/x-pack/qa/multi-cluster-search-security/src/test/resources/rest-api-spec/test/multi_cluster/20_info.yml
+++ b/x-pack/qa/multi-cluster-search-security/src/test/resources/rest-api-spec/test/multi_cluster/20_info.yml
@@ -11,7 +11,7 @@ setup:
         username: "joe"
         body:  >
             {
-              "password": "s3krit",
+              "password": "s3krit-password",
               "roles" : [ "x_cluster_role" ]
             }
   - do:
@@ -35,7 +35,7 @@ teardown:
 "Fetch remote cluster info for existing cluster":
 
   - do:
-      headers: { Authorization: "Basic am9lOnMza3JpdA==" }
+      headers: { Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA==" }
       cluster.remote_info: {}
   - match: { my_remote_cluster.connected: true }
   - match: { my_remote_cluster.num_nodes_connected: 1}
@@ -67,7 +67,7 @@ teardown:
         index: test_remote_cluster:test_index
 
   - do:
-      headers: { Authorization: "Basic am9lOnMza3JpdA==" }
+      headers: { Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA==" }
       cluster.remote_info: {}
   - match: { test_remote_cluster.connected: true }
   - match: { my_remote_cluster.connected: true }

--- a/x-pack/qa/multi-cluster-search-security/src/test/resources/rest-api-spec/test/multi_cluster/30_field_caps.yml
+++ b/x-pack/qa/multi-cluster-search-security/src/test/resources/rest-api-spec/test/multi_cluster/30_field_caps.yml
@@ -11,7 +11,7 @@ setup:
         username: "joe"
         body:  >
             {
-              "password": "s3krit",
+              "password": "s3krit-password",
               "roles" : [ "x_cluster_role" ]
             }
   - do:
@@ -64,7 +64,7 @@ teardown:
                         doc_values: true
 
   - do:
-      headers: { Authorization: "Basic am9lOnMza3JpdA==" }
+      headers: { Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA==" }
       field_caps:
         index: 'field_caps_index_2,my_remote_cluster:field_caps_index_1,my_remote_cluster:field_caps_index_3'
         fields: [text, keyword, number, geo]

--- a/x-pack/qa/multi-cluster-search-security/src/test/resources/rest-api-spec/test/multi_cluster/40_scroll.yml
+++ b/x-pack/qa/multi-cluster-search-security/src/test/resources/rest-api-spec/test/multi_cluster/40_scroll.yml
@@ -11,7 +11,7 @@ setup:
         username: "joe"
         body:  >
             {
-              "password": "s3krit",
+              "password": "s3krit-password",
               "roles" : [ "x_cluster_role" ]
             }
   - do:  # Remote indices only CCS does not require any privileges on the local cluster
@@ -36,7 +36,7 @@ teardown:
 "Scroll on the mixed cluster":
 
   - do:
-      headers: { Authorization: "Basic am9lOnMza3JpdA==" }
+      headers: { Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA==" }
       search:
         rest_total_hits_as_int: true
         index: my_remote_cluster:test_index
@@ -59,7 +59,7 @@ teardown:
   - match: {hits.hits.3._source.filter_field: 0 }
 
   - do:
-      headers: { Authorization: "Basic am9lOnMza3JpdA==" }
+      headers: { Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA==" }
       scroll:
         rest_total_hits_as_int: true
         body: { "scroll_id": "$scroll_id", "scroll": "1m"}
@@ -71,7 +71,7 @@ teardown:
   - match: {hits.hits.1._source.filter_field: 1 }
 
   - do:
-      headers: { Authorization: "Basic am9lOnMza3JpdA==" }
+      headers: { Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA==" }
       scroll:
         rest_total_hits_as_int: true
         scroll_id: $scroll_id
@@ -81,14 +81,14 @@ teardown:
   - length: {hits.hits:      0    }
 
   - do:
-      headers: { Authorization: "Basic am9lOnMza3JpdA==" }
+      headers: { Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA==" }
       clear_scroll:
         scroll_id: $scroll_id
 
 ---
 "Steal Scroll ID on the mixed cluster":
   - do:
-      headers: { Authorization: "Basic am9lOnMza3JpdA==" }
+      headers: { Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA==" }
       search:
         rest_total_hits_as_int: true
         index: my_remote_cluster:test_index
@@ -117,7 +117,7 @@ teardown:
         body: { "scroll_id": "$scroll_id", "scroll": "1m"}
 
   - do:
-      headers: { Authorization: "Basic am9lOnMza3JpdA==" }
+      headers: { Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA==" }
       catch: missing
       clear_scroll:
         scroll_id: $scroll_id

--- a/x-pack/qa/multi-cluster-search-security/src/test/resources/rest-api-spec/test/multi_cluster/50_missing.yml
+++ b/x-pack/qa/multi-cluster-search-security/src/test/resources/rest-api-spec/test/multi_cluster/50_missing.yml
@@ -11,7 +11,7 @@ setup:
         username: "joe"
         body:  >
             {
-              "password": "s3krit",
+              "password": "s3krit-password",
               "roles" : [ "x_cluster_role" ]
             }
   - do:
@@ -40,7 +40,7 @@ teardown:
 ---
 "Search with missing remote index pattern":
   - do:
-      headers: { Authorization: "Basic am9lOnMza3JpdA==" }
+      headers: { Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA==" }
       search:
         rest_total_hits_as_int: true
         index: "*:foo-*"
@@ -49,7 +49,7 @@ teardown:
   - match: { hits.total: 0 }
 
   - do:
-      headers: { Authorization: "Basic am9lOnMza3JpdA==" }
+      headers: { Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA==" }
       search:
         rest_total_hits_as_int: true
         index: "my_remote_cluster:foo-*"
@@ -59,14 +59,14 @@ teardown:
 
   - do:
       catch: "forbidden"
-      headers: { Authorization: "Basic am9lOnMza3JpdA==" }
+      headers: { Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA==" }
       search:
         rest_total_hits_as_int: true
         index: "*:foo-bar"
 
   - do:
       catch: "forbidden"
-      headers: { Authorization: "Basic am9lOnMza3JpdA==" }
+      headers: { Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA==" }
       search:
         rest_total_hits_as_int: true
         index: "my_remote_cluster:foo-bar"

--- a/x-pack/qa/multi-cluster-search-security/src/test/resources/rest-api-spec/test/multi_cluster/60_skip_shards.yml
+++ b/x-pack/qa/multi-cluster-search-security/src/test/resources/rest-api-spec/test/multi_cluster/60_skip_shards.yml
@@ -11,7 +11,7 @@ setup:
         username: "joe"
         body:  >
             {
-              "password": "s3krit",
+              "password": "s3krit-password",
               "roles" : [ "x_cluster_role" ]
             }
   - do:
@@ -63,7 +63,7 @@ teardown:
 
   # check that we skip the remote shard
   - do:
-     headers: { Authorization: "Basic am9lOnMza3JpdA==" }
+     headers: { Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA==" }
      search:
        ccs_minimize_roundtrips: false
        rest_total_hits_as_int: true
@@ -81,7 +81,7 @@ teardown:
 
   # check that we skip the local shard
   - do:
-     headers: { Authorization: "Basic am9lOnMza3JpdA==" }
+     headers: { Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA==" }
      search:
        ccs_minimize_roundtrips: false
        rest_total_hits_as_int: true

--- a/x-pack/qa/multi-cluster-search-security/src/test/resources/rest-api-spec/test/multi_cluster/80_point_in_time.yml
+++ b/x-pack/qa/multi-cluster-search-security/src/test/resources/rest-api-spec/test/multi_cluster/80_point_in_time.yml
@@ -11,7 +11,7 @@ setup:
         username: "joe"
         body:  >
           {
-            "password": "s3krit",
+            "password": "s3krit-password",
             "roles" : [ "x_cluster_role" ]
           }
   - do:
@@ -33,7 +33,7 @@ setup:
         username: "remote"
         body:  >
           {
-            "password": "s3krit",
+            "password": "s3krit-password",
             "roles" : [ "remote_ccs" ]
           }
   - do:
@@ -78,14 +78,14 @@ teardown:
           - '{"f": "l2", "created_at" : "2021-01-02"}'
 
   - do:
-      headers: { Authorization: "Basic am9lOnMza3JpdA==" }
+      headers: { Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA==" }
       open_point_in_time:
         index: my_remote_cluster:point_in_time_index,local_pit
         keep_alive: 5m
   - set: {id: pit_id}
 
   - do:
-      headers: { Authorization: "Basic am9lOnMza3JpdA==" }
+      headers: { Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA==" }
       search:
         rest_total_hits_as_int: true
         sort: created_at
@@ -107,7 +107,7 @@ teardown:
   - match: { hits.hits.2._source.f: "l2" }
 
   - do:
-      headers: { Authorization: "Basic am9lOnMza3JpdA==" }
+      headers: { Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA==" }
       close_point_in_time:
         body:
           id: "$pit_id"
@@ -116,14 +116,14 @@ teardown:
 "Point in time CCS with only remote indices requires no privileges on local cluster":
 
   - do:
-      headers: { Authorization: "Basic cmVtb3RlOnMza3JpdA==" }
+      headers: { Authorization: "Basic cmVtb3RlOnMza3JpdC1wYXNzd29yZA==" }
       open_point_in_time:
         index: "my_*:point_in_time_index"
         keep_alive: 5m
   - set: {id: pit_id}
 
   - do:
-      headers: { Authorization: "Basic cmVtb3RlOnMza3JpdA==" }
+      headers: { Authorization: "Basic cmVtb3RlOnMza3JpdC1wYXNzd29yZA==" }
       search:
         rest_total_hits_as_int: true
         sort: created_at
@@ -143,7 +143,7 @@ teardown:
   - match: { hits.hits.1._source.f: "r4" }
 
   - do:
-      headers: { Authorization: "Basic cmVtb3RlOnMza3JpdA==" }
+      headers: { Authorization: "Basic cmVtb3RlOnMza3JpdC1wYXNzd29yZA==" }
       close_point_in_time:
         body:
           id: "$pit_id"

--- a/x-pack/qa/multi-cluster-search-security/src/test/resources/rest-api-spec/test/remote_cluster/10_basic.yml
+++ b/x-pack/qa/multi-cluster-search-security/src/test/resources/rest-api-spec/test/remote_cluster/10_basic.yml
@@ -11,7 +11,7 @@ setup:
         username: "joe"
         body:  >
             {
-              "password": "s3krit",
+              "password": "s3krit-password",
               "roles" : [ "x_cluster_role" ]
             }
   - do:
@@ -34,7 +34,7 @@ setup:
         username: "remote"
         body:  >
             {
-              "password": "s3krit",
+              "password": "s3krit-password",
               "roles" : [ "remote_ccs" ]
             }
   - do:
@@ -220,7 +220,7 @@ setup:
 
 
   - do:
-      headers: { Authorization: "Basic am9lOnMza3JpdA==" }
+      headers: { Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA==" }
       search:
         rest_total_hits_as_int: true
         index: test_index
@@ -237,7 +237,7 @@ setup:
   - match: { aggregations.cluster.buckets.0.doc_count: 6 }
 
   - do:
-      headers: { Authorization: "Basic am9lOnMza3JpdA==" }
+      headers: { Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA==" }
       search:
         rest_total_hits_as_int: true
         index: aliased_test_index
@@ -248,7 +248,7 @@ setup:
   - match: { hits.hits.0._index: "test_index" }
 
   - do:
-      headers: { Authorization: "Basic am9lOnMza3JpdA==" }
+      headers: { Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA==" }
       search:
         rest_total_hits_as_int: true
         index: secure_alias
@@ -268,7 +268,7 @@ setup:
         username: "joe"
         body:  >
             {
-              "password": "s3krit",
+              "password": "s3krit-password",
               "roles" : [ ]
             }
   - match: { created: false }

--- a/x-pack/qa/multi-cluster-tests-with-security/src/test/resources/rest-api-spec/test/multi_cluster/80_transform.yml
+++ b/x-pack/qa/multi-cluster-tests-with-security/src/test/resources/rest-api-spec/test/multi_cluster/80_transform.yml
@@ -12,7 +12,7 @@ setup:
         username: "joe"
         body:  >
             {
-              "password": "transform",
+              "password": "transform-password",
               "roles" : [  "transform_admin", "x_cluster_role" ]
             }
   - do:
@@ -42,7 +42,7 @@ teardown:
 ---
 "Search remote cluster":
   - do:
-      headers: { Authorization: "Basic am9lOnRyYW5zZm9ybQ==" }
+      headers: { Authorization: "Basic am9lOnRyYW5zZm9ybS1wYXNzd29yZA==" }
       search:
         rest_total_hits_as_int: true
         index: my_remote_cluster:test_index
@@ -61,7 +61,7 @@ teardown:
 ---
 "Batch transform from remote cluster":
   - do:
-      headers: { Authorization: "Basic am9lOnRyYW5zZm9ybQ==" }
+      headers: { Authorization: "Basic am9lOnRyYW5zZm9ybS1wYXNzd29yZA==" }
       transform.put_transform:
         transform_id: "simple-remote-transform"
         body: >
@@ -76,7 +76,7 @@ teardown:
   - match: { acknowledged: true }
 
   - do:
-      headers: { Authorization: "Basic am9lOnRyYW5zZm9ybQ==" }
+      headers: { Authorization: "Basic am9lOnRyYW5zZm9ybS1wYXNzd29yZA==" }
       transform.start_transform:
         transform_id: "simple-remote-transform"
   - match: { acknowledged: true }
@@ -89,7 +89,7 @@ teardown:
   - match: { transforms.0.state: "/started|indexing|stopping|stopped/" }
 
   - do:
-      headers: { Authorization: "Basic am9lOnRyYW5zZm9ybQ==" }
+      headers: { Authorization: "Basic am9lOnRyYW5zZm9ybS1wYXNzd29yZA==" }
       transform.stop_transform:
         transform_id: "simple-remote-transform"
         wait_for_completion: true
@@ -97,7 +97,7 @@ teardown:
   - match: { acknowledged: true }
 
   - do:
-      headers: { Authorization: "Basic am9lOnRyYW5zZm9ybQ==" }
+      headers: { Authorization: "Basic am9lOnRyYW5zZm9ybS1wYXNzd29yZA==" }
       transform.get_transform_stats:
         transform_id: "simple-remote-transform"
   - match: { count: 1 }
@@ -107,12 +107,12 @@ teardown:
 
   # workaround: refresh dest index, to be removed, see gh #51154
   - do:
-      headers: { Authorization: "Basic am9lOnRyYW5zZm9ybQ==" }
+      headers: { Authorization: "Basic am9lOnRyYW5zZm9ybS1wYXNzd29yZA==" }
       indices.refresh:
         index: simple-remote-transform
 
   - do:
-      headers: { Authorization: "Basic am9lOnRyYW5zZm9ybQ==" }
+      headers: { Authorization: "Basic am9lOnRyYW5zZm9ybS1wYXNzd29yZA==" }
       search:
         rest_total_hits_as_int: true
         index: simple-remote-transform
@@ -126,7 +126,7 @@ teardown:
   - match: { hits.hits.1._source.user: b }
 
   - do:
-      headers: { Authorization: "Basic am9lOnRyYW5zZm9ybQ==" }
+      headers: { Authorization: "Basic am9lOnRyYW5zZm9ybS1wYXNzd29yZA==" }
       transform.update_transform:
         transform_id: "simple-remote-transform"
         body: >
@@ -134,7 +134,7 @@ teardown:
             "source": { "index": ["my_remote_cluster:test_index", "my_remote_cluster:test_index_2"] }
           }
   - do:
-      headers: { Authorization: "Basic am9lOnRyYW5zZm9ybQ==" }
+      headers: { Authorization: "Basic am9lOnRyYW5zZm9ybS1wYXNzd29yZA==" }
       transform.get_transform_stats:
         transform_id: "simple-remote-transform"
   - match: { count: 1 }
@@ -190,7 +190,7 @@ teardown:
             - '{"user": "c", "stars": 4, "date" : "2018-11-29T12:35:12.123456789Z"}'
 
   - do:
-      headers: { Authorization: "Basic am9lOnRyYW5zZm9ybQ==" }
+      headers: { Authorization: "Basic am9lOnRyYW5zZm9ybS1wYXNzd29yZA==" }
       transform.put_transform:
         transform_id: "simple-local-remote-transform"
         body: >
@@ -208,7 +208,7 @@ teardown:
   - match: { acknowledged: true }
 
   - do:
-      headers: { Authorization: "Basic am9lOnRyYW5zZm9ybQ==" }
+      headers: { Authorization: "Basic am9lOnRyYW5zZm9ybS1wYXNzd29yZA==" }
       transform.start_transform:
         transform_id: "simple-local-remote-transform"
   - match: { acknowledged: true }
@@ -221,7 +221,7 @@ teardown:
   - match: { transforms.0.state: "/started|indexing|stopping|stopped/" }
 
   - do:
-      headers: { Authorization: "Basic am9lOnRyYW5zZm9ybQ==" }
+      headers: { Authorization: "Basic am9lOnRyYW5zZm9ybS1wYXNzd29yZA==" }
       transform.stop_transform:
         transform_id: "simple-local-remote-transform"
         wait_for_completion: true
@@ -229,7 +229,7 @@ teardown:
   - match: { acknowledged: true }
 
   - do:
-      headers: { Authorization: "Basic am9lOnRyYW5zZm9ybQ==" }
+      headers: { Authorization: "Basic am9lOnRyYW5zZm9ybS1wYXNzd29yZA==" }
       transform.get_transform_stats:
         transform_id: "simple-local-remote-transform"
   - match: { count: 1 }
@@ -239,12 +239,12 @@ teardown:
 
   # workaround: refresh dest index, to be removed, see gh #51154
   - do:
-      headers: { Authorization: "Basic am9lOnRyYW5zZm9ybQ==" }
+      headers: { Authorization: "Basic am9lOnRyYW5zZm9ybS1wYXNzd29yZA==" }
       indices.refresh:
         index: simple-local-remote-transform
 
   - do:
-      headers: { Authorization: "Basic am9lOnRyYW5zZm9ybQ==" }
+      headers: { Authorization: "Basic am9lOnRyYW5zZm9ybS1wYXNzd29yZA==" }
       search:
         rest_total_hits_as_int: true
         index: simple-local-remote-transform

--- a/x-pack/qa/multi-cluster-tests-with-security/src/test/resources/rest-api-spec/test/remote_cluster/80_transform.yml
+++ b/x-pack/qa/multi-cluster-tests-with-security/src/test/resources/rest-api-spec/test/remote_cluster/80_transform.yml
@@ -11,7 +11,7 @@ setup:
         username: "joe"
         body:  >
             {
-              "password": "transform",
+              "password": "transform-password",
               "roles" : [ "x_cluster_role" ]
             }
   - do:

--- a/x-pack/qa/password-protected-keystore/build.gradle
+++ b/x-pack/qa/password-protected-keystore/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 testClusters.integTest {
   testDistribution = 'DEFAULT'
   numberOfNodes = 2
-  keystorePassword 's3cr3t'
+  keystorePassword 'keystore-password'
 
   setting 'xpack.security.enabled', 'true'
   setting 'xpack.security.authc.anonymous.roles', 'anonymous'
@@ -29,5 +29,5 @@ testClusters.integTest {
   extraConfigFile 'roles.yml', file('src/test/resources/roles.yml')
 
   user username: 'admin_user', password: 'admin-password'
-  user username:'test-user' ,password: 'test-password', role: 'user_role'
+  user username:'test-user' ,password: 'test-user-password', role: 'user_role'
 }

--- a/x-pack/qa/password-protected-keystore/src/test/java/org/elasticsearch/password_protected_keystore/ReloadSecureSettingsWithPasswordProtectedKeystoreRestIT.java
+++ b/x-pack/qa/password-protected-keystore/src/test/java/org/elasticsearch/password_protected_keystore/ReloadSecureSettingsWithPasswordProtectedKeystoreRestIT.java
@@ -23,7 +23,7 @@ import java.util.Map;
 
 public class ReloadSecureSettingsWithPasswordProtectedKeystoreRestIT extends ESRestTestCase {
     // From build.gradle
-    private final String KEYSTORE_PASSWORD = "s3cr3t";
+    private final String KEYSTORE_PASSWORD = "keystore-password";
     private final int NUM_NODES = 2;
 
     @SuppressWarnings("unchecked")
@@ -86,7 +86,7 @@ public class ReloadSecureSettingsWithPasswordProtectedKeystoreRestIT extends ESR
 
     @Override
     protected Settings restClientSettings() {
-        String token = basicAuthHeaderValue("test-user", new SecureString("test-password".toCharArray()));
+        String token = basicAuthHeaderValue("test-user", new SecureString("test-user-password".toCharArray()));
         return Settings.builder()
             .put(ThreadContext.PREFIX + ".Authorization", token)
             .build();

--- a/x-pack/qa/reindex-tests-with-security/build.gradle
+++ b/x-pack/qa/reindex-tests-with-security/build.gradle
@@ -19,14 +19,14 @@ tasks.named("forbiddenPatterns").configure {
   exclude '**/*.jks'
 }
 
-File caFile = project.file('src/test/resources/ssl/ca.p12')
+File caFile = project.file('src/test/resources/ssl/ca.crt')
 
 testClusters.integTest {
   testDistribution = 'DEFAULT'
   // Whitelist reindexing from the local node so we can test it.
   extraConfigFile 'http.key', file('src/test/resources/ssl/http.key')
   extraConfigFile 'http.crt', file('src/test/resources/ssl/http.crt')
-  extraConfigFile 'ca.p12', caFile
+  extraConfigFile 'ca.crt', caFile
   setting 'reindex.remote.whitelist', '127.0.0.1:*'
   setting 'xpack.security.enabled', 'true'
   setting 'xpack.ml.enabled', 'false'
@@ -35,8 +35,7 @@ testClusters.integTest {
   setting 'xpack.security.http.ssl.certificate', 'http.crt'
   setting 'xpack.security.http.ssl.key', 'http.key'
   setting 'xpack.security.http.ssl.key_passphrase', 'http-password'
-  setting 'reindex.ssl.truststore.path', 'ca.p12'
-  setting 'reindex.ssl.truststore.password', 'password'
+  setting 'reindex.ssl.certificate_authorities', 'ca.crt'
 
   // Workaround for JDK-8212885
   if (BuildParams.runtimeJavaVersion.isJava12Compatible() == false) {

--- a/x-pack/qa/reindex-tests-with-security/src/test/java/org/elasticsearch/xpack/security/ReindexWithSecurityClientYamlTestSuiteIT.java
+++ b/x-pack/qa/reindex-tests-with-security/src/test/java/org/elasticsearch/xpack/security/ReindexWithSecurityClientYamlTestSuiteIT.java
@@ -26,7 +26,7 @@ public class ReindexWithSecurityClientYamlTestSuiteIT extends ESClientYamlSuiteT
     private static final String USER = "test_admin";
     private static final String PASS = "x-pack-test-password";
 
-    private static Path httpTrustStore;
+    private static Path httpCertificateAuthority;
 
     public ReindexWithSecurityClientYamlTestSuiteIT(@Name("yaml") ClientYamlTestCandidate testCandidate) {
         super(testCandidate);
@@ -38,17 +38,17 @@ public class ReindexWithSecurityClientYamlTestSuiteIT extends ESClientYamlSuiteT
     }
 
     @BeforeClass
-    public static void findTrustStore( ) throws Exception {
-        final URL resource = ReindexWithSecurityClientYamlTestSuiteIT.class.getResource("/ssl/ca.p12");
+    public static void findTrustedCaCertificate( ) throws Exception {
+        final URL resource = ReindexWithSecurityClientYamlTestSuiteIT.class.getResource("/ssl/ca.crt");
         if (resource == null) {
-            throw new FileNotFoundException("Cannot find classpath resource /ssl/ca.p12");
+            throw new FileNotFoundException("Cannot find classpath resource /ssl/ca.crt");
         }
-        httpTrustStore = PathUtils.get(resource.toURI());
+        httpCertificateAuthority = PathUtils.get(resource.toURI());
     }
 
     @AfterClass
     public static void cleanupStatics() {
-        httpTrustStore = null;
+        httpCertificateAuthority = null;
     }
 
     @Override
@@ -64,8 +64,7 @@ public class ReindexWithSecurityClientYamlTestSuiteIT extends ESClientYamlSuiteT
         String token = basicAuthHeaderValue(USER, new SecureString(PASS.toCharArray()));
         return Settings.builder()
                 .put(ThreadContext.PREFIX + ".Authorization", token)
-                .put(TRUSTSTORE_PATH , httpTrustStore)
-                .put(TRUSTSTORE_PASSWORD, "password")
+                .put(CERTIFICATE_AUTHORITIES , httpCertificateAuthority)
                 .build();
     }
 }

--- a/x-pack/qa/reindex-tests-with-security/src/test/resources/rest-api-spec/test/15_reindex_from_remote.yml
+++ b/x-pack/qa/reindex-tests-with-security/src/test/resources/rest-api-spec/test/15_reindex_from_remote.yml
@@ -388,7 +388,7 @@
             remote:
               host: https://${host}
               username: test_admin
-              password: badpass
+              password: bad-x-pack-test-password
             index: source
           dest:
             index: dest

--- a/x-pack/qa/rolling-upgrade-basic/build.gradle
+++ b/x-pack/qa/rolling-upgrade-basic/build.gradle
@@ -9,6 +9,10 @@ apply from : "$rootDir/gradle/bwc-test.gradle"
 dependencies {
   testImplementation project(':x-pack:qa')
 }
+if (BuildParams.inFipsJvm){
+  // This test is testing rolling upgrades with a BASIC license and FIPS 140 mode is not available in BASIC
+  tasks.withType(Test).configureEach{ enabled = false }
+}
 
 for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
   String baseName = "v${bwcVersion}"
@@ -78,4 +82,13 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
   tasks.register(bwcTaskName(bwcVersion)) {
     dependsOn "${baseName}#upgradedClusterTest"
   }
+}
+
+
+// Security is explicitly disabled, do not run tests in FIPS mode
+tasks.withType(Test).configureEach {
+  onlyIf { BuildParams.inFipsJvm == false}
+}
+tasks.getByName("testingConventions") {
+  onlyIf { BuildParams.inFipsJvm == false }
 }

--- a/x-pack/qa/rolling-upgrade-multi-cluster/build.gradle
+++ b/x-pack/qa/rolling-upgrade-multi-cluster/build.gradle
@@ -94,3 +94,8 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
     dependsOn "${baseName}#leader#upgradedClusterTest"
   }
 }
+
+// Security is explicitly disabled, do not run tests in FIPS mode
+tasks.withType(Test).configureEach {
+  onlyIf { BuildParams.inFipsJvm == false}
+}

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/20_security.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/20_security.yml
@@ -64,7 +64,7 @@
         username: "logstash_system"
         body: >
             {
-              "password" : "changed-it"
+              "password" : "changed-password"
             }
 
   - do:

--- a/x-pack/qa/security-example-spi-extension/src/javaRestTest/java/org/elasticsearch/example/role/CustomRolesProviderIT.java
+++ b/x-pack/qa/security-example-spi-extension/src/javaRestTest/java/org/elasticsearch/example/role/CustomRolesProviderIT.java
@@ -35,7 +35,7 @@ import static org.hamcrest.Matchers.is;
  */
 public class CustomRolesProviderIT extends ESIntegTestCase {
     private static final String TEST_USER = "test_user";
-    private static final String TEST_PWD = "change_me";
+    private static final String TEST_PWD = "test-user-password";
 
     private static final RequestOptions AUTH_OPTIONS;
     static {

--- a/x-pack/qa/security-setup-password-tests/src/test/java/org/elasticsearch/xpack/security/authc/esnative/tool/SetupPasswordToolIT.java
+++ b/x-pack/qa/security-setup-password-tests/src/test/java/org/elasticsearch/xpack/security/authc/esnative/tool/SetupPasswordToolIT.java
@@ -80,8 +80,10 @@ public class SetupPasswordToolIT extends ESRestTestCase {
         final int status;
         if (randomBoolean()) {
             mockTerminal.addTextInput("y"); // answer yes to continue prompt
+            possiblyDecryptKeystore(mockTerminal);
             status = tool.main(new String[] { "auto" }, mockTerminal);
         } else {
+            possiblyDecryptKeystore(mockTerminal);
             status = tool.main(new String[] { "auto", "--batch" }, mockTerminal);
         }
         assertEquals(0, status);
@@ -118,6 +120,13 @@ public class SetupPasswordToolIT extends ESRestTestCase {
                 throw new UncheckedIOException(e);
             }
         });
+    }
+
+    private void possiblyDecryptKeystore(MockTerminal mockTerminal) {
+        if (inFipsJvm()) {
+            // In our FIPS 140-2 tests, we set the keystore password to `keystore-password`
+            mockTerminal.addSecretInput("keystore-password");
+        }
     }
 
     @SuppressForbidden(reason = "need to set sys props for CLI tool")

--- a/x-pack/qa/security-tools-tests/src/test/java/org/elasticsearch/xpack/security/authc/file/tool/UsersToolTests.java
+++ b/x-pack/qa/security-tools-tests/src/test/java/org/elasticsearch/xpack/security/authc/file/tool/UsersToolTests.java
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import static org.elasticsearch.test.SecurityIntegTestCase.getFastStoredHashAlgoForTests;
 import static org.hamcrest.Matchers.containsString;
 
 public class UsersToolTests extends CommandTestCase {
@@ -70,8 +71,7 @@ public class UsersToolTests extends CommandTestCase {
         IOUtils.rm(homeDir);
         confDir = homeDir.resolve("config");
         Files.createDirectories(confDir);
-        hasher = inFipsJvm() ? randomFrom(Hasher.PBKDF2, Hasher.PBKDF2_1000, Hasher.PBKDF2_STRETCH)
-            : randomFrom(Hasher.PBKDF2_1000, Hasher.PBKDF2, Hasher.BCRYPT, Hasher.BCRYPT9);
+        hasher = getFastStoredHashAlgoForTests();
         String defaultPassword = SecuritySettingsSourceField.TEST_PASSWORD;
         Files.write(confDir.resolve("users"), Arrays.asList(
             "existing_user:" + new String(hasher.hash(SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING)),
@@ -402,16 +402,16 @@ public class UsersToolTests extends CommandTestCase {
     }
 
     public void testPasswdNoPasswordOption() throws Exception {
-        terminal.addSecretInput("newpassword");
-        terminal.addSecretInput("newpassword");
+        terminal.addSecretInput("new-test-user-password");
+        terminal.addSecretInput("new-test-user-password");
         execute("passwd", pathHomeParameter, fileOrderParameter, "existing_user");
-        assertUser("existing_user", "newpassword");
+        assertUser("existing_user", "new-test-user-password");
         assertRole("test_admin", "existing_user", "existing_user2"); // roles unchanged
     }
 
     public void testPasswd() throws Exception {
-        execute("passwd", pathHomeParameter, fileOrderParameter, "existing_user", "-p", "newpassword");
-        assertUser("existing_user", "newpassword");
+        execute("passwd", pathHomeParameter, fileOrderParameter, "existing_user", "-p", "new-test-user-password");
+        assertUser("existing_user", "new-test-user-password");
         assertRole("test_admin", "existing_user"); // roles unchanged
     }
 
@@ -423,7 +423,7 @@ public class UsersToolTests extends CommandTestCase {
                 .put("xpack.security.fips_mode.enabled", true)
                 .build();
         UserException e = expectThrows(UserException.class, () -> {
-            execute("passwd", pathHomeParameter, fileOrderParameter, "existing_user", "-p", "newpassword");
+            execute("passwd", pathHomeParameter, fileOrderParameter, "existing_user", "-p", "new-test-user-password");
         });
         assertEquals(ExitCodes.CONFIG, e.exitCode);
         assertEquals("Only PBKDF2 is allowed for password hashing in a FIPS 140 JVM. " +

--- a/x-pack/qa/third-party/jira/build.gradle
+++ b/x-pack/qa/third-party/jira/build.gradle
@@ -3,6 +3,8 @@ import groovy.json.JsonSlurper
 import javax.net.ssl.HttpsURLConnection
 import java.nio.charset.StandardCharsets
 
+import org.elasticsearch.gradle.info.BuildParams
+
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
@@ -55,6 +57,11 @@ if (!jiraUrl && !jiraUser && !jiraPassword && !jiraProject) {
     keystore 'xpack.notification.jira.account.test.secure_password', jiraPassword
   }
   integTest.finalizedBy "cleanJira"
+}
+
+if (BuildParams.inFipsJvm){
+  // Test clusters run with security disabled
+  tasks.named("integTest").configure{enabled = false }
 }
 
 /** List all issues associated to a given Jira project **/

--- a/x-pack/qa/third-party/pagerduty/build.gradle
+++ b/x-pack/qa/third-party/pagerduty/build.gradle
@@ -1,3 +1,5 @@
+import org.elasticsearch.gradle.info.BuildParams
+
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
@@ -28,4 +30,9 @@ if (!pagerDutyServiceKey) {
     setting 'logger.org.elasticsearch.xpack.watcher', 'DEBUG'
     keystore 'xpack.notification.pagerduty.account.test_account.secure_service_api_key', pagerDutyServiceKey
   }
+}
+
+if (BuildParams.inFipsJvm){
+  // Test clusters run with security disabled
+  tasks.named("integTest").configure{enabled = false }
 }

--- a/x-pack/qa/third-party/slack/build.gradle
+++ b/x-pack/qa/third-party/slack/build.gradle
@@ -1,3 +1,5 @@
+import org.elasticsearch.gradle.info.BuildParams
+
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
@@ -28,4 +30,9 @@ if (!slackUrl) {
     setting 'logger.org.elasticsearch.xpack.watcher', 'DEBUG'
     keystore 'xpack.notification.slack.account.test_account.secure_url', slackUrl
   }
+}
+
+if (BuildParams.inFipsJvm){
+  // Test clusters run with security disabled
+  tasks.named("integTest").configure{enabled = false }
 }


### PR DESCRIPTION
We were depending on the BouncyCastle FIPS own mechanics to set
itself in approved only mode since we run with the Security
Manager enabled. The check during startup seems to happen before we
set our restrictive SecurityManager though in
org.elasticsearch.bootstrap.Elasticsearch , and this means that
BCFIPS would not be in approved only mode, unless explicitly
configured so.

This commit sets the appropriate JVM property to explicitly set
BCFIPS in approved only mode in CI and adds tests to ensure that we
will be running with BCFIPS in approved only mode when we expect to.
It also sets xpack.security.fips_mode.enabled to true for all test clusters
used in fips mode and sets the distribution to the default one. It adds a
password to the elasticsearch keystore for all test clusters that run in fips
mode.
Moreover, it changes a few unit tests where we would use bcrypt even in
FIPS 140 mode. These would still pass since we are bundling our own
bcrypt implementation, but are now changed to use FIPS 140 approved
algorithms instead for better coverage.

It also addresses a number of tests that would fail in approved only mode
Mainly:

- Tests that use PBKDF2 with a password less than 112 bits (14char). We
    elected to change the passwords used everywhere to be at least 14
    characters long instead of mandating
    the use of pbkdf2_stretch because both pbkdf2 and
    pbkdf2_stretch are supported and allowed in fips mode and it makes sense
    to test with both. We could possibly figure out the password algorithm used
    for each test and adjust password length accordingly only for pbkdf2 but
    there is little value in that. It's good practice to use strong passwords so if
    our docs and tests use longer passwords, then it's for the best. The approach
    is brittle as there is no guarantee that the next test that will be added won't
    use a short password, so we add some testing documentation too.
    This leaves us with a possible coverage gap since we do support passwords
    as short as 6 characters but we only test with > 14 chars but the
    validation itself was not tested even before. Tests can be added in a followup,
    outside of fips related context.

- Tests that use a PKCS12 keystore and were not already muted.

- Tests that depend on running test clusters with a basic license or
    using the OSS distribution as FIPS 140 support is not available in
    neither of these.

Finally, it adds some information around FIPS 140 testing in our testing
documentation reference so that developers can hopefully keep in
mind fips 140 related intricacies when writing/changing docs.

Backport of #64024