### PR TITLE
[Test][FIPS] Skip ingest-attachment plugin in FIPS

### DIFF
--- a/x-pack/qa/smoke-test-plugins/build.gradle
+++ b/x-pack/qa/smoke-test-plugins/build.gradle
@@ -1,4 +1,5 @@
 import org.elasticsearch.gradle.MavenFilteringHack
+import org.elasticsearch.gradle.info.BuildParams
 
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-rest-test'
@@ -18,6 +19,10 @@ testClusters.integTest {
   project(':plugins').getChildProjects().each { pluginName, pluginProject ->
     if (pluginName == 'quota-aware-fs') {
       // This plugin has to be configured to work via system properties
+      return
+    }
+    if (pluginName == 'ingest-attachment' && BuildParams.inFipsJvm) {
+      // This plugin is not supported in FIPS mode (due to jar hell from bouncy castle)
       return
     }
     plugin pluginProject.path


### PR DESCRIPTION
In the `x-pack:qa:smoke-test-plugins` test, do not install the
"ingest-attachment" plugin when running on a FIPS JVM because it has
Jar conflicts (the plugin ships BouncyCastle, but we use BC-FIPS
as our security provider in FIPS mode).

Resolves: #66971
