### PR TITLE
SQL: Bubble up negations in expressions

### DIFF
--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/optimizer/Optimizer.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/optimizer/Optimizer.java
@@ -35,6 +35,7 @@ import org.elasticsearch.xpack.ql.expression.predicate.regex.Like;
 import org.elasticsearch.xpack.ql.optimizer.OptimizerRules.BooleanFunctionEqualsElimination;
 import org.elasticsearch.xpack.ql.optimizer.OptimizerRules.BooleanLiteralsOnTheRight;
 import org.elasticsearch.xpack.ql.optimizer.OptimizerRules.BooleanSimplification;
+import org.elasticsearch.xpack.ql.optimizer.OptimizerRules.BubbleUpNegations;
 import org.elasticsearch.xpack.ql.optimizer.OptimizerRules.CombineBinaryComparisons;
 import org.elasticsearch.xpack.ql.optimizer.OptimizerRules.CombineDisjunctionsToIn;
 import org.elasticsearch.xpack.ql.optimizer.OptimizerRules.ConstantFolding;
@@ -86,6 +87,7 @@ public class Optimizer extends RuleExecutor<LogicalPlan> {
                 new CombineBinaryComparisons(),
                 new CombineDisjunctionsToIn(),
                 new PushDownAndCombineFilters(),
+                new BubbleUpNegations(),
                 // prune/elimination
                 new PruneFilters(),
                 new PruneLiteralsInOrderBy(),

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/optimizer/OptimizerRules.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/optimizer/OptimizerRules.java
@@ -1181,7 +1181,7 @@ public final class OptimizerRules {
             return e;
         }
 
-        public static boolean isMulOrDiv(ArithmeticOperation operation) {
+        protected static boolean isMulOrDiv(ArithmeticOperation operation) {
             String opSymbol = operation.symbol();
             return MUL.symbol().equals(opSymbol) || DIV.symbol().equals(opSymbol);
         }

--- a/x-pack/plugin/ql/src/test/resources/mapping-multi-field-variation.json
+++ b/x-pack/plugin/ql/src/test/resources/mapping-multi-field-variation.json
@@ -2,6 +2,7 @@
     "properties" : {
         "bool" : { "type" : "boolean" },
         "int" : { "type" : "integer" },
+        "float" : { "type" : "float" },
         "text" : { "type" : "text" },
         "keyword" : { "type" : "keyword" },
         "date" :  { "type" : "date" },

--- a/x-pack/plugin/sql/qa/server/src/main/resources/arithmetic.sql-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/arithmetic.sql-spec
@@ -87,3 +87,7 @@ orderByModulo
 SELECT emp_no FROM test_emp ORDER BY emp_no % 10000 LIMIT 10;
 orderByMul
 SELECT emp_no FROM test_emp ORDER BY emp_no * 2 LIMIT 10;
+
+// negations optimiser
+multipleNegations
+SELECT emp_no FROM test_emp WHERE ((1000000000 / -salary) / 2) * (-1 / (2 / -emp_no::FLOAT)) / -1000 >= 50000;

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/operator/arithmetic/SqlBinaryArithmeticOperation.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/operator/arithmetic/SqlBinaryArithmeticOperation.java
@@ -52,7 +52,7 @@ public enum SqlBinaryArithmeticOperation implements BinaryArithmeticOperation {
             return IntervalArithmetics.add((Temporal) r, ((IntervalDayTime) l).interval());
         }
 
-        throw new QlIllegalArgumentException("Cannot compute [+] between [{}] [{}]", l.getClass().getSimpleName(),
+        throw new QlIllegalArgumentException("Cannot compute [+] between [{}] and [{}]", l.getClass().getSimpleName(),
                 r.getClass().getSimpleName());
     }, "+"),
     SUB((Object l, Object r) -> {
@@ -77,7 +77,7 @@ public enum SqlBinaryArithmeticOperation implements BinaryArithmeticOperation {
             throw new QlIllegalArgumentException("Cannot subtract a date from an interval; do you mean the reverse?");
         }
 
-        throw new QlIllegalArgumentException("Cannot compute [-] between [{}] [{}]", l.getClass().getSimpleName(),
+        throw new QlIllegalArgumentException("Cannot compute [-] between [{}] and [{}]", l.getClass().getSimpleName(),
                 r.getClass().getSimpleName());
     }, "-"),
     MUL((Object l, Object r) -> {
@@ -99,7 +99,7 @@ public enum SqlBinaryArithmeticOperation implements BinaryArithmeticOperation {
             return ((IntervalDayTime) l).mul(((Number) r).longValue());
         }
 
-        throw new QlIllegalArgumentException("Cannot compute [*] between [{}] [{}]", l.getClass().getSimpleName(),
+        throw new QlIllegalArgumentException("Cannot compute [*] between [{}] and [{}]", l.getClass().getSimpleName(),
                 r.getClass().getSimpleName());
     }, "*"),
     DIV(Arithmetics::div, "/"),

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/optimizer/Optimizer.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/optimizer/Optimizer.java
@@ -36,6 +36,7 @@ import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.NotEq
 import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.NullEquals;
 import org.elasticsearch.xpack.ql.optimizer.OptimizerRules.BooleanLiteralsOnTheRight;
 import org.elasticsearch.xpack.ql.optimizer.OptimizerRules.BooleanSimplification;
+import org.elasticsearch.xpack.ql.optimizer.OptimizerRules.BubbleUpNegations;
 import org.elasticsearch.xpack.ql.optimizer.OptimizerRules.CombineBinaryComparisons;
 import org.elasticsearch.xpack.ql.optimizer.OptimizerRules.ConstantFolding;
 import org.elasticsearch.xpack.ql.optimizer.OptimizerRules.OptimizerExpressionRule;
@@ -148,6 +149,7 @@ public class Optimizer extends RuleExecutor<LogicalPlan> {
                 new PropagateEquals(),
                 new CombineBinaryComparisons(),
                 new CombineDisjunctionsToIn(),
+                new BubbleUpNegations(),
                 // prune/elimination
                 new PruneLiteralsInGroupBy(),
                 new PruneDuplicatesInGroupBy(),
@@ -158,7 +160,7 @@ public class Optimizer extends RuleExecutor<LogicalPlan> {
                 new PruneCast(),
                 // order by alignment of the aggs
                 new SortAggregateOnOrderBy()
-                );
+        );
 
         Batch aggregate = new Batch("Aggregation Rewrite",
                 new ReplaceMinMaxWithTopHits(),

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/FieldAttributeTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/FieldAttributeTests.java
@@ -165,7 +165,7 @@ public class FieldAttributeTests extends ESTestCase {
     public void testStarExpansionExcludesObjectAndUnsupportedTypes() {
         LogicalPlan plan = plan("SELECT * FROM test");
         List<? extends NamedExpression> list = ((Project) plan).projections();
-        assertThat(list, hasSize(10));
+        assertThat(list, hasSize(11));
         List<String> names = Expressions.names(list);
         assertThat(names, not(hasItem("some")));
         assertThat(names, not(hasItem("some.dotted")));

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/predicate/operator/arithmetic/SqlBinaryArithmeticTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/predicate/operator/arithmetic/SqlBinaryArithmeticTests.java
@@ -136,7 +136,7 @@ public class SqlBinaryArithmeticTests extends ESTestCase {
     public void testAddNumberToIntervalIllegal() {
         Literal r = interval(Duration.ofHours(2), INTERVAL_HOUR);
         QlIllegalArgumentException expect = expectThrows(QlIllegalArgumentException.class, () -> add(r, L(1)));
-        assertEquals("Cannot compute [+] between [IntervalDayTime] [Integer]", expect.getMessage());
+        assertEquals("Cannot compute [+] between [IntervalDayTime] and [Integer]", expect.getMessage());
     }
 
     public void testSubYearMonthIntervals() {
@@ -210,7 +210,7 @@ public class SqlBinaryArithmeticTests extends ESTestCase {
     public void testSubNumberFromIntervalIllegal() {
         Literal r = interval(Duration.ofHours(2), INTERVAL_HOUR);
         QlIllegalArgumentException expect = expectThrows(QlIllegalArgumentException.class, () -> sub(r, L(1)));
-        assertEquals("Cannot compute [-] between [IntervalDayTime] [Integer]", expect.getMessage());
+        assertEquals("Cannot compute [-] between [IntervalDayTime] and [Integer]", expect.getMessage());
     }
 
     public void testMulIntervalNumber() {

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/optimizer/OptimizerRunTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/optimizer/OptimizerRunTests.java
@@ -5,11 +5,27 @@
  */
 package org.elasticsearch.xpack.sql.optimizer;
 
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.ql.expression.Expression;
+import org.elasticsearch.xpack.ql.expression.FieldAttribute;
+import org.elasticsearch.xpack.ql.expression.Literal;
+import org.elasticsearch.xpack.ql.expression.UnresolvedAttribute;
 import org.elasticsearch.xpack.ql.expression.function.FunctionRegistry;
+import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.BinaryComparison;
+import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.Equals;
+import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.GreaterThan;
+import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.GreaterThanOrEqual;
+import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.LessThan;
+import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.LessThanOrEqual;
+import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.NotEquals;
+import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.NullEquals;
 import org.elasticsearch.xpack.ql.index.EsIndex;
 import org.elasticsearch.xpack.ql.index.IndexResolution;
+import org.elasticsearch.xpack.ql.optimizer.OptimizerRules.BooleanLiteralsOnTheRight;
+import org.elasticsearch.xpack.ql.plan.logical.Filter;
 import org.elasticsearch.xpack.ql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.ql.plan.logical.UnaryPlan;
 import org.elasticsearch.xpack.ql.type.EsField;
 import org.elasticsearch.xpack.sql.SqlTestUtils;
 import org.elasticsearch.xpack.sql.analysis.analyzer.Analyzer;
@@ -18,7 +34,19 @@ import org.elasticsearch.xpack.sql.parser.SqlParser;
 import org.elasticsearch.xpack.sql.stats.Metrics;
 import org.elasticsearch.xpack.sql.types.SqlTypesTests;
 
+import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.BinaryComparisonProcessor.BinaryComparisonOperation.EQ;
+import static org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.BinaryComparisonProcessor.BinaryComparisonOperation.GT;
+import static org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.BinaryComparisonProcessor.BinaryComparisonOperation.GTE;
+import static org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.BinaryComparisonProcessor.BinaryComparisonOperation.LT;
+import static org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.BinaryComparisonProcessor.BinaryComparisonOperation.LTE;
+import static org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.BinaryComparisonProcessor.BinaryComparisonOperation.NEQ;
+import static org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.BinaryComparisonProcessor.BinaryComparisonOperation.NULLEQ;
 
 public class OptimizerRunTests extends ESTestCase {
 
@@ -27,6 +55,7 @@ public class OptimizerRunTests extends ESTestCase {
     private final FunctionRegistry functionRegistry;
     private final Analyzer analyzer;
     private final Optimizer optimizer;
+    private static final BooleanLiteralsOnTheRight LITERALS_ON_THE_RIGHT = new BooleanLiteralsOnTheRight();
 
     public OptimizerRunTests() {
         parser = new SqlParser();
@@ -47,5 +76,42 @@ public class OptimizerRunTests extends ESTestCase {
     public void testWhereClause() {
         LogicalPlan p = plan("SELECT some.string l FROM test WHERE int IS NOT NULL AND int < 10005 ORDER BY int");
         assertNotNull(p);
+    }
+
+    public void testBubbleUpNegation() {
+        String provided = "(1 / -int) * (-float) * (-float / (2 / -int)) * -2 * (-float - int) * (-(-int)) * (-float / (-int + 1)) > 1";
+        String expected = "- ((1/int) * float * (float / (2 / int)) * -2 * (-float - int) * int * (float / (-int + 1))) > 1";
+        BinaryComparison bc = extractBinaryComparison(provided);
+        Expression exp = parser.createExpression(expected);
+        assertSemanticMatching(bc, exp);
+    }
+
+    private BinaryComparison extractBinaryComparison(String expression) {
+        LogicalPlan plan = planWithArithmeticCondition(expression);
+
+        assertTrue(plan instanceof UnaryPlan);
+        UnaryPlan unaryPlan = (UnaryPlan) plan;
+        assertTrue(unaryPlan.child() instanceof Filter);
+        Filter filter = (Filter) unaryPlan.child();
+        assertTrue(filter.condition() instanceof BinaryComparison);
+        return (BinaryComparison) filter.condition();
+    }
+
+    private LogicalPlan planWithArithmeticCondition(String condition) {
+        return plan("SELECT some.string FROM test WHERE " + condition);
+    }
+
+    private static void assertSemanticMatching(Expression fieldAttributeExp, Expression unresolvedAttributeExp) {
+        Expression unresolvedUpdated = unresolvedAttributeExp
+            .transformUp(LITERALS_ON_THE_RIGHT::rule)
+            .transformUp(x -> x.foldable() ? new Literal(x.source(), x.fold(), x.dataType()) : x);
+
+        List<Expression> resolvedFields = fieldAttributeExp.collectFirstChildren(x -> x instanceof FieldAttribute);
+        for (Expression field : resolvedFields) {
+            FieldAttribute fa = (FieldAttribute) field;
+            unresolvedUpdated = unresolvedUpdated.transformDown(UnresolvedAttribute.class, x -> x.name().equals(fa.name()) ? fa : x);
+        }
+
+        assertTrue(unresolvedUpdated.semanticEquals(fieldAttributeExp));
     }
 }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/optimizer/OptimizerRunTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/optimizer/OptimizerRunTests.java
@@ -5,7 +5,6 @@
  */
 package org.elasticsearch.xpack.sql.optimizer;
 
-import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.FieldAttribute;
@@ -13,13 +12,6 @@ import org.elasticsearch.xpack.ql.expression.Literal;
 import org.elasticsearch.xpack.ql.expression.UnresolvedAttribute;
 import org.elasticsearch.xpack.ql.expression.function.FunctionRegistry;
 import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.BinaryComparison;
-import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.Equals;
-import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.GreaterThan;
-import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.GreaterThanOrEqual;
-import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.LessThan;
-import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.LessThanOrEqual;
-import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.NotEquals;
-import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.NullEquals;
 import org.elasticsearch.xpack.ql.index.EsIndex;
 import org.elasticsearch.xpack.ql.index.IndexResolution;
 import org.elasticsearch.xpack.ql.optimizer.OptimizerRules.BooleanLiteralsOnTheRight;
@@ -34,19 +26,8 @@ import org.elasticsearch.xpack.sql.parser.SqlParser;
 import org.elasticsearch.xpack.sql.stats.Metrics;
 import org.elasticsearch.xpack.sql.types.SqlTypesTests;
 
-import java.time.ZonedDateTime;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-
-import static org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.BinaryComparisonProcessor.BinaryComparisonOperation.EQ;
-import static org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.BinaryComparisonProcessor.BinaryComparisonOperation.GT;
-import static org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.BinaryComparisonProcessor.BinaryComparisonOperation.GTE;
-import static org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.BinaryComparisonProcessor.BinaryComparisonOperation.LT;
-import static org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.BinaryComparisonProcessor.BinaryComparisonOperation.LTE;
-import static org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.BinaryComparisonProcessor.BinaryComparisonOperation.NEQ;
-import static org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.BinaryComparisonProcessor.BinaryComparisonOperation.NULLEQ;
 
 public class OptimizerRunTests extends ESTestCase {
 

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysColumnsTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysColumnsTests.java
@@ -58,7 +58,7 @@ public class SysColumnsTests extends ESTestCase {
         SysColumns.fillInRows("test", "index", loadMapping("mapping-multi-field-variation.json", true), null, rows, null,
                 randomValueOtherThanMany(Mode::isDriver, () -> randomFrom(Mode.values())));
         // nested fields are ignored
-        assertEquals(15, rows.size());
+        assertEquals(16, rows.size());
         assertEquals(24, rows.get(0).size());
 
         List<?> row = rows.get(0);
@@ -74,67 +74,73 @@ public class SysColumnsTests extends ESTestCase {
         assertEquals(4, bufferLength(row));
 
         row = rows.get(2);
-        assertEquals("text", name(row));
-        assertEquals(Types.VARCHAR, sqlType(row));
-        assertEquals(null, radix(row));
-        assertEquals(Integer.MAX_VALUE, bufferLength(row));
-        
+        assertEquals("float", name(row));
+        assertEquals(Types.REAL, sqlType(row));
+        assertEquals(2, radix(row));
+        assertEquals(4, bufferLength(row));
+
         row = rows.get(3);
-        assertEquals("keyword", name(row));
+        assertEquals("text", name(row));
         assertEquals(Types.VARCHAR, sqlType(row));
         assertEquals(null, radix(row));
         assertEquals(Integer.MAX_VALUE, bufferLength(row));
 
         row = rows.get(4);
+        assertEquals("keyword", name(row));
+        assertEquals(Types.VARCHAR, sqlType(row));
+        assertEquals(null, radix(row));
+        assertEquals(Integer.MAX_VALUE, bufferLength(row));
+
+        row = rows.get(5);
         assertEquals("date", name(row));
         assertEquals(Types.TIMESTAMP, sqlType(row));
         assertEquals(null, radix(row));
         assertEquals(29, precision(row));
         assertEquals(8, bufferLength(row));
 
-        row = rows.get(5);
+        row = rows.get(6);
         assertEquals("some.dotted.field", name(row));
         assertEquals(Types.VARCHAR, sqlType(row));
         assertEquals(null, radix(row));
         assertEquals(Integer.MAX_VALUE, bufferLength(row));
 
-        row = rows.get(6);
+        row = rows.get(7);
         assertEquals("some.string", name(row));
         assertEquals(Types.VARCHAR, sqlType(row));
         assertEquals(null, radix(row));
         assertEquals(Integer.MAX_VALUE, bufferLength(row));
-        
-        row = rows.get(7);
+
+        row = rows.get(8);
         assertEquals("some.string.normalized", name(row));
         assertEquals(Types.VARCHAR, sqlType(row));
         assertEquals(null, radix(row));
         assertEquals(Integer.MAX_VALUE, bufferLength(row));
-        
-        row = rows.get(8);
+
+        row = rows.get(9);
         assertEquals("some.string.typical", name(row));
         assertEquals(Types.VARCHAR, sqlType(row));
         assertEquals(null, radix(row));
         assertEquals(Integer.MAX_VALUE, bufferLength(row));
-        
-        row = rows.get(9);
+
+        row = rows.get(10);
         assertEquals("some.ambiguous", name(row));
         assertEquals(Types.VARCHAR, sqlType(row));
         assertEquals(null, radix(row));
         assertEquals(Integer.MAX_VALUE, bufferLength(row));
-        
-        row = rows.get(10);
-        assertEquals("some.ambiguous.one", name(row));
-        assertEquals(Types.VARCHAR, sqlType(row));
-        assertEquals(null, radix(row));
-        assertEquals(Integer.MAX_VALUE, bufferLength(row));
-        
+
         row = rows.get(11);
-        assertEquals("some.ambiguous.two", name(row));
+        assertEquals("some.ambiguous.one", name(row));
         assertEquals(Types.VARCHAR, sqlType(row));
         assertEquals(null, radix(row));
         assertEquals(Integer.MAX_VALUE, bufferLength(row));
 
         row = rows.get(12);
+        assertEquals("some.ambiguous.two", name(row));
+        assertEquals(Types.VARCHAR, sqlType(row));
+        assertEquals(null, radix(row));
+        assertEquals(Integer.MAX_VALUE, bufferLength(row));
+
+        row = rows.get(13);
         assertEquals("some.ambiguous.normalized", name(row));
         assertEquals(Types.VARCHAR, sqlType(row));
         assertEquals(null, radix(row));
@@ -145,7 +151,7 @@ public class SysColumnsTests extends ESTestCase {
         List<List<?>> rows = new ArrayList<>();
         SysColumns.fillInRows("test", "index", loadMapping("mapping-multi-field-variation.json", true), null, rows, null,
                 Mode.ODBC);
-        assertEquals(15, rows.size());
+        assertEquals(16, rows.size());
         assertEquals(24, rows.get(0).size());
 
         List<?> row = rows.get(0);
@@ -165,6 +171,16 @@ public class SysColumnsTests extends ESTestCase {
         assertEquals(Short.class, sqlDataTypeSub(row).getClass());
 
         row = rows.get(2);
+        assertEquals("float", name(row));
+        assertEquals((short) Types.REAL, sqlType(row));
+        assertEquals(Short.class, radix(row).getClass());
+        assertEquals(4, bufferLength(row));
+        assertNull(decimalPrecision(row));
+        assertEquals(Short.class, nullable(row).getClass());
+        assertEquals(Short.class, sqlDataType(row).getClass());
+        assertEquals(Short.class, sqlDataTypeSub(row).getClass());
+
+        row = rows.get(3);
         assertEquals("text", name(row));
         assertEquals((short) Types.VARCHAR, sqlType(row));
         assertEquals(null, radix(row));
@@ -174,7 +190,7 @@ public class SysColumnsTests extends ESTestCase {
         assertEquals(Short.class, sqlDataType(row).getClass());
         assertEquals(Short.class, sqlDataTypeSub(row).getClass());
 
-        row = rows.get(3);
+        row = rows.get(4);
         assertEquals("keyword", name(row));
         assertEquals((short) Types.VARCHAR, sqlType(row));
         assertEquals(null, radix(row));
@@ -184,7 +200,7 @@ public class SysColumnsTests extends ESTestCase {
         assertEquals(Short.class, sqlDataType(row).getClass());
         assertEquals(Short.class, sqlDataTypeSub(row).getClass());
 
-        row = rows.get(4);
+        row = rows.get(5);
         assertEquals("date", name(row));
         assertEquals((short) Types.TIMESTAMP, sqlType(row));
         assertEquals(null, radix(row));
@@ -195,7 +211,7 @@ public class SysColumnsTests extends ESTestCase {
         assertEquals(Short.class, sqlDataType(row).getClass());
         assertEquals(Short.class, sqlDataTypeSub(row).getClass());
 
-        row = rows.get(5);
+        row = rows.get(6);
         assertEquals("some.dotted.field", name(row));
         assertEquals((short) Types.VARCHAR, sqlType(row));
         assertEquals(null, radix(row));
@@ -205,7 +221,7 @@ public class SysColumnsTests extends ESTestCase {
         assertEquals(Short.class, sqlDataType(row).getClass());
         assertEquals(Short.class, sqlDataTypeSub(row).getClass());
 
-        row = rows.get(6);
+        row = rows.get(7);
         assertEquals("some.string", name(row));
         assertEquals((short) Types.VARCHAR, sqlType(row));
         assertEquals(null, radix(row));
@@ -215,7 +231,7 @@ public class SysColumnsTests extends ESTestCase {
         assertEquals(Short.class, sqlDataType(row).getClass());
         assertEquals(Short.class, sqlDataTypeSub(row).getClass());
 
-        row = rows.get(7);
+        row = rows.get(8);
         assertEquals("some.string.normalized", name(row));
         assertEquals((short) Types.VARCHAR, sqlType(row));
         assertEquals(null, radix(row));
@@ -225,7 +241,7 @@ public class SysColumnsTests extends ESTestCase {
         assertEquals(Short.class, sqlDataType(row).getClass());
         assertEquals(Short.class, sqlDataTypeSub(row).getClass());
 
-        row = rows.get(8);
+        row = rows.get(9);
         assertEquals("some.string.typical", name(row));
         assertEquals((short) Types.VARCHAR, sqlType(row));
         assertEquals(null, radix(row));
@@ -235,7 +251,7 @@ public class SysColumnsTests extends ESTestCase {
         assertEquals(Short.class, sqlDataType(row).getClass());
         assertEquals(Short.class, sqlDataTypeSub(row).getClass());
 
-        row = rows.get(9);
+        row = rows.get(10);
         assertEquals("some.ambiguous", name(row));
         assertEquals((short) Types.VARCHAR, sqlType(row));
         assertEquals(null, radix(row));
@@ -244,19 +260,9 @@ public class SysColumnsTests extends ESTestCase {
         assertEquals(Short.class, nullable(row).getClass());
         assertEquals(Short.class, sqlDataType(row).getClass());
         assertEquals(Short.class, sqlDataTypeSub(row).getClass());
-        
-        row = rows.get(10);
-        assertEquals("some.ambiguous.one", name(row));
-        assertEquals((short) Types.VARCHAR, sqlType(row));
-        assertEquals(null, radix(row));
-        assertEquals(Integer.MAX_VALUE, bufferLength(row));
-        assertNull(decimalPrecision(row));
-        assertEquals(Short.class, nullable(row).getClass());
-        assertEquals(Short.class, sqlDataType(row).getClass());
-        assertEquals(Short.class, sqlDataTypeSub(row).getClass());
-        
+
         row = rows.get(11);
-        assertEquals("some.ambiguous.two", name(row));
+        assertEquals("some.ambiguous.one", name(row));
         assertEquals((short) Types.VARCHAR, sqlType(row));
         assertEquals(null, radix(row));
         assertEquals(Integer.MAX_VALUE, bufferLength(row));
@@ -266,6 +272,16 @@ public class SysColumnsTests extends ESTestCase {
         assertEquals(Short.class, sqlDataTypeSub(row).getClass());
 
         row = rows.get(12);
+        assertEquals("some.ambiguous.two", name(row));
+        assertEquals((short) Types.VARCHAR, sqlType(row));
+        assertEquals(null, radix(row));
+        assertEquals(Integer.MAX_VALUE, bufferLength(row));
+        assertNull(decimalPrecision(row));
+        assertEquals(Short.class, nullable(row).getClass());
+        assertEquals(Short.class, sqlDataType(row).getClass());
+        assertEquals(Short.class, sqlDataTypeSub(row).getClass());
+
+        row = rows.get(13);
         assertEquals("some.ambiguous.normalized", name(row));
         assertEquals((short) Types.VARCHAR, sqlType(row));
         assertEquals(null, radix(row));
@@ -275,12 +291,12 @@ public class SysColumnsTests extends ESTestCase {
         assertEquals(Short.class, sqlDataType(row).getClass());
         assertEquals(Short.class, sqlDataTypeSub(row).getClass());
     }
-    
+
     public void testSysColumnsInJdbcMode() {
         List<List<?>> rows = new ArrayList<>();
         SysColumns.fillInRows("test", "index", loadMapping("mapping-multi-field-variation.json", true), null, rows, null,
                 Mode.JDBC);
-        assertEquals(15, rows.size());
+        assertEquals(16, rows.size());
         assertEquals(24, rows.get(0).size());
 
         List<?> row = rows.get(0);
@@ -300,6 +316,16 @@ public class SysColumnsTests extends ESTestCase {
         assertEquals(Integer.class, sqlDataTypeSub(row).getClass());
 
         row = rows.get(2);
+        assertEquals("float", name(row));
+        assertEquals(Types.REAL, sqlType(row));
+        assertEquals(Integer.class, radix(row).getClass());
+        assertEquals(4, bufferLength(row));
+        assertNull(decimalPrecision(row));
+        assertEquals(Integer.class, nullable(row).getClass());
+        assertEquals(Integer.class, sqlDataType(row).getClass());
+        assertEquals(Integer.class, sqlDataTypeSub(row).getClass());
+
+        row = rows.get(3);
         assertEquals("text", name(row));
         assertEquals(Types.VARCHAR, sqlType(row));
         assertEquals(null, radix(row));
@@ -309,7 +335,7 @@ public class SysColumnsTests extends ESTestCase {
         assertEquals(Integer.class, sqlDataType(row).getClass());
         assertEquals(Integer.class, sqlDataTypeSub(row).getClass());
 
-        row = rows.get(3);
+        row = rows.get(4);
         assertEquals("keyword", name(row));
         assertEquals(Types.VARCHAR, sqlType(row));
         assertEquals(null, radix(row));
@@ -319,7 +345,7 @@ public class SysColumnsTests extends ESTestCase {
         assertEquals(Integer.class, sqlDataType(row).getClass());
         assertEquals(Integer.class, sqlDataTypeSub(row).getClass());
 
-        row = rows.get(4);
+        row = rows.get(5);
         assertEquals("date", name(row));
         assertEquals(Types.TIMESTAMP, sqlType(row));
         assertEquals(null, radix(row));
@@ -330,7 +356,7 @@ public class SysColumnsTests extends ESTestCase {
         assertEquals(Integer.class, sqlDataType(row).getClass());
         assertEquals(Integer.class, sqlDataTypeSub(row).getClass());
 
-        row = rows.get(5);
+        row = rows.get(6);
         assertEquals("some.dotted.field", name(row));
         assertEquals(Types.VARCHAR, sqlType(row));
         assertEquals(null, radix(row));
@@ -340,7 +366,7 @@ public class SysColumnsTests extends ESTestCase {
         assertEquals(Integer.class, sqlDataType(row).getClass());
         assertEquals(Integer.class, sqlDataTypeSub(row).getClass());
 
-        row = rows.get(6);
+        row = rows.get(7);
         assertEquals("some.string", name(row));
         assertEquals(Types.VARCHAR, sqlType(row));
         assertEquals(null, radix(row));
@@ -350,7 +376,7 @@ public class SysColumnsTests extends ESTestCase {
         assertEquals(Integer.class, sqlDataType(row).getClass());
         assertEquals(Integer.class, sqlDataTypeSub(row).getClass());
 
-        row = rows.get(7);
+        row = rows.get(8);
         assertEquals("some.string.normalized", name(row));
         assertEquals(Types.VARCHAR, sqlType(row));
         assertEquals(null, radix(row));
@@ -360,7 +386,7 @@ public class SysColumnsTests extends ESTestCase {
         assertEquals(Integer.class, sqlDataType(row).getClass());
         assertEquals(Integer.class, sqlDataTypeSub(row).getClass());
 
-        row = rows.get(8);
+        row = rows.get(9);
         assertEquals("some.string.typical", name(row));
         assertEquals(Types.VARCHAR, sqlType(row));
         assertEquals(null, radix(row));
@@ -369,8 +395,8 @@ public class SysColumnsTests extends ESTestCase {
         assertEquals(Integer.class, nullable(row).getClass());
         assertEquals(Integer.class, sqlDataType(row).getClass());
         assertEquals(Integer.class, sqlDataTypeSub(row).getClass());
-        
-        row = rows.get(9);
+
+        row = rows.get(10);
         assertEquals("some.ambiguous", name(row));
         assertEquals(Types.VARCHAR, sqlType(row));
         assertEquals(null, radix(row));
@@ -379,19 +405,9 @@ public class SysColumnsTests extends ESTestCase {
         assertEquals(Integer.class, nullable(row).getClass());
         assertEquals(Integer.class, sqlDataType(row).getClass());
         assertEquals(Integer.class, sqlDataTypeSub(row).getClass());
-        
-        row = rows.get(10);
-        assertEquals("some.ambiguous.one", name(row));
-        assertEquals(Types.VARCHAR, sqlType(row));
-        assertEquals(null, radix(row));
-        assertEquals(Integer.MAX_VALUE, bufferLength(row));
-        assertNull(decimalPrecision(row));
-        assertEquals(Integer.class, nullable(row).getClass());
-        assertEquals(Integer.class, sqlDataType(row).getClass());
-        assertEquals(Integer.class, sqlDataTypeSub(row).getClass());
-        
+
         row = rows.get(11);
-        assertEquals("some.ambiguous.two", name(row));
+        assertEquals("some.ambiguous.one", name(row));
         assertEquals(Types.VARCHAR, sqlType(row));
         assertEquals(null, radix(row));
         assertEquals(Integer.MAX_VALUE, bufferLength(row));
@@ -401,6 +417,16 @@ public class SysColumnsTests extends ESTestCase {
         assertEquals(Integer.class, sqlDataTypeSub(row).getClass());
 
         row = rows.get(12);
+        assertEquals("some.ambiguous.two", name(row));
+        assertEquals(Types.VARCHAR, sqlType(row));
+        assertEquals(null, radix(row));
+        assertEquals(Integer.MAX_VALUE, bufferLength(row));
+        assertNull(decimalPrecision(row));
+        assertEquals(Integer.class, nullable(row).getClass());
+        assertEquals(Integer.class, sqlDataType(row).getClass());
+        assertEquals(Integer.class, sqlDataTypeSub(row).getClass());
+
+        row = rows.get(13);
         assertEquals("some.ambiguous.normalized", name(row));
         assertEquals(Types.VARCHAR, sqlType(row));
         assertEquals(null, radix(row));


### PR DESCRIPTION
This PR pushes the negations in expressions up the AST:
 * MUL/DIV - NEG - x => NEG - MUL/DIV - x
 * NEG - MUL/DIV - NEG - x => MUL/DIV - x
 * NEG - NEG - x => x

This can potentially simplify the expression, but canceling out two
negations, but also prepares the expression to later be simplified, if
part of a binary comparison.