### PR TITLE
Re-throw ResponseException as AssertionError in BasicLicenseUpgradeIT

### DIFF
--- a/x-pack/qa/rolling-upgrade-basic/src/test/java/org/elasticsearch/upgrades/BasicLicenseUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade-basic/src/test/java/org/elasticsearch/upgrades/BasicLicenseUpgradeIT.java
@@ -7,6 +7,7 @@ package org.elasticsearch.upgrades;
 
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
+import org.elasticsearch.client.ResponseException;
 
 import java.util.Map;
 
@@ -24,20 +25,30 @@ public class BasicLicenseUpgradeIT extends AbstractUpgradeTestCase {
 
     @SuppressWarnings("unchecked")
     private void checkBasicLicense() throws Exception {
-        Response licenseResponse = client().performRequest(new Request("GET", "/_license"));
-        Map<String, Object> licenseResponseMap = entityAsMap(licenseResponse);
-        Map<String, Object> licenseMap = (Map<String, Object>) licenseResponseMap.get("license");
-        assertEquals("basic", licenseMap.get("type"));
-        assertEquals("active", licenseMap.get("status"));
+        try {
+            Response licenseResponse = client().performRequest(new Request("GET", "/_license"));
+            Map<String, Object> licenseResponseMap = entityAsMap(licenseResponse);
+            Map<String, Object> licenseMap = (Map<String, Object>) licenseResponseMap.get("license");
+            assertEquals("basic", licenseMap.get("type"));
+            assertEquals("active", licenseMap.get("status"));
+        } catch (ResponseException e) {
+            // assertBusy only retries the code block if an AssertionError is thrown
+            throw new AssertionError("Failed to get license information", e);
+        }
     }
 
     @SuppressWarnings("unchecked")
     private void checkNonExpiringBasicLicense() throws Exception {
-        Response licenseResponse = client().performRequest(new Request("GET", "/_license"));
-        Map<String, Object> licenseResponseMap = entityAsMap(licenseResponse);
-        Map<String, Object> licenseMap = (Map<String, Object>) licenseResponseMap.get("license");
-        assertEquals("basic", licenseMap.get("type"));
-        assertEquals("active", licenseMap.get("status"));
-        assertNull(licenseMap.get("expiry_date_in_millis"));
+        try {
+            Response licenseResponse = client().performRequest(new Request("GET", "/_license"));
+            Map<String, Object> licenseResponseMap = entityAsMap(licenseResponse);
+            Map<String, Object> licenseMap = (Map<String, Object>) licenseResponseMap.get("license");
+            assertEquals("basic", licenseMap.get("type"));
+            assertEquals("active", licenseMap.get("status"));
+            assertNull(licenseMap.get("expiry_date_in_millis"));
+        } catch (ResponseException e) {
+            // assertBusy only retries the code block if an AssertionError is thrown
+            throw new AssertionError("Failed to get license information", e);
+        }
     }
 }

--- a/x-pack/qa/rolling-upgrade-basic/src/test/java/org/elasticsearch/upgrades/BasicLicenseUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade-basic/src/test/java/org/elasticsearch/upgrades/BasicLicenseUpgradeIT.java
@@ -7,7 +7,6 @@ package org.elasticsearch.upgrades;
 
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
-import org.elasticsearch.client.ResponseException;
 
 import java.util.Map;
 
@@ -25,30 +24,30 @@ public class BasicLicenseUpgradeIT extends AbstractUpgradeTestCase {
 
     @SuppressWarnings("unchecked")
     private void checkBasicLicense() throws Exception {
-        try {
-            Response licenseResponse = client().performRequest(new Request("GET", "/_license"));
-            Map<String, Object> licenseResponseMap = entityAsMap(licenseResponse);
-            Map<String, Object> licenseMap = (Map<String, Object>) licenseResponseMap.get("license");
-            assertEquals("basic", licenseMap.get("type"));
-            assertEquals("active", licenseMap.get("status"));
-        } catch (ResponseException e) {
-            // assertBusy only retries the code block if an AssertionError is thrown
-            throw new AssertionError("Failed to get license information", e);
-        }
+        final Request request = new Request("GET", "/_license");
+        // This avoids throwing a ResponseException when the license is not ready yet
+        // allowing to retry the check using assertBusy
+        request.addParameter("ignore", "404");
+        Response licenseResponse = client().performRequest(request);
+        assertOK(licenseResponse);
+        Map<String, Object> licenseResponseMap = entityAsMap(licenseResponse);
+        Map<String, Object> licenseMap = (Map<String, Object>) licenseResponseMap.get("license");
+        assertEquals("basic", licenseMap.get("type"));
+        assertEquals("active", licenseMap.get("status"));
     }
 
     @SuppressWarnings("unchecked")
     private void checkNonExpiringBasicLicense() throws Exception {
-        try {
-            Response licenseResponse = client().performRequest(new Request("GET", "/_license"));
-            Map<String, Object> licenseResponseMap = entityAsMap(licenseResponse);
-            Map<String, Object> licenseMap = (Map<String, Object>) licenseResponseMap.get("license");
-            assertEquals("basic", licenseMap.get("type"));
-            assertEquals("active", licenseMap.get("status"));
-            assertNull(licenseMap.get("expiry_date_in_millis"));
-        } catch (ResponseException e) {
-            // assertBusy only retries the code block if an AssertionError is thrown
-            throw new AssertionError("Failed to get license information", e);
-        }
+        final Request request = new Request("GET", "/_license");
+        // This avoids throwing a ResponseException when the license is not ready yet
+        // allowing to retry the check using assertBusy
+        request.addParameter("ignore", "404");
+        Response licenseResponse = client().performRequest(request);
+        assertOK(licenseResponse);
+        Map<String, Object> licenseResponseMap = entityAsMap(licenseResponse);
+        Map<String, Object> licenseMap = (Map<String, Object>) licenseResponseMap.get("license");
+        assertEquals("basic", licenseMap.get("type"));
+        assertEquals("active", licenseMap.get("status"));
+        assertNull(licenseMap.get("expiry_date_in_millis"));
     }
 }


### PR DESCRIPTION
It's possible that in a slow machine the cluster state updates
take a while to be applied, the license information is published
with NORMAL priority, meaning that it can take a while for the
License information to become available. This can lead to race
conditions. In order to wait until the license information is
available, the tests use assertBusy, but assertBusy only retries
if an AssertionException is raised, for that reason we use the 
`ignore` parameter in the http client and later check that the
response was correct, meaning that the check can be retried
if the license information is not ready yet.

Closes #64578