### PR TITLE
Default shouldCancelChildrenOnCancellation to true

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/node/tasks/CancellableTasksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/node/tasks/CancellableTasksIT.java
@@ -443,12 +443,7 @@ public class CancellableTasksIT extends ESIntegTestCase {
 
         @Override
         public Task createTask(long id, String type, String action, TaskId parentTaskId, Map<String, String> headers) {
-            return new CancellableTask(id, type, action, taskDescription(), parentTaskId, headers) {
-                @Override
-                public boolean shouldCancelChildrenOnCancellation() {
-                    return true;
-                }
-            };
+            return new CancellableTask(id, type, action, taskDescription(), parentTaskId, headers);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/action/search/MultiSearchRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/search/MultiSearchRequest.java
@@ -341,11 +341,6 @@ public class MultiSearchRequest extends ActionRequest implements CompositeIndice
                     .map(SearchRequest::buildDescription)
                     .collect(Collectors.joining(action + "[", ",", "]"));
             }
-
-            @Override
-            public boolean shouldCancelChildrenOnCancellation() {
-                return true;
-            }
         };
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/search/SearchTask.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchTask.java
@@ -58,8 +58,4 @@ public class SearchTask extends CancellableTask {
         return progressListener;
     }
 
-    @Override
-    public boolean shouldCancelChildrenOnCancellation() {
-        return true;
-    }
 }

--- a/server/src/main/java/org/elasticsearch/index/reindex/BulkByScrollTask.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/BulkByScrollTask.java
@@ -197,11 +197,6 @@ public class BulkByScrollTask extends CancellableTask {
         }
     }
 
-    @Override
-    public boolean shouldCancelChildrenOnCancellation() {
-        return true;
-    }
-
     /**
      * This class acts as a builder for {@link Status}. Once the {@link Status} object is built by calling
      * {@link #buildStatus()} it is immutable. Used by an instance of {@link ObjectParser} when parsing from

--- a/server/src/main/java/org/elasticsearch/persistent/AllocatedPersistentTask.java
+++ b/server/src/main/java/org/elasticsearch/persistent/AllocatedPersistentTask.java
@@ -54,20 +54,6 @@ public class AllocatedPersistentTask extends CancellableTask {
     }
 
     @Override
-    public boolean shouldCancelChildrenOnCancellation() {
-        return true;
-    }
-
-    // In case of persistent tasks we always need to return: `false`
-    // because in case of persistent task the parent task isn't a task in the task manager, but in cluster state.
-    // This instructs the task manager not to try to kill this persistent task when the task manager cannot find
-    // a fake parent node id "cluster" in the cluster state
-    @Override
-    public final boolean cancelOnParentLeaving() {
-        return false;
-    }
-
-    @Override
     public Status getStatus() {
         return new PersistentTasksNodeService.Status(state.get());
     }

--- a/server/src/main/java/org/elasticsearch/tasks/CancellableTask.java
+++ b/server/src/main/java/org/elasticsearch/tasks/CancellableTask.java
@@ -25,9 +25,9 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
- * A task that can be canceled
+ * A task that can be cancelled
  */
-public abstract class CancellableTask extends Task {
+public class CancellableTask extends Task {
 
     private volatile String reason;
     private final AtomicBoolean cancelled = new AtomicBoolean(false);
@@ -48,17 +48,13 @@ public abstract class CancellableTask extends Task {
     }
 
     /**
-     * Returns true if this task should be automatically cancelled if the coordinating node that
-     * requested this task left the cluster.
+     * Returns whether this task's children need to be cancelled too. {@code true} is a reasonable response even for tasks that have no
+     * children, since child tasks might be added in future and it'd be easy to forget to update this, but returning {@code false} saves
+     * a bit of computation in the task manager.
      */
-    public boolean cancelOnParentLeaving() {
+    public boolean shouldCancelChildrenOnCancellation() {
         return true;
     }
-
-    /**
-     * Returns true if this task can potentially have children that need to be cancelled when it parent is cancelled.
-     */
-    public abstract boolean shouldCancelChildrenOnCancellation();
 
     public boolean isCancelled() {
         return cancelled.get();

--- a/server/src/main/java/org/elasticsearch/transport/TransportActionProxy.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportActionProxy.java
@@ -141,11 +141,6 @@ public final class TransportActionProxy {
         public Task createTask(long id, String type, String action, TaskId parentTaskId, Map<String, String> headers) {
             return new CancellableTask(id, type, action, "", parentTaskId, headers) {
                 @Override
-                public boolean shouldCancelChildrenOnCancellation() {
-                    return true;
-                }
-
-                @Override
                 public String getDescription() {
                     return "proxy task [" + wrapped.getDescription() + "]";
                 }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/CancellableTasksTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/CancellableTasksTests.java
@@ -131,12 +131,7 @@ public class CancellableTasksTests extends TaskManagerTestCase {
 
         @Override
         public Task createTask(long id, String type, String action, TaskId parentTaskId, Map<String, String> headers) {
-            return new CancellableTask(id, type, action, getDescription(), parentTaskId, headers) {
-                @Override
-                public boolean shouldCancelChildrenOnCancellation() {
-                    return true;
-                }
-            };
+            return new CancellableTask(id, type, action, getDescription(), parentTaskId, headers);
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TestTaskPlugin.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TestTaskPlugin.java
@@ -258,12 +258,7 @@ public class TestTaskPlugin extends Plugin implements ActionPlugin, NetworkPlugi
 
         @Override
         public Task createTask(long id, String type, String action, TaskId parentTaskId, Map<String, String> headers) {
-            return new CancellableTask(id, type, action, getDescription(), parentTaskId, headers) {
-                @Override
-                public boolean shouldCancelChildrenOnCancellation() {
-                    return true;
-                }
-            };
+            return new CancellableTask(id, type, action, getDescription(), parentTaskId, headers);
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/RollupTask.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/RollupTask.java
@@ -43,11 +43,6 @@ public class RollupTask extends CancellableTask {
     }
 
     @Override
-    public boolean shouldCancelChildrenOnCancellation() {
-        return true;
-    }
-
-    @Override
     public void onCancelled() {
         // TODO(talevy): make things cancellable
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/SubmitAsyncSearchRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/SubmitAsyncSearchRequest.java
@@ -153,11 +153,6 @@ public class SubmitAsyncSearchRequest extends ActionRequest {
     public Task createTask(long id, String type, String action, TaskId parentTaskId, Map<String, String> headers) {
         return new CancellableTask(id, type, action, null, parentTaskId, headers) {
             @Override
-            public boolean shouldCancelChildrenOnCancellation() {
-                return true;
-            }
-
-            @Override
             public String getDescription() {
                 // generating description in a lazy way since source can be quite big
                 return "waitForCompletionTimeout[" + waitForCompletionTimeout +

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/async/StoredAsyncTask.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/async/StoredAsyncTask.java
@@ -38,11 +38,6 @@ public abstract class StoredAsyncTask<Response extends ActionResponse> extends C
     }
 
     @Override
-    public boolean shouldCancelChildrenOnCancellation() {
-        return true;
-    }
-
-    @Override
     public Map<String, String> getOriginHeaders() {
         return originHeaders;
     }


### PR DESCRIPTION
Today `CancellableTask#shouldCancelChildrenOnCancellation` is abstract,
requiring every implementation to make a decision on whether to cascade
cancellations or not. In practice `true` is a reasonable answer in
almost all cases, so this commit sets this as its default.