### PR TITLE
Enable bwc tests after elastic#67414 merge

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -175,8 +175,8 @@ tasks.register("verifyVersions") {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = false
-String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/67414" /* place a PR link here when committing bwc changes */
+boolean bwc_tests_enabled = true
+String bwc_tests_disabled_issue = "" /* place a PR link here when committing bwc changes */
 /*
  * FIPS 140-2 behavior was fixed in 7.11.0. Before that there is no way to run elasticsearch in a
  * JVM that is properly configured to be in fips mode with BCFIPS. For now we need to disable

--- a/qa/mixed-cluster/src/test/java/org/elasticsearch/backwards/SearchWithMinCompatibleSearchNodeIT.java
+++ b/qa/mixed-cluster/src/test/java/org/elasticsearch/backwards/SearchWithMinCompatibleSearchNodeIT.java
@@ -139,7 +139,7 @@ public class SearchWithMinCompatibleSearchNodeIT extends ESRestTestCase {
     }
 
     private void assertWithBwcVersionCheck(CheckedRunnable<Exception> code, RestClient client, Request request) throws Exception {
-        if (bwcVersion.before(Version.V_8_0_0)) {
+        if (bwcVersion.before(Version.V_7_12_0)) {
             // min_compatible_shard_node support doesn't exist in older versions and there will be an "unrecognized parameter" exception
             ResponseException exception = expectThrows(ResponseException.class, () -> client.performRequest(request));
             assertThat(exception.getResponse().getStatusLine().getStatusCode(),

--- a/qa/mixed-cluster/src/test/java/org/elasticsearch/backwards/SearchWithMinCompatibleSearchNodeIT.java
+++ b/qa/mixed-cluster/src/test/java/org/elasticsearch/backwards/SearchWithMinCompatibleSearchNodeIT.java
@@ -120,10 +120,9 @@ public class SearchWithMinCompatibleSearchNodeIT extends ESRestTestCase {
         try (RestClient client = buildClient(restClientSettings(),
             allNodes.stream().map(Node::getPublishAddress).toArray(HttpHost[]::new))) {
             Version version = randomBoolean() ? newVersion : bwcVersion;
-            boolean shouldSetCcsMinimizeRoundtrips = randomBoolean();
 
-            Request request = new Request("POST", index + "/_search?min_compatible_shard_node=" + version +
-                (shouldSetCcsMinimizeRoundtrips ? "&ccs_minimize_roundtrips=true" : ""));
+            Request request = new Request("POST", index + "/_search?min_compatible_shard_node=" + version
+                + "&ccs_minimize_roundtrips=true");
             assertBusy(() -> {
                 assertWithBwcVersionCheck(() -> {
                     ResponseException responseException = expectThrows(ResponseException.class, () -> client.performRequest(request));

--- a/server/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/server/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -1052,7 +1052,7 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
                 org.elasticsearch.action.search.VersionMismatchException.class,
                 org.elasticsearch.action.search.VersionMismatchException::new,
                 161,
-                Version.V_8_0_0);
+                Version.V_7_12_0);
 
         final Class<? extends ElasticsearchException> exceptionClass;
         final CheckedFunction<StreamInput, ? extends ElasticsearchException, IOException> constructor;

--- a/server/src/main/java/org/elasticsearch/action/search/SearchRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchRequest.java
@@ -231,7 +231,7 @@ public class SearchRequest extends ActionRequest implements IndicesRequest.Repla
             finalReduce = true;
         }
         ccsMinimizeRoundtrips = in.readBoolean();
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_12_0)) {
             if (in.readBoolean()) {
                 minCompatibleShardNode = Version.readVersion(in);
             }
@@ -263,7 +263,7 @@ public class SearchRequest extends ActionRequest implements IndicesRequest.Repla
             out.writeBoolean(finalReduce);
         }
         out.writeBoolean(ccsMinimizeRoundtrips);
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_12_0)) {
             out.writeBoolean(minCompatibleShardNode != null);
             if (minCompatibleShardNode != null) {
                 Version.writeVersion(minCompatibleShardNode, out);


### PR DESCRIPTION
Enable bwc tests and adjust versions.
Relates to https://github.com/elastic/elasticsearch/pull/65896.