### PR TITLE
[7.x] [DOCS] Fix grammar and style in README (#67317)

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -10,9 +10,9 @@ Elasticsearch is a distributed RESTful search engine built for the cloud. Featur
 ** Each index is fully sharded with a configurable number of shards.
 ** Each shard can have one or more replicas.
 ** Read / Search operations performed on any of the replica shards.
-* Multi Tenant.
+* Multi-tenant.
 ** Support for more than one index.
-** Index level configuration (number of shards, index storage, ...).
+** Index level configuration (number of shards, index storage, etc.).
 * Various set of APIs
 ** HTTP RESTful API
 ** All APIs perform automatic node operation rerouting.
@@ -20,12 +20,12 @@ Elasticsearch is a distributed RESTful search engine built for the cloud. Featur
 ** No need for upfront schema definition.
 ** Schema can be defined for customization of the indexing process.
 * Reliable, Asynchronous Write Behind for long term persistency.
-* (Near) Real Time Search.
+* Near real-time search.
 * Built on top of Apache Lucene
 ** Each shard is a fully functional Lucene index
-** All the power of Lucene easily exposed through simple configuration / plugins.
+** All the power of Lucene easily exposed through simple configuration and plugins.
 * Per operation consistency
-** Single document level operations are atomic, consistent, isolated and durable.
+** Single document-level operations are atomic, consistent, isolated, and durable.
 
 == Getting Started
 
@@ -178,15 +178,15 @@ curl -X GET 'http://localhost:9200/_search?pretty=true' -H 'Content-Type: applic
 
 === Distributed, highly available
 
-Let's face it, things will fail....
+Let's face it; things will fail...
 
-Elasticsearch is a highly available and distributed search engine. Each index is broken down into shards, and each shard can have one or more replicas. By default, an index is created with 1 shard and 1 replica per shard (1/1). There are many topologies that can be used, including 1/10 (improve search performance), or 20/1 (improve indexing performance, with search executed in a map reduce fashion across shards).
+Elasticsearch is a highly available and distributed search engine. Each index is broken down into shards, and each shard can have one or more replicas. By default, an index is created with 1 shard and 1 replica per shard (1/1). Many topologies can be used, including 1/10 (improve search performance) or 20/1 (improve indexing performance, with search executed in a MapReduce fashion across shards).
 
-In order to play with the distributed nature of Elasticsearch, simply bring more nodes up and shut down nodes. The system will continue to serve requests (make sure you use the correct http port) with the latest data indexed.
+To play with the distributed nature of Elasticsearch, bring more nodes up and shut down nodes. The system will continue to serve requests (ensure you use the correct HTTP port) with the latest data indexed.
 
 === Where to go from here?
 
-We have just covered a very small portion of what Elasticsearch is all about. For more information, please refer to the https://www.elastic.co/products/elasticsearch[elastic.co] website. General questions can be asked on the https://discuss.elastic.co[Elastic Forum] or https://ela.st/slack[on Slack]. The Elasticsearch GitHub repository is reserved for bug reports and feature requests only.
+We have just covered a tiny portion of what Elasticsearch is all about. For more information, please refer to the https://www.elastic.co/products/elasticsearch[elastic.co] website. General questions can be asked on the https://discuss.elastic.co[Elastic Forum] or https://ela.st/slack[on Slack]. The Elasticsearch GitHub repository is reserved for bug reports and feature requests only.
 
 === Building from source
 
@@ -216,4 +216,4 @@ See the xref:TESTING.asciidoc[TESTING] for more information about running the El
 
 === Upgrading from older Elasticsearch versions
 
-In order to ensure a smooth upgrade process from earlier versions of Elasticsearch, please see our https://www.elastic.co/guide/en/elasticsearch/reference/current/setup-upgrade.html[upgrade documentation] for more details on the upgrade process.
+To ensure a smooth upgrade process from earlier versions of Elasticsearch, please see our https://www.elastic.co/guide/en/elasticsearch/reference/current/setup-upgrade.html[upgrade documentation] for more details on the upgrade process.


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Fix grammar and style in README (#67317)