### PR TITLE
Drop testing against JDK 14

### DIFF
--- a/.ci/matrix-runtime-javas.yml
+++ b/.ci/matrix-runtime-javas.yml
@@ -7,7 +7,6 @@
 
 ES_RUNTIME_JAVA:
   - java11
-  - openjdk14
   - openjdk15
   - openjdk16
   - zulu11


### PR DESCRIPTION
JDK 14 is end of life. This commit drops testing against JDK 14.