### PR TITLE
[7.11] [DOCS] Add `nodes` and `parent_task_id` parms (#66562)

### DIFF
--- a/docs/reference/cat/tasks.asciidoc
+++ b/docs/reference/cat/tasks.asciidoc
@@ -37,6 +37,15 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-h]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=help]
 
+`nodes`::
+(Optional, string)
+Comma-separated list of node IDs or names used to limit the response. Supports
+wildcard (`*`) expressions.
+
+`parent_task_id`::
+(Optional, string)
+Parent task ID used to limit the response.
+
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-s]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=time]


### PR DESCRIPTION
Backports the following commits to 7.11:
 - [DOCS] Add `nodes` and `parent_task_id` parms (#66562)