### PR TITLE
Remove grace period from license expiration check

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/LicenseService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/LicenseService.java
@@ -77,11 +77,6 @@ public class LicenseService extends AbstractLifecycleComponent implements Cluste
         License.LicenseType.GOLD, License.LicenseType.PLATINUM, License.LicenseType.ENTERPRISE, License.LicenseType.TRIAL);
 
     /**
-     * Duration of grace period after a license has expired
-     */
-    static final TimeValue GRACE_PERIOD_DURATION = days(7);
-
-    /**
      * Period before the license expires when warning starts being added to the response header
      */
     static final TimeValue LICENSE_EXPIRATION_WARNING_PERIOD = days(7);
@@ -191,16 +186,9 @@ public class LicenseService extends AbstractLifecycleComponent implements Cluste
                 logExpirationWarning(license.expiryDate(), false);
             }
         });
-        expirationCallbacks.add(new ExpirationCallback.Pre(days(0), days(7), TimeValue.timeValueMinutes(10)) {
-            @Override
-            public void on(License license) {
-                logExpirationWarning(license.expiryDate(), false);
-            }
-        });
         expirationCallbacks.add(new ExpirationCallback.Post(days(0), null, TimeValue.timeValueMinutes(10)) {
             @Override
             public void on(License license) {
-                // logged when grace period begins
                 logExpirationWarning(license.expiryDate(), true);
             }
         });
@@ -485,22 +473,16 @@ public class LicenseService extends AbstractLifecycleComponent implements Cluste
         }
         if (license != null) {
             long time = clock.millis();
-            boolean active;
+            final boolean active;
             if (license.expiryDate() == BASIC_SELF_GENERATED_LICENSE_EXPIRATION_MILLIS) {
                 active = true;
             } else {
-                // We subtract the grace period from the current time to avoid overflowing on an expiration
-                // date that is near Long.MAX_VALUE
-                active = time >= license.issueDate() && time - GRACE_PERIOD_DURATION.getMillis() < license.expiryDate();
+                active = time >= license.issueDate() && time < license.expiryDate();
             }
             licenseState.update(license.operationMode(), active, license.expiryDate(), mostRecentTrialVersion);
 
             if (active) {
-                if (time < license.expiryDate()) {
-                    logger.debug("license [{}] - valid", license.uid());
-                } else {
-                    logger.warn("license [{}] - grace", license.uid());
-                }
+                logger.debug("license [{}] - valid", license.uid());
             } else {
                 logger.warn("license [{}] - expired", license.uid());
             }
@@ -551,8 +533,6 @@ public class LicenseService extends AbstractLifecycleComponent implements Cluste
                 return license.issueDate();
             } else if (time < license.expiryDate()) {
                 return license.expiryDate();
-            } else if (time < license.expiryDate() + GRACE_PERIOD_DURATION.getMillis()) {
-                return license.expiryDate() + GRACE_PERIOD_DURATION.getMillis();
             }
             return -1; // license is expired, no need to check again
         };

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicenseScheduleTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicenseScheduleTests.java
@@ -29,16 +29,8 @@ public class LicenseScheduleTests extends ESTestCase {
         assertThat(schedule.nextScheduledTimeAfter(license.issueDate(), triggeredTime), equalTo(license.expiryDate()));
     }
 
-    public void testGraceLicenseSchedule() throws Exception {
-        long triggeredTime = license.expiryDate() + between(1,
-                ((int) LicenseService.GRACE_PERIOD_DURATION.getMillis()));
-        assertThat(schedule.nextScheduledTimeAfter(license.issueDate(), triggeredTime),
-                equalTo(license.expiryDate() + LicenseService.GRACE_PERIOD_DURATION.getMillis()));
-    }
-
     public void testExpiredLicenseSchedule() throws Exception {
-        long triggeredTime = license.expiryDate() + LicenseService.GRACE_PERIOD_DURATION.getMillis() +
-                randomIntBetween(1, 1000);
+        long triggeredTime = license.expiryDate() + randomIntBetween(1, 1000);
         assertThat(schedule.nextScheduledTimeAfter(license.issueDate(), triggeredTime),
                 equalTo(-1L));
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicenseServiceClusterTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicenseServiceClusterTests.java
@@ -120,26 +120,12 @@ public class LicenseServiceClusterTests extends AbstractLicensesIntegrationTestC
         assertLicenseActive(true);
     }
 
-    public void testClusterRestartWhileGrace() throws Exception {
-        wipeAllLicenses();
-        internalCluster().startNode();
-        assertLicenseActive(true);
-        putLicense(TestUtils.generateSignedLicense(TimeValue.timeValueMillis(0)));
-        ensureGreen();
-        assertLicenseActive(true);
-        logger.info("--> restart node");
-        internalCluster().fullRestart();
-        ensureYellow();
-        logger.info("--> await node for grace_period");
-        assertLicenseActive(true);
-    }
-
     public void testClusterRestartWhileExpired() throws Exception {
         wipeAllLicenses();
         internalCluster().startNode();
         ensureGreen();
         assertLicenseActive(true);
-        putLicense(TestUtils.generateExpiredNonBasicLicense(System.currentTimeMillis() - LicenseService.GRACE_PERIOD_DURATION.getMillis()));
+        putLicense(TestUtils.generateExpiredNonBasicLicense(System.currentTimeMillis()));
         assertLicenseActive(false);
         logger.info("--> restart node");
         internalCluster().fullRestart();


### PR DESCRIPTION
License expiration checking currently has a 7 day grace period. When a
license expires, the licensing code acts as if it is not yet expired.
This was originally intended to protect users who may accidentally end up
letting their license expire from the pain of their licensed features
ceasing to work. However, the grace period effectively shifts the
license expiration by a week, resulting in confusion since the actual
license expiration date is not accurate. It also is less of a concern
now as not only do we emit several warnings for upcoming license
expiration, but the new license can be downloaded and installed quickly
by the user through the support portal.

This commit removes the license grace period altogether.