### PR TITLE
Use SequentialStoredFieldsLeafReader in reading Lucene changes

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/engine/LuceneChangesSnapshot.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/LuceneChangesSnapshot.java
@@ -34,6 +34,7 @@ import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.util.ArrayUtil;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.lucene.Lucene;
+import org.elasticsearch.common.lucene.index.SequentialStoredFieldsLeafReader;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.index.fieldvisitor.FieldsVisitor;
@@ -229,8 +230,12 @@ final class LuceneChangesSnapshot implements Translog.Snapshot {
         final String sourceField = parallelArray.hasRecoverySource[docIndex] ? SourceFieldMapper.RECOVERY_SOURCE_NAME :
             SourceFieldMapper.NAME;
         final FieldsVisitor fields = new FieldsVisitor(true, sourceField);
-        leaf.reader().document(segmentDocID, fields);
-
+        if (leaf.reader() instanceof SequentialStoredFieldsLeafReader) {
+            ((SequentialStoredFieldsLeafReader) leaf.reader()).getSequentialStoredFieldsReader().visitDocument(segmentDocID, fields);
+        } else {
+            assert false : "The changes reader isn't wrapped with Lucene#wrapAllDocsLive";
+            throw new IllegalStateException("The changes reader isn't wrapped with Lucene#wrapAllDocsLive");
+        }
         final Translog.Operation op;
         final boolean isTombstone = parallelArray.isTombStone[docIndex];
         if (isTombstone && fields.id() == null) {


### PR DESCRIPTION
**REVERTED:**

Reading operations in Lucene changes is likely sequential and more efficient with SequentialStoredFieldsLeafReader.

Relates #62509