### PR TITLE
Fix Tripping Assertion in IndicesServiceCloseTests (#67336)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/SingleObjectCache.java
+++ b/server/src/main/java/org/elasticsearch/common/util/SingleObjectCache.java
@@ -30,7 +30,7 @@ import java.util.concurrent.locks.ReentrantLock;
 public abstract class SingleObjectCache<T>{
 
     private volatile T cached;
-    private Lock refreshLock = new ReentrantLock();
+    private final Lock refreshLock = new ReentrantLock();
     private final TimeValue refreshInterval;
     protected long lastRefreshTimestamp = 0;
 


### PR DESCRIPTION
We can't use a method that returns `null` as `refresh` implementation
because that trips an assertion in `SingleObjectCache` so we must bubble
up an exception and handle it upstream instead.

backport of #67336
