### PR TITLE
Precompute ParsedMediaType for XContentType

### DIFF
--- a/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/ParsedMediaType.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/ParsedMediaType.java
@@ -107,7 +107,7 @@ public class ParsedMediaType {
     }
 
     public static ParsedMediaType parseMediaType(XContentType requestContentType, Map<String, String> parameters) {
-        ParsedMediaType parsedMediaType = parseMediaType(requestContentType.mediaTypeWithoutParameters());
+        ParsedMediaType parsedMediaType = requestContentType.toParsedMediaType();
         parsedMediaType.parameters.putAll(parameters);
         return parsedMediaType;
     }
@@ -159,8 +159,13 @@ public class ParsedMediaType {
         return originalHeaderValue;
     }
 
+    public String responseContentTypeHeader() {
+        return mediaTypeWithoutParameters() + formatParameters(parameters);
+    }
+
+    //used in testing
     public String responseContentTypeHeader(Map<String,String> parameters) {
-        return this.mediaTypeWithoutParameters() + formatParameters(parameters);
+        return mediaTypeWithoutParameters() + formatParameters(parameters);
     }
 
     private String formatParameters(Map<String, String> parameters) {

--- a/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/XContentBuilder.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/XContentBuilder.java
@@ -77,7 +77,7 @@ public final class XContentBuilder implements Closeable, Flushable {
      */
     public static XContentBuilder builder(XContentType xContentType, Set<String> includes, Set<String> excludes) throws IOException {
         return new XContentBuilder(xContentType.xContent(), new ByteArrayOutputStream(), includes, excludes,
-            ParsedMediaType.parseMediaType(xContentType.mediaType()));
+            xContentType.toParsedMediaType());
     }
 
     private static final Map<Class<?>, Writer> WRITERS;
@@ -175,9 +175,8 @@ public final class XContentBuilder implements Closeable, Flushable {
      * to call {@link #close()} when the builder is done with.
      */
     public XContentBuilder(XContent xContent, OutputStream bos) throws IOException {
-        this(xContent, bos, Collections.emptySet(), Collections.emptySet(), ParsedMediaType.parseMediaType(xContent.type().mediaType()));
+        this(xContent, bos, Collections.emptySet(), Collections.emptySet(), xContent.type().toParsedMediaType());
     }
-
     /**
      * Constructs a new builder using the provided XContent, an OutputStream and
      * some filters. If filters are specified, only those values matching a
@@ -185,7 +184,7 @@ public final class XContentBuilder implements Closeable, Flushable {
      * {@link #close()} when the builder is done with.
      */
     public XContentBuilder(XContentType xContentType, OutputStream bos, Set<String> includes) throws IOException {
-        this(xContentType.xContent(), bos, includes, Collections.emptySet(), ParsedMediaType.parseMediaType(xContentType.mediaType()));
+        this(xContentType.xContent(), bos, includes, Collections.emptySet(), xContentType.toParsedMediaType());
     }
 
     /**
@@ -208,9 +207,7 @@ public final class XContentBuilder implements Closeable, Flushable {
     }
 
     public String getResponseContentTypeString() {
-        Map<String, String> parameters = responseContentType != null ?
-            responseContentType.getParameters() : Collections.emptyMap();
-        return responseContentType.responseContentTypeHeader(parameters);
+        return responseContentType.responseContentTypeHeader();
     }
 
     public XContentType contentType() {

--- a/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/XContentType.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/XContentType.java
@@ -270,6 +270,7 @@ public enum XContentType implements MediaType {
         .register(XContentType.values());
     public static final String VENDOR_APPLICATION_PREFIX = "application/vnd.elasticsearch+";
 
+    private final ParsedMediaType mediaType = ParsedMediaType.parseMediaType(mediaTypeWithoutParameters());
     /**
      * Accepts a format string, which is most of the time is equivalent to MediaType's subtype i.e. <code>application/<b>json</b></code>
      * and attempts to match the value to an {@link XContentType}.
@@ -323,6 +324,10 @@ public enum XContentType implements MediaType {
     public abstract XContent xContent();
 
     public abstract String mediaTypeWithoutParameters();
+
+    public ParsedMediaType toParsedMediaType() {
+        return mediaType;
+    }
 
     /**
      * Returns a canonical XContentType for this XContentType.

--- a/server/src/test/java/org/elasticsearch/rest/RestControllerTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/RestControllerTests.java
@@ -33,7 +33,6 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.MediaType;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
-import org.elasticsearch.common.xcontent.ParsedMediaType;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.yaml.YamlXContent;
@@ -732,7 +731,7 @@ public class RestControllerTests extends ESTestCase {
 
     private String randomCompatibleMimeType(byte version) {
         XContentType type = randomFrom(XContentType.VND_JSON, XContentType.VND_SMILE, XContentType.VND_CBOR, XContentType.VND_YAML);
-        return ParsedMediaType.parseMediaType(type.mediaType())
+        return type.toParsedMediaType()
             .responseContentTypeHeader(Map.of(MediaType.COMPATIBLE_WITH_PARAMETER_NAME, String.valueOf(version)));
     }
 

--- a/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestGetAliasesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestGetAliasesActionTests.java
@@ -54,7 +54,7 @@ public class RestGetAliasesActionTests extends ESTestCase {
         final RestResponse restResponse = RestGetAliasesAction.buildRestResponse(false, new String[0], openMapBuilder.build(),
                 xContentBuilder);
         assertThat(restResponse.status(), equalTo(OK));
-        assertThat(restResponse.contentType(), equalTo("application/json;charset=utf-8"));
+        assertThat(restResponse.contentType(), equalTo("application/json"));
         assertThat(restResponse.content().utf8ToString(), equalTo("{\"index\":{\"aliases\":{\"foo\":{},\"foobar\":{}}}}"));
     }
 
@@ -64,7 +64,7 @@ public class RestGetAliasesActionTests extends ESTestCase {
         final RestResponse restResponse = RestGetAliasesAction.buildRestResponse(true, new String[] { "baz*" }, openMapBuilder.build(),
                 xContentBuilder);
         assertThat(restResponse.status(), equalTo(OK));
-        assertThat(restResponse.contentType(), equalTo("application/json;charset=utf-8"));
+        assertThat(restResponse.contentType(), equalTo("application/json"));
         assertThat(restResponse.content().utf8ToString(), equalTo("{}"));
     }
 
@@ -76,7 +76,7 @@ public class RestGetAliasesActionTests extends ESTestCase {
         final RestResponse restResponse = RestGetAliasesAction.buildRestResponse(true, new String[] { "baz*", "foobar*" },
                 openMapBuilder.build(), xContentBuilder);
         assertThat(restResponse.status(), equalTo(OK));
-        assertThat(restResponse.contentType(), equalTo("application/json;charset=utf-8"));
+        assertThat(restResponse.contentType(), equalTo("application/json"));
         assertThat(restResponse.content().utf8ToString(), equalTo("{\"index\":{\"aliases\":{\"foobar\":{}}}}"));
     }
 
@@ -86,7 +86,7 @@ public class RestGetAliasesActionTests extends ESTestCase {
         final RestResponse restResponse = RestGetAliasesAction.buildRestResponse(true, new String[] { "foob*", "-foo*" },
                 openMapBuilder.build(), xContentBuilder);
         assertThat(restResponse.status(), equalTo(OK));
-        assertThat(restResponse.contentType(), equalTo("application/json;charset=utf-8"));
+        assertThat(restResponse.contentType(), equalTo("application/json"));
         assertThat(restResponse.content().utf8ToString(), equalTo("{}"));
     }
 
@@ -98,7 +98,7 @@ public class RestGetAliasesActionTests extends ESTestCase {
         final RestResponse restResponse = RestGetAliasesAction.buildRestResponse(true, new String[] { "foo*", "-foob*" },
                 openMapBuilder.build(), xContentBuilder);
         assertThat(restResponse.status(), equalTo(OK));
-        assertThat(restResponse.contentType(), equalTo("application/json;charset=utf-8"));
+        assertThat(restResponse.contentType(), equalTo("application/json"));
         assertThat(restResponse.content().utf8ToString(), equalTo("{\"index\":{\"aliases\":{\"foo\":{}}}}"));
     }
 
@@ -117,7 +117,7 @@ public class RestGetAliasesActionTests extends ESTestCase {
         final RestResponse restResponse = RestGetAliasesAction.buildRestResponse(true, aliasPattern, openMapBuilder.build(),
                 xContentBuilder);
         assertThat(restResponse.status(), equalTo(NOT_FOUND));
-        assertThat(restResponse.contentType(), equalTo("application/json;charset=utf-8"));
+        assertThat(restResponse.contentType(), equalTo("application/json"));
         assertThat(restResponse.content().utf8ToString(),
                 equalTo("{\"error\":\"alias [missing] missing\",\"status\":404,\"index\":{\"aliases\":{\"foo\":{}}}}"));
     }
@@ -128,7 +128,7 @@ public class RestGetAliasesActionTests extends ESTestCase {
         final RestResponse restResponse = RestGetAliasesAction.buildRestResponse(true, new String[] { "foo", "foofoo", "-foo*" },
                 openMapBuilder.build(), xContentBuilder);
         assertThat(restResponse.status(), equalTo(OK));
-        assertThat(restResponse.contentType(), equalTo("application/json;charset=utf-8"));
+        assertThat(restResponse.contentType(), equalTo("application/json"));
         assertThat(restResponse.content().utf8ToString(), equalTo("{}"));
     }
 }

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/common/http/HttpRequest.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/common/http/HttpRequest.java
@@ -10,7 +10,6 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.common.xcontent.ParsedMediaType;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -510,7 +509,7 @@ public class HttpRequest implements ToXContentObject {
         try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
              XContentBuilder filteredBuilder = new XContentBuilder(xContentType.xContent(), bos,
                  Collections.emptySet(), Collections.singleton(excludeField),
-                 ParsedMediaType.parseMediaType(xContentType.mediaType()))) {
+                 xContentType.toParsedMediaType())) {
             request.toXContent(filteredBuilder, params);
             filteredBuilder.flush();
             return new ByteArrayInputStream(bos.toByteArray());


### PR DESCRIPTION
`XContentType` instances should have a precomputed `ParsedMediaType` instances that will prevent unnecessary parsing of its media type.

The unnecessary parsing was causing a performance drop and this commit addresses that. The performance was affected because XContentBuilder is newly created per each request, which in case of bulk request can be mane instances. Each `XContentBuilder` instance is using `XContentType.mediaType` which was parsed into `ParsedMediaType`.
That in bulk request is unnecessary as the content-type is already known - from `XContent#type`

By default when Accept or Content-Type headers are not specified, `application/json; charset=UTF-8` is used on a response content-type. The redundant charset parameter is dropped in this commit as well.
relates https://github.com/elastic/elasticsearch/pull/65500