### PR TITLE
[7.x] Fix NPE when updating settings on managed system indices (#67200)

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/settings/put/TransportUpdateSettingsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/settings/put/TransportUpdateSettingsAction.java
@@ -19,6 +19,13 @@
 
 package org.elasticsearch.action.admin.indices.settings.put;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
@@ -40,12 +47,6 @@ import org.elasticsearch.indices.SystemIndexDescriptor;
 import org.elasticsearch.indices.SystemIndices;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 public class TransportUpdateSettingsAction extends AcknowledgedTransportMasterNodeAction<UpdateSettingsRequest> {
 
@@ -142,7 +143,7 @@ public class TransportUpdateSettingsAction extends AcknowledgedTransportMasterNo
                     final String expectedValue = descriptorSettings.get(key);
                     final String actualValue = requestSettings.get(key);
 
-                    if (expectedValue.equals(actualValue) == false) {
+                    if (Objects.equals(expectedValue, actualValue) == false) {
                         failedKeys.add(key);
                     }
                 }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fix NPE when updating settings on managed system indices (#67200)