### PR TITLE
Avoid NOOP BytesReference Slices (#67330)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/bytes/BytesArray.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/BytesArray.java
@@ -21,6 +21,7 @@ package org.elasticsearch.common.bytes;
 
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.FutureArrays;
+import org.apache.lucene.util.FutureObjects;
 import org.elasticsearch.common.io.stream.StreamInput;
 
 import java.io.IOException;
@@ -90,10 +91,10 @@ public final class BytesArray extends AbstractBytesReference {
 
     @Override
     public BytesReference slice(int from, int length) {
-        if (from < 0 || (from + length) > this.length) {
-            throw new IllegalArgumentException("can't slice a buffer with length [" + this.length +
-                "], with slice parameters from [" + from + "], length [" + length + "]");
+        if (from == 0 && this.length == length) {
+            return this;
         }
+        FutureObjects.checkFromIndexSize(from, length, this.length);
         return new BytesArray(bytes, offset + from, length);
     }
 

--- a/server/src/main/java/org/elasticsearch/common/bytes/CompositeBytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/CompositeBytesReference.java
@@ -120,6 +120,9 @@ public final class CompositeBytesReference extends AbstractBytesReference {
 
     @Override
     public BytesReference slice(int from, int length) {
+        if (from == 0 && this.length == length) {
+            return this;
+        }
         FutureObjects.checkFromIndexSize(from, length, this.length);
 
         if (length == 0) {

--- a/server/src/main/java/org/elasticsearch/common/bytes/PagedBytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/PagedBytesReference.java
@@ -21,6 +21,7 @@ package org.elasticsearch.common.bytes;
 
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefIterator;
+import org.apache.lucene.util.FutureObjects;
 import org.elasticsearch.common.util.ByteArray;
 import org.elasticsearch.common.util.PageCacheRecycler;
 
@@ -57,9 +58,9 @@ public class PagedBytesReference extends AbstractBytesReference {
 
     @Override
     public BytesReference slice(int from, int length) {
-        if (from < 0 || (from + length) > length()) {
-            throw new IllegalArgumentException("can't slice a buffer with length [" + length() +
-                "], with slice parameters from [" + from + "], length [" + length + "]");
+        FutureObjects.checkFromIndexSize(from, length, this.length);
+        if (from == 0 && this.length == length) {
+            return this;
         }
         return new PagedBytesReference(byteArray, offset + from, length);
     }

--- a/server/src/main/java/org/elasticsearch/common/bytes/ReleasableBytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/ReleasableBytesReference.java
@@ -80,6 +80,9 @@ public final class ReleasableBytesReference implements RefCounted, Releasable, B
     }
 
     public ReleasableBytesReference retainedSlice(int from, int length) {
+        if (from == 0 && length() == length) {
+            return retain();
+        }
         return new ReleasableBytesReference(delegate.slice(from, length), refCounted);
     }
 


### PR DESCRIPTION
We have a number of spots where the logic creates these noop slices
and we can save a few objects here.
Also, this makes debugging memory leaks around the page recycling
a little easier which is how I found these.

backport of #67330 