### PR TITLE
QL: Move Node transform type argument to the front

### DIFF
--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/analysis/Analyzer.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/analysis/Analyzer.java
@@ -75,7 +75,7 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
                 log.trace("Attempting to resolve {}", plan.nodeString());
             }
 
-            return plan.transformExpressionsUp(u -> {
+            return plan.transformExpressionsUp(UnresolvedAttribute.class, u -> {
                 Collection<Attribute> childrenOutput = new LinkedHashSet<>();
                 for (LogicalPlan child : plan.children()) {
                     childrenOutput.addAll(child.output());
@@ -89,7 +89,7 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
                     return named;
                 }
                 return u;
-            }, UnresolvedAttribute.class);
+            });
         }
     }
 
@@ -97,7 +97,7 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
 
         @Override
         protected LogicalPlan rule(LogicalPlan plan) {
-            return plan.transformExpressionsUp(uf -> {
+            return plan.transformExpressionsUp(UnresolvedFunction.class, uf -> {
                 if (uf.analyzed()) {
                     return uf;
                 }
@@ -115,7 +115,7 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
                 FunctionDefinition def = functionRegistry.resolveFunction(functionName);
                 Function f = uf.buildResolved(configuration, def);
                 return f;
-            }, UnresolvedFunction.class);
+            });
         }
     }
 }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/analysis/AnalyzerRule.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/analysis/AnalyzerRule.java
@@ -15,7 +15,7 @@ public abstract class AnalyzerRule<SubPlan extends LogicalPlan> extends Rule<Sub
     // but with a twist; only if the tree is not resolved or analyzed
     @Override
     public final LogicalPlan apply(LogicalPlan plan) {
-        return plan.transformUp(t -> t.analyzed() || skipResolved() && t.resolved() ? t : rule(t), typeToken());
+        return plan.transformUp(typeToken(), t -> t.analyzed() || skipResolved() && t.resolved() ? t : rule(t));
     }
 
     @Override

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/analysis/PostAnalyzer.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/analysis/PostAnalyzer.java
@@ -26,7 +26,7 @@ import static org.elasticsearch.xpack.ql.tree.Source.synthetic;
  * Post processor of the user query once it got analyzed and verified.
  * The purpose of this class is to add implicit blocks to the query based on the user request
  * that help with the query execution not its semantics.
- * 
+ *
  * This could have been done in the optimizer however due to its wrapping nature (which is clunky to do with rules)
  * and since the optimized is not parameterized, making this a separate step (similar to the pre-analyzer) is more natural.
  */
@@ -42,22 +42,22 @@ public class PostAnalyzer {
             // implicit sequence fetch size
 
             // implicit project + fetch size (if needed)
-            
+
             Holder<Boolean> hasJoin = new Holder<>(Boolean.FALSE);
 
             Source projectCtx = synthetic("<implicit-project>");
             // first per KeyedFilter
-            plan = plan.transformUp(k -> {
+            plan = plan.transformUp(KeyedFilter.class, k -> {
                 hasJoin.set(Boolean.TRUE);
                 Project p = new Project(projectCtx, k.child(), k.extractionAttributes());
 
                 // TODO: this could be incorporated into the query generation
                 LogicalPlan fetchSize = new LimitWithOffset(synthetic("<fetch-size>"),
-                        new Literal(synthetic("<fetch-value>"), configuration.fetchSize(), DataTypes.INTEGER),
-                        p);
-                
+                    new Literal(synthetic("<fetch-value>"), configuration.fetchSize(), DataTypes.INTEGER),
+                    p);
+
                 return new KeyedFilter(k.source(), fetchSize, k.keys(), k.timestamp(), k.tiebreaker());
-            }, KeyedFilter.class);
+            });
 
             // in case of event queries, filter everything
             if (hasJoin.get() == false) {

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/analysis/PreAnalyzer.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/analysis/PreAnalyzer.java
@@ -27,7 +27,7 @@ public class PreAnalyzer {
         if (plan.analyzed() == false) {
             final EsRelation esRelation = new EsRelation(plan.source(), indices.get(), false);
             // FIXME: includeFrozen needs to be set already
-            plan = plan.transformUp(r -> esRelation, UnresolvedRelation.class);
+            plan = plan.transformUp(UnresolvedRelation.class, r -> esRelation);
             plan.forEachUp(LogicalPlan::setPreAnalyzed);
         }
         return plan;

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/RuntimeUtils.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/RuntimeUtils.java
@@ -123,7 +123,7 @@ public final class RuntimeUtils {
             Pipe proc = ((ComputedRef) ref).processor();
             // collect hitNames
             Set<String> hitNames = new LinkedHashSet<>();
-            proc = proc.transformDown(l -> {
+            proc = proc.transformDown(ReferenceInput.class, l -> {
                 HitExtractor he = createExtractor(l.context(), cfg);
                 hitNames.add(he.hitName());
 
@@ -132,7 +132,7 @@ public final class RuntimeUtils {
                 }
 
                 return new HitExtractorInput(l.source(), l.expression(), he);
-            }, ReferenceInput.class);
+            });
             String hitName = null;
             if (hitNames.size() == 1) {
                 hitName = hitNames.iterator().next();

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/optimizer/Optimizer.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/optimizer/Optimizer.java
@@ -113,7 +113,7 @@ public class Optimizer extends RuleExecutor<LogicalPlan> {
 
         @Override
         protected LogicalPlan rule(Filter filter) {
-            return filter.transformExpressionsUp(cmp -> {
+            return filter.transformExpressionsUp(InsensitiveBinaryComparison.class, cmp -> {
                 // expr : "wildcard*phrase?" || expr !: "wildcard*phrase?"
                 Expression result = cmp;
                 Expression target = null;
@@ -135,7 +135,7 @@ public class Optimizer extends RuleExecutor<LogicalPlan> {
                 }
 
                 return result;
-            }, InsensitiveBinaryComparison.class);
+            });
         }
 
         private static boolean isWildcard(Expression expr) {
@@ -155,7 +155,7 @@ public class Optimizer extends RuleExecutor<LogicalPlan> {
         @Override
         protected LogicalPlan rule(Filter filter) {
 
-            return filter.transformExpressionsUp(cmp -> {
+            return filter.transformExpressionsUp(BinaryComparison.class, cmp -> {
                 Expression result = cmp;
                 // expr == null || expr != null
                 if (cmp instanceof Equals || cmp instanceof NotEquals) {
@@ -168,7 +168,7 @@ public class Optimizer extends RuleExecutor<LogicalPlan> {
                     }
                 }
                 return result;
-            }, BinaryComparison.class);
+            });
         }
     }
 
@@ -317,8 +317,8 @@ public class Optimizer extends RuleExecutor<LogicalPlan> {
 
             // collect constraints for each filter
             join.queries().forEach(k ->
-                k.forEachDown(f -> constraints.addAll(detectKeyConstraints(f.condition(), k))
-                                  , Filter.class));
+                k.forEachDown(Filter.class, f -> constraints.addAll(detectKeyConstraints(f.condition(), k))
+                ));
 
             if (constraints.isEmpty() == false) {
                 List<KeyedFilter> queries = join.queries().stream()

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/planner/Mapper.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/planner/Mapper.java
@@ -78,7 +78,7 @@ class Mapper extends RuleExecutor<PhysicalPlan> {
                         map(s.until().child()),
                         s.timestamp(),
                         s.tiebreaker(),
-                        s.direction(), 
+                        s.direction(),
                         s.maxSpan());
             }
 
@@ -127,7 +127,7 @@ class Mapper extends RuleExecutor<PhysicalPlan> {
 
         @Override
         public final PhysicalPlan apply(PhysicalPlan plan) {
-            return plan.transformUp(this::rule, UnplannedExec.class);
+            return plan.transformUp(UnplannedExec.class, this::rule);
         }
 
         @SuppressWarnings("unchecked")

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/planner/QueryFolder.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/planner/QueryFolder.java
@@ -48,10 +48,10 @@ class QueryFolder extends RuleExecutor<PhysicalPlan> {
         Batch finish = new Batch("Finish query", Limiter.ONCE,
                 new PlanOutputToQueryRef()
         );
-        
+
         return Arrays.asList(fold, finish);
     }
-    
+
 
     private static class FoldProject extends QueryFoldingRule<ProjectExec> {
 
@@ -76,7 +76,7 @@ class QueryFolder extends RuleExecutor<PhysicalPlan> {
             return exec.with(qContainer);
         }
     }
-    
+
     private static class FoldOrderBy extends QueryFoldingRule<OrderExec> {
 
         @Override
@@ -143,7 +143,7 @@ class QueryFolder extends RuleExecutor<PhysicalPlan> {
 
         @Override
         public final PhysicalPlan apply(PhysicalPlan plan) {
-            return plan.transformUp(this::rule, typeToken());
+            return plan.transformUp(typeToken(), this::rule);
         }
 
         @Override

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/expression/function/scalar/math/ToNumberFunctionPipeTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/expression/function/scalar/math/ToNumberFunctionPipeTests.java
@@ -27,11 +27,11 @@ public class ToNumberFunctionPipeTests extends AbstractNodeTestCase<ToNumberFunc
     protected ToNumberFunctionPipe randomInstance() {
         return randomToNumberFunctionPipe();
     }
-    
+
     private Expression randomToNumberFunctionExpression() {
         return randomToNumberFunctionPipe().expression();
     }
-    
+
     public static ToNumberFunctionPipe randomToNumberFunctionPipe() {
         return (ToNumberFunctionPipe) (new ToNumber(
                 randomSource(),
@@ -51,8 +51,8 @@ public class ToNumberFunctionPipeTests extends AbstractNodeTestCase<ToNumberFunc
                 newExpression,
                 b1.value(),
                 b1.base());
-        assertEquals(newB, b1.transformPropertiesOnly(v -> Objects.equals(v, b1.expression()) ? newExpression : v, Expression.class));
-        
+        assertEquals(newB, b1.transformPropertiesOnly(Expression.class, v -> Objects.equals(v, b1.expression()) ? newExpression : v));
+
         ToNumberFunctionPipe b2 = randomInstance();
         Source newLoc = randomValueOtherThan(b2.source(), () -> randomSource());
         newB = new ToNumberFunctionPipe(
@@ -61,7 +61,7 @@ public class ToNumberFunctionPipeTests extends AbstractNodeTestCase<ToNumberFunc
                 b2.value(),
                 b2.base());
         assertEquals(newB,
-                b2.transformPropertiesOnly(v -> Objects.equals(v, b2.source()) ? newLoc : v, Source.class));
+                b2.transformPropertiesOnly(Source.class, v -> Objects.equals(v, b2.source()) ? newLoc : v));
     }
 
     @Override
@@ -70,19 +70,19 @@ public class ToNumberFunctionPipeTests extends AbstractNodeTestCase<ToNumberFunc
         Pipe newValue = randomValueOtherThan(b.value(), () -> pipe(randomStringLiteral()));
         Pipe newBase = b.base() == null ? null : randomValueOtherThan(b.base(), () -> pipe(randomIntLiteral()));
         ToNumberFunctionPipe newB = new ToNumberFunctionPipe(b.source(), b.expression(), b.value(), b.base());
-        
+
         ToNumberFunctionPipe transformed = newB.replaceChildren(newValue, b.base());
         assertEquals(transformed.value(), newValue);
         assertEquals(transformed.source(), b.source());
         assertEquals(transformed.expression(), b.expression());
         assertEquals(transformed.base(), b.base());
-        
+
         transformed = newB.replaceChildren(b.value(), newBase);
         assertEquals(transformed.value(), b.value());
         assertEquals(transformed.source(), b.source());
         assertEquals(transformed.expression(), b.expression());
         assertEquals(transformed.base(), newBase);
-        
+
         transformed = newB.replaceChildren(newValue, newBase);
         assertEquals(transformed.value(), newValue);
         assertEquals(transformed.source(), b.source());
@@ -105,7 +105,7 @@ public class ToNumberFunctionPipeTests extends AbstractNodeTestCase<ToNumberFunc
                 f.expression(),
                 pipe(((Expression) randomValueOtherThan(f.value(), () -> randomStringLiteral()))),
                 f.base() == null ? null : randomValueOtherThan(f.base(), () -> pipe(randomIntLiteral()))));
-        
+
         return randomFrom(randoms).apply(instance);
     }
 

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/BetweenFunctionPipeTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/BetweenFunctionPipeTests.java
@@ -58,8 +58,8 @@ public class BetweenFunctionPipeTests extends AbstractNodeTestCase<BetweenFuncti
             b1.greedy(),
             b1.caseSensitive());
 
-        assertEquals(newB, b1.transformPropertiesOnly(v -> Objects.equals(v, b1.expression()) ? newExpression : v, Expression.class));
-        
+        assertEquals(newB, b1.transformPropertiesOnly(Expression.class, v -> Objects.equals(v, b1.expression()) ? newExpression : v));
+
         BetweenFunctionPipe b2 = randomInstance();
         Source newLoc = randomValueOtherThan(b2.source(), () -> randomSource());
         newB = new BetweenFunctionPipe(
@@ -71,7 +71,7 @@ public class BetweenFunctionPipeTests extends AbstractNodeTestCase<BetweenFuncti
             b2.greedy(),
             b2.caseSensitive());
 
-        assertEquals(newB, b2.transformPropertiesOnly(v -> Objects.equals(v, b2.source()) ? newLoc : v, Source.class));
+        assertEquals(newB, b2.transformPropertiesOnly(Source.class, v -> Objects.equals(v, b2.source()) ? newLoc : v));
     }
 
     @Override
@@ -82,11 +82,11 @@ public class BetweenFunctionPipeTests extends AbstractNodeTestCase<BetweenFuncti
         Pipe newRight = randomValueOtherThan(b.right(), () -> pipe(randomStringLiteral()));
         Pipe newGreedy = b.greedy() == null ? null : randomValueOtherThan(b.greedy(), () -> pipe(randomBooleanLiteral()));
         Pipe newCaseSensitive = randomValueOtherThan(b.caseSensitive(), () -> pipe(randomBooleanLiteral()));
-        
+
         BetweenFunctionPipe newB = new BetweenFunctionPipe(b.source(), b.expression(), b.input(), b.left(), b.right(), b.greedy(),
             b.caseSensitive());
         BetweenFunctionPipe transformed = null;
-        
+
         // generate all the combinations of possible children modifications and test all of them
         for(int i = 1; i < 6; i++) {
             for(BitSet comb : new Combinations(5, i)) {
@@ -97,7 +97,7 @@ public class BetweenFunctionPipeTests extends AbstractNodeTestCase<BetweenFuncti
                         comb.get(2) ? newRight : b.right(),
                         tempNewGreedy,
                         comb.get(4) ? newCaseSensitive : b.caseSensitive());
-                
+
                 assertEquals(transformed.input(), comb.get(0) ? newInput : b.input());
                 assertEquals(transformed.left(), comb.get(1) ? newLeft : b.left());
                 assertEquals(transformed.right(), comb.get(2) ? newRight : b.right());
@@ -137,7 +137,7 @@ public class BetweenFunctionPipeTests extends AbstractNodeTestCase<BetweenFuncti
                 }
             }
         }
-        
+
         return randomFrom(randoms).apply(instance);
     }
 

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/CIDRMatchFunctionPipeTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/CIDRMatchFunctionPipeTests.java
@@ -52,8 +52,8 @@ public class CIDRMatchFunctionPipeTests extends AbstractNodeTestCase<CIDRMatchFu
             b1.input(),
             b1.addresses());
 
