### PR TITLE
Autoscaling allow no deciders

### DIFF
--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingDeciderResults.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingDeciderResults.java
@@ -52,9 +52,6 @@ public class AutoscalingDeciderResults implements ToXContent, Writeable {
         this.currentCapacity = currentCapacity;
         this.currentNodes = Objects.requireNonNull(currentNodes);
         Objects.requireNonNull(results);
-        if (results.isEmpty()) {
-            throw new IllegalArgumentException("results can not be empty");
-        }
         this.results = results;
     }
 
@@ -107,6 +104,9 @@ public class AutoscalingDeciderResults implements ToXContent, Writeable {
     }
 
     public AutoscalingCapacity requiredCapacity() {
+        if (results.isEmpty()) {
+            return null;
+        }
         if (results.values().stream().map(AutoscalingDeciderResult::requiredCapacity).anyMatch(Objects::isNull)) {
             // any undetermined decider cancels out all required capacities
             return null;

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingDeciderResultsTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingDeciderResultsTests.java
@@ -31,19 +31,19 @@ import java.util.stream.IntStream;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 public class AutoscalingDeciderResultsTests extends AutoscalingTestCase {
 
-    public void testAutoscalingDeciderResultsRejectsEmptyResults() {
-        final IllegalArgumentException e = expectThrows(
-            IllegalArgumentException.class,
-            () -> new AutoscalingDeciderResults(
-                new AutoscalingCapacity(randomAutoscalingResources(), randomAutoscalingResources()),
-                randomNodes(),
-                new TreeMap<>()
-            )
+    public void testEmptyResults() {
+        AutoscalingDeciderResults results = new AutoscalingDeciderResults(
+            new AutoscalingCapacity(randomAutoscalingResources(), randomAutoscalingResources()),
+            randomNodes(),
+            new TreeMap<>()
         );
-        assertThat(e.getMessage(), equalTo("results can not be empty"));
+
+        assertThat(results.requiredCapacity(), is(nullValue()));
     }
 
     public void testRequiredCapacity() {


### PR DESCRIPTION
No longer fail the capacity API when no deciders are enabled for a
policy. This helps us allow operators to configure all policies and
leave it to ES to determine whether any autoscaling can be made.
