### PR TITLE
[7.11] [DOCS] Make cat API verbose query param explicit (#67300)

### DIFF
--- a/docs/reference/cat.asciidoc
+++ b/docs/reference/cat.asciidoc
@@ -34,7 +34,7 @@ verbose output. For example:
 
 [source,console]
 --------------------------------------------------
-GET /_cat/master?v
+GET /_cat/master?v=true
 --------------------------------------------------
 
 Might respond with:
@@ -119,7 +119,7 @@ by shard storage in descending order.
 
 [source,console]
 --------------------------------------------------
-GET /_cat/indices?bytes=b&s=store.size:desc&v
+GET /_cat/indices?bytes=b&s=store.size:desc&v=true
 --------------------------------------------------
 // TEST[setup:my_index_huge]
 // TEST[s/^/PUT my-index-000002\n{"settings": {"number_of_replicas": 0}}\n/]
@@ -210,7 +210,7 @@ order by column3.
 
 [source,sh]
 --------------------------------------------------
-GET _cat/templates?v&s=order:desc,index_patterns
+GET _cat/templates?v=true&s=order:desc,index_patterns
 --------------------------------------------------
 //CONSOLE
 

--- a/docs/reference/cat/allocation.asciidoc
+++ b/docs/reference/cat/allocation.asciidoc
@@ -45,7 +45,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-v]
 
 [source,console]
 --------------------------------------------------
-GET /_cat/allocation?v
+GET /_cat/allocation?v=true
 --------------------------------------------------
 // TEST[s/^/PUT test\n{"settings": {"number_of_replicas": 0}}\n/]
 

--- a/docs/reference/cat/anomaly-detectors.asciidoc
+++ b/docs/reference/cat/anomaly-detectors.asciidoc
@@ -268,7 +268,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-v]
 
 [source,console]
 --------------------------------------------------
-GET _cat/ml/anomaly_detectors?h=id,s,dpr,mb&v
+GET _cat/ml/anomaly_detectors?h=id,s,dpr,mb&v=true
 --------------------------------------------------
 // TEST[skip:kibana sample data]
 

--- a/docs/reference/cat/count.asciidoc
+++ b/docs/reference/cat/count.asciidoc
@@ -55,7 +55,7 @@ The following `count` API request retrieves the document count for the
 
 [source,console]
 --------------------------------------------------
-GET /_cat/count/my-index-000001?v
+GET /_cat/count/my-index-000001?v=true
 --------------------------------------------------
 // TEST[setup:my_index_big]
 
@@ -77,7 +77,7 @@ streams and indices in the cluster.
 
 [source,console]
 --------------------------------------------------
-GET /_cat/count?v
+GET /_cat/count?v=true
 --------------------------------------------------
 // TEST[setup:my_index_big]
 // TEST[s/^/POST test\/_doc\?refresh\n{"test": "test"}\n/]

--- a/docs/reference/cat/datafeeds.asciidoc
+++ b/docs/reference/cat/datafeeds.asciidoc
@@ -116,7 +116,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-v]
 
 [source,console]
 --------------------------------------------------
-GET _cat/ml/datafeeds?v
+GET _cat/ml/datafeeds?v=true
 --------------------------------------------------
 // TEST[skip:kibana sample data]
 

--- a/docs/reference/cat/dataframeanalytics.asciidoc
+++ b/docs/reference/cat/dataframeanalytics.asciidoc
@@ -122,7 +122,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-v]
 
 [source,console]
 --------------------------------------------------
-GET _cat/ml/data_frame/analytics?v
+GET _cat/ml/data_frame/analytics?v=true
 --------------------------------------------------
 // TEST[skip:kibana sample data]
 

--- a/docs/reference/cat/fielddata.asciidoc
+++ b/docs/reference/cat/fielddata.asciidoc
@@ -88,7 +88,7 @@ following `fieldata` API request retrieves heap memory size information for the
 
 [source,console]
 --------------------------------------------------
-GET /_cat/fielddata?v&fields=body
+GET /_cat/fielddata?v=true&fields=body
 --------------------------------------------------
 // TEST[continued]
 
@@ -112,7 +112,7 @@ information for the `body` and `soul` fields.
 
 [source,console]
 --------------------------------------------------
-GET /_cat/fielddata/body,soul?v
+GET /_cat/fielddata/body,soul?v=true
 --------------------------------------------------
 // TEST[continued]
 
@@ -138,7 +138,7 @@ information all fields.
 
 [source,console]
 --------------------------------------------------
-GET /_cat/fielddata?v
+GET /_cat/fielddata?v=true
 --------------------------------------------------
 // TEST[continued]
 

--- a/docs/reference/cat/health.asciidoc
+++ b/docs/reference/cat/health.asciidoc
@@ -67,7 +67,7 @@ By default, the cat health API returns `HH:MM:SS` and
 
 [source,console]
 --------------------------------------------------
