### PR TITLE
Ensure azure-storage-blob jar is built when importing into IDE

### DIFF
--- a/gradle/ide.gradle
+++ b/gradle/ide.gradle
@@ -87,7 +87,7 @@ if (System.getProperty('idea.active') == 'true') {
   tasks.register('buildDependencyArtifacts') {
     group = 'ide'
     description = 'Builds artifacts needed as dependency for IDE modules'
-    dependsOn ':client:rest-high-level:shadowJar', ':plugins:repository-hdfs:hadoop-common:shadowJar'
+    dependsOn ':client:rest-high-level:shadowJar', ':plugins:repository-hdfs:hadoop-common:shadowJar', ':plugins:repository-azure:azure-storage-blob:shadowJar'
   }
 
   idea {


### PR DESCRIPTION
We want to ensure that any shadow jars we build which are in turn dependencies for other projects are built on import into IntelliJ, otherwise you'll compile errors when building in the IDE if those JARs are missing.