### PR TITLE
[ML] updating 7.11 breaking changes doc

### DIFF
--- a/docs/reference/migration/migrate_7_11.asciidoc
+++ b/docs/reference/migration/migrate_7_11.asciidoc
@@ -49,12 +49,12 @@ settings of the transform.
 
 [discrete]
 [[breaking_711_ml_changes]]
-=== Machine Learning changes
+=== Machine learning changes
 .The trained models API parameter `for_export` is now renamed to `exclude_generated`.
 [%collapsible]
 ====
 *Details* +
-The trained models API (`GET _ml/trained_models/`) no longer accepts `for_export` when
-getting a model. `exclude_generated` is required instead, which behaves the same.
+The {ref}/get-trained-models.html[get trained models API] no longer accepts `for_export`.
+Use `exclude_generated` instead.
 ====
 //end::notable-breaking-changes[]

--- a/docs/reference/migration/migrate_7_11.asciidoc
+++ b/docs/reference/migration/migrate_7_11.asciidoc
@@ -46,4 +46,15 @@ of `epoch_millis` values. Previously constructed transforms will still use
 `epoch_millis` values. You can configure and change the output format in the
 settings of the transform.
 ====
+
+[discrete]
+[[breaking_711_ml_changes]]
+=== Machine Learning changes
+.The trained models API parameter `for_export` is now renamed to `exclude_generated`.
+[%collapsible]
+====
+*Details* +
+The trained models API (`GET _ml/trained_models/`) no longer accepts `for_export` when
+getting a model. `exclude_generated` is required instead, which behaves the same.
+====
 //end::notable-breaking-changes[]

--- a/docs/reference/migration/migrate_7_11.asciidoc
+++ b/docs/reference/migration/migrate_7_11.asciidoc
@@ -18,6 +18,17 @@ See also <<release-highlights>> and <<es-release-notes>>.
 //tag::notable-breaking-changes[]
 
 [discrete]
+[[breaking_711_ml_changes]]
+=== Machine learning changes
+.The trained models API parameter `for_export` is now renamed to `exclude_generated`.
+[%collapsible]
+====
+*Details* +
+The {ref}/get-trained-models.html[get trained models API] no longer accepts `for_export`.
+Use `exclude_generated` instead.
+====
+
+[discrete]
 [[breaking_711_search_changes]]
 === Search changes
 
@@ -45,16 +56,5 @@ Transforms now write dates used in a `group_by` as formatted ISO strings instead
 of `epoch_millis` values. Previously constructed transforms will still use
 `epoch_millis` values. You can configure and change the output format in the
 settings of the transform.
-====
-
-[discrete]
-[[breaking_711_ml_changes]]
-=== Machine learning changes
-.The trained models API parameter `for_export` is now renamed to `exclude_generated`.
-[%collapsible]
-====
-*Details* +
-The {ref}/get-trained-models.html[get trained models API] no longer accepts `for_export`.
-Use `exclude_generated` instead.
 ====
 //end::notable-breaking-changes[]


### PR DESCRIPTION
Updates breaking changes doc for ML to include changes to the trained models API.