### PR TITLE
Fix runtime jdk vendor detection used in fips.gradle

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/info/BuildParams.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/info/BuildParams.java
@@ -209,7 +209,7 @@ public class BuildParams {
             BuildParams.runtimeJavaHome = requireNonNull(runtimeJavaHome);
         }
 
-        public void setIsRutimeJavaHomeSet(boolean isRutimeJavaHomeSet) {
+        public void setIsRuntimeJavaHomeSet(boolean isRutimeJavaHomeSet) {
             BuildParams.isRuntimeJavaHomeSet = isRutimeJavaHomeSet;
         }
 

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/info/GlobalBuildInfoPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/info/GlobalBuildInfoPlugin.java
@@ -32,6 +32,7 @@ import org.gradle.api.provider.ProviderFactory;
 import org.gradle.internal.jvm.Jvm;
 import org.gradle.internal.jvm.inspection.JvmInstallationMetadata;
 import org.gradle.internal.jvm.inspection.JvmMetadataDetector;
+import org.gradle.internal.jvm.inspection.JvmVendor;
 import org.gradle.jvm.toolchain.internal.InstallationLocation;
 import org.gradle.jvm.toolchain.internal.SharedJavaInstallationRegistry;
 import org.gradle.util.GradleVersion;
@@ -107,8 +108,9 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
             params.reset();
             params.setRuntimeJavaHome(runtimeJavaHome);
             params.setRuntimeJavaVersion(determineJavaVersion("runtime java.home", runtimeJavaHome, minimumRuntimeVersion));
-            params.setIsRutimeJavaHomeSet(Jvm.current().getJavaHome().equals(runtimeJavaHome) == false);
-            params.setRuntimeJavaDetails(getJavaInstallation(runtimeJavaHome).getDisplayName());
+            params.setIsRuntimeJavaHomeSet(Jvm.current().getJavaHome().equals(runtimeJavaHome) == false);
+            JvmInstallationMetadata runtimeJdkMetaData = metadataDetector.getMetadata(getJavaInstallation(runtimeJavaHome).getLocation());
+            params.setRuntimeJavaDetails(formatJavaVendorDetails(runtimeJdkMetaData));
             params.setJavaVersions(getAvailableJavaVersions());
             params.setMinimumCompilerVersion(minimumCompilerVersion);
             params.setMinimumRuntimeVersion(minimumRuntimeVersion);
@@ -129,6 +131,11 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
 
         // Print global build info header just before task execution
         project.getGradle().getTaskGraph().whenReady(graph -> logGlobalBuildInfo());
+    }
+
+    private String formatJavaVendorDetails(JvmInstallationMetadata runtimeJdkMetaData) {
+        JvmVendor vendor = runtimeJdkMetaData.getVendor();
+        return runtimeJdkMetaData.getVendor().getKnownVendor().name() + "/" + vendor.getRawVendor();
     }
 
     /* Introspect all versions of ES that may be tested against for backwards

--- a/gradle/fips.gradle
+++ b/gradle/fips.gradle
@@ -6,7 +6,7 @@ import org.elasticsearch.gradle.testclusters.TestDistribution
 if (BuildParams.inFipsJvm) {
 
   allprojects {
-    String javaSecurityFilename = BuildParams.runtimeJavaDetails.startsWith('Oracle') ? 'fips_java_oracle.security' : 'fips_java.security'
+    String javaSecurityFilename = BuildParams.runtimeJavaDetails.startsWith('oracle') ? 'fips_java_oracle.security' : 'fips_java.security'
     File fipsResourcesDir = new File(project.buildDir, 'fips-resources')
     File fipsSecurity = new File(fipsResourcesDir, javaSecurityFilename)
     File fipsPolicy = new File(fipsResourcesDir, 'fips_java.policy')


### PR DESCRIPTION
This fixes the jdk vendor detection used in fips.gradle that was broken by updating gradle to 6.8 which deprecated `JavaInstallation`. 