### PR TITLE
[DOCS] Add beta qualifier to transform latest APIs

### DIFF
--- a/docs/reference/transform/apis/preview-transform.asciidoc
+++ b/docs/reference/transform/apis/preview-transform.asciidoc
@@ -83,6 +83,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=frequency]
 //Begin latest
 `latest`::
 (Required^*^, object)
+beta:[]
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-latest]
 +
 .Properties of `latest`

--- a/docs/reference/transform/apis/put-transform.asciidoc
+++ b/docs/reference/transform/apis/put-transform.asciidoc
@@ -113,6 +113,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=frequency]
 //Begin latest
 `latest`::
 (Required^*^, object)
+beta:[]
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-latest]
 +
 .Properties of `latest`


### PR DESCRIPTION
This PR adds the missing beta qualifier to the "latest" parameter in the preview transform and create transform APIs.