-        assertEquals(newB, b1.transformPropertiesOnly(v -> Objects.equals(v, b1.expression()) ? newExpression : v, Expression.class));
-        
+        assertEquals(newB, b1.transformPropertiesOnly(Expression.class, v -> Objects.equals(v, b1.expression()) ? newExpression : v));
+
         CIDRMatchFunctionPipe b2 = randomInstance();
         Source newLoc = randomValueOtherThan(b2.source(), () -> randomSource());
         newB = new CIDRMatchFunctionPipe(
@@ -62,7 +62,7 @@ public class CIDRMatchFunctionPipeTests extends AbstractNodeTestCase<CIDRMatchFu
             b2.input(),
             b2.addresses());
 
-        assertEquals(newB, b2.transformPropertiesOnly(v -> Objects.equals(v, b2.source()) ? newLoc : v, Source.class));
+        assertEquals(newB, b2.transformPropertiesOnly(Source.class, v -> Objects.equals(v, b2.source()) ? newLoc : v));
     }
 
     @Override
@@ -70,21 +70,21 @@ public class CIDRMatchFunctionPipeTests extends AbstractNodeTestCase<CIDRMatchFu
         CIDRMatchFunctionPipe b = randomInstance();
         Pipe newInput = randomValueOtherThan(b.input(), () -> pipe(randomStringLiteral()));
         List<Pipe> newAddresses = mutateOneAddress(b.addresses());
-        
+
         CIDRMatchFunctionPipe newB = new CIDRMatchFunctionPipe(b.source(), b.expression(), b.input(), b.addresses());
         CIDRMatchFunctionPipe transformed = newB.replaceChildren(newInput, b.addresses());
-        
+
         assertEquals(transformed.input(), newInput);
         assertEquals(transformed.source(), b.source());
         assertEquals(transformed.expression(), b.expression());
         assertEquals(transformed.addresses(), b.addresses());
-        
+
         transformed = newB.replaceChildren(b.input(), newAddresses);
         assertEquals(transformed.input(), b.input());
         assertEquals(transformed.source(), b.source());
         assertEquals(transformed.expression(), b.expression());
         assertEquals(transformed.addresses(), newAddresses);
-        
+
         transformed = newB.replaceChildren(newInput, newAddresses);
         assertEquals(transformed.input(), newInput);
         assertEquals(transformed.source(), b.source());
@@ -107,7 +107,7 @@ public class CIDRMatchFunctionPipeTests extends AbstractNodeTestCase<CIDRMatchFu
                 f.expression(),
                 randomValueOtherThan(f.input(), () -> pipe(randomStringLiteral())),
                 mutateOneAddress(f.addresses())));
-        
+
         return randomFrom(randoms).apply(instance);
     }
 
@@ -115,11 +115,11 @@ public class CIDRMatchFunctionPipeTests extends AbstractNodeTestCase<CIDRMatchFu
     protected CIDRMatchFunctionPipe copy(CIDRMatchFunctionPipe instance) {
         return new CIDRMatchFunctionPipe(instance.source(), instance.expression(), instance.input(), instance.addresses());
     }
-    
+
     private List<Pipe> mutateOneAddress(List<Pipe> oldAddresses) {
         int size = oldAddresses.size();
         ArrayList<Pipe> newAddresses = new ArrayList<>(size);
-        
+
         int index = randomIntBetween(0, size - 1);
         for (int i = 0; i < size; i++) {
             Pipe p = oldAddresses.get(i);

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/ConcatFunctionPipeTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/ConcatFunctionPipeTests.java
@@ -50,8 +50,8 @@ public class ConcatFunctionPipeTests extends AbstractNodeTestCase<ConcatFunction
             newExpression,
             b1.values());
 
-        assertEquals(newB, b1.transformPropertiesOnly(v -> Objects.equals(v, b1.expression()) ? newExpression : v, Expression.class));
-        
+        assertEquals(newB, b1.transformPropertiesOnly(Expression.class, v -> Objects.equals(v, b1.expression()) ? newExpression : v));
+
         ConcatFunctionPipe b2 = randomInstance();
         Source newLoc = randomValueOtherThan(b2.source(), () -> randomSource());
         newB = new ConcatFunctionPipe(
@@ -59,17 +59,17 @@ public class ConcatFunctionPipeTests extends AbstractNodeTestCase<ConcatFunction
             b2.expression(),
             b2.values());
 
-        assertEquals(newB, b2.transformPropertiesOnly(v -> Objects.equals(v, b2.source()) ? newLoc : v, Source.class));
+        assertEquals(newB, b2.transformPropertiesOnly(Source.class, v -> Objects.equals(v, b2.source()) ? newLoc : v));
     }
 
     @Override
     public void testReplaceChildren() {
         ConcatFunctionPipe b = randomInstance();
         List<Pipe> newValues = mutateOneValue(b.values());
-        
+
         ConcatFunctionPipe newB = new ConcatFunctionPipe(b.source(), b.expression(), b.values());
         ConcatFunctionPipe transformed = newB.replaceChildren(newValues);
-        
+
         assertEquals(transformed.values(), newValues);
         assertEquals(transformed.source(), b.source());
         assertEquals(transformed.expression(), b.expression());
@@ -86,11 +86,11 @@ public class ConcatFunctionPipeTests extends AbstractNodeTestCase<ConcatFunction
     protected ConcatFunctionPipe copy(ConcatFunctionPipe instance) {
         return new ConcatFunctionPipe(instance.source(), instance.expression(), instance.values());
     }
-    
+
     private List<Pipe> mutateOneValue(List<Pipe> oldValues) {
         int size = oldValues.size();
         ArrayList<Pipe> newValues = new ArrayList<>(size);
-        
+
         int index = randomIntBetween(0, size - 1);
         for (int i = 0; i < size; i++) {
             Pipe p = oldValues.get(i);

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/EndsWithFunctionPipeTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/EndsWithFunctionPipeTests.java
@@ -27,11 +27,11 @@ public class EndsWithFunctionPipeTests extends AbstractNodeTestCase<EndsWithFunc
     protected EndsWithFunctionPipe randomInstance() {
         return randomEndsWithFunctionPipe();
     }
-    
+
     private Expression randomEndsWithFunctionExpression() {
         return randomEndsWithFunctionPipe().expression();
     }
-    
+
     public static EndsWithFunctionPipe randomEndsWithFunctionPipe() {
         return (EndsWithFunctionPipe) (new EndsWith(randomSource(),
                 randomStringLiteral(),
@@ -52,8 +52,8 @@ public class EndsWithFunctionPipeTests extends AbstractNodeTestCase<EndsWithFunc
                 b1.input(),
                 b1.pattern(),
                 b1.isCaseSensitive());
-        assertEquals(newB, b1.transformPropertiesOnly(v -> Objects.equals(v, b1.expression()) ? newExpression : v, Expression.class));
-        
+        assertEquals(newB, b1.transformPropertiesOnly(Expression.class, v -> Objects.equals(v, b1.expression()) ? newExpression : v));
+
         EndsWithFunctionPipe b2 = randomInstance();
         Source newLoc = randomValueOtherThan(b2.source(), () -> randomSource());
         newB = new EndsWithFunctionPipe(
@@ -63,7 +63,7 @@ public class EndsWithFunctionPipeTests extends AbstractNodeTestCase<EndsWithFunc
                 b2.pattern(),
                 b2.isCaseSensitive());
         assertEquals(newB,
-                b2.transformPropertiesOnly(v -> Objects.equals(v, b2.source()) ? newLoc : v, Source.class));
+                b2.transformPropertiesOnly(Source.class, v -> Objects.equals(v, b2.source()) ? newLoc : v));
     }
 
     @Override
@@ -74,19 +74,19 @@ public class EndsWithFunctionPipeTests extends AbstractNodeTestCase<EndsWithFunc
         boolean newCaseSensitive = randomValueOtherThan(b.isCaseSensitive(), () -> randomBoolean());
         EndsWithFunctionPipe newB =
                 new EndsWithFunctionPipe(b.source(), b.expression(), b.input(), b.pattern(), newCaseSensitive);
-        
+
         EndsWithFunctionPipe transformed = newB.replaceChildren(newInput, b.pattern());
         assertEquals(transformed.input(), newInput);
         assertEquals(transformed.source(), b.source());
         assertEquals(transformed.expression(), b.expression());
         assertEquals(transformed.pattern(), b.pattern());
-        
+
         transformed = newB.replaceChildren(b.input(), newPattern);
         assertEquals(transformed.input(), b.input());
         assertEquals(transformed.source(), b.source());
         assertEquals(transformed.expression(), b.expression());
         assertEquals(transformed.pattern(), newPattern);
-        
+
         transformed = newB.replaceChildren(newInput, newPattern);
         assertEquals(transformed.input(), newInput);
         assertEquals(transformed.source(), b.source());
@@ -112,7 +112,7 @@ public class EndsWithFunctionPipeTests extends AbstractNodeTestCase<EndsWithFunc
                 pipe(((Expression) randomValueOtherThan(f.input(), () -> randomStringLiteral()))),
                 pipe(((Expression) randomValueOtherThan(f.pattern(), () -> randomStringLiteral()))),
                 randomValueOtherThan(f.isCaseSensitive(), () -> randomBoolean())));
-        
+
         return randomFrom(randoms).apply(instance);
     }
 

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/IndexOfFunctionPipeTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/IndexOfFunctionPipeTests.java
@@ -58,8 +58,8 @@ public class IndexOfFunctionPipeTests extends AbstractNodeTestCase<IndexOfFuncti
             b1.start(),
             b1.isCaseSensitive());
 
-        assertEquals(newB, b1.transformPropertiesOnly(v -> Objects.equals(v, b1.expression()) ? newExpression : v, Expression.class));
-        
+        assertEquals(newB, b1.transformPropertiesOnly(Expression.class, v -> Objects.equals(v, b1.expression()) ? newExpression : v));
+
         IndexOfFunctionPipe b2 = randomInstance();
         Source newLoc = randomValueOtherThan(b2.source(), () -> randomSource());
         newB = new IndexOfFunctionPipe(
@@ -70,7 +70,7 @@ public class IndexOfFunctionPipeTests extends AbstractNodeTestCase<IndexOfFuncti
             b2.start(),
             b2.isCaseSensitive());
 
-        assertEquals(newB, b2.transformPropertiesOnly(v -> Objects.equals(v, b2.source()) ? newLoc : v, Source.class));
+        assertEquals(newB, b2.transformPropertiesOnly(Source.class, v -> Objects.equals(v, b2.source()) ? newLoc : v));
     }
 
     @Override
@@ -80,11 +80,11 @@ public class IndexOfFunctionPipeTests extends AbstractNodeTestCase<IndexOfFuncti
         Pipe newSubstring = randomValueOtherThan(b.substring(), () -> pipe(randomStringLiteral()));
         Pipe newStart = b.start() == null ? null : randomValueOtherThan(b.start(), () -> pipe(randomIntLiteral()));
         boolean newCaseSensitive = randomValueOtherThan(b.isCaseSensitive(), () -> randomBoolean());
-        
+
         IndexOfFunctionPipe newB = new IndexOfFunctionPipe(b.source(), b.expression(), b.input(), b.substring(), b.start(),
             newCaseSensitive);
         IndexOfFunctionPipe transformed = null;
-        
+
         // generate all the combinations of possible children modifications and test all of them
         for(int i = 1; i < 4; i++) {
             for(BitSet comb : new Combinations(3, i)) {
@@ -93,7 +93,7 @@ public class IndexOfFunctionPipeTests extends AbstractNodeTestCase<IndexOfFuncti
                         comb.get(0) ? newInput : b.input(),
                         comb.get(1) ? newSubstring : b.substring(),
                         tempNewStart);
-                
+
                 assertEquals(transformed.input(), comb.get(0) ? newInput : b.input());
                 assertEquals(transformed.substring(), comb.get(1) ? newSubstring : b.substring());
                 assertEquals(transformed.start(), tempNewStart);
@@ -129,7 +129,7 @@ public class IndexOfFunctionPipeTests extends AbstractNodeTestCase<IndexOfFuncti
                 }
             }
         }
-        
+
         return randomFrom(randoms).apply(instance);
     }
 

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/LengthFunctionPipeTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/LengthFunctionPipeTests.java
@@ -43,8 +43,8 @@ public class LengthFunctionPipeTests extends AbstractNodeTestCase<LengthFunction
             newExpression,
             b1.input());
 
-        assertEquals(newB, b1.transformPropertiesOnly(v -> Objects.equals(v, b1.expression()) ? newExpression : v, Expression.class));
-        
+        assertEquals(newB, b1.transformPropertiesOnly(Expression.class, v -> Objects.equals(v, b1.expression()) ? newExpression : v));
+
         LengthFunctionPipe b2 = randomInstance();
         Source newLoc = randomValueOtherThan(b2.source(), () -> randomSource());
         newB = new LengthFunctionPipe(
@@ -52,17 +52,17 @@ public class LengthFunctionPipeTests extends AbstractNodeTestCase<LengthFunction
             b2.expression(),
             b2.input());
 
-        assertEquals(newB, b2.transformPropertiesOnly(v -> Objects.equals(v, b2.source()) ? newLoc : v, Source.class));
+        assertEquals(newB, b2.transformPropertiesOnly(Source.class, v -> Objects.equals(v, b2.source()) ? newLoc : v));
     }
 
     @Override
     public void testReplaceChildren() {
         LengthFunctionPipe b = randomInstance();
         Pipe newInput = randomValueOtherThan(b.input(), () -> pipe(randomStringLiteral()));
-        
+
         LengthFunctionPipe newB = new LengthFunctionPipe(b.source(), b.expression(), b.input());
         LengthFunctionPipe transformed = newB.replaceChildren(newInput);
-        
+
         assertEquals(transformed.input(), newInput);
         assertEquals(transformed.source(), b.source());
         assertEquals(transformed.expression(), b.expression());

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/StringContainsFunctionPipeTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/StringContainsFunctionPipeTests.java
@@ -27,11 +27,11 @@ public class StringContainsFunctionPipeTests extends AbstractNodeTestCase<String
     protected StringContainsFunctionPipe randomInstance() {
         return randomStringContainsFunctionPipe();
     }
-    
+
     private Expression randomStringContainsFunctionExpression() {
         return randomStringContainsFunctionPipe().expression();
     }
-    
+
     public static StringContainsFunctionPipe randomStringContainsFunctionPipe() {
         return (StringContainsFunctionPipe) (new StringContains(randomSource(),
                                     randomStringLiteral(),
@@ -52,8 +52,8 @@ public class StringContainsFunctionPipeTests extends AbstractNodeTestCase<String
                 b1.string(),
                 b1.substring(),
                 b1.isCaseSensitive());
-        assertEquals(newB, b1.transformPropertiesOnly(v -> Objects.equals(v, b1.expression()) ? newExpression : v, Expression.class));
-        
+        assertEquals(newB, b1.transformPropertiesOnly(Expression.class, v -> Objects.equals(v, b1.expression()) ? newExpression : v));
+
         StringContainsFunctionPipe b2 = randomInstance();
         Source newLoc = randomValueOtherThan(b2.source(), () -> randomSource());
         newB = new StringContainsFunctionPipe(
@@ -63,7 +63,7 @@ public class StringContainsFunctionPipeTests extends AbstractNodeTestCase<String
                 b2.substring(),
                 b2.isCaseSensitive());
         assertEquals(newB,
-                b2.transformPropertiesOnly(v -> Objects.equals(v, b2.source()) ? newLoc : v, Source.class));
+                b2.transformPropertiesOnly(Source.class, v -> Objects.equals(v, b2.source()) ? newLoc : v));
     }
 
     @Override
@@ -74,19 +74,19 @@ public class StringContainsFunctionPipeTests extends AbstractNodeTestCase<String
         boolean newCaseSensitive = randomValueOtherThan(b.isCaseSensitive(), () -> randomBoolean());
         StringContainsFunctionPipe newB =
                 new StringContainsFunctionPipe(b.source(), b.expression(), b.string(), b.substring(), newCaseSensitive);
-        
+
         StringContainsFunctionPipe transformed = newB.replaceChildren(newString, b.substring());
         assertEquals(transformed.string(), newString);
         assertEquals(transformed.source(), b.source());
         assertEquals(transformed.expression(), b.expression());
         assertEquals(transformed.substring(), b.substring());
-        
+
         transformed = newB.replaceChildren(b.string(), newSubstring);
         assertEquals(transformed.string(), b.string());
         assertEquals(transformed.source(), b.source());
         assertEquals(transformed.expression(), b.expression());
         assertEquals(transformed.substring(), newSubstring);
-        
+
         transformed = newB.replaceChildren(newString, newSubstring);
         assertEquals(transformed.string(), newString);
         assertEquals(transformed.source(), b.source());
@@ -112,7 +112,7 @@ public class StringContainsFunctionPipeTests extends AbstractNodeTestCase<String
                 pipe(((Expression) randomValueOtherThan(f.string(), () -> randomStringLiteral()))),
                 pipe(((Expression) randomValueOtherThan(f.substring(), () -> randomStringLiteral()))),
                 randomValueOtherThan(f.isCaseSensitive(), () -> randomBoolean())));
