### PR TITLE
Test: fix testValidatePhases for delete phase

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ilm/LifecyclePolicyTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ilm/LifecyclePolicyTests.java
@@ -99,7 +99,8 @@ public class LifecyclePolicyTests extends AbstractXContentTestCase<LifecyclePoli
             phaseName += randomAlphaOfLength(5);
         }
         Map<String, Phase> phases = Collections.singletonMap(phaseName,
-            new Phase(phaseName, TimeValue.ZERO, Collections.emptyMap()));
+            new Phase(phaseName, TimeValue.ZERO, phaseName.equals("delete") ? Collections.singletonMap(DeleteAction.NAME,
+                new DeleteAction()) : Collections.emptyMap()));
         if (invalid) {
             Exception e = expectThrows(IllegalArgumentException.class, () -> new LifecyclePolicy(lifecycleName, phases));
             assertThat(e.getMessage(), equalTo("Lifecycle does not support phase [" + phaseName + "]"));


### PR DESCRIPTION
The delete phase can no longer be defined as empty (since #66664), it requires 
at least one action to be defined. This fixes the test that used an empty collection
of actions for the delete phase to include the delete action. 
