### PR TITLE
[7.x] Remove millis qualifier on all the variables that hold the timestamp range in IndexMetadata

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -392,7 +392,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
     private final ImmutableOpenMap<String, RolloverInfo> rolloverInfos;
     private final boolean isSystem;
 
-    private final IndexLongFieldRange timestampMillisRange;
+    private final IndexLongFieldRange timestampRange;
 
     private IndexMetadata(
             final Index index,
@@ -420,7 +420,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             final ActiveShardCount waitForActiveShards,
             final ImmutableOpenMap<String, RolloverInfo> rolloverInfos,
             final boolean isSystem,
-            final IndexLongFieldRange timestampMillisRange) {
+            final IndexLongFieldRange timestampRange) {
 
         this.index = index;
         this.version = version;
@@ -453,7 +453,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         this.waitForActiveShards = waitForActiveShards;
         this.rolloverInfos = rolloverInfos;
         this.isSystem = isSystem;
-        this.timestampMillisRange = timestampMillisRange;
+        this.timestampRange = timestampRange;
         assert numberOfShards * routingFactor == routingNumShards :  routingNumShards + " must be a multiple of " + numberOfShards;
     }
 
@@ -667,8 +667,8 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         return excludeFilters;
     }
 
-    public IndexLongFieldRange getTimestampMillisRange() {
-        return timestampMillisRange;
+    public IndexLongFieldRange getTimestampRange() {
+        return timestampRange;
     }
 
     @Override
@@ -780,7 +780,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         private final Diff<ImmutableOpenIntMap<Set<String>>> inSyncAllocationIds;
         private final Diff<ImmutableOpenMap<String, RolloverInfo>> rolloverInfos;
         private final boolean isSystem;
-        private final IndexLongFieldRange timestampMillisRange;
+        private final IndexLongFieldRange timestampRange;
 
         IndexMetadataDiff(IndexMetadata before, IndexMetadata after) {
             index = after.index.getName();
@@ -799,7 +799,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
                 DiffableUtils.getVIntKeySerializer(), DiffableUtils.StringSetValueSerializer.getInstance());
             rolloverInfos = DiffableUtils.diff(before.rolloverInfos, after.rolloverInfos, DiffableUtils.getStringKeySerializer());
             isSystem = after.isSystem;
-            timestampMillisRange = after.timestampMillisRange;
+            timestampRange = after.timestampRange;
         }
 
         private static final DiffableUtils.DiffableValueReader<String, AliasMetadata> ALIAS_METADATA_DIFF_VALUE_READER =
@@ -845,7 +845,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             } else {
                 isSystem = false;
             }
-            timestampMillisRange = IndexLongFieldRange.readFrom(in);
+            timestampRange = IndexLongFieldRange.readFrom(in);
         }
 
         @Override
@@ -875,7 +875,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             if (out.getVersion().onOrAfter(SYSTEM_INDEX_FLAG_ADDED)) {
                 out.writeBoolean(isSystem);
             }
-            timestampMillisRange.writeTo(out);
+            timestampRange.writeTo(out);
         }
 
         @Override
@@ -895,7 +895,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             builder.inSyncAllocationIds.putAll(inSyncAllocationIds.apply(part.inSyncAllocationIds));
             builder.rolloverInfos.putAll(rolloverInfos.apply(part.rolloverInfos));
             builder.system(part.isSystem);
-            builder.timestampMillisRange(timestampMillisRange);
+            builder.timestampRange(timestampRange);
             return builder.build();
         }
     }
@@ -953,7 +953,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         if (in.getVersion().onOrAfter(SYSTEM_INDEX_FLAG_ADDED)) {
             builder.system(in.readBoolean());
         }
-        builder.timestampMillisRange(IndexLongFieldRange.readFrom(in));
+        builder.timestampRange(IndexLongFieldRange.readFrom(in));
         return builder.build();
     }
 
@@ -1005,7 +1005,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         if (out.getVersion().onOrAfter(SYSTEM_INDEX_FLAG_ADDED)) {
             out.writeBoolean(isSystem);
         }
