### PR TITLE
fix assertion for inSyncAllocationIds

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/NodeVersionAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/NodeVersionAllocationDecider.java
@@ -43,7 +43,7 @@ public class NodeVersionAllocationDecider extends AllocationDecider {
             }
         } else {
             final ShardRouting primary = allocation.routingNodes().activePrimary(shardRouting.shardId());
-            // check that active primary has a newer version so that peer recovery works
+            // check that active primary has an older-or-equal version so that peer recovery works
             if (primary != null) {
                 return isVersionCompatibleAllocatingReplica(allocation.routingNodes(), primary.currentNodeId(), node, allocation);
             } else {

--- a/server/src/main/java/org/elasticsearch/gateway/PrimaryShardAllocator.java
+++ b/server/src/main/java/org/elasticsearch/gateway/PrimaryShardAllocator.java
@@ -99,7 +99,7 @@ public abstract class PrimaryShardAllocator extends BaseGatewayShardAllocator {
         final Set<String> inSyncAllocationIds = indexMetadata.inSyncAllocationIds(unassignedShard.id());
         final boolean snapshotRestore = unassignedShard.recoverySource().getType() == RecoverySource.Type.SNAPSHOT;
 
-        assert inSyncAllocationIds.isEmpty() == false;
+        assert snapshotRestore == true || inSyncAllocationIds.isEmpty() == false;
         // use in-sync allocation ids to select nodes
         final NodeShardsResult nodeShardsResult = buildNodeShardsResult(unassignedShard, snapshotRestore,
             allocation.getIgnoreNodes(unassignedShard.shardId()), inSyncAllocationIds, shardState, logger);

--- a/server/src/test/java/org/elasticsearch/gateway/PrimaryShardAllocatorTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/PrimaryShardAllocatorTests.java
@@ -332,7 +332,8 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
      * deciders say yes, we allocate to that node.
      */
     public void testRestore() {
-        RoutingAllocation allocation = getRestoreRoutingAllocation(yesAllocationDeciders(), randomLong(), "allocId");
+        RoutingAllocation allocation = getRestoreRoutingAllocation(yesAllocationDeciders(), randomLong(),
+                generateRandomStringArray(randomIntBetween(0, 2), 10, false));
         testAllocator.addData(node1, "some allocId", randomBoolean());
         allocateAllUnassigned(allocation);
         assertThat(allocation.routingNodesChanged(), equalTo(true));
@@ -346,7 +347,8 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
      * deciders say throttle, we add it to ignored shards.
      */
     public void testRestoreThrottle() {
-        RoutingAllocation allocation = getRestoreRoutingAllocation(throttleAllocationDeciders(), randomLong(), "allocId");
+        RoutingAllocation allocation = getRestoreRoutingAllocation(throttleAllocationDeciders(), randomLong(),
+                generateRandomStringArray(randomIntBetween(0, 2), 10, false));
         testAllocator.addData(node1, "some allocId", randomBoolean());
         allocateAllUnassigned(allocation);
         assertThat(allocation.routingNodesChanged(), equalTo(true));
@@ -360,7 +362,8 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
      */
     public void testRestoreForcesAllocateIfShardAvailable() {
         final long shardSize = randomNonNegativeLong();
-        RoutingAllocation allocation = getRestoreRoutingAllocation(noAllocationDeciders(), shardSize, "allocId");
+        RoutingAllocation allocation = getRestoreRoutingAllocation(noAllocationDeciders(), shardSize,
+                generateRandomStringArray(randomIntBetween(0, 2), 10, false));
         testAllocator.addData(node1, "some allocId", randomBoolean());
         allocateAllUnassigned(allocation);
         assertThat(allocation.routingNodesChanged(), equalTo(true));
@@ -376,7 +379,8 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
      * the unassigned list to be allocated later.
      */
     public void testRestoreDoesNotAssignIfNoShardAvailable() {
-        RoutingAllocation allocation = getRestoreRoutingAllocation(yesAllocationDeciders(), randomNonNegativeLong(), "allocId");
+        RoutingAllocation allocation = getRestoreRoutingAllocation(yesAllocationDeciders(), randomNonNegativeLong(),
+                generateRandomStringArray(randomIntBetween(0, 2), 10, false));
         testAllocator.addData(node1, null, randomBoolean());
         allocateAllUnassigned(allocation);
         assertThat(allocation.routingNodesChanged(), equalTo(false));
@@ -390,7 +394,8 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
      * the unassigned list to be allocated later.
      */
     public void testRestoreDoesNotAssignIfShardSizeNotAvailable() {
-        RoutingAllocation allocation = getRestoreRoutingAllocation(yesAllocationDeciders(), null, "allocId");
+        RoutingAllocation allocation = getRestoreRoutingAllocation(yesAllocationDeciders(), null,
+                generateRandomStringArray(randomIntBetween(0, 2), 10, false));
         testAllocator.addData(node1, null, false);
         allocateAllUnassigned(allocation);
         assertThat(allocation.routingNodesChanged(), equalTo(true));


### PR DESCRIPTION
1) inSyncAllocationIds is empty when recoverySource is SNAPSHOT while assigning primary shard;
2) update comment in NodeVersionAllocationDecider: active primary should has a **older-or-equal** version so that peer recovery works