### PR TITLE
[Test] increase password length when in FIPS mode for SamlAuthIT

### DIFF
--- a/x-pack/qa/saml-idp-tests/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlAuthenticationIT.java
+++ b/x-pack/qa/saml-idp-tests/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlAuthenticationIT.java
@@ -134,7 +134,7 @@ public class SamlAuthenticationIT extends ESRestTestCase {
         final Map<String, Object> body = MapBuilder.<String, Object>newMapBuilder()
             .put("roles", Collections.singletonList("kibana_admin"))
             .put("full_name", "Thor Son of Odin")
-            .put("password", randomAlphaOfLengthBetween(8, 16))
+            .put("password", randomAlphaOfLengthBetween(inFipsJvm() ? 14 : 8, 16))
             .put("metadata", Collections.singletonMap("is_native", true))
             .map();
         final Response response = adminClient().performRequest(buildRequest("PUT", "/_security/user/thor", body));


### PR DESCRIPTION
The native user password must be longer than 14 chars when JVM is in FIPS mode. 

Relates: #66879