### PR TITLE
[Test] Adjust assertions ReloadSecureSettings test for FIPS jvm

### DIFF
--- a/x-pack/qa/password-protected-keystore/src/test/java/org/elasticsearch/password_protected_keystore/ReloadSecureSettingsWithPasswordProtectedKeystoreRestIT.java
+++ b/x-pack/qa/password-protected-keystore/src/test/java/org/elasticsearch/password_protected_keystore/ReloadSecureSettingsWithPasswordProtectedKeystoreRestIT.java
@@ -15,6 +15,7 @@ import org.elasticsearch.test.rest.ESRestTestCase;
 
 import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.basicAuthHeaderValue;
 import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.nullValue;
@@ -65,7 +66,6 @@ public class ReloadSecureSettingsWithPasswordProtectedKeystoreRestIT extends ESR
     }
 
     @SuppressWarnings("unchecked")
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/66951")
     public void testReloadSecureSettingsWithEmptyPassword() throws Exception {
         final Request request = new Request("POST", "_nodes/reload_secure_settings");
         final Response response = client().performRequest(request);
@@ -78,10 +78,16 @@ public class ReloadSecureSettingsWithPasswordProtectedKeystoreRestIT extends ESR
             assertThat(entry.getValue(), instanceOf(Map.class));
             final Map<String, Object> node = (Map<String, Object>) entry.getValue();
             assertThat(node.get("reload_exception"), instanceOf(Map.class));
-            assertThat(ObjectPath.eval("reload_exception.reason", node), anyOf(
-                equalTo("Provided keystore password was incorrect"),
-                equalTo("Keystore has been corrupted or tampered with")));
-            assertThat(ObjectPath.eval("reload_exception.type", node), equalTo("security_exception"));
+            if (inFipsJvm()) {
+                assertThat(ObjectPath.eval("reload_exception.reason", node), containsString(
+                    "Error generating an encryption key from the provided password"));
+                assertThat(ObjectPath.eval("reload_exception.type", node), equalTo("general_security_exception"));
+            } else {
+                assertThat(ObjectPath.eval("reload_exception.reason", node), anyOf(
+                    equalTo("Provided keystore password was incorrect"),
+                    equalTo("Keystore has been corrupted or tampered with")));
+                assertThat(ObjectPath.eval("reload_exception.type", node), equalTo("security_exception"));
+            }
         }
     }
 


### PR DESCRIPTION
When the JVM is configured to be in FIPS mode, the reload security settings API returns a different error message that is specific to FIPS when given an empty password. This PR adjust the assertions so that they are matched correspondingly.

Resolves: #66880