### PR TITLE
Autoscaling add memory info service

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -5,6 +5,5 @@
     <inspection_tool class="PointlessBooleanExpression" enabled="false" level="WARNING" enabled_by_default="false">
       <option name="m_ignoreExpressionsContainingConstants" value="true" />
     </inspection_tool>
-    <inspection_tool class="UNUSED_IMPORT" enabled="true" level="ERROR" enabled_by_default="true" />
   </profile>
 </component>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -5,5 +5,6 @@
     <inspection_tool class="PointlessBooleanExpression" enabled="false" level="WARNING" enabled_by_default="false">
       <option name="m_ignoreExpressionsContainingConstants" value="true" />
     </inspection_tool>
+    <inspection_tool class="UNUSED_IMPORT" enabled="true" level="ERROR" enabled_by_default="true" />
   </profile>
 </component>

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/GreaterThanAssertion.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/GreaterThanAssertion.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 
 /**
  * Represents a gt assert section:

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/GreaterThanAssertion.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/GreaterThanAssertion.java
@@ -60,10 +60,13 @@ public class GreaterThanAssertion extends Assertion {
                 actualValue, instanceOf(Comparable.class));
         assertThat("expected value of [" + getField() + "] is not comparable (got [" + expectedValue.getClass() + "])",
                 expectedValue, instanceOf(Comparable.class));
+        if (actualValue instanceof Long && expectedValue instanceof Integer) {
+            expectedValue = (long) (int) expectedValue;
+        }
         try {
             assertThat(errorMessage(), (Comparable) actualValue, greaterThan((Comparable) expectedValue));
         } catch (ClassCastException e) {
-            fail("cast error while checking (" + errorMessage() + "): " + e);
+            throw new AssertionError("cast error while checking (" + errorMessage() + "): " + e, e);
         }
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/GreaterThanEqualToAssertion.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/GreaterThanEqualToAssertion.java
@@ -61,10 +61,13 @@ public class GreaterThanEqualToAssertion extends Assertion {
                 actualValue, instanceOf(Comparable.class));
         assertThat("expected value of [" + getField() + "] is not comparable (got [" + expectedValue.getClass() + "])",
                 expectedValue, instanceOf(Comparable.class));
+        if (actualValue instanceof Long && expectedValue instanceof Integer) {
+            expectedValue = (long) (int) expectedValue;
+        }
         try {
             assertThat(errorMessage(), (Comparable) actualValue, greaterThanOrEqualTo((Comparable) expectedValue));
         } catch (ClassCastException e) {
-            fail("cast error while checking (" + errorMessage() + "): " + e);
+            throw new AssertionError("cast error while checking (" + errorMessage() + "): " + e, e);
         }
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/GreaterThanEqualToAssertion.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/GreaterThanEqualToAssertion.java
@@ -30,7 +30,6 @@ import java.io.IOException;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 
 /**
  * Represents a gte assert section:

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/LessThanAssertion.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/LessThanAssertion.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 
 /**
  * Represents a lt assert section:

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/LessThanAssertion.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/LessThanAssertion.java
@@ -61,10 +61,13 @@ public class LessThanAssertion extends Assertion {
                 actualValue, instanceOf(Comparable.class));
         assertThat("expected value of [" + getField() + "] is not comparable (got [" + expectedValue.getClass() + "])",
                 expectedValue, instanceOf(Comparable.class));
+        if (actualValue instanceof Long && expectedValue instanceof Integer) {
+            expectedValue = (long) (int) expectedValue;
+        }
         try {
             assertThat(errorMessage(), (Comparable) actualValue, lessThan((Comparable) expectedValue));
         } catch (ClassCastException e) {
-            fail("cast error while checking (" + errorMessage() + "): " + e);
+            throw new AssertionError("cast error while checking (" + errorMessage() + "): " + e, e);
         }
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/LessThanOrEqualToAssertion.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/LessThanOrEqualToAssertion.java
@@ -30,7 +30,6 @@ import java.io.IOException;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 
 /**
  * Represents a lte assert section:

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/LessThanOrEqualToAssertion.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/LessThanOrEqualToAssertion.java
@@ -61,10 +61,13 @@ public class LessThanOrEqualToAssertion  extends Assertion {
                 actualValue, instanceOf(Comparable.class));
         assertThat("expected value of [" + getField() + "] is not comparable (got [" + expectedValue.getClass() + "])",
                 expectedValue, instanceOf(Comparable.class));
+        if (actualValue instanceof Long && expectedValue instanceof Integer) {
+            expectedValue = (long) (int) expectedValue;
+        }
         try {
             assertThat(errorMessage(), (Comparable) actualValue, lessThanOrEqualTo((Comparable) expectedValue));
         } catch (ClassCastException e) {
-            fail("cast error while checking (" + errorMessage() + "): " + e);
+            throw new AssertionError("cast error while checking (" + errorMessage() + "): " + e, e);
         }
     }
 

--- a/x-pack/plugin/autoscaling/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/autoscaling/get_autoscaling_capacity.yml
+++ b/x-pack/plugin/autoscaling/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/autoscaling/get_autoscaling_capacity.yml
@@ -28,6 +28,10 @@
   - match: { policies.my_autoscaling_policy.required_capacity.total.memory: 73310 }
   - match: { policies.my_autoscaling_policy.required_capacity.node.storage: 1337 }
   - match: { policies.my_autoscaling_policy.required_capacity.node.memory: 7331 }
+  - match: { policies.my_autoscaling_policy.current_capacity.total.storage: 0 }
+  - match: { policies.my_autoscaling_policy.current_capacity.total.memory: 0 }
+  - match: { policies.my_autoscaling_policy.current_capacity.node.storage: 0 }
+  - match: { policies.my_autoscaling_policy.current_capacity.node.memory: 0 }
   - match: { policies.my_autoscaling_policy.deciders.fixed.required_capacity.total.storage: 13370 }
   - match: { policies.my_autoscaling_policy.deciders.fixed.required_capacity.total.memory: 73310 }
   - match: { policies.my_autoscaling_policy.deciders.fixed.required_capacity.node.storage: 1337 }
@@ -40,3 +44,35 @@
   - do:
       autoscaling.delete_autoscaling_policy:
         name: my_autoscaling_policy
+
+---
+"Test get single node capacity":
+  - do:
+      autoscaling.put_autoscaling_policy:
+        name: my_autoscaling_policy
+        body:
+          # Notice that adding new default roles requires extending this list
+          roles: ["master",
+                  "data", "data_content", "data_hot", "data_warm", "data_cold",
+                  "ingest", "ml", "transform", "remote_cluster_client"]
+
+  - match: { "acknowledged": true }
+
+  - do:
+      autoscaling.get_autoscaling_capacity: {}
+  - set: { policies.my_autoscaling_policy.current_capacity.node.storage: current_node_storage }
+  - set: { policies.my_autoscaling_policy.current_capacity.node.memory: current_node_memory }
+  - match: { policies.my_autoscaling_policy.current_capacity.total.storage: $current_node_storage }
+  - match: { policies.my_autoscaling_policy.current_capacity.total.memory: $current_node_memory }
+  # would be great to validate an actual size is returned as well as a required capacity but
+  # due to asynchronous fetch of ClusterInfo and MemoryInfo we need an assertBusy like
+  # mechanism to do so.
+  - gte: { policies.my_autoscaling_policy.current_capacity.node.storage: 0 }
+  - gte: { policies.my_autoscaling_policy.current_capacity.node.memory: 0 }
+  - length: { policies.my_autoscaling_policy.current_nodes: 1 }
+
+  # test cleanup
+  - do:
+      autoscaling.delete_autoscaling_policy:
+        name: my_autoscaling_policy
+

--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/action/TransportGetAutoscalingCapacityActionIT.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/action/TransportGetAutoscalingCapacityActionIT.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.autoscaling.action;
+
+import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.monitor.os.OsProbe;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.xpack.autoscaling.AutoscalingIntegTestCase;
+import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingCapacity;
+import org.hamcrest.Matchers;
+
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.greaterThan;
+
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0)
+public class TransportGetAutoscalingCapacityActionIT extends AutoscalingIntegTestCase {
+
+    public void testCurrentCapacity() throws Exception {
+        assertThat(capacity().results().keySet(), Matchers.empty());
+        long memory = OsProbe.getInstance().getTotalPhysicalMemorySize();
+        long storage = internalCluster().getInstance(NodeEnvironment.class).nodePaths()[0].fileStore.getTotalSpace();
+        assertThat(memory, greaterThan(0L));
+        assertThat(storage, greaterThan(0L));
+        putAutoscalingPolicy("test");
+        assertCurrentCapacity(0, 0, 0);
+
+        int nodes = between(1, 5);
+        internalCluster().startDataOnlyNodes(nodes);
+
+        assertBusy(() -> { assertCurrentCapacity(memory, storage, nodes); });
+    }
+
+    public void assertCurrentCapacity(long memory, long storage, int nodes) {
+        GetAutoscalingCapacityAction.Response capacity = capacity();
+        AutoscalingCapacity currentCapacity = capacity.results().get("test").currentCapacity();
+        assertThat(currentCapacity.node().memory().getBytes(), Matchers.equalTo(memory));
+        assertThat(currentCapacity.total().memory().getBytes(), Matchers.equalTo(memory * nodes));
+        assertThat(currentCapacity.node().storage().getBytes(), Matchers.equalTo(storage));
+        assertThat(currentCapacity.total().storage().getBytes(), Matchers.equalTo(storage * nodes));
+    }
+
+    public GetAutoscalingCapacityAction.Response capacity() {
+        GetAutoscalingCapacityAction.Request request = new GetAutoscalingCapacityAction.Request();
+        GetAutoscalingCapacityAction.Response response = client().execute(GetAutoscalingCapacityAction.INSTANCE, request).actionGet();
+        return response;
+    }
+
+    private void putAutoscalingPolicy(String policyName) {
+        final PutAutoscalingPolicyAction.Request request = new PutAutoscalingPolicyAction.Request(
+            policyName,
+            new TreeSet<>(Set.of("data")),
+            new TreeMap<>()
+        );
+        assertAcked(client().execute(PutAutoscalingPolicyAction.INSTANCE, request).actionGet());
+    }
+
+}

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/Autoscaling.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/Autoscaling.java
@@ -20,6 +20,7 @@ import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.IndexScopedSettings;
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsFilter;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
@@ -46,6 +47,7 @@ import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingCalculateCapacity
 import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingDeciderResult;
 import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingDeciderService;
 import org.elasticsearch.xpack.autoscaling.capacity.FixedAutoscalingDeciderService;
+import org.elasticsearch.xpack.autoscaling.capacity.memory.AutoscalingMemoryInfoService;
 import org.elasticsearch.xpack.autoscaling.rest.RestDeleteAutoscalingPolicyHandler;
 import org.elasticsearch.xpack.autoscaling.rest.RestGetAutoscalingCapacityHandler;
 import org.elasticsearch.xpack.autoscaling.rest.RestGetAutoscalingPolicyHandler;
@@ -102,7 +104,16 @@ public class Autoscaling extends Plugin implements ActionPlugin, ExtensiblePlugi
         Supplier<RepositoriesService> repositoriesServiceSupplier
     ) {
         this.clusterService.set(clusterService);
-        return List.of(new AutoscalingCalculateCapacityService.Holder(this), autoscalingLicenseChecker);
+        return List.of(
+            new AutoscalingCalculateCapacityService.Holder(this),
+            autoscalingLicenseChecker,
+            new AutoscalingMemoryInfoService(clusterService, client)
+        );
+    }
+
+    @Override
+    public List<Setting<?>> getSettings() {
+        return List.of(AutoscalingMemoryInfoService.FETCH_TIMEOUT);
     }
 
     @Override

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/action/TransportGetAutoscalingCapacityAction.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/action/TransportGetAutoscalingCapacityAction.java
@@ -23,6 +23,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.autoscaling.AutoscalingLicenseChecker;
 import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingCalculateCapacityService;
+import org.elasticsearch.xpack.autoscaling.capacity.memory.AutoscalingMemoryInfoService;
 
 import java.util.Objects;
 
@@ -33,6 +34,7 @@ public class TransportGetAutoscalingCapacityAction extends TransportMasterNodeAc
     private final AutoscalingCalculateCapacityService capacityService;
     private final ClusterInfoService clusterInfoService;
     private final SnapshotsInfoService snapshotsInfoService;
+    private final AutoscalingMemoryInfoService memoryInfoService;
     private final AutoscalingLicenseChecker autoscalingLicenseChecker;
 
     @Inject
@@ -45,6 +47,7 @@ public class TransportGetAutoscalingCapacityAction extends TransportMasterNodeAc
         final AutoscalingCalculateCapacityService.Holder capacityServiceHolder,
         final ClusterInfoService clusterInfoService,
         final SnapshotsInfoService snapshotsInfoService,
+        final AutoscalingMemoryInfoService memoryInfoService,
         final AllocationDeciders allocationDeciders,
         final AutoscalingLicenseChecker autoscalingLicenseChecker
     ) {
@@ -60,6 +63,7 @@ public class TransportGetAutoscalingCapacityAction extends TransportMasterNodeAc
             ThreadPool.Names.SAME
         );
         this.snapshotsInfoService = snapshotsInfoService;
+        this.memoryInfoService = memoryInfoService;
         this.capacityService = capacityServiceHolder.get(allocationDeciders);
         this.clusterInfoService = clusterInfoService;
         this.autoscalingLicenseChecker = Objects.requireNonNull(autoscalingLicenseChecker);
@@ -80,7 +84,12 @@ public class TransportGetAutoscalingCapacityAction extends TransportMasterNodeAc
 
         listener.onResponse(
             new GetAutoscalingCapacityAction.Response(
-                capacityService.calculate(state, clusterInfoService.getClusterInfo(), snapshotsInfoService.snapshotShardSizes())
+                capacityService.calculate(
+                    state,
+                    clusterInfoService.getClusterInfo(),
+                    snapshotsInfoService.snapshotShardSizes(),
+                    memoryInfoService.snapshot()
+                )
             )
         );
     }

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingCalculateCapacityService.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingCalculateCapacityService.java
@@ -23,6 +23,7 @@ import org.elasticsearch.snapshots.SnapshotShardSizeInfo;
 import org.elasticsearch.xpack.autoscaling.Autoscaling;
 import org.elasticsearch.xpack.autoscaling.AutoscalingMetadata;
 import org.elasticsearch.xpack.autoscaling.action.PolicyValidator;
+import org.elasticsearch.xpack.autoscaling.capacity.memory.AutoscalingMemoryInfo;
 import org.elasticsearch.xpack.autoscaling.policy.AutoscalingPolicy;
 
 import java.util.Collections;
@@ -102,7 +103,8 @@ public class AutoscalingCalculateCapacityService implements PolicyValidator {
     public SortedMap<String, AutoscalingDeciderResults> calculate(
         ClusterState state,
         ClusterInfo clusterInfo,
-        SnapshotShardSizeInfo shardSizeInfo
+        SnapshotShardSizeInfo shardSizeInfo,
+        AutoscalingMemoryInfo memoryInfo
     ) {
         AutoscalingMetadata autoscalingMetadata = state.metadata().custom(AutoscalingMetadata.NAME);
         if (autoscalingMetadata != null) {
@@ -110,7 +112,12 @@ public class AutoscalingCalculateCapacityService implements PolicyValidator {
                 autoscalingMetadata.policies()
                     .entrySet()
                     .stream()
-                    .map(e -> Tuple.tuple(e.getKey(), calculateForPolicy(e.getValue().policy(), state, clusterInfo, shardSizeInfo)))
+                    .map(
+                        e -> Tuple.tuple(
+                            e.getKey(),
+                            calculateForPolicy(e.getValue().policy(), state, clusterInfo, shardSizeInfo, memoryInfo)
+                        )
+                    )
                     .collect(Collectors.toMap(Tuple::v1, Tuple::v2))
             );
         } else {
@@ -122,7 +129,8 @@ public class AutoscalingCalculateCapacityService implements PolicyValidator {
         AutoscalingPolicy policy,
         ClusterState state,
         ClusterInfo clusterInfo,
-        SnapshotShardSizeInfo shardSizeInfo
+        SnapshotShardSizeInfo shardSizeInfo,
+        AutoscalingMemoryInfo memoryInfo
     ) {
         if (hasUnknownRoles(policy)) {
             return new AutoscalingDeciderResults(
@@ -132,7 +140,7 @@ public class AutoscalingCalculateCapacityService implements PolicyValidator {
             );
         }
         SortedMap<String, Settings> deciders = addDefaultDeciders(policy);
-        DefaultAutoscalingDeciderContext context = createContext(policy.roles(), state, clusterInfo, shardSizeInfo);
+        DefaultAutoscalingDeciderContext context = createContext(policy.roles(), state, clusterInfo, shardSizeInfo, memoryInfo);
         SortedMap<String, AutoscalingDeciderResult> results = deciders.entrySet()
             .stream()
             .map(entry -> Tuple.tuple(entry.getKey(), calculateForDecider(entry.getKey(), entry.getValue(), context)))
@@ -170,9 +178,10 @@ public class AutoscalingCalculateCapacityService implements PolicyValidator {
         SortedSet<String> roles,
         ClusterState state,
         ClusterInfo clusterInfo,
-        SnapshotShardSizeInfo shardSizeInfo
+        SnapshotShardSizeInfo shardSizeInfo,
+        AutoscalingMemoryInfo memoryInfo
     ) {
-        return new DefaultAutoscalingDeciderContext(roles, state, clusterInfo, shardSizeInfo);
+        return new DefaultAutoscalingDeciderContext(roles, state, clusterInfo, shardSizeInfo, memoryInfo);
     }
 
     /**
@@ -195,6 +204,7 @@ public class AutoscalingCalculateCapacityService implements PolicyValidator {
         private final ClusterState state;
         private final ClusterInfo clusterInfo;
         private final SnapshotShardSizeInfo snapshotShardSizeInfo;
+        private final AutoscalingMemoryInfo memoryInfo;
         private final SortedSet<DiscoveryNode> currentNodes;
         private final AutoscalingCapacity currentCapacity;
         private final boolean currentCapacityAccurate;
@@ -203,7 +213,8 @@ public class AutoscalingCalculateCapacityService implements PolicyValidator {
             SortedSet<String> roles,
             ClusterState state,
             ClusterInfo clusterInfo,
-            SnapshotShardSizeInfo snapshotShardSizeInfo
+            SnapshotShardSizeInfo snapshotShardSizeInfo,
+            AutoscalingMemoryInfo memoryInfo
         ) {
             this.roles = roles.stream().map(DiscoveryNode::getRoleFromRoleName).collect(Sets.toUnmodifiableSortedSet());
             Objects.requireNonNull(state);
@@ -211,6 +222,7 @@ public class AutoscalingCalculateCapacityService implements PolicyValidator {
             this.state = state;
             this.clusterInfo = clusterInfo;
             this.snapshotShardSizeInfo = snapshotShardSizeInfo;
+            this.memoryInfo = memoryInfo;
             this.currentNodes = StreamSupport.stream(state.nodes().spliterator(), false)
                 .filter(this::rolesFilter)
                 .collect(Collectors.toCollection(() -> new TreeSet<>(AutoscalingDeciderResults.DISCOVERY_NODE_COMPARATOR)));
@@ -244,12 +256,18 @@ public class AutoscalingCalculateCapacityService implements PolicyValidator {
         }
 
         private boolean nodeHasAccurateCapacity(DiscoveryNode node) {
-            // todo: multiple data path support.
-            DiskUsage mostAvailable = clusterInfo.getNodeMostAvailableDiskUsages().get(node.getId());
-            DiskUsage leastAvailable = clusterInfo.getNodeLeastAvailableDiskUsages().get(node.getId());
-            return mostAvailable != null
-                && mostAvailable.getPath().equals(leastAvailable.getPath())
-                && totalStorage(clusterInfo.getNodeMostAvailableDiskUsages(), node) >= 0;
+            if (node.isDataNode()) {
+                // todo: multiple data path support.
+                DiskUsage mostAvailable = clusterInfo.getNodeMostAvailableDiskUsages().get(node.getId());
+                DiskUsage leastAvailable = clusterInfo.getNodeLeastAvailableDiskUsages().get(node.getId());
+                if (mostAvailable == null
+                    || mostAvailable.getPath().equals(leastAvailable.getPath()) == false
+                    || totalStorage(clusterInfo.getNodeMostAvailableDiskUsages(), node) < 0) {
+                    return false;
+                }
+            }
+
+            return memoryInfo.get(node) != null;
         }
 
         private AutoscalingCapacity calculateCurrentCapacity() {
@@ -266,15 +284,17 @@ public class AutoscalingCalculateCapacityService implements PolicyValidator {
         }
 
         private AutoscalingCapacity.AutoscalingResources resourcesFor(DiscoveryNode node) {
-            long storage = Math.max(
-                totalStorage(clusterInfo.getNodeLeastAvailableDiskUsages(), node),
-                totalStorage(clusterInfo.getNodeMostAvailableDiskUsages(), node)
-            );
+            long storage = node.isDataNode()
+                ? Math.max(
+                    totalStorage(clusterInfo.getNodeLeastAvailableDiskUsages(), node),
+                    totalStorage(clusterInfo.getNodeMostAvailableDiskUsages(), node)
+                )
+                : 0L;
 
-            // todo: also capture memory across cluster.
+            Long memory = memoryInfo.get(node);
             return new AutoscalingCapacity.AutoscalingResources(
                 storage == -1 ? ByteSizeValue.ZERO : new ByteSizeValue(storage),
-                ByteSizeValue.ZERO
+                memory == null ? ByteSizeValue.ZERO : new ByteSizeValue(memory)
             );
         }
 

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/memory/AutoscalingMemoryInfo.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/memory/AutoscalingMemoryInfo.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.autoscaling.capacity.memory;
+
+import org.elasticsearch.cluster.node.DiscoveryNode;
+
+public interface AutoscalingMemoryInfo {
+    AutoscalingMemoryInfo EMPTY = n -> null;
+
+    /**
+     * Get the memory use for the indicated node. Returns null if not available (new, fetching or failed).
+     * @param node the node to get info for
+     * @return info for node.
+     */
+    Long get(DiscoveryNode node);
+}

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/memory/AutoscalingMemoryInfoService.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/memory/AutoscalingMemoryInfoService.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.autoscaling.capacity.memory;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.FailedNodeException;
+import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
+import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsRequest;
+import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.xpack.autoscaling.AutoscalingMetadata;
+import org.elasticsearch.xpack.autoscaling.policy.AutoscalingPolicy;
+import org.elasticsearch.xpack.autoscaling.policy.AutoscalingPolicyMetadata;
+
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+public class AutoscalingMemoryInfoService {
+    public static final Setting<TimeValue> FETCH_TIMEOUT = Setting.timeSetting(
+        "xpack.autoscaling.memory.monitor.timeout",
+        TimeValue.timeValueSeconds(15),
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+    private static final Long FETCHING_SENTINEL = Long.MIN_VALUE;
+
+    private static final Logger logger = LogManager.getLogger(AutoscalingMemoryInfoService.class);
+
+    private volatile ImmutableOpenMap<String, Long> nodeToMemory = ImmutableOpenMap.<String, Long>builder().build();
+    private volatile TimeValue fetchTimeout;
+
+    private final Client client;
+    private final Object mutex = new Object();
+
+    @Inject
+    public AutoscalingMemoryInfoService(ClusterService clusterService, Client client) {
+
+        this.client = client;
+        this.fetchTimeout = FETCH_TIMEOUT.get(clusterService.getSettings());
+        if (DiscoveryNode.isMasterNode(clusterService.getSettings())) {
+            clusterService.addListener(this::onClusterChanged);
+            clusterService.getClusterSettings().addSettingsUpdateConsumer(FETCH_TIMEOUT, this::setFetchTimeout);
+        }
+    }
+
+    private void setFetchTimeout(TimeValue fetchTimeout) {
+        this.fetchTimeout = fetchTimeout;
+    }
+
+    void onClusterChanged(ClusterChangedEvent event) {
+        boolean master = event.localNodeMaster();
+        final ClusterState state = event.state();
+        final Set<DiscoveryNode> currentNodes = master ? relevantNodes(state) : Set.of();
+        Set<DiscoveryNode> missingNodes = null;
+        synchronized (mutex) {
+            retainAliveNodes(currentNodes);
+            if (master) {
+                missingNodes = addMissingNodes(currentNodes);
+            }
+        }
+        if (missingNodes != null) {
+            sendToMissingNodes(state.nodes()::get, missingNodes);
+        }
+    }
+
+    Set<DiscoveryNode> relevantNodes(ClusterState state) {
+        final Set<Set<DiscoveryNodeRole>> roleSets = calculateAutoscalingRoleSets(state);
+        return StreamSupport.stream(state.nodes().spliterator(), false)
+            .filter(n -> roleSets.contains(n.getRoles()))
+            .collect(Collectors.toSet());
+    }
+
+    private Set<DiscoveryNode> addMissingNodes(Set<DiscoveryNode> nodes) {
+        // we retain only current nodes first, so we can use size check for equality.
+        if (nodes.size() != nodeToMemory.size()) {
+            Set<DiscoveryNode> missingNodes = nodes.stream()
+                .filter(dn -> nodeToMemory.containsKey(dn.getEphemeralId()) == false)
+                .collect(Collectors.toSet());
+            if (missingNodes.size() > 0) {
+                ImmutableOpenMap.Builder<String, Long> builder = ImmutableOpenMap.<String, Long>builder(nodeToMemory);
+                missingNodes.stream().map(DiscoveryNode::getEphemeralId).forEach(id -> builder.put(id, FETCHING_SENTINEL));
+                nodeToMemory = builder.build();
+
+                return missingNodes;
+            }
+        }
+
+        return null;
+    }
+
+    private void sendToMissingNodes(Function<String, DiscoveryNode> nodeLookup, Set<DiscoveryNode> missingNodes) {
+        client.admin()
+            .cluster()
+            .nodesStats(
+                new NodesStatsRequest(missingNodes.stream().map(DiscoveryNode::getId).toArray(String[]::new)).clear()
+                    .addMetric(NodesStatsRequest.Metric.OS.metricName())
+                    .timeout(fetchTimeout),
+                new ActionListener<NodesStatsResponse>() {
+                    @Override
+                    public void onResponse(NodesStatsResponse nodesStatsResponse) {
+                        synchronized (mutex) {
+                            ImmutableOpenMap.Builder<String, Long> builder = ImmutableOpenMap.<String, Long>builder(nodeToMemory);
+                            nodesStatsResponse.failures()
+                                .stream()
+                                .map(FailedNodeException::nodeId)
+                                .map(nodeLookup)
+                                .map(DiscoveryNode::getEphemeralId)
+                                .forEach(builder::remove);
+
+                            nodesStatsResponse.getNodes().forEach(nodeStats -> addNodeStats(builder, nodeStats));
+                            nodeToMemory = builder.build();
+                        }
+                    }
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        synchronized (mutex) {
+                            ImmutableOpenMap.Builder<String, Long> builder = ImmutableOpenMap.<String, Long>builder(nodeToMemory);
+                            missingNodes.stream().map(DiscoveryNode::getEphemeralId).forEach(builder::remove);
+                            nodeToMemory = builder.build();
+                        }
+
+                        logger.warn("Unable to obtain memory info from [{}]", missingNodes);
+                    }
+                }
+            );
+    }
+
+    private Set<Set<DiscoveryNodeRole>> calculateAutoscalingRoleSets(ClusterState state) {
+        AutoscalingMetadata autoscalingMetadata = state.metadata().custom(AutoscalingMetadata.NAME);
+        if (autoscalingMetadata != null) {
+            return autoscalingMetadata.policies()
+                .values()
+                .stream()
+                .map(AutoscalingPolicyMetadata::policy)
+                .map(AutoscalingPolicy::roles)
+                .map(this::toRoles)
+                .collect(Collectors.toSet());
+        }
+        return Set.of();
+    }
+
+    private Set<DiscoveryNodeRole> toRoles(SortedSet<String> roleNames) {
+        return roleNames.stream().map(DiscoveryNode::getRoleFromRoleName).collect(Collectors.toSet());
+    }
+
+    private void retainAliveNodes(Set<DiscoveryNode> currentNodes) {
+        assert Thread.holdsLock(mutex);
+        Set<String> ephemeralIds = currentNodes.stream().map(DiscoveryNode::getEphemeralId).collect(Collectors.toSet());
+        Set<String> toRemove = StreamSupport.stream(nodeToMemory.keys().spliterator(), false)
+            .map(c -> c.value)
+            .filter(Predicate.not(ephemeralIds::contains))
+            .collect(Collectors.toSet());
+        if (toRemove.isEmpty() == false) {
+            ImmutableOpenMap.Builder<String, Long> builder = ImmutableOpenMap.<String, Long>builder(nodeToMemory);
+            builder.removeAll(toRemove::contains);
+            nodeToMemory = builder.build();
+        }
+    }
+
+    private void addNodeStats(ImmutableOpenMap.Builder<String, Long> builder, NodeStats nodeStats) {
+        // we might add nodes that already died here, but those will be removed on next cluster state update anyway and is only a small
+        // waste.
+        builder.put(nodeStats.getNode().getEphemeralId(), nodeStats.getOs().getMem().getTotal().getBytes());
+    }
+
+    public AutoscalingMemoryInfo snapshot() {
+        final ImmutableOpenMap<String, Long> nodeToMemory = this.nodeToMemory;
+        return node -> {
+            Long result = nodeToMemory.get(node.getEphemeralId());
+            // noinspection NumberEquality
+            if (result == FETCHING_SENTINEL) {
+                return null;
+            } else {
+                return result;
+            }
+        };
+    }
+}

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingCalculateCapacityServiceTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingCalculateCapacityServiceTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.snapshots.InternalSnapshotsInfoService;
 import org.elasticsearch.snapshots.SnapshotShardSizeInfo;
 import org.elasticsearch.xpack.autoscaling.AutoscalingMetadata;
 import org.elasticsearch.xpack.autoscaling.AutoscalingTestCase;
