### PR TITLE
Disable Encrypted Repo Tests during Release Build Runs (#66887)

### DIFF
--- a/x-pack/plugin/repository-encrypted/src/internalClusterTest/java/org/elasticsearch/repositories/encrypted/EncryptedAzureBlobStoreRepositoryIntegTests.java
+++ b/x-pack/plugin/repository-encrypted/src/internalClusterTest/java/org/elasticsearch/repositories/encrypted/EncryptedAzureBlobStoreRepositoryIntegTests.java
@@ -31,7 +31,8 @@ public final class EncryptedAzureBlobStoreRepositoryIntegTests extends AzureBlob
     private static List<String> repositoryNames;
 
     @BeforeClass
-    private static void preGenerateRepositoryNames() {
+    public static void preGenerateRepositoryNames() {
+        assumeFalse("Should only run when encrypted repo is enabled", EncryptedRepositoryPlugin.isDisabled());
         List<String> names = new ArrayList<>();
         for (int i = 0; i < 32; i++) {
             names.add("test-repo-" + i);

--- a/x-pack/plugin/repository-encrypted/src/internalClusterTest/java/org/elasticsearch/repositories/encrypted/EncryptedFSBlobStoreRepositoryIntegTests.java
+++ b/x-pack/plugin/repository-encrypted/src/internalClusterTest/java/org/elasticsearch/repositories/encrypted/EncryptedFSBlobStoreRepositoryIntegTests.java
@@ -43,7 +43,8 @@ public final class EncryptedFSBlobStoreRepositoryIntegTests extends ESFsBasedRep
     private static List<String> repositoryNames = new ArrayList<>();
 
     @BeforeClass
-    private static void preGenerateRepositoryNames() {
+    public static void preGenerateRepositoryNames() {
+        assumeFalse("Should only run when encrypted repo is enabled", EncryptedRepositoryPlugin.isDisabled());
         for (int i = 0; i < NUMBER_OF_TEST_REPOSITORIES; i++) {
             repositoryNames.add("test-repo-" + i);
         }

--- a/x-pack/plugin/repository-encrypted/src/internalClusterTest/java/org/elasticsearch/repositories/encrypted/EncryptedGCSBlobStoreRepositoryIntegTests.java
+++ b/x-pack/plugin/repository-encrypted/src/internalClusterTest/java/org/elasticsearch/repositories/encrypted/EncryptedGCSBlobStoreRepositoryIntegTests.java
@@ -32,7 +32,8 @@ public final class EncryptedGCSBlobStoreRepositoryIntegTests extends GoogleCloud
     private static List<String> repositoryNames;
 
     @BeforeClass
-    private static void preGenerateRepositoryNames() {
+    public static void preGenerateRepositoryNames() {
+        assumeFalse("Should only run when encrypted repo is enabled", EncryptedRepositoryPlugin.isDisabled());
         List<String> names = new ArrayList<>();
         for (int i = 0; i < 32; i++) {
             names.add("test-repo-" + i);

--- a/x-pack/plugin/repository-encrypted/src/internalClusterTest/java/org/elasticsearch/repositories/encrypted/EncryptedRepositorySecretIntegTests.java
+++ b/x-pack/plugin/repository-encrypted/src/internalClusterTest/java/org/elasticsearch/repositories/encrypted/EncryptedRepositorySecretIntegTests.java
@@ -35,6 +35,7 @@ import org.elasticsearch.snapshots.SnapshotMissingException;
 import org.elasticsearch.snapshots.SnapshotState;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.InternalTestCluster;
+import org.junit.BeforeClass;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -64,6 +65,11 @@ import static org.mockito.Mockito.when;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0, autoManageMasterNodes = false)
 public final class EncryptedRepositorySecretIntegTests extends ESIntegTestCase {
+
+    @BeforeClass
+    public static void checkEnabled() {
+        assumeFalse("Should only run when encrypted repo is enabled", EncryptedRepositoryPlugin.isDisabled());
+    }
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {

--- a/x-pack/plugin/repository-encrypted/src/internalClusterTest/java/org/elasticsearch/repositories/encrypted/EncryptedS3BlobStoreRepositoryIntegTests.java
+++ b/x-pack/plugin/repository-encrypted/src/internalClusterTest/java/org/elasticsearch/repositories/encrypted/EncryptedS3BlobStoreRepositoryIntegTests.java
@@ -31,7 +31,8 @@ public final class EncryptedS3BlobStoreRepositoryIntegTests extends S3BlobStoreR
     private static List<String> repositoryNames;
 
     @BeforeClass
-    private static void preGenerateRepositoryNames() {
+    public static void preGenerateRepositoryNames() {
+        assumeFalse("Should only run when encrypted repo is enabled", EncryptedRepositoryPlugin.isDisabled());
         List<String> names = new ArrayList<>();
         for (int i = 0; i < 32; i++) {
             names.add("test-repo-" + i);

--- a/x-pack/plugin/repository-encrypted/src/main/java/org/elasticsearch/repositories/encrypted/EncryptedRepositoryPlugin.java
+++ b/x-pack/plugin/repository-encrypted/src/main/java/org/elasticsearch/repositories/encrypted/EncryptedRepositoryPlugin.java
@@ -80,6 +80,13 @@ public class EncryptedRepositoryPlugin extends Plugin implements RepositoryPlugi
         return Collections.singletonList(ENCRYPTION_PASSWORD_SETTING);
     }
 
+    // public for testing
+    // Checks if the plugin is currently disabled because we're running a release build or the feature flag is turned off
+    public static boolean isDisabled() {
+        return false == Build.CURRENT.isSnapshot()
+            && (ENCRYPTED_REPOSITORY_FEATURE_FLAG_REGISTERED == null || ENCRYPTED_REPOSITORY_FEATURE_FLAG_REGISTERED == false);
+    }
+
     @Override
     public Map<String, Repository.Factory> getRepositories(
         Environment env,
@@ -88,6 +95,10 @@ public class EncryptedRepositoryPlugin extends Plugin implements RepositoryPlugi
         BigArrays bigArrays,
         RecoverySettings recoverySettings
     ) {
+        if (isDisabled()) {
+            return Collections.emptyMap();
+        }
+
         // load all the passwords from the keystore in memory because the keystore is not readable when the repository is created
         final Map<String, SecureString> repositoryPasswordsMapBuilder = new HashMap<>();
         for (String passwordName : ENCRYPTION_PASSWORD_SETTING.getNamespaces(env.settings())) {
@@ -96,11 +107,6 @@ public class EncryptedRepositoryPlugin extends Plugin implements RepositoryPlugi
             logger.debug("Loaded repository password [{}] from the node keystore", passwordName);
         }
         final Map<String, SecureString> repositoryPasswordsMap = repositoryPasswordsMapBuilder;
-
-        if (false == Build.CURRENT.isSnapshot()
-            && (ENCRYPTED_REPOSITORY_FEATURE_FLAG_REGISTERED == null || ENCRYPTED_REPOSITORY_FEATURE_FLAG_REGISTERED == false)) {
-            return Collections.emptyMap();
-        }
 
         return Collections.singletonMap(REPOSITORY_TYPE_NAME, new Repository.Factory() {
 


### PR DESCRIPTION
If the plugin is disabled for a build these tests fail because
the encrypted repo factory is not created.

Closes #66884

backport of #66887