### PR TITLE
[DOCS] Rewrite agg breakdown docs for profile API

### DIFF
--- a/docs/reference/search/profile.asciidoc
+++ b/docs/reference/search/profile.asciidoc
@@ -883,42 +883,26 @@ The `breakdown` component lists detailed statistics about low-level execution:
   "initialize_count": 1,
   "reduce_count": 0,
   "collect": 45786,
-  "collect_count": 4
+  "collect_count": 4,
+  "build_leaf_collector": 18211,
+  "build_leaf_collector_count": 1
 }
 --------------------------------------------------
 // NOTCONSOLE
+
+Each property in the `breakdown` component corresponds to an internal method for
+the aggregation. For example, the `build_leaf_collector` property measures
+nanoseconds spent running the aggregation's `getLeafCollector()` method.
+Properties ending in `_count` record the number of invocations of the particular
+method. For example, `"collect_count": 2` means the aggregation called the
+`collect()` on two different documents. The `reduce` property is reserved for
+future use and always returns `0`.
 
 Timings are listed in wall-clock nanoseconds and are not normalized at all. All 
 caveats about the overall `time` apply here.  The intention of the breakdown is 
 to give you a feel for A) what machinery in {es} is actually eating time, and B) 
 the magnitude of differences in times between the various components. Like the 
 overall time, the breakdown is inclusive of all children times.
-
-The meaning of the stats are as follows:
-
-[discrete]
-===== All parameters:
-
-[horizontal]
-`initialise`::
-
-    This times how long it takes to create and initialise the aggregation before starting to collect documents.
-
-`collect`::
-
-    This represents the cumulative time spent in the collect phase of the aggregation. This is where matching documents are passed to the aggregation and the state of the aggregator is updated based on the information contained in the documents.
-
-`build_aggregation`::
-
-    This represents the time spent creating the shard level results of the aggregation ready to pass back to the reducing node after the collection of documents is finished.
-
-`reduce`::
-
-    This is not currently used and will always report `0`. Currently aggregation profiling only times the shard level parts of the aggregation execution. Timing of the reduce phase will be added later.
-
-`*_count`::
-    Records the number of invocations of the particular method.  For example, `"collect_count": 2,`
-    means the `collect()` method was called on two different documents.
 
 [[profiling-considerations]]
 ===== Profiling Considerations


### PR DESCRIPTION
Rewrites the aggregation `breakdown` section of the profile API docs. Instead of explicitly defining each property of the `breakdown` component, the section now explains how each property relates to the aggregation's internal methods.

Relates to #62317.

Closes #66709.

### Preview

https://elasticsearch_67042.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/search-profile.html#_timing_breakdown_2