### PR TITLE
Update skip after backport of #66295

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/220_filters_bucket.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/220_filters_bucket.yml
@@ -277,8 +277,8 @@ setup:
 ---
 "cache":
   - skip:
-      version: " - 7.99.99"
-      reason:  cache fixed in 8.0.0 to be backported to 7.11.0
+      version: " - 7.10.99"
+      reason:  cache fixed in 7.11.0
 
   - do:
        bulk:


### PR DESCRIPTION
Now that #66295 has landed in 7.11 we can run the bwc tests it adds
against that branch.
