### PR TITLE
SQL: Add the dataloader gradle task

### DIFF
--- a/x-pack/plugin/sql/qa/server/build.gradle
+++ b/x-pack/plugin/sql/qa/server/build.gradle
@@ -43,9 +43,9 @@ dependencies {
 }
 
 tasks.register("dataloader", JavaExec) {
-  dependsOn "testClasses"
+  dependsOn build
   main 'org.elasticsearch.xpack.sql.qa.jdbc.DataLoader'
-  classpath sourceSets.main.runtimeClasspath + sourceSets.main.output
+  classpath sourceSets.main.runtimeClasspath
   systemProperty 'file.encoding', 'UTF-8'
 }
 

--- a/x-pack/plugin/sql/qa/server/build.gradle
+++ b/x-pack/plugin/sql/qa/server/build.gradle
@@ -42,6 +42,13 @@ dependencies {
   }
 }
 
+tasks.register("dataloader", JavaExec) {
+  dependsOn "testClasses"
+  main 'org.elasticsearch.xpack.sql.qa.jdbc.DataLoader'
+  classpath sourceSets.main.runtimeClasspath + sourceSets.main.output
+  systemProperty 'file.encoding', 'UTF-8'
+}
+
 subprojects {
   if (subprojects.isEmpty()) {
     // leaf project


### PR DESCRIPTION
* Ability to execute the DataLoader using the `./gradlew
':x-pack:plugin:sql:qa:server:dataloader'` command