### PR TITLE
Avoid NOOP BytesReference Slices

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/bytes/BytesArray.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/BytesArray.java
@@ -91,6 +91,9 @@ public final class BytesArray extends AbstractBytesReference {
 
     @Override
     public BytesReference slice(int from, int length) {
+        if (from == 0 && this.length == length) {
+            return this;
+        }
         Objects.checkFromIndexSize(from, length, this.length);
         return new BytesArray(bytes, offset + from, length);
     }

--- a/server/src/main/java/org/elasticsearch/common/bytes/CompositeBytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/CompositeBytesReference.java
@@ -119,6 +119,9 @@ public final class CompositeBytesReference extends AbstractBytesReference {
 
     @Override
     public BytesReference slice(int from, int length) {
+        if (from == 0 && this.length == length) {
+            return this;
+        }
         Objects.checkFromIndexSize(from, length, this.length);
 
         if (length == 0) {

--- a/server/src/main/java/org/elasticsearch/common/bytes/PagedBytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/PagedBytesReference.java
@@ -58,6 +58,9 @@ public class PagedBytesReference extends AbstractBytesReference {
 
     @Override
     public BytesReference slice(int from, int length) {
+        if (from == 0 && this.length == length) {
+            return this;
+        }
         Objects.checkFromIndexSize(from, length, this.length);
         return new PagedBytesReference(byteArray, offset + from, length);
     }

--- a/server/src/main/java/org/elasticsearch/common/bytes/ReleasableBytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/ReleasableBytesReference.java
@@ -80,6 +80,9 @@ public final class ReleasableBytesReference implements RefCounted, Releasable, B
     }
 
     public ReleasableBytesReference retainedSlice(int from, int length) {
+        if (from == 0 && length() == length) {
+            return retain();
+        }
         return new ReleasableBytesReference(delegate.slice(from, length), refCounted);
     }
 


### PR DESCRIPTION
We have a number of spots where the logic creates these noop slices
and we can save a few objects here.
Also, this makes debugging memory leaks around the page recycling
a little easier which is how I found these.