-        
+
         return randomFrom(randoms).apply(instance);
     }
 

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/SubstringFunctionPipeTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/SubstringFunctionPipeTests.java
@@ -55,8 +55,8 @@ public class SubstringFunctionPipeTests extends AbstractNodeTestCase<SubstringFu
             b1.start(),
             b1.end());
 
-        assertEquals(newB, b1.transformPropertiesOnly(v -> Objects.equals(v, b1.expression()) ? newExpression : v, Expression.class));
-        
+        assertEquals(newB, b1.transformPropertiesOnly(Expression.class, v -> Objects.equals(v, b1.expression()) ? newExpression : v));
+
         SubstringFunctionPipe b2 = randomInstance();
         Source newLoc = randomValueOtherThan(b2.source(), () -> randomSource());
         newB = new SubstringFunctionPipe(
@@ -66,7 +66,7 @@ public class SubstringFunctionPipeTests extends AbstractNodeTestCase<SubstringFu
             b2.start(),
             b2.end());
 
-        assertEquals(newB, b2.transformPropertiesOnly(v -> Objects.equals(v, b2.source()) ? newLoc : v, Source.class));
+        assertEquals(newB, b2.transformPropertiesOnly(Source.class, v -> Objects.equals(v, b2.source()) ? newLoc : v));
     }
 
     @Override
@@ -75,10 +75,10 @@ public class SubstringFunctionPipeTests extends AbstractNodeTestCase<SubstringFu
         Pipe newInput = randomValueOtherThan(b.input(), () -> pipe(randomStringLiteral()));
         Pipe newStart = randomValueOtherThan(b.start(), () -> pipe(randomIntLiteral()));
         Pipe newEnd = b.end() == null ? null : randomValueOtherThan(b.end(), () -> pipe(randomIntLiteral()));
-        
+
         SubstringFunctionPipe newB = new SubstringFunctionPipe(b.source(), b.expression(), b.input(), b.start(), b.end());
         SubstringFunctionPipe transformed = null;
-        
+
         // generate all the combinations of possible children modifications and test all of them
         for(int i = 1; i < 4; i++) {
             for(BitSet comb : new Combinations(3, i)) {
@@ -87,7 +87,7 @@ public class SubstringFunctionPipeTests extends AbstractNodeTestCase<SubstringFu
                         comb.get(0) ? newInput : b.input(),
                         comb.get(1) ? newStart : b.start(),
                         tempNewEnd);
-                
+
                 assertEquals(transformed.input(), comb.get(0) ? newInput : b.input());
                 assertEquals(transformed.start(), comb.get(1) ? newStart : b.start());
                 assertEquals(transformed.end(), tempNewEnd);
@@ -121,7 +121,7 @@ public class SubstringFunctionPipeTests extends AbstractNodeTestCase<SubstringFu
                 }
             }
         }
-        
+
         return randomFrom(randoms).apply(instance);
     }
 

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/ToStringFunctionPipeTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/ToStringFunctionPipeTests.java
@@ -43,8 +43,8 @@ public class ToStringFunctionPipeTests extends AbstractNodeTestCase<ToStringFunc
             newExpression,
             b1.input());
 
-        assertEquals(newB, b1.transformPropertiesOnly(v -> Objects.equals(v, b1.expression()) ? newExpression : v, Expression.class));
-        
+        assertEquals(newB, b1.transformPropertiesOnly(Expression.class, v -> Objects.equals(v, b1.expression()) ? newExpression : v));
+
         ToStringFunctionPipe b2 = randomInstance();
         Source newLoc = randomValueOtherThan(b2.source(), () -> randomSource());
         newB = new ToStringFunctionPipe(
@@ -52,17 +52,17 @@ public class ToStringFunctionPipeTests extends AbstractNodeTestCase<ToStringFunc
             b2.expression(),
             b2.input());
 
-        assertEquals(newB, b2.transformPropertiesOnly(v -> Objects.equals(v, b2.source()) ? newLoc : v, Source.class));
+        assertEquals(newB, b2.transformPropertiesOnly(Source.class, v -> Objects.equals(v, b2.source()) ? newLoc : v));
     }
 
     @Override
     public void testReplaceChildren() {
         ToStringFunctionPipe b = randomInstance();
         Pipe newInput = randomValueOtherThan(b.input(), () -> pipe(randomStringLiteral()));
-        
+
         ToStringFunctionPipe newB = new ToStringFunctionPipe(b.source(), b.expression(), b.input());
         ToStringFunctionPipe transformed = newB.replaceChildren(newInput);
-        
+
         assertEquals(transformed.input(), newInput);
         assertEquals(transformed.source(), b.source());
         assertEquals(transformed.expression(), b.expression());

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/expression/predicate/operator/comparison/InsensitiveBinaryComparisonPipeTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/expression/predicate/operator/comparison/InsensitiveBinaryComparisonPipeTests.java
@@ -55,7 +55,7 @@ public class InsensitiveBinaryComparisonPipeTests extends AbstractNodeTestCase<I
             pipe.right(),
             pipe.asProcessor().function());
         assertEquals(newPipe,
-            pipe.transformPropertiesOnly(v -> Objects.equals(v, pipe.expression()) ? newExpression : v, Expression.class));
+            pipe.transformPropertiesOnly(Expression.class, v -> Objects.equals(v, pipe.expression()) ? newExpression : v));
 
         InsensitiveBinaryComparisonPipe anotherPipe = randomInstance();
         Source newLoc = randomValueOtherThan(anotherPipe.source(), SourceTests::randomSource);
