### PR TITLE
SQL: Add backwards-compatibilty frame for clients

### DIFF
--- a/x-pack/plugin/sql/qa/jdbc/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/JdbcTestUtils.java
+++ b/x-pack/plugin/sql/qa/jdbc/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/JdbcTestUtils.java
@@ -5,6 +5,7 @@
  */
 package org.elasticsearch.xpack.sql.qa.jdbc;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.xpack.sql.proto.StringUtils;
 
 import java.sql.Date;
@@ -22,7 +23,30 @@ final class JdbcTestUtils {
 
     static final ZoneId UTC = ZoneId.of("Z");
     static final String JDBC_TIMEZONE = "timezone";
+    private static final String DRIVER_VERSION_PROPERTY_NAME = "jdbc.driver.version";
     static final LocalDate EPOCH = LocalDate.of(1970, 1, 1);
+
+    /*
+     * The version of the driver that the QA (bwc-)tests run against.
+     * Note: when adding a version-gated feature (i.e. new feature that would not be supported by old drivers) and adding code in these QA
+     * tests to check the feature, you'll want to compare the target release version of the feature against this variable, to selectively
+     * run the new tests only for drivers that will support the feature (i.e. of the target release version and newer).
+     * Until the feature + QA tests are actually ported to the target branch, the comparison will hold true only for the master
+     * branch. So you'll need to remove the equality, port the feature and subsequently add the equality; i.e. a two-step commit of a PR.
+     * <code>
+     *     public static boolean isUnsignedLongSupported() {
+     *         // TODO: add equality only once actually ported to 7.11
+     *         return V_7_11_0.compareTo(JDBC_DRIVER_VERSION) < 0;
+     *     }
+     * </code>
+     */
+    static final Version JDBC_DRIVER_VERSION;
+
+    static {
+        // master's version is x.0.0-SNAPSHOT, tho Version#fromString() won't accept that back for recent versions
+        String jdbcDriverVersion = System.getProperty(DRIVER_VERSION_PROPERTY_NAME, "").replace("-SNAPSHOT", "");
+        JDBC_DRIVER_VERSION = Version.fromString(jdbcDriverVersion); // takes empty and null strings, resolves them to CURRENT
+    }
 
     static String of(long millis, String zoneId) {
         return StringUtils.toString(ZonedDateTime.ofInstant(Instant.ofEpochMilli(millis), ZoneId.of(zoneId)));

--- a/x-pack/plugin/sql/qa/jdbc/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/PreparedStatementTestCase.java
+++ b/x-pack/plugin/sql/qa/jdbc/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/PreparedStatementTestCase.java
@@ -10,6 +10,7 @@ import org.elasticsearch.common.settings.Settings;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.sql.Connection;
 import java.sql.Date;
 import java.sql.JDBCType;
@@ -27,6 +28,14 @@ import java.util.Calendar;
 import java.util.Locale;
 import java.util.StringJoiner;
 
+import static org.elasticsearch.xpack.sql.jdbc.EsType.BOOLEAN;
+import static org.elasticsearch.xpack.sql.jdbc.EsType.BYTE;
+import static org.elasticsearch.xpack.sql.jdbc.EsType.DOUBLE;
+import static org.elasticsearch.xpack.sql.jdbc.EsType.FLOAT;
+import static org.elasticsearch.xpack.sql.jdbc.EsType.INTEGER;
+import static org.elasticsearch.xpack.sql.jdbc.EsType.KEYWORD;
+import static org.elasticsearch.xpack.sql.jdbc.EsType.LONG;
+import static org.elasticsearch.xpack.sql.jdbc.EsType.SHORT;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.startsWith;
 
@@ -65,25 +74,26 @@ public abstract class PreparedStatementTestCase extends JdbcIntegrationTestCase 
                 sql.add("?");
             }
             try (PreparedStatement statement = connection.prepareStatement(sql.toString())) {
-                statement.setString(1, stringVal);
-                statement.setInt(2, intVal);
-                statement.setLong(3, longVal);
-                statement.setFloat(4, floatVal);
-                statement.setDouble(5, doubleVal);
-                statement.setNull(6, JDBCType.DOUBLE.getVendorTypeNumber());
-                statement.setBoolean(7, booleanVal);
-                statement.setByte(8, byteVal);
-                statement.setShort(9, shortVal);
-                statement.setBigDecimal(10, bigDecimalVal);
-                statement.setTimestamp(11, timestampVal);
-                statement.setTimestamp(12, timestampVal, calendarVal);
-                statement.setDate(13, dateVal);
-                statement.setDate(14, dateVal, calendarVal);
-                statement.setTime(15, timeVal);
-                statement.setTime(16, timeVal, calendarVal);
-                statement.setObject(17, calendarVal);
-                statement.setObject(18, utilDateVal);
-                statement.setObject(19, localDateTimeVal);
+                int index = 1;
+                statement.setString(index++, stringVal);
+                statement.setInt(index++, intVal);
+                statement.setLong(index++, longVal);
+                statement.setFloat(index++, floatVal);
+                statement.setDouble(index++, doubleVal);
+                statement.setNull(index++, JDBCType.DOUBLE.getVendorTypeNumber());
+                statement.setBoolean(index++, booleanVal);
+                statement.setByte(index++, byteVal);
+                statement.setShort(index++, shortVal);
+                statement.setBigDecimal(index++, bigDecimalVal);
+                statement.setTimestamp(index++, timestampVal);
+                statement.setTimestamp(index++, timestampVal, calendarVal);
+                statement.setDate(index++, dateVal);
+                statement.setDate(index++, dateVal, calendarVal);
+                statement.setTime(index++, timeVal);
+                statement.setTime(index++, timeVal, calendarVal);
+                statement.setObject(index++, calendarVal);
+                statement.setObject(index++, utilDateVal);
+                statement.setObject(index++, localDateTimeVal);
 
                 try (ResultSet results = statement.executeQuery()) {
                     ResultSetMetaData resultSetMetaData = results.getMetaData();
@@ -94,25 +104,26 @@ public abstract class PreparedStatementTestCase extends JdbcIntegrationTestCase 
                         assertEquals(parameterMetaData.getParameterType(i), resultSetMetaData.getColumnType(i));
                     }
                     assertTrue(results.next());
-                    assertEquals(stringVal, results.getString(1));
-                    assertEquals(intVal, results.getInt(2));
-                    assertEquals(longVal, results.getLong(3));
-                    assertEquals(floatVal, results.getFloat(4), 0.00001f);
-                    assertEquals(doubleVal, results.getDouble(5), 0.00001f);
-                    assertNull(results.getObject(6));
-                    assertEquals(booleanVal, results.getBoolean(7));
-                    assertEquals(byteVal, results.getByte(8));
-                    assertEquals(shortVal, results.getShort(9));
-                    assertEquals(bigDecimalVal, results.getBigDecimal(10));
-                    assertEquals(timestampVal, results.getTimestamp(11));
-                    assertEquals(timestampValWithCal, results.getTimestamp(12));
-                    assertEquals(dateVal, results.getDate(13));
-                    assertEquals(dateValWithCal, results.getDate(14));
-                    assertEquals(timeVal, results.getTime(15));
-                    assertEquals(timeValWithCal, results.getTime(16));
-                    assertEquals(new Timestamp(calendarVal.getTimeInMillis()), results.getObject(17));
-                    assertEquals(timestampVal, results.getObject(18));
-                    assertEquals(timestampVal, results.getObject(19));
+                    index = 1;
+                    assertEquals(stringVal, results.getString(index++));
+                    assertEquals(intVal, results.getInt(index++));
+                    assertEquals(longVal, results.getLong(index++));
+                    assertEquals(floatVal, results.getFloat(index++), 0.00001f);
+                    assertEquals(doubleVal, results.getDouble(index++), 0.00001f);
+                    assertNull(results.getObject(index++));
+                    assertEquals(booleanVal, results.getBoolean(index++));
+                    assertEquals(byteVal, results.getByte(index++));
+                    assertEquals(shortVal, results.getShort(index++));
+                    assertEquals(bigDecimalVal, results.getBigDecimal(index++));
+                    assertEquals(timestampVal, results.getTimestamp(index++));
+                    assertEquals(timestampValWithCal, results.getTimestamp(index++));
+                    assertEquals(dateVal, results.getDate(index++));
+                    assertEquals(dateValWithCal, results.getDate(index++));
+                    assertEquals(timeVal, results.getTime(index++));
+                    assertEquals(timeValWithCal, results.getTime(index++));
+                    assertEquals(new Timestamp(calendarVal.getTimeInMillis()), results.getObject(index++));
+                    assertEquals(timestampVal, results.getObject(index++));
+                    assertEquals(timestampVal, results.getObject(index++));
                     assertFalse(results.next());
                 }
             }
@@ -341,32 +352,32 @@ public abstract class PreparedStatementTestCase extends JdbcIntegrationTestCase 
             try (PreparedStatement statement = connection.prepareStatement("SELECT ?")) {
 
                 statement.setString(1, stringVal);
-                assertEquals(new Tuple<>(JDBCType.VARCHAR.getVendorTypeNumber(), stringVal), execute(statement));
+                assertEquals(new Tuple<>(KEYWORD.getName(), stringVal), execute(statement));
                 statement.setInt(1, intVal);
-                assertEquals(new Tuple<>(JDBCType.INTEGER.getVendorTypeNumber(), intVal), execute(statement));
+                assertEquals(new Tuple<>(INTEGER.getName(), intVal), execute(statement));
                 statement.setLong(1, longVal);
-                assertEquals(new Tuple<>(JDBCType.BIGINT.getVendorTypeNumber(), longVal), execute(statement));
+                assertEquals(new Tuple<>(LONG.getName(), longVal), execute(statement));
                 statement.setFloat(1, floatVal);
-                assertEquals(new Tuple<>(JDBCType.REAL.getVendorTypeNumber(), floatVal), execute(statement));
+                assertEquals(new Tuple<>(FLOAT.getName(), floatVal), execute(statement));
                 statement.setDouble(1, doubleVal);
-                assertEquals(new Tuple<>(JDBCType.DOUBLE.getVendorTypeNumber(), doubleVal), execute(statement));
+                assertEquals(new Tuple<>(DOUBLE.getName(), doubleVal), execute(statement));
                 statement.setNull(1, JDBCType.DOUBLE.getVendorTypeNumber());
-                assertEquals(new Tuple<>(JDBCType.DOUBLE.getVendorTypeNumber(), null), execute(statement));
+                assertEquals(new Tuple<>(DOUBLE.getName(), null), execute(statement));
                 statement.setBoolean(1, booleanVal);
-                assertEquals(new Tuple<>(JDBCType.BOOLEAN.getVendorTypeNumber(), booleanVal), execute(statement));
+                assertEquals(new Tuple<>(BOOLEAN.getName(), booleanVal), execute(statement));
                 statement.setByte(1, byteVal);
-                assertEquals(new Tuple<>(JDBCType.TINYINT.getVendorTypeNumber(), byteVal), execute(statement));
+                assertEquals(new Tuple<>(BYTE.getName(), byteVal), execute(statement));
                 statement.setShort(1, shortVal);
-                assertEquals(new Tuple<>(JDBCType.SMALLINT.getVendorTypeNumber(), shortVal), execute(statement));
+                assertEquals(new Tuple<>(SHORT.getName(), shortVal), execute(statement));
             }
         }
     }
 
