### PR TITLE
Skip netty4 yaml test in FIPS mode

### DIFF
--- a/modules/transport-netty4/src/yamlRestTest/java/org/elasticsearch/http/netty4/Netty4ClientYamlTestSuiteIT.java
+++ b/modules/transport-netty4/src/yamlRestTest/java/org/elasticsearch/http/netty4/Netty4ClientYamlTestSuiteIT.java
@@ -27,6 +27,8 @@ import org.apache.lucene.util.TimeUnits;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
 import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
 
+import java.io.IOException;
+
 //TODO: This is a *temporary* workaround to ensure a timeout does not mask other problems
 @TimeoutSuite(millis = 30 * TimeUnits.MINUTE)
 public class Netty4ClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
@@ -40,4 +42,9 @@ public class Netty4ClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
         return ESClientYamlSuiteTestCase.createParameters();
     }
 
+    @Override
+    public void test() throws IOException {
+        assumeFalse("FIPS JVMs are configured to use the 'security4' transport rather than 'netty4'", inFipsJvm());
+        super.test();
+    }
 }


### PR DESCRIPTION
The "Netty loaded" YAML test asserts that the configured transport is
"netty4", however when in FIPS mode, the tests enable security and the
configured transport is "security4".

This change skips the netty4 yaml test when running in FIPS mode.

Resolves: #66818
