### PR TITLE
[DOCS] Clarify impact of delayed data in anomaly detection

### DIFF
--- a/docs/reference/ml/anomaly-detection/ml-delayed-data-detection.asciidoc
+++ b/docs/reference/ml/anomaly-detection/ml-delayed-data-detection.asciidoc
@@ -2,8 +2,9 @@
 [[ml-delayed-data-detection]]
 = Handling delayed data
 
-Delayed data are documents that are indexed late. That is to say, it is data
-related to a time that the {dfeed} has already processed.
+Delayed data are documents that are indexed late. That is to say, it is data 
+related to a time that your {dfeed} has already processed and it is therefore
+not analyzed by your {anomaly-job}.
 
 When you create a {dfeed}, you can specify a
 {ref}/ml-put-datafeed.html#ml-put-datafeed-request-body[`query_delay`] setting.
@@ -50,4 +51,3 @@ action to consider is to increase the `query_delay` of the datafeed. This
 increased delay allows more time for data to be indexed. If you have real-time
 constraints, however, an increased delay might not be desirable. In which case,
 you would have to {ref}/tune-for-indexing-speed.html[tune for better indexing speed].
-

--- a/docs/reference/ml/anomaly-detection/ml-delayed-data-detection.asciidoc
+++ b/docs/reference/ml/anomaly-detection/ml-delayed-data-detection.asciidoc
@@ -4,7 +4,7 @@
 
 Delayed data are documents that are indexed late. That is to say, it is data 
 related to a time that your {dfeed} has already processed and it is therefore
-not analyzed by your {anomaly-job}.
+never analyzed by your {anomaly-job}.
 
 When you create a {dfeed}, you can specify a
 {ref}/ml-put-datafeed.html#ml-put-datafeed-request-body[`query_delay`] setting.


### PR DESCRIPTION
This PR updates the delayed data page (https://www.elastic.co/guide/en/machine-learning/master/ml-delayed-data-detection.html) to address a question about whether "Datafeed has missed xxx documents due to ingest latency..." message in an anomaly detection job implies that the job will miss processing those records forever or will catch up with them eventually.

### Preview

https://elasticsearch_66816.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-delayed-data-detection.html