### PR TITLE
[7.x] Re-throw ResponseException as AssertionError in BasicLicenseUpgradeIT

### DIFF
--- a/x-pack/qa/rolling-upgrade-basic/src/test/java/org/elasticsearch/upgrades/BasicLicenseUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade-basic/src/test/java/org/elasticsearch/upgrades/BasicLicenseUpgradeIT.java
@@ -24,7 +24,12 @@ public class BasicLicenseUpgradeIT extends AbstractUpgradeTestCase {
 
     @SuppressWarnings("unchecked")
     private void checkBasicLicense() throws Exception {
-        Response licenseResponse = client().performRequest(new Request("GET", "/_license"));
+        final Request request = new Request("GET", "/_license");
+        // This avoids throwing a ResponseException when the license is not ready yet
+        // allowing to retry the check using assertBusy
+        request.addParameter("ignore", "404");
+        Response licenseResponse = client().performRequest(request);
+        assertOK(licenseResponse);
         Map<String, Object> licenseResponseMap = entityAsMap(licenseResponse);
         Map<String, Object> licenseMap = (Map<String, Object>) licenseResponseMap.get("license");
         assertEquals("basic", licenseMap.get("type"));
@@ -33,7 +38,12 @@ public class BasicLicenseUpgradeIT extends AbstractUpgradeTestCase {
 
     @SuppressWarnings("unchecked")
     private void checkNonExpiringBasicLicense() throws Exception {
-        Response licenseResponse = client().performRequest(new Request("GET", "/_license"));
+        final Request request = new Request("GET", "/_license");
+        // This avoids throwing a ResponseException when the license is not ready yet
+        // allowing to retry the check using assertBusy
+        request.addParameter("ignore", "404");
+        Response licenseResponse = client().performRequest(request);
+        assertOK(licenseResponse);
         Map<String, Object> licenseResponseMap = entityAsMap(licenseResponse);
         Map<String, Object> licenseMap = (Map<String, Object>) licenseResponseMap.get("license");
         assertEquals("basic", licenseMap.get("type"));


### PR DESCRIPTION
It's possible that in a slow machine the cluster state updates
take a while to be applied, the license information is published
with NORMAL priority, meaning that it can take a while for the
License information to become available. This can lead to race
conditions. In order to wait until the license information is
available, the tests use assertBusy, but assertBusy only retries
if an AssertionException is raised, for that reason we use the
ignore parameter in the http client and later check that the
response was correct, meaning that the check can be retried
if the license information is not ready yet.

Closes #64578
Backport of #67182