### PR TITLE
[7.11] [DOCS] Clean up index template xrefs (#67264)

### DIFF
--- a/docs/reference/analysis/specify-analyzer.asciidoc
+++ b/docs/reference/analysis/specify-analyzer.asciidoc
@@ -20,7 +20,7 @@ analyzer for indexing and search. It also lets you quickly see which analyzer
 applies to which field using the <<indices-get-mapping,get mapping API>>.
 
 If you don't typically create mappings for your indices, you can use
-<<indices-templates,index templates>> to achieve a similar effect.
+<<index-templates,index templates>> to achieve a similar effect.
 ====
 
 [[specify-index-time-analyzer]]

--- a/docs/reference/cat/templates.asciidoc
+++ b/docs/reference/cat/templates.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>cat templates</titleabbrev>
 ++++
 
-Returns information about <<indices-templates,index templates>> in a cluster.
+Returns information about <<indices-templates-v1,index templates>> in a cluster.
 You can use index templates to apply <<index-modules-settings,index settings>>
 and <<mapping,field mappings>> to new indices at creation.
 

--- a/docs/reference/data-streams/change-mappings-and-settings.asciidoc
+++ b/docs/reference/data-streams/change-mappings-and-settings.asciidoc
@@ -93,7 +93,7 @@ field mapping is added to future backing indices created for the stream.
 For example, `my-data-stream-template` is an existing index template used by
 `my-data-stream`.
 
-The following <<indices-templates,put index template>> request adds a mapping
+The following <<index-templates,put index template>> request adds a mapping
 for a new field, `message`, to the template.
 
 [source,console]
@@ -175,7 +175,7 @@ field mapping is added to future backing indices created for the stream.
 For example, `my-data-stream-template` is an existing index template used by
 `my-data-stream`.
 
-The following <<indices-templates,put index template>> request changes the
+The following <<index-templates,put index template>> request changes the
 argument for the `host.ip` field's <<ignore-malformed,`ignore_malformed`>>
 mapping parameter to `true`.
 
@@ -281,7 +281,7 @@ applied to future backing indices created for the stream.
 For example, `my-data-stream-template` is an existing index template used by
 `my-data-stream`.
 
-The following <<indices-templates,put index template>> request changes the
+The following <<index-templates,put index template>> request changes the
 template's `index.refresh_interval` index setting to `30s` (30 seconds).
 
 [source,console]
@@ -335,7 +335,7 @@ backing index created after the update.
 For example, `my-data-stream-template` is an existing index template used by
 `my-data-stream`.
 
-The following <<indices-templates,put index template API>> requests adds new
+The following <<index-templates,put index template API>> requests adds new
 `sort.field` and `sort.order index` settings to the template.
 
 [source,console]
@@ -428,7 +428,7 @@ new template by copying an existing one and modifying it as needed.
 For example, `my-data-stream-template` is an existing index template used by
 `my-data-stream`.
 
-The following <<indices-templates,put index template API>> request creates a new
+The following <<index-templates,put index template API>> request creates a new
 index template, `new-data-stream-template`. `new-data-stream-template`
 uses `my-data-stream-template` as its basis, with the following
 changes:

--- a/docs/reference/data-streams/data-streams.asciidoc
+++ b/docs/reference/data-streams/data-streams.asciidoc
@@ -27,7 +27,7 @@ backing indices.
 
 image::images/data-streams/data-streams-diagram.svg[align="center"]
 
-Each data stream requires a matching <<indices-templates,index template>>. The
+Each data stream requires a matching <<index-templates,index template>>. The
 template contains the mappings and settings used to configure the stream's
 backing indices.
 
@@ -121,7 +121,7 @@ If needed, you can <<update-delete-docs-in-a-backing-index,update or delete
 documents>> by submitting requests directly to the document's backing index.
 
 TIP: If you frequently update or delete existing documents, use an
-<<indices-add-alias,index alias>> and <<indices-templates,index template>>
+<<indices-add-alias,index alias>> and <<index-templates,index template>>
 instead of a data stream. You can still use
 <<index-lifecycle-management,{ilm-init}>> to manage indices for the alias.
 

--- a/docs/reference/docs/index_.asciidoc
+++ b/docs/reference/docs/index_.asciidoc
@@ -180,7 +180,7 @@ definition>>, the index operation automatically creates the data stream. See
 
 If the target doesn't exist and doesn't match a data stream template,
 the operation automatically creates the index and applies any matching
-<<indices-templates,index templates>>.
+<<index-templates,index templates>>.
 
 [IMPORTANT]
 ====

--- a/docs/reference/glossary.asciidoc
+++ b/docs/reference/glossary.asciidoc
@@ -61,7 +61,7 @@ that is accessed occasionally and not normally updated.
 
 [[glossary-component-template]] component template ::
 // tag::component-template-def[]
-A building block for constructing <<indices-templates,index templates>> that specifies index
+A building block for constructing <<index-templates,index templates>> that specifies index
 <<mapping,mappings>>, <<index-modules-settings,settings>>, and <<indices-aliases,aliases>>.
 // end::component-template-def[]
 

--- a/docs/reference/high-availability/cluster-design.asciidoc
+++ b/docs/reference/high-availability/cluster-design.asciidoc
@@ -80,7 +80,7 @@ If you have two nodes, we recommend they both be data nodes. You should also
 ensure every shard is stored redundantly on both nodes by setting
 <<dynamic-index-settings,`index.number_of_replicas`>> to `1` on every index.
 This is the default number of replicas but may be overridden by an
-<<indices-templates,index template>>. <<dynamic-index-settings,Auto-expand
+<<index-templates,index template>>. <<dynamic-index-settings,Auto-expand
 replicas>> can also achieve the same thing, but it's not necessary to use this
 feature in such a small cluster.
 

--- a/docs/reference/ilm/actions/ilm-allocate.asciidoc
+++ b/docs/reference/ilm/actions/ilm-allocate.asciidoc
@@ -9,7 +9,7 @@ and change the number of replicas.
 
 The allocate action is not allowed in the hot phase. 
 The initial allocation for the index must be done manually or via 
-<<indices-templates, index templates>>.
+<<index-templates, index templates>>.
 
 You can configure this action to modify both the allocation rules and number of replicas, 
 only the allocation rules, or only the number of replicas. 

--- a/docs/reference/ilm/actions/ilm-migrate.asciidoc
+++ b/docs/reference/ilm/actions/ilm-migrate.asciidoc
@@ -27,7 +27,7 @@ to `data_cold,data_warm,data_hot`. This moves the index to nodes in the
 
 The migrate action is not allowed in the hot phase.
 The initial index allocation is performed <<data-tier-allocation, automatically>>,
-and can be configured manually or via <<indices-templates, index templates>>.
+and can be configured manually or via <<index-templates, index templates>>.
 
 [[ilm-migrate-options]]
 ==== Options

--- a/docs/reference/ilm/ilm-tutorial.asciidoc
+++ b/docs/reference/ilm/ilm-tutorial.asciidoc
@@ -148,7 +148,7 @@ PUT _index_template/timeseries_template
 === Create the data stream
 
 To get things started, index a document into the name or wildcard pattern defined
-in the `index_patterns` of the <<indices-templates,index template>>. As long
+in the `index_patterns` of the <<index-templates,index template>>. As long
 as an existing data stream, index, or index alias does not already use the name, the index
 request automatically creates a corresponding data stream with a single backing index.
 {es} automatically indexes the request's documents into this backing index, which also

--- a/docs/reference/ilm/index-rollover.asciidoc
+++ b/docs/reference/ilm/index-rollover.asciidoc
@@ -15,7 +15,7 @@ Using rolling indices enables you to:
 We recommend using <<indices-create-data-stream, data streams>> to manage time series
 data. Data streams automatically track the write index while keeping configuration to a minimum.
 
-Each data stream requires an <<indices-templates,index template>> that contains:
+Each data stream requires an <<index-templates,index template>> that contains:
 
 * A name or wildcard (`*`) pattern for the data stream.
 

--- a/docs/reference/ilm/set-up-lifecycle-policy.asciidoc
+++ b/docs/reference/ilm/set-up-lifecycle-policy.asciidoc
@@ -7,7 +7,7 @@ For {ilm-init} to manage an index, a valid policy
 must be specified in the `index.lifecycle.name` index setting. 
 
 To configure a lifecycle policy for <<index-rollover, rolling indices>>, 
-you create the policy and add it to the <<indices-templates, index template>>.
+you create the policy and add it to the <<index-templates, index template>>.
 
 To use a policy to manage an index that doesn't roll over,
 you can specify a lifecycle policy when you create the index,

--- a/docs/reference/indices.asciidoc
+++ b/docs/reference/indices.asciidoc
@@ -56,7 +56,7 @@ Index templates automatically apply settings, mappings, and aliases to new indic
 They are most often used to configure rolling indices for time series data to 
 ensure that each new index has the same configuration as the previous one. 
 The index template associated with a data stream configures its backing indices. 
-For more information, see <<indices-templates, Index Templates>>.
+For more information, see <<index-templates, Index Templates>>.
 
 * <<indices-put-template>>
 * <<indices-get-template>>

--- a/docs/reference/indices/create-data-stream.asciidoc
+++ b/docs/reference/indices/create-data-stream.asciidoc
@@ -7,7 +7,7 @@
 
 Creates a new <<data-streams,data stream>>.
 
-Data streams require a matching <<indices-templates,index template>>.
+Data streams require a matching <<index-templates,index template>>.
 See <<set-up-a-data-stream>>.
 
 ////

--- a/docs/reference/indices/delete-component-template.asciidoc
+++ b/docs/reference/indices/delete-component-template.asciidoc
@@ -37,7 +37,7 @@ DELETE _component_template/template_1
 ==== {api-description-title}
 
 Use the delete component template API to delete one or more component templates
-Component templates are building blocks for constructing <<indices-templates,index templates>>  
+Component templates are building blocks for constructing <<index-templates,index templates>>  
 that specify index mappings, settings, and aliases. 
 
 [[delete-component-template-api-path-params]]

--- a/docs/reference/indices/migrate-to-data-stream.asciidoc
+++ b/docs/reference/indices/migrate-to-data-stream.asciidoc
@@ -7,7 +7,7 @@
 
 Converts an <<indices-aliases,index alias>> to a <<data-streams,data stream>>.
 
-Data streams require a matching <<indices-templates,index template>>.
+Data streams require a matching <<index-templates,index template>>.
 See <<set-up-a-data-stream>>.
 
 ////

--- a/docs/reference/indices/put-component-template.asciidoc
+++ b/docs/reference/indices/put-component-template.asciidoc
@@ -5,7 +5,7 @@
 ++++
 
 Creates or updates a component template.
-Component templates are building blocks for constructing <<indices-templates,index templates>>
+Component templates are building blocks for constructing <<index-templates,index templates>>
 that specify index <<mapping,mappings>>, <<index-modules-settings,settings>>,
 and <<indices-aliases,aliases>>.
 

--- a/docs/reference/indices/rollover-index.asciidoc
+++ b/docs/reference/indices/rollover-index.asciidoc
@@ -306,7 +306,7 @@ DELETE /_index_template/template
 ===== Specify settings for the target index
 
 The settings, mappings, and aliases for the new index are taken from any
-matching <<indices-templates,index templates>>. If the rollover target is an
+matching <<index-templates,index templates>>. If the rollover target is an
 index alias, you can specify `settings`, `mappings`, and `aliases` in the body
 of the request just like the <<indices-create-index,create index>> API. Values
 specified in the request override any values set in matching index templates.

--- a/docs/reference/indices/simulate-index.asciidoc
+++ b/docs/reference/indices/simulate-index.asciidoc
@@ -7,7 +7,7 @@
 experimental[]
 
 Returns the index configuration that would be applied to the specified index from an 
-existing <<indices-templates, index template>>.
+existing <<index-templates, index template>>.
 
 ////
 [source,console]

--- a/docs/reference/indices/simulate-template.asciidoc
+++ b/docs/reference/indices/simulate-template.asciidoc
@@ -5,7 +5,7 @@
 ++++
 
 Returns the index configuration that would be applied by a particular 
-<<indices-templates, index template>>.
+<<index-templates, index template>>.
 
 ////
 [source,console]

--- a/docs/reference/mapping/dynamic-mapping.asciidoc
+++ b/docs/reference/mapping/dynamic-mapping.asciidoc
@@ -28,7 +28,7 @@ purposes with:
 
     Custom rules to configure the mapping for dynamically added fields.
 
-TIP: <<indices-templates,Index templates>> allow you to configure the default
+TIP: <<index-templates,Index templates>> allow you to configure the default
 mappings, settings and aliases for new indices, whether created
 automatically or explicitly.
 

--- a/docs/reference/migration/migrate_7_0/migrate_to_java_time.asciidoc
+++ b/docs/reference/migration/migrate_7_0/migrate_to_java_time.asciidoc
@@ -45,7 +45,7 @@ The switch to java time only impacts custom <<date,`date`>> and
 These formats are commonly used in:
 
 * <<mapping,Index mappings>>
-* <<indices-templates,Index templates>>
+* <<index-templates,Index templates>>
 * <<pipeline,Ingest pipelines>>
 
 If you don't use custom date formats, you can skip the rest of this guide.

--- a/docs/reference/monitoring/indices.asciidoc
+++ b/docs/reference/monitoring/indices.asciidoc
@@ -3,7 +3,7 @@
 [[config-monitoring-indices]]
 == Configuring indices for monitoring
 
-<<indices-templates,Index templates>> are used to configure the indices
+<<indices-templates-v1,Index templates>> are used to configure the indices
 that store the monitoring data collected from a cluster.
 
 You can retrieve the templates through the `_template` API:


### PR DESCRIPTION
Backports the following commits to 7.11:
 - [DOCS] Clean up index template xrefs (#67264)