### PR TITLE
Improve LocalStateMonitoring for tests.

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/LocalStateCompositeXPackPlugin.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/LocalStateCompositeXPackPlugin.java
@@ -43,6 +43,7 @@ import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.analysis.TokenizerFactory;
 import org.elasticsearch.index.engine.EngineFactory;
+import org.elasticsearch.index.mapper.MetadataFieldMapper;
 import org.elasticsearch.index.shard.IndexSettingProvider;
 import org.elasticsearch.indices.SystemIndexDescriptor;
 import org.elasticsearch.indices.analysis.AnalysisModule;
@@ -553,5 +554,13 @@ public class LocalStateCompositeXPackPlugin extends XPackPlugin implements Scrip
             .stream()
             .flatMap(p -> p.getSystemIndexDescriptors(this.settings).stream())
             .collect(Collectors.toList());
+    }
+
+    @Override
+    public Map<String, MetadataFieldMapper.TypeParser> getMetadataMappers() {
+        return filterPlugins(MapperPlugin.class).stream()
+            .map(MapperPlugin::getMetadataMappers)
+            .flatMap (map -> map.entrySet().stream())
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 }

--- a/x-pack/plugin/monitoring/build.gradle
+++ b/x-pack/plugin/monitoring/build.gradle
@@ -20,6 +20,7 @@ dependencies {
   testImplementation project(xpackModule('watcher'))
 
   testImplementation project(xpackModule('ilm'))
+  testImplementation project(xpackModule('data-streams'))
 }
 
 configurations {

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/LocalStateMonitoring.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/LocalStateMonitoring.java
@@ -5,7 +5,11 @@
  */
 package org.elasticsearch.xpack.monitoring;
 
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
@@ -15,13 +19,19 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.license.LicenseService;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.protocol.xpack.XPackUsageRequest;
+import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.LocalStateCompositeXPackPlugin;
 import org.elasticsearch.xpack.core.action.TransportXPackUsageAction;
 import org.elasticsearch.xpack.core.action.XPackUsageFeatureAction;
 import org.elasticsearch.xpack.core.action.XPackUsageResponse;
+import org.elasticsearch.xpack.core.ccr.AutoFollowStats;
+import org.elasticsearch.xpack.core.ccr.action.CcrStatsAction;
+import org.elasticsearch.xpack.core.ccr.action.FollowStatsAction;
+import org.elasticsearch.xpack.core.enrich.action.EnrichStatsAction;
 import org.elasticsearch.xpack.core.ssl.SSLService;
+import org.elasticsearch.xpack.datastreams.DataStreamsPlugin;
 import org.elasticsearch.xpack.ilm.IndexLifecycle;
 import org.elasticsearch.xpack.watcher.Watcher;
 
@@ -79,6 +89,7 @@ public class LocalStateMonitoring extends LocalStateCompositeXPackPlugin {
             }
         });
         plugins.add(new IndexLifecycle(settings));