-    private Tuple<Integer, Object> execute(PreparedStatement statement) throws SQLException {
+    private Tuple<String, Object> execute(PreparedStatement statement) throws SQLException {
         try (ResultSet results = statement.executeQuery()) {
             ResultSetMetaData resultSetMetaData = results.getMetaData();
             assertTrue(results.next());
-            Tuple<Integer, Object> result = new Tuple<>(resultSetMetaData.getColumnType(1), results.getObject(1));
+            Tuple<String, Object> result = new Tuple<>(resultSetMetaData.getColumnTypeName(1), results.getObject(1));
             assertFalse(results.next());
             return result;
         }

--- a/x-pack/plugin/sql/sql-proto/src/main/java/org/elasticsearch/xpack/sql/proto/SqlVersion.java
+++ b/x-pack/plugin/sql/sql-proto/src/main/java/org/elasticsearch/xpack/sql/proto/SqlVersion.java
@@ -23,6 +23,7 @@ public class SqlVersion implements Comparable<SqlVersion>{
     public final byte major;
     public final byte minor;
     public final byte revision;
+    public final byte build; // the build is required for id-compatibility with ES's version
 
     public static final int REVISION_MULTIPLIER = 100;
     public static final int MINOR_MULTIPLIER = REVISION_MULTIPLIER * REVISION_MULTIPLIER;
@@ -45,17 +46,21 @@ public class SqlVersion implements Comparable<SqlVersion>{
         this.version = version;
 
         assert parts.length >= 3 : "Version must be initialized with all Major.Minor.Revision components";
-        this.major = parts[0];
-        this.minor = parts[1];
-        this.revision = parts[2];
+        major = parts[0];
+        minor = parts[1];
+        revision = parts[2];
+        build = (parts.length >= 4) ? parts[3] : REVISION_MULTIPLIER - 1;
 
-        if ((major | minor | revision) < 0 || minor >= REVISION_MULTIPLIER || revision >= REVISION_MULTIPLIER) {
-            throw new InvalidParameterException("Invalid version initialisers [" + major + ", " + minor + ", " + revision + "]");
+        if ((major | minor | revision | build) < 0 ||
+                minor >= REVISION_MULTIPLIER || revision >= REVISION_MULTIPLIER || build >= REVISION_MULTIPLIER) {
+            throw new InvalidParameterException("Invalid version initialisers [" + major + ", " + minor + ", " + revision + ", " +
+                build + "]");
         }
 
         id = Integer.valueOf(major) * MAJOR_MULTIPLIER
             + Integer.valueOf(minor) * MINOR_MULTIPLIER
-            + Integer.valueOf(revision) * REVISION_MULTIPLIER;
+            + Integer.valueOf(revision) * REVISION_MULTIPLIER
+            + Integer.valueOf(build);
     }
 
     public static SqlVersion fromString(String version) {
@@ -63,6 +68,15 @@ public class SqlVersion implements Comparable<SqlVersion>{
             return null;
         }
         return new SqlVersion(version, from(version));
+    }
+
+    public static SqlVersion fromId(int id) {
+        byte build = (byte) (id % REVISION_MULTIPLIER);
+        byte revision = (byte) ((id / REVISION_MULTIPLIER) % REVISION_MULTIPLIER);
+        byte minor = (byte) ((id / MINOR_MULTIPLIER) % REVISION_MULTIPLIER);
+        byte major = (byte) ((id / MAJOR_MULTIPLIER) % REVISION_MULTIPLIER);
+        /* the build is not reflected in the string format */
+        return new SqlVersion(toString(major, minor, revision), major, minor, revision, build);
     }
 
     protected static byte[] from(String ver) {

--- a/x-pack/plugin/sql/sql-proto/src/test/java/org/elasticsearch/xpack/sql/proto/SqlVersionTests.java
+++ b/x-pack/plugin/sql/sql-proto/src/test/java/org/elasticsearch/xpack/sql/proto/SqlVersionTests.java
@@ -8,13 +8,18 @@ package org.elasticsearch.xpack.sql.proto;
 
 import org.elasticsearch.test.ESTestCase;
 
+import static org.elasticsearch.xpack.sql.proto.SqlVersion.MAJOR_MULTIPLIER;
+import static org.elasticsearch.xpack.sql.proto.SqlVersion.MINOR_MULTIPLIER;
+import static org.elasticsearch.xpack.sql.proto.SqlVersion.REVISION_MULTIPLIER;
+
 public class SqlVersionTests extends ESTestCase {
     public void test123FromString() {
         SqlVersion ver = SqlVersion.fromString("1.2.3");
         assertEquals(1, ver.major);
         assertEquals(2, ver.minor);
         assertEquals(3, ver.revision);
-        assertEquals(1 * SqlVersion.MAJOR_MULTIPLIER + 2 * SqlVersion.MINOR_MULTIPLIER + 3 * SqlVersion.REVISION_MULTIPLIER, ver.id);
+        assertEquals(REVISION_MULTIPLIER - 1, ver.build);
+        assertEquals(1 * MAJOR_MULTIPLIER + 2 * MINOR_MULTIPLIER + 3 * REVISION_MULTIPLIER + REVISION_MULTIPLIER - 1, ver.id);
         assertEquals("1.2.3", ver.version);
     }
 
@@ -23,7 +28,8 @@ public class SqlVersionTests extends ESTestCase {
         assertEquals(1, ver.major);
         assertEquals(2, ver.minor);
         assertEquals(3, ver.revision);
-        assertEquals(1 * SqlVersion.MAJOR_MULTIPLIER + 2 * SqlVersion.MINOR_MULTIPLIER + 3 * SqlVersion.REVISION_MULTIPLIER, ver.id);
+        assertEquals(REVISION_MULTIPLIER - 1, ver.build);
+        assertEquals(1 * MAJOR_MULTIPLIER + 2 * MINOR_MULTIPLIER + 3 * REVISION_MULTIPLIER + REVISION_MULTIPLIER - 1, ver.id);
         assertEquals("1.2.3-Alpha", ver.version);
     }
 
@@ -32,8 +38,14 @@ public class SqlVersionTests extends ESTestCase {
         assertEquals(1, ver.major);
         assertEquals(2, ver.minor);
         assertEquals(3, ver.revision);
-        assertEquals(1 * SqlVersion.MAJOR_MULTIPLIER + 2 * SqlVersion.MINOR_MULTIPLIER + 3 * SqlVersion.REVISION_MULTIPLIER, ver.id);
+        assertEquals(REVISION_MULTIPLIER - 1, ver.build);
+        assertEquals(1 * MAJOR_MULTIPLIER + 2 * MINOR_MULTIPLIER + 3 * REVISION_MULTIPLIER + REVISION_MULTIPLIER - 1, ver.id);
         assertEquals("1.2.3-Alpha-SNAPSHOT", ver.version);
+    }
+
+    public void testFromId() {
+        SqlVersion ver = new SqlVersion((byte)randomIntBetween(0, 99), (byte)randomIntBetween(0, 99), (byte)randomIntBetween(0, 99));
+        assertEquals(ver, SqlVersion.fromId(ver.id));
     }
 
     public void testVersionsEqual() {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Analyzer.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Analyzer.java
@@ -41,7 +41,6 @@ import org.elasticsearch.xpack.ql.plan.logical.Project;
 import org.elasticsearch.xpack.ql.plan.logical.UnaryPlan;
 import org.elasticsearch.xpack.ql.plan.logical.UnresolvedRelation;
 import org.elasticsearch.xpack.ql.rule.RuleExecutor;
-import org.elasticsearch.xpack.ql.session.Configuration;
 import org.elasticsearch.xpack.ql.type.DataType;
 import org.elasticsearch.xpack.ql.type.DataTypes;
 import org.elasticsearch.xpack.ql.type.InvalidMappedField;
@@ -55,6 +54,7 @@ import org.elasticsearch.xpack.sql.plan.logical.LocalRelation;
 import org.elasticsearch.xpack.sql.plan.logical.Pivot;
 import org.elasticsearch.xpack.sql.plan.logical.SubQueryAlias;
 import org.elasticsearch.xpack.sql.plan.logical.With;
+import org.elasticsearch.xpack.sql.session.SqlConfiguration;
 import org.elasticsearch.xpack.sql.type.SqlDataTypeConverter;
 
 import java.util.ArrayList;
@@ -73,6 +73,7 @@ import static java.util.stream.Collectors.toList;
 import static org.elasticsearch.xpack.ql.analyzer.AnalyzerRules.AnalyzerRule;
 import static org.elasticsearch.xpack.ql.analyzer.AnalyzerRules.BaseAnalyzerRule;
 import static org.elasticsearch.xpack.ql.util.CollectionUtils.combine;
+import static org.elasticsearch.xpack.sql.session.VersionCompatibilityChecks.isTypeSupportedInVersion;
 
 public class Analyzer extends RuleExecutor<LogicalPlan> {
     /**
@@ -87,13 +88,13 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
      * Per-request specific settings needed in some of the functions (timezone, username and clustername),
      * to which they are attached.
      */
-    private final Configuration configuration;
+    private final SqlConfiguration configuration;
     /**
      * The verifier has the role of checking the analyzed tree for failures and build a list of failures.
      */
     private final Verifier verifier;
 
-    public Analyzer(Configuration configuration, FunctionRegistry functionRegistry, IndexResolution results, Verifier verifier) {
+    public Analyzer(SqlConfiguration configuration, FunctionRegistry functionRegistry, IndexResolution results, Verifier verifier) {
         this.configuration = configuration;
         this.functionRegistry = functionRegistry;
         this.indexResolution = results;
@@ -313,7 +314,7 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
         }
     }
 
-    private static class ResolveRefs extends BaseAnalyzerRule {
+    private class ResolveRefs extends BaseAnalyzerRule {
 
         @Override
         protected LogicalPlan doRule(LogicalPlan plan) {
@@ -427,10 +428,16 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
                 }
             }
 
-            return result;
+            return filterUnsupportedProjections(result);
         }
 
-        static List<NamedExpression> expandStar(UnresolvedStar us, List<Attribute> output) {
+        private List<NamedExpression> filterUnsupportedProjections(List<NamedExpression> projections) {
+            return projections.stream()
+                .filter(p -> p.resolved() == false || isTypeSupportedInVersion(p.dataType(), configuration.version()))
+                .collect(toList());
+        }
+
+        List<NamedExpression> expandStar(UnresolvedStar us, List<Attribute> output) {
             List<NamedExpression> expanded = new ArrayList<>();
 
             // a qualifier is specified - since this is a star, it should be a CompoundDataType
@@ -1202,7 +1209,6 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
             return e;
         }
     }
-
 
     public static class PruneSubqueryAliases extends AnalyzerRule<SubQueryAlias> {
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/PlanExecutor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/PlanExecutor.java
@@ -41,10 +41,9 @@ public class PlanExecutor {
 
     private final IndexResolver indexResolver;
     private final PreAnalyzer preAnalyzer;
-    private final Verifier verifier;
     private final Optimizer optimizer;
     private final Planner planner;
-    
+
     private final Metrics metrics;
 
     public PlanExecutor(Client client, IndexResolver indexResolver, NamedWriteableRegistry writeableRegistry) {
@@ -53,17 +52,17 @@ public class PlanExecutor {
 
         this.indexResolver = indexResolver;
         this.functionRegistry = new SqlFunctionRegistry();
-        
+
         this.metrics = new Metrics();
 
         this.preAnalyzer = new PreAnalyzer();
-        this.verifier = new Verifier(metrics);
         this.optimizer = new Optimizer();
         this.planner = new Planner();
     }
 
     private SqlSession newSession(SqlConfiguration cfg) {
-        return new SqlSession(cfg, client, functionRegistry, indexResolver, preAnalyzer, verifier, optimizer, planner, this);
+        return new SqlSession(cfg, client, functionRegistry, indexResolver, preAnalyzer, new Verifier(metrics, cfg.version()), optimizer,
+            planner, this);
     }
 
     public void searchSource(SqlConfiguration cfg, String sql, List<SqlTypedParamValue> params,
@@ -116,7 +115,7 @@ public class PlanExecutor {
     public void cleanCursor(SqlConfiguration cfg, Cursor cursor, ActionListener<Boolean> listener) {
         cursor.clear(cfg, client, listener);
     }
-    
+
     public Metrics metrics() {
         return this.metrics;
     }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/ShowColumns.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/ShowColumns.java
@@ -14,6 +14,7 @@ import org.elasticsearch.xpack.ql.tree.Source;
 import org.elasticsearch.xpack.ql.type.DataType;
 import org.elasticsearch.xpack.ql.type.EsField;
 import org.elasticsearch.xpack.ql.type.KeywordEsField;
+import org.elasticsearch.xpack.sql.proto.SqlVersion;
 import org.elasticsearch.xpack.sql.session.Cursor.Page;
 import org.elasticsearch.xpack.sql.session.SqlSession;
 import org.elasticsearch.xpack.sql.type.SqlDataTypes;
@@ -26,6 +27,7 @@ import java.util.Objects;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
+import static org.elasticsearch.xpack.sql.session.VersionCompatibilityChecks.isTypeSupportedInVersion;
 
 public class ShowColumns extends Command {
 
@@ -71,24 +73,24 @@ public class ShowColumns extends Command {
                     List<List<?>> rows = emptyList();
                     if (indexResult.isValid()) {
                         rows = new ArrayList<>();
-                        fillInRows(indexResult.get().mapping(), null, rows);
+                        fillInRows(indexResult.get().mapping(), null, session.configuration().version(), rows);
                     }
                     listener.onResponse(of(session, rows));
                 },
                 listener::onFailure));
     }
 
-    private void fillInRows(Map<String, EsField> mapping, String prefix, List<List<?>> rows) {
+    static void fillInRows(Map<String, EsField> mapping, String prefix, SqlVersion version, List<List<?>> rows) {
         for (Entry<String, EsField> e : mapping.entrySet()) {
             EsField field = e.getValue();
             DataType dt = field.getDataType();
             String name = e.getKey();
-            if (dt != null) {
+            if (dt != null && isTypeSupportedInVersion(dt, version)) {
                 // show only fields that exist in ES
                 rows.add(asList(prefix != null ? prefix + "." + name : name, SqlDataTypes.sqlType(dt).getName(), dt.typeName()));
                 if (field.getProperties().isEmpty() == false) {
                     String newPrefix = prefix != null ? prefix + "." + name : name;
-                    fillInRows(field.getProperties(), newPrefix, rows);
+                    fillInRows(field.getProperties(), newPrefix, version, rows);
                 }
             }
         }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTypes.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTypes.java
@@ -27,6 +27,7 @@ import static org.elasticsearch.xpack.ql.type.DataTypes.INTEGER;
 import static org.elasticsearch.xpack.ql.type.DataTypes.SHORT;
 import static org.elasticsearch.xpack.ql.type.DataTypes.isSigned;
 import static org.elasticsearch.xpack.ql.type.DataTypes.isString;
+import static org.elasticsearch.xpack.sql.session.VersionCompatibilityChecks.isTypeSupportedInVersion;
 import static org.elasticsearch.xpack.sql.type.SqlDataTypes.metaSqlDataType;
 import static org.elasticsearch.xpack.sql.type.SqlDataTypes.metaSqlDateTimeSub;
 import static org.elasticsearch.xpack.sql.type.SqlDataTypes.metaSqlMaximumScale;
@@ -81,7 +82,8 @@ public class SysTypes extends Command {
 
     @Override
     public final void execute(SqlSession session, ActionListener<Page> listener) {
-        Stream<DataType> values = SqlDataTypes.types().stream();
+        Stream<DataType> values = SqlDataTypes.types().stream()
+            .filter(t -> isTypeSupportedInVersion(t, session.configuration().version()));
         if (type.intValue() != 0) {
             values = values.filter(t -> type.equals(sqlType(t).getVendorTypeNumber()));
         }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TransportSqlClearCursorAction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TransportSqlClearCursorAction.java
@@ -46,8 +46,8 @@ public class TransportSqlClearCursorAction extends HandledTransportAction<SqlCle
         Cursor cursor = Cursors.decodeFromStringWithZone(request.getCursor()).v1();
         planExecutor.cleanCursor(
                 new SqlConfiguration(DateUtils.UTC, Protocol.FETCH_SIZE, Protocol.REQUEST_TIMEOUT, Protocol.PAGE_TIMEOUT, null,
-                        request.mode(), StringUtils.EMPTY, StringUtils.EMPTY, StringUtils.EMPTY, Protocol.FIELD_MULTI_VALUE_LENIENCY,
-                        Protocol.INDEX_INCLUDE_FROZEN),
+                        request.mode(), StringUtils.EMPTY, request.version(), StringUtils.EMPTY, StringUtils.EMPTY,
+                        Protocol.FIELD_MULTI_VALUE_LENIENCY, Protocol.INDEX_INCLUDE_FROZEN),
                 cursor, ActionListener.wrap(
                 success -> listener.onResponse(new SqlClearCursorResponse(success)), listener::onFailure));
     }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TransportSqlQueryAction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TransportSqlQueryAction.java
@@ -76,8 +76,8 @@ public class TransportSqlQueryAction extends HandledTransportAction<SqlQueryRequ
         // The configuration is always created however when dealing with the next page, only the timeouts are relevant
         // the rest having default values (since the query is already created)
         SqlConfiguration cfg = new SqlConfiguration(request.zoneId(), request.fetchSize(), request.requestTimeout(), request.pageTimeout(),
-                request.filter(), request.mode(), request.clientId(), username, clusterName, request.fieldMultiValueLeniency(),
-                request.indexIncludeFrozen());
+                request.filter(), request.mode(), request.clientId(), request.version(), username, clusterName,
+                request.fieldMultiValueLeniency(), request.indexIncludeFrozen());
 
         if (Strings.hasText(request.cursor()) == false) {
             planExecutor.sql(cfg, request.query(), request.params(),

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TransportSqlTranslateAction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TransportSqlTranslateAction.java
@@ -54,7 +54,7 @@ public class TransportSqlTranslateAction extends HandledTransportAction<SqlTrans
 
         SqlConfiguration cfg = new SqlConfiguration(request.zoneId(), request.fetchSize(),
                 request.requestTimeout(), request.pageTimeout(), request.filter(),
-                request.mode(), request.clientId(),
+                request.mode(), request.clientId(), request.version(),
                 username(securityContext), clusterName(clusterService), Protocol.FIELD_MULTI_VALUE_LENIENCY,
                 Protocol.INDEX_INCLUDE_FROZEN);
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/session/SqlConfiguration.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/session/SqlConfiguration.java
@@ -5,21 +5,24 @@
  */
 package org.elasticsearch.xpack.sql.session;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.xpack.sql.proto.Mode;
+import org.elasticsearch.xpack.sql.proto.SqlVersion;
 
 import java.time.ZoneId;
 
 // Typed object holding properties for a given query
 public class SqlConfiguration extends org.elasticsearch.xpack.ql.session.Configuration {
-    
+
     private final int pageSize;
     private final TimeValue requestTimeout;
     private final TimeValue pageTimeout;
     private final Mode mode;
     private final String clientId;
+    private final SqlVersion version;
     private final boolean multiValueFieldLeniency;
     private final boolean includeFrozenIndices;
 
@@ -27,7 +30,7 @@ public class SqlConfiguration extends org.elasticsearch.xpack.ql.session.Configu
     private QueryBuilder filter;
 
     public SqlConfiguration(ZoneId zi, int pageSize, TimeValue requestTimeout, TimeValue pageTimeout, QueryBuilder filter,
-                         Mode mode, String clientId,
+                         Mode mode, String clientId, SqlVersion version,
                          String username, String clusterName,
                          boolean multiValueFieldLeniency,
                          boolean includeFrozen) {
@@ -40,6 +43,7 @@ public class SqlConfiguration extends org.elasticsearch.xpack.ql.session.Configu
         this.filter = filter;
         this.mode = mode == null ? Mode.PLAIN : mode;
         this.clientId = clientId;
+        this.version = version != null ? version : SqlVersion.fromId(Version.CURRENT.id);
         this.multiValueFieldLeniency = multiValueFieldLeniency;
         this.includeFrozenIndices = includeFrozen;
     }
@@ -73,5 +77,9 @@ public class SqlConfiguration extends org.elasticsearch.xpack.ql.session.Configu
 
     public boolean includeFrozen() {
         return includeFrozenIndices;
+    }
+
+    public SqlVersion version() {
+        return version;
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/session/VersionCompatibilityChecks.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/session/VersionCompatibilityChecks.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.sql.session;
+
+import org.elasticsearch.xpack.ql.type.DataType;
+import org.elasticsearch.xpack.sql.proto.SqlVersion;
+
+/**
+ * The class contains checks gating newly introduced functionality that is exposed to clients, but not supported by those older than the
+ * version introducing the respective feature.
+ * Each new feature will have a method added, taking a version and returning a boolean reflecting that version's support of the feature.
+ * The comparison can only have the equal added once the feature is backported (see JdbcTestUtils.java). Example:
+ * <code>
+ *     public static boolean supportsUnsignedLong(SqlVersion version) {
+ *         // TODO: add equality only once actually ported to 7.11
+ *         return VERSION_INTRODUCING_UNSIGNED_LONG.compareTo(version) &lt; 0;
+ *     }
+ * </code>
+ */
+public final class VersionCompatibilityChecks {
+
+    private VersionCompatibilityChecks() {}
+
+    /**
+     * Is the provided {@code dataType} being supported in the provided {@code version}?
+     */
+    public static boolean isTypeSupportedInVersion(DataType dataType, SqlVersion version) {
+        return true;
+    }
+}

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/SqlTestUtils.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/SqlTestUtils.java
@@ -11,6 +11,7 @@ import org.elasticsearch.xpack.ql.expression.Literal;
 import org.elasticsearch.xpack.ql.tree.Source;
 import org.elasticsearch.xpack.sql.proto.Mode;
 import org.elasticsearch.xpack.sql.proto.Protocol;
+import org.elasticsearch.xpack.sql.proto.SqlVersion;
 import org.elasticsearch.xpack.sql.session.SqlConfiguration;
 import org.elasticsearch.xpack.sql.type.SqlDataTypes;
 import org.elasticsearch.xpack.sql.util.DateUtils;
@@ -38,16 +39,17 @@ public final class SqlTestUtils {
 
     public static final SqlConfiguration TEST_CFG = new SqlConfiguration(DateUtils.UTC, Protocol.FETCH_SIZE,
             Protocol.REQUEST_TIMEOUT, Protocol.PAGE_TIMEOUT, null, Mode.PLAIN,
-            null, null, null, false, false);
+            null, null, null, null, false, false);
 
     public static SqlConfiguration randomConfiguration() {
         return new SqlConfiguration(randomZone(),
-                randomIntBetween(0,  1000),
+                randomIntBetween(0, 1000),
                 new TimeValue(randomNonNegativeLong()),
                 new TimeValue(randomNonNegativeLong()),
                 null,
                 randomFrom(Mode.values()),
                 randomAlphaOfLength(10),
+                null,
                 randomAlphaOfLength(10),
                 randomAlphaOfLength(10),
                 false,
@@ -56,12 +58,28 @@ public final class SqlTestUtils {
 
     public static SqlConfiguration randomConfiguration(ZoneId providedZoneId) {
         return new SqlConfiguration(providedZoneId,
-                randomIntBetween(0,  1000),
+            randomIntBetween(0, 1000),
+            new TimeValue(randomNonNegativeLong()),
+            new TimeValue(randomNonNegativeLong()),
+            null,
+            randomFrom(Mode.values()),
+            randomAlphaOfLength(10),
+            null,
+            randomAlphaOfLength(10),
+            randomAlphaOfLength(10),
+            false,
+            randomBoolean());
+    }
+
+    public static SqlConfiguration randomConfiguration(SqlVersion version) {
+        return new SqlConfiguration(randomZone(),
+                randomIntBetween(0, 1000),
                 new TimeValue(randomNonNegativeLong()),
                 new TimeValue(randomNonNegativeLong()),
                 null,
                 randomFrom(Mode.values()),
                 randomAlphaOfLength(10),
+                version,
                 randomAlphaOfLength(10),
                 randomAlphaOfLength(10),
                 false,

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/FieldAttributeTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/FieldAttributeTests.java
@@ -53,7 +53,7 @@ public class FieldAttributeTests extends ESTestCase {
     public FieldAttributeTests() {
         parser = new SqlParser();
         functionRegistry = new SqlFunctionRegistry();
-        verifier = new Verifier(new Metrics());
+        verifier = new Verifier(new Metrics(), SqlTestUtils.TEST_CFG.version());
 
         Map<String, EsField> mapping = loadMapping("mapping-multi-field-variation.json");
 

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/VerifierErrorMessagesTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/VerifierErrorMessagesTests.java
@@ -50,7 +50,8 @@ public class VerifierErrorMessagesTests extends ESTestCase {
     }
 
     private String error(IndexResolution getIndexResult, String sql) {
-        Analyzer analyzer = new Analyzer(SqlTestUtils.TEST_CFG, new SqlFunctionRegistry(), getIndexResult, new Verifier(new Metrics()));
+        Analyzer analyzer = new Analyzer(SqlTestUtils.TEST_CFG, new SqlFunctionRegistry(), getIndexResult, new Verifier(new Metrics(),
+            SqlTestUtils.TEST_CFG.version()));
         VerificationException e = expectThrows(VerificationException.class, () -> analyzer.analyze(parser.createStatement(sql), true));
         String message = e.getMessage();
         assertTrue(message.startsWith("Found "));
@@ -70,7 +71,8 @@ public class VerifierErrorMessagesTests extends ESTestCase {
     }
 
     private LogicalPlan accept(IndexResolution resolution, String sql) {
-        Analyzer analyzer = new Analyzer(SqlTestUtils.TEST_CFG, new SqlFunctionRegistry(), resolution, new Verifier(new Metrics()));
+        Analyzer analyzer = new Analyzer(SqlTestUtils.TEST_CFG, new SqlFunctionRegistry(), resolution,
+            new Verifier(new Metrics(), SqlTestUtils.TEST_CFG.version()));
         return analyzer.analyze(parser.createStatement(sql), true);
     }
 

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/DatabaseFunctionTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/DatabaseFunctionTests.java
@@ -29,16 +29,17 @@ public class DatabaseFunctionTests extends ESTestCase {
         String clusterName = randomAlphaOfLengthBetween(1, 15);
         SqlParser parser = new SqlParser();
         EsIndex test = new EsIndex("test", SqlTypesTests.loadMapping("mapping-basic.json", true));
+        SqlConfiguration sqlConfig = new SqlConfiguration(DateUtils.UTC, Protocol.FETCH_SIZE, Protocol.REQUEST_TIMEOUT,
+                Protocol.PAGE_TIMEOUT, null,
+                randomFrom(Mode.values()), randomAlphaOfLength(10),
+                null, null, clusterName, randomBoolean(), randomBoolean());
         Analyzer analyzer = new Analyzer(
-                new SqlConfiguration(DateUtils.UTC, Protocol.FETCH_SIZE, Protocol.REQUEST_TIMEOUT,
-                                  Protocol.PAGE_TIMEOUT, null,
-                                  randomFrom(Mode.values()), randomAlphaOfLength(10),
-                                  null, clusterName, randomBoolean(), randomBoolean()),
+                sqlConfig,
                 new SqlFunctionRegistry(),
                 IndexResolution.valid(test),
-                new Verifier(new Metrics())
+                new Verifier(new Metrics(), sqlConfig.version())
         );
-        
+
         Project result = (Project) analyzer.analyze(parser.createStatement("SELECT DATABASE()"), true);
         NamedExpression ne = result.projections().get(0);
         assertTrue(ne instanceof Alias);

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/UserFunctionTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/UserFunctionTests.java
@@ -28,17 +28,18 @@ public class UserFunctionTests extends ESTestCase {
     public void testNoUsernameFunctionOutput() {
         SqlParser parser = new SqlParser();
         EsIndex test = new EsIndex("test", SqlTypesTests.loadMapping("mapping-basic.json", true));
+        SqlConfiguration sqlConfig = new SqlConfiguration(DateUtils.UTC, Protocol.FETCH_SIZE, Protocol.REQUEST_TIMEOUT,
+                Protocol.PAGE_TIMEOUT, null,
+                randomFrom(Mode.values()), randomAlphaOfLength(10),
+                null, null, randomAlphaOfLengthBetween(1, 15),
+                randomBoolean(), randomBoolean());
         Analyzer analyzer = new Analyzer(
-                new SqlConfiguration(DateUtils.UTC, Protocol.FETCH_SIZE, Protocol.REQUEST_TIMEOUT,
-                                  Protocol.PAGE_TIMEOUT, null,
-                                  randomFrom(Mode.values()), randomAlphaOfLength(10),
-                                  null, randomAlphaOfLengthBetween(1, 15),
-                                  randomBoolean(), randomBoolean()),
+                sqlConfig,
                 new SqlFunctionRegistry(),
                 IndexResolution.valid(test),
-                new Verifier(new Metrics())
+                new Verifier(new Metrics(), sqlConfig.version())
         );
-        
+
         Project result = (Project) analyzer.analyze(parser.createStatement("SELECT USER()"), true);
         NamedExpression ne = result.projections().get(0);
         assertTrue(ne instanceof Alias);

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/CurrentDateTimeTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/CurrentDateTimeTests.java
@@ -74,14 +74,14 @@ public class CurrentDateTimeTests extends AbstractNodeTestCase<CurrentDateTime, 
         assertEquals(123_456_780, CurrentDateTime.nanoPrecision(zdt, literal(8)).getNano());
         assertEquals(123_456_789, CurrentDateTime.nanoPrecision(zdt, literal(9)).getNano());
     }
-    
+
     public void testDefaultPrecision() {
         Configuration configuration = SqlTestUtils.randomConfiguration();
         // null precision means default precision
         CurrentDateTime cdt = new CurrentDateTime(EMPTY, null, configuration);
         ZonedDateTime now = configuration.now();
         assertEquals(now.get(ChronoField.MILLI_OF_SECOND), ((ZonedDateTime) cdt.fold()).get(ChronoField.MILLI_OF_SECOND));
-        
+
         ZonedDateTime zdt = ZonedDateTime.parse("2019-02-26T12:34:56.123456789Z");
         assertEquals(123_000_000, CurrentDateTime.nanoPrecision(zdt, null).getNano());
     }
@@ -91,7 +91,8 @@ public class CurrentDateTimeTests extends AbstractNodeTestCase<CurrentDateTime, 
         IndexResolution indexResolution = IndexResolution.valid(new EsIndex("test",
                 SqlTypesTests.loadMapping("mapping-multi-field-with-nested.json")));
 
-        Analyzer analyzer = new Analyzer(SqlTestUtils.TEST_CFG, new SqlFunctionRegistry(), indexResolution, new Verifier(new Metrics()));
+        Analyzer analyzer = new Analyzer(SqlTestUtils.TEST_CFG, new SqlFunctionRegistry(), indexResolution,
+            new Verifier(new Metrics(), SqlTestUtils.TEST_CFG.version()));
         ParsingException e = expectThrows(ParsingException.class, () ->
             analyzer.analyze(parser.createStatement("SELECT CURRENT_TIMESTAMP(100000000000000)"), true));
         assertEquals("line 1:27: invalid precision; [100000000000000] out of [integer] range", e.getMessage());

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/CurrentTimeTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/CurrentTimeTests.java
@@ -92,7 +92,8 @@ public class CurrentTimeTests extends AbstractNodeTestCase<CurrentTime, Expressi
         IndexResolution indexResolution = IndexResolution.valid(new EsIndex("test",
                 SqlTypesTests.loadMapping("mapping-multi-field-with-nested.json")));
 
-        Analyzer analyzer = new Analyzer(SqlTestUtils.TEST_CFG, new SqlFunctionRegistry(), indexResolution, new Verifier(new Metrics()));
+        Analyzer analyzer = new Analyzer(SqlTestUtils.TEST_CFG, new SqlFunctionRegistry(), indexResolution,
+            new Verifier(new Metrics(), SqlTestUtils.TEST_CFG.version()));
         ParsingException e = expectThrows(ParsingException.class, () ->
             analyzer.analyze(parser.createStatement("SELECT CURRENT_TIME(100000000000000)"), true));
         assertEquals("line 1:22: invalid precision; [100000000000000] out of [integer] range", e.getMessage());

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/optimizer/OptimizerRunTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/optimizer/OptimizerRunTests.java
@@ -36,7 +36,8 @@ public class OptimizerRunTests extends ESTestCase {
 
         EsIndex test = new EsIndex("test", mapping);
         getIndexResult = IndexResolution.valid(test);
-        analyzer = new Analyzer(SqlTestUtils.TEST_CFG, functionRegistry, getIndexResult, new Verifier(new Metrics()));
+        analyzer = new Analyzer(SqlTestUtils.TEST_CFG, functionRegistry, getIndexResult,
+            new Verifier(new Metrics(), SqlTestUtils.TEST_CFG.version()));
         optimizer = new Optimizer();
     }
 

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysColumnsTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysColumnsTests.java
@@ -5,6 +5,7 @@
  */
 package org.elasticsearch.xpack.sql.plan.logical.command.sys;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.test.ESTestCase;
@@ -20,6 +21,7 @@ import org.elasticsearch.xpack.sql.plan.logical.command.Command;
 import org.elasticsearch.xpack.sql.proto.Mode;
 import org.elasticsearch.xpack.sql.proto.Protocol;
 import org.elasticsearch.xpack.sql.proto.SqlTypedParamValue;
+import org.elasticsearch.xpack.sql.proto.SqlVersion;
 import org.elasticsearch.xpack.sql.session.Cursor;
 import org.elasticsearch.xpack.sql.session.SchemaRowSet;
 import org.elasticsearch.xpack.sql.session.SqlConfiguration;
@@ -52,363 +54,242 @@ public class SysColumnsTests extends ESTestCase {
 
     private final SqlParser parser = new SqlParser();
     private final Map<String, EsField> mapping = loadMapping("mapping-multi-field-with-nested.json", true);
+    private static final int FIELD_COUNT = 15;
 
     public void testSysColumns() {
         List<List<?>> rows = new ArrayList<>();
         SysColumns.fillInRows("test", "index", loadMapping("mapping-multi-field-variation.json", true), null, rows, null,
-                randomValueOtherThanMany(Mode::isDriver, () -> randomFrom(Mode.values())));
+                randomValueOtherThanMany(Mode::isDriver, () -> randomFrom(Mode.values())), SqlVersion.fromId(Version.CURRENT.id));
         // nested fields are ignored
-        assertEquals(15, rows.size());
+        assertEquals(FIELD_COUNT, rows.size());
         assertEquals(24, rows.get(0).size());
 
-        List<?> row = rows.get(0);
+        int index = 0;
+
+        List<?> row = rows.get(index++);
         assertEquals("bool", name(row));
         assertEquals(Types.BOOLEAN, sqlType(row));
         assertEquals(null, radix(row));
         assertEquals(1, bufferLength(row));
 
-        row = rows.get(1);
+        row = rows.get(index++);
         assertEquals("int", name(row));
         assertEquals(Types.INTEGER, sqlType(row));
         assertEquals(10, radix(row));
         assertEquals(4, bufferLength(row));
 
-        row = rows.get(2);
+        row = rows.get(index++);
         assertEquals("text", name(row));
         assertEquals(Types.VARCHAR, sqlType(row));
         assertEquals(null, radix(row));
         assertEquals(Integer.MAX_VALUE, bufferLength(row));
-        
-        row = rows.get(3);
+
+        row = rows.get(index++);
         assertEquals("keyword", name(row));
         assertEquals(Types.VARCHAR, sqlType(row));
         assertEquals(null, radix(row));
         assertEquals(Integer.MAX_VALUE, bufferLength(row));
 
-        row = rows.get(4);
+        row = rows.get(index++);
         assertEquals("date", name(row));
         assertEquals(Types.TIMESTAMP, sqlType(row));
         assertEquals(null, radix(row));
         assertEquals(29, precision(row));
         assertEquals(8, bufferLength(row));
 
-        row = rows.get(5);
+        row = rows.get(index++);
         assertEquals("some.dotted.field", name(row));
         assertEquals(Types.VARCHAR, sqlType(row));
         assertEquals(null, radix(row));
         assertEquals(Integer.MAX_VALUE, bufferLength(row));
 
-        row = rows.get(6);
+        row = rows.get(index++);
         assertEquals("some.string", name(row));
         assertEquals(Types.VARCHAR, sqlType(row));
         assertEquals(null, radix(row));
         assertEquals(Integer.MAX_VALUE, bufferLength(row));
-        
-        row = rows.get(7);
+
+        row = rows.get(index++);
         assertEquals("some.string.normalized", name(row));
         assertEquals(Types.VARCHAR, sqlType(row));
         assertEquals(null, radix(row));
         assertEquals(Integer.MAX_VALUE, bufferLength(row));
-        
-        row = rows.get(8);
+
+        row = rows.get(index++);
         assertEquals("some.string.typical", name(row));
         assertEquals(Types.VARCHAR, sqlType(row));
         assertEquals(null, radix(row));
         assertEquals(Integer.MAX_VALUE, bufferLength(row));
-        
-        row = rows.get(9);
+
+        row = rows.get(index++);
         assertEquals("some.ambiguous", name(row));
         assertEquals(Types.VARCHAR, sqlType(row));
         assertEquals(null, radix(row));
         assertEquals(Integer.MAX_VALUE, bufferLength(row));
-        
-        row = rows.get(10);
+
+        row = rows.get(index++);
         assertEquals("some.ambiguous.one", name(row));
         assertEquals(Types.VARCHAR, sqlType(row));
         assertEquals(null, radix(row));
         assertEquals(Integer.MAX_VALUE, bufferLength(row));
-        
-        row = rows.get(11);
+
+        row = rows.get(index++);
         assertEquals("some.ambiguous.two", name(row));
         assertEquals(Types.VARCHAR, sqlType(row));
         assertEquals(null, radix(row));
         assertEquals(Integer.MAX_VALUE, bufferLength(row));
 
-        row = rows.get(12);
+        row = rows.get(index++);
         assertEquals("some.ambiguous.normalized", name(row));
         assertEquals(Types.VARCHAR, sqlType(row));
         assertEquals(null, radix(row));
         assertEquals(Integer.MAX_VALUE, bufferLength(row));
+    }
+
+    public void sysColumnsInDriverMode(Mode mode) {
+        Class<? extends Number> typeClass = mode == Mode.ODBC ? Short.class : Integer.class;
+        List<List<?>> rows = new ArrayList<>();
+        SysColumns.fillInRows("test", "index", loadMapping("mapping-multi-field-variation.json", true), null, rows, null, mode,
+            SqlVersion.fromId(Version.CURRENT.id));
+        assertEquals(FIELD_COUNT, rows.size());
+        assertEquals(24, rows.get(0).size());
+
+        int index = 0;
+
+        List<?> row = rows.get(index++);
+        assertEquals("bool", name(row));
+        assertEquals(Types.BOOLEAN, typeClass.cast(sqlType(row)).intValue());
+        assertEquals(null, radix(row));
+        assertEquals(1, bufferLength(row));
+
+        row = rows.get(index++);
+        assertEquals("int", name(row));
+        assertEquals(Types.INTEGER, typeClass.cast(sqlType(row)).intValue());
+        assertEquals(typeClass, radix(row).getClass());
+        assertEquals(4, bufferLength(row));
+        assertNull(decimalPrecision(row));
+        assertEquals(typeClass, nullable(row).getClass());
+        assertEquals(typeClass, sqlDataType(row).getClass());
+        assertEquals(typeClass, sqlDataTypeSub(row).getClass());
+
+        row = rows.get(index++);
+        assertEquals("text", name(row));
+        assertEquals(Types.VARCHAR, typeClass.cast(sqlType(row)).intValue());
+        assertEquals(null, radix(row));
+        assertEquals(Integer.MAX_VALUE, bufferLength(row));
+        assertNull(decimalPrecision(row));
+        assertEquals(typeClass, nullable(row).getClass());
+        assertEquals(typeClass, sqlDataType(row).getClass());
+        assertEquals(typeClass, sqlDataTypeSub(row).getClass());
+
+        row = rows.get(index++);
+        assertEquals("keyword", name(row));
+        assertEquals(Types.VARCHAR, typeClass.cast(sqlType(row)).intValue());
+        assertEquals(null, radix(row));
+        assertEquals(Integer.MAX_VALUE, bufferLength(row));
+        assertNull(decimalPrecision(row));
+        assertEquals(typeClass, nullable(row).getClass());
+        assertEquals(typeClass, sqlDataType(row).getClass());
+        assertEquals(typeClass, sqlDataTypeSub(row).getClass());
+
+        row = rows.get(index++);
+        assertEquals("date", name(row));
+        assertEquals(Types.TIMESTAMP, typeClass.cast(sqlType(row)).intValue());
+        assertEquals(null, radix(row));
+        assertEquals(29, precision(row));
+        assertEquals(8, bufferLength(row));
+        assertNull(decimalPrecision(row));
+        assertEquals(typeClass, nullable(row).getClass());
+        assertEquals(typeClass, sqlDataType(row).getClass());
+        assertEquals(typeClass, sqlDataTypeSub(row).getClass());
+
+        row = rows.get(index++);
+        assertEquals("some.dotted.field", name(row));
+        assertEquals(Types.VARCHAR, typeClass.cast(sqlType(row)).intValue());
+        assertEquals(null, radix(row));
+        assertEquals(Integer.MAX_VALUE, bufferLength(row));
+        assertNull(decimalPrecision(row));
+        assertEquals(typeClass, nullable(row).getClass());
+        assertEquals(typeClass, sqlDataType(row).getClass());
+        assertEquals(typeClass, sqlDataTypeSub(row).getClass());
+
+        row = rows.get(index++);
+        assertEquals("some.string", name(row));
+        assertEquals(Types.VARCHAR, typeClass.cast(sqlType(row)).intValue());
+        assertEquals(null, radix(row));
+        assertEquals(Integer.MAX_VALUE, bufferLength(row));
+        assertNull(decimalPrecision(row));
+        assertEquals(typeClass, nullable(row).getClass());
+        assertEquals(typeClass, sqlDataType(row).getClass());
+        assertEquals(typeClass, sqlDataTypeSub(row).getClass());
+
+        row = rows.get(index++);
+        assertEquals("some.string.normalized", name(row));
+        assertEquals(Types.VARCHAR, typeClass.cast(sqlType(row)).intValue());
+        assertEquals(null, radix(row));
+        assertEquals(Integer.MAX_VALUE, bufferLength(row));
+        assertNull(decimalPrecision(row));
+        assertEquals(typeClass, nullable(row).getClass());
+        assertEquals(typeClass, sqlDataType(row).getClass());
+        assertEquals(typeClass, sqlDataTypeSub(row).getClass());
+
+        row = rows.get(index++);
+        assertEquals("some.string.typical", name(row));
+        assertEquals(Types.VARCHAR, typeClass.cast(sqlType(row)).intValue());
+        assertEquals(null, radix(row));
+        assertEquals(Integer.MAX_VALUE, bufferLength(row));
+        assertNull(decimalPrecision(row));
+        assertEquals(typeClass, nullable(row).getClass());
+        assertEquals(typeClass, sqlDataType(row).getClass());
+        assertEquals(typeClass, sqlDataTypeSub(row).getClass());
+
+        row = rows.get(index++);
+        assertEquals("some.ambiguous", name(row));
+        assertEquals(Types.VARCHAR, typeClass.cast(sqlType(row)).intValue());
+        assertEquals(null, radix(row));
+        assertEquals(Integer.MAX_VALUE, bufferLength(row));
+        assertNull(decimalPrecision(row));
+        assertEquals(typeClass, nullable(row).getClass());
+        assertEquals(typeClass, sqlDataType(row).getClass());
+        assertEquals(typeClass, sqlDataTypeSub(row).getClass());
+
+        row = rows.get(index++);
+        assertEquals("some.ambiguous.one", name(row));
+        assertEquals(Types.VARCHAR, typeClass.cast(sqlType(row)).intValue());
+        assertEquals(null, radix(row));
+        assertEquals(Integer.MAX_VALUE, bufferLength(row));
+        assertNull(decimalPrecision(row));
+        assertEquals(typeClass, nullable(row).getClass());
+        assertEquals(typeClass, sqlDataType(row).getClass());
+        assertEquals(typeClass, sqlDataTypeSub(row).getClass());
+
+        row = rows.get(index++);
+        assertEquals("some.ambiguous.two", name(row));
+        assertEquals(Types.VARCHAR, typeClass.cast(sqlType(row)).intValue());
+        assertEquals(null, radix(row));
+        assertEquals(Integer.MAX_VALUE, bufferLength(row));
+        assertNull(decimalPrecision(row));
+        assertEquals(typeClass, nullable(row).getClass());
+        assertEquals(typeClass, sqlDataType(row).getClass());
+        assertEquals(typeClass, sqlDataTypeSub(row).getClass());
+
+        row = rows.get(index++);
+        assertEquals("some.ambiguous.normalized", name(row));
+        assertEquals(Types.VARCHAR, typeClass.cast(sqlType(row)).intValue());
+        assertEquals(null, radix(row));
+        assertEquals(Integer.MAX_VALUE, bufferLength(row));
+        assertNull(decimalPrecision(row));
+        assertEquals(typeClass, nullable(row).getClass());
+        assertEquals(typeClass, sqlDataType(row).getClass());
+        assertEquals(typeClass, sqlDataTypeSub(row).getClass());
+    }
+
+    public void testSysColumnsInJdbcMode() {
+        sysColumnsInDriverMode(Mode.JDBC);
     }
 
     public void testSysColumnsInOdbcMode() {
-        List<List<?>> rows = new ArrayList<>();
-        SysColumns.fillInRows("test", "index", loadMapping("mapping-multi-field-variation.json", true), null, rows, null,
-                Mode.ODBC);
-        assertEquals(15, rows.size());
-        assertEquals(24, rows.get(0).size());
-
-        List<?> row = rows.get(0);
-        assertEquals("bool", name(row));
-        assertEquals((short) Types.BOOLEAN, sqlType(row));
-        assertEquals(null, radix(row));
-        assertEquals(1, bufferLength(row));
-
-        row = rows.get(1);
-        assertEquals("int", name(row));
-        assertEquals((short) Types.INTEGER, sqlType(row));
-        assertEquals(Short.class, radix(row).getClass());
-        assertEquals(4, bufferLength(row));
-        assertNull(decimalPrecision(row));
-        assertEquals(Short.class, nullable(row).getClass());
-        assertEquals(Short.class, sqlDataType(row).getClass());
-        assertEquals(Short.class, sqlDataTypeSub(row).getClass());
-
-        row = rows.get(2);
-        assertEquals("text", name(row));
-        assertEquals((short) Types.VARCHAR, sqlType(row));
-        assertEquals(null, radix(row));
-        assertEquals(Integer.MAX_VALUE, bufferLength(row));
-        assertNull(decimalPrecision(row));
-        assertEquals(Short.class, nullable(row).getClass());
-        assertEquals(Short.class, sqlDataType(row).getClass());
-        assertEquals(Short.class, sqlDataTypeSub(row).getClass());
-
-        row = rows.get(3);
-        assertEquals("keyword", name(row));
-        assertEquals((short) Types.VARCHAR, sqlType(row));
-        assertEquals(null, radix(row));
-        assertEquals(Integer.MAX_VALUE, bufferLength(row));
-        assertNull(decimalPrecision(row));
-        assertEquals(Short.class, nullable(row).getClass());
-        assertEquals(Short.class, sqlDataType(row).getClass());
-        assertEquals(Short.class, sqlDataTypeSub(row).getClass());
-
-        row = rows.get(4);
-        assertEquals("date", name(row));
-        assertEquals((short) Types.TIMESTAMP, sqlType(row));
-        assertEquals(null, radix(row));
-        assertEquals(29, precision(row));
-        assertEquals(8, bufferLength(row));
-        assertNull(decimalPrecision(row));
-        assertEquals(Short.class, nullable(row).getClass());
-        assertEquals(Short.class, sqlDataType(row).getClass());
-        assertEquals(Short.class, sqlDataTypeSub(row).getClass());
-
-        row = rows.get(5);
-        assertEquals("some.dotted.field", name(row));
-        assertEquals((short) Types.VARCHAR, sqlType(row));
-        assertEquals(null, radix(row));
-        assertEquals(Integer.MAX_VALUE, bufferLength(row));
-        assertNull(decimalPrecision(row));
-        assertEquals(Short.class, nullable(row).getClass());
-        assertEquals(Short.class, sqlDataType(row).getClass());
-        assertEquals(Short.class, sqlDataTypeSub(row).getClass());
-
-        row = rows.get(6);
-        assertEquals("some.string", name(row));
-        assertEquals((short) Types.VARCHAR, sqlType(row));
-        assertEquals(null, radix(row));
-        assertEquals(Integer.MAX_VALUE, bufferLength(row));
-        assertNull(decimalPrecision(row));
-        assertEquals(Short.class, nullable(row).getClass());
-        assertEquals(Short.class, sqlDataType(row).getClass());
-        assertEquals(Short.class, sqlDataTypeSub(row).getClass());
-
-        row = rows.get(7);
-        assertEquals("some.string.normalized", name(row));
-        assertEquals((short) Types.VARCHAR, sqlType(row));
-        assertEquals(null, radix(row));
-        assertEquals(Integer.MAX_VALUE, bufferLength(row));
-        assertNull(decimalPrecision(row));
-        assertEquals(Short.class, nullable(row).getClass());
-        assertEquals(Short.class, sqlDataType(row).getClass());
-        assertEquals(Short.class, sqlDataTypeSub(row).getClass());
-
-        row = rows.get(8);
-        assertEquals("some.string.typical", name(row));
-        assertEquals((short) Types.VARCHAR, sqlType(row));
-        assertEquals(null, radix(row));
-        assertEquals(Integer.MAX_VALUE, bufferLength(row));
-        assertNull(decimalPrecision(row));
-        assertEquals(Short.class, nullable(row).getClass());
-        assertEquals(Short.class, sqlDataType(row).getClass());
-        assertEquals(Short.class, sqlDataTypeSub(row).getClass());
-
-        row = rows.get(9);
-        assertEquals("some.ambiguous", name(row));
-        assertEquals((short) Types.VARCHAR, sqlType(row));
-        assertEquals(null, radix(row));
-        assertEquals(Integer.MAX_VALUE, bufferLength(row));
-        assertNull(decimalPrecision(row));
-        assertEquals(Short.class, nullable(row).getClass());
-        assertEquals(Short.class, sqlDataType(row).getClass());
-        assertEquals(Short.class, sqlDataTypeSub(row).getClass());
-        
-        row = rows.get(10);
-        assertEquals("some.ambiguous.one", name(row));
-        assertEquals((short) Types.VARCHAR, sqlType(row));
-        assertEquals(null, radix(row));
-        assertEquals(Integer.MAX_VALUE, bufferLength(row));
-        assertNull(decimalPrecision(row));
-        assertEquals(Short.class, nullable(row).getClass());
-        assertEquals(Short.class, sqlDataType(row).getClass());
-        assertEquals(Short.class, sqlDataTypeSub(row).getClass());
-        
-        row = rows.get(11);
-        assertEquals("some.ambiguous.two", name(row));
-        assertEquals((short) Types.VARCHAR, sqlType(row));
-        assertEquals(null, radix(row));
-        assertEquals(Integer.MAX_VALUE, bufferLength(row));
-        assertNull(decimalPrecision(row));
-        assertEquals(Short.class, nullable(row).getClass());
-        assertEquals(Short.class, sqlDataType(row).getClass());
-        assertEquals(Short.class, sqlDataTypeSub(row).getClass());
-
-        row = rows.get(12);
-        assertEquals("some.ambiguous.normalized", name(row));
-        assertEquals((short) Types.VARCHAR, sqlType(row));
-        assertEquals(null, radix(row));
-        assertEquals(Integer.MAX_VALUE, bufferLength(row));
-        assertNull(decimalPrecision(row));
-        assertEquals(Short.class, nullable(row).getClass());
-        assertEquals(Short.class, sqlDataType(row).getClass());
-        assertEquals(Short.class, sqlDataTypeSub(row).getClass());
-    }
-    
-    public void testSysColumnsInJdbcMode() {
-        List<List<?>> rows = new ArrayList<>();
-        SysColumns.fillInRows("test", "index", loadMapping("mapping-multi-field-variation.json", true), null, rows, null,
-                Mode.JDBC);
-        assertEquals(15, rows.size());
-        assertEquals(24, rows.get(0).size());
-
-        List<?> row = rows.get(0);
-        assertEquals("bool", name(row));
-        assertEquals(Types.BOOLEAN, sqlType(row));
-        assertEquals(null, radix(row));
-        assertEquals(1, bufferLength(row));
-
-        row = rows.get(1);
-        assertEquals("int", name(row));
-        assertEquals(Types.INTEGER, sqlType(row));
-        assertEquals(Integer.class, radix(row).getClass());
-        assertEquals(4, bufferLength(row));
-        assertNull(decimalPrecision(row));
-        assertEquals(Integer.class, nullable(row).getClass());
-        assertEquals(Integer.class, sqlDataType(row).getClass());
-        assertEquals(Integer.class, sqlDataTypeSub(row).getClass());
-
-        row = rows.get(2);
-        assertEquals("text", name(row));
-        assertEquals(Types.VARCHAR, sqlType(row));
-        assertEquals(null, radix(row));
-        assertEquals(Integer.MAX_VALUE, bufferLength(row));
-        assertNull(decimalPrecision(row));
-        assertEquals(Integer.class, nullable(row).getClass());
-        assertEquals(Integer.class, sqlDataType(row).getClass());
-        assertEquals(Integer.class, sqlDataTypeSub(row).getClass());
-
-        row = rows.get(3);
-        assertEquals("keyword", name(row));
-        assertEquals(Types.VARCHAR, sqlType(row));
-        assertEquals(null, radix(row));
-        assertEquals(Integer.MAX_VALUE, bufferLength(row));
-        assertNull(decimalPrecision(row));
-        assertEquals(Integer.class, nullable(row).getClass());
-        assertEquals(Integer.class, sqlDataType(row).getClass());
-        assertEquals(Integer.class, sqlDataTypeSub(row).getClass());
-
-        row = rows.get(4);
-        assertEquals("date", name(row));
-        assertEquals(Types.TIMESTAMP, sqlType(row));
-        assertEquals(null, radix(row));
-        assertEquals(29, precision(row));
-        assertEquals(8, bufferLength(row));
-        assertNull(decimalPrecision(row));
-        assertEquals(Integer.class, nullable(row).getClass());
-        assertEquals(Integer.class, sqlDataType(row).getClass());
-        assertEquals(Integer.class, sqlDataTypeSub(row).getClass());
-
-        row = rows.get(5);
-        assertEquals("some.dotted.field", name(row));
-        assertEquals(Types.VARCHAR, sqlType(row));
-        assertEquals(null, radix(row));
-        assertEquals(Integer.MAX_VALUE, bufferLength(row));
-        assertNull(decimalPrecision(row));
-        assertEquals(Integer.class, nullable(row).getClass());
-        assertEquals(Integer.class, sqlDataType(row).getClass());
-        assertEquals(Integer.class, sqlDataTypeSub(row).getClass());
-
-        row = rows.get(6);
-        assertEquals("some.string", name(row));
-        assertEquals(Types.VARCHAR, sqlType(row));
-        assertEquals(null, radix(row));
-        assertEquals(Integer.MAX_VALUE, bufferLength(row));
-        assertNull(decimalPrecision(row));
-        assertEquals(Integer.class, nullable(row).getClass());
-        assertEquals(Integer.class, sqlDataType(row).getClass());
-        assertEquals(Integer.class, sqlDataTypeSub(row).getClass());
-
-        row = rows.get(7);
-        assertEquals("some.string.normalized", name(row));
-        assertEquals(Types.VARCHAR, sqlType(row));
-        assertEquals(null, radix(row));
-        assertEquals(Integer.MAX_VALUE, bufferLength(row));
-        assertNull(decimalPrecision(row));
-        assertEquals(Integer.class, nullable(row).getClass());
-        assertEquals(Integer.class, sqlDataType(row).getClass());
-        assertEquals(Integer.class, sqlDataTypeSub(row).getClass());
-
-        row = rows.get(8);
-        assertEquals("some.string.typical", name(row));
-        assertEquals(Types.VARCHAR, sqlType(row));
-        assertEquals(null, radix(row));
-        assertEquals(Integer.MAX_VALUE, bufferLength(row));
-        assertNull(decimalPrecision(row));
-        assertEquals(Integer.class, nullable(row).getClass());
-        assertEquals(Integer.class, sqlDataType(row).getClass());
-        assertEquals(Integer.class, sqlDataTypeSub(row).getClass());
-        
-        row = rows.get(9);
-        assertEquals("some.ambiguous", name(row));
-        assertEquals(Types.VARCHAR, sqlType(row));
-        assertEquals(null, radix(row));
-        assertEquals(Integer.MAX_VALUE, bufferLength(row));
-        assertNull(decimalPrecision(row));
-        assertEquals(Integer.class, nullable(row).getClass());
-        assertEquals(Integer.class, sqlDataType(row).getClass());
-        assertEquals(Integer.class, sqlDataTypeSub(row).getClass());
-        
-        row = rows.get(10);
-        assertEquals("some.ambiguous.one", name(row));
-        assertEquals(Types.VARCHAR, sqlType(row));
-        assertEquals(null, radix(row));
-        assertEquals(Integer.MAX_VALUE, bufferLength(row));
-        assertNull(decimalPrecision(row));
-        assertEquals(Integer.class, nullable(row).getClass());
-        assertEquals(Integer.class, sqlDataType(row).getClass());
-        assertEquals(Integer.class, sqlDataTypeSub(row).getClass());
-        
-        row = rows.get(11);
-        assertEquals("some.ambiguous.two", name(row));
-        assertEquals(Types.VARCHAR, sqlType(row));
-        assertEquals(null, radix(row));
-        assertEquals(Integer.MAX_VALUE, bufferLength(row));
-        assertNull(decimalPrecision(row));
-        assertEquals(Integer.class, nullable(row).getClass());
-        assertEquals(Integer.class, sqlDataType(row).getClass());
-        assertEquals(Integer.class, sqlDataTypeSub(row).getClass());
-
-        row = rows.get(12);
-        assertEquals("some.ambiguous.normalized", name(row));
-        assertEquals(Types.VARCHAR, sqlType(row));
-        assertEquals(null, radix(row));
-        assertEquals(Integer.MAX_VALUE, bufferLength(row));
-        assertNull(decimalPrecision(row));
-        assertEquals(Integer.class, nullable(row).getClass());
-        assertEquals(Integer.class, sqlDataType(row).getClass());
-        assertEquals(Integer.class, sqlDataTypeSub(row).getClass());
+        sysColumnsInDriverMode(Mode.ODBC);
     }
 
     private static Object name(List<?> list) {
@@ -449,7 +330,7 @@ public class SysColumnsTests extends ESTestCase {
 
     public void testSysColumnsNoArg() throws Exception {
         executeCommand("SYS COLUMNS", emptyList(), r -> {
-            assertEquals(15, r.size());
+            assertEquals(FIELD_COUNT, r.size());
             assertEquals(CLUSTER_NAME, r.column(0));
             // no index specified
             assertEquals("test", r.column(2));
@@ -464,7 +345,7 @@ public class SysColumnsTests extends ESTestCase {
 
     public void testSysColumnsWithCatalogWildcard() throws Exception {
         executeCommand("SYS COLUMNS CATALOG 'cluster' TABLE LIKE 'test' LIKE '%'", emptyList(), r -> {
-            assertEquals(15, r.size());
+            assertEquals(FIELD_COUNT, r.size());
             assertEquals(CLUSTER_NAME, r.column(0));
             assertEquals("test", r.column(2));
             assertEquals("bool", r.column(3));
@@ -477,7 +358,7 @@ public class SysColumnsTests extends ESTestCase {
 
     public void testSysColumnsWithMissingCatalog() throws Exception {
         executeCommand("SYS COLUMNS TABLE LIKE 'test' LIKE '%'", emptyList(), r -> {
-            assertEquals(15, r.size());
+            assertEquals(FIELD_COUNT, r.size());
             assertEquals(CLUSTER_NAME, r.column(0));
             assertEquals("test", r.column(2));
             assertEquals("bool", r.column(3));
@@ -490,7 +371,7 @@ public class SysColumnsTests extends ESTestCase {
 
     public void testSysColumnsWithNullCatalog() throws Exception {
         executeCommand("SYS COLUMNS CATALOG ? TABLE LIKE 'test' LIKE '%'", singletonList(new SqlTypedParamValue("keyword", null)), r -> {
-            assertEquals(15, r.size());
+            assertEquals(FIELD_COUNT, r.size());
             assertEquals(CLUSTER_NAME, r.column(0));
             assertEquals("test", r.column(2));
             assertEquals("bool", r.column(3));
@@ -507,13 +388,13 @@ public class SysColumnsTests extends ESTestCase {
     }
 
     public void testSysColumnsPaginationInOdbcMode() {
-        assertEquals(15, executeCommandInOdbcModeAndCountRows("SYS COLUMNS"));
-        assertEquals(15, executeCommandInOdbcModeAndCountRows("SYS COLUMNS TABLE LIKE 'test'"));
+        assertEquals(FIELD_COUNT, executeCommandInOdbcModeAndCountRows("SYS COLUMNS"));
+        assertEquals(FIELD_COUNT, executeCommandInOdbcModeAndCountRows("SYS COLUMNS TABLE LIKE 'test'"));
     }
 
     private int executeCommandInOdbcModeAndCountRows(String sql) {
         final SqlConfiguration config = new SqlConfiguration(DateUtils.UTC, randomIntBetween(1, 15), Protocol.REQUEST_TIMEOUT,
-            Protocol.PAGE_TIMEOUT, null, Mode.ODBC, null, null, null, false, false);
+            Protocol.PAGE_TIMEOUT, null, Mode.ODBC, null, SqlVersion.fromId(Version.CURRENT.id), null, null, false, false);
         Tuple<Command, SqlSession> tuple = sql(sql, emptyList(), config, mapping);
 
         int[] rowCount = {0};
@@ -538,7 +419,7 @@ public class SysColumnsTests extends ESTestCase {
     private void executeCommand(String sql, List<SqlTypedParamValue> params, Mode mode, Consumer<SchemaRowSet> consumer,
                                 Map<String, EsField> mapping) {
         final SqlConfiguration config = new SqlConfiguration(DateUtils.UTC, Protocol.FETCH_SIZE, Protocol.REQUEST_TIMEOUT,
-            Protocol.PAGE_TIMEOUT, null, mode, null, null, null, false, false);
+            Protocol.PAGE_TIMEOUT, null, mode, null, SqlVersion.fromId(Version.CURRENT.id), null, null, false, false);
         Tuple<Command, SqlSession> tuple = sql(sql, params, config, mapping);
 
         tuple.v1().execute(tuple.v2(), wrap(p -> consumer.accept((SchemaRowSet) p.rowSet()), ex -> fail(ex.getMessage())));
@@ -553,7 +434,8 @@ public class SysColumnsTests extends ESTestCase {
     private Tuple<Command, SqlSession> sql(String sql, List<SqlTypedParamValue> params, SqlConfiguration config,
                                            Map<String, EsField> mapping) {
         EsIndex test = new EsIndex("test", mapping);
-        Analyzer analyzer = new Analyzer(config, new FunctionRegistry(), IndexResolution.valid(test), new Verifier(new Metrics()));
+        Analyzer analyzer = new Analyzer(config, new FunctionRegistry(), IndexResolution.valid(test), new Verifier(new Metrics(),
+            config.version()));
         Command cmd = (Command) analyzer.analyze(parser.createStatement(sql, params, UTC), true);
 
         IndexResolver resolver = mock(IndexResolver.class);
@@ -572,7 +454,7 @@ public class SysColumnsTests extends ESTestCase {
     }
 
     private static void checkOdbcShortTypes(SchemaRowSet r) {
-        assertEquals(15, r.size());
+        assertEquals(FIELD_COUNT, r.size());
         // https://github.com/elastic/elasticsearch/issues/35376
         // cols that need to be of short type: DATA_TYPE, DECIMAL_DIGITS, NUM_PREC_RADIX, NULLABLE, SQL_DATA_TYPE, SQL_DATETIME_SUB
         List<Integer> cols = Arrays.asList(4, 8, 9, 10, 13, 14);

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTablesTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTablesTests.java
@@ -59,7 +59,7 @@ public class SysTablesTests extends ESTestCase {
     private final IndexInfo frozen = new IndexInfo("frozen", IndexType.FROZEN_INDEX);
 
     private final SqlConfiguration FROZEN_CFG = new SqlConfiguration(DateUtils.UTC, Protocol.FETCH_SIZE, Protocol.REQUEST_TIMEOUT,
-            Protocol.PAGE_TIMEOUT, null, Mode.PLAIN, null, null, null, false, true);
+            Protocol.PAGE_TIMEOUT, null, Mode.PLAIN, null, null, null, null, false, true);
 
     //
     // catalog enumeration
@@ -334,7 +334,7 @@ public class SysTablesTests extends ESTestCase {
     private Tuple<Command, SqlSession> sql(String sql, List<SqlTypedParamValue> params, SqlConfiguration cfg) {
         EsIndex test = new EsIndex("test", mapping);
         Analyzer analyzer = new Analyzer(SqlTestUtils.TEST_CFG, new FunctionRegistry(), IndexResolution.valid(test),
-                                         new Verifier(new Metrics()));
+                                         new Verifier(new Metrics(), SqlTestUtils.TEST_CFG.version()));
         Command cmd = (Command) analyzer.analyze(parser.createStatement(sql, params, cfg.zoneId()), true);
 
         IndexResolver resolver = mock(IndexResolver.class);

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTypesTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTypesTests.java
@@ -5,6 +5,7 @@
  */
 package org.elasticsearch.xpack.sql.plan.logical.command.sys;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.ql.expression.function.FunctionRegistry;
@@ -12,14 +13,18 @@ import org.elasticsearch.xpack.ql.index.EsIndex;
 import org.elasticsearch.xpack.ql.index.IndexResolution;
 import org.elasticsearch.xpack.ql.index.IndexResolver;
 import org.elasticsearch.xpack.ql.type.DataTypes;
-import org.elasticsearch.xpack.sql.SqlTestUtils;
 import org.elasticsearch.xpack.sql.analysis.analyzer.Analyzer;
 import org.elasticsearch.xpack.sql.parser.SqlParser;
 import org.elasticsearch.xpack.sql.plan.logical.command.Command;
+import org.elasticsearch.xpack.sql.proto.Mode;
+import org.elasticsearch.xpack.sql.proto.Protocol;
+import org.elasticsearch.xpack.sql.proto.SqlVersion;
 import org.elasticsearch.xpack.sql.session.SchemaRowSet;
+import org.elasticsearch.xpack.sql.session.SqlConfiguration;
 import org.elasticsearch.xpack.sql.session.SqlSession;
 import org.elasticsearch.xpack.sql.type.SqlDataTypes;
 import org.elasticsearch.xpack.sql.types.SqlTypesTests;
+import org.elasticsearch.xpack.sql.util.DateUtils;
 
 import java.sql.JDBCType;
 import java.util.List;
@@ -32,32 +37,37 @@ public class SysTypesTests extends ESTestCase {
 
     private final SqlParser parser = new SqlParser();
 
-    private Tuple<Command, SqlSession> sql(String sql) {
+    private Tuple<Command, SqlSession> sql(String sql, Mode mode, SqlVersion version) {
+        SqlConfiguration configuration = new SqlConfiguration(DateUtils.UTC, Protocol.FETCH_SIZE,
+            Protocol.REQUEST_TIMEOUT, Protocol.PAGE_TIMEOUT, null, mode, null, version, null, null, false, false);
         EsIndex test = new EsIndex("test", SqlTypesTests.loadMapping("mapping-multi-field-with-nested.json", true));
-        Analyzer analyzer = new Analyzer(SqlTestUtils.TEST_CFG, new FunctionRegistry(), IndexResolution.valid(test), null);
+        Analyzer analyzer = new Analyzer(configuration, new FunctionRegistry(), IndexResolution.valid(test), null);
         Command cmd = (Command) analyzer.analyze(parser.createStatement(sql), false);
 
         IndexResolver resolver = mock(IndexResolver.class);
-        SqlSession session = new SqlSession(SqlTestUtils.TEST_CFG, null, null, resolver, null, null, null, null, null);
+        SqlSession session = new SqlSession(configuration, null, null, resolver, null, null, null, null, null);
         return new Tuple<>(cmd, session);
     }
+    private Tuple<Command, SqlSession> sql(String sql) {
+        return sql(sql, randomFrom(Mode.values()), randomBoolean() ? null : SqlVersion.fromId(Version.CURRENT.id));
+    }
+
+    static final List<String> ALL_TYPES = asList("BYTE", "LONG", "BINARY", "NULL", "INTEGER", "SHORT", "HALF_FLOAT",
+        "FLOAT", "DOUBLE", "SCALED_FLOAT", "IP", "KEYWORD", "TEXT", "BOOLEAN", "DATE", "TIME", "DATETIME",
+        "INTERVAL_YEAR", "INTERVAL_MONTH", "INTERVAL_DAY", "INTERVAL_HOUR", "INTERVAL_MINUTE", "INTERVAL_SECOND",
+        "INTERVAL_YEAR_TO_MONTH", "INTERVAL_DAY_TO_HOUR", "INTERVAL_DAY_TO_MINUTE", "INTERVAL_DAY_TO_SECOND",
+        "INTERVAL_HOUR_TO_MINUTE", "INTERVAL_HOUR_TO_SECOND", "INTERVAL_MINUTE_TO_SECOND",
+        "GEO_POINT", "GEO_SHAPE", "SHAPE", "UNSUPPORTED", "NESTED", "OBJECT");
 
     public void testSysTypes() {
-        Command cmd = sql("SYS TYPES").v1();
+        Tuple<Command, SqlSession> cmd = sql("SYS TYPES");
 
-        List<String> names = asList("BYTE", "LONG", "BINARY", "NULL", "INTEGER", "SHORT", "HALF_FLOAT", "FLOAT", "DOUBLE", "SCALED_FLOAT",
-                "IP", "KEYWORD", "TEXT", "BOOLEAN", "DATE", "TIME", "DATETIME",
-                "INTERVAL_YEAR", "INTERVAL_MONTH", "INTERVAL_DAY", "INTERVAL_HOUR", "INTERVAL_MINUTE", "INTERVAL_SECOND",
-                "INTERVAL_YEAR_TO_MONTH", "INTERVAL_DAY_TO_HOUR", "INTERVAL_DAY_TO_MINUTE", "INTERVAL_DAY_TO_SECOND",
-                "INTERVAL_HOUR_TO_MINUTE", "INTERVAL_HOUR_TO_SECOND", "INTERVAL_MINUTE_TO_SECOND",
-                "GEO_POINT", "GEO_SHAPE", "SHAPE", "UNSUPPORTED", "NESTED", "OBJECT");
-
-        cmd.execute(session(), wrap(p -> {
+        cmd.v1().execute(cmd.v2(), wrap(p -> {
             SchemaRowSet r = (SchemaRowSet) p.rowSet();
             assertEquals(19, r.columnCount());
             assertEquals(SqlDataTypes.types().size(), r.size());
             assertFalse(r.schema().types().contains(DataTypes.NULL));
-            // test numeric as signed
+            // test first numeric (i.e. BYTE) as signed
             assertFalse(r.column(9, Boolean.class));
             // make sure precision is returned as boolean (not int)
             assertFalse(r.column(10, Boolean.class));
@@ -65,7 +75,7 @@ public class SysTypesTests extends ESTestCase {
             assertFalse(r.column(11, Boolean.class));
 
             for (int i = 0; i < r.size(); i++) {
-                assertEquals(names.get(i), r.column(0));
+                assertEquals(ALL_TYPES.get(i), r.column(0));
                 r.advanceRow();
             }
 
@@ -73,9 +83,9 @@ public class SysTypesTests extends ESTestCase {
     }
 
     public void testSysTypesDefaultFiltering() {
-        Command cmd = sql("SYS TYPES 0").v1();
+        Tuple<Command, SqlSession> cmd = sql("SYS TYPES 0");
 
-        cmd.execute(session(), wrap(p -> {
+        cmd.v1().execute(cmd.v2(), wrap(p -> {
             SchemaRowSet r = (SchemaRowSet) p.rowSet();
             assertEquals(SqlDataTypes.types().size(), r.size());
         }, ex -> fail(ex.getMessage())));
@@ -83,9 +93,9 @@ public class SysTypesTests extends ESTestCase {
 
     public void testSysTypesPositiveFiltering() {
         // boolean = 16
-        Command cmd = sql("SYS TYPES " + JDBCType.BOOLEAN.getVendorTypeNumber()).v1();
+        Tuple<Command, SqlSession> cmd = sql("SYS TYPES " + JDBCType.BOOLEAN.getVendorTypeNumber());
 
-        cmd.execute(session(), wrap(p -> {
+        cmd.v1().execute(cmd.v2(), wrap(p -> {
             SchemaRowSet r = (SchemaRowSet) p.rowSet();
             assertEquals(1, r.size());
             assertEquals("BOOLEAN", r.column(0));
@@ -93,9 +103,9 @@ public class SysTypesTests extends ESTestCase {
     }
 
     public void testSysTypesNegativeFiltering() {
-        Command cmd = sql("SYS TYPES " + JDBCType.TINYINT.getVendorTypeNumber()).v1();
+        Tuple<Command, SqlSession> cmd = sql("SYS TYPES " + JDBCType.TINYINT.getVendorTypeNumber());
 
-        cmd.execute(session(), wrap(p -> {
+        cmd.v1().execute(cmd.v2(), wrap(p -> {
             SchemaRowSet r = (SchemaRowSet) p.rowSet();
             assertEquals(1, r.size());
             assertEquals("BYTE", r.column(0));
@@ -103,9 +113,9 @@ public class SysTypesTests extends ESTestCase {
     }
 
     public void testSysTypesMultipleMatches() {
-        Command cmd = sql("SYS TYPES " + JDBCType.VARCHAR.getVendorTypeNumber()).v1();
+        Tuple<Command, SqlSession> cmd = sql("SYS TYPES " + JDBCType.VARCHAR.getVendorTypeNumber());
 
-        cmd.execute(session(), wrap(p -> {
+        cmd.v1().execute(cmd.v2(), wrap(p -> {
             SchemaRowSet r = (SchemaRowSet) p.rowSet();
             assertEquals(3, r.size());
             assertEquals("IP", r.column(0));
@@ -114,9 +124,5 @@ public class SysTypesTests extends ESTestCase {
             assertTrue(r.advanceRow());
             assertEquals("TEXT", r.column(0));
         }, ex -> fail(ex.getMessage())));
-    }
-
-    private static SqlSession session() {
-        return new SqlSession(SqlTestUtils.TEST_CFG, null, null, null, null, null, null, null, null);
     }
 }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/planner/QueryFolderTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/planner/QueryFolderTests.java
@@ -52,7 +52,8 @@ public class QueryFolderTests extends ESTestCase {
         Map<String, EsField> mapping = SqlTypesTests.loadMapping("mapping-multi-field-variation.json");
         EsIndex test = new EsIndex("test", mapping);
         IndexResolution getIndexResult = IndexResolution.valid(test);
-        analyzer = new Analyzer(SqlTestUtils.TEST_CFG, new SqlFunctionRegistry(), getIndexResult, new Verifier(new Metrics()));
+        analyzer = new Analyzer(SqlTestUtils.TEST_CFG, new SqlFunctionRegistry(), getIndexResult,
+            new Verifier(new Metrics(), SqlTestUtils.TEST_CFG.version()));
         optimizer = new Optimizer();
         planner = new Planner();
     }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/planner/QueryTranslatorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/planner/QueryTranslatorTests.java
@@ -134,7 +134,8 @@ public class QueryTranslatorTests extends ESTestCase {
             Map<String, EsField> mapping = SqlTypesTests.loadMapping(mappingFile);
             EsIndex test = new EsIndex("test", mapping);
             IndexResolution getIndexResult = IndexResolution.valid(test);
-            analyzer = new Analyzer(SqlTestUtils.TEST_CFG, sqlFunctionRegistry, getIndexResult, new Verifier(new Metrics()));
+            analyzer = new Analyzer(SqlTestUtils.TEST_CFG, sqlFunctionRegistry, getIndexResult,
+                new Verifier(new Metrics(), SqlTestUtils.TEST_CFG.version()));
             optimizer = new Optimizer();
             planner = new Planner();
         }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/stats/VerifierMetricsTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/stats/VerifierMetricsTests.java
@@ -30,11 +30,11 @@ import static org.elasticsearch.xpack.sql.stats.FeatureMetric.WHERE;
 import static org.elasticsearch.xpack.sql.stats.Metrics.FPREFIX;
 
 public class VerifierMetricsTests extends ESTestCase {
-    
+
     private SqlParser parser = new SqlParser();
     private String[] commands = {"SHOW FUNCTIONS", "SHOW COLUMNS FROM library", "SHOW SCHEMAS",
                                  "SHOW TABLES", "SYS COLUMNS LIKE '%name'", "SYS TABLES", "SYS TYPES"};
-    
+
     public void testWhereQuery() {
         Counters c = sql("SELECT emp_no FROM test WHERE languages > 2");
         assertEquals(1L, where(c));
@@ -45,7 +45,7 @@ public class VerifierMetricsTests extends ESTestCase {
         assertEquals(0, command(c));
         assertEquals(0, local(c));
     }
-    
+
     public void testLimitQuery() {
         Counters c = sql("SELECT emp_no FROM test LIMIT 4");
         assertEquals(0, where(c));
@@ -56,7 +56,7 @@ public class VerifierMetricsTests extends ESTestCase {
         assertEquals(0, command(c));
         assertEquals(0, local(c));
     }
-    
+
     public void testGroupByQuery() {
         Counters c = sql("SELECT languages, MAX(languages) FROM test GROUP BY languages");
         assertEquals(0, where(c));
@@ -67,7 +67,7 @@ public class VerifierMetricsTests extends ESTestCase {
         assertEquals(0, command(c));
         assertEquals(0, local(c));
     }
-    
+
     public void testHavingQuery() {
         Counters c = sql("SELECT UCASE(gender), MAX(languages) FROM test GROUP BY gender HAVING MAX(languages) > 3");
         assertEquals(0, where(c));
@@ -78,7 +78,7 @@ public class VerifierMetricsTests extends ESTestCase {
         assertEquals(0, command(c));
         assertEquals(0, local(c));
     }
-    
+
     public void testOrderByQuery() {
         Counters c = sql("SELECT UCASE(gender) FROM test ORDER BY emp_no");
         assertEquals(0, where(c));
@@ -89,7 +89,7 @@ public class VerifierMetricsTests extends ESTestCase {
         assertEquals(0, command(c));
         assertEquals(0, local(c));
     }
-    
+
     public void testCommand() {
         Counters c = sql(randomFrom("SHOW FUNCTIONS", "SHOW COLUMNS FROM library", "SHOW SCHEMAS",
                                     "SHOW TABLES", "SYS COLUMNS LIKE '%name'", "SYS TABLES", "SYS TYPES"));
@@ -101,7 +101,7 @@ public class VerifierMetricsTests extends ESTestCase {
         assertEquals(1L, command(c));
         assertEquals(0, local(c));
     }
-    
+
     public void testLocalQuery() {
         Counters c = sql("SELECT CONCAT('Elastic','search')");
         assertEquals(0, where(c));
@@ -112,7 +112,7 @@ public class VerifierMetricsTests extends ESTestCase {
         assertEquals(0, command(c));
         assertEquals(1L, local(c));
     }
-    
+
     public void testWhereAndLimitQuery() {
         Counters c = sql("SELECT emp_no FROM test WHERE languages > 2 LIMIT 5");
         assertEquals(1L, where(c));
@@ -123,7 +123,7 @@ public class VerifierMetricsTests extends ESTestCase {
         assertEquals(0, command(c));
         assertEquals(0, local(c));
     }
-    
+
     public void testWhereLimitGroupByQuery() {
         Counters c = sql("SELECT languages FROM test WHERE languages > 2 GROUP BY languages LIMIT 5");
         assertEquals(1L, where(c));
@@ -134,7 +134,7 @@ public class VerifierMetricsTests extends ESTestCase {
         assertEquals(0, command(c));
         assertEquals(0, local(c));
     }
-    
+
     public void testWhereLimitGroupByHavingQuery() {
         Counters c = sql("SELECT languages FROM test WHERE languages > 2 GROUP BY languages HAVING MAX(languages) > 3 LIMIT 5");
         assertEquals(1L, where(c));
@@ -145,7 +145,7 @@ public class VerifierMetricsTests extends ESTestCase {
         assertEquals(0, command(c));
         assertEquals(0, local(c));
     }
-    
+
     public void testWhereLimitGroupByHavingOrderByQuery() {
         Counters c = sql("SELECT languages FROM test WHERE languages > 2 GROUP BY languages HAVING MAX(languages) > 3"
                       + " ORDER BY languages LIMIT 5");
@@ -157,15 +157,15 @@ public class VerifierMetricsTests extends ESTestCase {
         assertEquals(0, command(c));
         assertEquals(0, local(c));
     }
-    
+
     public void testTwoQueriesExecuted() {
         Metrics metrics = new Metrics();
-        Verifier verifier = new Verifier(metrics);
+        Verifier verifier = new Verifier(metrics, SqlTestUtils.TEST_CFG.version());
         sqlWithVerifier("SELECT languages FROM test WHERE languages > 2 GROUP BY languages LIMIT 5", verifier);
         sqlWithVerifier("SELECT languages FROM test WHERE languages > 2 GROUP BY languages HAVING MAX(languages) > 3 "
                       + "ORDER BY languages LIMIT 5", verifier);
         Counters c = metrics.stats();
-        
+
         assertEquals(2L, where(c));
         assertEquals(2L, limit(c));
         assertEquals(2L, groupby(c));
@@ -174,15 +174,15 @@ public class VerifierMetricsTests extends ESTestCase {
         assertEquals(0, command(c));
         assertEquals(0, local(c));
     }
-    
+
     public void testTwoCommandsExecuted() {
         String command1 = randomFrom(commands);
         Metrics metrics = new Metrics();
-        Verifier verifier = new Verifier(metrics);
+        Verifier verifier = new Verifier(metrics, SqlTestUtils.TEST_CFG.version());
         sqlWithVerifier(command1, verifier);
         sqlWithVerifier(randomValueOtherThan(command1, () -> randomFrom(commands)), verifier);
         Counters c = metrics.stats();
-        
+
         assertEquals(0, where(c));
         assertEquals(0, limit(c));
         assertEquals(0, groupby(c));
@@ -191,39 +191,39 @@ public class VerifierMetricsTests extends ESTestCase {
         assertEquals(2, command(c));
         assertEquals(0, local(c));
     }
-    
+
     private long where(Counters c) {
         return c.get(FPREFIX + WHERE);
     }
-    
+
     private long groupby(Counters c) {
         return c.get(FPREFIX + GROUPBY);
     }
-    
+
     private long limit(Counters c) {
         return c.get(FPREFIX + LIMIT);
     }
-    
+
     private long local(Counters c) {
         return c.get(FPREFIX + LOCAL);
     }
-    
+
     private long having(Counters c) {
         return c.get(FPREFIX + HAVING);
     }
-    
+
     private long orderby(Counters c) {
         return c.get(FPREFIX + ORDERBY);
     }
-    
+
     private long command(Counters c) {
         return c.get(FPREFIX + COMMAND);
     }
-    
+
     private Counters sql(String sql) {
         return sql(sql, null);
     }
-    
+
     private void sqlWithVerifier(String sql, Verifier verifier) {
         sql(sql, verifier);
     }
@@ -231,17 +231,17 @@ public class VerifierMetricsTests extends ESTestCase {
     private Counters sql(String sql, Verifier v) {
         Map<String, EsField> mapping = SqlTypesTests.loadMapping("mapping-basic.json");
         EsIndex test = new EsIndex("test", mapping);
-        
+
         Verifier verifier = v;
         Metrics metrics = null;
         if (v == null) {
             metrics = new Metrics();
-            verifier = new Verifier(metrics);
+            verifier = new Verifier(metrics, SqlTestUtils.TEST_CFG.version());
         }
 
         Analyzer analyzer = new Analyzer(SqlTestUtils.TEST_CFG, new SqlFunctionRegistry(), IndexResolution.valid(test), verifier);
         analyzer.analyze(parser.createStatement(sql), true);
-        
+
         return metrics == null ? null : metrics.stats();
     }
 }


### PR DESCRIPTION
This PR adds the framing code used for introducing a backwards-compatiblity breaking change, in respect to SQL's clients.

The PR also adds in a few collateral minor refactorings, meant to ease expanding the existing tests whenever a new feature is added, mostly geared towards new types being added.
