### PR TITLE
Require security to be provided by X-Pack

### DIFF
--- a/x-pack/plugin/security/qa/basic-enable-security/src/javaRestTest/java/org/elasticsearch/xpack/security/EnableSecurityOnBasicLicenseIT.java
+++ b/x-pack/plugin/security/qa/basic-enable-security/src/javaRestTest/java/org/elasticsearch/xpack/security/EnableSecurityOnBasicLicenseIT.java
@@ -5,10 +5,13 @@
  */
 package org.elasticsearch.xpack.security;
 
+import org.apache.http.HttpHost;
 import org.apache.http.util.EntityUtils;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestClientBuilder;
 import org.elasticsearch.common.Booleans;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
@@ -20,6 +23,7 @@ import org.junit.BeforeClass;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -56,6 +60,14 @@ public class EnableSecurityOnBasicLicenseIT extends ESRestTestCase {
     }
 
     @Override
+    protected RestClient buildClient(Settings settings, HttpHost[] hosts) throws IOException {
+        RestClientBuilder builder = RestClient.builder(hosts);
+        configureClient(builder, settings);
+        builder.setStrictDeprecationMode(false);
+        return builder.build();
+    }
+
+    @Override
     protected boolean preserveClusterUponCompletion() {
         // If this is the first run (security not yet enabled), then don't clean up afterwards because we want to test restart with data
         return securityEnabled == false;
@@ -82,6 +94,21 @@ public class EnableSecurityOnBasicLicenseIT extends ESRestTestCase {
             checkDeniedWrite(otherIndex);
         } else {
             checkAllowedWrite(otherIndex);
+        }
+    }
+
+    public void testSecurityDisabledWarning() throws Exception {
+        final Request request = new Request("GET", "/_cat/indices");
+        Response response = client().performRequest(request);
+        List<String> warningHeaders = response.getWarnings();
+        if (securityEnabled) {
+            assertThat (warningHeaders.isEmpty(), equalTo(true));
+        } else {
+            assertThat (warningHeaders.size(), equalTo(1));
+            assertThat (warningHeaders.get(0),
+                containsString("Elasticsearch security features are not enabled, anyone can access your cluster without " +
+                "authentication. Read https://www.elastic.co/guide/en/elasticsearch/reference/<autodetected version number>/" +
+                "get-started-enable-security.html for more information."));
         }
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -1034,9 +1034,6 @@ public class Security extends Plugin implements SystemIndexPlugin, IngestPlugin,
 
     @Override
     public UnaryOperator<RestHandler> getRestHandlerWrapper(ThreadContext threadContext) {
-        if (enabled == false) {
-            return null;
-        }
         final boolean ssl = HTTP_SSL_ENABLED.get(settings);
         final SSLConfiguration httpSSLConfig = getSslService().getHttpTransportSSLConfiguration();
         boolean extractClientCertificate = ssl && getSslService().isSSLClientAuthEnabled(httpSSLConfig);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/SecurityRestFilter.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/SecurityRestFilter.java
@@ -95,7 +95,12 @@ public class SecurityRestFilter implements RestHandler {
                         e -> handleException("Secondary authentication", request, channel, e)));
                 }, e -> handleException("Authentication", request, channel, e)));
         } else {
-            HeaderWarning.addWarning("Security is disabled. No authentication available for REST request.");
+            if (request.getHeaders() != null && request.getHeaders().containsKey("Authorization")) {
+                HeaderWarning.addWarning("Elasticsearch security features are not enabled, anyone can access your cluster without " +
+                    "authentication. Read https://www.elastic.co/guide/en/elasticsearch/reference/<autodetected version number>/" +
+                    "get-started-enable-security.html for more information.");
+            }
+            restHandler.handleRequest(request, channel, client);
         }
     }
 


### PR DESCRIPTION
In order to provide a stronger guarantee to our solutions, that if a 
 cluster is running the default distribution and has security 
 (authentication) enabled, 
 then it will be provided by Elastic's security features, and users can 
 rely on it behaving in the ways they expect, this change 1) mandate 
 that security in default distribution is provided by X-Pack by always 
 installing the Security Rest Filter and 2) adding warnings if 
 credentials are provided to a cluster that does not have security
  enabled.
 
Related: #188