+        plugins.add(new DataStreamsPlugin()); // Otherwise the watcher history index template can't be added
     }
 
     public Monitoring getMonitoring() {
@@ -89,4 +100,44 @@ public class LocalStateMonitoring extends LocalStateCompositeXPackPlugin {
     protected Class<? extends TransportAction<XPackUsageRequest, XPackUsageResponse>> getUsageAction() {
         return MonitoringTransportXPackUsageAction.class;
     }
+
+    @Override
+    public List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
+        var actions = super.getActions();
+        // ccr StatsCollector
+        actions.add(new ActionHandler<>(CcrStatsAction.INSTANCE, TransportCcrStatsStubAction.class));
+        // For EnrichStatsCollector:
+        actions.add(new ActionHandler<>(EnrichStatsAction.INSTANCE, TransportEnrichStatsStubAction.class));
+        return actions;
+    }
+
+    public static class TransportCcrStatsStubAction extends HandledTransportAction<CcrStatsAction.Request, CcrStatsAction.Response> {
+
+        @Inject
+        public TransportCcrStatsStubAction(TransportService transportService, ActionFilters actionFilters) {
+            super(CcrStatsAction.NAME, transportService, actionFilters, CcrStatsAction.Request::new);
+        }
+
+        @Override
+        protected void doExecute(Task task, CcrStatsAction.Request request, ActionListener<CcrStatsAction.Response> listener) {
+            AutoFollowStats autoFollowStats = new AutoFollowStats(0, 0, 0, Collections.emptyNavigableMap(), Collections.emptyNavigableMap());
+            FollowStatsAction.StatsResponses statsResponses =
+                new FollowStatsAction.StatsResponses(Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+            listener.onResponse(new CcrStatsAction.Response(autoFollowStats, statsResponses));
+        }
+    }
+
+    public static class TransportEnrichStatsStubAction extends HandledTransportAction<EnrichStatsAction.Request, EnrichStatsAction.Response> {
+
+        @Inject
+        public TransportEnrichStatsStubAction(TransportService transportService, ActionFilters actionFilters) {
+            super(EnrichStatsAction.NAME, transportService, actionFilters, EnrichStatsAction.Request::new);
+        }
+
+        @Override
+        protected void doExecute(Task task, EnrichStatsAction.Request request, ActionListener<EnrichStatsAction.Response> listener) {
+            listener.onResponse(new EnrichStatsAction.Response(Collections.emptyList(), Collections.emptyList()));
+        }
+    }
+
 }

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/LocalStateMonitoring.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/LocalStateMonitoring.java
@@ -120,14 +120,16 @@ public class LocalStateMonitoring extends LocalStateCompositeXPackPlugin {
 
         @Override
         protected void doExecute(Task task, CcrStatsAction.Request request, ActionListener<CcrStatsAction.Response> listener) {
-            AutoFollowStats autoFollowStats = new AutoFollowStats(0, 0, 0, Collections.emptyNavigableMap(), Collections.emptyNavigableMap());
+            AutoFollowStats autoFollowStats =
+                new AutoFollowStats(0, 0, 0, Collections.emptyNavigableMap(), Collections.emptyNavigableMap());
             FollowStatsAction.StatsResponses statsResponses =
                 new FollowStatsAction.StatsResponses(Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
             listener.onResponse(new CcrStatsAction.Response(autoFollowStats, statsResponses));
         }
     }
 
-    public static class TransportEnrichStatsStubAction extends HandledTransportAction<EnrichStatsAction.Request, EnrichStatsAction.Response> {
+    public static class TransportEnrichStatsStubAction
+        extends HandledTransportAction<EnrichStatsAction.Request, EnrichStatsAction.Response> {
 
         @Inject
         public TransportEnrichStatsStubAction(TransportService transportService, ActionFilters actionFilters) {

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/action/TransportMonitoringMigrateAlertsActionTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/action/TransportMonitoringMigrateAlertsActionTests.java
@@ -107,7 +107,6 @@ public class TransportMonitoringMigrateAlertsActionTests extends MonitoringInteg
         ));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/66586")
     public void testLocalAlertsRemoval() throws Exception {
         try {
             // start monitoring service
@@ -187,7 +186,6 @@ public class TransportMonitoringMigrateAlertsActionTests extends MonitoringInteg
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/66586")
     public void testDisabledLocalExporterAlertsRemoval() throws Exception {
         try {
             // start monitoring service
@@ -230,7 +228,6 @@ public class TransportMonitoringMigrateAlertsActionTests extends MonitoringInteg
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/66586")
     public void testLocalExporterWithAlertingDisabled() throws Exception {
         try {
             // start monitoring service


### PR DESCRIPTION
Adds data-streams plugin and dummy stats actions for ccr and enrich to LocalStateMonitoring.

The data stream plugin and dummy transport actions that are added to LocalStateMonitoring
will allow for monitoring java integration tests to function properly without printing error
messages that make debugging harder. For example the data stream plugin was added so that
index templates with data streams can be added without failing constantly in the background and
enrich stats dummy transport action so that the EnrichStatsCollector doesn't fail.

Also unmutes tests that were muted via #66586, to have another opportunity to look at logs without all the noise,
perhaps all these errors contributed to the test failures.