### PR TITLE
[DOCS] Note ILM uses snapshot of user privileges

### DIFF
--- a/docs/reference/ilm/apis/put-lifecycle.asciidoc
+++ b/docs/reference/ilm/apis/put-lifecycle.asciidoc
@@ -19,9 +19,10 @@ definitions of policy components.
 
 * If the {es} {security-features} are enabled, you must have the `manage_ilm`
 cluster privilege to use this API. You must also have the `manage` index
-privilege on all indices being managed by `policy`. All operations executed by
-{ilm} for a policy are executed as the user that put the latest version of a
-policy. For more information, see <<security-privileges>>.
+privilege on all indices being managed by `policy`. {ilm-init} performs
+operations as the user who last updated the policy. {ilm-init} only has the
+<<security-privileges,privileges>> assigned to the user at the time of the
+last policy update.
 
 [[ilm-put-lifecycle-desc]]
 ==== {api-description-title}

--- a/docs/reference/ilm/ilm-index-lifecycle.asciidoc
+++ b/docs/reference/ilm/ilm-index-lifecycle.asciidoc
@@ -17,12 +17,17 @@ slower.
 
 An index's _lifecycle policy_ specifies which phases 
 are applicable, what actions are performed in each phase,
-and when it transitions between phases. 
+and when it transitions between phases.
 
 You can manually apply a lifecycle policy when you create an index. 
 For time series indices, you need to associate the lifecycle policy with
 the index template used to create new indices in the series. 
 When an index rolls over, a manually-applied policy isn't automatically applied to the new index.
+
+If you use {es}'s Security features, {ilm-init} performs operations as the user
+who last updated the policy. {ilm-init} only has the
+<<security-privileges,privileges>> assigned to the user at the time of the
+last policy update.
 
 [discrete]
 [[ilm-phase-transitions]]


### PR DESCRIPTION
When performing operations, ILM only has the privileges of the user who last updated the policy _at the time of the update_.
This updates the ILM docs to reflect that.

Closes #66279