### PR TITLE
[ML] fixing MlJobSnapshotUpgradeIT.testSnapshotUpgrader test

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpgradeJobModelSnapshotAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpgradeJobModelSnapshotAction.java
@@ -15,6 +15,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
+import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
@@ -32,6 +33,7 @@ import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.XPackField;
+import org.elasticsearch.xpack.core.ml.MlConfigIndex;
 import org.elasticsearch.xpack.core.ml.MlTasks;
 import org.elasticsearch.xpack.core.ml.action.UpgradeJobModelSnapshotAction;
 import org.elasticsearch.xpack.core.ml.action.UpgradeJobModelSnapshotAction.Request;
@@ -39,6 +41,7 @@ import org.elasticsearch.xpack.core.ml.action.UpgradeJobModelSnapshotAction.Resp
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.config.JobState;
 import org.elasticsearch.xpack.core.ml.job.messages.Messages;
+import org.elasticsearch.xpack.core.ml.job.persistence.ElasticsearchMappings;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSnapshot;
 import org.elasticsearch.xpack.core.ml.job.results.Result;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
@@ -64,6 +67,7 @@ public class TransportUpgradeJobModelSnapshotAction extends TransportMasterNodeA
     private final JobResultsProvider jobResultsProvider;
     private final MlMemoryTracker memoryTracker;
     private final MlConfigMigrationEligibilityCheck migrationEligibilityCheck;
+    private final Client client;
 
     @Inject
     public TransportUpgradeJobModelSnapshotAction(Settings settings, TransportService transportService, ThreadPool threadPool,
@@ -71,7 +75,7 @@ public class TransportUpgradeJobModelSnapshotAction extends TransportMasterNodeA
                                                   PersistentTasksService persistentTasksService, ActionFilters actionFilters,
                                                   IndexNameExpressionResolver indexNameExpressionResolver,
                                                   JobConfigProvider jobConfigProvider, MlMemoryTracker memoryTracker,
-                                                  JobResultsProvider jobResultsProvider) {
+                                                  JobResultsProvider jobResultsProvider, Client client) {
         super(UpgradeJobModelSnapshotAction.NAME, transportService, clusterService, threadPool, actionFilters, Request::new,
             indexNameExpressionResolver, Response::new, ThreadPool.Names.SAME);
         this.licenseState = licenseState;
@@ -80,6 +84,7 @@ public class TransportUpgradeJobModelSnapshotAction extends TransportMasterNodeA
         this.jobResultsProvider = jobResultsProvider;
         this.memoryTracker = memoryTracker;
         this.migrationEligibilityCheck = new MlConfigMigrationEligibilityCheck(settings, clusterService);
+        this.client = client;
     }
 
     @Override
@@ -137,8 +142,8 @@ public class TransportUpgradeJobModelSnapshotAction extends TransportMasterNodeA
             });
 
         // Start job task
-        ActionListener<Long> memoryRequirementRefreshListener = ActionListener.wrap(
-            mem -> {
+        ActionListener<Boolean> configIndexMappingUpdaterListener = ActionListener.wrap(
+            _unused -> {
                 logger.info("[{}] [{}] sending start upgrade request", params.getJobId(), params.getSnapshotId());
                 persistentTasksService.sendStartRequest(
                     MlTasks.snapshotUpgradeTaskId(params.getJobId(), params.getSnapshotId()),
@@ -146,6 +151,17 @@ public class TransportUpgradeJobModelSnapshotAction extends TransportMasterNodeA
                     params,
                     waitForJobToStart);
             },
+            listener::onFailure
+        );
+
+        // Update config index if necessary
+        ActionListener<Long> memoryRequirementRefreshListener = ActionListener.wrap(
+            mem -> ElasticsearchMappings.addDocMappingIfMissing(
+                MlConfigIndex.indexName(),
+                MlConfigIndex::mapping,
+                client,
+                state,
+                configIndexMappingUpdaterListener),
             listener::onFailure
         );
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/snapshot/upgrader/SnapshotUpgradeTaskExecutor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/snapshot/upgrader/SnapshotUpgradeTaskExecutor.java
@@ -186,35 +186,24 @@ public class SnapshotUpgradeTaskExecutor extends AbstractJobPersistentTasksExecu
             task::markAsFailed
         );
 
-        // Make sure that the results index is updated if necessary
-        ActionListener<Boolean> configIndexMappingUpdaterListener = ActionListener.wrap(
+        // Try adding the results doc mapping - this updates to the latest version if an old mapping is present
+        ActionListener<Boolean> annotationsIndexUpdateHandler = ActionListener.wrap(
             ack -> ElasticsearchMappings.addDocMappingIfMissing(
                 AnomalyDetectorsIndex.jobResultsAliasedName(jobId),
                 AnomalyDetectorsIndex::resultsMapping,
                 client,
                 clusterState,
                 resultsMappingUpdateHandler),
-            task::markAsFailed
-        );
-
-        // Update the config index mapping if necessary
-        ActionListener<Boolean> annotationsIndexUpdateHandler = ActionListener.wrap(
-            ack -> ElasticsearchMappings.addDocMappingIfMissing(
-                MlConfigIndex.indexName(),
-                MlConfigIndex::mapping,
-                client,
-                clusterState,
-                configIndexMappingUpdaterListener),
             e -> {
                 // Due to a bug in 7.9.0 it's possible that the annotations index already has incorrect mappings
                 // and it would cause more harm than good to block jobs from opening in subsequent releases
                 logger.warn(new ParameterizedMessage("[{}] ML annotations index could not be updated with latest mappings", jobId), e);
                 ElasticsearchMappings.addDocMappingIfMissing(
-                    MlConfigIndex.indexName(),
-                    MlConfigIndex::mapping,
+                    AnomalyDetectorsIndex.jobResultsAliasedName(jobId),
+                    AnomalyDetectorsIndex::resultsMapping,
                     client,
                     clusterState,
-                    configIndexMappingUpdaterListener);
+                    resultsMappingUpdateHandler);
             }
         );
 

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlJobSnapshotUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlJobSnapshotUpgradeIT.java
@@ -86,7 +86,6 @@ public class MlJobSnapshotUpgradeIT extends AbstractUpgradeTestCase {
      * The purpose of this test is to ensure that when a job is open through a rolling upgrade we upgrade the results
      * index mappings when it is assigned to an upgraded node even if no other ML endpoint is called after the upgrade
      */
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/67059")
     public void testSnapshotUpgrader() throws Exception {
         hlrc = new HLRC(client()).machineLearning();
         Request adjustLoggingLevels = new Request("PUT", "/_cluster/settings");
@@ -238,7 +237,7 @@ public class MlJobSnapshotUpgradeIT extends AbstractUpgradeTestCase {
         }
         AnalysisConfig.Builder analysisConfig = new AnalysisConfig.Builder(detectors);
         analysisConfig.setBucketSpan(bucketSpan);
-        if (randomBoolean()) {
+        if (isCategorization) {
             analysisConfig.setCategorizationFieldName("text");
         }
         Job.Builder job = new Job.Builder(jobId);


### PR DESCRIPTION
fixes a minor typo that causes test flakiness.

closes https://github.com/elastic/elasticsearch/issues/67059