### PR TITLE
[DOCS] Document ILM rollup action

### DIFF
--- a/docs/reference/ilm/actions/ilm-rollup.asciidoc
+++ b/docs/reference/ilm/actions/ilm-rollup.asciidoc
@@ -5,7 +5,7 @@
 Phases allowed: hot, cold.
 
 Aggregates an index's time series data and stores the results in a new read-only
-index named `<original-index-name>-rollup`. For example, you can roll up hourly
+index named `rollup-<original-index-name>`. For example, you can roll up hourly
 data into daily or weekly summaries.
 
 If {ilm-init} performs the `rollup` action on a backing index for a data stream,

--- a/docs/reference/ilm/actions/ilm-rollup.asciidoc
+++ b/docs/reference/ilm/actions/ilm-rollup.asciidoc
@@ -1,0 +1,99 @@
+[role="xpack"]
+[[ilm-rollup]]
+=== Rollup
+
+Phases allowed: hot, cold.
+
+Aggregates an index's time series data and stores the results in a new read-only
+index named `<original-index-name>-rollup`. For example, you can roll up hourly
+data into daily or weekly summaries.
+
+If {ilm-init} performs the `rollup` action on a backing index for a data stream,
+the rollup index is a backing index for the same stream.
+
+To use the `rollup` action in the hot phase, the <<ilm-rollover,`rollover`>>
+action must be present. If no `rollover` action is configured, {ilm-init} will
+reject the policy.
+
+[role="child_attributes"]
+[[ilm-rollup-options]]
+==== Options
+
+`config`::
+(Required, object)
+Configures the rollup action.
++
+.Properties of `config`
+[%collapsible%open]
+====
+include::{es-repo-dir}/rollup/apis/rollup-api.asciidoc[tag=rollup-config]
+====
+
+`rollup_policy`::
+(Optional, string)
+Lifecycle policy for the resulting rollup index. If you don't specify a policy,
+{ilm-init} will not manage the rollup index.
+
+[[ilm-rollup-ex]]
+==== Example
+
+////
+[source,console]
+----
+PUT _ilm/policy/my-rollup-policy
+{
+  "policy": {
+    "phases": {
+      "delete": {
+        "actions": {
+          "delete" : { }
+        }
+      }
+    }
+  }
+}
+----
+////
+
+[source,console]
+----
+PUT _ilm/policy/my-policy
+{
+  "policy": {
+    "phases": {
+      "cold": {
+        "actions": {
+          "rollup": {
+            "config": {
+              "groups": {
+                "date_histogram": {
+                  "field": "@timestamp",
+                  "calendar_interval": "1d"
+                },
+                "terms": {
+                  "fields": [
+                    "my-keyword-field",
+                    "my-other-keyword-field"
+                  ]
+                }
+              },
+              "metrics": [
+                {
+                  "field": "my-numeric-field",
+                  "metrics": [
+                    "min",
+                    "max",
+                    "avg"
+                  ]
+                }
+              ]
+            },
+            "rollup_policy": "my-rollup-policy"
+          }
+        }
+      }
+    }
+  }
+}
+----
+// TEST[continued]

--- a/docs/reference/ilm/ilm-actions.asciidoc
+++ b/docs/reference/ilm/ilm-actions.asciidoc
@@ -28,6 +28,12 @@ Block write operations to the index.
 Remove the index as the write index for the rollover alias and 
 start indexing to a new index.
 
+ifdef::permanently-unreleased-branch[]
+<<ilm-rollup,Rollup>>::
+Aggregates the index’s time series data and stores the results in a new
+read-only index.
+endif::[]
+
 <<ilm-searchable-snapshot, Searchable snapshot>>::
 beta:[]
 Take a snapshot of the managed index in the configured repository
@@ -54,6 +60,9 @@ include::actions/ilm-freeze.asciidoc[]
 include::actions/ilm-migrate.asciidoc[]
 include::actions/ilm-readonly.asciidoc[]
 include::actions/ilm-rollover.asciidoc[]
+ifdef::permanently-unreleased-branch[]
+include::actions/ilm-rollup.asciidoc[]
+endif::[]
 include::actions/ilm-searchable-snapshot.asciidoc[]
 include::actions/ilm-set-priority.asciidoc[]
 include::actions/ilm-shrink.asciidoc[]

--- a/docs/reference/ilm/ilm-index-lifecycle.asciidoc
+++ b/docs/reference/ilm/ilm-index-lifecycle.asciidoc
@@ -81,6 +81,9 @@ the rollover criteria, it could be 20 minutes before the rollover is complete.
   - <<ilm-readonly,Read-Only>>
   - <<ilm-shrink,Shrink>>
   - <<ilm-forcemerge,Force Merge>>
+ifdef::permanently-unreleased-branch[]
+  - <<ilm-rollup,Rollup>>
+endif::[]
 * Warm
   - <<ilm-set-priority,Set Priority>>
   - <<ilm-unfollow,Unfollow>>
@@ -95,6 +98,9 @@ the rollover criteria, it could be 20 minutes before the rollover is complete.
   - <<ilm-allocate,Allocate>>
   - <<ilm-migrate,Migrate>>
   - <<ilm-freeze,Freeze>>
+ifdef::permanently-unreleased-branch[]
+  - <<ilm-rollup,Rollup>>
+endif::[]
   - <<ilm-searchable-snapshot, Searchable Snapshot>>
 * Delete
   - <<ilm-wait-for-snapshot,Wait For Snapshot>>

--- a/docs/reference/rollup/apis/rollup-api.asciidoc
+++ b/docs/reference/rollup/apis/rollup-api.asciidoc
@@ -74,6 +74,7 @@ for the same stream.
 [[rollup-api-request-body]]
 ==== {api-request-body-title}
 
+// tag::rollup-config[]
 `groups`::
 (Required, object)
 Aggregates and stores fields in the rollup.
@@ -188,6 +189,7 @@ values run faster but require more memory.
 +
 NOTE: This argument only affects the speed and memory usage of the rollup
 operation. It does not affect the rollup results.
+// end::rollup-config[]
 
 `timeout`::
 (Optional, <<time-units,time value>>)


### PR DESCRIPTION
Documents the ILM `rollup` action. Relates to #65633.

### Previews
- Rollup action: https://elasticsearch_67108.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ilm-rollup.html
- ILM action list: https://elasticsearch_67108.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ilm-actions.html
- Actions by phase: https://elasticsearch_67108.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ilm-index-lifecycle.html#ilm-phase-actions