### PR TITLE
Disable Encrypted Repo Tests during Release Build Runs

### DIFF
--- a/x-pack/plugin/repository-encrypted/src/internalClusterTest/java/org/elasticsearch/repositories/encrypted/EncryptedAzureBlobStoreRepositoryIntegTests.java
+++ b/x-pack/plugin/repository-encrypted/src/internalClusterTest/java/org/elasticsearch/repositories/encrypted/EncryptedAzureBlobStoreRepositoryIntegTests.java
@@ -30,7 +30,8 @@ public final class EncryptedAzureBlobStoreRepositoryIntegTests extends AzureBlob
     private static List<String> repositoryNames;
 
     @BeforeClass
-    private static void preGenerateRepositoryNames() {
+    public static void preGenerateRepositoryNames() {
+        assumeFalse("Should only run when encrypted repo is enabled", EncryptedRepositoryPlugin.isDisabled());
         List<String> names = new ArrayList<>();
         for (int i = 0; i < 32; i++) {
             names.add("test-repo-" + i);

--- a/x-pack/plugin/repository-encrypted/src/internalClusterTest/java/org/elasticsearch/repositories/encrypted/EncryptedFSBlobStoreRepositoryIntegTests.java
+++ b/x-pack/plugin/repository-encrypted/src/internalClusterTest/java/org/elasticsearch/repositories/encrypted/EncryptedFSBlobStoreRepositoryIntegTests.java
@@ -42,7 +42,8 @@ public final class EncryptedFSBlobStoreRepositoryIntegTests extends ESFsBasedRep
     private static List<String> repositoryNames = new ArrayList<>();
 
     @BeforeClass
-    private static void preGenerateRepositoryNames() {
+    public static void preGenerateRepositoryNames() {
+        assumeFalse("Should only run when encrypted repo is enabled", EncryptedRepositoryPlugin.isDisabled());
         for (int i = 0; i < NUMBER_OF_TEST_REPOSITORIES; i++) {
             repositoryNames.add("test-repo-" + i);
         }

--- a/x-pack/plugin/repository-encrypted/src/internalClusterTest/java/org/elasticsearch/repositories/encrypted/EncryptedGCSBlobStoreRepositoryIntegTests.java
+++ b/x-pack/plugin/repository-encrypted/src/internalClusterTest/java/org/elasticsearch/repositories/encrypted/EncryptedGCSBlobStoreRepositoryIntegTests.java
@@ -31,7 +31,8 @@ public final class EncryptedGCSBlobStoreRepositoryIntegTests extends GoogleCloud
     private static List<String> repositoryNames;
 
     @BeforeClass
-    private static void preGenerateRepositoryNames() {
+    public static void preGenerateRepositoryNames() {
+        assumeFalse("Should only run when encrypted repo is enabled", EncryptedRepositoryPlugin.isDisabled());
         List<String> names = new ArrayList<>();
         for (int i = 0; i < 32; i++) {
             names.add("test-repo-" + i);

--- a/x-pack/plugin/repository-encrypted/src/internalClusterTest/java/org/elasticsearch/repositories/encrypted/EncryptedRepositorySecretIntegTests.java
+++ b/x-pack/plugin/repository-encrypted/src/internalClusterTest/java/org/elasticsearch/repositories/encrypted/EncryptedRepositorySecretIntegTests.java
@@ -35,6 +35,7 @@ import org.elasticsearch.snapshots.SnapshotMissingException;
 import org.elasticsearch.snapshots.SnapshotState;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.InternalTestCluster;
+import org.junit.BeforeClass;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -64,6 +65,11 @@ import static org.mockito.Mockito.when;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0, autoManageMasterNodes = false)
 public final class EncryptedRepositorySecretIntegTests extends ESIntegTestCase {
+
+    @BeforeClass
+    public static void checkEnabled() {
+        assumeFalse("Should only run when encrypted repo is enabled", EncryptedRepositoryPlugin.isDisabled());
+    }
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {

--- a/x-pack/plugin/repository-encrypted/src/internalClusterTest/java/org/elasticsearch/repositories/encrypted/EncryptedS3BlobStoreRepositoryIntegTests.java
+++ b/x-pack/plugin/repository-encrypted/src/internalClusterTest/java/org/elasticsearch/repositories/encrypted/EncryptedS3BlobStoreRepositoryIntegTests.java
@@ -30,7 +30,8 @@ public final class EncryptedS3BlobStoreRepositoryIntegTests extends S3BlobStoreR
     private static List<String> repositoryNames;
 
     @BeforeClass
-    private static void preGenerateRepositoryNames() {
+    public static void preGenerateRepositoryNames() {
+        assumeFalse("Should only run when encrypted repo is enabled", EncryptedRepositoryPlugin.isDisabled());
         List<String> names = new ArrayList<>();
         for (int i = 0; i < 32; i++) {
             names.add("test-repo-" + i);


### PR DESCRIPTION
If the plugin is disabled for a build these tests fail because
the encrypted repo factory is not created.

Closes #66884
