### PR TITLE
[7.10] [DOCS] Fix acasting for agg types (#67469)

### DIFF
--- a/docs/reference/aggregations/bucket.asciidoc
+++ b/docs/reference/aggregations/bucket.asciidoc
@@ -1,5 +1,5 @@
 [[search-aggregations-bucket]]
-== Bucket Aggregations
+== Bucket aggregations
 
 Bucket aggregations don't calculate metrics over fields like the metrics aggregations do, but instead, they create
 buckets of documents. Each bucket is associated with a criterion (depending on the aggregation type) which determines

--- a/docs/reference/aggregations/metrics.asciidoc
+++ b/docs/reference/aggregations/metrics.asciidoc
@@ -1,5 +1,5 @@
 [[search-aggregations-metrics]]
-== Metrics Aggregations
+== Metrics aggregations
 
 The aggregations in this family compute metrics based on values extracted in one way or another from the documents that
 are being aggregated. The values are typically extracted from the fields of the document (using the field data), but

--- a/docs/reference/aggregations/pipeline.asciidoc
+++ b/docs/reference/aggregations/pipeline.asciidoc
@@ -1,6 +1,6 @@
 [[search-aggregations-pipeline]]
 
-== Pipeline Aggregations
+== Pipeline aggregations
 
 Pipeline aggregations work on the outputs produced from other aggregations rather than from document sets, adding
 information to the output tree. There are many different types of pipeline aggregation, each computing different information from


### PR DESCRIPTION
Backports the following commits to 7.10:
 - [DOCS] Fix acasting for agg types (#67469)