+import org.elasticsearch.xpack.autoscaling.capacity.memory.AutoscalingMemoryInfo;
 import org.elasticsearch.xpack.autoscaling.policy.AutoscalingPolicy;
 import org.elasticsearch.xpack.autoscaling.policy.AutoscalingPolicyMetadata;
 
@@ -60,7 +61,12 @@ public class AutoscalingCalculateCapacityServiceTests extends AutoscalingTestCas
         ClusterState state = ClusterState.builder(ClusterName.DEFAULT)
             .metadata(Metadata.builder().putCustom(AutoscalingMetadata.NAME, new AutoscalingMetadata(policies)))
             .build();
-        SortedMap<String, AutoscalingDeciderResults> resultsMap = service.calculate(state, ClusterInfo.EMPTY, null);
+        SortedMap<String, AutoscalingDeciderResults> resultsMap = service.calculate(
+            state,
+            ClusterInfo.EMPTY,
+            null,
+            AutoscalingMemoryInfo.EMPTY
+        );
         assertThat(resultsMap.keySet(), equalTo(policyNames));
         for (Map.Entry<String, AutoscalingDeciderResults> entry : resultsMap.entrySet()) {
             AutoscalingDeciderResults results = entry.getValue();
@@ -119,7 +125,10 @@ public class AutoscalingCalculateCapacityServiceTests extends AutoscalingTestCas
             .build();
 
         assertThat(
-            service.calculate(state, ClusterInfo.EMPTY, SnapshotShardSizeInfo.EMPTY).get("test").results().keySet(),
+            service.calculate(state, ClusterInfo.EMPTY, SnapshotShardSizeInfo.EMPTY, AutoscalingMemoryInfo.EMPTY)
+                .get("test")
+                .results()
+                .keySet(),
             equalTo(Set.of(defaultOn.name()))
         );
     }