-GET /_cat/health?v
+GET /_cat/health?v=true
 --------------------------------------------------
 // TEST[s/^/PUT my-index-000001\n{"settings":{"number_of_replicas": 0}}\n/]
 
@@ -87,7 +87,7 @@ You can use the `ts` (timestamps) parameter to disable timestamps. For example:
 
 [source,console]
 --------------------------------------------------
-GET /_cat/health?v&ts=false
+GET /_cat/health?v=true&ts=false
 --------------------------------------------------
 // TEST[s/^/PUT my-index-000001\n{"settings":{"number_of_replicas": 0}}\n/]
 

--- a/docs/reference/cat/indices.asciidoc
+++ b/docs/reference/cat/indices.asciidoc
@@ -101,7 +101,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 [[examples]]
 [source,console]
 --------------------------------------------------
-GET /_cat/indices/my-index-*?v&s=index
+GET /_cat/indices/my-index-*?v=true&s=index
 --------------------------------------------------
 // TEST[setup:my_index_huge]
 // TEST[s/^/PUT my-index-000002\n{"settings": {"number_of_replicas": 0}}\n/]

--- a/docs/reference/cat/master.asciidoc
+++ b/docs/reference/cat/master.asciidoc
@@ -37,7 +37,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-v]
 
 [source,console]
 --------------------------------------------------
-GET /_cat/master?v
+GET /_cat/master?v=true
 --------------------------------------------------
 
 The API returns the following response:

--- a/docs/reference/cat/nodeattrs.asciidoc
+++ b/docs/reference/cat/nodeattrs.asciidoc
@@ -67,9 +67,9 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-v]
 
 [source,console]
 --------------------------------------------------
-GET /_cat/nodeattrs?v
+GET /_cat/nodeattrs?v=true
 --------------------------------------------------
-// TEST[s/\?v/\?v&s=node,attr/]
+// TEST[s/\?v=true/\?v=true&s=node,attr/]
 // Sort the resulting attributes so we can assert on them more easily
 
 The API returns the following response:
@@ -98,7 +98,7 @@ columns.
 
 [source,console]
 --------------------------------------------------
-GET /_cat/nodeattrs?v&h=name,pid,attr,value
+GET /_cat/nodeattrs?v=true&h=name,pid,attr,value
 --------------------------------------------------
 // TEST[s/,value/,value&s=node,attr/]
 // Sort the resulting attributes so we can assert on them more easily

--- a/docs/reference/cat/nodes.asciidoc
+++ b/docs/reference/cat/nodes.asciidoc
@@ -319,7 +319,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-v]
 
 [source,console]
 --------------------------------------------------
-GET /_cat/nodes?v
+GET /_cat/nodes?v=true
 --------------------------------------------------
 
 The API returns the following response:
@@ -347,7 +347,7 @@ The following API request returns the `id`, `ip`, `port`, `v` (version), and `m`
 
 [source,console]
 --------------------------------------------------
-GET /_cat/nodes?v&h=id,ip,port,v,m
+GET /_cat/nodes?v=true&h=id,ip,port,v,m
 --------------------------------------------------
 
 The API returns the following response:

--- a/docs/reference/cat/pending_tasks.asciidoc
+++ b/docs/reference/cat/pending_tasks.asciidoc
@@ -37,7 +37,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-v]
 
 [source,console]
 --------------------------------------------------
-GET /_cat/pending_tasks?v
+GET /_cat/pending_tasks?v=true
 --------------------------------------------------
 
 The API returns the following response:

--- a/docs/reference/cat/plugins.asciidoc
+++ b/docs/reference/cat/plugins.asciidoc
@@ -36,7 +36,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-v]
 
 [source,console]
 ------------------------------------------------------------------------------
-GET /_cat/plugins?v&s=component&h=name,component,version,description
+GET /_cat/plugins?v=true&s=component&h=name,component,version,description
 ------------------------------------------------------------------------------
 
 The API returns the following response:

--- a/docs/reference/cat/recovery.asciidoc
+++ b/docs/reference/cat/recovery.asciidoc
@@ -73,7 +73,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-v]
 
 [source,console]
 ----------------------------------------------------------------------------
-GET _cat/recovery?v
+GET _cat/recovery?v=true
 ----------------------------------------------------------------------------
 // TEST[setup:my_index]
 
@@ -102,7 +102,7 @@ host the replicas, you can retrieve information about an ongoing recovery.
 
 [source,console]
 ----------------------------------------------------------------------------
-GET _cat/recovery?v&h=i,s,t,ty,st,shost,thost,f,fp,b,bp
+GET _cat/recovery?v=true&h=i,s,t,ty,st,shost,thost,f,fp,b,bp
 ----------------------------------------------------------------------------
 // TEST[setup:my_index]
 
