### PR TITLE
Fix preallocted breaker test failure (backport of #67022)

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/breaker/PreallocatedCircuitBreakerServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/common/breaker/PreallocatedCircuitBreakerServiceTests.java
@@ -21,12 +21,15 @@ package org.elasticsearch.common.breaker;
 
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.elasticsearch.test.ESTestCase;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assume.assumeThat;
 
 public class PreallocatedCircuitBreakerServiceTests extends ESTestCase {
     public void testUseNotPreallocated() {
@@ -87,7 +90,9 @@ public class PreallocatedCircuitBreakerServiceTests extends ESTestCase {
     public void testRandom() {
         try (HierarchyCircuitBreakerService real = real()) {
             CircuitBreaker realBreaker = real.getBreaker(CircuitBreaker.REQUEST);
-            long preallocatedBytes = randomLongBetween(1, realBreaker.getLimit());
+            long limit = ByteSizeValue.ofMb(100).getBytes();
+            assumeThat(limit, lessThanOrEqualTo(realBreaker.getLimit()));
+            long preallocatedBytes = randomLongBetween(1, limit);
             try (PreallocatedCircuitBreakerService preallocated = preallocateRequest(real, preallocatedBytes)) {
                 CircuitBreaker b = preallocated.getBreaker(CircuitBreaker.REQUEST);
                 boolean usedPreallocated = false;
@@ -102,12 +107,12 @@ public class PreallocatedCircuitBreakerServiceTests extends ESTestCase {
                         assertThat(realBreaker.getUsed(), equalTo(preallocatedBytes));
                     }
                     if (current > 0 && randomBoolean()) {
-                        long delta = randomLongBetween(Math.max(-current, -realBreaker.getLimit() / 100), 0);
+                        long delta = randomLongBetween(-Math.min(current, limit / 100), 0);
                         b.addWithoutBreaking(delta);
                         current += delta;
                         continue;
                     }
-                    long delta = randomLongBetween(0, realBreaker.getLimit() / 100);
+                    long delta = randomLongBetween(0, limit / 100);
                     if (randomBoolean()) {
                         b.addWithoutBreaking(delta);
                         current += delta;


### PR DESCRIPTION
The randomized test for pre-allocated breakers would sometimes attempt
to consume the entire request breaker and fail. This limits it to 100mb
and aborts the test if that doesn't fit comfortable into the breaker.

The 100mb limit also fixes another sneaky issue - the randomized values
for the test used to depend on the size of the request breaker which
itself depends on the size of the heap. We run the tests with 512m heap
in gradle but IDEs are kind of the wild west. That made it very
difficult to reproduce the issue.

There is still some heap dependent randomization here, sadly. We use
non-heap dependent randomization to bump the breaker but whether or not
the breaker trips is dependent on heap size. This is, sadly, kind of
inevitable because we want to test against a real breaker so we can make
sure we handle circuit breaking sensibly.
