### PR TITLE
[7.11] Fix NPE when validating composable template with no template (#67310)

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutComposableIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutComposableIndexTemplateAction.java
@@ -95,8 +95,9 @@ public class PutComposableIndexTemplateAction extends ActionType<AcknowledgedRes
             if (indexTemplate == null) {
                 validationException = addValidationError("an index template is required", validationException);
             } else {
-                if (indexTemplate.indexPatterns().stream().anyMatch(Regex::isMatchAllPattern)) {
-                    if (IndexMetadata.INDEX_HIDDEN_SETTING.exists(indexTemplate.template().settings())) {
+                if (indexTemplate.template() != null && indexTemplate.indexPatterns().stream().anyMatch(Regex::isMatchAllPattern)) {
+                    if (indexTemplate.template().settings() != null &&
+                        IndexMetadata.INDEX_HIDDEN_SETTING.exists(indexTemplate.template().settings())) {
                         validationException = addValidationError("global composable templates may not specify the setting "
                                 + IndexMetadata.INDEX_HIDDEN_SETTING.getKey(),
                             validationException

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplate.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplate.java
@@ -170,6 +170,7 @@ public class ComposableIndexTemplate extends AbstractDiffable<ComposableIndexTem
         return componentTemplates;
     }
 
+    @Nullable
     public Long priority() {
         return priority;
     }
@@ -181,14 +182,17 @@ public class ComposableIndexTemplate extends AbstractDiffable<ComposableIndexTem
         return priority;
     }
 
+    @Nullable
     public Long version() {
         return version;
     }
 
+    @Nullable
     public Map<String, Object> metadata() {
         return metadata;
     }
 
+    @Nullable
     public DataStreamTemplate getDataStreamTemplate() {
         return dataStreamTemplate;
     }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Template.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Template.java
@@ -100,14 +100,17 @@ public class Template extends AbstractDiffable<Template> implements ToXContentOb
         }
     }
 
+    @Nullable
     public Settings settings() {
         return settings;
     }
 
+    @Nullable
     public CompressedXContent mappings() {
         return mappings;
     }
 
+    @Nullable
     public Map<String, AliasMetadata> aliases() {
         return aliases;
     }

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/template/put/PutComposableIndexTemplateRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/template/put/PutComposableIndexTemplateRequestTests.java
@@ -30,6 +30,7 @@ import org.elasticsearch.test.AbstractWireSerializingTestCase;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.hamcrest.Matchers.is;
@@ -92,5 +93,15 @@ public class PutComposableIndexTemplateRequestTests extends AbstractWireSerializ
         assertThat(validationErrors.size(), is(1));
         String error = validationErrors.get(0);
         assertThat(error, is("index template priority must be >= 0"));
+    }
+
+    public void testValidateNoTemplate() {
+        PutComposableIndexTemplateAction.Request req = new PutComposableIndexTemplateAction.Request("test");
+        req.indexTemplate(new ComposableIndexTemplate(Collections.singletonList("*"), null, null, null, null, null));
+        assertNull(req.validate());
+
+        req.indexTemplate(new ComposableIndexTemplate(Collections.singletonList("*"),
+                        new Template(null, null, null), null, null, null, null));
+        assertNull(req.validate());
     }
 }


### PR DESCRIPTION
Backports the following commits to 7.11:
 - Fix NPE when validating composable template with no template (#67310)