@@ -132,7 +132,7 @@ snapshot recovery.
 
 [source,console]
 --------------------------------------------------------------------------------
-GET _cat/recovery?v&h=i,s,t,ty,st,rep,snap,f,fp,b,bp
+GET _cat/recovery?v=true&h=i,s,t,ty,st,rep,snap,f,fp,b,bp
 --------------------------------------------------------------------------------
 // TEST[skip:no need to execute snapshot/restore here]
 

--- a/docs/reference/cat/repositories.asciidoc
+++ b/docs/reference/cat/repositories.asciidoc
@@ -36,7 +36,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-v]
 
 [source,console]
 --------------------------------------------------
-GET /_cat/repositories?v
+GET /_cat/repositories?v=true
 --------------------------------------------------
 // TEST[s/^/PUT \/_snapshot\/repo1\n{"type": "fs", "settings": {"location": "repo\/1"}}\n/]
 

--- a/docs/reference/cat/segments.asciidoc
+++ b/docs/reference/cat/segments.asciidoc
@@ -114,7 +114,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-v]
 
 [source,console]
 --------------------------------------------------
-GET /_cat/segments?v
+GET /_cat/segments?v=true
 --------------------------------------------------
 // TEST[s/^/PUT \/test\/test\/1?refresh\n{"test":"test"}\nPUT \/test1\/test\/1?refresh\n{"test":"test"}\n/]
 

--- a/docs/reference/cat/snapshots.asciidoc
+++ b/docs/reference/cat/snapshots.asciidoc
@@ -110,7 +110,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-v]
 
 [source,console]
 --------------------------------------------------
-GET /_cat/snapshots/repo1?v&s=id
+GET /_cat/snapshots/repo1?v=true&s=id
 --------------------------------------------------
 // TEST[s/^/PUT \/_snapshot\/repo1\/snap1?wait_for_completion=true\n/]
 // TEST[s/^/PUT \/_snapshot\/repo1\/snap2?wait_for_completion=true\n/]

--- a/docs/reference/cat/tasks.asciidoc
+++ b/docs/reference/cat/tasks.asciidoc
@@ -64,7 +64,7 @@ include::{es-repo-dir}/cluster/tasks.asciidoc[tag=tasks-api-404]
 
 [source,console]
 ----
-GET _cat/tasks?v
+GET _cat/tasks?v=true
 ----
 // TEST[skip:No tasks to retrieve]
 

--- a/docs/reference/cat/templates.asciidoc
+++ b/docs/reference/cat/templates.asciidoc
@@ -48,7 +48,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-v]
 
 [source,console]
 ----
-GET _cat/templates/my-template-*?v&s=name
+GET _cat/templates/my-template-*?v=true&s=name
 ----
 // TEST[s/^/PUT _index_template\/my-template-0\n{"index_patterns": "te*", "priority": 200}\n/]
 // TEST[s/^/PUT _index_template\/my-template-1\n{"index_patterns": "tea*", "priority": 201}\n/]

--- a/docs/reference/cat/thread_pool.asciidoc
+++ b/docs/reference/cat/thread_pool.asciidoc
@@ -159,7 +159,7 @@ thread pool.
 
 [source,console]
 --------------------------------------------------
-GET /_cat/thread_pool/generic?v&h=id,name,active,rejected,completed
+GET /_cat/thread_pool/generic?v=true&h=id,name,active,rejected,completed
 --------------------------------------------------
 
 The API returns the following response:

--- a/docs/reference/cat/trainedmodel.asciidoc
+++ b/docs/reference/cat/trainedmodel.asciidoc
@@ -110,7 +110,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-v]
 
 [source,console]
 --------------------------------------------------
-GET _cat/ml/trained_models?h=c,o,l,ct,v&v
+GET _cat/ml/trained_models?h=c,o,l,ct,v&v=ture
 --------------------------------------------------
 // TEST[skip:kibana sample data]
 

--- a/docs/reference/cat/transforms.asciidoc
+++ b/docs/reference/cat/transforms.asciidoc
@@ -170,7 +170,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-v]
 
 [source,console]
 --------------------------------------------------
-GET /_cat/transforms?v&format=json
+GET /_cat/transforms?v=true&format=json
 --------------------------------------------------
 // TEST[skip:kibana sample data]
 

--- a/docs/reference/eql/detect-threats-with-eql.asciidoc
+++ b/docs/reference/eql/detect-threats-with-eql.asciidoc
@@ -50,7 +50,7 @@ curl -H "Content-Type: application/json" -XPOST "localhost:9200/my-index-000001/
 +
 [source,console]
 ----
-GET /_cat/indices/my-index-000001?v&h=health,status,index,docs.count
+GET /_cat/indices/my-index-000001?v=true&h=health,status,index,docs.count
 ----
 // TEST[setup:atomic_red_regsvr32]
 +

