### PR TITLE
Fix descending _shard_doc sort

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/sort/ShardDocSortField.java
+++ b/server/src/main/java/org/elasticsearch/search/sort/ShardDocSortField.java
@@ -46,9 +46,19 @@ public class ShardDocSortField extends SortField {
 
     @Override
     public FieldComparator<?> getComparator(int numHits, int sortPos) {
-        final DocComparator delegate = new DocComparator(numHits, false, sortPos);
+        final DocComparator delegate = new DocComparator(numHits, getReverse(), sortPos);
 
         return new FieldComparator<Long>() {
+            @Override
+            public void setSingleSort() {
+                delegate.setSingleSort();
+            }
+
+            @Override
+            public void disableSkipping() {
+                delegate.disableSkipping();
+            }
+
             @Override
             public int compare(int slot1, int slot2) {
                 return delegate.compare(slot1, slot2);

--- a/server/src/main/java/org/elasticsearch/search/sort/ShardDocSortField.java
+++ b/server/src/main/java/org/elasticsearch/search/sort/ShardDocSortField.java
@@ -50,16 +50,6 @@ public class ShardDocSortField extends SortField {
 
         return new FieldComparator<Long>() {
             @Override
-            public void setSingleSort() {
-                delegate.setSingleSort();
-            }
-
-            @Override
-            public void disableSkipping() {
-                delegate.disableSkipping();
-            }
-
-            @Override
             public int compare(int slot1, int slot2) {
                 return delegate.compare(slot1, slot2);
             }


### PR DESCRIPTION
This commit fixes the new _shard_doc sort when the order is descending. 
It is a non-issue since the feature has not been released yet.