### PR TITLE
Update serialization of XPackInfoRequest

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/XPackInfoRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/XPackInfoRequest.java
@@ -11,6 +11,7 @@ import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.license.License;
+import org.elasticsearch.tasks.TaskId;
 
 import java.io.IOException;
 import java.util.EnumSet;
@@ -48,7 +49,12 @@ public class XPackInfoRequest extends ActionRequest {
     }
 
     public XPackInfoRequest(StreamInput in) throws IOException {
-        // NOTE: this does *not* call super, THIS IS A BUG
+        // NOTE: this does *not* call super, THIS IS A BUG that will be fixed in 8.x
+        if (in.getVersion().onOrAfter(Version.V_7_12_0)) {
+            // The superclass constructor would set the parent task ID, but for now
+            // we must serialize and deserialize manually.
+            setParentTask(TaskId.readFromStream(in));
+        }
         this.verbose = in.readBoolean();
         EnumSet<Category> categories = EnumSet.noneOf(Category.class);
         int size = in.readVInt();
@@ -92,6 +98,10 @@ public class XPackInfoRequest extends ActionRequest {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
+        // NOTE: this does *not* call super.writeTo(out), THIS IS A BUG that will be fixed in 8.x
+        if (out.getVersion().onOrAfter(Version.V_7_12_0)) {
+            getParentTask().writeTo(out);
+        }
         out.writeBoolean(verbose);
         out.writeVInt(categories.size());
         for (Category category : categories) {


### PR DESCRIPTION
Our normal pattern with Writeable objects is for their constructors and
writeTo() methods to call the superclass methods. XPackInfoRequest
didn't do this. In order to fix this, we first need to update the
serialization in a backwards-compatible way for a particular 7.x
version. Once this is done, we can update the master branch to use the
correct pattern.

Backport of #67358