### PR TITLE
fix the NPE bug when creating match-all index template

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutComposableIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutComposableIndexTemplateAction.java
@@ -96,7 +96,7 @@ public class PutComposableIndexTemplateAction extends ActionType<AcknowledgedRes
                 validationException = addValidationError("an index template is required", validationException);
             } else {
                 if (indexTemplate.indexPatterns().stream().anyMatch(Regex::isMatchAllPattern)) {
-                    if (IndexMetadata.INDEX_HIDDEN_SETTING.exists(indexTemplate.template().settings())) {
+                    if (indexTemplate.template() != null && IndexMetadata.INDEX_HIDDEN_SETTING.exists(indexTemplate.template().settings())) {
                         validationException = addValidationError("global composable templates may not specify the setting "
                                 + IndexMetadata.INDEX_HIDDEN_SETTING.getKey(),
                             validationException

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/template/put/PutComposableIndexTemplateRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/template/put/PutComposableIndexTemplateRequestTests.java
@@ -69,6 +69,12 @@ public class PutComposableIndexTemplateRequestTests extends AbstractWireSerializ
         assertThat(validationErrors.size(), is(1));
         String error = validationErrors.get(0);
         assertThat(error, is("global composable templates may not specify the setting " + IndexMetadata.SETTING_INDEX_HIDDEN));
+
+        // Solve the NPE problem. See https://github.com/elastic/elasticsearch/issues/66949.
+        globalTemplate = new ComposableIndexTemplate(List.of("*"), null, null, null, null, null, null, null);
+        request.indexTemplate(globalTemplate);
+        validationException = request.validate();
+        assertNull(validationException);
     }
 
     public void testPutIndexTemplateV2RequestMustContainTemplate() {


### PR DESCRIPTION

Fixes #66949 

I debug the code, and found that NPE comes from the following code:
```
                    if (IndexMetadata.INDEX_HIDDEN_SETTING.exists(indexTemplate.template().settings())) {
                        validationException = addValidationError("global composable templates may not specify the setting "
                                + IndexMetadata.INDEX_HIDDEN_SETTING.getKey(),
                            validationException
                        );
```
Because indexTemplate.template() is null.