@@ -157,12 +166,19 @@ public class AutoscalingCalculateCapacityServiceTests extends AutoscalingTestCas
         ClusterState state = ClusterState.builder(ClusterName.DEFAULT).build();
         ClusterInfo info = ClusterInfo.EMPTY;
         SortedSet<String> roleNames = randomRoles();
+        boolean hasDataRole = roleNames.stream().anyMatch(r -> r.equals("data") || r.startsWith("data_"));
 
         AutoscalingCalculateCapacityService service = new AutoscalingCalculateCapacityService(Set.of(new FixedAutoscalingDeciderService()));
         SnapshotShardSizeInfo snapshotShardSizeInfo = new SnapshotShardSizeInfo(
             ImmutableOpenMap.<InternalSnapshotsInfoService.SnapshotShard, Long>builder().build()
         );
-        AutoscalingDeciderContext context = service.createContext(roleNames, state, info, snapshotShardSizeInfo);
+        AutoscalingDeciderContext context = service.createContext(
+            roleNames,
+            state,
+            info,
+            snapshotShardSizeInfo,
+            n -> randomNonNegativeLong()
+        );
 
         assertSame(state, context.state());
         assertThat(context.nodes(), equalTo(Set.of()));
@@ -174,16 +190,24 @@ public class AutoscalingCalculateCapacityServiceTests extends AutoscalingTestCas
         Set<DiscoveryNodeRole> otherRoles = mutateRoles(roleNames).stream()
             .map(DiscoveryNode::getRoleFromRoleName)
             .collect(Collectors.toSet());
