### PR TITLE
[6.8] Backport some fixes to CharArraysTest#testConstantTimeEquals()

### DIFF
--- a/libs/core/src/test/java/org/elasticsearch/common/CharArraysTests.java
+++ b/libs/core/src/test/java/org/elasticsearch/common/CharArraysTests.java
@@ -23,6 +23,8 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.nio.charset.StandardCharsets;
 
+import static org.hamcrest.Matchers.is;
+
 public class CharArraysTests extends ESTestCase {
 
     public void testCharsToBytes() {
@@ -70,10 +72,12 @@ public class CharArraysTests extends ESTestCase {
         assertTrue(CharArrays.constantTimeEquals(value.toCharArray(), value.toCharArray()));
 
         // we want a different string, so ensure the first character is different, but the same overall length
-        final String other = new String(
-            randomAlphaOfLengthNotBeginningWith(value.substring(0, 1), value.length(), value.length()));
-        assertFalse("value: " + value + ", other: " + other, CharArrays.constantTimeEquals(value, other));
-        assertFalse(CharArrays.constantTimeEquals(value.toCharArray(), other.toCharArray()));
+        final int length = value.length();
+        final String other = length > 0 ? new String(randomAlphaOfLengthNotBeginningWith(value.substring(0, 1), length, length)) : "";
+        final boolean expectedEquals = length == 0;
+
+        assertThat("value: " + value + ", other: " + other, CharArrays.constantTimeEquals(value, other), is(expectedEquals));
+        assertThat(CharArrays.constantTimeEquals(value.toCharArray(), other.toCharArray()), is(expectedEquals));
     }
 
     private char[] randomAlphaOfLengthNotBeginningWith(String undesiredPrefix, int min, int max) {

--- a/libs/core/src/test/java/org/elasticsearch/common/CharArraysTests.java
+++ b/libs/core/src/test/java/org/elasticsearch/common/CharArraysTests.java
@@ -69,8 +69,10 @@ public class CharArraysTests extends ESTestCase {
         assertTrue(CharArrays.constantTimeEquals(value, value));
         assertTrue(CharArrays.constantTimeEquals(value.toCharArray(), value.toCharArray()));
 
-        final String other = randomAlphaOfLengthBetween(1, 32);
-        assertFalse(CharArrays.constantTimeEquals(value, other));
+        // we want a different string, so ensure the first character is different, but the same overall length
+        final String other = new String(
+            randomAlphaOfLengthNotBeginningWith(value.substring(0, 1), value.length(), value.length()));
+        assertFalse("value: " + value + ", other: " + other, CharArrays.constantTimeEquals(value, other));
         assertFalse(CharArrays.constantTimeEquals(value.toCharArray(), other.toCharArray()));
     }
 


### PR DESCRIPTION
We fixed some edge cases for CharArraysTest#testConstantTimeEquals() in 7.x and master. This PR brings those fixes to 6.8 in order to avoid some occasional test failures.

Original fixes: https://github.com/elastic/elasticsearch/pull/47238 and https://github.com/elastic/elasticsearch/pull/47346

Closes https://github.com/elastic/elasticsearch/issues/47076