### PR TITLE
[Backport] In FIPS/TestClusters, set hasher to pbkdf2_stretch

### DIFF
--- a/gradle/fips.gradle
+++ b/gradle/fips.gradle
@@ -72,6 +72,7 @@ if (BuildParams.inFipsJvm) {
           systemProperty 'org.bouncycastle.fips.approved_only', 'true'
           setting 'xpack.security.fips_mode.enabled', 'true'
           setting 'xpack.license.self_generated.type', 'trial'
+          setting 'xpack.security.authc.password_hashing.algorithm', 'pbkdf2_stretch'
           keystorePassword 'keystore-password'
         }
       }


### PR DESCRIPTION
When running tests in FIPS mode, automatically set the password hasher
to pbkdf2_stretch rather than relying on the default (which is
bcrypt).

This is only relevant to the 7.x series, as this setting has a FIPS
specific default when run in FIPS mode on 8.0+

Backport of: #66841
