### PR TITLE
Fix ignoring existed cluster settings in DataTierAllocationDecider

### DIFF
--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderDecisionTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderDecisionTests.java
@@ -365,7 +365,7 @@ public class ReactiveStorageDeciderDecisionTests extends AutoscalingTestCase {
         return new AllocationDeciders(
             Stream.of(
                 Stream.of(extraDeciders),
-                Stream.of(new DataTierAllocationDecider(clusterSettings)),
+                Stream.of(new DataTierAllocationDecider(Settings.EMPTY, clusterSettings)),
                 systemAllocationDeciders.stream()
             ).flatMap(s -> s).collect(Collectors.toList())
         );

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDecider.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDecider.java
@@ -70,11 +70,14 @@ public class DataTierAllocationDecider extends AllocationDecider {
         }
     }
 
-    private volatile String clusterRequire = null;
-    private volatile String clusterInclude = null;
-    private volatile String clusterExclude = null;
+    private volatile String clusterRequire;
+    private volatile String clusterInclude;
+    private volatile String clusterExclude;
 
-    public DataTierAllocationDecider(ClusterSettings clusterSettings) {
+    public DataTierAllocationDecider(Settings settings, ClusterSettings clusterSettings) {
+        clusterRequire = CLUSTER_ROUTING_REQUIRE_SETTING.get(settings);
+        clusterInclude = CLUSTER_ROUTING_INCLUDE_SETTING.get(settings);
+        clusterExclude = CLUSTER_ROUTING_EXCLUDE_SETTING.get(settings);
         clusterSettings.addSettingsUpdateConsumer(CLUSTER_ROUTING_REQUIRE_SETTING, s -> this.clusterRequire = s);
         clusterSettings.addSettingsUpdateConsumer(CLUSTER_ROUTING_INCLUDE_SETTING, s -> this.clusterInclude = s);
         clusterSettings.addSettingsUpdateConsumer(CLUSTER_ROUTING_EXCLUDE_SETTING, s -> this.clusterExclude = s);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackPlugin.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackPlugin.java
@@ -394,7 +394,7 @@ public class XPackPlugin extends XPackClientPlugin implements ExtensiblePlugin, 
 
     @Override
     public Collection<AllocationDecider> createAllocationDeciders(Settings settings, ClusterSettings clusterSettings) {
-        return Collections.singleton(new DataTierAllocationDecider(clusterSettings));
+        return Collections.singleton(new DataTierAllocationDecider(settings, clusterSettings));
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/SetSingleNodeAllocateStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/SetSingleNodeAllocateStep.java
@@ -74,7 +74,7 @@ public class SetSingleNodeAllocateStep extends AsyncActionStep {
         AllocationDeciders allocationDeciders = new AllocationDeciders(List.of(
             new FilterAllocationDecider(clusterState.getMetadata().settings(),
                 new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)),
-            new DataTierAllocationDecider(new ClusterSettings(Settings.EMPTY, ALL_CLUSTER_SETTINGS)),
+            new DataTierAllocationDecider(clusterState.getMetadata().settings(), new ClusterSettings(Settings.EMPTY, ALL_CLUSTER_SETTINGS)),
             new NodeVersionAllocationDecider()
         ));
         final RoutingNodes routingNodes = clusterState.getRoutingNodes();

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDeciderTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDeciderTests.java
@@ -37,6 +37,7 @@ import org.elasticsearch.xpack.core.DataTier;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -53,7 +54,7 @@ public class DataTierAllocationDeciderTests extends ESAllocationTestCase {
     private static final DiscoveryNode DATA_NODE = newNode("node-data", Collections.singleton(DiscoveryNodeRole.DATA_ROLE));
 
     private final ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, ALL_SETTINGS);
-    private final DataTierAllocationDecider decider = new DataTierAllocationDecider(clusterSettings);
+    private final DataTierAllocationDecider decider = new DataTierAllocationDecider(Settings.EMPTY, clusterSettings);
     private final AllocationDeciders allocationDeciders = new AllocationDeciders(
         Arrays.asList(decider,
             new SameShardAllocationDecider(Settings.EMPTY, clusterSettings),
@@ -646,6 +647,60 @@ public class DataTierAllocationDeciderTests extends ESAllocationTestCase {
             equalTo(Optional.of("data_content")));
         assertThat(DataTierAllocationDecider.preferredAvailableTier("data_hot,data_cold,data_warm", nodes),
             equalTo(Optional.of("data_warm")));
+    }
+
+    public void testExistedClusterFilters() {
+        Settings existedSettings = Settings.builder()
+            .put("cluster.routing.allocation.include._tier", "data_hot,data_warm")
+            .put("cluster.routing.allocation.exclude._tier", "data_cold")
+            .build();
+        ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, ALL_SETTINGS);
+        DataTierAllocationDecider dataTierAllocationDecider = new DataTierAllocationDecider(existedSettings, clusterSettings);
+        AllocationDeciders allocationDeciders = new AllocationDeciders(
+            List.of(dataTierAllocationDecider));
+        AllocationService service = new AllocationService(allocationDeciders,
+            new TestGatewayAllocator(), new BalancedShardsAllocator(Settings.EMPTY), EmptyClusterInfoService.INSTANCE,
+            EmptySnapshotsInfoService.INSTANCE);
+
+        ClusterState clusterState = prepareState(service.reroute(ClusterState.EMPTY_STATE, "initial state"));
+
+        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, clusterState.getRoutingNodes(), clusterState,
+            null, null, 0);
+        allocation.debugDecision(true);
+        Decision d;
+        RoutingNode node;
+
+        for (DiscoveryNode n : Arrays.asList(HOT_NODE, WARM_NODE)) {
+            node = new RoutingNode(n.getId(), n, shard);
+            d = dataTierAllocationDecider.canAllocate(shard, node, allocation);
+            assertThat(d.type(), equalTo(Decision.Type.YES));
+            d = dataTierAllocationDecider.canRemain(shard, node, allocation);
+            assertThat(d.type(), equalTo(Decision.Type.YES));
+        }
+
+        node = new RoutingNode(DATA_NODE.getId(), DATA_NODE, shard);
+        d = dataTierAllocationDecider.canAllocate(shard, node, allocation);
+        assertThat(d.type(), equalTo(Decision.Type.NO));
+        assertThat(d.getExplanation(),
+            containsString("node matches any cluster setting [cluster.routing.allocation.exclude._tier] " +
+                "tier filters [data_cold]"));
+        d = dataTierAllocationDecider.canRemain(shard, node, allocation);
+        assertThat(d.type(), equalTo(Decision.Type.NO));
+        assertThat(d.getExplanation(),
+            containsString("node matches any cluster setting [cluster.routing.allocation.exclude._tier] " +
+                "tier filters [data_cold]"));
+
+        node = new RoutingNode(COLD_NODE.getId(), COLD_NODE, shard);
+        d = dataTierAllocationDecider.canAllocate(shard, node, allocation);
+        assertThat(d.type(), equalTo(Decision.Type.NO));
+        assertThat(d.getExplanation(),
+            containsString("node does not match any cluster setting [cluster.routing.allocation.include._tier] " +
+                "tier filters [data_hot,data_warm]"));
+        d = dataTierAllocationDecider.canRemain(shard, node, allocation);
+        assertThat(d.type(), equalTo(Decision.Type.NO));
+        assertThat(d.getExplanation(),
+            containsString("node does not match any cluster setting [cluster.routing.allocation.include._tier] " +
+                "tier filters [data_hot,data_warm]"));
     }
 
     private ClusterState prepareState(ClusterState initialState) {


### PR DESCRIPTION
Relates to #67133.
Seem to #65037.

The main changes of this PR are:

1. Modify the construction method of `DataTierAllocationDecider`, add a param `settings` like `FilterAllocationDecider`.
1. Create `DataTierAllocationDecider` in the main method of `DataTierMigrationRoutedStep` and `SetSingleNodeAllocateStep`, and the `DataTierAllocationDecider` is constructed using the cluster settings in the cluster metadata, so the cluster level _tier filters can be seen when executing the steps.
2. Add some tests for the change.