### PR TITLE
[7.x] [ML] write notification messages indicating required capacity when a job is not assigned to a node (#67181)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
@@ -155,6 +155,10 @@ public final class Messages {
     public static final String JOB_AUDIT_MEMORY_STATUS_HARD_LIMIT_PRE_7_2 = "Job memory status changed to hard_limit at {0}; adjust the " +
         "analysis_limits.model_memory_limit setting to ensure all data is analyzed";
 
+    public static final String JOB_AUDIT_REQUIRES_MORE_MEMORY_TO_RUN = "Job requires at least [{0}] free memory "
+        + "on a machine learning capable node to run; [{1}] are available. "
+        + "The current total capacity for ML [total: {2}, largest node: {3}].";
+
     public static final String JOB_CONFIG_CATEGORIZATION_FILTERS_CONTAINS_DUPLICATES = "categorization_filters contain duplicates";
     public static final String JOB_CONFIG_CATEGORIZATION_FILTERS_CONTAINS_EMPTY =
             "categorization_filters are not allowed to contain empty strings";

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsAction.java
@@ -631,7 +631,7 @@ public class TransportStartDataFrameAnalyticsAction
                     node -> nodeFilter(node, params));
             // Pass an effectively infinite value for max concurrent opening jobs, because data frame analytics jobs do
             // not have an "opening" state so would never be rejected for causing too many jobs in the "opening" state
-            return jobNodeSelector.selectNode(
+            PersistentTasksCustomMetadata.Assignment assignment = jobNodeSelector.selectNode(
                 maxOpenJobs,
                 Integer.MAX_VALUE,
                 maxMachineMemoryPercent,
@@ -639,6 +639,8 @@ public class TransportStartDataFrameAnalyticsAction
                 isMemoryTrackerRecentlyRefreshed,
                 useAutoMemoryPercentage
             );
+            auditRequireMemoryIfNecessary(params.getId(), auditor, assignment, jobNodeSelector, isMemoryTrackerRecentlyRefreshed);
+            return assignment;
         }
 
         @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/NativeMemoryCapacity.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/NativeMemoryCapacity.java
@@ -10,6 +10,8 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingCapacity;
 import org.elasticsearch.xpack.ml.utils.NativeMemoryCalculator;
 
+import java.util.Objects;
+
 // Used for storing native memory capacity and then transforming it into an autoscaling capacity
 // which takes into account the whole node size
 public class NativeMemoryCapacity  {
@@ -24,7 +26,7 @@ public class NativeMemoryCapacity  {
     private long node;
     private Long jvmSize;
 
-    NativeMemoryCapacity(long tier, long node, Long jvmSize) {
+    public NativeMemoryCapacity(long tier, long node, Long jvmSize) {
         this.tier = tier;
         this.node = node;
         this.jvmSize = jvmSize;
@@ -70,5 +72,26 @@ public class NativeMemoryCapacity  {
 
     public Long getJvmSize() {
         return jvmSize;
+    }
+
+    @Override
+    public String toString() {
+        return "NativeMemoryCapacity{" +
+            "total bytes=" + ByteSizeValue.ofBytes(tier) +
+            ", largest node bytes=" + ByteSizeValue.ofBytes(node) +
+            '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        NativeMemoryCapacity that = (NativeMemoryCapacity) o;
+        return tier == that.tier && node == that.node && Objects.equals(jvmSize, that.jvmSize);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(tier, node, jvmSize);
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobNodeSelector.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobNodeSelector.java
@@ -12,8 +12,11 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.xpack.ml.MachineLearning;
+import org.elasticsearch.xpack.ml.autoscaling.MlAutoscalingDeciderService;
+import org.elasticsearch.xpack.ml.autoscaling.NativeMemoryCapacity;
 import org.elasticsearch.xpack.ml.process.MlMemoryTracker;
 import org.elasticsearch.xpack.ml.utils.NativeMemoryCalculator;
 
@@ -23,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.xpack.ml.MachineLearning.MAX_OPEN_JOBS_PER_NODE;
 
@@ -81,6 +85,36 @@ public class JobNodeSelector {
             }
             return "Not opening job [" + jobId + "] on node [" + nodeNameOrId(node) + "], because this node isn't a ml node.";
         };
+    }
+
+    public Tuple<NativeMemoryCapacity, Long> perceivedCapacityAndMaxFreeMemory(int maxMachineMemoryPercent,
+                                                                               boolean useAutoMemoryPercentage,
+                                                                               int maxOpenJobs,
+                                                                               boolean isMemoryTrackerRecentlyRefreshed) {
+        List<DiscoveryNode> capableNodes = clusterState.getNodes()
+            .mastersFirstStream()
+            .filter(n -> this.nodeFilter.apply(n) == null)
+            .collect(Collectors.toList());
+        NativeMemoryCapacity currentCapacityForMl = MlAutoscalingDeciderService.currentScale(
+            capableNodes,
+            maxMachineMemoryPercent,
+            useAutoMemoryPercentage
+        );
+        long mostAvailableMemory = capableNodes.stream()
+            .map(n -> nodeLoadDetector.detectNodeLoad(
+                clusterState,
+                true,
+                n,
+                maxOpenJobs,
+                maxMachineMemoryPercent,
+                isMemoryTrackerRecentlyRefreshed,
+                useAutoMemoryPercentage)
+            )
+            .filter(nl -> nl.remainingJobs() > 0)
+            .mapToLong(NodeLoad::getFreeMemory)
+            .max()
+            .orElse(0L);
+        return Tuple.tuple(currentCapacityForMl, mostAvailableMemory);
     }
 
     public PersistentTasksCustomMetadata.Assignment selectNode(int dynamicMaxOpenJobs,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/NodeLoad.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/NodeLoad.java
@@ -93,6 +93,20 @@ public class NodeLoad {
     }
 
     /**
+     * @return The available memory on the node
+     */
+    public long getFreeMemory() {
+        return Math.max(maxMemory - assignedJobMemory, 0L);
+    }
+
+    /**
+     * @return The number of jobs that can still be assigned to the node
+     */
+    public int remainingJobs() {
+        return Math.max(maxJobs - (int)numAssignedJobs, 0);
+    }
+
+    /**
      * @return Returns a comma delimited string of errors if any were encountered.
      */
     @Nullable

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutor.java
@@ -24,6 +24,7 @@ import org.elasticsearch.index.engine.DocumentMissingException;
 import org.elasticsearch.persistent.AllocatedPersistentTask;
 import org.elasticsearch.persistent.PersistentTaskState;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
+import org.elasticsearch.persistent.PersistentTasksCustomMetadata.Assignment;
 import org.elasticsearch.persistent.decider.EnableAssignmentDecider;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.tasks.TaskId;
@@ -45,6 +46,7 @@ import org.elasticsearch.xpack.ml.datafeed.persistence.DatafeedConfigProvider;
 import org.elasticsearch.xpack.ml.job.JobNodeSelector;
 import org.elasticsearch.xpack.ml.job.persistence.JobResultsProvider;
 import org.elasticsearch.xpack.ml.job.process.autodetect.AutodetectProcessManager;
+import org.elasticsearch.xpack.ml.notifications.AnomalyDetectionAuditor;
 import org.elasticsearch.xpack.ml.process.MlMemoryTracker;
 import org.elasticsearch.xpack.ml.task.AbstractJobPersistentTasksExecutor;
 
@@ -58,6 +60,7 @@ import java.util.Set;
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
 import static org.elasticsearch.xpack.core.ml.MlTasks.AWAITING_UPGRADE;
+import static org.elasticsearch.xpack.ml.job.JobNodeSelector.AWAITING_LAZY_ASSIGNMENT;
 
 public class OpenJobPersistentTasksExecutor extends AbstractJobPersistentTasksExecutor<OpenJobAction.JobParams> {
 
@@ -80,23 +83,28 @@ public class OpenJobPersistentTasksExecutor extends AbstractJobPersistentTasksEx
     private final DatafeedConfigProvider datafeedConfigProvider;
     private final Client client;
     private final JobResultsProvider jobResultsProvider;
+    private final AnomalyDetectionAuditor auditor;
 
     private volatile ClusterState clusterState;
 
-    public OpenJobPersistentTasksExecutor(Settings settings, ClusterService clusterService,
+    public OpenJobPersistentTasksExecutor(Settings settings,
+                                          ClusterService clusterService,
                                           AutodetectProcessManager autodetectProcessManager,
-                                          DatafeedConfigProvider datafeedConfigProvider, MlMemoryTracker memoryTracker, Client client,
+                                          DatafeedConfigProvider datafeedConfigProvider,
+                                          MlMemoryTracker memoryTracker,
+                                          Client client,
                                           IndexNameExpressionResolver expressionResolver) {
         super(MlTasks.JOB_TASK_NAME, MachineLearning.UTILITY_THREAD_POOL_NAME, settings, clusterService, memoryTracker, expressionResolver);
         this.autodetectProcessManager = Objects.requireNonNull(autodetectProcessManager);
         this.datafeedConfigProvider = Objects.requireNonNull(datafeedConfigProvider);
         this.client = Objects.requireNonNull(client);
         this.jobResultsProvider = new JobResultsProvider(client, settings, expressionResolver);
+        this.auditor = new AnomalyDetectionAuditor(client, clusterService);
         clusterService.addListener(event -> clusterState = event.state());
     }
 
     @Override
-    public PersistentTasksCustomMetadata.Assignment getAssignment(OpenJobAction.JobParams params, ClusterState clusterState) {
+    public Assignment getAssignment(OpenJobAction.JobParams params, ClusterState clusterState) {
         // If the task parameters do not have a job field then the job
         // was first opened on a pre v6.6 node and has not been migrated
         Job job = params.getJob();
@@ -104,20 +112,22 @@ public class OpenJobPersistentTasksExecutor extends AbstractJobPersistentTasksEx
             return AWAITING_MIGRATION;
         }
         boolean isMemoryTrackerRecentlyRefreshed = memoryTracker.isRecentlyRefreshed();
-        Optional<PersistentTasksCustomMetadata.Assignment> optionalAssignment = getPotentialAssignment(params, clusterState);
+        Optional<Assignment> optionalAssignment = getPotentialAssignment(params, clusterState);
         if (optionalAssignment.isPresent()) {
             return optionalAssignment.get();
         }
 
         JobNodeSelector jobNodeSelector = new JobNodeSelector(clusterState, params.getJobId(), MlTasks.JOB_TASK_NAME, memoryTracker,
             job.allowLazyOpen() ? Integer.MAX_VALUE : maxLazyMLNodes, node -> nodeFilter(node, job));
-        return jobNodeSelector.selectNode(
+        Assignment assignment = jobNodeSelector.selectNode(
             maxOpenJobs,
             maxConcurrentJobAllocations,
             maxMachineMemoryPercent,
             maxNodeMemory,
             isMemoryTrackerRecentlyRefreshed,
             useAutoMemoryPercentage);
+        auditRequireMemoryIfNecessary(params.getJobId(), auditor, assignment, jobNodeSelector, isMemoryTrackerRecentlyRefreshed);
+        return assignment;
     }
 
     private static boolean nodeSupportsModelSnapshotVersion(DiscoveryNode node, Job job) {
@@ -173,7 +183,7 @@ public class OpenJobPersistentTasksExecutor extends AbstractJobPersistentTasksEx
             throw makeCurrentlyBeingUpgradedException(logger, params.getJobId());
         }
 
-        if (assignment.getExecutorNode() == null && assignment.equals(JobNodeSelector.AWAITING_LAZY_ASSIGNMENT) == false) {
+        if (assignment.getExecutorNode() == null && assignment.equals(AWAITING_LAZY_ASSIGNMENT) == false) {
             throw makeNoSuitableNodesException(logger, params.getJobId(), assignment.getExplanation());
         }
     }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutorTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.cluster.routing.RecoverySource;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
+import org.elasticsearch.cluster.routing.allocation.decider.AwarenessAllocationDecider;
 import org.elasticsearch.cluster.service.ClusterApplierService;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.cluster.service.MasterService;
@@ -87,13 +88,17 @@ public class OpenJobPersistentTasksExecutorTests extends ESTestCase {
         ThreadPool tp = mock(ThreadPool.class);
         ExecutorService executorService = EsExecutors.newDirectExecutorService();
         when(tp.generic()).thenReturn(executorService);
-        Settings settings = Settings.builder().put("node.name", "OpenJobPersistentTasksExecutorTests").build();
+        Settings settings = Settings.builder()
+            .put("node.name", "OpenJobPersistentTasksExecutorTests")
+            .put("client.type", "node")
+            .build();
         ClusterSettings clusterSettings = new ClusterSettings(settings,
             new HashSet<>(Arrays.asList(InferenceProcessor.MAX_INFERENCE_PROCESSORS,
                 MasterService.MASTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING,
                 OperationRouting.USE_ADAPTIVE_REPLICA_SELECTION_SETTING,
                 ClusterService.USER_DEFINED_METADATA,
                 ClusterApplierService.CLUSTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING,
+                AwarenessAllocationDecider.CLUSTER_ROUTING_ALLOCATION_AWARENESS_ATTRIBUTE_SETTING,
                 MachineLearning.CONCURRENT_JOB_ALLOCATIONS,
                 MachineLearning.MAX_MACHINE_MEMORY_PERCENT,
                 MachineLearning.MAX_LAZY_ML_NODES,
@@ -104,6 +109,7 @@ public class OpenJobPersistentTasksExecutorTests extends ESTestCase {
         autodetectProcessManager = mock(AutodetectProcessManager.class);
         datafeedConfigProvider = mock(DatafeedConfigProvider.class);
         client = mock(Client.class);
+        when(client.settings()).thenReturn(settings);
         mlMemoryTracker = mock(MlMemoryTracker.class);
     }
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ML] write notification messages indicating required capacity when a job is not assigned to a node (#67181)