### PR TITLE
Prevent unnecessary system index access warnings in Deprecation Info API

### DIFF
--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoAction.java
@@ -5,6 +5,14 @@
  */
 package org.elasticsearch.xpack.deprecation;
 
+import static org.elasticsearch.xpack.deprecation.DeprecationChecks.CLUSTER_SETTINGS_CHECKS;
+import static org.elasticsearch.xpack.deprecation.DeprecationChecks.INDEX_SETTINGS_CHECKS;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
@@ -21,6 +29,7 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -91,10 +100,17 @@ public class TransportDeprecationInfoAction extends TransportMasterNodeReadActio
                 new OriginSettingClient(client, ClientHelper.DEPRECATION_ORIGIN)
             );
             pluginSettingIssues(PLUGIN_CHECKERS, components, ActionListener.wrap(
-                deprecationIssues -> listener.onResponse(
-                    DeprecationInfoAction.Response.from(state, indexNameExpressionResolver,
-                        request, response, INDEX_SETTINGS_CHECKS, CLUSTER_SETTINGS_CHECKS,
-                        deprecationIssues)),
+                deprecationIssues -> {
+                    final DeprecationInfoAction.Response finalResponse;
+                    try (ThreadContext.StoredContext ctx = client.threadPool().getThreadContext().newStoredContext(false)) {
+                        // We store the context here and drop any new response headers to prevent getting a deprecation warning on the
+                        // deprecation info API call when we resolve indices. This is a temporary hack, and this should be removed
+                        // once REST system index access has been disabled.
+                        finalResponse = DeprecationInfoAction.Response.from(state, indexNameExpressionResolver,
+                            request, response, INDEX_SETTINGS_CHECKS, CLUSTER_SETTINGS_CHECKS, deprecationIssues);
+                    }
+                    listener.onResponse(finalResponse);
+                },
                 listener::onFailure
             ));
 

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoAction.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.deprecation;
 import static org.elasticsearch.xpack.deprecation.DeprecationChecks.CLUSTER_SETTINGS_CHECKS;
 import static org.elasticsearch.xpack.deprecation.DeprecationChecks.INDEX_SETTINGS_CHECKS;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -38,15 +39,6 @@ import org.elasticsearch.xpack.core.deprecation.DeprecationInfoAction;
 import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
 import org.elasticsearch.xpack.core.deprecation.NodesDeprecationCheckAction;
 import org.elasticsearch.xpack.core.deprecation.NodesDeprecationCheckRequest;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
-import static org.elasticsearch.xpack.deprecation.DeprecationChecks.CLUSTER_SETTINGS_CHECKS;
-import static org.elasticsearch.xpack.deprecation.DeprecationChecks.INDEX_SETTINGS_CHECKS;
 
 public class TransportDeprecationInfoAction extends TransportMasterNodeReadAction<DeprecationInfoAction.Request,
         DeprecationInfoAction.Response> {
@@ -104,8 +96,7 @@ public class TransportDeprecationInfoAction extends TransportMasterNodeReadActio
                     final DeprecationInfoAction.Response finalResponse;
                     try (ThreadContext.StoredContext ctx = client.threadPool().getThreadContext().newStoredContext(false)) {
                         // We store the context here and drop any new response headers to prevent getting a deprecation warning on the
-                        // deprecation info API call when we resolve indices. This is a temporary hack, and this should be removed
-                        // once REST system index access has been disabled.
+                        // deprecation info API call when we resolve indices.
                         finalResponse = DeprecationInfoAction.Response.from(state, indexNameExpressionResolver,
                             request, response, INDEX_SETTINGS_CHECKS, CLUSTER_SETTINGS_CHECKS, deprecationIssues);
                     }


### PR DESCRIPTION
This commit drops the warning headers caused when resolving indices in
the Deprecation Info API, as these warnings are unnecessary.

The headers are dropped, rather than simply marking this API as "allowed
to access system indices by default" because this API will be restricted
to non-system indices once everything else is as well, but until then
should report any issues with system indices which need to be addressed
manually.

[Note this PR is targeted at 7.x only]

Fixes https://github.com/elastic/elasticsearch/issues/66063