### PR TITLE
Fix Tripping Assertion in IndicesServiceCloseTests

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/SingleObjectCache.java
+++ b/server/src/main/java/org/elasticsearch/common/util/SingleObjectCache.java
@@ -30,7 +30,7 @@ import java.util.concurrent.locks.ReentrantLock;
 public abstract class SingleObjectCache<T>{
 
     private volatile T cached;
-    private Lock refreshLock = new ReentrantLock();
+    private final Lock refreshLock = new ReentrantLock();
     private final TimeValue refreshInterval;
     protected long lastRefreshTimestamp = 0;
 

--- a/server/src/main/java/org/elasticsearch/monitor/fs/FsService.java
+++ b/server/src/main/java/org/elasticsearch/monitor/fs/FsService.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.util.SingleObjectCache;
 import org.elasticsearch.env.NodeEnvironment;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.function.Supplier;
 
 public class FsService {
@@ -58,7 +59,16 @@ public class FsService {
         } else {
             final TimeValue refreshInterval = REFRESH_INTERVAL_SETTING.get(settings);
             logger.debug("using refresh_interval [{}]", refreshInterval);
-            fsInfoSupplier = new FsInfoCache(refreshInterval, initialValue, probe)::getOrRefresh;
+            final FsInfoCache fsInfoCache = new FsInfoCache(refreshInterval, initialValue, probe);
+            fsInfoSupplier = () -> {
+                try {
+                    return fsInfoCache.getOrRefresh();
+                } catch (UncheckedIOException e) {
+                    // catch exception here instead of just
+                    logger.debug("unexpected exception reading filesystem info", e);
+                    return null;
+                }
+            };
         }
     }
 
@@ -88,7 +98,11 @@ public class FsService {
 
         @Override
         protected FsInfo refresh() {
-            return stats(probe, initialValue);
+            try {
+                return probe.stats(initialValue);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
         }
 
     }

--- a/server/src/main/java/org/elasticsearch/monitor/fs/FsService.java
+++ b/server/src/main/java/org/elasticsearch/monitor/fs/FsService.java
@@ -64,7 +64,6 @@ public class FsService {
                 try {
                     return fsInfoCache.getOrRefresh();
                 } catch (UncheckedIOException e) {
-                    // catch exception here instead of just
                     logger.debug("unexpected exception reading filesystem info", e);
                     return null;
                 }


### PR DESCRIPTION
We can't use a method that returns `null` as `refresh` implementation
because that trips an assertion in `SingleObjectCache` so we must bubble
up an exception and handle it upstream instead.

Example failure excerpt:

```
[2021-01-12T12:23:47,060][INFO ][o.e.c.s.MasterService    ] [node_s_0] elected-as-master ([1] nodes joined)[{node_s_0}{3BnxmKHeRqC-BHtk-reHOA}{IeEehDypQVuM1tWMhNbKkg}{127.0.0.1}{127.0.0.1:9300}{dimr} elect leader, _BECOME_MASTER_TASK_, _FINISH_ELECTION_], term: 1, version: 1, delta: master node changed {previous [], current [{node_s_0}{3BnxmKHeRqC-BHtk-reHOA}{IeEehDypQVuM1tWMhNbKkg}{127.0.0.1}{127.0.0.1:9300}{dimr}]}
[2021-01-12T12:23:47,063][INFO ][o.e.c.c.CoordinationState] [node_s_0] cluster UUID set to [OuA-ioqSRxWRmKXadTs45Q]
[2021-01-12T12:23:47,066][INFO ][o.e.c.s.ClusterApplierService] [node_s_0] master node changed {previous [], current [{node_s_0}{3BnxmKHeRqC-BHtk-reHOA}{IeEehDypQVuM1tWMhNbKkg}{127.0.0.1}{127.0.0.1:9300}{dimr}]}, term: 1, version: 1, reason: Publication{term=1, version=1}
[2021-01-12T12:23:47,067][INFO ][o.e.n.Node               ] [testCloseWhileOngoingRequestUsesRequestCache] started
[2021-01-12T12:23:47,069][INFO ][o.e.g.GatewayService     ] [node_s_0] recovered [0] indices into cluster_state
[2021-01-12T12:23:47,070][INFO ][o.e.c.m.MetadataCreateIndexService] [node_s_0] [test] creating index, cause [api], templates [], shards [1]/[0]
[2021-01-12T12:23:47,089][INFO ][o.e.c.r.a.AllocationService] [node_s_0] current.health="GREEN" message="Cluster health status changed from [YELLOW] to [GREEN] (reason: [shards started [[test][0]]])." previous.health="YELLOW" reason="shards started [[test][0]]"
[2021-01-12T12:23:47,098][INFO ][o.e.c.m.MetadataMappingService] [node_s_0] [test/Cl7Q_nGTReC2aJ7h_N-fmg] create_mapping
[2021-01-12T12:23:47,110][INFO ][o.e.n.Node               ] [testCloseWhileOngoingRequestUsesRequestCache] stopping ...
[2021-01-12T12:23:47,128][INFO ][o.e.n.Node               ] [testCloseWhileOngoingRequestUsesRequestCache] stopped
[2021-01-12T12:23:47,128][INFO ][o.e.n.Node               ] [testCloseWhileOngoingRequestUsesRequestCache] closing ...
[2021-01-12T12:23:47,129][INFO ][o.e.n.Node               ] [testCloseWhileOngoingRequestUsesRequestCache] closed
[2021-01-12T12:23:47,130][INFO ][o.e.i.IndicesServiceCloseTests] [testCloseWhileOngoingRequestUsesRequestCache] after test
[2021-01-12T12:23:47,133][INFO ][o.e.i.IndicesServiceCloseTests] [testCloseNonEmptyIndicesService] before test
[2021-01-12T12:23:47,136][INFO ][o.e.n.Node               ] [testCloseNonEmptyIndicesService] version[8.0.0], pid[915712], build[unknown/unknown/unknown/unknown], OS[Linux/5.8.0-36-generic/amd64], JVM[Oracle Corporation/OpenJDK 64-Bit Server VM/14/14+36-1461]
[2021-01-12T12:23:47,136][INFO ][o.e.n.Node               ] [testCloseNonEmptyIndicesService] JVM home [/usr/lib/jvm/jdk-14]
[2021-01-12T12:23:47,137][DEPRECATION][o.e.d.n.Node             ] [testCloseNonEmptyIndicesService] data_stream.dataset="deprecation.elasticsearch" data_stream.namespace="default" data_stream.type="logs" ecs.version="1.6" key="no-jdk" message="no-jdk distributions that do not bundle a JDK are deprecated and will be removed in a future release"
[2021-01-12T12:23:47,137][INFO ][o.e.n.Node               ] [testCloseNonEmptyIndicesService] JVM arguments [-agentlib:jdwp=transport=dt_socket,address=127.0.0.1:53935,suspend=y,server=n, -ea, -Djava.locale.providers=SPI,COMPAT, -Dtests.seed=17ECDFD5A6D85C36, -Didea.test.cyclic.buffer.size=1048576, -javaagent:/home/brownbear/idea/plugins/Groovy/lib/agent/gragent.jar, -javaagent:/home/brownbear/idea/plugins/java/lib/rt/debugger-agent.jar, -agentpath:/tmp/libmemory_agent.so=, -Dfile.encoding=UTF-8]
[2021-01-12T12:23:47,137][INFO ][o.e.p.PluginsService     ] [testCloseNonEmptyIndicesService] no modules loaded
[2021-01-12T12:23:47,137][INFO ][o.e.p.PluginsService     ] [testCloseNonEmptyIndicesService] loaded plugin [org.elasticsearch.test.InternalSettingsPlugin]
[2021-01-12T12:23:47,137][INFO ][o.e.p.PluginsService     ] [testCloseNonEmptyIndicesService] loaded plugin [org.elasticsearch.test.MockHttpTransport$TestPlugin]
[2021-01-12T12:23:47,137][INFO ][o.e.p.PluginsService     ] [testCloseNonEmptyIndicesService] loaded plugin [org.elasticsearch.transport.nio.MockNioTransportPlugin]
[2021-01-12T12:23:47,139][INFO ][o.e.e.NodeEnvironment    ] [testCloseNonEmptyIndicesService] using [1] data paths, mounts [[/ (/dev/nvme0n1p2)]], net usable_space [157.1gb], net total_space [467.9gb], types [ext4]
[2021-01-12T12:23:47,139][INFO ][o.e.e.NodeEnvironment    ] [testCloseNonEmptyIndicesService] heap size [15.6gb], compressed ordinary object pointers [true]
[2021-01-12T12:23:47,140][INFO ][o.e.n.Node               ] [testCloseNonEmptyIndicesService] node name [node_s_0], node ID [e42WZxwrQT-ZaBbFv7tBeg], cluster name [single-node-cluster-TEST_WORKER_VM=[--not-gradle--]-CLUSTER_SEED=[1329309153455850345]-HASH=[1242556CC800]], roles [data, remote_cluster_client, master, ingest]
[2021-01-12T12:23:47,152][INFO ][o.e.d.DiscoveryModule    ] [testCloseNonEmptyIndicesService] using discovery type [zen] and seed hosts providers [settings]
[2021-01-12T12:23:47,165][INFO ][o.e.n.Node               ] [testCloseNonEmptyIndicesService] initialized
[2021-01-12T12:23:47,166][INFO ][o.e.n.Node               ] [testCloseNonEmptyIndicesService] starting ...
[2021-01-12T12:23:47,168][INFO ][o.e.t.TransportService   ] [testCloseNonEmptyIndicesService] publish_address {127.0.0.1:9300}, bound_addresses {[::1]:9300}, {127.0.0.1:9300}
[2021-01-12T12:23:47,174][INFO ][o.e.c.c.Coordinator      ] [testCloseNonEmptyIndicesService] setting initial configuration to VotingConfiguration{e42WZxwrQT-ZaBbFv7tBeg}
[2021-01-12T12:23:47,191][INFO ][o.e.c.s.MasterService    ] [node_s_0] elected-as-master ([1] nodes joined)[{node_s_0}{e42WZxwrQT-ZaBbFv7tBeg}{jSsJOEnUQ3irbpe8uBow6w}{127.0.0.1}{127.0.0.1:9300}{dimr} elect leader, _BECOME_MASTER_TASK_, _FINISH_ELECTION_], term: 1, version: 1, delta: master node changed {previous [], current [{node_s_0}{e42WZxwrQT-ZaBbFv7tBeg}{jSsJOEnUQ3irbpe8uBow6w}{127.0.0.1}{127.0.0.1:9300}{dimr}]}
[2021-01-12T12:23:47,194][INFO ][o.e.c.c.CoordinationState] [node_s_0] cluster UUID set to [djfcWq7NRtSwLN6v7BPXNA]
[2021-01-12T12:23:47,198][INFO ][o.e.c.s.ClusterApplierService] [node_s_0] master node changed {previous [], current [{node_s_0}{e42WZxwrQT-ZaBbFv7tBeg}{jSsJOEnUQ3irbpe8uBow6w}{127.0.0.1}{127.0.0.1:9300}{dimr}]}, term: 1, version: 1, reason: Publication{term=1, version=1}
[2021-01-12T12:23:47,199][INFO ][o.e.n.Node               ] [testCloseNonEmptyIndicesService] started
[2021-01-12T12:23:47,200][INFO ][o.e.g.GatewayService     ] [node_s_0] recovered [0] indices into cluster_state
[2021-01-12T12:23:47,202][INFO ][o.e.c.m.MetadataCreateIndexService] [node_s_0] [test] creating index, cause [api], templates [], shards [1]/[0]
[2021-01-12T12:23:47,220][INFO ][o.e.c.r.a.AllocationService] [node_s_0] current.health="GREEN" message="Cluster health status changed from [YELLOW] to [GREEN] (reason: [shards started [[test][0]]])." previous.health="YELLOW" reason="shards started [[test][0]]"
[2021-01-12T12:23:47,226][INFO ][o.e.n.Node               ] [testCloseNonEmptyIndicesService] stopping ...
[2021-01-12T12:23:47,228][INFO ][o.e.n.Node               ] [testCloseNonEmptyIndicesService] stopped
[2021-01-12T12:23:47,228][INFO ][o.e.n.Node               ] [testCloseNonEmptyIndicesService] closing ...
[2021-01-12T12:23:47,229][INFO ][o.e.n.Node               ] [testCloseNonEmptyIndicesService] closed
[2021-01-12T12:23:47,229][INFO ][o.e.i.IndicesServiceCloseTests] [testCloseNonEmptyIndicesService] after test
[2021-01-12T12:23:47,231][INFO ][o.e.i.IndicesServiceCloseTests] [testCloseEmptyIndicesService] before test
[2021-01-12T12:23:47,234][INFO ][o.e.n.Node               ] [testCloseEmptyIndicesService] version[8.0.0], pid[915712], build[unknown/unknown/unknown/unknown], OS[Linux/5.8.0-36-generic/amd64], JVM[Oracle Corporation/OpenJDK 64-Bit Server VM/14/14+36-1461]
[2021-01-12T12:23:47,234][INFO ][o.e.n.Node               ] [testCloseEmptyIndicesService] JVM home [/usr/lib/jvm/jdk-14]
[2021-01-12T12:23:47,234][DEPRECATION][o.e.d.n.Node             ] [testCloseEmptyIndicesService] data_stream.dataset="deprecation.elasticsearch" data_stream.namespace="default" data_stream.type="logs" ecs.version="1.6" key="no-jdk" message="no-jdk distributions that do not bundle a JDK are deprecated and will be removed in a future release"
[2021-01-12T12:23:47,234][INFO ][o.e.n.Node               ] [testCloseEmptyIndicesService] JVM arguments [-agentlib:jdwp=transport=dt_socket,address=127.0.0.1:53935,suspend=y,server=n, -ea, -Djava.locale.providers=SPI,COMPAT, -Dtests.seed=17ECDFD5A6D85C36, -Didea.test.cyclic.buffer.size=1048576, -javaagent:/home/brownbear/idea/plugins/Groovy/lib/agent/gragent.jar, -javaagent:/home/brownbear/idea/plugins/java/lib/rt/debugger-agent.jar, -agentpath:/tmp/libmemory_agent.so=, -Dfile.encoding=UTF-8]
[2021-01-12T12:23:47,235][INFO ][o.e.p.PluginsService     ] [testCloseEmptyIndicesService] no modules loaded
[2021-01-12T12:23:47,235][INFO ][o.e.p.PluginsService     ] [testCloseEmptyIndicesService] loaded plugin [org.elasticsearch.test.InternalSettingsPlugin]
[2021-01-12T12:23:47,235][INFO ][o.e.p.PluginsService     ] [testCloseEmptyIndicesService] loaded plugin [org.elasticsearch.test.MockHttpTransport$TestPlugin]
[2021-01-12T12:23:47,235][INFO ][o.e.p.PluginsService     ] [testCloseEmptyIndicesService] loaded plugin [org.elasticsearch.transport.nio.MockNioTransportPlugin]
[2021-01-12T12:23:47,236][INFO ][o.e.e.NodeEnvironment    ] [testCloseEmptyIndicesService] using [1] data paths, mounts [[/ (/dev/nvme0n1p2)]], net usable_space [157.1gb], net total_space [467.9gb], types [ext4]
[2021-01-12T12:23:47,236][INFO ][o.e.e.NodeEnvironment    ] [testCloseEmptyIndicesService] heap size [15.6gb], compressed ordinary object pointers [true]
[2021-01-12T12:23:47,237][INFO ][o.e.n.Node               ] [testCloseEmptyIndicesService] node name [node_s_0], node ID [sS_DMBoNThSFrSbWEzOe8g], cluster name [single-node-cluster-TEST_WORKER_VM=[--not-gradle--]-CLUSTER_SEED=[8306329229741820601]-HASH=[12425B4588B3]], roles [data, remote_cluster_client, master, ingest]
[2021-01-12T12:23:47,247][INFO ][o.e.d.DiscoveryModule    ] [testCloseEmptyIndicesService] using discovery type [zen] and seed hosts providers [settings]
[2021-01-12T12:23:47,258][INFO ][o.e.n.Node               ] [testCloseEmptyIndicesService] initialized
[2021-01-12T12:23:47,258][INFO ][o.e.n.Node               ] [testCloseEmptyIndicesService] starting ...
[2021-01-12T12:23:47,261][INFO ][o.e.t.TransportService   ] [testCloseEmptyIndicesService] publish_address {127.0.0.1:9302}, bound_addresses {[::1]:9302}, {127.0.0.1:9302}
[2021-01-12T12:23:47,266][INFO ][o.e.c.c.Coordinator      ] [testCloseEmptyIndicesService] setting initial configuration to VotingConfiguration{sS_DMBoNThSFrSbWEzOe8g}
[2021-01-12T12:23:47,288][INFO ][o.e.c.s.MasterService    ] [node_s_0] elected-as-master ([1] nodes joined)[{node_s_0}{sS_DMBoNThSFrSbWEzOe8g}{vkvV3koiQju0gKWHjQkAhQ}{127.0.0.1}{127.0.0.1:9302}{dimr} elect leader, _BECOME_MASTER_TASK_, _FINISH_ELECTION_], term: 1, version: 1, delta: master node changed {previous [], current [{node_s_0}{sS_DMBoNThSFrSbWEzOe8g}{vkvV3koiQju0gKWHjQkAhQ}{127.0.0.1}{127.0.0.1:9302}{dimr}]}
[2021-01-12T12:23:47,291][INFO ][o.e.c.c.CoordinationState] [node_s_0] cluster UUID set to [Ztf9R7YNQM6hIvPbeVwrjQ]
[2021-01-12T12:23:47,295][INFO ][o.e.c.s.ClusterApplierService] [node_s_0] master node changed {previous [], current [{node_s_0}{sS_DMBoNThSFrSbWEzOe8g}{vkvV3koiQju0gKWHjQkAhQ}{127.0.0.1}{127.0.0.1:9302}{dimr}]}, term: 1, version: 1, reason: Publication{term=1, version=1}
[2021-01-12T12:23:47,296][INFO ][o.e.n.Node               ] [testCloseEmptyIndicesService] started
[2021-01-12T12:23:47,296][INFO ][o.e.n.Node               ] [testCloseEmptyIndicesService] stopping ...
[2021-01-12T12:23:47,297][INFO ][o.e.n.Node               ] [testCloseEmptyIndicesService] stopped
[2021-01-12T12:23:47,297][INFO ][o.e.n.Node               ] [testCloseEmptyIndicesService] closing ...
[2021-01-12T12:23:47,297][WARN ][o.e.c.InternalClusterInfoService] [node_s_0] failed to retrieve stats for node [sS_DMBoNThSFrSbWEzOe8g]: [node_s_0][127.0.0.1:9302][cluster:monitor/nodes/stats[n]]
[2021-01-12T12:23:47,297][INFO ][o.e.n.Node               ] [testCloseEmptyIndicesService] closed
[2021-01-12T12:23:47,297][INFO ][o.e.i.IndicesServiceCloseTests] [testCloseEmptyIndicesService] after test
Jan 12, 2021 1:23:47 PM com.carrotsearch.randomizedtesting.ThreadLeakControl checkThreadLeaks
WARNING: Will linger awaiting termination of 1 leaked thread(s).
Jan 12, 2021 1:23:47 PM com.carrotsearch.randomizedtesting.RandomizedRunner$QueueUncaughtExceptionsHandler uncaughtException
WARNING: Uncaught exception in thread: Thread[elasticsearch[node_s_0][management][T#1],5,TGRP-IndicesServiceCloseTests]
java.lang.AssertionError
	at __randomizedtesting.SeedInfo.seed([17ECDFD5A6D85C36]:0)
	at org.elasticsearch.common.util.SingleObjectCache.getOrRefresh(SingleObjectCache.java:55)
	at org.elasticsearch.monitor.fs.FsService.stats(FsService.java:66)
	at org.elasticsearch.node.NodeService.stats(NodeService.java:124)
	at org.elasticsearch.action.admin.cluster.node.stats.TransportNodesStatsAction.nodeOperation(TransportNodesStatsAction.java:73)
	at org.elasticsearch.action.admin.cluster.node.stats.TransportNodesStatsAction.nodeOperation(TransportNodesStatsAction.java:39)
	at org.elasticsearch.action.support.nodes.TransportNodesAction$NodeTransportHandler.messageReceived(TransportNodesAction.java:259)
	at org.elasticsearch.transport.RequestHandlerRegistry.processMessageReceived(RequestHandlerRegistry.java:72)
	at org.elasticsearch.transport.TransportService$8.doRun(TransportService.java:811)
	at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:739)
	at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:37)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
	at java.base/java.lang.Thread.run(Thread.java:832)


com.carrotsearch.randomizedtesting.UncaughtExceptionError: Captured an uncaught exception in thread: Thread[id=2603, name=elasticsearch[node_s_0][management][T#1], state=RUNNABLE, group=TGRP-IndicesServiceCloseTests]

Caused by: java.lang.AssertionError
	at __randomizedtesting.SeedInfo.seed([17ECDFD5A6D85C36]:0)
	at org.elasticsearch.common.util.SingleObjectCache.getOrRefresh(SingleObjectCache.java:55)
	at org.elasticsearch.monitor.fs.FsService.stats(FsService.java:66)
	at org.elasticsearch.node.NodeService.stats(NodeService.java:124)
	at org.elasticsearch.action.admin.cluster.node.stats.TransportNodesStatsAction.nodeOperation(TransportNodesStatsAction.java:73)
	at org.elasticsearch.action.admin.cluster.node.stats.TransportNodesStatsAction.nodeOperation(TransportNodesStatsAction.java:39)
	at org.elasticsearch.action.support.nodes.TransportNodesAction$NodeTransportHandler.messageReceived(TransportNodesAction.java:259)
	at org.elasticsearch.transport.RequestHandlerRegistry.processMessageReceived(RequestHandlerRegistry.java:72)
	at org.elasticsearch.transport.TransportService$8.doRun(TransportService.java:811)
	at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:739)
	at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:37)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
	at java.base/java.lang.Thread.run(Thread.java:832)

```