### PR TITLE
Update to jimfs 1.2

### DIFF
--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -43,3 +43,8 @@ mocksocket        = 1.2
 
 # benchmark dependencies
 jmh               = 1.19
+
+# test dependencies
+# when updating this version, also update :qa:evil-tests
+jimfs = 1.2
+jimfs_guava = 30.1-jre

--- a/distribution/tools/keystore-cli/build.gradle
+++ b/distribution/tools/keystore-cli/build.gradle
@@ -23,6 +23,6 @@ dependencies {
   compileOnly project(":server")
   compileOnly project(":libs:elasticsearch-cli")
   testImplementation project(":test:framework")
-  testImplementation 'com.google.jimfs:jimfs:1.1'
-  testRuntimeOnly 'com.google.guava:guava:18.0'
+  testImplementation "com.google.jimfs:jimfs:${versions.jimfs}"
+  testRuntimeOnly "com.google.guava:guava:${versions.jimfs_guava}"
 }

--- a/distribution/tools/plugin-cli/build.gradle
+++ b/distribution/tools/plugin-cli/build.gradle
@@ -27,8 +27,8 @@ dependencies {
   api "org.bouncycastle:bcpg-fips:1.0.4"
   api "org.bouncycastle:bc-fips:1.0.2"
   testImplementation project(":test:framework")
-  testImplementation 'com.google.jimfs:jimfs:1.1'
-  testRuntimeOnly 'com.google.guava:guava:18.0'
+  testImplementation "com.google.jimfs:jimfs:${versions.jimfs}"
+  testRuntimeOnly "com.google.guava:guava:${versions.jimfs_guava}"
 }
 
 tasks.named("dependencyLicenses").configure {

--- a/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/InstallPluginCommand.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/InstallPluginCommand.java
@@ -746,19 +746,6 @@ class InstallPluginCommand extends EnvironmentAwareCommand {
     private Path stagingDirectory(Path pluginsDir) throws IOException {
         try {
             return Files.createTempDirectory(pluginsDir, ".installing-", PosixFilePermissions.asFileAttribute(PLUGIN_DIR_PERMS));
-        } catch (IllegalArgumentException e) {
-            // Jimfs throws an IAE where it should throw an UOE
-            // remove when google/jimfs#30 is integrated into Jimfs
-            // and the Jimfs test dependency is upgraded to include
-            // this pull request
-            final StackTraceElement[] elements = e.getStackTrace();
-            if (elements.length >= 1
-                && elements[0].getClassName().equals("com.google.common.jimfs.AttributeService")
-                && elements[0].getMethodName().equals("setAttributeInternal")) {
-                return stagingDirectoryWithoutPosixPermissions(pluginsDir);
-            } else {
-                throw e;
-            }
         } catch (UnsupportedOperationException e) {
             return stagingDirectoryWithoutPosixPermissions(pluginsDir);
         }

--- a/qa/evil-tests/build.gradle
+++ b/qa/evil-tests/build.gradle
@@ -27,7 +27,7 @@ apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-test'
 
 dependencies {
-  testImplementation 'com.google.jimfs:jimfs:1.1'
+  testImplementation "com.google.jimfs:jimfs:1.2"
 }
 
 // TODO: give each evil test its own fresh JVM for more isolation.
@@ -46,7 +46,16 @@ tasks.named("thirdPartyAudit").configure {
     'com.google.common.cache.Striped64',
     'com.google.common.cache.Striped64$1',
     'com.google.common.cache.Striped64$Cell',
+    'com.google.common.hash.LittleEndianByteArray$UnsafeByteArray',
+    'com.google.common.hash.LittleEndianByteArray$UnsafeByteArray$1',
+    'com.google.common.hash.LittleEndianByteArray$UnsafeByteArray$2',
+    'com.google.common.hash.LittleEndianByteArray$UnsafeByteArray$3',
+    'com.google.common.hash.Striped64',
+    'com.google.common.hash.Striped64$1',
+    'com.google.common.hash.Striped64$Cell',
     'com.google.common.primitives.UnsignedBytes$LexicographicalComparatorHolder$UnsafeComparator',
-    'com.google.common.primitives.UnsignedBytes$LexicographicalComparatorHolder$UnsafeComparator$1'
+    'com.google.common.primitives.UnsignedBytes$LexicographicalComparatorHolder$UnsafeComparator$1',
+    'com.google.common.util.concurrent.AbstractFuture$UnsafeAtomicHelper',
+    'com.google.common.util.concurrent.AbstractFuture$UnsafeAtomicHelper$1'
   )
 }

--- a/x-pack/plugin/security/cli/build.gradle
+++ b/x-pack/plugin/security/cli/build.gradle
@@ -10,11 +10,11 @@ dependencies {
   compileOnly project(path: xpackModule('core'), configuration: 'default')
   api "org.bouncycastle:bcpkix-jdk15on:${versions.bouncycastle}"
   api "org.bouncycastle:bcprov-jdk15on:${versions.bouncycastle}"
-  testImplementation('com.google.jimfs:jimfs:1.1') {
+  testImplementation("com.google.jimfs:jimfs:${versions.jimfs}") {
     // this is provided by the runtime classpath, from the security project
-    exclude group: 'com.google.guava', module: 'guava'
+    exclude group: "com.google.guava", module: "guava"
   }
-  testRuntimeOnly 'com.google.guava:guava:19.0'
+  testRuntimeOnly "com.google.guava:guava:${versions.jimfs_guava}"
   testImplementation project(":test:framework")
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }

--- a/x-pack/qa/saml-idp-tests/build.gradle
+++ b/x-pack/qa/saml-idp-tests/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'elasticsearch.test.fixtures'
 
 dependencies {
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
-  testImplementation 'com.google.jimfs:jimfs:1.1'
+  testImplementation "com.google.jimfs:jimfs:${versions.jimfs}"
 }
 testFixtures.useFixture ":x-pack:test:idp-fixture"
 
@@ -105,8 +105,17 @@ tasks.named("thirdPartyAudit").configure {
     'com.google.common.cache.Striped64',
     'com.google.common.cache.Striped64$1',
     'com.google.common.cache.Striped64$Cell',
+    'com.google.common.hash.LittleEndianByteArray$UnsafeByteArray',
+    'com.google.common.hash.LittleEndianByteArray$UnsafeByteArray$1',
+    'com.google.common.hash.LittleEndianByteArray$UnsafeByteArray$2',
+    'com.google.common.hash.LittleEndianByteArray$UnsafeByteArray$3',
+    'com.google.common.hash.Striped64',
+    'com.google.common.hash.Striped64$1',
+    'com.google.common.hash.Striped64$Cell',
     'com.google.common.primitives.UnsignedBytes$LexicographicalComparatorHolder$UnsafeComparator',
-    'com.google.common.primitives.UnsignedBytes$LexicographicalComparatorHolder$UnsafeComparator$1'
+    'com.google.common.primitives.UnsignedBytes$LexicographicalComparatorHolder$UnsafeComparator$1',
+    'com.google.common.util.concurrent.AbstractFuture$UnsafeAtomicHelper',
+    'com.google.common.util.concurrent.AbstractFuture$UnsafeAtomicHelper$1'
   )
 
   ignoreMissingClasses(

--- a/x-pack/qa/security-tools-tests/build.gradle
+++ b/x-pack/qa/security-tools-tests/build.gradle
@@ -3,8 +3,8 @@ apply plugin: 'elasticsearch.standalone-test'
 dependencies {
   testImplementation project(xpackModule('security'))
   testImplementation project(path: xpackModule('security'), configuration: 'testArtifacts')
-  testImplementation 'com.google.jimfs:jimfs:1.1'
-  testRuntimeOnly 'com.google.guava:guava:16.0.1'
+  testImplementation "com.google.jimfs:jimfs:${versions.jimfs}"
+  testRuntimeOnly "com.google.guava:guava:${versions.jimfs_guava}"
 }
 
 // add test resources from security, so certificate tool tests can use example certs


### PR DESCRIPTION
A new version of this test dependency is finally available, enabling us to remove a hack from production code we've long carried because of a bug in that test dependency. This commit upgrades our tests to use jimfs-1.2.

Relates google/jimfs#30
Relates https://github.com/google/jimfs/issues/65#issuecomment-755417876
