### PR TITLE
[7.x] [DOCS] Fix attribute typo (#66858)

### DIFF
--- a/docs/reference/ilm/ilm-actions.asciidoc
+++ b/docs/reference/ilm/ilm-actions.asciidoc
@@ -19,7 +19,7 @@ Freeze the index to minimize its memory footprint.
 
 <<ilm-migrate,Migrate>>::
 Move the index shards to the <<data-tiers, data tier>> that corresponds
-to the current {ilm-init] phase.
+to the current {ilm-init} phase.
 
 <<ilm-readonly,Read only>>::
 Block write operations to the index. 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Fix attribute typo (#66858)