### PR TITLE
Make the construction of alias abstractions immutable (#66508)

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexAbstraction.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexAbstraction.java
@@ -18,12 +18,10 @@
  */
 package org.elasticsearch.cluster.metadata;
 
-import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.Tuple;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -180,14 +178,35 @@ public interface IndexAbstraction {
 
         private final String aliasName;
         private final List<IndexMetadata> referenceIndexMetadatas;
-        private final SetOnce<IndexMetadata> writeIndex = new SetOnce<>();
+        private final IndexMetadata writeIndex;
         private final boolean isHidden;
 
-        public Alias(AliasMetadata aliasMetadata, IndexMetadata indexMetadata) {
+        public Alias(AliasMetadata aliasMetadata, List<IndexMetadata> indices) {
             this.aliasName = aliasMetadata.getAlias();
-            this.referenceIndexMetadatas = new ArrayList<>();
-            this.referenceIndexMetadatas.add(indexMetadata);
+            this.referenceIndexMetadatas = indices;
+
+            List<IndexMetadata> writeIndices = indices.stream()
+                .filter(idxMeta -> Boolean.TRUE.equals(idxMeta.getAliases().get(aliasName).writeIndex()))
+                .collect(Collectors.toList());
+
+            if (writeIndices.isEmpty() && referenceIndexMetadatas.size() == 1
+                && referenceIndexMetadatas.get(0).getAliases().get(aliasName).writeIndex() == null) {
+                writeIndices.add(referenceIndexMetadatas.get(0));
+            }
+
+            if (writeIndices.size() == 0) {
+                this.writeIndex = null;
+            } else if (writeIndices.size() == 1) {
+                this.writeIndex = writeIndices.get(0);
+            } else {
+                List<String> writeIndicesStrings = writeIndices.stream()
+                    .map(i -> i.getIndex().getName()).collect(Collectors.toList());
+                throw new IllegalStateException("alias [" + aliasName + "] has more than one write index [" +
+                    Strings.collectionToCommaDelimitedString(writeIndicesStrings) + "]");
+            }
+
             this.isHidden = aliasMetadata.isHidden() == null ? false : aliasMetadata.isHidden();
+            validateAliasProperties();
         }
 
         @Override
@@ -207,7 +226,7 @@ public interface IndexAbstraction {
 
         @Nullable
         public IndexMetadata getWriteIndex() {
-            return writeIndex.get();
+            return writeIndex;
         }
 
         @Override
@@ -254,30 +273,7 @@ public interface IndexAbstraction {
             return referenceIndexMetadatas.get(0).getAliases().get(aliasName);
         }
 
-        void addIndex(IndexMetadata indexMetadata) {
-            this.referenceIndexMetadatas.add(indexMetadata);
-        }
-
-        public void computeAndValidateAliasProperties() {
-            // Validate write indices
-            List<IndexMetadata> writeIndices = referenceIndexMetadatas.stream()
-                .filter(idxMeta -> Boolean.TRUE.equals(idxMeta.getAliases().get(aliasName).writeIndex()))
-                .collect(Collectors.toList());
-
-            if (writeIndices.isEmpty() && referenceIndexMetadatas.size() == 1
-                    && referenceIndexMetadatas.get(0).getAliases().get(aliasName).writeIndex() == null) {
-                writeIndices.add(referenceIndexMetadatas.get(0));
-            }
-
-            if (writeIndices.size() == 1) {
-                writeIndex.set(writeIndices.get(0));
-            } else if (writeIndices.size() > 1) {
-                List<String> writeIndicesStrings = writeIndices.stream()
-                    .map(i -> i.getIndex().getName()).collect(Collectors.toList());
-                throw new IllegalStateException("alias [" + aliasName + "] has more than one write index [" +
-                    Strings.collectionToCommaDelimitedString(writeIndicesStrings) + "]");
-            }
-
+        private void validateAliasProperties() {
             // Validate hidden status
             final Map<Boolean, List<IndexMetadata>> groupedByHiddenStatus = referenceIndexMetadatas.stream()
                 .collect(Collectors.groupingBy(idxMeta -> Boolean.TRUE.equals(idxMeta.getAliases().get(aliasName).isHidden())));

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherIndexingListenerTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherIndexingListenerTests.java
@@ -27,6 +27,7 @@ import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.TestShardRouting;
 import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.index.Index;
@@ -719,8 +720,12 @@ public class WatcherIndexingListenerTests extends ESTestCase {
             // now point the alias, if the watch index is not .watches
             if (watchIndex.equals(Watch.INDEX) == false) {
                 AliasMetadata aliasMetadata = mock(AliasMetadata.class);
-                when(aliasMetadata.alias()).thenReturn(watchIndex);
-                indices.put(Watch.INDEX, new IndexAbstraction.Alias(aliasMetadata, indexMetadata));
+                when(aliasMetadata.writeIndex()).thenReturn(true);
+                when(aliasMetadata.getAlias()).thenReturn(Watch.INDEX);
+                ImmutableOpenMap.Builder<String, AliasMetadata> aliases = ImmutableOpenMap.builder();
+                aliases.put(Watch.INDEX, aliasMetadata);
+                when(indexMetadata.getAliases()).thenReturn(aliases.build());
+                indices.put(Watch.INDEX, new IndexAbstraction.Alias(aliasMetadata, Collections.singletonList(indexMetadata)));
             }
 
             when(metadata.getIndicesLookup()).thenReturn(indices);


### PR DESCRIPTION
Backport of #66508 to 7.x branch.

and change validation to be an implementation detail and
part of construction of the alias abstraction.

This change is part of series of changes to clean up the usage
IndexAbstraction.Alias in the codebase, so that it is no longer
needed to cast to IndexAbstraction.Alias and just use the methods
on the IndexAbstraction interface. This should help adding data
stream aliases, so that IndexAbstraction instances of type ALIAS
can also be data stream aliases.

Relates to #66163