### PR TITLE
Stop ignoring exceptions in mock loggers

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/logging/MockAppender.java
+++ b/server/src/test/java/org/elasticsearch/common/logging/MockAppender.java
@@ -28,7 +28,7 @@ public class MockAppender extends AbstractAppender {
     public LogEvent lastEvent;
 
     public MockAppender(final String name) throws IllegalAccessException {
-        super(name, RegexFilter.createFilter(".*(\n.*)*", new String[0], false, null, null), null);
+        super(name, RegexFilter.createFilter(".*(\n.*)*", new String[0], false, null, null), null, false);
     }
 
     @Override


### PR DESCRIPTION
Today when testing loggers we use `MockAppender` which is configured to
ignore exceptions encountered during logging. These exceptions are
captured by the `StatusLogger` and ultimately cause tests to fail, but
the failure lacks the context we need to diagnose the problem.

This commit sets the `ignoreExceptions` flag to `false` on all
`MockAppender` objects so that exceptions are thrown to the caller for a
more informative debugging experience.

Relates #66630