### PR TITLE
Make FilterAllocationDecider totally ignore tier-based allocation settings

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeFilters.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeFilters.java
@@ -95,7 +95,7 @@ public class DiscoveryNodeFilters {
      * filters after trimming, {@code null} is returned.
      */
     @Nullable
-    public static DiscoveryNodeFilters trim(@Nullable DiscoveryNodeFilters original) {
+    public static DiscoveryNodeFilters trimTier(@Nullable DiscoveryNodeFilters original) {
         if (original == null) {
             return null;
         }

--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeFilters.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeFilters.java
@@ -104,8 +104,6 @@ public class DiscoveryNodeFilters {
             // Remove all entries that start with "_tier", as these will be handled elsewhere
             .filter(entry -> {
                 String attr = entry.getKey();
-                if (attr != null && attr.startsWith("_tier")) {
-                }
                 return attr != null && attr.startsWith("_tier") == false;
             })
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));

--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeFilters.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeFilters.java
@@ -30,6 +30,7 @@ import org.elasticsearch.common.transport.TransportAddress;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
 
 public class DiscoveryNodeFilters {
 
@@ -86,6 +87,34 @@ public class DiscoveryNodeFilters {
             }
         }
         return false;
+    }
+
+    /**
+     * Removes any filters that should not be considered, returning a new
+     * {@link DiscoveryNodeFilters} object. If the filtered object has no
+     * filters after trimming, {@code null} is returned.
+     */
+    @Nullable
+    public static DiscoveryNodeFilters trim(@Nullable DiscoveryNodeFilters original) {
+        if (original == null) {
+            return null;
+        }
+
+        Map<String, String[]> newFilters = original.filters.entrySet().stream()
+            // Remove all entries that start with "_tier", as these will be handled elsewhere
+            .filter(entry -> {
+                String attr = entry.getKey();
+                if (attr != null && attr.startsWith("_tier")) {
+                }
+                return attr != null && attr.startsWith("_tier") == false;
+            })
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        if (newFilters.size() == 0) {
+            return null;
+        } else {
+            return new DiscoveryNodeFilters(original.opType, newFilters);
+        }
     }
 
     public boolean match(DiscoveryNode node) {
@@ -181,9 +210,6 @@ public class DiscoveryNodeFilters {
                         }
                     }
                 }
