### PR TITLE
Safer Refresh of Index Stats in CCR IT (#66830)

### DIFF
--- a/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/CcrRepositoryIT.java
+++ b/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/CcrRepositoryIT.java
@@ -14,7 +14,6 @@ import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequ
 import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotRequest;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
-import org.elasticsearch.action.admin.indices.forcemerge.ForceMergeResponse;
 import org.elasticsearch.action.admin.indices.stats.IndexStats;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsAction;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsRequest;
@@ -78,6 +77,7 @@ import java.util.stream.Collectors;
 
 import static java.util.Collections.singletonMap;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAllSuccessful;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.equalTo;
@@ -491,13 +491,12 @@ public class CcrRepositoryIT extends CcrIntegTestCase {
             assertThat(bulkRequest.get().hasFailures(), is(false));
         }
 
-        final ForceMergeResponse forceMergeResponse = leaderClient().admin().indices().prepareForceMerge(leaderIndex)
-            .setMaxNumSegments(1)
-            .setFlush(true)
-            .get();
-        assertThat(forceMergeResponse.getSuccessfulShards(), equalTo(numberOfShards));
-        assertThat(forceMergeResponse.getFailedShards(), equalTo(0));
         ensureLeaderGreen(leaderIndex);
+        assertAllSuccessful(leaderClient().admin().indices().prepareForceMerge(leaderIndex)
+                .setMaxNumSegments(1)
+                .setFlush(true)
+                .get());
+        refresh(leaderClient(), leaderIndex);
 
         final IndexStats indexStats = leaderClient().admin().indices().prepareStats(leaderIndex)
             .clear()


### PR DESCRIPTION
We should only force merge after we know that an index is green and refresh after
forcemerge to ensure we get the latest stats in any case.

closes #64167

backport of #66830