### PR TITLE
[7.11] [DOCS] Mark template exists API as legacy (#67286)

### DIFF
--- a/docs/reference/indices.asciidoc
+++ b/docs/reference/indices.asciidoc
@@ -64,7 +64,6 @@ For more information, see <<index-templates, Index Templates>>.
 * <<indices-component-template>>
 * <<getting-component-templates>>
 * <<indices-delete-component-template>>
-* <<indices-template-exists>>
 * <<indices-simulate-index>>
 * <<indices-simulate-template>>
 
@@ -150,7 +149,7 @@ include::indices/shard-stores.asciidoc[]
 
 include::indices/stats.asciidoc[]
 
-include::indices/template-exists.asciidoc[]
+include::indices/index-template-exists-v1.asciidoc[]
 
 include::indices/open-close.asciidoc[]
 

--- a/docs/reference/indices/delete-index-template-v1.asciidoc
+++ b/docs/reference/indices/delete-index-template-v1.asciidoc
@@ -7,7 +7,7 @@
 IMPORTANT: This documentation is about <<indices-templates-v1,legacy index
 templates>>, which are deprecated and will be replaced by the composable
 templates introduced in {es} 7.8. For information about composable templates,
-<<indices-templates>>.
+see <<index-templates>>.
 
 Deletes a legacy index template.
 

--- a/docs/reference/indices/get-index-template-v1.asciidoc
+++ b/docs/reference/indices/get-index-template-v1.asciidoc
@@ -6,7 +6,7 @@
 
 IMPORTANT: This documentation is about legacy index templates, 
 which are deprecated and will be replaced by the composable templates introduced in {es} 7.8. 
-For information about composable templates, <<indices-templates>>.
+For information about composable templates, see <<index-templates>>.
 
 Retrieves information about one or more index templates.
 

--- a/docs/reference/indices/index-template-exists-v1.asciidoc
+++ b/docs/reference/indices/index-template-exists-v1.asciidoc
@@ -1,10 +1,15 @@
-[[indices-template-exists]]
+[[indices-template-exists-v1]]
 === Index template exists API
 ++++
-<titleabbrev>Index template exists</titleabbrev>
+<titleabbrev>Index template exists (legacy)</titleabbrev>
 ++++
 
-Checks if an <<index-templates, index template>> exists.
+IMPORTANT: This documentation is about <<indices-templates-v1,legacy index
+templates>>, which are deprecated and will be replaced by the composable
+templates introduced in {es} 7.8. For information about composable templates,
+see <<index-templates>>.
+
+Checks if an <<indices-templates-v1,legacy index template>> exists.
 
 
 

--- a/docs/reference/indices/put-component-template.asciidoc
+++ b/docs/reference/indices/put-component-template.asciidoc
@@ -162,7 +162,7 @@ actual index name that the template gets applied to, during index creation.
 ===== Applying component templates
 
 You cannot directly apply a component template to a data stream or index.
-To be applied, a component template must be included in an index template's `composed_of` list. See <<indices-templates>>.
+To be applied, a component template must be included in an index template's `composed_of` list. See <<index-templates>>.
 
 [[component-templates-version]]
 ===== Component template versioning

--- a/docs/reference/indices/put-index-template-v1.asciidoc
+++ b/docs/reference/indices/put-index-template-v1.asciidoc
@@ -6,7 +6,7 @@
 
 IMPORTANT: This documentation is about legacy index templates, 
 which are deprecated and will be replaced by the composable templates introduced in {es} 7.8. 
-For information about composable templates, <<indices-templates>>.
+For information about composable templates, see <<index-templates>>.
 
 Creates or updates an index template.
 

--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -1075,6 +1075,11 @@ The `xpack.sql.enabled` setting has been deprecated. SQL access is always enable
 
 See <<index-templates>>.
 
+[role="exclude",id="indices-template-exists"]
+=== Index template exists (legacy)
+
+See <<indices-template-exists-v1>>.
+
 [role="exclude",id="run-a-search"]
 === Run a search
 


### PR DESCRIPTION
Backports the following commits to 7.11:
 - [DOCS] Mark template exists API as legacy (#67286)