### PR TITLE
Add requested headers to YAML REST error stash

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestExecutionContext.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestExecutionContext.java
@@ -108,6 +108,9 @@ public class ClientYamlTestExecutionContext {
             Object responseBody = response != null ? response.getBody() : null;
             //we always stash the last response body
             stash.stashValue("body", responseBody);
+            if(requestHeaders.isEmpty() == false) {
+                stash.stashValue("request_headers", requestHeaders);
+            }
         }
     }
 

--- a/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/ClientYamlTestExecutionContextTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/ClientYamlTestExecutionContextTests.java
@@ -20,28 +20,18 @@
 package org.elasticsearch.test.rest.yaml;
 
 import org.apache.http.HttpEntity;
-import org.apache.http.RequestLine;
-import org.apache.http.StatusLine;
 import org.elasticsearch.Version;
 import org.elasticsearch.client.NodeSelector;
-import org.elasticsearch.client.Response;
-import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.VersionUtils;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.core.IsIterableContaining;
-import org.mockito.Mock;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.hamcrest.Matchers.is;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class ClientYamlTestExecutionContextTests extends ESTestCase {
 


### PR DESCRIPTION
This commit adds the request_headers if defined by the do/headers
to the stash that is used to display test failures for YAML based 
REST tests. 

====

For example: 
```
  1> [2021-01-12T15:12:03,914][INFO ][o.e.x.t.r.XPackRestIT    ] [test] Stash dump on test failure [{
  1>   "stash" : {
  1>     "request_headers" : {
  1>       "Authorization" : "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==",
  1>       "Content-Type" : "application/json"
  1>     },
  1>     "body" : {
  1>       "job_id" : "custom-all-test-2",
  1>       "job_type" : "anomaly_detector",
```