### PR TITLE
Use DateUtils when deserialising timezones

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -884,7 +884,7 @@ public abstract class StreamInput extends InputStream {
      */
     public ZoneId readOptionalZoneId() throws IOException {
         if (readBoolean()) {
-            return ZoneId.of(readString());
+            return DateUtils.of(readString());
         }
         return null;
     }

--- a/server/src/main/java/org/elasticsearch/common/time/DateUtils.java
+++ b/server/src/main/java/org/elasticsearch/common/time/DateUtils.java
@@ -201,7 +201,7 @@ public class DateUtils {
                 "Use of short timezone id " + zoneId + " is deprecated. Use " + deprecatedId + " instead");
             return ZoneId.of(deprecatedId);
         }
-        return ZoneId.of(zoneId).normalized();
+        return ZoneId.of(zoneId)/*.normalized()*/;
     }
 
     static final Instant MAX_NANOSECOND_INSTANT = Instant.parse("2262-04-11T23:47:16.854775807Z");
@@ -395,4 +395,11 @@ public class DateUtils {
         Clock millisResolutionClock = Clock.tick(clock, Duration.ofMillis(1));
         return ZonedDateTime.now(millisResolutionClock);
     }
+
+//    public static boolean timeZonesEqual(ZoneId zone1, ZoneId zone2) {
+//        if (zone1 != null && zone2 != null) {
+//            return zone1.normalized().equals(zone2.normalized());
+//        }
+//        return zone1 == zone2;// check if both null
+//    }
 }

--- a/server/src/main/java/org/elasticsearch/common/time/DateUtils.java
+++ b/server/src/main/java/org/elasticsearch/common/time/DateUtils.java
@@ -201,7 +201,7 @@ public class DateUtils {
                 "Use of short timezone id " + zoneId + " is deprecated. Use " + deprecatedId + " instead");
             return ZoneId.of(deprecatedId);
         }
-        return ZoneId.of(zoneId)/*.normalized()*/;
+        return ZoneId.of(zoneId);
     }
 
     static final Instant MAX_NANOSECOND_INSTANT = Instant.parse("2262-04-11T23:47:16.854775807Z");
@@ -395,11 +395,4 @@ public class DateUtils {
         Clock millisResolutionClock = Clock.tick(clock, Duration.ofMillis(1));
         return ZonedDateTime.now(millisResolutionClock);
     }
-
-//    public static boolean timeZonesEqual(ZoneId zone1, ZoneId zone2) {
-//        if (zone1 != null && zone2 != null) {
-//            return zone1.normalized().equals(zone2.normalized());
-//        }
-//        return zone1 == zone2;// check if both null
-//    }
 }

--- a/server/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
@@ -29,7 +29,6 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.regex.Regex;
-import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.XContentBuilder;

--- a/server/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.regex.Regex;
+import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -811,9 +812,7 @@ public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQue
                 Objects.equals(rewrite, other.rewrite) &&
                 Objects.equals(minimumShouldMatch, other.minimumShouldMatch) &&
                 Objects.equals(lenient, other.lenient) &&
-                Objects.equals(
-                        timeZone == null ? null : timeZone.getId(),
-                        other.timeZone == null ? null : other.timeZone.getId()) &&
+                Objects.equals(timeZone, other.timeZone) &&
                 Objects.equals(escape, other.escape) &&
                 Objects.equals(maxDeterminizedStates, other.maxDeterminizedStates) &&
                 Objects.equals(autoGenerateSynonymsPhraseQuery, other.autoGenerateSynonymsPhraseQuery) &&
@@ -826,7 +825,7 @@ public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQue
                 quoteFieldSuffix, allowLeadingWildcard, analyzeWildcard,
                 enablePositionIncrements, fuzziness, fuzzyPrefixLength,
                 fuzzyMaxExpansions, fuzzyRewrite, phraseSlop, type, tieBreaker, rewrite, minimumShouldMatch, lenient,
-                timeZone == null ? 0 : timeZone.getId(), escape, maxDeterminizedStates, autoGenerateSynonymsPhraseQuery,
+                timeZone, escape, maxDeterminizedStates, autoGenerateSynonymsPhraseQuery,
                 fuzzyTranspositions);
     }
 


### PR DESCRIPTION
DateUtils.of methods allows to emit deprecation message when a
deprecated timezone was used
This method is also no longer normalising the timezone. 
This is in order to keep the timezone text consistent across nodes.

closes #38449
