### PR TITLE
Remove assertion that makes many test failing

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheService.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheService.java
@@ -409,7 +409,6 @@ public class CacheService extends AbstractLifecycleComponent {
                 }
                 success = true;
             } finally {
-                assert success : "shard eviction should be successful: " + shardEviction;
                 if (success == false) {
                     final boolean added = evictedShards.add(shardEviction);
                     assert added : shardEviction;


### PR DESCRIPTION
This pull request removes an assertion that makes many tests to fail on CI until #67160 is merged, which has been opened to fix the underlying issues around that assertion tripping (and brings back the assertion).

The goal here is to limit test triage workload.