### PR TITLE
QL: Rename incorrect plural in method name

### DIFF
--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/analysis/Verifier.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/analysis/Verifier.java
@@ -92,7 +92,7 @@ public class Verifier {
             if (p instanceof Unresolvable) {
                 localFailures.add(fail(p, ((Unresolvable) p).unresolvedMessage()));
             } else {
-                p.forEachExpressions(e -> {
+                p.forEachExpression(e -> {
                     // everything is fine, skip expression
                     if (e.resolved()) {
                         return;

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/planner/Verifier.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/planner/Verifier.java
@@ -24,7 +24,7 @@ abstract class Verifier {
             if (p instanceof UnplannedExec) {
                 failures.add(fail(p, "Unplanned item {}", ((UnplannedExec) p).plan().nodeName()));
             }
-            p.forEachExpressionsUp(e -> {
+            p.forEachExpressionUp(e -> {
                 if (e.childrenResolved() && !e.resolved()) {
                     failures.add(fail(e, "Unresolved expression"));
                 }
@@ -40,7 +40,7 @@ abstract class Verifier {
             if (p instanceof Unexecutable) {
                 failures.add(fail(p, "Unexecutable item {}", p.nodeName()));
             }
-            p.forEachExpressionsUp(e -> {
+            p.forEachExpressionUp(e -> {
                 if (e.childrenResolved() && !e.resolved()) {
                     failures.add(fail(e, "Unresolved expression"));
                 }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/plan/QueryPlan.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/plan/QueryPlan.java
@@ -109,28 +109,28 @@ public abstract class QueryPlan<PlanType extends QueryPlan<PlanType>> extends No
         return arg;
     }
 
-    public void forEachExpressions(Consumer<? super Expression> rule) {
-        forEachExpressions(Expression.class, rule);
+    public void forEachExpression(Consumer<? super Expression> rule) {
+        forEachExpression(Expression.class, rule);
     }
 
-    public <E extends Expression> void forEachExpressions(Class<E> typeToken, Consumer<? super E> rule) {
-        forEachPropertiesOnly(Object.class, e -> doForEachExpression(e, exp -> exp.forEachDown(typeToken, rule)));
+    public <E extends Expression> void forEachExpression(Class<E> typeToken, Consumer<? super E> rule) {
+        forEachPropertyOnly(Object.class, e -> doForEachExpression(e, exp -> exp.forEachDown(typeToken, rule)));
     }
 
-    public void forEachExpressionsDown(Consumer<? super Expression> rule) {
-        forEachExpressionsDown(Expression.class, rule);
+    public void forEachExpressionDown(Consumer<? super Expression> rule) {
+        forEachExpressionDown(Expression.class, rule);
     }
 
-    public <E extends Expression> void forEachExpressionsDown(Class<? extends E> typeToken, Consumer<? super E> rule) {
-        forEachPropertiesDown(Object.class, e -> doForEachExpression(e, exp -> exp.forEachDown(typeToken, rule)));
+    public <E extends Expression> void forEachExpressionDown(Class<? extends E> typeToken, Consumer<? super E> rule) {
+        forEachPropertyDown(Object.class, e -> doForEachExpression(e, exp -> exp.forEachDown(typeToken, rule)));
     }
 
-    public void forEachExpressionsUp(Consumer<? super Expression> rule) {
-        forEachExpressionsUp(Expression.class, rule);
+    public void forEachExpressionUp(Consumer<? super Expression> rule) {
+        forEachExpressionUp(Expression.class, rule);
     }
 
-    public <E extends Expression> void forEachExpressionsUp(Class<E> typeToken, Consumer<? super E> rule) {
-        forEachPropertiesUp(Object.class, e -> doForEachExpression(e, exp -> exp.forEachUp(typeToken, rule)));
+    public <E extends Expression> void forEachExpressionUp(Class<E> typeToken, Consumer<? super E> rule) {
+        forEachPropertyUp(Object.class, e -> doForEachExpression(e, exp -> exp.forEachUp(typeToken, rule)));
     }
 
     @SuppressWarnings("unchecked")

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/tree/Node.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/tree/Node.java
@@ -92,15 +92,15 @@ public abstract class Node<T extends Node<T>> {
         });
     }
 
-    public <E> void forEachPropertiesOnly(Class<E> typeToken, Consumer<? super E> rule) {
+    public <E> void forEachPropertyOnly(Class<E> typeToken, Consumer<? super E> rule) {
         forEachProperty(typeToken, rule);
     }
 
-    public <E> void forEachPropertiesDown(Class<E> typeToken, Consumer<? super E> rule) {
+    public <E> void forEachPropertyDown(Class<E> typeToken, Consumer<? super E> rule) {
         forEachDown(e -> e.forEachProperty(typeToken, rule));
     }
 
-    public <E> void forEachPropertiesUp(Class<E> typeToken, Consumer<? super E> rule) {
+    public <E> void forEachPropertyUp(Class<E> typeToken, Consumer<? super E> rule) {
         forEachUp(e -> e.forEachProperty(typeToken, rule));
     }
 

--- a/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/plan/QueryPlanTests.java
+++ b/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/plan/QueryPlanTests.java
@@ -74,7 +74,7 @@ public class QueryPlanTests extends ESTestCase {
         Project project = new Project(EMPTY, relation(), asList(one, two));
 
         List<Object> list = new ArrayList<>();
-        project.forEachExpressions(Literal.class, l -> {
+        project.forEachExpression(Literal.class, l -> {
             if (l.fold().equals(42)) {
                 list.add(l.fold());
             }
@@ -88,7 +88,7 @@ public class QueryPlanTests extends ESTestCase {
         OrderBy o = new OrderBy(EMPTY, limit, emptyList());
 
         List<Object> list = new ArrayList<>();
-        o.forEachExpressionsDown(Literal.class, l -> {
+        o.forEachExpressionDown(Literal.class, l -> {
             if (l.fold().equals(42)) {
                 list.add(l.fold());
             }
@@ -104,7 +104,7 @@ public class QueryPlanTests extends ESTestCase {
         Project project = new Project(EMPTY, relation(), asList(one, two));
 
         List<NamedExpression> list = new ArrayList<>();
-        project.forEachExpressions(NamedExpression.class, n -> {
+        project.forEachExpression(NamedExpression.class, n -> {
             if (n.name().equals("one")) {
                 list.add(n);
             }
@@ -120,7 +120,7 @@ public class QueryPlanTests extends ESTestCase {
         Project project = new Project(EMPTY, relation(), asList(one, two));
 
         List<Object> list = new ArrayList<>();
-        project.forEachExpressions(Literal.class, l -> {
+        project.forEachExpression(Literal.class, l -> {
             if (l.fold().equals(42)) {
                 list.add(l.fold());
             }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Analyzer.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Analyzer.java
@@ -633,7 +633,7 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
                     final Map<Attribute, Expression> collectRefs = new LinkedHashMap<>();
 
                     // collect aliases
-                    child.forEachUp(p -> p.forEachExpressionsUp(e -> {
+                    child.forEachUp(p -> p.forEachExpressionUp(e -> {
                         if (e instanceof Alias) {
                             Alias a = (Alias) e;
                             collectRefs.put(a.toAttribute(), a.child());

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/optimizer/Optimizer.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/optimizer/Optimizer.java
@@ -217,7 +217,7 @@ public class Optimizer extends RuleExecutor<LogicalPlan> {
             final Map<Attribute, Expression> collectRefs = new LinkedHashMap<>();
 
             // collect aliases
-            plan.forEachExpressionsUp(e -> {
+            plan.forEachExpressionUp(e -> {
                 if (e instanceof Alias) {
                     Alias a = (Alias) e;
                     collectRefs.put(a.toAttribute(), a.child());
@@ -315,7 +315,7 @@ public class Optimizer extends RuleExecutor<LogicalPlan> {
                 // collect Attribute sources
                 // only Aliases are interesting since these are the only ones that hide expressions
                 // FieldAttribute for example are self replicating.
-                project.forEachUp(p -> p.forEachExpressionsUp(e -> {
+                project.forEachUp(p -> p.forEachExpressionUp(e -> {
                     if (e instanceof Alias) {
                         Alias a = (Alias) e;
                         if (a.child() instanceof Function) {
@@ -923,7 +923,7 @@ public class Optimizer extends RuleExecutor<LogicalPlan> {
             // 1. first check whether there are at least 2 aggs for the same fields so that there can be a promotion
             final Map<Expression, Match> potentialPromotions = new LinkedHashMap<>();
 
-            p.forEachExpressionsUp(e -> {
+            p.forEachExpressionUp(e -> {
                 if (Stats.isTypeCompatible(e)) {
                     AggregateFunction f = (AggregateFunction) e;
 
@@ -971,7 +971,7 @@ public class Optimizer extends RuleExecutor<LogicalPlan> {
         public LogicalPlan apply(LogicalPlan plan) {
             final Map<Expression, Stats> statsPerField = new LinkedHashMap<>();
 
-            plan.forEachExpressionsUp(e -> {
+            plan.forEachExpressionUp(e -> {
                 if (e instanceof Sum) {
                     statsPerField.computeIfAbsent(((Sum) e).field(), field -> {
                         Source source = new Source(field.sourceLocation(), "STATS(" + field.sourceText() + ")");
@@ -995,7 +995,7 @@ public class Optimizer extends RuleExecutor<LogicalPlan> {
             final Map<Expression, ExtendedStats> seen = new LinkedHashMap<>();
 
             // count the extended stats
-            p.forEachExpressionsUp(e -> {
+            p.forEachExpressionUp(e -> {
                 if (e instanceof InnerAggregate) {
                     InnerAggregate ia = (InnerAggregate) e;
                     if (ia.outer() instanceof ExtendedStats) {
@@ -1043,7 +1043,7 @@ public class Optimizer extends RuleExecutor<LogicalPlan> {
         public LogicalPlan apply(LogicalPlan p) {
             Map<PercentileKey, Set<Expression>> percentsPerAggKey = new LinkedHashMap<>();
 
-            p.forEachExpressionsUp(e -> {
+            p.forEachExpressionUp(e -> {
                 if (e instanceof Percentile) {
                     Percentile per = (Percentile) e;
                     percentsPerAggKey.computeIfAbsent(new PercentileKey(per), v -> new LinkedHashSet<>())
@@ -1072,7 +1072,7 @@ public class Optimizer extends RuleExecutor<LogicalPlan> {
         public LogicalPlan apply(LogicalPlan p) {
             final Map<PercentileKey, Set<Expression>> valuesPerAggKey = new LinkedHashMap<>();
 
-            p.forEachExpressionsUp(e -> {
+            p.forEachExpressionUp(e -> {
                 if (e instanceof PercentileRank) {
                     PercentileRank per = (PercentileRank) e;
                     valuesPerAggKey.computeIfAbsent(new PercentileKey(per), v -> new LinkedHashSet<>())

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/planner/Verifier.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/planner/Verifier.java
@@ -24,7 +24,7 @@ abstract class Verifier {
             if (p instanceof UnplannedExec) {
                 failures.add(fail(p, "Unplanned item"));
             }
-            p.forEachExpressionsUp(e -> {
+            p.forEachExpressionUp(e -> {
                 if (e.childrenResolved() && !e.resolved()) {
                     failures.add(fail(e, "Unresolved expression"));
                 }
@@ -41,7 +41,7 @@ abstract class Verifier {
             if (p instanceof Unexecutable) {
                 failures.add(fail(p, "Unexecutable item"));
             }
-            p.forEachExpressionsUp(e -> {
+            p.forEachExpressionUp(e -> {
                 if (e.childrenResolved() && !e.resolved()) {
                     failures.add(fail(e, "Unresolved expression"));
                 }


### PR DESCRIPTION
forEachExpressions -> forEachExpression (singular)