### PR TITLE
Disable autoscaling capacity test on debian 8

### DIFF
--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/action/TransportGetAutoscalingCapacityActionIT.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/action/TransportGetAutoscalingCapacityActionIT.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.autoscaling.action;
 
 import org.apache.lucene.util.Constants;
+import org.elasticsearch.bootstrap.JavaVersion;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.monitor.os.OsProbe;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -28,10 +29,9 @@ public class TransportGetAutoscalingCapacityActionIT extends AutoscalingIntegTes
 
     public void testCurrentCapacity() throws Exception {
         boolean looksLikeDebian8 = Constants.LINUX && Constants.OS_VERSION.startsWith("3.16.0");
-        final StringTokenizer st = new StringTokenizer(JVM_SPEC_VERSION, ".");
-        int major = Integer.parseInt(st.nextToken());
+        boolean java15Plus = JavaVersion.current().compareTo(JavaVersion.parse("15")) >= 0;
         // see: https://github.com/elastic/elasticsearch/issues/67089#issuecomment-756114654
-        assumeTrue("cannot run on debian 8 prior to java 15", major >= 15 || looksLikeDebian8 == false);
+        assumeTrue("cannot run on debian 8 prior to java 15", java15Plus || looksLikeDebian8 == false);
 
         assertThat(capacity().results().keySet(), Matchers.empty());
         long memory = OsProbe.getInstance().getTotalPhysicalMemorySize();

--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/action/TransportGetAutoscalingCapacityActionIT.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/action/TransportGetAutoscalingCapacityActionIT.java
@@ -28,8 +28,9 @@ public class TransportGetAutoscalingCapacityActionIT extends AutoscalingIntegTes
 
     public void testCurrentCapacity() throws Exception {
         final NodesInfoResponse response = client().admin().cluster().prepareNodesInfo().execute().actionGet();
-        final boolean anyDebian8Nodes =
-            response.getNodes().stream().anyMatch(ni -> ni.getInfo(OsInfo.class).getPrettyName().equals("Debian GNU/Linux 8 (jessie)"));
+        final boolean anyDebian8Nodes = response.getNodes()
+            .stream()
+            .anyMatch(ni -> ni.getInfo(OsInfo.class).getPrettyName().equals("Debian GNU/Linux 8 (jessie)"));
         boolean java15Plus = JavaVersion.current().compareTo(JavaVersion.parse("15")) >= 0;
         // see: https://github.com/elastic/elasticsearch/issues/67089#issuecomment-756114654
         assumeTrue("cannot run on debian 8 prior to java 15", java15Plus || anyDebian8Nodes == false);

--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/action/TransportGetAutoscalingCapacityActionIT.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/action/TransportGetAutoscalingCapacityActionIT.java
@@ -16,11 +16,9 @@ import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingCapacity;
 import org.hamcrest.Matchers;
 
 import java.util.Set;
-import java.util.StringTokenizer;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
-import static org.apache.lucene.util.Constants.JVM_SPEC_VERSION;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.greaterThan;
 


### PR DESCRIPTION
Prior to java 15, ES running on debian 8 will report 0 memory of host,
therefore this test cannot run on debian 8.

Relates #67089
