### PR TITLE
revert dot in diagnostics name

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -151,7 +151,7 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                                     .privileges("view_index_metadata", "monitor").build(),
                                 // Endpoint diagnostic information. Kibana reads from these indices to send telemetry
                                 RoleDescriptor.IndicesPrivileges.builder()
-                                    .indices(".logs-endpoint.diagnostic.collection-*")
+                                    .indices("logs-endpoint.diagnostic.collection-*")
                                     .privileges("read").build(),
                         },
                         null,

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -463,7 +463,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
         });
 
         // read-only indices for Endpoint diagnostic information
-        Arrays.asList(".logs-endpoint.diagnostic.collection-" + randomAlphaOfLength(randomIntBetween(0, 13))).forEach((index) -> {
+        Arrays.asList("logs-endpoint.diagnostic.collection-" + randomAlphaOfLength(randomIntBetween(0, 13))).forEach((index) -> {
             assertThat(kibanaRole.indices().allowedIndicesMatcher("indices:foo").test(mockIndexAbstraction(index)), is(false));
             assertThat(kibanaRole.indices().allowedIndicesMatcher("indices:bar").test(mockIndexAbstraction(index)), is(false));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(DeleteIndexAction.NAME).test(mockIndexAbstraction(index)), is(false));


### PR DESCRIPTION
This PR takes the `.` out of the index name for the diagnostics index.  This is due to permission issues in the `fleet_enroll` user in Kibana which may require further investigation.

This PR is based on the previous one here: https://github.com/elastic/elasticsearch/pull/66135

For background, I filed this bug for more information: https://github.com/elastic/kibana/issues/87995

Inside the bug above, is more context and provides 2 potential solutions for the bug.  One requires this PR and one does not

Option 1:
- Revert the changes that add a leading `.` to the diagnostic index name.  This change will not require any extended permissions for the `fleet_enroll` user and so the migration issues will not be present

Option 2:
- Add a migration for the `fleet_enroll` user to ensure that the new permissions are added to the user regardless of server upgrade or fresh install.  Note that this is the more correct solution, but may be more complicated to implement in a short amount of time.

For additional information on the original ES PR, see this issue: https://github.com/elastic/kibana/issues/85391
