### PR TITLE
Fix static inner class resolution in Painless

### DIFF
--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/BasicAPITests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/BasicAPITests.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.painless;
 
+import java.text.MessageFormat.Field;
+import java.text.Normalizer;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -165,5 +167,10 @@ public class BasicAPITests extends ScriptTestCase {
                     )
                 ).matches()
         );
+    }
+
+    public void testStaticInnerClassResolution() {
+        assertEquals(Field.ARGUMENT, exec("MessageFormat.Field.ARGUMENT"));
+        assertEquals(Normalizer.Form.NFD, exec("Normalizer.Form.NFD"));
     }
 }


### PR DESCRIPTION
A bug was found (https://github.com/elastic/elasticsearch/issues/66823) related to (https://github.com/elastic/elasticsearch/pull/56293). When removing the "lexer hack" to remove type context from the lexer,  static inner class resolution wasn't properly accounted for. This change adds code to handle static inner class resolution.

Note for review: Majority of the lines here are tabbed in due to an extra if/else path for the new resolution type. New resolution is from lines 2477 thru 2490.