### PR TITLE
[7.11] Remove assertion that checks the exception message on AzureBlobContainerRetriesTests#testRetryUntilFail

### DIFF
--- a/plugins/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureBlobContainerRetriesTests.java
+++ b/plugins/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureBlobContainerRetriesTests.java
@@ -412,7 +412,8 @@ public class AzureBlobContainerRetriesTests extends ESTestCase {
                     throw new AssertionError("Should not receive any data");
                 }
             } catch (IOException e) {
-                assertThat(e.getMessage(), equalTo("connection closed before all data received"));
+              // Suppress the exception since it's expected that the
+              // connection is closed before anything can be read
             } finally {
                 exchange.close();
             }


### PR DESCRIPTION
The error message might change depending on the timing when we try
to read from the stream. Since we already check that we're not able
to read any data this assertion doesn't add much value.

Backport of #67258
