### PR TITLE
[7.x] Make FilterAllocationDecider totally ignore tier-based allocation settings (#67019)

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/FilterAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/FilterAllocationDeciderTests.java
@@ -140,9 +140,54 @@ public class FilterAllocationDeciderTests extends ESAllocationTestCase {
         assertEquals("node passes include/exclude/require filters", decision.getExplanation());
     }
 
-    private ClusterState createInitialClusterState(AllocationService service, Settings settings) {
+    public void testTierFilterIgnored() {
+        ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        FilterAllocationDecider filterAllocationDecider = new FilterAllocationDecider(Settings.EMPTY, clusterSettings);
+        AllocationDeciders allocationDeciders = new AllocationDeciders(
+            Arrays.asList(filterAllocationDecider,
+                new SameShardAllocationDecider(Settings.EMPTY, clusterSettings),
+                new ReplicaAfterPrimaryActiveAllocationDecider()));
+        AllocationService service = new AllocationService(allocationDeciders,
+            new TestGatewayAllocator(), new BalancedShardsAllocator(Settings.EMPTY), EmptyClusterInfoService.INSTANCE,
+            EmptySnapshotsInfoService.INSTANCE);
+        ClusterState state = createInitialClusterState(service, Settings.builder()
+            .put("index.routing.allocation.require._tier", "data_cold")
+            .put("index.routing.allocation.include._tier", "data_cold")
+            .put("index.routing.allocation.include._tier_preference", "data_cold")
+            .put("index.routing.allocation.exclude._tier", "data_cold")
+            .build(),
+            Settings.builder()
+                .put("cluster.routing.allocation.require._tier", "data_cold")
+                .put("cluster.routing.allocation.include._tier", "data_cold")
+                .put("cluster.routing.allocation.exclude._tier", "data_cold")
+                .build());
+        RoutingTable routingTable = state.routingTable();
+        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state.getRoutingNodes(), state,
+            null, null, 0);
+        allocation.debugDecision(true);
+        allocation = new RoutingAllocation(allocationDeciders, state.getRoutingNodes(), state,
+            null, null, 0);
+        allocation.debugDecision(true);
+        Decision.Single decision = (Decision.Single) filterAllocationDecider.canAllocate(
+            routingTable.index("idx").shard(0).shards().get(0),
+            state.getRoutingNodes().node("node2"), allocation);
+        assertEquals(decision.toString(), Type.YES, decision.type());
+        assertEquals("node passes include/exclude/require filters", decision.getExplanation());
+        decision = (Decision.Single) filterAllocationDecider.canAllocate(
+            routingTable.index("idx").shard(0).shards().get(0),
+            state.getRoutingNodes().node("node1"), allocation);
+        assertEquals(Type.YES, decision.type());
+        assertEquals("node passes include/exclude/require filters", decision.getExplanation());
+    }
+
+    private ClusterState createInitialClusterState(AllocationService service, Settings indexSettings) {
+        return createInitialClusterState(service, indexSettings, Settings.EMPTY);
+    }
+
+    private ClusterState createInitialClusterState(AllocationService service, Settings idxSettings, Settings clusterSettings) {
         Metadata.Builder metadata = Metadata.builder();
-        final Settings.Builder indexSettings = settings(Version.CURRENT).put(settings);
+        metadata.persistentSettings(clusterSettings);
+        final Settings.Builder indexSettings = settings(Version.CURRENT).put(idxSettings);
         final IndexMetadata sourceIndex;
         //put a fake closed source index
         sourceIndex = IndexMetadata.builder("sourceIndex")

--- a/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierIT.java
+++ b/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierIT.java
@@ -247,6 +247,26 @@ public class DataTierIT extends ESIntegTestCase {
         assertThat(usage.getTierStats().get(DataTier.DATA_HOT).primaryShardBytesMAD, greaterThanOrEqualTo(0L));
     }
 
+    public void testTierFilteringIgnoredByFilterAllocationDecider() {
+        startContentOnlyNode();
+        startHotOnlyNode();
+
+        // Exclude all data_cold nodes
+        client().admin().cluster().prepareUpdateSettings()
+            .setTransientSettings(Settings.builder()
+                .put(DataTierAllocationDecider.CLUSTER_ROUTING_EXCLUDE, "data_cold")
+                .build())
+            .get();
+
+        // Create an index, which should be excluded just fine, ignored by the FilterAllocationDecider
+        client().admin().indices().prepareCreate(index)
+            .setSettings(Settings.builder()
+                .put("index.number_of_shards", 2)
+                .put("index.number_of_replicas", 0))
+            .setWaitForActiveShards(0)
+            .get();
+    }
+
     private DataTiersFeatureSetUsage getUsage() {
         XPackUsageResponse usages = new XPackUsageRequestBuilder(client()).execute().actionGet();
         XPackFeatureSet.Usage dtUsage = usages.getUsages().stream()


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Make FilterAllocationDecider totally ignore tier-based allocation settings (#67019)