### PR TITLE
Fix S3ClientSettings Class Loading

### DIFF
--- a/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3ClientSettings.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3ClientSettings.java
@@ -41,6 +41,16 @@ import java.util.function.Function;
  */
 final class S3ClientSettings {
 
+    static {
+        // Make sure repository plugin class is loaded before this class is used to trigger static initializer for that class which applies
+        // necessary Jackson workaround
+        try {
+            Class.forName("org.elasticsearch.repositories.s3.S3RepositoryPlugin");
+        } catch (ClassNotFoundException e) {
+            throw new AssertionError(e);
+        }
+    }
+
     // prefix for s3 client settings
     private static final String PREFIX = "s3.client.";
 


### PR DESCRIPTION
This is motivated by the inability to run
`org.elasticsearch.repositories.encrypted.EncryptedS3BlobStoreRepositoryIntegTests`
in isolation without this workaround. The way integration tests load classes
otherwise leads to a load order which doesn't load the plugin class first,
thus fails to apply the jackson workaround before further S3 classes are loaded
but depend on our Jackson workaround.

Without this fix this happens:

```

java.lang.ExceptionInInitializerError
	at __randomizedtesting.SeedInfo.seed([3D25C136A679F021:22A1752F93AADB1E]:0)
	at com.amazonaws.util.VersionInfoUtils.userAgent(VersionInfoUtils.java:142)
	at com.amazonaws.util.VersionInfoUtils.initializeUserAgent(VersionInfoUtils.java:137)
	at com.amazonaws.util.VersionInfoUtils.getUserAgent(VersionInfoUtils.java:100)
	at com.amazonaws.ClientConfiguration.<clinit>(ClientConfiguration.java:80)
	at org.elasticsearch.repositories.s3.S3ClientSettings.lambda$static$12(S3ClientSettings.java:92)
	at org.elasticsearch.common.settings.Setting.lambda$affixKeySetting$59(Setting.java:1745)
	at org.elasticsearch.common.settings.Setting.affixKeySetting(Setting.java:1757)
	at org.elasticsearch.common.settings.Setting.affixKeySetting(Setting.java:1746)
	at org.elasticsearch.repositories.s3.S3ClientSettings.<clinit>(S3ClientSettings.java:91)
	at org.elasticsearch.repositories.s3.S3BlobStoreRepositoryTests.nodeSettings(S3BlobStoreRepositoryTests.java:128)
	at org.elasticsearch.repositories.encrypted.EncryptedS3BlobStoreRepositoryIntegTests.nodeSettings(EncryptedS3BlobStoreRepositoryIntegTests.java:44)
	at org.elasticsearch.test.ESIntegTestCase$1.nodeSettings(ESIntegTestCase.java:1839)
	at org.elasticsearch.test.InternalTestCluster.getSettings(InternalTestCluster.java:429)
	at org.elasticsearch.test.InternalTestCluster.getNodeSettings(InternalTestCluster.java:632)
	at org.elasticsearch.test.InternalTestCluster.reset(InternalTestCluster.java:1065)
	at org.elasticsearch.test.InternalTestCluster.beforeTest(InternalTestCluster.java:1008)
	at org.elasticsearch.test.ESIntegTestCase.lambda$beforeInternal$0(ESIntegTestCase.java:355)
	at org.elasticsearch.test.ESIntegTestCase.beforeInternal(ESIntegTestCase.java:368)
	at org.elasticsearch.test.ESIntegTestCase.setupTestCluster(ESIntegTestCase.java:2045)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:564)
	at com.carrotsearch.randomizedtesting.RandomizedRunner.invoke(RandomizedRunner.java:1758)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$9.evaluate(RandomizedRunner.java:980)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$10.evaluate(RandomizedRunner.java:996)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at org.apache.lucene.util.TestRuleSetupTeardownChained$1.evaluate(TestRuleSetupTeardownChained.java:49)
	at org.apache.lucene.util.AbstractBeforeAfterRule$1.evaluate(AbstractBeforeAfterRule.java:45)
	at org.apache.lucene.util.TestRuleThreadAndTestName$1.evaluate(TestRuleThreadAndTestName.java:48)
	at org.apache.lucene.util.TestRuleIgnoreAfterMaxFailures$1.evaluate(TestRuleIgnoreAfterMaxFailures.java:64)
	at org.apache.lucene.util.TestRuleMarkFailure$1.evaluate(TestRuleMarkFailure.java:47)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl$StatementRunner.run(ThreadLeakControl.java:375)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl.forkTimeoutingTask(ThreadLeakControl.java:824)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl$3.evaluate(ThreadLeakControl.java:475)
	at com.carrotsearch.randomizedtesting.RandomizedRunner.runSingleTest(RandomizedRunner.java:955)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$5.evaluate(RandomizedRunner.java:840)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$6.evaluate(RandomizedRunner.java:891)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$7.evaluate(RandomizedRunner.java:902)
	at org.apache.lucene.util.AbstractBeforeAfterRule$1.evaluate(AbstractBeforeAfterRule.java:45)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at org.apache.lucene.util.TestRuleStoreClassName$1.evaluate(TestRuleStoreClassName.java:41)
	at com.carrotsearch.randomizedtesting.rules.NoShadowingOrOverridesOnMethodsRule$1.evaluate(NoShadowingOrOverridesOnMethodsRule.java:40)
	at com.carrotsearch.randomizedtesting.rules.NoShadowingOrOverridesOnMethodsRule$1.evaluate(NoShadowingOrOverridesOnMethodsRule.java:40)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at org.apache.lucene.util.TestRuleAssertionsRequired$1.evaluate(TestRuleAssertionsRequired.java:53)
	at org.apache.lucene.util.TestRuleMarkFailure$1.evaluate(TestRuleMarkFailure.java:47)
	at org.apache.lucene.util.TestRuleIgnoreAfterMaxFailures$1.evaluate(TestRuleIgnoreAfterMaxFailures.java:64)
	at org.apache.lucene.util.TestRuleIgnoreTestSuites$1.evaluate(TestRuleIgnoreTestSuites.java:54)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl$StatementRunner.run(ThreadLeakControl.java:375)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl.lambda$forkTimeoutingTask$0(ThreadLeakControl.java:831)
	at java.base/java.lang.Thread.run(Thread.java:832)
Caused by: java.lang.IllegalStateException: Fatal: Failed to load the internal config for AWS Java SDK
	at com.amazonaws.internal.config.InternalConfig$Factory.<clinit>(InternalConfig.java:340)
	... 55 more
Caused by: com.fasterxml.jackson.databind.JsonMappingException: Cannot access public void com.amazonaws.internal.config.InternalConfigJsonHelper.setDefaultSigner(com.amazonaws.internal.config.SignerConfigJsonHelper) (from class com.amazonaws.internal.config.InternalConfigJsonHelper; failed to set access: access denied ("java.lang.reflect.ReflectPermission" "suppressAccessChecks")
 at [Source: (URL); line: 1, column: 1]
	at com.fasterxml.jackson.databind.JsonMappingException.from(JsonMappingException.java:309)
	at com.fasterxml.jackson.databind.deser.DeserializerCache._createAndCache2(DeserializerCache.java:268)
	at com.fasterxml.jackson.databind.deser.DeserializerCache._createAndCacheValueDeserializer(DeserializerCache.java:244)
	at com.fasterxml.jackson.databind.deser.DeserializerCache.findValueDeserializer(DeserializerCache.java:142)
	at com.fasterxml.jackson.databind.DeserializationContext.findRootValueDeserializer(DeserializationContext.java:479)
	at com.fasterxml.jackson.databind.ObjectMapper._findRootDeserializer(ObjectMapper.java:4405)
	at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:4214)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3145)
	at com.amazonaws.internal.config.InternalConfig.loadfrom(InternalConfig.java:250)
	at com.amazonaws.internal.config.InternalConfig.load(InternalConfig.java:263)
	at com.amazonaws.internal.config.InternalConfig$Factory.<clinit>(InternalConfig.java:336)
	... 55 more
```
