### PR TITLE
Fix test failure

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/breaker/PreallocatedCircuitBreakerServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/common/breaker/PreallocatedCircuitBreakerServiceTests.java
@@ -109,12 +109,12 @@ public class PreallocatedCircuitBreakerServiceTests extends ESTestCase {
                         assertThat(realBreaker.getUsed(), equalTo(preallocatedBytes));
                     }
                     if (current > 0 && randomBoolean()) {
-                        long delta = randomLongBetween(Math.max(-current, -realBreaker.getLimit() / 100), 0);
+                        long delta = randomLongBetween(-Math.min(current, limit / 100), 0);
                         b.addWithoutBreaking(delta);
                         current += delta;
                         continue;
                     }
-                    long delta = randomLongBetween(0, realBreaker.getLimit() / 100);
+                    long delta = randomLongBetween(0, limit / 100);
                     if (randomBoolean()) {
                         b.addWithoutBreaking(delta);
                         current += delta;


### PR DESCRIPTION
The randomized test for pre-allocated breakers would sometimes attempt
to consume the entire request breaker and fail. This limits it to 100mb
and aborts the test if that doesn't fit comfortable into the breaker.

The 100mb limit also fixes another sneaky issue - the randomized values
for the test used to depend on the size of the request breaker which
itself depends on the size of the heap. We run the tests with 512m heap
in gradle but IDEs are kind of the wild west. That made it very
difficult to reproduce the issue.

There is still some heap dependent randomization here, sadly. We use
non-heap dependent randomization to bump the breaker but whether or not
the breaker trips is dependent on heap size. This is, sadly, kind of
inevitable because we want to test against a real breaker so we can make
sure we handle circuit breaking sensibly.
