### PR TITLE
Fix the problem of ES cluster crash, when the default_account setting is wrong

### DIFF
--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/NotificationService.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/NotificationService.java
@@ -157,7 +157,8 @@ public abstract class NotificationService<Account> {
         } else {
             final LazyInitializable<Account, SettingsException> account = accounts.get(defaultAccountName);
             if (account == null) {
-                throw new SettingsException("could not find default account [" + defaultAccountName + "]");
+                logger.warn("could not find default account [" + defaultAccountName + "]");
+                return null;
             }
             return account;
         }

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/notification/NotificationServiceTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/notification/NotificationServiceTests.java
@@ -78,8 +78,8 @@ public class NotificationServiceTests extends ESTestCase {
                 .put("xpack.notification.test.default_account", "non-existing")
                 .build();
 
-        SettingsException e = expectThrows(SettingsException.class, () -> new TestNotificationService(settings));
-        assertThat(e.getMessage(), is("could not find default account [non-existing]"));
+        TestNotificationService service = new TestNotificationService(settings);
+        expectThrows(IllegalArgumentException.class, () -> service.getAccount("non-existing"));
     }
 
     public void testNoSpecifiedDefaultAccount() {

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/notification/email/AccountsTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/notification/email/AccountsTests.java
@@ -90,9 +90,8 @@ public class AccountsTests extends ESTestCase {
         addAccountSettings("account1", builder);
         addAccountSettings("account2", builder);
         ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, new HashSet<>(EmailService.getSettings()));
-        SettingsException e = expectThrows(SettingsException.class,
-            () -> new EmailService(builder.build(), null, mock(SSLService.class), clusterSettings));
-        assertThat(e.getMessage(), is("could not find default account [unknown]"));
+        EmailService service = new EmailService(builder.build(), null, mock(SSLService.class), clusterSettings);
+        expectThrows(IllegalArgumentException.class, () -> service.getAccount("unknown"));
     }
 
     public void testNoAccount() throws Exception {
@@ -105,9 +104,8 @@ public class AccountsTests extends ESTestCase {
     public void testNoAccountWithDefaultAccount() throws Exception {
         Settings settings = Settings.builder().put("xpack.notification.email.default_account", "unknown").build();
         ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, new HashSet<>(EmailService.getSettings()));
-        SettingsException e = expectThrows(SettingsException.class,
-            () -> new EmailService(settings, null, mock(SSLService.class), clusterSettings));
-        assertThat(e.getMessage(), is("could not find default account [unknown]"));
+        EmailService service = new EmailService(settings, null, mock(SSLService.class), clusterSettings);
+        expectThrows(IllegalArgumentException.class, () -> service.getAccount("unknown"));
     }
 
     private void addAccountSettings(String name, Settings.Builder builder) {


### PR DESCRIPTION
Fixes #65337

## Problem recurrence
Let me add another case on the basis of this case #65337. The case is the cluster will crash due to a wrong default_account setting.

**The following example is performed on the master branch code.**

The first step is to start a 3-node cluster:
```
bin/elasticsearch -Enode.name=node1 -Ehttp.port=9201 -Etransport.port=9301 -Epath.data=dir1/data -Epath.logs=dir1/logs -Enode.master=true -Enode.data=true

bin/elasticsearch -Enode.name=node2 -Ehttp.port=9202 -Etransport.port=9302 -Epath.data=dir2/data -Epath.logs=dir2/logs -Enode.master=true -Enode.data=true 

bin/elasticsearch -Enode.name=node3 -Ehttp.port=9203 -Etransport.port=9303 -Epath.data=dir3/data -Epath.logs=dir3/logs -Enode.master=true -Enode.data=true
 ```

The second step is to set a default_account that does not exist:
``` 
curl -XPUT "127.0.0.1:9201/_cluster/settings?pretty" -H 'Content-Type: application/json' -d'
{
    "transient": {
        "xpack.notification.email": {
            "default_account": "default"
        }
    }
}
'
```

In the third step, the cluster started to print the following logs crazily:
```
[2020-12-29T16:31:41,882][INFO ][o.e.c.c.JoinHelper       ] [node1] failed to join {node1}{P3OVep_zQsu5nH722qUIPA}{9s2UIgfPQFyNK93ygub1BQ}{127.0.0.1}{127.0.0.1:9301}{cdhilmrstw}{ml.machine_mem
ory=34359738368, xpack.installed=true, transform.node=true, ml.max_open_jobs=20, ml.max_jvm_size=17179869184} with JoinRequest{sourceNode={node1}{P3OVep_zQsu5nH722qUIPA}{9s2UIgfPQFyNK93ygub1BQ
}{127.0.0.1}{127.0.0.1:9301}{cdhilmrstw}{ml.machine_memory=34359738368, xpack.installed=true, transform.node=true, ml.max_open_jobs=20, ml.max_jvm_size=17179869184}, minimumTerm=96, optionalJo
in=Optional[Join{term=97, lastAcceptedTerm=96, lastAcceptedVersion=139, sourceNode={node1}{P3OVep_zQsu5nH722qUIPA}{9s2UIgfPQFyNK93ygub1BQ}{127.0.0.1}{127.0.0.1:9301}{cdhilmrstw}{ml.machine_mem
ory=34359738368, xpack.installed=true, transform.node=true, ml.max_open_jobs=20, ml.max_jvm_size=17179869184}, targetNode={node1}{P3OVep_zQsu5nH722qUIPA}{9s2UIgfPQFyNK93ygub1BQ}{127.0.0.1}{127
.0.0.1:9301}{cdhilmrstw}{ml.machine_memory=34359738368, xpack.installed=true, transform.node=true, ml.max_open_jobs=20, ml.max_jvm_size=17179869184}}]}
org.elasticsearch.transport.SendRequestTransportException: [node1][127.0.0.1:9301][internal:cluster/coordination/join]
        at org.elasticsearch.transport.TransportService$4.doRun(TransportService.java:279) [elasticsearch-8.0.0-SNAPSHOT.jar:8.0.0-SNAPSHOT]
        at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:739) [elasticsearch-8.0.0-SNAPSHOT.jar:8.0.0-SNAPSHOT]
        at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:37) [elasticsearch-8.0.0-SNAPSHOT.jar:8.0.0-SNAPSHOT]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630) [?:?]
        at java.lang.Thread.run(Thread.java:832) [?:?]
Caused by: org.elasticsearch.node.NodeClosedException: node closed {node1}{P3OVep_zQsu5nH722qUIPA}{9s2UIgfPQFyNK93ygub1BQ}{127.0.0.1}{127.0.0.1:9301}{cdhilmrstw}{ml.machine_memory=34359738368,
 xpack.installed=true, transform.node=true, ml.max_open_jobs=20, ml.max_jvm_size=17179869184}
        ... 6 more
```

## Solution

After I analyzed the source code, I found that it was caused by the following code, because the default_account setting cannot be found, the program threw a SettingsException, which caused the ES to fail to start and the cluster to crash.
```
else {
            final LazyInitializable<Account, SettingsException> account = accounts.get(defaultAccountName);
            if (account == null) {
                **throw new SettingsException("could not find default account [" + defaultAccountName + "]");**
            }
            return account;
        }
```
My solution is not to throw an exception, but to print the warn log and return Null.