### PR TITLE
Fix NPE when validating composable template with no template

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutComposableIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutComposableIndexTemplateAction.java
@@ -95,8 +95,9 @@ public class PutComposableIndexTemplateAction extends ActionType<AcknowledgedRes
             if (indexTemplate == null) {
                 validationException = addValidationError("an index template is required", validationException);
             } else {
-                if (indexTemplate.indexPatterns().stream().anyMatch(Regex::isMatchAllPattern)) {
-                    if (IndexMetadata.INDEX_HIDDEN_SETTING.exists(indexTemplate.template().settings())) {
+                if (indexTemplate.template() != null && indexTemplate.indexPatterns().stream().anyMatch(Regex::isMatchAllPattern)) {
+                    if (indexTemplate.template().settings() != null &&
+                        IndexMetadata.INDEX_HIDDEN_SETTING.exists(indexTemplate.template().settings())) {
                         validationException = addValidationError("global composable templates may not specify the setting "
                                 + IndexMetadata.INDEX_HIDDEN_SETTING.getKey(),
                             validationException

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplate.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplate.java
@@ -168,6 +168,7 @@ public class ComposableIndexTemplate extends AbstractDiffable<ComposableIndexTem
         return componentTemplates;
     }
 
+    @Nullable
     public Long priority() {
         return priority;
     }
@@ -179,14 +180,17 @@ public class ComposableIndexTemplate extends AbstractDiffable<ComposableIndexTem
         return priority;
     }
 
+    @Nullable
     public Long version() {
         return version;
     }
 
+    @Nullable
     public Map<String, Object> metadata() {
         return metadata;
     }
 
+    @Nullable
     public DataStreamTemplate getDataStreamTemplate() {
         return dataStreamTemplate;
     }
@@ -347,7 +351,7 @@ public class ComposableIndexTemplate extends AbstractDiffable<ComposableIndexTem
             return Objects.hash(hidden);
         }
     }
-    
+
     public static class Builder{
         private List<String> indexPatterns;
         private Template template;
@@ -357,51 +361,51 @@ public class ComposableIndexTemplate extends AbstractDiffable<ComposableIndexTem
         private Map<String, Object> metadata;
         private DataStreamTemplate dataStreamTemplate;
         private Boolean allowAutoCreate;
-        
+
         public Builder() {
         }
-        
-        public Builder indexPatterns(List<String> indexPatterns) { 
+
+        public Builder indexPatterns(List<String> indexPatterns) {
             this.indexPatterns = indexPatterns;
             return this;
         }
-        
-        public Builder template(Template template) { 
+
+        public Builder template(Template template) {
             this.template = template;
             return this;
         }
-        
-        public Builder componentTemplates(List<String> componentTemplates) { 
+
+        public Builder componentTemplates(List<String> componentTemplates) {
             this.componentTemplates = componentTemplates;
             return this;
         }
-        
-        public Builder priority(Long priority) { 
+
+        public Builder priority(Long priority) {
             this.priority = priority;
             return this;
         }
-        
-        public Builder version(Long version) { 
+
+        public Builder version(Long version) {
             this.version = version;
             return this;
         }
-        
-        public Builder metadata(Map<String, Object> metadata) { 
+
+        public Builder metadata(Map<String, Object> metadata) {
             this.metadata = metadata;
             return this;
         }
-        
-        public Builder dataStreamTemplate(DataStreamTemplate dataStreamTemplate) { 
+
+        public Builder dataStreamTemplate(DataStreamTemplate dataStreamTemplate) {
             this.dataStreamTemplate = dataStreamTemplate;
             return this;
         }
-        
-        public Builder allowAutoCreate(Boolean allowAutoCreate) { 
+
+        public Builder allowAutoCreate(Boolean allowAutoCreate) {
             this.allowAutoCreate = allowAutoCreate;
             return this;
         }
-        
-        public ComposableIndexTemplate build() { 
+
+        public ComposableIndexTemplate build() {
             return new ComposableIndexTemplate(this.indexPatterns,this.template,this.componentTemplates,
                     this.priority,this.version,this.metadata,this.dataStreamTemplate,this.allowAutoCreate);
         }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Template.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Template.java
@@ -100,14 +100,17 @@ public class Template extends AbstractDiffable<Template> implements ToXContentOb
         }
     }
 
+    @Nullable
     public Settings settings() {
         return settings;
     }
 
+    @Nullable
     public CompressedXContent mappings() {
         return mappings;
     }
 
+    @Nullable
     public Map<String, AliasMetadata> aliases() {
         return aliases;
     }

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/template/put/PutComposableIndexTemplateRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/template/put/PutComposableIndexTemplateRequestTests.java
@@ -30,6 +30,7 @@ import org.elasticsearch.test.AbstractWireSerializingTestCase;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.hamcrest.Matchers.is;
@@ -93,5 +94,19 @@ public class PutComposableIndexTemplateRequestTests extends AbstractWireSerializ
         assertThat(validationErrors.size(), is(1));
         String error = validationErrors.get(0);
         assertThat(error, is("index template priority must be >= 0"));
+    }
+
+    public void testValidateNoTemplate() {
+        PutComposableIndexTemplateAction.Request req = new PutComposableIndexTemplateAction.Request("test");
+        req.indexTemplate(new ComposableIndexTemplate.Builder()
+            .indexPatterns(Collections.singletonList("*"))
+            .build());
+        assertNull(req.validate());
+
+        req.indexTemplate(new ComposableIndexTemplate.Builder()
+            .indexPatterns(Collections.singletonList("*"))
+            .template(new Template(null, null, null))
+            .build());
+        assertNull(req.validate());
     }
 }


### PR DESCRIPTION
Internally we check for the presence of the hidden index setting, but if there is no template or no
settings object, a `NullPointerException` would be thrown. This fixes the problem and adds a unit
test.

Resolves #66949
