### PR TITLE
[Test] Adjust assertions ReloadSecureSettings test for FIPS jvm (#66965)

### DIFF
--- a/x-pack/qa/password-protected-keystore/src/test/java/org/elasticsearch/password_protected_keystore/ReloadSecureSettingsWithPasswordProtectedKeystoreRestIT.java
+++ b/x-pack/qa/password-protected-keystore/src/test/java/org/elasticsearch/password_protected_keystore/ReloadSecureSettingsWithPasswordProtectedKeystoreRestIT.java
@@ -15,6 +15,7 @@ import org.elasticsearch.test.rest.ESRestTestCase;
 
 import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.basicAuthHeaderValue;
 import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.nullValue;
@@ -79,8 +80,13 @@ public class ReloadSecureSettingsWithPasswordProtectedKeystoreRestIT extends ESR
             assertThat(node.get("reload_exception"), instanceOf(Map.class));
             assertThat(ObjectPath.eval("reload_exception.reason", node), anyOf(
                 equalTo("Provided keystore password was incorrect"),
-                equalTo("Keystore has been corrupted or tampered with")));
-            assertThat(ObjectPath.eval("reload_exception.type", node), equalTo("security_exception"));
+                equalTo("Keystore has been corrupted or tampered with"),
+                containsString("Error generating an encryption key from the provided password") // FIPS
+            ));
+            assertThat(ObjectPath.eval("reload_exception.type", node), 
+                // Depends on exact security provider (eg Sun vs BCFIPS)
+                anyOf(equalTo("security_exception"), equalTo("general_security_exception"))
+            );
         }
     }
 


### PR DESCRIPTION
When the JVM is configured to be in FIPS mode, the reload security settings API
returns a different error message that is specific to FIPS when given an empty
password. This PR adjust the assertions so that they are matched
correspondingly.

Co-authored-by: Tim Vernum <tim@adjective.org>