### PR TITLE
[Transform] Add yml tests for transform latest function

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/transform/preview_transforms.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/transform/preview_transforms.yml
@@ -151,6 +151,55 @@ setup:
   - match: { generated_dest_index.mappings.properties.avg_response.type: "double" }
 
 ---
+"Test preview transform latest":
+  - do:
+      transform.preview_transform:
+        body: >
+          {
+            "source": { "index": "airline-data" },
+            "latest": {
+              "unique_key": ["airline"],
+              "sort": "time"
+            }
+          }
+  - match: { preview.0.airline: bar }
+  - match: { preview.0.time: "2017-02-18T01:00:00Z" }
+  - match: { preview.1.airline: foo }
+  - match: { preview.1.time: "2017-02-18T01:01:00Z" }
+  - match: { generated_dest_index.mappings.properties: {} }
+
+  - do:
+      ingest.put_pipeline:
+        id: "data_frame_simple_pipeline"
+        body:  >
+          {
+            "processors": [
+             {
+               "set" : {
+                 "field" : "my_field",
+                 "value": 42
+               }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+  - do:
+      transform.preview_transform:
+        body: >
+          {
+            "source": { "index": "airline-data" },
+            "latest": {
+              "unique_key": ["airline"],
+              "sort": "time"
+            }
+          }
+  - match: { preview.0.airline: bar }
+  - match: { preview.0.time: "2017-02-18T01:00:00Z" }
+  - match: { preview.1.airline: foo }
+  - match: { preview.1.time: "2017-02-18T01:01:00Z" }
+  - match: { generated_dest_index.mappings.properties: {} }
+
+---
 "Test preview transform with invalid config":
   - do:
       catch: /\[data_frame_terms_group\] unknown field \[not_a_terms_param\]/

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/transform/preview_transforms.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/transform/preview_transforms.yml
@@ -170,7 +170,7 @@ setup:
 
   - do:
       ingest.put_pipeline:
-        id: "data_frame_simple_pipeline"
+        id: "transform_latest_simple_pipeline"
         body:  >
           {
             "processors": [
@@ -188,6 +188,7 @@ setup:
         body: >
           {
             "source": { "index": "airline-data" },
+            "dest": { "pipeline": "transform_latest_simple_pipeline" },
             "latest": {
               "unique_key": ["airline"],
               "sort": "time"
@@ -195,8 +196,10 @@ setup:
           }
   - match: { preview.0.airline: bar }
   - match: { preview.0.time: "2017-02-18T01:00:00Z" }
+  - match: { preview.0.my_field: 42 }
   - match: { preview.1.airline: foo }
   - match: { preview.1.time: "2017-02-18T01:01:00Z" }
+  - match: { preview.1.my_field: 42 }
   - match: { generated_dest_index.mappings.properties: {} }
 
 ---

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/transform/transforms_cat_apis.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/transform/transforms_cat_apis.yml
@@ -41,34 +41,51 @@ setup:
               "aggs": {"avg_response": {"avg": {"field": "responsetime"}}}
             }
           }
+  - do:
+      transform.put_transform:
+        transform_id: "airline-transform-latest"
+        body: >
+          {
+            "source": { "index": "airline-data" },
+            "dest": { "index": "airline-data-latest" },
+            "latest": {
+              "unique_key": [ "airline" ],
+              "sort": "time"
+            }
+          }
 
 ---
 teardown:
   - do:
       transform.delete_transform:
         transform_id: "airline-transform-stats"
+  - do:
+      transform.delete_transform:
+        transform_id: "airline-transform-latest"
 
 ---
 "Test cat transform stats hiding headers":
   - do:
       cat.transforms:
-        transform_id: "airline-transform-stats"
+        transform_id: "airline-transform-*"
   - match:
       $body: |
         /^  #id                           \s+ create_time \s+ version \s+ source_index \s+ dest_index              \s+ pipeline \s+ transform_type \s+ frequency \s+ max_page_search_size \s+ docs_per_second \s+ state    \n
+            (airline\-transform\-latest   \s+ [^\s]+      \s+ [^\s]+  \s+ airline-data \s+ airline-data-latest     \s+          \s+ batch          \s+ 1m        \s+ 500                  \s+ -               \s+ STOPPED \n)+
             (airline\-transform\-stats    \s+ [^\s]+      \s+ [^\s]+  \s+ airline-data \s+ airline-data-by-airline \s+          \s+ batch          \s+ 1m        \s+ 500                  \s+ -               \s+ STOPPED \n)+  $/
 
 ---
 "Test cat transform stats with column selection":
   - do:
       cat.transforms:
-        transform_id: "airline-transform-stats"
+        transform_id: "airline-transform-*"
         v: true
         h: id,version,source_index,dest_index,search_total,index_total,docp,cdtea,indexed_documents_exp_avg
   - match:
       $body: |
-        /^   id                       \s+ version \s+ source_index \s+ dest_index              \s+ search_total \s+ index_total \s+ docp \s+ cdtea  \s+ indexed_documents_exp_avg \n
-            (airline\-transform-stats \s+ [^\s]+  \s+ airline-data \s+ airline-data-by-airline \s+ 0            \s+ 0           \s+ 0  \s+ 0.0    \s+ 0.0 \n)+  $/
+        /^   id                         \s+ version \s+ source_index \s+ dest_index              \s+ search_total \s+ index_total \s+ docp \s+ cdtea  \s+ indexed_documents_exp_avg \n
+            (airline\-transform-latest  \s+ [^\s]+  \s+ airline-data \s+ airline-data-latest     \s+ 0            \s+ 0           \s+ 0  \s+ 0.0    \s+ 0.0 \n)+
+            (airline\-transform-stats   \s+ [^\s]+  \s+ airline-data \s+ airline-data-by-airline \s+ 0            \s+ 0           \s+ 0  \s+ 0.0    \s+ 0.0 \n)+  $/
 
 
 ---

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/transform/transforms_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/transform/transforms_crud.yml
@@ -701,3 +701,102 @@ setup:
   - match: {transforms.0.id: "airline-transform"}
   - is_false: transforms.0.create_time
   - is_false: transforms.0.version
+
+---
+"Test creation failures of latest function":
+  - do:
+      catch: /latest.unique_key must be non-empty/
+      transform.put_transform:
+        transform_id: "duplicate-field-transform"
+        body: >
+          {
+            "source": {
+              "index": "airline-data"
+            },
+            "dest": { "index": "dest-index" },
+            "latest": {
+              "unique_key": [],
+              "sort": "time"
+            }
+          }
+
+  - do:
+      catch: /latest.unique_key\[1\] element must be non-empty/
+      transform.put_transform:
+        transform_id: "duplicate-field-transform"
+        body: >
+          {
+            "source": {
+              "index": "airline-data"
+            },
+            "dest": { "index": "dest-index" },
+            "latest": {
+              "unique_key": [ "airline", "" ],
+              "sort": "time"
+            }
+          }
+
+  - do:
+      catch: /latest.unique_key elements must be unique, found duplicate element \[airline\]/
+      transform.put_transform:
+        transform_id: "duplicate-field-transform"
+        body: >
+          {
+            "source": {
+              "index": "airline-data"
+            },
+            "dest": { "index": "dest-index" },
+            "latest": {
+              "unique_key": [ "airline", "airline" ],
+              "sort": "time"
+            }
+          }
+
+  - do:
+      catch: /latest.sort must be non-empty/
+      transform.put_transform:
+        transform_id: "duplicate-field-transform"
+        body: >
+          {
+            "source": {
+              "index": "airline-data"
+            },
+            "dest": { "index": "dest-index" },
+            "latest": {
+              "unique_key": [ "airline" ],
+              "sort": ""
+            }
+          }
+
+---
+"Test creation of latest function":
+  - do:
+      transform.put_transform:
+        transform_id: "latest-by-airline-transform"
+        body: >
+          {
+            "source": {
+              "index": "airline-data"
+            },
+            "dest": { "index": "latest-by-airline" },
+            "latest": {
+              "unique_key": [ "airline" ],
+              "sort": "time"
+            },
+            "description": "yaml test latest transform on airline-data"
+          }
+  - match: { acknowledged: true }
+
+  - do:
+      transform.get_transform:
+        transform_id: "latest-by-airline-transform"
+  - match: { count: 1 }
+  - match: { transforms.0.id: "latest-by-airline-transform" }
+  - match: { transforms.0.source.index.0: "airline-data" }
+  - match: { transforms.0.dest.index: "latest-by-airline" }
+  - is_true: transforms.0.source.query.match_all
+  - is_true: transforms.0.create_time
+  - is_true: transforms.0.version
+  - match: { transforms.0.latest.unique_key.0: "airline" }
+  - match: { transforms.0.latest.sort: "time" }
+  - match: { transforms.0.description: "yaml test latest transform on airline-data" }


### PR DESCRIPTION
This PR increases coverage of latest transform function by adding a bunch of yml tests.

Relates https://github.com/elastic/elasticsearch/issues/65869