### PR TITLE
[7.x] [DOCS] Update example for GET /_cat/aliases (#67263)

### DIFF
--- a/docs/reference/cat/alias.asciidoc
+++ b/docs/reference/cat/alias.asciidoc
@@ -73,7 +73,7 @@ PUT test1
 
 [source,console]
 --------------------------------------------------
-GET /_cat/aliases?v
+GET /_cat/aliases?v=true
 --------------------------------------------------
 // TEST[continued]
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Update example for GET /_cat/aliases (#67263)