### PR TITLE
[7.x] [DOCS] Fix formatting for breaking changes (#67267)

### DIFF
--- a/docs/reference/migration/migrate_7_11.asciidoc
+++ b/docs/reference/migration/migrate_7_11.asciidoc
@@ -39,6 +39,12 @@ snippets in lower case.
 [discrete]
 ==== {dataframe-transform-cap} API changes
 
+.Transform now writes `group_by` dates as a string.
+[%collapsible]
+====
+*Details* +
 Transform no longer writes dates used in a `group_by` as `epoch_millis` but as
 formatted ISO string. Previously constructed transforms will still use `epoch_millis`.
 You can configure and change the output format in the settings of the transform.
+====
+//end::notable-breaking-changes[]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Fix formatting for breaking changes (#67267)