### PR TITLE
BACKPORT 7x Fix azure repo stream exhaust check for multipart uploads (#66769)

### DIFF
--- a/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureBlobStore.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureBlobStore.java
@@ -411,8 +411,7 @@ public class AzureBlobStore implements BlobStore {
             final BlobAsyncClient blobAsyncClient = asyncClient.getBlobContainerAsyncClient(container).getBlobAsyncClient(blobName);
             final BlockBlobAsyncClient blockBlobAsyncClient = blobAsyncClient.getBlockBlobAsyncClient();
 
-            final Flux<ByteBuffer> byteBufferFlux =
-                convertStreamToByteBuffer(inputStream, blobSize, DEFAULT_UPLOAD_BUFFERS_SIZE);
+            final Flux<ByteBuffer> byteBufferFlux = convertStreamToByteBuffer(inputStream, blobSize, DEFAULT_UPLOAD_BUFFERS_SIZE);
             final BlockBlobSimpleUploadOptions options = new BlockBlobSimpleUploadOptions(byteBufferFlux, blobSize);
             BlobRequestConditions requestConditions = new BlobRequestConditions();
             if (failIfAlreadyExists) {
@@ -439,8 +438,7 @@ public class AzureBlobStore implements BlobStore {
             final List<String> blockIds = new ArrayList<>(nbParts);
             for (int i = 0; i < nbParts; i++) {
                 final long length = i < nbParts - 1 ? partSize : lastPartSize;
-                final Flux<ByteBuffer> byteBufferFlux =
-                    convertStreamToByteBuffer(inputStream, length, DEFAULT_UPLOAD_BUFFERS_SIZE);
+                Flux<ByteBuffer> byteBufferFlux = convertStreamToByteBuffer(inputStream, length, DEFAULT_UPLOAD_BUFFERS_SIZE);
 
                 final String blockId = UUIDs.base64UUID();
                 blockBlobAsyncClient.stageBlock(blockId, byteBufferFlux, length).block();
@@ -500,20 +498,11 @@ public class AzureBlobStore implements BlobStore {
                     return ByteBuffer.wrap(buffer);
                 }))
                 .doOnComplete(() -> {
-                    try {
-                        if (inputStream.available() > 0) {
-                            long totalLength = currentTotalLength.get() + inputStream.available();
-                            throw new IllegalStateException(
-                                "InputStream provided " + totalLength + " bytes, more than the expected " + length + " bytes"
-                            );
-                        } else if (currentTotalLength.get() > length) {
-                            throw new IllegalStateException(
-                                "Read more data than was requested. Size of data read: " + currentTotalLength.get() + "." +
-                                    " Size of data requested: " + length
-                            );
-                        }
-                    } catch (IOException e) {
-                        throw new RuntimeException(e);
+                    if (currentTotalLength.get() > length) {
+                        throw new IllegalStateException(
+                            "Read more data than was requested. Size of data read: " + currentTotalLength.get() + "." +
+                                " Size of data requested: " + length
+                        );
                     }
                 });
         }).subscribeOn(Schedulers.elastic()); // We need to subscribe on a different scheduler to avoid blocking the io threads when

--- a/x-pack/plugin/repository-encrypted/src/main/java/org/elasticsearch/repositories/encrypted/EncryptionPacketsInputStream.java
+++ b/x-pack/plugin/repository-encrypted/src/main/java/org/elasticsearch/repositories/encrypted/EncryptionPacketsInputStream.java
@@ -138,12 +138,6 @@ public final class EncryptionPacketsInputStream extends ChainingInputStream {
         return new CountingInputStream(encryptionInputStream, false);
     }
 
-    // remove after https://github.com/elastic/elasticsearch/pull/66769 is merged in
-    @Override
-    public int available() throws IOException {
-        return 0;
-    }
-
     @Override
     public boolean markSupported() {
         return source.markSupported();


### PR DESCRIPTION
Backport of https://github.com/elastic/elasticsearch/pull/66769

This PR fixes the validation of the conversion from an input stream to a flux in the
AzureBlobStore's multipart update logic, which erroneously checked that the upload
input stream is exhausted after each part's flux is completed.