### PR TITLE
Determine data role based on convention

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/env/NodeRepurposeCommandIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/env/NodeRepurposeCommandIT.java
@@ -20,14 +20,10 @@ package org.elasticsearch.env;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.NoShardAvailableActionException;
-import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.NodeRoles;
 import org.hamcrest.Matcher;
-
-import java.util.Set;
 
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
@@ -59,7 +55,8 @@ public class NodeRepurposeCommandIT extends ESIntegTestCase {
         final Settings masterNodeDataPathSettings = internalCluster().dataPathSettings(masterNode);
         final Settings dataNodeDataPathSettings = internalCluster().dataPathSettings(dataNode);
 
-        final Settings noMasterNoDataSettings = NodeRoles.removeRoles(Set.of(DiscoveryNodeRole.DATA_ROLE, DiscoveryNodeRole.MASTER_ROLE));
+        // put some unknown role here to make sure the tool does not bark when encountering an unknown role
+        final Settings noMasterNoDataSettings = Settings.builder().putList("node.roles", "unknown_role").build();
 
         final Settings noMasterNoDataSettingsForMasterNode = Settings.builder()
             .put(noMasterNoDataSettings)

--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
@@ -81,6 +81,14 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
         return getRolesFromSettings(settings).stream().anyMatch(DiscoveryNodeRole::canContainData);
     }
 
+    /**
+     * Allows determining the "data" property without the need to load plugins, but does this purely based on
+     * naming conventions. Prefer using {@link #isDataNode(Settings)} if possible.
+     */
+    public static boolean isDataNodeBasedOnNamingConvention(final Settings settings) {
+        return settings.getAsList("node.roles").stream().anyMatch(DiscoveryNodeRole::isDataRoleBasedOnNamingConvention);
+    }
+
     public static boolean isIngestNode(final Settings settings) {
         return hasRole(settings, DiscoveryNodeRole.INGEST_ROLE);
     }

--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
@@ -86,7 +86,8 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
      * naming conventions. Prefer using {@link #isDataNode(Settings)} if possible.
      */
     public static boolean isDataNodeBasedOnNamingConvention(final Settings settings) {
-        return settings.getAsList("node.roles").stream().anyMatch(DiscoveryNodeRole::isDataRoleBasedOnNamingConvention);
+        return DiscoveryNode.hasRole(settings, DiscoveryNodeRole.DATA_ROLE) ||
+            settings.getAsList("node.roles").stream().anyMatch(DiscoveryNodeRole::isDataRoleBasedOnNamingConvention);
     }
 
     public static boolean isIngestNode(final Settings settings) {

--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeRole.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeRole.java
@@ -79,6 +79,8 @@ public abstract class DiscoveryNodeRole implements Comparable<DiscoveryNodeRole>
 
     protected DiscoveryNodeRole(final String roleName, final String roleNameAbbreviation, final boolean canContainData) {
         this(true, roleName, roleNameAbbreviation, canContainData);
+        assert canContainData == isDataRoleBasedOnNamingConvention(roleName) :
+            "Role '" + roleName + "' not compliant to data role naming convention";
     }
 
     private DiscoveryNodeRole(
@@ -138,6 +140,14 @@ public abstract class DiscoveryNodeRole implements Comparable<DiscoveryNodeRole>
         }
 
     };
+
+    /**
+     * Allows determining the "data" property without the need to load plugins, but does this purely based on
+     * naming conventions.
+     */
+    static boolean isDataRoleBasedOnNamingConvention(String role) {
+        return role.equals("data") || role.startsWith("data_");
+    }
 
     /**
      * Represents the role for an ingest node.

--- a/server/src/main/java/org/elasticsearch/env/NodeRepurposeCommand.java
+++ b/server/src/main/java/org/elasticsearch/env/NodeRepurposeCommand.java
@@ -65,7 +65,7 @@ public class NodeRepurposeCommand extends ElasticsearchNodeCommand {
     @Override
     protected boolean validateBeforeLock(Terminal terminal, Environment env) {
         Settings settings = env.settings();
-        if (DiscoveryNode.isDataNode(settings)) {
+        if (DiscoveryNode.isDataNodeBasedOnNamingConvention(settings)) {
             terminal.println(Terminal.Verbosity.NORMAL, NO_CLEANUP);
             return false;
         }
@@ -75,7 +75,7 @@ public class NodeRepurposeCommand extends ElasticsearchNodeCommand {
 
     @Override
     protected void processNodePaths(Terminal terminal, Path[] dataPaths, OptionSet options, Environment env) throws IOException {
-        assert DiscoveryNode.isDataNode(env.settings()) == false;
+        assert DiscoveryNode.isDataNodeBasedOnNamingConvention(env.settings()) == false;
 
         if (DiscoveryNode.isMasterNode(env.settings()) == false) {
             processNoMasterNoDataNode(terminal, dataPaths, env);

--- a/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeTests.java
@@ -95,7 +95,7 @@ public class DiscoveryNodeTests extends ESTestCase {
         InetAddress inetAddress = InetAddress.getByAddress("name1", new byte[] { (byte) 192, (byte) 168, (byte) 0, (byte) 1});
         TransportAddress transportAddress = new TransportAddress(inetAddress, randomIntBetween(0, 65535));
 
-        DiscoveryNodeRole customRole = new DiscoveryNodeRole("custom_role", "z", true) {
+        DiscoveryNodeRole customRole = new DiscoveryNodeRole("data_custom_role", "z", true) {
             @Override
             public Setting<Boolean> legacySetting() {
                 return null;
@@ -117,7 +117,7 @@ public class DiscoveryNodeTests extends ESTestCase {
             final Set<DiscoveryNodeRole> roles = serialized.getRoles();
             assertThat(roles, hasSize(1));
             @SuppressWarnings("OptionalGetWithoutIsPresent") final DiscoveryNodeRole role = roles.stream().findFirst().get();
-            assertThat(role.roleName(), equalTo("custom_role"));
+            assertThat(role.roleName(), equalTo("data_custom_role"));
             assertThat(role.roleNameAbbreviation(), equalTo("z"));
             assertTrue(role.canContainData());
         }
@@ -133,7 +133,7 @@ public class DiscoveryNodeTests extends ESTestCase {
             final Set<DiscoveryNodeRole> roles = serialized.getRoles();
             assertThat(roles, hasSize(1));
             @SuppressWarnings("OptionalGetWithoutIsPresent") final DiscoveryNodeRole role = roles.stream().findFirst().get();
-            assertThat(role.roleName(), equalTo("custom_role"));
+            assertThat(role.roleName(), equalTo("data_custom_role"));
             assertThat(role.roleNameAbbreviation(), equalTo("z"));
             assertTrue(role.canContainData());
         }


### PR DESCRIPTION
Introduces naming convention-based matching for the "data" roles (`data`, `data_hot`, ...), allowing the command-line tools such as `elasticsearch-node repurpose` to run without the need to load (the roles from) plugins.

Closes #66000