### PR TITLE
[ML] Make inference stats yaml tests more reliable

### DIFF
--- a/x-pack/plugin/ml/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/InferenceProcessorIT.java
+++ b/x-pack/plugin/ml/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/InferenceProcessorIT.java
@@ -10,14 +10,16 @@ import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.test.rest.ESRestTestCase;
-import org.junit.After;
 import org.junit.Before;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 
 
 public class InferenceProcessorIT extends ESRestTestCase {
@@ -60,7 +62,8 @@ public class InferenceProcessorIT extends ESRestTestCase {
         assertThat(client().performRequest(model).getStatusLine().getStatusCode(), equalTo(200));
     }
 
-    public void testCreateAndDeletePipelineWithInferenceProcessor() throws IOException {
+    @SuppressWarnings("unchecked")
+    public void testCreateAndDeletePipelineWithInferenceProcessor() throws Exception {
         putRegressionModel();
 
         Request putPipeline = new Request("PUT", "_ingest/pipeline/regression-model-pipeline");
@@ -69,7 +72,7 @@ public class InferenceProcessorIT extends ESRestTestCase {
                 "            \"processors\": [\n" +
                 "              {\n" +
                 "                \"inference\" : {\n" +
-                "                  \"model_id\" : \"a-perfect-regression-model\",\n" +
+                "                  \"model_id\" : \"" + MODEL_ID + "\",\n" +
                 "                  \"inference_config\": {\"regression\": {}},\n" +
                 "                  \"target_field\": \"regression_field\",\n" +
                 "                  \"field_map\": {}\n" +
@@ -81,14 +84,51 @@ public class InferenceProcessorIT extends ESRestTestCase {
 
         assertThat(client().performRequest(putPipeline).getStatusLine().getStatusCode(), equalTo(200));
 
+        Map<String, Object> statsAsMap = getStats();
+        List<Integer> pipelineCount =
+            (List<Integer>)XContentMapValues.extractValue("trained_model_stats.pipeline_count", statsAsMap);
+        assertThat(pipelineCount.get(0), equalTo(1));
+
+        List<Map<String, Object>> counts =
+            (List<Map<String, Object>>)XContentMapValues.extractValue("trained_model_stats.ingest.total", statsAsMap);
+        assertThat(counts.get(0).get("count"), equalTo(0));
+        assertThat(counts.get(0).get("time_in_millis"), equalTo(0));
+        assertThat(counts.get(0).get("current"), equalTo(0));
+        assertThat(counts.get(0).get("failed"), equalTo(0));
+
         // using the model will ensure it is loaded and stats will be written before it is deleted
         infer("regression-model-pipeline");
 
         Request deletePipeline = new Request("DELETE", "_ingest/pipeline/regression-model-pipeline");
         assertThat(client().performRequest(deletePipeline).getStatusLine().getStatusCode(), equalTo(200));
+
+        // check stats are updated
+        assertBusy(() -> {
+            Map<String, Object> updatedStatsMap = null;
+            try {
+                updatedStatsMap = getStats();
+            } catch (ResponseException e) {
+                // the search may fail because the index is not ready yet in which case retry
+                if (e.getMessage().contains("search_phase_execution_exception")) {
+                    fail("search failed- retry");
+                } else {
+                    throw e;
+                }
+            }
+
+            List<Integer> updatedPipelineCount =
+                (List<Integer>) XContentMapValues.extractValue("trained_model_stats.pipeline_count", updatedStatsMap);
+            assertThat(updatedPipelineCount.get(0), equalTo(0));
+
+            List<Map<String, Object>> inferenceStats =
+                (List<Map<String, Object>>) XContentMapValues.extractValue("trained_model_stats.inference_stats", updatedStatsMap);
+            assertNotNull(inferenceStats);
+            assertThat(inferenceStats, hasSize(1));
+            assertThat(inferenceStats.get(0).get("inference_count"), equalTo(1));
+        });
     }
 
-    public void testCreateProcessorWithDeprecatedFields() throws IOException {
+    public void testCreateProcessorWithDeprecatedFields() throws Exception {
         putRegressionModel();
 
         Request putPipeline = new Request("PUT", "_ingest/pipeline/regression-model-deprecated-pipeline");
@@ -97,7 +137,7 @@ public class InferenceProcessorIT extends ESRestTestCase {
                 "  \"processors\": [\n" +
                 "    {\n" +
                 "      \"inference\" : {\n" +
-                "        \"model_id\" : \"a-perfect-regression-model\",\n" +
+                "        \"model_id\" : \"" + MODEL_ID + "\",\n" +
                 "        \"inference_config\": {\"regression\": {}},\n" +
                 "        \"field_mappings\": {}\n" +
                 "      }\n" +
@@ -117,6 +157,8 @@ public class InferenceProcessorIT extends ESRestTestCase {
         Request deletePipeline = new Request("DELETE", "_ingest/pipeline/regression-model-deprecated-pipeline");
         Response deleteResponse = client().performRequest(deletePipeline);
         assertThat(deleteResponse.getStatusLine().getStatusCode(), equalTo(200));
+
+        waitForStatsDoc();
     }
 
     public void infer(String pipelineId) throws IOException {
@@ -127,7 +169,6 @@ public class InferenceProcessorIT extends ESRestTestCase {
         assertThat(response.getStatusLine().getStatusCode(), equalTo(201));
     }
 
-    @After
     @SuppressWarnings("unchecked")
     public void waitForStatsDoc() throws Exception {
         assertBusy( () -> {
@@ -166,5 +207,11 @@ public class InferenceProcessorIT extends ESRestTestCase {
                 }
             }
         });
+    }
+
+    private Map<String, Object> getStats() throws IOException {
+        Request getStats = new Request("GET", "_ml/trained_models/" + MODEL_ID + "/_stats");
+        Response statsResponse = client().performRequest(getStats);
+        return entityAsMap(statsResponse);
     }
 }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/get_trained_model_stats.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/get_trained_model_stats.yml
@@ -59,7 +59,7 @@ setup:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       ml.put_trained_model:
-        model_id: a-used-regression-model
+        model_id: another-regression-model
         body: >
           {
             "description": "empty model for tests",
@@ -79,60 +79,6 @@ setup:
                }
             }
           }
-
-  - do:
-      headers:
-        Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
-      ingest.put_pipeline:
-        id: "regression-model-pipeline"
-        body:  >
-          {
-            "processors": [
-              {
-                "inference" : {
-                  "model_id" : "a-used-regression-model",
-                  "inference_config": {"regression": {}},
-                  "target_field": "regression_field",
-                  "field_map": {}
-                }
-              }
-            ]
-          }
-  - do:
-      headers:
-        Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
-      ingest.put_pipeline:
-        id: "regression-model-pipeline-1"
-        body:  >
-          {
-            "processors": [
-              {
-                "inference" : {
-                  "model_id" : "a-used-regression-model",
-                  "inference_config": {"regression": {}},
-                  "target_field": "regression_field",
-                  "field_map": {}
-                }
-              }
-            ]
-          }
-  # automatically create concrete index so shards get allocated
-  - do:
-      headers:
-        Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
-      index:
-        index: .ml-stats-000001
-        body: >
-          {
-          }
-
-  - do:
-      headers:
-        Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
-      cluster.health:
-        wait_for_status: yellow
-        index: .ml-stats*
-
 ---
 "Test get stats given missing trained model":
 
@@ -176,8 +122,8 @@ setup:
   - match: { trained_model_stats.1.model_id: a-unused-regression-model1 }
   - match: { trained_model_stats.1.pipeline_count: 0 }
   - is_false: trained_model_stats.1.ingest
-  - match: { trained_model_stats.2.pipeline_count: 2 }
-  - is_true: trained_model_stats.2.ingest
+  - match: { trained_model_stats.2.pipeline_count: 0 }
+  - is_false: trained_model_stats.2.ingest
 
   - do:
       ml.get_trained_models_stats:
@@ -189,8 +135,8 @@ setup:
   - match: { trained_model_stats.1.model_id: a-unused-regression-model1 }
   - match: { trained_model_stats.1.pipeline_count: 0 }
   - is_false: trained_model_stats.1.ingest
-  - match: { trained_model_stats.2.pipeline_count: 2 }
-  - is_true: trained_model_stats.2.ingest
+  - match: { trained_model_stats.2.pipeline_count: 0 }
+  - is_false: trained_model_stats.2.ingest
 
   - do:
       ml.get_trained_models_stats:
@@ -224,44 +170,8 @@ setup:
 
   - do:
       ml.get_trained_models_stats:
-        model_id: "a-used-regression-model"
+        model_id: "another-regression-model"
 
   - match: { count: 1 }
-  - match: { trained_model_stats.0.model_id: a-used-regression-model }
-  - match: { trained_model_stats.0.pipeline_count: 2 }
-  - match:
-      trained_model_stats.0.ingest.total:
-        count: 0
-        time_in_millis: 0
-        current: 0
-        failed: 0
-
-  - match:
-      trained_model_stats.0.ingest.pipelines.regression-model-pipeline:
-        count: 0
-        time_in_millis: 0
-        current: 0
-        failed: 0
-        processors:
-          - inference:
-              type: inference
-              stats:
-                count: 0
-                time_in_millis: 0
-                current: 0
-                failed: 0
-
-  - match:
-      trained_model_stats.0.ingest.pipelines.regression-model-pipeline-1:
-        count: 0
-        time_in_millis: 0
-        current: 0
-        failed: 0
-        processors:
-          - inference:
-              type: inference
-              stats:
-                count: 0
-                time_in_millis: 0
-                current: 0
-                failed: 0
+  - match: { trained_model_stats.0.model_id: another-regression-model }
+  - match: { trained_model_stats.0.pipeline_count: 0 }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/get_trained_model_stats.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/get_trained_model_stats.yml
@@ -3,72 +3,82 @@ setup:
       features:
         - headers
         - allowed_warnings
-        - warnings
   - do:
       allowed_warnings:
         - "index [.ml-inference-000003] matches multiple legacy templates [.ml-inference-000003, global], composable templates will only match a single template"
-      warnings:
-        - "this request accesses system indices: [.ml-inference-000003], but in a future major version, direct access to system indices will be prevented by default"
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
-      index:
-        id: trained_model_config-a-unused-regression-model1-0
-        index: .ml-inference-000003
+      ml.put_trained_model:
+        model_id: a-unused-regression-model1
         body: >
           {
-            "model_id": "a-unused-regression-model1",
-            "created_by": "ml_tests",
-            "version": "8.0.0",
-            "inference_config": {"regression": {}},
             "description": "empty model for tests",
-            "create_time": 0,
-            "doc_type": "trained_model_config"
+            "tags": ["regression", "tag1"],
+            "input": {"field_names": ["field1", "field2"]},
+            "inference_config": {"regression": {}},
+            "definition": {
+               "preprocessors": [],
+               "trained_model": {
+                  "tree": {
+                     "feature_names": ["field1", "field2"],
+                     "tree_structure": [
+                        {"node_index": 0, "leaf_value": 1}
+                     ],
+                     "target_type": "regression"
+                  }
+               }
+            }
           }
 
   - do:
-      warnings:
-        - "this request accesses system indices: [.ml-inference-000003], but in a future major version, direct access to system indices will be prevented by default"
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
-      index:
-        id: trained_model_config-a-unused-regression-model-0
-        index: .ml-inference-000003
+      ml.put_trained_model:
+        model_id: a-unused-regression-model
         body: >
           {
-            "model_id": "a-unused-regression-model",
-            "created_by": "ml_tests",
-            "version": "8.0.0",
-            "inference_config": {"regression": {}},
             "description": "empty model for tests",
-            "create_time": 0,
-            "doc_type": "trained_model_config"
-          }
-  - do:
-      warnings:
-        - "this request accesses system indices: [.ml-inference-000003], but in a future major version, direct access to system indices will be prevented by default"
-      headers:
-        Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
-      index:
-        id: trained_model_config-a-used-regression-model-0
-        index: .ml-inference-000003
-        body: >
-          {
-            "model_id": "a-used-regression-model",
-            "created_by": "ml_tests",
-            "version": "8.0.0",
+            "tags": ["regression", "tag1"],
+            "input": {"field_names": ["field1", "field2"]},
             "inference_config": {"regression": {}},
-            "description": "empty model for tests",
-            "create_time": 0,
-            "doc_type": "trained_model_config"
+            "definition": {
+               "preprocessors": [],
+               "trained_model": {
+                  "tree": {
+                     "feature_names": ["field1", "field2"],
+                     "tree_structure": [
+                        {"node_index": 0, "leaf_value": 1}
+                     ],
+                     "target_type": "regression"
+                  }
+               }
+            }
           }
 
   - do:
-      warnings:
-        - "this request accesses system indices: [.ml-inference-000003], but in a future major version, direct access to system indices will be prevented by default"
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
-      indices.refresh:
-        index: ".ml-inference-*"
+      ml.put_trained_model:
+        model_id: a-used-regression-model
+        body: >
+          {
+            "description": "empty model for tests",
+            "tags": ["regression", "tag1"],
+            "input": {"field_names": ["field1", "field2"]},
+            "inference_config": {"regression": {}},
+            "definition": {
+               "preprocessors": [],
+               "trained_model": {
+                  "tree": {
+                     "feature_names": ["field1", "field2"],
+                     "tree_structure": [
+                        {"node_index": 0, "leaf_value": 1}
+                     ],
+                     "target_type": "regression"
+                  }
+               }
+            }
+          }
 
   - do:
       headers:
@@ -115,37 +125,14 @@ setup:
         body: >
           {
           }
-  # reference and then de-reference a model to flush the stats
-  - do:
-      headers:
-        Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
-      ingest.put_pipeline:
-        id: "regression-model-pipeline-2"
-        body:  >
-          {
-            "processors": [
-              {
-                "inference" : {
-                  "model_id" : "a-unused-regression-model",
-                  "inference_config": {"regression": {}},
-                  "target_field": "regression_field",
-                  "field_map": {}
-                }
-              }
-            ]
-          }
 
-  - do:
-      headers:
-        Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
-      ingest.delete_pipeline:
-        id: "regression-model-pipeline-2"
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       cluster.health:
         wait_for_status: yellow
         index: .ml-stats*
+
 ---
 "Test get stats given missing trained model":
 


### PR DESCRIPTION
Investigating #66931 it looks like the root cause is a late creation of the .ml-stats-00001 index from the `inference_stats_crud` yml tests leaking into the next test. Most likely because of a pipeline referencing a model being deleted. This PR makes a few changes to the set up section

- Rename the file to `get_trained_model_stats.yml`
- Use the ml APIs to PUT the models rather than indexing directly. This also fixes an error in the logs because the old models were invalid. 
- Remove the warnings about direct access to a system index
- Remove a pipeline that was added and deleted in order to flush stats. Testing flushing stats is covered in `InferenceProcessorIT`

Closes #66931

