### PR TITLE
Extend the selective muting of memory tests on Debian 8

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -131,7 +131,6 @@ import org.elasticsearch.indices.IndicesRequestCache;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.store.IndicesStore;
 import org.elasticsearch.ingest.IngestMetadata;
-import org.elasticsearch.monitor.os.OsInfo;
 import org.elasticsearch.node.NodeMocksPlugin;
 import org.elasticsearch.plugins.NetworkPlugin;
 import org.elasticsearch.plugins.Plugin;
@@ -2366,7 +2365,7 @@ public abstract class ESIntegTestCase extends ESTestCase {
         final NodesInfoResponse response = client().admin().cluster().prepareNodesInfo().execute().actionGet();
         final boolean anyDebian8Nodes = response.getNodes()
             .stream()
-            .anyMatch(ni -> ni.getInfo(OsInfo.class).getPrettyName().equals("Debian GNU/Linux 8 (jessie)"));
+            .anyMatch(ni -> ni.getOs().getPrettyName().equals("Debian GNU/Linux 8 (jessie)"));
         boolean java15Plus = JavaVersion.current().compareTo(JavaVersion.parse("15")) >= 0;
         return anyDebian8Nodes && java15Plus == false;
     }

--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -57,6 +57,7 @@ import org.elasticsearch.action.search.ClearScrollResponse;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
 import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.bootstrap.JavaVersion;
 import org.elasticsearch.client.AdminClient;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.Requests;
@@ -130,6 +131,7 @@ import org.elasticsearch.indices.IndicesRequestCache;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.store.IndicesStore;
 import org.elasticsearch.ingest.IngestMetadata;
+import org.elasticsearch.monitor.os.OsInfo;
 import org.elasticsearch.node.NodeMocksPlugin;
 import org.elasticsearch.plugins.NetworkPlugin;
 import org.elasticsearch.plugins.Plugin;
@@ -2349,5 +2351,23 @@ public abstract class ESIntegTestCase extends ESTestCase {
 
     public static boolean inFipsJvm() {
         return Security.getProviders()[0].getName().toLowerCase(Locale.ROOT).contains("fips");
+    }
+
+    /**
+     * On Debian 8 the "memory" subsystem is not mounted by default
+     * when cgroups are enabled, and this confuses many versions of
+     * Java prior to Java 15.  Tests that rely on machine memory
+     * being accurately determined will not work on such setups,
+     * and can use this method for selective muting.
+     * See https://github.com/elastic/elasticsearch/issues/67089
+     * and https://github.com/elastic/elasticsearch/issues/66885
+     */
+    protected boolean willSufferDebian8MemoryProblem() {
+        final NodesInfoResponse response = client().admin().cluster().prepareNodesInfo().execute().actionGet();
+        final boolean anyDebian8Nodes = response.getNodes()
+            .stream()
+            .anyMatch(ni -> ni.getInfo(OsInfo.class).getPrettyName().equals("Debian GNU/Linux 8 (jessie)"));
+        boolean java15Plus = JavaVersion.current().compareTo(JavaVersion.parse("15")) >= 0;
+        return anyDebian8Nodes && java15Plus == false;
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/MlDistributedFailureIT.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/MlDistributedFailureIT.java
@@ -337,6 +337,9 @@ public class MlDistributedFailureIT extends BaseMlIntegTestCase {
 
     public void testJobRelocationIsMemoryAware() throws Exception {
 
+        // see: https://github.com/elastic/elasticsearch/issues/66885#issuecomment-758790179
+        assumeFalse("cannot run on debian 8 prior to java 15", willSufferDebian8MemoryProblem());
+
         internalCluster().ensureAtLeastNumDataNodes(1);
         ensureStableClusterOnAllNodes(1);
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/TooManyJobsIT.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/TooManyJobsIT.java
@@ -124,10 +124,14 @@ public class TooManyJobsIT extends BaseMlIntegTestCase {
     }
 
     public void testSingleNode() throws Exception {
+        // see: https://github.com/elastic/elasticsearch/issues/66885#issuecomment-758790179
+        assumeFalse("cannot run on debian 8 prior to java 15", willSufferDebian8MemoryProblem());
         verifyMaxNumberOfJobsLimit(1, randomIntBetween(1, 20));
     }
 
     public void testMultipleNodes() throws Exception {
+        // see: https://github.com/elastic/elasticsearch/issues/66885#issuecomment-758790179
+        assumeFalse("cannot run on debian 8 prior to java 15", willSufferDebian8MemoryProblem());
         verifyMaxNumberOfJobsLimit(3, randomIntBetween(1, 20));
     }
 


### PR DESCRIPTION
The selective muting implemented for autoscaling in #67159
is extended to the ML tests that also fail when machine
memory is reported as 0.

Most of the logic to determine when memory will not be
accurately reported is now in a utility method in the
base class.

Relates #66885
Backport of #67422