-        timestampMillisRange.writeTo(out);
+        timestampRange.writeTo(out);
     }
 
     public boolean isSystem() {
@@ -1037,7 +1037,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         private final ImmutableOpenMap.Builder<String, RolloverInfo> rolloverInfos;
         private Integer routingNumShards;
         private boolean isSystem;
-        private IndexLongFieldRange timestampMillisRange = IndexLongFieldRange.NO_SHARDS;
+        private IndexLongFieldRange timestampRange = IndexLongFieldRange.NO_SHARDS;
 
         public Builder(String index) {
             this.index = index;
@@ -1065,7 +1065,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             this.inSyncAllocationIds = ImmutableOpenIntMap.builder(indexMetadata.inSyncAllocationIds);
             this.rolloverInfos = ImmutableOpenMap.builder(indexMetadata.rolloverInfos);
             this.isSystem = indexMetadata.isSystem;
-            this.timestampMillisRange = indexMetadata.timestampMillisRange;
+            this.timestampRange = indexMetadata.timestampRange;
         }
 
         public Builder index(String index) {
@@ -1274,13 +1274,13 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             return isSystem;
         }
 
-        public Builder timestampMillisRange(IndexLongFieldRange timestampMillisRange) {
-            this.timestampMillisRange = timestampMillisRange;
+        public Builder timestampRange(IndexLongFieldRange timestampRange) {
+            this.timestampRange = timestampRange;
             return this;
         }
 
-        public IndexLongFieldRange getTimestampMillisRange() {
-            return timestampMillisRange;
+        public IndexLongFieldRange getTimestampRange() {
+            return timestampRange;
         }
 
         public IndexMetadata build() {
@@ -1397,7 +1397,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
                     waitForActiveShards,
                     rolloverInfos.build(),
                     isSystem,
-                    timestampMillisRange);
+                timestampRange);
         }
 
         public static void toXContent(IndexMetadata indexMetadata, XContentBuilder builder, ToXContent.Params params) throws IOException {
@@ -1499,7 +1499,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             builder.field(KEY_SYSTEM, indexMetadata.isSystem);
 
             builder.startObject(KEY_TIMESTAMP_RANGE);
-            indexMetadata.timestampMillisRange.toXContent(builder, params);
+            indexMetadata.timestampRange.toXContent(builder, params);
             builder.endObject();
 
             builder.endObject();
@@ -1583,7 +1583,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
                         assert Version.CURRENT.major <= 5;
                         parser.skipChildren();
                     } else if (KEY_TIMESTAMP_RANGE.equals(currentFieldName)) {
-                        builder.timestampMillisRange(IndexLongFieldRange.fromXContent(parser));
+                        builder.timestampRange(IndexLongFieldRange.fromXContent(parser));
                     } else {
                         // assume it's custom index metadata
                         builder.putCustom(currentFieldName, parser.mapStrings());

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexStateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexStateService.java
@@ -770,7 +770,7 @@ public class MetadataIndexStateService {
                     routingTable.remove(index.getName());
                 } else {
                     metadata.put(updatedMetadata
-                        .timestampMillisRange(IndexLongFieldRange.NO_SHARDS)
+                        .timestampRange(IndexLongFieldRange.NO_SHARDS)
                         .settingsVersion(indexMetadata.getSettingsVersion() + 1)
                         .settings(Settings.builder()
                             .put(indexMetadata.getSettings())
@@ -860,7 +860,7 @@ public class MetadataIndexStateService {
                     .state(IndexMetadata.State.OPEN)
                     .settingsVersion(indexMetadata.getSettingsVersion() + 1)
                     .settings(updatedSettings)
-                    .timestampMillisRange(IndexLongFieldRange.NO_SHARDS)
+                    .timestampRange(IndexLongFieldRange.NO_SHARDS)
                     .build();
 
                 // The index might be closed because we couldn't import it due to old incompatible version

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/IndexMetadataUpdater.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/IndexMetadataUpdater.java
@@ -170,7 +170,7 @@ public class IndexMetadataUpdater extends RoutingChangesObserver.AbstractRouting
                 final String allocationId;
                 if (recoverySource == RecoverySource.ExistingStoreRecoverySource.FORCE_STALE_PRIMARY_INSTANCE) {
                     allocationId = RecoverySource.ExistingStoreRecoverySource.FORCED_ALLOCATION_ID;
-                    indexMetadataBuilder.timestampMillisRange(indexMetadataBuilder.getTimestampMillisRange()
+                    indexMetadataBuilder.timestampRange(indexMetadataBuilder.getTimestampRange()
                             .removeShard(shardId.id(), oldIndexMetadata.getNumberOfShards()));
                 } else {
                     assert recoverySource instanceof RecoverySource.SnapshotRecoverySource : recoverySource;

--- a/server/src/main/java/org/elasticsearch/index/query/CoordinatorRewriteContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/CoordinatorRewriteContext.java
@@ -35,7 +35,7 @@ import java.util.function.LongSupplier;
  * Instances of this object rely on information stored in the {@code IndexMetadata} for certain indices.
  * Right now this context object is able to rewrite range queries that include a known timestamp field
  * (i.e. the timestamp field for DataStreams) into a MatchNoneQueryBuilder and skip the shards that
- * don't hold queried data. See IndexMetadata#getTimestampMillisRange() for more details
+ * don't hold queried data. See IndexMetadata#getTimestampRange() for more details
  */
 public class CoordinatorRewriteContext extends QueryRewriteContext {
     private final Index index;

--- a/server/src/main/java/org/elasticsearch/index/query/CoordinatorRewriteContextProvider.java
+++ b/server/src/main/java/org/elasticsearch/index/query/CoordinatorRewriteContextProvider.java
@@ -60,7 +60,7 @@ public class CoordinatorRewriteContextProvider {
         ClusterState clusterState = clusterStateSupplier.get();
         IndexMetadata indexMetadata = clusterState.metadata().index(index);
 
-        if (indexMetadata == null || indexMetadata.getTimestampMillisRange().containsAllShardRanges() == false) {
+        if (indexMetadata == null || indexMetadata.getTimestampRange().containsAllShardRanges() == false) {
             return null;
         }
 
@@ -70,13 +70,13 @@ public class CoordinatorRewriteContextProvider {
             return null;
         }
 
-        IndexLongFieldRange timestampMillisRange = indexMetadata.getTimestampMillisRange();
+        IndexLongFieldRange timestampRange = indexMetadata.getTimestampRange();
         return new CoordinatorRewriteContext(xContentRegistry,
             writeableRegistry,
             client,
             nowInMillis,
             index,
-            timestampMillisRange,
+            timestampRange,
             dateFieldType
         );
     }

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -1796,7 +1796,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     }
 
     @Override
-    public ShardLongFieldRange getTimestampMillisRange() {
+    public ShardLongFieldRange getTimestampRange() {
         if (mapperService() == null) {
             return ShardLongFieldRange.UNKNOWN; // no mapper service, no idea if the field even exists
         }
@@ -2821,7 +2821,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         markAsRecovering(reason, recoveryState); // mark the shard as recovering on the cluster state thread
         threadPool.generic().execute(ActionRunnable.wrap(ActionListener.wrap(r -> {
                 if (r) {
-                    recoveryListener.onRecoveryDone(recoveryState, getTimestampMillisRange());
+                    recoveryListener.onRecoveryDone(recoveryState, getTimestampRange());
                 }
             },
             e -> recoveryListener.onRecoveryFailure(recoveryState, new RecoveryFailedException(recoveryState, null, e), true)), action));

--- a/server/src/main/java/org/elasticsearch/indices/TimestampFieldMapperService.java
+++ b/server/src/main/java/org/elasticsearch/indices/TimestampFieldMapperService.java
@@ -144,8 +144,8 @@ public class TimestampFieldMapperService extends AbstractLifecycleComponent impl
         if (indexMetadata == null) {
             return false;
         }
-        final IndexLongFieldRange timestampMillisRange = indexMetadata.getTimestampMillisRange();
-        return timestampMillisRange.isComplete() && timestampMillisRange != IndexLongFieldRange.UNKNOWN;
+        final IndexLongFieldRange timestampRange = indexMetadata.getTimestampRange();
+        return timestampRange.isComplete() && timestampRange != IndexLongFieldRange.UNKNOWN;
     }
 
     private static DateFieldMapper.DateFieldType fromMapperService(MapperService mapperService) {

--- a/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -641,7 +641,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
                         primaryTerm,
                         "master " + nodes.getMasterNode() + " marked shard as initializing, but shard state is [" + state +
                                 "], mark shard as started",
-                        shard.getTimestampMillisRange(),
+                        shard.getTimestampRange(),
                         SHARD_STATE_ACTION_LISTENER,
                         clusterState);
             }
@@ -796,11 +796,11 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
         RecoveryState recoveryState();
 
         /**
-         * @return the range of the {@code @timestamp} field for this shard, in milliseconds since the epoch, or {@link
-         * ShardLongFieldRange#EMPTY} if this field is not found, or {@link ShardLongFieldRange#UNKNOWN} if its range is not fixed.
+         * @return the range of the {@code @timestamp} field for this shard, or {@link ShardLongFieldRange#EMPTY} if this field is not
+         * found, or {@link ShardLongFieldRange#UNKNOWN} if its range is not fixed.
          */
         @Nullable
-        ShardLongFieldRange getTimestampMillisRange();
+        ShardLongFieldRange getTimestampRange();
 
         /**
          * Updates the shard state based on an incoming cluster state:

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
@@ -279,7 +279,7 @@ public class RecoveryTarget extends AbstractRefCounted implements RecoveryTarget
                 // release the initial reference. recovery files will be cleaned as soon as ref count goes to zero, potentially now
                 decRef();
             }
-            listener.onRecoveryDone(state(), indexShard.getTimestampMillisRange());
+            listener.onRecoveryDone(state(), indexShard.getTimestampRange());
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -350,7 +350,7 @@ public class RestoreService implements ClusterStateApplier {
                                     indexMdBuilder.settings(Settings.builder()
                                         .put(snapshotIndexMetadata.getSettings())
                                         .put(IndexMetadata.SETTING_INDEX_UUID, UUIDs.randomBase64UUID()))
-                                        .timestampMillisRange(IndexLongFieldRange.NO_SHARDS);
+                                        .timestampRange(IndexLongFieldRange.NO_SHARDS);
                                     shardLimitValidator.validateShardLimit(snapshotIndexMetadata.getSettings(), currentState);
                                     if (!request.includeAliases() && !snapshotIndexMetadata.getAliases().isEmpty()) {
                                         // Remove all aliases - they shouldn't be restored
@@ -383,7 +383,7 @@ public class RestoreService implements ClusterStateApplier {
                                             1 + currentIndexMetadata.getSettingsVersion()));
                                     indexMdBuilder.aliasesVersion(
                                         Math.max(snapshotIndexMetadata.getAliasesVersion(), 1 + currentIndexMetadata.getAliasesVersion()));
-                                    indexMdBuilder.timestampMillisRange(IndexLongFieldRange.NO_SHARDS);
+                                    indexMdBuilder.timestampRange(IndexLongFieldRange.NO_SHARDS);
 
                                     for (int shard = 0; shard < snapshotIndexMetadata.getNumberOfShards(); shard++) {
                                         indexMdBuilder.primaryTerm(shard,

--- a/server/src/test/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhaseTests.java
@@ -771,7 +771,7 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
                 throw new IllegalArgumentException("Min/Max timestamps for " + index + " were already defined");
             }
 
-            IndexLongFieldRange timestampMillisRange = IndexLongFieldRange.NO_SHARDS
+            IndexLongFieldRange timestampRange = IndexLongFieldRange.NO_SHARDS
                 .extendWithShardRange(0, 1, ShardLongFieldRange.of(minTimeStamp, maxTimestamp));
 
             Settings.Builder indexSettings = settings(Version.CURRENT)
@@ -781,7 +781,7 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
                 .settings(indexSettings)
                 .numberOfShards(1)
                 .numberOfReplicas(0)
-                .timestampMillisRange(timestampMillisRange);
+                .timestampRange(timestampRange);
 
             Metadata.Builder metadataBuilder =
                 Metadata.builder(clusterState.metadata())

--- a/server/src/test/java/org/elasticsearch/cluster/action/shard/ShardStartedClusterStateTaskExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/action/shard/ShardStartedClusterStateTaskExecutorTests.java
@@ -287,17 +287,17 @@ public class ShardStartedClusterStateTaskExecutorTests extends ESAllocationTestC
         final ShardRouting primaryShard = clusterState.routingTable().shardRoutingTable(shardId).primaryShard();
         final String primaryAllocationId = primaryShard.allocationId().getId();
 
-        assertThat(indexMetadata.getTimestampMillisRange(), sameInstance(IndexLongFieldRange.NO_SHARDS));
+        assertThat(indexMetadata.getTimestampRange(), sameInstance(IndexLongFieldRange.NO_SHARDS));
 
-        final ShardLongFieldRange shardTimestampMillisRange = randomBoolean() ? ShardLongFieldRange.UNKNOWN :
+        final ShardLongFieldRange shardTimestampRange = randomBoolean() ? ShardLongFieldRange.UNKNOWN :
                 randomBoolean() ? ShardLongFieldRange.EMPTY : ShardLongFieldRange.of(1606407943000L, 1606407944000L);
 
         final List<StartedShardEntry> tasks = new ArrayList<>();
-        tasks.add(new StartedShardEntry(shardId, primaryAllocationId, primaryTerm, "test", shardTimestampMillisRange));
+        tasks.add(new StartedShardEntry(shardId, primaryAllocationId, primaryTerm, "test", shardTimestampRange));
         if (randomBoolean()) {
             final ShardRouting replicaShard = clusterState.routingTable().shardRoutingTable(shardId).replicaShards().iterator().next();
             final String replicaAllocationId = replicaShard.allocationId().getId();
-            tasks.add(new StartedShardEntry(shardId, replicaAllocationId, primaryTerm, "test", shardTimestampMillisRange));
+            tasks.add(new StartedShardEntry(shardId, replicaAllocationId, primaryTerm, "test", shardTimestampRange));
         }
         final ClusterStateTaskExecutor.ClusterTasksResult result = executeTasks(clusterState, tasks);
         assertNotSame(clusterState, result.resultingState);
@@ -309,15 +309,15 @@ public class ShardStartedClusterStateTaskExecutorTests extends ESAllocationTestC
             final IndexShardRoutingTable shardRoutingTable = result.resultingState.routingTable().shardRoutingTable(task.shardId);
             assertThat(shardRoutingTable.getByAllocationId(task.allocationId).state(), is(ShardRoutingState.STARTED));
 
-            final IndexLongFieldRange timestampMillisRange = result.resultingState.metadata().index(indexName).getTimestampMillisRange();
-            if (shardTimestampMillisRange == ShardLongFieldRange.UNKNOWN) {
-                assertThat(timestampMillisRange, sameInstance(IndexLongFieldRange.UNKNOWN));
-            } else if (shardTimestampMillisRange == ShardLongFieldRange.EMPTY) {
-                assertThat(timestampMillisRange, sameInstance(IndexLongFieldRange.EMPTY));
+            final IndexLongFieldRange timestampRange = result.resultingState.metadata().index(indexName).getTimestampRange();
+            if (shardTimestampRange == ShardLongFieldRange.UNKNOWN) {
+                assertThat(timestampRange, sameInstance(IndexLongFieldRange.UNKNOWN));
+            } else if (shardTimestampRange == ShardLongFieldRange.EMPTY) {
+                assertThat(timestampRange, sameInstance(IndexLongFieldRange.EMPTY));
             } else {
-                assertTrue(timestampMillisRange.isComplete());
-                assertThat(timestampMillisRange.getMin(), equalTo(shardTimestampMillisRange.getMin()));
-                assertThat(timestampMillisRange.getMax(), equalTo(shardTimestampMillisRange.getMax()));
+                assertTrue(timestampRange.isComplete());
+                assertThat(timestampRange.getMin(), equalTo(shardTimestampRange.getMin()));
+                assertThat(timestampRange.getMax(), equalTo(shardTimestampRange.getMax()));
             }
         });
     }

--- a/server/src/test/java/org/elasticsearch/cluster/action/shard/ShardStateActionTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/action/shard/ShardStateActionTests.java
@@ -436,7 +436,7 @@ public class ShardStateActionTests extends ESTestCase {
         assertThat(entry.shardId, equalTo(shardRouting.shardId()));
         assertThat(entry.allocationId, equalTo(shardRouting.allocationId().getId()));
         assertThat(entry.primaryTerm, equalTo(primaryTerm));
-        assertThat(entry.timestampMillisRange, sameInstance(ShardLongFieldRange.UNKNOWN));
+        assertThat(entry.timestampRange, sameInstance(ShardLongFieldRange.UNKNOWN));
 
         transport.handleResponse(capturedRequests[0].requestId, TransportResponse.Empty.INSTANCE);
         listener.await();
@@ -544,13 +544,13 @@ public class ShardStateActionTests extends ESTestCase {
         final String message = randomRealisticUnicodeOfCodepointLengthBetween(10, 100);
 
         final Version version = randomFrom(randomCompatibleVersion(random(), Version.CURRENT));
-        final ShardLongFieldRange timestampMillisRange = ShardLongFieldRangeWireTests.randomRange();
+        final ShardLongFieldRange timestampRange = ShardLongFieldRangeWireTests.randomRange();
         final StartedShardEntry startedShardEntry = new StartedShardEntry(
                 shardId,
                 allocationId,
                 primaryTerm,
                 message,
-                timestampMillisRange);
+                timestampRange);
         try (StreamInput in = serialize(startedShardEntry, version).streamInput()) {
             in.setVersion(version);
             final StartedShardEntry deserialized = new StartedShardEntry(in);
@@ -562,8 +562,8 @@ public class ShardStateActionTests extends ESTestCase {
                 assertThat(deserialized.primaryTerm, equalTo(0L));
             }
             assertThat(deserialized.message, equalTo(message));
-            assertThat(deserialized.timestampMillisRange, version.onOrAfter(ShardLongFieldRange.LONG_FIELD_RANGE_VERSION_INTRODUCED) ?
-                    equalTo(timestampMillisRange) : sameInstance(ShardLongFieldRange.UNKNOWN));
+            assertThat(deserialized.timestampRange, version.onOrAfter(ShardLongFieldRange.LONG_FIELD_RANGE_VERSION_INTRODUCED) ?
+                    equalTo(timestampRange) : sameInstance(ShardLongFieldRange.UNKNOWN));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/indices/cluster/AbstractIndicesClusterStateServiceTestCase.java
+++ b/server/src/test/java/org/elasticsearch/indices/cluster/AbstractIndicesClusterStateServiceTestCase.java
@@ -410,7 +410,7 @@ public abstract class AbstractIndicesClusterStateServiceTestCase extends ESTestC
         }
 
         @Override
-        public ShardLongFieldRange getTimestampMillisRange() {
+        public ShardLongFieldRange getTimestampRange() {
             return ShardLongFieldRange.EMPTY;
         }
 

--- a/test/framework/src/main/java/org/elasticsearch/action/support/replication/ClusterStateCreationUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/action/support/replication/ClusterStateCreationUtils.java
@@ -98,7 +98,7 @@ public class ClusterStateCreationUtils {
                 .put(SETTING_VERSION_CREATED, Version.CURRENT)
                 .put(SETTING_NUMBER_OF_SHARDS, 1).put(SETTING_NUMBER_OF_REPLICAS, numberOfReplicas)
                 .put(SETTING_CREATION_DATE, System.currentTimeMillis())).primaryTerm(0, primaryTerm)
-                .timestampMillisRange(primaryState == ShardRoutingState.STARTED || primaryState == ShardRoutingState.RELOCATING
+                .timestampRange(primaryState == ShardRoutingState.STARTED || primaryState == ShardRoutingState.RELOCATING
                         ? IndexLongFieldRange.UNKNOWN : IndexLongFieldRange.NO_SHARDS)
             .build();
 
@@ -303,7 +303,7 @@ public class ClusterStateCreationUtils {
             IndexMetadata indexMetadata = IndexMetadata.builder(index)
                     .settings(Settings.builder().put(SETTING_VERSION_CREATED, Version.CURRENT).put(SETTING_NUMBER_OF_SHARDS, numberOfShards)
                             .put(SETTING_NUMBER_OF_REPLICAS, numberOfReplicas).put(SETTING_CREATION_DATE, System.currentTimeMillis()))
-                    .timestampMillisRange(IndexLongFieldRange.UNKNOWN)
+                    .timestampRange(IndexLongFieldRange.UNKNOWN)
                     .build();
             metadataBuilder.put(indexMetadata, false).generateClusterUuidIfNeeded();
             IndexRoutingTable.Builder indexRoutingTableBuilder = IndexRoutingTable.builder(indexMetadata.getIndex());

--- a/x-pack/plugin/frozen-indices/src/internalClusterTest/java/org/elasticsearch/index/engine/FrozenIndexIT.java
+++ b/x-pack/plugin/frozen-indices/src/internalClusterTest/java/org/elasticsearch/index/engine/FrozenIndexIT.java
@@ -80,7 +80,7 @@ public class FrozenIndexIT extends ESIntegTestCase {
         assertAcked(client().execute(FreezeIndexAction.INSTANCE,
                 new FreezeRequest("index").waitForActiveShards(ActiveShardCount.ONE)).actionGet());
 
-        assertThat(client().admin().cluster().prepareState().get().getState().metadata().index("index").getTimestampMillisRange(),
+        assertThat(client().admin().cluster().prepareState().get().getState().metadata().index("index").getTimestampRange(),
                 sameInstance(IndexLongFieldRange.EMPTY));
 
         internalCluster().stopRandomNode(InternalTestCluster.nameFilter(nodeNames.get(1)));
@@ -95,7 +95,7 @@ public class FrozenIndexIT extends ESIntegTestCase {
         ensureYellowAndNoInitializingShards("index");
 
         final IndexLongFieldRange timestampFieldRange
-                = client().admin().cluster().prepareState().get().getState().metadata().index("index").getTimestampMillisRange();
+                = client().admin().cluster().prepareState().get().getState().metadata().index("index").getTimestampRange();
         assertThat(timestampFieldRange, not(sameInstance(IndexLongFieldRange.UNKNOWN)));
         assertThat(timestampFieldRange, not(sameInstance(IndexLongFieldRange.EMPTY)));
         assertTrue(timestampFieldRange.isComplete());

--- a/x-pack/plugin/frozen-indices/src/internalClusterTest/java/org/elasticsearch/index/engine/FrozenIndexTests.java
+++ b/x-pack/plugin/frozen-indices/src/internalClusterTest/java/org/elasticsearch/index/engine/FrozenIndexTests.java
@@ -199,7 +199,7 @@ public class FrozenIndexTests extends ESSingleNodeTestCase {
 
     public void testFreezeAndUnfreeze() throws ExecutionException, InterruptedException {
         final IndexService originalIndexService = createIndex("index", Settings.builder().put("index.number_of_shards", 2).build());
-        assertThat(originalIndexService.getMetadata().getTimestampMillisRange(), sameInstance(IndexLongFieldRange.UNKNOWN));
+        assertThat(originalIndexService.getMetadata().getTimestampRange(), sameInstance(IndexLongFieldRange.UNKNOWN));
 
             client().prepareIndex("index", "_doc", "1").setSource("field", "value").setRefreshPolicy(IMMEDIATE).get();
             client().prepareIndex("index", "_doc", "2").setSource("field", "value").setRefreshPolicy(IMMEDIATE).get();
@@ -218,7 +218,7 @@ public class FrozenIndexTests extends ESSingleNodeTestCase {
             assertTrue(indexService.getIndexSettings().isSearchThrottled());
             IndexShard shard = indexService.getShard(0);
             assertEquals(0, shard.refreshStats().getTotal());
-            assertThat(indexService.getMetadata().getTimestampMillisRange(), sameInstance(IndexLongFieldRange.UNKNOWN));
+            assertThat(indexService.getMetadata().getTimestampRange(), sameInstance(IndexLongFieldRange.UNKNOWN));
         }
         assertAcked(xPackClient.freeze(new FreezeRequest("index").setFreeze(false)));
         {
@@ -229,7 +229,7 @@ public class FrozenIndexTests extends ESSingleNodeTestCase {
             IndexShard shard = indexService.getShard(0);
             Engine engine = IndexShardTestCase.getEngine(shard);
             assertThat(engine, Matchers.instanceOf(InternalEngine.class));
-            assertThat(indexService.getMetadata().getTimestampMillisRange(), sameInstance(IndexLongFieldRange.UNKNOWN));
+            assertThat(indexService.getMetadata().getTimestampRange(), sameInstance(IndexLongFieldRange.UNKNOWN));
         }
         client().prepareIndex("index", "_doc", "4").setSource("field", "value").setRefreshPolicy(IMMEDIATE).get();
     }
@@ -508,7 +508,7 @@ public class FrozenIndexTests extends ESSingleNodeTestCase {
         assertAcked(client().execute(FreezeIndexAction.INSTANCE, new FreezeRequest("index")).actionGet());
 
         final IndexLongFieldRange timestampFieldRange
-                = client().admin().cluster().prepareState().get().getState().metadata().index("index").getTimestampMillisRange();
+                = client().admin().cluster().prepareState().get().getState().metadata().index("index").getTimestampRange();
         assertThat(timestampFieldRange, not(sameInstance(IndexLongFieldRange.UNKNOWN)));
         assertThat(timestampFieldRange, not(sameInstance(IndexLongFieldRange.EMPTY)));
         assertTrue(timestampFieldRange.isComplete());
@@ -541,7 +541,7 @@ public class FrozenIndexTests extends ESSingleNodeTestCase {
         assertAcked(client().execute(FreezeIndexAction.INSTANCE, new FreezeRequest("index")).actionGet());
 
         final IndexLongFieldRange timestampFieldRange
-                = client().admin().cluster().prepareState().get().getState().metadata().index("index").getTimestampMillisRange();
+                = client().admin().cluster().prepareState().get().getState().metadata().index("index").getTimestampRange();
         assertThat(timestampFieldRange, not(sameInstance(IndexLongFieldRange.UNKNOWN)));
         assertThat(timestampFieldRange, not(sameInstance(IndexLongFieldRange.EMPTY)));
         assertTrue(timestampFieldRange.isComplete());

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsCanMatchOnCoordinatorIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsCanMatchOnCoordinatorIntegTests.java
@@ -136,7 +136,7 @@ public class SearchableSnapshotsCanMatchOnCoordinatorIntegTests extends BaseSear
         client().execute(MountSearchableSnapshotAction.INSTANCE, mountRequest).actionGet();
 
         final IndexMetadata indexMetadata = getIndexMetadata(searchableSnapshotIndexOutsideSearchRange);
-        assertThat(indexMetadata.getTimestampMillisRange(), equalTo(IndexLongFieldRange.NO_SHARDS));
+        assertThat(indexMetadata.getTimestampRange(), equalTo(IndexLongFieldRange.NO_SHARDS));
 
         DateFieldMapper.DateFieldType timestampFieldType = indicesService.getTimestampFieldType(indexMetadata.getIndex());
         assertThat(timestampFieldType, nullValue());
@@ -177,7 +177,7 @@ public class SearchableSnapshotsCanMatchOnCoordinatorIntegTests extends BaseSear
         ensureGreen(searchableSnapshotIndexOutsideSearchRange);
 
         final IndexMetadata updatedIndexMetadata = getIndexMetadata(searchableSnapshotIndexOutsideSearchRange);
-        final IndexLongFieldRange updatedTimestampMillisRange = updatedIndexMetadata.getTimestampMillisRange();
+        final IndexLongFieldRange updatedTimestampMillisRange = updatedIndexMetadata.getTimestampRange();
         final DateFieldMapper.DateFieldType dateFieldType = indicesService.getTimestampFieldType(updatedIndexMetadata.getIndex());
         assertThat(dateFieldType, notNullValue());
         final DateFieldMapper.Resolution resolution = dateFieldType.resolution();
@@ -272,7 +272,7 @@ public class SearchableSnapshotsCanMatchOnCoordinatorIntegTests extends BaseSear
         final int searchableSnapshotShardCount = indexOutsideSearchRangeShardCount;
 
         final IndexMetadata indexMetadata = getIndexMetadata(searchableSnapshotIndexOutsideSearchRange);
-        assertThat(indexMetadata.getTimestampMillisRange(), equalTo(IndexLongFieldRange.NO_SHARDS));
+        assertThat(indexMetadata.getTimestampRange(), equalTo(IndexLongFieldRange.NO_SHARDS));
 
         DateFieldMapper.DateFieldType timestampFieldType = indicesService.getTimestampFieldType(indexMetadata.getIndex());
         assertThat(timestampFieldType, nullValue());
@@ -303,7 +303,7 @@ public class SearchableSnapshotsCanMatchOnCoordinatorIntegTests extends BaseSear
         ensureGreen(searchableSnapshotIndexOutsideSearchRange);
 
         final IndexMetadata updatedIndexMetadata = getIndexMetadata(searchableSnapshotIndexOutsideSearchRange);
-        final IndexLongFieldRange updatedTimestampMillisRange = updatedIndexMetadata.getTimestampMillisRange();
+        final IndexLongFieldRange updatedTimestampMillisRange = updatedIndexMetadata.getTimestampRange();
         final DateFieldMapper.DateFieldType dateFieldType = indicesService.getTimestampFieldType(updatedIndexMetadata.getIndex());
         assertThat(dateFieldType, notNullValue());
         final DateFieldMapper.Resolution resolution = dateFieldType.resolution();
@@ -379,7 +379,7 @@ public class SearchableSnapshotsCanMatchOnCoordinatorIntegTests extends BaseSear
         client().execute(MountSearchableSnapshotAction.INSTANCE, mountRequest).actionGet();
 
         final IndexMetadata indexMetadata = getIndexMetadata(searchableSnapshotIndexWithinSearchRange);
-        assertThat(indexMetadata.getTimestampMillisRange(), equalTo(IndexLongFieldRange.NO_SHARDS));
+        assertThat(indexMetadata.getTimestampRange(), equalTo(IndexLongFieldRange.NO_SHARDS));
 
         DateFieldMapper.DateFieldType timestampFieldType = indicesService.getTimestampFieldType(indexMetadata.getIndex());
         assertThat(timestampFieldType, nullValue());
@@ -403,7 +403,7 @@ public class SearchableSnapshotsCanMatchOnCoordinatorIntegTests extends BaseSear
         ensureGreen(searchableSnapshotIndexWithinSearchRange);
 
         final IndexMetadata updatedIndexMetadata = getIndexMetadata(searchableSnapshotIndexWithinSearchRange);
-        final IndexLongFieldRange updatedTimestampMillisRange = updatedIndexMetadata.getTimestampMillisRange();
+        final IndexLongFieldRange updatedTimestampMillisRange = updatedIndexMetadata.getTimestampRange();
         final DateFieldMapper.DateFieldType dateFieldType = indicesService.getTimestampFieldType(updatedIndexMetadata.getIndex());
         assertThat(dateFieldType, notNullValue());
         final DateFieldMapper.Resolution resolution = dateFieldType.resolution();

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
@@ -156,7 +156,7 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
                 .getState()
                 .metadata()
                 .index(indexName)
-                .getTimestampMillisRange(),
+                .getTimestampRange(),
             sameInstance(IndexLongFieldRange.UNKNOWN)
         );
 
@@ -253,7 +253,7 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
                 .getState()
                 .metadata()
                 .index(restoredIndexName)
-                .getTimestampMillisRange(),
+                .getTimestampRange(),
             sameInstance(IndexLongFieldRange.UNKNOWN)
         );
 
@@ -772,7 +772,7 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
         mountSnapshot(repositoryName, snapshotOne.getName(), indexName, indexName, Settings.EMPTY);
         ensureGreen(indexName);
 
-        final IndexLongFieldRange timestampMillisRange = client().admin()
+        final IndexLongFieldRange timestampRange = client().admin()
             .cluster()
             .prepareState()
             .clear()
@@ -782,19 +782,19 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
             .getState()
             .metadata()
             .index(indexName)
-            .getTimestampMillisRange();
+            .getTimestampRange();
 
-        assertTrue(timestampMillisRange.isComplete());
-        assertThat(timestampMillisRange, not(sameInstance(IndexLongFieldRange.UNKNOWN)));
+        assertTrue(timestampRange.isComplete());
+        assertThat(timestampRange, not(sameInstance(IndexLongFieldRange.UNKNOWN)));
         if (docCount == 0) {
-            assertThat(timestampMillisRange, sameInstance(IndexLongFieldRange.EMPTY));
+            assertThat(timestampRange, sameInstance(IndexLongFieldRange.EMPTY));
         } else {
-            assertThat(timestampMillisRange, not(sameInstance(IndexLongFieldRange.EMPTY)));
+            assertThat(timestampRange, not(sameInstance(IndexLongFieldRange.EMPTY)));
             DateFieldMapper.Resolution resolution = dateType.equals("date")
                 ? DateFieldMapper.Resolution.MILLISECONDS
                 : DateFieldMapper.Resolution.NANOSECONDS;
-            assertThat(timestampMillisRange.getMin(), greaterThanOrEqualTo(resolution.convert(Instant.parse("2020-11-26T00:00:00Z"))));
-            assertThat(timestampMillisRange.getMin(), lessThanOrEqualTo(resolution.convert(Instant.parse("2020-11-27T00:00:00Z"))));
+            assertThat(timestampRange.getMin(), greaterThanOrEqualTo(resolution.convert(Instant.parse("2020-11-26T00:00:00Z"))));
+            assertThat(timestampRange.getMin(), lessThanOrEqualTo(resolution.convert(Instant.parse("2020-11-27T00:00:00Z"))));
         }
     }
 


### PR DESCRIPTION
Since we introduced (#65583) we are storing the timestamp range in the
mappings resolution so the qualifier can be misleading, for that
reason we rename all related variables to remove any references
to milliseconds.

Backport of #66688