### PR TITLE
[7.x] [ML] fixes snapshot upgrader for categorization jobs (#67037)

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/JobModelSnapshotUpgrader.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/JobModelSnapshotUpgrader.java
@@ -189,7 +189,13 @@ public final class JobModelSnapshotUpgrader {
                     fieldIndexes.put(field, index++);
                 }
             }
-            fieldIndexes.put(LengthEncodedWriter.CONTROL_FIELD_NAME, index);
+            // field for categorization tokens
+            if (MachineLearning.CATEGORIZATION_TOKENIZATION_IN_JAVA && job.getAnalysisConfig().getCategorizationFieldName() != null) {
+                fieldIndexes.put(LengthEncodedWriter.PRETOKENISED_TOKEN_FIELD, index++);
+            }
+
+            // control field
+            fieldIndexes.put(LengthEncodedWriter.CONTROL_FIELD_NAME, index++);
             return fieldIndexes;
         }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/snapshot/upgrader/SnapshotUpgradeTaskExecutor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/snapshot/upgrader/SnapshotUpgradeTaskExecutor.java
@@ -187,35 +187,24 @@ public class SnapshotUpgradeTaskExecutor extends AbstractJobPersistentTasksExecu
             task::markAsFailed
         );
 
-        // Make sure that the results index is updated if necessary
-        ActionListener<Boolean> configIndexMappingUpdaterListener = ActionListener.wrap(
+        // Try adding the results doc mapping - this updates to the latest version if an old mapping is present
+        ActionListener<Boolean> annotationsIndexUpdateHandler = ActionListener.wrap(
             ack -> ElasticsearchMappings.addDocMappingIfMissing(
                 AnomalyDetectorsIndex.jobResultsAliasedName(jobId),
                 AnomalyDetectorsIndex::resultsMapping,
                 client,
                 clusterState,
                 resultsMappingUpdateHandler),
-            task::markAsFailed
-        );
-
-        // Update the config index mapping if necessary
-        ActionListener<Boolean> annotationsIndexUpdateHandler = ActionListener.wrap(
-            ack -> ElasticsearchMappings.addDocMappingIfMissing(
-                MlConfigIndex.indexName(),
-                MlConfigIndex::mapping,
-                client,
-                clusterState,
-                configIndexMappingUpdaterListener),
             e -> {
                 // Due to a bug in 7.9.0 it's possible that the annotations index already has incorrect mappings
                 // and it would cause more harm than good to block jobs from opening in subsequent releases
                 logger.warn(new ParameterizedMessage("[{}] ML annotations index could not be updated with latest mappings", jobId), e);
                 ElasticsearchMappings.addDocMappingIfMissing(
-                    MlConfigIndex.indexName(),
-                    MlConfigIndex::mapping,
+                    AnomalyDetectorsIndex.jobResultsAliasedName(jobId),
+                    AnomalyDetectorsIndex::resultsMapping,
                     client,
                     clusterState,
-                    configIndexMappingUpdaterListener);
+                    resultsMappingUpdateHandler);
             }
         );
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/snapshot/upgrader/SnapshotUpgradeTaskExecutor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/snapshot/upgrader/SnapshotUpgradeTaskExecutor.java
@@ -187,24 +187,35 @@ public class SnapshotUpgradeTaskExecutor extends AbstractJobPersistentTasksExecu
             task::markAsFailed
         );
 
-        // Try adding the results doc mapping - this updates to the latest version if an old mapping is present
-        ActionListener<Boolean> annotationsIndexUpdateHandler = ActionListener.wrap(
+        // Make sure that the results index is updated if necessary
+        ActionListener<Boolean> configIndexMappingUpdaterListener = ActionListener.wrap(
             ack -> ElasticsearchMappings.addDocMappingIfMissing(
                 AnomalyDetectorsIndex.jobResultsAliasedName(jobId),
                 AnomalyDetectorsIndex::resultsMapping,
                 client,
                 clusterState,
                 resultsMappingUpdateHandler),
+            task::markAsFailed
+        );
+
+        // Update the config index mapping if necessary
+        ActionListener<Boolean> annotationsIndexUpdateHandler = ActionListener.wrap(
+            ack -> ElasticsearchMappings.addDocMappingIfMissing(
+                MlConfigIndex.indexName(),
+                MlConfigIndex::mapping,
+                client,
+                clusterState,
+                configIndexMappingUpdaterListener),
             e -> {
                 // Due to a bug in 7.9.0 it's possible that the annotations index already has incorrect mappings
                 // and it would cause more harm than good to block jobs from opening in subsequent releases
                 logger.warn(new ParameterizedMessage("[{}] ML annotations index could not be updated with latest mappings", jobId), e);
                 ElasticsearchMappings.addDocMappingIfMissing(
-                    AnomalyDetectorsIndex.jobResultsAliasedName(jobId),
-                    AnomalyDetectorsIndex::resultsMapping,
+                    MlConfigIndex.indexName(),
+                    MlConfigIndex::mapping,
                     client,
                     clusterState,
-                    resultsMappingUpdateHandler);
+                    configIndexMappingUpdaterListener);
             }
         );
 

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlJobSnapshotUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlJobSnapshotUpgradeIT.java
@@ -211,7 +211,7 @@ public class MlJobSnapshotUpgradeIT extends AbstractUpgradeTestCase {
         }
         AnalysisConfig.Builder analysisConfig = new AnalysisConfig.Builder(detectors);
         analysisConfig.setBucketSpan(bucketSpan);
-        if (randomBoolean()) {
+        if (isCategorization) {
             analysisConfig.setCategorizationFieldName("text");
         }
         Job.Builder job = new Job.Builder(jobId);

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlJobSnapshotUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlJobSnapshotUpgradeIT.java
@@ -203,8 +203,17 @@ public class MlJobSnapshotUpgradeIT extends AbstractUpgradeTestCase {
     private PutJobResponse buildAndPutJob(String jobId, TimeValue bucketSpan) throws Exception {
         Detector.Builder detector = new Detector.Builder("mean", "value");
         detector.setPartitionFieldName("series");
-        AnalysisConfig.Builder analysisConfig = new AnalysisConfig.Builder(Arrays.asList(detector.build()));
+        List<Detector> detectors = new ArrayList<>();
+        detectors.add(detector.build());
+        boolean isCategorization = randomBoolean();
+        if (isCategorization) {
+            detectors.add(new Detector.Builder("count", null).setByFieldName("mlcategory").build());
+        }
+        AnalysisConfig.Builder analysisConfig = new AnalysisConfig.Builder(detectors);
         analysisConfig.setBucketSpan(bucketSpan);
+        if (randomBoolean()) {
+            analysisConfig.setCategorizationFieldName("text");
+        }
         Job.Builder job = new Job.Builder(jobId);
         job.setAnalysisConfig(analysisConfig);
         DataDescription.Builder dataDescription = new DataDescription.Builder();
@@ -221,6 +230,7 @@ public class MlJobSnapshotUpgradeIT extends AbstractUpgradeTestCase {
                 Map<String, Object> record = new HashMap<>();
                 record.put("time", now);
                 record.put("value", timeAndSeriesToValueFunction.apply(i, field));
+                record.put("text", randomFrom("foo has landed 3", "bar has landed 5", "bar has finished 2", "foo has finished 10"));
                 record.put("series", field);
                 data.add(createJsonRecord(record));
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ML] fixes snapshot upgrader for categorization jobs (#67037)