### PR TITLE
Fix AllocationIdIT test failure on WindowFS

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/AllocationIdIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/AllocationIdIT.java
@@ -136,17 +136,13 @@ public class AllocationIdIT extends ESIntegTestCase {
             assertThat(shardRouting.unassignedInfo().getReason(), equalTo(UnassignedInfo.Reason.ALLOCATION_FAILED));
         });
 
+        internalCluster().stopNode(node1);
         try(Store store = new Store(shardId, indexSettings, new SimpleFSDirectory(indexPath), new DummyShardLock(shardId))) {
             store.removeCorruptionMarker();
         }
+        node1 = internalCluster().startNode(node1DataPathSettings);
 
         // index is red: no any shard is allocated (allocation id is a fake id that does not match to anything)
-        checkHealthStatus(indexName, ClusterHealthStatus.RED);
-        checkNoValidShardCopy(indexName, shardId);
-
-        internalCluster().restartNode(node1, InternalTestCluster.EMPTY_CALLBACK);
-
-        // index is still red due to mismatch of allocation id
         checkHealthStatus(indexName, ClusterHealthStatus.RED);
         checkNoValidShardCopy(indexName, shardId);
 


### PR DESCRIPTION
This test failed on WindowsFS. We failed to remove the corrupted file if it's being opened (for a short window by ListShardStore action) and the pending delete files were clear when we restarted that node.

This commit fixes the issue by shutting down the node before removing the corrupted file to avoid any access to that file.

Closes #66893