### PR TITLE
Remove leniency for casting from def to void in Painless

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/AnalyzerCaster.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/AnalyzerCaster.java
@@ -400,7 +400,7 @@ public final class AnalyzerCaster {
         }
 
         if (
-                actual == def.class                             ||
+                (actual == def.class && expected != void.class) ||
                 (actual != void.class && expected == def.class) ||
                 expected.isAssignableFrom(actual)               ||
                 (actual.isAssignableFrom(expected) && explicit)

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/FactoryTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/FactoryTests.java
@@ -282,6 +282,9 @@ public class FactoryTests extends ScriptTestCase {
         IllegalArgumentException iae = expectScriptThrows(IllegalArgumentException.class, () ->
                 scriptEngine.compile("void_return_test", "1 + 1", VoidReturnTestScript.CONTEXT, Collections.emptyMap()));
         assertEquals(iae.getMessage(), "not a statement: result not used from addition operation [+]");
+        ClassCastException cce = expectScriptThrows(ClassCastException.class, () ->
+                scriptEngine.compile("void_return_test", "def x = 1; return x;", VoidReturnTestScript.CONTEXT, Collections.emptyMap()));
+        assertEquals(cce.getMessage(), "Cannot cast from [def] to [void].");
     }
 
     public abstract static class FactoryTestConverterScript {


### PR DESCRIPTION
This leniency was originally for lambda and method reference conversions, but they are both special cased now. This removes change removes the unnecessary leniency of a cast from a `def` type to a `void` type. This also fixes (https://github.com/elastic/elasticsearch/issues/66175).