### PR TITLE
Autoscaling APIs marked public and stable

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/autoscaling.delete_autoscaling_policy.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/autoscaling.delete_autoscaling_policy.json
@@ -2,11 +2,10 @@
   "autoscaling.delete_autoscaling_policy":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/autoscaling-delete-autoscaling-policy.html",
-      "description":"Deletes an autoscaling policy."
+      "description":"Deletes an autoscaling policy. Designed for indirect use by ECE/ESS and ECK. Direct use is not supported."
     },
-    "stability":"experimental",
-    "visibility":"feature_flag",
-    "feature_flag":"es.autoscaling_feature_flag_registered",
+    "stability":"stable",
+    "visibility":"public",
     "headers":{
       "accept": [ "application/json"]
     },

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/autoscaling.get_autoscaling_capacity.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/autoscaling.get_autoscaling_capacity.json
@@ -2,11 +2,10 @@
   "autoscaling.get_autoscaling_capacity":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/autoscaling-get-autoscaling-capacity.html",
-      "description": "Gets the current autoscaling capacity based on the configured autoscaling policy."
+      "description": "Gets the current autoscaling capacity based on the configured autoscaling policy. Designed for indirect use by ECE/ESS and ECK. Direct use is not supported."
     },
-    "stability":"experimental",
-    "visibility":"feature_flag",
-    "feature_flag":"es.autoscaling_feature_flag_registered",
+    "stability":"stable",
+    "visibility":"public",
     "headers":{
       "accept": [ "application/json"]
     },

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/autoscaling.get_autoscaling_policy.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/autoscaling.get_autoscaling_policy.json
@@ -2,11 +2,10 @@
   "autoscaling.get_autoscaling_policy":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/autoscaling-get-autoscaling-policy.html",
-      "description": "Retrieves an autoscaling policy."
+      "description": "Retrieves an autoscaling policy. Designed for indirect use by ECE/ESS and ECK. Direct use is not supported."
     },
-    "stability":"experimental",
-    "visibility":"feature_flag",
-    "feature_flag":"es.autoscaling_feature_flag_registered",
+    "stability":"stable",
+    "visibility":"public",
     "headers":{
       "accept": [ "application/json"]
     },

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/autoscaling.put_autoscaling_policy.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/autoscaling.put_autoscaling_policy.json
@@ -2,11 +2,10 @@
   "autoscaling.put_autoscaling_policy":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/autoscaling-put-autoscaling-policy.html",
-      "description": "Creates a new autoscaling policy."
+      "description": "Creates a new autoscaling policy. Designed for indirect use by ECE/ESS and ECK. Direct use is not supported."
     },
-    "stability":"experimental",
-    "visibility":"feature_flag",
-    "feature_flag":"es.autoscaling_feature_flag_registered",
+    "stability":"stable",
+    "visibility":"public",
     "headers":{
       "accept": [ "application/json"],
       "content_type": ["application/json"]


### PR DESCRIPTION
Autoscaling APIs are no longer considered experimental and no longer
hidden behind a feature flags. Updated the API specification
accordingly.

Relates #67202 and #65973
