### PR TITLE
[DOCS] Update casing in FIPS docs

### DIFF
--- a/x-pack/docs/en/security/fips-140-compliance.asciidoc
+++ b/x-pack/docs/en/security/fips-140-compliance.asciidoc
@@ -30,7 +30,7 @@ For {es}, adherence to FIPS 140-2 is ensured by
 If you plan to upgrade your existing cluster to a version that can be run in
 a FIPS 140-2 configured JVM, we recommend to first perform a rolling
 upgrade to the new version in your existing JVM and perform all necessary
-configuration changes in preparation for running in fips mode. You can then
+configuration changes in preparation for running in FIPS mode. You can then
 perform a rolling restart of the nodes, starting each node in a FIPS 140-2 JVM.
 During the restart, {es}:
 
@@ -60,7 +60,7 @@ and able to run {es} successfully in a FIPS 140-2 configured JVM.
 
 FIPS 140-2 (via NIST Special Publication 800-132) dictates that encryption keys should at
 least have an effective strength of 112 bits.
-As such, the elasticsearch keystore that stores the node's <<secure-settings,secure settings>>
+As such, the {es} keystore that stores the node's <<secure-settings,secure settings>>
 needs to be password protected with a password that satisfies this requirement.
 This means that the password needs to be 14 bytes long which is equivalent
 to a 14 character ASCII encoded password, or a 7 character UTF-8 encoded password.
@@ -147,7 +147,7 @@ using the compliant `PBKDF2` based algorithm you have selected.
 === Limitations
 
 Due to the limitations that FIPS 140-2 compliance enforces, a small number of
-features are not available while running in fips mode. The list is as follows:
+features are not available while running in FIPS mode. The list is as follows:
 
 * Azure Classic Discovery Plugin
 * Ingest Attachment Plugin

--- a/x-pack/docs/en/security/fips-140-compliance.asciidoc
+++ b/x-pack/docs/en/security/fips-140-compliance.asciidoc
@@ -12,7 +12,7 @@ IMPORTANT: The JVM bundled with {es} is not configured for FIPS 140-2. You must
 either configure the bundled JVM to run with a FIPS 140-2 certified Java
 Security Provider or use an external JVM configured for FIPS 140-2.
 
-After configuring your JVM for FIPS 140-2, you can run {es} in FIPS mode by
+After configuring your JVM for FIPS 140-2, you can run {es} in FIPS 140-2 mode by
 setting the `xpack.security.fips_mode.enabled` to `true` in `elasticsearch.yml`.
 
 For {es}, adherence to FIPS 140-2 is ensured by
@@ -30,7 +30,7 @@ For {es}, adherence to FIPS 140-2 is ensured by
 If you plan to upgrade your existing cluster to a version that can be run in
 a FIPS 140-2 configured JVM, we recommend to first perform a rolling
 upgrade to the new version in your existing JVM and perform all necessary
-configuration changes in preparation for running in FIPS mode. You can then
+configuration changes in preparation for running in FIPS 140-2 mode. You can then
 perform a rolling restart of the nodes, starting each node in a FIPS 140-2 JVM.
 During the restart, {es}:
 
@@ -147,7 +147,7 @@ using the compliant `PBKDF2` based algorithm you have selected.
 === Limitations
 
 Due to the limitations that FIPS 140-2 compliance enforces, a small number of
-features are not available while running in FIPS mode. The list is as follows:
+features are not available while running in FIPS 140-2 mode. The list is as follows:
 
 * Azure Classic Discovery Plugin
 * Ingest Attachment Plugin


### PR DESCRIPTION
Changes `fips` to `FIPS` and `elasticsearch` to `{es}` in FIPS docs.