+        final long memory = between(0, 1000);
         state = ClusterState.builder(ClusterName.DEFAULT)
             .nodes(
                 DiscoveryNodes.builder().add(new DiscoveryNode("nodeId", buildNewFakeTransportAddress(), Map.of(), roles, Version.CURRENT))
             )
             .build();
-        context = new AutoscalingCalculateCapacityService.DefaultAutoscalingDeciderContext(roleNames, state, info, null);
+        context = new AutoscalingCalculateCapacityService.DefaultAutoscalingDeciderContext(roleNames, state, info, null, n -> memory);
 
         assertThat(context.nodes().size(), equalTo(1));
         assertThat(context.nodes(), equalTo(StreamSupport.stream(state.nodes().spliterator(), false).collect(Collectors.toSet())));
-        assertNull(context.currentCapacity());
+        if (hasDataRole) {
+            assertNull(context.currentCapacity());
+        } else {
+            assertThat(context.currentCapacity().node().memory(), equalTo(new ByteSizeValue(memory)));
+            assertThat(context.currentCapacity().total().memory(), equalTo(new ByteSizeValue(memory)));
+            assertThat(context.currentCapacity().node().storage(), equalTo(ByteSizeValue.ZERO));
+            assertThat(context.currentCapacity().total().storage(), equalTo(ByteSizeValue.ZERO));
+        }
 
         ImmutableOpenMap.Builder<String, DiskUsage> leastUsagesBuilder = ImmutableOpenMap.builder();
         ImmutableOpenMap.Builder<String, DiskUsage> mostUsagesBuilder = ImmutableOpenMap.builder();
