### PR TITLE
Skip cluster state serialization to closed channel

### DIFF
--- a/qa/smoke-test-http/src/test/java/org/elasticsearch/http/ClusterStateRestCancellationIT.java
+++ b/qa/smoke-test-http/src/test/java/org/elasticsearch/http/ClusterStateRestCancellationIT.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.http;
+
+import org.apache.http.client.methods.HttpGet;
+import org.elasticsearch.Version;
+import org.elasticsearch.action.admin.cluster.state.ClusterStateAction;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.client.Cancellable;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.ResponseListener;
+import org.elasticsearch.cluster.AbstractDiffable;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateUpdateTask;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.tasks.TaskInfo;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CancellationException;
+import java.util.function.UnaryOperator;
+
+public class ClusterStateRestCancellationIT extends HttpSmokeTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return CollectionUtils.appendToCopy(super.nodePlugins(), AssertingCustomPlugin.class);
+    }
+
+    private void updateClusterState(ClusterService clusterService, UnaryOperator<ClusterState> updateOperator) {
+        final PlainActionFuture<Void> future = new PlainActionFuture<>();
+        clusterService.submitStateUpdateTask("update state", new ClusterStateUpdateTask() {
+            @Override
+            public ClusterState execute(ClusterState currentState) {
+                return updateOperator.apply(currentState);
+            }
+
+            @Override
+            public void onFailure(String source, Exception e) {
+                throw new AssertionError(source, e);
+            }
+
+            @Override
+            public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+                future.onResponse(null);
+            }
+        });
+        future.actionGet();
+    }
+
+    public void testClusterStateRestCancellation() throws Exception {
+
+        final ClusterService clusterService = internalCluster().getInstance(ClusterService.class, internalCluster().getMasterName());
+        updateClusterState(clusterService, s -> ClusterState.builder(s).putCustom(AssertingCustom.NAME, AssertingCustom.INSTANCE).build());
+
+        final Request clusterStateRequest = new Request(HttpGet.METHOD_NAME, "/_cluster/state");
+        clusterStateRequest.addParameter("wait_for_metadata_version", Long.toString(Long.MAX_VALUE));
+        clusterStateRequest.addParameter("wait_for_timeout", "1h");
+
+        final PlainActionFuture<Void> future = new PlainActionFuture<>();
+        logger.info("--> sending cluster state request");
+        final Cancellable cancellable = getRestClient().performRequestAsync(clusterStateRequest, new ResponseListener() {
+            @Override
+            public void onSuccess(Response response) {
+                future.onResponse(null);
+            }
+
+            @Override
+            public void onFailure(Exception exception) {
+                future.onFailure(exception);
+            }
+        });
+
+        logger.info("--> waiting for task to start");
+        assertBusy(() -> {
+            final List<TaskInfo> tasks = client().admin().cluster().prepareListTasks().get().getTasks();
+            assertTrue(tasks.toString(), tasks.stream().anyMatch(t -> t.getAction().equals(ClusterStateAction.NAME)));
+        });
+
+        logger.info("--> cancelling cluster state request");
+        cancellable.cancel();
+        expectThrows(CancellationException.class, future::actionGet);
+
+        logger.info("--> checking cluster state task completed");
+        assertBusy(() -> {
+            updateClusterState(clusterService, s -> ClusterState.builder(s).build());
+            final List<TaskInfo> tasks = client().admin().cluster().prepareListTasks().get().getTasks();
+            assertTrue(tasks.toString(), tasks.stream().noneMatch(t -> t.getAction().equals(ClusterStateAction.NAME)));
+        });
+
+        updateClusterState(clusterService, s -> ClusterState.builder(s).removeCustom(AssertingCustom.NAME).build());
+    }
+
+    private static class AssertingCustom extends AbstractDiffable<ClusterState.Custom> implements ClusterState.Custom {
+
+        static final String NAME = "asserting";
+        static final AssertingCustom INSTANCE = new AssertingCustom();
+
+        @Override
+        public String getWriteableName() {
+            return NAME;
+        }
+
+        @Override
+        public Version getMinimalSupportedVersion() {
+            return Version.CURRENT;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) {
+            // no content
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) {
+            throw new AssertionError("task should have been cancelled before serializing this custom");
+        }
+    }
+
+    public static class AssertingCustomPlugin extends Plugin {
+        @Override
+        public List<NamedWriteableRegistry.Entry> getNamedWriteables() {
+            return Collections.singletonList(
+                    new NamedWriteableRegistry.Entry(ClusterState.Custom.class, AssertingCustom.NAME, in -> AssertingCustom.INSTANCE));
+        }
+    }
+
+
+}

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
@@ -39,6 +39,7 @@ import org.elasticsearch.cluster.metadata.RepositoryMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.network.CloseableChannel;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsFilter;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
@@ -454,6 +455,8 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
                     assertThat(response.content().utf8ToString(), not(containsString("verysecretpassword")));
                 } catch (AssertionError ex) {
                     clusterStateError.set(ex);
+                } finally {
+                    CloseableChannel.closeChannel(clusterStateRequest.getHttpChannel());
                 }
                 clusterStateLatch.countDown();
             }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateAction.java
