### PR TITLE
[7.11] [ML] fix autoscaling capacity responses when the required native memory is tiny (#67015)

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/AutoscalingIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/AutoscalingIT.java
@@ -103,7 +103,7 @@ public class AutoscalingIT extends MlNativeAutodetectIntegTestCase {
                 + currentScale.getTier()
             ) * 100 / 30.0
         );
-        expectedNodeBytes = (long)Math.ceil(ByteSizeValue.ofMb(60_000 + BASELINE_OVERHEAD_MB).getBytes() * 100 / 30.0);
+        expectedNodeBytes = (long) (ByteSizeValue.ofMb(60_000 + BASELINE_OVERHEAD_MB).getBytes() * 100 / 30.0);
 
 
         assertMlCapacity(

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlScalingReason.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlScalingReason.java
@@ -27,7 +27,8 @@ public class MlScalingReason implements AutoscalingDeciderResult.Reason {
     static final String CONFIGURATION = "configuration";
     static final String LARGEST_WAITING_ANALYTICS_JOB = "largest_waiting_analytics_job";
     static final String LARGEST_WAITING_ANOMALY_JOB = "largest_waiting_anomaly_job";
-    static final String CURRENT_CAPACITY = "current_capacity";
+    static final String CURRENT_CAPACITY = "perceived_current_capacity";
+    static final String REQUIRED_CAPACITY = "required_capacity";
     static final String REASON = "reason";
 
     private final List<String> waitingAnalyticsJobs;
@@ -36,6 +37,7 @@ public class MlScalingReason implements AutoscalingDeciderResult.Reason {
     private final Long largestWaitingAnalyticsJob;
     private final Long largestWaitingAnomalyJob;
     private final AutoscalingCapacity currentMlCapacity;
+    private final AutoscalingCapacity requiredCapacity;
     private final String simpleReason;
 
     public MlScalingReason(StreamInput in) throws IOException {
@@ -43,6 +45,7 @@ public class MlScalingReason implements AutoscalingDeciderResult.Reason {
         this.waitingAnomalyJobs = in.readStringList();
         this.passedConfiguration = Settings.readSettingsFromStream(in);;
         this.currentMlCapacity = new AutoscalingCapacity(in);
+        this.requiredCapacity = in.readOptionalWriteable(AutoscalingCapacity::new);
         this.largestWaitingAnalyticsJob = in.readOptionalVLong();
         this.largestWaitingAnomalyJob = in.readOptionalVLong();
         this.simpleReason = in.readString();
@@ -54,6 +57,7 @@ public class MlScalingReason implements AutoscalingDeciderResult.Reason {
                     Long largestWaitingAnalyticsJob,
                     Long largestWaitingAnomalyJob,
                     AutoscalingCapacity currentMlCapacity,
+                    AutoscalingCapacity requiredCapacity,
                     String simpleReason) {
         this.waitingAnalyticsJobs = waitingAnalyticsJobs == null ? Collections.emptyList() : waitingAnalyticsJobs;
         this.waitingAnomalyJobs = waitingAnomalyJobs == null ? Collections.emptyList() : waitingAnomalyJobs;
@@ -61,6 +65,7 @@ public class MlScalingReason implements AutoscalingDeciderResult.Reason {
         this.largestWaitingAnalyticsJob = largestWaitingAnalyticsJob;
         this.largestWaitingAnomalyJob = largestWaitingAnomalyJob;
         this.currentMlCapacity = ExceptionsHelper.requireNonNull(currentMlCapacity, CURRENT_CAPACITY);
+        this.requiredCapacity = requiredCapacity;
         this.simpleReason = ExceptionsHelper.requireNonNull(simpleReason, REASON);
     }
 
@@ -79,6 +84,7 @@ public class MlScalingReason implements AutoscalingDeciderResult.Reason {
             Objects.equals(largestWaitingAnalyticsJob, that.largestWaitingAnalyticsJob) &&
             Objects.equals(largestWaitingAnomalyJob, that.largestWaitingAnomalyJob) &&
             Objects.equals(currentMlCapacity, that.currentMlCapacity) &&
+            Objects.equals(requiredCapacity, that.requiredCapacity) &&
             Objects.equals(simpleReason, that.simpleReason);
     }
 
@@ -90,6 +96,7 @@ public class MlScalingReason implements AutoscalingDeciderResult.Reason {
             largestWaitingAnalyticsJob,
             largestWaitingAnomalyJob,
             currentMlCapacity,
+            requiredCapacity,
             simpleReason);
     }
 
@@ -109,6 +116,7 @@ public class MlScalingReason implements AutoscalingDeciderResult.Reason {
         out.writeStringCollection(this.waitingAnomalyJobs);
         Settings.writeSettingsToStream(this.passedConfiguration, out);
         this.currentMlCapacity.writeTo(out);
+        out.writeOptionalWriteable(this.requiredCapacity);
         out.writeOptionalVLong(largestWaitingAnalyticsJob);
         out.writeOptionalVLong(largestWaitingAnomalyJob);
         out.writeString(this.simpleReason);
@@ -127,6 +135,9 @@ public class MlScalingReason implements AutoscalingDeciderResult.Reason {
             builder.field(LARGEST_WAITING_ANOMALY_JOB, largestWaitingAnomalyJob);
         }
         builder.field(CURRENT_CAPACITY, currentMlCapacity);
+        if (requiredCapacity != null) {
+            builder.field(REQUIRED_CAPACITY, requiredCapacity);
+        }
         builder.field(REASON, simpleReason);
         builder.endObject();
         return builder;
@@ -144,6 +155,7 @@ public class MlScalingReason implements AutoscalingDeciderResult.Reason {
         private Long largestWaitingAnalyticsJob;
         private Long largestWaitingAnomalyJob;
         private AutoscalingCapacity currentMlCapacity;
+        private AutoscalingCapacity requiredCapacity;
         private String simpleReason;
 
         public Builder setWaitingAnalyticsJobs(List<String> waitingAnalyticsJobs) {
@@ -181,6 +193,11 @@ public class MlScalingReason implements AutoscalingDeciderResult.Reason {
             return this;
         }
 
+        public Builder setRequiredCapacity(AutoscalingCapacity requiredCapacity) {
+            this.requiredCapacity = requiredCapacity;
+            return this;
+        }
+
         public MlScalingReason build() {
             return new MlScalingReason(
                 waitingAnalyticsJobs,
@@ -189,6 +206,7 @@ public class MlScalingReason implements AutoscalingDeciderResult.Reason {
                 largestWaitingAnalyticsJob,
                 largestWaitingAnomalyJob,
                 currentMlCapacity,
+                requiredCapacity,
                 simpleReason
             );
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/NativeMemoryCalculator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/NativeMemoryCalculator.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 
+import java.util.Locale;
 import java.util.OptionalLong;
 
 import static org.elasticsearch.xpack.ml.MachineLearning.MACHINE_MEMORY_NODE_ATTR;
@@ -21,6 +22,7 @@ import static org.elasticsearch.xpack.ml.MachineLearning.USE_AUTO_MACHINE_MEMORY
 
 public final class NativeMemoryCalculator {
 
+    static final long MINIMUM_AUTOMATIC_NODE_SIZE = ByteSizeValue.ofGb(1).getBytes();
     private static final long OS_OVERHEAD = ByteSizeValue.ofMb(200L).getBytes();
 
     private NativeMemoryCalculator() { }
@@ -70,12 +72,38 @@ public final class NativeMemoryCalculator {
         return OptionalLong.of(allowedBytesForMl(machineMemory, jvmMemory, maxMemoryPercent, useAuto));
     }
 
-    public static int modelMemoryPercent(long machineMemory, long jvmSize, int maxMemoryPercent, boolean useAuto) {
+    public static long calculateApproxNecessaryNodeSize(long nativeMachineMemory, Long jvmSize, int maxMemoryPercent, boolean useAuto) {
+        if (nativeMachineMemory == 0) {
+            return 0;
+        }
         if (useAuto) {
-            // It is conceivable that there is a machine smaller than 200MB.
-            // If the administrator wants to use the auto configuration, the node should be larger.
+            // TODO utilize official ergonomic JVM size calculations when available.
+            jvmSize = jvmSize == null ? dynamicallyCalculateJvmSizeFromNativeMemorySize(nativeMachineMemory) : jvmSize;
+            // We use a Math.floor here to ensure we have AT LEAST enough memory given rounding.
+            int modelMemoryPercent = (int)Math.floor(modelMemoryPercent(
+                nativeMachineMemory + jvmSize + OS_OVERHEAD,
+                jvmSize,
+                maxMemoryPercent,
+                true));
+            // We calculate the inverse percentage of `nativeMachineMemory + OS_OVERHEAD` as `OS_OVERHEAD` is always present
+            // on the native memory side and we need to account for it when we invert the model memory percentage
+            return Math.max((long)Math.ceil((100.0/modelMemoryPercent) * (nativeMachineMemory + OS_OVERHEAD)), MINIMUM_AUTOMATIC_NODE_SIZE);
+        }
+        return (long) ((100.0/maxMemoryPercent) * nativeMachineMemory);
+    }
+
+    public static double modelMemoryPercent(long machineMemory, Long jvmSize, int maxMemoryPercent, boolean useAuto) {
+        if (useAuto) {
+            jvmSize = jvmSize == null ? dynamicallyCalculateJvmSizeFromNodeSize(machineMemory) : jvmSize;
             if (machineMemory - jvmSize < OS_OVERHEAD || machineMemory == 0) {
-                return 0;
+                assert false: String.format(
+                    Locale.ROOT,
+                    "machine memory [%d] minus jvm [%d] is less than overhead [%d]",
+                    machineMemory,
+                    jvmSize,
+                    OS_OVERHEAD
+                );
+                return maxMemoryPercent;
             }
             // This calculation is dynamic and designed to maximally take advantage of the underlying machine for machine learning
             // We only allow 200MB for the Operating system itself and take up to 90% of the underlying native memory left
@@ -84,20 +112,16 @@ public final class NativeMemoryCalculator {
             // 2GB node -> 66%
             // 16GB node -> 87%
             // 64GB node -> 90%
-            return Math.min(90, (int)Math.ceil(((machineMemory - jvmSize - OS_OVERHEAD) / (double)machineMemory) * 100.0D));
+            return Math.min(90.0, ((machineMemory - jvmSize - OS_OVERHEAD) / (double)machineMemory) * 100.0D);
         }
         return maxMemoryPercent;
     }
 
-    public static int modelMemoryPercent(long machineMemory, double jvmFraction, int maxMemoryPercent, boolean useAuto) {
-        return modelMemoryPercent(machineMemory, (long) (jvmFraction * machineMemory), maxMemoryPercent, useAuto);
-    }
-
     public static int modelMemoryPercent(long machineMemory, int maxMemoryPercent, boolean useAuto) {
-        return modelMemoryPercent(machineMemory,
-            useAuto ? dynamicallyCalculateJvm(machineMemory) : machineMemory / 2,
+        return (int)Math.ceil(modelMemoryPercent(machineMemory,
+            null,
             maxMemoryPercent,
-            useAuto);
+            useAuto));
     }
 
     private static long allowedBytesForMl(long machineMemory, Long jvmSize, int maxMemoryPercent, boolean useAuto) {
@@ -115,26 +139,42 @@ public final class NativeMemoryCalculator {
             // 16GB node -> 87%
             // 64GB node -> 90%
             long memoryPercent = Math.min(90, (int)Math.ceil(((machineMemory - jvmSize - OS_OVERHEAD) / (double)machineMemory) * 100.0D));
-            return machineMemory * memoryPercent / 100;
+            return (long)(machineMemory * (memoryPercent / 100.0));
         }
 
-        return machineMemory * maxMemoryPercent / 100;
+        return (long)(machineMemory * (maxMemoryPercent / 100.0));
     }
 
     public static long allowedBytesForMl(long machineMemory, int maxMemoryPercent, boolean useAuto) {
         return allowedBytesForMl(machineMemory,
-            useAuto ? dynamicallyCalculateJvm(machineMemory) : machineMemory / 2,
+            useAuto ? dynamicallyCalculateJvmSizeFromNodeSize(machineMemory) : machineMemory / 2,
             maxMemoryPercent,
             useAuto);
     }
 
     // TODO replace with official ergonomic calculation
-    private static long dynamicallyCalculateJvm(long nodeSize) {
+    private static long dynamicallyCalculateJvmSizeFromNodeSize(long nodeSize) {
         if (nodeSize < ByteSizeValue.ofGb(2).getBytes()) {
-            return (long)(nodeSize * 0.40);
+            return (long) (nodeSize * 0.40);
         }
         if (nodeSize < ByteSizeValue.ofGb(8).getBytes()) {
             return (long) (nodeSize * 0.25);
+        }
+        return ByteSizeValue.ofGb(2).getBytes();
+    }
+
+    private static long dynamicallyCalculateJvmSizeFromNativeMemorySize(long nativeMachineMemory) {
+        // See dynamicallyCalculateJvm the following JVM calculations are arithmetic inverses of JVM calculation
+        //
+        // Example: For < 2GB node, the JVM is 0.4 * total_node_size. This means, the rest is 0.6 the node size.
+        // So, the `nativeAndOverhead` is == 0.6 * total_node_size => total_node_size = (nativeAndOverHead / 0.6)
+        // Consequently jvmSize = (nativeAndOverHead / 0.6)*0.4 = nativeAndOverHead * 2/3
+        long nativeAndOverhead = nativeMachineMemory + OS_OVERHEAD;
+        if (nativeAndOverhead < (ByteSizeValue.ofGb(2).getBytes() * 0.60)) {
+            return (long) Math.ceil(nativeAndOverhead * (2.0 / 3.0));
+        }
+        if (nativeAndOverhead < (ByteSizeValue.ofGb(8).getBytes() * 0.75)) {
+            return (long) Math.ceil(nativeAndOverhead / 3.0);
         }
         return ByteSizeValue.ofGb(2).getBytes();
     }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlScalingReasonTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlScalingReasonTests.java
@@ -39,11 +39,18 @@ public class MlScalingReasonTests extends AbstractWireSerializingTestCase<MlScal
             randomConfiguration(),
             randomBoolean() ? null : randomLongBetween(10, ByteSizeValue.ofGb(1).getBytes()),
             randomBoolean() ? null : randomLongBetween(10, ByteSizeValue.ofGb(1).getBytes()),
-            new AutoscalingCapacity(AutoscalingCapacity.AutoscalingResources.ZERO, AutoscalingCapacity.AutoscalingResources.ZERO),
+            new AutoscalingCapacity(randomAutoscalingResources(), randomAutoscalingResources()),
+            randomBoolean() ? null : new AutoscalingCapacity(randomAutoscalingResources(), randomAutoscalingResources()),
             randomAlphaOfLength(10)
             );
     }
 
+    protected static AutoscalingCapacity.AutoscalingResources randomAutoscalingResources() {
+        return new AutoscalingCapacity.AutoscalingResources(
+            ByteSizeValue.ofBytes(randomLongBetween(10, ByteSizeValue.ofGb(10).getBytes())),
+            ByteSizeValue.ofBytes(randomLongBetween(10, ByteSizeValue.ofGb(10).getBytes()))
+        );
+    }
     @Override
     protected NamedWriteableRegistry getNamedWriteableRegistry() {
         return new NamedWriteableRegistry(MlAutoscalingNamedWritableProvider.getNamedWriteables());

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/NativeMemoryCapacityTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/NativeMemoryCapacityTests.java
@@ -51,8 +51,8 @@ public class NativeMemoryCapacityTests extends ESTestCase {
         }
         { // auto is true
             AutoscalingCapacity autoscalingCapacity = capacity.autoscalingCapacity(25, true);
-            assertThat(autoscalingCapacity.node().memory().getBytes(), equalTo(1412818190L));
-            assertThat(autoscalingCapacity.total().memory().getBytes(), equalTo(5651272758L));
+            assertThat(autoscalingCapacity.node().memory().getBytes(), equalTo(1604321280L));
+            assertThat(autoscalingCapacity.total().memory().getBytes(), equalTo(5174659393L));
         }
         { // auto is true with unknown jvm size
             capacity = new NativeMemoryCapacity(
@@ -60,8 +60,8 @@ public class NativeMemoryCapacityTests extends ESTestCase {
                 ByteSizeValue.ofGb(1).getBytes()
             );
             AutoscalingCapacity autoscalingCapacity = capacity.autoscalingCapacity(25, true);
-            assertThat(autoscalingCapacity.node().memory().getBytes(), equalTo(2618882498L));
-            assertThat(autoscalingCapacity.total().memory().getBytes(), equalTo(10475529991L));
+            assertThat(autoscalingCapacity.node().memory().getBytes(), equalTo(2566914048L));
+            assertThat(autoscalingCapacity.total().memory().getBytes(), equalTo(6507526207L));
         }
 
     }


### PR DESCRIPTION
Backports the following commits to 7.11:
 - [ML] fix autoscaling capacity responses when the required native memory is tiny (#67015)