--- a/docs/reference/frozen-indices.asciidoc
+++ b/docs/reference/frozen-indices.asciidoc
@@ -95,7 +95,7 @@ Frozen indices are ordinary indices that use search throttling and a memory effi
 
 [source,console]
 --------------------------------------------------
-GET /_cat/indices/my-index-000001?v&h=i,sth
+GET /_cat/indices/my-index-000001?v=true&h=i,sth
 --------------------------------------------------
 // TEST[s/^/PUT my-index-000001\nPOST my-index-000001\/_freeze\n/]
 

--- a/docs/reference/getting-started.asciidoc
+++ b/docs/reference/getting-started.asciidoc
@@ -165,7 +165,7 @@ clients] when you're ready to start using {es} in your own applications.
 +
 [source,console]
 --------------------------------------------------
-GET /_cat/health?v
+GET /_cat/health?v=true
 --------------------------------------------------
 +
 The response should indicate that the status of the `elasticsearch` cluster
@@ -353,7 +353,7 @@ To get some data into {es} that you can start searching and analyzing:
 [source,sh]
 --------------------------------------------------
 curl -H "Content-Type: application/json" -XPOST "localhost:9200/bank/_bulk?pretty&refresh" --data-binary "@accounts.json"
-curl "localhost:9200/_cat/indices?v"
+curl "localhost:9200/_cat/indices?v=true"
 --------------------------------------------------
 // NOTCONSOLE
 +
@@ -363,7 +363,7 @@ in the docs:
 +
 [source,console]
 --------------------------------------------------
-GET /_cat/indices?v
+GET /_cat/indices?v=true
 --------------------------------------------------
 // TEST[setup:bank]
 ////

--- a/docs/reference/how-to/size-your-shards.asciidoc
+++ b/docs/reference/how-to/size-your-shards.asciidoc
@@ -151,7 +151,7 @@ API>>.
 
 [source,console]
 ----
-GET _cat/nodes?v&h=heap.current
+GET _cat/nodes?v=true&h=heap.current
 ----
 // TEST[setup:my_index]
 
@@ -224,7 +224,7 @@ You can find these empty indices using the <<cat-count,cat count API>>.
 
 [source,console]
 ----
-GET /_cat/count/my-index-000001?v
+GET /_cat/count/my-index-000001?v=true
 ----
 // TEST[setup:my_index]
 

--- a/docs/reference/ingest/apis/simulate-pipeline.asciidoc
+++ b/docs/reference/ingest/apis/simulate-pipeline.asciidoc
@@ -298,7 +298,7 @@ you can add the `verbose` parameter to the request.
 
 [source,console]
 ----
-POST /_ingest/pipeline/_simulate?verbose
+POST /_ingest/pipeline/_simulate?verbose=true
 {
   "pipeline" :
   {

--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -120,7 +120,7 @@ docker-compose up
 +
 [source,sh]
 --------------------------------------------------
-curl -X GET "localhost:9200/_cat/nodes?v&pretty"
+curl -X GET "localhost:9200/_cat/nodes?v=true&pretty"
 --------------------------------------------------
 // NOTCONSOLE
 

--- a/docs/reference/upgrade/rolling_upgrade.asciidoc
+++ b/docs/reference/upgrade/rolling_upgrade.asciidoc
@@ -142,7 +142,7 @@ You can check progress by submitting a <<cat-health,`_cat/health`>> request:
 
 [source,console]
 --------------------------------------------------
-GET _cat/health?v
+GET _cat/health?v=true
 --------------------------------------------------
 
 Wait for the `status` column to switch to `green`. Once the node is `green`, all
@@ -189,14 +189,14 @@ with a <<cat-health,`_cat/health`>> request:
 
 [source,console]
 --------------------------------------------------
-GET /_cat/health?v
+GET /_cat/health?v=true
 --------------------------------------------------
 
 And check which nodes have been upgraded with a <<cat-nodes,`_cat/nodes`>> request:
 
 [source,console]
 --------------------------------------------------
-GET /_cat/nodes?h=ip,name,version&v
+GET /_cat/nodes?h=ip,name,version&v=true
 --------------------------------------------------
 
 --

--- a/x-pack/docs/en/security/securing-communications/tutorial-tls-addnodes.asciidoc
+++ b/x-pack/docs/en/security/securing-communications/tutorial-tls-addnodes.asciidoc
@@ -164,7 +164,7 @@ node:
 
 [source,console]
 ----------------------------------
-GET _cat/nodes?v
+GET _cat/nodes?v=true
 ----------------------------------
 
 The node that has an asterisk(*) in the `master` column is the elected master


### PR DESCRIPTION
Backports the following commits to 7.11:
 - [DOCS] Make cat API verbose query param explicit (#67300)