@@ -66,7 +66,7 @@ public class InsensitiveBinaryComparisonPipeTests extends AbstractNodeTestCase<I
             anotherPipe.right(),
             anotherPipe.asProcessor().function());
         assertEquals(newPipe,
-            anotherPipe.transformPropertiesOnly(v -> Objects.equals(v, anotherPipe.source()) ? newLoc : v, Source.class));
+            anotherPipe.transformPropertiesOnly(Source.class, v -> Objects.equals(v, anotherPipe.source()) ? newLoc : v));
     }
 
     @Override

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/analyzer/AnalyzerRules.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/analyzer/AnalyzerRules.java
@@ -31,9 +31,9 @@ public final class AnalyzerRules {
             Expression condition = replaceRawBoolFieldWithEquals(filter.condition());
             // otherwise look for binary logic
             if (condition == filter.condition()) {
-                condition = condition.transformUp(b ->
-                        b.replaceChildren(asList(replaceRawBoolFieldWithEquals(b.left()), replaceRawBoolFieldWithEquals(b.right())))
-                    , BinaryLogic.class);
+                condition = condition.transformUp(BinaryLogic.class, b ->
+                    b.replaceChildren(asList(replaceRawBoolFieldWithEquals(b.left()), replaceRawBoolFieldWithEquals(b.right())))
+                );
             }
 
             if (condition != filter.condition()) {
@@ -62,7 +62,7 @@ public final class AnalyzerRules {
         // but with a twist; only if the tree is not resolved or analyzed
         @Override
         public final LogicalPlan apply(LogicalPlan plan) {
-            return plan.transformUp(t -> t.analyzed() || skipResolved() && t.resolved() ? t : rule(t), typeToken());
+            return plan.transformUp(typeToken(), t -> t.analyzed() || skipResolved() && t.resolved() ? t : rule(t));
         }
 
         @Override

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/optimizer/OptimizerRules.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/optimizer/OptimizerRules.java
@@ -1232,14 +1232,14 @@ public final class OptimizerRules {
             super(TransformDirection.DOWN);
         }
 
+        @Override
         protected Expression rule(Expression e) {
             if (e instanceof RegexMatch) {
                 RegexMatch<?> regexMatch = (RegexMatch<?>) e;
                 StringPattern pattern = regexMatch.pattern();
                 if (pattern.matchesAll()) {
                     e = new IsNotNull(e.source(), regexMatch.field());
-                }
-                else if (pattern.isExactMatch()) {
+                } else if (pattern.isExactMatch()) {
                     Literal literal = new Literal(regexMatch.source(), regexMatch.pattern().asString(), DataTypes.KEYWORD);
                     e = new Equals(e.source(), regexMatch.field(), literal);
                 }
@@ -1281,7 +1281,7 @@ public final class OptimizerRules {
         @Override
         public final LogicalPlan apply(LogicalPlan plan) {
             return direction == TransformDirection.DOWN ?
-                plan.transformDown(this::rule, typeToken()) : plan.transformUp(this::rule, typeToken());
+                plan.transformDown(typeToken(), this::rule) : plan.transformUp(typeToken(), this::rule);
         }
 
         @Override

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/plan/QueryPlan.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/plan/QueryPlan.java
@@ -25,7 +25,6 @@ public abstract class QueryPlan<PlanType extends QueryPlan<PlanType>> extends No
     private AttributeSet lazyOutputSet;
     private AttributeSet lazyInputSet;
 
-
     public QueryPlan(Source source, List<PlanType> children) {
         super(source, children);
     }
@@ -55,27 +54,27 @@ public abstract class QueryPlan<PlanType extends QueryPlan<PlanType>> extends No
     //
 
     public PlanType transformExpressionsOnly(Function<Expression, ? extends Expression> rule) {
-        return transformPropertiesOnly(rule, Expression.class);
+        return transformPropertiesOnly(Expression.class, rule);
     }
 
-    public <E extends Expression> PlanType transformExpressionsOnly(Function<E, ? extends Expression> rule, Class<E> typeToken) {
-        return transformPropertiesOnly(e -> doTransformExpression(e, exp -> exp.transformDown(rule, typeToken)), Object.class);
+    public <E extends Expression> PlanType transformExpressionsOnly(Class<E> typeToken, Function<E, ? extends Expression> rule) {
+        return transformPropertiesOnly(Object.class, e -> doTransformExpression(e, exp -> exp.transformDown(typeToken, rule)));
     }
 
     public PlanType transformExpressionsDown(Function<Expression, ? extends Expression> rule) {
-        return transformExpressionsDown(rule, Expression.class);
+        return transformExpressionsDown(Expression.class, rule);
     }
 
-    public <E extends Expression> PlanType transformExpressionsDown(Function<E, ? extends Expression> rule, Class<E> typeToken) {
-        return transformPropertiesDown(e -> doTransformExpression(e, exp -> exp.transformDown(rule, typeToken)), Object.class);
+    public <E extends Expression> PlanType transformExpressionsDown(Class<E> typeToken, Function<E, ? extends Expression> rule) {
+        return transformPropertiesDown(Object.class, e -> doTransformExpression(e, exp -> exp.transformDown(typeToken, rule)));
     }
 
     public PlanType transformExpressionsUp(Function<Expression, ? extends Expression> rule) {
-        return transformExpressionsUp(rule, Expression.class);
+        return transformExpressionsUp(Expression.class, rule);
     }
 
-    public <E extends Expression> PlanType transformExpressionsUp(Function<E, ? extends Expression> rule, Class<E> typeToken) {
-        return transformPropertiesUp(e -> doTransformExpression(e, exp -> exp.transformUp(rule, typeToken)), Object.class);
+    public <E extends Expression> PlanType transformExpressionsUp(Class<E> typeToken, Function<E, ? extends Expression> rule) {
+        return transformPropertiesUp(Object.class, e -> doTransformExpression(e, exp -> exp.transformUp(typeToken, rule)));
     }
 
     @SuppressWarnings("unchecked")
@@ -111,27 +110,27 @@ public abstract class QueryPlan<PlanType extends QueryPlan<PlanType>> extends No
     }
 
     public void forEachExpressions(Consumer<? super Expression> rule) {
-        forEachExpressions(rule, Expression.class);
+        forEachExpressions(Expression.class, rule);
     }
 
-    public <E extends Expression> void forEachExpressions(Consumer<? super E> rule, Class<E> typeToken) {
-        forEachPropertiesOnly(e -> doForEachExpression(e, exp -> exp.forEachDown(rule, typeToken)), Object.class);
+    public <E extends Expression> void forEachExpressions(Class<E> typeToken, Consumer<? super E> rule) {
+        forEachPropertiesOnly(Object.class, e -> doForEachExpression(e, exp -> exp.forEachDown(typeToken, rule)));
     }
 
     public void forEachExpressionsDown(Consumer<? super Expression> rule) {
-        forEachExpressionsDown(rule, Expression.class);
+        forEachExpressionsDown(Expression.class, rule);
     }
 
-    public <E extends Expression> void forEachExpressionsDown(Consumer<? super E> rule, Class<? extends E> typeToken) {
-        forEachPropertiesDown(e -> doForEachExpression(e, exp -> exp.forEachDown(rule, typeToken)), Object.class);
+    public <E extends Expression> void forEachExpressionsDown(Class<? extends E> typeToken, Consumer<? super E> rule) {
+        forEachPropertiesDown(Object.class, e -> doForEachExpression(e, exp -> exp.forEachDown(typeToken, rule)));
     }
 
     public void forEachExpressionsUp(Consumer<? super Expression> rule) {
-        forEachExpressionsUp(rule, Expression.class);
+        forEachExpressionsUp(Expression.class, rule);
     }
 
-    public <E extends Expression> void forEachExpressionsUp(Consumer<? super E> rule, Class<E> typeToken) {
-        forEachPropertiesUp(e -> doForEachExpression(e, exp -> exp.forEachUp(rule, typeToken)), Object.class);
+    public <E extends Expression> void forEachExpressionsUp(Class<E> typeToken, Consumer<? super E> rule) {
+        forEachPropertiesUp(Object.class, e -> doForEachExpression(e, exp -> exp.forEachUp(typeToken, rule)));
     }
 
     @SuppressWarnings("unchecked")

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/tree/Node.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/tree/Node.java
@@ -69,9 +69,9 @@ public abstract class Node<T extends Node<T>> {
     }
 
     @SuppressWarnings("unchecked")
-    public <E extends T> void forEachDown(Consumer<? super E> action, final Class<E> typeToken) {
+    public <E extends T> void forEachDown(Class<E> typeToken, Consumer<? super E> action) {
         forEachDown(t -> {
-            if (typeToken.isInstance(t))  {
+            if (typeToken.isInstance(t)) {
                 action.accept((E) t);
             }
         });
@@ -84,7 +84,7 @@ public abstract class Node<T extends Node<T>> {
     }
 
     @SuppressWarnings("unchecked")
-    public <E extends T> void forEachUp(Consumer<? super E> action, final Class<E> typeToken) {
+    public <E extends T> void forEachUp(Class<E> typeToken, Consumer<? super E> action) {
         forEachUp(t -> {
             if (typeToken.isInstance(t)) {
                 action.accept((E) t);
@@ -92,20 +92,20 @@ public abstract class Node<T extends Node<T>> {
         });
     }
 
-    public <E> void forEachPropertiesOnly(Consumer<? super E> rule, Class<E> typeToken) {
-        forEachProperty(rule, typeToken);
+    public <E> void forEachPropertiesOnly(Class<E> typeToken, Consumer<? super E> rule) {
+        forEachProperty(typeToken, rule);
     }
 
-    public <E> void forEachPropertiesDown(Consumer<? super E> rule, Class<E> typeToken) {
-        forEachDown(e -> e.forEachProperty(rule, typeToken));
+    public <E> void forEachPropertiesDown(Class<E> typeToken, Consumer<? super E> rule) {
+        forEachDown(e -> e.forEachProperty(typeToken, rule));
     }
 
-    public <E> void forEachPropertiesUp(Consumer<? super E> rule, Class<E> typeToken) {
-        forEachUp(e -> e.forEachProperty(rule, typeToken));
+    public <E> void forEachPropertiesUp(Class<E> typeToken, Consumer<? super E> rule) {
+        forEachUp(e -> e.forEachProperty(typeToken, rule));
     }
 
     @SuppressWarnings("unchecked")
-    protected <E> void forEachProperty(Consumer<? super E> rule, Class<E> typeToken) {
+    protected <E> void forEachProperty(Class<E> typeToken, Consumer<? super E> rule) {
         for (Object prop : info().properties()) {
             // skip children (only properties are interesting)
             if (prop != children && !children.contains(prop) && typeToken.isInstance(prop)) {
@@ -179,7 +179,7 @@ public abstract class Node<T extends Node<T>> {
     }
 
     @SuppressWarnings("unchecked")
-    public <E extends T> T transformDown(Function<E, ? extends T> rule, final Class<E> typeToken) {
+    public <E extends T> T transformDown(Class<E> typeToken, Function<E, ? extends T> rule) {
         // type filtering function
         return transformDown((t) -> (typeToken.isInstance(t) ? rule.apply((E) t) : t));
     }
@@ -192,7 +192,7 @@ public abstract class Node<T extends Node<T>> {
     }
 
     @SuppressWarnings("unchecked")
-    public <E extends T> T transformUp(Function<E, ? extends T> rule, final Class<E> typeToken) {
+    public <E extends T> T transformUp(Class<E> typeToken, Function<E, ? extends T> rule) {
         // type filtering function
         return transformUp((t) -> (typeToken.isInstance(t) ? rule.apply((E) t) : t));
     }
@@ -229,16 +229,16 @@ public abstract class Node<T extends Node<T>> {
     // transform the node properties and use the tree only for navigation
     //
 
-    public <E> T transformPropertiesOnly(Function<? super E, ? extends E> rule, Class<E> typeToken) {
-        return transformNodeProps(rule, typeToken);
+    public <E> T transformPropertiesOnly(Class<E> typeToken, Function<? super E, ? extends E> rule) {
+        return transformNodeProps(typeToken, rule);
     }
 
-    public <E> T transformPropertiesDown(Function<? super E, ? extends E> rule, Class<E> typeToken) {
-        return transformDown(t -> t.transformNodeProps(rule, typeToken));
+    public <E> T transformPropertiesDown(Class<E> typeToken, Function<? super E, ? extends E> rule) {
+        return transformDown(t -> t.transformNodeProps(typeToken, rule));
     }
 
-    public <E> T transformPropertiesUp(Function<? super E, ? extends E> rule, Class<E> typeToken) {
-        return transformUp(t -> t.transformNodeProps(rule, typeToken));
+    public <E> T transformPropertiesUp(Class<E> typeToken, Function<? super E, ? extends E> rule) {
+        return transformUp(t -> t.transformNodeProps(typeToken, rule));
     }
 
     /**
@@ -249,7 +249,7 @@ public abstract class Node<T extends Node<T>> {
      * we return the closest thing we do have: {@code T}, which is the
      * root of the hierarchy for the this node.
      */
-    protected final <E> T transformNodeProps(Function<? super E, ? extends E> rule, Class<E> typeToken) {
+    protected final <E> T transformNodeProps(Class<E> typeToken, Function<? super E, ? extends E> rule) {
         return info().transform(rule, typeToken);
     }
 

--- a/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/expression/LiteralTests.java
+++ b/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/expression/LiteralTests.java
@@ -92,14 +92,14 @@ public class LiteralTests extends AbstractNodeTestCase<Literal, Expression> {
         // Replace value
         Object newValue = randomValueOfTypeOtherThan(literal.value(), literal.dataType());
         assertEquals(new Literal(literal.source(), newValue, literal.dataType()),
-                literal.transformPropertiesOnly(p -> p == literal.value() ? newValue : p, Object.class));
+            literal.transformPropertiesOnly(Object.class, p -> p == literal.value() ? newValue : p));
 
         // Replace data type if there are more compatible data types
         List<DataType> validDataTypes = validReplacementDataTypes(literal.value(), literal.dataType());
         if (validDataTypes.size() > 1) {
             DataType newDataType = randomValueOtherThan(literal.dataType(), () -> randomFrom(validDataTypes));
             assertEquals(new Literal(literal.source(), literal.value(), newDataType),
-                    literal.transformPropertiesOnly(p -> newDataType, DataType.class));
+                literal.transformPropertiesOnly(DataType.class, p -> newDataType));
         }
     }
 

--- a/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/expression/UnresolvedAttributeTests.java
+++ b/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/expression/UnresolvedAttributeTests.java
@@ -75,27 +75,27 @@ public class UnresolvedAttributeTests extends AbstractNodeTestCase<UnresolvedAtt
         String newName = randomValueOtherThan(a.name(), () -> randomAlphaOfLength(5));
         assertEquals(new UnresolvedAttribute(a.source(), newName, a.qualifier(), a.id(),
                 a.unresolvedMessage(), a.resolutionMetadata()),
-            a.transformPropertiesOnly(v -> Objects.equals(v, a.name()) ? newName : v, Object.class));
+            a.transformPropertiesOnly(Object.class, v -> Objects.equals(v, a.name()) ? newName : v));
 
         String newQualifier = randomValueOtherThan(a.qualifier(), UnresolvedAttributeTests::randomQualifier);
         assertEquals(new UnresolvedAttribute(a.source(), a.name(), newQualifier, a.id(),
                 a.unresolvedMessage(), a.resolutionMetadata()),
-            a.transformPropertiesOnly(v -> Objects.equals(v, a.qualifier()) ? newQualifier : v, Object.class));
+            a.transformPropertiesOnly(Object.class, v -> Objects.equals(v, a.qualifier()) ? newQualifier : v));
 
         NameId newId = new NameId();
         assertEquals(new UnresolvedAttribute(a.source(), a.name(), a.qualifier(), newId,
                 a.unresolvedMessage(), a.resolutionMetadata()),
-            a.transformPropertiesOnly(v -> Objects.equals(v, a.id()) ? newId : v, Object.class));
+            a.transformPropertiesOnly(Object.class, v -> Objects.equals(v, a.id()) ? newId : v));
 
         String newMessage = randomValueOtherThan(a.unresolvedMessage(), UnresolvedAttributeTests::randomUnresolvedMessage);
         assertEquals(new UnresolvedAttribute(a.source(), a.name(), a.qualifier(), a.id(),
                 newMessage, a.resolutionMetadata()),
-            a.transformPropertiesOnly(v -> Objects.equals(v, a.unresolvedMessage()) ? newMessage : v, Object.class));
+            a.transformPropertiesOnly(Object.class, v -> Objects.equals(v, a.unresolvedMessage()) ? newMessage : v));
 
         Object newMeta = new Object();
         assertEquals(new UnresolvedAttribute(a.source(), a.name(), a.qualifier(), a.id(),
                 a.unresolvedMessage(), newMeta),
-            a.transformPropertiesOnly(v -> Objects.equals(v, a.resolutionMetadata()) ? newMeta : v, Object.class));
+            a.transformPropertiesOnly(Object.class, v -> Objects.equals(v, a.resolutionMetadata()) ? newMeta : v));
     }
 
     @Override

--- a/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/expression/function/UnresolvedFunctionTests.java
+++ b/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/expression/function/UnresolvedFunctionTests.java
@@ -90,23 +90,23 @@ public class UnresolvedFunctionTests extends AbstractNodeTestCase<UnresolvedFunc
         String newName = randomValueOtherThan(uf.name(), () -> randomAlphaOfLength(5));
         assertEquals(new UnresolvedFunction(uf.source(), newName, uf.resolutionType(), uf.children(),
                     uf.analyzed(), uf.unresolvedMessage()),
-                uf.transformPropertiesOnly(p -> Objects.equals(p, uf.name()) ? newName : p, Object.class));
+                uf.transformPropertiesOnly(Object.class, p -> Objects.equals(p, uf.name()) ? newName : p));
 
         UnresolvedFunction.ResolutionType newResolutionType = randomValueOtherThan(uf.resolutionType(),
                 () -> randomFrom(UnresolvedFunction.ResolutionType.values()));
         assertEquals(new UnresolvedFunction(uf.source(), uf.name(), newResolutionType, uf.children(),
                     uf.analyzed(), uf.unresolvedMessage()),
-                uf.transformPropertiesOnly(p -> Objects.equals(p, uf.resolutionType()) ? newResolutionType : p, Object.class));
+                uf.transformPropertiesOnly(Object.class, p -> Objects.equals(p, uf.resolutionType()) ? newResolutionType : p));
 
         String newUnresolvedMessage = randomValueOtherThan(uf.unresolvedMessage(),
                 UnresolvedFunctionTests::randomUnresolvedMessage);
         assertEquals(new UnresolvedFunction(uf.source(), uf.name(), uf.resolutionType(), uf.children(),
                     uf.analyzed(), newUnresolvedMessage),
-                uf.transformPropertiesOnly(p -> Objects.equals(p, uf.unresolvedMessage()) ? newUnresolvedMessage : p, Object.class));
+                uf.transformPropertiesOnly(Object.class, p -> Objects.equals(p, uf.unresolvedMessage()) ? newUnresolvedMessage : p));
 
         assertEquals(new UnresolvedFunction(uf.source(), uf.name(), uf.resolutionType(), uf.children(),
                 !uf.analyzed(), uf.unresolvedMessage()),
-            uf.transformPropertiesOnly(p -> Objects.equals(p, uf.analyzed()) ? !uf.analyzed() : p, Object.class));
+            uf.transformPropertiesOnly(Object.class, p -> Objects.equals(p, uf.analyzed()) ? !uf.analyzed() : p));
 
     }
 

--- a/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/expression/function/scalar/string/StartsWithFunctionPipeTests.java
+++ b/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/expression/function/scalar/string/StartsWithFunctionPipeTests.java
@@ -29,11 +29,11 @@ public class StartsWithFunctionPipeTests extends AbstractNodeTestCase<StartsWith
     protected StartsWithFunctionPipe randomInstance() {
         return randomStartsWithFunctionPipe();
     }
-    
+
     private Expression randomStartsWithFunctionExpression() {
         return randomStartsWithFunctionPipe().expression();
     }
-    
+
     public static StartsWithFunctionPipe randomStartsWithFunctionPipe() {
         return (StartsWithFunctionPipe) (new StartsWith(randomSource(),
                             randomStringLiteral(),
@@ -55,8 +55,8 @@ public class StartsWithFunctionPipeTests extends AbstractNodeTestCase<StartsWith
                 b1.pattern(),
                 b1.isCaseSensitive());
 
-        assertEquals(newB, b1.transformPropertiesOnly(v -> Objects.equals(v, b1.expression()) ? newExpression : v, Expression.class));
-        
+        assertEquals(newB, b1.transformPropertiesOnly(Expression.class, v -> Objects.equals(v, b1.expression()) ? newExpression : v));
+
         StartsWithFunctionPipe b2 = randomInstance();
         Source newLoc = randomValueOtherThan(b2.source(), () -> randomSource());
         newB = new StartsWithFunctionPipe(
@@ -67,7 +67,7 @@ public class StartsWithFunctionPipeTests extends AbstractNodeTestCase<StartsWith
                 b2.isCaseSensitive());
 
         assertEquals(newB,
-                b2.transformPropertiesOnly(v -> Objects.equals(v, b2.source()) ? newLoc : v, Source.class));
+                b2.transformPropertiesOnly(Source.class, v -> Objects.equals(v, b2.source()) ? newLoc : v));
     }
 
     @Override
@@ -75,20 +75,20 @@ public class StartsWithFunctionPipeTests extends AbstractNodeTestCase<StartsWith
         StartsWithFunctionPipe b = randomInstance();
         Pipe newInput = randomValueOtherThan(b.input(), () -> pipe(randomStringLiteral()));
         Pipe newPattern = randomValueOtherThan(b.pattern(), () -> pipe(randomStringLiteral()));
-        
+
         StartsWithFunctionPipe newB = new StartsWithFunctionPipe(b.source(), b.expression(), b.input(), b.pattern(), b.isCaseSensitive());
         StartsWithFunctionPipe transformed = (StartsWithFunctionPipe) newB.replaceChildren(newInput, b.pattern());
         assertEquals(transformed.input(), newInput);
         assertEquals(transformed.source(), b.source());
         assertEquals(transformed.expression(), b.expression());
         assertEquals(transformed.pattern(), b.pattern());
-        
+
         transformed = (StartsWithFunctionPipe) newB.replaceChildren(b.input(), newPattern);
         assertEquals(transformed.input(), b.input());
         assertEquals(transformed.source(), b.source());
         assertEquals(transformed.expression(), b.expression());
         assertEquals(transformed.pattern(), newPattern);
-        
+
         transformed = (StartsWithFunctionPipe) newB.replaceChildren(newInput, newPattern);
         assertEquals(transformed.input(), newInput);
         assertEquals(transformed.source(), b.source());
@@ -108,7 +108,7 @@ public class StartsWithFunctionPipeTests extends AbstractNodeTestCase<StartsWith
                         comb.get(2) ? randomValueOtherThan(f.isCaseSensitive(), () -> randomBoolean()) : f.isCaseSensitive()));
             }
         }
-        
+
         return randomFrom(randoms).apply(instance);
     }
 

--- a/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/plan/QueryPlanTests.java
+++ b/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/plan/QueryPlanTests.java
@@ -32,7 +32,7 @@ public class QueryPlanTests extends ESTestCase {
 
     public void testTransformWithExpressionTopLevel() throws Exception {
         Limit limit = new Limit(EMPTY, of(42), relation());
-        LogicalPlan transformed = limit.transformExpressionsOnly(l -> of(24), Literal.class);
+        LogicalPlan transformed = limit.transformExpressionsOnly(Literal.class, l -> of(24));
 
         assertEquals(Limit.class, transformed.getClass());
         Limit l = (Limit) transformed;
@@ -42,7 +42,7 @@ public class QueryPlanTests extends ESTestCase {
     public void testTransformWithExpressionTree() throws Exception {
         Limit limit = new Limit(EMPTY, of(42), relation());
         OrderBy o = new OrderBy(EMPTY, limit, emptyList());
-        LogicalPlan transformed = o.transformExpressionsDown(l -> of(24), Literal.class);
+        LogicalPlan transformed = o.transformExpressionsDown(Literal.class, l -> of(24));
 
         assertEquals(OrderBy.class, transformed.getClass());
         OrderBy order = (OrderBy) transformed;
@@ -55,8 +55,8 @@ public class QueryPlanTests extends ESTestCase {
         FieldAttribute two = fieldAttribute("two", INTEGER);
 
         Project project = new Project(EMPTY, relation(), asList(one, two));
-        LogicalPlan transformed = project.transformExpressionsOnly(n -> n.name().equals("one") ?
-            new FieldAttribute(EMPTY, "changed", one.field()) : n, NamedExpression.class);
+        LogicalPlan transformed = project.transformExpressionsOnly(NamedExpression.class, n -> n.name().equals("one") ?
+            new FieldAttribute(EMPTY, "changed", one.field()) : n);
 
         assertEquals(Project.class, transformed.getClass());
         Project p = (Project) transformed;
@@ -74,11 +74,11 @@ public class QueryPlanTests extends ESTestCase {
         Project project = new Project(EMPTY, relation(), asList(one, two));
 
         List<Object> list = new ArrayList<>();
-        project.forEachExpressions(l -> {
+        project.forEachExpressions(Literal.class, l -> {
             if (l.fold().equals(42)) {
                 list.add(l.fold());
             }
-        }, Literal.class);
+        });
 
         assertEquals(singletonList(one.child().fold()), list);
     }
@@ -88,11 +88,11 @@ public class QueryPlanTests extends ESTestCase {
         OrderBy o = new OrderBy(EMPTY, limit, emptyList());
 
         List<Object> list = new ArrayList<>();
-        o.forEachExpressionsDown(l -> {
+        o.forEachExpressionsDown(Literal.class, l -> {
             if (l.fold().equals(42)) {
                 list.add(l.fold());
             }
-        }, Literal.class);
+        });
 
         assertEquals(singletonList(limit.limit().fold()), list);
     }
@@ -104,11 +104,11 @@ public class QueryPlanTests extends ESTestCase {
         Project project = new Project(EMPTY, relation(), asList(one, two));
 
         List<NamedExpression> list = new ArrayList<>();
-        project.forEachExpressions(n -> {
+        project.forEachExpressions(NamedExpression.class, n -> {
             if (n.name().equals("one")) {
                 list.add(n);
             }
-        }, NamedExpression.class);
+        });
 
         assertEquals(singletonList(one), list);
     }
@@ -120,11 +120,11 @@ public class QueryPlanTests extends ESTestCase {
         Project project = new Project(EMPTY, relation(), asList(one, two));
 
         List<Object> list = new ArrayList<>();
-        project.forEachExpressions(l -> {
+        project.forEachExpressions(Literal.class, l -> {
             if (l.fold().equals(42)) {
                 list.add(l.fold());
             }
-        }, Literal.class);
+        });
 
         assertEquals(singletonList(one.child().fold()), list);
     }

--- a/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/tree/NodeSubclassTests.java
+++ b/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/tree/NodeSubclassTests.java
@@ -6,7 +6,6 @@
 package org.elasticsearch.xpack.ql.tree;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
-
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.SuppressForbidden;
 import org.elasticsearch.common.io.PathUtils;
@@ -115,7 +114,7 @@ public class NodeSubclassTests<T extends B, B extends Node<B>> extends ESTestCas
     }
 
     /**
-     * Test {@link Node#transformPropertiesOnly(java.util.function.Function, Class)}
+     * Test {@link Node#transformPropertiesOnly(Class, java.util.function.Function)}
      * implementation on {@link #subclass} which tests the implementation of
      * {@link Node#info()}. And tests the actual {@link NodeInfo} subclass
      * implementations in the process.
@@ -133,7 +132,7 @@ public class NodeSubclassTests<T extends B, B extends Node<B>> extends ESTestCas
             Type changedArgType = argTypes[changedArgOffset];
             Object changedArgValue = randomValueOtherThan(nodeCtorArgs[changedArgOffset], () -> makeArg(changedArgType));
 
-            B transformed = node.transformNodeProps(prop -> Objects.equals(prop, originalArgValue) ? changedArgValue : prop, Object.class);
+            B transformed = node.transformNodeProps(Object.class, prop -> Objects.equals(prop, originalArgValue) ? changedArgValue : prop);
 
             if (node.children().contains(originalArgValue) || node.children().equals(originalArgValue)) {
                 if (node.children().equals(emptyList()) && originalArgValue.equals(emptyList())) {
@@ -639,7 +638,7 @@ public class NodeSubclassTests<T extends B, B extends Node<B>> extends ESTestCas
             }
             // for folders, just use the FileSystems API
             else {
-                Files.walkFileTree(root, new SimpleFileVisitor<Path>() {
+                Files.walkFileTree(root, new SimpleFileVisitor<>() {
                     @Override
                     public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
                         if (Files.isRegularFile(file) && file.getFileName().toString().endsWith(".class")) {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Analyzer.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Analyzer.java
@@ -284,7 +284,7 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
                 return p;
             }
 
-            return p.transformExpressionsDown(sq -> sq.withQuery(substituteCTE(sq.query(), subQueries)), SubQueryExpression.class);
+            return p.transformExpressionsDown(SubQueryExpression.class, sq -> sq.withQuery(substituteCTE(sq.query(), subQueries)));
         }
 
         @Override
@@ -386,7 +386,7 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
                 log.trace("Attempting to resolve {}", plan.nodeString());
             }
 
-            return plan.transformExpressionsUp(u -> {
+            return plan.transformExpressionsUp(UnresolvedAttribute.class, u -> {
                 List<Attribute> childrenOutput = new ArrayList<>();
                 for (LogicalPlan child : plan.children()) {
                     childrenOutput.addAll(child.output());
@@ -401,7 +401,7 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
                 }
                 //TODO: likely have to expand * inside functions as well
                 return u;
-            }, UnresolvedAttribute.class);
+            });
         }
 
         private List<NamedExpression> expandProjections(List<? extends NamedExpression> projections, LogicalPlan child) {
@@ -669,8 +669,8 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
                         List<Order> newOrders = new ArrayList<>();
                         // transform the orders with the failed information
                         for (Order order : o.order()) {
-                            Order transformed = (Order) order.transformUp(ua -> resolveMetadataToMessage(ua, failedAttrs, "order"),
-                                    UnresolvedAttribute.class);
+                            Order transformed = (Order) order.transformUp(UnresolvedAttribute.class, ua -> resolveMetadataToMessage(ua, failedAttrs, "order")
+                            );
                             newOrders.add(order.equals(transformed) ? order : transformed);
                         }
 
@@ -704,8 +704,8 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
                     // resolution failed and the failed expressions might contain resolution information so copy it over
                     if (!failedAttrs.isEmpty()) {
                         // transform the orders with the failed information
-                        Expression transformed = f.condition().transformUp(ua -> resolveMetadataToMessage(ua, failedAttrs, "filter"),
-                                UnresolvedAttribute.class);
+                        Expression transformed = f.condition().transformUp(UnresolvedAttribute.class, ua -> resolveMetadataToMessage(ua, failedAttrs, "filter")
+                        );
 
                         return f.condition().equals(transformed) ? f : new Filter(f.source(), f.child(), transformed);
                     }
@@ -855,19 +855,19 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
                 }
             });
 
-            return condition.transformDown(u -> {
+            return condition.transformDown(UnresolvedAttribute.class, u -> {
                 boolean qualified = u.qualifier() != null;
                 for (Alias alias : aliases) {
                     // don't replace field with their own aliases (it creates infinite cycles)
                     if (alias.anyMatch(e -> e == u) == false &&
-                           (qualified ?
-                               Objects.equals(alias.qualifiedName(), u.qualifiedName()) :
-                               Objects.equals(alias.name(), u.name()))) {
+                        (qualified ?
+                            Objects.equals(alias.qualifiedName(), u.qualifiedName()) :
+                            Objects.equals(alias.name(), u.name()))) {
                         return alias;
                     }
                 }
                 return u;
-             }, UnresolvedAttribute.class);
+            });
         }
     }
 
@@ -875,7 +875,7 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
 
         @Override
         protected LogicalPlan rule(LogicalPlan plan) {
-            return plan.transformExpressionsUp(uf -> {
+            return plan.transformExpressionsUp(UnresolvedFunction.class, uf -> {
                 if (uf.analyzed()) {
                     return uf;
                 }
@@ -901,7 +901,7 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
                 FunctionDefinition def = functionRegistry.resolveFunction(functionName);
                 Function f = uf.buildResolved(configuration, def);
                 return f;
-            }, UnresolvedFunction.class);
+            });
         }
     }
 
@@ -944,7 +944,7 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
         private List<NamedExpression> assignAliases(List<? extends NamedExpression> exprs) {
             List<NamedExpression> newExpr = new ArrayList<>(exprs.size());
             for (NamedExpression expr : exprs) {
-                NamedExpression transformed = (NamedExpression) expr.transformUp(ua -> {
+                NamedExpression transformed = (NamedExpression) expr.transformUp(UnresolvedAlias.class, ua -> {
                     Expression child = ua.child();
                     if (child instanceof NamedExpression) {
                         return child;
@@ -959,7 +959,7 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
                         }
                     }
                     return new Alias(child.source(), child.sourceText(), child);
-                }, UnresolvedAlias.class);
+                });
                 newExpr.add(expr.equals(transformed) ? expr : transformed);
             }
             return newExpr;
@@ -1127,7 +1127,7 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
             // 2. find first Aggregate child and update it
             final Holder<Boolean> found = new Holder<>(Boolean.FALSE);
 
-            LogicalPlan plan = ob.transformDown(a -> {
+            LogicalPlan plan = ob.transformDown(Aggregate.class, a -> {
                 if (found.get() == Boolean.FALSE) {
                     found.set(Boolean.TRUE);
 
@@ -1150,7 +1150,7 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
                     }
                 }
                 return a;
-            }, Aggregate.class);
+            });
 
             // if the plan was updated, project the initial aggregates
             if (plan != ob) {
@@ -1244,7 +1244,7 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
                         cleanChildrenAliases(p.aggregates()));
             }
 
-            return plan.transformExpressionsOnly(a -> a.child(), Alias.class);
+            return plan.transformExpressionsOnly(Alias.class, a -> a.child());
         }
 
         private List<NamedExpression> cleanChildrenAliases(List<? extends NamedExpression> args) {
@@ -1272,7 +1272,7 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
         }
 
         private static Expression trimAliases(Expression e) {
-            return e.transformDown(Alias::child, Alias.class);
+            return e.transformDown(Alias.class, Alias::child);
         }
 
         @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Analyzer.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Analyzer.java
@@ -669,7 +669,8 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
                         List<Order> newOrders = new ArrayList<>();
                         // transform the orders with the failed information
                         for (Order order : o.order()) {
-                            Order transformed = (Order) order.transformUp(UnresolvedAttribute.class, ua -> resolveMetadataToMessage(ua, failedAttrs, "order")
+                            Order transformed = (Order) order.transformUp(UnresolvedAttribute.class,
+                                ua -> resolveMetadataToMessage(ua, failedAttrs, "order")
                             );
                             newOrders.add(order.equals(transformed) ? order : transformed);
                         }
@@ -704,7 +705,8 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
                     // resolution failed and the failed expressions might contain resolution information so copy it over
                     if (!failedAttrs.isEmpty()) {
                         // transform the orders with the failed information
-                        Expression transformed = f.condition().transformUp(UnresolvedAttribute.class, ua -> resolveMetadataToMessage(ua, failedAttrs, "filter")
+                        Expression transformed = f.condition().transformUp(UnresolvedAttribute.class,
+                            ua -> resolveMetadataToMessage(ua, failedAttrs, "filter")
                         );
 
                         return f.condition().equals(transformed) ? f : new Filter(f.source(), f.child(), transformed);

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/PreAnalyzer.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/PreAnalyzer.java
@@ -39,12 +39,12 @@ public class PreAnalyzer {
 
     private PreAnalysis doPreAnalyze(LogicalPlan plan) {
         List<TableInfo> indices = new ArrayList<>();
-        
-        plan.forEachUp(p -> indices.add(new TableInfo(p.table(), p.frozen())), UnresolvedRelation.class);
-        
+
+        plan.forEachUp(UnresolvedRelation.class, p -> indices.add(new TableInfo(p.table(), p.frozen())));
+
         // mark plan as preAnalyzed (if it were marked, there would be no analysis)
         plan.forEachUp(LogicalPlan::setPreAnalyzed);
-        
+
         return new PreAnalysis(indices);
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/Querier.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/Querier.java
@@ -58,13 +58,13 @@ import org.elasticsearch.xpack.sql.querydsl.container.QueryContainer;
 import org.elasticsearch.xpack.sql.querydsl.container.ScriptFieldRef;
 import org.elasticsearch.xpack.sql.querydsl.container.SearchHitFieldRef;
 import org.elasticsearch.xpack.sql.querydsl.container.TopHitsAggRef;
-import org.elasticsearch.xpack.sql.session.SqlConfiguration;
 import org.elasticsearch.xpack.sql.session.Cursor;
 import org.elasticsearch.xpack.sql.session.Cursor.Page;
 import org.elasticsearch.xpack.sql.session.ListCursor;
 import org.elasticsearch.xpack.sql.session.RowSet;
 import org.elasticsearch.xpack.sql.session.Rows;
 import org.elasticsearch.xpack.sql.session.SchemaRowSet;
+import org.elasticsearch.xpack.sql.session.SqlConfiguration;
 import org.elasticsearch.xpack.sql.session.SqlSession;
 
 import java.io.IOException;
@@ -441,10 +441,10 @@ public class Querier {
                 Pipe proc = ((ComputedRef) ref).processor();
 
                 // wrap only agg inputs
-                proc = proc.transformDown(l -> {
+                proc = proc.transformDown(AggPathInput.class, l -> {
                     BucketExtractor be = createExtractor(l.context(), totalCount);
                     return new AggExtractorInput(l.source(), l.expression(), l.action(), be);
-                }, AggPathInput.class);
+                });
 
                 return new ComputingExtractor(proc.asProcessor());
             }
@@ -500,7 +500,7 @@ public class Querier {
                 Pipe proc = ((ComputedRef) ref).processor();
                 // collect hitNames
                 Set<String> hitNames = new LinkedHashSet<>();
-                proc = proc.transformDown(l -> {
+                proc = proc.transformDown(ReferenceInput.class, l -> {
                     HitExtractor he = createExtractor(l.context());
                     hitNames.add(he.hitName());
 
@@ -509,7 +509,7 @@ public class Querier {
                     }
 
                     return new HitExtractorInput(l.source(), l.expression(), he);
-                }, ReferenceInput.class);
+                });
                 String hitName = null;
                 if (hitNames.size() == 1) {
                     hitName = hitNames.iterator().next();

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/package-info.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/package-info.java
@@ -143,7 +143,7 @@
  * {@code instanceof} checks. Which is how many rules are implemented in
  * the SQL engine as well. Where possible though, one can use <i>typed</i>
  * traversal by passing a {@code Class} token to the lambdas (i.e.
- * {@link org.elasticsearch.xpack.ql.tree.Node#transformDown(java.util.function.Function, Class)
+ * {@link org.elasticsearch.xpack.ql.tree.Node#transformDown(Class, java.util.function.Function)
  * pre-order transformation}).
  *
  * <h2>Components</h2>

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/planner/Mapper.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/planner/Mapper.java
@@ -142,7 +142,7 @@ class Mapper extends RuleExecutor<PhysicalPlan> {
 
         @Override
         public final PhysicalPlan apply(PhysicalPlan plan) {
-            return plan.transformUp(this::rule, UnplannedExec.class);
+            return plan.transformUp(UnplannedExec.class, this::rule);
         }
 
         @SuppressWarnings("unchecked")

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/planner/QueryFolder.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/planner/QueryFolder.java
@@ -873,7 +873,7 @@ class QueryFolder extends RuleExecutor<PhysicalPlan> {
 
         @Override
         public final PhysicalPlan apply(PhysicalPlan plan) {
-            return plan.transformUp(this::rule, typeToken());
+            return plan.transformUp(typeToken(), this::rule);
         }
 
         @Override

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateAddPipeTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateAddPipeTests.java
@@ -61,19 +61,19 @@ public class DateAddPipeTests extends AbstractNodeTestCase<DateAddPipe, Pipe> {
                 b1.second(),
                 b1.third(),
                 b1.zoneId());
-        assertEquals(newB, b1.transformPropertiesOnly(v -> Objects.equals(v, b1.expression()) ? newExpression : v, Expression.class));
+        assertEquals(newB, b1.transformPropertiesOnly(Expression.class, v -> Objects.equals(v, b1.expression()) ? newExpression : v));
 
         DateAddPipe b2 = randomInstance();
         Source newLoc = randomValueOtherThan(b2.source(), SourceTests::randomSource);
         newB = new DateAddPipe(
-                newLoc,
-                b2.expression(),
-                b2.first(),
-                b2.second(),
-                b2.third(),
-                b2.zoneId());
+            newLoc,
+            b2.expression(),
+            b2.first(),
+            b2.second(),
+            b2.third(),
+            b2.zoneId());
         assertEquals(newB,
-                b2.transformPropertiesOnly(v -> Objects.equals(v, b2.source()) ? newLoc : v, Source.class));
+            b2.transformPropertiesOnly(Source.class, v -> Objects.equals(v, b2.source()) ? newLoc : v));
     }
 
     @Override

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateDiffPipeTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateDiffPipeTests.java
@@ -60,19 +60,19 @@ public class DateDiffPipeTests extends AbstractNodeTestCase<DateDiffPipe, Pipe> 
                 b1.second(),
                 b1.third(),
                 b1.zoneId());
-        assertEquals(newB, b1.transformPropertiesOnly(v -> Objects.equals(v, b1.expression()) ? newExpression : v, Expression.class));
+        assertEquals(newB, b1.transformPropertiesOnly(Expression.class, v -> Objects.equals(v, b1.expression()) ? newExpression : v));
 
         DateDiffPipe b2 = randomInstance();
         Source newLoc = randomValueOtherThan(b2.source(), SourceTests::randomSource);
         newB = new DateDiffPipe(
-                newLoc,
-                b2.expression(),
-                b2.first(),
-                b2.second(),
-                b2.third(),
-                b2.zoneId());
+            newLoc,
+            b2.expression(),
+            b2.first(),
+            b2.second(),
+            b2.third(),
+            b2.zoneId());
         assertEquals(newB,
-                b2.transformPropertiesOnly(v -> Objects.equals(v, b2.source()) ? newLoc : v, Source.class));
+            b2.transformPropertiesOnly(Source.class, v -> Objects.equals(v, b2.source()) ? newLoc : v));
     }
 
     @Override

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DatePartPipeTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DatePartPipeTests.java
@@ -59,7 +59,7 @@ public class DatePartPipeTests extends AbstractNodeTestCase<DatePartPipe, Pipe> 
             b1.left(),
             b1.right(),
             b1.zoneId());
-        assertEquals(newB, b1.transformPropertiesOnly(v -> Objects.equals(v, b1.expression()) ? newExpression : v, Expression.class));
+        assertEquals(newB, b1.transformPropertiesOnly(Expression.class, v -> Objects.equals(v, b1.expression()) ? newExpression : v));
 
         DatePartPipe b2 = randomInstance();
         Source newLoc = randomValueOtherThan(b2.source(), SourceTests::randomSource);
@@ -70,7 +70,7 @@ public class DatePartPipeTests extends AbstractNodeTestCase<DatePartPipe, Pipe> 
             b2.right(),
             b2.zoneId());
         assertEquals(newB,
-            b2.transformPropertiesOnly(v -> Objects.equals(v, b2.source()) ? newLoc : v, Source.class));
+            b2.transformPropertiesOnly(Source.class, v -> Objects.equals(v, b2.source()) ? newLoc : v));
     }
 
     @Override

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTimeFormatPipeTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTimeFormatPipeTests.java
@@ -55,22 +55,22 @@ public class DateTimeFormatPipeTests extends AbstractNodeTestCase<DateTimeFormat
 
         Expression newExpression = randomValueOtherThan(b1.expression(), this::randomDateTimeFormatPipeExpression);
         DateTimeFormatPipe newB = new DateTimeFormatPipe(b1.source(), newExpression, b1.left(), b1.right(), b1.zoneId(), b1.formatter());
-        assertEquals(newB, b1.transformPropertiesOnly(v -> Objects.equals(v, b1.expression()) ? newExpression : v, Expression.class));
+        assertEquals(newB, b1.transformPropertiesOnly(Expression.class, v -> Objects.equals(v, b1.expression()) ? newExpression : v));
 
         DateTimeFormatPipe b2 = randomInstance();
         Source newLoc = randomValueOtherThan(b2.source(), SourceTests::randomSource);
         newB = new DateTimeFormatPipe(newLoc, b2.expression(), b2.left(), b2.right(), b2.zoneId(), b2.formatter());
-        assertEquals(newB, b2.transformPropertiesOnly(v -> Objects.equals(v, b2.source()) ? newLoc : v, Source.class));
+        assertEquals(newB, b2.transformPropertiesOnly(Source.class, v -> Objects.equals(v, b2.source()) ? newLoc : v));
 
         DateTimeFormatPipe b3 = randomInstance();
         Formatter newFormatter = randomValueOtherThan(b3.formatter(), () -> randomFrom(Formatter.values()));
         newB = new DateTimeFormatPipe(b3.source(), b3.expression(), b3.left(), b3.right(), b3.zoneId(), newFormatter);
-        assertEquals(newB, b3.transformPropertiesOnly(v -> Objects.equals(v, b3.formatter()) ? newFormatter : v, Formatter.class));
+        assertEquals(newB, b3.transformPropertiesOnly(Formatter.class, v -> Objects.equals(v, b3.formatter()) ? newFormatter : v));
 
         DateTimeFormatPipe b4 = randomInstance();
         ZoneId newZI = randomValueOtherThan(b4.zoneId(), ESTestCase::randomZone);
         newB = new DateTimeFormatPipe(b4.source(), b4.expression(), b4.left(), b4.right(), newZI, b4.formatter());
-        assertEquals(newB, b4.transformPropertiesOnly(v -> Objects.equals(v, b4.zoneId()) ? newZI : v, ZoneId.class));
+        assertEquals(newB, b4.transformPropertiesOnly(ZoneId.class, v -> Objects.equals(v, b4.zoneId()) ? newZI : v));
     }
 
     @Override

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTimeParsePipeTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTimeParsePipeTests.java
@@ -28,10 +28,10 @@ import static org.elasticsearch.xpack.sql.expression.function.scalar.datetime.Da
 
 
 public class DateTimeParsePipeTests extends AbstractNodeTestCase<DateTimeParsePipe, Pipe> {
-    
+
     public static DateTimeParsePipe randomDateTimeParsePipe() {
         List<Pipe> functions = new ArrayList<>();
-        functions.add(new DateTimeParse(            
+        functions.add(new DateTimeParse(
                 randomSource(),
                 randomStringLiteral(),
                 randomStringLiteral(),
@@ -69,28 +69,28 @@ public class DateTimeParsePipeTests extends AbstractNodeTestCase<DateTimeParsePi
 
         Expression newExpression = randomValueOtherThan(b1.expression(), this::randomDateTimeParsePipeExpression);
         DateTimeParsePipe newB = new DateTimeParsePipe(
-                b1.source(), 
-                newExpression, 
-                b1.left(), 
-                b1.right(), 
-                b1.zoneId(), 
+                b1.source(),
+                newExpression,
+                b1.left(),
+                b1.right(),
+                b1.zoneId(),
                 b1.parser());
-        assertEquals(newB, b1.transformPropertiesOnly(v -> Objects.equals(v, b1.expression()) ? newExpression : v, Expression.class));
+        assertEquals(newB, b1.transformPropertiesOnly(Expression.class, v -> Objects.equals(v, b1.expression()) ? newExpression : v));
 
         DateTimeParsePipe b2 = randomInstance();
         Source newLoc = randomValueOtherThan(b2.source(), SourceTests::randomSource);
         newB = new DateTimeParsePipe(newLoc, b2.expression(), b2.left(), b2.right(), b2.zoneId(), b2.parser());
-        assertEquals(newB, b2.transformPropertiesOnly(v -> Objects.equals(v, b2.source()) ? newLoc : v, Source.class));
-    
+        assertEquals(newB, b2.transformPropertiesOnly(Source.class, v -> Objects.equals(v, b2.source()) ? newLoc : v));
+
         DateTimeParsePipe b3 = randomInstance();
         Parser newPr = randomValueOtherThan(b3.parser(), () -> randomFrom(Parser.values()));
         newB = new DateTimeParsePipe(b3.source(), b3.expression(), b3.left(), b3.right(), b3.zoneId(), newPr);
-        assertEquals(newB, b3.transformPropertiesOnly(v -> Objects.equals(v, b3.parser()) ? newPr : v, Parser.class));
-    
+        assertEquals(newB, b3.transformPropertiesOnly(Parser.class, v -> Objects.equals(v, b3.parser()) ? newPr : v));
+
         DateTimeParsePipe b4 = randomInstance();
         ZoneId newZI = randomValueOtherThan(b4.zoneId(), ESTestCase::randomZone);
         newB = new DateTimeParsePipe(b3.source(), b4.expression(), b4.left(), b4.right(), newZI, b4.parser());
-        assertEquals(newB, b4.transformPropertiesOnly(v -> Objects.equals(v, b4.zoneId()) ? newZI : v, ZoneId.class));
+        assertEquals(newB, b4.transformPropertiesOnly(ZoneId.class, v -> Objects.equals(v, b4.zoneId()) ? newZI : v));
     }
 
     @Override
@@ -99,11 +99,11 @@ public class DateTimeParsePipeTests extends AbstractNodeTestCase<DateTimeParsePi
         Pipe newLeft = pipe(((Expression) randomValueOtherThan(b.left(), FunctionTestUtils::randomDatetimeLiteral)));
         Pipe newRight = pipe(((Expression) randomValueOtherThan(b.right(), FunctionTestUtils::randomStringLiteral)));
         DateTimeParsePipe newB = new DateTimeParsePipe(
-                b.source(), 
-                b.expression(), 
-                b.left(), 
-                b.right(), 
-                b.zoneId(), 
+                b.source(),
+                b.expression(),
+                b.left(),
+                b.right(),
+                b.zoneId(),
                 b.parser());
         BinaryPipe transformed = newB.replaceChildren(newLeft, b.right());
 
@@ -144,7 +144,7 @@ public class DateTimeParsePipeTests extends AbstractNodeTestCase<DateTimeParsePi
                 f.expression(),
                 f.left(),
                 pipe(((Expression) randomValueOtherThan(f.right(), FunctionTestUtils::randomStringLiteral))),
-                f.zoneId(), 
+                f.zoneId(),
                 f.parser()
             )
         );
@@ -164,7 +164,7 @@ public class DateTimeParsePipeTests extends AbstractNodeTestCase<DateTimeParsePi
                 f.expression(),
                 pipe(((Expression) randomValueOtherThan(f.left(), FunctionTestUtils::randomDatetimeLiteral))),
                 pipe(((Expression) randomValueOtherThan(f.right(), FunctionTestUtils::randomStringLiteral))),
-                randomValueOtherThan(f.zoneId(), ESTestCase::randomZone), 
+                randomValueOtherThan(f.zoneId(), ESTestCase::randomZone),
                 f.parser()
             )
         );
@@ -185,10 +185,10 @@ public class DateTimeParsePipeTests extends AbstractNodeTestCase<DateTimeParsePi
     @Override
     protected DateTimeParsePipe copy(DateTimeParsePipe instance) {
         return new DateTimeParsePipe(
-                instance.source(), 
-                instance.expression(), 
-                instance.left(), 
-                instance.right(), 
+                instance.source(),
+                instance.expression(),
+                instance.left(),
+                instance.right(),
                 instance.zoneId(),
                 instance.parser());
     }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTruncPipeTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTruncPipeTests.java
@@ -59,7 +59,7 @@ public class DateTruncPipeTests extends AbstractNodeTestCase<DateTruncPipe, Pipe
             b1.left(),
             b1.right(),
             b1.zoneId());
-        assertEquals(newB, b1.transformPropertiesOnly(v -> Objects.equals(v, b1.expression()) ? newExpression : v, Expression.class));
+        assertEquals(newB, b1.transformPropertiesOnly(Expression.class, v -> Objects.equals(v, b1.expression()) ? newExpression : v));
 
         DateTruncPipe b2 = randomInstance();
         Source newLoc = randomValueOtherThan(b2.source(), SourceTests::randomSource);
@@ -70,7 +70,7 @@ public class DateTruncPipeTests extends AbstractNodeTestCase<DateTruncPipe, Pipe
             b2.right(),
             b2.zoneId());
         assertEquals(newB,
-            b2.transformPropertiesOnly(v -> Objects.equals(v, b2.source()) ? newLoc : v, Source.class));
+            b2.transformPropertiesOnly(Source.class, v -> Objects.equals(v, b2.source()) ? newLoc : v));
     }
 
     @Override

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/BinaryStringNumericPipeTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/BinaryStringNumericPipeTests.java
@@ -30,21 +30,21 @@ public class BinaryStringNumericPipeTests
     protected BinaryStringNumericPipe randomInstance() {
         return randomBinaryStringNumericPipe();
     }
-    
+
     private Expression randomBinaryStringNumericExpression() {
         return randomBinaryStringNumericPipe().expression();
     }
-    
+
     private BinaryStringNumericOperation randomBinaryStringNumericOperation() {
         return randomBinaryStringNumericPipe().operation();
     }
-    
+
     public static BinaryStringNumericPipe randomBinaryStringNumericPipe() {
         List<Pipe> functions = new ArrayList<>();
         functions.add(new Left(randomSource(), randomStringLiteral(), randomIntLiteral()).makePipe());
         functions.add(new Right(randomSource(), randomStringLiteral(), randomIntLiteral()).makePipe());
         functions.add(new Repeat(randomSource(), randomStringLiteral(), randomIntLiteral()).makePipe());
-        
+
         return (BinaryStringNumericPipe) randomFrom(functions);
     }
 
@@ -53,7 +53,7 @@ public class BinaryStringNumericPipeTests
         // test transforming only the properties (source, expression, operation),
         // skipping the children (the two parameters of the binary function) which are tested separately
         BinaryStringNumericPipe b1 = randomInstance();
-        
+
         Expression newExpression = randomValueOtherThan(b1.expression(), () -> randomBinaryStringNumericExpression());
         BinaryStringNumericPipe newB = new BinaryStringNumericPipe(
                 b1.source(),
@@ -61,29 +61,29 @@ public class BinaryStringNumericPipeTests
                 b1.left(),
                 b1.right(),
                 b1.operation());
-        assertEquals(newB, b1.transformPropertiesOnly(v -> Objects.equals(v, b1.expression()) ? newExpression : v, Expression.class));
-        
+        assertEquals(newB, b1.transformPropertiesOnly(Expression.class, v -> Objects.equals(v, b1.expression()) ? newExpression : v));
+
         BinaryStringNumericPipe b2 = randomInstance();
         BinaryStringNumericOperation newOp = randomValueOtherThan(b2.operation(), () -> randomBinaryStringNumericOperation());
         newB = new BinaryStringNumericPipe(
-                b2.source(),
-                b2.expression(),
-                b2.left(),
-                b2.right(),
-                newOp);
+            b2.source(),
+            b2.expression(),
+            b2.left(),
+            b2.right(),
+            newOp);
         assertEquals(newB,
-                b2.transformPropertiesOnly(v -> Objects.equals(v, b2.operation()) ? newOp : v, BinaryStringNumericOperation.class));
-        
+            b2.transformPropertiesOnly(BinaryStringNumericOperation.class, v -> Objects.equals(v, b2.operation()) ? newOp : v));
+
         BinaryStringNumericPipe b3 = randomInstance();
         Source newLoc = randomValueOtherThan(b3.source(), () -> randomSource());
         newB = new BinaryStringNumericPipe(
-                newLoc,
-                b3.expression(),
-                b3.left(),
-                b3.right(),
-                b3.operation());
+            newLoc,
+            b3.expression(),
+            b3.left(),
+            b3.right(),
+            b3.operation());
         assertEquals(newB,
-                b3.transformPropertiesOnly(v -> Objects.equals(v, b3.source()) ? newLoc : v, Source.class));
+            b3.transformPropertiesOnly(Source.class, v -> Objects.equals(v, b3.source()) ? newLoc : v));
     }
 
     @Override
@@ -94,25 +94,25 @@ public class BinaryStringNumericPipeTests
         BinaryStringNumericPipe newB =
                 new BinaryStringNumericPipe(b.source(), b.expression(), b.left(), b.right(), b.operation());
         BinaryPipe transformed = newB.replaceChildren(newLeft, b.right());
-        
+
         assertEquals(transformed.left(), newLeft);
         assertEquals(transformed.source(), b.source());
         assertEquals(transformed.expression(), b.expression());
         assertEquals(transformed.right(), b.right());
-        
+
         transformed = newB.replaceChildren(b.left(), newRight);
         assertEquals(transformed.left(), b.left());
         assertEquals(transformed.source(), b.source());
         assertEquals(transformed.expression(), b.expression());
         assertEquals(transformed.right(), newRight);
-        
+
         transformed = newB.replaceChildren(newLeft, newRight);
         assertEquals(transformed.left(), newLeft);
         assertEquals(transformed.source(), b.source());
         assertEquals(transformed.expression(), b.expression());
         assertEquals(transformed.right(), newRight);
     }
-    
+
     @Override
     protected BinaryStringNumericPipe mutate(BinaryStringNumericPipe instance) {
         List<Function<BinaryStringNumericPipe, BinaryStringNumericPipe>> randoms = new ArrayList<>();
@@ -131,7 +131,7 @@ public class BinaryStringNumericPipeTests
                 pipe(((Expression) randomValueOtherThan(f.left(), () -> randomStringLiteral()))),
                 pipe(((Expression) randomValueOtherThan(f.right(), () -> randomIntLiteral()))),
                 f.operation()));
-        
+
         return randomFrom(randoms).apply(instance);
     }
 

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/BinaryStringStringPipeTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/BinaryStringStringPipeTests.java
@@ -28,11 +28,11 @@ public class BinaryStringStringPipeTests
     protected BinaryStringStringPipe randomInstance() {
         return randomBinaryStringStringPipe();
     }
-    
+
     private Expression randomBinaryStringStringExpression() {
         return randomBinaryStringStringPipe().expression();
     }
-    
+
     public static BinaryStringStringPipe randomBinaryStringStringPipe() {
         List<Pipe> functions = new ArrayList<>();
         functions.add(new Position(
@@ -56,18 +56,18 @@ public class BinaryStringStringPipeTests
                 b1.left(),
                 b1.right(),
                 b1.operation());
-        assertEquals(newB, b1.transformPropertiesOnly(v -> Objects.equals(v, b1.expression()) ? newExpression : v, Expression.class));
-        
+        assertEquals(newB, b1.transformPropertiesOnly(Expression.class, v -> Objects.equals(v, b1.expression()) ? newExpression : v));
+
         BinaryStringStringPipe b2 = randomInstance();
         Source newLoc = randomValueOtherThan(b2.source(), () -> randomSource());
         newB = new BinaryStringStringPipe(
-                newLoc,
-                b2.expression(),
-                b2.left(),
-                b2.right(),
-                b2.operation());
+            newLoc,
+            b2.expression(),
+            b2.left(),
+            b2.right(),
+            b2.operation());
         assertEquals(newB,
-                b2.transformPropertiesOnly(v -> Objects.equals(v, b2.source()) ? newLoc : v, Source.class));
+            b2.transformPropertiesOnly(Source.class, v -> Objects.equals(v, b2.source()) ? newLoc : v));
     }
 
     @Override
@@ -77,19 +77,19 @@ public class BinaryStringStringPipeTests
         Pipe newRight = pipe(((Expression) randomValueOtherThan(b.right(), () -> randomStringLiteral())));
         BinaryStringStringPipe newB =
                 new BinaryStringStringPipe(b.source(), b.expression(), b.left(), b.right(), b.operation());
-        
+
         BinaryPipe transformed = newB.replaceChildren(newLeft, b.right());
         assertEquals(transformed.left(), newLeft);
         assertEquals(transformed.source(), b.source());
         assertEquals(transformed.expression(), b.expression());
         assertEquals(transformed.right(), b.right());
-        
+
         transformed = newB.replaceChildren(b.left(), newRight);
         assertEquals(transformed.left(), b.left());
         assertEquals(transformed.source(), b.source());
         assertEquals(transformed.expression(), b.expression());
         assertEquals(transformed.right(), newRight);
-        
+
         transformed = newB.replaceChildren(newLeft, newRight);
         assertEquals(transformed.left(), newLeft);
         assertEquals(transformed.source(), b.source());
@@ -115,7 +115,7 @@ public class BinaryStringStringPipeTests
                 pipe(((Expression) randomValueOtherThan(f.left(), () -> randomStringLiteral()))),
                 pipe(((Expression) randomValueOtherThan(f.right(), () -> randomStringLiteral()))),
                 f.operation()));
-        
+
         return randomFrom(randoms).apply(instance);
     }
 

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/ConcatFunctionPipeTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/ConcatFunctionPipeTests.java
@@ -27,11 +27,11 @@ public class ConcatFunctionPipeTests extends AbstractNodeTestCase<ConcatFunction
     protected ConcatFunctionPipe randomInstance() {
         return randomConcatFunctionPipe();
     }
-    
+
     private Expression randomConcatFunctionExpression() {
         return randomConcatFunctionPipe().expression();
     }
-    
+
     public static ConcatFunctionPipe randomConcatFunctionPipe() {
         return (ConcatFunctionPipe) new Concat(
                 randomSource(),
@@ -45,24 +45,24 @@ public class ConcatFunctionPipeTests extends AbstractNodeTestCase<ConcatFunction
         // test transforming only the properties (source, expression),
         // skipping the children (the two parameters of the binary function) which are tested separately
         ConcatFunctionPipe b1 = randomInstance();
-        
+
         Expression newExpression = randomValueOtherThan(b1.expression(), () -> randomConcatFunctionExpression());
         ConcatFunctionPipe newB = new ConcatFunctionPipe(
                 b1.source(),
                 newExpression,
                 b1.left(),
                 b1.right());
-        assertEquals(newB, b1.transformPropertiesOnly(v -> Objects.equals(v, b1.expression()) ? newExpression : v, Expression.class));
-        
+        assertEquals(newB, b1.transformPropertiesOnly(Expression.class, v -> Objects.equals(v, b1.expression()) ? newExpression : v));
+
         ConcatFunctionPipe b2 = randomInstance();
         Source newLoc = randomValueOtherThan(b2.source(), () -> randomSource());
         newB = new ConcatFunctionPipe(
-                newLoc,
-                b2.expression(),
-                b2.left(),
-                b2.right());
+            newLoc,
+            b2.expression(),
+            b2.left(),
+            b2.right());
         assertEquals(newB,
-                b2.transformPropertiesOnly(v -> Objects.equals(v, b2.source()) ? newLoc : v, Source.class));
+            b2.transformPropertiesOnly(Source.class, v -> Objects.equals(v, b2.source()) ? newLoc : v));
     }
 
     @Override
@@ -73,18 +73,18 @@ public class ConcatFunctionPipeTests extends AbstractNodeTestCase<ConcatFunction
         ConcatFunctionPipe newB =
                 new ConcatFunctionPipe(b.source(), b.expression(), b.left(), b.right());
         BinaryPipe transformed = newB.replaceChildren(newLeft, b.right());
-        
+
         assertEquals(transformed.left(), newLeft);
         assertEquals(transformed.source(), b.source());
         assertEquals(transformed.expression(), b.expression());
         assertEquals(transformed.right(), b.right());
-        
+
         transformed = newB.replaceChildren(b.left(), newRight);
         assertEquals(transformed.left(), b.left());
         assertEquals(transformed.source(), b.source());
         assertEquals(transformed.expression(), b.expression());
         assertEquals(transformed.right(), newRight);
-        
+
         transformed = newB.replaceChildren(newLeft, newRight);
         assertEquals(transformed.left(), newLeft);
         assertEquals(transformed.source(), b.source());
@@ -107,7 +107,7 @@ public class ConcatFunctionPipeTests extends AbstractNodeTestCase<ConcatFunction
                 f.expression(),
                 randomValueOtherThan(f.left(), () -> pipe(randomStringLiteral())),
                 randomValueOtherThan(f.right(), () -> pipe(randomStringLiteral()))));
-        
+
         return randomFrom(randoms).apply(instance);
     }
 

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/InsertFunctionPipeTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/InsertFunctionPipeTests.java
@@ -29,11 +29,11 @@ public class InsertFunctionPipeTests extends AbstractNodeTestCase<InsertFunction
     protected InsertFunctionPipe randomInstance() {
         return randomInsertFunctionPipe();
     }
-    
+
     private Expression randomInsertFunctionExpression() {
         return randomInsertFunctionPipe().expression();
     }
-    
+
     public static InsertFunctionPipe randomInsertFunctionPipe() {
         return (InsertFunctionPipe) (new Insert(randomSource(),
                             randomStringLiteral(),
@@ -56,19 +56,19 @@ public class InsertFunctionPipeTests extends AbstractNodeTestCase<InsertFunction
                 b1.start(),
                 b1.length(),
                 b1.replacement());
-        assertEquals(newB, b1.transformPropertiesOnly(v -> Objects.equals(v, b1.expression()) ? newExpression : v, Expression.class));
-        
+        assertEquals(newB, b1.transformPropertiesOnly(Expression.class, v -> Objects.equals(v, b1.expression()) ? newExpression : v));
+
         InsertFunctionPipe b2 = randomInstance();
         Source newLoc = randomValueOtherThan(b2.source(), () -> randomSource());
         newB = new InsertFunctionPipe(
-                newLoc,
-                b2.expression(),
-                b2.input(),
-                b2.start(),
-                b2.length(),
-                b2.replacement());
+            newLoc,
+            b2.expression(),
+            b2.input(),
+            b2.start(),
+            b2.length(),
+            b2.replacement());
         assertEquals(newB,
-                b2.transformPropertiesOnly(v -> Objects.equals(v, b2.source()) ? newLoc : v, Source.class));
+            b2.transformPropertiesOnly(Source.class, v -> Objects.equals(v, b2.source()) ? newLoc : v));
     }
 
     @Override
@@ -81,7 +81,7 @@ public class InsertFunctionPipeTests extends AbstractNodeTestCase<InsertFunction
         InsertFunctionPipe newB =
                 new InsertFunctionPipe(b.source(), b.expression(), b.input(), b.start(), b.length(), b.replacement());
         InsertFunctionPipe transformed = null;
-        
+
         // generate all the combinations of possible children modifications and test all of them
         for(int i = 1; i < 5; i++) {
             for(BitSet comb : new Combinations(4, i)) {
@@ -103,7 +103,7 @@ public class InsertFunctionPipeTests extends AbstractNodeTestCase<InsertFunction
     @Override
     protected InsertFunctionPipe mutate(InsertFunctionPipe instance) {
         List<Function<InsertFunctionPipe, InsertFunctionPipe>> randoms = new ArrayList<>();
-        
+
         for(int i = 1; i < 5; i++) {
             for(BitSet comb : new Combinations(4, i)) {
                 randoms.add(f -> new InsertFunctionPipe(

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/LocateFunctionPipeTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/LocateFunctionPipeTests.java
@@ -29,11 +29,11 @@ public class LocateFunctionPipeTests extends AbstractNodeTestCase<LocateFunction
     protected LocateFunctionPipe randomInstance() {
         return randomLocateFunctionPipe();
     }
-    
+
     private Expression randomLocateFunctionExpression() {
         return randomLocateFunctionPipe().expression();
     }
-    
+
     public static LocateFunctionPipe randomLocateFunctionPipe() {
         return (LocateFunctionPipe) (new Locate(randomSource(),
                             randomStringLiteral(),
@@ -55,8 +55,8 @@ public class LocateFunctionPipeTests extends AbstractNodeTestCase<LocateFunction
             b1.input(),
             b1.start());
 
-        assertEquals(newB, b1.transformPropertiesOnly(v -> Objects.equals(v, b1.expression()) ? newExpression : v, Expression.class));
-        
+        assertEquals(newB, b1.transformPropertiesOnly(Expression.class, v -> Objects.equals(v, b1.expression()) ? newExpression : v));
+
         LocateFunctionPipe b2 = randomInstance();
         Source newLoc = randomValueOtherThan(b2.source(), () -> randomSource());
         newB = new LocateFunctionPipe(
@@ -67,7 +67,7 @@ public class LocateFunctionPipeTests extends AbstractNodeTestCase<LocateFunction
                 b2.start());
 
         assertEquals(newB,
-                b2.transformPropertiesOnly(v -> Objects.equals(v, b2.source()) ? newLoc : v, Source.class));
+            b2.transformPropertiesOnly(Source.class, v -> Objects.equals(v, b2.source()) ? newLoc : v));
     }
 
     @Override
@@ -76,10 +76,10 @@ public class LocateFunctionPipeTests extends AbstractNodeTestCase<LocateFunction
         Pipe newPattern = randomValueOtherThan(b.pattern(), () -> pipe(randomStringLiteral()));
         Pipe newInput = randomValueOtherThan(b.input(), () -> pipe(randomStringLiteral()));
         Pipe newStart = b.start() == null ? null : randomValueOtherThan(b.start(), () -> pipe(randomIntLiteral()));
-        
+
         LocateFunctionPipe newB = new LocateFunctionPipe(b.source(), b.expression(), b.pattern(), b.input(), b.start());
         LocateFunctionPipe transformed = null;
-        
+
         // generate all the combinations of possible children modifications and test all of them
         for(int i = 1; i < 4; i++) {
             for(BitSet comb : new Combinations(3, i)) {
@@ -88,7 +88,7 @@ public class LocateFunctionPipeTests extends AbstractNodeTestCase<LocateFunction
                         comb.get(0) ? newPattern : b.pattern(),
                         comb.get(1) ? newInput : b.input(),
                         tempNewStart);
-                
+
                 assertEquals(transformed.pattern(), comb.get(0) ? newPattern : b.pattern());
                 assertEquals(transformed.input(), comb.get(1) ? newInput : b.input());
                 assertEquals(transformed.start(), tempNewStart);
@@ -122,7 +122,7 @@ public class LocateFunctionPipeTests extends AbstractNodeTestCase<LocateFunction
                 }
             }
         }
-        
+
         return randomFrom(randoms).apply(instance);
     }
 

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/ReplaceFunctionPipeTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/ReplaceFunctionPipeTests.java
@@ -28,11 +28,11 @@ public class ReplaceFunctionPipeTests extends AbstractNodeTestCase<ReplaceFuncti
     protected ReplaceFunctionPipe randomInstance() {
         return randomReplaceFunctionPipe();
     }
-    
+
     private Expression randomReplaceFunctionExpression() {
         return randomReplaceFunctionPipe().expression();
     }
-    
+
     public static ReplaceFunctionPipe randomReplaceFunctionPipe() {
         return (ReplaceFunctionPipe) (new Replace(randomSource(),
                             randomStringLiteral(),
@@ -46,7 +46,7 @@ public class ReplaceFunctionPipeTests extends AbstractNodeTestCase<ReplaceFuncti
         // test transforming only the properties (source, expression),
         // skipping the children (the two parameters of the binary function) which are tested separately
         ReplaceFunctionPipe b1 = randomInstance();
-        
+
         Expression newExpression = randomValueOtherThan(b1.expression(), () -> randomReplaceFunctionExpression());
         ReplaceFunctionPipe newB = new ReplaceFunctionPipe(
                 b1.source(),
@@ -54,18 +54,18 @@ public class ReplaceFunctionPipeTests extends AbstractNodeTestCase<ReplaceFuncti
                 b1.input(),
                 b1.pattern(),
                 b1.replacement());
-        assertEquals(newB, b1.transformPropertiesOnly(v -> Objects.equals(v, b1.expression()) ? newExpression : v, Expression.class));
-        
+        assertEquals(newB, b1.transformPropertiesOnly(Expression.class, v -> Objects.equals(v, b1.expression()) ? newExpression : v));
+
         ReplaceFunctionPipe b2 = randomInstance();
         Source newLoc = randomValueOtherThan(b2.source(), () -> randomSource());
         newB = new ReplaceFunctionPipe(
-                newLoc,
-                b2.expression(),
-                b2.input(),
-                b2.pattern(),
-                b2.replacement());
+            newLoc,
+            b2.expression(),
+            b2.input(),
+            b2.pattern(),
+            b2.replacement());
         assertEquals(newB,
-                b2.transformPropertiesOnly(v -> Objects.equals(v, b2.source()) ? newLoc : v, Source.class));
+            b2.transformPropertiesOnly(Source.class, v -> Objects.equals(v, b2.source()) ? newLoc : v));
     }
 
     @Override
@@ -76,7 +76,7 @@ public class ReplaceFunctionPipeTests extends AbstractNodeTestCase<ReplaceFuncti
         Pipe newR = randomValueOtherThan(b.replacement(), () -> pipe(randomStringLiteral()));
         ReplaceFunctionPipe newB = new ReplaceFunctionPipe(b.source(), b.expression(), b.input(), b.pattern(), b.replacement());
         ReplaceFunctionPipe transformed = null;
-        
+
         // generate all the combinations of possible children modifications and test all of them
         for(int i = 1; i < 4; i++) {
             for(BitSet comb : new Combinations(3, i)) {
@@ -84,7 +84,7 @@ public class ReplaceFunctionPipeTests extends AbstractNodeTestCase<ReplaceFuncti
                         comb.get(0) ? newInput : b.input(),
                         comb.get(1) ? newPattern : b.pattern(),
                         comb.get(2) ? newR : b.replacement());
-                
+
                 assertEquals(transformed.input(), comb.get(0) ? newInput : b.input());
                 assertEquals(transformed.pattern(), comb.get(1) ? newPattern : b.pattern());
                 assertEquals(transformed.replacement(), comb.get(2) ? newR : b.replacement());
@@ -97,7 +97,7 @@ public class ReplaceFunctionPipeTests extends AbstractNodeTestCase<ReplaceFuncti
     @Override
     protected ReplaceFunctionPipe mutate(ReplaceFunctionPipe instance) {
         List<Function<ReplaceFunctionPipe, ReplaceFunctionPipe>> randoms = new ArrayList<>();
-        
+
         for(int i = 1; i < 4; i++) {
             for(BitSet comb : new Combinations(3, i)) {
                 randoms.add(f -> new ReplaceFunctionPipe(f.source(),
@@ -107,7 +107,7 @@ public class ReplaceFunctionPipeTests extends AbstractNodeTestCase<ReplaceFuncti
                         comb.get(2) ? randomValueOtherThan(f.replacement(), () -> pipe(randomStringLiteral())) : f.replacement()));
             }
         }
-        
+
         return randomFrom(randoms).apply(instance);
     }
 

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/SubstringFunctionPipeTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/SubstringFunctionPipeTests.java
@@ -30,11 +30,11 @@ public class SubstringFunctionPipeTests
     protected SubstringFunctionPipe randomInstance() {
         return randomSubstringFunctionPipe();
     }
-    
+
     private Expression randomSubstringFunctionExpression() {
         return randomSubstringFunctionPipe().expression();
     }
-    
+
     public static SubstringFunctionPipe randomSubstringFunctionPipe() {
         return (SubstringFunctionPipe) (new Substring(randomSource(),
                             randomStringLiteral(),
@@ -55,18 +55,18 @@ public class SubstringFunctionPipeTests
                 b1.input(),
                 b1.start(),
                 b1.length());
-        assertEquals(newB, b1.transformPropertiesOnly(v -> Objects.equals(v, b1.expression()) ? newExpression : v, Expression.class));
-        
+        assertEquals(newB, b1.transformPropertiesOnly(Expression.class, v -> Objects.equals(v, b1.expression()) ? newExpression : v));
+
         SubstringFunctionPipe b2 = randomInstance();
         Source newLoc = randomValueOtherThan(b2.source(), () -> randomSource());
         newB = new SubstringFunctionPipe(
-                newLoc,
-                b2.expression(),
-                b2.input(),
-                b2.start(),
-                b2.length());
+            newLoc,
+            b2.expression(),
+            b2.input(),
+            b2.start(),
+            b2.length());
         assertEquals(newB,
-                b2.transformPropertiesOnly(v -> Objects.equals(v, b2.source()) ? newLoc : v, Source.class));
+            b2.transformPropertiesOnly(Source.class, v -> Objects.equals(v, b2.source()) ? newLoc : v));
     }
 
     @Override
@@ -77,7 +77,7 @@ public class SubstringFunctionPipeTests
         Pipe newLength = randomValueOtherThan(b.length(), () -> pipe(randomIntLiteral()));
         SubstringFunctionPipe newB = new SubstringFunctionPipe(b.source(), b.expression(), b.input(), b.start(), b.length());
         SubstringFunctionPipe transformed = null;
-        
+
         // generate all the combinations of possible children modifications and test all of them
         for(int i = 1; i < 4; i++) {
             for(BitSet comb : new Combinations(3, i)) {
@@ -97,7 +97,7 @@ public class SubstringFunctionPipeTests
     @Override
     protected SubstringFunctionPipe mutate(SubstringFunctionPipe instance) {
         List<Function<SubstringFunctionPipe, SubstringFunctionPipe>> randoms = new ArrayList<>();
-        
+
         for(int i = 1; i < 4; i++) {
             for(BitSet comb : new Combinations(3, i)) {
                 randoms.add(f -> new SubstringFunctionPipe(
@@ -108,7 +108,7 @@ public class SubstringFunctionPipeTests
                         comb.get(2) ? randomValueOtherThan(f.length(), () -> pipe(randomIntLiteral())): f.length()));
             }
         }
-        
+
         return randomFrom(randoms).apply(instance);
     }
 

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/predicate/conditional/CaseTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/predicate/conditional/CaseTests.java
@@ -72,7 +72,7 @@ public class CaseTests extends AbstractNodeTestCase<Case, Expression> {
 
         Source newSource = randomValueOtherThan(c.source(), SourceTests::randomSource);
         assertEquals(new Case(c.source(), c.children()),
-            c.transformPropertiesOnly(p -> Objects.equals(p, c.source()) ? newSource: p, Object.class));
+            c.transformPropertiesOnly(Object.class, p -> Objects.equals(p, c.source()) ? newSource: p));
     }
 
     @Override

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/predicate/conditional/IifTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/predicate/conditional/IifTests.java
@@ -62,7 +62,7 @@ public class IifTests extends AbstractNodeTestCase<Iif, Expression> {
 
         Source newSource = randomValueOtherThan(iif.source(), SourceTests::randomSource);
         assertEquals(new Iif(iif.source(), iif.conditions().get(0).condition(), iif.conditions().get(0).result(), iif.elseResult()),
-            iif.transformPropertiesOnly(p -> Objects.equals(p, iif.source()) ? newSource: p, Object.class));
+            iif.transformPropertiesOnly(Object.class, p -> Objects.equals(p, iif.source()) ? newSource: p));
     }
 
     @Override

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/planner/QueryTranslatorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/planner/QueryTranslatorTests.java
@@ -2388,11 +2388,11 @@ public class QueryTranslatorTests extends ESTestCase {
                 "   PERCENTILE(int, 50), " +
                 // 4: this has a different method parameter
                 // just to make sure we don't fold everything to default
-                "   PERCENTILE(int, 50, 'tdigest', 22) " 
+                "   PERCENTILE(int, 50, 'tdigest', 22) "
                 + "FROM test").replaceAll("PERCENTILE", fnName);
-            
+
             List<AbstractPercentilesAggregationBuilder> aggs = percentilesAggsByField(optimizeAndPlan(sql), fieldCount);
-            
+
             // 0-3
             assertEquals(aggs.get(0), aggs.get(1));
             assertEquals(aggs.get(0), aggs.get(2));
@@ -2404,7 +2404,7 @@ public class QueryTranslatorTests extends ESTestCase {
             assertEquals(new PercentilesConfig.TDigest(22), aggs.get(4).percentilesConfig());
             assertArrayEquals(new double[] { 50 }, pctOrValFn.apply(aggs.get(4)), 0);
         };
-        
+
         test.accept("PERCENTILE", p -> ((PercentilesAggregationBuilder)p).percentiles());
         test.accept("PERCENTILE_RANK", p -> ((PercentileRanksAggregationBuilder)p).values());
     }
@@ -2417,17 +2417,17 @@ public class QueryTranslatorTests extends ESTestCase {
                 // 0-1: fold into the same aggregation
                 "   PERCENTILE(int, 50, 'tdigest'), " +
                 "   PERCENTILE(int, 60, 'tdigest'), " +
-                
+
                 // 2-3: fold into one aggregation
                 "   PERCENTILE(int, 50, 'hdr'), " +
                 "   PERCENTILE(int, 60, 'hdr', 3), " +
-                
+
                 // 4: folds into a separate aggregation
                 "   PERCENTILE(int, 60, 'hdr', 4)" +
                 "FROM test").replaceAll("PERCENTILE", fnName);
 
             List<AbstractPercentilesAggregationBuilder> aggs = percentilesAggsByField(optimizeAndPlan(sql), fieldCount);
-            
+
             // 0-1
             assertEquals(aggs.get(0), aggs.get(1));
             assertEquals(new PercentilesConfig.TDigest(), aggs.get(0).percentilesConfig());
@@ -2437,7 +2437,7 @@ public class QueryTranslatorTests extends ESTestCase {
             assertEquals(aggs.get(2), aggs.get(3));
             assertEquals(new PercentilesConfig.Hdr(), aggs.get(2).percentilesConfig());
             assertArrayEquals(new double[]{50, 60}, pctOrValFn.apply(aggs.get(2)), 0);
-            
+
             // 4
             assertEquals(new PercentilesConfig.Hdr(4), aggs.get(4).percentilesConfig());
             assertArrayEquals(new double[]{60}, pctOrValFn.apply(aggs.get(4)), 0);
@@ -2448,7 +2448,7 @@ public class QueryTranslatorTests extends ESTestCase {
     }
 
     // Tests the workaround for the SUM(all zeros) = NULL issue raised in https://github.com/elastic/elasticsearch/issues/45251 and
-    // should be removed as soon as root cause is fixed and the sum aggregation results can differentiate between SUM(all zeroes) 
+    // should be removed as soon as root cause is fixed and the sum aggregation results can differentiate between SUM(all zeroes)
     // and SUM(all nulls)
     public void testReplaceSumWithStats() {
         List<String> testCases = asList(
@@ -2503,8 +2503,8 @@ public class QueryTranslatorTests extends ESTestCase {
         assertEquals(1, expectedInts.size());
 
         condition = condition
-            .transformDown(x -> x.name().equals("bool") ? (FieldAttribute) expectedBools.toArray()[0] : x, FieldAttribute.class)
-            .transformDown(x -> x.name().equals("int") ? (FieldAttribute) expectedInts.toArray()[0] : x , FieldAttribute.class);
+            .transformDown(FieldAttribute.class, x -> x.name().equals("bool") ? (FieldAttribute) expectedBools.toArray()[0] : x)
+            .transformDown(FieldAttribute.class, x -> x.name().equals("int") ? (FieldAttribute) expectedInts.toArray()[0] : x);
 
         assertEquals(expectedCondition, condition);
     }


### PR DESCRIPTION
Improve readability of Node transform/forEach typed methods by moving
the "type token" to the front of the method, before the lambda
declaration.

Fix #67174