### PR TITLE
Reduce number of cache/prewarm threads

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
@@ -376,14 +376,14 @@ public class SearchableSnapshots extends Plugin implements IndexStorePlugin, Eng
             new ScalingExecutorBuilder(
                 CACHE_FETCH_ASYNC_THREAD_POOL_NAME,
                 0,
-                32,
+                28,
                 TimeValue.timeValueSeconds(30L),
                 CACHE_FETCH_ASYNC_THREAD_POOL_SETTING
             ),
             new ScalingExecutorBuilder(
                 CACHE_PREWARMING_THREAD_POOL_NAME,
                 0,
-                32,
+                16,
                 TimeValue.timeValueSeconds(30L),
                 CACHE_PREWARMING_THREAD_POOL_SETTING
             ) };


### PR DESCRIPTION
S3 by default allows 50 simultaneous connections. The number of prewarm
and cache threads have been reduced to 16/28 to fit safely within the
50 available connections.
