### PR TITLE
Stop Copying Large Byte Arrays from Transport Messages (#65921)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/index/store/CorruptedFileIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/store/CorruptedFileIT.java
@@ -47,6 +47,7 @@ import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDeci
 import org.elasticsearch.cluster.routing.allocation.decider.ThrottlingAllocationDecider;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.common.io.PathUtils;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.lucene.Lucene;
@@ -436,7 +437,8 @@ public class CorruptedFileIT extends ESIntegTestCase {
                         BytesRef bytesRef = req.content().toBytesRef();
                         BytesArray array = new BytesArray(bytesRef.bytes, bytesRef.offset, (int) req.length() - 1);
                         request = new RecoveryFileChunkRequest(req.recoveryId(), req.requestSeqNo(), req.shardId(), req.metadata(),
-                            req.position(), array, req.lastChunk(), req.totalTranslogOps(), req.sourceThrottleTimeInNanos());
+                            req.position(), ReleasableBytesReference.wrap(array), req.lastChunk(), req.totalTranslogOps(),
+                            req.sourceThrottleTimeInNanos());
                     } else {
                         assert req.content().toBytesRef().bytes == req.content().toBytesRef().bytes : "no internal reference!!";
                         final byte[] array = req.content().toBytesRef().bytes;

--- a/server/src/main/java/org/elasticsearch/common/bytes/AbstractBytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/AbstractBytesReference.java
@@ -23,7 +23,6 @@ import org.apache.lucene.util.BytesRefIterator;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
-import java.io.EOFException;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.function.ToIntBiFunction;
@@ -50,7 +49,7 @@ public abstract class AbstractBytesReference implements BytesReference {
 
     @Override
     public StreamInput streamInput() throws IOException {
-        return new BytesReferenceStreamInput();
+        return new BytesReferenceStreamInput(this);
     }
 
     @Override
@@ -186,153 +185,4 @@ public abstract class AbstractBytesReference implements BytesReference {
         return builder.value(bytes.bytes, bytes.offset, bytes.length);
     }
 
-    /**
-     * A StreamInput that reads off a {@link BytesRefIterator}. This is used to provide
-     * generic stream access to {@link BytesReference} instances without materializing the
-     * underlying bytes.
-     */
-    private final class BytesReferenceStreamInput extends StreamInput {
-
-        private BytesRefIterator iterator;
-        private int sliceIndex;
-        private BytesRef slice;
-        private int sliceStartOffset; // the offset on the stream at which the current slice starts
-
-        private int mark = 0;
-
-        BytesReferenceStreamInput() throws IOException {
-            this.iterator = iterator();
-            this.slice = iterator.next();
-            this.sliceStartOffset = 0;
-            this.sliceIndex = 0;
-        }
-
-        @Override
-        public byte readByte() throws IOException {
-            if (offset() >= length()) {
-                throw new EOFException();
-            }
-            maybeNextSlice();
-            return slice.bytes[slice.offset + (sliceIndex++)];
-        }
-
-        private int offset() {
-            return sliceStartOffset + sliceIndex;
-        }
-
-        private void maybeNextSlice() throws IOException {
-            while (sliceIndex == slice.length) {
-                sliceStartOffset += sliceIndex;
-                slice = iterator.next();
-                sliceIndex = 0;
-                if (slice == null) {
-                    throw new EOFException();
-                }
-            }
-        }
-
-        @Override
-        public void readBytes(byte[] b, int bOffset, int len) throws IOException {
-            final int length = length();
-            final int offset = offset();
-            if (offset + len > length) {
-                throw new IndexOutOfBoundsException(
-                        "Cannot read " + len + " bytes from stream with length " + length + " at offset " + offset);
-            }
-            final int bytesRead = read(b, bOffset, len);
-            assert bytesRead == len : bytesRead + " vs " + len;
-        }
-
-        @Override
-        public int read() throws IOException {
-            if (offset() >= length()) {
-                return -1;
-            }
-            return Byte.toUnsignedInt(readByte());
-        }
-
-        @Override
-        public int read(final byte[] b, final int bOffset, final int len) throws IOException {
-            final int length = length();
-            final int offset = offset();
-            if (offset >= length) {
-                return -1;
-            }
-            final int numBytesToCopy = Math.min(len, length - offset);
-            int remaining = numBytesToCopy; // copy the full length or the remaining part
-            int destOffset = bOffset;
-            while (remaining > 0) {
-                maybeNextSlice();
-                final int currentLen = Math.min(remaining, slice.length - sliceIndex);
-                assert currentLen > 0 : "length has to be > 0 to make progress but was: " + currentLen;
-                System.arraycopy(slice.bytes, slice.offset + sliceIndex, b, destOffset, currentLen);
-                destOffset += currentLen;
-                remaining -= currentLen;
-                sliceIndex += currentLen;
-                assert remaining >= 0 : "remaining: " + remaining;
-            }
-            return numBytesToCopy;
-        }
-
-        @Override
-        public void close() {
-            // do nothing
-        }
-
-        @Override
-        public int available() {
-            return length() - offset();
-        }
-
-        @Override
-        protected void ensureCanReadBytes(int bytesToRead) throws EOFException {
-            int bytesAvailable = length() - offset();
-            if (bytesAvailable < bytesToRead) {
-                throw new EOFException("tried to read: " + bytesToRead + " bytes but only " + bytesAvailable + " remaining");
-            }
-        }
-
-        @Override
-        public long skip(long n) throws IOException {
-            if (n <= 0L) {
-                return 0L;
-            }
-            assert offset() <= length() : offset() + " vs " + length();
-            final int numBytesSkipped = (int)Math.min(n, length() - offset()); // definitely >= 0 and <= Integer.MAX_VALUE so casting is ok
-            int remaining = numBytesSkipped;
-            while (remaining > 0) {
-                maybeNextSlice();
-                int currentLen = Math.min(remaining, slice.length - sliceIndex);
-                remaining -= currentLen;
-                sliceIndex += currentLen;
-                assert remaining >= 0 : "remaining: " + remaining;
-            }
-            return numBytesSkipped;
-        }
-
-        @Override
-        public void reset() throws IOException {
-            if (sliceStartOffset <= mark) {
-                sliceIndex = mark - sliceStartOffset;
-            } else {
-                iterator = iterator();
-                slice = iterator.next();
-                sliceStartOffset = 0;
-                sliceIndex = 0;
-                final long skipped = skip(mark);
-                assert skipped == mark : skipped + " vs " + mark;
-            }
-        }
-
-        @Override
-        public boolean markSupported() {
-            return true;
-        }
-
-        @Override
-        public void mark(int readLimit) {
-            // We ignore readLimit since the data is all in-memory and therefore we can reset the mark no matter how far we advance.
-            this.mark = offset();
-        }
-    }
 }

--- a/server/src/main/java/org/elasticsearch/common/bytes/BytesReferenceStreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/BytesReferenceStreamInput.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.bytes;
+
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefIterator;
+import org.elasticsearch.common.io.stream.StreamInput;
+
+import java.io.EOFException;
+import java.io.IOException;
+
+/**
+ * A StreamInput that reads off a {@link BytesRefIterator}. This is used to provide
+ * generic stream access to {@link BytesReference} instances without materializing the
+ * underlying bytes.
+ */
+class BytesReferenceStreamInput extends StreamInput {
+
+    protected final BytesReference bytesReference;
+    private BytesRefIterator iterator;
+    private int sliceIndex;
+    private BytesRef slice;
+    private int sliceStartOffset; // the offset on the stream at which the current slice starts
+
+    private int mark = 0;
+
+    BytesReferenceStreamInput(BytesReference bytesReference) throws IOException {
+        this.bytesReference = bytesReference;
+        this.iterator = bytesReference.iterator();
+        this.slice = iterator.next();
+        this.sliceStartOffset = 0;
+        this.sliceIndex = 0;
+    }
+
+    @Override
+    public byte readByte() throws IOException {
+        if (offset() >= bytesReference.length()) {
+            throw new EOFException();
+        }
+        maybeNextSlice();
+        return slice.bytes[slice.offset + (sliceIndex++)];
+    }
+
+    protected int offset() {
+        return sliceStartOffset + sliceIndex;
+    }
+
+    private void maybeNextSlice() throws IOException {
+        while (sliceIndex == slice.length) {
+            sliceStartOffset += sliceIndex;
+            slice = iterator.next();
+            sliceIndex = 0;
+            if (slice == null) {
+                throw new EOFException();
+            }
+        }
+    }
+
+    @Override
+    public void readBytes(byte[] b, int bOffset, int len) throws IOException {
+        final int length = bytesReference.length();
+        final int offset = offset();
+        if (offset + len > length) {
+            throw new IndexOutOfBoundsException(
+                    "Cannot read " + len + " bytes from stream with length " + length + " at offset " + offset);
+        }
+        final int bytesRead = read(b, bOffset, len);
+        assert bytesRead == len : bytesRead + " vs " + len;
+    }
+
+    @Override
+    public int read() throws IOException {
+        if (offset() >= bytesReference.length()) {
+            return -1;
+        }
+        return Byte.toUnsignedInt(readByte());
+    }
+
+    @Override
+    public int read(final byte[] b, final int bOffset, final int len) throws IOException {
+        final int length = bytesReference.length();
+        final int offset = offset();
+        if (offset >= length) {
+            return -1;
+        }
+        final int numBytesToCopy = Math.min(len, length - offset);
+        int remaining = numBytesToCopy; // copy the full length or the remaining part
+        int destOffset = bOffset;
+        while (remaining > 0) {
+            maybeNextSlice();
+            final int currentLen = Math.min(remaining, slice.length - sliceIndex);
+            assert currentLen > 0 : "length has to be > 0 to make progress but was: " + currentLen;
+            System.arraycopy(slice.bytes, slice.offset + sliceIndex, b, destOffset, currentLen);
+            destOffset += currentLen;
+            remaining -= currentLen;
+            sliceIndex += currentLen;
+            assert remaining >= 0 : "remaining: " + remaining;
+        }
+        return numBytesToCopy;
+    }
+
+    @Override
+    public void close() {
+        // do nothing
+    }
+
+    @Override
+    public int available() {
+        return bytesReference.length() - offset();
+    }
+
+    @Override
+    protected void ensureCanReadBytes(int bytesToRead) throws EOFException {
+        int bytesAvailable = bytesReference.length() - offset();
+        if (bytesAvailable < bytesToRead) {
+            throw new EOFException("tried to read: " + bytesToRead + " bytes but only " + bytesAvailable + " remaining");
+        }
+    }
+
+    @Override
+    public long skip(long n) throws IOException {
+        if (n <= 0L) {
+            return 0L;
+        }
+        assert offset() <= bytesReference.length() : offset() + " vs " + bytesReference.length();
+        // definitely >= 0 and <= Integer.MAX_VALUE so casting is ok
+        final int numBytesSkipped = (int) Math.min(n, bytesReference.length() - offset());
+        int remaining = numBytesSkipped;
+        while (remaining > 0) {
+            maybeNextSlice();
+            int currentLen = Math.min(remaining, slice.length - sliceIndex);
+            remaining -= currentLen;
+            sliceIndex += currentLen;
+            assert remaining >= 0 : "remaining: " + remaining;
+        }
+        return numBytesSkipped;
+    }
+
+    @Override
+    public void reset() throws IOException {
+        if (sliceStartOffset <= mark) {
+            sliceIndex = mark - sliceStartOffset;
+        } else {
+            iterator = bytesReference.iterator();
+            slice = iterator.next();
+            sliceStartOffset = 0;
+            sliceIndex = 0;
+            final long skipped = skip(mark);
+            assert skipped == mark : skipped + " vs " + mark;
+        }
+    }
+
+    @Override
+    public boolean markSupported() {
+        return true;
+    }
+
+    @Override
+    public void mark(int readLimit) {
+        // We ignore readLimit since the data is all in-memory and therefore we can reset the mark no matter how far we advance.
+        this.mark = offset();
+    }
+}

--- a/server/src/main/java/org/elasticsearch/common/bytes/ReleasableBytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/ReleasableBytesReference.java
@@ -24,6 +24,7 @@ import org.apache.lucene.util.BytesRefIterator;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.util.concurrent.AbstractRefCounted;
+import org.elasticsearch.common.util.concurrent.RefCounted;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -33,7 +34,7 @@ import java.io.OutputStream;
  * An extension to {@link BytesReference} that requires releasing its content. This
  * class exists to make it explicit when a bytes reference needs to be released, and when not.
  */
-public final class ReleasableBytesReference implements Releasable, BytesReference {
+public final class ReleasableBytesReference implements RefCounted, Releasable, BytesReference {
 
     public static final Releasable NO_OP = () -> {};
     private final BytesReference delegate;
@@ -56,6 +57,21 @@ public final class ReleasableBytesReference implements Releasable, BytesReferenc
 
     public int refCount() {
         return refCounted.refCount();
+    }
+
+    @Override
+    public void incRef() {
+        refCounted.incRef();
+    }
+
+    @Override
+    public boolean tryIncRef() {
+        return refCounted.tryIncRef();
+    }
+
+    @Override
+    public boolean decRef() {
+        return refCounted.decRef();
     }
 
     public ReleasableBytesReference retain() {
@@ -94,6 +110,7 @@ public final class ReleasableBytesReference implements Releasable, BytesReferenc
 
     @Override
     public BytesReference slice(int from, int length) {
+        assert refCount() > 0;
         return delegate.slice(from, length);
     }
 
@@ -104,26 +121,41 @@ public final class ReleasableBytesReference implements Releasable, BytesReferenc
 
     @Override
     public StreamInput streamInput() throws IOException {
-        return delegate.streamInput();
+        assert refCount() > 0;
+        return new BytesReferenceStreamInput(this) {
+            @Override
+            public ReleasableBytesReference readReleasableBytesReference() throws IOException {
+                final int len = readArraySize();
+                // instead of reading the bytes from a stream we just create a slice of the underlying bytes
+                final ReleasableBytesReference result = retainedSlice(offset(), len);
+                // move the stream manually since creating the slice didn't move it
+                skip(len);
+                return result;
+            }
+        };
     }
 
     @Override
     public void writeTo(OutputStream os) throws IOException {
+        assert refCount() > 0;
         delegate.writeTo(os);
     }
 
     @Override
     public String utf8ToString() {
+        assert refCount() > 0;
         return delegate.utf8ToString();
     }
 
     @Override
     public BytesRef toBytesRef() {
+        assert refCount() > 0;
         return delegate.toBytesRef();
     }
 
     @Override
     public BytesRefIterator iterator() {
+        assert refCount() > 0;
         return delegate.iterator();
     }
 
@@ -134,6 +166,7 @@ public final class ReleasableBytesReference implements Releasable, BytesReferenc
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        assert refCount() > 0;
         return delegate.toXContent(builder, params);
     }
 
@@ -144,11 +177,13 @@ public final class ReleasableBytesReference implements Releasable, BytesReferenc
 
     @Override
     public boolean equals(Object obj) {
+        assert refCount() > 0;
         return delegate.equals(obj);
     }
 
     @Override
     public int hashCode() {
+        assert refCount() > 0;
         return delegate.hashCode();
     }
 

--- a/server/src/main/java/org/elasticsearch/common/io/stream/FilterStreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/FilterStreamInput.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.common.io.stream;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.common.bytes.ReleasableBytesReference;
 
 import java.io.EOFException;
 import java.io.IOException;
@@ -43,6 +44,11 @@ public abstract class FilterStreamInput extends StreamInput {
     @Override
     public void readBytes(byte[] b, int offset, int len) throws IOException {
         delegate.readBytes(b, offset, len);
+    }
+
+    @Override
+    public ReleasableBytesReference readReleasableBytesReference() throws IOException {
+        return delegate.readReleasableBytesReference();
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -35,6 +35,7 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.settings.SecureString;
@@ -129,12 +130,21 @@ public abstract class StreamInput extends InputStream {
     public abstract void readBytes(byte[] b, int offset, int len) throws IOException;
 
     /**
-     * Reads a bytes reference from this stream, might hold an actual reference to the underlying
-     * bytes of the stream.
+     * Reads a bytes reference from this stream, copying any bytes read to a new {@code byte[]}. Use {@link #readReleasableBytesReference()}
+     * when reading large bytes references where possible top avoid needless allocations and copying.
      */
     public BytesReference readBytesReference() throws IOException {
         int length = readArraySize();
         return readBytesReference(length);
+    }
+
+    /**
+     * Reads a releasable bytes reference from this stream. Unlike {@link #readBytesReference()} the returned bytes reference may reference
+     * bytes in a pooled buffer and must be explicitly released via {@link ReleasableBytesReference#close()} once no longer used.
+     * Prefer this method over {@link #readBytesReference()} when reading large bytes references to avoid allocations and copying.
+     */
+    public ReleasableBytesReference readReleasableBytesReference() throws IOException {
+        return ReleasableBytesReference.wrap(readBytesReference());
     }
 
     /**
@@ -1291,7 +1301,7 @@ public abstract class StreamInput extends InputStream {
      * Reads a vint via {@link #readVInt()} and applies basic checks to ensure the read array size is sane.
      * This method uses {@link #ensureCanReadBytes(int)} to ensure this stream has enough bytes to read for the read array size.
      */
-    private int readArraySize() throws IOException {
+    protected int readArraySize() throws IOException {
         final int arraySize = readVInt();
         if (arraySize > ArrayUtil.MAX_ARRAY_LENGTH) {
             throw new IllegalStateException("array length must be <= to " + ArrayUtil.MAX_ARRAY_LENGTH  + " but was: " + arraySize);

--- a/server/src/main/java/org/elasticsearch/indices/recovery/MultiFileWriter.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/MultiFileWriter.java
@@ -26,7 +26,9 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefIterator;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.common.lease.Releasable;
+import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.util.concurrent.AbstractRefCounted;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.index.store.Store;
@@ -67,11 +69,16 @@ public class MultiFileWriter extends AbstractRefCounted implements Releasable {
 
     final Map<String, String> tempFileNames = ConcurrentCollections.newConcurrentMap();
 
-    public void writeFileChunk(StoreFileMetadata fileMetadata, long position, BytesReference content, boolean lastChunk)
+    public void writeFileChunk(StoreFileMetadata fileMetadata, long position, ReleasableBytesReference content, boolean lastChunk)
         throws IOException {
         assert Transports.assertNotTransportThread("multi_file_writer");
         final FileChunkWriter writer = fileChunkWriters.computeIfAbsent(fileMetadata.name(), name -> new FileChunkWriter());
-        writer.writeChunk(new FileChunk(fileMetadata, content, position, lastChunk));
+        incRef();
+        try {
+            writer.writeChunk(new FileChunk(fileMetadata, content, position, lastChunk));
+        } finally {
+            decRef();
+        }
     }
 
     /** Get a temporary name for the provided file name. */
@@ -151,6 +158,7 @@ public class MultiFileWriter extends AbstractRefCounted implements Releasable {
 
     @Override
     protected void closeInternal() {
+        Releasables.close(fileChunkWriters.values());
         fileChunkWriters.clear();
         // clean open index outputs
         Iterator<Map.Entry<String, IndexOutput>> iterator = openIndexOutputs.entrySet().iterator();
@@ -179,20 +187,25 @@ public class MultiFileWriter extends AbstractRefCounted implements Releasable {
         store.renameTempFilesSafe(tempFileNames);
     }
 
-    static final class FileChunk {
+    private static final class FileChunk implements Releasable {
         final StoreFileMetadata md;
-        final BytesReference content;
+        final ReleasableBytesReference content;
         final long position;
         final boolean lastChunk;
-        FileChunk(StoreFileMetadata md, BytesReference content, long position, boolean lastChunk) {
+        FileChunk(StoreFileMetadata md, ReleasableBytesReference content, long position, boolean lastChunk) {
             this.md = md;
-            this.content = content;
+            this.content = content.retain();
             this.position = position;
             this.lastChunk = lastChunk;
         }
+
+        @Override
+        public void close() {
+            content.decRef();
+        }
     }
 
-    private final class FileChunkWriter {
+    private final class FileChunkWriter implements Releasable {
         // chunks can be delivered out of order, we need to buffer chunks if there's a gap between them.
         final PriorityQueue<FileChunk> pendingChunks = new PriorityQueue<>(Comparator.comparing(fc -> fc.position));
         long lastPosition = 0;
@@ -210,17 +223,24 @@ public class MultiFileWriter extends AbstractRefCounted implements Releasable {
                     }
                     pendingChunks.remove();
                 }
-                innerWriteFileChunk(chunk.md, chunk.position, chunk.content, chunk.lastChunk);
-                synchronized (this) {
-                    assert lastPosition == chunk.position : "last_position " + lastPosition + " != chunk_position " + chunk.position;
-                    lastPosition += chunk.content.length();
-                    if (chunk.lastChunk) {
-                        assert pendingChunks.isEmpty() : "still have pending chunks [" + pendingChunks + "]";
-                        fileChunkWriters.remove(chunk.md.name());
-                        assert fileChunkWriters.containsValue(this) == false : "chunk writer [" + newChunk.md + "] was not removed";
+                try (Releasable ignored = chunk) {
+                    innerWriteFileChunk(chunk.md, chunk.position, chunk.content, chunk.lastChunk);
+                    synchronized (this) {
+                        assert lastPosition == chunk.position : "last_position " + lastPosition + " != chunk_position " + chunk.position;
+                        lastPosition += chunk.content.length();
+                        if (chunk.lastChunk) {
+                            assert pendingChunks.isEmpty() : "still have pending chunks [" + pendingChunks + "]";
+                            fileChunkWriters.remove(chunk.md.name());
+                            assert fileChunkWriters.containsValue(this) == false : "chunk writer [" + newChunk.md + "] was not removed";
+                        }
                     }
                 }
             }
+        }
+
+        @Override
+        public synchronized void close() {
+            Releasables.close(pendingChunks);
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -44,6 +44,7 @@ import org.elasticsearch.common.CheckedRunnable;
 import org.elasticsearch.common.StopWatch;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.logging.Loggers;
@@ -955,8 +956,8 @@ public class RecoverySourceHandler {
                 protected void executeChunkRequest(FileChunk request, ActionListener<Void> listener) {
                     cancellableThreads.checkForCancel();
                     recoveryTarget.writeFileChunk(
-                        request.md, request.position, request.content, request.lastChunk, translogOps.getAsInt(),
-                        ActionListener.runBefore(listener, request::close));
+                        request.md, request.position, ReleasableBytesReference.wrap(request.content), request.lastChunk,
+                            translogOps.getAsInt(), ActionListener.runBefore(listener, request::close));
                 }
 
                 @Override

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
@@ -32,7 +32,7 @@ import org.elasticsearch.action.admin.indices.flush.FlushRequest;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.UUIDs;
-import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.lucene.Lucene;
@@ -498,7 +498,7 @@ public class RecoveryTarget extends AbstractRefCounted implements RecoveryTarget
     }
 
     @Override
-    public void writeFileChunk(StoreFileMetadata fileMetadata, long position, BytesReference content,
+    public void writeFileChunk(StoreFileMetadata fileMetadata, long position, ReleasableBytesReference content,
                                boolean lastChunk, int totalTranslogOps, ActionListener<Void> listener) {
         try {
             state().getTranslog().totalOperations(totalTranslogOps);

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTargetHandler.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTargetHandler.java
@@ -19,7 +19,7 @@
 package org.elasticsearch.indices.recovery;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.index.seqno.ReplicationTracker;
 import org.elasticsearch.index.seqno.RetentionLeases;
 import org.elasticsearch.index.store.Store;
@@ -104,7 +104,7 @@ public interface RecoveryTargetHandler {
     void cleanFiles(int totalTranslogOps, long globalCheckpoint, Store.MetadataSnapshot sourceMetadata, ActionListener<Void> listener);
 
     /** writes a partial file chunk to the target store */
-    void writeFileChunk(StoreFileMetadata fileMetadata, long position, BytesReference content,
+    void writeFileChunk(StoreFileMetadata fileMetadata, long position, ReleasableBytesReference content,
                         boolean lastChunk, int totalTranslogOps, ActionListener<Void> listener);
 
     default void cancel() {}

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RemoteRecoveryTargetHandler.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RemoteRecoveryTargetHandler.java
@@ -30,7 +30,7 @@ import org.elasticsearch.action.ActionListenerResponseHandler;
 import org.elasticsearch.action.support.RetryableAction;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
-import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.CancellableThreads;
@@ -180,7 +180,7 @@ public class RemoteRecoveryTargetHandler implements RecoveryTargetHandler {
     }
 
     @Override
-    public void writeFileChunk(StoreFileMetadata fileMetadata, long position, BytesReference content,
+    public void writeFileChunk(StoreFileMetadata fileMetadata, long position, ReleasableBytesReference content,
                                boolean lastChunk, int totalTranslogOps, ActionListener<Void> listener) {
         // Pause using the rate limiter, if desired, to throttle the recovery
         final long throttleTimeInNanos;

--- a/server/src/main/java/org/elasticsearch/transport/InboundHandler.java
+++ b/server/src/main/java/org/elasticsearch/transport/InboundHandler.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.common.util.concurrent.RefCounted;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.threadpool.ThreadPool;
 
@@ -38,6 +39,11 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 
+/**
+ * Handles inbound messages by first deserializing a {@link TransportMessage} from an {@link InboundMessage} and then passing
+ * it to the appropriate handler. Any deserialized {@code TransportMessage} that is found to implement {@link RefCounted} will have its
+ * reference count decremented by one after having been passed to its handler.
+ */
 public class InboundHandler {
 
     private static final Logger logger = LogManager.getLogger(InboundHandler.class);
@@ -193,23 +199,58 @@ public class InboundHandler {
                     final RequestHandlerRegistry<T> reg = requestHandlers.getHandler(action);
                     assert reg != null;
                     final T request = reg.newRequest(stream);
-                    request.remoteAddress(new TransportAddress(channel.getRemoteAddress()));
-                    // in case we throw an exception, i.e. when the limit is hit, we don't want to verify
-                    final int nextByte = stream.read();
-                    // calling read() is useful to make sure the message is fully read, even if there some kind of EOS marker
-                    if (nextByte != -1) {
-                        throw new IllegalStateException("Message not fully read (request) for requestId [" + requestId + "], action ["
-                            + action + "], available [" + stream.available() + "]; resetting");
-                    }
-                    final String executor = reg.getExecutor();
-                    if (ThreadPool.Names.SAME.equals(executor)) {
-                        try {
-                            reg.processMessageReceived(request, transportChannel);
-                        } catch (Exception e) {
-                            sendErrorResponse(reg.getAction(), transportChannel, e);
+                    try {
+                        request.remoteAddress(new TransportAddress(channel.getRemoteAddress()));
+                        // in case we throw an exception, i.e. when the limit is hit, we don't want to verify
+                        final int nextByte = stream.read();
+                        // calling read() is useful to make sure the message is fully read, even if there some kind of EOS marker
+                        if (nextByte != -1) {
+                            throw new IllegalStateException("Message not fully read (request) for requestId [" + requestId + "], action ["
+                                + action + "], available [" + stream.available() + "]; resetting");
                         }
-                    } else {
-                        threadPool.executor(executor).execute(new RequestHandler<>(reg, request, transportChannel));
+                        final String executor = reg.getExecutor();
+                        if (ThreadPool.Names.SAME.equals(executor)) {
+                            try {
+                                reg.processMessageReceived(request, transportChannel);
+                            } catch (Exception e) {
+                                sendErrorResponse(reg.getAction(), transportChannel, e);
+                            }
+                        } else {
+                            boolean success = false;
+                            if (request instanceof RefCounted) {
+                                ((RefCounted) request).incRef();
+                            }
+                            try {
+                                threadPool.executor(executor).execute(new AbstractRunnable() {
+                                    @Override
+                                    protected void doRun() throws Exception {
+                                        reg.processMessageReceived(request, transportChannel);
+                                    }
+
+                                    @Override
+                                    public boolean isForceExecution() {
+                                        return reg.isForceExecution();
+                                    }
+
+                                    @Override
+                                    public void onFailure(Exception e) {
+                                        sendErrorResponse(reg.getAction(), transportChannel, e);
+                                    }
+
+                                    @Override
+                                    public void onAfter() {
+                                        request.decRef();
+                                    }
+                                });
+                                success = true;
+                            } finally {
+                                if (success == false) {
+                                    request.decRef();
+                                }
+                            }
+                        }
+                    } finally {
+                        request.decRef();
                     }
                 }
             } catch (Exception e) {
@@ -244,7 +285,15 @@ public class InboundHandler {
         if (ThreadPool.Names.SAME.equals(executor)) {
             doHandleResponse(handler, response);
         } else {
-            threadPool.executor(executor).execute(() -> doHandleResponse(handler, response));
+            boolean success = false;
+            try {
+                threadPool.executor(executor).execute(() -> doHandleResponse(handler, response));
+                success = true;
+            } finally {
+                if (success == false) {
+                    response.decRef();
+                }
+            }
         }
     }
 
@@ -253,6 +302,8 @@ public class InboundHandler {
             handler.handleResponse(response);
         } catch (Exception e) {
             handleException(handler, new ResponseHandlerFailureTransportException(e));
+        } finally {
+            response.decRef();
         }
     }
 
@@ -287,32 +338,5 @@ public class InboundHandler {
 
     static void assertRemoteVersion(StreamInput in, Version version) {
         assert version.equals(in.getVersion()) : "Stream version [" + in.getVersion() + "] does not match version [" + version + "]";
-    }
-
-    private static class RequestHandler<T extends TransportRequest> extends AbstractRunnable {
-        private final RequestHandlerRegistry<T> reg;
-        private final T request;
-        private final TransportChannel transportChannel;
-
-        RequestHandler(RequestHandlerRegistry<T> reg, T request, TransportChannel transportChannel) {
-            this.reg = reg;
-            this.request = request;
-            this.transportChannel = transportChannel;
-        }
-
-        @Override
-        protected void doRun() throws Exception {
-            reg.processMessageReceived(request, transportChannel);
-        }
-
-        @Override
-        public boolean isForceExecution() {
-            return reg.isForceExecution();
-        }
-
-        @Override
-        public void onFailure(Exception e) {
-            sendErrorResponse(reg.getAction(), transportChannel, e);
-        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/transport/TransportMessage.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportMessage.java
@@ -22,8 +22,9 @@ package org.elasticsearch.transport;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.common.util.concurrent.RefCounted;
 
-public abstract class TransportMessage implements Writeable {
+public abstract class TransportMessage implements Writeable, RefCounted {
 
     private TransportAddress remoteAddress;
 
@@ -45,4 +46,20 @@ public abstract class TransportMessage implements Writeable {
      * currently a no-op
      */
     public TransportMessage(StreamInput in) {}
+
+    @Override
+    public void incRef() {
+        // noop, override to manage the life-cycle of resources held by a transport message
+    }
+
+    @Override
+    public boolean tryIncRef() {
+        return true;
+    }
+
+    @Override
+    public boolean decRef() {
+        // noop, override to manage the life-cycle of resources held by a transport message
+        return false;
+    }
 }

--- a/server/src/test/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetServiceTests.java
@@ -33,6 +33,7 @@ import org.elasticsearch.cluster.routing.ShardRoutingHelper;
 import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.core.internal.io.IOUtils;
@@ -97,7 +98,8 @@ public class PeerRecoveryTargetServiceTests extends IndexShardTestCase {
                     int length = between(1, Math.toIntExact(md.length() - pos));
                     byte[] buffer = new byte[length];
                     in.readBytes(buffer, 0, length);
-                    requests.add(new RecoveryFileChunkRequest(0, seqNo++, sourceShard.shardId(), md, pos, new BytesArray(buffer),
+                    requests.add(new RecoveryFileChunkRequest(0, seqNo++, sourceShard.shardId(), md, pos,
+                        ReleasableBytesReference.wrap(new BytesArray(buffer)),
                         pos + length == md.length(), 1, 1));
                     pos += length;
                 }

--- a/server/src/test/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
@@ -46,6 +46,7 @@ import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.common.io.FileSystemUtils;
 import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.lucene.store.IndexOutputOutputStream;
@@ -180,7 +181,7 @@ public class RecoverySourceHandlerTests extends ESTestCase {
         MultiFileWriter multiFileWriter = new MultiFileWriter(targetStore, mock(RecoveryState.Index.class), "", logger, () -> {});
         RecoveryTargetHandler target = new TestRecoveryTargetHandler() {
             @Override
-            public void writeFileChunk(StoreFileMetadata md, long position, BytesReference content, boolean lastChunk,
+            public void writeFileChunk(StoreFileMetadata md, long position, ReleasableBytesReference content, boolean lastChunk,
                                        int totalTranslogOps, ActionListener<Void> listener) {
                 ActionListener.completeWith(listener, () -> {
                     multiFileWriter.writeFileChunk(md, position, content, lastChunk);
@@ -415,7 +416,7 @@ public class RecoverySourceHandlerTests extends ESTestCase {
         MultiFileWriter multiFileWriter = new MultiFileWriter(targetStore, mock(RecoveryState.Index.class), "", logger, () -> {});
         RecoveryTargetHandler target = new TestRecoveryTargetHandler() {
              @Override
-            public void writeFileChunk(StoreFileMetadata md, long position, BytesReference content, boolean lastChunk,
+            public void writeFileChunk(StoreFileMetadata md, long position, ReleasableBytesReference content, boolean lastChunk,
                                        int totalTranslogOps, ActionListener<Void> listener) {
                  ActionListener.completeWith(listener, () -> {
                      multiFileWriter.writeFileChunk(md, position, content, lastChunk);
@@ -471,7 +472,7 @@ public class RecoverySourceHandlerTests extends ESTestCase {
         final boolean throwCorruptedIndexException = randomBoolean();
         RecoveryTargetHandler target = new TestRecoveryTargetHandler() {
             @Override
-            public void writeFileChunk(StoreFileMetadata md, long position, BytesReference content, boolean lastChunk,
+            public void writeFileChunk(StoreFileMetadata md, long position, ReleasableBytesReference content, boolean lastChunk,
                                        int totalTranslogOps, ActionListener<Void> listener) {
                 if (throwCorruptedIndexException) {
                     listener.onFailure(new RuntimeException(new CorruptIndexException("foo", "bar")));
@@ -602,7 +603,7 @@ public class RecoverySourceHandlerTests extends ESTestCase {
         final TestRecoveryTargetHandler recoveryTarget = new TestRecoveryTargetHandler() {
             final AtomicLong chunkNumberGenerator = new AtomicLong();
             @Override
-            public void writeFileChunk(StoreFileMetadata md, long position, BytesReference content, boolean lastChunk,
+            public void writeFileChunk(StoreFileMetadata md, long position, ReleasableBytesReference content, boolean lastChunk,
                                        int totalTranslogOps, ActionListener<Void> listener) {
                 final long chunkNumber = chunkNumberGenerator.getAndIncrement();
                 logger.info("--> write chunk name={} seq={}, position={}", md.name(), chunkNumber, position);
@@ -660,7 +661,7 @@ public class RecoverySourceHandlerTests extends ESTestCase {
         final TestRecoveryTargetHandler recoveryTarget = new TestRecoveryTargetHandler() {
             final AtomicLong chunkNumberGenerator = new AtomicLong();
             @Override
-            public void writeFileChunk(StoreFileMetadata md, long position, BytesReference content, boolean lastChunk,
+            public void writeFileChunk(StoreFileMetadata md, long position, ReleasableBytesReference content, boolean lastChunk,
                                        int totalTranslogOps, ActionListener<Void> listener) {
                 final long chunkNumber = chunkNumberGenerator.getAndIncrement();
                 logger.info("--> write chunk name={} seq={}, position={}", md.name(), chunkNumber, position);
@@ -731,7 +732,7 @@ public class RecoverySourceHandlerTests extends ESTestCase {
             }
 
             @Override
-            public void writeFileChunk(StoreFileMetadata md, long position, BytesReference content,
+            public void writeFileChunk(StoreFileMetadata md, long position, ReleasableBytesReference content,
                                        boolean lastChunk, int totalTranslogOps, ActionListener<Void> listener) {
                 recoveryExecutor.execute(() -> listener.onResponse(null));
                 if (rarely()) {
@@ -890,7 +891,7 @@ public class RecoverySourceHandlerTests extends ESTestCase {
         }
 
         @Override
-        public void writeFileChunk(StoreFileMetadata fileMetadata, long position, BytesReference content, boolean lastChunk,
+        public void writeFileChunk(StoreFileMetadata fileMetadata, long position, ReleasableBytesReference content, boolean lastChunk,
                                    int totalTranslogOps, ActionListener<Void> listener) {
         }
     }

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/repositories/GetCcrRestoreFileChunkAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/repositories/GetCcrRestoreFileChunkAction.java
@@ -18,6 +18,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.ByteArray;
+import org.elasticsearch.common.util.concurrent.RefCounted;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportActionProxy;
@@ -57,8 +58,6 @@ public class GetCcrRestoreFileChunkAction extends ActionType<GetCcrRestoreFileCh
             ByteArray array = bigArrays.newByteArray(bytesRequested, false);
             String fileName = request.getFileName();
             String sessionUUID = request.getSessionUUID();
-            // This is currently safe to do because calling `onResponse` will serialize the bytes to the network layer data
-            // structure on the same thread. So the bytes will be copied before the reference is released.
             BytesReference pagedBytesReference = BytesReference.fromByteArray(array, bytesRequested);
             try (ReleasableBytesReference reference = new ReleasableBytesReference(pagedBytesReference, array)) {
                 try (CcrRestoreSourceService.SessionReader sessionReader = restoreSourceService.getSessionReader(sessionUUID)) {
@@ -72,27 +71,27 @@ public class GetCcrRestoreFileChunkAction extends ActionType<GetCcrRestoreFileCh
         }
     }
 
-    public static class GetCcrRestoreFileChunkResponse extends ActionResponse {
+    public static class GetCcrRestoreFileChunkResponse extends ActionResponse implements RefCounted {
 
         private final long offset;
-        private final BytesReference chunk;
+        private final ReleasableBytesReference chunk;
 
         GetCcrRestoreFileChunkResponse(StreamInput streamInput) throws IOException {
             super(streamInput);
             offset = streamInput.readVLong();
-            chunk = streamInput.readBytesReference();
+            chunk = streamInput.readReleasableBytesReference();
         }
 
-        GetCcrRestoreFileChunkResponse(long offset, BytesReference chunk) {
+        GetCcrRestoreFileChunkResponse(long offset, ReleasableBytesReference chunk) {
             this.offset = offset;
-            this.chunk = chunk;
+            this.chunk = chunk.retain();
         }
 
         public long getOffset() {
             return offset;
         }
 
-        public BytesReference getChunk() {
+        public ReleasableBytesReference getChunk() {
             return chunk;
         }
 
@@ -102,5 +101,19 @@ public class GetCcrRestoreFileChunkAction extends ActionType<GetCcrRestoreFileCh
             out.writeBytesReference(chunk);
         }
 
+        @Override
+        public void incRef() {
+            chunk.incRef();
+        }
+
+        @Override
+        public boolean tryIncRef() {
+            return chunk.tryIncRef();
+        }
+
+        @Override
+        public boolean decRef() {
+            return chunk.decRef();
+        }
     }
 }

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
@@ -18,6 +18,7 @@ import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
@@ -25,7 +26,6 @@ import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
 import org.elasticsearch.action.admin.indices.stats.ShardStats;
 import org.elasticsearch.action.support.ListenerTimeouts;
 import org.elasticsearch.action.support.PlainActionFuture;
-import org.elasticsearch.action.support.ThreadedActionListener;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
@@ -563,16 +563,23 @@ public class CcrRepository extends AbstractLifecycleComponent implements Reposit
 
                 @Override
                 protected void executeChunkRequest(FileChunk request, ActionListener<Void> listener) {
-                    final ActionListener<GetCcrRestoreFileChunkAction.GetCcrRestoreFileChunkResponse> threadedListener
-                        = new ThreadedActionListener<>(logger, threadPool, ThreadPool.Names.GENERIC, ActionListener.wrap(r -> {
-                            writeFileChunk(request.md, r);
-                            listener.onResponse(null);
-                        }, listener::onFailure), false);
-
                     remoteClient.execute(GetCcrRestoreFileChunkAction.INSTANCE,
                         new GetCcrRestoreFileChunkRequest(node, sessionUUID, request.md.name(), request.bytesRequested),
-                        ListenerTimeouts.wrapWithTimeout(threadPool, threadedListener, ccrSettings.getRecoveryActionTimeout(),
-                            ThreadPool.Names.GENERIC, GetCcrRestoreFileChunkAction.NAME));
+                            ListenerTimeouts.wrapWithTimeout(threadPool, ActionListener.delegateFailure(listener, (l, r) -> {
+                                r.incRef();
+                                threadPool.generic().execute(new ActionRunnable<Void>(listener) {
+                                    @Override
+                                    protected void doRun() throws Exception {
+                                        writeFileChunk(request.md, r);
+                                        listener.onResponse(null);
+                                    }
+
+                                    @Override
+                                    public void onAfter() {
+                                        r.decRef();
+                                    }
+                                });
+                            }), ccrSettings.getRecoveryActionTimeout(), ThreadPool.Names.GENERIC, GetCcrRestoreFileChunkAction.NAME));
                 }
 
                 private void writeFileChunk(StoreFileMetadata md,


### PR DESCRIPTION
We were copying any byte arrays we would read streams that are backed by
a `BytesReference`. This would mean copying e.g. 500k chunks during
file based recovery, large chunks during CCR file copy, or many MB when
receiving a large cluster state for the first time.

This PR adds the ability to read shared bytes from streams that support it,
adds reference counting to transport messages that make use of these bytes
and makes use of the new functionality in recovery, CCR and CS publication.

This should reduce memory usage by all 3 adjusted transport APIs significantly
and could be extended to other very large messages that currently get copied
during deserialization like e.g. bulk requests.

backport of #65921