### PR TITLE
[DOCS] Fix API titles

### DIFF
--- a/docs/reference/graph/explore.asciidoc
+++ b/docs/reference/graph/explore.asciidoc
@@ -2,9 +2,6 @@
 [testenv="platinum"]
 [[graph-explore-api]]
 == Graph explore API
-++++
-<titleabbrev>Graph explore</titleabbrev>
-++++
 
 The graph explore API enables you to extract and summarize information about
 the documents and terms in an {es} data stream or index.

--- a/docs/reference/ilm/apis/ilm-api.asciidoc
+++ b/docs/reference/ilm/apis/ilm-api.asciidoc
@@ -1,5 +1,5 @@
 [[index-lifecycle-management-api]]
-== {ilm-cap} API
+== {ilm-cap} APIs
 
 You use the following APIs to set up policies to automatically manage the index lifecycle. 
 For more information about {ilm} ({ilm-init}), see <<index-lifecycle-management>>.

--- a/docs/reference/indices/apis/reload-analyzers.asciidoc
+++ b/docs/reference/indices/apis/reload-analyzers.asciidoc
@@ -2,9 +2,6 @@
 [testenv="basic"]
 [[indices-reload-analyzers]]
 == Reload search analyzers API
-++++
-<titleabbrev>Reload search analyzers</titleabbrev>
-++++
 
 Reloads an index's <<search-analyzer,search analyzers>> and their resources.
 For data streams, the API reloads search analyzers and resources for the

--- a/docs/reference/slm/apis/slm-api.asciidoc
+++ b/docs/reference/slm/apis/slm-api.asciidoc
@@ -1,7 +1,7 @@
 [role="xpack"]
 [testenv="basic"]
 [[snapshot-lifecycle-management-api]]
-== {slm-cap} API
+== {slm-cap} APIs
 
 You use the following APIs to set up policies to automatically take snapshots and 
 control how long they are retained. 

--- a/docs/reference/text-structure/apis/find-structure.asciidoc
+++ b/docs/reference/text-structure/apis/find-structure.asciidoc
@@ -2,9 +2,6 @@
 [testenv="basic"]
 [[find-structure]]
 = Find structure API
-++++
-<titleabbrev>Find structure</titleabbrev>
-++++
 
 Finds the structure of a text file. The text file must
 contain data that is suitable to be ingested into the
@@ -16,6 +13,7 @@ contain data that is suitable to be ingested into the
 
 `POST _text_structure/find_structure`
 
+[discrete]
 [[find-structure-prereqs]]
 == {api-prereq-title}
 


### PR DESCRIPTION
Adjusts the titles of a few pages so titles display consistently in the TOC.

### Before

<img width="342" alt="Screen Shot 2021-01-13 at 2 48 51 PM" src="https://user-images.githubusercontent.com/40268737/104503145-b12b2f80-55ae-11eb-8713-f69b3d5ece43.PNG">


### After

<img width="339" alt="Screen Shot 2021-01-13 at 2 48 16 PM" src="https://user-images.githubusercontent.com/40268737/104503151-b38d8980-55ae-11eb-9d1f-5d5c3f0a88fe.PNG">