@@ -41,7 +41,9 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.node.NodeClosedException;
+import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
@@ -73,18 +75,22 @@ public class TransportClusterStateAction extends TransportMasterNodeReadAction<C
     protected void masterOperation(Task task, final ClusterStateRequest request, final ClusterState state,
                                    final ActionListener<ClusterStateResponse> listener) throws IOException {
 
+        assert task instanceof CancellableTask : task + " not cancellable";
+        final CancellableTask cancellableTask = (CancellableTask) task;
+
         final Predicate<ClusterState> acceptableClusterStatePredicate
             = request.waitForMetadataVersion() == null ? clusterState -> true
             : clusterState -> clusterState.metadata().version() >= request.waitForMetadataVersion();
 
-        final Predicate<ClusterState> acceptableClusterStateOrNotMasterPredicate = request.local()
+        final Predicate<ClusterState> acceptableClusterStateOrFailedPredicate = request.local()
             ? acceptableClusterStatePredicate
-            : acceptableClusterStatePredicate.or(clusterState -> clusterState.nodes().isLocalNodeElectedMaster() == false);
+            : acceptableClusterStatePredicate.or(clusterState ->
+                cancellableTask.isCancelled() || clusterState.nodes().isLocalNodeElectedMaster() == false);
 
         if (acceptableClusterStatePredicate.test(state)) {
             ActionListener.completeWith(listener, () -> buildResponse(request, state));
         } else {
-            assert acceptableClusterStateOrNotMasterPredicate.test(state) == false;
+            assert acceptableClusterStateOrFailedPredicate.test(state) == false;
             new ClusterStateObserver(state, clusterService, request.waitForTimeout(), logger, threadPool.getThreadContext())
                 .waitForNextChange(new ClusterStateObserver.Listener() {
 
@@ -92,6 +98,8 @@ public class TransportClusterStateAction extends TransportMasterNodeReadAction<C
                 public void onNewClusterState(ClusterState newState) {
                     if (acceptableClusterStatePredicate.test(newState)) {
                         ActionListener.completeWith(listener, () -> buildResponse(request, newState));
+                    } else if (cancellableTask.isCancelled()) {
+                        listener.onFailure(new TaskCancelledException("task cancelled"));
                     } else {
                         listener.onFailure(new NotMasterException(
                             "master stepped down waiting for metadata version " + request.waitForMetadataVersion()));
@@ -106,12 +114,16 @@ public class TransportClusterStateAction extends TransportMasterNodeReadAction<C
                 @Override
                 public void onTimeout(TimeValue timeout) {
                     try {
-                        listener.onResponse(new ClusterStateResponse(state.getClusterName(), null, true));
+                        if (cancellableTask.isCancelled()) {
+                            listener.onFailure(new TaskCancelledException("task cancelled"));
+                        } else {
+                            listener.onResponse(new ClusterStateResponse(state.getClusterName(), null, true));
+                        }
                     } catch (Exception e) {
                         listener.onFailure(e);
                     }
                 }
-            }, acceptableClusterStateOrNotMasterPredicate);
+            }, acceptableClusterStateOrFailedPredicate);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateAction.java
@@ -96,10 +96,10 @@ public class TransportClusterStateAction extends TransportMasterNodeReadAction<C
 
                 @Override
                 public void onNewClusterState(ClusterState newState) {
-                    if (acceptableClusterStatePredicate.test(newState)) {
-                        ActionListener.completeWith(listener, () -> buildResponse(request, newState));
-                    } else if (cancellableTask.isCancelled()) {
+                    if (cancellableTask.isCancelled()) {
                         listener.onFailure(new TaskCancelledException("task cancelled"));
+                    } else if (acceptableClusterStatePredicate.test(newState)) {
+                        ActionListener.completeWith(listener, () -> buildResponse(request, newState));
                     } else {
                         listener.onFailure(new NotMasterException(
                             "master stepped down waiting for metadata version " + request.waitForMetadataVersion()));

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequestTests.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.VersionUtils;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 
 /**
@@ -84,5 +85,20 @@ public class ClusterStateRequestTests extends ESTestCase {
         assertThat(in.expandWildcardsClosed(), equalTo(out.expandWildcardsClosed()));
         assertThat(in.expandWildcardsOpen(), equalTo(out.expandWildcardsOpen()));
         assertThat(in.allowNoIndices(), equalTo(out.allowNoIndices()));
+    }
+
+    public void testDescription() {
+        assertThat(new ClusterStateRequest().clear().getDescription(), equalTo("cluster state [master timeout [30s]]"));
+        assertThat(new ClusterStateRequest().masterNodeTimeout("5m").getDescription(),
+                equalTo("cluster state [routing table, nodes, metadata, blocks, customs, master timeout [5m]]"));
+        assertThat(new ClusterStateRequest().clear().routingTable(true).getDescription(), containsString("routing table"));
+        assertThat(new ClusterStateRequest().clear().nodes(true).getDescription(), containsString("nodes"));
+        assertThat(new ClusterStateRequest().clear().metadata(true).getDescription(), containsString("metadata"));
+        assertThat(new ClusterStateRequest().clear().blocks(true).getDescription(), containsString("blocks"));
+        assertThat(new ClusterStateRequest().clear().customs(true).getDescription(), containsString("customs"));
+        assertThat(new ClusterStateRequest().local(true).getDescription(), containsString("local"));
+        assertThat(new ClusterStateRequest().waitForMetadataVersion(23L).getDescription(),
+                containsString("wait for metadata version [23] with timeout [1m]"));
+        assertThat(new ClusterStateRequest().indices("foo", "bar").getDescription(), containsString("indices [foo, bar]"));
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/FakeRestRequest.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/FakeRestRequest.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.test.rest;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.PlainListenableActionFuture;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
@@ -139,6 +140,7 @@ public class FakeRestRequest extends RestRequest {
     private static class FakeHttpChannel implements HttpChannel {
 
         private final InetSocketAddress remoteAddress;
+        private final PlainListenableActionFuture<Void> closeFuture = PlainListenableActionFuture.newListenableFuture();
 
         private FakeHttpChannel(InetSocketAddress remoteAddress) {
             this.remoteAddress = remoteAddress;
@@ -161,7 +163,7 @@ public class FakeRestRequest extends RestRequest {
 
         @Override
         public void addCloseListener(ActionListener<Void> listener) {
-
+            closeFuture.addListener(listener);
         }
 
         @Override
@@ -171,7 +173,7 @@ public class FakeRestRequest extends RestRequest {
 
         @Override
         public void close() {
-
+            closeFuture.onResponse(null);
         }
     }
 


### PR DESCRIPTION
Today if a client requests a cluster state and then closes the
connection then we still do all the work of computing and serializing
the cluster state before finally dropping it all on the floor.

With this commit we introduce checks to make sure that the HTTP channel
is still open before starting the serialization process. We also make
the tasks themselves cancellable and abort any ongoing waiting if the
channel is closed (mainly to make the cancellability testing easier).
Finally we introduce a more detailed description of the task to help
identify cases where clients are inefficiently requesting more
components of the cluster state than they need.