### PR TITLE
[Backport] Increase test password length in FIPS

### DIFF
--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/esnative/ESNativeMigrateToolTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/esnative/ESNativeMigrateToolTests.java
@@ -35,6 +35,8 @@ import static org.hamcrest.Matchers.is;
  */
 public class ESNativeMigrateToolTests extends NativeRealmIntegTestCase {
 
+    private static final int MIN_PASSWORD_LENGTH = inFipsJvm() ? 14 : 6;
+
     // Randomly use SSL (or not)
     private static boolean useSSL;
 
@@ -81,8 +83,9 @@ public class ESNativeMigrateToolTests extends NativeRealmIntegTestCase {
         int numToAdd = randomIntBetween(1,10);
         Set<String> addedUsers = new HashSet<>(numToAdd);
         for (int i = 0; i < numToAdd; i++) {
-            String uname = randomAlphaOfLength(5);
-            c.preparePutUser(uname, "s3kirt".toCharArray(), getFastStoredHashAlgoForTests(), "role1", "user").get();
+            final String uname = randomAlphaOfLength(5);
+            final char[] password = randomAlphaOfLengthBetween(MIN_PASSWORD_LENGTH, MIN_PASSWORD_LENGTH * 2).toCharArray();
+            c.preparePutUser(uname, password, getFastStoredHashAlgoForTests(), "role1", "user").get();
             addedUsers.add(uname);
         }
         logger.error("--> waiting for .security index");


### PR DESCRIPTION
This changes the ESNativeMigrateToolTests to generate a random
password instead of a fixed-length password when creating test users.

When on a FIPS JVM the random password will have at least 14
characters (to allow it to work with the PBKDF2 hasher), in regular
mode it will have at least 6 characters (the ES security minimum)

Backport of: #66844
