### PR TITLE
Port UrlFixture to test fixture plugin

### DIFF
--- a/modules/repository-url/Dockerfile
+++ b/modules/repository-url/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:18.04
+
+RUN apt-get update -qqy
+RUN apt-get install -qqy openjdk-11-jre-headless
+
+ARG port
+ARG workingDir
+ARG repositoryDir
+
+ENV URL_FIXTURE_PORT=${port}
+ENV URL_FIXTURE_WORKING_DIR=${workingDir}
+ENV URL_FIXTURE_REPO_DIR=${repositoryDir}
+
+ENTRYPOINT exec java -classpath "/fixture/shared/*" \
+    org.elasticsearch.repositories.url.URLFixture "$URL_FIXTURE_PORT" "$URL_FIXTURE_WORKING_DIR" "$URL_FIXTURE_REPO_DIR"
+
+EXPOSE $port

--- a/modules/repository-url/build.gradle
+++ b/modules/repository-url/build.gradle
@@ -23,7 +23,7 @@ import org.elasticsearch.gradle.test.AntFixture
 
 apply plugin: 'elasticsearch.yaml-rest-test'
 apply plugin: 'elasticsearch.internal-cluster-test'
-
+apply plugin: 'elasticsearch.test.fixtures'
 
 esplugin {
   description 'Module for URL repository'
@@ -39,23 +39,30 @@ restResources {
  // This directory is shared between two URL repositories and one FS repository in YAML integration tests
 File repositoryDir = new File(project.buildDir, "shared-repository")
 
-/** A task to start the URLFixture which exposes the repositoryDir over HTTP **/
-def urlFixtureTaskProvider = tasks.register("urlFixture", AntFixture) {
-  dependsOn "testClasses"
-  doFirst {
+def testJar = tasks.register("testJar", Jar) {
+  from sourceSets.test.output
+  classifier = "test"
+}
+
+tasks.named("preProcessFixture").configure {
+  inputs.files(testJar, sourceSets.test.runtimeClasspath)
+  doLast {
+    file("${testFixturesDir}/shared").mkdirs()
+    project.copy {
+      from testJar.get().archiveFile
+      from sourceSets.test.runtimeClasspath
+      into "${testFixturesDir}/shared"
+    }
     repositoryDir.mkdirs()
   }
-  env 'CLASSPATH', "${-> project.sourceSets.test.runtimeClasspath.asPath}"
-  executable = "${BuildParams.runtimeJavaHome}/bin/java"
-  args 'org.elasticsearch.repositories.url.URLFixture', baseDir, "${repositoryDir.absolutePath}"
 }
 
-tasks.named("yamlRestTest").configure {
-  dependsOn urlFixtureTaskProvider
-}
+testFixtures.useFixture()
 
-tasks.named("internalClusterTest").configure {
-  dependsOn urlFixtureTaskProvider
+def fixtureAddress = {
+  int ephemeralPort = tasks.named("postProcessFixture").get().ext."test.fixtures.url-fixture.tcp.80"
+  assert ephemeralPort > 0
+  'http://127.0.0.1:' + ephemeralPort
 }
 
 testClusters.all {
@@ -63,7 +70,7 @@ testClusters.all {
   setting 'path.repo', "${repositoryDir.absolutePath}", PropertyNormalization.IGNORE_VALUE
   // repositoryDir is used by two URL repositories to restore snapshots
   setting 'repositories.url.allowed_urls', {
-    "http://snapshot.test*,http://${urlFixture.addressAndPort}"
+    "http://snapshot.test*,${fixtureAddress()}"
   }, PropertyNormalization.IGNORE_VALUE
 }
 

--- a/modules/repository-url/build.gradle
+++ b/modules/repository-url/build.gradle
@@ -49,7 +49,7 @@ tasks.named("preProcessFixture").configure {
   doLast {
     file("${testFixturesDir}/shared").mkdirs()
     project.copy {
-      from testJar.get().archiveFile
+      from testJar
       from sourceSets.test.runtimeClasspath
       into "${testFixturesDir}/shared"
     }
@@ -66,6 +66,7 @@ def fixtureAddress = {
 }
 
 testClusters.all {
+  println "repositoryDir.absolutePath = $repositoryDir.absolutePath"
   // repositoryDir is used by a FS repository to create snapshots
   setting 'path.repo', "${repositoryDir.absolutePath}", PropertyNormalization.IGNORE_VALUE
   // repositoryDir is used by two URL repositories to restore snapshots

--- a/modules/repository-url/docker-compose.yml
+++ b/modules/repository-url/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3'
+services:
+  url-fixture:
+    build:
+      context: .
+      args:
+        port: 80
+        workingDir: "/fixture/work"
+        repositoryDir: "/fixture/repo"
+      dockerfile: Dockerfile
+    volumes:
+      - ./testfixtures_shared/shared:/fixture/shared
+      - ./build/shared-repository:/fixture/repo
+      - ./testfixtures_shared/work:/fixture/work
+    ports:
+      - "80"

--- a/modules/repository-url/docker-compose.yml
+++ b/modules/repository-url/docker-compose.yml
@@ -7,7 +7,6 @@ services:
         port: 80
         workingDir: "/fixture/work"
         repositoryDir: "/fixture/repo"
-      dockerfile: Dockerfile
     volumes:
       - ./testfixtures_shared/shared:/fixture/shared
       - ./build/shared-repository:/fixture/repo

--- a/modules/repository-url/src/test/java/org/elasticsearch/repositories/url/URLFixture.java
+++ b/modules/repository-url/src/test/java/org/elasticsearch/repositories/url/URLFixture.java
@@ -40,17 +40,16 @@ public class URLFixture extends AbstractHttpFixture {
     /**
      * Creates a {@link URLFixture}
      */
-    private URLFixture(final String workingDir, final String repositoryDir) {
-        super(workingDir);
+    private URLFixture(final int port, final String workingDir, final String repositoryDir) {
+        super(workingDir, port);
         this.repositoryDir = dir(repositoryDir);
     }
 
     public static void main(String[] args) throws Exception {
-        if (args == null || args.length != 2) {
-            throw new IllegalArgumentException("URLFixture <working directory> <repository directory>");
+        if (args == null || args.length != 3) {
+            throw new IllegalArgumentException("URLFixture <port> <working directory> <repository directory>");
         }
-
-        final URLFixture fixture = new URLFixture(args[0], args[1]);
+        final URLFixture fixture = new URLFixture(Integer.parseInt(args[0]), args[1], args[2]);
         fixture.listen();
     }
 

--- a/modules/repository-url/src/test/java/org/elasticsearch/repositories/url/URLFixture.java
+++ b/modules/repository-url/src/test/java/org/elasticsearch/repositories/url/URLFixture.java
@@ -23,6 +23,7 @@ import org.elasticsearch.common.SuppressForbidden;
 import org.elasticsearch.rest.RestStatus;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -50,7 +51,7 @@ public class URLFixture extends AbstractHttpFixture {
             throw new IllegalArgumentException("URLFixture <port> <working directory> <repository directory>");
         }
         final URLFixture fixture = new URLFixture(Integer.parseInt(args[0]), args[1], args[2]);
-        fixture.listen(false);
+        fixture.listen(InetAddress.getByName("0.0.0.0"), false);
     }
 
     @Override

--- a/modules/repository-url/src/test/java/org/elasticsearch/repositories/url/URLFixture.java
+++ b/modules/repository-url/src/test/java/org/elasticsearch/repositories/url/URLFixture.java
@@ -50,7 +50,7 @@ public class URLFixture extends AbstractHttpFixture {
             throw new IllegalArgumentException("URLFixture <port> <working directory> <repository directory>");
         }
         final URLFixture fixture = new URLFixture(Integer.parseInt(args[0]), args[1], args[2]);
-        fixture.listen();
+        fixture.listen(false);
     }
 
     @Override

--- a/modules/repository-url/src/test/java/org/elasticsearch/repositories/url/URLFixture.java
+++ b/modules/repository-url/src/test/java/org/elasticsearch/repositories/url/URLFixture.java
@@ -50,7 +50,15 @@ public class URLFixture extends AbstractHttpFixture {
         if (args == null || args.length != 3) {
             throw new IllegalArgumentException("URLFixture <port> <working directory> <repository directory>");
         }
-        final URLFixture fixture = new URLFixture(Integer.parseInt(args[0]), args[1], args[2]);
+        String workingDirectory = args[1];
+        if(Files.exists(dir(workingDirectory)) == false) {
+            throw new IllegalArgumentException("Configured working direcotry " + workingDirectory + " does not exist");
+        }
+        String repositoryDirectory = args[1];
+        if(Files.exists(dir(repositoryDirectory)) == false) {
+            throw new IllegalArgumentException("Configured repository direcotry " + repositoryDirectory + " does not exist");
+        }
+        final URLFixture fixture = new URLFixture(Integer.parseInt(args[0]), workingDirectory, repositoryDirectory);
         fixture.listen(InetAddress.getByName("0.0.0.0"), false);
     }
 

--- a/modules/repository-url/src/test/java/org/elasticsearch/repositories/url/URLFixture.java
+++ b/modules/repository-url/src/test/java/org/elasticsearch/repositories/url/URLFixture.java
@@ -52,11 +52,11 @@ public class URLFixture extends AbstractHttpFixture {
         }
         String workingDirectory = args[1];
         if(Files.exists(dir(workingDirectory)) == false) {
-            throw new IllegalArgumentException("Configured working direcotry " + workingDirectory + " does not exist");
+            throw new IllegalArgumentException("Configured working directory " + workingDirectory + " does not exist");
         }
-        String repositoryDirectory = args[1];
+        String repositoryDirectory = args[2];
         if(Files.exists(dir(repositoryDirectory)) == false) {
-            throw new IllegalArgumentException("Configured repository direcotry " + repositoryDirectory + " does not exist");
+            throw new IllegalArgumentException("Configured repository directory " + repositoryDirectory + " does not exist");
         }
         final URLFixture fixture = new URLFixture(Integer.parseInt(args[0]), workingDirectory, repositoryDirectory);
         fixture.listen(InetAddress.getByName("0.0.0.0"), false);

--- a/test/framework/src/main/java/org/elasticsearch/test/fixture/AbstractHttpFixture.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/fixture/AbstractHttpFixture.java
@@ -77,16 +77,25 @@ public abstract class AbstractHttpFixture {
      * Opens a {@link HttpServer} and start listening on a random port.
      */
     public final void listen() throws IOException, InterruptedException {
+        listen(true);
+    }
+
+    /**
+     * Opens a {@link HttpServer} and start listening on a provided or random port.
+     */
+    public final void listen(boolean exposePidAndPort) throws IOException, InterruptedException {
         final InetSocketAddress socketAddress = new InetSocketAddress(InetAddress.getByName("0.0.0.0"), port);
         final HttpServer httpServer = HttpServer.create(socketAddress, 0);
 
         try {
-            /// Writes the PID of the current Java process in a `pid` file located in the working directory
-            writeFile(workingDirectory, "pid", ManagementFactory.getRuntimeMXBean().getName().split("@")[0]);
+            if(exposePidAndPort) {
+                /// Writes the PID of the current Java process in a `pid` file located in the working directory
+                writeFile(workingDirectory, "pid", ManagementFactory.getRuntimeMXBean().getName().split("@")[0]);
 
-            final String addressAndPort = addressToString(httpServer.getAddress());
-            // Writes the address and port of the http server in a `ports` file located in the working directory
-            writeFile(workingDirectory, "ports", addressAndPort);
+                final String addressAndPort = addressToString(httpServer.getAddress());
+                // Writes the address and port of the http server in a `ports` file located in the working directory
+                writeFile(workingDirectory, "ports", addressAndPort);
+            }
 
             httpServer.createContext("/", exchange -> {
                 try {
@@ -104,7 +113,6 @@ public abstract class AbstractHttpFixture {
                         try {
                             final long requestId = requests.getAndIncrement();
                             final String method = exchange.getRequestMethod();
-
 
                             final Map<String, String> headers = new HashMap<>();
                             for (Map.Entry<String, List<String>> header : exchange.getRequestHeaders().entrySet()) {
@@ -200,11 +208,7 @@ public abstract class AbstractHttpFixture {
 
         @Override
         public String toString() {
-            return "Response{" +
-                "status=" + status +
-                ", headers=" + headers +
-                ", body=" + new String(body, UTF_8) +
-                '}';
+            return "Response{" + "status=" + status + ", headers=" + headers + ", body=" + new String(body, UTF_8) + '}';
         }
     }
 
@@ -224,8 +228,8 @@ public abstract class AbstractHttpFixture {
             this.id = id;
             this.method = Objects.requireNonNull(method);
             this.uri = Objects.requireNonNull(uri);
-            this.headers =  Objects.requireNonNull(headers);
-            this.body =  Objects.requireNonNull(body);
+            this.headers = Objects.requireNonNull(headers);
+            this.body = Objects.requireNonNull(body);
 
             final Map<String, String> params = new HashMap<>();
             if (uri.getQuery() != null && uri.getQuery().length() > 0) {
@@ -289,13 +293,19 @@ public abstract class AbstractHttpFixture {
 
         @Override
         public String toString() {
-            return "Request{" +
-                "method='" + method + '\'' +
-                ", uri=" + uri +
-                ", parameters=" + parameters +
-                ", headers=" + headers +
-                ", body=" + body +
-                '}';
+            return "Request{"
+                + "method='"
+                + method
+                + '\''
+                + ", uri="
+                + uri
+                + ", parameters="
+                + parameters
+                + ", headers="
+                + headers
+                + ", body="
+                + body
+                + '}';
         }
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/fixture/AbstractHttpFixture.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/fixture/AbstractHttpFixture.java
@@ -74,17 +74,17 @@ public abstract class AbstractHttpFixture {
     }
 
     /**
-     * Opens a {@link HttpServer} and start listening on a random port.
+     * Opens a {@link HttpServer} and start listening on a provided or random port.
      */
     public final void listen() throws IOException, InterruptedException {
-        listen(true);
+        listen(InetAddress.getLoopbackAddress(), true);
     }
 
     /**
      * Opens a {@link HttpServer} and start listening on a provided or random port.
      */
-    public final void listen(boolean exposePidAndPort) throws IOException, InterruptedException {
-        final InetSocketAddress socketAddress = new InetSocketAddress(InetAddress.getByName("0.0.0.0"), port);
+    public final void listen(InetAddress inetAddress, boolean exposePidAndPort) throws IOException, InterruptedException {
+        final InetSocketAddress socketAddress = new InetSocketAddress(inetAddress, port);
         final HttpServer httpServer = HttpServer.create(socketAddress, 0);
 
         try {

--- a/test/framework/src/main/java/org/elasticsearch/test/fixture/AbstractHttpFixture.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/fixture/AbstractHttpFixture.java
@@ -62,8 +62,14 @@ public abstract class AbstractHttpFixture {
 
     /** Current working directory of the fixture **/
     private final Path workingDirectory;
+    private final int port;
 
     protected AbstractHttpFixture(final String workingDir) {
+        this(workingDir, 0);
+    }
+
+    protected AbstractHttpFixture(final String workingDir, int port) {
+        this.port = port;
         this.workingDirectory = PathUtils.get(Objects.requireNonNull(workingDir));
     }
 
@@ -71,7 +77,7 @@ public abstract class AbstractHttpFixture {
      * Opens a {@link HttpServer} and start listening on a random port.
      */
     public final void listen() throws IOException, InterruptedException {
-        final InetSocketAddress socketAddress = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
+        final InetSocketAddress socketAddress = new InetSocketAddress(InetAddress.getByName("0.0.0.0"), port);
         final HttpServer httpServer = HttpServer.create(socketAddress, 0);
 
         try {


### PR DESCRIPTION
As part of moving away from AntFixture (https://github.com/elastic/elasticsearch/issues/66991) this ports
the UrlFixture to use the test fixture plugin instead of relying on AntFixture