### PR TITLE
BACKPORT 711 SmokeTestPlugins use certificate authorities (#67107)

### DIFF
--- a/x-pack/qa/smoke-test-plugins-ssl/src/test/java/org/elasticsearch/smoketest/SmokeTestPluginsSslClientYamlTestSuiteIT.java
+++ b/x-pack/qa/smoke-test-plugins-ssl/src/test/java/org/elasticsearch/smoketest/SmokeTestPluginsSslClientYamlTestSuiteIT.java
@@ -29,7 +29,6 @@ public class SmokeTestPluginsSslClientYamlTestSuiteIT extends ESClientYamlSuiteT
 
     private static final String USER = "test_user";
     private static final String PASS = "x-pack-test-password";
-    private static final String KEYSTORE_PASS = "testnode";
 
     public SmokeTestPluginsSslClientYamlTestSuiteIT(@Name("yaml") ClientYamlTestCandidate testCandidate) {
         super(testCandidate);
@@ -40,23 +39,23 @@ public class SmokeTestPluginsSslClientYamlTestSuiteIT extends ESClientYamlSuiteT
         return ESClientYamlSuiteTestCase.createParameters();
     }
 
-    static Path keyStore;
+    static Path certificateAuthorities;
 
     @BeforeClass
     public static void getKeyStore() {
       try {
-          keyStore = PathUtils.get(SmokeTestPluginsSslClientYamlTestSuiteIT.class.getResource("/testnode.jks").toURI());
+          certificateAuthorities = PathUtils.get(SmokeTestPluginsSslClientYamlTestSuiteIT.class.getResource("/testnode.crt").toURI());
       } catch (URISyntaxException e) {
           throw new ElasticsearchException("exception while reading the store", e);
       }
-      if (!Files.exists(keyStore)) {
-          throw new IllegalStateException("Keystore file [" + keyStore + "] does not exist.");
+      if (!Files.exists(certificateAuthorities)) {
+          throw new IllegalStateException("Keystore file [" + certificateAuthorities + "] does not exist.");
       }
     }
 
     @AfterClass
     public static void clearKeyStore() {
-      keyStore = null;
+      certificateAuthorities = null;
     }
 
     @Override
@@ -64,8 +63,7 @@ public class SmokeTestPluginsSslClientYamlTestSuiteIT extends ESClientYamlSuiteT
         String token = basicAuthHeaderValue(USER, new SecureString(PASS.toCharArray()));
         return Settings.builder()
                 .put(ThreadContext.PREFIX + ".Authorization", token)
-                .put(ESRestTestCase.TRUSTSTORE_PATH, keyStore)
-                .put(ESRestTestCase.TRUSTSTORE_PASSWORD, KEYSTORE_PASS)
+                .put(ESRestTestCase.CERTIFICATE_AUTHORITIES, certificateAuthorities)
                 .build();
     }
 


### PR DESCRIPTION
Backport of #67107

The client in the SmokeTestPluginsSslClientYamlTestSuiteIT uses
certificate_authorities in place of the keystore so it can be run when
`tests.fips.enable: true`.