### PR TITLE
[7.10] [DOCS] Fix formatting for `fieldata` docs (#67017)

### DIFF
--- a/docs/reference/mapping/types/text.asciidoc
+++ b/docs/reference/mapping/types/text.asciidoc
@@ -154,9 +154,8 @@ The following parameters are accepted by `text` fields:
 aggregations, sorting, or scripting. If you try to sort, aggregate, or access
 values from a script on a `text` field, you will see this exception:
 
-[literal]
 Fielddata is disabled on text fields by default.  Set `fielddata=true` on
-[`your_field_name`] in order to load fielddata in memory by uninverting the
+`your_field_name` in order to load fielddata in memory by uninverting the
 inverted index. Note that this can however use significant memory.
 
 Field data is the only way to access the analyzed tokens from a full text field


### PR DESCRIPTION
Backports the following commits to 7.10:
 - [DOCS] Fix formatting for `fieldata` docs (#67017)