### PR TITLE
Shortcut to avoid fmod

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -751,6 +751,12 @@ public class NumberFieldMapper extends FieldMapper {
          * Returns true if the object is a number and has a decimal part
          */
         public static boolean hasDecimalPart(Object number) {
+            if (number instanceof Byte
+                || number instanceof Short
+                || number instanceof Integer
+                || number instanceof Long) {
+                return false;
+            }
             if (number instanceof Number) {
                 double doubleValue = ((Number) number).doubleValue();
                 return doubleValue % 1 != 0;


### PR DESCRIPTION
# Description
When benchmarking terms query (10000+ terms) on long type, I was supperised to find that the part costing most CPU is to judge whether terms have a decimal part because we execute a double mod for each long. So doing some check before mod may make sense.

![image](https://user-images.githubusercontent.com/52390227/103471437-6abe1f80-4dbb-11eb-8967-325d92b57385.png)
