### PR TITLE
Make Searchable Snapshot Cache Stats Action Internal (#67416)

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/cache/TransportSearchableSnapshotCacheStoresAction.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/cache/TransportSearchableSnapshotCacheStoresAction.java
@@ -35,7 +35,7 @@ public class TransportSearchableSnapshotCacheStoresAction extends TransportNodes
     TransportSearchableSnapshotCacheStoresAction.NodeRequest,
     TransportSearchableSnapshotCacheStoresAction.NodeCacheFilesMetadata> {
 
-    public static final String ACTION_NAME = "cluster:admin/xpack/searchable_snapshots/cache/store";
+    public static final String ACTION_NAME = "internal:admin/xpack/searchable_snapshots/cache/store";
 
     public static final ActionType<NodesCacheFilesMetadata> TYPE = new ActionType<>(ACTION_NAME, NodesCacheFilesMetadata::new);
 

--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
@@ -156,7 +156,6 @@ public class Constants {
         "cluster:admin/xpack/rollup/start",
         "cluster:admin/xpack/rollup/stop",
         "cluster:admin/xpack/searchable_snapshots/cache/clear",
-        "cluster:admin/xpack/searchable_snapshots/cache/store",
         "cluster:admin/xpack/security/api_key/create",
         "cluster:admin/xpack/security/api_key/get",
         "cluster:admin/xpack/security/api_key/grant",
@@ -368,6 +367,7 @@ public class Constants {
         "internal:admin/ccr/restore/file_chunk/get",
         "internal:admin/ccr/restore/session/clear",
         "internal:admin/ccr/restore/session/put",
+        "internal:admin/xpack/searchable_snapshots/cache/store",
         "internal:indices/admin/upgrade"
     );
 }


### PR DESCRIPTION
Make searchable snapshot cache stats action internal to not trip
authorization checks.

backport of #67416