-            } else if (attr != null && attr.startsWith("_tier")) {
-                // Always allow _tier as an attribute, will be handled elsewhere
-                return true;
             } else {
                 String nodeAttributeValue = node.getAttributes().get(attr);
                 if (nodeAttributeValue == null) {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/FilterAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/FilterAllocationDecider.java
@@ -101,7 +101,7 @@ public class FilterAllocationDecider extends AllocationDecider {
             // that once it has been allocated post API the replicas can be allocated elsewhere without user interaction
             // this is a setting that can only be set within the system!
             IndexMetadata indexMd = allocation.metadata().getIndexSafe(shardRouting.index());
-            DiscoveryNodeFilters initialRecoveryFilters = DiscoveryNodeFilters.trim(indexMd.getInitialRecoveryFilters());
+            DiscoveryNodeFilters initialRecoveryFilters = DiscoveryNodeFilters.trimTier(indexMd.getInitialRecoveryFilters());
             if (initialRecoveryFilters != null  &&
                 shardRouting.recoverySource().getType() == RecoverySource.Type.LOCAL_SHARDS &&
                 initialRecoveryFilters.match(node.node()) == false) {
@@ -155,9 +155,9 @@ public class FilterAllocationDecider extends AllocationDecider {
     }
 
     private Decision shouldIndexFilter(IndexMetadata indexMd, DiscoveryNode node, RoutingAllocation allocation) {
-        DiscoveryNodeFilters indexRequireFilters = DiscoveryNodeFilters.trim(indexMd.requireFilters());
-        DiscoveryNodeFilters indexIncludeFilters = DiscoveryNodeFilters.trim(indexMd.includeFilters());
-        DiscoveryNodeFilters indexExcludeFilters = DiscoveryNodeFilters.trim(indexMd.excludeFilters());
+        DiscoveryNodeFilters indexRequireFilters = DiscoveryNodeFilters.trimTier(indexMd.requireFilters());
+        DiscoveryNodeFilters indexIncludeFilters = DiscoveryNodeFilters.trimTier(indexMd.includeFilters());
+        DiscoveryNodeFilters indexExcludeFilters = DiscoveryNodeFilters.trimTier(indexMd.excludeFilters());
 
         if (indexRequireFilters != null) {
             if (indexRequireFilters.match(node) == false) {
@@ -203,12 +203,12 @@ public class FilterAllocationDecider extends AllocationDecider {
     }
 
     private void setClusterRequireFilters(Map<String, String> filters) {
-        clusterRequireFilters = DiscoveryNodeFilters.trim(DiscoveryNodeFilters.buildFromKeyValue(AND, filters));
+        clusterRequireFilters = DiscoveryNodeFilters.trimTier(DiscoveryNodeFilters.buildFromKeyValue(AND, filters));
     }
     private void setClusterIncludeFilters(Map<String, String> filters) {
-        clusterIncludeFilters = DiscoveryNodeFilters.trim(DiscoveryNodeFilters.buildFromKeyValue(OR, filters));
+        clusterIncludeFilters = DiscoveryNodeFilters.trimTier(DiscoveryNodeFilters.buildFromKeyValue(OR, filters));
     }
     private void setClusterExcludeFilters(Map<String, String> filters) {
-        clusterExcludeFilters = DiscoveryNodeFilters.trim(DiscoveryNodeFilters.buildFromKeyValue(OR, filters));
+        clusterExcludeFilters = DiscoveryNodeFilters.trimTier(DiscoveryNodeFilters.buildFromKeyValue(OR, filters));
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/FilterAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/FilterAllocationDecider.java
@@ -101,7 +101,7 @@ public class FilterAllocationDecider extends AllocationDecider {
             // that once it has been allocated post API the replicas can be allocated elsewhere without user interaction
             // this is a setting that can only be set within the system!
             IndexMetadata indexMd = allocation.metadata().getIndexSafe(shardRouting.index());
-            DiscoveryNodeFilters initialRecoveryFilters = indexMd.getInitialRecoveryFilters();
+            DiscoveryNodeFilters initialRecoveryFilters = DiscoveryNodeFilters.trim(indexMd.getInitialRecoveryFilters());
             if (initialRecoveryFilters != null  &&
                 shardRouting.recoverySource().getType() == RecoverySource.Type.LOCAL_SHARDS &&
                 initialRecoveryFilters.match(node.node()) == false) {
@@ -155,22 +155,26 @@ public class FilterAllocationDecider extends AllocationDecider {
     }
 
     private Decision shouldIndexFilter(IndexMetadata indexMd, DiscoveryNode node, RoutingAllocation allocation) {
-        if (indexMd.requireFilters() != null) {
-            if (indexMd.requireFilters().match(node) == false) {
+        DiscoveryNodeFilters indexRequireFilters = DiscoveryNodeFilters.trim(indexMd.requireFilters());
+        DiscoveryNodeFilters indexIncludeFilters = DiscoveryNodeFilters.trim(indexMd.includeFilters());
+        DiscoveryNodeFilters indexExcludeFilters = DiscoveryNodeFilters.trim(indexMd.excludeFilters());
+
+        if (indexRequireFilters != null) {
+            if (indexRequireFilters.match(node) == false) {
                 return allocation.decision(Decision.NO, NAME, "node does not match index setting [%s] filters [%s]",
-                    IndexMetadata.INDEX_ROUTING_REQUIRE_GROUP_PREFIX, indexMd.requireFilters());
+                    IndexMetadata.INDEX_ROUTING_REQUIRE_GROUP_PREFIX, indexRequireFilters);
             }
         }
-        if (indexMd.includeFilters() != null) {
-            if (indexMd.includeFilters().match(node) == false) {
+        if (indexIncludeFilters != null) {
+            if (indexIncludeFilters.match(node) == false) {
                 return allocation.decision(Decision.NO, NAME, "node does not match index setting [%s] filters [%s]",
-                    IndexMetadata.INDEX_ROUTING_INCLUDE_GROUP_PREFIX, indexMd.includeFilters());
+                    IndexMetadata.INDEX_ROUTING_INCLUDE_GROUP_PREFIX, indexIncludeFilters);
             }
         }
-        if (indexMd.excludeFilters() != null) {
-            if (indexMd.excludeFilters().match(node)) {
+        if (indexExcludeFilters != null) {
+            if (indexExcludeFilters.match(node)) {
                 return allocation.decision(Decision.NO, NAME, "node matches index setting [%s] filters [%s]",
-                    IndexMetadata.INDEX_ROUTING_EXCLUDE_GROUP_SETTING.getKey(), indexMd.excludeFilters());
+                    IndexMetadata.INDEX_ROUTING_EXCLUDE_GROUP_SETTING.getKey(), indexExcludeFilters);
             }
         }
         return null;
@@ -199,12 +203,12 @@ public class FilterAllocationDecider extends AllocationDecider {
     }
 
     private void setClusterRequireFilters(Map<String, String> filters) {
-        clusterRequireFilters = DiscoveryNodeFilters.buildFromKeyValue(AND, filters);
+        clusterRequireFilters = DiscoveryNodeFilters.trim(DiscoveryNodeFilters.buildFromKeyValue(AND, filters));
     }
     private void setClusterIncludeFilters(Map<String, String> filters) {
-        clusterIncludeFilters = DiscoveryNodeFilters.buildFromKeyValue(OR, filters);
+        clusterIncludeFilters = DiscoveryNodeFilters.trim(DiscoveryNodeFilters.buildFromKeyValue(OR, filters));
     }
     private void setClusterExcludeFilters(Map<String, String> filters) {
-        clusterExcludeFilters = DiscoveryNodeFilters.buildFromKeyValue(OR, filters);
+        clusterExcludeFilters = DiscoveryNodeFilters.trim(DiscoveryNodeFilters.buildFromKeyValue(OR, filters));
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/FilterAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/FilterAllocationDeciderTests.java
@@ -140,9 +140,54 @@ public class FilterAllocationDeciderTests extends ESAllocationTestCase {
         assertEquals("node passes include/exclude/require filters", decision.getExplanation());
     }
 
-    private ClusterState createInitialClusterState(AllocationService service, Settings settings) {
+    public void testTierFilterIgnored() {
+        ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        FilterAllocationDecider filterAllocationDecider = new FilterAllocationDecider(Settings.EMPTY, clusterSettings);
+        AllocationDeciders allocationDeciders = new AllocationDeciders(
+            Arrays.asList(filterAllocationDecider,
+                new SameShardAllocationDecider(Settings.EMPTY, clusterSettings),
+                new ReplicaAfterPrimaryActiveAllocationDecider()));
+        AllocationService service = new AllocationService(allocationDeciders,
+            new TestGatewayAllocator(), new BalancedShardsAllocator(Settings.EMPTY), EmptyClusterInfoService.INSTANCE,
+            EmptySnapshotsInfoService.INSTANCE);
+        ClusterState state = createInitialClusterState(service, Settings.builder()
+            .put("index.routing.allocation.require._tier", "data_cold")
+            .put("index.routing.allocation.include._tier", "data_cold")
+            .put("index.routing.allocation.include._tier_preference", "data_cold")
+            .put("index.routing.allocation.exclude._tier", "data_cold")
+            .build(),
+            Settings.builder()
+                .put("cluster.routing.allocation.require._tier", "data_cold")
+                .put("cluster.routing.allocation.include._tier", "data_cold")
+                .put("cluster.routing.allocation.exclude._tier", "data_cold")
+                .build());
+        RoutingTable routingTable = state.routingTable();
+        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state.getRoutingNodes(), state,
+            null, null, 0);
+        allocation.debugDecision(true);
+        allocation = new RoutingAllocation(allocationDeciders, state.getRoutingNodes(), state,
+            null, null, 0);
+        allocation.debugDecision(true);
+        Decision.Single decision = (Decision.Single) filterAllocationDecider.canAllocate(
+            routingTable.index("idx").shard(0).shards().get(0),
+            state.getRoutingNodes().node("node2"), allocation);
+        assertEquals(decision.toString(), Type.YES, decision.type());
+        assertEquals("node passes include/exclude/require filters", decision.getExplanation());
+        decision = (Decision.Single) filterAllocationDecider.canAllocate(
+            routingTable.index("idx").shard(0).shards().get(0),
+            state.getRoutingNodes().node("node1"), allocation);
+        assertEquals(Type.YES, decision.type());
+        assertEquals("node passes include/exclude/require filters", decision.getExplanation());
+    }
+
+    private ClusterState createInitialClusterState(AllocationService service, Settings indexSettings) {
+        return createInitialClusterState(service, indexSettings, Settings.EMPTY);
+    }
+
+    private ClusterState createInitialClusterState(AllocationService service, Settings idxSettings, Settings clusterSettings) {
         Metadata.Builder metadata = Metadata.builder();
-        final Settings.Builder indexSettings = settings(Version.CURRENT).put(settings);
+        metadata.persistentSettings(clusterSettings);
+        final Settings.Builder indexSettings = settings(Version.CURRENT).put(idxSettings);
         final IndexMetadata sourceIndex;
         //put a fake closed source index
         sourceIndex = IndexMetadata.builder("sourceIndex")


### PR DESCRIPTION
Previously we treated attribute filtering for `_tier`-prefixed attributes a pass-through, meaning
that they were essentially always treated as matching in `DiscoveryNodeFilters.match`, however, for
exclude settings, this meant that the node was considered to match the node if a `_tier*` filter was
specified.

This commit prunes these attributes from the DiscoveryNodeFilters when considering the filters for
`FilterAllocationDecider` so that they are *only* considered in `DataTierAllocationDecider`.

Resolves #66679