@@ -225,17 +249,30 @@ public class AutoscalingCalculateCapacityServiceTests extends AutoscalingTestCas
         ImmutableOpenMap<String, DiskUsage> leastUsages = leastUsagesBuilder.build();
         ImmutableOpenMap<String, DiskUsage> mostUsages = mostUsagesBuilder.build();
         info = new ClusterInfo(leastUsages, mostUsages, null, null, null);
-        context = new AutoscalingCalculateCapacityService.DefaultAutoscalingDeciderContext(roleNames, state, info, null);
+        context = new AutoscalingCalculateCapacityService.DefaultAutoscalingDeciderContext(roleNames, state, info, null, n -> memory);
 
         assertThat(context.nodes(), equalTo(expectedNodes));
-        AutoscalingCapacity capacity = context.currentCapacity();
-        assertThat(capacity.node().storage(), equalTo(new ByteSizeValue(maxTotal)));
-        assertThat(capacity.total().storage(), equalTo(new ByteSizeValue(sumTotal)));
-        // todo: fix these once we know memory of all nodes on master.
-        assertThat(capacity.node().memory(), equalTo(ByteSizeValue.ZERO));
-        assertThat(capacity.total().memory(), equalTo(ByteSizeValue.ZERO));
+        if (hasDataRole) {
+            assertThat(context.currentCapacity().node().storage(), equalTo(new ByteSizeValue(maxTotal)));
+            assertThat(context.currentCapacity().total().storage(), equalTo(new ByteSizeValue(sumTotal)));
+        } else {
+            assertThat(context.currentCapacity().node().storage(), equalTo(ByteSizeValue.ZERO));
+            assertThat(context.currentCapacity().total().storage(), equalTo(ByteSizeValue.ZERO));
+        }
+        assertThat(context.currentCapacity().node().memory(), equalTo(new ByteSizeValue(memory * Integer.signum(expectedNodes.size()))));
+        assertThat(context.currentCapacity().total().memory(), equalTo(new ByteSizeValue(memory * expectedNodes.size())));
 
         if (expectedNodes.isEmpty() == false) {
+            context = new AutoscalingCalculateCapacityService.DefaultAutoscalingDeciderContext(
+                roleNames,
+                state,
+                info,
+                null,
+                AutoscalingMemoryInfo.EMPTY
+            );
+            assertThat(context.nodes(), equalTo(expectedNodes));
+            assertThat(context.currentCapacity(), is(nullValue()));
+
             String multiPathNodeId = randomFrom(expectedNodes).getId();
             mostUsagesBuilder = ImmutableOpenMap.builder(mostUsages);
             DiskUsage original = mostUsagesBuilder.get(multiPathNodeId);
@@ -251,9 +288,16 @@ public class AutoscalingCalculateCapacityServiceTests extends AutoscalingTestCas
             );
 
             info = new ClusterInfo(leastUsages, mostUsagesBuilder.build(), null, null, null);
