### PR TITLE
[7.10] [DOCS] Fix synced flush request typos (#67446)

### DIFF
--- a/docs/reference/indices/synced-flush.asciidoc
+++ b/docs/reference/indices/synced-flush.asciidoc
@@ -18,13 +18,13 @@ POST /my-index-000001/_flush/synced
 [[synced-flush-api-request]]
 ==== {api-request-title}
 
-`POST /<index>/flush/synced`
+`POST /<index>/_flush/synced`
 
-`GET /<index>/flush/synced`
+`GET /<index>/_flush/synced`
 
-`POST /flush/synced`
+`POST /_flush/synced`
 
-`GET /flush/synced`
+`GET /_flush/synced`
 
 
 [[synced-flush-api-desc]]


### PR DESCRIPTION
Backports the following commits to 7.10:
 - [DOCS] Fix synced flush request typos (#67446)