### PR TITLE
Update example for GET /_cat/aliases

### DIFF
--- a/docs/reference/cat/alias.asciidoc
+++ b/docs/reference/cat/alias.asciidoc
@@ -73,7 +73,7 @@ PUT test1
 
 [source,console]
 --------------------------------------------------
-GET /_cat/aliases?v
+GET /_cat/aliases?v=true
 --------------------------------------------------
 // TEST[continued]
 


### PR DESCRIPTION
The example is `GET /_cat/aliases?v` however this does not work in the Elastic Cloud API console. The `v` needs a value such as `true` otherwise it defaults to `false` meaning the example is incorrect as the API would not return the headers. Thusly the example should be amended to be `GET /_cat/aliases?v=true`

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
