### PR TITLE
Fix missing `QuotaPath.unwrap()` instances

### DIFF
--- a/x-pack/quota-aware-fs/src/main/java/org/elasticsearch/fs/quotaaware/QuotaAwareFileSystemProvider.java
+++ b/x-pack/quota-aware-fs/src/main/java/org/elasticsearch/fs/quotaaware/QuotaAwareFileSystemProvider.java
@@ -408,12 +408,12 @@ public class QuotaAwareFileSystemProvider extends FileSystemProvider implements 
 
     @Override
     public void createLink(Path link, Path existing) throws IOException {
-        delegate.createLink(link, existing);
+        delegate.createLink(QuotaAwarePath.unwrap(link), QuotaAwarePath.unwrap(existing));
     }
 
     @Override
     public void createSymbolicLink(Path link, Path target, FileAttribute<?>... attrs) throws IOException {
-        delegate.createSymbolicLink(link, target, attrs);
+        delegate.createSymbolicLink(QuotaAwarePath.unwrap(link), QuotaAwarePath.unwrap(target), attrs);
     }
 
     void purge(FileSystem delegateFileSystem) {


### PR DESCRIPTION
Closes #67164. There were a couple of places in
`QuotaAwareFileSystemProvider` where the supplied paths were not being
unwrapped back into platform-specific path objects.
