### PR TITLE
Make InternalClusterInfoService async

### DIFF
--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/DeleteByQueryBasicTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/DeleteByQueryBasicTests.java
@@ -22,6 +22,7 @@ package org.elasticsearch.index.reindex;
 import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.cluster.ClusterInfoService;
+import org.elasticsearch.cluster.ClusterInfoServiceUtils;
 import org.elasticsearch.cluster.InternalClusterInfoService;
 import org.elasticsearch.cluster.routing.allocation.DiskThresholdSettings;
 import org.elasticsearch.common.settings.Settings;
@@ -257,7 +258,10 @@ public class DeleteByQueryBasicTests extends ReindexTestCase {
                     .getInstance(ClusterInfoService.class, internalTestCluster.getMasterName());
                 ThreadPool threadPool = internalTestCluster.getInstance(ThreadPool.class, internalTestCluster.getMasterName());
                 // Refresh the cluster info after a random delay to check the disk threshold and release the block on the index
-                threadPool.schedule(infoService::refresh, TimeValue.timeValueMillis(randomIntBetween(1, 100)), ThreadPool.Names.MANAGEMENT);
+                threadPool.schedule(
+                        () -> ClusterInfoServiceUtils.refresh(infoService),
+                        TimeValue.timeValueMillis(randomIntBetween(1, 100)),
+                        ThreadPool.Names.MANAGEMENT);
                 // The delete by query request will be executed successfully because the block will be released
                 assertThat(deleteByQuery().source("test").filter(QueryBuilders.matchAllQuery()).refresh(true).get(),
                     matcher().deleted(docs));

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainIT.java
@@ -82,6 +82,7 @@ public final class ClusterAllocationExplainIT extends ESIntegTestCase {
         logger.info("--> stopping the node with the primary");
         internalCluster().stopRandomNode(InternalTestCluster.nameFilter(primaryNodeName()));
         ensureStableCluster(1);
+        refreshClusterInfo();
 
         boolean includeYesDecisions = randomBoolean();
         boolean includeDiskInfo = randomBoolean();
@@ -159,6 +160,7 @@ public final class ClusterAllocationExplainIT extends ESIntegTestCase {
         logger.info("--> stopping the node with the replica");
         internalCluster().stopRandomNode(InternalTestCluster.nameFilter(replicaNode().getName()));
         ensureStableCluster(2);
+        refreshClusterInfo();
         assertBusy(() ->
             // wait till we have passed any pending shard data fetching
             assertEquals(AllocationDecision.ALLOCATION_DELAYED, client().admin().cluster().prepareAllocationExplain()

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/create/ShrinkIndexIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/create/ShrinkIndexIT.java
@@ -39,9 +39,7 @@ import org.elasticsearch.action.admin.indices.stats.ShardStats;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.client.Client;
-import org.elasticsearch.cluster.ClusterInfoService;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.InternalClusterInfoService;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.Murmur3HashFunction;
@@ -398,9 +396,7 @@ public class ShrinkIndexIT extends ESIntegTestCase {
                 .put("index.routing.allocation.require._name", mergeNode)).get();
         ensureGreen("source");
 
-        final InternalClusterInfoService infoService = (InternalClusterInfoService) internalCluster().getInstance(ClusterInfoService.class,
-            internalCluster().getMasterName());
-        infoService.refresh();
+        refreshClusterInfo();
         // kick off a retry and wait until it's done!
         ClusterRerouteResponse clusterRerouteResponse = client().admin().cluster().prepareReroute().setRetryFailed(true).get();
         long expectedShardSize = clusterRerouteResponse.getState().routingTable().index("target")

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterInfoServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterInfoServiceIT.java
@@ -58,6 +58,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singletonList;
@@ -67,6 +68,8 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.notNullValue;
 
 /**
  * Integration tests for the ClusterInfoService collecting information
@@ -146,7 +149,7 @@ public class ClusterInfoServiceIT extends ESIntegTestCase {
         final InternalClusterInfoService infoService = (InternalClusterInfoService) internalTestCluster
             .getInstance(ClusterInfoService.class, internalTestCluster.getMasterName());
         infoService.setUpdateFrequency(TimeValue.timeValueMillis(200));
-        ClusterInfo info = infoService.refresh();
+        ClusterInfo info = ClusterInfoServiceUtils.refresh(infoService);
         assertNotNull("info should not be null", info);
         ImmutableOpenMap<String, DiskUsage> leastUsages = info.getNodeLeastAvailableDiskUsages();
         ImmutableOpenMap<String, DiskUsage> mostUsages = info.getNodeMostAvailableDiskUsages();
@@ -190,15 +193,22 @@ public class ClusterInfoServiceIT extends ESIntegTestCase {
             Settings.builder().put(InternalClusterInfoService.INTERNAL_CLUSTER_INFO_UPDATE_INTERVAL_SETTING.getKey(), "60m").build());
         prepareCreate("test").setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)).get();
         ensureGreen("test");
+
+        final List<ShardRouting> shardRoutings = client().admin().cluster().prepareState().clear().setRoutingTable(true).get()
+                .getState().getRoutingTable().index("test").shard(0).shards();
+
         InternalTestCluster internalTestCluster = internalCluster();
         InternalClusterInfoService infoService = (InternalClusterInfoService) internalTestCluster
             .getInstance(ClusterInfoService.class, internalTestCluster.getMasterName());
-        // get one healthy sample
-        ClusterInfo info = infoService.refresh();
-        assertNotNull("failed to collect info", info);
-        assertThat("some usages are populated", info.getNodeLeastAvailableDiskUsages().size(), Matchers.equalTo(2));
-        assertThat("some shard sizes are populated", info.shardSizes.size(), greaterThan(0));
 
+        // get one healthy sample
+        ClusterInfo originalInfo = ClusterInfoServiceUtils.refresh(infoService);
+        assertNotNull("failed to collect info", originalInfo);
+        assertThat("some usages are populated", originalInfo.getNodeLeastAvailableDiskUsages().size(), Matchers.equalTo(2));
+        assertThat("some shard sizes are populated", originalInfo.shardSizes.size(), greaterThan(0));
+        for (ShardRouting shardRouting : shardRoutings) {
+            assertThat("size for shard " + shardRouting + " found", originalInfo.getShardSize(shardRouting), notNullValue());
+        }
 
         MockTransportService mockTransportService = (MockTransportService) internalCluster()
             .getInstance(TransportService.class, internalTestCluster.getMasterName());
@@ -223,15 +233,15 @@ public class ClusterInfoServiceIT extends ESIntegTestCase {
         setClusterInfoTimeout("1s");
         // timeouts shouldn't clear the info
         timeout.set(true);
-        info = infoService.refresh();
-        assertNotNull("info should not be null", info);
-        // node info will time out both on the request level on the count down latch. this means
-        // it is likely to update the node disk usage based on the one response that came be from local
-        // node.
-        assertThat(info.getNodeLeastAvailableDiskUsages().size(), greaterThanOrEqualTo(1));
-        assertThat(info.getNodeMostAvailableDiskUsages().size(), greaterThanOrEqualTo(1));
-        // indices is guaranteed to time out on the latch, not updating anything.
-        assertThat(info.shardSizes.size(), greaterThan(1));
+        final ClusterInfo infoAfterTimeout = ClusterInfoServiceUtils.refresh(infoService);
+        assertNotNull("info should not be null", infoAfterTimeout);
+        // node stats from remote nodes will time out, but the local node will be included
+        assertThat(infoAfterTimeout.getNodeLeastAvailableDiskUsages().size(), equalTo(1));
+        assertThat(infoAfterTimeout.getNodeMostAvailableDiskUsages().size(), equalTo(1));
+        // indices stats from remote nodes will time out, but the local node's shard will be included
+        assertThat(infoAfterTimeout.shardSizes.size(), greaterThan(0));
+        assertThat(shardRoutings.stream().filter(shardRouting -> infoAfterTimeout.getShardSize(shardRouting) != null)
+                .collect(Collectors.toList()), hasSize(1));
 
         // now we cause an exception
         timeout.set(false);
@@ -246,25 +256,29 @@ public class ClusterInfoServiceIT extends ESIntegTestCase {
 
         assertNotNull("failed to find BlockingActionFilter", blockingActionFilter);
         blockingActionFilter.blockActions(blockedActions.toArray(Strings.EMPTY_ARRAY));
-        info = infoService.refresh();
-        assertNotNull("info should not be null", info);
-        assertThat(info.getNodeLeastAvailableDiskUsages().size(), equalTo(0));
-        assertThat(info.getNodeMostAvailableDiskUsages().size(), equalTo(0));
-        assertThat(info.shardSizes.size(), equalTo(0));
-        assertThat(info.reservedSpace.size(), equalTo(0));
+        final ClusterInfo infoAfterException = ClusterInfoServiceUtils.refresh(infoService);
+        assertNotNull("info should not be null", infoAfterException);
+        assertThat(infoAfterException.getNodeLeastAvailableDiskUsages().size(), equalTo(0));
+        assertThat(infoAfterException.getNodeMostAvailableDiskUsages().size(), equalTo(0));
+        assertThat(infoAfterException.shardSizes.size(), equalTo(0));
+        assertThat(infoAfterException.reservedSpace.size(), equalTo(0));
 
         // check we recover
         blockingActionFilter.blockActions();
         setClusterInfoTimeout("15s");
-        info = infoService.refresh();
-        assertNotNull("info should not be null", info);
-        assertThat(info.getNodeLeastAvailableDiskUsages().size(), equalTo(2));
-        assertThat(info.getNodeMostAvailableDiskUsages().size(), equalTo(2));
-        assertThat(info.shardSizes.size(), greaterThan(0));
+        final ClusterInfo infoAfterRecovery = ClusterInfoServiceUtils.refresh(infoService);
+        assertNotNull("info should not be null", infoAfterRecovery);
+        assertThat(infoAfterRecovery.getNodeLeastAvailableDiskUsages().size(), equalTo(2));
+        assertThat(infoAfterRecovery.getNodeMostAvailableDiskUsages().size(), equalTo(2));
+        assertThat(infoAfterRecovery.shardSizes.size(), greaterThan(0));
+        for (ShardRouting shardRouting : shardRoutings) {
+            assertThat("size for shard " + shardRouting + " found", originalInfo.getShardSize(shardRouting), notNullValue());
+        }
 
         RoutingTable routingTable = client().admin().cluster().prepareState().clear().setRoutingTable(true).get().getState().routingTable();
         for (ShardRouting shard : routingTable.allShards()) {
-            assertTrue(info.getReservedSpace(shard.currentNodeId(), info.getDataPath(shard)).containsShardId(shard.shardId()));
+            assertTrue(infoAfterRecovery.getReservedSpace(shard.currentNodeId(),
+                    infoAfterRecovery.getDataPath(shard)).containsShardId(shard.shardId()));
         }
 
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderIT.java
@@ -24,6 +24,7 @@ import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotR
 import org.elasticsearch.action.admin.indices.stats.ShardStats;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.cluster.ClusterInfoService;
+import org.elasticsearch.cluster.ClusterInfoServiceUtils;
 import org.elasticsearch.cluster.DiskUsageIntegTestCase;
 import org.elasticsearch.cluster.InternalClusterInfoService;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -83,7 +84,8 @@ public class DiskThresholdDeciderIT extends DiskUsageIntegTestCase {
 
         final InternalClusterInfoService clusterInfoService
                 = (InternalClusterInfoService) internalCluster().getCurrentMasterNodeInstance(ClusterInfoService.class);
-        internalCluster().getCurrentMasterNodeInstance(ClusterService.class).addListener(event -> clusterInfoService.refresh());
+        internalCluster().getCurrentMasterNodeInstance(ClusterService.class).addListener(
+                event -> ClusterInfoServiceUtils.refresh(clusterInfoService));
 
         final String dataNode0Id = internalCluster().getInstance(NodeEnvironment.class, dataNodeName).nodeId();
 
@@ -119,7 +121,8 @@ public class DiskThresholdDeciderIT extends DiskUsageIntegTestCase {
 
         final InternalClusterInfoService clusterInfoService
             = (InternalClusterInfoService) internalCluster().getCurrentMasterNodeInstance(ClusterInfoService.class);
-        internalCluster().getCurrentMasterNodeInstance(ClusterService.class).addListener(event -> clusterInfoService.refresh());
+        internalCluster().getCurrentMasterNodeInstance(ClusterService.class).addListener(
+                event -> ClusterInfoServiceUtils.refresh(clusterInfoService));
 
         final String dataNode0Id = internalCluster().getInstance(NodeEnvironment.class, dataNodeName).nodeId();
 
@@ -211,7 +214,7 @@ public class DiskThresholdDeciderIT extends DiskUsageIntegTestCase {
 
     private void refreshDiskUsage() {
         final ClusterInfoService clusterInfoService = internalCluster().getCurrentMasterNodeInstance(ClusterInfoService.class);
-        ((InternalClusterInfoService) clusterInfoService).refresh();
+        ClusterInfoServiceUtils.refresh(((InternalClusterInfoService) clusterInfoService));
         // if the nodes were all under the low watermark already (but unbalanced) then a change in the disk usage doesn't trigger a reroute
         // even though it's now possible to achieve better balance, so we have to do an explicit reroute. TODO fix this?
         if (StreamSupport.stream(clusterInfoService.getClusterInfo().getNodeMostAvailableDiskUsages().values().spliterator(), false)

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/shard/IndexShardIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/shard/IndexShardIT.java
@@ -32,6 +32,7 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.ClusterInfoService;
+import org.elasticsearch.cluster.ClusterInfoServiceUtils;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.InternalClusterInfoService;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -272,7 +273,7 @@ public class IndexShardIT extends ESSingleNodeTestCase {
         }
         ensureGreen("test");
         InternalClusterInfoService clusterInfoService = (InternalClusterInfoService) getInstanceFromNode(ClusterInfoService.class);
-        clusterInfoService.refresh();
+        ClusterInfoServiceUtils.refresh(clusterInfoService);
         ClusterState state = getInstanceFromNode(ClusterService.class).state();
         Long test = clusterInfoService.getClusterInfo().getShardSize(state.getRoutingTable().index("test")
             .getShards().get(0).primaryShard());

--- a/server/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastRequest.java
@@ -19,33 +19,49 @@
 
 package org.elasticsearch.action.support.broadcast;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.unit.TimeValue;
 
 import java.io.IOException;
 
 public class BroadcastRequest<Request extends BroadcastRequest<Request>> extends ActionRequest implements IndicesRequest.Replaceable {
 
     protected String[] indices;
-    private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpenAndForbidClosed();
+    private IndicesOptions indicesOptions;
+
+    @Nullable // if timeout is infinite
+    private TimeValue timeout;
 
     public BroadcastRequest(StreamInput in) throws IOException {
         super(in);
         indices = in.readStringArray();
         indicesOptions = IndicesOptions.readIndicesOptions(in);
+        if (in.getVersion().onOrAfter(Version.V_7_12_0)) {
+            timeout = in.readOptionalTimeValue();
+        } else {
+            timeout = null;
+        }
     }
 
     protected BroadcastRequest(String... indices) {
-        this.indices = indices;
+        this(indices, IndicesOptions.strictExpandOpenAndForbidClosed());
     }
 
     protected BroadcastRequest(String[] indices, IndicesOptions indicesOptions) {
+        this(indices, indicesOptions, null);
+    }
+
+    protected BroadcastRequest(String[] indices, IndicesOptions indicesOptions, @Nullable TimeValue timeout) {
         this.indices = indices;
         this.indicesOptions = indicesOptions;
+        this.timeout = timeout;
     }
 
     @Override
@@ -76,6 +92,17 @@ public class BroadcastRequest<Request extends BroadcastRequest<Request>> extends
         return (Request) this;
     }
 
+    @Nullable // if timeout is infinite
+    public TimeValue timeout() {
+        return timeout;
+    }
+
+    @SuppressWarnings("unchecked")
+    public final Request timeout(@Nullable TimeValue timeout) {
+        this.timeout = timeout;
+        return (Request) this;
+    }
+
     @Override
     public boolean includeDataStreams() {
         return true;
@@ -86,5 +113,8 @@ public class BroadcastRequest<Request extends BroadcastRequest<Request>> extends
         super.writeTo(out);
         out.writeStringArrayNullable(indices);
         indicesOptions.writeIndicesOptions(out);
+        if (out.getVersion().onOrAfter(Version.V_7_12_0)) {
+            out.writeOptionalTimeValue(timeout);
+        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/InternalClusterInfoService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/InternalClusterInfoService.java
@@ -19,19 +19,20 @@
 
 package org.elasticsearch.cluster;
 
-import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.LatchedActionListener;
+import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
 import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsRequest;
 import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsResponse;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsRequest;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
 import org.elasticsearch.action.admin.indices.stats.ShardStats;
+import org.elasticsearch.action.support.DefaultShardOperationFailedException;
 import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -44,20 +45,18 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.common.util.concurrent.AbstractRunnable;
-import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
+import org.elasticsearch.common.util.concurrent.CountDown;
 import org.elasticsearch.index.store.StoreStats;
 import org.elasticsearch.monitor.fs.FsInfo;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.transport.ReceiveTimeoutTransportException;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 /**
@@ -75,8 +74,6 @@ public class InternalClusterInfoService implements ClusterInfoService, ClusterSt
 
     private static final Logger logger = LogManager.getLogger(InternalClusterInfoService.class);
 
-    private static final String REFRESH_EXECUTOR = ThreadPool.Names.MANAGEMENT;
-
     public static final Setting<TimeValue> INTERNAL_CLUSTER_INFO_UPDATE_INTERVAL_SETTING =
         Setting.timeSetting("cluster.info.update.interval", TimeValue.timeValueSeconds(30), TimeValue.timeValueSeconds(10),
             Property.Dynamic, Property.NodeScope);
@@ -84,18 +81,22 @@ public class InternalClusterInfoService implements ClusterInfoService, ClusterSt
         Setting.positiveTimeSetting("cluster.info.update.timeout", TimeValue.timeValueSeconds(15),
             Property.Dynamic, Property.NodeScope);
 
+    private volatile boolean enabled;
     private volatile TimeValue updateFrequency;
+    private volatile TimeValue fetchTimeout;
 
     private volatile ImmutableOpenMap<String, DiskUsage> leastAvailableSpaceUsages;
     private volatile ImmutableOpenMap<String, DiskUsage> mostAvailableSpaceUsages;
     private volatile IndicesStatsSummary indicesStatsSummary;
-    // null if this node is not currently the master
-    private final AtomicReference<RefreshAndRescheduleRunnable> refreshAndRescheduleRunnable = new AtomicReference<>();
-    private volatile boolean enabled;
-    private volatile TimeValue fetchTimeout;
+
     private final ThreadPool threadPool;
     private final Client client;
     private final List<Consumer<ClusterInfo>> listeners = new CopyOnWriteArrayList<>();
+
+    private final Object mutex = new Object();
+    private final List<ActionListener<ClusterInfo>> nextRefreshListeners = new ArrayList<>();
+    private AsyncRefresh currentRefresh;
+    private RefreshScheduler refreshScheduler;
 
     public InternalClusterInfoService(Settings settings, ClusterService clusterService, ThreadPool threadPool, Client client) {
         this.leastAvailableSpaceUsages = ImmutableOpenMap.of();
@@ -127,52 +128,238 @@ public class InternalClusterInfoService implements ClusterInfoService, ClusterSt
 
     @Override
     public void clusterChanged(ClusterChangedEvent event) {
-        if (event.localNodeMaster() && refreshAndRescheduleRunnable.get() == null) {
-            logger.trace("elected as master, scheduling cluster info update tasks");
-            executeRefresh(event.state(), "became master");
+        final Runnable newRefresh;
+        synchronized (mutex) {
+            if (event.localNodeMaster() == false) {
+                refreshScheduler = null;
+                return;
+            }
 
-            final RefreshAndRescheduleRunnable newRunnable = new RefreshAndRescheduleRunnable();
-            refreshAndRescheduleRunnable.set(newRunnable);
-            threadPool.scheduleUnlessShuttingDown(updateFrequency, REFRESH_EXECUTOR, newRunnable);
-        } else if (event.localNodeMaster() == false) {
-            refreshAndRescheduleRunnable.set(null);
-            return;
+            if (refreshScheduler == null) {
+                logger.trace("elected as master, scheduling cluster info update tasks");
+                refreshScheduler = new RefreshScheduler();
+                nextRefreshListeners.add(refreshScheduler.getListener());
+            }
+            newRefresh = getNewRefresh();
+            assert assertRefreshInvariant();
         }
-
-        if (enabled == false) {
-            return;
-        }
+        newRefresh.run();
 
         // Refresh if a data node was added
         for (DiscoveryNode addedNode : event.nodesDelta().addedNodes()) {
             if (addedNode.isDataNode()) {
-                executeRefresh(event.state(), "data node added");
+                refreshAsync(new PlainActionFuture<>());
                 break;
             }
         }
+    }
 
-        // Clean up info for any removed nodes
-        for (DiscoveryNode removedNode : event.nodesDelta().removedNodes()) {
-            if (removedNode.isDataNode()) {
-                logger.trace("Removing node from cluster info: {}", removedNode.getId());
-                if (leastAvailableSpaceUsages.containsKey(removedNode.getId())) {
-                    ImmutableOpenMap.Builder<String, DiskUsage> newMaxUsages = ImmutableOpenMap.builder(leastAvailableSpaceUsages);
-                    newMaxUsages.remove(removedNode.getId());
-                    leastAvailableSpaceUsages = newMaxUsages.build();
+    private class AsyncRefresh {
+
+        private final List<ActionListener<ClusterInfo>> thisRefreshListeners;
+        private final CountDown countDown = new CountDown(2);
+
+        AsyncRefresh(List<ActionListener<ClusterInfo>> thisRefreshListeners) {
+            this.thisRefreshListeners = thisRefreshListeners;
+        }
+
+        void execute() {
+            assert countDown.isCountedDown() == false;
+
+            logger.trace("starting async refresh");
+
+            final NodesStatsRequest nodesStatsRequest = new NodesStatsRequest("data:true");
+            nodesStatsRequest.clear();
+            nodesStatsRequest.addMetric(NodesStatsRequest.Metric.FS.metricName());
+            nodesStatsRequest.timeout(fetchTimeout);
+            client.admin().cluster().nodesStats(nodesStatsRequest, ActionListener.runAfter(new ActionListener<NodesStatsResponse>() {
+                @Override
+                public void onResponse(NodesStatsResponse nodesStatsResponse) {
+                    logger.trace("received node stats response");
+
+                    for (final FailedNodeException failure : nodesStatsResponse.failures()) {
+                        final Throwable cause = failure.getCause();
+                        if (logger.isDebugEnabled()) {
+                            logger.warn(new ParameterizedMessage("failed to retrieve stats for node [{}]", failure.nodeId()), cause);
+                        } else {
+                            logger.warn("failed to retrieve stats for node [{}]: {}", failure.nodeId(), cause.getMessage());
+                        }
+                    }
+
+                    ImmutableOpenMap.Builder<String, DiskUsage> leastAvailableUsagesBuilder = ImmutableOpenMap.builder();
+                    ImmutableOpenMap.Builder<String, DiskUsage> mostAvailableUsagesBuilder = ImmutableOpenMap.builder();
+                    fillDiskUsagePerNode(adjustNodesStats(nodesStatsResponse.getNodes()),
+                            leastAvailableUsagesBuilder, mostAvailableUsagesBuilder);
+                    leastAvailableSpaceUsages = leastAvailableUsagesBuilder.build();
+                    mostAvailableSpaceUsages = mostAvailableUsagesBuilder.build();
                 }
-                if (mostAvailableSpaceUsages.containsKey(removedNode.getId())) {
-                    ImmutableOpenMap.Builder<String, DiskUsage> newMinUsages = ImmutableOpenMap.builder(mostAvailableSpaceUsages);
-                    newMinUsages.remove(removedNode.getId());
-                    mostAvailableSpaceUsages = newMinUsages.build();
+
+                @Override
+                public void onFailure(Exception e) {
+                    if (e instanceof ClusterBlockException) {
+                        logger.trace("failed to retrieve node stats", e);
+                    } else {
+                        logger.warn("failed to retrieve node stats", e);
+                    }
+                    leastAvailableSpaceUsages = ImmutableOpenMap.of();
+                    mostAvailableSpaceUsages = ImmutableOpenMap.of();
+                }
+            }, this::onStatsProcessed));
+
+            final IndicesStatsRequest indicesStatsRequest = new IndicesStatsRequest();
+            indicesStatsRequest.clear();
+            indicesStatsRequest.store(true);
+            indicesStatsRequest.indicesOptions(IndicesOptions.STRICT_EXPAND_OPEN_CLOSED_HIDDEN);
+            indicesStatsRequest.timeout(fetchTimeout);
+            client.admin().indices().stats(indicesStatsRequest, ActionListener.runAfter(new ActionListener<IndicesStatsResponse>() {
+                @Override
+                public void onResponse(IndicesStatsResponse indicesStatsResponse) {
+                    logger.trace("received indices stats response");
+
+                    if (indicesStatsResponse.getShardFailures().length > 0) {
+                        final Set<String> failedNodeIds = new HashSet<>();
+                        for (final DefaultShardOperationFailedException shardFailure : indicesStatsResponse.getShardFailures()) {
+                            if (shardFailure.getCause() instanceof FailedNodeException) {
+                                final FailedNodeException failedNodeException = (FailedNodeException) shardFailure.getCause();
+                                if (failedNodeIds.add(failedNodeException.nodeId())) {
+                                    if (logger.isDebugEnabled()) {
+                                        logger.warn(new ParameterizedMessage("failed to retrieve shard stats from node [{}]",
+                                                failedNodeException.nodeId()), failedNodeException);
+                                    } else {
+                                        logger.warn("failed to retrieve shard stats from node [{}]: {}",
+                                                failedNodeException.nodeId(), failedNodeException.getCause().getMessage());
+                                    }
+                                }
+                                logger.trace(new ParameterizedMessage("failed to retrieve stats for shard [{}][{}]",
+                                        shardFailure.index(), shardFailure.shardId()), shardFailure.getCause());
+                            } else {
+                                logger.warn(new ParameterizedMessage("failed to retrieve stats for shard [{}][{}]",
+                                        shardFailure.index(), shardFailure.shardId()), shardFailure.getCause());
+                            }
+                        }
+                    }
+
+                    final ShardStats[] stats = indicesStatsResponse.getShards();
+                    final ImmutableOpenMap.Builder<String, Long> shardSizeByIdentifierBuilder = ImmutableOpenMap.builder();
+                    final ImmutableOpenMap.Builder<ShardRouting, String> dataPathByShardRoutingBuilder = ImmutableOpenMap.builder();
+                    final Map<ClusterInfo.NodeAndPath, ClusterInfo.ReservedSpace.Builder> reservedSpaceBuilders = new HashMap<>();
+                    buildShardLevelInfo(stats, shardSizeByIdentifierBuilder, dataPathByShardRoutingBuilder, reservedSpaceBuilders);
+
+                    final ImmutableOpenMap.Builder<ClusterInfo.NodeAndPath, ClusterInfo.ReservedSpace> rsrvdSpace
+                            = ImmutableOpenMap.builder();
+                    reservedSpaceBuilders.forEach((nodeAndPath, builder) -> rsrvdSpace.put(nodeAndPath, builder.build()));
+
+                    indicesStatsSummary = new IndicesStatsSummary(
+                            shardSizeByIdentifierBuilder.build(),
+                            dataPathByShardRoutingBuilder.build(),
+                            rsrvdSpace.build());
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    if (e instanceof ClusterBlockException) {
+                        logger.trace("failed to retrieve indices stats", e);
+                    } else {
+                        logger.warn("failed to retrieve indices stats", e);
+                    }
+                    indicesStatsSummary = IndicesStatsSummary.EMPTY;
+                }
+            }, this::onStatsProcessed));
+        }
+
+        private void onStatsProcessed() {
+            if (countDown.countDown()) {
+                logger.trace("stats all received, computing cluster info and notifying listeners");
+                try {
+                    final ClusterInfo clusterInfo = getClusterInfo();
+                    boolean anyListeners = false;
+                    for (final Consumer<ClusterInfo> listener : listeners) {
+                        anyListeners = true;
+                        try {
+                            logger.trace("notifying [{}] of new cluster info", listener);
+                            listener.accept(clusterInfo);
+                        } catch (Exception e) {
+                            logger.info(new ParameterizedMessage("failed to notify [{}] of new cluster info", listener), e);
+                        }
+                    }
+                    assert anyListeners : "expected to notify at least one listener";
+
+                    for (final ActionListener<ClusterInfo> listener : thisRefreshListeners) {
+                        listener.onResponse(clusterInfo);
+                    }
+                } finally {
+                    onRefreshComplete(this);
                 }
             }
         }
     }
 
-    private void executeRefresh(ClusterState clusterState, String reason) {
-        if (clusterState.nodes().getDataNodes().size() > 1) {
-            logger.trace("refreshing cluster info in background [{}]", reason);
-            threadPool.executor(REFRESH_EXECUTOR).execute(new RefreshRunnable(reason));
+    private void onRefreshComplete(AsyncRefresh completedRefresh) {
+        final Runnable newRefresh;
+        synchronized (mutex) {
+            assert currentRefresh == completedRefresh;
+            currentRefresh = null;
+
+            // We only ever run one refresh at once; if another refresh was requested while this one was running then we must start another
+            // to ensure that the stats it sees are up-to-date.
+            newRefresh = getNewRefresh();
+            assert assertRefreshInvariant();
+        }
+        newRefresh.run();
+    }
+
+    private Runnable getNewRefresh() {
+        assert Thread.holdsLock(mutex) : "mutex not held";
+
+        if (currentRefresh != null) {
+            return () -> {};
+        }
+
+        if (nextRefreshListeners.isEmpty()) {
+            return () -> {};
+        }
+
+        final ArrayList<ActionListener<ClusterInfo>> thisRefreshListeners = new ArrayList<>(nextRefreshListeners);
+        nextRefreshListeners.clear();
+
+        if (enabled) {
+            currentRefresh = new AsyncRefresh(thisRefreshListeners);
+            return currentRefresh::execute;
+        } else {
+            return () -> {
+                leastAvailableSpaceUsages = ImmutableOpenMap.of();
+                mostAvailableSpaceUsages = ImmutableOpenMap.of();
+                indicesStatsSummary = IndicesStatsSummary.EMPTY;
+                thisRefreshListeners.forEach(l -> l.onResponse(ClusterInfo.EMPTY));
+            };
+        }
+    }
+
+    private boolean assertRefreshInvariant() {
+        assert Thread.holdsLock(mutex) : "mutex not held";
+        // We never leave a refresh listener waiting unless we're already refreshing (which will pick up the waiting listener on completion)
+        assert nextRefreshListeners.isEmpty() || currentRefresh != null;
+        return true;
+    }
+
+    private class RefreshScheduler {
+
+        ActionListener<ClusterInfo> getListener() {
+            return ActionListener.wrap(() -> {
+                if (shouldRefresh()) {
+                    threadPool.scheduleUnlessShuttingDown(updateFrequency, ThreadPool.Names.SAME, () -> {
+                        if (shouldRefresh()) {
+                            refreshAsync(getListener());
+                        }
+                    });
+                }
+            });
+        }
+
+        private boolean shouldRefresh() {
+            synchronized (mutex) {
+                return refreshScheduler == this;
+            }
         }
     }
 
@@ -183,139 +370,19 @@ public class InternalClusterInfoService implements ClusterInfoService, ClusterSt
             indicesStatsSummary.shardSizes, indicesStatsSummary.shardRoutingToDataPath, indicesStatsSummary.reservedSpace);
     }
 
-    /**
-     * Retrieve the latest nodes stats, calling the listener when complete
-     * @return a latch that can be used to wait for the nodes stats to complete if desired
-     */
-    protected CountDownLatch updateNodeStats(final ActionListener<NodesStatsResponse> listener) {
-        final CountDownLatch latch = new CountDownLatch(1);
-        final NodesStatsRequest nodesStatsRequest = new NodesStatsRequest("data:true");
-        nodesStatsRequest.clear();
-        nodesStatsRequest.addMetric(NodesStatsRequest.Metric.FS.metricName());
-        nodesStatsRequest.timeout(fetchTimeout);
-        client.admin().cluster().nodesStats(nodesStatsRequest, new LatchedActionListener<>(listener, latch));
-        return latch;
-    }
-
-    /**
-     * Retrieve the latest indices stats, calling the listener when complete
-     * @return a latch that can be used to wait for the indices stats to complete if desired
-     */
-    protected CountDownLatch updateIndicesStats(final ActionListener<IndicesStatsResponse> listener) {
-        final CountDownLatch latch = new CountDownLatch(1);
-        final IndicesStatsRequest indicesStatsRequest = new IndicesStatsRequest();
-        indicesStatsRequest.clear();
-        indicesStatsRequest.store(true);
-        indicesStatsRequest.indicesOptions(IndicesOptions.STRICT_EXPAND_OPEN_CLOSED_HIDDEN);
-
-        client.admin().indices().stats(indicesStatsRequest, new LatchedActionListener<>(listener, latch));
-        return latch;
-    }
-
     // allow tests to adjust the node stats on receipt
     List<NodeStats> adjustNodesStats(List<NodeStats> nodeStats) {
         return nodeStats;
     }
 
-    /**
-     * Refreshes the ClusterInfo in a blocking fashion
-     */
-    public final ClusterInfo refresh() {
-        logger.trace("refreshing cluster info");
-        final CountDownLatch nodeLatch = updateNodeStats(new ActionListener<NodesStatsResponse>() {
-            @Override
-            public void onResponse(NodesStatsResponse nodesStatsResponse) {
-                ImmutableOpenMap.Builder<String, DiskUsage> leastAvailableUsagesBuilder = ImmutableOpenMap.builder();
-                ImmutableOpenMap.Builder<String, DiskUsage> mostAvailableUsagesBuilder = ImmutableOpenMap.builder();
-                fillDiskUsagePerNode(logger, adjustNodesStats(nodesStatsResponse.getNodes()),
-                    leastAvailableUsagesBuilder, mostAvailableUsagesBuilder);
-                leastAvailableSpaceUsages = leastAvailableUsagesBuilder.build();
-                mostAvailableSpaceUsages = mostAvailableUsagesBuilder.build();
-            }
-
-            @Override
-            public void onFailure(Exception e) {
-                if (e instanceof ReceiveTimeoutTransportException) {
-                    logger.error("NodeStatsAction timed out for ClusterInfoUpdateJob", e);
-                } else {
-                    if (e instanceof ClusterBlockException) {
-                        if (logger.isTraceEnabled()) {
-                            logger.trace("Failed to execute NodeStatsAction for ClusterInfoUpdateJob", e);
-                        }
-                    } else {
-                        logger.warn("Failed to execute NodeStatsAction for ClusterInfoUpdateJob", e);
-                    }
-                    // we empty the usages list, to be safe - we don't know what's going on.
-                    leastAvailableSpaceUsages = ImmutableOpenMap.of();
-                    mostAvailableSpaceUsages = ImmutableOpenMap.of();
-                }
-            }
-        });
-
-        final CountDownLatch indicesLatch = updateIndicesStats(new ActionListener<IndicesStatsResponse>() {
-            @Override
-            public void onResponse(IndicesStatsResponse indicesStatsResponse) {
-                final ShardStats[] stats = indicesStatsResponse.getShards();
-                final ImmutableOpenMap.Builder<String, Long> shardSizeByIdentifierBuilder = ImmutableOpenMap.builder();
-                final ImmutableOpenMap.Builder<ShardRouting, String> dataPathByShardRoutingBuilder = ImmutableOpenMap.builder();
-                final Map<ClusterInfo.NodeAndPath, ClusterInfo.ReservedSpace.Builder> reservedSpaceBuilders = new HashMap<>();
-                buildShardLevelInfo(logger, stats, shardSizeByIdentifierBuilder, dataPathByShardRoutingBuilder, reservedSpaceBuilders);
-
-                final ImmutableOpenMap.Builder<ClusterInfo.NodeAndPath, ClusterInfo.ReservedSpace> rsrvdSpace = ImmutableOpenMap.builder();
-                reservedSpaceBuilders.forEach((nodeAndPath, builder) -> rsrvdSpace.put(nodeAndPath, builder.build()));
-
-                indicesStatsSummary = new IndicesStatsSummary(
-                    shardSizeByIdentifierBuilder.build(),
-                    dataPathByShardRoutingBuilder.build(),
-                    rsrvdSpace.build());
-            }
-
-            @Override
-            public void onFailure(Exception e) {
-                if (e instanceof ReceiveTimeoutTransportException) {
-                    logger.error("IndicesStatsAction timed out for ClusterInfoUpdateJob", e);
-                } else {
-                    if (e instanceof ClusterBlockException) {
-                        if (logger.isTraceEnabled()) {
-                            logger.trace("Failed to execute IndicesStatsAction for ClusterInfoUpdateJob", e);
-                        }
-                    } else {
-                        logger.warn("Failed to execute IndicesStatsAction for ClusterInfoUpdateJob", e);
-                    }
-                    // we empty the usages list, to be safe - we don't know what's going on.
-                    indicesStatsSummary = IndicesStatsSummary.EMPTY;
-                }
-            }
-        });
-
-        try {
-            if (nodeLatch.await(fetchTimeout.getMillis(), TimeUnit.MILLISECONDS) == false) {
-                logger.warn("Failed to update node information for ClusterInfoUpdateJob within {} timeout", fetchTimeout);
-            }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt(); // restore interrupt status
+    void refreshAsync(ActionListener<ClusterInfo> future) {
+        final Runnable newRefresh;
+        synchronized (mutex) {
+            nextRefreshListeners.add(future);
+            newRefresh = getNewRefresh();
+            assert assertRefreshInvariant();
         }
-
-        try {
-            if (indicesLatch.await(fetchTimeout.getMillis(), TimeUnit.MILLISECONDS) == false) {
-                logger.warn("Failed to update shard information for ClusterInfoUpdateJob within {} timeout", fetchTimeout);
-            }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt(); // restore interrupt status
-        }
-        ClusterInfo clusterInfo = getClusterInfo();
-        boolean anyListeners = false;
-        for (final Consumer<ClusterInfo> listener : listeners) {
-            anyListeners = true;
-            try {
-                logger.trace("notifying [{}] of new cluster info", listener);
-                listener.accept(clusterInfo);
-            } catch (Exception e) {
-                logger.info(new ParameterizedMessage("failed to notify [{}] of new cluster info", listener), e);
-            }
-        }
-        assert anyListeners : "expected to notify at least one listener";
-        return clusterInfo;
+        newRefresh.run();
     }
 
     @Override
@@ -323,7 +390,7 @@ public class InternalClusterInfoService implements ClusterInfoService, ClusterSt
         listeners.add(clusterInfoConsumer);
     }
 
-    static void buildShardLevelInfo(Logger logger, ShardStats[] stats, ImmutableOpenMap.Builder<String, Long> shardSizes,
+    static void buildShardLevelInfo(ShardStats[] stats, ImmutableOpenMap.Builder<String, Long> shardSizes,
                                     ImmutableOpenMap.Builder<ShardRouting, String> newShardRoutingToDataPath,
                                     Map<ClusterInfo.NodeAndPath, ClusterInfo.ReservedSpace.Builder> reservedSpaceByShard) {
         for (ShardStats s : stats) {
@@ -350,53 +417,61 @@ public class InternalClusterInfoService implements ClusterInfoService, ClusterSt
         }
     }
 
-    static void fillDiskUsagePerNode(Logger logger, List<NodeStats> nodeStatsArray,
+    static void fillDiskUsagePerNode(List<NodeStats> nodeStatsArray,
             ImmutableOpenMap.Builder<String, DiskUsage> newLeastAvailableUsages,
             ImmutableOpenMap.Builder<String, DiskUsage> newMostAvailableUsages) {
         for (NodeStats nodeStats : nodeStatsArray) {
             if (nodeStats.getFs() == null) {
-                logger.warn("Unable to retrieve node FS stats for {}", nodeStats.getNode().getName());
-            } else {
-                FsInfo.Path leastAvailablePath = null;
-                FsInfo.Path mostAvailablePath = null;
-                for (FsInfo.Path info : nodeStats.getFs()) {
-                    if (leastAvailablePath == null) {
-                        assert mostAvailablePath == null;
-                        mostAvailablePath = leastAvailablePath = info;
-                    } else if (leastAvailablePath.getAvailable().getBytes() > info.getAvailable().getBytes()) {
-                        leastAvailablePath = info;
-                    } else if (mostAvailablePath.getAvailable().getBytes() < info.getAvailable().getBytes()) {
-                        mostAvailablePath = info;
-                    }
-                }
-                String nodeId = nodeStats.getNode().getId();
-                String nodeName = nodeStats.getNode().getName();
-                if (logger.isTraceEnabled()) {
-                    logger.trace("node: [{}], most available: total disk: {}," +
-                            " available disk: {} / least available: total disk: {}, available disk: {}",
-                            nodeId, mostAvailablePath.getTotal(), mostAvailablePath.getAvailable(),
-                            leastAvailablePath.getTotal(), leastAvailablePath.getAvailable());
-                }
-                if (leastAvailablePath.getTotal().getBytes() < 0) {
-                    if (logger.isTraceEnabled()) {
-                        logger.trace("node: [{}] least available path has less than 0 total bytes of disk [{}], skipping",
-                                nodeId, leastAvailablePath.getTotal().getBytes());
-                    }
-                } else {
-                    newLeastAvailableUsages.put(nodeId, new DiskUsage(nodeId, nodeName, leastAvailablePath.getPath(),
-                        leastAvailablePath.getTotal().getBytes(), leastAvailablePath.getAvailable().getBytes()));
-                }
-                if (mostAvailablePath.getTotal().getBytes() < 0) {
-                    if (logger.isTraceEnabled()) {
-                        logger.trace("node: [{}] most available path has less than 0 total bytes of disk [{}], skipping",
-                                nodeId, mostAvailablePath.getTotal().getBytes());
-                    }
-                } else {
-                    newMostAvailableUsages.put(nodeId, new DiskUsage(nodeId, nodeName, mostAvailablePath.getPath(),
-                        mostAvailablePath.getTotal().getBytes(), mostAvailablePath.getAvailable().getBytes()));
-                }
-
+                logger.warn("node [{}/{}] did not return any filesystem stats", nodeStats.getNode().getName(), nodeStats.getNode().getId());
+                continue;
             }
+
+            FsInfo.Path leastAvailablePath = null;
+            FsInfo.Path mostAvailablePath = null;
+            for (FsInfo.Path info : nodeStats.getFs()) {
+                if (leastAvailablePath == null) {
+                    //noinspection ConstantConditions this assertion is for the benefit of readers, it's always true
+                    assert mostAvailablePath == null;
+                    mostAvailablePath = leastAvailablePath = info;
+                } else if (leastAvailablePath.getAvailable().getBytes() > info.getAvailable().getBytes()) {
+                    leastAvailablePath = info;
+                } else if (mostAvailablePath.getAvailable().getBytes() < info.getAvailable().getBytes()) {
+                    mostAvailablePath = info;
+                }
+            }
+            if (leastAvailablePath == null) {
+                //noinspection ConstantConditions this assertion is for the benefit of readers, it's always true
+                assert mostAvailablePath == null;
+                logger.warn("node [{}/{}] did not return any filesystem stats", nodeStats.getNode().getName(), nodeStats.getNode().getId());
+                continue;
+            }
+
+            final String nodeId = nodeStats.getNode().getId();
+            final String nodeName = nodeStats.getNode().getName();
+            if (logger.isTraceEnabled()) {
+                logger.trace("node [{}]: most available: total: {}, available: {} / least available: total: {}, available: {}",
+                        nodeId, mostAvailablePath.getTotal(), mostAvailablePath.getAvailable(),
+                        leastAvailablePath.getTotal(), leastAvailablePath.getAvailable());
+            }
+            if (leastAvailablePath.getTotal().getBytes() < 0) {
+                if (logger.isTraceEnabled()) {
+                    logger.trace("node: [{}] least available path has less than 0 total bytes of disk [{}], skipping",
+                            nodeId, leastAvailablePath.getTotal().getBytes());
+                }
+            } else {
+                newLeastAvailableUsages.put(nodeId, new DiskUsage(nodeId, nodeName, leastAvailablePath.getPath(),
+                    leastAvailablePath.getTotal().getBytes(), leastAvailablePath.getAvailable().getBytes()));
+            }
+            if (mostAvailablePath.getTotal().getBytes() < 0) {
+                if (logger.isTraceEnabled()) {
+                    logger.trace("node: [{}] most available path has less than 0 total bytes of disk [{}], skipping",
+                            nodeId, mostAvailablePath.getTotal().getBytes());
+                }
+            } else {
+                newMostAvailableUsages.put(nodeId, new DiskUsage(nodeId, nodeName, mostAvailablePath.getPath(),
+                    mostAvailablePath.getTotal().getBytes(), mostAvailablePath.getAvailable().getBytes()));
+            }
+
         }
     }
 
@@ -417,63 +492,4 @@ public class InternalClusterInfoService implements ClusterInfoService, ClusterSt
         }
     }
 
-    /**
-     * Runs {@link InternalClusterInfoService#refresh()}, logging failures/rejections appropriately.
-     */
-    private class RefreshRunnable extends AbstractRunnable {
-        private final String reason;
-
-        RefreshRunnable(String reason) {
-            this.reason = reason;
-        }
-
-        @Override
-        protected void doRun() {
-            if (enabled) {
-                logger.trace("refreshing cluster info [{}]", reason);
-                refresh();
-            } else {
-                logger.trace("skipping cluster info refresh [{}] since it is disabled", reason);
-            }
-        }
-
-        @Override
-        public void onFailure(Exception e) {
-            logger.warn(new ParameterizedMessage("refreshing cluster info failed [{}]", reason), e);
-        }
-
-
-        @Override
-        public void onRejection(Exception e) {
-            final boolean shutDown = e instanceof EsRejectedExecutionException && ((EsRejectedExecutionException) e).isExecutorShutdown();
-            logger.log(shutDown ? Level.DEBUG : Level.WARN, "refreshing cluster info rejected [{}]", reason, e);
-        }
-    }
-
-
-    /**
-     * Runs {@link InternalClusterInfoService#refresh()}, logging failures/rejections appropriately, and reschedules itself on completion.
-     */
-    private class RefreshAndRescheduleRunnable extends RefreshRunnable {
-        RefreshAndRescheduleRunnable() {
-            super("scheduled");
-        }
-
-        @Override
-        protected void doRun() {
-            if (this == refreshAndRescheduleRunnable.get()) {
-                super.doRun();
-            } else {
-                logger.trace("master changed, scheduled refresh job is stale");
-            }
-        }
-
-        @Override
-        public void onAfter() {
-            if (this == refreshAndRescheduleRunnable.get()) {
-                logger.trace("scheduling next cluster info refresh in [{}]", updateFrequency);
-                threadPool.scheduleUnlessShuttingDown(updateFrequency, REFRESH_EXECUTOR, this);
-            }
-        }
-    }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/DiskUsageTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/DiskUsageTests.java
@@ -120,7 +120,7 @@ public class DiskUsageTests extends ESTestCase {
         ImmutableOpenMap.Builder<String, Long> shardSizes = ImmutableOpenMap.builder();
         ImmutableOpenMap.Builder<ShardRouting, String> routingToPath = ImmutableOpenMap.builder();
         ClusterState state = ClusterState.builder(new ClusterName("blarg")).version(0).build();
-        InternalClusterInfoService.buildShardLevelInfo(logger, stats, shardSizes, routingToPath, new HashMap<>());
+        InternalClusterInfoService.buildShardLevelInfo(stats, shardSizes, routingToPath, new HashMap<>());
         assertEquals(2, shardSizes.size());
         assertTrue(shardSizes.containsKey(ClusterInfo.shardIdentifierFromRouting(test_0)));
         assertTrue(shardSizes.containsKey(ClusterInfo.shardIdentifierFromRouting(test_1)));
@@ -161,7 +161,7 @@ public class DiskUsageTests extends ESTestCase {
                         null,null,null,null,null, new FsInfo(0, null, node3FSInfo), null,null,null,null,null, null, null,
                         null, null)
         );
-        InternalClusterInfoService.fillDiskUsagePerNode(logger, nodeStats, newLeastAvaiableUsages, newMostAvaiableUsages);
+        InternalClusterInfoService.fillDiskUsagePerNode(nodeStats, newLeastAvaiableUsages, newMostAvaiableUsages);
         DiskUsage leastNode_1 = newLeastAvaiableUsages.get("node_1");
         DiskUsage mostNode_1 = newMostAvaiableUsages.get("node_1");
         assertDiskUsage(mostNode_1, node1FSInfo[2]);
@@ -205,7 +205,7 @@ public class DiskUsageTests extends ESTestCase {
                         null,null,null,null,null, new FsInfo(0, null, node3FSInfo), null,null,null,null,null, null, null,
                         null, null)
         );
-        InternalClusterInfoService.fillDiskUsagePerNode(logger, nodeStats, newLeastAvailableUsages, newMostAvailableUsages);
+        InternalClusterInfoService.fillDiskUsagePerNode(nodeStats, newLeastAvailableUsages, newMostAvailableUsages);
         DiskUsage leastNode_1 = newLeastAvailableUsages.get("node_1");
         DiskUsage mostNode_1 = newMostAvailableUsages.get("node_1");
         assertNull("node1 should have been skipped", leastNode_1);

--- a/test/framework/src/main/java/org/elasticsearch/cluster/ClusterInfoServiceUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/ClusterInfoServiceUtils.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.cluster.service.ClusterApplierService;
+
+import java.util.concurrent.TimeUnit;
+
+public class ClusterInfoServiceUtils {
+
+    private static final Logger logger = LogManager.getLogger(ClusterInfoServiceUtils.class);
+
+    public static ClusterInfo refresh(InternalClusterInfoService internalClusterInfoService) {
+        logger.trace("refreshing cluster info");
+        final PlainActionFuture<ClusterInfo> future = new PlainActionFuture<ClusterInfo>(){
+            @Override
+            protected boolean blockingAllowed() {
+                // In tests we permit blocking the applier thread here so that we know a followup reroute isn't working with stale data.
+                return Thread.currentThread().getName().contains(ClusterApplierService.CLUSTER_UPDATE_THREAD_NAME)
+                        || super.blockingAllowed();
+            }
+        };
+        internalClusterInfoService.refreshAsync(future);
+        try {
+            return future.actionGet(10, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            throw new AssertionError(e);
+        }
+    }
+}

--- a/test/framework/src/main/java/org/elasticsearch/cluster/MockInternalClusterInfoService.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/MockInternalClusterInfoService.java
@@ -54,12 +54,12 @@ public class MockInternalClusterInfoService extends InternalClusterInfoService {
 
     public void setDiskUsageFunctionAndRefresh(BiFunction<DiscoveryNode, FsInfo.Path, FsInfo.Path> diskUsageFunction) {
         this.diskUsageFunction = diskUsageFunction;
-        refresh();
+        ClusterInfoServiceUtils.refresh(this);
     }
 
     public void setShardSizeFunctionAndRefresh(Function<ShardRouting, Long> shardSizeFunction) {
         this.shardSizeFunction = shardSizeFunction;
-        refresh();
+        ClusterInfoServiceUtils.refresh(this);
     }
 
     @Override

--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/storage/AutoscalingStorageIntegTestCase.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/storage/AutoscalingStorageIntegTestCase.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.autoscaling.storage;
 
 import org.elasticsearch.cluster.ClusterInfoService;
+import org.elasticsearch.cluster.ClusterInfoServiceUtils;
 import org.elasticsearch.cluster.DiskUsageIntegTestCase;
 import org.elasticsearch.cluster.InternalClusterInfoService;
 import org.elasticsearch.cluster.routing.allocation.DiskThresholdSettings;
@@ -45,7 +46,7 @@ public class AutoscalingStorageIntegTestCase extends DiskUsageIntegTestCase {
     public void setTotalSpace(String dataNodeName, long totalSpace) {
         getTestFileStore(dataNodeName).setTotalSpace(totalSpace);
         final ClusterInfoService clusterInfoService = internalCluster().getCurrentMasterNodeInstance(ClusterInfoService.class);
-        ((InternalClusterInfoService) clusterInfoService).refresh();
+        ClusterInfoServiceUtils.refresh(((InternalClusterInfoService) clusterInfoService));
     }
 
     public GetAutoscalingCapacityAction.Response capacity() {

--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageIT.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageIT.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.autoscaling.storage;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.cluster.ClusterInfoService;
+import org.elasticsearch.cluster.ClusterInfoServiceUtils;
 import org.elasticsearch.cluster.InternalClusterInfoService;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -127,7 +128,7 @@ public class ReactiveStorageIT extends AutoscalingStorageIntegTestCase {
     public void setTotalSpace(String dataNodeName, long totalSpace) {
         getTestFileStore(dataNodeName).setTotalSpace(totalSpace);
         final ClusterInfoService clusterInfoService = internalCluster().getCurrentMasterNodeInstance(ClusterInfoService.class);
-        ((InternalClusterInfoService) clusterInfoService).refresh();
+        ClusterInfoServiceUtils.refresh(((InternalClusterInfoService) clusterInfoService));
     }
 
     public GetAutoscalingCapacityAction.Response capacity() {


### PR DESCRIPTION
This commit reworks the InternalClusterInfoService to run
asynchronously, using timeouts on the stats requests instead of
implementing its own blocking timeouts. It also improves the logging of
failures by identifying the nodes that failed or timed out. Finally it
ensures that only a single refresh is running at once, enqueueing later
refresh requests to run immediately after the current refresh is
finished rather than racing them against each other.

Backport of #66993