### PR TITLE
Clarify message emitted on cluster UUID mismatch

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -168,7 +168,7 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
         this.onJoinValidators = JoinTaskExecutor.addBuiltInJoinValidators(onJoinValidators);
         this.singleNodeDiscovery = DiscoveryModule.isSingleNodeDiscovery(settings);
         this.electionStrategy = electionStrategy;
-        this.joinHelper = new JoinHelper(allocationService, masterService, transportService, this::getCurrentTerm,
+        this.joinHelper = new JoinHelper(settings, allocationService, masterService, transportService, this::getCurrentTerm,
             this::getStateForMasterService, this::handleJoinRequest, this::joinLeaderInTerm, this.onJoinValidators, rerouteService,
             nodeHealthService);
         this.persistedStateSupplier = persistedStateSupplier;


### PR DESCRIPTION
Today we report a join failure due to a cluster UUID mismatch with the
following (accurate, but mystifying) message:

    join validation on cluster state with a different cluster uuid [...] than local cluster uuid [...], rejecting

This tends to occur mostly when setting up a cluster for the first time
and gives users no clue what they've actually done wrong or what they
should do to fix it.

This commit adjusts this message to indicate that the problem is likely
discovery or cluster bootstrapping configuration and indicates that the
cluster UUID persists across restarts and suggests the usual fix of
wiping the node's data path to get out of the mess.