### PR TITLE
VND content types comparisons with corresponding Non VND types

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/enrich/PutPolicyRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/enrich/PutPolicyRequest.java
@@ -80,7 +80,7 @@ public final class PutPolicyRequest implements Validatable, ToXContentObject {
 
     // package private for testing only
     void setQuery(BytesReference query) {
-        assert query == null || XContentHelper.xContentType(query) == XContentType.JSON :
+        assert query == null || XContentHelper.xContentType(query).canonical() == XContentType.JSON :
                 "Only accepts JSON encoded query but received [" + Strings.toString(query) + "]";
         this.query = query;
     }

--- a/server/src/main/java/org/elasticsearch/common/xcontent/XContentHelper.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/XContentHelper.java
@@ -209,7 +209,7 @@ public class XContentHelper {
     public static String convertToJson(BytesReference bytes, boolean reformatJson, boolean prettyPrint, XContentType xContentType)
         throws IOException {
         Objects.requireNonNull(xContentType);
-        if (xContentType == XContentType.JSON && !reformatJson) {
+        if (xContentType.canonical() == XContentType.JSON && !reformatJson) {
             return bytes.utf8ToString();
         }
 

--- a/server/src/test/java/org/elasticsearch/common/xcontent/XContentFactoryTests.java
+++ b/server/src/test/java/org/elasticsearch/common/xcontent/XContentFactoryTests.java
@@ -49,6 +49,13 @@ public class XContentFactoryTests extends ESTestCase {
         testGuessType(XContentType.CBOR);
     }
 
+    public void testGuessVndTypes() throws IOException {
+        testGuessType(XContentType.VND_JSON);
+        testGuessType(XContentType.VND_SMILE);
+        testGuessType(XContentType.VND_YAML);
+        testGuessType(XContentType.VND_CBOR);
+    }
+
     private void testGuessType(XContentType type) throws IOException {
         XContentBuilder builder = XContentFactory.contentBuilder(type);
         builder.startObject();
@@ -56,7 +63,7 @@ public class XContentFactoryTests extends ESTestCase {
         builder.endObject();
 
         final BytesReference bytes;
-        if (type == XContentType.JSON && randomBoolean()) {
+        if (type.canonical() == XContentType.JSON && randomBoolean()) {
             final int length = randomIntBetween(0, 8 * XContentFactory.GUESS_HEADER_LENGTH);
             final String content = Strings.toString(builder);
             final StringBuilder sb = new StringBuilder(length + content.length());
@@ -68,12 +75,12 @@ public class XContentFactoryTests extends ESTestCase {
             bytes = BytesReference.bytes(builder);
         }
 
-        assertThat(XContentHelper.xContentType(bytes), equalTo(type));
-        assertThat(XContentFactory.xContentType(bytes.streamInput()), equalTo(type));
+        assertThat(XContentHelper.xContentType(bytes), equalTo(type.canonical()));
+        assertThat(XContentFactory.xContentType(bytes.streamInput()), equalTo(type.canonical()));
 
         // CBOR is binary, cannot use String
-        if (type != XContentType.CBOR && type != XContentType.SMILE) {
-            assertThat(XContentFactory.xContentType(Strings.toString(builder)), equalTo(type));
+        if (type.canonical() != XContentType.CBOR && type.canonical() != XContentType.SMILE) {
+            assertThat(XContentFactory.xContentType(Strings.toString(builder)), equalTo(type.canonical()));
         }
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/RandomObjects.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/RandomObjects.java
@@ -136,7 +136,7 @@ public final class RandomObjects {
      */
     public static Object getExpectedParsedValue(XContentType xContentType, Object value) {
         if (value instanceof BytesArray) {
-            if (xContentType == XContentType.JSON) {
+            if (xContentType.canonical() == XContentType.JSON) {
                 //JSON writes base64 format
                 return Base64.getEncoder().encodeToString(((BytesArray)value).toBytesRef().bytes);
             }

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestResponse.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestResponse.java
@@ -126,7 +126,8 @@ public class ClientYamlTestResponse {
     public String getBodyAsString() {
         if (bodyAsString == null && body != null) {
             //content-type null means that text was returned
-            if (bodyContentType == null || bodyContentType == XContentType.JSON || bodyContentType == XContentType.YAML) {
+            if (bodyContentType == null || bodyContentType.canonical() == XContentType.JSON ||
+                bodyContentType.canonical() == XContentType.YAML) {
                 bodyAsString = new String(body, StandardCharsets.UTF_8);
             } else {
                 //if the body is in a binary format and gets requested as a string (e.g. to log a test failure), we convert it to json

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/support/WatcherTemplateTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/support/WatcherTemplateTests.java
@@ -45,7 +45,7 @@ public class WatcherTemplateTests extends ESTestCase {
     }
 
     public void testEscaping() throws Exception {
-        XContentType contentType = randomFrom(XContentType.values());
+        XContentType contentType = randomFrom(XContentType.values()).canonical();
         if (rarely()) {
             contentType = null;
         }


### PR DESCRIPTION
VND types like application/vnd.elasticsearch+json
(XContentType.VND_JSON) when compared with
application/json (XContentType.JSON) should use `canonnical`
These comparisons are often used in test data generation, where a special logic has to be peformed for some XContentType instances. When testing with all possible XContentType vendor (VND*) enumerations should be treated as their corresponding non vendor instances. Hence the use of canonical method.
closes #67064

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