-            context = new AutoscalingCalculateCapacityService.DefaultAutoscalingDeciderContext(roleNames, state, info, null);
+            context = new AutoscalingCalculateCapacityService.DefaultAutoscalingDeciderContext(roleNames, state, info, null, n -> memory);
             assertThat(context.nodes(), equalTo(expectedNodes));
-            assertThat(context.currentCapacity(), is(nullValue()));
+            if (hasDataRole) {
+                assertThat(context.currentCapacity(), is(nullValue()));
+            } else {
+                assertThat(context.currentCapacity().node().memory(), equalTo(new ByteSizeValue(memory)));
+                assertThat(context.currentCapacity().total().memory(), equalTo(new ByteSizeValue(memory * expectedNodes.size())));
+                assertThat(context.currentCapacity().node().storage(), equalTo(ByteSizeValue.ZERO));
+                assertThat(context.currentCapacity().total().storage(), equalTo(ByteSizeValue.ZERO));
+            }
         }
     }
 

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/memory/AutoscalingMemoryInfoServiceTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/memory/AutoscalingMemoryInfoServiceTests.java
@@ -1,0 +1,442 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.autoscaling.capacity.memory;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.FailedNodeException;
+import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
+import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsAction;
+import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsRequest;
+import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsResponse;
+import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.monitor.os.OsStats;
+import org.elasticsearch.test.client.NoOpClient;
+import org.elasticsearch.xpack.autoscaling.AutoscalingMetadata;
+import org.elasticsearch.xpack.autoscaling.AutoscalingTestCase;
+import org.elasticsearch.xpack.autoscaling.policy.AutoscalingPolicy;
+import org.elasticsearch.xpack.autoscaling.policy.AutoscalingPolicyMetadata;
+import org.hamcrest.Matchers;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class AutoscalingMemoryInfoServiceTests extends AutoscalingTestCase {
+
+    private NodeStatsClient client;
+    private AutoscalingMemoryInfoService service;
+    private TimeValue fetchTimeout;
+    private AutoscalingMetadata autoscalingMetadata;
+    private Metadata metadata;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        client = new NodeStatsClient();
+        final ClusterService clusterService = mock(ClusterService.class);
+        Settings settings;
+        if (randomBoolean()) {
+            fetchTimeout = TimeValue.timeValueSeconds(15);
+            settings = Settings.EMPTY;
+        } else {
+            fetchTimeout = TimeValue.timeValueMillis(randomLongBetween(1, 10000));
+            settings = Settings.builder().put(AutoscalingMemoryInfoService.FETCH_TIMEOUT.getKey(), fetchTimeout).build();
+        }
+        when(clusterService.getSettings()).thenReturn(settings);
+        Set<Setting<?>> settingsSet = Sets.union(
+            ClusterSettings.BUILT_IN_CLUSTER_SETTINGS,
+            Set.of(AutoscalingMemoryInfoService.FETCH_TIMEOUT)
+        );
+        ClusterSettings clusterSettings = new ClusterSettings(settings, settingsSet);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+        service = new AutoscalingMemoryInfoService(clusterService, client);
+        autoscalingMetadata = randomAutoscalingMetadataOfPolicyCount(between(1, 8));
+        metadata = Metadata.builder().putCustom(AutoscalingMetadata.NAME, autoscalingMetadata).build();
+    }
+
+    @After
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        client.close();
+    }
+
+    public void testAddRemoveNode() {
+        if (randomBoolean()) {
+            service.onClusterChanged(new ClusterChangedEvent("test", ClusterState.EMPTY_STATE, ClusterState.EMPTY_STATE));
+        }
+        ClusterState previousState = ClusterState.EMPTY_STATE;
+        Set<DiscoveryNode> previousNodes = new HashSet<>();
+        Set<DiscoveryNode> previousSucceededNodes = new HashSet<>();
+        for (int i = 0; i < 5; ++i) {
+            Set<DiscoveryNode> newNodes = IntStream.range(0, between(1, 10))
+                .mapToObj(n -> newNode("test_" + n))
+                .collect(Collectors.toSet());
+            Set<DiscoveryNode> nodes = Sets.union(newNodes, new HashSet<>(randomSubsetOf(previousNodes)));
+            ClusterState state = ClusterState.builder(ClusterName.DEFAULT)
+                .metadata(metadata)
+                .nodes(discoveryNodesBuilder(nodes, true))
+                .build();
+            Set<DiscoveryNode> missingNodes = Sets.difference(nodes, previousSucceededNodes);
+            Set<DiscoveryNode> failingNodes = new HashSet<>(randomSubsetOf(missingNodes));
+            Set<DiscoveryNode> succeedingNodes = Sets.difference(missingNodes, failingNodes);
+            List<FailedNodeException> failures = failingNodes.stream()
+                .map(node -> new FailedNodeException(node.getId(), randomAlphaOfLength(10), new Exception()))
+                .collect(Collectors.toList());
+            NodesStatsResponse response = new NodesStatsResponse(
+                ClusterName.DEFAULT,
+                succeedingNodes.stream()
+                    .map(n -> statsForNode(n, randomLongBetween(0, Long.MAX_VALUE / 1000)))
+                    .collect(Collectors.toList()),
+                failures
+            );
+            client.respond(response, () -> {
+                Sets.union(missingNodes, Sets.difference(previousNodes, nodes))
+                    .forEach(n -> { assertThat(service.snapshot().get(n), nullValue()); });
+                Sets.intersection(previousSucceededNodes, nodes).forEach(n -> assertThat(service.snapshot().get(n), notNullValue()));
+            });
+
+            service.onClusterChanged(new ClusterChangedEvent("test", state, previousState));
+            client.assertNoResponder();
+
+            assertMatchesResponse(succeedingNodes, response, service);
+            failingNodes.forEach(n -> { assertThat(service.snapshot().get(n), nullValue()); });
+
+            previousNodes.clear();
+            previousNodes.addAll(nodes);
+            previousSucceededNodes.retainAll(nodes);
+            previousSucceededNodes.addAll(succeedingNodes);
+            previousState = state;
+        }
+    }
+
+    public void testNotMaster() {
+        Set<DiscoveryNode> nodes = IntStream.range(0, between(1, 10)).mapToObj(n -> newNode("test_" + n)).collect(Collectors.toSet());
+        DiscoveryNodes.Builder nodesBuilder = discoveryNodesBuilder(nodes, false);
+        ClusterState state = ClusterState.builder(ClusterName.DEFAULT).nodes(nodesBuilder).metadata(metadata).build();
+
+        // client throws if called.
+        service.onClusterChanged(new ClusterChangedEvent("test", state, ClusterState.EMPTY_STATE));
+
+        nodes.forEach(n -> assertThat(service.snapshot().get(n), nullValue()));
+    }
+
+    public void testNoLongerMaster() {
+        Set<DiscoveryNode> nodes = IntStream.range(0, between(1, 10)).mapToObj(n -> newNode("test_" + n)).collect(Collectors.toSet());
+        ClusterState masterState = ClusterState.builder(ClusterName.DEFAULT)
+            .nodes(discoveryNodesBuilder(nodes, true))
+            .metadata(metadata)
+            .build();
+        NodesStatsResponse response = new NodesStatsResponse(
+            ClusterName.DEFAULT,
+            nodes.stream().map(n -> statsForNode(n, randomLongBetween(0, Long.MAX_VALUE / 1000))).collect(Collectors.toList()),
+            List.of()
+        );
+
+        client.respond(response, () -> {});
+        service.onClusterChanged(new ClusterChangedEvent("test", masterState, ClusterState.EMPTY_STATE));
+        client.assertNoResponder();
+
+        assertMatchesResponse(nodes, response, service);
+
+        ClusterState notMasterState = ClusterState.builder(masterState)
+            .nodes(DiscoveryNodes.builder(masterState.nodes()).masterNodeId(null))
+            .build();
+
+        // client throws if called.
+        service.onClusterChanged(new ClusterChangedEvent("test", notMasterState, masterState));
+
+        nodes.forEach(n -> assertThat(service.snapshot().get(n), nullValue()));
+    }
+
+    public void testFails() {
+        Set<DiscoveryNode> nodes = IntStream.range(0, between(1, 10)).mapToObj(n -> newNode("test_" + n)).collect(Collectors.toSet());
+        ClusterState state = ClusterState.builder(ClusterName.DEFAULT).nodes(discoveryNodesBuilder(nodes, true)).metadata(metadata).build();
+
+        client.respond((r, l) -> { l.onFailure(randomFrom(new IllegalStateException(), new RejectedExecutionException())); });
+        service.onClusterChanged(new ClusterChangedEvent("test", state, ClusterState.EMPTY_STATE));
+
+        nodes.forEach(n -> assertThat(service.snapshot().get(n), nullValue()));
+
+        NodesStatsResponse response = new NodesStatsResponse(
+            ClusterName.DEFAULT,
+            nodes.stream().map(n -> statsForNode(n, randomLongBetween(0, Long.MAX_VALUE / 1000))).collect(Collectors.toList()),
+            List.of()
+        );
+
+        // implicit retry on cluster state update.
+        client.respond(response, () -> {});
+        service.onClusterChanged(new ClusterChangedEvent("test", state, state));
+        client.assertNoResponder();
+    }
+
+    public void testRestartNode() {
+        Set<DiscoveryNode> nodes = IntStream.range(0, between(1, 10)).mapToObj(n -> newNode("test_" + n)).collect(Collectors.toSet());
+        ClusterState state = ClusterState.builder(ClusterName.DEFAULT).nodes(discoveryNodesBuilder(nodes, true)).metadata(metadata).build();
+
+        NodesStatsResponse response = new NodesStatsResponse(
+            ClusterName.DEFAULT,
+            nodes.stream().map(n -> statsForNode(n, randomLongBetween(0, Long.MAX_VALUE / 1000))).collect(Collectors.toList()),
+            List.of()
+        );
+
+        client.respond(response, () -> {});
+        service.onClusterChanged(new ClusterChangedEvent("test", state, ClusterState.EMPTY_STATE));
+        client.assertNoResponder();
+
+        assertMatchesResponse(nodes, response, service);
+
+        Set<DiscoveryNode> restartedNodes = randomValueOtherThan(
+            nodes,
+            () -> nodes.stream().map(n -> randomBoolean() ? restartNode(n) : n).collect(Collectors.toSet())
+        );
+
+        ClusterState restartedState = ClusterState.builder(state).nodes(discoveryNodesBuilder(restartedNodes, true)).build();
+
+        NodesStatsResponse restartedStatsResponse = new NodesStatsResponse(
+            ClusterName.DEFAULT,
+            Sets.difference(restartedNodes, nodes)
+                .stream()
+                .map(n -> statsForNode(n, randomLongBetween(0, Long.MAX_VALUE / 1000)))
+                .collect(Collectors.toList()),
+            List.of()
+        );
+
+        client.respond(restartedStatsResponse, () -> {});
+        service.onClusterChanged(new ClusterChangedEvent("test", restartedState, state));
+        client.assertNoResponder();
+
+        assertMatchesResponse(Sets.intersection(restartedNodes, nodes), response, service);
+        assertMatchesResponse(Sets.difference(restartedNodes, nodes), restartedStatsResponse, service);
+
+        Sets.difference(nodes, restartedNodes).forEach(n -> assertThat(service.snapshot().get(n), nullValue()));
+    }
+
+    public void testConcurrentStateUpdate() throws Exception {
+        Set<DiscoveryNode> nodes = IntStream.range(0, between(1, 10)).mapToObj(n -> newNode("test_" + n)).collect(Collectors.toSet());
+        ClusterState state = ClusterState.builder(ClusterName.DEFAULT).nodes(discoveryNodesBuilder(nodes, true)).metadata(metadata).build();
+
+        NodesStatsResponse response = new NodesStatsResponse(
+            ClusterName.DEFAULT,
+            nodes.stream().map(n -> statsForNode(n, randomLongBetween(0, Long.MAX_VALUE / 1000))).collect(Collectors.toList()),
+            List.of()
+        );
+
+        List<Thread> threads = new ArrayList<>();
+        client.respond((r, l) -> {
+            CountDownLatch latch = new CountDownLatch(1);
+            threads.add(startThread(() -> {
+                try {
+                    assertThat(latch.await(10, TimeUnit.SECONDS), is(true));
+                } catch (InterruptedException e) {
+                    throw new AssertionError(e);
+                }
+                l.onResponse(response);
+            }));
+            threads.add(startThread(() -> {
+                // we do not register a new responder, so this will fail if it calls anything on client.
+                service.onClusterChanged(new ClusterChangedEvent("test_concurrent", state, state));
+                latch.countDown();
+            }));
+        });
+        service.onClusterChanged(new ClusterChangedEvent("test", state, ClusterState.EMPTY_STATE));
+        client.assertNoResponder();
+        for (Thread thread : threads) {
+            thread.join(10000);
+        }
+
+        threads.forEach(t -> assertThat(t.isAlive(), is(false)));
+    }
+
+    public void testRelevantNodes() {
+        Set<DiscoveryNode> nodes = IntStream.range(0, between(1, 10)).mapToObj(n -> newNode("test_" + n)).collect(Collectors.toSet());
+        ClusterState state = ClusterState.builder(ClusterName.DEFAULT).nodes(discoveryNodesBuilder(nodes, true)).metadata(metadata).build();
+        Set<DiscoveryNode> relevantNodes = service.relevantNodes(state);
+        assertThat(relevantNodes, equalTo(nodes));
+    }
+
+    private DiscoveryNodes.Builder discoveryNodesBuilder(Set<DiscoveryNode> nodes, boolean master) {
+        DiscoveryNodes.Builder nodesBuilder = DiscoveryNodes.builder();
+        String masterNodeId = randomAlphaOfLength(10);
+        nodesBuilder.localNodeId(masterNodeId);
+        nodesBuilder.masterNodeId(master ? masterNodeId : null);
+        nodes.forEach(nodesBuilder::add);
+        addIrrelevantNodes(nodesBuilder);
+        return nodesBuilder;
+    }
+
+    /**
+     * Add irrelevant nodes. NodeStatsClient will validate that they are not asked for.
+     */
+    private void addIrrelevantNodes(DiscoveryNodes.Builder nodesBuilder) {
+        Set<Set<String>> relevantRoleSets = autoscalingMetadata.policies()
+            .values()
+            .stream()
+            .map(AutoscalingPolicyMetadata::policy)
+            .map(AutoscalingPolicy::roles)
+            .collect(Collectors.toSet());
+
+        IntStream.range(0, 5).mapToObj(i -> newNode("irrelevant_" + i, randomIrrelevantRoles(relevantRoleSets))).forEach(nodesBuilder::add);
+    }
+
+    private Set<DiscoveryNodeRole> randomIrrelevantRoles(Set<Set<String>> relevantRoleSets) {
+        return randomValueOtherThanMany(relevantRoleSets::contains, AutoscalingTestCase::randomRoles).stream()
+            .map(DiscoveryNode::getRoleFromRoleName)
+            .collect(Collectors.toSet());
+    }
+
+    // todo: remove service arg.
+    public void assertMatchesResponse(Set<DiscoveryNode> nodes, NodesStatsResponse response, AutoscalingMemoryInfoService service) {
+        nodes.forEach(
+            n -> {
+                assertThat(
+                    service.snapshot().get(n),
+                    equalTo(response.getNodesMap().get(n.getId()).getOs().getMem().getTotal().getBytes())
+                );
+            }
+        );
+    }
+
+    private Thread startThread(Runnable runnable) {
+        Thread thread = new Thread(runnable);
+        thread.start();
+        return thread;
+    }
+
+    private static NodeStats statsForNode(DiscoveryNode node, long memory) {
+        OsStats osStats = new OsStats(
+            randomNonNegativeLong(),
+            new OsStats.Cpu(randomShort(), null),
+            new OsStats.Mem(memory, randomLongBetween(0, memory)),
+            new OsStats.Swap(randomNonNegativeLong(), randomNonNegativeLong()),
+            null
+        );
+        return new NodeStats(
+            node,
+            randomNonNegativeLong(),
+            null,
+            osStats,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        );
+    }
+
+    private class NodeStatsClient extends NoOpClient {
+        private BiConsumer<NodesStatsRequest, ActionListener<NodesStatsResponse>> responder;
+
+        private NodeStatsClient() {
+            super(getTestName());
+        }
+
+        public void respond(NodesStatsResponse response, Runnable whileFetching) {
+            respond((r, l) -> {
+                assertThat(
+                    Set.of(r.nodesIds()),
+                    Matchers.equalTo(
+                        Stream.concat(
+                            response.getNodesMap().keySet().stream(),
+                            response.failures().stream().map(FailedNodeException::nodeId)
+                        ).collect(Collectors.toSet())
+                    )
+                );
+                whileFetching.run();
+                l.onResponse(response);
+            });
+        }
+
+        public void respond(BiConsumer<NodesStatsRequest, ActionListener<NodesStatsResponse>> responder) {
+            assertThat(responder, notNullValue());
+            this.responder = responder;
+        }
+
+        @Override
+        protected <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
+            ActionType<Response> action,
+            Request request,
+            ActionListener<Response> listener
+        ) {
+            assertThat(action, Matchers.sameInstance(NodesStatsAction.INSTANCE));
+            NodesStatsRequest nodesStatsRequest = (NodesStatsRequest) request;
+            assertThat(nodesStatsRequest.timeout(), equalTo(fetchTimeout));
+            assertThat(responder, notNullValue());
+            BiConsumer<NodesStatsRequest, ActionListener<NodesStatsResponse>> responder = this.responder;
+            this.responder = null;
+            @SuppressWarnings("unchecked")
+            ActionListener<NodesStatsResponse> statsListener = (ActionListener<NodesStatsResponse>) listener;
+            responder.accept(nodesStatsRequest, statsListener);
+        }
+
+        public void assertNoResponder() {
+            assertThat(responder, nullValue());
+        }
+    }
+
+    private DiscoveryNode newNode(String nodeName) {
+        return newNode(
+            nodeName,
+            randomFrom(autoscalingMetadata.policies().values()).policy()
+                .roles()
+                .stream()
+                .map(DiscoveryNode::getRoleFromRoleName)
+                .collect(Collectors.toSet())
+        );
+    }
+
+    private DiscoveryNode newNode(String nodeName, Set<DiscoveryNodeRole> roles) {
+        return new DiscoveryNode(nodeName, UUIDs.randomBase64UUID(), buildNewFakeTransportAddress(), Map.of(), roles, Version.CURRENT);
+    }
+
+    private DiscoveryNode restartNode(DiscoveryNode node) {
+        return new DiscoveryNode(node.getName(), node.getId(), node.getAddress(), node.getAttributes(), node.getRoles(), node.getVersion());
+    }
+}


### PR DESCRIPTION
Autoscaling would respond with no memory info in current capacity and
ML non-scaling events. However, this does not play nicely with trying
to short circuit the decision made by autoscaling capacity API clients,
it is reasonable to compare required to current to determine if a
scale up is necessary.

This commit adds a service that asks all nodes for their info and
ensures that current capacity includes this information when available.
