### PR TITLE
[7.10] Avoid accidental cleanups in indices cleaner tests (#67338)

### DIFF
--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/cleaner/AbstractIndicesCleanerTestCase.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/cleaner/AbstractIndicesCleanerTestCase.java
@@ -14,6 +14,7 @@ import org.elasticsearch.xpack.core.monitoring.exporter.MonitoringTemplateUtils;
 import org.elasticsearch.xpack.monitoring.exporter.Exporter;
 import org.elasticsearch.xpack.monitoring.exporter.Exporters;
 import org.elasticsearch.xpack.monitoring.test.MonitoringIntegTestCase;
+import org.junit.Before;
 
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -27,17 +28,22 @@ public abstract class AbstractIndicesCleanerTestCase extends MonitoringIntegTest
     static final DateFormatter DATE_FORMATTER = DateFormatter.forPattern("yyyy.MM.dd").withZone(ZoneOffset.UTC);
     static Integer INDEX_TEMPLATE_VERSION = null;
 
-    public void testNothingToDelete() throws Exception {
+    @Before
+    public void setup() {
         internalCluster().startNode();
 
+        //Set max retention time to avoid any accidental cleanups
+        CleanerService cleanerService = internalCluster().getInstance(CleanerService.class, internalCluster().getMasterName());
+        cleanerService.setGlobalRetention(TimeValue.MAX_VALUE);
+    }
+
+    public void testNothingToDelete() throws Exception {
         CleanerService.Listener listener = getListener();
         listener.onCleanUpIndices(days(0));
         assertIndicesCount(0);
     }
 
     public void testDeleteIndex() throws Exception {
-        internalCluster().startNode();
-
         createTimestampedIndex(now().minusDays(10));
         assertIndicesCount(1);
 
@@ -47,8 +53,6 @@ public abstract class AbstractIndicesCleanerTestCase extends MonitoringIntegTest
     }
 
     public void testIgnoreCurrentAlertsIndex() throws Exception {
-        internalCluster().startNode();
-
         // Will be deleted
         createTimestampedIndex(now().minusDays(10));
 
@@ -63,8 +67,6 @@ public abstract class AbstractIndicesCleanerTestCase extends MonitoringIntegTest
     }
 
     public void testDoesNotIgnoreIndicesInOtherVersions() throws Exception {
-        internalCluster().startNode();
-
         // Will be deleted
         createTimestampedIndex(now().minusDays(10));
         createIndex(".monitoring-data-2", now().minusDays(10));
@@ -88,8 +90,6 @@ public abstract class AbstractIndicesCleanerTestCase extends MonitoringIntegTest
     }
 
     public void testIgnoreCurrentTimestampedIndex() throws Exception {
-        internalCluster().startNode();
-
         // Will be deleted
         createTimestampedIndex(now().minusDays(10));
 
@@ -104,8 +104,6 @@ public abstract class AbstractIndicesCleanerTestCase extends MonitoringIntegTest
     }
 
     public void testDeleteIndices() throws Exception {
-        internalCluster().startNode();
-
         CleanerService.Listener listener = getListener();
 
         final ZonedDateTime now = now();


### PR DESCRIPTION
Backports the following commits to 7.10:
 - Avoid accidental cleanups in indices cleaner tests (#67338)