### PR TITLE
Replace IndexAbstraction.Alias.getFirstAliasMetadata(...) method and related casts

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/aliases/IndexAliasesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/aliases/IndexAliasesIT.java
@@ -679,8 +679,8 @@ public class IndexAliasesIT extends ESIntegTestCase {
         assertThat(stopWatch.stop().lastTaskTime().millis(), lessThan(timeout.millis()));
 
         logger.info("--> verify that filter was updated");
-        AliasMetadata aliasMetadata = ((IndexAbstraction.Alias) internalCluster()
-            .clusterService().state().metadata().getIndicesLookup().get("alias1")).getFirstAliasMetadata();
+        IndexAbstraction ia = internalCluster().clusterService().state().metadata().getIndicesLookup().get("alias1");
+        AliasMetadata aliasMetadata = AliasMetadata.getFirstAliasMetadata(ia);
         assertThat(aliasMetadata.getFilter().toString(), equalTo("{\"term\":{\"name\":{\"value\":\"bar\",\"boost\":1.0}}}"));
 
         logger.info("--> deleting alias1");

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/AliasMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/AliasMetadata.java
@@ -252,6 +252,14 @@ public class AliasMetadata extends AbstractDiffable<AliasMetadata> implements To
         return builder;
     }
 
+    public static AliasMetadata getFirstAliasMetadata(IndexAbstraction ia) {
+        if (ia.getType() != IndexAbstraction.Type.ALIAS) {
+            throw new IllegalArgumentException("unexpected type: [" + ia.getType() + "]");
+        }
+
+        return ia.getIndices().get(0).getAliases().get(ia.getName());
+    }
+
     public static class Builder {
 
         private final String alias;

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexAbstraction.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexAbstraction.java
@@ -242,10 +242,6 @@ public interface IndexAbstraction {
             return referenceIndexMetadatas.stream().allMatch(IndexMetadata::isSystem);
         }
 
-        public AliasMetadata getFirstAliasMetadata() {
-            return referenceIndexMetadatas.get(0).getAliases().get(aliasName);
-        }
-
         private void validateAliasProperties() {
             // Validate hidden status
             final Map<Boolean, List<IndexMetadata>> groupedByHiddenStatus = referenceIndexMetadatas.stream()

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -651,11 +651,10 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
         if (result == null || result.getType() != IndexAbstraction.Type.ALIAS) {
             return routing;
         }
-        IndexAbstraction.Alias alias = (IndexAbstraction.Alias) result;
         if (result.getIndices().size() > 1) {
             rejectSingleIndexOperation(aliasOrIndex, result);
         }
-        AliasMetadata aliasMd = alias.getFirstAliasMetadata();
+        AliasMetadata aliasMd = AliasMetadata.getFirstAliasMetadata(result);
         if (aliasMd.indexRouting() != null) {
             if (aliasMd.indexRouting().indexOf(',') != -1) {
                 throw new IllegalArgumentException("index/alias [" + aliasOrIndex + "] provided with routing value [" +

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataMigrateToDataStreamService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataMigrateToDataStreamService.java
@@ -142,14 +142,12 @@ public class MetadataMigrateToDataStreamService {
         if (ia == null || ia.getType() != IndexAbstraction.Type.ALIAS) {
             throw new IllegalArgumentException("alias [" + request.aliasName + "] does not exist");
         }
-        IndexAbstraction.Alias alias = (IndexAbstraction.Alias) ia;
-
-        if (alias.getWriteIndex() == null) {
+        if (ia.getWriteIndex() == null) {
             throw new IllegalArgumentException("alias [" + request.aliasName + "] must specify a write index");
         }
 
         // check for "clean" alias without routing or filter query
-        AliasMetadata aliasMetadata = alias.getFirstAliasMetadata();
+        AliasMetadata aliasMetadata = AliasMetadata.getFirstAliasMetadata(ia);
         assert aliasMetadata != null : "alias metadata may not be null";
         if (aliasMetadata.filteringRequired() || aliasMetadata.getIndexRouting() != null || aliasMetadata.getSearchRouting() != null) {
             throw new IllegalArgumentException("alias [" + request.aliasName + "] may not have custom filtering or routing");


### PR DESCRIPTION
Backport #66178 to 7.x branch.

This change is part of series of changes to clean up the usage IndexAbstraction.Alias in the codebase,
so that it is no longer needed to cast to IndexAbstraction.Alias and just use the methods on the IndexAbstraction
interface. This should help adding data stream aliases, so that IndexAbstraction instances of type ALIAS can
also be data stream aliases.

Relates to #66163