### PR TITLE
Fix how system indices are auto-created

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/create/CreateSystemIndicesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/create/CreateSystemIndicesIT.java
@@ -39,9 +39,9 @@ import org.junit.Before;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Map;
 
+import static java.util.Collections.singletonMap;
 import static org.elasticsearch.indices.TestSystemIndexDescriptor.INDEX_NAME;
 import static org.elasticsearch.indices.TestSystemIndexDescriptor.PRIMARY_INDEX_NAME;
 import static org.elasticsearch.test.XContentTestUtils.convertToXContent;
@@ -105,10 +105,8 @@ public class CreateSystemIndicesIT extends ESIntegTestCase {
     public void testCreateSystemIndexIgnoresExplicitSettingsAndMappings() {
         doCreateTest(
             () -> assertAcked(
-                prepareCreate(PRIMARY_INDEX_NAME).addMapping(
-                    "foo",
-                    Collections.singletonMap("foo", TestSystemIndexDescriptor.getNewMappings())
-                ).setSettings(Settings.builder().put(IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 999).build())
+                prepareCreate(PRIMARY_INDEX_NAME).addMapping("foo", singletonMap("foo", TestSystemIndexDescriptor.getNewMappings()))
+                    .setSettings(Settings.builder().put(IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 999).build())
             )
         );
     }
@@ -155,7 +153,7 @@ public class CreateSystemIndicesIT extends ESIntegTestCase {
         final Map<String, Object> sourceAsMap = mappings.get(PRIMARY_INDEX_NAME).get(MapperService.SINGLE_MAPPING_NAME).getSourceAsMap();
 
         try {
-            assertThat(convertToXContent(sourceAsMap, XContentType.JSON).utf8ToString(), equalTo(expectedMappings));
+            assertThat(convertToXContent(singletonMap("_doc", sourceAsMap), XContentType.JSON).utf8ToString(), equalTo(expectedMappings));
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/create/CreateSystemIndicesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/create/CreateSystemIndicesIT.java
@@ -153,7 +153,10 @@ public class CreateSystemIndicesIT extends ESIntegTestCase {
         final Map<String, Object> sourceAsMap = mappings.get(PRIMARY_INDEX_NAME).get(MapperService.SINGLE_MAPPING_NAME).getSourceAsMap();
 
         try {
-            assertThat(convertToXContent(singletonMap("_doc", sourceAsMap), XContentType.JSON).utf8ToString(), equalTo(expectedMappings));
+            assertThat(
+                convertToXContent(singletonMap(MapperService.SINGLE_MAPPING_NAME, sourceAsMap), XContentType.JSON).utf8ToString(),
+                equalTo(expectedMappings)
+            );
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/SystemIndexManagerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/SystemIndexManagerIT.java
@@ -41,6 +41,7 @@ import java.util.Locale;
 import java.util.Map;
 
 import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
 import static org.elasticsearch.indices.TestSystemIndexDescriptor.INDEX_NAME;
 import static org.elasticsearch.indices.TestSystemIndexDescriptor.PRIMARY_INDEX_NAME;
 import static org.elasticsearch.test.XContentTestUtils.convertToXContent;
@@ -132,7 +133,10 @@ public class SystemIndexManagerIT extends ESIntegTestCase {
         );
         final Map<String, Object> sourceAsMap = mappings.get(PRIMARY_INDEX_NAME).get(MapperService.SINGLE_MAPPING_NAME).getSourceAsMap();
         try {
-            assertThat(convertToXContent(sourceAsMap, XContentType.JSON).utf8ToString(), equalTo(expectedMappings));
+            assertThat(
+                convertToXContent(singletonMap(MapperService.SINGLE_MAPPING_NAME, sourceAsMap), XContentType.JSON).utf8ToString(),
+                equalTo(expectedMappings)
+            );
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/TestSystemIndexDescriptor.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/TestSystemIndexDescriptor.java
@@ -31,6 +31,7 @@ import java.io.UncheckedIOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.index.mapper.MapperService.SINGLE_MAPPING_NAME;
 
 /**
  * A special kind of {@link SystemIndexDescriptor} that can toggle what kind of mappings it
@@ -80,16 +81,20 @@ public class TestSystemIndexDescriptor extends SystemIndexDescriptor {
 
             builder.startObject();
             {
-                final Version previousMajor = Version.fromId((Version.CURRENT.major - 1) * 1000000 + 99);
-
-                builder.startObject("_meta");
-                builder.field("version", previousMajor.toString());
-                builder.endObject();
-
-                builder.startObject("properties");
+                builder.startObject(SINGLE_MAPPING_NAME);
                 {
-                    builder.startObject("foo");
-                    builder.field("type", "text");
+                    final Version previousMajor = Version.fromId((Version.CURRENT.major - 1) * 1000000 + 99);
+
+                    builder.startObject("_meta");
+                    builder.field("version", previousMajor.toString());
+                    builder.endObject();
+
+                    builder.startObject("properties");
+                    {
+                        builder.startObject("foo");
+                        builder.field("type", "text");
+                        builder.endObject();
+                    }
                     builder.endObject();
                 }
                 builder.endObject();
@@ -98,7 +103,7 @@ public class TestSystemIndexDescriptor extends SystemIndexDescriptor {
             builder.endObject();
             return Strings.toString(builder);
         } catch (IOException e) {
-            throw new UncheckedIOException("Failed to build .test-index-1 index mappings", e);
+            throw new UncheckedIOException("Failed to build old .test-index-1 index mappings", e);
         }
     }
 
@@ -108,17 +113,21 @@ public class TestSystemIndexDescriptor extends SystemIndexDescriptor {
 
             builder.startObject();
             {
-                builder.startObject("_meta");
-                builder.field("version", Version.CURRENT.toString());
-                builder.endObject();
-
-                builder.startObject("properties");
+                builder.startObject(SINGLE_MAPPING_NAME);
                 {
-                    builder.startObject("bar");
-                    builder.field("type", "text");
+                    builder.startObject("_meta");
+                    builder.field("version", Version.CURRENT.toString());
                     builder.endObject();
-                    builder.startObject("foo");
-                    builder.field("type", "text");
+
+                    builder.startObject("properties");
+                    {
+                        builder.startObject("bar");
+                        builder.field("type", "text");
+                        builder.endObject();
+                        builder.startObject("foo");
+                        builder.field("type", "text");
+                        builder.endObject();
+                    }
                     builder.endObject();
                 }
                 builder.endObject();
@@ -127,7 +136,7 @@ public class TestSystemIndexDescriptor extends SystemIndexDescriptor {
             builder.endObject();
             return Strings.toString(builder);
         } catch (IOException e) {
-            throw new UncheckedIOException("Failed to build .test-index-1 index mappings", e);
+            throw new UncheckedIOException("Failed to build new .test-index-1 index mappings", e);
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/AutoCreateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/AutoCreateAction.java
@@ -182,7 +182,7 @@ public final class AutoCreateAction extends ActionType<CreateIndexResponse> {
                     updateRequest.waitForActiveShards(ActiveShardCount.ALL);
 
                     if (mappings != null) {
-                        updateRequest.mappings(Collections.singletonMap(descriptor.getIndexType(), descriptor.getMappingsWithType()));
+                        updateRequest.mappings(Collections.singletonMap(descriptor.getIndexType(), descriptor.getMappings()));
                     }
                     if (settings != null) {
                         updateRequest.settings(settings);

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreateIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreateIndexAction.java
@@ -121,7 +121,7 @@ public class TransportCreateIndexAction extends TransportMasterNodeAction<Create
             .masterNodeTimeout(request.masterNodeTimeout())
             .aliases(aliases)
             .waitForActiveShards(ActiveShardCount.ALL)
-            .mappings(singletonMap(descriptor.getIndexType(), descriptor.getMappingsWithType()))
+            .mappings(singletonMap(descriptor.getIndexType(), descriptor.getMappings()))
             .settings(settings);
     }
 }

--- a/server/src/main/java/org/elasticsearch/indices/SystemIndexDescriptor.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemIndexDescriptor.java
@@ -217,15 +217,6 @@ public class SystemIndexDescriptor {
         return mappings;
     }
 
-    /**
-     * Returns this descriptor's mappings JSON nested under the type. This is necessary as this is the expected format
-     * when creating an index, even though it can be retrieved again without the nesting.
-     */
-    public String getMappingsWithType() {
-        // don't reference mappings directly as a test class exists that customises the mappings returned.
-        return "{\"" + indexType + "\": " + getMappings() + "}";
-    }
-
     public Settings getSettings() {
         return settings;
     }

--- a/server/src/main/java/org/elasticsearch/tasks/TaskResultsService.java
+++ b/server/src/main/java/org/elasticsearch/tasks/TaskResultsService.java
@@ -47,7 +47,6 @@ import java.util.Iterator;
 import static org.elasticsearch.action.admin.cluster.node.tasks.get.GetTaskAction.TASKS_ORIGIN;
 import static org.elasticsearch.common.unit.TimeValue.timeValueMillis;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
-import static org.elasticsearch.index.mapper.MapperService.SINGLE_MAPPING_NAME;
 
 /**
  * Service that can store task results.
@@ -134,14 +133,13 @@ public class TaskResultsService {
 
             builder.startObject();
             {
-                builder.startObject(SINGLE_MAPPING_NAME);
+                builder.startObject(TASK_TYPE);
                 builder.field("dynamic", "strict");
                 {
                     builder.startObject("_meta");
                     builder.field(TASK_RESULT_MAPPING_VERSION_META_FIELD, Version.CURRENT.toString());
                     builder.endObject();
 
-                    builder.field("dynamic", "strict");
                     builder.startObject("properties");
                     {
                         builder.startObject("completed");

--- a/server/src/main/java/org/elasticsearch/tasks/TaskResultsService.java
+++ b/server/src/main/java/org/elasticsearch/tasks/TaskResultsService.java
@@ -47,6 +47,7 @@ import java.util.Iterator;
 import static org.elasticsearch.action.admin.cluster.node.tasks.get.GetTaskAction.TASKS_ORIGIN;
 import static org.elasticsearch.common.unit.TimeValue.timeValueMillis;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.index.mapper.MapperService.SINGLE_MAPPING_NAME;
 
 /**
  * Service that can store task results.
@@ -133,79 +134,84 @@ public class TaskResultsService {
 
             builder.startObject();
             {
-                builder.startObject("_meta");
-                builder.field(TASK_RESULT_MAPPING_VERSION_META_FIELD, Version.CURRENT.toString());
-                builder.endObject();
-
+                builder.startObject(SINGLE_MAPPING_NAME);
                 builder.field("dynamic", "strict");
-                builder.startObject("properties");
                 {
-                    builder.startObject("completed");
-                    builder.field("type", "boolean");
+                    builder.startObject("_meta");
+                    builder.field(TASK_RESULT_MAPPING_VERSION_META_FIELD, Version.CURRENT.toString());
                     builder.endObject();
 
-                    builder.startObject("task");
+                    builder.field("dynamic", "strict");
+                    builder.startObject("properties");
                     {
-                        builder.startObject("properties");
+                        builder.startObject("completed");
+                        builder.field("type", "boolean");
+                        builder.endObject();
+
+                        builder.startObject("task");
                         {
-                            builder.startObject("action");
-                            builder.field("type", "keyword");
-                            builder.endObject();
+                            builder.startObject("properties");
+                            {
+                                builder.startObject("action");
+                                builder.field("type", "keyword");
+                                builder.endObject();
 
-                            builder.startObject("cancellable");
-                            builder.field("type", "boolean");
-                            builder.endObject();
+                                builder.startObject("cancellable");
+                                builder.field("type", "boolean");
+                                builder.endObject();
 
-                            builder.startObject("id");
-                            builder.field("type", "long");
-                            builder.endObject();
+                                builder.startObject("id");
+                                builder.field("type", "long");
+                                builder.endObject();
 
-                            builder.startObject("parent_task_id");
-                            builder.field("type", "keyword");
-                            builder.endObject();
+                                builder.startObject("parent_task_id");
+                                builder.field("type", "keyword");
+                                builder.endObject();
 
-                            builder.startObject("node");
-                            builder.field("type", "keyword");
-                            builder.endObject();
+                                builder.startObject("node");
+                                builder.field("type", "keyword");
+                                builder.endObject();
 
-                            builder.startObject("running_time_in_nanos");
-                            builder.field("type", "long");
-                            builder.endObject();
+                                builder.startObject("running_time_in_nanos");
+                                builder.field("type", "long");
+                                builder.endObject();
 
-                            builder.startObject("start_time_in_millis");
-                            builder.field("type", "long");
-                            builder.endObject();
+                                builder.startObject("start_time_in_millis");
+                                builder.field("type", "long");
+                                builder.endObject();
 
-                            builder.startObject("type");
-                            builder.field("type", "keyword");
-                            builder.endObject();
+                                builder.startObject("type");
+                                builder.field("type", "keyword");
+                                builder.endObject();
 
-                            builder.startObject("status");
-                            builder.field("type", "object");
-                            builder.field("enabled", false);
-                            builder.endObject();
+                                builder.startObject("status");
+                                builder.field("type", "object");
+                                builder.field("enabled", false);
+                                builder.endObject();
 
-                            builder.startObject("description");
-                            builder.field("type", "text");
-                            builder.endObject();
+                                builder.startObject("description");
+                                builder.field("type", "text");
+                                builder.endObject();
 
-                            builder.startObject("headers");
-                            builder.field("type", "object");
-                            builder.field("enabled", false);
+                                builder.startObject("headers");
+                                builder.field("type", "object");
+                                builder.field("enabled", false);
+                                builder.endObject();
+                            }
                             builder.endObject();
                         }
                         builder.endObject();
+
+                        builder.startObject("response");
+                        builder.field("type", "object");
+                        builder.field("enabled", false);
+                        builder.endObject();
+
+                        builder.startObject("error");
+                        builder.field("type", "object");
+                        builder.field("enabled", false);
+                        builder.endObject();
                     }
-                    builder.endObject();
-
-                    builder.startObject("response");
-                    builder.field("type", "object");
-                    builder.field("enabled", false);
-                    builder.endObject();
-
-                    builder.startObject("error");
-                    builder.field("type", "object");
-                    builder.field("enabled", false);
                     builder.endObject();
                 }
                 builder.endObject();


### PR DESCRIPTION
Apparently, the backport of how system indices are created in 7.x was fumbled, as tried too hard to copy with index types and instead got it wrong. This PR fixes it.