### PR TITLE
[7.11] [DOCS] Fix typo (#67230)

### DIFF
--- a/docs/painless/painless-lang-spec/painless-operators-numeric.asciidoc
+++ b/docs/painless/painless-lang-spec/painless-operators-numeric.asciidoc
@@ -268,7 +268,7 @@ decrement.
 
 [source,ANTLR4]
 ----
-pre_increment: '--' ( variable | field );
+pre_decrement: '--' ( variable | field );
 ----
 
 *Promotion*


### PR DESCRIPTION
Backports the following commits to 7.11:
 - [DOCS] Fix typo (#67230)