### PR TITLE
Rename QueryShardContext -> SearchExecutionContext.

### DIFF
--- a/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/DisableGraphQueryTests.java
+++ b/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/DisableGraphQueryTests.java
@@ -32,7 +32,7 @@ import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.query.MatchPhraseQueryBuilder;
 import org.elasticsearch.index.query.MatchQueryBuilder;
 import org.elasticsearch.index.query.MultiMatchQueryBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.QueryStringQueryBuilder;
 import org.elasticsearch.index.query.SimpleQueryStringBuilder;
 import org.elasticsearch.index.query.SimpleQueryStringFlag;
@@ -54,7 +54,7 @@ import static org.hamcrest.Matchers.equalTo;
  */
 public class DisableGraphQueryTests extends ESSingleNodeTestCase {
     private static IndexService indexService;
-    private static QueryShardContext shardContext;
+    private static SearchExecutionContext searchExecutionContext;
     private static Query expectedQuery;
     private static Query expectedPhraseQuery;
     private static Query expectedQueryWithUnigram;
@@ -85,7 +85,7 @@ public class DisableGraphQueryTests extends ESSingleNodeTestCase {
         indexService = createIndex("test", settings, "t",
             "text_shingle", "type=text,analyzer=text_shingle",
             "text_shingle_unigram", "type=text,analyzer=text_shingle_unigram");
-        shardContext = indexService.newQueryShardContext(0, 0, null, () -> 0L, null, emptyMap());
+        searchExecutionContext = indexService.newSearchExecutionContext(0, 0, null, () -> 0L, null, emptyMap());
 
         // parsed queries for "text_shingle_unigram:(foo bar baz)" with query parsers
         // that ignores position length attribute
@@ -158,7 +158,7 @@ public class DisableGraphQueryTests extends ESSingleNodeTestCase {
     @After
     public void cleanup() {
         indexService = null;
-        shardContext = null;
+        searchExecutionContext = null;
         expectedQuery = null;
         expectedPhraseQuery = null;
     }
@@ -166,42 +166,42 @@ public class DisableGraphQueryTests extends ESSingleNodeTestCase {
     public void testMatchPhraseQuery() throws IOException {
         MatchPhraseQueryBuilder builder =
             new MatchPhraseQueryBuilder("text_shingle_unigram", "foo bar baz");
-        Query query = builder.toQuery(shardContext);
+        Query query = builder.toQuery(searchExecutionContext);
         assertThat(expectedPhraseQueryWithUnigram, equalTo(query));
 
         builder =
             new MatchPhraseQueryBuilder("text_shingle", "foo bar baz biz");
-        query = builder.toQuery(shardContext);
+        query = builder.toQuery(searchExecutionContext);
         assertThat(expectedPhraseQuery, equalTo(query));
     }
 
     public void testMatchQuery() throws IOException {
         MatchQueryBuilder builder =
             new MatchQueryBuilder("text_shingle_unigram", "foo bar baz");
-        Query query = builder.toQuery(shardContext);
+        Query query = builder.toQuery(searchExecutionContext);
         assertThat(expectedQueryWithUnigram, equalTo(query));
 
         builder = new MatchQueryBuilder("text_shingle", "foo bar baz biz");
-        query = builder.toQuery(shardContext);
+        query = builder.toQuery(searchExecutionContext);
         assertThat(expectedQuery, equalTo(query));
     }
 
     public void testMultiMatchQuery() throws IOException {
         MultiMatchQueryBuilder builder = new MultiMatchQueryBuilder("foo bar baz",
             "text_shingle_unigram");
-        Query query = builder.toQuery(shardContext);
+        Query query = builder.toQuery(searchExecutionContext);
         assertThat(expectedQueryWithUnigram, equalTo(query));
 
         builder.type(MatchQuery.Type.PHRASE);
-        query = builder.toQuery(shardContext);
+        query = builder.toQuery(searchExecutionContext);
         assertThat(expectedPhraseQueryWithUnigram, equalTo(query));
 
         builder = new MultiMatchQueryBuilder("foo bar baz biz", "text_shingle");
-        query = builder.toQuery(shardContext);
+        query = builder.toQuery(searchExecutionContext);
         assertThat(expectedQuery, equalTo(query));
 
         builder.type(MatchQuery.Type.PHRASE);
-        query = builder.toQuery(shardContext);
+        query = builder.toQuery(searchExecutionContext);
         assertThat(expectedPhraseQuery, equalTo(query));
     }
 
@@ -209,47 +209,47 @@ public class DisableGraphQueryTests extends ESSingleNodeTestCase {
         SimpleQueryStringBuilder builder = new SimpleQueryStringBuilder("foo bar baz");
         builder.field("text_shingle_unigram");
         builder.flags(SimpleQueryStringFlag.NONE);
-        Query query = builder.toQuery(shardContext);
+        Query query = builder.toQuery(searchExecutionContext);
         assertThat(expectedQueryWithUnigram, equalTo(query));
 
         builder = new SimpleQueryStringBuilder("\"foo bar baz\"");
         builder.field("text_shingle_unigram");
         builder.flags(SimpleQueryStringFlag.PHRASE);
-        query = builder.toQuery(shardContext);
+        query = builder.toQuery(searchExecutionContext);
         assertThat(expectedPhraseQueryWithUnigram, equalTo(query));
 
         builder = new SimpleQueryStringBuilder("foo bar baz biz");
         builder.field("text_shingle");
         builder.flags(SimpleQueryStringFlag.NONE);
-        query = builder.toQuery(shardContext);
+        query = builder.toQuery(searchExecutionContext);
         assertThat(expectedQuery, equalTo(query));
 
         builder = new SimpleQueryStringBuilder("\"foo bar baz biz\"");
         builder.field("text_shingle");
         builder.flags(SimpleQueryStringFlag.PHRASE);
-        query = builder.toQuery(shardContext);
+        query = builder.toQuery(searchExecutionContext);
         assertThat(expectedPhraseQuery, equalTo(query));
     }
 
     public void testQueryString() throws IOException {
         QueryStringQueryBuilder builder = new QueryStringQueryBuilder("foo bar baz");
         builder.field("text_shingle_unigram");
-        Query query = builder.toQuery(shardContext);
+        Query query = builder.toQuery(searchExecutionContext);
         assertThat(expectedQueryWithUnigram, equalTo(query));
 
         builder = new QueryStringQueryBuilder("\"foo bar baz\"");
         builder.field("text_shingle_unigram");
-        query = builder.toQuery(shardContext);
+        query = builder.toQuery(searchExecutionContext);
         assertThat(expectedPhraseQueryWithUnigram, equalTo(query));
 
         builder = new QueryStringQueryBuilder("foo bar baz biz");
         builder.field("text_shingle");
-        query = builder.toQuery(shardContext);
+        query = builder.toQuery(searchExecutionContext);
         assertThat(expectedQuery, equalTo(query));
 
         builder = new QueryStringQueryBuilder("\"foo bar baz biz\"");
         builder.field("text_shingle");
-        query = builder.toQuery(shardContext);
+        query = builder.toQuery(searchExecutionContext);
         assertThat(expectedPhraseQuery, equalTo(query));
     }
 }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessExecuteAction.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessExecuteAction.java
@@ -65,7 +65,7 @@ import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.mapper.SourceToParse;
 import org.elasticsearch.index.query.AbstractQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.rest.BaseRestHandler;
@@ -538,7 +538,7 @@ public class PainlessExecuteAction extends ActionType<PainlessExecuteAction.Resp
         }
 
         private static Response prepareRamIndex(Request request,
-                                                CheckedBiFunction<QueryShardContext, LeafReaderContext, Response, IOException> handler,
+                                                CheckedBiFunction<SearchExecutionContext, LeafReaderContext, Response, IOException> handler,
                                                 IndexService indexService) throws IOException {
 
             Analyzer defaultAnalyzer = indexService.getIndexAnalyzers().getDefaultIndexAnalyzer();
@@ -555,8 +555,8 @@ public class PainlessExecuteAction extends ActionType<PainlessExecuteAction.Resp
                         final IndexSearcher searcher = new IndexSearcher(indexReader);
                         searcher.setQueryCache(null);
                         final long absoluteStartMillis = System.currentTimeMillis();
-                        QueryShardContext context =
-                            indexService.newQueryShardContext(0, 0, searcher, () -> absoluteStartMillis, null, emptyMap());
+                        SearchExecutionContext context =
+                            indexService.newSearchExecutionContext(0, 0, searcher, () -> absoluteStartMillis, null, emptyMap());
                         return handler.apply(context, indexReader.leaves().get(0));
                     }
                 }

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/NeedsScoreTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/NeedsScoreTests.java
@@ -21,7 +21,7 @@ package org.elasticsearch.painless;
 
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexService;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.painless.spi.Whitelist;
 import org.elasticsearch.script.NumberSortScript;
 import org.elasticsearch.script.ScriptContext;
@@ -47,22 +47,22 @@ public class NeedsScoreTests extends ESSingleNodeTestCase {
         contexts.put(NumberSortScript.CONTEXT, Whitelist.BASE_WHITELISTS);
         PainlessScriptEngine service = new PainlessScriptEngine(Settings.EMPTY, contexts);
 
-        QueryShardContext shardContext = index.newQueryShardContext(0, 0, null, () -> 0, null, emptyMap());
+        SearchExecutionContext searchExecutionContext = index.newSearchExecutionContext(0, 0, null, () -> 0, null, emptyMap());
 
         NumberSortScript.Factory factory = service.compile(null, "1.2", NumberSortScript.CONTEXT, Collections.emptyMap());
-        NumberSortScript.LeafFactory ss = factory.newFactory(Collections.emptyMap(), shardContext.lookup());
+        NumberSortScript.LeafFactory ss = factory.newFactory(Collections.emptyMap(), searchExecutionContext.lookup());
         assertFalse(ss.needs_score());
 
         factory = service.compile(null, "doc['d'].value", NumberSortScript.CONTEXT, Collections.emptyMap());
-        ss = factory.newFactory(Collections.emptyMap(), shardContext.lookup());
+        ss = factory.newFactory(Collections.emptyMap(), searchExecutionContext.lookup());
         assertFalse(ss.needs_score());
 
         factory = service.compile(null, "1/_score", NumberSortScript.CONTEXT, Collections.emptyMap());
-        ss = factory.newFactory(Collections.emptyMap(), shardContext.lookup());
+        ss = factory.newFactory(Collections.emptyMap(), searchExecutionContext.lookup());
         assertTrue(ss.needs_score());
 
         factory = service.compile(null, "doc['d'].value * _score", NumberSortScript.CONTEXT, Collections.emptyMap());
-        ss = factory.newFactory(Collections.emptyMap(), shardContext.lookup());
+        ss = factory.newFactory(Collections.emptyMap(), searchExecutionContext.lookup());
         assertTrue(ss.needs_score());
     }
 }

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/RankFeatureFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/RankFeatureFieldMapper.java
@@ -28,7 +28,7 @@ import org.apache.lucene.search.TermQuery;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.xcontent.XContentParser.Token;
 import org.elasticsearch.index.fielddata.IndexFieldData;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.io.IOException;
@@ -103,7 +103,7 @@ public class RankFeatureFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query existsQuery(QueryShardContext context) {
+        public Query existsQuery(SearchExecutionContext context) {
             return new TermQuery(new Term("_feature", name()));
         }
 
@@ -113,7 +113,7 @@ public class RankFeatureFieldMapper extends FieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             if (format != null) {
                 throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
             }
@@ -126,7 +126,7 @@ public class RankFeatureFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query termQuery(Object value, QueryShardContext context) {
+        public Query termQuery(Object value, SearchExecutionContext context) {
             throw new IllegalArgumentException("Queries on [rank_feature] fields are not supported");
         }
     }

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/RankFeatureMetaFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/RankFeatureMetaFieldMapper.java
@@ -20,7 +20,7 @@
 package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.search.Query;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 
 import java.util.Collections;
 
@@ -51,17 +51,17 @@ public class RankFeatureMetaFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             throw new UnsupportedOperationException("Cannot fetch values for internal field [" + typeName() + "].");
         }
 
         @Override
-        public Query existsQuery(QueryShardContext context) {
+        public Query existsQuery(SearchExecutionContext context) {
             throw new UnsupportedOperationException("Cannot run exists query on [_feature]");
         }
 
         @Override
-        public Query termQuery(Object value, QueryShardContext context) {
+        public Query termQuery(Object value, SearchExecutionContext context) {
             throw new UnsupportedOperationException("The [_feature] field may not be queried directly");
         }
     }

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/RankFeaturesFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/RankFeaturesFieldMapper.java
@@ -24,7 +24,7 @@ import org.apache.lucene.search.Query;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.xcontent.XContentParser.Token;
 import org.elasticsearch.index.fielddata.IndexFieldData;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.io.IOException;
@@ -76,7 +76,7 @@ public class RankFeaturesFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query existsQuery(QueryShardContext context) {
+        public Query existsQuery(SearchExecutionContext context) {
             throw new IllegalArgumentException("[rank_features] fields do not support [exists] queries");
         }
 
@@ -86,12 +86,12 @@ public class RankFeaturesFieldMapper extends FieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             return SourceValueFetcher.identity(name(), context, format);
         }
 
         @Override
-        public Query termQuery(Object value, QueryShardContext context) {
+        public Query termQuery(Object value, SearchExecutionContext context) {
             throw new IllegalArgumentException("Queries on [rank_features] fields are not supported");
         }
     }

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
@@ -173,7 +173,9 @@ public class ScaledFloatFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, SearchExecutionContext context) {
+        public Query rangeQuery(Object lowerTerm, Object upperTerm,
+                                boolean includeLower, boolean includeUpper,
+                                SearchExecutionContext context) {
             failIfNotIndexed();
             Long lo = null;
             if (lowerTerm != null) {

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
@@ -41,7 +41,7 @@ import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 import org.elasticsearch.index.fielddata.plain.SortedNumericIndexFieldData;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 import org.elasticsearch.search.lookup.SearchLookup;
@@ -155,14 +155,14 @@ public class ScaledFloatFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query termQuery(Object value, QueryShardContext context) {
+        public Query termQuery(Object value, SearchExecutionContext context) {
             failIfNotIndexed();
             long scaledValue = Math.round(scale(value));
             return NumberFieldMapper.NumberType.LONG.termQuery(name(), scaledValue);
         }
 
         @Override
-        public Query termsQuery(List<?> values, QueryShardContext context) {
+        public Query termsQuery(List<?> values, SearchExecutionContext context) {
             failIfNotIndexed();
             List<Long> scaledValues = new ArrayList<>(values.size());
             for (Object value : values) {
@@ -173,7 +173,7 @@ public class ScaledFloatFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, QueryShardContext context) {
+        public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, SearchExecutionContext context) {
             failIfNotIndexed();
             Long lo = null;
             if (lowerTerm != null) {
@@ -207,7 +207,7 @@ public class ScaledFloatFieldMapper extends FieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             if (format != null) {
                 throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
             }

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/SearchAsYouTypeFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/SearchAsYouTypeFieldMapper.java
@@ -50,7 +50,7 @@ import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.index.analysis.AnalyzerScope;
 import org.elasticsearch.index.analysis.IndexAnalyzers;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.similarity.SimilarityProvider;
 
 import java.io.IOException;
@@ -264,12 +264,12 @@ public class SearchAsYouTypeFieldMapper extends FieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             return SourceValueFetcher.toString(name(), context, format);
         }
 
         @Override
-        public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive, QueryShardContext context) {
+        public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive, SearchExecutionContext context) {
             if (prefixField == null || prefixField.termLengthWithinBounds(value.length()) == false) {
                 return super.prefixQuery(value, method, caseInsensitive, context);
             } else {
@@ -319,7 +319,7 @@ public class SearchAsYouTypeFieldMapper extends FieldMapper {
         }
 
         @Override
-        public SpanQuery spanPrefixQuery(String value, SpanMultiTermQueryWrapper.SpanRewriteMethod method, QueryShardContext context) {
+        public SpanQuery spanPrefixQuery(String value, SpanMultiTermQueryWrapper.SpanRewriteMethod method, SearchExecutionContext context) {
             if (prefixField != null && prefixField.termLengthWithinBounds(value.length())) {
                 return new FieldMaskingSpanQuery(new SpanTermQuery(new Term(prefixField.name(), indexedValueForSearch(value))), name());
             } else {
@@ -353,7 +353,7 @@ public class SearchAsYouTypeFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive, QueryShardContext context) {
+        public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive, SearchExecutionContext context) {
             if (value.length() >= minChars) {
                 if(caseInsensitive) {
                     return super.termQueryCaseInsensitive(value, context);
@@ -375,7 +375,7 @@ public class SearchAsYouTypeFieldMapper extends FieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             // Because this internal field is modelled as a multi-field, SourceValueFetcher will look up its
             // parent field in _source. So we don't need to use the parent field name here.
             return SourceValueFetcher.toString(name(), context, format);
@@ -482,7 +482,7 @@ public class SearchAsYouTypeFieldMapper extends FieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             // Because this internal field is modelled as a multi-field, SourceValueFetcher will look up its
             // parent field in _source. So we don't need to use the parent field name here.
             return SourceValueFetcher.toString(name(), context, format);
@@ -494,7 +494,7 @@ public class SearchAsYouTypeFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive, QueryShardContext context) {
+        public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive, SearchExecutionContext context) {
             if (prefixFieldType == null || prefixFieldType.termLengthWithinBounds(value.length()) == false) {
                 return super.prefixQuery(value, method, caseInsensitive, context);
             } else {
@@ -529,7 +529,7 @@ public class SearchAsYouTypeFieldMapper extends FieldMapper {
         }
 
         @Override
-        public SpanQuery spanPrefixQuery(String value, SpanMultiTermQueryWrapper.SpanRewriteMethod method, QueryShardContext context) {
+        public SpanQuery spanPrefixQuery(String value, SpanMultiTermQueryWrapper.SpanRewriteMethod method, SearchExecutionContext context) {
             if (prefixFieldType != null && prefixFieldType.termLengthWithinBounds(value.length())) {
                 return new FieldMaskingSpanQuery(new SpanTermQuery(new Term(prefixFieldType.name(), indexedValueForSearch(value))), name());
             } else {

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/SearchAsYouTypeFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/SearchAsYouTypeFieldMapper.java
@@ -269,7 +269,8 @@ public class SearchAsYouTypeFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive, SearchExecutionContext context) {
+        public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive,
+                                 SearchExecutionContext context) {
             if (prefixField == null || prefixField.termLengthWithinBounds(value.length()) == false) {
                 return super.prefixQuery(value, method, caseInsensitive, context);
             } else {
@@ -353,7 +354,8 @@ public class SearchAsYouTypeFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive, SearchExecutionContext context) {
+        public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive,
+                                 SearchExecutionContext context) {
             if (value.length() >= minChars) {
                 if(caseInsensitive) {
                     return super.termQueryCaseInsensitive(value, context);
@@ -494,7 +496,8 @@ public class SearchAsYouTypeFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive, SearchExecutionContext context) {
+        public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive,
+                                 SearchExecutionContext context) {
             if (prefixFieldType == null || prefixFieldType.termLengthWithinBounds(value.length()) == false) {
                 return super.prefixQuery(value, method, caseInsensitive, context);
             } else {

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/TokenCountFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/TokenCountFieldMapper.java
@@ -23,7 +23,7 @@ import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -92,7 +92,7 @@ public class TokenCountFieldMapper extends FieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             if (hasDocValues() == false) {
                 return lookup -> List.of();
             }

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/query/RankFeatureQueryBuilder.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/query/RankFeatureQueryBuilder.java
@@ -336,7 +336,7 @@ public final class RankFeatureQueryBuilder extends AbstractQueryBuilder<RankFeat
     }
 
     @Override
-    protected Query doToQuery(QueryShardContext context) throws IOException {
+    protected Query doToQuery(SearchExecutionContext context) throws IOException {
         final MappedFieldType ft = context.getFieldType(field);
 
         if (ft instanceof RankFeatureFieldType) {

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/ScaledFloatFieldTypeTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/ScaledFloatFieldTypeTests.java
@@ -88,8 +88,8 @@ public class ScaledFloatFieldTypeTests extends FieldTypeTestCase {
             Double u = randomBoolean() ? null : (randomDouble() * 2 - 1) * 10000;
             boolean includeLower = randomBoolean();
             boolean includeUpper = randomBoolean();
-            Query doubleQ = NumberFieldMapper.NumberType.DOUBLE.rangeQuery("double", l, u, includeLower, includeUpper, false, MOCK_QSC);
-            Query scaledFloatQ = ft.rangeQuery(l, u, includeLower, includeUpper, MOCK_QSC);
+            Query doubleQ = NumberFieldMapper.NumberType.DOUBLE.rangeQuery("double", l, u, includeLower, includeUpper, false, MOCK_CONTEXT);
+            Query scaledFloatQ = ft.rangeQuery(l, u, includeLower, includeUpper, MOCK_CONTEXT);
             assertEquals(searcher.count(doubleQ), searcher.count(scaledFloatQ));
         }
         IOUtils.close(reader, dir);
@@ -98,36 +98,36 @@ public class ScaledFloatFieldTypeTests extends FieldTypeTestCase {
     public void testRoundsUpperBoundCorrectly() {
         ScaledFloatFieldMapper.ScaledFloatFieldType ft
             = new ScaledFloatFieldMapper.ScaledFloatFieldType("scaled_float", 100);
-        Query scaledFloatQ = ft.rangeQuery(null, 0.1, true, false, MOCK_QSC);
+        Query scaledFloatQ = ft.rangeQuery(null, 0.1, true, false, MOCK_CONTEXT);
         assertEquals("scaled_float:[-9223372036854775808 TO 9]", scaledFloatQ.toString());
-        scaledFloatQ = ft.rangeQuery(null, 0.1, true, true, MOCK_QSC);
+        scaledFloatQ = ft.rangeQuery(null, 0.1, true, true, MOCK_CONTEXT);
         assertEquals("scaled_float:[-9223372036854775808 TO 10]", scaledFloatQ.toString());
-        scaledFloatQ = ft.rangeQuery(null, 0.095, true, false, MOCK_QSC);
+        scaledFloatQ = ft.rangeQuery(null, 0.095, true, false, MOCK_CONTEXT);
         assertEquals("scaled_float:[-9223372036854775808 TO 9]", scaledFloatQ.toString());
-        scaledFloatQ = ft.rangeQuery(null, 0.095, true, true, MOCK_QSC);
+        scaledFloatQ = ft.rangeQuery(null, 0.095, true, true, MOCK_CONTEXT);
         assertEquals("scaled_float:[-9223372036854775808 TO 9]", scaledFloatQ.toString());
-        scaledFloatQ = ft.rangeQuery(null, 0.105, true, false, MOCK_QSC);
+        scaledFloatQ = ft.rangeQuery(null, 0.105, true, false, MOCK_CONTEXT);
         assertEquals("scaled_float:[-9223372036854775808 TO 10]", scaledFloatQ.toString());
-        scaledFloatQ = ft.rangeQuery(null, 0.105, true, true, MOCK_QSC);
+        scaledFloatQ = ft.rangeQuery(null, 0.105, true, true, MOCK_CONTEXT);
         assertEquals("scaled_float:[-9223372036854775808 TO 10]", scaledFloatQ.toString());
-        scaledFloatQ = ft.rangeQuery(null, 79.99, true, true, MOCK_QSC);
+        scaledFloatQ = ft.rangeQuery(null, 79.99, true, true, MOCK_CONTEXT);
         assertEquals("scaled_float:[-9223372036854775808 TO 7999]", scaledFloatQ.toString());
     }
 
     public void testRoundsLowerBoundCorrectly() {
         ScaledFloatFieldMapper.ScaledFloatFieldType ft
             = new ScaledFloatFieldMapper.ScaledFloatFieldType("scaled_float", 100);
-        Query scaledFloatQ = ft.rangeQuery(-0.1, null, false, true, MOCK_QSC);
+        Query scaledFloatQ = ft.rangeQuery(-0.1, null, false, true, MOCK_CONTEXT);
         assertEquals("scaled_float:[-9 TO 9223372036854775807]", scaledFloatQ.toString());
-        scaledFloatQ = ft.rangeQuery(-0.1, null, true, true, MOCK_QSC);
+        scaledFloatQ = ft.rangeQuery(-0.1, null, true, true, MOCK_CONTEXT);
         assertEquals("scaled_float:[-10 TO 9223372036854775807]", scaledFloatQ.toString());
-        scaledFloatQ = ft.rangeQuery(-0.095, null, false, true, MOCK_QSC);
+        scaledFloatQ = ft.rangeQuery(-0.095, null, false, true, MOCK_CONTEXT);
         assertEquals("scaled_float:[-9 TO 9223372036854775807]", scaledFloatQ.toString());
-        scaledFloatQ = ft.rangeQuery(-0.095, null, true, true, MOCK_QSC);
+        scaledFloatQ = ft.rangeQuery(-0.095, null, true, true, MOCK_CONTEXT);
         assertEquals("scaled_float:[-9 TO 9223372036854775807]", scaledFloatQ.toString());
-        scaledFloatQ = ft.rangeQuery(-0.105, null, false, true, MOCK_QSC);
+        scaledFloatQ = ft.rangeQuery(-0.105, null, false, true, MOCK_CONTEXT);
         assertEquals("scaled_float:[-10 TO 9223372036854775807]", scaledFloatQ.toString());
-        scaledFloatQ = ft.rangeQuery(-0.105, null, true, true, MOCK_QSC);
+        scaledFloatQ = ft.rangeQuery(-0.105, null, true, true, MOCK_CONTEXT);
         assertEquals("scaled_float:[-10 TO 9223372036854775807]", scaledFloatQ.toString());
     }
 

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/SearchAsYouTypeFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/SearchAsYouTypeFieldMapperTests.java
@@ -55,7 +55,7 @@ import org.elasticsearch.index.mapper.SearchAsYouTypeFieldMapper.ShingleFieldTyp
 import org.elasticsearch.index.query.MatchPhrasePrefixQueryBuilder;
 import org.elasticsearch.index.query.MatchPhraseQueryBuilder;
 import org.elasticsearch.index.query.MultiMatchQueryBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.search.QueryStringQueryParser;
 import org.elasticsearch.plugins.Plugin;
 
@@ -412,22 +412,23 @@ public class SearchAsYouTypeFieldMapperTests extends MapperTestCase {
     }
 
     public void testMatchPhrasePrefix() throws IOException {
-        QueryShardContext queryShardContext = createQueryShardContext(createMapperService(fieldMapping(this::minimalMapping)));
+        SearchExecutionContext searchExecutionContext = createSearchExecutionContext(
+            createMapperService(fieldMapping(this::minimalMapping)));
         {
-            Query q = new MatchPhrasePrefixQueryBuilder("field", "two words").toQuery(queryShardContext);
+            Query q = new MatchPhrasePrefixQueryBuilder("field", "two words").toQuery(searchExecutionContext);
             Query expected = new SynonymQuery.Builder("field._index_prefix").addTerm(new Term("field._index_prefix", "two words")).build();
             assertThat(q, equalTo(expected));
         }
 
         {
-            Query q = new MatchPhrasePrefixQueryBuilder("field", "three words here").toQuery(queryShardContext);
+            Query q = new MatchPhrasePrefixQueryBuilder("field", "three words here").toQuery(searchExecutionContext);
             Query expected = new SynonymQuery.Builder("field._index_prefix").addTerm(new Term("field._index_prefix", "three words here"))
                 .build();
             assertThat(q, equalTo(expected));
         }
 
         {
-            Query q = new MatchPhrasePrefixQueryBuilder("field", "two words").slop(1).toQuery(queryShardContext);
+            Query q = new MatchPhrasePrefixQueryBuilder("field", "two words").slop(1).toQuery(searchExecutionContext);
             MultiPhrasePrefixQuery mpq = new MultiPhrasePrefixQuery("field");
             mpq.setSlop(1);
             mpq.add(new Term("field", "two"));
@@ -436,7 +437,7 @@ public class SearchAsYouTypeFieldMapperTests extends MapperTestCase {
         }
 
         {
-            Query q = new MatchPhrasePrefixQueryBuilder("field", "more than three words").toQuery(queryShardContext);
+            Query q = new MatchPhrasePrefixQueryBuilder("field", "more than three words").toQuery(searchExecutionContext);
             Query expected = new SpanNearQuery.Builder("field._3gram", true)
                 .addClause(new SpanTermQuery(new Term("field._3gram", "more than three")))
                 .addClause(new FieldMaskingSpanQuery(
@@ -447,7 +448,7 @@ public class SearchAsYouTypeFieldMapperTests extends MapperTestCase {
         }
 
         {
-            Query q = new MatchPhrasePrefixQueryBuilder("field._3gram", "more than three words").toQuery(queryShardContext);
+            Query q = new MatchPhrasePrefixQueryBuilder("field._3gram", "more than three words").toQuery(searchExecutionContext);
             Query expected = new SpanNearQuery.Builder("field._3gram", true)
                 .addClause(new SpanTermQuery(new Term("field._3gram", "more than three")))
                 .addClause(new FieldMaskingSpanQuery(
@@ -458,7 +459,7 @@ public class SearchAsYouTypeFieldMapperTests extends MapperTestCase {
         }
 
         {
-            Query q = new MatchPhrasePrefixQueryBuilder("field._3gram", "two words").toQuery(queryShardContext);
+            Query q = new MatchPhrasePrefixQueryBuilder("field._3gram", "two words").toQuery(searchExecutionContext);
             Query expected = new MatchNoDocsQuery();
             assertThat(q, equalTo(expected));
         }
@@ -466,7 +467,7 @@ public class SearchAsYouTypeFieldMapperTests extends MapperTestCase {
         {
             Query actual = new MatchPhrasePrefixQueryBuilder("field._3gram", "one two three four")
                 .slop(1)
-                .toQuery(queryShardContext);
+                .toQuery(searchExecutionContext);
             MultiPhrasePrefixQuery expected = new MultiPhrasePrefixQuery("field._3gram");
             expected.setSlop(1);
             expected.add(new Term("field._3gram", "one two three"));
@@ -477,17 +478,17 @@ public class SearchAsYouTypeFieldMapperTests extends MapperTestCase {
     }
 
     public void testMatchPhrase() throws IOException {
-        QueryShardContext queryShardContext = createQueryShardContext(createMapperService(fieldMapping(this::minimalMapping)));
+        SearchExecutionContext searchExecutionContext = createSearchExecutionContext(createMapperService(fieldMapping(this::minimalMapping)));
         {
             Query actual = new MatchPhraseQueryBuilder("field", "one")
-                .toQuery(queryShardContext);
+                .toQuery(searchExecutionContext);
             Query expected = new TermQuery(new Term("field", "one"));
             assertThat(actual, equalTo(expected));
         }
 
         {
             Query actual = new MatchPhraseQueryBuilder("field", "one two")
-                .toQuery(queryShardContext);
+                .toQuery(searchExecutionContext);
             Query expected = new MultiPhraseQuery.Builder()
                 .add(new Term("field._2gram", "one two"))
                 .build();
@@ -496,7 +497,7 @@ public class SearchAsYouTypeFieldMapperTests extends MapperTestCase {
 
         {
             Query actual = new MatchPhraseQueryBuilder("field", "one two three")
-                .toQuery(queryShardContext);
+                .toQuery(searchExecutionContext);
             Query expected = new MultiPhraseQuery.Builder()
                 .add(new Term("field._3gram", "one two three"))
                 .build();
@@ -505,7 +506,7 @@ public class SearchAsYouTypeFieldMapperTests extends MapperTestCase {
 
         {
             Query actual = new MatchPhraseQueryBuilder("field", "one two three four")
-                .toQuery(queryShardContext);
+                .toQuery(searchExecutionContext);
             Query expected = new MultiPhraseQuery.Builder()
                 .add(new Term("field._3gram", "one two three"))
                 .add(new Term("field._3gram", "two three four"))
@@ -516,7 +517,7 @@ public class SearchAsYouTypeFieldMapperTests extends MapperTestCase {
         {
             Query actual = new MatchPhraseQueryBuilder("field", "one two")
                 .slop(1)
-                .toQuery(queryShardContext);
+                .toQuery(searchExecutionContext);
             Query expected = new MultiPhraseQuery.Builder()
                 .add(new Term("field", "one"))
                 .add(new Term("field", "two"))
@@ -527,14 +528,14 @@ public class SearchAsYouTypeFieldMapperTests extends MapperTestCase {
 
         {
             Query actual = new MatchPhraseQueryBuilder("field._2gram", "one two")
-                .toQuery(queryShardContext);
+                .toQuery(searchExecutionContext);
             Query expected = new TermQuery(new Term("field._2gram", "one two"));
             assertThat(actual, equalTo(expected));
         }
 
         {
             Query actual = new MatchPhraseQueryBuilder("field._2gram", "one two three")
-                .toQuery(queryShardContext);
+                .toQuery(searchExecutionContext);
             Query expected = new MultiPhraseQuery.Builder()
                 .add(new Term("field._2gram", "one two"))
                 .add(new Term("field._2gram", "two three"))
@@ -544,14 +545,14 @@ public class SearchAsYouTypeFieldMapperTests extends MapperTestCase {
 
         {
             Query actual = new MatchPhraseQueryBuilder("field._3gram", "one two three")
-                .toQuery(queryShardContext);
+                .toQuery(searchExecutionContext);
             Query expected = new TermQuery(new Term("field._3gram", "one two three"));
             assertThat(actual, equalTo(expected));
         }
 
         {
             Query actual = new MatchPhraseQueryBuilder("field._3gram", "one two three four")
-                .toQuery(queryShardContext);
+                .toQuery(searchExecutionContext);
             Query expected = new MultiPhraseQuery.Builder()
                 .add(new Term("field._3gram", "one two three"))
                 .add(new Term("field._3gram", "two three four"))
@@ -561,7 +562,7 @@ public class SearchAsYouTypeFieldMapperTests extends MapperTestCase {
 
         {
             expectThrows(IllegalArgumentException.class,
-                () -> new MatchPhraseQueryBuilder("field._index_prefix", "one two three four").toQuery(queryShardContext));
+                () -> new MatchPhraseQueryBuilder("field._index_prefix", "one two three four").toQuery(searchExecutionContext));
         }
     }
 
@@ -582,8 +583,8 @@ public class SearchAsYouTypeFieldMapperTests extends MapperTestCase {
             }
             b.endObject();
         }));
-        QueryShardContext qsc = createQueryShardContext(ms);
-        QueryStringQueryParser parser = new QueryStringQueryParser(qsc, "f");
+        SearchExecutionContext context = createSearchExecutionContext(ms);
+        QueryStringQueryParser parser = new QueryStringQueryParser(context, "f");
         Query q = parser.parse("foo:*");
         assertEquals(new ConstantScoreQuery(new BooleanQuery.Builder()
             .add(new NormsFieldExistsQuery("foo.bar"), BooleanClause.Occur.SHOULD)
@@ -606,7 +607,7 @@ public class SearchAsYouTypeFieldMapperTests extends MapperTestCase {
     }
 
     public void testMultiMatchBoolPrefix() throws IOException {
-        QueryShardContext queryShardContext = createQueryShardContext(
+        SearchExecutionContext searchExecutionContext = createSearchExecutionContext(
             createMapperService(fieldMapping(b -> b.field("type", "search_as_you_type").field("max_shingle_size", 4)))
         );
 
@@ -619,7 +620,7 @@ public class SearchAsYouTypeFieldMapperTests extends MapperTestCase {
         );
         builder.type(MultiMatchQueryBuilder.Type.BOOL_PREFIX);
 
-        final Query actual = builder.toQuery(queryShardContext);
+        final Query actual = builder.toQuery(searchExecutionContext);
         assertThat(actual, instanceOf(DisjunctionMaxQuery.class));
         final DisjunctionMaxQuery disMaxQuery = (DisjunctionMaxQuery) actual;
         assertThat(disMaxQuery.getDisjuncts(), hasSize(4));

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/SearchAsYouTypeFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/SearchAsYouTypeFieldMapperTests.java
@@ -478,7 +478,8 @@ public class SearchAsYouTypeFieldMapperTests extends MapperTestCase {
     }
 
     public void testMatchPhrase() throws IOException {
-        SearchExecutionContext searchExecutionContext = createSearchExecutionContext(createMapperService(fieldMapping(this::minimalMapping)));
+        SearchExecutionContext searchExecutionContext = createSearchExecutionContext(
+            createMapperService(fieldMapping(this::minimalMapping)));
         {
             Query actual = new MatchPhraseQueryBuilder("field", "one")
                 .toQuery(searchExecutionContext);

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/SearchAsYouTypeFieldTypeTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/SearchAsYouTypeFieldTypeTests.java
@@ -96,18 +96,18 @@ public class SearchAsYouTypeFieldTypeTests extends FieldTypeTestCase {
 
         // this term should be a length that can be rewriteable to a term query on the prefix field
         final String withinBoundsTerm = "foo";
-        assertThat(fieldType.prefixQuery(withinBoundsTerm, CONSTANT_SCORE_REWRITE, randomMockShardContext()),
+        assertThat(fieldType.prefixQuery(withinBoundsTerm, CONSTANT_SCORE_REWRITE, randomMockContext()),
             equalTo(new ConstantScoreQuery(new TermQuery(new Term(NAME + "._index_prefix", withinBoundsTerm)))));
 
         // our defaults don't allow a situation where a term can be too small
 
         // this term should be too long to be rewriteable to a term query on the prefix field
         final String longTerm = "toolongforourprefixfieldthistermis";
-        assertThat(fieldType.prefixQuery(longTerm, CONSTANT_SCORE_REWRITE, MOCK_QSC),
+        assertThat(fieldType.prefixQuery(longTerm, CONSTANT_SCORE_REWRITE, MOCK_CONTEXT),
             equalTo(new PrefixQuery(new Term(NAME, longTerm))));
 
         ElasticsearchException ee = expectThrows(ElasticsearchException.class,
-                () -> fieldType.prefixQuery(longTerm, CONSTANT_SCORE_REWRITE, MOCK_QSC_DISALLOW_EXPENSIVE));
+                () -> fieldType.prefixQuery(longTerm, CONSTANT_SCORE_REWRITE, MOCK_CONTEXT_DISALLOW_EXPENSIVE));
         assertEquals("[prefix] queries cannot be executed when 'search.allow_expensive_queries' is set to false. " +
                 "For optimised prefix queries on text fields please enable [index_prefixes].", ee.getMessage());
     }

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/query/RankFeatureQueryBuilderTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/query/RankFeatureQueryBuilderTests.java
@@ -91,7 +91,7 @@ public class RankFeatureQueryBuilderTests extends AbstractQueryTestCase<RankFeat
     }
 
     @Override
-    protected void doAssertLuceneQuery(RankFeatureQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
+    protected void doAssertLuceneQuery(RankFeatureQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
         Class<?> expectedClass = FeatureField.newSaturationQuery("", "", 1, 1).getClass();
         assertThat(query, either(instanceOf(MatchNoDocsQuery.class)).or(instanceOf(expectedClass)));
     }
@@ -102,7 +102,7 @@ public class RankFeatureQueryBuilderTests extends AbstractQueryTestCase<RankFeat
                 "        \"field\": \"my_feature_field\"\n" +
                 "    }\n" +
                 "}";
-        Query parsedQuery = parseQuery(query).toQuery(createShardContext());
+        Query parsedQuery = parseQuery(query).toQuery(createSearchExecutionContext());
         assertEquals(FeatureField.newSaturationQuery("_feature", "my_feature_field"), parsedQuery);
     }
 
@@ -112,7 +112,7 @@ public class RankFeatureQueryBuilderTests extends AbstractQueryTestCase<RankFeat
                 "        \"field\": \"" + TEXT_FIELD_NAME + "\"\n" +
                 "    }\n" +
                 "}";
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> parseQuery(query).toQuery(createShardContext()));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> parseQuery(query).toQuery(createSearchExecutionContext()));
         assertEquals("[rank_feature] query only works on [rank_feature] fields and features of [rank_features] fields, not [text]",
             e.getMessage());
     }
@@ -126,7 +126,7 @@ public class RankFeatureQueryBuilderTests extends AbstractQueryTestCase<RankFeat
                 "        }\n" +
                 "    }\n" +
                 "}";
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> parseQuery(query).toQuery(createShardContext()));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> parseQuery(query).toQuery(createSearchExecutionContext()));
         assertEquals(
                 "Cannot use the [log] function with a field that has a negative score impact as it would trigger negative scores",
                 e.getMessage());

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/query/RankFeatureQueryBuilderTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/query/RankFeatureQueryBuilderTests.java
@@ -91,7 +91,7 @@ public class RankFeatureQueryBuilderTests extends AbstractQueryTestCase<RankFeat
     }
 
     @Override
-    protected void doAssertLuceneQuery(RankFeatureQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
+    protected void doAssertLuceneQuery(RankFeatureQueryBuilder queryBuilder, Query query, SearchExecutionContext context) {
         Class<?> expectedClass = FeatureField.newSaturationQuery("", "", 1, 1).getClass();
         assertThat(query, either(instanceOf(MatchNoDocsQuery.class)).or(instanceOf(expectedClass)));
     }
@@ -112,7 +112,8 @@ public class RankFeatureQueryBuilderTests extends AbstractQueryTestCase<RankFeat
                 "        \"field\": \"" + TEXT_FIELD_NAME + "\"\n" +
                 "    }\n" +
                 "}";
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> parseQuery(query).toQuery(createSearchExecutionContext()));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+            () -> parseQuery(query).toQuery(createSearchExecutionContext()));
         assertEquals("[rank_feature] query only works on [rank_feature] fields and features of [rank_features] fields, not [text]",
             e.getMessage());
     }
@@ -126,7 +127,8 @@ public class RankFeatureQueryBuilderTests extends AbstractQueryTestCase<RankFeat
                 "        }\n" +
                 "    }\n" +
                 "}";
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> parseQuery(query).toQuery(createSearchExecutionContext()));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+            () -> parseQuery(query).toQuery(createSearchExecutionContext()));
         assertEquals(
                 "Cannot use the [log] function with a field that has a negative score impact as it would trigger negative scores",
                 e.getMessage());

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/Joiner.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/Joiner.java
@@ -26,7 +26,7 @@ import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 
 import java.util.HashMap;
@@ -46,7 +46,7 @@ public final class Joiner {
     /**
      * Get the Joiner for this context, or {@code null} if none is configured
      */
-    public static Joiner getJoiner(QueryShardContext context) {
+    public static Joiner getJoiner(SearchExecutionContext context) {
         return getJoiner(context::isFieldMapped, context::getFieldType);
     }
 

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/MetaJoinFieldMapper.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/MetaJoinFieldMapper.java
@@ -26,7 +26,7 @@ import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.StringFieldType;
 import org.elasticsearch.index.mapper.TextSearchInfo;
 import org.elasticsearch.index.mapper.ValueFetcher;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.io.IOException;
@@ -65,7 +65,7 @@ public class MetaJoinFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             throw new UnsupportedOperationException("Cannot fetch values for metadata field [" + NAME + "].");
         }
 
@@ -79,7 +79,7 @@ public class MetaJoinFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
-        public Query existsQuery(QueryShardContext context) {
+        public Query existsQuery(SearchExecutionContext context) {
             throw new UnsupportedOperationException("Exists query not supported for fields of type" + typeName());
         }
     }

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentIdFieldMapper.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentIdFieldMapper.java
@@ -32,7 +32,7 @@ import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.StringFieldType;
 import org.elasticsearch.index.mapper.TextSearchInfo;
 import org.elasticsearch.index.mapper.ValueFetcher;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.lookup.SearchLookup;
 
@@ -75,7 +75,7 @@ public final class ParentIdFieldMapper extends FieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             throw new UnsupportedOperationException("Cannot fetch values for internal field [" + typeName() + "].");
         }
 

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentJoinFieldMapper.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentJoinFieldMapper.java
@@ -39,7 +39,7 @@ import org.elasticsearch.index.mapper.SourceValueFetcher;
 import org.elasticsearch.index.mapper.StringFieldType;
 import org.elasticsearch.index.mapper.TextSearchInfo;
 import org.elasticsearch.index.mapper.ValueFetcher;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.lookup.SearchLookup;
 
@@ -162,7 +162,7 @@ public final class ParentJoinFieldMapper extends FieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             return SourceValueFetcher.identity(name(), context, format);
         }
 

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/query/HasChildQueryBuilder.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/query/HasChildQueryBuilder.java
@@ -44,7 +44,7 @@ import org.elasticsearch.index.query.InnerHitContextBuilder;
 import org.elasticsearch.index.query.NestedQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryRewriteContext;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.QueryShardException;
 import org.elasticsearch.join.mapper.Joiner;
 
@@ -296,7 +296,7 @@ public class HasChildQueryBuilder extends AbstractQueryBuilder<HasChildQueryBuil
     }
 
     @Override
-    protected Query doToQuery(QueryShardContext context) throws IOException {
+    protected Query doToQuery(SearchExecutionContext context) throws IOException {
         if (context.allowExpensiveQueries() == false) {
             throw new ElasticsearchException("[joining] queries cannot be executed when '" +
                     ALLOW_EXPENSIVE_QUERIES.getKey() + "' is set to false.");
@@ -460,8 +460,8 @@ public class HasChildQueryBuilder extends AbstractQueryBuilder<HasChildQueryBuil
     }
 
     @Override
-    protected QueryBuilder doRewrite(QueryRewriteContext queryShardContext) throws IOException {
-        QueryBuilder rewrittenQuery = query.rewrite(queryShardContext);
+    protected QueryBuilder doRewrite(QueryRewriteContext queryRewriteContext) throws IOException {
+        QueryBuilder rewrittenQuery = query.rewrite(queryRewriteContext);
         if (rewrittenQuery != query) {
             HasChildQueryBuilder hasChildQueryBuilder =
                 new HasChildQueryBuilder(type, rewrittenQuery, minChildren, maxChildren, scoreMode, innerHitBuilder);

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/query/HasParentQueryBuilder.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/query/HasParentQueryBuilder.java
@@ -36,7 +36,7 @@ import org.elasticsearch.index.query.InnerHitBuilder;
 import org.elasticsearch.index.query.InnerHitContextBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryRewriteContext;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.QueryShardException;
 import org.elasticsearch.join.mapper.Joiner;
 
@@ -159,7 +159,7 @@ public class HasParentQueryBuilder extends AbstractQueryBuilder<HasParentQueryBu
     }
 
     @Override
-    protected Query doToQuery(QueryShardContext context) throws IOException {
+    protected Query doToQuery(SearchExecutionContext context) throws IOException {
         if (context.allowExpensiveQueries() == false) {
             throw new ElasticsearchException("[joining] queries cannot be executed when '" +
                     ALLOW_EXPENSIVE_QUERIES.getKey() + "' is set to false.");
@@ -277,8 +277,8 @@ public class HasParentQueryBuilder extends AbstractQueryBuilder<HasParentQueryBu
     }
 
     @Override
-    protected QueryBuilder doRewrite(QueryRewriteContext queryShardContext) throws IOException {
-        QueryBuilder rewrittenQuery = query.rewrite(queryShardContext);
+    protected QueryBuilder doRewrite(QueryRewriteContext queryRewriteContext) throws IOException {
+        QueryBuilder rewrittenQuery = query.rewrite(queryRewriteContext);
         if (rewrittenQuery != query) {
             HasParentQueryBuilder hasParentQueryBuilder = new HasParentQueryBuilder(parentType, rewrittenQuery, score, innerHitBuilder);
             hasParentQueryBuilder.ignoreUnmapped(ignoreUnmapped);

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/query/ParentChildInnerHitContextBuilder.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/query/ParentChildInnerHitContextBuilder.java
@@ -44,7 +44,7 @@ import org.elasticsearch.index.mapper.IdFieldMapper;
 import org.elasticsearch.index.query.InnerHitBuilder;
 import org.elasticsearch.index.query.InnerHitContextBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.join.mapper.Joiner;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.fetch.subphase.InnerHitsContext;
@@ -69,13 +69,13 @@ class ParentChildInnerHitContextBuilder extends InnerHitContextBuilder {
 
     @Override
     protected void doBuild(SearchContext context, InnerHitsContext innerHitsContext) throws IOException {
-        QueryShardContext queryShardContext = context.getQueryShardContext();
-        Joiner joiner = Joiner.getJoiner(queryShardContext);
+        SearchExecutionContext searchExecutionContext = context.getSearchExecutionContext();
+        Joiner joiner = Joiner.getJoiner(searchExecutionContext);
         if (joiner != null) {
             String name = innerHitBuilder.getName() != null ? innerHitBuilder.getName() : typeName;
             JoinFieldInnerHitSubContext joinFieldInnerHits = new JoinFieldInnerHitSubContext(name, context, typeName,
                 fetchChildInnerHits, joiner);
-            setupInnerHitsContext(queryShardContext, joinFieldInnerHits);
+            setupInnerHitsContext(searchExecutionContext, joinFieldInnerHits);
             innerHitsContext.addInnerHitDefinition(joinFieldInnerHits);
         } else {
             if (innerHitBuilder.isIgnoreUnmapped() == false) {
@@ -105,7 +105,7 @@ class ParentChildInnerHitContextBuilder extends InnerHitContextBuilder {
                 return new TopDocsAndMaxScore(Lucene.EMPTY_TOP_DOCS, Float.NaN);
             }
 
-            QueryShardContext qsc = context.getQueryShardContext();
+            SearchExecutionContext context = this.context.getSearchExecutionContext();
             Query q;
             if (fetchChildInnerHits) {
                 Query hitQuery = new TermQuery(new Term(joiner.parentJoinField(typeName), hit.getId()));
@@ -116,17 +116,17 @@ class ParentChildInnerHitContextBuilder extends InnerHitContextBuilder {
                     .add(new TermQuery(new Term(joiner.getJoinField(), typeName)), BooleanClause.Occur.FILTER)
                     .build();
             } else {
-                String parentId = getSortedDocValue(joiner.childJoinField(typeName), context, hit.docId());
+                String parentId = getSortedDocValue(joiner.childJoinField(typeName), this.context, hit.docId());
                 if (parentId == null) {
                     return new TopDocsAndMaxScore(Lucene.EMPTY_TOP_DOCS, Float.NaN);
                 }
-                q = context.getQueryShardContext().getFieldType(IdFieldMapper.NAME).termQuery(parentId, qsc);
+                q = this.context.getSearchExecutionContext().getFieldType(IdFieldMapper.NAME).termQuery(parentId, context);
             }
 
-            Weight weight = context.searcher().createWeight(context.searcher().rewrite(q), ScoreMode.COMPLETE_NO_SCORES, 1f);
+            Weight weight = this.context.searcher().createWeight(this.context.searcher().rewrite(q), ScoreMode.COMPLETE_NO_SCORES, 1f);
             if (size() == 0) {
                 TotalHitCountCollector totalHitCountCollector = new TotalHitCountCollector();
-                for (LeafReaderContext ctx : context.searcher().getIndexReader().leaves()) {
+                for (LeafReaderContext ctx : this.context.searcher().getIndexReader().leaves()) {
                     intersect(weight, innerHitQueryWeight, totalHitCountCollector, ctx);
                 }
                 return new TopDocsAndMaxScore(
@@ -135,7 +135,7 @@ class ParentChildInnerHitContextBuilder extends InnerHitContextBuilder {
                         Lucene.EMPTY_SCORE_DOCS
                     ), Float.NaN);
             } else {
-                int topN = Math.min(from() + size(), context.searcher().getIndexReader().maxDoc());
+                int topN = Math.min(from() + size(), this.context.searcher().getIndexReader().maxDoc());
                 TopDocsCollector<?> topDocsCollector;
                 MaxScoreCollector maxScoreCollector = null;
                 if (sort() != null) {
@@ -147,7 +147,7 @@ class ParentChildInnerHitContextBuilder extends InnerHitContextBuilder {
                     topDocsCollector = TopScoreDocCollector.create(topN, Integer.MAX_VALUE);
                     maxScoreCollector = new MaxScoreCollector();
                 }
-                for (LeafReaderContext ctx : context.searcher().getIndexReader().leaves()) {
+                for (LeafReaderContext ctx : this.context.searcher().getIndexReader().leaves()) {
                     intersect(weight, innerHitQueryWeight, MultiCollector.wrap(topDocsCollector, maxScoreCollector), ctx);
                 }
                 TopDocs topDocs = topDocsCollector.topDocs(from(), size());

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/query/ParentIdQueryBuilder.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/query/ParentIdQueryBuilder.java
@@ -33,7 +33,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.query.AbstractQueryBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.QueryShardException;
 import org.elasticsearch.join.mapper.Joiner;
 
@@ -156,7 +156,7 @@ public final class ParentIdQueryBuilder extends AbstractQueryBuilder<ParentIdQue
 
 
     @Override
-    protected Query doToQuery(QueryShardContext context) throws IOException {
+    protected Query doToQuery(SearchExecutionContext context) throws IOException {
         if (context.allowExpensiveQueries() == false) {
             throw new ElasticsearchException("[joining] queries cannot be executed when '" +
                     ALLOW_EXPENSIVE_QUERIES.getKey() + "' is set to false.");

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/query/HasChildQueryBuilderTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/query/HasChildQueryBuilderTests.java
@@ -159,7 +159,8 @@ public class HasChildQueryBuilderTests extends AbstractQueryTestCase<HasChildQue
     }
 
     @Override
-    protected void doAssertLuceneQuery(HasChildQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
+    protected void doAssertLuceneQuery(HasChildQueryBuilder queryBuilder, Query query,
+                                       SearchExecutionContext context) throws IOException {
         assertThat(query, instanceOf(LateParsingQuery.class));
         LateParsingQuery lpq = (LateParsingQuery) query;
         assertEquals(queryBuilder.minChildren(), lpq.getMinChildren());

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/query/HasChildQueryBuilderTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/query/HasChildQueryBuilderTests.java
@@ -45,7 +45,7 @@ import org.elasticsearch.index.query.InnerHitBuilder;
 import org.elasticsearch.index.query.InnerHitContextBuilder;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.QueryShardException;
 import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.index.query.WrapperQueryBuilder;
@@ -159,7 +159,7 @@ public class HasChildQueryBuilderTests extends AbstractQueryTestCase<HasChildQue
     }
 
     @Override
-    protected void doAssertLuceneQuery(HasChildQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
+    protected void doAssertLuceneQuery(HasChildQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
         assertThat(query, instanceOf(LateParsingQuery.class));
         LateParsingQuery lpq = (LateParsingQuery) query;
         assertEquals(queryBuilder.minChildren(), lpq.getMinChildren());
@@ -267,9 +267,9 @@ public class HasChildQueryBuilderTests extends AbstractQueryTestCase<HasChildQue
     }
 
     public void testToQueryInnerQueryType() throws IOException {
-        QueryShardContext shardContext = createShardContext();
+        SearchExecutionContext searchExecutionContext = createSearchExecutionContext();
         HasChildQueryBuilder hasChildQueryBuilder = hasChildQuery(CHILD_DOC, new IdsQueryBuilder().addIds("id"), ScoreMode.None);
-        Query query = hasChildQueryBuilder.toQuery(shardContext);
+        Query query = hasChildQueryBuilder.toQuery(searchExecutionContext);
         assertLateParsingQuery(query, CHILD_DOC, "id");
     }
 
@@ -311,10 +311,10 @@ public class HasChildQueryBuilderTests extends AbstractQueryTestCase<HasChildQue
     }
 
     public void testNonDefaultSimilarity() throws Exception {
-        QueryShardContext shardContext = createShardContext();
+        SearchExecutionContext searchExecutionContext = createSearchExecutionContext();
         HasChildQueryBuilder hasChildQueryBuilder =
             hasChildQuery(CHILD_DOC, new TermQueryBuilder("custom_string", "value"), ScoreMode.None);
-        LateParsingQuery query = (LateParsingQuery) hasChildQueryBuilder.toQuery(shardContext);
+        LateParsingQuery query = (LateParsingQuery) hasChildQueryBuilder.toQuery(searchExecutionContext);
         Similarity expected = SimilarityService.BUILT_IN.get(similarity)
             .apply(Settings.EMPTY, Version.CURRENT, null);
         assertThat(((PerFieldSimilarityWrapper) query.getSimilarity()).get("custom_string"), instanceOf(expected.getClass()));
@@ -326,7 +326,7 @@ public class HasChildQueryBuilderTests extends AbstractQueryTestCase<HasChildQue
         assertFalse(queryBuilder.innerHit().isIgnoreUnmapped());
         queryBuilder.ignoreUnmapped(true);
         assertTrue(queryBuilder.innerHit().isIgnoreUnmapped());
-        Query query = queryBuilder.toQuery(createShardContext());
+        Query query = queryBuilder.toQuery(createSearchExecutionContext());
         assertThat(query, notNullValue());
         assertThat(query, instanceOf(MatchNoDocsQuery.class));
 
@@ -335,7 +335,7 @@ public class HasChildQueryBuilderTests extends AbstractQueryTestCase<HasChildQue
         assertFalse(failingQueryBuilder.innerHit().isIgnoreUnmapped());
         failingQueryBuilder.ignoreUnmapped(false);
         assertFalse(failingQueryBuilder.innerHit().isIgnoreUnmapped());
-        QueryShardException e = expectThrows(QueryShardException.class, () -> failingQueryBuilder.toQuery(createShardContext()));
+        QueryShardException e = expectThrows(QueryShardException.class, () -> failingQueryBuilder.toQuery(createSearchExecutionContext()));
         assertThat(e.getMessage(), containsString("[" + HasChildQueryBuilder.NAME +
             "] join field [join_field] doesn't hold [unmapped] as a child"));
     }
@@ -345,8 +345,8 @@ public class HasChildQueryBuilderTests extends AbstractQueryTestCase<HasChildQue
         final HasChildQueryBuilder queryBuilder
             = new HasChildQueryBuilder("unmapped", new WrapperQueryBuilder(new MatchAllQueryBuilder().toString()), ScoreMode.None);
         queryBuilder.ignoreUnmapped(true);
-        QueryShardContext queryShardContext = createShardContext();
-        Query query = queryBuilder.rewrite(queryShardContext).toQuery(queryShardContext);
+        SearchExecutionContext searchExecutionContext = createSearchExecutionContext();
+        Query query = queryBuilder.rewrite(searchExecutionContext).toQuery(searchExecutionContext);
         assertThat(query, notNullValue());
         assertThat(query, instanceOf(MatchNoDocsQuery.class));
     }
@@ -361,13 +361,13 @@ public class HasChildQueryBuilderTests extends AbstractQueryTestCase<HasChildQue
     }
 
     public void testDisallowExpensiveQueries() {
-        QueryShardContext queryShardContext = mock(QueryShardContext.class);
-        when(queryShardContext.allowExpensiveQueries()).thenReturn(false);
+        SearchExecutionContext searchExecutionContext = mock(SearchExecutionContext.class);
+        when(searchExecutionContext.allowExpensiveQueries()).thenReturn(false);
 
         HasChildQueryBuilder queryBuilder =
                 hasChildQuery(CHILD_DOC, new TermQueryBuilder("custom_string", "value"), ScoreMode.None);
         ElasticsearchException e = expectThrows(ElasticsearchException.class,
-                () -> queryBuilder.toQuery(queryShardContext));
+                () -> queryBuilder.toQuery(searchExecutionContext));
         assertEquals("[joining] queries cannot be executed when 'search.allow_expensive_queries' is set to false.",
                 e.getMessage());
     }

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/query/HasParentQueryBuilderTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/query/HasParentQueryBuilderTests.java
@@ -33,7 +33,7 @@ import org.elasticsearch.index.query.InnerHitBuilder;
 import org.elasticsearch.index.query.InnerHitContextBuilder;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.QueryShardException;
 import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.index.query.WrapperQueryBuilder;
@@ -132,7 +132,7 @@ public class HasParentQueryBuilderTests extends AbstractQueryTestCase<HasParentQ
     }
 
     @Override
-    protected void doAssertLuceneQuery(HasParentQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
+    protected void doAssertLuceneQuery(HasParentQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
         assertThat(query, instanceOf(LateParsingQuery.class));
         LateParsingQuery lpq = (LateParsingQuery) query;
         assertEquals(queryBuilder.score() ? ScoreMode.Max : ScoreMode.None, lpq.getScoreMode());
@@ -171,17 +171,17 @@ public class HasParentQueryBuilderTests extends AbstractQueryTestCase<HasParentQ
                 () -> hasParentQuery("foo", null, false));
         assertThat(e.getMessage(), equalTo("[has_parent] requires 'query' field"));
 
-        QueryShardContext context = createShardContext();
+        SearchExecutionContext context = createSearchExecutionContext();
         HasParentQueryBuilder qb = hasParentQuery("just_a_type", new MatchAllQueryBuilder(), false);
         QueryShardException qse = expectThrows(QueryShardException.class, () -> qb.doToQuery(context));
         assertThat(qse.getMessage(), equalTo("[has_parent] join field [join_field] doesn't hold [just_a_type] as a parent"));
     }
 
     public void testToQueryInnerQueryType() throws IOException {
-        QueryShardContext shardContext = createShardContext();
+        SearchExecutionContext searchExecutionContext = createSearchExecutionContext();
         HasParentQueryBuilder hasParentQueryBuilder = new HasParentQueryBuilder(PARENT_DOC, new IdsQueryBuilder().addIds("id"),
                 false);
-        Query query = hasParentQueryBuilder.toQuery(shardContext);
+        Query query = hasParentQueryBuilder.toQuery(searchExecutionContext);
         HasChildQueryBuilderTests.assertLateParsingQuery(query, PARENT_DOC, "id");
     }
 
@@ -226,7 +226,7 @@ public class HasParentQueryBuilderTests extends AbstractQueryTestCase<HasParentQ
         assertFalse(queryBuilder.innerHit().isIgnoreUnmapped());
         queryBuilder.ignoreUnmapped(true);
         assertTrue(queryBuilder.innerHit().isIgnoreUnmapped());
-        Query query = queryBuilder.toQuery(createShardContext());
+        Query query = queryBuilder.toQuery(createSearchExecutionContext());
         assertThat(query, notNullValue());
         assertThat(query, instanceOf(MatchNoDocsQuery.class));
 
@@ -235,7 +235,7 @@ public class HasParentQueryBuilderTests extends AbstractQueryTestCase<HasParentQ
         assertFalse(failingQueryBuilder.innerHit().isIgnoreUnmapped());
         failingQueryBuilder.ignoreUnmapped(false);
         assertFalse(failingQueryBuilder.innerHit().isIgnoreUnmapped());
-        QueryShardException e = expectThrows(QueryShardException.class, () -> failingQueryBuilder.toQuery(createShardContext()));
+        QueryShardException e = expectThrows(QueryShardException.class, () -> failingQueryBuilder.toQuery(createSearchExecutionContext()));
         assertThat(e.getMessage(),
                     containsString("[has_parent] join field [join_field] doesn't hold [unmapped] as a parent"));
     }
@@ -245,8 +245,8 @@ public class HasParentQueryBuilderTests extends AbstractQueryTestCase<HasParentQ
         final HasParentQueryBuilder queryBuilder =
             new HasParentQueryBuilder("unmapped", new WrapperQueryBuilder(new MatchAllQueryBuilder().toString()), false);
         queryBuilder.ignoreUnmapped(true);
-        QueryShardContext queryShardContext = createShardContext();
-        Query query = queryBuilder.rewrite(queryShardContext).toQuery(queryShardContext);
+        SearchExecutionContext searchExecutionContext = createSearchExecutionContext();
+        Query query = queryBuilder.rewrite(searchExecutionContext).toQuery(searchExecutionContext);
         assertThat(query, notNullValue());
         assertThat(query, instanceOf(MatchNoDocsQuery.class));
     }
@@ -261,13 +261,13 @@ public class HasParentQueryBuilderTests extends AbstractQueryTestCase<HasParentQ
     }
 
     public void testDisallowExpensiveQueries() {
-        QueryShardContext queryShardContext = mock(QueryShardContext.class);
-        when(queryShardContext.allowExpensiveQueries()).thenReturn(false);
+        SearchExecutionContext searchExecutionContext = mock(SearchExecutionContext.class);
+        when(searchExecutionContext.allowExpensiveQueries()).thenReturn(false);
 
         HasParentQueryBuilder queryBuilder = new HasParentQueryBuilder(
                 CHILD_DOC, new WrapperQueryBuilder(new MatchAllQueryBuilder().toString()), false);
         ElasticsearchException e = expectThrows(ElasticsearchException.class,
-                () -> queryBuilder.toQuery(queryShardContext));
+                () -> queryBuilder.toQuery(searchExecutionContext));
         assertEquals("[joining] queries cannot be executed when 'search.allow_expensive_queries' is set to false.",
                 e.getMessage());
     }

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/query/HasParentQueryBuilderTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/query/HasParentQueryBuilderTests.java
@@ -132,7 +132,8 @@ public class HasParentQueryBuilderTests extends AbstractQueryTestCase<HasParentQ
     }
 
     @Override
-    protected void doAssertLuceneQuery(HasParentQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
+    protected void doAssertLuceneQuery(HasParentQueryBuilder queryBuilder, Query query,
+                                       SearchExecutionContext context) throws IOException {
         assertThat(query, instanceOf(LateParsingQuery.class));
         LateParsingQuery lpq = (LateParsingQuery) query;
         assertEquals(queryBuilder.score() ? ScoreMode.Max : ScoreMode.None, lpq.getScoreMode());

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/query/ParentIdQueryBuilderTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/query/ParentIdQueryBuilderTests.java
@@ -104,7 +104,7 @@ public class ParentIdQueryBuilderTests extends AbstractQueryTestCase<ParentIdQue
     }
 
     @Override
-    protected void doAssertLuceneQuery(ParentIdQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
+    protected void doAssertLuceneQuery(ParentIdQueryBuilder queryBuilder, Query query, SearchExecutionContext context) {
         assertThat(query, Matchers.instanceOf(BooleanQuery.class));
         BooleanQuery booleanQuery = (BooleanQuery) query;
         assertThat(booleanQuery.clauses().size(), Matchers.equalTo(2));

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/query/ParentIdQueryBuilderTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/query/ParentIdQueryBuilderTests.java
@@ -30,7 +30,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.mapper.MapperService;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.QueryShardException;
 import org.elasticsearch.join.ParentJoinPlugin;
 import org.elasticsearch.plugins.Plugin;
@@ -104,7 +104,7 @@ public class ParentIdQueryBuilderTests extends AbstractQueryTestCase<ParentIdQue
     }
 
     @Override
-    protected void doAssertLuceneQuery(ParentIdQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
+    protected void doAssertLuceneQuery(ParentIdQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
         assertThat(query, Matchers.instanceOf(BooleanQuery.class));
         BooleanQuery booleanQuery = (BooleanQuery) query;
         assertThat(booleanQuery.clauses().size(), Matchers.equalTo(2));
@@ -137,23 +137,23 @@ public class ParentIdQueryBuilderTests extends AbstractQueryTestCase<ParentIdQue
     public void testIgnoreUnmapped() throws IOException {
         final ParentIdQueryBuilder queryBuilder = new ParentIdQueryBuilder("unmapped", "foo");
         queryBuilder.ignoreUnmapped(true);
-        Query query = queryBuilder.toQuery(createShardContext());
+        Query query = queryBuilder.toQuery(createSearchExecutionContext());
         assertThat(query, notNullValue());
         assertThat(query, instanceOf(MatchNoDocsQuery.class));
 
         final ParentIdQueryBuilder failingQueryBuilder = new ParentIdQueryBuilder("unmapped", "foo");
         failingQueryBuilder.ignoreUnmapped(false);
-        QueryShardException e = expectThrows(QueryShardException.class, () -> failingQueryBuilder.toQuery(createShardContext()));
+        QueryShardException e = expectThrows(QueryShardException.class, () -> failingQueryBuilder.toQuery(createSearchExecutionContext()));
         assertThat(e.getMessage(), containsString("[" + ParentIdQueryBuilder.NAME + "] no relation found for child [unmapped]"));
     }
 
     public void testDisallowExpensiveQueries() {
-        QueryShardContext queryShardContext = mock(QueryShardContext.class);
-        when(queryShardContext.allowExpensiveQueries()).thenReturn(false);
+        SearchExecutionContext searchExecutionContext = mock(SearchExecutionContext.class);
+        when(searchExecutionContext.allowExpensiveQueries()).thenReturn(false);
 
         ParentIdQueryBuilder queryBuilder = doCreateTestQueryBuilder();
         ElasticsearchException e = expectThrows(ElasticsearchException.class,
-                () -> queryBuilder.toQuery(queryShardContext));
+                () -> queryBuilder.toQuery(searchExecutionContext));
         assertEquals("[joining] queries cannot be executed when 'search.allow_expensive_queries' is set to false.",
                 e.getMessage());
     }

--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorFieldMapper.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorFieldMapper.java
@@ -185,7 +185,7 @@ public class PercolatorFieldMapper extends FieldMapper {
 
         @Override
         public Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
-            return new Builder(name, parserContext.searchExecutionContextSupplier(), getMapUnmappedFieldAsText(parserContext.getSettings()));
+            return new Builder(name, parserContext.searchExecutionContext(), getMapUnmappedFieldAsText(parserContext.getSettings()));
         }
     }
 

--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorFieldMapper.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorFieldMapper.java
@@ -72,7 +72,7 @@ import org.elasticsearch.index.query.BoostingQueryBuilder;
 import org.elasticsearch.index.query.ConstantScoreQueryBuilder;
 import org.elasticsearch.index.query.DisMaxQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.QueryShardException;
 import org.elasticsearch.index.query.Rewriteable;
 import org.elasticsearch.index.query.functionscore.FunctionScoreQueryBuilder;
@@ -109,19 +109,19 @@ public class PercolatorFieldMapper extends FieldMapper {
 
     @Override
     public FieldMapper.Builder getMergeBuilder() {
-        return new Builder(simpleName(), queryShardContext, mapUnmappedFieldsAsText).init(this);
+        return new Builder(simpleName(), searchExecutionContext, mapUnmappedFieldsAsText).init(this);
     }
 
     static class Builder extends FieldMapper.Builder {
 
         private final Parameter<Map<String, String>> meta = Parameter.metaParam();
 
-        private final Supplier<QueryShardContext> queryShardContext;
+        private final Supplier<SearchExecutionContext> searchExecutionContext;
         private final boolean mapUnmappedFieldsAsText;
 
-        Builder(String fieldName, Supplier<QueryShardContext> queryShardContext, boolean mapUnmappedFieldsAsText) {
+        Builder(String fieldName, Supplier<SearchExecutionContext> searchExecutionContext, boolean mapUnmappedFieldsAsText) {
             super(fieldName);
-            this.queryShardContext = queryShardContext;
+            this.searchExecutionContext = searchExecutionContext;
             this.mapUnmappedFieldsAsText = mapUnmappedFieldsAsText;
         }
 
@@ -150,7 +150,7 @@ public class PercolatorFieldMapper extends FieldMapper {
 
             contentPath.remove();
             return new PercolatorFieldMapper(name(), fieldType,
-                multiFieldsBuilder.build(this, contentPath), copyTo.build(), queryShardContext, extractedTermsField,
+                multiFieldsBuilder.build(this, contentPath), copyTo.build(), searchExecutionContext, extractedTermsField,
                 extractionResultField, queryBuilderField, rangeFieldMapper, minimumShouldMatchFieldMapper,
                 mapUnmappedFieldsAsText);
         }
@@ -185,7 +185,7 @@ public class PercolatorFieldMapper extends FieldMapper {
 
         @Override
         public Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
-            return new Builder(name, parserContext.queryShardContextSupplier(), getMapUnmappedFieldAsText(parserContext.getSettings()));
+            return new Builder(name, parserContext.searchExecutionContextSupplier(), getMapUnmappedFieldAsText(parserContext.getSettings()));
         }
     }
 
@@ -213,12 +213,12 @@ public class PercolatorFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query termQuery(Object value, QueryShardContext context) {
+        public Query termQuery(Object value, SearchExecutionContext context) {
             throw new QueryShardException(context, "Percolator fields are not searchable directly, use a percolate query instead");
         }
 
         @Override
-        public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             return SourceValueFetcher.identity(name(), context, format);
         }
 
@@ -318,7 +318,7 @@ public class PercolatorFieldMapper extends FieldMapper {
 
     }
 
-    private final Supplier<QueryShardContext> queryShardContext;
+    private final Supplier<SearchExecutionContext> searchExecutionContext;
     private final KeywordFieldMapper queryTermsField;
     private final KeywordFieldMapper extractionResultField;
     private final BinaryFieldMapper queryBuilderField;
@@ -327,12 +327,12 @@ public class PercolatorFieldMapper extends FieldMapper {
     private final boolean mapUnmappedFieldsAsText;
 
     PercolatorFieldMapper(String simpleName, MappedFieldType mappedFieldType,
-                          MultiFields multiFields, CopyTo copyTo, Supplier<QueryShardContext> queryShardContext,
+                          MultiFields multiFields, CopyTo copyTo, Supplier<SearchExecutionContext> searchExecutionContext,
                           KeywordFieldMapper queryTermsField, KeywordFieldMapper extractionResultField,
                           BinaryFieldMapper queryBuilderField, RangeFieldMapper rangeFieldMapper,
                           NumberFieldMapper minimumShouldMatchFieldMapper, boolean mapUnmappedFieldsAsText) {
         super(simpleName, mappedFieldType, multiFields, copyTo);
-        this.queryShardContext = queryShardContext;
+        this.searchExecutionContext = searchExecutionContext;
         this.queryTermsField = queryTermsField;
         this.extractionResultField = extractionResultField;
         this.queryBuilderField = queryBuilderField;
@@ -343,7 +343,7 @@ public class PercolatorFieldMapper extends FieldMapper {
 
     @Override
     public void parse(ParseContext context) throws IOException {
-        QueryShardContext queryShardContext = this.queryShardContext.get();
+        SearchExecutionContext searchExecutionContext = this.searchExecutionContext.get();
         if (context.doc().getField(queryBuilderField.name()) != null) {
             // If a percolator query has been defined in an array object then multiple percolator queries
             // could be provided. In order to prevent this we fail if we try to parse more than one query
@@ -351,7 +351,7 @@ public class PercolatorFieldMapper extends FieldMapper {
             throw new IllegalArgumentException("a document can only contain one percolator query");
         }
 
-        configureContext(queryShardContext, isMapUnmappedFieldAsText());
+        configureContext(searchExecutionContext, isMapUnmappedFieldAsText());
 
         XContentParser parser = context.parser();
         QueryBuilder queryBuilder = parseQueryBuilder(
@@ -360,14 +360,14 @@ public class PercolatorFieldMapper extends FieldMapper {
         verifyQuery(queryBuilder);
         // Fetching of terms, shapes and indexed scripts happen during this rewrite:
         PlainActionFuture<QueryBuilder> future = new PlainActionFuture<>();
-        Rewriteable.rewriteAndFetch(queryBuilder, queryShardContext, future);
+        Rewriteable.rewriteAndFetch(queryBuilder, searchExecutionContext, future);
         queryBuilder = future.actionGet();
 
         Version indexVersion = context.indexSettings().getIndexVersionCreated();
         createQueryBuilderField(indexVersion, queryBuilderField, queryBuilder, context);
 
-        QueryBuilder queryBuilderForProcessing = queryBuilder.rewrite(new QueryShardContext(queryShardContext));
-        Query query = queryBuilderForProcessing.toQuery(queryShardContext);
+        QueryBuilder queryBuilderForProcessing = queryBuilder.rewrite(new SearchExecutionContext(searchExecutionContext));
+        Query query = queryBuilderForProcessing.toQuery(searchExecutionContext);
         processQuery(query, context);
     }
 
@@ -429,7 +429,7 @@ public class PercolatorFieldMapper extends FieldMapper {
         doc.add(new NumericDocValuesField(minimumShouldMatchFieldMapper.name(), result.minimumShouldMatch));
     }
 
-    static void configureContext(QueryShardContext context, boolean mapUnmappedFieldsAsString) {
+    static void configureContext(SearchExecutionContext context, boolean mapUnmappedFieldsAsString) {
         // This means that fields in the query need to exist in the mapping prior to registering this query
         // The reason that this is required, is that if a field doesn't exist then the query assumes defaults, which may be undesired.
         //

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/CandidateQueryTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/CandidateQueryTests.java
@@ -92,7 +92,7 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.mapper.ParseContext;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.elasticsearch.test.VersionUtils;
@@ -197,7 +197,7 @@ public class CandidateQueryTests extends ESSingleNodeTestCase {
         }
         Collections.sort(intValues);
 
-        QueryShardContext context = createSearchContext(indexService).getQueryShardContext();
+        SearchExecutionContext context = createSearchContext(indexService).getSearchExecutionContext();
         MappedFieldType intFieldType = mapperService.fieldType("int_field");
 
         List<Supplier<Query>> queryFunctions = new ArrayList<>();
@@ -336,7 +336,7 @@ public class CandidateQueryTests extends ESSingleNodeTestCase {
         ranges.add(new int[]{0, 10});
         ranges.add(new int[]{15, 50});
 
-        QueryShardContext context = createSearchContext(indexService).getQueryShardContext();
+        SearchExecutionContext context = createSearchContext(indexService).getSearchExecutionContext();
         List<ParseContext.Document> documents = new ArrayList<>();
         {
             addQuery(new TermQuery(new Term("string_field", randomFrom(stringValues))), documents);
@@ -391,7 +391,7 @@ public class CandidateQueryTests extends ESSingleNodeTestCase {
     }
 
     private BooleanQuery randomBQ(int depth, List<String> stringValues, List<int[]> ranges,
-                                  MappedFieldType intFieldType, QueryShardContext context) {
+                                  MappedFieldType intFieldType, SearchExecutionContext context) {
         final int numClauses = randomIntBetween(1, 4);
         final boolean onlyShouldClauses = randomBoolean();
         final BooleanQuery.Builder builder = new BooleanQuery.Builder();

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolateQueryBuilderTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolateQueryBuilderTests.java
@@ -168,7 +168,7 @@ public class PercolateQueryBuilderTests extends AbstractQueryTestCase<PercolateQ
     }
 
     @Override
-    protected void doAssertLuceneQuery(PercolateQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
+    protected void doAssertLuceneQuery(PercolateQueryBuilder queryBuilder, Query query, SearchExecutionContext context) {
         assertThat(query, Matchers.instanceOf(PercolateQuery.class));
         PercolateQuery percolateQuery = (PercolateQuery) query;
         assertThat(percolateQuery.getDocuments(), Matchers.equalTo(documentSource));

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolateQueryBuilderTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolateQueryBuilderTests.java
@@ -37,7 +37,7 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.get.GetResult;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.Rewriteable;
 import org.elasticsearch.ingest.RandomDocumentPicks;
 import org.elasticsearch.plugins.Plugin;
@@ -168,7 +168,7 @@ public class PercolateQueryBuilderTests extends AbstractQueryTestCase<PercolateQ
     }
 
     @Override
-    protected void doAssertLuceneQuery(PercolateQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
+    protected void doAssertLuceneQuery(PercolateQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
         assertThat(query, Matchers.instanceOf(PercolateQuery.class));
         PercolateQuery percolateQuery = (PercolateQuery) query;
         assertThat(percolateQuery.getDocuments(), Matchers.equalTo(documentSource));
@@ -177,9 +177,9 @@ public class PercolateQueryBuilderTests extends AbstractQueryTestCase<PercolateQ
     @Override
     public void testMustRewrite() throws IOException {
         PercolateQueryBuilder pqb = doCreateTestQueryBuilder(true);
-        IllegalStateException e = expectThrows(IllegalStateException.class, () -> pqb.toQuery(createShardContext()));
+        IllegalStateException e = expectThrows(IllegalStateException.class, () -> pqb.toQuery(createSearchExecutionContext()));
         assertThat(e.getMessage(), equalTo("query builder must be rewritten first"));
-        QueryBuilder rewrite = rewriteAndFetch(pqb, createShardContext());
+        QueryBuilder rewrite = rewriteAndFetch(pqb, createSearchExecutionContext());
         PercolateQueryBuilder geoShapeQueryBuilder =
             new PercolateQueryBuilder(pqb.getField(), documentSource, XContentType.JSON);
         assertEquals(geoShapeQueryBuilder, rewrite);
@@ -189,7 +189,7 @@ public class PercolateQueryBuilderTests extends AbstractQueryTestCase<PercolateQ
         indexedDocumentExists = false;
         PercolateQueryBuilder pqb = doCreateTestQueryBuilder(true);
         ResourceNotFoundException e = expectThrows(ResourceNotFoundException.class, () -> rewriteAndFetch(pqb,
-            createShardContext()));
+            createSearchExecutionContext()));
         String expectedString = "indexed document [" + indexedDocumentIndex + "/" +
                 indexedDocumentId +  "] couldn't be found";
         assertThat(e.getMessage() , equalTo(expectedString));
@@ -229,9 +229,9 @@ public class PercolateQueryBuilderTests extends AbstractQueryTestCase<PercolateQ
     }
 
     public void testFromJsonNoDocumentType() throws IOException {
-        QueryShardContext queryShardContext = createShardContext();
+        SearchExecutionContext searchExecutionContext = createSearchExecutionContext();
         QueryBuilder queryBuilder = parseQuery("{\"percolate\" : { \"document\": {}, \"field\":\"" + queryField + "\"}}");
-        queryBuilder.toQuery(queryShardContext);
+        queryBuilder.toQuery(searchExecutionContext);
     }
 
     public void testFromJsonNoType() throws IOException {
@@ -240,10 +240,10 @@ public class PercolateQueryBuilderTests extends AbstractQueryTestCase<PercolateQ
         indexedDocumentVersion = Versions.MATCH_ANY;
         documentSource = Collections.singletonList(randomSource(new HashSet<>()));
 
-        QueryShardContext queryShardContext = createShardContext();
+        SearchExecutionContext searchExecutionContext = createSearchExecutionContext();
         QueryBuilder queryBuilder =  parseQuery("{\"percolate\" : { \"index\": \"" + indexedDocumentIndex + "\", \"id\": \"" +
                 indexedDocumentId + "\", \"field\":\"" + queryField + "\"}}");
-        rewriteAndFetch(queryBuilder, queryShardContext).toQuery(queryShardContext);
+        rewriteAndFetch(queryBuilder, searchExecutionContext).toQuery(searchExecutionContext);
     }
 
     public void testBothDocumentAndDocumentsSpecified() {
@@ -284,9 +284,9 @@ public class PercolateQueryBuilderTests extends AbstractQueryTestCase<PercolateQ
     @Override
     public void testCacheability() throws IOException {
         PercolateQueryBuilder queryBuilder = createTestQueryBuilder();
-        QueryShardContext context = createShardContext();
+        SearchExecutionContext context = createSearchExecutionContext();
         assert context.isCacheable();
-        QueryBuilder rewritten = rewriteQuery(queryBuilder, new QueryShardContext(context));
+        QueryBuilder rewritten = rewriteQuery(queryBuilder, new SearchExecutionContext(context));
         assertNotNull(rewritten.toQuery(context));
         assertFalse("query should not be cacheable: " + queryBuilder.toString(), context.isCacheable());
     }
@@ -298,25 +298,25 @@ public class PercolateQueryBuilderTests extends AbstractQueryTestCase<PercolateQ
 
     public void testSerializationFailsUnlessFetched() throws IOException {
         QueryBuilder builder = doCreateTestQueryBuilder(true);
-        QueryBuilder queryBuilder = Rewriteable.rewrite(builder, createShardContext());
+        QueryBuilder queryBuilder = Rewriteable.rewrite(builder, createSearchExecutionContext());
         IllegalStateException ise = expectThrows(IllegalStateException.class, () -> queryBuilder.writeTo(new BytesStreamOutput(10)));
         assertEquals(ise.getMessage(), "supplier must be null, can't serialize suppliers, missing a rewriteAndFetch?");
-        builder = rewriteAndFetch(builder, createShardContext());
+        builder = rewriteAndFetch(builder, createSearchExecutionContext());
         builder.writeTo(new BytesStreamOutput(10));
     }
 
     public void testFieldAlias() throws IOException {
-        QueryShardContext shardContext = createShardContext();
+        SearchExecutionContext searchExecutionContext = createSearchExecutionContext();
 
         PercolateQueryBuilder builder = doCreateTestQueryBuilder(false);
-        QueryBuilder rewrittenBuilder = rewriteAndFetch(builder, shardContext);
-        PercolateQuery query = (PercolateQuery) rewrittenBuilder.toQuery(shardContext);
+        QueryBuilder rewrittenBuilder = rewriteAndFetch(builder, searchExecutionContext);
+        PercolateQuery query = (PercolateQuery) rewrittenBuilder.toQuery(searchExecutionContext);
 
         PercolateQueryBuilder aliasBuilder = new PercolateQueryBuilder(aliasField,
             builder.getDocuments(),
             builder.getXContentType());
-        QueryBuilder rewrittenAliasBuilder = rewriteAndFetch(aliasBuilder, shardContext);
-        PercolateQuery aliasQuery = (PercolateQuery) rewrittenAliasBuilder.toQuery(shardContext);
+        QueryBuilder rewrittenAliasBuilder = rewriteAndFetch(aliasBuilder, searchExecutionContext);
+        PercolateQuery aliasQuery = (PercolateQuery) rewrittenAliasBuilder.toQuery(searchExecutionContext);
 
         assertEquals(query.getCandidateMatchesQuery(), aliasQuery.getCandidateMatchesQuery());
         assertEquals(query.getVerifiedMatchesQuery(), aliasQuery.getVerifiedMatchesQuery());
@@ -324,11 +324,11 @@ public class PercolateQueryBuilderTests extends AbstractQueryTestCase<PercolateQ
 
     public void testSettingNameWhileRewriting() {
         String testName = "name1";
-        QueryShardContext shardContext = createShardContext();
+        SearchExecutionContext searchExecutionContext = createSearchExecutionContext();
         PercolateQueryBuilder percolateQueryBuilder = doCreateTestQueryBuilder(true);
         percolateQueryBuilder.setName(testName);
 
-        QueryBuilder rewrittenQueryBuilder = percolateQueryBuilder.doRewrite(shardContext);
+        QueryBuilder rewrittenQueryBuilder = percolateQueryBuilder.doRewrite(searchExecutionContext);
 
         assertEquals(testName, ((PercolateQueryBuilder) rewrittenQueryBuilder).getQueryName());
         assertNotEquals(rewrittenQueryBuilder, percolateQueryBuilder);
@@ -337,23 +337,23 @@ public class PercolateQueryBuilderTests extends AbstractQueryTestCase<PercolateQ
     public void testSettingNameWhileRewritingWhenDocumentSupplierAndSourceNotNull() {
         Supplier<BytesReference> supplier = () -> new BytesArray("{\"test\": \"test\"}");
         String testName = "name1";
-        QueryShardContext shardContext = createShardContext();
+        SearchExecutionContext searchExecutionContext = createSearchExecutionContext();
         PercolateQueryBuilder percolateQueryBuilder = new PercolateQueryBuilder(queryField, supplier);
         percolateQueryBuilder.setName(testName);
 
-        QueryBuilder rewrittenQueryBuilder = percolateQueryBuilder.doRewrite(shardContext);
+        QueryBuilder rewrittenQueryBuilder = percolateQueryBuilder.doRewrite(searchExecutionContext);
 
         assertEquals(testName, ((PercolateQueryBuilder) rewrittenQueryBuilder).getQueryName());
         assertNotEquals(rewrittenQueryBuilder, percolateQueryBuilder);
     }
 
     public void testDisallowExpensiveQueries() {
-        QueryShardContext queryShardContext = mock(QueryShardContext.class);
-        when(queryShardContext.allowExpensiveQueries()).thenReturn(false);
+        SearchExecutionContext searchExecutionContext = mock(SearchExecutionContext.class);
+        when(searchExecutionContext.allowExpensiveQueries()).thenReturn(false);
 
         PercolateQueryBuilder queryBuilder = doCreateTestQueryBuilder(true);
         ElasticsearchException e = expectThrows(ElasticsearchException.class,
-                () -> queryBuilder.toQuery(queryShardContext));
+                () -> queryBuilder.toQuery(searchExecutionContext));
         assertEquals("[percolate] queries cannot be executed when 'search.allow_expensive_queries' is set to false.",
                 e.getMessage());
     }

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolateWithNestedQueryBuilderTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolateWithNestedQueryBuilderTests.java
@@ -26,7 +26,7 @@ import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 
 import java.io.IOException;
 
@@ -40,18 +40,18 @@ public class PercolateWithNestedQueryBuilderTests extends PercolateQueryBuilderT
     }
 
     public void testDetectsNestedDocuments() throws IOException {
-        QueryShardContext shardContext = createShardContext();
+        SearchExecutionContext searchExecutionContext = createSearchExecutionContext();
 
         PercolateQueryBuilder builder = new PercolateQueryBuilder(queryField,
                 new BytesArray("{ \"foo\": \"bar\" }"), XContentType.JSON);
-        QueryBuilder rewrittenBuilder = rewriteAndFetch(builder, shardContext);
-        PercolateQuery query = (PercolateQuery) rewrittenBuilder.toQuery(shardContext);
+        QueryBuilder rewrittenBuilder = rewriteAndFetch(builder, searchExecutionContext);
+        PercolateQuery query = (PercolateQuery) rewrittenBuilder.toQuery(searchExecutionContext);
         assertFalse(query.excludesNestedDocs());
 
         builder = new PercolateQueryBuilder(queryField,
                 new BytesArray("{ \"foo\": \"bar\", \"some_nested_object\": [ { \"baz\": 42 } ] }"), XContentType.JSON);
-        rewrittenBuilder = rewriteAndFetch(builder, shardContext);
-        query = (PercolateQuery) rewrittenBuilder.toQuery(shardContext);
+        rewrittenBuilder = rewriteAndFetch(builder, searchExecutionContext);
+        query = (PercolateQuery) rewrittenBuilder.toQuery(searchExecutionContext);
         assertTrue(query.excludesNestedDocs());
     }
 }

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorFieldMapperTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorFieldMapperTests.java
@@ -70,7 +70,7 @@ import org.elasticsearch.index.query.ConstantScoreQueryBuilder;
 import org.elasticsearch.index.query.DisMaxQueryBuilder;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.QueryShardException;
 import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.elasticsearch.index.query.Rewriteable;
@@ -220,7 +220,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
     }
 
     public void testExtractRanges() throws Exception {
-        QueryShardContext context = createSearchContext(indexService).getQueryShardContext();
+        SearchExecutionContext context = createSearchContext(indexService).getSearchExecutionContext();
         addQueryFieldMappings();
         BooleanQuery.Builder bq = new BooleanQuery.Builder();
         Query rangeQuery1 = mapperService.fieldType("number_field1")
@@ -517,12 +517,12 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
                                 .endObject()),
                         XContentType.JSON));
         BytesRef qbSource = doc.rootDoc().getFields(fieldType.queryBuilderField.name())[0].binaryValue();
-        QueryShardContext shardContext = indexService.newQueryShardContext(
+        SearchExecutionContext searchExecutionContext = indexService.newSearchExecutionContext(
             randomInt(20), 0, null, () -> {
                 throw new UnsupportedOperationException();
             }, null, emptyMap());
         PlainActionFuture<QueryBuilder> future = new PlainActionFuture<>();
-        Rewriteable.rewriteAndFetch(queryBuilder, shardContext, future);
+        Rewriteable.rewriteAndFetch(queryBuilder, searchExecutionContext, future);
         assertQueryBuilder(qbSource, future.get());
     }
 

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorQuerySearchTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorQuerySearchTests.java
@@ -34,7 +34,7 @@ import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.index.query.Operator;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.script.MockScriptPlugin;
 import org.elasticsearch.script.Script;
@@ -258,15 +258,15 @@ public class PercolatorQuerySearchTests extends ESSingleNodeTestCase {
 
         try (Engine.Searcher searcher = indexService.getShard(0).acquireSearcher("test")) {
             long[] currentTime = new long[] {System.currentTimeMillis()};
-            QueryShardContext queryShardContext =
-                indexService.newQueryShardContext(0, 0, searcher, () -> currentTime[0], null, emptyMap());
+            SearchExecutionContext searchExecutionContext =
+                indexService.newSearchExecutionContext(0, 0, searcher, () -> currentTime[0], null, emptyMap());
 
             BytesReference source = BytesReference.bytes(jsonBuilder().startObject()
                 .field("field1", "value")
                 .field("field2", currentTime[0])
                 .endObject());
             QueryBuilder queryBuilder = new PercolateQueryBuilder("query", source, XContentType.JSON);
-            Query query = queryBuilder.toQuery(queryShardContext);
+            Query query = queryBuilder.toQuery(searchExecutionContext);
             assertThat(searcher.count(query), equalTo(3));
 
             currentTime[0] = currentTime[0] + 10800000; // + 3 hours
@@ -275,7 +275,7 @@ public class PercolatorQuerySearchTests extends ESSingleNodeTestCase {
                 .field("field2", currentTime[0])
                 .endObject());
             queryBuilder = new PercolateQueryBuilder("query", source, XContentType.JSON);
-            query = queryBuilder.toQuery(queryShardContext);
+            query = queryBuilder.toQuery(searchExecutionContext);
             assertThat(searcher.count(query), equalTo(3));
         }
     }

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/QueryBuilderStoreTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/QueryBuilderStoreTests.java
@@ -39,7 +39,7 @@ import org.elasticsearch.index.mapper.BinaryFieldMapper;
 import org.elasticsearch.index.mapper.ContentPath;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.ParseContext;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.mock.orig.Mockito;
 import org.elasticsearch.search.SearchModule;
@@ -87,17 +87,17 @@ public class QueryBuilderStoreTests extends ESTestCase {
                 }
             }
 
-            QueryShardContext queryShardContext = mock(QueryShardContext.class);
-            when(queryShardContext.indexVersionCreated()).thenReturn(version);
-            when(queryShardContext.getWriteableRegistry()).thenReturn(writableRegistry());
-            when(queryShardContext.getXContentRegistry()).thenReturn(xContentRegistry());
-            when(queryShardContext.getForField(fieldMapper.fieldType()))
+            SearchExecutionContext searchExecutionContext = mock(SearchExecutionContext.class);
+            when(searchExecutionContext.indexVersionCreated()).thenReturn(version);
+            when(searchExecutionContext.getWriteableRegistry()).thenReturn(writableRegistry());
+            when(searchExecutionContext.getXContentRegistry()).thenReturn(xContentRegistry());
+            when(searchExecutionContext.getForField(fieldMapper.fieldType()))
                 .thenReturn(new BytesBinaryIndexFieldData(fieldMapper.name(), CoreValuesSourceType.KEYWORD));
-            when(queryShardContext.getFieldType(Mockito.anyString())).thenAnswer(invocation -> {
+            when(searchExecutionContext.getFieldType(Mockito.anyString())).thenAnswer(invocation -> {
                 final String fieldName = (String) invocation.getArguments()[0];
                 return new KeywordFieldMapper.KeywordFieldType(fieldName);
             });
-            PercolateQuery.QueryStore queryStore = PercolateQueryBuilder.createStore(fieldMapper.fieldType(), queryShardContext);
+            PercolateQuery.QueryStore queryStore = PercolateQueryBuilder.createStore(fieldMapper.fieldType(), searchExecutionContext);
 
             try (IndexReader indexReader = DirectoryReader.open(directory)) {
                 LeafReaderContext leafContext = indexReader.leaves().get(0);

--- a/plugins/analysis-icu/src/main/java/org/elasticsearch/index/mapper/ICUCollationKeywordFieldMapper.java
+++ b/plugins/analysis-icu/src/main/java/org/elasticsearch/index/mapper/ICUCollationKeywordFieldMapper.java
@@ -38,7 +38,7 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.analysis.IndexableBinaryStringTools;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.plain.SortedSetOrdinalsIndexFieldData;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.lookup.SearchLookup;
@@ -81,7 +81,7 @@ public class ICUCollationKeywordFieldMapper extends FieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             if (format != null) {
                 throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
             }
@@ -123,13 +123,13 @@ public class ICUCollationKeywordFieldMapper extends FieldMapper {
 
         @Override
         public Query fuzzyQuery(Object value, Fuzziness fuzziness, int prefixLength, int maxExpansions,
-                                boolean transpositions, QueryShardContext context) {
+                                boolean transpositions, SearchExecutionContext context) {
             throw new UnsupportedOperationException("[fuzzy] queries are not supported on [" + CONTENT_TYPE + "] fields.");
         }
 
         @Override
         public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method,
-                                 boolean caseInsensitive, QueryShardContext context) {
+                                 boolean caseInsensitive, SearchExecutionContext context) {
             throw new UnsupportedOperationException("[prefix] queries are not supported on [" + CONTENT_TYPE + "] fields.");
         }
 
@@ -137,13 +137,13 @@ public class ICUCollationKeywordFieldMapper extends FieldMapper {
         public Query wildcardQuery(String value,
                                    @Nullable MultiTermQuery.RewriteMethod method,
                                    boolean caseInsensitive,
-                                   QueryShardContext context) {
+                                   SearchExecutionContext context) {
             throw new UnsupportedOperationException("[wildcard] queries are not supported on [" + CONTENT_TYPE + "] fields.");
         }
 
         @Override
         public Query regexpQuery(String value, int syntaxFlags, int matchFlags, int maxDeterminizedStates,
-                                 MultiTermQuery.RewriteMethod method, QueryShardContext context) {
+                                 MultiTermQuery.RewriteMethod method, SearchExecutionContext context) {
             throw new UnsupportedOperationException("[regexp] queries are not supported on [" + CONTENT_TYPE + "] fields.");
         }
 

--- a/plugins/analysis-icu/src/test/java/org/elasticsearch/index/mapper/CollationFieldTypeTests.java
+++ b/plugins/analysis-icu/src/test/java/org/elasticsearch/index/mapper/CollationFieldTypeTests.java
@@ -94,28 +94,28 @@ public class CollationFieldTypeTests extends FieldTypeTestCase{
     public void testRegexpQuery() {
         MappedFieldType ft = createFieldType();
         UnsupportedOperationException e = expectThrows(UnsupportedOperationException.class,
-            () -> ft.regexpQuery("foo.*", 0, 0, 10, null, randomMockShardContext()));
+            () -> ft.regexpQuery("foo.*", 0, 0, 10, null, randomMockContext()));
         assertEquals("[regexp] queries are not supported on [icu_collation_keyword] fields.", e.getMessage());
     }
 
     public void testFuzzyQuery() {
         MappedFieldType ft = createFieldType();
         UnsupportedOperationException e = expectThrows(UnsupportedOperationException.class,
-            () -> ft.fuzzyQuery("foo", Fuzziness.fromEdits(2), 1, 50, true, randomMockShardContext()));
+            () -> ft.fuzzyQuery("foo", Fuzziness.fromEdits(2), 1, 50, true, randomMockContext()));
         assertEquals("[fuzzy] queries are not supported on [icu_collation_keyword] fields.", e.getMessage());
     }
 
     public void testPrefixQuery() {
         MappedFieldType ft = createFieldType();
         UnsupportedOperationException e = expectThrows(UnsupportedOperationException.class,
-            () -> ft.prefixQuery("prefix", null, randomMockShardContext()));
+            () -> ft.prefixQuery("prefix", null, randomMockContext()));
         assertEquals("[prefix] queries are not supported on [icu_collation_keyword] fields.", e.getMessage());
     }
 
     public void testWildcardQuery() {
         MappedFieldType ft = createFieldType();
         UnsupportedOperationException e = expectThrows(UnsupportedOperationException.class,
-            () -> ft.wildcardQuery("foo*", null, randomMockShardContext()));
+            () -> ft.wildcardQuery("foo*", null, randomMockContext()));
         assertEquals("[wildcard] queries are not supported on [icu_collation_keyword] fields.", e.getMessage());
     }
 
@@ -127,16 +127,16 @@ public class CollationFieldTypeTests extends FieldTypeTestCase{
         TermRangeQuery expected = new TermRangeQuery("field", new BytesRef(aKey.bytes, 0, aKey.size),
             new BytesRef(bKey.bytes, 0, bKey.size), false, false);
 
-        assertEquals(expected, ft.rangeQuery("a", "b", false, false, null, null, null, MOCK_QSC));
+        assertEquals(expected, ft.rangeQuery("a", "b", false, false, null, null, null, MOCK_CONTEXT));
 
         ElasticsearchException ee = expectThrows(ElasticsearchException.class,
-                () -> ft.rangeQuery("a", "b", true, true, null, null, null, MOCK_QSC_DISALLOW_EXPENSIVE));
+                () -> ft.rangeQuery("a", "b", true, true, null, null, null, MOCK_CONTEXT_DISALLOW_EXPENSIVE));
         assertEquals("[range] queries on [text] or [keyword] fields cannot be executed when " +
                 "'search.allow_expensive_queries' is set to false.", ee.getMessage());
 
         MappedFieldType unsearchable = new CollationFieldType("field", false, DEFAULT_COLLATOR);
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
-            () -> unsearchable.rangeQuery("a", "b", false, false, null, null, null, MOCK_QSC));
+            () -> unsearchable.rangeQuery("a", "b", false, false, null, null, null, MOCK_CONTEXT));
         assertEquals("Cannot search on field [field] since it is not indexed.", e.getMessage());
     }
 }

--- a/plugins/examples/custom-suggester/src/main/java/org/elasticsearch/example/customsuggester/CustomSuggestionBuilder.java
+++ b/plugins/examples/custom-suggester/src/main/java/org/elasticsearch/example/customsuggester/CustomSuggestionBuilder.java
@@ -26,7 +26,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.suggest.SuggestionBuilder;
 import org.elasticsearch.search.suggest.SuggestionSearchContext;
 
@@ -129,7 +129,7 @@ public class CustomSuggestionBuilder extends SuggestionBuilder<CustomSuggestionB
     }
 
     @Override
-    public SuggestionSearchContext.SuggestionContext build(QueryShardContext context) throws IOException {
+    public SuggestionSearchContext.SuggestionContext build(SearchExecutionContext context) throws IOException {
         Map<String, Object> options = new HashMap<>();
         options.put(FIELDNAME_FIELD.getPreferredName(), field());
         options.put(RANDOM_SUFFIX_FIELD.getPreferredName(), randomSuffix);

--- a/plugins/examples/custom-suggester/src/main/java/org/elasticsearch/example/customsuggester/CustomSuggestionContext.java
+++ b/plugins/examples/custom-suggester/src/main/java/org/elasticsearch/example/customsuggester/CustomSuggestionContext.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.example.customsuggester;
 
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.suggest.SuggestionSearchContext;
 
 import java.util.Map;
@@ -28,7 +28,7 @@ public class CustomSuggestionContext extends SuggestionSearchContext.SuggestionC
 
     public Map<String, Object> options;
 
-    public CustomSuggestionContext(QueryShardContext context, Map<String, Object> options) {
+    public CustomSuggestionContext(SearchExecutionContext context, Map<String, Object> options) {
         super(new CustomSuggester(), context);
         this.options = options;
     }

--- a/plugins/examples/rescore/src/main/java/org/elasticsearch/example/rescore/ExampleRescoreBuilder.java
+++ b/plugins/examples/rescore/src/main/java/org/elasticsearch/example/rescore/ExampleRescoreBuilder.java
@@ -36,7 +36,7 @@ import org.elasticsearch.index.fielddata.LeafFieldData;
 import org.elasticsearch.index.fielddata.LeafNumericFieldData;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 import org.elasticsearch.index.query.QueryRewriteContext;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.rescore.RescoreContext;
 import org.elasticsearch.search.rescore.Rescorer;
 import org.elasticsearch.search.rescore.RescorerBuilder;
@@ -107,7 +107,7 @@ public class ExampleRescoreBuilder extends RescorerBuilder<ExampleRescoreBuilder
     }
 
     @Override
-    public RescoreContext innerBuildContext(int windowSize, QueryShardContext context) throws IOException {
+    public RescoreContext innerBuildContext(int windowSize, SearchExecutionContext context) throws IOException {
         IndexFieldData<?> factorField =
                 this.factorField == null ? null : context.getForField(context.getFieldType(this.factorField));
         return new ExampleRescoreContext(windowSize, factor, factorField);

--- a/plugins/mapper-annotated-text/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/AnnotatedTextHighlighter.java
+++ b/plugins/mapper-annotated-text/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/AnnotatedTextHighlighter.java
@@ -26,7 +26,7 @@ import org.apache.lucene.search.uhighlight.PassageFormatter;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.annotatedtext.AnnotatedTextFieldMapper.AnnotatedHighlighterAnalyzer;
 import org.elasticsearch.index.mapper.annotatedtext.AnnotatedTextFieldMapper.AnnotatedText;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.fetch.FetchSubPhase.HitContext;
 
 import java.io.IOException;
@@ -41,12 +41,12 @@ public class AnnotatedTextHighlighter extends UnifiedHighlighter {
     @Override
     protected List<Object> loadFieldValues(
         CustomUnifiedHighlighter highlighter,
-        QueryShardContext qsc,
+        SearchExecutionContext searchContext,
         MappedFieldType fieldType,
         HitContext hitContext,
         boolean forceSource
     ) throws IOException {
-        List<Object> fieldValues = super.loadFieldValues(highlighter, qsc, fieldType, hitContext, forceSource);
+        List<Object> fieldValues = super.loadFieldValues(highlighter, searchContext, fieldType, hitContext, forceSource);
 
         List<Object> strings = new ArrayList<>(fieldValues.size());
         AnnotatedText[] annotations = new AnnotatedText[fieldValues.size()];

--- a/plugins/mapper-murmur3/src/main/java/org/elasticsearch/index/mapper/murmur3/Murmur3FieldMapper.java
+++ b/plugins/mapper-murmur3/src/main/java/org/elasticsearch/index/mapper/murmur3/Murmur3FieldMapper.java
@@ -36,7 +36,7 @@ import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.SourceValueFetcher;
 import org.elasticsearch.index.mapper.TextSearchInfo;
 import org.elasticsearch.index.mapper.ValueFetcher;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.io.IOException;
@@ -104,12 +104,12 @@ public class Murmur3FieldMapper extends FieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             return SourceValueFetcher.toString(name(), context, format);
         }
 
         @Override
-        public Query termQuery(Object value, QueryShardContext context) {
+        public Query termQuery(Object value, SearchExecutionContext context) {
             throw new IllegalArgumentException("Murmur3 fields are not searchable: [" + name() + "]");
         }
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/NestedIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/NestedIT.java
@@ -585,7 +585,7 @@ public class NestedIT extends ESIntegTestCase {
                             .startArray("parameters")
                                 .startObject()
                                     .field("name", "context")
-                                    .field("type", "QueryShardContext")
+                                    .field("type", "SearchExecutionContext")
                                 .endObject()
                             .endArray()
                         .endObject()

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/TransportSimulateIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/TransportSimulateIndexTemplateAction.java
@@ -183,7 +183,7 @@ public class TransportSimulateIndexTemplateAction
                 resolvedAliases, tempClusterState.metadata(), aliasValidator, xContentRegistry,
                 // the context is only used for validation so it's fine to pass fake values for the
                 // shard id and the current timestamp
-                tempIndexService.newQueryShardContext(0, 0, null, () -> 0L, null, emptyMap())));
+                tempIndexService.newSearchExecutionContext(0, 0, null, () -> 0L, null, emptyMap())));
         Map<String, AliasMetadata> aliasesByName = aliases.stream().collect(
             Collectors.toMap(AliasMetadata::getAlias, Function.identity()));
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/validate/query/TransportValidateQueryAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/validate/query/TransportValidateQueryAction.java
@@ -199,7 +199,7 @@ public class TransportValidateQueryAction extends TransportBroadcastAction<
             request.nowInMillis(), request.filteringAliases());
         SearchContext searchContext = searchService.createSearchContext(shardSearchLocalRequest, SearchService.NO_TIMEOUT);
         try {
-            ParsedQuery parsedQuery = searchContext.getQueryShardContext().toQuery(request.query());
+            ParsedQuery parsedQuery = searchContext.getSearchExecutionContext().toQuery(request.query());
             searchContext.parsedQuery(parsedQuery);
             searchContext.preProcess(request.rewrite());
             valid = true;

--- a/server/src/main/java/org/elasticsearch/action/explain/TransportExplainAction.java
+++ b/server/src/main/java/org/elasticsearch/action/explain/TransportExplainAction.java
@@ -114,7 +114,7 @@ public class TransportExplainAction extends TransportSingleShardAction<ExplainRe
             if (!result.exists()) {
                 return new ExplainResponse(shardId.getIndexName(), request.id(), false);
             }
-            context.parsedQuery(context.getQueryShardContext().toQuery(request.query()));
+            context.parsedQuery(context.getSearchExecutionContext().toQuery(request.query()));
             context.preProcess(true);
             int topLevelDocId = result.docIdAndVersion().docId + result.docIdAndVersion().docBase;
             Explanation explanation = context.searcher().explain(context.query(), topLevelDocId);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/AliasValidator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/AliasValidator.java
@@ -29,7 +29,7 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.Rewriteable;
 import org.elasticsearch.indices.InvalidAliasNameException;
 
@@ -108,15 +108,15 @@ public class AliasValidator {
 
     /**
      * Validates an alias filter by parsing it using the
-     * provided {@link org.elasticsearch.index.query.QueryShardContext}
+     * provided {@link SearchExecutionContext}
      * @throws IllegalArgumentException if the filter is not valid
      */
-    public void validateAliasFilter(String alias, String filter, QueryShardContext queryShardContext,
+    public void validateAliasFilter(String alias, String filter, SearchExecutionContext searchExecutionContext,
             NamedXContentRegistry xContentRegistry) {
-        assert queryShardContext != null;
+        assert searchExecutionContext != null;
         try (XContentParser parser = XContentFactory.xContent(filter)
             .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, filter)) {
-            validateAliasFilter(parser, queryShardContext);
+            validateAliasFilter(parser, searchExecutionContext);
         } catch (Exception e) {
             throw new IllegalArgumentException("failed to parse filter for alias [" + alias + "]", e);
         }
@@ -124,25 +124,25 @@ public class AliasValidator {
 
     /**
      * Validates an alias filter by parsing it using the
-     * provided {@link org.elasticsearch.index.query.QueryShardContext}
+     * provided {@link SearchExecutionContext}
      * @throws IllegalArgumentException if the filter is not valid
      */
-    public void validateAliasFilter(String alias, BytesReference filter, QueryShardContext queryShardContext,
+    public void validateAliasFilter(String alias, BytesReference filter, SearchExecutionContext searchExecutionContext,
                                     NamedXContentRegistry xContentRegistry) {
-        assert queryShardContext != null;
+        assert searchExecutionContext != null;
 
         try (InputStream inputStream = filter.streamInput();
              XContentParser parser = XContentFactory.xContentType(inputStream).xContent()
                      .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, filter.streamInput())) {
-            validateAliasFilter(parser, queryShardContext);
+            validateAliasFilter(parser, searchExecutionContext);
         } catch (Exception e) {
             throw new IllegalArgumentException("failed to parse filter for alias [" + alias + "]", e);
         }
     }
 
-    private static void validateAliasFilter(XContentParser parser, QueryShardContext queryShardContext) throws IOException {
+    private static void validateAliasFilter(XContentParser parser, SearchExecutionContext searchExecutionContext) throws IOException {
         QueryBuilder parseInnerQueryBuilder = parseInnerQueryBuilder(parser);
-        QueryBuilder queryBuilder = Rewriteable.rewrite(parseInnerQueryBuilder, queryShardContext, true);
-        queryBuilder.toQuery(queryShardContext);
+        QueryBuilder queryBuilder = Rewriteable.rewrite(parseInnerQueryBuilder, searchExecutionContext, true);
+        queryBuilder.toQuery(searchExecutionContext);
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -67,7 +67,7 @@ import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MapperService.MergeReason;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.shard.IndexSettingProvider;
 import org.elasticsearch.indices.IndexCreationException;
 import org.elasticsearch.indices.IndicesService;
@@ -487,7 +487,7 @@ public class MetadataCreateIndexService {
                 MetadataIndexTemplateService.resolveAliases(templates), currentState.metadata(), aliasValidator,
                 // the context is only used for validation so it's fine to pass fake values for the
                 // shard id and the current timestamp
-                xContentRegistry, indexService.newQueryShardContext(0, 0, null, () -> 0L, null, emptyMap())),
+                xContentRegistry, indexService.newSearchExecutionContext(0, 0, null, () -> 0L, null, emptyMap())),
             templates.stream().map(IndexTemplateMetadata::getName).collect(toList()), metadataTransformer);
     }
 
@@ -520,7 +520,7 @@ public class MetadataCreateIndexService {
                 MetadataIndexTemplateService.resolveAliases(currentState.metadata(), templateName), currentState.metadata(), aliasValidator,
                 // the context is only used for validation so it's fine to pass fake values for the
                 // shard id and the current timestamp
-                xContentRegistry, indexService.newQueryShardContext(0, 0, null, () -> 0L, null, emptyMap())),
+                xContentRegistry, indexService.newSearchExecutionContext(0, 0, null, () -> 0L, null, emptyMap())),
             Collections.singletonList(templateName), metadataTransformer);
     }
 
@@ -566,7 +566,7 @@ public class MetadataCreateIndexService {
                 currentState.metadata(), aliasValidator, xContentRegistry,
                 // the context is only used for validation so it's fine to pass fake values for the
                 // shard id and the current timestamp
-                indexService.newQueryShardContext(0, 0, null, () -> 0L, null, emptyMap())),
+                indexService.newSearchExecutionContext(0, 0, null, () -> 0L, null, emptyMap())),
             List.of(), metadataTransformer);
     }
 
@@ -766,12 +766,12 @@ public class MetadataCreateIndexService {
     public static List<AliasMetadata> resolveAndValidateAliases(String index, Set<Alias> aliases,
                                                                 List<Map<String, AliasMetadata>> templateAliases, Metadata metadata,
                                                                 AliasValidator aliasValidator, NamedXContentRegistry xContentRegistry,
-                                                                QueryShardContext queryShardContext) {
+                                                                SearchExecutionContext searchExecutionContext) {
         List<AliasMetadata> resolvedAliases = new ArrayList<>();
         for (Alias alias : aliases) {
             aliasValidator.validateAlias(alias, index, metadata);
             if (Strings.hasLength(alias.filter())) {
-                aliasValidator.validateAliasFilter(alias.name(), alias.filter(), queryShardContext, xContentRegistry);
+                aliasValidator.validateAliasFilter(alias.name(), alias.filter(), searchExecutionContext, xContentRegistry);
             }
             AliasMetadata aliasMetadata = AliasMetadata.builder(alias.name()).filter(alias.filter())
                 .indexRouting(alias.indexRouting()).searchRouting(alias.searchRouting()).writeIndex(alias.writeIndex())
@@ -804,7 +804,7 @@ public class MetadataCreateIndexService {
                 aliasValidator.validateAliasMetadata(aliasMetadata, index, metadata);
                 if (aliasMetadata.filter() != null) {
                     aliasValidator.validateAliasFilter(aliasMetadata.alias(), aliasMetadata.filter().uncompressed(),
-                        queryShardContext, xContentRegistry);
+                        searchExecutionContext, xContentRegistry);
                 }
                 templatesAliases.put(aliasMetadata.alias(), aliasMetadata);
                 resolvedAliases.add((aliasMetadata));

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexAliasesService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexAliasesService.java
@@ -149,7 +149,7 @@ public class MetadataIndexAliasesService {
                         }
                         // the context is only used for validation so it's fine to pass fake values for the shard id,
                         // but the current timestamp should be set to real value as we may use `now` in a filtered alias
-                        aliasValidator.validateAliasFilter(alias, filter, indexService.newQueryShardContext(0, 0,
+                        aliasValidator.validateAliasFilter(alias, filter, indexService.newSearchExecutionContext(0, 0,
                                 null, () -> System.currentTimeMillis(), null, emptyMap()), xContentRegistry);
                     }
                 };

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
@@ -1119,7 +1119,7 @@ public class MetadataIndexTemplateService {
                     new AliasValidator(),
                     // the context is only used for validation so it's fine to pass fake values for the
                     // shard id and the current timestamp
-                    xContentRegistry, tempIndexService.newQueryShardContext(0, 0, null, () -> 0L, null, emptyMap()));
+                    xContentRegistry, tempIndexService.newSearchExecutionContext(0, 0, null, () -> 0L, null, emptyMap()));
 
                 // triggers inclusion of _timestamp field and its validation:
                 String indexName = DataStream.BACKING_INDEX_PREFIX + temporaryIndexName;

--- a/server/src/main/java/org/elasticsearch/common/geo/GeoShapeUtils.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeoShapeUtils.java
@@ -32,7 +32,7 @@ import org.elasticsearch.geometry.MultiPolygon;
 import org.elasticsearch.geometry.Point;
 import org.elasticsearch.geometry.Polygon;
 import org.elasticsearch.geometry.Rectangle;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.QueryShardException;
 
 import java.util.ArrayList;
@@ -79,7 +79,7 @@ public class GeoShapeUtils {
 
     public static LatLonGeometry[] toLuceneGeometry(
         String name,
-        QueryShardContext context,
+        SearchExecutionContext context,
         Geometry geometry,
         List<Class<? extends Geometry>> unsupportedGeometries
     ) {

--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -61,7 +61,7 @@ import org.elasticsearch.index.engine.EngineFactory;
 import org.elasticsearch.index.fielddata.IndexFieldDataCache;
 import org.elasticsearch.index.fielddata.IndexFieldDataService;
 import org.elasticsearch.index.mapper.MapperService;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.SearchIndexNameMatcher;
 import org.elasticsearch.index.seqno.RetentionLeaseSyncer;
 import org.elasticsearch.index.shard.IndexEventListener;
@@ -197,7 +197,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
             assert indexAnalyzers != null;
             this.mapperService = new MapperService(indexSettings, indexAnalyzers, xContentRegistry, similarityService, mapperRegistry,
                 // we parse all percolator queries as they would be parsed on shard 0
-                () -> newQueryShardContext(0, 0, null, System::currentTimeMillis, null, emptyMap()), idFieldDataEnabled, scriptService);
+                () -> newSearchExecutionContext(0, 0, null, System::currentTimeMillis, null, emptyMap()), idFieldDataEnabled, scriptService);
             this.indexFieldData = new IndexFieldDataService(indexSettings, indicesFieldDataCache, circuitBreakerService, mapperService);
             if (indexSettings.getIndexSortConfig().hasIndexSort()) {
                 // we delay the actual creation of the sort order for this index because the mapping has not been merged yet.
@@ -589,12 +589,12 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
     }
 
     /**
-     * Creates a new QueryShardContext.
+     * Creates a new {@link SearchExecutionContext}.
      *
      * Passing a {@code null} {@link IndexSearcher} will return a valid context, however it won't be able to make
      * {@link IndexReader}-specific optimizations, such as rewriting containing range queries.
      */
-    public QueryShardContext newQueryShardContext(
+    public SearchExecutionContext newSearchExecutionContext(
         int shardId,
         int shardRequestIndex,
         IndexSearcher searcher,
@@ -604,7 +604,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
     ) {
         final SearchIndexNameMatcher indexNameMatcher =
             new SearchIndexNameMatcher(index().getName(), clusterAlias, clusterService, expressionResolver);
-        return new QueryShardContext(
+        return new SearchExecutionContext(
             shardId,
             shardRequestIndex,
             indexSettings,

--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -197,7 +197,8 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
             assert indexAnalyzers != null;
             this.mapperService = new MapperService(indexSettings, indexAnalyzers, xContentRegistry, similarityService, mapperRegistry,
                 // we parse all percolator queries as they would be parsed on shard 0
-                () -> newSearchExecutionContext(0, 0, null, System::currentTimeMillis, null, emptyMap()), idFieldDataEnabled, scriptService);
+                () -> newSearchExecutionContext(0, 0, null, System::currentTimeMillis, null, emptyMap()),
+                idFieldDataEnabled, scriptService);
             this.indexFieldData = new IndexFieldDataService(indexSettings, indicesFieldDataCache, circuitBreakerService, mapperService);
             if (indexSettings.getIndexSortConfig().hasIndexSort()) {
                 // we delay the actual creation of the sort order for this index because the mapping has not been merged yet.

--- a/server/src/main/java/org/elasticsearch/index/mapper/AbstractGeometryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/AbstractGeometryFieldMapper.java
@@ -28,7 +28,7 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.support.MapXContentParser;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -117,13 +117,13 @@ public abstract class AbstractGeometryFieldMapper<Parsed, Processed> extends Fie
         }
 
         @Override
-        public final Query termQuery(Object value, QueryShardContext context) {
+        public final Query termQuery(Object value, SearchExecutionContext context) {
             throw new IllegalArgumentException("Geometry fields do not support exact searching, use dedicated geometry queries instead: ["
                     + name() + "]");
         }
 
         @Override
-        public final ValueFetcher valueFetcher(QueryShardContext context, String format) {
+        public final ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             String geoFormat = format != null ? format : GeoJsonGeometryFormat.NAME;
 
             Function<Object, Object> valueParser = value -> geometryParser.parseAndFormatObject(value, geoFormat);

--- a/server/src/main/java/org/elasticsearch/index/mapper/ArraySourceValueFetcher.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ArraySourceValueFetcher.java
@@ -20,7 +20,7 @@
 package org.elasticsearch.index.mapper;
 
 import org.elasticsearch.common.Nullable;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.lookup.SourceLookup;
 
 import java.util.ArrayList;
@@ -39,7 +39,7 @@ public abstract class ArraySourceValueFetcher implements ValueFetcher {
     private final Set<String> sourcePaths;
     private final @Nullable Object nullValue;
 
-    public ArraySourceValueFetcher(String fieldName, QueryShardContext context) {
+    public ArraySourceValueFetcher(String fieldName, SearchExecutionContext context) {
         this(fieldName, context, null);
     }
 
@@ -48,7 +48,7 @@ public abstract class ArraySourceValueFetcher implements ValueFetcher {
      * @param context The query shard context
      * @param nullValue A optional substitute value if the _source value is 'null'.
      */
-    public ArraySourceValueFetcher(String fieldName, QueryShardContext context, Object nullValue) {
+    public ArraySourceValueFetcher(String fieldName, SearchExecutionContext context, Object nullValue) {
         this.sourcePaths = context.sourcePath(fieldName);
         this.nullValue = nullValue;
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
@@ -31,7 +31,7 @@ import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.plain.BytesBinaryIndexFieldData;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.lookup.SearchLookup;
@@ -97,7 +97,7 @@ public class BinaryFieldMapper extends FieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             return SourceValueFetcher.identity(name(), context, format);
         }
 
@@ -132,7 +132,7 @@ public class BinaryFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query termQuery(Object value, QueryShardContext context) {
+        public Query termQuery(Object value, SearchExecutionContext context) {
             throw new IllegalArgumentException("Binary fields do not support searching");
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
@@ -35,7 +35,7 @@ import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData.NumericType;
 import org.elasticsearch.index.fielddata.plain.SortedNumericIndexFieldData;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.lookup.SearchLookup;
 
@@ -128,7 +128,7 @@ public class BooleanFieldMapper extends FieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             if (format != null) {
                 throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
             }
@@ -205,7 +205,7 @@ public class BooleanFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, QueryShardContext context) {
+        public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, SearchExecutionContext context) {
             failIfNotIndexed();
             return new TermRangeQuery(name(),
                 lowerTerm == null ? null : indexedValueForSearch(lowerTerm),

--- a/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
@@ -205,7 +205,8 @@ public class BooleanFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, SearchExecutionContext context) {
+        public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper,
+                                SearchExecutionContext context) {
             failIfNotIndexed();
             return new TermRangeQuery(name(),
                 lowerTerm == null ? null : indexedValueForSearch(lowerTerm),

--- a/server/src/main/java/org/elasticsearch/index/mapper/CompletionFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/CompletionFieldMapper.java
@@ -40,7 +40,7 @@ import org.elasticsearch.common.xcontent.XContentParser.NumberType;
 import org.elasticsearch.common.xcontent.XContentParser.Token;
 import org.elasticsearch.index.analysis.AnalyzerScope;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.suggest.completion.CompletionSuggester;
 import org.elasticsearch.search.suggest.completion.context.ContextMapping;
 import org.elasticsearch.search.suggest.completion.context.ContextMappings;
@@ -286,7 +286,7 @@ public class CompletionFieldMapper extends FieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             if (format != null) {
                 throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
             }

--- a/server/src/main/java/org/elasticsearch/index/mapper/ConstantFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ConstantFieldType.java
@@ -27,7 +27,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.regex.Regex;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 
 import java.util.List;
 import java.util.Map;
@@ -59,7 +59,7 @@ public abstract class ConstantFieldType extends MappedFieldType {
      * Return whether the constant value of this field matches the provided {@code pattern}
      * as documented in {@link Regex#simpleMatch}.
      */
-    protected abstract boolean matches(String pattern, boolean caseInsensitive, QueryShardContext context);
+    protected abstract boolean matches(String pattern, boolean caseInsensitive, SearchExecutionContext context);
 
     private static String valueToString(Object value) {
         return value instanceof BytesRef
@@ -68,7 +68,7 @@ public abstract class ConstantFieldType extends MappedFieldType {
     }
 
     @Override
-    public final Query termQuery(Object value, QueryShardContext context) {
+    public final Query termQuery(Object value, SearchExecutionContext context) {
         String pattern = valueToString(value);
         if (matches(pattern, false, context)) {
             return Queries.newMatchAllQuery();
@@ -78,7 +78,7 @@ public abstract class ConstantFieldType extends MappedFieldType {
     }
 
     @Override
-    public final Query termQueryCaseInsensitive(Object value, QueryShardContext context) {
+    public final Query termQueryCaseInsensitive(Object value, SearchExecutionContext context) {
         String pattern = valueToString(value);
         if (matches(pattern, true, context)) {
             return Queries.newMatchAllQuery();
@@ -88,7 +88,7 @@ public abstract class ConstantFieldType extends MappedFieldType {
     }
 
     @Override
-    public final Query termsQuery(List<?> values, QueryShardContext context) {
+    public final Query termsQuery(List<?> values, SearchExecutionContext context) {
         for (Object value : values) {
             String pattern = valueToString(value);
             if (matches(pattern, false, context)) {
@@ -103,7 +103,7 @@ public abstract class ConstantFieldType extends MappedFieldType {
     public final Query prefixQuery(String prefix,
                              @Nullable MultiTermQuery.RewriteMethod method,
                              boolean caseInsensitive,
-                             QueryShardContext context) {
+                             SearchExecutionContext context) {
         String pattern = prefix + "*";
         if (matches(pattern, caseInsensitive, context)) {
             return Queries.newMatchAllQuery();
@@ -116,7 +116,7 @@ public abstract class ConstantFieldType extends MappedFieldType {
     public final Query wildcardQuery(String value,
                                @Nullable MultiTermQuery.RewriteMethod method,
                                boolean caseInsensitive,
-                               QueryShardContext context) {
+                               SearchExecutionContext context) {
         if (matches(value, caseInsensitive, context)) {
             return Queries.newMatchAllQuery();
         } else {

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -44,7 +44,7 @@ import org.elasticsearch.index.fielddata.IndexNumericFieldData.NumericType;
 import org.elasticsearch.index.fielddata.plain.SortedNumericIndexFieldData;
 import org.elasticsearch.index.query.DateRangeIncludingNowQuery;
 import org.elasticsearch.index.query.QueryRewriteContext;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.lookup.SearchLookup;
 
@@ -355,7 +355,7 @@ public final class DateFieldMapper extends FieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             DateFormatter defaultFormatter = dateTimeFormatter();
             DateFormatter formatter = format != null
                 ? DateFormatter.forPattern(format).withLocale(defaultFormatter.locale())
@@ -373,13 +373,13 @@ public final class DateFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query termQuery(Object value, @Nullable QueryShardContext context) {
+        public Query termQuery(Object value, @Nullable SearchExecutionContext context) {
             return rangeQuery(value, value, true, true, ShapeRelation.INTERSECTS, null, null, context);
         }
 
         @Override
         public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, ShapeRelation relation,
-                                @Nullable ZoneId timeZone, @Nullable DateMathParser forcedDateParser, QueryShardContext context) {
+                                @Nullable ZoneId timeZone, @Nullable DateMathParser forcedDateParser, SearchExecutionContext context) {
             failIfNotIndexed();
             if (relation == ShapeRelation.DISJOINT) {
                 throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() +
@@ -417,7 +417,7 @@ public final class DateFieldMapper extends FieldMapper {
             boolean includeUpper,
             @Nullable ZoneId timeZone,
             DateMathParser parser,
-            QueryShardContext context,
+            SearchExecutionContext context,
             Resolution resolution,
             BiFunction<Long, Long, Query> builder
         ) {
@@ -449,7 +449,7 @@ public final class DateFieldMapper extends FieldMapper {
          * @param builder build the query
          * @return the result of the builder, wrapped in {@link DateRangeIncludingNowQuery} if {@code now} was used.
          */
-        public static Query handleNow(QueryShardContext context, Function<LongSupplier, Query> builder) {
+        public static Query handleNow(SearchExecutionContext context, Function<LongSupplier, Query> builder) {
             boolean[] nowUsed = new boolean[1];
             LongSupplier nowSupplier = () -> {
                 nowUsed[0] = true;
@@ -476,7 +476,7 @@ public final class DateFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query distanceFeatureQuery(Object origin, String pivot, QueryShardContext context) {
+        public Query distanceFeatureQuery(Object origin, String pivot, SearchExecutionContext context) {
             long originLong = parseToLong(origin, true, null, null, context::nowInMillis);
             TimeValue pivotTime = TimeValue.parseTimeValue(pivot, "distance_feature.pivot");
             // As we already apply boost in AbstractQueryBuilder::toQuery, we always passing a boost of 1.0 to distanceFeatureQuery

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocCountFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocCountFieldMapper.java
@@ -21,7 +21,7 @@ package org.elasticsearch.index.mapper;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentParserUtils;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.QueryShardException;
 
 import java.io.IOException;
@@ -56,17 +56,17 @@ public class DocCountFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
-        public Query existsQuery(QueryShardContext context) {
+        public Query existsQuery(SearchExecutionContext context) {
             throw new QueryShardException(context, "Field [" + name() + "] of type [" + typeName() + "] does not support exists queries");
         }
 
         @Override
-        public Query termQuery(Object value, QueryShardContext context) {
+        public Query termQuery(Object value, SearchExecutionContext context) {
             throw new QueryShardException(context, "Field [" + name() + "] of type [" + typeName() + "] is not searchable");
         }
 
         @Override
-        public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             if (format != null) {
                 throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
             }

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -40,7 +40,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 
 /** A parser for documents, given mappings from a DocumentMapper */
 final class DocumentParser {
@@ -825,7 +825,7 @@ final class DocumentParser {
         NoOpFieldMapper(String simpleName, RuntimeFieldType runtimeField) {
             super(simpleName, new MappedFieldType(runtimeField.name(), false, false, false, TextSearchInfo.NONE, Collections.emptyMap()) {
                 @Override
-                public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+                public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
                     throw new UnsupportedOperationException();
                 }
 
@@ -835,7 +835,7 @@ final class DocumentParser {
                 }
 
                 @Override
-                public Query termQuery(Object value, QueryShardContext context) {
+                public Query termQuery(Object value, SearchExecutionContext context) {
                     throw new UnsupportedOperationException();
                 }
             }, MultiFields.empty(), CopyTo.empty());

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldNamesFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldNamesFieldMapper.java
@@ -25,7 +25,7 @@ import org.apache.lucene.search.Query;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.Explicit;
 import org.elasticsearch.common.logging.DeprecationLogger;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 
 import java.util.Collections;
 import java.util.Iterator;
@@ -130,17 +130,17 @@ public class FieldNamesFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             throw new UnsupportedOperationException("Cannot fetch values for internal field [" + name() + "].");
         }
 
         @Override
-        public Query existsQuery(QueryShardContext context) {
+        public Query existsQuery(SearchExecutionContext context) {
             throw new UnsupportedOperationException("Cannot run exists query on _field_names");
         }
 
         @Override
-        public Query termQuery(Object value, QueryShardContext context) {
+        public Query termQuery(Object value, SearchExecutionContext context) {
             if (isEnabled() == false) {
                 throw new IllegalStateException("Cannot run [exists] queries if the [_field_names] field is disabled");
             }

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
@@ -34,7 +34,7 @@ import org.elasticsearch.geometry.Point;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.plain.AbstractLatLonPointIndexFieldData;
 import org.elasticsearch.index.mapper.GeoPointFieldMapper.ParsedGeoPoint;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.VectorGeoPointShapeQueryProcessor;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.lookup.SearchLookup;
@@ -203,7 +203,7 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<List<P
         }
 
         @Override
-        public Query geoShapeQuery(Geometry shape, String fieldName, ShapeRelation relation, QueryShardContext context) {
+        public Query geoShapeQuery(Geometry shape, String fieldName, ShapeRelation relation, SearchExecutionContext context) {
             return queryProcessor.geoShapeQuery(shape, fieldName, relation, context);
         }
 
@@ -214,7 +214,7 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<List<P
         }
 
         @Override
-        public Query distanceFeatureQuery(Object origin, String pivot, QueryShardContext context) {
+        public Query distanceFeatureQuery(Object origin, String pivot, SearchExecutionContext context) {
             GeoPoint originGeoPoint;
             if (origin instanceof GeoPoint) {
                 originGeoPoint = (GeoPoint) origin;

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeFieldMapper.java
@@ -26,7 +26,7 @@ import org.elasticsearch.common.geo.GeometryParser;
 import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.geo.builders.ShapeBuilder.Orientation;
 import org.elasticsearch.geometry.Geometry;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.VectorGeoShapeQueryProcessor;
 
 import java.util.Arrays;
@@ -123,7 +123,7 @@ public class GeoShapeFieldMapper extends AbstractShapeGeometryFieldMapper<Geomet
         }
 
         @Override
-        public Query geoShapeQuery(Geometry shape, String fieldName, ShapeRelation relation, QueryShardContext context) {
+        public Query geoShapeQuery(Geometry shape, String fieldName, ShapeRelation relation, SearchExecutionContext context) {
             return queryProcessor.geoShapeQuery(shape, fieldName, relation, context);
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeQueryable.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeQueryable.java
@@ -23,7 +23,7 @@ import org.apache.lucene.search.Query;
 import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.geo.SpatialStrategy;
 import org.elasticsearch.geometry.Geometry;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 
 /**
  * Implemented by {@link org.elasticsearch.index.mapper.MappedFieldType} that support
@@ -31,11 +31,11 @@ import org.elasticsearch.index.query.QueryShardContext;
  */
 public interface GeoShapeQueryable {
 
-    Query geoShapeQuery(Geometry shape, String fieldName, ShapeRelation relation, QueryShardContext context);
+    Query geoShapeQuery(Geometry shape, String fieldName, ShapeRelation relation, SearchExecutionContext context);
 
     @Deprecated
     default Query geoShapeQuery(Geometry shape, String fieldName, SpatialStrategy strategy, ShapeRelation relation,
-                          QueryShardContext context) {
+                          SearchExecutionContext context) {
         return geoShapeQuery(shape, fieldName, relation, context);
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/IdFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IdFieldMapper.java
@@ -39,7 +39,7 @@ import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.index.fielddata.fieldcomparator.BytesRefFieldComparatorSource;
 import org.elasticsearch.index.fielddata.plain.PagedBytesIndexFieldData;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.search.DocValueFormat;
@@ -118,22 +118,22 @@ public class IdFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             throw new UnsupportedOperationException("Cannot fetch values for internal field [" + name() + "].");
         }
 
         @Override
-        public Query termQuery(Object value, QueryShardContext context) {
+        public Query termQuery(Object value, SearchExecutionContext context) {
             return termsQuery(Arrays.asList(value), context);
         }
 
         @Override
-        public Query existsQuery(QueryShardContext context) {
+        public Query existsQuery(SearchExecutionContext context) {
             return new MatchAllDocsQuery();
         }
 
         @Override
-        public Query termsQuery(List<?> values, QueryShardContext context) {
+        public Query termsQuery(List<?> values, SearchExecutionContext context) {
             failIfNotIndexed();
             BytesRef[] bytesRefs = new BytesRef[values.size()];
             for (int i = 0; i < bytesRefs.length; i++) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/IgnoredFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IgnoredFieldMapper.java
@@ -24,7 +24,7 @@ import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermRangeQuery;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 
 import java.util.Collections;
 
@@ -67,7 +67,7 @@ public final class IgnoredFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
-        public Query existsQuery(QueryShardContext context) {
+        public Query existsQuery(SearchExecutionContext context) {
             // This query is not performance sensitive, it only helps assess
             // quality of the data, so we may use a slow query. It shouldn't
             // be too slow in practice since the number of unique terms in this
@@ -76,7 +76,7 @@ public final class IgnoredFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             throw new UnsupportedOperationException("Cannot fetch values for internal field [" + name() + "].");
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/IndexFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IndexFieldMapper.java
@@ -24,7 +24,7 @@ import org.apache.lucene.search.Query;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.plain.ConstantIndexFieldData;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.lookup.SearchLookup;
 
@@ -53,7 +53,7 @@ public class IndexFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
-        protected boolean matches(String pattern, boolean caseInsensitive, QueryShardContext context) {
+        protected boolean matches(String pattern, boolean caseInsensitive, SearchExecutionContext context) {
             if (caseInsensitive) {
                 // Thankfully, all index names are lower-cased so we don't have to pass a case_insensitive mode flag
                 // down to all the index name-matching logic. We just lower-case the search string
@@ -63,7 +63,7 @@ public class IndexFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
-        public Query existsQuery(QueryShardContext context) {
+        public Query existsQuery(SearchExecutionContext context) {
             return new MatchAllDocsQuery();
         }
 
@@ -73,7 +73,7 @@ public class IndexFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             throw new UnsupportedOperationException("Cannot fetch values for internal field [" + name() + "].");
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -220,7 +220,8 @@ public class IpFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, SearchExecutionContext context) {
+        public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper,
+                                SearchExecutionContext context) {
             failIfNotIndexed();
             return rangeQuery(
                 lowerTerm,

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -35,7 +35,7 @@ import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.index.fielddata.plain.SortedSetOrdinalsIndexFieldData;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.lookup.SearchLookup;
@@ -158,7 +158,7 @@ public class IpFieldMapper extends FieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             if (format != null) {
                 throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
             }
@@ -177,7 +177,7 @@ public class IpFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query termQuery(Object value, @Nullable QueryShardContext context) {
+        public Query termQuery(Object value, @Nullable SearchExecutionContext context) {
             failIfNotIndexed();
             if (value instanceof InetAddress) {
                 return InetAddressPoint.newExactQuery(name(), (InetAddress) value);
@@ -196,7 +196,7 @@ public class IpFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query termsQuery(List<?> values, QueryShardContext context) {
+        public Query termsQuery(List<?> values, SearchExecutionContext context) {
             InetAddress[] addresses = new InetAddress[values.size()];
             int i = 0;
             for (Object value : values) {
@@ -220,7 +220,7 @@ public class IpFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, QueryShardContext context) {
+        public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, SearchExecutionContext context) {
             failIfNotIndexed();
             return rangeQuery(
                 lowerTerm,

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -32,7 +32,7 @@ import org.elasticsearch.index.analysis.IndexAnalyzers;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.plain.SortedSetOrdinalsIndexFieldData;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.similarity.SimilarityProvider;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.lookup.SearchLookup;
@@ -239,7 +239,7 @@ public final class KeywordFieldMapper extends FieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             if (format != null) {
                 throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
             }

--- a/server/src/main/java/org/elasticsearch/index/mapper/LegacyGeoShapeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/LegacyGeoShapeFieldMapper.java
@@ -44,7 +44,7 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.index.query.LegacyGeoShapeQueryProcessor;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.locationtech.spatial4j.shape.Shape;
 
 import java.io.IOException;
@@ -365,13 +365,13 @@ public class LegacyGeoShapeFieldMapper extends AbstractShapeGeometryFieldMapper<
         }
 
         @Override
-        public Query geoShapeQuery(Geometry shape, String fieldName, ShapeRelation relation, QueryShardContext context) {
+        public Query geoShapeQuery(Geometry shape, String fieldName, ShapeRelation relation, SearchExecutionContext context) {
             throw new UnsupportedOperationException("process method should not be called for PrefixTree based geo_shapes");
         }
 
         @Override
         public Query geoShapeQuery(Geometry shape, String fieldName, SpatialStrategy strategy, ShapeRelation relation,
-                            QueryShardContext context) {
+                            SearchExecutionContext context) {
             return queryProcessor.geoShapeQuery(shape, fieldName, strategy, relation, context);
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
@@ -129,7 +129,7 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
                 return indexVersionCreated;
             }
 
-            public Supplier<SearchExecutionContext> searchExecutionContextSupplier() {
+            public Supplier<SearchExecutionContext> searchExecutionContext() {
                 return searchExecutionContextSupplier;
             }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
@@ -25,7 +25,7 @@ import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.analysis.IndexAnalyzers;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.similarity.SimilarityProvider;
 import org.elasticsearch.script.ScriptService;
 
@@ -62,7 +62,7 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
             private final Function<String, RuntimeFieldType.Parser> runtimeTypeParsers;
             private final boolean supportsDynamicRuntimeMappings;
             private final Version indexVersionCreated;
-            private final Supplier<QueryShardContext> queryShardContextSupplier;
+            private final Supplier<SearchExecutionContext> searchExecutionContextSupplier;
             private final DateFormatter dateFormatter;
             private final ScriptService scriptService;
             private final IndexAnalyzers indexAnalyzers;
@@ -73,7 +73,7 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
                                  Function<String, TypeParser> typeParsers,
                                  Function<String, RuntimeFieldType.Parser> runtimeTypeParsers,
                                  Version indexVersionCreated,
-                                 Supplier<QueryShardContext> queryShardContextSupplier,
+                                 Supplier<SearchExecutionContext> searchExecutionContextSupplier,
                                  DateFormatter dateFormatter,
                                  ScriptService scriptService,
                                  IndexAnalyzers indexAnalyzers,
@@ -84,7 +84,7 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
                 this.typeParsers = typeParsers;
                 this.runtimeTypeParsers = runtimeTypeParsers;
                 this.indexVersionCreated = indexVersionCreated;
-                this.queryShardContextSupplier = queryShardContextSupplier;
+                this.searchExecutionContextSupplier = searchExecutionContextSupplier;
                 this.dateFormatter = dateFormatter;
                 this.scriptService = scriptService;
                 this.indexAnalyzers = indexAnalyzers;
@@ -129,8 +129,8 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
                 return indexVersionCreated;
             }
 
-            public Supplier<QueryShardContext> queryShardContextSupplier() {
-                return queryShardContextSupplier;
+            public Supplier<SearchExecutionContext> searchExecutionContextSupplier() {
+                return searchExecutionContextSupplier;
             }
 
             /**
@@ -160,7 +160,7 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
             static class MultiFieldParserContext extends ParserContext {
                 MultiFieldParserContext(ParserContext in) {
                     super(in.similarityLookupService, in.typeParsers, in.runtimeTypeParsers, in.indexVersionCreated,
-                        in.queryShardContextSupplier, in.dateFormatter, in.scriptService, in.indexAnalyzers, in.indexSettings,
+                        in.searchExecutionContextSupplier, in.dateFormatter, in.scriptService, in.indexAnalyzers, in.indexSettings,
                         in.idFieldDataEnabled, in.supportsDynamicRuntimeMappings);
                 }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -44,7 +44,7 @@ import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.analysis.ReloadableCustomAnalyzer;
 import org.elasticsearch.index.analysis.TokenFilterFactory;
 import org.elasticsearch.index.analysis.TokenizerFactory;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.similarity.SimilarityService;
 import org.elasticsearch.indices.IndicesModule;
 import org.elasticsearch.indices.mapper.MapperRegistry;
@@ -112,7 +112,7 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
 
     public MapperService(IndexSettings indexSettings, IndexAnalyzers indexAnalyzers, NamedXContentRegistry xContentRegistry,
                          SimilarityService similarityService, MapperRegistry mapperRegistry,
-                         Supplier<QueryShardContext> queryShardContextSupplier, BooleanSupplier idFieldDataEnabled,
+                         Supplier<SearchExecutionContext> searchExecutionContextSupplier, BooleanSupplier idFieldDataEnabled,
                          ScriptService scriptService) {
         super(indexSettings);
         this.indexVersionCreated = indexSettings.getIndexVersionCreated();
@@ -120,7 +120,7 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
         this.mapperRegistry = mapperRegistry;
         Function<DateFormatter, Mapper.TypeParser.ParserContext> parserContextFunction =
             dateFormatter -> new Mapper.TypeParser.ParserContext(similarityService::getSimilarity, mapperRegistry.getMapperParsers()::get,
-                mapperRegistry.getRuntimeFieldTypeParsers()::get, indexVersionCreated, queryShardContextSupplier, dateFormatter,
+                mapperRegistry.getRuntimeFieldTypeParsers()::get, indexVersionCreated, searchExecutionContextSupplier, dateFormatter,
                 scriptService, indexAnalyzers, indexSettings, idFieldDataEnabled, mapperRegistry.getDynamicRuntimeFieldsBuilder() != null);
         this.documentParser = new DocumentParser(xContentRegistry, parserContextFunction, mapperRegistry.getDynamicRuntimeFieldsBuilder());
         Map<String, MetadataFieldMapper.TypeParser> metadataMapperParsers =

--- a/server/src/main/java/org/elasticsearch/index/mapper/NestedPathFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NestedPathFieldMapper.java
@@ -27,7 +27,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.Version;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 
 import java.util.Collections;
 
@@ -78,12 +78,12 @@ public class NestedPathFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
-        public Query existsQuery(QueryShardContext context) {
+        public Query existsQuery(SearchExecutionContext context) {
             throw new UnsupportedOperationException("Cannot run exists() query against the nested field path");
         }
 
         @Override
-        public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             throw new UnsupportedOperationException("Cannot fetch values for internal field [" + name() + "].");
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -46,7 +46,7 @@ import org.elasticsearch.common.xcontent.XContentParser.Token;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData.NumericType;
 import org.elasticsearch.index.fielddata.plain.SortedNumericIndexFieldData;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.lookup.SearchLookup;
 
@@ -178,7 +178,7 @@ public class NumberFieldMapper extends FieldMapper {
             @Override
             public Query rangeQuery(String field, Object lowerTerm, Object upperTerm,
                                     boolean includeLower, boolean includeUpper,
-                                    boolean hasDocValues, QueryShardContext context) {
+                                    boolean hasDocValues, SearchExecutionContext context) {
                 float l = Float.NEGATIVE_INFINITY;
                 float u = Float.POSITIVE_INFINITY;
                 if (lowerTerm != null) {
@@ -275,7 +275,7 @@ public class NumberFieldMapper extends FieldMapper {
             @Override
             public Query rangeQuery(String field, Object lowerTerm, Object upperTerm,
                                     boolean includeLower, boolean includeUpper,
-                                    boolean hasDocValues, QueryShardContext context) {
+                                    boolean hasDocValues, SearchExecutionContext context) {
                 float l = Float.NEGATIVE_INFINITY;
                 float u = Float.POSITIVE_INFINITY;
                 if (lowerTerm != null) {
@@ -361,7 +361,7 @@ public class NumberFieldMapper extends FieldMapper {
             @Override
             public Query rangeQuery(String field, Object lowerTerm, Object upperTerm,
                                     boolean includeLower, boolean includeUpper,
-                                    boolean hasDocValues, QueryShardContext context) {
+                                    boolean hasDocValues, SearchExecutionContext context) {
                 return doubleRangeQuery(lowerTerm, upperTerm, includeLower, includeUpper, (l, u) -> {
                     Query query = DoublePoint.newRangeQuery(field, l, u);
                     if (hasDocValues) {
@@ -443,7 +443,7 @@ public class NumberFieldMapper extends FieldMapper {
             @Override
             public Query rangeQuery(String field, Object lowerTerm, Object upperTerm,
                                     boolean includeLower, boolean includeUpper,
-                                    boolean hasDocValues, QueryShardContext context) {
+                                    boolean hasDocValues, SearchExecutionContext context) {
                 return INTEGER.rangeQuery(field, lowerTerm, upperTerm, includeLower, includeUpper, hasDocValues, context);
             }
 
@@ -500,7 +500,7 @@ public class NumberFieldMapper extends FieldMapper {
             @Override
             public Query rangeQuery(String field, Object lowerTerm, Object upperTerm,
                                     boolean includeLower, boolean includeUpper,
-                                    boolean hasDocValues, QueryShardContext context) {
+                                    boolean hasDocValues, SearchExecutionContext context) {
                 return INTEGER.rangeQuery(field, lowerTerm, upperTerm, includeLower, includeUpper, hasDocValues, context);
             }
 
@@ -576,7 +576,7 @@ public class NumberFieldMapper extends FieldMapper {
             @Override
             public Query rangeQuery(String field, Object lowerTerm, Object upperTerm,
                                     boolean includeLower, boolean includeUpper,
-                                    boolean hasDocValues, QueryShardContext context) {
+                                    boolean hasDocValues, SearchExecutionContext context) {
                 int l = Integer.MIN_VALUE;
                 int u = Integer.MAX_VALUE;
                 if (lowerTerm != null) {
@@ -681,7 +681,7 @@ public class NumberFieldMapper extends FieldMapper {
             @Override
             public Query rangeQuery(String field, Object lowerTerm, Object upperTerm,
                                     boolean includeLower, boolean includeUpper,
-                                    boolean hasDocValues, QueryShardContext context) {
+                                    boolean hasDocValues, SearchExecutionContext context) {
                 return longRangeQuery(lowerTerm, upperTerm, includeLower, includeUpper, (l, u) -> {
                     Query query = LongPoint.newRangeQuery(field, l, u);
                     if (hasDocValues) {
@@ -737,7 +737,7 @@ public class NumberFieldMapper extends FieldMapper {
         public abstract Query termsQuery(String field, List<?> values);
         public abstract Query rangeQuery(String field, Object lowerTerm, Object upperTerm,
                                          boolean includeLower, boolean includeUpper,
-                                         boolean hasDocValues, QueryShardContext context);
+                                         boolean hasDocValues, SearchExecutionContext context);
         public abstract Number parse(XContentParser parser, boolean coerce) throws IOException;
         public abstract Number parse(Object value, boolean coerce);
         public abstract Number parsePoint(byte[] value);
@@ -918,19 +918,19 @@ public class NumberFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query termQuery(Object value, QueryShardContext context) {
+        public Query termQuery(Object value, SearchExecutionContext context) {
             failIfNotIndexed();
             return type.termQuery(name(), value);
         }
 
         @Override
-        public Query termsQuery(List<?> values, QueryShardContext context) {
+        public Query termsQuery(List<?> values, SearchExecutionContext context) {
             failIfNotIndexed();
             return type.termsQuery(name(), values);
         }
 
         @Override
-        public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, QueryShardContext context) {
+        public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, SearchExecutionContext context) {
             failIfNotIndexed();
             return type.rangeQuery(name(), lowerTerm, upperTerm, includeLower, includeUpper, hasDocValues(), context);
         }
@@ -958,7 +958,7 @@ public class NumberFieldMapper extends FieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             if (format != null) {
                 throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
             }

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -930,7 +930,8 @@ public class NumberFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, SearchExecutionContext context) {
+        public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper,
+                                SearchExecutionContext context) {
             failIfNotIndexed();
             return type.rangeQuery(name(), lowerTerm, upperTerm, includeLower, includeUpper, hasDocValues(), context);
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/RangeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RangeFieldMapper.java
@@ -34,7 +34,7 @@ import org.elasticsearch.common.util.LocaleUtils;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.plain.BinaryIndexFieldData;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.lookup.SearchLookup;
@@ -186,7 +186,7 @@ public class RangeFieldMapper extends FieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             DateFormatter defaultFormatter = dateTimeFormatter();
             DateFormatter formatter = format != null
                 ? DateFormatter.forPattern(format).withLocale(defaultFormatter.locale())
@@ -247,13 +247,13 @@ public class RangeFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query termQuery(Object value, QueryShardContext context) {
+        public Query termQuery(Object value, SearchExecutionContext context) {
             return rangeQuery(value, value, true, true, ShapeRelation.INTERSECTS, null, null, context);
         }
 
         @Override
         public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper,
-                                ShapeRelation relation, ZoneId timeZone, DateMathParser parser, QueryShardContext context) {
+                                ShapeRelation relation, ZoneId timeZone, DateMathParser parser, SearchExecutionContext context) {
             failIfNotIndexed();
             if (parser == null) {
                 parser = dateMathParser();

--- a/server/src/main/java/org/elasticsearch/index/mapper/RangeType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RangeType.java
@@ -39,7 +39,7 @@ import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.time.DateMathParser;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -249,7 +249,7 @@ public enum RangeType {
         @Override
         public Query rangeQuery(String field, boolean hasDocValues, Object lowerTerm, Object upperTerm, boolean includeLower,
                                 boolean includeUpper, ShapeRelation relation, @Nullable ZoneId timeZone,
-                                @Nullable DateMathParser parser, QueryShardContext context) {
+                                @Nullable DateMathParser parser, SearchExecutionContext context) {
             ZoneId zone = (timeZone == null) ? ZoneOffset.UTC : timeZone;
 
             DateMathParser dateMathParser = (parser == null) ?
@@ -653,7 +653,7 @@ public enum RangeType {
 
     public Query rangeQuery(String field, boolean hasDocValues, Object from, Object to, boolean includeFrom, boolean includeTo,
                             ShapeRelation relation, @Nullable ZoneId timeZone, @Nullable DateMathParser dateMathParser,
-                            QueryShardContext context) {
+                            SearchExecutionContext context) {
         Object lower = from == null ? minValue() : parseValue(from, false, dateMathParser);
         Object upper = to == null ? maxValue() : parseValue(to, false, dateMathParser);
         return createRangeQuery(field, hasDocValues, lower, upper, includeFrom, includeTo, relation);

--- a/server/src/main/java/org/elasticsearch/index/mapper/RoutingFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RoutingFieldMapper.java
@@ -23,7 +23,7 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.IndexOptions;
 import org.elasticsearch.common.lucene.Lucene;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 
 import java.util.Collections;
 import java.util.List;
@@ -94,7 +94,7 @@ public class RoutingFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             throw new UnsupportedOperationException("Cannot fetch values for internal field [" + name() + "].");
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/SeqNoFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SeqNoFieldMapper.java
@@ -30,7 +30,7 @@ import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData.NumericType;
 import org.elasticsearch.index.fielddata.plain.SortedNumericIndexFieldData;
 import org.elasticsearch.index.mapper.ParseContext.Document;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.seqno.SequenceNumbers;
 import org.elasticsearch.search.lookup.SearchLookup;
 
@@ -122,18 +122,18 @@ public class SeqNoFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             throw new UnsupportedOperationException("Cannot fetch values for internal field [" + name() + "].");
         }
 
         @Override
-        public Query termQuery(Object value, @Nullable QueryShardContext context) {
+        public Query termQuery(Object value, @Nullable SearchExecutionContext context) {
             long v = parse(value);
             return LongPoint.newExactQuery(name(), v);
         }
 
         @Override
-        public Query termsQuery(List<?> values, @Nullable QueryShardContext context) {
+        public Query termsQuery(List<?> values, @Nullable SearchExecutionContext context) {
             long[] v = new long[values.size()];
             for (int i = 0; i < values.size(); ++i) {
                 v[i] = parse(values.get(i));
@@ -143,7 +143,7 @@ public class SeqNoFieldMapper extends MetadataFieldMapper {
 
         @Override
         public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower,
-                                boolean includeUpper, QueryShardContext context) {
+                                boolean includeUpper, SearchExecutionContext context) {
             long l = Long.MIN_VALUE;
             long u = Long.MAX_VALUE;
             if (lowerTerm != null) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/SimpleMappedFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SimpleMappedFieldType.java
@@ -22,7 +22,7 @@ package org.elasticsearch.index.mapper;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.time.DateMathParser;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 
 import java.time.ZoneId;
 import java.util.Map;
@@ -39,7 +39,7 @@ public abstract class SimpleMappedFieldType extends MappedFieldType {
 
     @Override
     public final Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper,
-                                  ShapeRelation relation, ZoneId timeZone, DateMathParser parser, QueryShardContext context) {
+                                  ShapeRelation relation, ZoneId timeZone, DateMathParser parser, SearchExecutionContext context) {
         if (relation == ShapeRelation.DISJOINT) {
             throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() +
                     "] does not support DISJOINT ranges");
@@ -51,11 +51,11 @@ public abstract class SimpleMappedFieldType extends MappedFieldType {
     }
 
     /**
-     * Same as {@link #rangeQuery(Object, Object, boolean, boolean, ShapeRelation, ZoneId, DateMathParser, QueryShardContext)}
+     * Same as {@link #rangeQuery(Object, Object, boolean, boolean, ShapeRelation, ZoneId, DateMathParser, SearchExecutionContext)}
      * but without the trouble of relations or date-specific options.
      */
     protected Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper,
-            QueryShardContext context) {
+            SearchExecutionContext context) {
         throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] does not support range queries");
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
@@ -36,7 +36,7 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.QueryShardException;
 
 import java.io.IOException;
@@ -111,17 +111,17 @@ public class SourceFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             throw new UnsupportedOperationException("Cannot fetch values for internal field [" + name() + "].");
         }
 
         @Override
-        public Query existsQuery(QueryShardContext context) {
+        public Query existsQuery(SearchExecutionContext context) {
             throw new QueryShardException(context, "The _source field is not searchable");
         }
 
         @Override
-        public Query termQuery(Object value, QueryShardContext context) {
+        public Query termQuery(Object value, SearchExecutionContext context) {
             throw new QueryShardException(context, "The _source field is not searchable");
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceValueFetcher.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceValueFetcher.java
@@ -20,7 +20,7 @@
 package org.elasticsearch.index.mapper;
 
 import org.elasticsearch.common.Nullable;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.lookup.SourceLookup;
 
 import java.util.ArrayDeque;
@@ -40,7 +40,7 @@ public abstract class SourceValueFetcher implements ValueFetcher {
     private final Set<String> sourcePaths;
     private final @Nullable Object nullValue;
 
-    public SourceValueFetcher(String fieldName, QueryShardContext context) {
+    public SourceValueFetcher(String fieldName, SearchExecutionContext context) {
         this(fieldName, context, null);
     }
 
@@ -49,7 +49,7 @@ public abstract class SourceValueFetcher implements ValueFetcher {
      * @param context The query shard context
      * @param nullValue A optional substitute value if the _source value is 'null'.
      */
-    public SourceValueFetcher(String fieldName, QueryShardContext context, Object nullValue) {
+    public SourceValueFetcher(String fieldName, SearchExecutionContext context, Object nullValue) {
         this.sourcePaths = context.sourcePath(fieldName);
         this.nullValue = nullValue;
     }
@@ -92,7 +92,7 @@ public abstract class SourceValueFetcher implements ValueFetcher {
     /**
      * Creates a {@link SourceValueFetcher} that passes through source values unmodified.
      */
-    public static SourceValueFetcher identity(String fieldName, QueryShardContext context, String format) {
+    public static SourceValueFetcher identity(String fieldName, SearchExecutionContext context, String format) {
         if (format != null) {
             throw new IllegalArgumentException("Field [" + fieldName + "] doesn't support formats.");
         }
@@ -107,7 +107,7 @@ public abstract class SourceValueFetcher implements ValueFetcher {
     /**
      * Creates a {@link SourceValueFetcher} that converts source values to strings.
      */
-    public static SourceValueFetcher toString(String fieldName, QueryShardContext context, String format) {
+    public static SourceValueFetcher toString(String fieldName, SearchExecutionContext context, String format) {
         if (format != null) {
             throw new IllegalArgumentException("Field [" + fieldName + "] doesn't support formats.");
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/StringFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/StringFieldType.java
@@ -35,7 +35,7 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.lucene.search.AutomatonQueries;
 import org.elasticsearch.common.unit.Fuzziness;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.support.QueryParsers;
 
 import java.util.Map;
@@ -59,7 +59,7 @@ public abstract class StringFieldType extends TermBasedFieldType {
 
     @Override
     public Query fuzzyQuery(Object value, Fuzziness fuzziness, int prefixLength, int maxExpansions,
-            boolean transpositions, QueryShardContext context) {
+            boolean transpositions, SearchExecutionContext context) {
         if (context.allowExpensiveQueries() == false) {
             throw new ElasticsearchException("[fuzzy] queries cannot be executed when '" +
                     ALLOW_EXPENSIVE_QUERIES.getKey() + "' is set to false.");
@@ -70,7 +70,7 @@ public abstract class StringFieldType extends TermBasedFieldType {
     }
 
     @Override
-    public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive, QueryShardContext context) {
+    public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive, SearchExecutionContext context) {
         if (context.allowExpensiveQueries() == false) {
             throw new ElasticsearchException("[prefix] queries cannot be executed when '" +
                     ALLOW_EXPENSIVE_QUERIES.getKey() + "' is set to false. For optimised prefix queries on text " +
@@ -123,7 +123,7 @@ public abstract class StringFieldType extends TermBasedFieldType {
     }
 
     @Override
-    public Query wildcardQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive, QueryShardContext context) {
+    public Query wildcardQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive, SearchExecutionContext context) {
         failIfNotIndexed();
         if (context.allowExpensiveQueries() == false) {
             throw new ElasticsearchException("[wildcard] queries cannot be executed when '" +
@@ -149,7 +149,7 @@ public abstract class StringFieldType extends TermBasedFieldType {
 
     @Override
     public Query regexpQuery(String value, int syntaxFlags, int matchFlags, int maxDeterminizedStates,
-            MultiTermQuery.RewriteMethod method, QueryShardContext context) {
+            MultiTermQuery.RewriteMethod method, SearchExecutionContext context) {
         if (context.allowExpensiveQueries() == false) {
             throw new ElasticsearchException("[regexp] queries cannot be executed when '" +
                     ALLOW_EXPENSIVE_QUERIES.getKey() + "' is set to false.");
@@ -164,7 +164,7 @@ public abstract class StringFieldType extends TermBasedFieldType {
     }
 
     @Override
-    public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, QueryShardContext context) {
+    public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, SearchExecutionContext context) {
         if (context.allowExpensiveQueries() == false) {
             throw new ElasticsearchException("[range] queries on [text] or [keyword] fields cannot be executed when '" +
                     ALLOW_EXPENSIVE_QUERIES.getKey() + "' is set to false.");

--- a/server/src/main/java/org/elasticsearch/index/mapper/StringFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/StringFieldType.java
@@ -164,7 +164,8 @@ public abstract class StringFieldType extends TermBasedFieldType {
     }
 
     @Override
-    public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, SearchExecutionContext context) {
+    public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper,
+                            SearchExecutionContext context) {
         if (context.allowExpensiveQueries() == false) {
             throw new ElasticsearchException("[range] queries on [text] or [keyword] fields cannot be executed when '" +
                     ALLOW_EXPENSIVE_QUERIES.getKey() + "' is set to false.");

--- a/server/src/main/java/org/elasticsearch/index/mapper/TermBasedFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TermBasedFieldType.java
@@ -26,7 +26,7 @@ import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.lucene.search.AutomatonQueries;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 
 import java.util.List;
 import java.util.Map;
@@ -48,19 +48,19 @@ public abstract class TermBasedFieldType extends SimpleMappedFieldType {
     }
 
     @Override
-    public Query termQueryCaseInsensitive(Object value, QueryShardContext context) {
+    public Query termQueryCaseInsensitive(Object value, SearchExecutionContext context) {
         failIfNotIndexed();
         return AutomatonQueries.caseInsensitiveTermQuery(new Term(name(), indexedValueForSearch(value)));
     }
 
     @Override
-    public Query termQuery(Object value, QueryShardContext context) {
+    public Query termQuery(Object value, SearchExecutionContext context) {
         failIfNotIndexed();
         return new TermQuery(new Term(name(), indexedValueForSearch(value)));
     }
 
     @Override
-    public Query termsQuery(List<?> values, QueryShardContext context) {
+    public Query termsQuery(List<?> values, SearchExecutionContext context) {
         failIfNotIndexed();
         BytesRef[] bytesRefs = new BytesRef[values.size()];
         for (int i = 0; i < bytesRefs.length; i++) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -70,7 +70,7 @@ import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.plain.PagedBytesIndexFieldData;
 import org.elasticsearch.index.mapper.Mapper.TypeParser.ParserContext;
 import org.elasticsearch.index.query.IntervalBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.similarity.SimilarityProvider;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.lookup.SearchLookup;
@@ -497,7 +497,7 @@ public class TextFieldMapper extends FieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             throw new UnsupportedOperationException();
         }
 
@@ -506,7 +506,7 @@ public class TextFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive, QueryShardContext context) {
+        public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive, SearchExecutionContext context) {
             if (value.length() >= minChars) {
                 if (caseInsensitive) {
                     return super.termQueryCaseInsensitive(value, context);
@@ -557,7 +557,7 @@ public class TextFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query existsQuery(QueryShardContext context) {
+        public Query existsQuery(SearchExecutionContext context) {
             throw new UnsupportedOperationException();
         }
     }
@@ -643,12 +643,12 @@ public class TextFieldMapper extends FieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             return SourceValueFetcher.toString(name(), context, format);
         }
 
         @Override
-        public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive, QueryShardContext context) {
+        public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive, SearchExecutionContext context) {
             if (prefixFieldType == null || prefixFieldType.accept(value.length()) == false) {
                 return super.prefixQuery(value, method, caseInsensitive,context);
             }
@@ -661,7 +661,7 @@ public class TextFieldMapper extends FieldMapper {
         }
 
         @Override
-        public SpanQuery spanPrefixQuery(String value, SpanMultiTermQueryWrapper.SpanRewriteMethod method, QueryShardContext context) {
+        public SpanQuery spanPrefixQuery(String value, SpanMultiTermQueryWrapper.SpanRewriteMethod method, SearchExecutionContext context) {
             failIfNotIndexed();
             if (prefixFieldType != null
                     && value.length() >= prefixFieldType.minChars

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -506,7 +506,8 @@ public class TextFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive, SearchExecutionContext context) {
+        public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive,
+                                 SearchExecutionContext context) {
             if (value.length() >= minChars) {
                 if (caseInsensitive) {
                     return super.termQueryCaseInsensitive(value, context);
@@ -648,7 +649,8 @@ public class TextFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive, SearchExecutionContext context) {
+        public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive,
+                                 SearchExecutionContext context) {
             if (prefixFieldType == null || prefixFieldType.accept(value.length()) == false) {
                 return super.prefixQuery(value, method, caseInsensitive,context);
             }

--- a/server/src/main/java/org/elasticsearch/index/mapper/TypeFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TypeFieldType.java
@@ -24,7 +24,7 @@ import org.apache.lucene.search.Query;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.plain.ConstantIndexFieldData;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.lookup.SearchLookup;
 
@@ -64,7 +64,7 @@ public final class TypeFieldType extends ConstantFieldType {
     }
 
     @Override
-    public Query existsQuery(QueryShardContext context) {
+    public Query existsQuery(SearchExecutionContext context) {
         deprecationLogger.deprecate("typefieldtype", TYPES_V7_DEPRECATION_MESSAGE);
         return new MatchAllDocsQuery();
     }
@@ -76,12 +76,12 @@ public final class TypeFieldType extends ConstantFieldType {
     }
 
     @Override
-    public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+    public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
         throw new UnsupportedOperationException("Cannot fetch values for internal field [" + name() + "].");
     }
 
     @Override
-    protected boolean matches(String pattern, boolean caseInsensitive, QueryShardContext context) {
+    protected boolean matches(String pattern, boolean caseInsensitive, SearchExecutionContext context) {
         deprecationLogger.deprecate("typefieldtype", TYPES_V7_DEPRECATION_MESSAGE);
         if (caseInsensitive) {
             return pattern.equalsIgnoreCase(type);

--- a/server/src/main/java/org/elasticsearch/index/mapper/VersionFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/VersionFieldMapper.java
@@ -23,7 +23,7 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.index.mapper.ParseContext.Document;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.QueryShardException;
 
 import java.util.Collections;
@@ -50,12 +50,12 @@ public class VersionFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
-        public Query termQuery(Object value, QueryShardContext context) {
+        public Query termQuery(Object value, SearchExecutionContext context) {
             throw new QueryShardException(context, "The _version field is not searchable");
         }
 
         @Override
-        public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             throw new UnsupportedOperationException("Cannot fetch values for internal field [" + name() + "].");
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/query/AbstractGeometryQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/AbstractGeometryQueryBuilder.java
@@ -332,7 +332,7 @@ public abstract class AbstractGeometryQueryBuilder<QB extends AbstractGeometryQu
     }
 
     /** builds the appropriate lucene shape query */
-    protected abstract Query buildShapeQuery(QueryShardContext context, MappedFieldType fieldType);
+    protected abstract Query buildShapeQuery(SearchExecutionContext context, MappedFieldType fieldType);
     /** writes the xcontent specific to this shape query */
     protected abstract void doShapeQueryXContent(XContentBuilder builder, Params params) throws IOException;
     /** creates a new ShapeQueryBuilder from the provided field name and shape builder */
@@ -343,7 +343,7 @@ public abstract class AbstractGeometryQueryBuilder<QB extends AbstractGeometryQu
 
 
     @Override
-    protected Query doToQuery(QueryShardContext context) {
+    protected Query doToQuery(SearchExecutionContext context) {
         if (shape == null || supplier != null) {
             throw new UnsupportedOperationException("query must be rewritten first");
         }

--- a/server/src/main/java/org/elasticsearch/index/query/AbstractQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/AbstractQueryBuilder.java
@@ -99,7 +99,7 @@ public abstract class AbstractQueryBuilder<QB extends AbstractQueryBuilder<QB>> 
     }
 
     @Override
-    public final Query toQuery(QueryShardContext context) throws IOException {
+    public final Query toQuery(SearchExecutionContext context) throws IOException {
         Query query = doToQuery(context);
         if (query != null) {
             if (boost != DEFAULT_BOOST) {
@@ -116,7 +116,7 @@ public abstract class AbstractQueryBuilder<QB extends AbstractQueryBuilder<QB>> 
         return query;
     }
 
-    protected abstract Query doToQuery(QueryShardContext context) throws IOException;
+    protected abstract Query doToQuery(SearchExecutionContext context) throws IOException;
 
     /**
      * Sets the query name for the query.
@@ -229,10 +229,10 @@ public abstract class AbstractQueryBuilder<QB extends AbstractQueryBuilder<QB>> 
     /**
      * Helper method to convert collection of {@link QueryBuilder} instances to lucene
      * {@link Query} instances. {@link QueryBuilder} that return {@code null} calling
-     * their {@link QueryBuilder#toQuery(QueryShardContext)} method are not added to the
+     * their {@link QueryBuilder#toQuery(SearchExecutionContext)} method are not added to the
      * resulting collection.
      */
-    static Collection<Query> toQueries(Collection<QueryBuilder> queryBuilders, QueryShardContext context) throws QueryShardException,
+    static Collection<Query> toQueries(Collection<QueryBuilder> queryBuilders, SearchExecutionContext context) throws QueryShardException,
             IOException {
         List<Query> queries = new ArrayList<>(queryBuilders.size());
         for (QueryBuilder queryBuilder : queryBuilders) {
@@ -267,8 +267,8 @@ public abstract class AbstractQueryBuilder<QB extends AbstractQueryBuilder<QB>> 
     }
 
     @Override
-    public final QueryBuilder rewrite(QueryRewriteContext queryShardContext) throws IOException {
-        QueryBuilder rewritten = doRewrite(queryShardContext);
+    public final QueryBuilder rewrite(QueryRewriteContext queryRewriteContext) throws IOException {
+        QueryBuilder rewritten = doRewrite(queryRewriteContext);
         if (rewritten == this) {
             return rewritten;
         }
@@ -281,7 +281,7 @@ public abstract class AbstractQueryBuilder<QB extends AbstractQueryBuilder<QB>> 
         return rewritten;
     }
 
-    protected QueryBuilder doRewrite(QueryRewriteContext queryShardContext) throws IOException {
+    protected QueryBuilder doRewrite(QueryRewriteContext queryRewriteContext) throws IOException {
         return this;
     }
 

--- a/server/src/main/java/org/elasticsearch/index/query/BoolQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/BoolQueryBuilder.java
@@ -316,7 +316,7 @@ public class BoolQueryBuilder extends AbstractQueryBuilder<BoolQueryBuilder> {
     }
 
     @Override
-    protected Query doToQuery(QueryShardContext context) throws IOException {
+    protected Query doToQuery(SearchExecutionContext context) throws IOException {
         BooleanQuery.Builder booleanQueryBuilder = new BooleanQuery.Builder();
         addBooleanClauses(context, booleanQueryBuilder, mustClauses, BooleanClause.Occur.MUST);
         addBooleanClauses(context, booleanQueryBuilder, mustNotClauses, BooleanClause.Occur.MUST_NOT);
@@ -331,7 +331,7 @@ public class BoolQueryBuilder extends AbstractQueryBuilder<BoolQueryBuilder> {
         return adjustPureNegative ? fixNegativeQueryIfNeeded(query) : query;
     }
 
-    private static void addBooleanClauses(QueryShardContext context, BooleanQuery.Builder booleanQueryBuilder,
+    private static void addBooleanClauses(SearchExecutionContext context, BooleanQuery.Builder booleanQueryBuilder,
                                           List<QueryBuilder> clauses, Occur occurs) throws IOException {
         for (QueryBuilder query : clauses) {
             Query luceneQuery = query.toQuery(context);

--- a/server/src/main/java/org/elasticsearch/index/query/BoostingQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/BoostingQueryBuilder.java
@@ -198,7 +198,7 @@ public class BoostingQueryBuilder extends AbstractQueryBuilder<BoostingQueryBuil
     }
 
     @Override
-    protected Query doToQuery(QueryShardContext context) throws IOException {
+    protected Query doToQuery(SearchExecutionContext context) throws IOException {
         Query positive = positiveQuery.toQuery(context);
         Query negative = negativeQuery.toQuery(context);
         return FunctionScoreQuery.boostByQuery(positive, negative, negativeBoost);

--- a/server/src/main/java/org/elasticsearch/index/query/ConstantScoreQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/ConstantScoreQueryBuilder.java
@@ -128,7 +128,7 @@ public class ConstantScoreQueryBuilder extends AbstractQueryBuilder<ConstantScor
     }
 
     @Override
-    protected Query doToQuery(QueryShardContext context) throws IOException {
+    protected Query doToQuery(SearchExecutionContext context) throws IOException {
         Query innerFilter = filterBuilder.toQuery(context);
         return new ConstantScoreQuery(innerFilter);
     }

--- a/server/src/main/java/org/elasticsearch/index/query/DisMaxQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/DisMaxQueryBuilder.java
@@ -180,7 +180,7 @@ public class DisMaxQueryBuilder extends AbstractQueryBuilder<DisMaxQueryBuilder>
     }
 
     @Override
-    protected Query doToQuery(QueryShardContext context) throws IOException {
+    protected Query doToQuery(SearchExecutionContext context) throws IOException {
         // return null if there are no queries at all
         Collection<Query> luceneQueries = toQueries(queries, context);
         if (luceneQueries.isEmpty()) {
@@ -191,11 +191,11 @@ public class DisMaxQueryBuilder extends AbstractQueryBuilder<DisMaxQueryBuilder>
     }
 
     @Override
-    protected QueryBuilder doRewrite(QueryRewriteContext queryShardContext) throws IOException {
+    protected QueryBuilder doRewrite(QueryRewriteContext queryRewriteContext) throws IOException {
         DisMaxQueryBuilder newBuilder = new DisMaxQueryBuilder();
         boolean changed = false;
         for (QueryBuilder query : queries) {
-            QueryBuilder result = query.rewrite(queryShardContext);
+            QueryBuilder result = query.rewrite(queryRewriteContext);
             if (result != query) {
                 changed = true;
             }

--- a/server/src/main/java/org/elasticsearch/index/query/DistanceFeatureQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/DistanceFeatureQueryBuilder.java
@@ -107,7 +107,7 @@ public class DistanceFeatureQueryBuilder extends AbstractQueryBuilder<DistanceFe
     }
 
     @Override
-    protected Query doToQuery(QueryShardContext context) throws IOException {
+    protected Query doToQuery(SearchExecutionContext context) throws IOException {
         MappedFieldType fieldType = context.getFieldType(field);
         if (fieldType == null) {
             return Queries.newMatchNoDocsQuery("Can't run [" + NAME + "] query on unmapped fields!");

--- a/server/src/main/java/org/elasticsearch/index/query/ExistsQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/ExistsQueryBuilder.java
@@ -78,15 +78,15 @@ public class ExistsQueryBuilder extends AbstractQueryBuilder<ExistsQueryBuilder>
     }
 
     @Override
-    protected QueryBuilder doRewrite(QueryRewriteContext queryShardContext) throws IOException {
-        QueryShardContext context = queryShardContext.convertToShardContext();
+    protected QueryBuilder doRewrite(QueryRewriteContext queryRewriteContext) throws IOException {
+        SearchExecutionContext context = queryRewriteContext.convertToSearchExecutionContext();
         if (context != null) {
             Collection<String> fields = getMappedField(context, fieldName);
             if (fields.isEmpty()) {
                 return new MatchNoneQueryBuilder();
             }
         }
-        return super.doRewrite(queryShardContext);
+        return super.doRewrite(queryRewriteContext);
     }
 
     @Override
@@ -135,11 +135,11 @@ public class ExistsQueryBuilder extends AbstractQueryBuilder<ExistsQueryBuilder>
     }
 
     @Override
-    protected Query doToQuery(QueryShardContext context) throws IOException {
+    protected Query doToQuery(SearchExecutionContext context) throws IOException {
         return newFilter(context, fieldName, true);
     }
 
-    public static Query newFilter(QueryShardContext context, String fieldPattern, boolean checkRewrite) {
+    public static Query newFilter(SearchExecutionContext context, String fieldPattern, boolean checkRewrite) {
 
        Collection<String> fields = getMappedField(context, fieldPattern);
 
@@ -163,7 +163,7 @@ public class ExistsQueryBuilder extends AbstractQueryBuilder<ExistsQueryBuilder>
         return new ConstantScoreQuery(boolFilterBuilder.build());
     }
 
-    private static Query newFieldExistsQuery(QueryShardContext context, String field) {
+    private static Query newFieldExistsQuery(SearchExecutionContext context, String field) {
         if (context.isFieldMapped(field)) {
             Query filter = context.getFieldType(field).existsQuery(context);
             return new ConstantScoreQuery(filter);
@@ -177,7 +177,7 @@ public class ExistsQueryBuilder extends AbstractQueryBuilder<ExistsQueryBuilder>
         }
     }
 
-    private static Query newObjectFieldExistsQuery(QueryShardContext context, String objField) {
+    private static Query newObjectFieldExistsQuery(SearchExecutionContext context, String objField) {
         BooleanQuery.Builder booleanQuery = new BooleanQuery.Builder();
         Collection<String> fields = context.simpleMatchToIndexNames(objField + ".*");
         for (String field : fields) {
@@ -191,7 +191,7 @@ public class ExistsQueryBuilder extends AbstractQueryBuilder<ExistsQueryBuilder>
      * Helper method to get field mapped to this fieldPattern
      * @return return collection of fields if exists else return empty.
      */
-    private static Collection<String> getMappedField(QueryShardContext context, String fieldPattern) {
+    private static Collection<String> getMappedField(SearchExecutionContext context, String fieldPattern) {
         if (context.isFieldMapped(FieldNamesFieldMapper.NAME) == false) {
             // can only happen when no types exist, so no docs exist either
             return Collections.emptySet();

--- a/server/src/main/java/org/elasticsearch/index/query/FieldMaskingSpanQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/FieldMaskingSpanQueryBuilder.java
@@ -150,7 +150,7 @@ public class FieldMaskingSpanQueryBuilder extends AbstractQueryBuilder<FieldMask
     }
 
     @Override
-    protected SpanQuery doToQuery(QueryShardContext context) throws IOException {
+    protected SpanQuery doToQuery(SearchExecutionContext context) throws IOException {
         String fieldInQuery = fieldName;
         MappedFieldType fieldType = context.getFieldType(fieldName);
         if (fieldType != null) {

--- a/server/src/main/java/org/elasticsearch/index/query/FuzzyQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/FuzzyQueryBuilder.java
@@ -322,7 +322,7 @@ public class FuzzyQueryBuilder extends AbstractQueryBuilder<FuzzyQueryBuilder> i
 
     @Override
     protected QueryBuilder doRewrite(QueryRewriteContext queryRewriteContext) throws IOException {
-        QueryShardContext context = queryRewriteContext.convertToShardContext();
+        SearchExecutionContext context = queryRewriteContext.convertToSearchExecutionContext();
         if (context != null) {
             MappedFieldType fieldType = context.getFieldType(fieldName);
             if (fieldType == null) {
@@ -333,7 +333,7 @@ public class FuzzyQueryBuilder extends AbstractQueryBuilder<FuzzyQueryBuilder> i
     }
 
     @Override
-    protected Query doToQuery(QueryShardContext context) throws IOException {
+    protected Query doToQuery(SearchExecutionContext context) throws IOException {
         MappedFieldType fieldType = context.getFieldType(fieldName);
         if (fieldType == null) {
             throw new IllegalStateException("Rewrite first");

--- a/server/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilder.java
@@ -302,7 +302,7 @@ public class GeoBoundingBoxQueryBuilder extends AbstractQueryBuilder<GeoBounding
     }
 
     @Override
-    public Query doToQuery(QueryShardContext context) {
+    public Query doToQuery(SearchExecutionContext context) {
         MappedFieldType fieldType = context.getFieldType(fieldName);
         if (fieldType == null) {
             if (ignoreUnmapped) {

--- a/server/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryBuilder.java
@@ -226,24 +226,24 @@ public class GeoDistanceQueryBuilder extends AbstractQueryBuilder<GeoDistanceQue
     }
 
     @Override
-    protected Query doToQuery(QueryShardContext shardContext) throws IOException {
-        MappedFieldType fieldType = shardContext.getFieldType(fieldName);
+    protected Query doToQuery(SearchExecutionContext context) throws IOException {
+        MappedFieldType fieldType = context.getFieldType(fieldName);
         if (fieldType == null) {
             if (ignoreUnmapped) {
                 return new MatchNoDocsQuery();
             } else {
-                throw new QueryShardException(shardContext, "failed to find geo field [" + fieldName + "]");
+                throw new QueryShardException(context, "failed to find geo field [" + fieldName + "]");
             }
         }
 
         if (!(fieldType instanceof GeoShapeQueryable)) {
-            throw new QueryShardException(shardContext,
+            throw new QueryShardException(context,
                 "Field [" + fieldName + "] is of unsupported type [" + fieldType.typeName() + "] for [" + NAME + "] query");
         }
 
         QueryValidationException exception = checkLatLon();
         if (exception != null) {
-            throw new QueryShardException(shardContext, "couldn't validate latitude/ longitude values", exception);
+            throw new QueryShardException(context, "couldn't validate latitude/ longitude values", exception);
         }
 
         if (GeoValidationMethod.isCoerce(validationMethod)) {
@@ -254,7 +254,7 @@ public class GeoDistanceQueryBuilder extends AbstractQueryBuilder<GeoDistanceQue
         final Circle circle =
             new Circle(center.lon(), center.lat(), this.distance);
         return geoShapeQueryable.geoShapeQuery(circle, fieldType.name(),
-            SpatialStrategy.RECURSIVE, ShapeRelation.INTERSECTS, shardContext);
+            SpatialStrategy.RECURSIVE, ShapeRelation.INTERSECTS, context);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/query/GeoPolygonQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/GeoPolygonQueryBuilder.java
@@ -152,7 +152,7 @@ public class GeoPolygonQueryBuilder extends AbstractQueryBuilder<GeoPolygonQuery
     }
 
     @Override
-    protected Query doToQuery(QueryShardContext context) throws IOException {
+    protected Query doToQuery(SearchExecutionContext context) throws IOException {
         MappedFieldType fieldType = context.getFieldType(fieldName);
         if (fieldType == null) {
             if (ignoreUnmapped) {

--- a/server/src/main/java/org/elasticsearch/index/query/GeoShapeQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/GeoShapeQueryBuilder.java
@@ -181,7 +181,7 @@ public class GeoShapeQueryBuilder extends AbstractGeometryQueryBuilder<GeoShapeQ
     }
 
     @Override
-    public Query buildShapeQuery(QueryShardContext context, MappedFieldType fieldType) {
+    public Query buildShapeQuery(SearchExecutionContext context, MappedFieldType fieldType) {
         if ((fieldType instanceof GeoShapeQueryable) == false) {
             throw new QueryShardException(context,
                 "Field [" + fieldName + "] is of unsupported type [" + fieldType.typeName() + "] for [" + NAME + "] query");

--- a/server/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
@@ -139,7 +139,7 @@ public class IdsQueryBuilder extends AbstractQueryBuilder<IdsQueryBuilder> {
         if (ids.isEmpty()) {
             return new MatchNoneQueryBuilder();
         }
-        QueryShardContext context = queryRewriteContext.convertToShardContext();
+        SearchExecutionContext context = queryRewriteContext.convertToSearchExecutionContext();
         if (context != null && context.getFieldType(IdFieldMapper.NAME) == null) {
             // no mappings yet
             return new MatchNoneQueryBuilder();
@@ -148,7 +148,7 @@ public class IdsQueryBuilder extends AbstractQueryBuilder<IdsQueryBuilder> {
     }
 
     @Override
-    protected Query doToQuery(QueryShardContext context) throws IOException {
+    protected Query doToQuery(SearchExecutionContext context) throws IOException {
         MappedFieldType idField = context.getFieldType(IdFieldMapper.NAME);
         if (idField == null || ids.isEmpty()) {
             throw new IllegalStateException("Rewrite first");

--- a/server/src/main/java/org/elasticsearch/index/query/IntervalQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/IntervalQueryBuilder.java
@@ -131,7 +131,7 @@ public class IntervalQueryBuilder extends AbstractQueryBuilder<IntervalQueryBuil
     }
 
     @Override
-    protected Query doToQuery(QueryShardContext context) throws IOException {
+    protected Query doToQuery(SearchExecutionContext context) throws IOException {
         MappedFieldType fieldType = context.getFieldType(field);
         if (fieldType == null) {
             // Be lenient with unmapped fields so that cross-index search will work nicely

--- a/server/src/main/java/org/elasticsearch/index/query/IntervalsSourceProvider.java
+++ b/server/src/main/java/org/elasticsearch/index/query/IntervalsSourceProvider.java
@@ -64,7 +64,7 @@ import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optiona
  */
 public abstract class IntervalsSourceProvider implements NamedWriteable, ToXContentFragment {
 
-    public abstract IntervalsSource getSource(QueryShardContext context, MappedFieldType fieldType) throws IOException;
+    public abstract IntervalsSource getSource(SearchExecutionContext context, MappedFieldType fieldType) throws IOException;
 
     public abstract void extractFields(Set<String> fields);
 
@@ -140,7 +140,7 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
         }
 
         @Override
-        public IntervalsSource getSource(QueryShardContext context, MappedFieldType fieldType) throws IOException {
+        public IntervalsSource getSource(SearchExecutionContext context, MappedFieldType fieldType) throws IOException {
             NamedAnalyzer analyzer = null;
             if (this.analyzer != null) {
                 analyzer = context.getIndexAnalyzers().get(this.analyzer);
@@ -287,7 +287,7 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
         }
 
         @Override
-        public IntervalsSource getSource(QueryShardContext ctx, MappedFieldType fieldType) throws IOException {
+        public IntervalsSource getSource(SearchExecutionContext ctx, MappedFieldType fieldType) throws IOException {
             List<IntervalsSource> sources = new ArrayList<>();
             for (IntervalsSourceProvider provider : subSources) {
                 sources.add(provider.getSource(ctx, fieldType));
@@ -398,7 +398,7 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
         }
 
         @Override
-        public IntervalsSource getSource(QueryShardContext ctx, MappedFieldType fieldType) throws IOException {
+        public IntervalsSource getSource(SearchExecutionContext ctx, MappedFieldType fieldType) throws IOException {
             List<IntervalsSource> ss = new ArrayList<>();
             for (IntervalsSourceProvider provider : subSources) {
                 ss.add(provider.getSource(ctx, fieldType));
@@ -523,7 +523,7 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
         }
 
         @Override
-        public IntervalsSource getSource(QueryShardContext context, MappedFieldType fieldType) throws IOException {
+        public IntervalsSource getSource(SearchExecutionContext context, MappedFieldType fieldType) throws IOException {
             NamedAnalyzer analyzer = null;
             if (this.analyzer != null) {
                 analyzer = context.getIndexAnalyzers().get(this.analyzer);
@@ -638,7 +638,7 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
         }
 
         @Override
-        public IntervalsSource getSource(QueryShardContext context, MappedFieldType fieldType) {
+        public IntervalsSource getSource(SearchExecutionContext context, MappedFieldType fieldType) {
             NamedAnalyzer analyzer = fieldType.getTextSearchInfo().getSearchAnalyzer();
             if (this.analyzer != null) {
                 analyzer = context.getIndexAnalyzers().get(this.analyzer);
@@ -775,7 +775,7 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
         }
 
         @Override
-        public IntervalsSource getSource(QueryShardContext context, MappedFieldType fieldType) {
+        public IntervalsSource getSource(SearchExecutionContext context, MappedFieldType fieldType) {
             NamedAnalyzer analyzer = fieldType.getTextSearchInfo().getSearchAnalyzer();
             if (this.analyzer != null) {
                 analyzer = context.getIndexAnalyzers().get(this.analyzer);
@@ -958,7 +958,7 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
             }
         }
 
-        public IntervalsSource filter(IntervalsSource input, QueryShardContext context, MappedFieldType fieldType) throws IOException {
+        public IntervalsSource filter(IntervalsSource input, SearchExecutionContext context, MappedFieldType fieldType) throws IOException {
             if (script != null) {
                 IntervalFilterScript ifs = context.compile(script, IntervalFilterScript.CONTEXT).newInstance();
                 return new ScriptFilterSource(input, script.getIdOrCode(), ifs);

--- a/server/src/main/java/org/elasticsearch/index/query/LegacyGeoShapeQueryProcessor.java
+++ b/server/src/main/java/org/elasticsearch/index/query/LegacyGeoShapeQueryProcessor.java
@@ -71,7 +71,7 @@ public class LegacyGeoShapeQueryProcessor  {
     }
 
     public Query geoShapeQuery(Geometry shape, String fieldName, SpatialStrategy strategy,
-                               ShapeRelation relation, QueryShardContext context) {
+                               ShapeRelation relation, SearchExecutionContext context) {
         if (context.allowExpensiveQueries() == false) {
             throw new ElasticsearchException("[geo-shape] queries on [PrefixTree geo shapes] cannot be executed when '"
                     + ALLOW_EXPENSIVE_QUERIES.getKey() + "' is set to false.");

--- a/server/src/main/java/org/elasticsearch/index/query/MatchAllQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/MatchAllQueryBuilder.java
@@ -73,7 +73,7 @@ public class MatchAllQueryBuilder extends AbstractQueryBuilder<MatchAllQueryBuil
     }
 
     @Override
-    protected Query doToQuery(QueryShardContext context) {
+    protected Query doToQuery(SearchExecutionContext context) {
         return Queries.newMatchAllQuery();
     }
 

--- a/server/src/main/java/org/elasticsearch/index/query/MatchBoolPrefixQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/MatchBoolPrefixQueryBuilder.java
@@ -346,7 +346,7 @@ public class MatchBoolPrefixQueryBuilder extends AbstractQueryBuilder<MatchBoolP
     }
 
     @Override
-    protected Query doToQuery(QueryShardContext context) throws IOException {
+    protected Query doToQuery(SearchExecutionContext context) throws IOException {
         if (analyzer != null && context.getIndexAnalyzers().get(analyzer) == null) {
             throw new QueryShardException(context, "[" + NAME + "] analyzer [" + analyzer + "] not found");
         }

--- a/server/src/main/java/org/elasticsearch/index/query/MatchNoneQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/MatchNoneQueryBuilder.java
@@ -87,7 +87,7 @@ public class MatchNoneQueryBuilder extends AbstractQueryBuilder<MatchNoneQueryBu
     }
 
     @Override
-    protected Query doToQuery(QueryShardContext context) throws IOException {
+    protected Query doToQuery(SearchExecutionContext context) throws IOException {
         return Queries.newMatchNoDocsQuery("User requested \"" + this.getName() + "\" query.");
     }
 

--- a/server/src/main/java/org/elasticsearch/index/query/MatchPhrasePrefixQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/MatchPhrasePrefixQueryBuilder.java
@@ -190,7 +190,7 @@ public class MatchPhrasePrefixQueryBuilder extends AbstractQueryBuilder<MatchPhr
     }
 
     @Override
-    protected Query doToQuery(QueryShardContext context) throws IOException {
+    protected Query doToQuery(SearchExecutionContext context) throws IOException {
         // validate context specific fields
         if (analyzer != null && context.getIndexAnalyzers().get(analyzer) == null) {
             throw new QueryShardException(context, "[" + NAME + "] analyzer [" + analyzer + "] not found");

--- a/server/src/main/java/org/elasticsearch/index/query/MatchPhraseQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/MatchPhraseQueryBuilder.java
@@ -161,7 +161,7 @@ public class MatchPhraseQueryBuilder extends AbstractQueryBuilder<MatchPhraseQue
     }
 
     @Override
-    protected Query doToQuery(QueryShardContext context) throws IOException {
+    protected Query doToQuery(SearchExecutionContext context) throws IOException {
         // validate context specific fields
         if (analyzer != null && context.getIndexAnalyzers().get(analyzer) == null) {
             throw new QueryShardException(context, "[" + NAME + "] analyzer [" + analyzer + "] not found");

--- a/server/src/main/java/org/elasticsearch/index/query/MatchQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/MatchQueryBuilder.java
@@ -359,7 +359,7 @@ public class MatchQueryBuilder extends AbstractQueryBuilder<MatchQueryBuilder> {
     }
 
     @Override
-    protected Query doToQuery(QueryShardContext context) throws IOException {
+    protected Query doToQuery(SearchExecutionContext context) throws IOException {
         // validate context specific fields
         if (analyzer != null && context.getIndexAnalyzers().get(analyzer) == null) {
             throw new QueryShardException(context, "[" + NAME + "] analyzer [" + analyzer + "] not found");

--- a/server/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilder.java
@@ -936,7 +936,7 @@ public class MoreLikeThisQueryBuilder extends AbstractQueryBuilder<MoreLikeThisQ
     }
 
     @Override
-    protected Query doToQuery(QueryShardContext context) throws IOException {
+    protected Query doToQuery(SearchExecutionContext context) throws IOException {
         Item[] likeItems = new Item[this.likeItems.length];
         for (int i = 0; i < likeItems.length; i++) {
             likeItems[i] = new Item(this.likeItems[i]);
@@ -1026,7 +1026,7 @@ public class MoreLikeThisQueryBuilder extends AbstractQueryBuilder<MoreLikeThisQ
         }
     }
 
-    private Query handleItems(QueryShardContext context, MoreLikeThisQuery mltQuery, Item[] likeItems, Item[] unlikeItems,
+    private Query handleItems(SearchExecutionContext context, MoreLikeThisQuery mltQuery, Item[] likeItems, Item[] unlikeItems,
                               boolean include, List<String> moreLikeFields, boolean useDefaultField) throws IOException {
         // set default index, type and fields if not specified
         for (Item item : likeItems) {
@@ -1060,7 +1060,7 @@ public class MoreLikeThisQueryBuilder extends AbstractQueryBuilder<MoreLikeThisQ
         return boolQuery.build();
     }
 
-    private static void setDefaultIndexTypeFields(QueryShardContext context, Item item, List<String> moreLikeFields,
+    private static void setDefaultIndexTypeFields(SearchExecutionContext context, Item item, List<String> moreLikeFields,
                                                   boolean useDefaultField) {
         if (item.index() == null) {
             item.index(context.index().getName());
@@ -1108,7 +1108,7 @@ public class MoreLikeThisQueryBuilder extends AbstractQueryBuilder<MoreLikeThisQ
         }
     }
 
-    private static void handleExclude(BooleanQuery.Builder boolQuery, Item[] likeItems, QueryShardContext context) {
+    private static void handleExclude(BooleanQuery.Builder boolQuery, Item[] likeItems, SearchExecutionContext context) {
         MappedFieldType idField = context.getFieldType(IdFieldMapper.NAME);
         if (idField == null) {
             // no mappings, nothing to exclude

--- a/server/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
@@ -718,7 +718,7 @@ public class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQuery
     }
 
     @Override
-    protected Query doToQuery(QueryShardContext context) throws IOException {
+    protected Query doToQuery(SearchExecutionContext context) throws IOException {
         MultiMatchQuery multiMatchQuery = new MultiMatchQuery(context);
         if (analyzer != null) {
             if (context.getIndexAnalyzers().get(analyzer) == null) {

--- a/server/src/main/java/org/elasticsearch/index/query/NestedQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/NestedQueryBuilder.java
@@ -267,7 +267,7 @@ public class NestedQueryBuilder extends AbstractQueryBuilder<NestedQueryBuilder>
     }
 
     @Override
-    protected Query doToQuery(QueryShardContext context) throws IOException {
+    protected Query doToQuery(SearchExecutionContext context) throws IOException {
         if (context.allowExpensiveQueries() == false) {
             throw new ElasticsearchException("[joining] queries cannot be executed when '" +
                     ALLOW_EXPENSIVE_QUERIES.getKey() + "' is set to false.");
@@ -349,8 +349,8 @@ public class NestedQueryBuilder extends AbstractQueryBuilder<NestedQueryBuilder>
         @Override
         protected void doBuild(SearchContext parentSearchContext,
                           InnerHitsContext innerHitsContext) throws IOException {
-            QueryShardContext queryShardContext = parentSearchContext.getQueryShardContext();
-            ObjectMapper nestedObjectMapper = queryShardContext.getObjectMapper(path);
+            SearchExecutionContext searchExecutionContext = parentSearchContext.getSearchExecutionContext();
+            ObjectMapper nestedObjectMapper = searchExecutionContext.getObjectMapper(path);
             if (nestedObjectMapper == null) {
                 if (innerHitBuilder.isIgnoreUnmapped() == false) {
                     throw new IllegalStateException("[" + query.getName() + "] no mapping found for type [" + path + "]");
@@ -359,12 +359,12 @@ public class NestedQueryBuilder extends AbstractQueryBuilder<NestedQueryBuilder>
                 }
             }
             String name =  innerHitBuilder.getName() != null ? innerHitBuilder.getName() : nestedObjectMapper.fullPath();
-            ObjectMapper parentObjectMapper = queryShardContext.nestedScope().nextLevel(nestedObjectMapper);
+            ObjectMapper parentObjectMapper = searchExecutionContext.nestedScope().nextLevel(nestedObjectMapper);
             NestedInnerHitSubContext nestedInnerHits = new NestedInnerHitSubContext(
                 name, parentSearchContext, parentObjectMapper, nestedObjectMapper
             );
-            setupInnerHitsContext(queryShardContext, nestedInnerHits);
-            queryShardContext.nestedScope().previousLevel();
+            setupInnerHitsContext(searchExecutionContext, nestedInnerHits);
+            searchExecutionContext.nestedScope().previousLevel();
             innerHitsContext.addInnerHitDefinition(nestedInnerHits);
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/query/PrefixQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/PrefixQueryBuilder.java
@@ -200,7 +200,7 @@ public class PrefixQueryBuilder extends AbstractQueryBuilder<PrefixQueryBuilder>
 
     @Override
     protected QueryBuilder doRewrite(QueryRewriteContext queryRewriteContext) throws IOException {
-        QueryShardContext context = queryRewriteContext.convertToShardContext();
+        SearchExecutionContext context = queryRewriteContext.convertToSearchExecutionContext();
         if (context != null) {
             MappedFieldType fieldType = context.getFieldType(this.fieldName);
             if (fieldType == null) {
@@ -224,7 +224,7 @@ public class PrefixQueryBuilder extends AbstractQueryBuilder<PrefixQueryBuilder>
     }
 
     @Override
-    protected Query doToQuery(QueryShardContext context) throws IOException {
+    protected Query doToQuery(SearchExecutionContext context) throws IOException {
         MultiTermQuery.RewriteMethod method = QueryParsers.parseRewriteMethod(rewrite, null, LoggingDeprecationHandler.INSTANCE);
 
         MappedFieldType fieldType = context.getFieldType(fieldName);

--- a/server/src/main/java/org/elasticsearch/index/query/QueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryBuilder.java
@@ -35,7 +35,7 @@ public interface QueryBuilder extends NamedWriteable, ToXContentObject, Rewritea
      * @param context additional information needed to construct the queries
      * @return the {@link Query} or {@code null} if this query should be ignored upstream
      */
-    Query toQuery(QueryShardContext context) throws IOException;
+    Query toQuery(SearchExecutionContext context) throws IOException;
 
     /**
      * Sets the arbitrary name to be assigned to the query (see named queries).
@@ -74,7 +74,7 @@ public interface QueryBuilder extends NamedWriteable, ToXContentObject, Rewritea
      * did not change the identity reference must be returned otherwise the builder will be rewritten infinitely.
      */
     @Override
-    default QueryBuilder rewrite(QueryRewriteContext queryShardContext) throws IOException {
+    default QueryBuilder rewrite(QueryRewriteContext queryRewriteContext) throws IOException {
         return this;
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/query/QueryRewriteContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryRewriteContext.java
@@ -69,9 +69,9 @@ public class QueryRewriteContext {
     }
 
     /**
-     * Returns an instance of {@link QueryShardContext} if available of null otherwise
+     * Returns an instance of {@link SearchExecutionContext} if available of null otherwise
      */
-    public QueryShardContext convertToShardContext() {
+    public SearchExecutionContext convertToSearchExecutionContext() {
         return null;
     }
 

--- a/server/src/main/java/org/elasticsearch/index/query/QueryShardException.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryShardException.java
@@ -32,17 +32,17 @@ import java.io.IOException;
  */
 public class QueryShardException extends ElasticsearchException {
 
-    public QueryShardException(QueryShardContext context, String msg, Object... args) {
+    public QueryShardException(SearchExecutionContext context, String msg, Object... args) {
         this(context, msg, null, args);
     }
 
-    public QueryShardException(QueryShardContext context, String msg, Throwable cause, Object... args) {
+    public QueryShardException(SearchExecutionContext context, String msg, Throwable cause, Object... args) {
         this(context.getFullyQualifiedIndex(), msg, cause, args);
     }
 
     /**
      * This constructor is provided for use in unit tests where a
-     * {@link QueryShardContext} may not be available
+     * {@link SearchExecutionContext} may not be available
      */
     public QueryShardException(Index index, String msg, Throwable cause, Object... args) {
         super(msg, cause, args);

--- a/server/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
@@ -831,7 +831,7 @@ public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQue
     }
 
     @Override
-    protected Query doToQuery(QueryShardContext context) throws IOException {
+    protected Query doToQuery(SearchExecutionContext context) throws IOException {
         String rewrittenQueryString = escape ? org.apache.lucene.queryparser.classic.QueryParser.escape(this.queryString) : queryString;
         if (fieldsAndWeights.size() > 0 && this.defaultField != null) {
             throw addValidationError("cannot use [fields] parameter in conjunction with [default_field]", null);

--- a/server/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
@@ -445,19 +445,19 @@ public class RangeQueryBuilder extends AbstractQueryBuilder<RangeQueryBuilder> i
             }
         }
 
-        QueryShardContext shardContext = queryRewriteContext.convertToShardContext();
-        if (shardContext != null) {
-            final MappedFieldType fieldType = shardContext.getFieldType(fieldName);
+        SearchExecutionContext searchExecutionContext = queryRewriteContext.convertToSearchExecutionContext();
+        if (searchExecutionContext != null) {
+            final MappedFieldType fieldType = searchExecutionContext.getFieldType(fieldName);
             if (fieldType == null) {
                 return MappedFieldType.Relation.DISJOINT;
             }
-            if (shardContext.getIndexReader() == null) {
+            if (searchExecutionContext.getIndexReader() == null) {
                 // No reader, this may happen e.g. for percolator queries.
                 return MappedFieldType.Relation.INTERSECTS;
             }
 
             DateMathParser dateMathParser = getForceDateParser();
-            return fieldType.isFieldWithinQuery(shardContext.getIndexReader(), from, to, includeLower,
+            return fieldType.isFieldWithinQuery(searchExecutionContext.getIndexReader(), from, to, includeLower,
                     includeUpper, timeZone, dateMathParser, queryRewriteContext);
         }
 
@@ -490,7 +490,7 @@ public class RangeQueryBuilder extends AbstractQueryBuilder<RangeQueryBuilder> i
     }
 
     @Override
-    protected Query doToQuery(QueryShardContext context) throws IOException {
+    protected Query doToQuery(SearchExecutionContext context) throws IOException {
         if (from == null && to == null) {
             /*
              * Open bounds on both side, we can rewrite to an exists query

--- a/server/src/main/java/org/elasticsearch/index/query/RegexpQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/RegexpQueryBuilder.java
@@ -268,7 +268,7 @@ public class RegexpQueryBuilder extends AbstractQueryBuilder<RegexpQueryBuilder>
     }
 
     @Override
-    protected Query doToQuery(QueryShardContext context) throws QueryShardException, IOException {
+    protected Query doToQuery(SearchExecutionContext context) throws QueryShardException, IOException {
         final int maxAllowedRegexLength = context.getIndexSettings().getMaxRegexLength();
         if (value.length() > maxAllowedRegexLength) {
             throw new IllegalArgumentException(

--- a/server/src/main/java/org/elasticsearch/index/query/ScriptQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/ScriptQueryBuilder.java
@@ -132,7 +132,7 @@ public class ScriptQueryBuilder extends AbstractQueryBuilder<ScriptQueryBuilder>
     }
 
     @Override
-    protected Query doToQuery(QueryShardContext context) throws IOException {
+    protected Query doToQuery(SearchExecutionContext context) throws IOException {
         if (context.allowExpensiveQueries() == false) {
             throw new ElasticsearchException("[script] queries cannot be executed when '" +
                     ALLOW_EXPENSIVE_QUERIES.getKey() + "' is set to false.");

--- a/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
@@ -85,7 +85,7 @@ import java.util.function.Supplier;
 /**
  * Context object used to create lucene queries on the shard level.
  */
-public class QueryShardContext extends QueryRewriteContext {
+public class SearchExecutionContext extends QueryRewriteContext {
 
     private final ScriptService scriptService;
     private final IndexSettings indexSettings;
@@ -112,9 +112,9 @@ public class QueryShardContext extends QueryRewriteContext {
     private final Map<String, MappedFieldType> runtimeMappings;
 
     /**
-     * Build a {@linkplain QueryShardContext}.
+     * Build a {@linkplain SearchExecutionContext}.
      */
-    public QueryShardContext(
+    public SearchExecutionContext(
         int shardId,
         int shardRequestIndex,
         IndexSettings indexSettings,
@@ -161,7 +161,7 @@ public class QueryShardContext extends QueryRewriteContext {
         );
     }
 
-    public QueryShardContext(QueryShardContext source) {
+    public SearchExecutionContext(SearchExecutionContext source) {
         this(
             source.shardId,
             source.shardRequestIndex,
@@ -184,25 +184,25 @@ public class QueryShardContext extends QueryRewriteContext {
         );
     }
 
-    private QueryShardContext(int shardId,
-                              int shardRequestIndex,
-                              IndexSettings indexSettings,
-                              BitsetFilterCache bitsetFilterCache,
-                              TriFunction<MappedFieldType, String, Supplier<SearchLookup>, IndexFieldData<?>> indexFieldDataLookup,
-                              MapperService mapperService,
-                              MappingLookup mappingLookup,
-                              SimilarityService similarityService,
-                              ScriptService scriptService,
-                              NamedXContentRegistry xContentRegistry,
-                              NamedWriteableRegistry namedWriteableRegistry,
-                              Client client,
-                              IndexSearcher searcher,
-                              LongSupplier nowInMillis,
-                              Predicate<String> indexNameMatcher,
-                              Index fullyQualifiedIndex,
-                              BooleanSupplier allowExpensiveQueries,
-                              ValuesSourceRegistry valuesSourceRegistry,
-                              Map<String, MappedFieldType> runtimeMappings) {
+    private SearchExecutionContext(int shardId,
+                                   int shardRequestIndex,
+                                   IndexSettings indexSettings,
+                                   BitsetFilterCache bitsetFilterCache,
+                                   TriFunction<MappedFieldType, String, Supplier<SearchLookup>, IndexFieldData<?>> indexFieldDataLookup,
+                                   MapperService mapperService,
+                                   MappingLookup mappingLookup,
+                                   SimilarityService similarityService,
+                                   ScriptService scriptService,
+                                   NamedXContentRegistry xContentRegistry,
+                                   NamedWriteableRegistry namedWriteableRegistry,
+                                   Client client,
+                                   IndexSearcher searcher,
+                                   LongSupplier nowInMillis,
+                                   Predicate<String> indexNameMatcher,
+                                   Index fullyQualifiedIndex,
+                                   BooleanSupplier allowExpensiveQueries,
+                                   ValuesSourceRegistry valuesSourceRegistry,
+                                   Map<String, MappedFieldType> runtimeMappings) {
         super(xContentRegistry, namedWriteableRegistry, client, nowInMillis);
         this.shardId = shardId;
         this.shardRequestIndex = shardRequestIndex;
@@ -317,8 +317,8 @@ public class QueryShardContext extends QueryRewriteContext {
      * In case unmapped fields are allowed, null is returned when the field is not mapped.
      * In case unmapped fields are not allowed, either an exception is thrown or the field is automatically mapped as a text field.
      * @throws QueryShardException if unmapped fields are not allowed and automatically mapping unmapped fields as text is disabled.
-     * @see QueryShardContext#setAllowUnmappedFields(boolean)
-     * @see QueryShardContext#setMapUnmappedFieldAsString(boolean)
+     * @see SearchExecutionContext#setAllowUnmappedFields(boolean)
+     * @see SearchExecutionContext#setMapUnmappedFieldAsString(boolean)
      */
     public MappedFieldType getFieldType(String name) {
         return failIfFieldMappingNotFound(name, fieldType(name));
@@ -569,7 +569,7 @@ public class QueryShardContext extends QueryRewriteContext {
     }
 
     @Override
-    public final QueryShardContext convertToShardContext() {
+    public final SearchExecutionContext convertToSearchExecutionContext() {
         return this;
     }
 

--- a/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
@@ -83,7 +83,11 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 /**
- * Context object used to create lucene queries on the shard level.
+ * The context used to execute a search request on a shard. It provides access
+ * to required information like mapping definitions and document data.
+ *
+ * This context is used in several components of search execution, including
+ * building queries and fetching hits.
  */
 public class SearchExecutionContext extends QueryRewriteContext {
 
@@ -94,6 +98,8 @@ public class SearchExecutionContext extends QueryRewriteContext {
     private final SimilarityService similarityService;
     private final BitsetFilterCache bitsetFilterCache;
     private final TriFunction<MappedFieldType, String, Supplier<SearchLookup>, IndexFieldData<?>> indexFieldDataService;
+    private SearchLookup lookup = null;
+
     private final int shardId;
     private final int shardRequestIndex;
     private final IndexSearcher searcher;
@@ -418,8 +424,6 @@ public class SearchExecutionContext extends QueryRewriteContext {
         NamedAnalyzer a = mappingLookup.indexAnalyzer(field, f -> null);
         return a == null ? false : a.containsBrokenAnalysis();
     }
-
-    private SearchLookup lookup = null;
 
     /**
      * Get the lookup to use during the search.

--- a/server/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
@@ -390,7 +390,7 @@ public class SimpleQueryStringBuilder extends AbstractQueryBuilder<SimpleQuerySt
     }
 
     @Override
-    protected Query doToQuery(QueryShardContext context) throws IOException {
+    protected Query doToQuery(SearchExecutionContext context) throws IOException {
         Settings newSettings = new Settings(settings);
         final Map<String, Float> resolvedFieldsAndWeights;
         boolean isAllField;

--- a/server/src/main/java/org/elasticsearch/index/query/SpanContainingQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/SpanContainingQueryBuilder.java
@@ -147,7 +147,7 @@ public class SpanContainingQueryBuilder extends AbstractQueryBuilder<SpanContain
     }
 
     @Override
-    protected Query doToQuery(QueryShardContext context) throws IOException {
+    protected Query doToQuery(SearchExecutionContext context) throws IOException {
         Query innerBig = big.toQuery(context);
         assert innerBig instanceof SpanQuery;
         Query innerLittle = little.toQuery(context);

--- a/server/src/main/java/org/elasticsearch/index/query/SpanFirstQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/SpanFirstQueryBuilder.java
@@ -148,7 +148,7 @@ public class SpanFirstQueryBuilder extends AbstractQueryBuilder<SpanFirstQueryBu
     }
 
     @Override
-    protected Query doToQuery(QueryShardContext context) throws IOException {
+    protected Query doToQuery(SearchExecutionContext context) throws IOException {
         Query innerSpanQuery = matchBuilder.toQuery(context);
         assert innerSpanQuery instanceof SpanQuery;
         return new SpanFirstQuery((SpanQuery) innerSpanQuery, end);

--- a/server/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryBuilder.java
@@ -125,7 +125,7 @@ public class SpanMultiTermQueryBuilder extends AbstractQueryBuilder<SpanMultiTer
     }
 
     @Override
-    protected Query doToQuery(QueryShardContext context) throws IOException {
+    protected Query doToQuery(SearchExecutionContext context) throws IOException {
         // We do the rewrite in toQuery to not have to deal with the case when a multi-term builder rewrites to a non-multi-term
         // builder.
         QueryBuilder multiTermQueryBuilder = Rewriteable.rewrite(this.multiTermQueryBuilder, context);

--- a/server/src/main/java/org/elasticsearch/index/query/SpanNearQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/SpanNearQueryBuilder.java
@@ -209,7 +209,7 @@ public class SpanNearQueryBuilder extends AbstractQueryBuilder<SpanNearQueryBuil
     }
 
     @Override
-    protected Query doToQuery(QueryShardContext context) throws IOException {
+    protected Query doToQuery(SearchExecutionContext context) throws IOException {
         SpanQueryBuilder queryBuilder = clauses.get(0);
         boolean isGap = queryBuilder instanceof SpanGapQueryBuilder;
         Query query = null;
@@ -263,7 +263,7 @@ public class SpanNearQueryBuilder extends AbstractQueryBuilder<SpanNearQueryBuil
         return builder.build();
     }
 
-    private String queryFieldName(QueryShardContext context, String fieldName) {
+    private String queryFieldName(SearchExecutionContext context, String fieldName) {
         MappedFieldType fieldType = context.getFieldType(fieldName);
         return fieldType != null ? fieldType.name() : fieldName;
     }
@@ -342,7 +342,7 @@ public class SpanNearQueryBuilder extends AbstractQueryBuilder<SpanNearQueryBuil
         }
 
         @Override
-        public Query toQuery(QueryShardContext context) throws IOException {
+        public Query toQuery(SearchExecutionContext context) throws IOException {
             throw new UnsupportedOperationException();
         }
 

--- a/server/src/main/java/org/elasticsearch/index/query/SpanNotQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/SpanNotQueryBuilder.java
@@ -239,7 +239,7 @@ public class SpanNotQueryBuilder extends AbstractQueryBuilder<SpanNotQueryBuilde
     }
 
     @Override
-    protected Query doToQuery(QueryShardContext context) throws IOException {
+    protected Query doToQuery(SearchExecutionContext context) throws IOException {
 
         Query includeQuery = this.include.toQuery(context);
         assert includeQuery instanceof SpanQuery;

--- a/server/src/main/java/org/elasticsearch/index/query/SpanOrQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/SpanOrQueryBuilder.java
@@ -149,7 +149,7 @@ public class SpanOrQueryBuilder extends AbstractQueryBuilder<SpanOrQueryBuilder>
     }
 
     @Override
-    protected Query doToQuery(QueryShardContext context) throws IOException {
+    protected Query doToQuery(SearchExecutionContext context) throws IOException {
         SpanQuery[] spanQueries = new SpanQuery[clauses.size()];
         for (int i = 0; i < clauses.size(); i++) {
             Query query = clauses.get(i).toQuery(context);

--- a/server/src/main/java/org/elasticsearch/index/query/SpanTermQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/SpanTermQueryBuilder.java
@@ -79,7 +79,7 @@ public class SpanTermQueryBuilder extends BaseTermQueryBuilder<SpanTermQueryBuil
     }
 
     @Override
-    protected SpanQuery doToQuery(QueryShardContext context) throws IOException {
+    protected SpanQuery doToQuery(SearchExecutionContext context) throws IOException {
         MappedFieldType mapper = context.getFieldType(fieldName);
         Term term;
         if (mapper == null) {

--- a/server/src/main/java/org/elasticsearch/index/query/SpanWithinQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/SpanWithinQueryBuilder.java
@@ -158,7 +158,7 @@ public class SpanWithinQueryBuilder extends AbstractQueryBuilder<SpanWithinQuery
     }
 
     @Override
-    protected Query doToQuery(QueryShardContext context) throws IOException {
+    protected Query doToQuery(SearchExecutionContext context) throws IOException {
         Query innerBig = big.toQuery(context);
         assert innerBig instanceof SpanQuery;
         Query innerLittle = little.toQuery(context);

--- a/server/src/main/java/org/elasticsearch/index/query/TermQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/TermQueryBuilder.java
@@ -173,7 +173,7 @@ public class TermQueryBuilder extends BaseTermQueryBuilder<TermQueryBuilder> {
 
     @Override
     protected QueryBuilder doRewrite(QueryRewriteContext queryRewriteContext) throws IOException {
-        QueryShardContext context = queryRewriteContext.convertToShardContext();
+        SearchExecutionContext context = queryRewriteContext.convertToSearchExecutionContext();
         if (context != null) {
             MappedFieldType fieldType = context.getFieldType(this.fieldName);
             if (fieldType == null) {
@@ -202,7 +202,7 @@ public class TermQueryBuilder extends BaseTermQueryBuilder<TermQueryBuilder> {
     }
 
     @Override
-    protected Query doToQuery(QueryShardContext context) throws IOException {
+    protected Query doToQuery(SearchExecutionContext context) throws IOException {
         MappedFieldType mapper = context.getFieldType(this.fieldName);
         if (mapper == null) {
             throw new IllegalStateException("Rewrite first");

--- a/server/src/main/java/org/elasticsearch/index/query/TermsQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/TermsQueryBuilder.java
@@ -416,7 +416,7 @@ public class TermsQueryBuilder extends AbstractQueryBuilder<TermsQueryBuilder> {
     }
 
     @Override
-    protected Query doToQuery(QueryShardContext context) throws IOException {
+    protected Query doToQuery(SearchExecutionContext context) throws IOException {
         if (termsLookup != null || supplier != null || values == null || values.isEmpty()) {
             throw new UnsupportedOperationException("query must be rewritten first");
         }
@@ -478,7 +478,7 @@ public class TermsQueryBuilder extends AbstractQueryBuilder<TermsQueryBuilder> {
             return new MatchNoneQueryBuilder();
         }
 
-        QueryShardContext context = queryRewriteContext.convertToShardContext();
+        SearchExecutionContext context = queryRewriteContext.convertToSearchExecutionContext();
         if (context != null) {
             MappedFieldType fieldType = context.getFieldType(this.fieldName);
             if (fieldType == null) {

--- a/server/src/main/java/org/elasticsearch/index/query/TermsSetQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/TermsSetQueryBuilder.java
@@ -221,7 +221,7 @@ public final class TermsSetQueryBuilder extends AbstractQueryBuilder<TermsSetQue
     }
 
     @Override
-    protected Query doToQuery(QueryShardContext context) {
+    protected Query doToQuery(SearchExecutionContext context) {
         if (values.isEmpty()) {
             return Queries.newMatchNoDocsQuery("No terms supplied for \"" + getName() + "\" query.");
         }
@@ -238,7 +238,7 @@ public final class TermsSetQueryBuilder extends AbstractQueryBuilder<TermsSetQue
     /**
      * Visible only for testing purposes.
      */
-    List<Query> createTermQueries(QueryShardContext context) {
+    List<Query> createTermQueries(SearchExecutionContext context) {
         final MappedFieldType fieldType = context.getFieldType(fieldName);
         final List<Query> queries = new ArrayList<>(values.size());
         for (Object value : values) {
@@ -251,7 +251,7 @@ public final class TermsSetQueryBuilder extends AbstractQueryBuilder<TermsSetQue
         return queries;
     }
 
-    private LongValuesSource createValuesSource(QueryShardContext context) {
+    private LongValuesSource createValuesSource(SearchExecutionContext context) {
         LongValuesSource longValuesSource;
         if (minimumShouldMatchField != null) {
             MappedFieldType msmFieldType = context.getFieldType(minimumShouldMatchField);

--- a/server/src/main/java/org/elasticsearch/index/query/VectorGeoPointShapeQueryProcessor.java
+++ b/server/src/main/java/org/elasticsearch/index/query/VectorGeoPointShapeQueryProcessor.java
@@ -48,7 +48,7 @@ import java.util.ArrayList;
 
 public class VectorGeoPointShapeQueryProcessor {
 
-    public Query geoShapeQuery(Geometry shape, String fieldName, ShapeRelation relation, QueryShardContext context) {
+    public Query geoShapeQuery(Geometry shape, String fieldName, ShapeRelation relation, SearchExecutionContext context) {
         validateIsGeoPointFieldType(fieldName, context);
         // geo points only support intersects
         if (relation != ShapeRelation.INTERSECTS) {
@@ -59,7 +59,7 @@ public class VectorGeoPointShapeQueryProcessor {
         return getVectorQueryFromShape(shape, fieldName, relation, context);
     }
 
-    private void validateIsGeoPointFieldType(String fieldName, QueryShardContext context) {
+    private void validateIsGeoPointFieldType(String fieldName, SearchExecutionContext context) {
         MappedFieldType fieldType = context.getFieldType(fieldName);
         if (fieldType instanceof GeoPointFieldMapper.GeoPointFieldType == false) {
             throw new QueryShardException(context, "Expected " + GeoPointFieldMapper.CONTENT_TYPE
@@ -68,18 +68,18 @@ public class VectorGeoPointShapeQueryProcessor {
     }
 
     protected Query getVectorQueryFromShape(
-        Geometry queryShape, String fieldName, ShapeRelation relation, QueryShardContext context) {
+        Geometry queryShape, String fieldName, ShapeRelation relation, SearchExecutionContext context) {
         ShapeVisitor shapeVisitor = new ShapeVisitor(context, fieldName, relation);
         return queryShape.visit(shapeVisitor);
     }
 
     private class ShapeVisitor implements GeometryVisitor<Query, RuntimeException> {
-        QueryShardContext context;
+        SearchExecutionContext context;
         MappedFieldType fieldType;
         String fieldName;
         ShapeRelation relation;
 
-        ShapeVisitor(QueryShardContext context, String fieldName, ShapeRelation relation) {
+        ShapeVisitor(SearchExecutionContext context, String fieldName, ShapeRelation relation) {
             this.context = context;
             this.fieldType = context.getFieldType(fieldName);
             this.fieldName = fieldName;

--- a/server/src/main/java/org/elasticsearch/index/query/VectorGeoShapeQueryProcessor.java
+++ b/server/src/main/java/org/elasticsearch/index/query/VectorGeoShapeQueryProcessor.java
@@ -43,7 +43,7 @@ public class VectorGeoShapeQueryProcessor {
         WITHIN_UNSUPPORTED_GEOMETRIES.add(MultiLine.class);
     }
 
-    public Query geoShapeQuery(Geometry shape, String fieldName, ShapeRelation relation, QueryShardContext context) {
+    public Query geoShapeQuery(Geometry shape, String fieldName, ShapeRelation relation, SearchExecutionContext context) {
         // CONTAINS queries are not supported by VECTOR strategy for indices created before version 7.5.0 (Lucene 8.3.0)
         if (relation == ShapeRelation.CONTAINS && context.indexVersionCreated().before(Version.V_7_5_0)) {
             throw new QueryShardException(context,
@@ -53,7 +53,7 @@ public class VectorGeoShapeQueryProcessor {
         return getVectorQueryFromShape(shape, fieldName, relation, context);
     }
 
-    private Query getVectorQueryFromShape(Geometry queryShape, String fieldName, ShapeRelation relation, QueryShardContext context) {
+    private Query getVectorQueryFromShape(Geometry queryShape, String fieldName, ShapeRelation relation, SearchExecutionContext context) {
         final LatLonGeometry[] luceneGeometries;
         if (relation == ShapeRelation.WITHIN) {
             luceneGeometries = GeoShapeUtils.toLuceneGeometry(fieldName, context, queryShape, WITHIN_UNSUPPORTED_GEOMETRIES);

--- a/server/src/main/java/org/elasticsearch/index/query/WildcardQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/WildcardQueryBuilder.java
@@ -211,7 +211,7 @@ public class WildcardQueryBuilder extends AbstractQueryBuilder<WildcardQueryBuil
 
     @Override
     protected QueryBuilder doRewrite(QueryRewriteContext queryRewriteContext) throws IOException {
-        QueryShardContext context = queryRewriteContext.convertToShardContext();
+        SearchExecutionContext context = queryRewriteContext.convertToSearchExecutionContext();
         if (context != null) {
             MappedFieldType fieldType = context.getFieldType(this.fieldName);
             if (fieldType == null) {
@@ -235,7 +235,7 @@ public class WildcardQueryBuilder extends AbstractQueryBuilder<WildcardQueryBuil
     }
 
     @Override
-    protected Query doToQuery(QueryShardContext context) throws IOException {
+    protected Query doToQuery(SearchExecutionContext context) throws IOException {
         MappedFieldType fieldType = context.getFieldType(fieldName);
 
         if (fieldType == null) {

--- a/server/src/main/java/org/elasticsearch/index/query/WrapperQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/WrapperQueryBuilder.java
@@ -143,7 +143,7 @@ public class WrapperQueryBuilder extends AbstractQueryBuilder<WrapperQueryBuilde
     }
 
     @Override
-    protected Query doToQuery(QueryShardContext context) throws IOException {
+    protected Query doToQuery(SearchExecutionContext context) throws IOException {
         throw new UnsupportedOperationException("this query must be rewritten first");
     }
 

--- a/server/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionBuilder.java
@@ -51,7 +51,7 @@ import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.GeoPointFieldMapper.GeoPointFieldType;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.MultiValueMode;
 
 import java.io.IOException;
@@ -184,7 +184,7 @@ public abstract class DecayFunctionBuilder<DFB extends DecayFunctionBuilder<DFB>
     }
 
     @Override
-    protected ScoreFunction doToFunction(QueryShardContext context) throws IOException {
+    protected ScoreFunction doToFunction(SearchExecutionContext context) throws IOException {
         AbstractDistanceScoreFunction scoreFunction;
         // EMPTY is safe because parseVariable doesn't use namedObject
         try (InputStream stream = functionBytes.streamInput();
@@ -200,7 +200,7 @@ public abstract class DecayFunctionBuilder<DFB extends DecayFunctionBuilder<DFB>
      * */
     protected abstract DecayFunction getDecayFunction();
 
-    private AbstractDistanceScoreFunction parseVariable(String fieldName, XContentParser parser, QueryShardContext context,
+    private AbstractDistanceScoreFunction parseVariable(String fieldName, XContentParser parser, SearchExecutionContext context,
             MultiValueMode mode) throws IOException {
         //the field must exist, else we cannot read the value for the doc later
         MappedFieldType fieldType = context.getFieldType(fieldName);
@@ -223,7 +223,7 @@ public abstract class DecayFunctionBuilder<DFB extends DecayFunctionBuilder<DFB>
         }
     }
 
-    private AbstractDistanceScoreFunction parseNumberVariable(XContentParser parser, QueryShardContext context,
+    private AbstractDistanceScoreFunction parseNumberVariable(XContentParser parser, SearchExecutionContext context,
             MappedFieldType fieldType, MultiValueMode mode) throws IOException {
         XContentParser.Token token;
         String parameterName = null;
@@ -258,7 +258,7 @@ public abstract class DecayFunctionBuilder<DFB extends DecayFunctionBuilder<DFB>
         return new NumericFieldDataScoreFunction(origin, scale, decay, offset, getDecayFunction(), numericFieldData, mode);
     }
 
-    private AbstractDistanceScoreFunction parseGeoVariable(XContentParser parser, QueryShardContext context,
+    private AbstractDistanceScoreFunction parseGeoVariable(XContentParser parser, SearchExecutionContext context,
             MappedFieldType fieldType, MultiValueMode mode) throws IOException {
         XContentParser.Token token;
         String parameterName = null;
@@ -292,7 +292,7 @@ public abstract class DecayFunctionBuilder<DFB extends DecayFunctionBuilder<DFB>
 
     }
 
-    private AbstractDistanceScoreFunction parseDateVariable(XContentParser parser, QueryShardContext context,
+    private AbstractDistanceScoreFunction parseDateVariable(XContentParser parser, SearchExecutionContext context,
             MappedFieldType dateFieldType, MultiValueMode mode) throws IOException {
         XContentParser.Token token;
         String parameterName = null;

--- a/server/src/main/java/org/elasticsearch/index/query/functionscore/FieldValueFactorFunctionBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/functionscore/FieldValueFactorFunctionBuilder.java
@@ -28,7 +28,7 @@ import org.elasticsearch.common.lucene.search.function.ScoreFunction;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 
 import java.io.IOException;
 import java.util.Locale;
@@ -142,7 +142,7 @@ public class FieldValueFactorFunctionBuilder extends ScoreFunctionBuilder<FieldV
     }
 
     @Override
-    protected ScoreFunction doToFunction(QueryShardContext context) {
+    protected ScoreFunction doToFunction(SearchExecutionContext context) {
         IndexNumericFieldData fieldData = null;
         if (context.isFieldMapped(field)) {
             fieldData = context.getForField(context.getFieldType(field));

--- a/server/src/main/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilder.java
@@ -39,7 +39,7 @@ import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.MatchNoneQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryRewriteContext;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -292,7 +292,7 @@ public class FunctionScoreQueryBuilder extends AbstractQueryBuilder<FunctionScor
     }
 
     @Override
-    protected Query doToQuery(QueryShardContext context) throws IOException {
+    protected Query doToQuery(SearchExecutionContext context) throws IOException {
         ScoreFunction[] filterFunctions = new ScoreFunction[filterFunctionBuilders.length];
         int i = 0;
         for (FilterFunctionBuilder filterFunctionBuilder : filterFunctionBuilders) {

--- a/server/src/main/java/org/elasticsearch/index/query/functionscore/RandomScoreFunctionBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/functionscore/RandomScoreFunctionBuilder.java
@@ -27,7 +27,7 @@ import org.elasticsearch.common.lucene.search.function.ScoreFunction;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.IdFieldMapper;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -149,7 +149,7 @@ public class RandomScoreFunctionBuilder extends ScoreFunctionBuilder<RandomScore
     }
 
     @Override
-    protected ScoreFunction doToFunction(QueryShardContext context) {
+    protected ScoreFunction doToFunction(SearchExecutionContext context) {
         final int salt = (context.index().getName().hashCode() << 10) | context.getShardId();
         if (seed == null) {
             // DocID-based random score generation

--- a/server/src/main/java/org/elasticsearch/index/query/functionscore/ScoreFunctionBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/functionscore/ScoreFunctionBuilder.java
@@ -26,7 +26,7 @@ import org.elasticsearch.common.lucene.search.function.ScoreFunction;
 import org.elasticsearch.common.lucene.search.function.WeightFactorFunction;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -139,7 +139,7 @@ public abstract class ScoreFunctionBuilder<FB extends ScoreFunctionBuilder<FB>> 
     /**
      * Called on a data node, converts this ScoreFunctionBuilder into its corresponding Lucene function object.
      */
-    public final ScoreFunction toFunction(QueryShardContext context) throws IOException {
+    public final ScoreFunction toFunction(SearchExecutionContext context) throws IOException {
         ScoreFunction scoreFunction = doToFunction(context);
         if (weight == null) {
             return scoreFunction;
@@ -151,5 +151,5 @@ public abstract class ScoreFunctionBuilder<FB extends ScoreFunctionBuilder<FB>> 
      * Build the Lucene ScoreFunction for this builder. Implementers should ignore things defined in ScoreFunctionBuilder like weight as
      * they will be handled by the function that calls this one.
      */
-    protected abstract ScoreFunction doToFunction(QueryShardContext context) throws IOException;
+    protected abstract ScoreFunction doToFunction(SearchExecutionContext context) throws IOException;
 }

--- a/server/src/main/java/org/elasticsearch/index/query/functionscore/ScriptScoreFunctionBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/functionscore/ScriptScoreFunctionBuilder.java
@@ -26,7 +26,7 @@ import org.elasticsearch.common.lucene.search.function.ScoreFunction;
 import org.elasticsearch.common.lucene.search.function.ScriptScoreFunction;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.QueryShardException;
 import org.elasticsearch.script.ScoreScript;
 import org.elasticsearch.script.Script;
@@ -90,7 +90,7 @@ public class ScriptScoreFunctionBuilder extends ScoreFunctionBuilder<ScriptScore
     }
 
     @Override
-    protected ScoreFunction doToFunction(QueryShardContext context) {
+    protected ScoreFunction doToFunction(SearchExecutionContext context) {
         try {
             ScoreScript.Factory factory = context.compile(script, ScoreScript.CONTEXT);
             ScoreScript.LeafFactory searchScript = factory.newFactory(script.getParams(), context.lookup());

--- a/server/src/main/java/org/elasticsearch/index/query/functionscore/ScriptScoreQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/functionscore/ScriptScoreQueryBuilder.java
@@ -33,7 +33,7 @@ import org.elasticsearch.index.query.InnerHitContextBuilder;
 import org.elasticsearch.index.query.MatchNoneQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryRewriteContext;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.script.ScoreScript;
 import org.elasticsearch.script.Script;
 
@@ -163,7 +163,7 @@ public class ScriptScoreQueryBuilder extends AbstractQueryBuilder<ScriptScoreQue
     }
 
     @Override
-    protected Query doToQuery(QueryShardContext context) throws IOException {
+    protected Query doToQuery(SearchExecutionContext context) throws IOException {
         if (context.allowExpensiveQueries() == false) {
             throw new ElasticsearchException("[script score] queries cannot be executed when '"
                     + ALLOW_EXPENSIVE_QUERIES.getKey() + "' is set to false.");

--- a/server/src/main/java/org/elasticsearch/index/query/functionscore/WeightBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/functionscore/WeightBuilder.java
@@ -23,7 +23,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.search.function.ScoreFunction;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 
 import java.io.IOException;
 
@@ -70,7 +70,7 @@ public class WeightBuilder extends ScoreFunctionBuilder<WeightBuilder> {
     }
 
     @Override
-    protected ScoreFunction doToFunction(QueryShardContext context) throws IOException {
+    protected ScoreFunction doToFunction(SearchExecutionContext context) throws IOException {
         //nothing to do here, weight will be applied by the parent class, no score function
         return null;
     }

--- a/server/src/main/java/org/elasticsearch/index/search/MatchQuery.java
+++ b/server/src/main/java/org/elasticsearch/index/search/MatchQuery.java
@@ -53,7 +53,7 @@ import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.TextFieldMapper;
 import org.elasticsearch.index.mapper.TextSearchInfo;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.support.QueryParsers;
 
 import java.io.IOException;
@@ -144,7 +144,7 @@ public class MatchQuery {
 
     public static final ZeroTermsQuery DEFAULT_ZERO_TERMS_QUERY = ZeroTermsQuery.NONE;
 
-    protected final QueryShardContext context;
+    protected final SearchExecutionContext context;
 
     protected Analyzer analyzer;
 
@@ -173,7 +173,7 @@ public class MatchQuery {
 
     protected boolean autoGenerateSynonymsPhraseQuery = true;
 
-    public MatchQuery(QueryShardContext context) {
+    public MatchQuery(SearchExecutionContext context) {
         this.context = context;
     }
 

--- a/server/src/main/java/org/elasticsearch/index/search/MultiMatchQuery.java
+++ b/server/src/main/java/org/elasticsearch/index/search/MultiMatchQuery.java
@@ -33,7 +33,7 @@ import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.AbstractQueryBuilder;
 import org.elasticsearch.index.query.MultiMatchQueryBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -49,7 +49,7 @@ public class MultiMatchQuery extends MatchQuery {
 
     private Float groupTieBreaker = null;
 
-    public MultiMatchQuery(QueryShardContext context) {
+    public MultiMatchQuery(SearchExecutionContext context) {
         super(context);
     }
 
@@ -233,13 +233,13 @@ public class MultiMatchQuery extends MatchQuery {
         }
     }
 
-    static Query blendTerm(QueryShardContext context, BytesRef value, float tieBreaker,
+    static Query blendTerm(SearchExecutionContext context, BytesRef value, float tieBreaker,
                            boolean lenient, List<FieldAndBoost> blendedFields) {
 
         return blendTerms(context, new BytesRef[] {value}, tieBreaker, lenient, blendedFields);
     }
 
-    static Query blendTerms(QueryShardContext context, BytesRef[] values, float tieBreaker,
+    static Query blendTerms(SearchExecutionContext context, BytesRef[] values, float tieBreaker,
                             boolean lenient, List<FieldAndBoost> blendedFields) {
 
         List<Query> queries = new ArrayList<>();

--- a/server/src/main/java/org/elasticsearch/index/search/QueryParserHelper.java
+++ b/server/src/main/java/org/elasticsearch/index/search/QueryParserHelper.java
@@ -23,7 +23,7 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.TextSearchInfo;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.SearchModule;
 
 import java.util.Collection;
@@ -65,23 +65,23 @@ public final class QueryParserHelper {
         return fieldsAndWeights;
     }
 
-    public static Map<String, Float> resolveMappingFields(QueryShardContext context,
+    public static Map<String, Float> resolveMappingFields(SearchExecutionContext context,
                                                           Map<String, Float> fieldsAndWeights) {
         return resolveMappingFields(context, fieldsAndWeights, null);
     }
 
     /**
      * Resolve all the field names and patterns present in the provided map with the
-     * {@link QueryShardContext} and returns a new map containing all the expanded fields with their original boost.
+     * {@link SearchExecutionContext} and returns a new map containing all the expanded fields with their original boost.
      * @param context The context of the query.
      * @param fieldsAndWeights The map of fields and weights to expand.
      * @param fieldSuffix The suffix name to add to the expanded field names if a mapping exists for that name.
      *                    The original name of the field is kept if adding the suffix to the field name does not point to a valid field
      *                    in the mapping.
      */
-    static Map<String, Float> resolveMappingFields(QueryShardContext context,
-                                                          Map<String, Float> fieldsAndWeights,
-                                                          String fieldSuffix) {
+    static Map<String, Float> resolveMappingFields(SearchExecutionContext context,
+                                                   Map<String, Float> fieldsAndWeights,
+                                                   String fieldSuffix) {
         Map<String, Float> resolvedFields = new HashMap<>();
         for (Map.Entry<String, Float> fieldEntry : fieldsAndWeights.entrySet()) {
             boolean allField = Regex.isMatchAllPattern(fieldEntry.getKey());
@@ -102,7 +102,7 @@ public final class QueryParserHelper {
     }
 
     /**
-     * Resolves the provided pattern or field name from the {@link QueryShardContext} and return a map of
+     * Resolves the provided pattern or field name from the {@link SearchExecutionContext} and return a map of
      * the expanded fields with their original boost.
      * @param context The context of the query
      * @param fieldOrPattern The field name or the pattern to resolve
@@ -114,8 +114,8 @@ public final class QueryParserHelper {
      *                    The original name of the field is kept if adding the suffix to the field name does not point to a valid field
      *                    in the mapping.
      */
-    static Map<String, Float> resolveMappingField(QueryShardContext context, String fieldOrPattern, float weight,
-                                                         boolean acceptAllTypes, boolean acceptMetadataField, String fieldSuffix) {
+    static Map<String, Float> resolveMappingField(SearchExecutionContext context, String fieldOrPattern, float weight,
+                                                  boolean acceptAllTypes, boolean acceptMetadataField, String fieldSuffix) {
         Set<String> allFields = context.simpleMatchToIndexNames(fieldOrPattern);
         Map<String, Float> fields = new HashMap<>();
 
@@ -152,7 +152,7 @@ public final class QueryParserHelper {
         return fields;
     }
 
-    static void checkForTooManyFields(int numberOfFields, QueryShardContext context, @Nullable String inputPattern) {
+    static void checkForTooManyFields(int numberOfFields, SearchExecutionContext context, @Nullable String inputPattern) {
         Integer limit = SearchModule.INDICES_MAX_CLAUSE_COUNT_SETTING.get(context.getIndexSettings().getSettings());
         if (numberOfFields > limit) {
             StringBuilder errorMsg = new StringBuilder("field expansion ");

--- a/server/src/main/java/org/elasticsearch/index/search/QueryStringQueryParser.java
+++ b/server/src/main/java/org/elasticsearch/index/search/QueryStringQueryParser.java
@@ -56,7 +56,7 @@ import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.TextSearchInfo;
 import org.elasticsearch.index.query.ExistsQueryBuilder;
 import org.elasticsearch.index.query.MultiMatchQueryBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.support.QueryParsers;
 
 import java.io.IOException;
@@ -82,7 +82,7 @@ import static org.elasticsearch.index.search.QueryParserHelper.resolveMappingFie
 public class QueryStringQueryParser extends XQueryParser {
     private static final String EXISTS_FIELD = "_exists_";
 
-    private final QueryShardContext context;
+    private final SearchExecutionContext context;
     private final Map<String, Float> fieldsAndWeights;
     private final boolean lenient;
 
@@ -104,7 +104,7 @@ public class QueryStringQueryParser extends XQueryParser {
      * @param context The query shard context.
      * @param defaultField The default field for query terms.
      */
-    public QueryStringQueryParser(QueryShardContext context, String defaultField) {
+    public QueryStringQueryParser(SearchExecutionContext context, String defaultField) {
         this(context, defaultField, Collections.emptyMap(), false);
     }
 
@@ -113,7 +113,7 @@ public class QueryStringQueryParser extends XQueryParser {
      * @param defaultField The default field for query terms.
      * @param lenient If set to `true` will cause format based failures (like providing text to a numeric field) to be ignored.
      */
-    public QueryStringQueryParser(QueryShardContext context, String defaultField, boolean lenient) {
+    public QueryStringQueryParser(SearchExecutionContext context, String defaultField, boolean lenient) {
         this(context, defaultField, Collections.emptyMap(), lenient);
     }
 
@@ -121,7 +121,7 @@ public class QueryStringQueryParser extends XQueryParser {
      * @param context The query shard context
      * @param fieldsAndWeights The default fields and weights expansion for query terms
      */
-    public QueryStringQueryParser(QueryShardContext context, Map<String, Float> fieldsAndWeights) {
+    public QueryStringQueryParser(SearchExecutionContext context, Map<String, Float> fieldsAndWeights) {
         this(context, null, fieldsAndWeights, false);
     }
 
@@ -130,7 +130,7 @@ public class QueryStringQueryParser extends XQueryParser {
      * @param fieldsAndWeights The default fields and weights expansion for query terms.
      * @param lenient If set to `true` will cause format based failures (like providing text to a numeric field) to be ignored.
      */
-    public QueryStringQueryParser(QueryShardContext context, Map<String, Float> fieldsAndWeights, boolean lenient) {
+    public QueryStringQueryParser(SearchExecutionContext context, Map<String, Float> fieldsAndWeights, boolean lenient) {
         this(context, null, fieldsAndWeights, lenient);
     }
 
@@ -139,13 +139,13 @@ public class QueryStringQueryParser extends XQueryParser {
      * @param context The query shard context
      * @param lenient If set to `true` will cause format based failures (like providing text to a numeric field) to be ignored.
      */
-    public QueryStringQueryParser(QueryShardContext context, boolean lenient) {
+    public QueryStringQueryParser(SearchExecutionContext context, boolean lenient) {
         this(context, "*",
             resolveMappingField(context, "*", 1.0f, false, false, null),
             lenient);
     }
 
-    private QueryStringQueryParser(QueryShardContext context, String defaultField,
+    private QueryStringQueryParser(SearchExecutionContext context, String defaultField,
                                    Map<String, Float> fieldsAndWeights,
                                    boolean lenient) {
         super(defaultField, context.getIndexAnalyzers().getDefaultSearchAnalyzer());
@@ -415,7 +415,7 @@ public class QueryStringQueryParser extends XQueryParser {
     }
 
     private Query getRangeQuerySingle(String field, String part1, String part2,
-                                      boolean startInclusive, boolean endInclusive, QueryShardContext context) {
+                                      boolean startInclusive, boolean endInclusive, SearchExecutionContext context) {
         MappedFieldType currentFieldType = context.getFieldType(field);
         if (currentFieldType == null || currentFieldType.getTextSearchInfo() == TextSearchInfo.NONE) {
             return newUnmappedFieldQuery(field);

--- a/server/src/main/java/org/elasticsearch/index/search/SimpleQueryStringQueryParser.java
+++ b/server/src/main/java/org/elasticsearch/index/search/SimpleQueryStringQueryParser.java
@@ -39,7 +39,7 @@ import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.AbstractQueryBuilder;
 import org.elasticsearch.index.query.MultiMatchQueryBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.SimpleQueryStringBuilder;
 
 import java.io.IOException;
@@ -57,18 +57,18 @@ import static org.elasticsearch.common.lucene.search.Queries.newUnmappedFieldQue
 public class SimpleQueryStringQueryParser extends SimpleQueryParser {
 
     private final Settings settings;
-    private QueryShardContext context;
+    private SearchExecutionContext context;
     private final MultiMatchQuery queryBuilder;
 
     /** Creates a new parser with custom flags used to enable/disable certain features. */
     public SimpleQueryStringQueryParser(Map<String, Float> weights, int flags,
-                                        Settings settings, QueryShardContext context) {
+                                        Settings settings, SearchExecutionContext context) {
         this(null, weights, flags, settings, context);
     }
 
     /** Creates a new parser with custom flags used to enable/disable certain features. */
     public SimpleQueryStringQueryParser(Analyzer analyzer, Map<String, Float> weights, int flags,
-                                        Settings settings, QueryShardContext context) {
+                                        Settings settings, SearchExecutionContext context) {
         super(analyzer, weights, flags);
         this.settings = settings;
         this.context = context;

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -1390,7 +1390,7 @@ public class IndicesService extends AbstractLifecycleComponent
 
         // if now in millis is used (or in the future, a more generic "isDeterministic" flag
         // then we can't cache based on "now" key within the search request, as it is not deterministic
-        if (context.getQueryShardContext().isCacheable() == false) {
+        if (context.getSearchExecutionContext().isCacheable() == false) {
             return false;
         }
         return true;
@@ -1412,7 +1412,7 @@ public class IndicesService extends AbstractLifecycleComponent
         BytesReference cacheKey = request.cacheKey();
         BytesReference bytesReference = cacheShardLevelResult(
             context.indexShard(),
-            context.getQueryShardContext().mappingCacheKey(),
+            context.getSearchExecutionContext().mappingCacheKey(),
             directoryReader,
             cacheKey,
             out -> {
@@ -1438,7 +1438,7 @@ public class IndicesService extends AbstractLifecycleComponent
             // cache. One other option is to not cache requests with a timeout at all...
             indicesRequestCache.invalidate(
                 new IndexShardCacheEntity(context.indexShard()),
-                context.getQueryShardContext().mappingCacheKey(),
+                context.getSearchExecutionContext().mappingCacheKey(),
                 directoryReader,
                 cacheKey
             );

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -65,7 +65,7 @@ import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.MatchNoneQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryRewriteContext;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.Rewriteable;
 import org.elasticsearch.index.shard.IndexEventListener;
 import org.elasticsearch.index.shard.IndexShard;
@@ -370,7 +370,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
      */
     private void loadOrExecuteQueryPhase(final ShardSearchRequest request, final SearchContext context) throws Exception {
         final boolean canCache = indicesService.canCache(request, context);
-        context.getQueryShardContext().freezeContext();
+        context.getSearchExecutionContext().freezeContext();
         if (canCache) {
             indicesService.loadIntoContext(request, context, queryPhase);
         } else {
@@ -792,9 +792,9 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
             // we clone the query shard context here just for rewriting otherwise we
             // might end up with incorrect state since we are using now() or script services
             // during rewrite and normalized / evaluate templates etc.
-            QueryShardContext context = new QueryShardContext(searchContext.getQueryShardContext());
+            SearchExecutionContext context = new SearchExecutionContext(searchContext.getSearchExecutionContext());
             Rewriteable.rewrite(request.getRewriteable(), context, true);
-            assert searchContext.getQueryShardContext().isCacheable();
+            assert searchContext.getSearchExecutionContext().isCacheable();
             success = true;
         } finally {
             if (success == false) {
@@ -903,17 +903,17 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
             return;
         }
         SearchShardTarget shardTarget = context.shardTarget();
-        QueryShardContext queryShardContext = context.getQueryShardContext();
+        SearchExecutionContext searchExecutionContext = context.getSearchExecutionContext();
         context.from(source.from());
         context.size(source.size());
         Map<String, InnerHitContextBuilder> innerHitBuilders = new HashMap<>();
         if (source.query() != null) {
             InnerHitContextBuilder.extractInnerHits(source.query(), innerHitBuilders);
-            context.parsedQuery(queryShardContext.toQuery(source.query()));
+            context.parsedQuery(searchExecutionContext.toQuery(source.query()));
         }
         if (source.postFilter() != null) {
             InnerHitContextBuilder.extractInnerHits(source.postFilter(), innerHitBuilders);
-            context.parsedPostFilter(queryShardContext.toQuery(source.postFilter()));
+            context.parsedPostFilter(searchExecutionContext.toQuery(source.postFilter()));
         }
         if (innerHitBuilders.size() > 0) {
             for (Map.Entry<String, InnerHitContextBuilder> entry : innerHitBuilders.entrySet()) {
@@ -926,7 +926,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         }
         if (source.sorts() != null) {
             try {
-                Optional<SortAndFormats> optionalSort = SortBuilder.buildSort(source.sorts(), context.getQueryShardContext());
+                Optional<SortAndFormats> optionalSort = SortBuilder.buildSort(source.sorts(), context.getSearchExecutionContext());
                 if (optionalSort.isPresent()) {
                     context.sort(optionalSort.get());
                 }
@@ -955,7 +955,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         context.terminateAfter(source.terminateAfter());
         if (source.aggregations() != null && includeAggregations) {
             AggregationContext aggContext = new ProductionAggregationContext(
-                context.getQueryShardContext(),
+                context.getSearchExecutionContext(),
                 bigArrays,
                 source.aggregations().bytesToPreallocate(),
                 /*
@@ -982,7 +982,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         }
         if (source.suggest() != null) {
             try {
-                context.suggest(source.suggest().build(queryShardContext));
+                context.suggest(source.suggest().build(searchExecutionContext));
             } catch (IOException e) {
                 throw new SearchException(shardTarget, "failed to create SuggestionSearchContext", e);
             }
@@ -990,7 +990,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         if (source.rescores() != null) {
             try {
                 for (RescorerBuilder<?> rescore : source.rescores()) {
-                    context.addRescore(rescore.buildContext(queryShardContext));
+                    context.addRescore(rescore.buildContext(searchExecutionContext));
                 }
             } catch (IOException e) {
                 throw new SearchException(shardTarget, "failed to create RescoreSearchContext", e);
@@ -1003,7 +1003,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
             context.fetchSourceContext(source.fetchSource());
         }
         if (source.docValueFields() != null) {
-            FetchDocValuesContext docValuesContext = new FetchDocValuesContext(context.getQueryShardContext(), source.docValueFields());
+            FetchDocValuesContext docValuesContext = new FetchDocValuesContext(context.getSearchExecutionContext(), source.docValueFields());
             context.docValuesContext(docValuesContext);
         }
         if (source.fetchFields() != null) {
@@ -1013,13 +1013,13 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         if (source.highlighter() != null) {
             HighlightBuilder highlightBuilder = source.highlighter();
             try {
-                context.highlight(highlightBuilder.build(queryShardContext));
+                context.highlight(highlightBuilder.build(searchExecutionContext));
             } catch (IOException e) {
                 throw new SearchException(shardTarget, "failed to create SearchContextHighlighter", e);
             }
         }
         if (source.scriptFields() != null && source.size() != 0) {
-            int maxAllowedScriptFields = queryShardContext.getIndexSettings().getMaxScriptFields();
+            int maxAllowedScriptFields = searchExecutionContext.getIndexSettings().getMaxScriptFields();
             if (source.scriptFields().size() > maxAllowedScriptFields) {
                 throw new IllegalArgumentException(
                         "Trying to retrieve too many script_fields. Must be less than or equal to: [" + maxAllowedScriptFields
@@ -1028,7 +1028,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
             }
             for (org.elasticsearch.search.builder.SearchSourceBuilder.ScriptField field : source.scriptFields()) {
                 FieldScript.Factory factory = scriptService.compile(field.script(), FieldScript.CONTEXT);
-                SearchLookup lookup = context.getQueryShardContext().lookup();
+                SearchLookup lookup = context.getSearchExecutionContext().lookup();
                 FieldScript.LeafFactory searchScript = factory.newFactory(field.script().getParams(), lookup);
                 context.scriptFields().add(new ScriptField(field.fieldName(), searchScript, field.ignoreFailure()));
             }
@@ -1089,7 +1089,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
             if (context.rescore() != null && context.rescore().isEmpty() == false) {
                 throw new SearchException(shardTarget, "cannot use `collapse` in conjunction with `rescore`");
             }
-            final CollapseContext collapseContext = source.collapse().build(queryShardContext);
+            final CollapseContext collapseContext = source.collapse().build(searchExecutionContext);
             context.collapse(collapseContext);
         }
     }
@@ -1230,7 +1230,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
                 canMatchSearcher = indexShard.acquireSearcher(Engine.CAN_MATCH_SEARCH_SOURCE);
             }
             try (canMatchSearcher) {
-                QueryShardContext context = indexService.newQueryShardContext(request.shardId().id(), 0,
+                SearchExecutionContext context = indexService.newSearchExecutionContext(request.shardId().id(), 0,
                     canMatchSearcher, request::nowInMillis, request.getClusterAlias(), request.getRuntimeMappings());
                 final boolean canMatch = queryStillMatchesAfterRewrite(request, context);
                 final MinAndMax<?> minMax;

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -1003,7 +1003,8 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
             context.fetchSourceContext(source.fetchSource());
         }
         if (source.docValueFields() != null) {
-            FetchDocValuesContext docValuesContext = new FetchDocValuesContext(context.getSearchExecutionContext(), source.docValueFields());
+            FetchDocValuesContext docValuesContext = new FetchDocValuesContext(
+                context.getSearchExecutionContext(), source.docValueFields());
             context.docValuesContext(docValuesContext);
         }
         if (source.fetchFields() != null) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregationBuilder.java
@@ -130,7 +130,7 @@ public abstract class AggregationBuilder
      * identity reference must be returned otherwise the builder will be
      * rewritten infinitely.
      */
-    protected AggregationBuilder doRewrite(QueryRewriteContext queryShardContext) throws IOException {
+    protected AggregationBuilder doRewrite(QueryRewriteContext queryRewriteContext) throws IOException {
         return this;
     }
 
@@ -148,7 +148,7 @@ public abstract class AggregationBuilder
      * and pipeline aggregations. Just "zero", "one", and "many".
      * <p>
      * Unlike {@link CardinalityUpperBound} which is <strong>total</strong>
-     * instead of <strong>per parent bucket</strong>. 
+     * instead of <strong>per parent bucket</strong>.
      */
     public enum BucketCardinality {
         NONE, ONE, MANY;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/adjacency/AdjacencyMatrixAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/adjacency/AdjacencyMatrixAggregationBuilder.java
@@ -196,11 +196,11 @@ public class AdjacencyMatrixAggregationBuilder extends AbstractAggregationBuilde
     }
 
     @Override
-    protected AdjacencyMatrixAggregationBuilder doRewrite(QueryRewriteContext queryShardContext) throws IOException {
+    protected AdjacencyMatrixAggregationBuilder doRewrite(QueryRewriteContext queryRewriteContext) throws IOException {
         boolean modified = false;
         List<KeyedFilter> rewrittenFilters = new ArrayList<>(filters.size());
         for (KeyedFilter kf : filters) {
-            QueryBuilder rewritten = Rewriteable.rewrite(kf.filter(), queryShardContext);
+            QueryBuilder rewritten = Rewriteable.rewrite(kf.filter(), queryRewriteContext);
             modified = modified || rewritten != kf.filter();
             rewrittenFilters.add(new KeyedFilter(kf.key(), rewritten));
         }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FilterAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FilterAggregationBuilder.java
@@ -89,8 +89,8 @@ public class FilterAggregationBuilder extends AbstractAggregationBuilder<FilterA
     }
 
     @Override
-    protected AggregationBuilder doRewrite(QueryRewriteContext queryShardContext) throws IOException {
-        QueryBuilder result = Rewriteable.rewrite(filter, queryShardContext);
+    protected AggregationBuilder doRewrite(QueryRewriteContext queryRewriteContext) throws IOException {
+        QueryBuilder result = Rewriteable.rewrite(filter, queryRewriteContext);
         if (result != filter) {
             return new FilterAggregationBuilder(getName(), result);
         }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FiltersAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FiltersAggregationBuilder.java
@@ -202,11 +202,11 @@ public class FiltersAggregationBuilder extends AbstractAggregationBuilder<Filter
     }
 
     @Override
-    protected AggregationBuilder doRewrite(QueryRewriteContext queryShardContext) throws IOException {
+    protected AggregationBuilder doRewrite(QueryRewriteContext queryRewriteContext) throws IOException {
         List<KeyedFilter> rewrittenFilters = new ArrayList<>(filters.size());
         boolean changed = false;
         for (KeyedFilter kf : filters) {
-            QueryBuilder result = Rewriteable.rewrite(kf.filter(), queryShardContext);
+            QueryBuilder result = Rewriteable.rewrite(kf.filter(), queryRewriteContext);
             rewrittenFilters.add(new KeyedFilter(kf.key(), result));
             if (result != kf.filter()) {
                 changed = true;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTermsAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTermsAggregationBuilder.java
@@ -137,16 +137,16 @@ public class SignificantTermsAggregationBuilder extends ValuesSourceAggregationB
         return new SignificantTermsAggregationBuilder(this, factoriesBuilder, metadata);
     }
 
-    protected AggregationBuilder doRewrite(QueryRewriteContext queryShardContext) throws IOException {
+    protected AggregationBuilder doRewrite(QueryRewriteContext queryRewriteContext) throws IOException {
         if (filterBuilder != null) {
-            QueryBuilder rewrittenFilter = filterBuilder.rewrite(queryShardContext);
+            QueryBuilder rewrittenFilter = filterBuilder.rewrite(queryRewriteContext);
             if (rewrittenFilter != filterBuilder) {
                 SignificantTermsAggregationBuilder rewritten = shallowCopy(factoriesBuilder, metadata);
                 rewritten.backgroundFilter(rewrittenFilter);
                 return rewritten;
             }
         }
-        return super.doRewrite(queryShardContext);
+        return super.doRewrite(queryRewriteContext);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregatorFactory.java
@@ -106,7 +106,8 @@ class TopHitsAggregatorFactory extends AggregatorFactory {
             subSearchContext.storedFieldsContext(storedFieldsContext);
         }
         if (docValueFields != null) {
-            FetchDocValuesContext docValuesContext = new FetchDocValuesContext(subSearchContext.getSearchExecutionContext(), docValueFields);
+            FetchDocValuesContext docValuesContext = new FetchDocValuesContext(
+                subSearchContext.getSearchExecutionContext(), docValueFields);
             subSearchContext.docValuesContext(docValuesContext);
         }
         if (fetchFields != null) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregatorFactory.java
@@ -106,7 +106,7 @@ class TopHitsAggregatorFactory extends AggregatorFactory {
             subSearchContext.storedFieldsContext(storedFieldsContext);
         }
         if (docValueFields != null) {
-            FetchDocValuesContext docValuesContext = new FetchDocValuesContext(subSearchContext.getQueryShardContext(), docValueFields);
+            FetchDocValuesContext docValuesContext = new FetchDocValuesContext(subSearchContext.getSearchExecutionContext(), docValueFields);
             subSearchContext.docValuesContext(docValuesContext);
         }
         if (fetchFields != null) {
@@ -120,7 +120,7 @@ class TopHitsAggregatorFactory extends AggregatorFactory {
             subSearchContext.fetchSourceContext(fetchSourceContext);
         }
         if (highlightBuilder != null) {
-            subSearchContext.highlight(highlightBuilder.build(subSearchContext.getQueryShardContext()));
+            subSearchContext.highlight(highlightBuilder.build(subSearchContext.getSearchExecutionContext()));
         }
         return new TopHitsAggregator(subSearchContext, name, context, parent, metadata);
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/AggregationContext.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/AggregationContext.java
@@ -35,7 +35,7 @@ import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.ObjectMapper;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.Rewriteable;
 import org.elasticsearch.index.query.support.NestedScope;
 import org.elasticsearch.script.Script;
@@ -64,12 +64,12 @@ import java.util.function.Supplier;
  * <p>
  * In production we always use the {@link ProductionAggregationContext} but
  * this is {@code abstract} so that tests can build it without creating the
- * massing {@link QueryShardContext}.
+ * massing {@link SearchExecutionContext}.
  * <p>
  * {@linkplain AggregationContext}s are {@link Releasable} because they track
  * the {@link Aggregator}s they build and {@link Aggregator#close} them when
  * the request is done. {@linkplain AggregationContext} may also preallocate
- * bytes on the "REQUEST" breaker and is responsible for releasing those bytes. 
+ * bytes on the "REQUEST" breaker and is responsible for releasing those bytes.
  */
 public abstract class AggregationContext implements Releasable {
     /**
@@ -191,7 +191,7 @@ public abstract class AggregationContext implements Releasable {
     public abstract SubSearchContext subSearchContext();
 
     /**
-     * Cause this aggregation to be released when the search is finished. 
+     * Cause this aggregation to be released when the search is finished.
      */
     public abstract void addReleasable(Aggregator aggregator);
 
@@ -244,13 +244,13 @@ public abstract class AggregationContext implements Releasable {
 
     /**
      * Implementation of {@linkplain AggregationContext} for production usage
-     * that wraps our ubiquitous {@link QueryShardContext} and anything else
+     * that wraps our ubiquitous {@link SearchExecutionContext} and anything else
      * specific to aggregations. Unit tests should generally avoid using this
      * because it requires a <strong>huge</strong> portion of a real
      * Elasticsearch node.
      */
     public static class ProductionAggregationContext extends AggregationContext {
-        private final QueryShardContext context;
+        private final SearchExecutionContext context;
         private final PreallocatedCircuitBreakerService preallocatedBreakerService;
         private final BigArrays bigArrays;
         private final Supplier<Query> topLevelQuery;
@@ -265,7 +265,7 @@ public abstract class AggregationContext implements Releasable {
         private final List<Aggregator> releaseMe = new ArrayList<>();
 
         public ProductionAggregationContext(
-            QueryShardContext context,
+            SearchExecutionContext context,
             BigArrays bigArrays,
             long bytesToPreallocate,
             Supplier<Query> topLevelQuery,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceRegistry.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceRegistry.java
@@ -31,8 +31,8 @@ import java.util.Objects;
 
 /**
  * {@link ValuesSourceRegistry} holds the mapping from {@link ValuesSourceType}s to functions for building aggregation components.  DO NOT
- * directly instantiate this class, instead get an already-configured copy from {@link SearchExecutionContext#getValuesSourceRegistry()}, or (in
- * the case of some test scenarios only) directly from {@link SearchModule#getValuesSourceRegistry()}
+ * directly instantiate this class, instead get an already-configured copy from {@link SearchExecutionContext#getValuesSourceRegistry()},
+ * or (in the case of some test scenarios only) directly from {@link SearchModule#getValuesSourceRegistry()}
  *
  */
 public class ValuesSourceRegistry {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceRegistry.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceRegistry.java
@@ -18,7 +18,7 @@
  */
 package org.elasticsearch.search.aggregations.support;
 
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.search.aggregations.AggregationExecutionException;
 
@@ -31,7 +31,7 @@ import java.util.Objects;
 
 /**
  * {@link ValuesSourceRegistry} holds the mapping from {@link ValuesSourceType}s to functions for building aggregation components.  DO NOT
- * directly instantiate this class, instead get an already-configured copy from {@link QueryShardContext#getValuesSourceRegistry()}, or (in
+ * directly instantiate this class, instead get an already-configured copy from {@link SearchExecutionContext#getValuesSourceRegistry()}, or (in
  * the case of some test scenarios only) directly from {@link SearchModule#getValuesSourceRegistry()}
  *
  */

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/package-info.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/package-info.java
@@ -40,7 +40,8 @@ package org.elasticsearch.search.aggregations.support;
  * <p>
  * ValuesSourceRegistry stores the mappings for what types are supported by what aggregations.  It is configured at startup, when
  * {@link org.elasticsearch.search.SearchModule} is configuring aggregations.  It shouldn't be necessary to access the registry in most
- * cases, but you can get a read copy from {@link org.elasticsearch.index.query.SearchExecutionContext#getValuesSourceRegistry()} if necessary.
+ * cases, but you can get a read copy from {@link org.elasticsearch.index.query.SearchExecutionContext#getValuesSourceRegistry()} if
+ * necessary.
  * </p>
  *
  * <h3> {@link org.elasticsearch.search.aggregations.support.ValuesSourceType} </h3>

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/package-info.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/package-info.java
@@ -40,7 +40,7 @@ package org.elasticsearch.search.aggregations.support;
  * <p>
  * ValuesSourceRegistry stores the mappings for what types are supported by what aggregations.  It is configured at startup, when
  * {@link org.elasticsearch.search.SearchModule} is configuring aggregations.  It shouldn't be necessary to access the registry in most
- * cases, but you can get a read copy from {@link org.elasticsearch.index.query.QueryShardContext#getValuesSourceRegistry()} if necessary.
+ * cases, but you can get a read copy from {@link org.elasticsearch.index.query.SearchExecutionContext#getValuesSourceRegistry()} if necessary.
  * </p>
  *
  * <h3> {@link org.elasticsearch.search.aggregations.support.ValuesSourceType} </h3>

--- a/server/src/main/java/org/elasticsearch/search/collapse/CollapseBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/collapse/CollapseBuilder.java
@@ -31,7 +31,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.InnerHitBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.mapper.MappedFieldType.CollapseType;
 
 import java.io.IOException;
@@ -197,8 +197,8 @@ public class CollapseBuilder implements Writeable, ToXContentObject {
         return result;
     }
 
-    public CollapseContext build(QueryShardContext queryShardContext) {
-        MappedFieldType fieldType = queryShardContext.getFieldType(field);
+    public CollapseContext build(SearchExecutionContext searchExecutionContext) {
+        MappedFieldType fieldType = searchExecutionContext.getFieldType(field);
         if (fieldType == null) {
             throw new IllegalArgumentException("no mapping found for `" + field + "` in order to collapse on");
         }

--- a/server/src/main/java/org/elasticsearch/search/fetch/FetchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/FetchContext.java
@@ -21,7 +21,7 @@ package org.elasticsearch.search.fetch;
 
 import org.apache.lucene.search.Query;
 import org.elasticsearch.index.query.ParsedQuery;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.SearchExtBuilder;
 import org.elasticsearch.search.fetch.subphase.FetchDocValuesContext;
 import org.elasticsearch.search.fetch.subphase.FetchFieldsContext;
@@ -53,7 +53,7 @@ public class FetchContext {
      */
     public FetchContext(SearchContext searchContext) {
         this.searchContext = searchContext;
-        this.searchLookup = searchContext.getQueryShardContext().lookup();
+        this.searchLookup = searchContext.getSearchExecutionContext().lookup();
     }
 
     /**
@@ -136,7 +136,7 @@ public class FetchContext {
             String name = searchContext.collapse().getFieldName();
             if (dvContext == null) {
                 return new FetchDocValuesContext(
-                    searchContext.getQueryShardContext(),
+                    searchContext.getSearchExecutionContext(),
                     Collections.singletonList(new FieldAndFormat(name, null))
                 );
             } else if (searchContext.docValuesContext().fields().stream().map(ff -> ff.field).anyMatch(name::equals) == false) {
@@ -158,7 +158,7 @@ public class FetchContext {
      * backwards offsets in term vectors
      */
     public boolean containsBrokenAnalysis(String field) {
-        return getQueryShardContext().containsBrokenAnalysis(field);
+        return getSearchExecutionContext().containsBrokenAnalysis(field);
     }
 
     /**
@@ -203,8 +203,8 @@ public class FetchContext {
         return searchContext.getSearchExt(name);
     }
 
-    public QueryShardContext getQueryShardContext() {
-        return searchContext.getQueryShardContext();
+    public SearchExecutionContext getSearchExecutionContext() {
+        return searchContext.getSearchExecutionContext();
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchDocValuesContext.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchDocValuesContext.java
@@ -19,7 +19,7 @@
 package org.elasticsearch.search.fetch.subphase;
 
 import org.elasticsearch.index.IndexSettings;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -40,17 +40,17 @@ public class FetchDocValuesContext {
      * Create a new FetchDocValuesContext using the provided input list.
      * Field patterns containing wildcards are resolved and unmapped fields are filtered out.
      */
-    public FetchDocValuesContext(QueryShardContext shardContext, List<FieldAndFormat> fieldPatterns) {
+    public FetchDocValuesContext(SearchExecutionContext searchExecutionContext, List<FieldAndFormat> fieldPatterns) {
         for (FieldAndFormat field : fieldPatterns) {
-            Collection<String> fieldNames = shardContext.simpleMatchToIndexNames(field.field);
+            Collection<String> fieldNames = searchExecutionContext.simpleMatchToIndexNames(field.field);
             for (String fieldName : fieldNames) {
-                if (shardContext.isFieldMapped(fieldName)) {
+                if (searchExecutionContext.isFieldMapped(fieldName)) {
                     fields.add(new FieldAndFormat(fieldName, field.format, field.includeUnmapped));
                 }
             }
         }
 
-        int maxAllowedDocvalueFields = shardContext.getIndexSettings().getMaxDocvalueFields();
+        int maxAllowedDocvalueFields = searchExecutionContext.getIndexSettings().getMaxDocvalueFields();
         if (fields.size() > maxAllowedDocvalueFields) {
             throw new IllegalArgumentException(
                 "Trying to retrieve too many docvalue_fields. Must be less than or equal to: [" + maxAllowedDocvalueFields

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchDocValuesPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchDocValuesPhase.java
@@ -52,7 +52,7 @@ public final class FetchDocValuesPhase implements FetchSubPhase {
          */
         List<DocValueField> fields = new ArrayList<>();
         for (FieldAndFormat fieldAndFormat : context.docValuesContext().fields()) {
-            MappedFieldType ft = context.getQueryShardContext().getFieldType(fieldAndFormat.field);
+            MappedFieldType ft = context.getSearchExecutionContext().getFieldType(fieldAndFormat.field);
             if (ft == null) {
                 continue;
             }

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchFieldsPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchFieldsPhase.java
@@ -48,12 +48,12 @@ public final class FetchFieldsPhase implements FetchSubPhase {
         }
 
         SearchLookup searchLookup = fetchContext.searchLookup();
-        if (fetchContext.getQueryShardContext().isSourceEnabled() == false) {
+        if (fetchContext.getSearchExecutionContext().isSourceEnabled() == false) {
             throw new IllegalArgumentException("Unable to retrieve the requested [fields] since _source is disabled " +
                 "in the mappings for index [" + fetchContext.getIndexName() + "]");
         }
 
-        FieldFetcher fieldFetcher = FieldFetcher.create(fetchContext.getQueryShardContext(), searchLookup, fetchFieldsContext.fields());
+        FieldFetcher fieldFetcher = FieldFetcher.create(fetchContext.getSearchExecutionContext(), searchLookup, fetchFieldsContext.fields());
 
         return new FetchSubPhaseProcessor() {
             @Override

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchFieldsPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchFieldsPhase.java
@@ -53,7 +53,9 @@ public final class FetchFieldsPhase implements FetchSubPhase {
                 "in the mappings for index [" + fetchContext.getIndexName() + "]");
         }
 
-        FieldFetcher fieldFetcher = FieldFetcher.create(fetchContext.getSearchExecutionContext(), searchLookup, fetchFieldsContext.fields());
+        FieldFetcher fieldFetcher = FieldFetcher.create(fetchContext.getSearchExecutionContext(),
+            searchLookup,
+            fetchFieldsContext.fields());
 
         return new FetchSubPhaseProcessor() {
             @Override

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FieldFetcher.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FieldFetcher.java
@@ -26,7 +26,7 @@ import org.elasticsearch.common.document.DocumentField;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.ValueFetcher;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.search.lookup.SourceLookup;
 
@@ -44,7 +44,7 @@ import java.util.Set;
  * Then given a specific document, it can retrieve the corresponding fields from the document's source.
  */
 public class FieldFetcher {
-    public static FieldFetcher create(QueryShardContext context,
+    public static FieldFetcher create(SearchExecutionContext context,
                                       SearchLookup searchLookup,
                                       Collection<FieldAndFormat> fieldAndFormats) {
 

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightBuilder.java
@@ -31,7 +31,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryRewriteContext;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.Rewriteable;
 import org.elasticsearch.search.fetch.subphase.highlight.SearchHighlightContext.FieldOptions;
 
@@ -273,7 +273,7 @@ public class HighlightBuilder extends AbstractHighlighterBuilder<HighlightBuilde
         return PARSER.apply(p, new HighlightBuilder());
     }
 
-    public SearchHighlightContext build(QueryShardContext context) throws IOException {
+    public SearchHighlightContext build(SearchExecutionContext context) throws IOException {
         // create template global options that are later merged with any partial field options
         final SearchHighlightContext.FieldOptions.Builder globalOptionsBuilder = new SearchHighlightContext.FieldOptions.Builder();
         globalOptionsBuilder.encoder(this.encoder);
@@ -310,7 +310,7 @@ public class HighlightBuilder extends AbstractHighlighterBuilder<HighlightBuilde
     @SuppressWarnings({ "rawtypes", "unchecked" })
     private static void transferOptions(AbstractHighlighterBuilder highlighterBuilder,
                                         SearchHighlightContext.FieldOptions.Builder targetOptionsBuilder,
-                                        QueryShardContext context) throws IOException {
+                                        SearchExecutionContext context) throws IOException {
         if (highlighterBuilder.preTags != null) {
             targetOptionsBuilder.preTags(highlighterBuilder.preTags);
         }

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightPhase.java
@@ -107,13 +107,13 @@ public class HighlightPhase implements FetchSubPhase {
             Highlighter highlighter = getHighlighter(field);
             Collection<String> fieldNamesToHighlight;
             if (Regex.isSimpleMatchPattern(field.field())) {
-                fieldNamesToHighlight = context.getQueryShardContext().simpleMatchToIndexNames(field.field());
+                fieldNamesToHighlight = context.getSearchExecutionContext().simpleMatchToIndexNames(field.field());
             } else {
                 fieldNamesToHighlight = Collections.singletonList(field.field());
             }
 
             if (highlightContext.forceSource(field)) {
-                if (context.getQueryShardContext().isSourceEnabled() == false) {
+                if (context.getSearchExecutionContext().isSourceEnabled() == false) {
                     throw new IllegalArgumentException("source is forced for fields " + fieldNamesToHighlight
                         + " but _source is disabled");
                 }
@@ -121,7 +121,7 @@ public class HighlightPhase implements FetchSubPhase {
 
             boolean fieldNameContainsWildcards = field.field().contains("*");
             for (String fieldName : fieldNamesToHighlight) {
-                MappedFieldType fieldType = context.getQueryShardContext().getFieldType(fieldName);
+                MappedFieldType fieldType = context.getSearchExecutionContext().getFieldType(fieldName);
                 if (fieldType == null) {
                     continue;
                 }

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightUtils.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightUtils.java
@@ -24,7 +24,7 @@ import org.apache.lucene.search.highlight.SimpleHTMLEncoder;
 import org.elasticsearch.index.fieldvisitor.CustomFieldsVisitor;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.ValueFetcher;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.fetch.FetchSubPhase;
 
 import java.io.IOException;
@@ -48,7 +48,7 @@ public final class HighlightUtils {
      * Load field values for highlighting.
      */
     public static List<Object> loadFieldValues(MappedFieldType fieldType,
-                                               QueryShardContext qsc,
+                                               SearchExecutionContext searchContext,
                                                FetchSubPhase.HitContext hitContext,
                                                boolean forceSource) throws IOException {
         if (forceSource == false && fieldType.isStored()) {
@@ -57,7 +57,7 @@ public final class HighlightUtils {
             List<Object> textsToHighlight = fieldVisitor.fields().get(fieldType.name());
             return Objects.requireNonNullElse(textsToHighlight, Collections.emptyList());
         }
-        ValueFetcher fetcher = fieldType.valueFetcher(qsc, null);
+        ValueFetcher fetcher = fieldType.valueFetcher(searchContext, null);
         fetcher.setNextReader(hitContext.readerContext());
         return fetcher.fetchValues(hitContext.sourceLookup());
     }

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/PlainHighlighter.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/PlainHighlighter.java
@@ -100,11 +100,11 @@ public class PlainHighlighter implements Highlighter {
         int numberOfFragments = field.fieldOptions().numberOfFragments() == 0 ? 1 : field.fieldOptions().numberOfFragments();
         ArrayList<TextFragment> fragsList = new ArrayList<>();
         List<Object> textsToHighlight;
-        Analyzer analyzer = context.getQueryShardContext().getIndexAnalyzer(f -> Lucene.KEYWORD_ANALYZER);
-        final int maxAnalyzedOffset = context.getQueryShardContext().getIndexSettings().getHighlightMaxAnalyzedOffset();
+        Analyzer analyzer = context.getSearchExecutionContext().getIndexAnalyzer(f -> Lucene.KEYWORD_ANALYZER);
+        final int maxAnalyzedOffset = context.getSearchExecutionContext().getIndexSettings().getHighlightMaxAnalyzedOffset();
 
         textsToHighlight
-            = HighlightUtils.loadFieldValues(fieldType, context.getQueryShardContext(), hitContext, fieldContext.forceSource);
+            = HighlightUtils.loadFieldValues(fieldType, context.getSearchExecutionContext(), hitContext, fieldContext.forceSource);
 
         for (Object textToHighlight : textsToHighlight) {
             String text = convertFieldValue(fieldType, textToHighlight);

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/UnifiedHighlighter.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/UnifiedHighlighter.java
@@ -37,7 +37,7 @@ import org.elasticsearch.common.text.Text;
 import org.elasticsearch.index.mapper.IdFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.TextSearchInfo;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.fetch.FetchSubPhase;
 import org.elasticsearch.search.fetch.FetchSubPhase.HitContext;
 
@@ -73,7 +73,7 @@ public class UnifiedHighlighter implements Highlighter {
         FetchSubPhase.HitContext hitContext = fieldContext.hitContext;
 
         CheckedSupplier<String, IOException> loadFieldValues = () -> {
-            List<Object> fieldValues = loadFieldValues(highlighter, fieldContext.context.getQueryShardContext(), fieldType,
+            List<Object> fieldValues = loadFieldValues(highlighter, fieldContext.context.getSearchExecutionContext(), fieldType,
                 hitContext, fieldContext.forceSource);
             if (fieldValues.size() == 0) {
                 return null;
@@ -112,9 +112,9 @@ public class UnifiedHighlighter implements Highlighter {
         Encoder encoder = fieldContext.field.fieldOptions().encoder().equals("html")
             ? HighlightUtils.Encoders.HTML
             : HighlightUtils.Encoders.DEFAULT;
-        int maxAnalyzedOffset = fieldContext.context.getQueryShardContext().getIndexSettings().getHighlightMaxAnalyzedOffset();
+        int maxAnalyzedOffset = fieldContext.context.getSearchExecutionContext().getIndexSettings().getHighlightMaxAnalyzedOffset();
         int numberOfFragments = fieldContext.field.fieldOptions().numberOfFragments();
-        Analyzer analyzer = wrapAnalyzer(fieldContext.context.getQueryShardContext().getIndexAnalyzer(f -> Lucene.KEYWORD_ANALYZER));
+        Analyzer analyzer = wrapAnalyzer(fieldContext.context.getSearchExecutionContext().getIndexAnalyzer(f -> Lucene.KEYWORD_ANALYZER));
         PassageFormatter passageFormatter = getPassageFormatter(fieldContext.hitContext, fieldContext.field, encoder);
         IndexSearcher searcher = fieldContext.context.searcher();
         OffsetSource offsetSource = getOffsetSource(fieldContext.fieldType);
@@ -164,12 +164,12 @@ public class UnifiedHighlighter implements Highlighter {
 
     protected List<Object> loadFieldValues(
         CustomUnifiedHighlighter highlighter,
-        QueryShardContext qsc,
+        SearchExecutionContext searchContext,
         MappedFieldType fieldType,
         FetchSubPhase.HitContext hitContext,
         boolean forceSource
     ) throws IOException {
-        List<Object> fieldValues = HighlightUtils.loadFieldValues(fieldType, qsc, hitContext, forceSource);
+        List<Object> fieldValues = HighlightUtils.loadFieldValues(fieldType, searchContext, hitContext, forceSource);
         fieldValues = fieldValues.stream()
             .map((s) -> convertFieldValue(fieldType, s))
             .collect(Collectors.toList());

--- a/server/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
@@ -27,7 +27,7 @@ import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.cache.bitset.BitsetFilterCache;
 import org.elasticsearch.index.query.ParsedQuery;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.search.SearchExtBuilder;
 import org.elasticsearch.search.SearchShardTarget;
@@ -418,8 +418,8 @@ public abstract class FilteredSearchContext extends SearchContext {
     public Map<Class<?>, Collector> queryCollectors() { return in.queryCollectors();}
 
     @Override
-    public QueryShardContext getQueryShardContext() {
-        return in.getQueryShardContext();
+    public SearchExecutionContext getSearchExecutionContext() {
+        return in.getSearchExecutionContext();
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/internal/SearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/SearchContext.java
@@ -30,7 +30,7 @@ import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.cache.bitset.BitsetFilterCache;
 import org.elasticsearch.index.query.ParsedQuery;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.search.RescoreDocIds;
 import org.elasticsearch.search.SearchExtBuilder;
@@ -344,7 +344,7 @@ public abstract class SearchContext implements Releasable {
     /** Return a view of the additional query collectors that should be run for this context. */
     public abstract Map<Class<?>, Collector> queryCollectors();
 
-    public abstract QueryShardContext getQueryShardContext();
+    public abstract SearchExecutionContext getSearchExecutionContext();
 
     @Override
     public String toString() {

--- a/server/src/main/java/org/elasticsearch/search/internal/ShardSearchRequest.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/ShardSearchRequest.java
@@ -42,7 +42,7 @@ import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.MatchNoneQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryRewriteContext;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.Rewriteable;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.AliasFilterParsingException;
@@ -442,12 +442,12 @@ public class ShardSearchRequest extends TransportRequest implements IndicesReque
             SearchSourceBuilder newSource = request.source() == null ? null : Rewriteable.rewrite(request.source(), ctx);
             AliasFilter newAliasFilter = Rewriteable.rewrite(request.getAliasFilter(), ctx);
 
-            QueryShardContext shardContext = ctx.convertToShardContext();
+            SearchExecutionContext searchExecutionContext = ctx.convertToSearchExecutionContext();
 
             FieldSortBuilder primarySort = FieldSortBuilder.getPrimaryFieldSortOrNull(newSource);
-            if (shardContext != null
+            if (searchExecutionContext != null
                     && primarySort != null
-                    && primarySort.isBottomSortShardDisjoint(shardContext, request.getBottomSortValues())) {
+                    && primarySort.isBottomSortShardDisjoint(searchExecutionContext, request.getBottomSortValues())) {
                 assert newSource != null : "source should contain a primary sort field";
                 newSource = newSource.shallowCopy();
                 int trackTotalHitsUpTo = SearchRequest.resolveTrackTotalHitsUpTo(request.scroll, request.source);

--- a/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
@@ -55,7 +55,7 @@ import org.elasticsearch.common.util.concurrent.EsThreadPoolExecutor;
 import org.elasticsearch.index.IndexSortConfig;
 import org.elasticsearch.index.mapper.DateFieldMapper.DateFieldType;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.SearchContextSourcePrinter;
 import org.elasticsearch.search.SearchService;
@@ -429,9 +429,9 @@ public class QueryPhase {
 
         // check if this is a field of type Long or Date, that is indexed and has doc values
         String fieldName = sortField.getField();
-        QueryShardContext queryShardContext = searchContext.getQueryShardContext();
+        SearchExecutionContext searchExecutionContext = searchContext.getSearchExecutionContext();
         if (fieldName == null) return null; // happens when _score or _doc is the 1st sort field
-        final MappedFieldType fieldType = queryShardContext.getFieldType(fieldName);
+        final MappedFieldType fieldType = searchExecutionContext.getFieldType(fieldName);
         if (fieldType == null) return null; // for unmapped fields, default behaviour depending on "unmapped_type" flag
         if ((fieldType.typeName().equals("long") == false) && (fieldType instanceof DateFieldType == false)) return null;
         if (fieldType.isSearchable() == false) return null;
@@ -446,7 +446,7 @@ public class QueryPhase {
                 if (SortField.FIELD_DOC.equals(sField) == false) return null;
             } else {
                 //TODO: find out how to cover _script sort that don't use _score
-                if (queryShardContext.getFieldType(sFieldName) == null) return null; // could be _script sort that uses _score
+                if (searchExecutionContext.getFieldType(sFieldName) == null) return null; // could be _script sort that uses _score
             }
         }
 

--- a/server/src/main/java/org/elasticsearch/search/rescore/QueryRescorerBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/rescore/QueryRescorerBuilder.java
@@ -28,7 +28,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryRewriteContext;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.rescore.QueryRescorer.QueryRescoreContext;
 
 import java.io.IOException;
@@ -171,7 +171,7 @@ public class QueryRescorerBuilder extends RescorerBuilder<QueryRescorerBuilder> 
     }
 
     @Override
-    public QueryRescoreContext innerBuildContext(int windowSize, QueryShardContext context) throws IOException {
+    public QueryRescoreContext innerBuildContext(int windowSize, SearchExecutionContext context) throws IOException {
         QueryRescoreContext queryRescoreContext = new QueryRescoreContext(windowSize);
         // query is rewritten at this point already
         queryRescoreContext.setQuery(queryBuilder.toQuery(context));

--- a/server/src/main/java/org/elasticsearch/search/rescore/RescorerBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/rescore/RescorerBuilder.java
@@ -28,7 +28,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.Rewriteable;
 
 import java.io.IOException;
@@ -122,7 +122,7 @@ public abstract class RescorerBuilder<RB extends RescorerBuilder<RB>>
      * Build the {@linkplain RescoreContext} that will be used to actually
      * execute the rescore against a particular shard.
      */
-    public final RescoreContext buildContext(QueryShardContext context) throws IOException {
+    public final RescoreContext buildContext(SearchExecutionContext context) throws IOException {
         int finalWindowSize = windowSize == null ? DEFAULT_WINDOW_SIZE : windowSize;
         RescoreContext rescoreContext = innerBuildContext(finalWindowSize, context);
         return rescoreContext;
@@ -131,7 +131,7 @@ public abstract class RescorerBuilder<RB extends RescorerBuilder<RB>>
     /**
      * Extensions override this to build the context that they need for rescoring.
      */
-    protected abstract RescoreContext innerBuildContext(int windowSize, QueryShardContext context) throws IOException;
+    protected abstract RescoreContext innerBuildContext(int windowSize, SearchExecutionContext context) throws IOException;
 
     @Override
     public int hashCode() {

--- a/server/src/main/java/org/elasticsearch/search/slice/SliceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/slice/SliceBuilder.java
@@ -35,7 +35,7 @@ import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData;
 import org.elasticsearch.index.mapper.IdFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.internal.ShardSearchRequest;
 
 import java.io.IOException;
@@ -197,7 +197,7 @@ public class SliceBuilder implements Writeable, ToXContentObject {
      * @param context Additional information needed to build the query
      */
     @SuppressWarnings("rawtypes")
-    public Query toFilter(ShardSearchRequest request, QueryShardContext context) {
+    public Query toFilter(ShardSearchRequest request, SearchExecutionContext context) {
         final MappedFieldType type = context.getFieldType(field);
         if (type == null) {
             throw new IllegalArgumentException("field " + field + " not found");

--- a/server/src/main/java/org/elasticsearch/search/sort/FieldSortBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/sort/FieldSortBuilder.java
@@ -379,7 +379,8 @@ public class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
      * Returns whether some values of the given {@link SearchExecutionContext#getIndexReader()} are within the
      * primary sort value provided in the <code>bottomSortValues</code>.
      */
-    public boolean isBottomSortShardDisjoint(SearchExecutionContext context, SearchSortValuesAndFormats bottomSortValues) throws IOException {
+    public boolean isBottomSortShardDisjoint(SearchExecutionContext context,
+                                             SearchSortValuesAndFormats bottomSortValues) throws IOException {
         if (bottomSortValues == null || bottomSortValues.getRawSortValues().length == 0) {
             return false;
         }

--- a/server/src/main/java/org/elasticsearch/search/sort/FieldSortBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/sort/FieldSortBuilder.java
@@ -49,7 +49,7 @@ import org.elasticsearch.index.mapper.NumberFieldMapper.NumberFieldType;
 import org.elasticsearch.index.mapper.ObjectMapper;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryRewriteContext;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.QueryShardException;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.MultiValueMode;
@@ -327,7 +327,7 @@ public class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
     }
 
     @Override
-    public SortFieldAndFormat build(QueryShardContext context) throws IOException {
+    public SortFieldAndFormat build(SearchExecutionContext context) throws IOException {
         final boolean reverse = order == SortOrder.DESC;
 
         if (DOC_FIELD_NAME.equals(fieldName)) {
@@ -376,10 +376,10 @@ public class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
     }
 
     /**
-     * Returns whether some values of the given {@link QueryShardContext#getIndexReader()} are within the
+     * Returns whether some values of the given {@link SearchExecutionContext#getIndexReader()} are within the
      * primary sort value provided in the <code>bottomSortValues</code>.
      */
-    public boolean isBottomSortShardDisjoint(QueryShardContext context, SearchSortValuesAndFormats bottomSortValues) throws IOException {
+    public boolean isBottomSortShardDisjoint(SearchExecutionContext context, SearchSortValuesAndFormats bottomSortValues) throws IOException {
         if (bottomSortValues == null || bottomSortValues.getRawSortValues().length == 0) {
             return false;
         }
@@ -416,7 +416,7 @@ public class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
     }
 
     @Override
-    public BucketedSort buildBucketedSort(QueryShardContext context, BigArrays bigArrays, int bucketSize, BucketedSort.ExtraData extra)
+    public BucketedSort buildBucketedSort(SearchExecutionContext context, BigArrays bigArrays, int bucketSize, BucketedSort.ExtraData extra)
         throws IOException {
         if (DOC_FIELD_NAME.equals(fieldName)) {
             throw new IllegalArgumentException("sorting by _doc is not supported");
@@ -452,7 +452,7 @@ public class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
         }
     }
 
-    private MappedFieldType resolveUnmappedType(QueryShardContext context) {
+    private MappedFieldType resolveUnmappedType(SearchExecutionContext context) {
         if (unmappedType == null) {
             throw new QueryShardException(context, "No mapping found for [" + fieldName + "] in order to sort on");
         }
@@ -467,7 +467,7 @@ public class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
         return order == SortOrder.DESC ? MultiValueMode.MAX : MultiValueMode.MIN;
     }
 
-    private Nested nested(QueryShardContext context, MappedFieldType fieldType) throws IOException {
+    private Nested nested(SearchExecutionContext context, MappedFieldType fieldType) throws IOException {
         if (fieldType == null) {
             return null;
         }
@@ -503,7 +503,7 @@ public class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
      * The value can be extracted on non-nested indexed mapped fields of type keyword, numeric or date, other fields
      * and configurations return <code>null</code>.
      */
-    public static MinAndMax<?> getMinMaxOrNull(QueryShardContext context, FieldSortBuilder sortBuilder) throws IOException {
+    public static MinAndMax<?> getMinMaxOrNull(SearchExecutionContext context, FieldSortBuilder sortBuilder) throws IOException {
         SortAndFormats sort = SortBuilder.buildSort(Collections.singletonList(sortBuilder), context).get();
         SortField sortField = sort.sort.getSort()[0];
         if (sortField.getField() == null) {
@@ -584,7 +584,7 @@ public class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
     /**
      * Throws an exception if max children is not located at top level nested sort.
      */
-    static void validateMaxChildrenExistOnlyInTopLevelNestedSort(QueryShardContext context, NestedSortBuilder nestedSort) {
+    static void validateMaxChildrenExistOnlyInTopLevelNestedSort(SearchExecutionContext context, NestedSortBuilder nestedSort) {
         for (NestedSortBuilder child = nestedSort.getNestedSort(); child != null; child = child.getNestedSort()) {
             if (child.getMaxChildren() != Integer.MAX_VALUE) {
                 throw new QueryShardException(context,
@@ -596,7 +596,7 @@ public class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
     /**
      * Throws an exception if the provided <code>field</code> requires a nested context.
      */
-    static void validateMissingNestedPath(QueryShardContext context, String field) {
+    static void validateMissingNestedPath(SearchExecutionContext context, String field) {
         ObjectMapper contextMapper = context.nestedScope().getObjectMapper();
         if (contextMapper != null && contextMapper.nested().isNested() == false) {
             // already in nested context

--- a/server/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortBuilder.java
@@ -54,7 +54,7 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.GeoValidationMethod;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryRewriteContext;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
@@ -492,7 +492,7 @@ public class GeoDistanceSortBuilder extends SortBuilder<GeoDistanceSortBuilder> 
     }
 
     @Override
-    public SortFieldAndFormat build(QueryShardContext context) throws IOException {
+    public SortFieldAndFormat build(SearchExecutionContext context) throws IOException {
         GeoPoint[] localPoints = localPoints();
         boolean reverse = order == SortOrder.DESC;
         MultiValueMode localSortMode = localSortMode();
@@ -516,7 +516,7 @@ public class GeoDistanceSortBuilder extends SortBuilder<GeoDistanceSortBuilder> 
     }
 
     @Override
-    public BucketedSort buildBucketedSort(QueryShardContext context, BigArrays bigArrays, int bucketSize, BucketedSort.ExtraData extra)
+    public BucketedSort buildBucketedSort(SearchExecutionContext context, BigArrays bigArrays, int bucketSize, BucketedSort.ExtraData extra)
         throws IOException {
         GeoPoint[] localPoints = localPoints();
         MultiValueMode localSortMode = localSortMode();
@@ -567,7 +567,7 @@ public class GeoDistanceSortBuilder extends SortBuilder<GeoDistanceSortBuilder> 
         return order == SortOrder.DESC ? MultiValueMode.MAX : MultiValueMode.MIN;
     }
 
-    private IndexGeoPointFieldData fieldData(QueryShardContext context) {
+    private IndexGeoPointFieldData fieldData(SearchExecutionContext context) {
         MappedFieldType fieldType = context.getFieldType(fieldName);
         if (fieldType == null) {
             if (ignoreUnmapped) {
@@ -579,7 +579,7 @@ public class GeoDistanceSortBuilder extends SortBuilder<GeoDistanceSortBuilder> 
         return context.getForField(fieldType);
     }
 
-    private Nested nested(QueryShardContext context) throws IOException {
+    private Nested nested(SearchExecutionContext context) throws IOException {
         // TODO this is pretty similar to FieldSortBuilder. Share?
         if (nestedSort == null) {
             validateMissingNestedPath(context, fieldName);

--- a/server/src/main/java/org/elasticsearch/search/sort/ScoreSortBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/sort/ScoreSortBuilder.java
@@ -29,7 +29,7 @@ import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.query.QueryRewriteContext;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.DocValueFormat;
 
 import java.io.IOException;
@@ -96,7 +96,7 @@ public class ScoreSortBuilder extends SortBuilder<ScoreSortBuilder> {
     }
 
     @Override
-    public SortFieldAndFormat build(QueryShardContext context) {
+    public SortFieldAndFormat build(SearchExecutionContext context) {
         if (order == SortOrder.DESC) {
             return SORT_SCORE;
         } else {
@@ -105,7 +105,7 @@ public class ScoreSortBuilder extends SortBuilder<ScoreSortBuilder> {
     }
 
     @Override
-    public BucketedSort buildBucketedSort(QueryShardContext context, BigArrays bigArrays, int bucketSize, BucketedSort.ExtraData extra)
+    public BucketedSort buildBucketedSort(SearchExecutionContext context, BigArrays bigArrays, int bucketSize, BucketedSort.ExtraData extra)
         throws IOException {
         return new BucketedSort.ForFloats(bigArrays, order, DocValueFormat.RAW, bucketSize, extra) {
             @Override

--- a/server/src/main/java/org/elasticsearch/search/sort/ScriptSortBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/sort/ScriptSortBuilder.java
@@ -46,7 +46,7 @@ import org.elasticsearch.index.fielddata.fieldcomparator.BytesRefFieldComparator
 import org.elasticsearch.index.fielddata.fieldcomparator.DoubleValuesComparatorSource;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryRewriteContext;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.QueryShardException;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.NumberSortScript;
@@ -232,19 +232,19 @@ public class ScriptSortBuilder extends SortBuilder<ScriptSortBuilder> {
 
 
     @Override
-    public SortFieldAndFormat build(QueryShardContext context) throws IOException {
+    public SortFieldAndFormat build(SearchExecutionContext context) throws IOException {
         return new SortFieldAndFormat(
                 new SortField("_script", fieldComparatorSource(context), order == SortOrder.DESC),
                 DocValueFormat.RAW);
     }
 
     @Override
-    public BucketedSort buildBucketedSort(QueryShardContext context, BigArrays bigArrays, int bucketSize, BucketedSort.ExtraData extra)
+    public BucketedSort buildBucketedSort(SearchExecutionContext context, BigArrays bigArrays, int bucketSize, BucketedSort.ExtraData extra)
         throws IOException {
         return fieldComparatorSource(context).newBucketedSort(bigArrays, order, DocValueFormat.RAW, bucketSize, extra);
     }
 
-    private IndexFieldData.XFieldComparatorSource fieldComparatorSource(QueryShardContext context) throws IOException {
+    private IndexFieldData.XFieldComparatorSource fieldComparatorSource(SearchExecutionContext context) throws IOException {
         MultiValueMode valueMode = null;
         if (sortMode != null) {
             valueMode = MultiValueMode.fromString(sortMode.toString());

--- a/server/src/main/java/org/elasticsearch/search/sort/SortBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/sort/SortBuilder.java
@@ -34,7 +34,7 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource.Nested;
 import org.elasticsearch.index.mapper.ObjectMapper;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.QueryShardException;
 import org.elasticsearch.index.query.Rewriteable;
 import org.elasticsearch.search.DocValueFormat;
@@ -66,13 +66,13 @@ public abstract class SortBuilder<T extends SortBuilder<T>> implements NamedWrit
     /**
      * Create a {@linkplain SortFieldAndFormat} from this builder.
      */
-    protected abstract SortFieldAndFormat build(QueryShardContext context) throws IOException;
+    protected abstract SortFieldAndFormat build(SearchExecutionContext context) throws IOException;
 
     /**
      * Create a {@linkplain BucketedSort} which is useful for sorting inside of aggregations.
      */
     public abstract BucketedSort buildBucketedSort(
-        QueryShardContext context,
+        SearchExecutionContext context,
         BigArrays bigArrays,
         int bucketSize,
         BucketedSort.ExtraData extra
@@ -150,7 +150,7 @@ public abstract class SortBuilder<T extends SortBuilder<T>> implements NamedWrit
         }
     }
 
-    public static Optional<SortAndFormats> buildSort(List<SortBuilder<?>> sortBuilders, QueryShardContext context) throws IOException {
+    public static Optional<SortAndFormats> buildSort(List<SortBuilder<?>> sortBuilders, SearchExecutionContext context) throws IOException {
         List<SortField> sortFields = new ArrayList<>(sortBuilders.size());
         List<DocValueFormat> sortFormats = new ArrayList<>(sortBuilders.size());
         for (SortBuilder<?> builder : sortBuilders) {
@@ -181,7 +181,7 @@ public abstract class SortBuilder<T extends SortBuilder<T>> implements NamedWrit
         return Optional.empty();
     }
 
-    protected static Nested resolveNested(QueryShardContext context, NestedSortBuilder nestedSort) throws IOException {
+    protected static Nested resolveNested(SearchExecutionContext context, NestedSortBuilder nestedSort) throws IOException {
         final Query childQuery = resolveNestedQuery(context, nestedSort, null);
         if (childQuery == null) {
             return null;
@@ -196,7 +196,7 @@ public abstract class SortBuilder<T extends SortBuilder<T>> implements NamedWrit
         return new Nested(context.bitsetFilter(parentQuery), childQuery, nestedSort, context.searcher());
     }
 
-    private static Query resolveNestedQuery(QueryShardContext context, NestedSortBuilder nestedSort, Query parentQuery) throws IOException {
+    private static Query resolveNestedQuery(SearchExecutionContext context, NestedSortBuilder nestedSort, Query parentQuery) throws IOException {
         if (nestedSort == null || nestedSort.getPath() == null) {
             return null;
         }

--- a/server/src/main/java/org/elasticsearch/search/sort/SortBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/sort/SortBuilder.java
@@ -196,7 +196,9 @@ public abstract class SortBuilder<T extends SortBuilder<T>> implements NamedWrit
         return new Nested(context.bitsetFilter(parentQuery), childQuery, nestedSort, context.searcher());
     }
 
-    private static Query resolveNestedQuery(SearchExecutionContext context, NestedSortBuilder nestedSort, Query parentQuery) throws IOException {
+    private static Query resolveNestedQuery(SearchExecutionContext context,
+                                            NestedSortBuilder nestedSort,
+                                            Query parentQuery) throws IOException {
         if (nestedSort == null || nestedSort.getPath() == null) {
             return null;
         }

--- a/server/src/main/java/org/elasticsearch/search/suggest/SuggestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/SuggestBuilder.java
@@ -29,7 +29,7 @@ import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.suggest.SuggestionSearchContext.SuggestionContext;
 
 import java.io.IOException;
@@ -169,7 +169,7 @@ public class SuggestBuilder implements Writeable, ToXContentObject {
         return suggestBuilder;
     }
 
-    public SuggestionSearchContext build(QueryShardContext context) throws IOException {
+    public SuggestionSearchContext build(SearchExecutionContext context) throws IOException {
         SuggestionSearchContext suggestionSearchContext = new SuggestionSearchContext();
         for (Entry<String, SuggestionBuilder<?>> suggestion : suggestions.entrySet()) {
             SuggestionContext suggestionContext = suggestion.getValue().build(context);

--- a/server/src/main/java/org/elasticsearch/search/suggest/SuggestionBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/SuggestionBuilder.java
@@ -31,7 +31,7 @@ import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.suggest.SuggestionSearchContext.SuggestionContext;
 
 import java.io.IOException;
@@ -291,13 +291,13 @@ public abstract class SuggestionBuilder<T extends SuggestionBuilder<T>> implemen
         return suggestionBuilder;
     }
 
-    protected abstract SuggestionContext build(QueryShardContext context) throws IOException;
+    protected abstract SuggestionContext build(SearchExecutionContext context) throws IOException;
 
     /**
      * Transfers the text, prefix, regex, analyzer, field, size and shard size settings from the
      * original {@link SuggestionBuilder} to the target {@link SuggestionContext}
      */
-    protected void populateCommonFields(QueryShardContext context, SuggestionSearchContext.SuggestionContext suggestionContext) {
+    protected void populateCommonFields(SearchExecutionContext context, SuggestionSearchContext.SuggestionContext suggestionContext) {
 
         Objects.requireNonNull(field, "field must not be null");
         if (context.isFieldMapped(field) == false) {

--- a/server/src/main/java/org/elasticsearch/search/suggest/SuggestionSearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/SuggestionSearchContext.java
@@ -20,7 +20,7 @@ package org.elasticsearch.search.suggest;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -46,12 +46,12 @@ public class SuggestionSearchContext {
         private Analyzer analyzer;
         private int size = 5;
         private int shardSize = -1;
-        private QueryShardContext shardContext;
+        private SearchExecutionContext searchExecutionContext;
         private Suggester<?> suggester;
 
-        protected SuggestionContext(Suggester<?> suggester, QueryShardContext shardContext) {
+        protected SuggestionContext(Suggester<?> suggester, SearchExecutionContext searchExecutionContext) {
             this.suggester = suggester;
-            this.shardContext = shardContext;
+            this.searchExecutionContext = searchExecutionContext;
         }
 
         public BytesRef getText() {
@@ -121,8 +121,8 @@ public class SuggestionSearchContext {
             this.shardSize = shardSize;
         }
 
-        public QueryShardContext getShardContext() {
-            return this.shardContext;
+        public SearchExecutionContext getSearchExecutionContext() {
+            return this.searchExecutionContext;
         }
 
         @Override
@@ -136,7 +136,7 @@ public class SuggestionSearchContext {
                        ",shardSize=" + shardSize +
                        ",suggester=" + suggester +
                        ",analyzer=" + analyzer +
-                       ",shardContext=" + shardContext +
+                       ",searchExecutionContext=" + searchExecutionContext +
                    "]";
         }
     }

--- a/server/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestionBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestionBuilder.java
@@ -35,7 +35,7 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.mapper.CompletionFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.suggest.SuggestionBuilder;
 import org.elasticsearch.search.suggest.SuggestionSearchContext.SuggestionContext;
 import org.elasticsearch.search.suggest.completion.context.ContextMapping;
@@ -280,7 +280,7 @@ public class CompletionSuggestionBuilder extends SuggestionBuilder<CompletionSug
     }
 
     @Override
-    public SuggestionContext build(QueryShardContext context) throws IOException {
+    public SuggestionContext build(SearchExecutionContext context) throws IOException {
         CompletionSuggestionContext suggestionContext = new CompletionSuggestionContext(context);
         // copy over common settings to each suggestion builder
         populateCommonFields(context, suggestionContext);

--- a/server/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestionContext.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestionContext.java
@@ -22,7 +22,7 @@ import org.apache.lucene.search.suggest.document.CompletionQuery;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.index.mapper.CompletionFieldMapper;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.suggest.SuggestionSearchContext;
 import org.elasticsearch.search.suggest.completion.context.ContextMapping;
 import org.elasticsearch.search.suggest.completion.context.ContextMappings;
@@ -33,8 +33,8 @@ import java.util.Map;
 
 public class CompletionSuggestionContext extends SuggestionSearchContext.SuggestionContext {
 
-    protected CompletionSuggestionContext(QueryShardContext shardContext) {
-        super(CompletionSuggester.INSTANCE, shardContext);
+    protected CompletionSuggestionContext(SearchExecutionContext searchExecutionContext) {
+        super(CompletionSuggester.INSTANCE, searchExecutionContext);
     }
 
     private CompletionFieldMapper.CompletionFieldType fieldType;

--- a/server/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggester.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggester.java
@@ -37,7 +37,7 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.query.AbstractQueryBuilder;
 import org.elasticsearch.index.query.ParsedQuery;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.script.TemplateScript;
 import org.elasticsearch.search.suggest.Suggest.Suggestion;
 import org.elasticsearch.search.suggest.Suggest.Suggestion.Entry;
@@ -117,12 +117,12 @@ public final class PhraseSuggester extends Suggester<PhraseSuggestionContext> {
                     // from the index for a correction, collateMatch is updated
                     final Map<String, Object> vars = suggestion.getCollateScriptParams();
                     vars.put(SUGGESTION_TEMPLATE_VAR_NAME, spare.toString());
-                    QueryShardContext shardContext = suggestion.getShardContext();
+                    SearchExecutionContext searchExecutionContext = suggestion.getSearchExecutionContext();
                     final String querySource = scriptFactory.newInstance(vars).execute();
                     try (XContentParser parser = XContentFactory.xContent(querySource)
-                            .createParser(shardContext.getXContentRegistry(), LoggingDeprecationHandler.INSTANCE, querySource)) {
+                            .createParser(searchExecutionContext.getXContentRegistry(), LoggingDeprecationHandler.INSTANCE, querySource)) {
                         QueryBuilder innerQueryBuilder = AbstractQueryBuilder.parseInnerQueryBuilder(parser);
-                        final ParsedQuery parsedQuery = shardContext.toQuery(innerQueryBuilder);
+                        final ParsedQuery parsedQuery = searchExecutionContext.toQuery(innerQueryBuilder);
                         collateMatch = Lucene.exists(searcher, parsedQuery.query());
                     }
                 }

--- a/server/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilder.java
@@ -36,7 +36,7 @@ import org.elasticsearch.index.analysis.IndexAnalyzers;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.analysis.ShingleTokenFilterFactory;
 import org.elasticsearch.index.analysis.TokenFilterFactory;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.script.TemplateScript;
@@ -604,7 +604,7 @@ public class PhraseSuggestionBuilder extends SuggestionBuilder<PhraseSuggestionB
 
 
     @Override
-    public SuggestionContext build(QueryShardContext context) throws IOException {
+    public SuggestionContext build(SearchExecutionContext context) throws IOException {
         PhraseSuggestionContext suggestionContext = new PhraseSuggestionContext(context);
         // copy over common settings to each suggestion builder
         populateCommonFields(context, suggestionContext);

--- a/server/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionContext.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionContext.java
@@ -22,7 +22,7 @@ import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.script.TemplateScript;
 import org.elasticsearch.search.suggest.DirectSpellcheckerSettings;
 import org.elasticsearch.search.suggest.SuggestionSearchContext.SuggestionContext;
@@ -58,8 +58,8 @@ class PhraseSuggestionContext extends SuggestionContext {
     private Map<String, Object> collateScriptParams = new HashMap<>(1);
     private WordScorer.WordScorerFactory scorer = DEFAULT_SCORER;
 
-    PhraseSuggestionContext(QueryShardContext shardContext) {
-        super(PhraseSuggester.INSTANCE, shardContext);
+    PhraseSuggestionContext(SearchExecutionContext searchExecutionContext) {
+        super(PhraseSuggester.INSTANCE, searchExecutionContext);
     }
 
     public float maxErrors() {

--- a/server/src/main/java/org/elasticsearch/search/suggest/term/TermSuggestionBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/term/TermSuggestionBuilder.java
@@ -32,7 +32,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.suggest.DirectSpellcheckerSettings;
 import org.elasticsearch.search.suggest.SortBy;
 import org.elasticsearch.search.suggest.SuggestionBuilder;
@@ -442,7 +442,7 @@ public class TermSuggestionBuilder extends SuggestionBuilder<TermSuggestionBuild
     }
 
     @Override
-    public SuggestionContext build(QueryShardContext context) throws IOException {
+    public SuggestionContext build(SearchExecutionContext context) throws IOException {
         TermSuggestionContext suggestionContext = new TermSuggestionContext(context);
         // copy over common settings to each suggestion builder
         populateCommonFields(context, suggestionContext);

--- a/server/src/main/java/org/elasticsearch/search/suggest/term/TermSuggestionContext.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/term/TermSuggestionContext.java
@@ -18,7 +18,7 @@
  */
 package org.elasticsearch.search.suggest.term;
 
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.suggest.DirectSpellcheckerSettings;
 import org.elasticsearch.search.suggest.SuggestionSearchContext.SuggestionContext;
 
@@ -26,8 +26,8 @@ final class TermSuggestionContext extends SuggestionContext {
 
     private final DirectSpellcheckerSettings settings = new DirectSpellcheckerSettings();
 
-    TermSuggestionContext(QueryShardContext shardContext) {
-        super(TermSuggester.INSTANCE, shardContext);
+    TermSuggestionContext(SearchExecutionContext searchExecutionContext) {
+        super(TermSuggester.INSTANCE, searchExecutionContext);
     }
 
     public DirectSpellcheckerSettings getDirectSpellCheckerSettings() {

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexServiceTests.java
@@ -52,7 +52,7 @@ import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.mapper.MapperService;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.indices.InvalidAliasNameException;
 import org.elasticsearch.indices.InvalidIndexNameException;
 import org.elasticsearch.indices.ShardLimitValidator;
@@ -114,7 +114,7 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
 
     private AliasValidator aliasValidator;
     private CreateIndexClusterStateUpdateRequest request;
-    private QueryShardContext queryShardContext;
+    private SearchExecutionContext searchExecutionContext;
 
     @Before
     public void setupCreateIndexRequestAndAliasValidator() {
@@ -122,7 +122,7 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
         request = new CreateIndexClusterStateUpdateRequest("create index", "test", "test");
         Settings indexSettings = Settings.builder().put(SETTING_VERSION_CREATED, Version.CURRENT)
             .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1).build();
-        queryShardContext = new QueryShardContext(0, 0,
+        searchExecutionContext = new SearchExecutionContext(0, 0,
             new IndexSettings(IndexMetadata.builder("test").settings(indexSettings).build(), indexSettings),
             null, null, null, null, null, null, xContentRegistry(), writableRegistry(),
             null, null, () -> randomNonNegativeLong(), null, null, () -> true, null, emptyMap());
@@ -598,7 +598,7 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
 
         expectThrows(InvalidAliasNameException.class, () ->
             resolveAndValidateAliases(request.index(), request.aliases(), List.of(), Metadata.builder().build(),
-                aliasValidator, xContentRegistry(), queryShardContext)
+                aliasValidator, xContentRegistry(), searchExecutionContext)
         );
     }
 
@@ -620,7 +620,7 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
             List.of(templateMetadata.mappings()), xContentRegistry());
         List<AliasMetadata> resolvedAliases = resolveAndValidateAliases(request.index(), request.aliases(),
             MetadataIndexTemplateService.resolveAliases(List.of(templateMetadata)),
-            Metadata.builder().build(), aliasValidator, xContentRegistry(), queryShardContext);
+            Metadata.builder().build(), aliasValidator, xContentRegistry(), searchExecutionContext);
         Settings aggregatedIndexSettings = aggregateIndexSettings(ClusterState.EMPTY_STATE, request, templateMetadata.settings(),
             null, Settings.EMPTY, IndexScopedSettings.DEFAULT_SCOPED_SETTINGS, randomShardLimitService(),
             Collections.emptySet());
@@ -673,7 +673,7 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
             IndexScopedSettings.DEFAULT_SCOPED_SETTINGS, randomShardLimitService(), Collections.emptySet());
         List<AliasMetadata> resolvedAliases = resolveAndValidateAliases(request.index(), request.aliases(),
             MetadataIndexTemplateService.resolveAliases(templates),
-            Metadata.builder().build(), aliasValidator, xContentRegistry(), queryShardContext);
+            Metadata.builder().build(), aliasValidator, xContentRegistry(), searchExecutionContext);
         assertThat(aggregatedIndexSettings.get(SETTING_NUMBER_OF_SHARDS), equalTo("12"));
         AliasMetadata alias = resolvedAliases.get(0);
         assertThat(alias.getSearchRouting(), equalTo("3"));

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateServiceTests.java
@@ -48,7 +48,7 @@ import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MetadataFieldMapper;
 import org.elasticsearch.index.mapper.TextSearchInfo;
 import org.elasticsearch.index.mapper.ValueFetcher;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.indices.IndexTemplateMissingException;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.InvalidIndexTemplateException;
@@ -1584,7 +1584,7 @@ public class MetadataIndexTemplateServiceTests extends ESSingleNodeTestCase {
         public MetadataTimestampFieldMapper(boolean enabled) {
             super(new MappedFieldType("_data_stream_timestamp", false, false, false, TextSearchInfo.NONE, Map.of()) {
                 @Override
-                public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+                public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
                     throw new UnsupportedOperationException();
                 }
 
@@ -1594,12 +1594,12 @@ public class MetadataIndexTemplateServiceTests extends ESSingleNodeTestCase {
                 }
 
                 @Override
-                public Query termQuery(Object value, QueryShardContext context) {
+                public Query termQuery(Object value, SearchExecutionContext context) {
                     return null;
                 }
 
                 @Override
-                public Query existsQuery(QueryShardContext context) {
+                public Query existsQuery(SearchExecutionContext context) {
                     return null;
                 }
             });

--- a/server/src/test/java/org/elasticsearch/index/IndexSortSettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexSortSettingsTests.java
@@ -27,7 +27,7 @@ import org.elasticsearch.index.fielddata.IndexFieldDataService;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.RuntimeFieldType;
 import org.elasticsearch.index.mapper.ValueFetcher;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.indices.fielddata.cache.IndicesFieldDataCache;
 import org.elasticsearch.search.MultiValueMode;
@@ -154,7 +154,7 @@ public class IndexSortSettingsTests extends ESTestCase {
         final IndexFieldDataService indexFieldDataService = new IndexFieldDataService(indexSettings, cache, circuitBreakerService, null);
         MappedFieldType fieldType = new RuntimeFieldType("field", Collections.emptyMap()) {
             @Override
-            public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+            public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
                 throw new UnsupportedOperationException();
             }
 
@@ -170,7 +170,7 @@ public class IndexSortSettingsTests extends ESTestCase {
             }
 
             @Override
-            public Query termQuery(Object value, QueryShardContext context) {
+            public Query termQuery(Object value, SearchExecutionContext context) {
                 throw new UnsupportedOperationException();
             }
 

--- a/server/src/test/java/org/elasticsearch/index/fielddata/AbstractFieldDataTestCase.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/AbstractFieldDataTestCase.java
@@ -44,7 +44,7 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.mapper.TextFieldMapper;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.fielddata.cache.IndicesFieldDataCache;
@@ -71,7 +71,7 @@ public abstract class AbstractFieldDataTestCase extends ESSingleNodeTestCase {
     protected List<LeafReaderContext> readerContexts = null;
     protected DirectoryReader topLevelReader = null;
     protected IndicesFieldDataCache indicesFieldDataCache;
-    protected QueryShardContext shardContext;
+    protected SearchExecutionContext searchExecutionContext;
 
     protected abstract String getFieldDataType();
 
@@ -127,7 +127,7 @@ public abstract class AbstractFieldDataTestCase extends ESSingleNodeTestCase {
         } else {
             throw new UnsupportedOperationException(type);
         }
-        return shardContext.getForField(fieldType);
+        return searchExecutionContext.getForField(fieldType);
     }
 
     @Before
@@ -139,7 +139,7 @@ public abstract class AbstractFieldDataTestCase extends ESSingleNodeTestCase {
         writer = new IndexWriter(
             new ByteBuffersDirectory(), new IndexWriterConfig(new StandardAnalyzer()).setMergePolicy(new LogByteSizeMergePolicy())
         );
-        shardContext = indexService.newQueryShardContext(0, 0, null, () -> 0, null, emptyMap());
+        searchExecutionContext = indexService.newSearchExecutionContext(0, 0, null, () -> 0, null, emptyMap());
     }
 
     protected final List<LeafReaderContext> refreshReader() throws Exception {
@@ -159,7 +159,7 @@ public abstract class AbstractFieldDataTestCase extends ESSingleNodeTestCase {
             topLevelReader.close();
         }
         writer.close();
-        shardContext = null;
+        searchExecutionContext = null;
     }
 
     protected Nested createNested(IndexSearcher searcher, Query parentFilter, Query childFilter) throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/fielddata/FilterFieldDataTests.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/FilterFieldDataTests.java
@@ -67,7 +67,7 @@ public class FilterFieldDataTests extends AbstractFieldDataTestCase {
                     .fielddata(true)
                     .fielddataFrequencyFilter(0, random.nextBoolean() ? 100 : 0.5d, 0)
                     .build(contentPath).fieldType();
-            IndexOrdinalsFieldData fieldData = shardContext.getForField(ft);
+            IndexOrdinalsFieldData fieldData = searchExecutionContext.getForField(ft);
             for (LeafReaderContext context : contexts) {
                 LeafOrdinalsFieldData loadDirect = fieldData.loadDirect(context);
                 SortedSetDocValues bytesValues = loadDirect.getOrdinalsValues();
@@ -82,7 +82,7 @@ public class FilterFieldDataTests extends AbstractFieldDataTestCase {
                     .fielddata(true)
                     .fielddataFrequencyFilter(random.nextBoolean() ? 101 : 101d/200.0d, 201, 100)
                     .build(contentPath).fieldType();
-            IndexOrdinalsFieldData fieldData = shardContext.getForField(ft);
+            IndexOrdinalsFieldData fieldData = searchExecutionContext.getForField(ft);
             for (LeafReaderContext context : contexts) {
                 LeafOrdinalsFieldData loadDirect = fieldData.loadDirect(context);
                 SortedSetDocValues bytesValues = loadDirect.getOrdinalsValues();
@@ -97,7 +97,7 @@ public class FilterFieldDataTests extends AbstractFieldDataTestCase {
                     .fielddata(true)
                     .fielddataFrequencyFilter(random.nextBoolean() ? 101 : 101d/200.0d, Integer.MAX_VALUE, 101)
                     .build(contentPath).fieldType();
-            IndexOrdinalsFieldData fieldData = shardContext.getForField(ft);
+            IndexOrdinalsFieldData fieldData = searchExecutionContext.getForField(ft);
             for (LeafReaderContext context : contexts) {
                 LeafOrdinalsFieldData loadDirect = fieldData.loadDirect(context);
                 SortedSetDocValues bytesValues = loadDirect.getOrdinalsValues();
@@ -113,7 +113,7 @@ public class FilterFieldDataTests extends AbstractFieldDataTestCase {
                     .fielddata(true)
                     .fielddataFrequencyFilter(random.nextBoolean() ? 101 : 101d/200.0d, Integer.MAX_VALUE, 101)
                     .build(contentPath).fieldType();
-            IndexOrdinalsFieldData fieldData = shardContext.getForField(ft);
+            IndexOrdinalsFieldData fieldData = searchExecutionContext.getForField(ft);
             for (LeafReaderContext context : contexts) {
                 LeafOrdinalsFieldData loadDirect = fieldData.loadDirect(context);
                 SortedSetDocValues bytesValues = loadDirect.getOrdinalsValues();

--- a/server/src/test/java/org/elasticsearch/index/mapper/DateFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DateFieldTypeTests.java
@@ -49,7 +49,7 @@ import org.elasticsearch.index.mapper.MappedFieldType.Relation;
 import org.elasticsearch.index.mapper.ParseContext.Document;
 import org.elasticsearch.index.query.DateRangeIncludingNowQuery;
 import org.elasticsearch.index.query.QueryRewriteContext;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.joda.time.DateTimeZone;
 
 import java.io.IOException;
@@ -164,7 +164,7 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
     public void testTermQuery() {
         Settings indexSettings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
                 .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1).build();
-        QueryShardContext context = new QueryShardContext(0, 0,
+        SearchExecutionContext context = new SearchExecutionContext(0, 0,
                 new IndexSettings(IndexMetadata.builder("foo").settings(indexSettings).build(), indexSettings),
                 null, null, null, null, null, null,
                 xContentRegistry(), writableRegistry(), null, null, () -> nowInMillis, null, null, () -> true, null, emptyMap());
@@ -186,7 +186,7 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
     public void testRangeQuery() throws IOException {
         Settings indexSettings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
                 .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1).build();
-        QueryShardContext context = new QueryShardContext(0, 0,
+        SearchExecutionContext context = new SearchExecutionContext(0, 0,
                 new IndexSettings(IndexMetadata.builder("foo").settings(indexSettings).build(), indexSettings),
                 null, null, null, null, null, null, xContentRegistry(), writableRegistry(),
                 null, null, () -> nowInMillis, null, null, () -> true, null, emptyMap());
@@ -231,7 +231,7 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
             .build();
         IndexSettings indexSettings = new IndexSettings(indexMetadata, settings);
 
-        QueryShardContext context = new QueryShardContext(0, 0, indexSettings,
+        SearchExecutionContext context = new SearchExecutionContext(0, 0, indexSettings,
             null, null, null, null, null, null, xContentRegistry(), writableRegistry(),
             null, null, () -> 0L, null, null, () -> true, null, emptyMap());
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocCountFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocCountFieldTypeTests.java
@@ -28,7 +28,7 @@ public class DocCountFieldTypeTests extends FieldTypeTestCase {
     public void testTermQuery() {
         MappedFieldType ft = new DocCountFieldMapper.DocCountFieldType();
         QueryShardException e = expectThrows(QueryShardException.class,
-            () -> ft.termQuery(10L, randomMockShardContext()));
+            () -> ft.termQuery(10L, randomMockContext()));
         assertEquals("Field [_doc_count] of type [_doc_count] is not searchable", e.getMessage());
     }
 
@@ -41,7 +41,7 @@ public class DocCountFieldTypeTests extends FieldTypeTestCase {
 
     public void testExistsQuery() {
         MappedFieldType ft = new DocCountFieldMapper.DocCountFieldType();
-        QueryShardException e = expectThrows(QueryShardException.class, () -> ft.existsQuery(randomMockShardContext()));
+        QueryShardException e = expectThrows(QueryShardException.class, () -> ft.existsQuery(randomMockContext()));
         assertEquals("Field [_doc_count] of type [_doc_count] does not support exists queries", e.getMessage());
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/DoubleIndexingDocTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DoubleIndexingDocTests.java
@@ -20,7 +20,7 @@ package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.TopDocs;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.mock;
@@ -40,32 +40,32 @@ public class DoubleIndexingDocTests extends MapperServiceTestCase {
         assertNotNull(doc.dynamicMappingsUpdate());
         merge(mapperService, dynamicMapping(doc.dynamicMappingsUpdate()));
 
-        QueryShardContext qsc = mock(QueryShardContext.class);
+        SearchExecutionContext context = mock(SearchExecutionContext.class);
 
         withLuceneIndex(mapperService, iw -> {
             iw.addDocument(doc.rootDoc());
             iw.addDocument(doc.rootDoc());
         }, reader -> {
             IndexSearcher searcher = new IndexSearcher(reader);
-            TopDocs topDocs = searcher.search(mapperService.fieldType("field1").termQuery("value1", qsc), 10);
+            TopDocs topDocs = searcher.search(mapperService.fieldType("field1").termQuery("value1", context), 10);
             assertThat(topDocs.totalHits.value, equalTo(2L));
 
-            topDocs = searcher.search(mapperService.fieldType("field2").termQuery("1", qsc), 10);
+            topDocs = searcher.search(mapperService.fieldType("field2").termQuery("1", context), 10);
             assertThat(topDocs.totalHits.value, equalTo(2L));
 
-            topDocs = searcher.search(mapperService.fieldType("field3").termQuery("1.1", qsc), 10);
+            topDocs = searcher.search(mapperService.fieldType("field3").termQuery("1.1", context), 10);
             assertThat(topDocs.totalHits.value, equalTo(2L));
 
-            topDocs = searcher.search(mapperService.fieldType("field4").termQuery("2010-01-01", qsc), 10);
+            topDocs = searcher.search(mapperService.fieldType("field4").termQuery("2010-01-01", context), 10);
             assertThat(topDocs.totalHits.value, equalTo(2L));
 
-            topDocs = searcher.search(mapperService.fieldType("field5").termQuery("1", qsc), 10);
+            topDocs = searcher.search(mapperService.fieldType("field5").termQuery("1", context), 10);
             assertThat(topDocs.totalHits.value, equalTo(2L));
 
-            topDocs = searcher.search(mapperService.fieldType("field5").termQuery("2", qsc), 10);
+            topDocs = searcher.search(mapperService.fieldType("field5").termQuery("2", context), 10);
             assertThat(topDocs.totalHits.value, equalTo(2L));
 
-            topDocs = searcher.search(mapperService.fieldType("field5").termQuery("3", qsc), 10);
+            topDocs = searcher.search(mapperService.fieldType("field5").termQuery("3", context), 10);
             assertThat(topDocs.totalHits.value, equalTo(2L));
         });
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/ExternalMapper.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ExternalMapper.java
@@ -27,7 +27,7 @@ import org.elasticsearch.geometry.Point;
 import org.elasticsearch.index.analysis.AnalyzerScope;
 import org.elasticsearch.index.analysis.IndexAnalyzers;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -113,7 +113,7 @@ public class ExternalMapper extends FieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             return SourceValueFetcher.identity(name(), context, format);
         }
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/FakeStringFieldMapper.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FakeStringFieldMapper.java
@@ -23,7 +23,7 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.IndexOptions;
 import org.elasticsearch.common.lucene.Lucene;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -75,7 +75,7 @@ public class FakeStringFieldMapper extends FieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             return SourceValueFetcher.toString(name(), context, format);
         }
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/FieldNamesFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FieldNamesFieldTypeTests.java
@@ -25,7 +25,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexSettings;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.List;
@@ -46,10 +46,10 @@ public class FieldNamesFieldTypeTests extends ESTestCase {
                 new IndexMetadata.Builder("foo").settings(settings).numberOfShards(1).numberOfReplicas(0).build(), settings);
         List<FieldMapper> mappers = Stream.of(fieldNamesFieldType, fieldType).map(MockFieldMapper::new).collect(Collectors.toList());
         MappingLookup mappingLookup = new MappingLookup(Mapping.EMPTY, mappers, emptyList(), emptyList(), null, null, null);
-        QueryShardContext queryShardContext = new QueryShardContext(0, 0,
+        SearchExecutionContext searchExecutionContext = new SearchExecutionContext(0, 0,
                 indexSettings, null, null, null, mappingLookup,
                 null, null, null, null, null, null, () -> 0L, null, null, () -> true, null, emptyMap());
-                Query termQuery = fieldNamesFieldType.termQuery("field_name", queryShardContext);
+                Query termQuery = fieldNamesFieldType.termQuery("field_name", searchExecutionContext);
         assertEquals(new TermQuery(new Term(FieldNamesFieldMapper.CONTENT_TYPE, "field_name")), termQuery);
         assertWarnings("terms query on the _field_names field is deprecated and will be removed, use exists query instead");
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/IdFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IdFieldTypeTests.java
@@ -25,7 +25,7 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexSettings;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.test.ESTestCase;
 import org.mockito.Mockito;
 
@@ -39,7 +39,7 @@ public class IdFieldTypeTests extends ESTestCase {
     }
 
     public void testTermsQuery() {
-        QueryShardContext context = Mockito.mock(QueryShardContext.class);
+        SearchExecutionContext context = Mockito.mock(SearchExecutionContext.class);
         Settings indexSettings = Settings.builder()
                 .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
                 .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)

--- a/server/src/test/java/org/elasticsearch/index/mapper/IgnoredFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IgnoredFieldTypeTests.java
@@ -33,10 +33,10 @@ public class IgnoredFieldTypeTests extends FieldTypeTestCase {
         MappedFieldType ft = IgnoredFieldMapper.IgnoredFieldType.INSTANCE;
 
         Query expected = new PrefixQuery(new Term("_ignored", new BytesRef("foo*")));
-        assertEquals(expected, ft.prefixQuery("foo*", null, MOCK_QSC));
+        assertEquals(expected, ft.prefixQuery("foo*", null, MOCK_CONTEXT));
 
         ElasticsearchException ee = expectThrows(ElasticsearchException.class,
-                () -> ft.prefixQuery("foo*", null, MOCK_QSC_DISALLOW_EXPENSIVE));
+                () -> ft.prefixQuery("foo*", null, MOCK_CONTEXT_DISALLOW_EXPENSIVE));
         assertEquals("[prefix] queries cannot be executed when 'search.allow_expensive_queries' is set to false. " +
                         "For optimised prefix queries on text fields please enable [index_prefixes].", ee.getMessage());
     }
@@ -45,10 +45,10 @@ public class IgnoredFieldTypeTests extends FieldTypeTestCase {
         MappedFieldType ft = IgnoredFieldMapper.IgnoredFieldType.INSTANCE;
 
         Query expected = new RegexpQuery(new Term("_ignored", new BytesRef("foo?")));
-        assertEquals(expected, ft.regexpQuery("foo?", 0, 0, 10, null, MOCK_QSC));
+        assertEquals(expected, ft.regexpQuery("foo?", 0, 0, 10, null, MOCK_CONTEXT));
 
         ElasticsearchException ee = expectThrows(ElasticsearchException.class,
-                () -> ft.regexpQuery("foo?", randomInt(10), 0, randomInt(10) + 1, null, MOCK_QSC_DISALLOW_EXPENSIVE));
+                () -> ft.regexpQuery("foo?", randomInt(10), 0, randomInt(10) + 1, null, MOCK_CONTEXT_DISALLOW_EXPENSIVE));
         assertEquals("[regexp] queries cannot be executed when 'search.allow_expensive_queries' is set to false.",
                 ee.getMessage());
     }
@@ -57,10 +57,10 @@ public class IgnoredFieldTypeTests extends FieldTypeTestCase {
         MappedFieldType ft = IgnoredFieldMapper.IgnoredFieldType.INSTANCE;
 
         Query expected = new WildcardQuery(new Term("_ignored", new BytesRef("foo*")));
-        assertEquals(expected, ft.wildcardQuery("foo*", null, MOCK_QSC));
+        assertEquals(expected, ft.wildcardQuery("foo*", null, MOCK_CONTEXT));
 
         ElasticsearchException ee = expectThrows(ElasticsearchException.class,
-                () -> ft.wildcardQuery("valu*", null, MOCK_QSC_DISALLOW_EXPENSIVE));
+                () -> ft.wildcardQuery("valu*", null, MOCK_CONTEXT_DISALLOW_EXPENSIVE));
         assertEquals("[wildcard] queries cannot be executed when 'search.allow_expensive_queries' is set to false.",
                 ee.getMessage());
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/IndexFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IndexFieldTypeTests.java
@@ -25,7 +25,7 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexSettings;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.QueryShardException;
 import org.elasticsearch.test.ESTestCase;
 
@@ -60,7 +60,7 @@ public class IndexFieldTypeTests extends ESTestCase {
         assertThat(e.getMessage(), containsString("Can only use regexp queries on keyword and text fields"));
     }
 
-    private QueryShardContext createContext() {
+    private SearchExecutionContext createContext() {
         IndexMetadata indexMetadata = IndexMetadata.builder("index")
             .settings(Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT))
             .numberOfShards(1)
@@ -69,7 +69,7 @@ public class IndexFieldTypeTests extends ESTestCase {
         IndexSettings indexSettings = new IndexSettings(indexMetadata, Settings.EMPTY);
 
         Predicate<String> indexNameMatcher = pattern -> Regex.simpleMatch(pattern, "index");
-        return new QueryShardContext(0, 0, indexSettings, null, null, null, null, null, null, xContentRegistry(), writableRegistry(),
+        return new SearchExecutionContext(0, 0, indexSettings, null, null, null, null, null, null, xContentRegistry(), writableRegistry(),
             null, null, System::currentTimeMillis, null, indexNameMatcher, () -> true, null, emptyMap());
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldTypeTests.java
@@ -130,10 +130,10 @@ public class KeywordFieldTypeTests extends FieldTypeTestCase {
     public void testRangeQuery() {
         MappedFieldType ft = new KeywordFieldType("field");
         assertEquals(new TermRangeQuery("field", BytesRefs.toBytesRef("foo"), BytesRefs.toBytesRef("bar"), true, false),
-                ft.rangeQuery("foo", "bar", true, false, null, null, null, MOCK_QSC));
+                ft.rangeQuery("foo", "bar", true, false, null, null, null, MOCK_CONTEXT));
 
         ElasticsearchException ee = expectThrows(ElasticsearchException.class,
-                () -> ft.rangeQuery("foo", "bar", true, false, null, null, null, MOCK_QSC_DISALLOW_EXPENSIVE));
+                () -> ft.rangeQuery("foo", "bar", true, false, null, null, null, MOCK_CONTEXT_DISALLOW_EXPENSIVE));
         assertEquals("[range] queries on [text] or [keyword] fields cannot be executed when " +
                 "'search.allow_expensive_queries' is set to false.", ee.getMessage());
     }
@@ -141,15 +141,15 @@ public class KeywordFieldTypeTests extends FieldTypeTestCase {
     public void testRegexpQuery() {
         MappedFieldType ft = new KeywordFieldType("field");
         assertEquals(new RegexpQuery(new Term("field","foo.*")),
-                ft.regexpQuery("foo.*", 0, 0, 10, null, MOCK_QSC));
+                ft.regexpQuery("foo.*", 0, 0, 10, null, MOCK_CONTEXT));
 
         MappedFieldType unsearchable = new KeywordFieldType("field", false, true, Collections.emptyMap());
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
-                () -> unsearchable.regexpQuery("foo.*", 0, 0, 10, null, MOCK_QSC));
+                () -> unsearchable.regexpQuery("foo.*", 0, 0, 10, null, MOCK_CONTEXT));
         assertEquals("Cannot search on field [field] since it is not indexed.", e.getMessage());
 
         ElasticsearchException ee = expectThrows(ElasticsearchException.class,
-                () -> ft.regexpQuery("foo.*", randomInt(10), 0, randomInt(10) + 1, null, MOCK_QSC_DISALLOW_EXPENSIVE));
+                () -> ft.regexpQuery("foo.*", randomInt(10), 0, randomInt(10) + 1, null, MOCK_CONTEXT_DISALLOW_EXPENSIVE));
         assertEquals("[regexp] queries cannot be executed when 'search.allow_expensive_queries' is set to false.",
                 ee.getMessage());
     }
@@ -157,16 +157,16 @@ public class KeywordFieldTypeTests extends FieldTypeTestCase {
     public void testFuzzyQuery() {
         MappedFieldType ft = new KeywordFieldType("field");
         assertEquals(new FuzzyQuery(new Term("field","foo"), 2, 1, 50, true),
-                ft.fuzzyQuery("foo", Fuzziness.fromEdits(2), 1, 50, true, MOCK_QSC));
+                ft.fuzzyQuery("foo", Fuzziness.fromEdits(2), 1, 50, true, MOCK_CONTEXT));
 
         MappedFieldType unsearchable = new KeywordFieldType("field", false, true, Collections.emptyMap());
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
-                () -> unsearchable.fuzzyQuery("foo", Fuzziness.fromEdits(2), 1, 50, true, MOCK_QSC));
+                () -> unsearchable.fuzzyQuery("foo", Fuzziness.fromEdits(2), 1, 50, true, MOCK_CONTEXT));
         assertEquals("Cannot search on field [field] since it is not indexed.", e.getMessage());
 
         ElasticsearchException ee = expectThrows(ElasticsearchException.class,
                 () -> ft.fuzzyQuery("foo", Fuzziness.AUTO, randomInt(10) + 1, randomInt(10) + 1,
-                        randomBoolean(), MOCK_QSC_DISALLOW_EXPENSIVE));
+                        randomBoolean(), MOCK_CONTEXT_DISALLOW_EXPENSIVE));
         assertEquals("[fuzzy] queries cannot be executed when 'search.allow_expensive_queries' is set to false.",
                 ee.getMessage());
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/LegacyGeoShapeFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/LegacyGeoShapeFieldMapperTests.java
@@ -32,7 +32,7 @@ import org.elasticsearch.common.geo.builders.ShapeBuilder;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.geometry.Point;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.TestGeoShapeFieldMapperPlugin;
 
@@ -568,8 +568,8 @@ public class LegacyGeoShapeFieldMapperTests extends MapperTestCase {
     }
 
     public void testDisallowExpensiveQueries() throws IOException {
-        QueryShardContext queryShardContext = mock(QueryShardContext.class);
-        when(queryShardContext.allowExpensiveQueries()).thenReturn(false);
+        SearchExecutionContext searchExecutionContext = mock(SearchExecutionContext.class);
+        when(searchExecutionContext.allowExpensiveQueries()).thenReturn(false);
         DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", "geo_shape").field("tree", "quadtree")));
         Mapper fieldMapper = mapper.mappers().getMapper("field");
         assertThat(fieldMapper, instanceOf(LegacyGeoShapeFieldMapper.class));
@@ -577,7 +577,7 @@ public class LegacyGeoShapeFieldMapperTests extends MapperTestCase {
 
         ElasticsearchException e = expectThrows(ElasticsearchException.class,
                 () -> geoShapeFieldMapper.fieldType().geoShapeQuery(
-                        new Point(-10, 10), "location", SpatialStrategy.TERM, ShapeRelation.INTERSECTS, queryShardContext));
+                        new Point(-10, 10), "location", SpatialStrategy.TERM, ShapeRelation.INTERSECTS, searchExecutionContext));
         assertEquals("[geo-shape] queries on [PrefixTree geo shapes] cannot be executed when " +
                         "'search.allow_expensive_queries' is set to false.", e.getMessage());
         assertFieldWarnings("tree", "strategy");

--- a/server/src/test/java/org/elasticsearch/index/mapper/MappingLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/MappingLookupTests.java
@@ -27,7 +27,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.common.Explicit;
 import org.elasticsearch.index.analysis.AnalyzerScope;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
@@ -159,7 +159,7 @@ public class MappingLookupTests extends ESTestCase {
         }
 
         @Override
-        public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             throw new UnsupportedOperationException();
         }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldTypeTests.java
@@ -52,7 +52,7 @@ import org.elasticsearch.index.fielddata.IndexNumericFieldData;
 import org.elasticsearch.index.mapper.MappedFieldType.Relation;
 import org.elasticsearch.index.mapper.NumberFieldMapper.NumberFieldType;
 import org.elasticsearch.index.mapper.NumberFieldMapper.NumberType;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.MultiValueMode;
 import org.junit.Before;
 
@@ -148,106 +148,106 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
 
     public void testRangeQueryWithNegativeBounds() {
         MappedFieldType ftInt = new NumberFieldMapper.NumberFieldType("field", NumberType.INTEGER);
-        assertEquals(ftInt.rangeQuery(-3, -3, true, true, null, null, null, MOCK_QSC),
-                ftInt.rangeQuery(-3.5, -2.5, true, true, null, null, null, MOCK_QSC));
-        assertEquals(ftInt.rangeQuery(-3, -3, true, true, null, null, null, MOCK_QSC),
-                ftInt.rangeQuery(-3.5, -2.5, false, false, null, null, null, MOCK_QSC));
-        assertEquals(ftInt.rangeQuery(0, 0, true, true, null, null, null, MOCK_QSC),
-                ftInt.rangeQuery(-0.5, 0.5, true, true, null, null, null, MOCK_QSC));
-        assertEquals(ftInt.rangeQuery(0, 0, true, true, null, null, null, MOCK_QSC),
-                ftInt.rangeQuery(-0.5, 0.5, false, false, null, null, null, MOCK_QSC));
-        assertEquals(ftInt.rangeQuery(1, 2, true, true, null, null, null, MOCK_QSC),
-                ftInt.rangeQuery(0.5, 2.5, true, true, null, null, null, MOCK_QSC));
-        assertEquals(ftInt.rangeQuery(1, 2, true, true, null, null, null, MOCK_QSC),
-                ftInt.rangeQuery(0.5, 2.5, false, false, null, null, null, MOCK_QSC));
-        assertEquals(ftInt.rangeQuery(0, 2, true, true, null, null, null, MOCK_QSC),
-                ftInt.rangeQuery(-0.5, 2.5, true, true, null, null, null, MOCK_QSC));
-        assertEquals(ftInt.rangeQuery(0, 2, true, true, null, null, null, MOCK_QSC),
-                ftInt.rangeQuery(-0.5, 2.5, false, false, null, null, null, MOCK_QSC));
+        assertEquals(ftInt.rangeQuery(-3, -3, true, true, null, null, null, MOCK_CONTEXT),
+                ftInt.rangeQuery(-3.5, -2.5, true, true, null, null, null, MOCK_CONTEXT));
+        assertEquals(ftInt.rangeQuery(-3, -3, true, true, null, null, null, MOCK_CONTEXT),
+                ftInt.rangeQuery(-3.5, -2.5, false, false, null, null, null, MOCK_CONTEXT));
+        assertEquals(ftInt.rangeQuery(0, 0, true, true, null, null, null, MOCK_CONTEXT),
+                ftInt.rangeQuery(-0.5, 0.5, true, true, null, null, null, MOCK_CONTEXT));
+        assertEquals(ftInt.rangeQuery(0, 0, true, true, null, null, null, MOCK_CONTEXT),
+                ftInt.rangeQuery(-0.5, 0.5, false, false, null, null, null, MOCK_CONTEXT));
+        assertEquals(ftInt.rangeQuery(1, 2, true, true, null, null, null, MOCK_CONTEXT),
+                ftInt.rangeQuery(0.5, 2.5, true, true, null, null, null, MOCK_CONTEXT));
+        assertEquals(ftInt.rangeQuery(1, 2, true, true, null, null, null, MOCK_CONTEXT),
+                ftInt.rangeQuery(0.5, 2.5, false, false, null, null, null, MOCK_CONTEXT));
+        assertEquals(ftInt.rangeQuery(0, 2, true, true, null, null, null, MOCK_CONTEXT),
+                ftInt.rangeQuery(-0.5, 2.5, true, true, null, null, null, MOCK_CONTEXT));
+        assertEquals(ftInt.rangeQuery(0, 2, true, true, null, null, null, MOCK_CONTEXT),
+                ftInt.rangeQuery(-0.5, 2.5, false, false, null, null, null, MOCK_CONTEXT));
 
-        assertEquals(ftInt.rangeQuery(-2, 0, true, true, null, null, null, MOCK_QSC),
-                ftInt.rangeQuery(-2.5, 0.5, true, true, null, null, null, MOCK_QSC));
-        assertEquals(ftInt.rangeQuery(-2, 0, true, true, null, null, null, MOCK_QSC),
-                ftInt.rangeQuery(-2.5, 0.5, false, false, null, null, null, MOCK_QSC));
-        assertEquals(ftInt.rangeQuery(-2, -1, true, true, null, null, null, MOCK_QSC),
-                ftInt.rangeQuery(-2.5, -0.5, true, true, null, null, null, MOCK_QSC));
-        assertEquals(ftInt.rangeQuery(-2, -1, true, true, null, null, null, MOCK_QSC),
-                ftInt.rangeQuery(-2.5, -0.5, false, false, null, null, null, MOCK_QSC));
+        assertEquals(ftInt.rangeQuery(-2, 0, true, true, null, null, null, MOCK_CONTEXT),
+                ftInt.rangeQuery(-2.5, 0.5, true, true, null, null, null, MOCK_CONTEXT));
+        assertEquals(ftInt.rangeQuery(-2, 0, true, true, null, null, null, MOCK_CONTEXT),
+                ftInt.rangeQuery(-2.5, 0.5, false, false, null, null, null, MOCK_CONTEXT));
+        assertEquals(ftInt.rangeQuery(-2, -1, true, true, null, null, null, MOCK_CONTEXT),
+                ftInt.rangeQuery(-2.5, -0.5, true, true, null, null, null, MOCK_CONTEXT));
+        assertEquals(ftInt.rangeQuery(-2, -1, true, true, null, null, null, MOCK_CONTEXT),
+                ftInt.rangeQuery(-2.5, -0.5, false, false, null, null, null, MOCK_CONTEXT));
 
         MappedFieldType ftLong = new NumberFieldMapper.NumberFieldType("field", NumberType.LONG);
-        assertEquals(ftLong.rangeQuery(-3, -3, true, true, null, null, null, MOCK_QSC),
-                ftLong.rangeQuery(-3.5, -2.5, true, true, null, null, null, MOCK_QSC));
-        assertEquals(ftLong.rangeQuery(-3, -3, true, true, null, null, null, MOCK_QSC),
-                ftLong.rangeQuery(-3.5, -2.5, false, false, null, null, null, MOCK_QSC));
-        assertEquals(ftLong.rangeQuery(0, 0, true, true, null, null, null, MOCK_QSC),
-                ftLong.rangeQuery(-0.5, 0.5, true, true, null, null, null, MOCK_QSC));
-        assertEquals(ftLong.rangeQuery(0, 0, true, true, null, null, null, MOCK_QSC),
-                ftLong.rangeQuery(-0.5, 0.5, false, false, null, null, null, MOCK_QSC));
-        assertEquals(ftLong.rangeQuery(1, 2, true, true, null, null, null, MOCK_QSC),
-                ftLong.rangeQuery(0.5, 2.5, true, true, null, null, null, MOCK_QSC));
-        assertEquals(ftLong.rangeQuery(1, 2, true, true, null, null, null, MOCK_QSC),
-                ftLong.rangeQuery(0.5, 2.5, false, false, null, null, null, MOCK_QSC));
-        assertEquals(ftLong.rangeQuery(0, 2, true, true, null, null, null, MOCK_QSC),
-                ftLong.rangeQuery(-0.5, 2.5, true, true, null, null, null, MOCK_QSC));
-        assertEquals(ftLong.rangeQuery(0, 2, true, true, null, null, null, MOCK_QSC),
-                ftLong.rangeQuery(-0.5, 2.5, false, false, null, null, null, MOCK_QSC));
+        assertEquals(ftLong.rangeQuery(-3, -3, true, true, null, null, null, MOCK_CONTEXT),
+                ftLong.rangeQuery(-3.5, -2.5, true, true, null, null, null, MOCK_CONTEXT));
+        assertEquals(ftLong.rangeQuery(-3, -3, true, true, null, null, null, MOCK_CONTEXT),
+                ftLong.rangeQuery(-3.5, -2.5, false, false, null, null, null, MOCK_CONTEXT));
+        assertEquals(ftLong.rangeQuery(0, 0, true, true, null, null, null, MOCK_CONTEXT),
+                ftLong.rangeQuery(-0.5, 0.5, true, true, null, null, null, MOCK_CONTEXT));
+        assertEquals(ftLong.rangeQuery(0, 0, true, true, null, null, null, MOCK_CONTEXT),
+                ftLong.rangeQuery(-0.5, 0.5, false, false, null, null, null, MOCK_CONTEXT));
+        assertEquals(ftLong.rangeQuery(1, 2, true, true, null, null, null, MOCK_CONTEXT),
+                ftLong.rangeQuery(0.5, 2.5, true, true, null, null, null, MOCK_CONTEXT));
+        assertEquals(ftLong.rangeQuery(1, 2, true, true, null, null, null, MOCK_CONTEXT),
+                ftLong.rangeQuery(0.5, 2.5, false, false, null, null, null, MOCK_CONTEXT));
+        assertEquals(ftLong.rangeQuery(0, 2, true, true, null, null, null, MOCK_CONTEXT),
+                ftLong.rangeQuery(-0.5, 2.5, true, true, null, null, null, MOCK_CONTEXT));
+        assertEquals(ftLong.rangeQuery(0, 2, true, true, null, null, null, MOCK_CONTEXT),
+                ftLong.rangeQuery(-0.5, 2.5, false, false, null, null, null, MOCK_CONTEXT));
 
-        assertEquals(ftLong.rangeQuery(-2, 0, true, true, null, null, null, MOCK_QSC),
-                ftLong.rangeQuery(-2.5, 0.5, true, true, null, null, null, MOCK_QSC));
-        assertEquals(ftLong.rangeQuery(-2, 0, true, true, null, null, null, MOCK_QSC),
-                ftLong.rangeQuery(-2.5, 0.5, false, false, null, null, null, MOCK_QSC));
-        assertEquals(ftLong.rangeQuery(-2, -1, true, true, null, null, null, MOCK_QSC),
-                ftLong.rangeQuery(-2.5, -0.5, true, true, null, null, null, MOCK_QSC));
-        assertEquals(ftLong.rangeQuery(-2, -1, true, true, null, null, null, MOCK_QSC),
-                ftLong.rangeQuery(-2.5, -0.5, false, false, null, null, null, MOCK_QSC));
+        assertEquals(ftLong.rangeQuery(-2, 0, true, true, null, null, null, MOCK_CONTEXT),
+                ftLong.rangeQuery(-2.5, 0.5, true, true, null, null, null, MOCK_CONTEXT));
+        assertEquals(ftLong.rangeQuery(-2, 0, true, true, null, null, null, MOCK_CONTEXT),
+                ftLong.rangeQuery(-2.5, 0.5, false, false, null, null, null, MOCK_CONTEXT));
+        assertEquals(ftLong.rangeQuery(-2, -1, true, true, null, null, null, MOCK_CONTEXT),
+                ftLong.rangeQuery(-2.5, -0.5, true, true, null, null, null, MOCK_CONTEXT));
+        assertEquals(ftLong.rangeQuery(-2, -1, true, true, null, null, null, MOCK_CONTEXT),
+                ftLong.rangeQuery(-2.5, -0.5, false, false, null, null, null, MOCK_CONTEXT));
     }
 
     public void testByteRangeQueryWithDecimalParts() {
         MappedFieldType ft = new NumberFieldMapper.NumberFieldType("field", NumberType.BYTE);
-        assertEquals(ft.rangeQuery(2, 10, true, true, null, null, null, MOCK_QSC),
-                ft.rangeQuery(1.1, 10, true, true, null, null, null, MOCK_QSC));
-        assertEquals(ft.rangeQuery(2, 10, true, true, null, null, null, MOCK_QSC),
-                ft.rangeQuery(1.1, 10, false, true, null, null, null, MOCK_QSC));
-        assertEquals(ft.rangeQuery(1, 10, true, true, null, null, null, MOCK_QSC),
-                ft.rangeQuery(1, 10.1, true, true, null, null, null, MOCK_QSC));
-        assertEquals(ft.rangeQuery(1, 10, true, true, null, null, null, MOCK_QSC),
-                ft.rangeQuery(1, 10.1, true, false, null, null, null, MOCK_QSC));
+        assertEquals(ft.rangeQuery(2, 10, true, true, null, null, null, MOCK_CONTEXT),
+                ft.rangeQuery(1.1, 10, true, true, null, null, null, MOCK_CONTEXT));
+        assertEquals(ft.rangeQuery(2, 10, true, true, null, null, null, MOCK_CONTEXT),
+                ft.rangeQuery(1.1, 10, false, true, null, null, null, MOCK_CONTEXT));
+        assertEquals(ft.rangeQuery(1, 10, true, true, null, null, null, MOCK_CONTEXT),
+                ft.rangeQuery(1, 10.1, true, true, null, null, null, MOCK_CONTEXT));
+        assertEquals(ft.rangeQuery(1, 10, true, true, null, null, null, MOCK_CONTEXT),
+                ft.rangeQuery(1, 10.1, true, false, null, null, null, MOCK_CONTEXT));
     }
 
     public void testShortRangeQueryWithDecimalParts() {
         MappedFieldType ft = new NumberFieldMapper.NumberFieldType("field", NumberType.SHORT);
-        assertEquals(ft.rangeQuery(2, 10, true, true, null, null, null, MOCK_QSC),
-                ft.rangeQuery(1.1, 10, true, true, null, null, null, MOCK_QSC));
-        assertEquals(ft.rangeQuery(2, 10, true, true, null, null, null, MOCK_QSC),
-                ft.rangeQuery(1.1, 10, false, true, null, null, null, MOCK_QSC));
-        assertEquals(ft.rangeQuery(1, 10, true, true, null, null, null, MOCK_QSC),
-                ft.rangeQuery(1, 10.1, true, true, null, null, null, MOCK_QSC));
-        assertEquals(ft.rangeQuery(1, 10, true, true, null, null, null, MOCK_QSC),
-                ft.rangeQuery(1, 10.1, true, false, null, null, null, MOCK_QSC));
+        assertEquals(ft.rangeQuery(2, 10, true, true, null, null, null, MOCK_CONTEXT),
+                ft.rangeQuery(1.1, 10, true, true, null, null, null, MOCK_CONTEXT));
+        assertEquals(ft.rangeQuery(2, 10, true, true, null, null, null, MOCK_CONTEXT),
+                ft.rangeQuery(1.1, 10, false, true, null, null, null, MOCK_CONTEXT));
+        assertEquals(ft.rangeQuery(1, 10, true, true, null, null, null, MOCK_CONTEXT),
+                ft.rangeQuery(1, 10.1, true, true, null, null, null, MOCK_CONTEXT));
+        assertEquals(ft.rangeQuery(1, 10, true, true, null, null, null, MOCK_CONTEXT),
+                ft.rangeQuery(1, 10.1, true, false, null, null, null, MOCK_CONTEXT));
     }
 
     public void testIntegerRangeQueryWithDecimalParts() {
         MappedFieldType ft = new NumberFieldMapper.NumberFieldType("field", NumberType.INTEGER);
-        assertEquals(ft.rangeQuery(2, 10, true, true, null, null, null, MOCK_QSC),
-                ft.rangeQuery(1.1, 10, true, true, null, null, null, MOCK_QSC));
-        assertEquals(ft.rangeQuery(2, 10, true, true, null, null, null, MOCK_QSC),
-                ft.rangeQuery(1.1, 10, false, true, null, null, null, MOCK_QSC));
-        assertEquals(ft.rangeQuery(1, 10, true, true, null, null, null, MOCK_QSC),
-                ft.rangeQuery(1, 10.1, true, true, null, null, null, MOCK_QSC));
-        assertEquals(ft.rangeQuery(1, 10, true, true, null, null, null, MOCK_QSC),
-                ft.rangeQuery(1, 10.1, true, false, null, null, null, MOCK_QSC));
+        assertEquals(ft.rangeQuery(2, 10, true, true, null, null, null, MOCK_CONTEXT),
+                ft.rangeQuery(1.1, 10, true, true, null, null, null, MOCK_CONTEXT));
+        assertEquals(ft.rangeQuery(2, 10, true, true, null, null, null, MOCK_CONTEXT),
+                ft.rangeQuery(1.1, 10, false, true, null, null, null, MOCK_CONTEXT));
+        assertEquals(ft.rangeQuery(1, 10, true, true, null, null, null, MOCK_CONTEXT),
+                ft.rangeQuery(1, 10.1, true, true, null, null, null, MOCK_CONTEXT));
+        assertEquals(ft.rangeQuery(1, 10, true, true, null, null, null, MOCK_CONTEXT),
+                ft.rangeQuery(1, 10.1, true, false, null, null, null, MOCK_CONTEXT));
     }
 
     public void testLongRangeQueryWithDecimalParts() {
         MappedFieldType ft = new NumberFieldMapper.NumberFieldType("field", NumberType.LONG);
-        assertEquals(ft.rangeQuery(2, 10, true, true, null, null, null, MOCK_QSC),
-                ft.rangeQuery(1.1, 10, true, true, null, null, null, MOCK_QSC));
-        assertEquals(ft.rangeQuery(2, 10, true, true, null, null, null, MOCK_QSC),
-                ft.rangeQuery(1.1, 10, false, true, null, null, null, MOCK_QSC));
-        assertEquals(ft.rangeQuery(1, 10, true, true, null, null, null, MOCK_QSC),
-                ft.rangeQuery(1, 10.1, true, true, null, null, null, MOCK_QSC));
-        assertEquals(ft.rangeQuery(1, 10, true, true, null, null, null, MOCK_QSC),
-                ft.rangeQuery(1, 10.1, true, false, null, null, null, MOCK_QSC));
+        assertEquals(ft.rangeQuery(2, 10, true, true, null, null, null, MOCK_CONTEXT),
+                ft.rangeQuery(1.1, 10, true, true, null, null, null, MOCK_CONTEXT));
+        assertEquals(ft.rangeQuery(2, 10, true, true, null, null, null, MOCK_CONTEXT),
+                ft.rangeQuery(1.1, 10, false, true, null, null, null, MOCK_CONTEXT));
+        assertEquals(ft.rangeQuery(1, 10, true, true, null, null, null, MOCK_CONTEXT),
+                ft.rangeQuery(1, 10.1, true, true, null, null, null, MOCK_CONTEXT));
+        assertEquals(ft.rangeQuery(1, 10, true, true, null, null, null, MOCK_CONTEXT),
+                ft.rangeQuery(1, 10.1, true, false, null, null, null, MOCK_CONTEXT));
     }
 
     public void testRangeQuery() {
@@ -255,11 +255,11 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
         Query expected = new IndexOrDocValuesQuery(
                 LongPoint.newRangeQuery("field", 1, 3),
                 SortedNumericDocValuesField.newSlowRangeQuery("field", 1, 3));
-        assertEquals(expected, ft.rangeQuery("1", "3", true, true, null, null, null, MOCK_QSC));
+        assertEquals(expected, ft.rangeQuery("1", "3", true, true, null, null, null, MOCK_CONTEXT));
 
         MappedFieldType unsearchable = unsearchable();
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
-                () -> unsearchable.rangeQuery("1", "3", true, true, null, null, null, MOCK_QSC));
+                () -> unsearchable.rangeQuery("1", "3", true, true, null, null, null, MOCK_CONTEXT));
         assertEquals("Cannot search on field [field] since it is not indexed.", e.getMessage());
     }
 
@@ -351,8 +351,8 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
             float u = (randomFloat() * 2 - 1) * 65504;
             boolean includeLower = randomBoolean();
             boolean includeUpper = randomBoolean();
-            Query floatQ = NumberType.FLOAT.rangeQuery("float", l, u, includeLower, includeUpper, false, MOCK_QSC);
-            Query halfFloatQ = NumberType.HALF_FLOAT.rangeQuery("half_float", l, u, includeLower, includeUpper, false, MOCK_QSC);
+            Query floatQ = NumberType.FLOAT.rangeQuery("float", l, u, includeLower, includeUpper, false, MOCK_CONTEXT);
+            Query halfFloatQ = NumberType.HALF_FLOAT.rangeQuery("half_float", l, u, includeLower, includeUpper, false, MOCK_CONTEXT);
             assertEquals(searcher.count(floatQ), searcher.count(halfFloatQ));
         }
         IOUtils.close(reader, dir);
@@ -360,14 +360,14 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
 
     public void testNegativeZero() {
         assertEquals(
-                NumberType.DOUBLE.rangeQuery("field", null, -0d, true, true, false, MOCK_QSC),
-                NumberType.DOUBLE.rangeQuery("field", null, +0d, true, false, false, MOCK_QSC));
+                NumberType.DOUBLE.rangeQuery("field", null, -0d, true, true, false, MOCK_CONTEXT),
+                NumberType.DOUBLE.rangeQuery("field", null, +0d, true, false, false, MOCK_CONTEXT));
         assertEquals(
-                NumberType.FLOAT.rangeQuery("field", null, -0f, true, true, false, MOCK_QSC),
-                NumberType.FLOAT.rangeQuery("field", null, +0f, true, false, false, MOCK_QSC));
+                NumberType.FLOAT.rangeQuery("field", null, -0f, true, true, false, MOCK_CONTEXT),
+                NumberType.FLOAT.rangeQuery("field", null, +0f, true, false, false, MOCK_CONTEXT));
         assertEquals(
-                NumberType.HALF_FLOAT.rangeQuery("field", null, -0f, true, true, false, MOCK_QSC),
-                NumberType.HALF_FLOAT.rangeQuery("field", null, +0f, true, false, false, MOCK_QSC));
+                NumberType.HALF_FLOAT.rangeQuery("field", null, -0f, true, true, false, MOCK_CONTEXT),
+                NumberType.HALF_FLOAT.rangeQuery("field", null, +0f, true, false, false, MOCK_CONTEXT));
 
         assertFalse(NumberType.DOUBLE.termQuery("field", -0d).equals(NumberType.DOUBLE.termQuery("field", +0d)));
         assertFalse(NumberType.FLOAT.termQuery("field", -0f).equals(NumberType.FLOAT.termQuery("field", +0f)));
@@ -419,7 +419,7 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
             Query query = type.rangeQuery("foo",
                     random().nextBoolean() ? null : valueSupplier.get(),
                     random().nextBoolean() ? null : valueSupplier.get(),
-                    randomBoolean(), randomBoolean(), true, MOCK_QSC);
+                    randomBoolean(), randomBoolean(), true, MOCK_CONTEXT);
             assertThat(query, instanceOf(IndexOrDocValuesQuery.class));
             IndexOrDocValuesQuery indexOrDvQuery = (IndexOrDocValuesQuery) query;
             assertEquals(
@@ -473,7 +473,7 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
         DirectoryReader reader = DirectoryReader.open(w);
         IndexSearcher searcher = newSearcher(reader);
 
-        QueryShardContext context = new QueryShardContext(0, 0, indexSettings,
+        SearchExecutionContext context = new SearchExecutionContext(0, 0, indexSettings,
             null, null, null, null, null, null, xContentRegistry(), writableRegistry(),
             null, null, () -> 0L, null, null, () -> true, null, emptyMap());
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldQueryStringQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldQueryStringQueryBuilderTests.java
@@ -103,7 +103,8 @@ public class RangeFieldQueryStringQueryBuilderTests extends AbstractQueryTestCas
         SearchExecutionContext context = createSearchExecutionContext();
         RangeFieldMapper.RangeFieldType type = (RangeFieldMapper.RangeFieldType) context.getFieldType(DATE_RANGE_FIELD_NAME);
         DateMathParser parser = type.dateMathParser;
-        Query query = new QueryStringQueryBuilder(DATE_RANGE_FIELD_NAME + ":[2010-01-01 TO 2018-01-01]").toQuery(createSearchExecutionContext());
+        Query query = new QueryStringQueryBuilder(DATE_RANGE_FIELD_NAME + ":[2010-01-01 TO 2018-01-01]")
+            .toQuery(createSearchExecutionContext());
         String lowerBoundExact = "2010-01-01T00:00:00.000";
         String upperBoundExact = "2018-01-01T23:59:59.999";
         Query range = LongRange.newIntersectsQuery(DATE_RANGE_FIELD_NAME,
@@ -118,7 +119,8 @@ public class RangeFieldQueryStringQueryBuilderTests extends AbstractQueryTestCas
         // also make sure the produced bounds are the same as on a regular `date` field
         DateFieldMapper.DateFieldType dateType = (DateFieldMapper.DateFieldType) context.getFieldType(DATE_FIELD_NAME);
         parser = dateType.dateMathParser;
-        Query queryOnDateField = new QueryStringQueryBuilder(DATE_FIELD_NAME + ":[2010-01-01 TO 2018-01-01]").toQuery(createSearchExecutionContext());
+        Query queryOnDateField = new QueryStringQueryBuilder(DATE_FIELD_NAME + ":[2010-01-01 TO 2018-01-01]")
+            .toQuery(createSearchExecutionContext());
         Query controlQuery = LongPoint.newRangeQuery(DATE_FIELD_NAME,
                 new long[]{ parser.parse(lowerBoundExact, () -> 0).toEpochMilli()},
                 new long[]{ parser.parse(upperBoundExact, () -> 0).toEpochMilli()});
@@ -132,7 +134,8 @@ public class RangeFieldQueryStringQueryBuilderTests extends AbstractQueryTestCas
     public void testIPRangeQuery() throws Exception {
         InetAddress lower = InetAddresses.forString("192.168.0.1");
         InetAddress upper = InetAddresses.forString("192.168.0.5");
-        Query query = new QueryStringQueryBuilder(IP_RANGE_FIELD_NAME + ":[192.168.0.1 TO 192.168.0.5]").toQuery(createSearchExecutionContext());
+        Query query = new QueryStringQueryBuilder(IP_RANGE_FIELD_NAME + ":[192.168.0.1 TO 192.168.0.5]")
+            .toQuery(createSearchExecutionContext());
         Query range = InetAddressRange.newIntersectsQuery(IP_RANGE_FIELD_NAME, lower, upper);
         Query dv = RangeType.IP.dvRangeQuery(IP_RANGE_FIELD_NAME,
             BinaryDocValuesRangeQuery.QueryType.INTERSECTS,
@@ -146,7 +149,7 @@ public class RangeFieldQueryStringQueryBuilderTests extends AbstractQueryTestCas
     }
 
     @Override
-    protected void doAssertLuceneQuery(QueryStringQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
+    protected void doAssertLuceneQuery(QueryStringQueryBuilder queryBuilder, Query query, SearchExecutionContext context) {
         assertThat(query, either(instanceOf(PointRangeQuery.class)).or(instanceOf(IndexOrDocValuesQuery.class)));
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldQueryStringQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldQueryStringQueryBuilderTests.java
@@ -35,7 +35,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.time.DateMathParser;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.QueryStringQueryBuilder;
 import org.elasticsearch.test.AbstractQueryTestCase;
 
@@ -68,7 +68,7 @@ public class RangeFieldQueryStringQueryBuilderTests extends AbstractQueryTestCas
     }
 
     public void testIntegerRangeQuery() throws Exception {
-        Query query = new QueryStringQueryBuilder(INTEGER_RANGE_FIELD_NAME + ":[-450 TO 45000]").toQuery(createShardContext());
+        Query query = new QueryStringQueryBuilder(INTEGER_RANGE_FIELD_NAME + ":[-450 TO 45000]").toQuery(createSearchExecutionContext());
         Query range = IntRange.newIntersectsQuery(INTEGER_RANGE_FIELD_NAME, new int[]{-450}, new int[]{45000});
         Query dv = RangeType.INTEGER.dvRangeQuery(INTEGER_RANGE_FIELD_NAME,
             BinaryDocValuesRangeQuery.QueryType.INTERSECTS, -450, 45000, true, true);
@@ -76,7 +76,7 @@ public class RangeFieldQueryStringQueryBuilderTests extends AbstractQueryTestCas
     }
 
     public void testLongRangeQuery() throws Exception {
-        Query query = new QueryStringQueryBuilder(LONG_RANGE_FIELD_NAME + ":[-450 TO 45000]").toQuery(createShardContext());
+        Query query = new QueryStringQueryBuilder(LONG_RANGE_FIELD_NAME + ":[-450 TO 45000]").toQuery(createSearchExecutionContext());
         Query range = LongRange.newIntersectsQuery(LONG_RANGE_FIELD_NAME, new long[]{-450}, new long[]{45000});
         Query dv = RangeType.LONG.dvRangeQuery(LONG_RANGE_FIELD_NAME,
             BinaryDocValuesRangeQuery.QueryType.INTERSECTS, -450, 45000, true, true);
@@ -84,7 +84,7 @@ public class RangeFieldQueryStringQueryBuilderTests extends AbstractQueryTestCas
     }
 
     public void testFloatRangeQuery() throws Exception {
-        Query query = new QueryStringQueryBuilder(FLOAT_RANGE_FIELD_NAME + ":[-450 TO 45000]").toQuery(createShardContext());
+        Query query = new QueryStringQueryBuilder(FLOAT_RANGE_FIELD_NAME + ":[-450 TO 45000]").toQuery(createSearchExecutionContext());
         Query range = FloatRange.newIntersectsQuery(FLOAT_RANGE_FIELD_NAME, new float[]{-450}, new float[]{45000});
         Query dv = RangeType.FLOAT.dvRangeQuery(FLOAT_RANGE_FIELD_NAME,
             BinaryDocValuesRangeQuery.QueryType.INTERSECTS, -450.0f, 45000.0f, true, true);
@@ -92,7 +92,7 @@ public class RangeFieldQueryStringQueryBuilderTests extends AbstractQueryTestCas
     }
 
     public void testDoubleRangeQuery() throws Exception {
-        Query query = new QueryStringQueryBuilder(DOUBLE_RANGE_FIELD_NAME + ":[-450 TO 45000]").toQuery(createShardContext());
+        Query query = new QueryStringQueryBuilder(DOUBLE_RANGE_FIELD_NAME + ":[-450 TO 45000]").toQuery(createSearchExecutionContext());
         Query range = DoubleRange.newIntersectsQuery(DOUBLE_RANGE_FIELD_NAME, new double[]{-450}, new double[]{45000});
         Query dv = RangeType.DOUBLE.dvRangeQuery(DOUBLE_RANGE_FIELD_NAME,
             BinaryDocValuesRangeQuery.QueryType.INTERSECTS, -450.0, 45000.0, true, true);
@@ -100,10 +100,10 @@ public class RangeFieldQueryStringQueryBuilderTests extends AbstractQueryTestCas
     }
 
     public void testDateRangeQuery() throws Exception {
-        QueryShardContext context = createShardContext();
+        SearchExecutionContext context = createSearchExecutionContext();
         RangeFieldMapper.RangeFieldType type = (RangeFieldMapper.RangeFieldType) context.getFieldType(DATE_RANGE_FIELD_NAME);
         DateMathParser parser = type.dateMathParser;
-        Query query = new QueryStringQueryBuilder(DATE_RANGE_FIELD_NAME + ":[2010-01-01 TO 2018-01-01]").toQuery(createShardContext());
+        Query query = new QueryStringQueryBuilder(DATE_RANGE_FIELD_NAME + ":[2010-01-01 TO 2018-01-01]").toQuery(createSearchExecutionContext());
         String lowerBoundExact = "2010-01-01T00:00:00.000";
         String upperBoundExact = "2018-01-01T23:59:59.999";
         Query range = LongRange.newIntersectsQuery(DATE_RANGE_FIELD_NAME,
@@ -118,7 +118,7 @@ public class RangeFieldQueryStringQueryBuilderTests extends AbstractQueryTestCas
         // also make sure the produced bounds are the same as on a regular `date` field
         DateFieldMapper.DateFieldType dateType = (DateFieldMapper.DateFieldType) context.getFieldType(DATE_FIELD_NAME);
         parser = dateType.dateMathParser;
-        Query queryOnDateField = new QueryStringQueryBuilder(DATE_FIELD_NAME + ":[2010-01-01 TO 2018-01-01]").toQuery(createShardContext());
+        Query queryOnDateField = new QueryStringQueryBuilder(DATE_FIELD_NAME + ":[2010-01-01 TO 2018-01-01]").toQuery(createSearchExecutionContext());
         Query controlQuery = LongPoint.newRangeQuery(DATE_FIELD_NAME,
                 new long[]{ parser.parse(lowerBoundExact, () -> 0).toEpochMilli()},
                 new long[]{ parser.parse(upperBoundExact, () -> 0).toEpochMilli()});
@@ -132,7 +132,7 @@ public class RangeFieldQueryStringQueryBuilderTests extends AbstractQueryTestCas
     public void testIPRangeQuery() throws Exception {
         InetAddress lower = InetAddresses.forString("192.168.0.1");
         InetAddress upper = InetAddresses.forString("192.168.0.5");
-        Query query = new QueryStringQueryBuilder(IP_RANGE_FIELD_NAME + ":[192.168.0.1 TO 192.168.0.5]").toQuery(createShardContext());
+        Query query = new QueryStringQueryBuilder(IP_RANGE_FIELD_NAME + ":[192.168.0.1 TO 192.168.0.5]").toQuery(createSearchExecutionContext());
         Query range = InetAddressRange.newIntersectsQuery(IP_RANGE_FIELD_NAME, lower, upper);
         Query dv = RangeType.IP.dvRangeQuery(IP_RANGE_FIELD_NAME,
             BinaryDocValuesRangeQuery.QueryType.INTERSECTS,
@@ -146,7 +146,7 @@ public class RangeFieldQueryStringQueryBuilderTests extends AbstractQueryTestCas
     }
 
     @Override
-    protected void doAssertLuceneQuery(QueryStringQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
+    protected void doAssertLuceneQuery(QueryStringQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
         assertThat(query, either(instanceOf(PointRangeQuery.class)).or(instanceOf(IndexOrDocValuesQuery.class)));
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldTypeTests.java
@@ -40,7 +40,7 @@ import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.mapper.DateFieldMapper.DateFieldType;
 import org.elasticsearch.index.mapper.RangeFieldMapper.RangeFieldType;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.QueryShardException;
 import org.elasticsearch.test.IndexSettingsModule;
 import org.joda.time.DateTime;
@@ -74,7 +74,7 @@ public class RangeFieldTypeTests extends FieldTypeTestCase {
     }
 
     public void testRangeQuery() throws Exception {
-        QueryShardContext context = createContext();
+        SearchExecutionContext context = createContext();
         RangeFieldType ft = createDefaultFieldType();
 
         ShapeRelation relation = randomFrom(ShapeRelation.values());
@@ -95,7 +95,7 @@ public class RangeFieldTypeTests extends FieldTypeTestCase {
      * test the queries are correct if from/to are adjacent and the range is exclusive of those values
      */
     public void testRangeQueryIntersectsAdjacentValues() throws Exception {
-        QueryShardContext context = createContext();
+        SearchExecutionContext context = createContext();
         ShapeRelation relation = randomFrom(ShapeRelation.values());
         RangeFieldType ft = createDefaultFieldType();
 
@@ -153,7 +153,7 @@ public class RangeFieldTypeTests extends FieldTypeTestCase {
      * check that we catch cases where the user specifies larger "from" than "to" value, not counting the include upper/lower settings
      */
     public void testFromLargerToErrors() throws Exception {
-        QueryShardContext context = createContext();
+        SearchExecutionContext context = createContext();
         RangeFieldType ft = createDefaultFieldType();
 
         final Object from;
@@ -208,16 +208,16 @@ public class RangeFieldTypeTests extends FieldTypeTestCase {
         assertTrue(ex.getMessage().contains("is greater than `to` value"));
     }
 
-    private QueryShardContext createContext() {
+    private SearchExecutionContext createContext() {
         Settings indexSettings = Settings.builder()
             .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT).build();
         IndexSettings idxSettings = IndexSettingsModule.newIndexSettings(randomAlphaOfLengthBetween(1, 10), indexSettings);
-        return new QueryShardContext(0, 0, idxSettings, null, null, null, null, null, null,
+        return new SearchExecutionContext(0, 0, idxSettings, null, null, null, null, null, null,
             xContentRegistry(), writableRegistry(), null, null, () -> nowInMillis, null, null, () -> true, null, emptyMap());
     }
 
     public void testDateRangeQueryUsingMappingFormat() {
-        QueryShardContext context = createContext();
+        SearchExecutionContext context = createContext();
         RangeFieldType strict = new RangeFieldType("field", RangeFieldMapper.Defaults.DATE_FORMATTER);
         // don't use DISJOINT here because it doesn't work on date fields which we want to compare bounds with
         ShapeRelation relation = randomValueOtherThan(ShapeRelation.DISJOINT,() -> randomFrom(ShapeRelation.values()));
@@ -253,7 +253,7 @@ public class RangeFieldTypeTests extends FieldTypeTestCase {
      * field, so we randomize a few cases and compare the generated queries here
      */
     public void testDateVsDateRangeBounds() {
-        QueryShardContext context = createContext();
+        SearchExecutionContext context = createContext();
 
         // date formatter that truncates seconds, so we get some rounding behavior
         final DateFormatter formatter = DateFormatter.forPattern("yyyy-dd-MM'T'HH:mm");
@@ -472,7 +472,7 @@ public class RangeFieldTypeTests extends FieldTypeTestCase {
 
     public void testTermQuery() throws Exception {
         // See https://github.com/elastic/elasticsearch/issues/25950
-        QueryShardContext context = createContext();
+        SearchExecutionContext context = createContext();
         RangeFieldType ft = createDefaultFieldType();
 
         Object value = nextFrom();
@@ -484,7 +484,7 @@ public class RangeFieldTypeTests extends FieldTypeTestCase {
     }
 
     public void testCaseInsensitiveQuery() throws Exception {
-        QueryShardContext context = createContext();
+        SearchExecutionContext context = createContext();
         RangeFieldType ft = createDefaultFieldType();
 
         Object value = nextFrom();

--- a/server/src/test/java/org/elasticsearch/index/mapper/RootObjectMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RootObjectMapperTests.java
@@ -27,7 +27,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.mapper.MapperService.MergeReason;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.plugins.MapperPlugin;
 import org.elasticsearch.plugins.Plugin;
 
@@ -739,12 +739,12 @@ public class RootObjectMapperTests extends MapperServiceTestCase {
         }
 
         @Override
-        public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             return null;
         }
 
         @Override
-        public Query termQuery(Object value, QueryShardContext context) {
+        public Query termQuery(Object value, SearchExecutionContext context) {
             return null;
         }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/RoutingFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RoutingFieldTypeTests.java
@@ -32,10 +32,10 @@ public class RoutingFieldTypeTests extends FieldTypeTestCase {
         MappedFieldType ft = RoutingFieldMapper.RoutingFieldType.INSTANCE;
 
         Query expected = new PrefixQuery(new Term("_routing", new BytesRef("foo*")));
-        assertEquals(expected, ft.prefixQuery("foo*", null, MOCK_QSC));
+        assertEquals(expected, ft.prefixQuery("foo*", null, MOCK_CONTEXT));
 
         ElasticsearchException ee = expectThrows(ElasticsearchException.class,
-                () -> ft.prefixQuery("foo*", null, MOCK_QSC_DISALLOW_EXPENSIVE));
+                () -> ft.prefixQuery("foo*", null, MOCK_CONTEXT_DISALLOW_EXPENSIVE));
         assertEquals("[prefix] queries cannot be executed when 'search.allow_expensive_queries' is set to false. " +
                 "For optimised prefix queries on text fields please enable [index_prefixes].", ee.getMessage());
     }
@@ -44,10 +44,10 @@ public class RoutingFieldTypeTests extends FieldTypeTestCase {
         MappedFieldType ft = RoutingFieldMapper.RoutingFieldType.INSTANCE;
 
         Query expected = new RegexpQuery(new Term("_routing", new BytesRef("foo?")));
-        assertEquals(expected, ft.regexpQuery("foo?", 0, 0, 10, null, MOCK_QSC));
+        assertEquals(expected, ft.regexpQuery("foo?", 0, 0, 10, null, MOCK_CONTEXT));
 
         ElasticsearchException ee = expectThrows(ElasticsearchException.class,
-                () -> ft.regexpQuery("foo?", randomInt(10), 0, randomInt(10) + 1, null, MOCK_QSC_DISALLOW_EXPENSIVE));
+                () -> ft.regexpQuery("foo?", randomInt(10), 0, randomInt(10) + 1, null, MOCK_CONTEXT_DISALLOW_EXPENSIVE));
         assertEquals("[regexp] queries cannot be executed when 'search.allow_expensive_queries' is set to false.",
                 ee.getMessage());
     }
@@ -56,10 +56,10 @@ public class RoutingFieldTypeTests extends FieldTypeTestCase {
         MappedFieldType ft = RoutingFieldMapper.RoutingFieldType.INSTANCE;
 
         Query expected = new WildcardQuery(new Term("_routing", new BytesRef("foo*")));
-        assertEquals(expected, ft.wildcardQuery("foo*", null, MOCK_QSC));
+        assertEquals(expected, ft.wildcardQuery("foo*", null, MOCK_CONTEXT));
 
         ElasticsearchException ee = expectThrows(ElasticsearchException.class,
-                () -> ft.wildcardQuery("valu*", null, MOCK_QSC_DISALLOW_EXPENSIVE));
+                () -> ft.wildcardQuery("valu*", null, MOCK_CONTEXT_DISALLOW_EXPENSIVE));
         assertEquals("[wildcard] queries cannot be executed when 'search.allow_expensive_queries' is set to false.",
                 ee.getMessage());
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/TestRuntimeField.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TestRuntimeField.java
@@ -22,7 +22,7 @@ package org.elasticsearch.index.mapper;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.plugins.MapperPlugin;
 
 import java.io.IOException;
@@ -43,7 +43,7 @@ public class TestRuntimeField extends RuntimeFieldType {
     }
 
     @Override
-    public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+    public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
         return null;
     }
 
@@ -53,7 +53,7 @@ public class TestRuntimeField extends RuntimeFieldType {
     }
 
     @Override
-    public Query termQuery(Object value, QueryShardContext context) {
+    public Query termQuery(Object value, SearchExecutionContext context) {
         return null;
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
@@ -68,7 +68,7 @@ import org.elasticsearch.index.analysis.TokenFilterFactory;
 import org.elasticsearch.index.mapper.TextFieldMapper.TextFieldType;
 import org.elasticsearch.index.query.MatchPhrasePrefixQueryBuilder;
 import org.elasticsearch.index.query.MatchPhraseQueryBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.search.MatchQuery;
 import org.elasticsearch.index.search.QueryStringQueryParser;
 
@@ -689,25 +689,25 @@ public class TextFieldMapperTests extends MapperTestCase {
             // "standard" will be replaced with MockSynonymAnalyzer
             b.startObject("synfield").field("type", "text").field("analyzer", "standard").field("index_phrases", true).endObject();
         }));
-        QueryShardContext queryShardContext = createQueryShardContext(mapperService);
+        SearchExecutionContext searchExecutionContext = createSearchExecutionContext(mapperService);
 
-        Query q = new MatchPhraseQueryBuilder("field", "two words").toQuery(queryShardContext);
+        Query q = new MatchPhraseQueryBuilder("field", "two words").toQuery(searchExecutionContext);
         assertThat(q, is(new PhraseQuery("field._index_phrase", "two words")));
 
-        Query q2 = new MatchPhraseQueryBuilder("field", "three words here").toQuery(queryShardContext);
+        Query q2 = new MatchPhraseQueryBuilder("field", "three words here").toQuery(searchExecutionContext);
         assertThat(q2, is(new PhraseQuery("field._index_phrase", "three words", "words here")));
 
-        Query q3 = new MatchPhraseQueryBuilder("field", "two words").slop(1).toQuery(queryShardContext);
+        Query q3 = new MatchPhraseQueryBuilder("field", "two words").slop(1).toQuery(searchExecutionContext);
         assertThat(q3, is(new PhraseQuery(1, "field", "two", "words")));
 
-        Query q4 = new MatchPhraseQueryBuilder("field", "singleton").toQuery(queryShardContext);
+        Query q4 = new MatchPhraseQueryBuilder("field", "singleton").toQuery(searchExecutionContext);
         assertThat(q4, is(new TermQuery(new Term("field", "singleton"))));
 
-        Query q5 = new MatchPhraseQueryBuilder("field", "sparkle a stopword").toQuery(queryShardContext);
+        Query q5 = new MatchPhraseQueryBuilder("field", "sparkle a stopword").toQuery(searchExecutionContext);
         assertThat(q5,
             is(new PhraseQuery.Builder().add(new Term("field", "sparkle")).add(new Term("field", "stopword"), 2).build()));
 
-        MatchQuery matchQuery = new MatchQuery(queryShardContext);
+        MatchQuery matchQuery = new MatchQuery(searchExecutionContext);
         matchQuery.setAnalyzer(new MockSynonymAnalyzer());
         Query q6 = matchQuery.parse(MatchQuery.Type.PHRASE, "synfield", "motor dogs");
         assertThat(q6, is(new MultiPhraseQuery.Builder()
@@ -783,8 +783,8 @@ public class TextFieldMapperTests extends MapperTestCase {
             }
             b.endObject();
         }));
-        QueryShardContext qsc = createQueryShardContext(ms);
-        QueryStringQueryParser parser = new QueryStringQueryParser(qsc, "f");
+        SearchExecutionContext context = createSearchExecutionContext(ms);
+        QueryStringQueryParser parser = new QueryStringQueryParser(context, "f");
         Query q = parser.parse("foo:*");
         assertEquals(new ConstantScoreQuery(new BooleanQuery.Builder()
             .add(new NormsFieldExistsQuery("foo.bar"), BooleanClause.Occur.SHOULD)
@@ -908,10 +908,10 @@ public class TextFieldMapperTests extends MapperTestCase {
         ParsedDocument doc = mapperService.documentMapper().parse(source(b -> b.field("synfield", "some text which we will index")));
         withLuceneIndex(mapperService, iw -> iw.addDocument(doc.rootDoc()), ir -> {}); // check indexing
 
-        QueryShardContext queryShardContext = createQueryShardContext(mapperService);
+        SearchExecutionContext searchExecutionContext = createSearchExecutionContext(mapperService);
 
         {
-            Query q = new MatchPhrasePrefixQueryBuilder("field", "two words").toQuery(queryShardContext);
+            Query q = new MatchPhrasePrefixQueryBuilder("field", "two words").toQuery(searchExecutionContext);
             Query expected = new SpanNearQuery.Builder("field", true)
                 .addClause(new SpanTermQuery(new Term("field", "two")))
                 .addClause(new FieldMaskingSpanQuery(
@@ -922,7 +922,7 @@ public class TextFieldMapperTests extends MapperTestCase {
         }
 
         {
-            Query q = new MatchPhrasePrefixQueryBuilder("field", "three words here").toQuery(queryShardContext);
+            Query q = new MatchPhrasePrefixQueryBuilder("field", "three words here").toQuery(searchExecutionContext);
             Query expected = new SpanNearQuery.Builder("field", true)
                 .addClause(new SpanTermQuery(new Term("field", "three")))
                 .addClause(new SpanTermQuery(new Term("field", "words")))
@@ -934,7 +934,7 @@ public class TextFieldMapperTests extends MapperTestCase {
         }
 
         {
-            Query q = new MatchPhrasePrefixQueryBuilder("field", "two words").slop(1).toQuery(queryShardContext);
+            Query q = new MatchPhrasePrefixQueryBuilder("field", "two words").slop(1).toQuery(searchExecutionContext);
             MultiPhrasePrefixQuery mpq = new MultiPhrasePrefixQuery("field");
             mpq.setSlop(1);
             mpq.add(new Term("field", "two"));
@@ -943,7 +943,7 @@ public class TextFieldMapperTests extends MapperTestCase {
         }
 
         {
-            Query q = new MatchPhrasePrefixQueryBuilder("field", "singleton").toQuery(queryShardContext);
+            Query q = new MatchPhrasePrefixQueryBuilder("field", "singleton").toQuery(searchExecutionContext);
             assertThat(
                 q,
                 is(new SynonymQuery.Builder("field._index_prefix").addTerm(new Term("field._index_prefix", "singleton")).build())
@@ -952,7 +952,7 @@ public class TextFieldMapperTests extends MapperTestCase {
 
         {
 
-            Query q = new MatchPhrasePrefixQueryBuilder("field", "sparkle a stopword").toQuery(queryShardContext);
+            Query q = new MatchPhrasePrefixQueryBuilder("field", "sparkle a stopword").toQuery(searchExecutionContext);
             Query expected = new SpanNearQuery.Builder("field", true)
                 .addClause(new SpanTermQuery(new Term("field", "sparkle")))
                 .addGap(1)
@@ -964,7 +964,7 @@ public class TextFieldMapperTests extends MapperTestCase {
         }
 
         {
-            MatchQuery matchQuery = new MatchQuery(queryShardContext);
+            MatchQuery matchQuery = new MatchQuery(searchExecutionContext);
             matchQuery.setAnalyzer(new MockSynonymAnalyzer());
             Query q = matchQuery.parse(MatchQuery.Type.PHRASE_PREFIX, "synfield", "motor dogs");
             Query expected = new SpanNearQuery.Builder("synfield", true)
@@ -984,7 +984,7 @@ public class TextFieldMapperTests extends MapperTestCase {
         }
 
         {
-            MatchQuery matchQuery = new MatchQuery(queryShardContext);
+            MatchQuery matchQuery = new MatchQuery(searchExecutionContext);
             matchQuery.setPhraseSlop(1);
             matchQuery.setAnalyzer(new MockSynonymAnalyzer());
             Query q = matchQuery.parse(MatchQuery.Type.PHRASE_PREFIX, "synfield", "two dogs");
@@ -996,7 +996,7 @@ public class TextFieldMapperTests extends MapperTestCase {
         }
 
         {
-            Query q = new MatchPhrasePrefixQueryBuilder("field", "motor d").toQuery(queryShardContext);
+            Query q = new MatchPhrasePrefixQueryBuilder("field", "motor d").toQuery(searchExecutionContext);
             MultiPhrasePrefixQuery mpq = new MultiPhrasePrefixQuery("field");
             mpq.add(new Term("field", "motor"));
             mpq.add(new Term("field", "d"));

--- a/server/src/test/java/org/elasticsearch/index/mapper/TextFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TextFieldTypeTests.java
@@ -90,10 +90,10 @@ public class TextFieldTypeTests extends FieldTypeTestCase {
     public void testRangeQuery() {
         MappedFieldType ft = createFieldType();
         assertEquals(new TermRangeQuery("field", BytesRefs.toBytesRef("foo"), BytesRefs.toBytesRef("bar"), true, false),
-                ft.rangeQuery("foo", "bar", true, false, null, null, null, MOCK_QSC));
+                ft.rangeQuery("foo", "bar", true, false, null, null, null, MOCK_CONTEXT));
 
         ElasticsearchException ee = expectThrows(ElasticsearchException.class,
-                () -> ft.rangeQuery("foo", "bar", true, false, null, null, null, MOCK_QSC_DISALLOW_EXPENSIVE));
+                () -> ft.rangeQuery("foo", "bar", true, false, null, null, null, MOCK_CONTEXT_DISALLOW_EXPENSIVE));
         assertEquals("[range] queries on [text] or [keyword] fields cannot be executed when " +
                         "'search.allow_expensive_queries' is set to false.", ee.getMessage());
     }
@@ -101,15 +101,15 @@ public class TextFieldTypeTests extends FieldTypeTestCase {
     public void testRegexpQuery() {
         MappedFieldType ft = createFieldType();
         assertEquals(new RegexpQuery(new Term("field","foo.*")),
-                ft.regexpQuery("foo.*", 0, 0, 10, null, MOCK_QSC));
+                ft.regexpQuery("foo.*", 0, 0, 10, null, MOCK_CONTEXT));
 
         MappedFieldType unsearchable = new TextFieldType("field", false, false, Collections.emptyMap());
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
-                () -> unsearchable.regexpQuery("foo.*", 0, 0, 10, null, MOCK_QSC));
+                () -> unsearchable.regexpQuery("foo.*", 0, 0, 10, null, MOCK_CONTEXT));
         assertEquals("Cannot search on field [field] since it is not indexed.", e.getMessage());
 
         ElasticsearchException ee = expectThrows(ElasticsearchException.class,
-                () -> ft.regexpQuery("foo.*", randomInt(10), 0, randomInt(10) + 1, null, MOCK_QSC_DISALLOW_EXPENSIVE));
+                () -> ft.regexpQuery("foo.*", randomInt(10), 0, randomInt(10) + 1, null, MOCK_CONTEXT_DISALLOW_EXPENSIVE));
         assertEquals("[regexp] queries cannot be executed when 'search.allow_expensive_queries' is set to false.",
                 ee.getMessage());
     }
@@ -117,16 +117,16 @@ public class TextFieldTypeTests extends FieldTypeTestCase {
     public void testFuzzyQuery() {
         MappedFieldType ft = createFieldType();
         assertEquals(new FuzzyQuery(new Term("field","foo"), 2, 1, 50, true),
-                ft.fuzzyQuery("foo", Fuzziness.fromEdits(2), 1, 50, true, MOCK_QSC));
+                ft.fuzzyQuery("foo", Fuzziness.fromEdits(2), 1, 50, true, MOCK_CONTEXT));
 
         MappedFieldType unsearchable = new TextFieldType("field", false, false, Collections.emptyMap());
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
-                () -> unsearchable.fuzzyQuery("foo", Fuzziness.fromEdits(2), 1, 50, true, MOCK_QSC));
+                () -> unsearchable.fuzzyQuery("foo", Fuzziness.fromEdits(2), 1, 50, true, MOCK_CONTEXT));
         assertEquals("Cannot search on field [field] since it is not indexed.", e.getMessage());
 
         ElasticsearchException ee = expectThrows(ElasticsearchException.class,
                 () -> ft.fuzzyQuery("foo", Fuzziness.AUTO, randomInt(10) + 1, randomInt(10) + 1,
-                        randomBoolean(), MOCK_QSC_DISALLOW_EXPENSIVE));
+                        randomBoolean(), MOCK_CONTEXT_DISALLOW_EXPENSIVE));
         assertEquals("[fuzzy] queries cannot be executed when 'search.allow_expensive_queries' is set to false.",
                 ee.getMessage());
     }
@@ -135,22 +135,22 @@ public class TextFieldTypeTests extends FieldTypeTestCase {
         TextFieldType ft = createFieldType();
         ft.setIndexPrefixes(2, 10);
 
-        Query q = ft.prefixQuery("goin", CONSTANT_SCORE_REWRITE, false, randomMockShardContext());
+        Query q = ft.prefixQuery("goin", CONSTANT_SCORE_REWRITE, false, randomMockContext());
         assertEquals(new ConstantScoreQuery(new TermQuery(new Term("field._index_prefix", "goin"))), q);
 
-        q = ft.prefixQuery("internationalisatio", CONSTANT_SCORE_REWRITE, false, MOCK_QSC);
+        q = ft.prefixQuery("internationalisatio", CONSTANT_SCORE_REWRITE, false, MOCK_CONTEXT);
         assertEquals(new PrefixQuery(new Term("field", "internationalisatio")), q);
 
-        q = ft.prefixQuery("Internationalisatio", CONSTANT_SCORE_REWRITE, true, MOCK_QSC);
+        q = ft.prefixQuery("Internationalisatio", CONSTANT_SCORE_REWRITE, true, MOCK_CONTEXT);
         assertEquals(AutomatonQueries.caseInsensitivePrefixQuery(new Term("field", "Internationalisatio")), q);
 
 
         ElasticsearchException ee = expectThrows(ElasticsearchException.class,
-                () -> ft.prefixQuery("internationalisatio", null, false, MOCK_QSC_DISALLOW_EXPENSIVE));
+                () -> ft.prefixQuery("internationalisatio", null, false, MOCK_CONTEXT_DISALLOW_EXPENSIVE));
         assertEquals("[prefix] queries cannot be executed when 'search.allow_expensive_queries' is set to false. " +
                 "For optimised prefix queries on text fields please enable [index_prefixes].", ee.getMessage());
 
-        q = ft.prefixQuery("g", CONSTANT_SCORE_REWRITE, false, randomMockShardContext());
+        q = ft.prefixQuery("g", CONSTANT_SCORE_REWRITE, false, randomMockContext());
         Automaton automaton
             = Operations.concatenate(Arrays.asList(Automata.makeChar('g'), Automata.makeAnyChar()));
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/TypeFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TypeFieldTypeTests.java
@@ -28,7 +28,7 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.fielddata.IndexFieldDataCache;
 import org.elasticsearch.index.fielddata.IndexOrdinalsFieldData;
 import org.elasticsearch.index.fielddata.LeafOrdinalsFieldData;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.mockito.Mockito;
 
@@ -68,7 +68,7 @@ public class TypeFieldTypeTests extends MapperServiceTestCase {
     }
 
     public void testTermsQuery() {
-        QueryShardContext context = Mockito.mock(QueryShardContext.class);
+        SearchExecutionContext context = Mockito.mock(SearchExecutionContext.class);
 
         TypeFieldType ft = new TypeFieldType("_doc");
 
@@ -89,7 +89,7 @@ public class TypeFieldTypeTests extends MapperServiceTestCase {
     }
 
     public void testExistsQuery() {
-        QueryShardContext context = Mockito.mock(QueryShardContext.class);
+        SearchExecutionContext context = Mockito.mock(SearchExecutionContext.class);
         TypeFieldType ft = new TypeFieldType("_doc");
         Query query = ft.existsQuery(context);
         assertEquals(new MatchAllDocsQuery(), query);

--- a/server/src/test/java/org/elasticsearch/index/query/BoostingQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/BoostingQueryBuilderTests.java
@@ -40,7 +40,7 @@ public class BoostingQueryBuilderTests extends AbstractQueryTestCase<BoostingQue
     }
 
     @Override
-    protected void doAssertLuceneQuery(BoostingQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
+    protected void doAssertLuceneQuery(BoostingQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
         Query positive = queryBuilder.positiveQuery().rewrite(context).toQuery(context);
         Query negative = queryBuilder.negativeQuery().rewrite(context).toQuery(context);
         if (positive == null || negative == null) {
@@ -98,12 +98,12 @@ public class BoostingQueryBuilderTests extends AbstractQueryTestCase<BoostingQue
         QueryBuilder negative = randomBoolean() ? new MatchAllQueryBuilder() :
             new WrapperQueryBuilder(new TermQueryBuilder(TEXT_FIELD_NAME, "bar").toString());
         BoostingQueryBuilder qb = new BoostingQueryBuilder(positive, negative);
-        QueryBuilder rewrite = qb.rewrite(createShardContext());
+        QueryBuilder rewrite = qb.rewrite(createSearchExecutionContext());
         if (positive instanceof MatchAllQueryBuilder && negative instanceof MatchAllQueryBuilder) {
             assertSame(rewrite, qb);
         } else {
             assertNotSame(rewrite, qb);
-            assertEquals(new BoostingQueryBuilder(positive.rewrite(createShardContext()), negative.rewrite(createShardContext())), rewrite);
+            assertEquals(new BoostingQueryBuilder(positive.rewrite(createSearchExecutionContext()), negative.rewrite(createSearchExecutionContext())), rewrite);
         }
     }
 
@@ -111,13 +111,13 @@ public class BoostingQueryBuilderTests extends AbstractQueryTestCase<BoostingQue
         BoostingQueryBuilder builder = new BoostingQueryBuilder(
             new TermQueryBuilder("unmapped_field", "value"),
             new TermQueryBuilder(KEYWORD_FIELD_NAME, "other_value"));
-        QueryBuilder rewrite = builder.rewrite(createShardContext());
+        QueryBuilder rewrite = builder.rewrite(createSearchExecutionContext());
         assertThat(rewrite, instanceOf(MatchNoneQueryBuilder.class));
     }
 
     @Override
     public void testMustRewrite() throws IOException {
-        QueryShardContext context = createShardContext();
+        SearchExecutionContext context = createSearchExecutionContext();
         context.setAllowUnmappedFields(true);
 
         BoostingQueryBuilder queryBuilder1 = new BoostingQueryBuilder(

--- a/server/src/test/java/org/elasticsearch/index/query/BoostingQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/BoostingQueryBuilderTests.java
@@ -103,7 +103,8 @@ public class BoostingQueryBuilderTests extends AbstractQueryTestCase<BoostingQue
             assertSame(rewrite, qb);
         } else {
             assertNotSame(rewrite, qb);
-            assertEquals(new BoostingQueryBuilder(positive.rewrite(createSearchExecutionContext()), negative.rewrite(createSearchExecutionContext())), rewrite);
+            assertEquals(new BoostingQueryBuilder(positive.rewrite(createSearchExecutionContext()),
+                negative.rewrite(createSearchExecutionContext())), rewrite);
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/index/query/ConstantScoreQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/ConstantScoreQueryBuilderTests.java
@@ -41,7 +41,8 @@ public class ConstantScoreQueryBuilderTests extends AbstractQueryTestCase<Consta
     }
 
     @Override
-    protected void doAssertLuceneQuery(ConstantScoreQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
+    protected void doAssertLuceneQuery(ConstantScoreQueryBuilder queryBuilder, Query query,
+                                       SearchExecutionContext context) throws IOException {
         Query innerQuery = queryBuilder.innerQuery().rewrite(context).toQuery(context);
         if (innerQuery == null) {
             assertThat(query, nullValue());

--- a/server/src/test/java/org/elasticsearch/index/query/ConstantScoreQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/ConstantScoreQueryBuilderTests.java
@@ -41,7 +41,7 @@ public class ConstantScoreQueryBuilderTests extends AbstractQueryTestCase<Consta
     }
 
     @Override
-    protected void doAssertLuceneQuery(ConstantScoreQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
+    protected void doAssertLuceneQuery(ConstantScoreQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
         Query innerQuery = queryBuilder.innerQuery().rewrite(context).toQuery(context);
         if (innerQuery == null) {
             assertThat(query, nullValue());
@@ -107,13 +107,13 @@ public class ConstantScoreQueryBuilderTests extends AbstractQueryTestCase<Consta
 
     public void testRewriteToMatchNone() throws IOException {
         ConstantScoreQueryBuilder constantScoreQueryBuilder = new ConstantScoreQueryBuilder(new MatchNoneQueryBuilder());
-        QueryBuilder rewrite = constantScoreQueryBuilder.rewrite(createShardContext());
+        QueryBuilder rewrite = constantScoreQueryBuilder.rewrite(createSearchExecutionContext());
         assertEquals(rewrite, new MatchNoneQueryBuilder());
     }
 
     @Override
     public void testMustRewrite() throws IOException {
-        QueryShardContext context = createShardContext();
+        SearchExecutionContext context = createSearchExecutionContext();
         context.setAllowUnmappedFields(true);
         ConstantScoreQueryBuilder queryBuilder = new ConstantScoreQueryBuilder(new TermQueryBuilder("unmapped_field", "foo"));
         IllegalStateException e = expectThrows(IllegalStateException.class,

--- a/server/src/test/java/org/elasticsearch/index/query/DisMaxQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/DisMaxQueryBuilderTests.java
@@ -55,7 +55,7 @@ public class DisMaxQueryBuilderTests extends AbstractQueryTestCase<DisMaxQueryBu
     }
 
     @Override
-    protected void doAssertLuceneQuery(DisMaxQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
+    protected void doAssertLuceneQuery(DisMaxQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
         Collection<Query> queries = AbstractQueryBuilder.toQueries(queryBuilder.innerQueries(), context);
         assertThat(query, instanceOf(DisjunctionMaxQuery.class));
         DisjunctionMaxQuery disjunctionMaxQuery = (DisjunctionMaxQuery) query;
@@ -102,7 +102,7 @@ public class DisMaxQueryBuilderTests extends AbstractQueryTestCase<DisMaxQueryBu
                 "        ]\n" +
                 "    }\n" +
                 "}";
-        Query query = parseQuery(queryAsString).toQuery(createShardContext());
+        Query query = parseQuery(queryAsString).toQuery(createSearchExecutionContext());
         assertThat(query, instanceOf(DisjunctionMaxQuery.class));
         DisjunctionMaxQuery disjunctionMaxQuery = (DisjunctionMaxQuery) query;
 
@@ -154,15 +154,15 @@ public class DisMaxQueryBuilderTests extends AbstractQueryTestCase<DisMaxQueryBu
     public void testRewriteMultipleTimes() throws IOException {
         DisMaxQueryBuilder dismax = new DisMaxQueryBuilder();
         dismax.add(new WrapperQueryBuilder(new WrapperQueryBuilder(new MatchAllQueryBuilder().toString()).toString()));
-        QueryBuilder rewritten = dismax.rewrite(createShardContext());
+        QueryBuilder rewritten = dismax.rewrite(createSearchExecutionContext());
         DisMaxQueryBuilder expected = new DisMaxQueryBuilder();
         expected.add(new MatchAllQueryBuilder());
         assertEquals(expected, rewritten);
 
         expected = new DisMaxQueryBuilder();
         expected.add(new MatchAllQueryBuilder());
-        QueryBuilder rewrittenAgain = rewritten.rewrite(createShardContext());
+        QueryBuilder rewrittenAgain = rewritten.rewrite(createSearchExecutionContext());
         assertEquals(rewrittenAgain, expected);
-        assertEquals(Rewriteable.rewrite(dismax, createShardContext()), expected);
+        assertEquals(Rewriteable.rewrite(dismax, createSearchExecutionContext()), expected);
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/query/DistanceFeatureQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/DistanceFeatureQueryBuilderTests.java
@@ -227,7 +227,8 @@ public class DistanceFeatureQueryBuilderTests extends AbstractQueryTestCase<Dist
             "            \"pivot\" : \"random_string\"\n" +
             "    }\n" +
             "}";
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> parseQuery(query).toQuery(createSearchExecutionContext()));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+            () -> parseQuery(query).toQuery(createSearchExecutionContext()));
         assertThat(e.getMessage(), containsString("query can only be run on a date, date_nanos or geo_point field type!"));
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/query/DistanceFeatureQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/DistanceFeatureQueryBuilderTests.java
@@ -73,7 +73,7 @@ public class DistanceFeatureQueryBuilderTests extends AbstractQueryTestCase<Dist
     @Override
     protected void doAssertLuceneQuery(DistanceFeatureQueryBuilder queryBuilder,
                                        Query query,
-                                       QueryShardContext context) throws IOException {
+                                       SearchExecutionContext context) throws IOException {
         String fieldName = expectedFieldName(queryBuilder.fieldName());
         Object origin = queryBuilder.origin().origin();
         String pivot = queryBuilder.pivot();
@@ -215,7 +215,7 @@ public class DistanceFeatureQueryBuilderTests extends AbstractQueryTestCase<Dist
             "            \"pivot\" : \"random_string\"\n" +
             "    }\n" +
             "}";
-        Query query = parseQuery(queryString).toQuery(createShardContext());
+        Query query = parseQuery(queryString).toQuery(createSearchExecutionContext());
         assertEquals(expectedQuery, query);
     }
 
@@ -227,7 +227,7 @@ public class DistanceFeatureQueryBuilderTests extends AbstractQueryTestCase<Dist
             "            \"pivot\" : \"random_string\"\n" +
             "    }\n" +
             "}";
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> parseQuery(query).toQuery(createShardContext()));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> parseQuery(query).toQuery(createSearchExecutionContext()));
         assertThat(e.getMessage(), containsString("query can only be run on a date, date_nanos or geo_point field type!"));
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/query/ExistsQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/ExistsQueryBuilderTests.java
@@ -57,7 +57,7 @@ public class ExistsQueryBuilderTests extends AbstractQueryTestCase<ExistsQueryBu
     }
 
     @Override
-    protected void doAssertLuceneQuery(ExistsQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
+    protected void doAssertLuceneQuery(ExistsQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
         String fieldPattern = queryBuilder.fieldName();
         Collection<String> fields = context.simpleMatchToIndexNames(fieldPattern);
         Collection<String> mappedFields = fields.stream().filter((field) -> context.getObjectMapper(field) != null
@@ -106,7 +106,7 @@ public class ExistsQueryBuilderTests extends AbstractQueryTestCase<ExistsQueryBu
 
     @Override
     public void testMustRewrite() {
-        QueryShardContext context = createShardContext();
+        SearchExecutionContext context = createSearchExecutionContext();
         context.setAllowUnmappedFields(true);
         ExistsQueryBuilder queryBuilder = new ExistsQueryBuilder("foo");
         IllegalStateException e = expectThrows(IllegalStateException.class,

--- a/server/src/test/java/org/elasticsearch/index/query/FieldMaskingSpanQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/FieldMaskingSpanQueryBuilderTests.java
@@ -44,7 +44,7 @@ public class FieldMaskingSpanQueryBuilderTests extends AbstractQueryTestCase<Fie
     @Override
     protected void doAssertLuceneQuery(FieldMaskingSpanQueryBuilder queryBuilder,
                                        Query query,
-                                       QueryShardContext context) throws IOException {
+                                       SearchExecutionContext context) throws IOException {
         String fieldInQuery = expectedFieldName(queryBuilder.fieldName());
         assertThat(query, instanceOf(FieldMaskingSpanQuery.class));
         FieldMaskingSpanQuery fieldMaskingSpanQuery = (FieldMaskingSpanQuery) query;

--- a/server/src/test/java/org/elasticsearch/index/query/FuzzyQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/FuzzyQueryBuilderTests.java
@@ -73,7 +73,7 @@ public class FuzzyQueryBuilderTests extends AbstractQueryTestCase<FuzzyQueryBuil
     }
 
     @Override
-    protected void doAssertLuceneQuery(FuzzyQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
+    protected void doAssertLuceneQuery(FuzzyQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
         assertThat(query, instanceOf(FuzzyQuery.class));
 
         FuzzyQuery fuzzyQuery = (FuzzyQuery) query;
@@ -104,7 +104,7 @@ public class FuzzyQueryBuilderTests extends AbstractQueryTestCase<FuzzyQueryBuil
                 "        }\n" +
                 "    }\n" +
                 "}";
-        Query parsedQuery = parseQuery(query).toQuery(createShardContext());
+        Query parsedQuery = parseQuery(query).toQuery(createSearchExecutionContext());
         assertThat(parsedQuery, instanceOf(BoostQuery.class));
         BoostQuery boostQuery = (BoostQuery) parsedQuery;
         assertThat(boostQuery.getBoost(), equalTo(2.0f));
@@ -126,7 +126,7 @@ public class FuzzyQueryBuilderTests extends AbstractQueryTestCase<FuzzyQueryBuil
             "        }\n" +
             "    }\n" +
             "}";
-        Query parsedQuery = parseQuery(query).toQuery(createShardContext());
+        Query parsedQuery = parseQuery(query).toQuery(createSearchExecutionContext());
         assertThat(parsedQuery, instanceOf(BoostQuery.class));
         BoostQuery boostQuery = (BoostQuery) parsedQuery;
         assertThat(boostQuery.getBoost(), equalTo(2.0f));
@@ -149,7 +149,7 @@ public class FuzzyQueryBuilderTests extends AbstractQueryTestCase<FuzzyQueryBuil
             "    }\n" +
             "}";
         ElasticsearchParseException e = expectThrows(ElasticsearchParseException.class,
-            () -> parseQuery(queryMissingFuzzinessUpLimit).toQuery(createShardContext()));
+            () -> parseQuery(queryMissingFuzzinessUpLimit).toQuery(createSearchExecutionContext()));
         String msg = "failed to find low and high distance values";
         assertTrue(e.getMessage() + " didn't contain: " + msg + " but: " + e.getMessage(), e.getMessage().contains(msg));
 
@@ -165,7 +165,7 @@ public class FuzzyQueryBuilderTests extends AbstractQueryTestCase<FuzzyQueryBuil
             "}";
         String msg2 = "fuzziness wrongly configured";
         ElasticsearchParseException e2 = expectThrows(ElasticsearchParseException.class,
-            () -> parseQuery(queryHavingNegativeFuzzinessLowLimit).toQuery(createShardContext()));
+            () -> parseQuery(queryHavingNegativeFuzzinessLowLimit).toQuery(createSearchExecutionContext()));
         assertTrue(e2.getMessage() + " didn't contain: " + msg2 + " but: " + e.getMessage(), e.getMessage().contains
             (msg));
 
@@ -180,7 +180,7 @@ public class FuzzyQueryBuilderTests extends AbstractQueryTestCase<FuzzyQueryBuil
             "    }\n" +
             "}";
         e = expectThrows(ElasticsearchParseException.class,
-            () -> parseQuery(queryMissingFuzzinessUpLimit2).toQuery(createShardContext()));
+            () -> parseQuery(queryMissingFuzzinessUpLimit2).toQuery(createSearchExecutionContext()));
         assertTrue(e.getMessage() + " didn't contain: " + msg + " but: " + e.getMessage(), e.getMessage().contains(msg));
 
         String queryMissingFuzzinessLowLimit = "{\n" +
@@ -194,7 +194,7 @@ public class FuzzyQueryBuilderTests extends AbstractQueryTestCase<FuzzyQueryBuil
             "    }\n" +
             "}";
         e = expectThrows(ElasticsearchParseException.class,
-            () -> parseQuery(queryMissingFuzzinessLowLimit).toQuery(createShardContext()));
+            () -> parseQuery(queryMissingFuzzinessLowLimit).toQuery(createSearchExecutionContext()));
         msg = "failed to parse [AUTO:,5] as a \"auto:int,int\"";
         assertTrue(e.getMessage() + " didn't contain: " + msg + " but: " + e.getMessage(), e.getMessage().contains(msg));
     }
@@ -209,7 +209,7 @@ public class FuzzyQueryBuilderTests extends AbstractQueryTestCase<FuzzyQueryBuil
                 "    }\n" +
                 "}\n";
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
-                () -> parseQuery(query).toQuery(createShardContext()));
+                () -> parseQuery(query).toQuery(createSearchExecutionContext()));
         assertEquals("Can only use fuzzy queries on keyword and text fields - not on [mapped_int] which is of type [integer]",
                 e.getMessage());
     }
@@ -284,15 +284,15 @@ public class FuzzyQueryBuilderTests extends AbstractQueryTestCase<FuzzyQueryBuil
     }
 
     public void testToQueryWithTranspositions() throws Exception {
-        Query query = new FuzzyQueryBuilder(TEXT_FIELD_NAME, "text").toQuery(createShardContext());
+        Query query = new FuzzyQueryBuilder(TEXT_FIELD_NAME, "text").toQuery(createSearchExecutionContext());
         assertThat(query, instanceOf(FuzzyQuery.class));
         assertEquals(FuzzyQuery.defaultTranspositions, ((FuzzyQuery)query).getTranspositions());
 
-        query = new FuzzyQueryBuilder(TEXT_FIELD_NAME, "text").transpositions(true).toQuery(createShardContext());
+        query = new FuzzyQueryBuilder(TEXT_FIELD_NAME, "text").transpositions(true).toQuery(createSearchExecutionContext());
         assertThat(query, instanceOf(FuzzyQuery.class));
         assertEquals(true, ((FuzzyQuery)query).getTranspositions());
 
-        query = new FuzzyQueryBuilder(TEXT_FIELD_NAME, "text").transpositions(false).toQuery(createShardContext());
+        query = new FuzzyQueryBuilder(TEXT_FIELD_NAME, "text").transpositions(false).toQuery(createSearchExecutionContext());
         assertThat(query, instanceOf(FuzzyQuery.class));
         assertEquals(false, ((FuzzyQuery)query).getTranspositions());
     }

--- a/server/src/test/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilderTests.java
@@ -111,7 +111,7 @@ public class GeoBoundingBoxQueryBuilderTests extends AbstractQueryTestCase<GeoBo
     }
 
     public void testExceptionOnMissingTypes() {
-        QueryShardContext context = createShardContextWithNoType();
+        SearchExecutionContext context = createShardContextWithNoType();
         GeoBoundingBoxQueryBuilder qb = createTestQueryBuilder();
         qb.ignoreUnmapped(false);
         QueryShardException e = expectThrows(QueryShardException.class, () -> qb.toQuery(context));
@@ -206,7 +206,7 @@ public class GeoBoundingBoxQueryBuilderTests extends AbstractQueryTestCase<GeoBo
     }
 
     @Override
-    protected void doAssertLuceneQuery(GeoBoundingBoxQueryBuilder queryBuilder, Query query, QueryShardContext context)
+    protected void doAssertLuceneQuery(GeoBoundingBoxQueryBuilder queryBuilder, Query query, SearchExecutionContext context)
         throws IOException {
         final MappedFieldType fieldType = context.getFieldType(queryBuilder.fieldName());
         if (fieldType == null) {
@@ -373,9 +373,9 @@ public class GeoBoundingBoxQueryBuilderTests extends AbstractQueryTestCase<GeoBo
     }
 
     private void assertGeoBoundingBoxQuery(String query) throws IOException {
-        QueryShardContext shardContext = createShardContext();
+        SearchExecutionContext searchExecutionContext = createSearchExecutionContext();
         // just check if we can parse the query
-        parseQuery(query).toQuery(shardContext);
+        parseQuery(query).toQuery(searchExecutionContext);
     }
 
     public void testFromJson() throws IOException {
@@ -532,14 +532,14 @@ public class GeoBoundingBoxQueryBuilderTests extends AbstractQueryTestCase<GeoBo
     public void testIgnoreUnmapped() throws IOException {
         final GeoBoundingBoxQueryBuilder queryBuilder = new GeoBoundingBoxQueryBuilder("unmapped").setCorners(1.0, 0.0, 0.0, 1.0);
         queryBuilder.ignoreUnmapped(true);
-        QueryShardContext shardContext = createShardContext();
-        Query query = queryBuilder.toQuery(shardContext);
+        SearchExecutionContext searchExecutionContext = createSearchExecutionContext();
+        Query query = queryBuilder.toQuery(searchExecutionContext);
         assertThat(query, notNullValue());
         assertThat(query, instanceOf(MatchNoDocsQuery.class));
 
         final GeoBoundingBoxQueryBuilder failingQueryBuilder = new GeoBoundingBoxQueryBuilder("unmapped").setCorners(1.0, 0.0, 0.0, 1.0);
         failingQueryBuilder.ignoreUnmapped(false);
-        QueryShardException e = expectThrows(QueryShardException.class, () -> failingQueryBuilder.toQuery(shardContext));
+        QueryShardException e = expectThrows(QueryShardException.class, () -> failingQueryBuilder.toQuery(searchExecutionContext));
         assertThat(e.getMessage(), containsString("failed to find geo field [unmapped]"));
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/query/GeoDistanceQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/GeoDistanceQueryBuilderTests.java
@@ -128,7 +128,8 @@ public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDista
     }
 
     @Override
-    protected void doAssertLuceneQuery(GeoDistanceQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
+    protected void doAssertLuceneQuery(GeoDistanceQueryBuilder queryBuilder, Query query,
+                                       SearchExecutionContext context) throws IOException {
         final MappedFieldType fieldType = context.getFieldType(queryBuilder.fieldName());
         if (fieldType == null) {
             assertTrue("Found no indexed geo query.", query instanceof MatchNoDocsQuery);
@@ -337,6 +338,7 @@ public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDista
         final GeoDistanceQueryBuilder queryBuilder =
             new GeoDistanceQueryBuilder("unmapped").point(0.0, 0.0).distance("20m");
         queryBuilder.ignoreUnmapped(true);
+
         SearchExecutionContext searchExecutionContext = createSearchExecutionContext();
         Query query = queryBuilder.toQuery(searchExecutionContext);
         assertThat(query, notNullValue());

--- a/server/src/test/java/org/elasticsearch/index/query/GeoDistanceQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/GeoDistanceQueryBuilderTests.java
@@ -128,7 +128,7 @@ public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDista
     }
 
     @Override
-    protected void doAssertLuceneQuery(GeoDistanceQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
+    protected void doAssertLuceneQuery(GeoDistanceQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
         final MappedFieldType fieldType = context.getFieldType(queryBuilder.fieldName());
         if (fieldType == null) {
             assertTrue("Found no indexed geo query.", query instanceof MatchNoDocsQuery);
@@ -307,7 +307,7 @@ public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDista
 
     private void assertGeoDistanceRangeQuery(String query, double lat, double lon, double distance, DistanceUnit distanceUnit)
             throws IOException {
-        Query parsedQuery = parseQuery(query).toQuery(createShardContext());
+        Query parsedQuery = parseQuery(query).toQuery(createSearchExecutionContext());
         // The parsedQuery contains IndexOrDocValuesQuery, which wraps LatLonPointDistanceQuery which in turn has default visibility,
         // so we cannot access its fields directly to check and have to use toString() here instead.
         assertEquals(parsedQuery.toString(),
@@ -337,15 +337,15 @@ public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDista
         final GeoDistanceQueryBuilder queryBuilder =
             new GeoDistanceQueryBuilder("unmapped").point(0.0, 0.0).distance("20m");
         queryBuilder.ignoreUnmapped(true);
-        QueryShardContext shardContext = createShardContext();
-        Query query = queryBuilder.toQuery(shardContext);
+        SearchExecutionContext searchExecutionContext = createSearchExecutionContext();
+        Query query = queryBuilder.toQuery(searchExecutionContext);
         assertThat(query, notNullValue());
         assertThat(query, instanceOf(MatchNoDocsQuery.class));
 
         final GeoDistanceQueryBuilder failingQueryBuilder =
             new GeoDistanceQueryBuilder("unmapped").point(0.0, 0.0).distance("20m");
         failingQueryBuilder.ignoreUnmapped(false);
-        QueryShardException e = expectThrows(QueryShardException.class, () -> failingQueryBuilder.toQuery(shardContext));
+        QueryShardException e = expectThrows(QueryShardException.class, () -> failingQueryBuilder.toQuery(searchExecutionContext));
         assertThat(e.getMessage(), containsString("failed to find geo field [unmapped]"));
     }
 

--- a/server/src/test/java/org/elasticsearch/index/query/GeoPolygonQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/GeoPolygonQueryBuilderTests.java
@@ -62,7 +62,8 @@ public class GeoPolygonQueryBuilderTests extends AbstractQueryTestCase<GeoPolygo
     }
 
     @Override
-    protected void doAssertLuceneQuery(GeoPolygonQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
+    protected void doAssertLuceneQuery(GeoPolygonQueryBuilder queryBuilder, Query query,
+                                       SearchExecutionContext context) throws IOException {
         MappedFieldType fieldType = context.getFieldType(queryBuilder.fieldName());
         if (fieldType == null) {
             assertTrue("Found no indexed geo query.", query instanceof MatchNoDocsQuery);

--- a/server/src/test/java/org/elasticsearch/index/query/GeoPolygonQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/GeoPolygonQueryBuilderTests.java
@@ -62,7 +62,7 @@ public class GeoPolygonQueryBuilderTests extends AbstractQueryTestCase<GeoPolygo
     }
 
     @Override
-    protected void doAssertLuceneQuery(GeoPolygonQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
+    protected void doAssertLuceneQuery(GeoPolygonQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
         MappedFieldType fieldType = context.getFieldType(queryBuilder.fieldName());
         if (fieldType == null) {
             assertTrue("Found no indexed geo query.", query instanceof MatchNoDocsQuery);
@@ -217,7 +217,7 @@ public class GeoPolygonQueryBuilderTests extends AbstractQueryTestCase<GeoPolygo
     }
 
     private void assertGeoPolygonQuery(String query) throws IOException {
-        QueryShardContext context = createShardContext();
+        SearchExecutionContext context = createSearchExecutionContext();
         GeoPolygonQueryBuilder queryBuilder = (GeoPolygonQueryBuilder) parseQuery(query);
         doAssertLuceneQuery(queryBuilder, queryBuilder.toQuery(context), context);
     }
@@ -243,18 +243,18 @@ public class GeoPolygonQueryBuilderTests extends AbstractQueryTestCase<GeoPolygo
         List<GeoPoint> polygon = randomPolygon();
         final GeoPolygonQueryBuilder queryBuilder = new GeoPolygonQueryBuilder("unmapped", polygon);
         queryBuilder.ignoreUnmapped(true);
-        Query query = queryBuilder.toQuery(createShardContext());
+        Query query = queryBuilder.toQuery(createSearchExecutionContext());
         assertThat(query, notNullValue());
         assertThat(query, instanceOf(MatchNoDocsQuery.class));
 
         final GeoPolygonQueryBuilder failingQueryBuilder = new GeoPolygonQueryBuilder("unmapped", polygon);
         failingQueryBuilder.ignoreUnmapped(false);
-        QueryShardException e = expectThrows(QueryShardException.class, () -> failingQueryBuilder.toQuery(createShardContext()));
+        QueryShardException e = expectThrows(QueryShardException.class, () -> failingQueryBuilder.toQuery(createSearchExecutionContext()));
         assertThat(e.getMessage(), containsString("failed to find geo_point field [unmapped]"));
     }
 
     public void testPointValidation() throws IOException {
-        QueryShardContext context = createShardContext();
+        SearchExecutionContext context = createSearchExecutionContext();
         String queryInvalidLat = "{\n" +
             "    \"geo_polygon\":{\n" +
             "        \"" + GEO_POINT_FIELD_NAME + "\":{\n" +

--- a/server/src/test/java/org/elasticsearch/index/query/GeoShapeQueryBuilderGeoShapeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/GeoShapeQueryBuilderGeoShapeTests.java
@@ -59,7 +59,7 @@ public class GeoShapeQueryBuilderGeoShapeTests extends GeoShapeQueryBuilderTests
             }
         }
         if (randomBoolean()) {
-            QueryShardContext context = createShardContext();
+            SearchExecutionContext context = createSearchExecutionContext();
             if (context.indexVersionCreated().onOrAfter(Version.V_7_5_0)) { // CONTAINS is only supported from version 7.5
                 if (shapeType == RandomShapeGenerator.ShapeType.LINESTRING || shapeType == RandomShapeGenerator.ShapeType.MULTILINESTRING) {
                     builder.relation(randomFrom(ShapeRelation.DISJOINT, ShapeRelation.INTERSECTS, ShapeRelation.CONTAINS));

--- a/server/src/test/java/org/elasticsearch/index/query/GeoShapeQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/GeoShapeQueryBuilderTests.java
@@ -102,7 +102,7 @@ public abstract class GeoShapeQueryBuilderTests extends AbstractQueryTestCase<Ge
     }
 
     @Override
-    protected void doAssertLuceneQuery(GeoShapeQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
+    protected void doAssertLuceneQuery(GeoShapeQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
         // Logic for doToQuery is complex and is hard to test here. Need to rely
         // on Integration tests to determine if created query is correct
         // TODO improve GeoShapeQueryBuilder.doToQuery() method to make it
@@ -166,9 +166,9 @@ public abstract class GeoShapeQueryBuilderTests extends AbstractQueryTestCase<Ge
     public void testMustRewrite() throws IOException {
         GeoShapeQueryBuilder query = doCreateTestQueryBuilder(true);
 
-        UnsupportedOperationException e = expectThrows(UnsupportedOperationException.class, () -> query.toQuery(createShardContext()));
+        UnsupportedOperationException e = expectThrows(UnsupportedOperationException.class, () -> query.toQuery(createSearchExecutionContext()));
         assertEquals("query must be rewritten first", e.getMessage());
-        QueryBuilder rewrite = rewriteAndFetch(query, createShardContext());
+        QueryBuilder rewrite = rewriteAndFetch(query, createSearchExecutionContext());
         GeoShapeQueryBuilder geoShapeQueryBuilder = randomBoolean() ?
             new GeoShapeQueryBuilder(fieldName(), indexedShapeToReturn) :
             new GeoShapeQueryBuilder(fieldName(), indexedShapeToReturn.buildGeometry());
@@ -183,7 +183,7 @@ public abstract class GeoShapeQueryBuilderTests extends AbstractQueryTestCase<Ge
             .should(shape)
             .should(shape);
 
-        builder = rewriteAndFetch(builder, createShardContext());
+        builder = rewriteAndFetch(builder, createSearchExecutionContext());
 
         GeoShapeQueryBuilder expectedShape = randomBoolean() ?
             new GeoShapeQueryBuilder(fieldName(), indexedShapeToReturn) :
@@ -203,7 +203,7 @@ public abstract class GeoShapeQueryBuilderTests extends AbstractQueryTestCase<Ge
             new GeoShapeQueryBuilder("unmapped", shape) :
             new GeoShapeQueryBuilder("unmapped", shape.buildGeometry());
         queryBuilder.ignoreUnmapped(true);
-        Query query = queryBuilder.toQuery(createShardContext());
+        Query query = queryBuilder.toQuery(createSearchExecutionContext());
         assertThat(query, notNullValue());
         assertThat(query, instanceOf(MatchNoDocsQuery.class));
 
@@ -211,7 +211,7 @@ public abstract class GeoShapeQueryBuilderTests extends AbstractQueryTestCase<Ge
             new GeoShapeQueryBuilder("unmapped", shape) :
             new GeoShapeQueryBuilder("unmapped", shape.buildGeometry());
         failingQueryBuilder.ignoreUnmapped(false);
-        QueryShardException e = expectThrows(QueryShardException.class, () -> failingQueryBuilder.toQuery(createShardContext()));
+        QueryShardException e = expectThrows(QueryShardException.class, () -> failingQueryBuilder.toQuery(createSearchExecutionContext()));
         assertThat(e.getMessage(), containsString("failed to find type for field [unmapped]"));
     }
 
@@ -221,16 +221,16 @@ public abstract class GeoShapeQueryBuilderTests extends AbstractQueryTestCase<Ge
         final GeoShapeQueryBuilder queryBuilder = randomBoolean() ?
             new GeoShapeQueryBuilder(TEXT_FIELD_NAME, shape) :
             new GeoShapeQueryBuilder(TEXT_FIELD_NAME, shape.buildGeometry());
-        QueryShardException e = expectThrows(QueryShardException.class, () -> queryBuilder.toQuery(createShardContext()));
+        QueryShardException e = expectThrows(QueryShardException.class, () -> queryBuilder.toQuery(createSearchExecutionContext()));
         assertThat(e.getMessage(), containsString("Field [mapped_string] is of unsupported type [text] for [geo_shape] query"));
     }
 
     public void testSerializationFailsUnlessFetched() throws IOException {
         QueryBuilder builder = doCreateTestQueryBuilder(true);
-        QueryBuilder queryBuilder = Rewriteable.rewrite(builder, createShardContext());
+        QueryBuilder queryBuilder = Rewriteable.rewrite(builder, createSearchExecutionContext());
         IllegalStateException ise = expectThrows(IllegalStateException.class, () -> queryBuilder.writeTo(new BytesStreamOutput(10)));
         assertEquals(ise.getMessage(), "supplier must be null, can't serialize suppliers, missing a rewriteAndFetch?");
-        builder = rewriteAndFetch(builder, createShardContext());
+        builder = rewriteAndFetch(builder, createSearchExecutionContext());
         builder.writeTo(new BytesStreamOutput(10));
     }
 

--- a/server/src/test/java/org/elasticsearch/index/query/GeoShapeQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/GeoShapeQueryBuilderTests.java
@@ -166,7 +166,8 @@ public abstract class GeoShapeQueryBuilderTests extends AbstractQueryTestCase<Ge
     public void testMustRewrite() throws IOException {
         GeoShapeQueryBuilder query = doCreateTestQueryBuilder(true);
 
-        UnsupportedOperationException e = expectThrows(UnsupportedOperationException.class, () -> query.toQuery(createSearchExecutionContext()));
+        UnsupportedOperationException e = expectThrows(UnsupportedOperationException.class,
+            () -> query.toQuery(createSearchExecutionContext()));
         assertEquals("query must be rewritten first", e.getMessage());
         QueryBuilder rewrite = rewriteAndFetch(query, createSearchExecutionContext());
         GeoShapeQueryBuilder geoShapeQueryBuilder = randomBoolean() ?

--- a/server/src/test/java/org/elasticsearch/index/query/IdsQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/IdsQueryBuilderTests.java
@@ -48,7 +48,7 @@ public class IdsQueryBuilderTests extends AbstractQueryTestCase<IdsQueryBuilder>
     }
 
     @Override
-    protected void doAssertLuceneQuery(IdsQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
+    protected void doAssertLuceneQuery(IdsQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
         if (queryBuilder.ids().size() == 0) {
             assertThat(query, instanceOf(MatchNoDocsQuery.class));
         } else {
@@ -102,7 +102,7 @@ public class IdsQueryBuilderTests extends AbstractQueryTestCase<IdsQueryBuilder>
 
     @Override
     public void testMustRewrite() throws IOException {
-        QueryShardContext context = createShardContextWithNoType();
+        SearchExecutionContext context = createShardContextWithNoType();
         context.setAllowUnmappedFields(true);
         IdsQueryBuilder queryBuilder = createTestQueryBuilder();
         IllegalStateException e = expectThrows(IllegalStateException.class,

--- a/server/src/test/java/org/elasticsearch/index/query/IntervalQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/IntervalQueryBuilderTests.java
@@ -155,8 +155,8 @@ public class IntervalQueryBuilderTests extends AbstractQueryTestCase<IntervalQue
     @Override
     public void testCacheability() throws IOException {
         IntervalQueryBuilder queryBuilder = new IntervalQueryBuilder(TEXT_FIELD_NAME, createRandomSource(0, false));
-        QueryShardContext context = createShardContext();
-        QueryBuilder rewriteQuery = rewriteQuery(queryBuilder, new QueryShardContext(context));
+        SearchExecutionContext context = createSearchExecutionContext();
+        QueryBuilder rewriteQuery = rewriteQuery(queryBuilder, new SearchExecutionContext(context));
         assertNotNull(rewriteQuery.toQuery(context));
         assertTrue("query should be cacheable: " + queryBuilder.toString(), context.isCacheable());
 
@@ -165,13 +165,13 @@ public class IntervalQueryBuilderTests extends AbstractQueryTestCase<IntervalQue
         );
         IntervalsSourceProvider source = new IntervalsSourceProvider.Match("text", 0, true, "simple", scriptFilter, null);
         queryBuilder = new IntervalQueryBuilder(TEXT_FIELD_NAME, source);
-        rewriteQuery = rewriteQuery(queryBuilder, new QueryShardContext(context));
+        rewriteQuery = rewriteQuery(queryBuilder, new SearchExecutionContext(context));
         assertNotNull(rewriteQuery.toQuery(context));
         assertFalse("query with scripts should not be cacheable: " + queryBuilder.toString(), context.isCacheable());
     }
 
     @Override
-    protected void doAssertLuceneQuery(IntervalQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
+    protected void doAssertLuceneQuery(IntervalQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
         assertThat(query, instanceOf(IntervalQuery.class));
     }
 
@@ -195,7 +195,7 @@ public class IntervalQueryBuilderTests extends AbstractQueryTestCase<IntervalQue
         Query expected = new IntervalQuery(TEXT_FIELD_NAME,
             Intervals.unordered(Intervals.term("hello"), Intervals.term("world")));
 
-        assertEquals(expected, builder.toQuery(createShardContext()));
+        assertEquals(expected, builder.toQuery(createSearchExecutionContext()));
 
         json = "{ \"intervals\" : " +
             "{ \"" + TEXT_FIELD_NAME + "\" : { " +
@@ -206,7 +206,7 @@ public class IntervalQueryBuilderTests extends AbstractQueryTestCase<IntervalQue
         builder = (IntervalQueryBuilder) parseQuery(json);
         expected = new IntervalQuery(TEXT_FIELD_NAME,
             Intervals.maxgaps(40, Intervals.unordered(Intervals.term("hello"), Intervals.term("world"))));
-        assertEquals(expected, builder.toQuery(createShardContext()));
+        assertEquals(expected, builder.toQuery(createSearchExecutionContext()));
 
         json = "{ \"intervals\" : " +
             "{ \"" + TEXT_FIELD_NAME + "\" : { " +
@@ -218,7 +218,7 @@ public class IntervalQueryBuilderTests extends AbstractQueryTestCase<IntervalQue
         builder = (IntervalQueryBuilder) parseQuery(json);
         expected = new BoostQuery(new IntervalQuery(TEXT_FIELD_NAME,
             Intervals.ordered(Intervals.term("hello"), Intervals.term("world"))), 2);
-        assertEquals(expected, builder.toQuery(createShardContext()));
+        assertEquals(expected, builder.toQuery(createSearchExecutionContext()));
 
         json = "{ \"intervals\" : " +
             "{ \"" + TEXT_FIELD_NAME + "\" : { " +
@@ -231,7 +231,7 @@ public class IntervalQueryBuilderTests extends AbstractQueryTestCase<IntervalQue
         builder = (IntervalQueryBuilder) parseQuery(json);
         expected = new IntervalQuery(TEXT_FIELD_NAME,
             Intervals.maxgaps(10, Intervals.ordered(Intervals.term("Hello"), Intervals.term("world"))));
-        assertEquals(expected, builder.toQuery(createShardContext()));
+        assertEquals(expected, builder.toQuery(createSearchExecutionContext()));
 
         json = "{ \"intervals\" : " +
             "{ \"" + TEXT_FIELD_NAME + "\" : { " +
@@ -246,7 +246,7 @@ public class IntervalQueryBuilderTests extends AbstractQueryTestCase<IntervalQue
         expected = new IntervalQuery(TEXT_FIELD_NAME,
             Intervals.fixField(MASKED_FIELD,
                                 Intervals.maxgaps(10, Intervals.ordered(Intervals.term("Hello"), Intervals.term("world")))));
-        assertEquals(expected, builder.toQuery(createShardContext()));
+        assertEquals(expected, builder.toQuery(createSearchExecutionContext()));
 
         json = "{ \"intervals\" : " +
             "{ \"" + TEXT_FIELD_NAME + "\" : { " +
@@ -263,7 +263,7 @@ public class IntervalQueryBuilderTests extends AbstractQueryTestCase<IntervalQue
         expected = new IntervalQuery(TEXT_FIELD_NAME,
             Intervals.containing(Intervals.maxgaps(10, Intervals.ordered(Intervals.term("Hello"), Intervals.term("world"))),
                                  Intervals.term("blah")));
-        assertEquals(expected, builder.toQuery(createShardContext()));
+        assertEquals(expected, builder.toQuery(createSearchExecutionContext()));
     }
 
     public void testOrInterval() throws IOException {
@@ -276,7 +276,7 @@ public class IntervalQueryBuilderTests extends AbstractQueryTestCase<IntervalQue
         IntervalQueryBuilder builder = (IntervalQueryBuilder) parseQuery(json);
         Query expected = new IntervalQuery(TEXT_FIELD_NAME,
             Intervals.or(Intervals.term("one"), Intervals.term("two")));
-        assertEquals(expected, builder.toQuery(createShardContext()));
+        assertEquals(expected, builder.toQuery(createSearchExecutionContext()));
 
         json = "{ \"intervals\" : { \"" + TEXT_FIELD_NAME + "\": {" +
             "       \"any_of\" : { " +
@@ -290,7 +290,7 @@ public class IntervalQueryBuilderTests extends AbstractQueryTestCase<IntervalQue
             Intervals.notContaining(
                 Intervals.or(Intervals.term("one"), Intervals.term("two")),
                 Intervals.term("three")));
-        assertEquals(expected, builder.toQuery(createShardContext()));
+        assertEquals(expected, builder.toQuery(createSearchExecutionContext()));
     }
 
     public void testCombineInterval() throws IOException {
@@ -319,7 +319,7 @@ public class IntervalQueryBuilderTests extends AbstractQueryTestCase<IntervalQue
                         Intervals.term("one"),
                         Intervals.unordered(Intervals.term("two"), Intervals.term("three")))),
                     Intervals.term("SENTENCE"))), 1.5f);
-        assertEquals(expected, builder.toQuery(createShardContext()));
+        assertEquals(expected, builder.toQuery(createSearchExecutionContext()));
 
     }
 
@@ -347,24 +347,24 @@ public class IntervalQueryBuilderTests extends AbstractQueryTestCase<IntervalQue
                     Intervals.or(Intervals.term("cold"), Intervals.term("outside"))
                 )),
                 Intervals.term("freeze")));
-        assertEquals(expected, builder.toQuery(createShardContext()));
+        assertEquals(expected, builder.toQuery(createSearchExecutionContext()));
     }
 
     public void testNonIndexedFields() throws IOException {
         IntervalsSourceProvider provider = new IntervalsSourceProvider.Match("test", 0, true, null, null, null);
         IntervalQueryBuilder b = new IntervalQueryBuilder("no_such_field", provider);
-        assertThat(b.toQuery(createShardContext()), equalTo(new MatchNoDocsQuery()));
+        assertThat(b.toQuery(createSearchExecutionContext()), equalTo(new MatchNoDocsQuery()));
 
         Exception e = expectThrows(IllegalArgumentException.class, () -> {
             IntervalQueryBuilder builder = new IntervalQueryBuilder(INT_FIELD_NAME, provider);
-            builder.doToQuery(createShardContext());
+            builder.doToQuery(createSearchExecutionContext());
         });
         assertThat(e.getMessage(), equalTo("Can only use interval queries on text fields - not on ["
             + INT_FIELD_NAME + "] which is of type [integer]"));
 
         e = expectThrows(IllegalArgumentException.class, () -> {
             IntervalQueryBuilder builder = new IntervalQueryBuilder(NO_POSITIONS_FIELD, provider);
-            builder.doToQuery(createShardContext());
+            builder.doToQuery(createSearchExecutionContext());
         });
         assertThat(e.getMessage(), equalTo("Cannot create intervals over field ["
             + NO_POSITIONS_FIELD + "] with no positions indexed"));
@@ -380,7 +380,7 @@ public class IntervalQueryBuilderTests extends AbstractQueryTestCase<IntervalQue
 
         e = expectThrows(IllegalArgumentException.class, () -> {
             IntervalQueryBuilder builder = (IntervalQueryBuilder) parseQuery(json);
-            builder.doToQuery(createShardContext());
+            builder.doToQuery(createSearchExecutionContext());
         });
         assertThat(e.getMessage(), equalTo("Cannot create intervals over field ["
             + NO_POSITIONS_FIELD + "] with no positions indexed"));
@@ -405,7 +405,7 @@ public class IntervalQueryBuilderTests extends AbstractQueryTestCase<IntervalQue
                 return interval.getStart() > 3;
             }
         };
-        QueryShardContext context = new QueryShardContext(createShardContext()) {
+        SearchExecutionContext context = new SearchExecutionContext(createSearchExecutionContext()) {
             @Override
             @SuppressWarnings("unchecked")
             public <FactoryType> FactoryType compile(Script script, ScriptContext<FactoryType> context) {
@@ -436,27 +436,27 @@ public class IntervalQueryBuilderTests extends AbstractQueryTestCase<IntervalQue
             "\"prefix\" : { \"prefix\" : \"term\" } } } }";
         IntervalQueryBuilder builder = (IntervalQueryBuilder) parseQuery(json);
         Query expected = new IntervalQuery(TEXT_FIELD_NAME, Intervals.prefix(new BytesRef("term")));
-        assertEquals(expected, builder.toQuery(createShardContext()));
+        assertEquals(expected, builder.toQuery(createSearchExecutionContext()));
 
         String no_positions_json = "{ \"intervals\" : { \"" + NO_POSITIONS_FIELD + "\": { " +
             "\"prefix\" : { \"prefix\" : \"term\" } } } }";
         expectThrows(IllegalArgumentException.class, () -> {
             IntervalQueryBuilder builder1 = (IntervalQueryBuilder) parseQuery(no_positions_json);
-            builder1.toQuery(createShardContext());
+            builder1.toQuery(createSearchExecutionContext());
             });
 
         String no_positions_fixed_field_json = "{ \"intervals\" : { \"" + TEXT_FIELD_NAME + "\": { " +
             "\"prefix\" : { \"prefix\" : \"term\", \"use_field\" : \"" + NO_POSITIONS_FIELD + "\" } } } }";
         expectThrows(IllegalArgumentException.class, () -> {
             IntervalQueryBuilder builder1 = (IntervalQueryBuilder) parseQuery(no_positions_fixed_field_json);
-            builder1.toQuery(createShardContext());
+            builder1.toQuery(createSearchExecutionContext());
         });
 
         String prefix_json = "{ \"intervals\" : { \"" + PREFIXED_FIELD + "\": { " +
             "\"prefix\" : { \"prefix\" : \"term\" } } } }";
         builder = (IntervalQueryBuilder) parseQuery(prefix_json);
         expected = new IntervalQuery(PREFIXED_FIELD, Intervals.fixField(PREFIXED_FIELD + "._index_prefix", Intervals.term("term")));
-        assertEquals(expected, builder.toQuery(createShardContext()));
+        assertEquals(expected, builder.toQuery(createSearchExecutionContext()));
 
         String short_prefix_json = "{ \"intervals\" : { \"" + PREFIXED_FIELD + "\": { " +
             "\"prefix\" : { \"prefix\" : \"t\" } } } }";
@@ -464,7 +464,7 @@ public class IntervalQueryBuilderTests extends AbstractQueryTestCase<IntervalQue
         expected = new IntervalQuery(PREFIXED_FIELD, Intervals.or(
             Intervals.fixField(PREFIXED_FIELD + "._index_prefix", Intervals.wildcard(new BytesRef("t?"))),
             Intervals.term("t")));
-        assertEquals(expected, builder.toQuery(createShardContext()));
+        assertEquals(expected, builder.toQuery(createSearchExecutionContext()));
 
         String fix_field_prefix_json =  "{ \"intervals\" : { \"" + TEXT_FIELD_NAME + "\": { " +
             "\"prefix\" : { \"prefix\" : \"term\", \"use_field\" : \"" + PREFIXED_FIELD + "\" } } } }";
@@ -472,20 +472,20 @@ public class IntervalQueryBuilderTests extends AbstractQueryTestCase<IntervalQue
         // This looks weird, but it's fine, because the innermost fixField wins
         expected = new IntervalQuery(TEXT_FIELD_NAME,
             Intervals.fixField(PREFIXED_FIELD, Intervals.fixField(PREFIXED_FIELD + "._index_prefix", Intervals.term("term"))));
-        assertEquals(expected, builder.toQuery(createShardContext()));
+        assertEquals(expected, builder.toQuery(createSearchExecutionContext()));
 
         String keyword_json = "{ \"intervals\" : { \"" + PREFIXED_FIELD + "\": { " +
             "\"prefix\" : { \"prefix\" : \"Term\", \"analyzer\" : \"keyword\" } } } }";
         builder = (IntervalQueryBuilder) parseQuery(keyword_json);
         expected = new IntervalQuery(PREFIXED_FIELD, Intervals.fixField(PREFIXED_FIELD + "._index_prefix", Intervals.term("Term")));
-        assertEquals(expected, builder.toQuery(createShardContext()));
+        assertEquals(expected, builder.toQuery(createSearchExecutionContext()));
 
         String keyword_fix_field_json = "{ \"intervals\" : { \"" + TEXT_FIELD_NAME + "\": { " +
             "\"prefix\" : { \"prefix\" : \"Term\", \"analyzer\" : \"keyword\", \"use_field\" : \"" + PREFIXED_FIELD + "\" } } } }";
         builder = (IntervalQueryBuilder) parseQuery(keyword_fix_field_json);
         expected = new IntervalQuery(TEXT_FIELD_NAME,
             Intervals.fixField(PREFIXED_FIELD, Intervals.fixField(PREFIXED_FIELD + "._index_prefix", Intervals.term("Term"))));
-        assertEquals(expected, builder.toQuery(createShardContext()));
+        assertEquals(expected, builder.toQuery(createSearchExecutionContext()));
     }
 
     public void testWildcard() throws IOException {
@@ -495,13 +495,13 @@ public class IntervalQueryBuilderTests extends AbstractQueryTestCase<IntervalQue
 
         IntervalQueryBuilder builder = (IntervalQueryBuilder) parseQuery(json);
         Query expected = new IntervalQuery(TEXT_FIELD_NAME, Intervals.wildcard(new BytesRef("te?m")));
-        assertEquals(expected, builder.toQuery(createShardContext()));
+        assertEquals(expected, builder.toQuery(createSearchExecutionContext()));
 
         String no_positions_json = "{ \"intervals\" : { \"" + NO_POSITIONS_FIELD + "\": { " +
             "\"wildcard\" : { \"pattern\" : \"term\" } } } }";
         expectThrows(IllegalArgumentException.class, () -> {
             IntervalQueryBuilder builder1 = (IntervalQueryBuilder) parseQuery(no_positions_json);
-            builder1.toQuery(createShardContext());
+            builder1.toQuery(createSearchExecutionContext());
         });
 
         String keyword_json = "{ \"intervals\" : { \"" + TEXT_FIELD_NAME + "\": { " +
@@ -509,20 +509,20 @@ public class IntervalQueryBuilderTests extends AbstractQueryTestCase<IntervalQue
 
         builder = (IntervalQueryBuilder) parseQuery(keyword_json);
         expected = new IntervalQuery(TEXT_FIELD_NAME, Intervals.wildcard(new BytesRef("Te?m")));
-        assertEquals(expected, builder.toQuery(createShardContext()));
+        assertEquals(expected, builder.toQuery(createSearchExecutionContext()));
 
         String fixed_field_json = "{ \"intervals\" : { \"" + TEXT_FIELD_NAME + "\": { " +
             "\"wildcard\" : { \"pattern\" : \"Te?m\", \"use_field\" : \"masked_field\" } } } }";
 
         builder = (IntervalQueryBuilder) parseQuery(fixed_field_json);
         expected = new IntervalQuery(TEXT_FIELD_NAME, Intervals.fixField(MASKED_FIELD, Intervals.wildcard(new BytesRef("te?m"))));
-        assertEquals(expected, builder.toQuery(createShardContext()));
+        assertEquals(expected, builder.toQuery(createSearchExecutionContext()));
 
         String fixed_field_json_no_positions = "{ \"intervals\" : { \"" + TEXT_FIELD_NAME + "\": { " +
             "\"wildcard\" : { \"pattern\" : \"Te?m\", \"use_field\" : \"" + NO_POSITIONS_FIELD + "\" } } } }";
         expectThrows(IllegalArgumentException.class, () -> {
             IntervalQueryBuilder builder1 = (IntervalQueryBuilder) parseQuery(fixed_field_json_no_positions);
-            builder1.toQuery(createShardContext());
+            builder1.toQuery(createSearchExecutionContext());
         });
 
         String fixed_field_analyzer_json = "{ \"intervals\" : { \"" + TEXT_FIELD_NAME + "\": { " +
@@ -531,7 +531,7 @@ public class IntervalQueryBuilderTests extends AbstractQueryTestCase<IntervalQue
         builder = (IntervalQueryBuilder) parseQuery(fixed_field_analyzer_json);
         expected = new IntervalQuery(TEXT_FIELD_NAME, Intervals.fixField(MASKED_FIELD,
             Intervals.wildcard(new BytesRef("Te?m"))));
-        assertEquals(expected, builder.toQuery(createShardContext()));
+        assertEquals(expected, builder.toQuery(createSearchExecutionContext()));
     }
 
     private static IntervalsSource buildFuzzySource(String term, String label, int prefixLength, boolean transpositions, int editDistance) {
@@ -547,35 +547,35 @@ public class IntervalQueryBuilderTests extends AbstractQueryTestCase<IntervalQue
 
         Query expected = new IntervalQuery(TEXT_FIELD_NAME,
             buildFuzzySource("term", "Term", FuzzyQueryBuilder.DEFAULT_PREFIX_LENGTH, true, Fuzziness.AUTO.asDistance("term")));
-        assertEquals(expected, builder.toQuery(createShardContext()));
+        assertEquals(expected, builder.toQuery(createSearchExecutionContext()));
 
         String json_with_prefix = "{ \"intervals\" : { \"" + TEXT_FIELD_NAME + "\": { " +
             "\"fuzzy\" : { \"term\" : \"Term\", \"prefix_length\" : 2 } } } }";
         builder = (IntervalQueryBuilder) parseQuery(json_with_prefix);
         expected = new IntervalQuery(TEXT_FIELD_NAME,
             buildFuzzySource("term", "Term", 2, true, Fuzziness.AUTO.asDistance("term")));
-        assertEquals(expected, builder.toQuery(createShardContext()));
+        assertEquals(expected, builder.toQuery(createSearchExecutionContext()));
 
         String json_with_fuzziness = "{ \"intervals\" : { \"" + TEXT_FIELD_NAME + "\": { " +
             "\"fuzzy\" : { \"term\" : \"Term\", \"prefix_length\" : 2, \"fuzziness\" : \"1\" } } } }";
         builder = (IntervalQueryBuilder) parseQuery(json_with_fuzziness);
         expected = new IntervalQuery(TEXT_FIELD_NAME,
             buildFuzzySource("term", "Term", 2, true, Fuzziness.ONE.asDistance("term")));
-        assertEquals(expected, builder.toQuery(createShardContext()));
+        assertEquals(expected, builder.toQuery(createSearchExecutionContext()));
 
         String json_no_transpositions = "{ \"intervals\" : { \"" + TEXT_FIELD_NAME + "\": { " +
             "\"fuzzy\" : { \"term\" : \"Term\", \"prefix_length\" : 2, \"transpositions\" : false } } } }";
         builder = (IntervalQueryBuilder) parseQuery(json_no_transpositions);
         expected = new IntervalQuery(TEXT_FIELD_NAME,
             buildFuzzySource("term", "Term", 2, false, Fuzziness.AUTO.asDistance("term")));
-        assertEquals(expected, builder.toQuery(createShardContext()));
+        assertEquals(expected, builder.toQuery(createSearchExecutionContext()));
 
         String json_with_analyzer = "{ \"intervals\" : { \"" + TEXT_FIELD_NAME + "\": { " +
             "\"fuzzy\" : { \"term\" : \"Term\", \"prefix_length\" : 2, \"analyzer\" : \"keyword\" } } } }";
         builder = (IntervalQueryBuilder) parseQuery(json_with_analyzer);
         expected = new IntervalQuery(TEXT_FIELD_NAME,
             buildFuzzySource("Term", "Term", 2, true, Fuzziness.AUTO.asDistance("term")));
-        assertEquals(expected, builder.toQuery(createShardContext()));
+        assertEquals(expected, builder.toQuery(createSearchExecutionContext()));
 
         String json_with_fixfield = "{ \"intervals\" : { \"" + TEXT_FIELD_NAME + "\": { " +
             "\"fuzzy\" : { \"term\" : \"Term\", \"prefix_length\" : 2, \"fuzziness\" : \"1\", " +
@@ -583,7 +583,7 @@ public class IntervalQueryBuilderTests extends AbstractQueryTestCase<IntervalQue
         builder = (IntervalQueryBuilder) parseQuery(json_with_fixfield);
         expected = new IntervalQuery(TEXT_FIELD_NAME, Intervals.fixField(MASKED_FIELD,
             buildFuzzySource("term", "Term", 2, true, Fuzziness.ONE.asDistance("term"))));
-        assertEquals(expected, builder.toQuery(createShardContext()));
+        assertEquals(expected, builder.toQuery(createSearchExecutionContext()));
 
     }
 

--- a/server/src/test/java/org/elasticsearch/index/query/MatchAllQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/MatchAllQueryBuilderTests.java
@@ -35,7 +35,7 @@ public class MatchAllQueryBuilderTests extends AbstractQueryTestCase<MatchAllQue
     }
 
     @Override
-    protected void doAssertLuceneQuery(MatchAllQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
+    protected void doAssertLuceneQuery(MatchAllQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
         assertThat(query, instanceOf(MatchAllDocsQuery.class));
     }
 

--- a/server/src/test/java/org/elasticsearch/index/query/MatchBoolPrefixQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/MatchBoolPrefixQueryBuilderTests.java
@@ -100,7 +100,7 @@ public class MatchBoolPrefixQueryBuilderTests extends AbstractQueryTestCase<Matc
     @Override
     protected void doAssertLuceneQuery(MatchBoolPrefixQueryBuilder queryBuilder,
                                        Query query,
-                                       QueryShardContext context) throws IOException {
+                                       SearchExecutionContext context) throws IOException {
         assertThat(query, notNullValue());
         assertThat(query, anyOf(instanceOf(BooleanQuery.class), instanceOf(PrefixQuery.class)));
 
@@ -157,7 +157,7 @@ public class MatchBoolPrefixQueryBuilderTests extends AbstractQueryTestCase<Matc
         {
             final MatchBoolPrefixQueryBuilder builder = new MatchBoolPrefixQueryBuilder("name", "value");
             builder.analyzer("bogusAnalyzer");
-            QueryShardException e = expectThrows(QueryShardException.class, () -> builder.toQuery(createShardContext()));
+            QueryShardException e = expectThrows(QueryShardException.class, () -> builder.toQuery(createSearchExecutionContext()));
             assertThat(e.getMessage(), containsString("analyzer [bogusAnalyzer] not found"));
         }
     }
@@ -244,7 +244,7 @@ public class MatchBoolPrefixQueryBuilderTests extends AbstractQueryTestCase<Matc
 
     public void testAnalysis() throws Exception {
         final MatchBoolPrefixQueryBuilder builder = new MatchBoolPrefixQueryBuilder(TEXT_FIELD_NAME, "foo bar baz");
-        final Query query = builder.toQuery(createShardContext());
+        final Query query = builder.toQuery(createSearchExecutionContext());
 
         assertBooleanQuery(query, asList(
             new TermQuery(new Term(TEXT_FIELD_NAME, "foo")),
@@ -254,7 +254,7 @@ public class MatchBoolPrefixQueryBuilderTests extends AbstractQueryTestCase<Matc
     }
 
     public void testAnalysisSynonym() throws Exception {
-        final MatchQuery matchQuery = new MatchQuery(createShardContext());
+        final MatchQuery matchQuery = new MatchQuery(createSearchExecutionContext());
         matchQuery.setAnalyzer(new MockSynonymAnalyzer());
         final Query query = matchQuery.parse(MatchQuery.Type.BOOLEAN_PREFIX, TEXT_FIELD_NAME, "fox dogs red");
 
@@ -267,7 +267,7 @@ public class MatchBoolPrefixQueryBuilderTests extends AbstractQueryTestCase<Matc
 
     public void testAnalysisSingleTerm() throws Exception {
         final MatchBoolPrefixQueryBuilder builder = new MatchBoolPrefixQueryBuilder(TEXT_FIELD_NAME, "foo");
-        final Query query = builder.toQuery(createShardContext());
+        final Query query = builder.toQuery(createSearchExecutionContext());
         assertThat(query, equalTo(new PrefixQuery(new Term(TEXT_FIELD_NAME, "foo"))));
     }
 

--- a/server/src/test/java/org/elasticsearch/index/query/MatchNoneQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/MatchNoneQueryBuilderTests.java
@@ -35,7 +35,7 @@ public class MatchNoneQueryBuilderTests extends AbstractQueryTestCase<MatchNoneQ
     }
 
     @Override
-    protected void doAssertLuceneQuery(MatchNoneQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
+    protected void doAssertLuceneQuery(MatchNoneQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
         assertThat(query, instanceOf(MatchNoDocsQuery.class));
     }
 

--- a/server/src/test/java/org/elasticsearch/index/query/MatchPhrasePrefixQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/MatchPhrasePrefixQueryBuilderTests.java
@@ -88,7 +88,7 @@ public class MatchPhrasePrefixQueryBuilderTests extends AbstractQueryTestCase<Ma
     }
 
     @Override
-    protected void doAssertLuceneQuery(MatchPhrasePrefixQueryBuilder queryBuilder, Query query, QueryShardContext context)
+    protected void doAssertLuceneQuery(MatchPhrasePrefixQueryBuilder queryBuilder, Query query, SearchExecutionContext context)
             throws IOException {
         assertThat(query, notNullValue());
 
@@ -117,24 +117,24 @@ public class MatchPhrasePrefixQueryBuilderTests extends AbstractQueryTestCase<Ma
         MatchPhrasePrefixQueryBuilder matchQuery = new MatchPhrasePrefixQueryBuilder("fieldName", "text");
         matchQuery.analyzer("bogusAnalyzer");
 
-        QueryShardException e = expectThrows(QueryShardException.class, () -> matchQuery.toQuery(createShardContext()));
+        QueryShardException e = expectThrows(QueryShardException.class, () -> matchQuery.toQuery(createSearchExecutionContext()));
         assertThat(e.getMessage(), containsString("analyzer [bogusAnalyzer] not found"));
     }
 
     public void testPhraseOnFieldWithNoTerms() {
         MatchPhrasePrefixQueryBuilder matchQuery = new MatchPhrasePrefixQueryBuilder(DATE_FIELD_NAME, "three term phrase");
         matchQuery.analyzer("whitespace");
-        expectThrows(IllegalStateException.class, () -> matchQuery.doToQuery(createShardContext()));
+        expectThrows(IllegalStateException.class, () -> matchQuery.doToQuery(createSearchExecutionContext()));
     }
 
     public void testPhrasePrefixZeroTermsQuery() throws IOException {
         MatchPhrasePrefixQueryBuilder matchQuery = new MatchPhrasePrefixQueryBuilder(TEXT_FIELD_NAME, "");
         matchQuery.zeroTermsQuery(ZeroTermsQuery.NONE);
-        assertEquals(new MatchNoDocsQuery(), matchQuery.doToQuery(createShardContext()));
+        assertEquals(new MatchNoDocsQuery(), matchQuery.doToQuery(createSearchExecutionContext()));
 
         matchQuery = new MatchPhrasePrefixQueryBuilder(TEXT_FIELD_NAME, "");
         matchQuery.zeroTermsQuery(ZeroTermsQuery.ALL);
-        assertEquals(new MatchAllDocsQuery(), matchQuery.doToQuery(createShardContext()));
+        assertEquals(new MatchAllDocsQuery(), matchQuery.doToQuery(createSearchExecutionContext()));
     }
 
     public void testPhrasePrefixMatchQuery() throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/query/MatchPhraseQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/MatchPhraseQueryBuilderTests.java
@@ -90,7 +90,7 @@ public class MatchPhraseQueryBuilderTests extends AbstractQueryTestCase<MatchPhr
     }
 
     @Override
-    protected void doAssertLuceneQuery(MatchPhraseQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
+    protected void doAssertLuceneQuery(MatchPhraseQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
         assertThat(query, notNullValue());
 
         if (query instanceof MatchAllDocsQuery) {
@@ -114,7 +114,7 @@ public class MatchPhraseQueryBuilderTests extends AbstractQueryTestCase<MatchPhr
     public void testBadAnalyzer() throws IOException {
         MatchPhraseQueryBuilder matchQuery = new MatchPhraseQueryBuilder("fieldName", "text");
         matchQuery.analyzer("bogusAnalyzer");
-        QueryShardException e = expectThrows(QueryShardException.class, () -> matchQuery.toQuery(createShardContext()));
+        QueryShardException e = expectThrows(QueryShardException.class, () -> matchQuery.toQuery(createSearchExecutionContext()));
         assertThat(e.getMessage(), containsString("analyzer [bogusAnalyzer] not found"));
     }
 

--- a/server/src/test/java/org/elasticsearch/index/query/MatchPhraseQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/MatchPhraseQueryBuilderTests.java
@@ -90,7 +90,8 @@ public class MatchPhraseQueryBuilderTests extends AbstractQueryTestCase<MatchPhr
     }
 
     @Override
-    protected void doAssertLuceneQuery(MatchPhraseQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
+    protected void doAssertLuceneQuery(MatchPhraseQueryBuilder queryBuilder, Query query,
+                                       SearchExecutionContext context) throws IOException {
         assertThat(query, notNullValue());
 
         if (query instanceof MatchAllDocsQuery) {

--- a/server/src/test/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilderTests.java
@@ -259,7 +259,7 @@ public class MoreLikeThisQueryBuilderTests extends AbstractQueryTestCase<MoreLik
     }
 
     @Override
-    protected void doAssertLuceneQuery(MoreLikeThisQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
+    protected void doAssertLuceneQuery(MoreLikeThisQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
         if (CollectionUtils.isEmpty(queryBuilder.likeItems()) == false) {
             assertThat(query, instanceOf(BooleanQuery.class));
             BooleanQuery booleanQuery = (BooleanQuery) query;
@@ -294,14 +294,14 @@ public class MoreLikeThisQueryBuilderTests extends AbstractQueryTestCase<MoreLik
         MoreLikeThisQueryBuilder queryBuilder =
             new MoreLikeThisQueryBuilder(new String[] {unsupportedField}, new String[]{"some text"}, null)
                 .failOnUnsupportedField(true);
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> queryBuilder.toQuery(createShardContext()));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> queryBuilder.toQuery(createSearchExecutionContext()));
         assertThat(e.getMessage(), containsString("more_like_this only supports text/keyword fields"));
     }
 
     public void testUsesIndexAnalyzer() throws IOException {
         MoreLikeThisQueryBuilder qb
             = new MoreLikeThisQueryBuilder(new String[]{KEYWORD_FIELD_NAME}, new String[]{"some text"}, null);
-        MoreLikeThisQuery q = (MoreLikeThisQuery) qb.toQuery(createShardContext());
+        MoreLikeThisQuery q = (MoreLikeThisQuery) qb.toQuery(createSearchExecutionContext());
         try (TokenStream ts = q.getAnalyzer().tokenStream(KEYWORD_FIELD_NAME, "some text")) {
             ts.reset();
             CharTermAttribute termAtt = ts.addAttribute(CharTermAttribute.class);
@@ -313,7 +313,7 @@ public class MoreLikeThisQueryBuilderTests extends AbstractQueryTestCase<MoreLik
     }
 
     public void testDefaultField() throws IOException {
-        QueryShardContext context = createShardContext();
+        SearchExecutionContext context = createSearchExecutionContext();
 
         {
             MoreLikeThisQueryBuilder builder =
@@ -348,7 +348,7 @@ public class MoreLikeThisQueryBuilderTests extends AbstractQueryTestCase<MoreLik
     public void testMoreLikeThisBuilder() throws Exception {
         Query parsedQuery =
             parseQuery(moreLikeThisQuery(new String[]{"name.first", "name.last"}, new String[]{"something"}, null)
-                .minTermFreq(1).maxQueryTerms(12)).toQuery(createShardContext());
+                .minTermFreq(1).maxQueryTerms(12)).toQuery(createSearchExecutionContext());
         assertThat(parsedQuery, instanceOf(MoreLikeThisQuery.class));
         MoreLikeThisQuery mltQuery = (MoreLikeThisQuery) parsedQuery;
         assertThat(mltQuery.getMoreLikeFields()[0], equalTo("name.first"));
@@ -396,25 +396,25 @@ public class MoreLikeThisQueryBuilderTests extends AbstractQueryTestCase<MoreLik
     public void testCacheability() throws IOException {
         MoreLikeThisQueryBuilder queryBuilder = createTestQueryBuilder();
         boolean isCacheable = queryBuilder.likeItems().length == 0; // items are always fetched
-        QueryShardContext context = createShardContext();
-        QueryBuilder rewriteQuery = rewriteQuery(queryBuilder, new QueryShardContext(context));
+        SearchExecutionContext context = createSearchExecutionContext();
+        QueryBuilder rewriteQuery = rewriteQuery(queryBuilder, new SearchExecutionContext(context));
         assertNotNull(rewriteQuery.toQuery(context));
         assertEquals("query should " + (isCacheable ? "" : "not") + " be cacheable: " + queryBuilder.toString(), isCacheable,
                 context.isCacheable());
 
         // specifically trigger case where query is cacheable
         queryBuilder = new MoreLikeThisQueryBuilder(randomStringFields(), new String[] {"some text"}, null);
-        context = createShardContext();
-        rewriteQuery(queryBuilder, new QueryShardContext(context));
-        rewriteQuery = rewriteQuery(queryBuilder, new QueryShardContext(context));
+        context = createSearchExecutionContext();
+        rewriteQuery(queryBuilder, new SearchExecutionContext(context));
+        rewriteQuery = rewriteQuery(queryBuilder, new SearchExecutionContext(context));
         assertNotNull(rewriteQuery.toQuery(context));
         assertTrue("query should be cacheable: " + queryBuilder.toString(), context.isCacheable());
 
         // specifically trigger case where query is not cacheable
         queryBuilder = new MoreLikeThisQueryBuilder(randomStringFields(), null, new Item[] { new Item("foo", "1") });
-        context = createShardContext();
-        rewriteQuery(queryBuilder, new QueryShardContext(context));
-        rewriteQuery = rewriteQuery(queryBuilder, new QueryShardContext(context));
+        context = createSearchExecutionContext();
+        rewriteQuery(queryBuilder, new SearchExecutionContext(context));
+        rewriteQuery = rewriteQuery(queryBuilder, new SearchExecutionContext(context));
         assertNotNull(rewriteQuery.toQuery(context));
         assertFalse("query should be cacheable: " + queryBuilder.toString(), context.isCacheable());
     }

--- a/server/src/test/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilderTests.java
@@ -259,7 +259,7 @@ public class MoreLikeThisQueryBuilderTests extends AbstractQueryTestCase<MoreLik
     }
 
     @Override
-    protected void doAssertLuceneQuery(MoreLikeThisQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
+    protected void doAssertLuceneQuery(MoreLikeThisQueryBuilder queryBuilder, Query query,SearchExecutionContext context) {
         if (CollectionUtils.isEmpty(queryBuilder.likeItems()) == false) {
             assertThat(query, instanceOf(BooleanQuery.class));
             BooleanQuery booleanQuery = (BooleanQuery) query;
@@ -294,7 +294,8 @@ public class MoreLikeThisQueryBuilderTests extends AbstractQueryTestCase<MoreLik
         MoreLikeThisQueryBuilder queryBuilder =
             new MoreLikeThisQueryBuilder(new String[] {unsupportedField}, new String[]{"some text"}, null)
                 .failOnUnsupportedField(true);
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> queryBuilder.toQuery(createSearchExecutionContext()));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+            () -> queryBuilder.toQuery(createSearchExecutionContext()));
         assertThat(e.getMessage(), containsString("more_like_this only supports text/keyword fields"));
     }
 

--- a/server/src/test/java/org/elasticsearch/index/query/MultiMatchQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/MultiMatchQueryBuilderTests.java
@@ -155,7 +155,7 @@ public class MultiMatchQueryBuilderTests extends AbstractQueryTestCase<MultiMatc
     }
 
     @Override
-    protected void doAssertLuceneQuery(MultiMatchQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
+    protected void doAssertLuceneQuery(MultiMatchQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
         // we rely on integration tests for deeper checks here
         assertThat(query, anyOf(Arrays.asList(
             instanceOf(BoostQuery.class),
@@ -181,16 +181,16 @@ public class MultiMatchQueryBuilderTests extends AbstractQueryTestCase<MultiMatc
     }
 
     public void testToQueryBoost() throws IOException {
-        QueryShardContext shardContext = createShardContext();
+        SearchExecutionContext searchExecutionContext = createSearchExecutionContext();
         MultiMatchQueryBuilder multiMatchQueryBuilder = new MultiMatchQueryBuilder("test");
         multiMatchQueryBuilder.field(TEXT_FIELD_NAME, 5f);
-        Query query = multiMatchQueryBuilder.toQuery(shardContext);
+        Query query = multiMatchQueryBuilder.toQuery(searchExecutionContext);
         assertTermOrBoostQuery(query, TEXT_FIELD_NAME, "test", 5f);
 
         multiMatchQueryBuilder = new MultiMatchQueryBuilder("test");
         multiMatchQueryBuilder.field(TEXT_FIELD_NAME, 5f);
         multiMatchQueryBuilder.boost(2f);
-        query = multiMatchQueryBuilder.toQuery(shardContext);
+        query = multiMatchQueryBuilder.toQuery(searchExecutionContext);
         assertThat(query, instanceOf(BoostQuery.class));
         BoostQuery boostQuery = (BoostQuery) query;
         assertThat(boostQuery.getBoost(), equalTo(2f));
@@ -198,7 +198,7 @@ public class MultiMatchQueryBuilderTests extends AbstractQueryTestCase<MultiMatc
     }
 
     public void testToQueryMultipleTermsBooleanQuery() throws Exception {
-        Query query = multiMatchQuery("test1 test2").field(TEXT_FIELD_NAME).toQuery(createShardContext());
+        Query query = multiMatchQuery("test1 test2").field(TEXT_FIELD_NAME).toQuery(createSearchExecutionContext());
         assertThat(query, instanceOf(BooleanQuery.class));
         BooleanQuery bQuery = (BooleanQuery) query;
         assertThat(bQuery.clauses().size(), equalTo(2));
@@ -208,7 +208,7 @@ public class MultiMatchQueryBuilderTests extends AbstractQueryTestCase<MultiMatc
 
     public void testToQueryMultipleFieldsDisableDismax() throws Exception {
         Query query = multiMatchQuery("test").field(TEXT_FIELD_NAME).field(KEYWORD_FIELD_NAME).tieBreaker(1.0f)
-                .toQuery(createShardContext());
+                .toQuery(createSearchExecutionContext());
         assertThat(query, instanceOf(DisjunctionMaxQuery.class));
         DisjunctionMaxQuery dQuery = (DisjunctionMaxQuery) query;
         assertThat(dQuery.getTieBreakerMultiplier(), equalTo(1.0f));
@@ -218,7 +218,7 @@ public class MultiMatchQueryBuilderTests extends AbstractQueryTestCase<MultiMatc
     }
 
     public void testToQueryMultipleFieldsDisMaxQuery() throws Exception {
-        Query query = multiMatchQuery("test").field(TEXT_FIELD_NAME).field(KEYWORD_FIELD_NAME).toQuery(createShardContext());
+        Query query = multiMatchQuery("test").field(TEXT_FIELD_NAME).field(KEYWORD_FIELD_NAME).toQuery(createSearchExecutionContext());
         assertThat(query, instanceOf(DisjunctionMaxQuery.class));
         DisjunctionMaxQuery disMaxQuery = (DisjunctionMaxQuery) query;
         assertThat(disMaxQuery.getTieBreakerMultiplier(), equalTo(0.0f));
@@ -230,7 +230,7 @@ public class MultiMatchQueryBuilderTests extends AbstractQueryTestCase<MultiMatc
     }
 
     public void testToQueryFieldsWildcard() throws Exception {
-        Query query = multiMatchQuery("test").field("mapped_str*").tieBreaker(1.0f).toQuery(createShardContext());
+        Query query = multiMatchQuery("test").field("mapped_str*").tieBreaker(1.0f).toQuery(createSearchExecutionContext());
         assertThat(query, instanceOf(DisjunctionMaxQuery.class));
         DisjunctionMaxQuery dQuery = (DisjunctionMaxQuery) query;
         assertThat(dQuery.getTieBreakerMultiplier(), equalTo(1.0f));
@@ -240,16 +240,16 @@ public class MultiMatchQueryBuilderTests extends AbstractQueryTestCase<MultiMatc
     }
 
     public void testToQueryFieldMissing() throws Exception {
-        assertThat(multiMatchQuery("test").field(MISSING_WILDCARD_FIELD_NAME).toQuery(createShardContext()),
+        assertThat(multiMatchQuery("test").field(MISSING_WILDCARD_FIELD_NAME).toQuery(createSearchExecutionContext()),
             instanceOf(MatchNoDocsQuery.class));
-        assertThat(multiMatchQuery("test").field(MISSING_FIELD_NAME).toQuery(createShardContext()),
+        assertThat(multiMatchQuery("test").field(MISSING_FIELD_NAME).toQuery(createSearchExecutionContext()),
             instanceOf(MatchNoDocsQuery.class));
     }
 
     public void testToQueryBooleanPrefixSingleField() throws IOException {
         final MultiMatchQueryBuilder builder = new MultiMatchQueryBuilder("foo bar", TEXT_FIELD_NAME);
         builder.type(Type.BOOL_PREFIX);
-        final Query query = builder.toQuery(createShardContext());
+        final Query query = builder.toQuery(createSearchExecutionContext());
         assertThat(query, instanceOf(BooleanQuery.class));
         final BooleanQuery booleanQuery = (BooleanQuery) query;
         assertThat(booleanQuery.clauses(), hasSize(2));
@@ -262,7 +262,7 @@ public class MultiMatchQueryBuilderTests extends AbstractQueryTestCase<MultiMatc
             // STRING_FIELD_NAME_2 is a keyword field
             final MultiMatchQueryBuilder queryBuilder = new MultiMatchQueryBuilder("foo bar", TEXT_FIELD_NAME, KEYWORD_FIELD_NAME);
             queryBuilder.type(Type.BOOL_PREFIX);
-            final Query query = queryBuilder.toQuery(createShardContext());
+            final Query query = queryBuilder.toQuery(createSearchExecutionContext());
             assertThat(query, instanceOf(DisjunctionMaxQuery.class));
             final DisjunctionMaxQuery disMaxQuery = (DisjunctionMaxQuery) query;
             assertThat(disMaxQuery.getDisjuncts(), hasSize(2));
@@ -339,18 +339,18 @@ public class MultiMatchQueryBuilderTests extends AbstractQueryTestCase<MultiMatc
     }
 
     public void testExceptionUsingAnalyzerOnNumericField() {
-        QueryShardContext shardContext = createShardContext();
+        SearchExecutionContext searchExecutionContext = createSearchExecutionContext();
         MultiMatchQueryBuilder multiMatchQueryBuilder = new MultiMatchQueryBuilder(6.075210893508043E-4);
         multiMatchQueryBuilder.field(DOUBLE_FIELD_NAME);
         multiMatchQueryBuilder.analyzer("simple");
-        NumberFormatException e = expectThrows(NumberFormatException.class, () -> multiMatchQueryBuilder.toQuery(shardContext));
+        NumberFormatException e = expectThrows(NumberFormatException.class, () -> multiMatchQueryBuilder.toQuery(searchExecutionContext));
         assertEquals("For input string: \"e\"", e.getMessage());
     }
 
     public void testFuzzinessOnNonStringField() throws Exception {
         MultiMatchQueryBuilder query = new MultiMatchQueryBuilder(42).field(INT_FIELD_NAME).field(BOOLEAN_FIELD_NAME);
         query.fuzziness(randomFuzziness(INT_FIELD_NAME));
-        QueryShardContext context = createShardContext();
+        SearchExecutionContext context = createSearchExecutionContext();
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
                 () -> query.toQuery(context));
         assertThat(e.getMessage(), containsString("Can only use fuzzy queries on keyword and text fields"));
@@ -372,7 +372,7 @@ public class MultiMatchQueryBuilderTests extends AbstractQueryTestCase<MultiMatc
         qb.maxExpansions(5);
         qb.fuzzyTranspositions(false);
 
-        Query query = qb.toQuery(createShardContext());
+        Query query = qb.toQuery(createSearchExecutionContext());
         FuzzyQuery expected = new FuzzyQuery(new Term(TEXT_FIELD_NAME, "text"), 2, 2,
             5, false);
 
@@ -380,7 +380,7 @@ public class MultiMatchQueryBuilderTests extends AbstractQueryTestCase<MultiMatc
     }
 
     public void testDefaultField() throws Exception {
-        QueryShardContext context = createShardContext();
+        SearchExecutionContext context = createSearchExecutionContext();
         MultiMatchQueryBuilder builder = new MultiMatchQueryBuilder("hello");
         // default value `*` sets leniency to true
         Query query = builder.toQuery(context);
@@ -443,7 +443,7 @@ public class MultiMatchQueryBuilderTests extends AbstractQueryTestCase<MultiMatc
     }
 
     public void testAllFieldsWildcard() throws Exception {
-        QueryShardContext context = createShardContext();
+        SearchExecutionContext context = createSearchExecutionContext();
         Query query = new MultiMatchQueryBuilder("hello")
             .field("*")
             .toQuery(context);
@@ -461,7 +461,7 @@ public class MultiMatchQueryBuilderTests extends AbstractQueryTestCase<MultiMatc
         Query query = new MultiMatchQueryBuilder("the quick fox")
             .field(TEXT_FIELD_NAME)
             .analyzer("stop")
-            .toQuery(createShardContext());
+            .toQuery(createSearchExecutionContext());
         Query expected = new BooleanQuery.Builder()
             .add(new TermQuery(new Term(TEXT_FIELD_NAME, "quick")), BooleanClause.Occur.SHOULD)
             .add(new TermQuery(new Term(TEXT_FIELD_NAME, "fox")), BooleanClause.Occur.SHOULD)
@@ -472,7 +472,7 @@ public class MultiMatchQueryBuilderTests extends AbstractQueryTestCase<MultiMatc
             .field(TEXT_FIELD_NAME)
             .field(KEYWORD_FIELD_NAME)
             .analyzer("stop")
-            .toQuery(createShardContext());
+            .toQuery(createSearchExecutionContext());
         expected = new DisjunctionMaxQuery(
             Arrays.asList(
                 new BooleanQuery.Builder()
@@ -490,7 +490,7 @@ public class MultiMatchQueryBuilderTests extends AbstractQueryTestCase<MultiMatc
             .field(TEXT_FIELD_NAME)
             .field(KEYWORD_FIELD_NAME)
             .analyzer("stop")
-            .toQuery(createShardContext());
+            .toQuery(createSearchExecutionContext());
         expected = new DisjunctionMaxQuery(Arrays.asList(new MatchNoDocsQuery(), new MatchNoDocsQuery()), 0f);
         assertEquals(expected, query);
 
@@ -500,7 +500,7 @@ public class MultiMatchQueryBuilderTests extends AbstractQueryTestCase<MultiMatc
                     .field(TEXT_FIELD_NAME)
                     .analyzer("stop")
             )
-            .toQuery(createShardContext());
+            .toQuery(createSearchExecutionContext());
         expected = new BooleanQuery.Builder()
             .add(new MatchNoDocsQuery(), BooleanClause.Occur.SHOULD)
             .build();
@@ -513,7 +513,7 @@ public class MultiMatchQueryBuilderTests extends AbstractQueryTestCase<MultiMatc
                     .field(KEYWORD_FIELD_NAME)
                     .analyzer("stop")
             )
-            .toQuery(createShardContext());
+            .toQuery(createSearchExecutionContext());
         expected = new BooleanQuery.Builder()
             .add(new DisjunctionMaxQuery(Arrays.asList(new MatchNoDocsQuery(), new MatchNoDocsQuery()),
                 0f), BooleanClause.Occur.SHOULD)
@@ -526,7 +526,7 @@ public class MultiMatchQueryBuilderTests extends AbstractQueryTestCase<MultiMatc
             () -> new MultiMatchQueryBuilder("the quick fox")
                 .field(TEXT_FIELD_NAME, -1.0f)
                 .field(KEYWORD_FIELD_NAME)
-                .toQuery(createShardContext()));
+                .toQuery(createSearchExecutionContext()));
         assertThat(exc.getMessage(), containsString("negative [boost]"));
     }
 
@@ -557,21 +557,21 @@ public class MultiMatchQueryBuilderTests extends AbstractQueryTestCase<MultiMatc
     public void testCachingStrategiesWithNow() throws IOException {
         // if we hit a date field with "now", this should diable cachability
         MultiMatchQueryBuilder queryBuilder = new MultiMatchQueryBuilder("now", DATE_FIELD_NAME);
-        QueryShardContext context = createShardContext();
+        SearchExecutionContext context = createSearchExecutionContext();
         assert context.isCacheable();
         /*
          * We use a private rewrite context here since we want the most realistic way of asserting that we are cacheable or not. We do it
          * this way in SearchService where we first rewrite the query with a private context, then reset the context and then build the
          * actual lucene query
          */
-        QueryBuilder rewritten = rewriteQuery(queryBuilder, new QueryShardContext(context));
+        QueryBuilder rewritten = rewriteQuery(queryBuilder, new SearchExecutionContext(context));
         assertNotNull(rewritten.toQuery(context));
         assertFalse("query should not be cacheable: " + queryBuilder.toString(), context.isCacheable());
     }
 
     public void testLenientFlag() throws Exception {
         MultiMatchQueryBuilder query = new MultiMatchQueryBuilder("test", BINARY_FIELD_NAME);
-        QueryShardContext context = createShardContext();
+        SearchExecutionContext context = createSearchExecutionContext();
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> query.toQuery(context));
         assertEquals("Field [mapped_binary] of type [binary] does not support match queries", e.getMessage());
         query.lenient(true);

--- a/server/src/test/java/org/elasticsearch/index/query/MultiMatchQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/MultiMatchQueryBuilderTests.java
@@ -155,7 +155,7 @@ public class MultiMatchQueryBuilderTests extends AbstractQueryTestCase<MultiMatc
     }
 
     @Override
-    protected void doAssertLuceneQuery(MultiMatchQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
+    protected void doAssertLuceneQuery(MultiMatchQueryBuilder queryBuilder, Query query, SearchExecutionContext context) {
         // we rely on integration tests for deeper checks here
         assertThat(query, anyOf(Arrays.asList(
             instanceOf(BoostQuery.class),

--- a/server/src/test/java/org/elasticsearch/index/query/NestedQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/NestedQueryBuilderTests.java
@@ -90,7 +90,7 @@ public class NestedQueryBuilderTests extends AbstractQueryTestCase<NestedQueryBu
     }
 
     @Override
-    protected void doAssertLuceneQuery(NestedQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
+    protected void doAssertLuceneQuery(NestedQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
         assertThat(query, instanceOf(ESToParentBlockJoinQuery.class));
         // TODO how to assert this?
         if (queryBuilder.innerHit() != null) {
@@ -179,7 +179,7 @@ public class NestedQueryBuilderTests extends AbstractQueryTestCase<NestedQueryBu
 
     @Override
     public void testMustRewrite() throws IOException {
-        QueryShardContext context = createShardContext();
+        SearchExecutionContext context = createSearchExecutionContext();
         context.setAllowUnmappedFields(true);
         TermQueryBuilder innerQueryBuilder = new TermQueryBuilder("nested1.unmapped_field", "foo");
         NestedQueryBuilder nestedQueryBuilder = new NestedQueryBuilder("nested1", innerQueryBuilder,
@@ -192,13 +192,13 @@ public class NestedQueryBuilderTests extends AbstractQueryTestCase<NestedQueryBu
     public void testIgnoreUnmapped() throws IOException {
         final NestedQueryBuilder queryBuilder = new NestedQueryBuilder("unmapped", new MatchAllQueryBuilder(), ScoreMode.None);
         queryBuilder.ignoreUnmapped(true);
-        Query query = queryBuilder.toQuery(createShardContext());
+        Query query = queryBuilder.toQuery(createSearchExecutionContext());
         assertThat(query, notNullValue());
         assertThat(query, instanceOf(MatchNoDocsQuery.class));
 
         final NestedQueryBuilder failingQueryBuilder = new NestedQueryBuilder("unmapped", new MatchAllQueryBuilder(), ScoreMode.None);
         failingQueryBuilder.ignoreUnmapped(false);
-        IllegalStateException e = expectThrows(IllegalStateException.class, () -> failingQueryBuilder.toQuery(createShardContext()));
+        IllegalStateException e = expectThrows(IllegalStateException.class, () -> failingQueryBuilder.toQuery(createSearchExecutionContext()));
         assertThat(e.getMessage(), containsString("[" + NestedQueryBuilder.NAME + "] failed to find nested object under path [unmapped]"));
     }
 
@@ -207,8 +207,8 @@ public class NestedQueryBuilderTests extends AbstractQueryTestCase<NestedQueryBu
         final NestedQueryBuilder queryBuilder =
             new NestedQueryBuilder("unmapped", new WrapperQueryBuilder(new MatchAllQueryBuilder().toString()), ScoreMode.None);
         queryBuilder.ignoreUnmapped(true);
-        QueryShardContext queryShardContext = createShardContext();
-        Query query = queryBuilder.rewrite(queryShardContext).toQuery(queryShardContext);
+        SearchExecutionContext searchExecutionContext = createSearchExecutionContext();
+        Query query = queryBuilder.rewrite(searchExecutionContext).toQuery(searchExecutionContext);
         assertThat(query, notNullValue());
         assertThat(query, instanceOf(MatchNoDocsQuery.class));
     }
@@ -309,12 +309,12 @@ public class NestedQueryBuilderTests extends AbstractQueryTestCase<NestedQueryBu
     }
 
     public void testBuildIgnoreUnmappedNestQuery() throws Exception {
-        QueryShardContext queryShardContext = mock(QueryShardContext.class);
-        when(queryShardContext.getObjectMapper("path")).thenReturn(null);
+        SearchExecutionContext searchExecutionContext = mock(SearchExecutionContext.class);
+        when(searchExecutionContext.getObjectMapper("path")).thenReturn(null);
         IndexSettings settings = new IndexSettings(newIndexMeta("index", Settings.EMPTY), Settings.EMPTY);
-        when(queryShardContext.getIndexSettings()).thenReturn(settings);
+        when(searchExecutionContext.getIndexSettings()).thenReturn(settings);
         SearchContext searchContext = mock(SearchContext.class);
-        when(searchContext.getQueryShardContext()).thenReturn(queryShardContext);
+        when(searchContext.getSearchExecutionContext()).thenReturn(searchExecutionContext);
         InnerHitBuilder leafInnerHits = randomNestedInnerHits();
         NestedQueryBuilder query1 = new NestedQueryBuilder("path", new MatchAllQueryBuilder(), ScoreMode.None);
         query1.innerHit(leafInnerHits);
@@ -350,12 +350,12 @@ public class NestedQueryBuilderTests extends AbstractQueryTestCase<NestedQueryBu
     }
 
     public void testDisallowExpensiveQueries() {
-        QueryShardContext queryShardContext = mock(QueryShardContext.class);
-        when(queryShardContext.allowExpensiveQueries()).thenReturn(false);
+        SearchExecutionContext searchExecutionContext = mock(SearchExecutionContext.class);
+        when(searchExecutionContext.allowExpensiveQueries()).thenReturn(false);
 
         NestedQueryBuilder queryBuilder = new NestedQueryBuilder("path", new MatchAllQueryBuilder(), ScoreMode.None);
         ElasticsearchException e = expectThrows(ElasticsearchException.class,
-                () -> queryBuilder.toQuery(queryShardContext));
+                () -> queryBuilder.toQuery(searchExecutionContext));
         assertEquals("[joining] queries cannot be executed when 'search.allow_expensive_queries' is set to false.",
                 e.getMessage());
     }

--- a/server/src/test/java/org/elasticsearch/index/query/NestedQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/NestedQueryBuilderTests.java
@@ -198,7 +198,8 @@ public class NestedQueryBuilderTests extends AbstractQueryTestCase<NestedQueryBu
 
         final NestedQueryBuilder failingQueryBuilder = new NestedQueryBuilder("unmapped", new MatchAllQueryBuilder(), ScoreMode.None);
         failingQueryBuilder.ignoreUnmapped(false);
-        IllegalStateException e = expectThrows(IllegalStateException.class, () -> failingQueryBuilder.toQuery(createSearchExecutionContext()));
+        IllegalStateException e = expectThrows(IllegalStateException.class,
+            () -> failingQueryBuilder.toQuery(createSearchExecutionContext()));
         assertThat(e.getMessage(), containsString("[" + NestedQueryBuilder.NAME + "] failed to find nested object under path [unmapped]"));
     }
 

--- a/server/src/test/java/org/elasticsearch/index/query/QueryShardExceptionTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/QueryShardExceptionTests.java
@@ -36,7 +36,8 @@ public class QueryShardExceptionTests extends ESTestCase {
             assertThat(queryShardException.getIndex().getUUID(), equalTo(indexUuid));
         }
         {
-            QueryShardException queryShardException = new QueryShardException(searchExecutionContext, "error", new IllegalArgumentException());
+            QueryShardException queryShardException = new QueryShardException(
+                searchExecutionContext, "error", new IllegalArgumentException());
             assertThat(queryShardException.getIndex().getName(), equalTo(clusterAlias + ":index"));
             assertThat(queryShardException.getIndex().getUUID(), equalTo(indexUuid));
         }

--- a/server/src/test/java/org/elasticsearch/index/query/QueryShardExceptionTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/QueryShardExceptionTests.java
@@ -26,17 +26,17 @@ import static org.hamcrest.CoreMatchers.equalTo;
 
 public class QueryShardExceptionTests extends ESTestCase {
 
-    public void testCreateFromQueryShardContext() {
+    public void testCreateFromSearchExecutionContext() {
         String indexUuid = randomAlphaOfLengthBetween(5, 10);
         String clusterAlias = randomAlphaOfLengthBetween(5, 10);
-        QueryShardContext queryShardContext = QueryShardContextTests.createQueryShardContext(indexUuid, clusterAlias);
+        SearchExecutionContext searchExecutionContext = SearchExecutionContextTests.createSearchExecutionContext(indexUuid, clusterAlias);
         {
-            QueryShardException queryShardException = new QueryShardException(queryShardContext, "error");
+            QueryShardException queryShardException = new QueryShardException(searchExecutionContext, "error");
             assertThat(queryShardException.getIndex().getName(), equalTo(clusterAlias + ":index"));
             assertThat(queryShardException.getIndex().getUUID(), equalTo(indexUuid));
         }
         {
-            QueryShardException queryShardException = new QueryShardException(queryShardContext, "error", new IllegalArgumentException());
+            QueryShardException queryShardException = new QueryShardException(searchExecutionContext, "error", new IllegalArgumentException());
             assertThat(queryShardException.getIndex().getName(), equalTo(clusterAlias + ":index"));
             assertThat(queryShardException.getIndex().getUUID(), equalTo(indexUuid));
         }

--- a/server/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
@@ -398,7 +398,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
 
     @Override
     protected void doAssertLuceneQuery(QueryStringQueryBuilder queryBuilder,
-                                       Query query, QueryShardContext context) throws IOException {
+                                       Query query, SearchExecutionContext context) throws IOException {
         // nothing yet, put additional assertions here.
     }
 
@@ -417,12 +417,12 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
     }
 
     public void testToQueryMatchAllQuery() throws Exception {
-        Query query = queryStringQuery("*:*").toQuery(createShardContext());
+        Query query = queryStringQuery("*:*").toQuery(createSearchExecutionContext());
         assertThat(query, instanceOf(MatchAllDocsQuery.class));
     }
 
     public void testToQueryTermQuery() throws IOException {
-        Query query = queryStringQuery("test").defaultField(TEXT_FIELD_NAME).toQuery(createShardContext());
+        Query query = queryStringQuery("test").defaultField(TEXT_FIELD_NAME).toQuery(createSearchExecutionContext());
         assertThat(query, instanceOf(TermQuery.class));
         TermQuery termQuery = (TermQuery) query;
         assertThat(termQuery.getTerm(), equalTo(new Term(TEXT_FIELD_NAME, "test")));
@@ -432,7 +432,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
         Query query = queryStringQuery("\"term1 term2\"")
             .defaultField(TEXT_FIELD_NAME)
             .phraseSlop(3)
-            .toQuery(createShardContext());
+            .toQuery(createSearchExecutionContext());
         assertThat(query, instanceOf(PhraseQuery.class));
         PhraseQuery phraseQuery = (PhraseQuery) query;
         assertThat(phraseQuery.getTerms().length, equalTo(2));
@@ -442,16 +442,16 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
     }
 
     public void testToQueryBoosts() throws Exception {
-        QueryShardContext shardContext = createShardContext();
+        SearchExecutionContext searchExecutionContext = createSearchExecutionContext();
         QueryStringQueryBuilder queryStringQuery = queryStringQuery(TEXT_FIELD_NAME + ":boosted^2");
-        Query query = queryStringQuery.toQuery(shardContext);
+        Query query = queryStringQuery.toQuery(searchExecutionContext);
         assertThat(query, instanceOf(BoostQuery.class));
         BoostQuery boostQuery = (BoostQuery) query;
         assertThat(boostQuery.getBoost(), equalTo(2.0f));
         assertThat(boostQuery.getQuery(), instanceOf(TermQuery.class));
         assertThat(((TermQuery) boostQuery.getQuery()).getTerm(), equalTo(new Term(TEXT_FIELD_NAME, "boosted")));
         queryStringQuery.boost(2.0f);
-        query = queryStringQuery.toQuery(shardContext);
+        query = queryStringQuery.toQuery(searchExecutionContext);
         assertThat(query, instanceOf(BoostQuery.class));
         boostQuery = (BoostQuery) query;
         assertThat(boostQuery.getBoost(), equalTo(2.0f));
@@ -461,7 +461,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
 
         queryStringQuery =
             queryStringQuery("((" + TEXT_FIELD_NAME + ":boosted^2) AND (" + TEXT_FIELD_NAME + ":foo^1.5))^3");
-        query = queryStringQuery.toQuery(shardContext);
+        query = queryStringQuery.toQuery(searchExecutionContext);
         assertThat(query, instanceOf(BoostQuery.class));
         boostQuery = (BoostQuery) query;
         assertThat(boostQuery.getBoost(), equalTo(3.0f));
@@ -474,7 +474,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
         assertThat(boostQuery2.getQuery(), instanceOf(TermQuery.class));
         assertThat(((TermQuery)boostQuery2.getQuery()).getTerm(), equalTo(new Term(TEXT_FIELD_NAME, "foo")));
         queryStringQuery.boost(2.0f);
-        query = queryStringQuery.toQuery(shardContext);
+        query = queryStringQuery.toQuery(searchExecutionContext);
         assertThat(query, instanceOf(BoostQuery.class));
         boostQuery = (BoostQuery) query;
         assertThat(boostQuery.getBoost(), equalTo(2.0f));
@@ -482,7 +482,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
 
     public void testToQueryMultipleTermsBooleanQuery() throws Exception {
         Query query = queryStringQuery("test1 test2").field(TEXT_FIELD_NAME)
-            .toQuery(createShardContext());
+            .toQuery(createSearchExecutionContext());
         assertThat(query, instanceOf(BooleanQuery.class));
         BooleanQuery bQuery = (BooleanQuery) query;
         assertThat(bQuery.clauses().size(), equalTo(2));
@@ -495,7 +495,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
     public void testToQueryMultipleFieldsBooleanQuery() throws Exception {
         Query query = queryStringQuery("test").field(TEXT_FIELD_NAME)
             .field(KEYWORD_FIELD_NAME)
-            .toQuery(createShardContext());
+            .toQuery(createSearchExecutionContext());
         assertThat(query, instanceOf(DisjunctionMaxQuery.class));
         DisjunctionMaxQuery bQuery = (DisjunctionMaxQuery) query;
         assertThat(bQuery.getDisjuncts().size(), equalTo(2));
@@ -507,7 +507,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
 
     public void testToQueryMultipleFieldsDisMaxQuery() throws Exception {
         Query query = queryStringQuery("test").field(TEXT_FIELD_NAME).field(KEYWORD_FIELD_NAME)
-            .toQuery(createShardContext());
+            .toQuery(createSearchExecutionContext());
         assertThat(query, instanceOf(DisjunctionMaxQuery.class));
         DisjunctionMaxQuery disMaxQuery = (DisjunctionMaxQuery) query;
         List<Query> disjuncts = disMaxQuery.getDisjuncts();
@@ -516,7 +516,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
     }
 
     public void testToQueryFieldsWildcard() throws Exception {
-        Query query = queryStringQuery("test").field("mapped_str*").toQuery(createShardContext());
+        Query query = queryStringQuery("test").field("mapped_str*").toQuery(createSearchExecutionContext());
         assertThat(query, instanceOf(DisjunctionMaxQuery.class));
         DisjunctionMaxQuery dQuery = (DisjunctionMaxQuery) query;
         assertThat(dQuery.getDisjuncts().size(), equalTo(2));
@@ -530,11 +530,11 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
      * Test that dissalowing leading wildcards causes exception
      */
     public void testAllowLeadingWildcard() throws Exception {
-        Query query = queryStringQuery("*test").field("mapped_string").allowLeadingWildcard(true).toQuery(createShardContext());
+        Query query = queryStringQuery("*test").field("mapped_string").allowLeadingWildcard(true).toQuery(createSearchExecutionContext());
         assertThat(query, instanceOf(WildcardQuery.class));
         QueryShardException ex = expectThrows(
             QueryShardException.class,
-            () -> queryStringQuery("*test").field("mapped_string").allowLeadingWildcard(false).toQuery(createShardContext())
+            () -> queryStringQuery("*test").field("mapped_string").allowLeadingWildcard(false).toQuery(createSearchExecutionContext())
         );
         assertEquals("Failed to parse query [*test]", ex.getMessage());
         assertEquals("Cannot parse '*test': '*' or '?' not allowed as first character in WildcardQuery", ex.getCause().getMessage());
@@ -543,7 +543,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
     public void testToQueryDisMaxQuery() throws Exception {
         Query query = queryStringQuery("test").field(TEXT_FIELD_NAME, 2.2f)
             .field(KEYWORD_FIELD_NAME)
-            .toQuery(createShardContext());
+            .toQuery(createSearchExecutionContext());
         assertThat(query, instanceOf(DisjunctionMaxQuery.class));
         DisjunctionMaxQuery disMaxQuery = (DisjunctionMaxQuery) query;
         List<Query> disjuncts = disMaxQuery.getDisjuncts();
@@ -554,7 +554,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
     public void testToQueryWildcardQuery() throws Exception {
         for (Operator op : Operator.values()) {
             BooleanClause.Occur defaultOp = op.toBooleanClauseOccur();
-            QueryStringQueryParser queryParser = new QueryStringQueryParser(createShardContext(), TEXT_FIELD_NAME);
+            QueryStringQueryParser queryParser = new QueryStringQueryParser(createSearchExecutionContext(), TEXT_FIELD_NAME);
             queryParser.setAnalyzeWildcard(true);
             queryParser.setMultiTermRewriteMethod(MultiTermQuery.CONSTANT_SCORE_REWRITE);
             queryParser.setDefaultOperator(op.toQueryParserOperator());
@@ -574,7 +574,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
     }
 
     public void testToQueryWildcardWithIndexedPrefixes() throws Exception {
-        QueryStringQueryParser queryParser = new QueryStringQueryParser(createShardContext(), "prefix_field");
+        QueryStringQueryParser queryParser = new QueryStringQueryParser(createSearchExecutionContext(), "prefix_field");
         Query query = queryParser.parse("foo*");
         Query expectedQuery = new ConstantScoreQuery(new TermQuery(new Term("prefix_field._index_prefix", "foo")));
         assertThat(query, equalTo(expectedQuery));
@@ -591,7 +591,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
     public void testToQueryWilcardQueryWithSynonyms() throws Exception {
         for (Operator op : Operator.values()) {
             BooleanClause.Occur defaultOp = op.toBooleanClauseOccur();
-            QueryStringQueryParser queryParser = new QueryStringQueryParser(createShardContext(), TEXT_FIELD_NAME);
+            QueryStringQueryParser queryParser = new QueryStringQueryParser(createSearchExecutionContext(), TEXT_FIELD_NAME);
             queryParser.setAnalyzeWildcard(true);
             queryParser.setMultiTermRewriteMethod(MultiTermQuery.CONSTANT_SCORE_REWRITE);
             queryParser.setDefaultOperator(op.toQueryParserOperator());
@@ -623,7 +623,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
     public void testToQueryWithGraph() throws Exception {
         for (Operator op : Operator.values()) {
             BooleanClause.Occur defaultOp = op.toBooleanClauseOccur();
-            QueryStringQueryParser queryParser = new QueryStringQueryParser(createShardContext(), TEXT_FIELD_NAME);
+            QueryStringQueryParser queryParser = new QueryStringQueryParser(createSearchExecutionContext(), TEXT_FIELD_NAME);
             queryParser.setAnalyzeWildcard(true);
             queryParser.setMultiTermRewriteMethod(MultiTermQuery.CONSTANT_SCORE_REWRITE);
             queryParser.setDefaultOperator(op.toQueryParserOperator());
@@ -743,7 +743,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
     public void testToQueryRegExpQuery() throws Exception {
         Query query = queryStringQuery("/foo*bar/").defaultField(TEXT_FIELD_NAME)
             .maxDeterminizedStates(5000)
-            .toQuery(createShardContext());
+            .toQuery(createSearchExecutionContext());
         assertThat(query, instanceOf(RegexpQuery.class));
         RegexpQuery regexpQuery = (RegexpQuery) query;
         assertTrue(regexpQuery.toString().contains("/foo*bar/"));
@@ -753,7 +753,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
         QueryStringQueryBuilder queryBuilder = queryStringQuery("/[ac]*a[ac]{50,200}/").defaultField(TEXT_FIELD_NAME);
 
         TooComplexToDeterminizeException e = expectThrows(TooComplexToDeterminizeException.class,
-                () -> queryBuilder.toQuery(createShardContext()));
+                () -> queryBuilder.toQuery(createSearchExecutionContext()));
         assertThat(e.getMessage(), containsString("Determinizing [ac]*"));
         assertThat(e.getMessage(), containsString("would result in more than 10000 states"));
     }
@@ -775,7 +775,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
 
         QueryBuilder queryBuilder = parseInnerQueryBuilder(createParser(builder));
         TooComplexToDeterminizeException e = expectThrows(TooComplexToDeterminizeException.class,
-                () -> queryBuilder.toQuery(createShardContext()));
+                () -> queryBuilder.toQuery(createSearchExecutionContext()));
         assertThat(e.getMessage(), containsString("Determinizing [ac]*"));
         assertThat(e.getMessage(), containsString("would result in more than 10 states"));
     }
@@ -807,7 +807,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
                 Query query = queryStringQuery(queryString + (j == 0 ? "~" : "~auto"))
                     .defaultField(TEXT_FIELD_NAME)
                     .fuzziness(Fuzziness.AUTO)
-                    .toQuery(createShardContext());
+                    .toQuery(createSearchExecutionContext());
                 assertThat(query, instanceOf(FuzzyQuery.class));
                 FuzzyQuery fuzzyQuery = (FuzzyQuery) query;
                 assertEquals(expectedEdits, fuzzyQuery.getMaxEdits());
@@ -817,7 +817,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
 
     public void testToQueryDateWithTimeZone() throws Exception {
         QueryStringQueryBuilder qsq = queryStringQuery(DATE_FIELD_NAME + ":1970-01-01");
-        QueryShardContext context = createShardContext();
+        SearchExecutionContext context = createSearchExecutionContext();
         Query query = qsq.toQuery(context);
         assertThat(query, instanceOf(IndexOrDocValuesQuery.class));
         long lower = 0; // 1970-01-01T00:00:00.999 UTC
@@ -836,7 +836,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
 
     public void testFuzzyNumeric() throws Exception {
         QueryStringQueryBuilder query = queryStringQuery("12~1.0").defaultField(INT_FIELD_NAME);
-        QueryShardContext context = createShardContext();
+        SearchExecutionContext context = createSearchExecutionContext();
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
                 () -> query.toQuery(context));
         assertEquals("Can only use fuzzy queries on keyword and text fields - not on [mapped_int] which is of type [integer]",
@@ -847,7 +847,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
 
     public void testPrefixNumeric() throws Exception {
         QueryStringQueryBuilder query = queryStringQuery("12*").defaultField(INT_FIELD_NAME);
-        QueryShardContext context = createShardContext();
+        SearchExecutionContext context = createSearchExecutionContext();
         QueryShardException e = expectThrows(QueryShardException.class,
                 () -> query.toQuery(context));
         assertEquals("Can only use prefix queries on keyword, text and wildcard fields - not on [mapped_int] which is of type [integer]",
@@ -858,7 +858,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
 
     public void testExactGeo() throws Exception {
         QueryStringQueryBuilder query = queryStringQuery("2,3").defaultField(GEO_POINT_FIELD_NAME);
-        QueryShardContext context = createShardContext();
+        SearchExecutionContext context = createSearchExecutionContext();
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> query.toQuery(context));
         assertEquals("Field [mapped_geo_point] of type [geo_point] does not support match queries", e.getMessage());
         query.lenient(true);
@@ -867,7 +867,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
 
     public void testLenientFlag() throws Exception {
         QueryStringQueryBuilder query = queryStringQuery("test").defaultField(BINARY_FIELD_NAME);
-        QueryShardContext context = createShardContext();
+        SearchExecutionContext context = createSearchExecutionContext();
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> query.toQuery(context));
         assertEquals("Field [mapped_binary] of type [binary] does not support match queries", e.getMessage());
         query.lenient(true);
@@ -913,7 +913,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
         QueryStringQueryBuilder queryStringQueryBuilder =
             new QueryStringQueryBuilder(queryString).field(TEXT_FIELD_NAME)
                 .minimumShouldMatch("2").boost(mainBoost);
-        Query query = queryStringQueryBuilder.toQuery(createShardContext());
+        Query query = queryStringQueryBuilder.toQuery(createSearchExecutionContext());
 
         for (int i = boosts.length - 1; i >= 0; i--) {
             assertThat(query, instanceOf(BoostQuery.class));
@@ -936,7 +936,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
     public void testToQueryPhraseQueryBoostAndSlop() throws IOException {
         QueryStringQueryBuilder queryStringQueryBuilder =
             new QueryStringQueryBuilder("\"test phrase\"~2").field(TEXT_FIELD_NAME, 5f);
-        Query query = queryStringQueryBuilder.toQuery(createShardContext());
+        Query query = queryStringQueryBuilder.toQuery(createSearchExecutionContext());
         assertThat(query, instanceOf(BoostQuery.class));
         BoostQuery boostQuery = (BoostQuery) query;
         assertThat(boostQuery.getBoost(), equalTo(5f));
@@ -949,14 +949,14 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
     public void testToQueryWildcardNonExistingFields() throws IOException {
         QueryStringQueryBuilder queryStringQueryBuilder =
             new QueryStringQueryBuilder("foo bar").field("invalid*");
-        Query query = queryStringQueryBuilder.toQuery(createShardContext());
+        Query query = queryStringQueryBuilder.toQuery(createSearchExecutionContext());
 
         Query expectedQuery = new MatchNoDocsQuery("empty fields");
         assertThat(expectedQuery, equalTo(query));
 
         queryStringQueryBuilder =
             new QueryStringQueryBuilder(TEXT_FIELD_NAME + ":foo bar").field("invalid*");
-        query = queryStringQueryBuilder.toQuery(createShardContext());
+        query = queryStringQueryBuilder.toQuery(createSearchExecutionContext());
         expectedQuery = new BooleanQuery.Builder()
             .add(new TermQuery(new Term(TEXT_FIELD_NAME, "foo")), Occur.SHOULD)
             .add(new MatchNoDocsQuery("empty fields"), Occur.SHOULD)
@@ -969,7 +969,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
             QueryStringQueryBuilder queryBuilder =
                 new QueryStringQueryBuilder("foo bar")
                     .field(TEXT_FIELD_NAME).field(KEYWORD_FIELD_NAME);
-            Query query = queryBuilder.toQuery(createShardContext());
+            Query query = queryBuilder.toQuery(createSearchExecutionContext());
             BooleanQuery bq1 =
                 new BooleanQuery.Builder()
                     .add(new BooleanClause(new TermQuery(new Term(TEXT_FIELD_NAME, "foo")), BooleanClause.Occur.SHOULD))
@@ -988,7 +988,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
                 new QueryStringQueryBuilder("foo bar")
                     .field(TEXT_FIELD_NAME).field(KEYWORD_FIELD_NAME);
             queryBuilder.type(MultiMatchQueryBuilder.Type.PHRASE);
-            Query query = queryBuilder.toQuery(createShardContext());
+            Query query = queryBuilder.toQuery(createSearchExecutionContext());
 
             List<Query> disjuncts = new ArrayList<>();
             PhraseQuery pq = new PhraseQuery.Builder()
@@ -1005,7 +1005,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
             QueryStringQueryBuilder queryBuilder =
                 new QueryStringQueryBuilder("mapped_string:other foo bar")
                     .field(TEXT_FIELD_NAME).field(KEYWORD_FIELD_NAME);
-            Query query = queryBuilder.toQuery(createShardContext());
+            Query query = queryBuilder.toQuery(createSearchExecutionContext());
             BooleanQuery bq1 =
                 new BooleanQuery.Builder()
                     .add(new BooleanClause(new TermQuery(new Term(TEXT_FIELD_NAME, "foo")), BooleanClause.Occur.SHOULD))
@@ -1027,7 +1027,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
             QueryStringQueryBuilder queryBuilder =
                 new QueryStringQueryBuilder("foo OR bar")
                     .field(TEXT_FIELD_NAME).field(KEYWORD_FIELD_NAME);
-            Query query = queryBuilder.toQuery(createShardContext());
+            Query query = queryBuilder.toQuery(createSearchExecutionContext());
 
             List<Query> disjuncts1 = new ArrayList<>();
             disjuncts1.add(new TermQuery(new Term(TEXT_FIELD_NAME, "foo")));
@@ -1054,13 +1054,13 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
                 new QueryStringQueryBuilder(">10 foo")
                     .field(INT_FIELD_NAME);
             IllegalArgumentException exc =
-                expectThrows(IllegalArgumentException.class, () -> queryBuilder.toQuery(createShardContext()));
+                expectThrows(IllegalArgumentException.class, () -> queryBuilder.toQuery(createSearchExecutionContext()));
             assertThat(exc.getMessage(), equalTo("For input string: \">10 foo\""));
         }
     }
 
     public void testExistsFieldQuery() throws Exception {
-        QueryShardContext context = createShardContext();
+        SearchExecutionContext context = createSearchExecutionContext();
         QueryStringQueryBuilder queryBuilder = new QueryStringQueryBuilder(TEXT_FIELD_NAME + ":*");
         Query query = queryBuilder.toQuery(context);
         if (context.getFieldType(TEXT_FIELD_NAME).getTextSearchInfo().hasNorms()) {
@@ -1079,7 +1079,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
                 assertThat(query, equalTo(new ConstantScoreQuery(new TermQuery(new Term("_field_names", TEXT_FIELD_NAME)))));
             }
         }
-        QueryShardContext contextNoType = createShardContextWithNoType();
+        SearchExecutionContext contextNoType = createShardContextWithNoType();
         query = queryBuilder.toQuery(contextNoType);
         assertThat(query, equalTo(new MatchNoDocsQuery()));
 
@@ -1130,37 +1130,37 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
         Query query = new QueryStringQueryBuilder("aBc*")
                 .field(TEXT_FIELD_NAME)
                 .analyzer("whitespace")
-                .toQuery(createShardContext());
+                .toQuery(createSearchExecutionContext());
         assertEquals(new PrefixQuery(new Term(TEXT_FIELD_NAME, "aBc")), query);
         query = new QueryStringQueryBuilder("aBc*")
                 .field(TEXT_FIELD_NAME)
                 .analyzer("standard")
-                .toQuery(createShardContext());
+                .toQuery(createSearchExecutionContext());
         assertEquals(new PrefixQuery(new Term(TEXT_FIELD_NAME, "abc")), query);
 
         // Wildcard
         query = new QueryStringQueryBuilder("aBc*D")
                 .field(TEXT_FIELD_NAME)
                 .analyzer("whitespace")
-                .toQuery(createShardContext());
+                .toQuery(createSearchExecutionContext());
         assertEquals(new WildcardQuery(new Term(TEXT_FIELD_NAME, "aBc*D")), query);
         query = new QueryStringQueryBuilder("aBc*D")
                 .field(TEXT_FIELD_NAME)
                 .analyzer("standard")
-                .toQuery(createShardContext());
+                .toQuery(createSearchExecutionContext());
         assertEquals(new WildcardQuery(new Term(TEXT_FIELD_NAME, "abc*d")), query);
 
         // Fuzzy
         query = new QueryStringQueryBuilder("aBc~1")
                 .field(TEXT_FIELD_NAME)
                 .analyzer("whitespace")
-                .toQuery(createShardContext());
+                .toQuery(createSearchExecutionContext());
         FuzzyQuery fuzzyQuery = (FuzzyQuery) query;
         assertEquals(new Term(TEXT_FIELD_NAME, "aBc"), fuzzyQuery.getTerm());
         query = new QueryStringQueryBuilder("aBc~1")
                 .field(TEXT_FIELD_NAME)
                 .analyzer("standard")
-                .toQuery(createShardContext());
+                .toQuery(createSearchExecutionContext());
         fuzzyQuery = (FuzzyQuery) query;
         assertEquals(new Term(TEXT_FIELD_NAME, "abc"), fuzzyQuery.getTerm());
 
@@ -1168,17 +1168,17 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
         query = new QueryStringQueryBuilder("[aBc TO BcD]")
                 .field(TEXT_FIELD_NAME)
                 .analyzer("whitespace")
-                .toQuery(createShardContext());
+                .toQuery(createSearchExecutionContext());
         assertEquals(new TermRangeQuery(TEXT_FIELD_NAME, new BytesRef("aBc"), new BytesRef("BcD"), true, true), query);
         query = new QueryStringQueryBuilder("[aBc TO BcD]")
                 .field(TEXT_FIELD_NAME)
                 .analyzer("standard")
-                .toQuery(createShardContext());
+                .toQuery(createSearchExecutionContext());
         assertEquals(new TermRangeQuery(TEXT_FIELD_NAME, new BytesRef("abc"), new BytesRef("bcd"), true, true), query);
     }
 
     public void testDefaultFieldsWithFields() throws IOException {
-        QueryShardContext context = createShardContext();
+        SearchExecutionContext context = createSearchExecutionContext();
         QueryStringQueryBuilder builder = new QueryStringQueryBuilder("aBc*")
             .field("field")
             .defaultField("*");
@@ -1192,21 +1192,21 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
         Query query = new QueryStringQueryBuilder("hello")
             .field(INT_FIELD_NAME)
             .lenient(true)
-            .toQuery(createShardContext());
+            .toQuery(createSearchExecutionContext());
         assertEquals(new MatchNoDocsQuery(""), query);
 
         // prefix
         query = new QueryStringQueryBuilder("hello*")
             .field(INT_FIELD_NAME)
             .lenient(true)
-            .toQuery(createShardContext());
+            .toQuery(createSearchExecutionContext());
         assertEquals(new MatchNoDocsQuery(""), query);
 
         // Fuzzy
         query = new QueryStringQueryBuilder("hello~2")
             .field(INT_FIELD_NAME)
             .lenient(true)
-            .toQuery(createShardContext());
+            .toQuery(createSearchExecutionContext());
         assertEquals(new MatchNoDocsQuery(""), query);
     }
 
@@ -1215,13 +1215,13 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
         Query query = new QueryStringQueryBuilder("hello")
             .field("unmapped_field")
             .lenient(true)
-            .toQuery(createShardContext());
+            .toQuery(createSearchExecutionContext());
         assertEquals(new MatchNoDocsQuery(), query);
 
         // Unmapped prefix field
         query = new QueryStringQueryBuilder("unmapped_field:hello")
             .lenient(true)
-            .toQuery(createShardContext());
+            .toQuery(createSearchExecutionContext());
         assertEquals(new MatchNoDocsQuery(), query);
 
         // Unmapped fields
@@ -1229,7 +1229,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
             .lenient(true)
             .field("unmapped_field")
             .field("another_field")
-            .toQuery(createShardContext());
+            .toQuery(createSearchExecutionContext());
         assertEquals(new MatchNoDocsQuery(), query);
 
         // Multi block
@@ -1238,7 +1238,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
             .field("unmapped")
             .field("another_unmapped")
             .defaultOperator(Operator.AND)
-            .toQuery(createShardContext());
+            .toQuery(createSearchExecutionContext());
         BooleanQuery expected = new BooleanQuery.Builder()
             .add(new TermQuery(new Term(TEXT_FIELD_NAME, "first")), BooleanClause.Occur.MUST)
             .add(new MatchNoDocsQuery(), BooleanClause.Occur.MUST)
@@ -1249,7 +1249,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
             .field("unmapped")
             .field("another_unmapped")
             .defaultOperator(Operator.AND)
-            .toQuery(createShardContext());
+            .toQuery(createSearchExecutionContext());
         expected = new BooleanQuery.Builder()
             .add(new MatchNoDocsQuery(), BooleanClause.Occur.MUST)
             .add(new MatchNoDocsQuery(), BooleanClause.Occur.MUST)
@@ -1259,7 +1259,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
     }
 
     public void testDefaultField() throws Exception {
-        QueryShardContext context = createShardContext();
+        SearchExecutionContext context = createSearchExecutionContext();
         // default value `*` sets leniency to true
         Query query = new QueryStringQueryBuilder("hello")
             .toQuery(context);
@@ -1299,7 +1299,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
     }
 
     public void testAllFieldsWildcard() throws Exception {
-        QueryShardContext context = createShardContext();
+        SearchExecutionContext context = createSearchExecutionContext();
         Query query = new QueryStringQueryBuilder("hello")
             .field("*")
             .toQuery(context);
@@ -1322,7 +1322,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
                 .field(TEXT_FIELD_NAME)
                 .analyzer("whitespace")
                 .quoteAnalyzer("simple")
-                .toQuery(createShardContext());
+                .toQuery(createSearchExecutionContext());
         Query expectedQuery =
                 new BooleanQuery.Builder()
                         .add(new BooleanClause(new TermQuery(new Term(TEXT_FIELD_NAME, "ONE")), Occur.SHOULD))
@@ -1335,7 +1335,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
     }
 
     public void testQuoteFieldSuffix() throws IOException {
-        QueryShardContext context = createShardContext();
+        SearchExecutionContext context = createSearchExecutionContext();
         assertEquals(new TermQuery(new Term(TEXT_FIELD_NAME, "bar")),
             new QueryStringQueryBuilder("bar")
                 .quoteFieldSuffix("_2")
@@ -1370,7 +1370,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
             .fuzzyPrefixLength(2)
             .fuzzyMaxExpansions(5)
             .fuzzyTranspositions(false)
-            .toQuery(createShardContext());
+            .toQuery(createSearchExecutionContext());
         FuzzyQuery expected = new FuzzyQuery(new Term(TEXT_FIELD_NAME, "text"), 2, 2, 5, false);
         assertEquals(expected, query);
     }
@@ -1379,7 +1379,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
         Query query = new QueryStringQueryBuilder("the quick fox")
             .field(TEXT_FIELD_NAME)
             .analyzer("stop")
-            .toQuery(createShardContext());
+            .toQuery(createSearchExecutionContext());
         Query expected = new BooleanQuery.Builder()
             .add(new TermQuery(new Term(TEXT_FIELD_NAME, "quick")), BooleanClause.Occur.SHOULD)
             .add(new TermQuery(new Term(TEXT_FIELD_NAME, "fox")), BooleanClause.Occur.SHOULD)
@@ -1390,7 +1390,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
             .field(TEXT_FIELD_NAME)
             .field(KEYWORD_FIELD_NAME)
             .analyzer("stop")
-            .toQuery(createShardContext());
+            .toQuery(createSearchExecutionContext());
         expected = new DisjunctionMaxQuery(
             Arrays.asList(
                 new BooleanQuery.Builder()
@@ -1408,7 +1408,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
             .field(TEXT_FIELD_NAME)
             .field(KEYWORD_FIELD_NAME)
             .analyzer("stop")
-            .toQuery(createShardContext());
+            .toQuery(createSearchExecutionContext());
         assertEquals(new BooleanQuery.Builder().build(), query);
 
         query = new BoolQueryBuilder()
@@ -1417,7 +1417,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
                     .field(TEXT_FIELD_NAME)
                     .analyzer("stop")
             )
-            .toQuery(createShardContext());
+            .toQuery(createSearchExecutionContext());
         expected = new BooleanQuery.Builder()
             .add(new BooleanQuery.Builder().build(), BooleanClause.Occur.SHOULD)
             .build();
@@ -1430,7 +1430,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
                     .field(KEYWORD_FIELD_NAME)
                     .analyzer("stop")
             )
-            .toQuery(createShardContext());
+            .toQuery(createSearchExecutionContext());
         assertEquals(expected, query);
     }
 
@@ -1439,7 +1439,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
             .field(TEXT_FIELD_NAME)
             .analyzer("stop")
             .enablePositionIncrements(false)
-            .toQuery(createShardContext());
+            .toQuery(createSearchExecutionContext());
         PhraseQuery expected = new PhraseQuery.Builder()
             .add(new Term(TEXT_FIELD_NAME, "quick"))
             .add(new Term(TEXT_FIELD_NAME, "fox"))
@@ -1451,7 +1451,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
         Query query = new QueryStringQueryBuilder("the* quick fox")
             .field(TEXT_FIELD_NAME)
             .analyzer("stop")
-            .toQuery(createShardContext());
+            .toQuery(createSearchExecutionContext());
         BooleanQuery expected = new BooleanQuery.Builder()
             .add(new PrefixQuery(new Term(TEXT_FIELD_NAME, "the")), Occur.SHOULD)
             .add(new TermQuery(new Term(TEXT_FIELD_NAME, "quick")), Occur.SHOULD)
@@ -1461,7 +1461,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
     }
 
     public void testCrossFields() throws Exception {
-        final QueryShardContext context = createShardContext();
+        final SearchExecutionContext context = createSearchExecutionContext();
         context.getIndexSettings().updateIndexMetadata(
             newIndexMeta("index", context.getIndexSettings().getSettings(),
                 Settings.builder().putList("index.query.default_field",
@@ -1475,14 +1475,14 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
             Query query = new QueryStringQueryBuilder("foo")
                 .analyzer("whitespace")
                 .type(MultiMatchQueryBuilder.Type.CROSS_FIELDS)
-                .toQuery(createShardContext());
+                .toQuery(createSearchExecutionContext());
             Query expected = BlendedTermQuery.dismaxBlendedQuery(blendedTerms, 1.0f);
             assertEquals(expected, query);
 
             query = new QueryStringQueryBuilder("foo mapped_string:10")
                 .analyzer("whitespace")
                 .type(MultiMatchQueryBuilder.Type.CROSS_FIELDS)
-                .toQuery(createShardContext());
+                .toQuery(createSearchExecutionContext());
             expected = new BooleanQuery.Builder()
                 .add(BlendedTermQuery.dismaxBlendedQuery(blendedTerms, 1.0f), Occur.SHOULD)
                 .add(new TermQuery(new Term(TEXT_FIELD_NAME, "10")), Occur.SHOULD)
@@ -1502,7 +1502,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
         Query query = new QueryStringQueryBuilder("quick fox")
             .field(TEXT_FIELD_NAME)
             .type(MultiMatchQueryBuilder.Type.PHRASE)
-            .toQuery(createShardContext());
+            .toQuery(createSearchExecutionContext());
 
         PhraseQuery expected = new PhraseQuery.Builder()
             .add(new Term(TEXT_FIELD_NAME, "quick"))
@@ -1514,7 +1514,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
             .field(TEXT_FIELD_NAME)
             .type(MultiMatchQueryBuilder.Type.PHRASE)
             .phraseSlop(2)
-            .toQuery(createShardContext());
+            .toQuery(createSearchExecutionContext());
 
         expected = new PhraseQuery.Builder()
             .add(new Term(TEXT_FIELD_NAME, "quick"))
@@ -1526,13 +1526,13 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
         query = new QueryStringQueryBuilder("\"quick fox\"")
             .field(TEXT_FIELD_NAME)
             .phraseSlop(2)
-            .toQuery(createShardContext());
+            .toQuery(createSearchExecutionContext());
         assertEquals(expected, query);
 
         query = new QueryStringQueryBuilder("\"quick fox\"~2")
             .field(TEXT_FIELD_NAME)
             .phraseSlop(10)
-            .toQuery(createShardContext());
+            .toQuery(createSearchExecutionContext());
         assertEquals(expected, query);
     }
 
@@ -1541,7 +1541,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
             .field(TEXT_FIELD_NAME)
             .analyzer("standard")
             .analyzeWildcard(true)
-            .toQuery(createShardContext());
+            .toQuery(createSearchExecutionContext());
         Query expected = new PrefixQuery(new Term(TEXT_FIELD_NAME, "quick"));
         assertEquals(expected, query);
     }
@@ -1551,7 +1551,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
             () -> new QueryStringQueryBuilder("the quick fox")
                 .field(TEXT_FIELD_NAME, -1.0f)
                 .field(KEYWORD_FIELD_NAME)
-                .toQuery(createShardContext()));
+                .toQuery(createSearchExecutionContext()));
         assertThat(exc.getMessage(), CoreMatchers.containsString("negative [boost]"));
     }
 
@@ -1560,7 +1560,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
             .type(MultiMatchQueryBuilder.Type.MOST_FIELDS)
             .field(TEXT_FIELD_NAME, 0.3f)
             .field(TEXT_FIELD_NAME.substring(0, TEXT_FIELD_NAME.length()-2) + "*", 0.5f)
-            .toQuery(createShardContext());
+            .toQuery(createSearchExecutionContext());
         List<Query> terms = new ArrayList<>();
         terms.add(new BoostQuery(new TermQuery(new Term(TEXT_FIELD_NAME, "first")), 0.075f));
         terms.add(new BoostQuery(new TermQuery(new Term(KEYWORD_FIELD_NAME, "first")), 0.5f));
@@ -1611,14 +1611,14 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
     }
 
     private void assertQueryCachability(QueryStringQueryBuilder qb, boolean cachingExpected) throws IOException {
-        QueryShardContext context = createShardContext();
+        SearchExecutionContext context = createSearchExecutionContext();
         assert context.isCacheable();
         /*
          * We use a private rewrite context here since we want the most realistic way of asserting that we are cacheable or not. We do it
          * this way in SearchService where we first rewrite the query with a private context, then reset the context and then build the
          * actual lucene query
          */
-        QueryBuilder rewritten = rewriteQuery(qb, new QueryShardContext(context));
+        QueryBuilder rewritten = rewriteQuery(qb, new SearchExecutionContext(context));
         assertNotNull(rewritten.toQuery(context));
         assertEquals("query should " + (cachingExpected ? "" : "not") + " be cacheable: " + qb.toString(), cachingExpected,
                 context.isCacheable());

--- a/server/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTests.java
@@ -79,7 +79,7 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
                 query.to(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.format(end));
                 // Create timestamp option only then we have a date mapper,
                 // otherwise we could trigger exception.
-                if (createShardContext().getFieldType(DATE_FIELD_NAME) != null) {
+                if (createSearchExecutionContext().getFieldType(DATE_FIELD_NAME) != null) {
                     if (randomBoolean()) {
                         query.timeZone(randomZone().getId());
                     }
@@ -131,7 +131,7 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
     }
 
     @Override
-    protected void doAssertLuceneQuery(RangeQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
+    protected void doAssertLuceneQuery(RangeQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
         String expectedFieldName = expectedFieldName(queryBuilder.fieldName());
         if (queryBuilder.from() == null && queryBuilder.to() == null) {
             final Query expectedQuery;
@@ -242,7 +242,7 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
     }
 
     public void testToQueryNumericField() throws IOException {
-        Query parsedQuery = rangeQuery(INT_FIELD_NAME).from(23).to(54).includeLower(true).includeUpper(false).toQuery(createShardContext());
+        Query parsedQuery = rangeQuery(INT_FIELD_NAME).from(23).to(54).includeLower(true).includeUpper(false).toQuery(createSearchExecutionContext());
         // since age is automatically registered in data, we encode it as numeric
         assertThat(parsedQuery, instanceOf(IndexOrDocValuesQuery.class));
         parsedQuery = ((IndexOrDocValuesQuery) parsedQuery).getIndexQuery();
@@ -261,7 +261,7 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
                 "        }\n" +
                 "    }\n" +
                 "}";
-        Query parsedQuery = parseQuery(query).toQuery(createShardContext());
+        Query parsedQuery = parseQuery(query).toQuery(createSearchExecutionContext());
         assertThat(parsedQuery, instanceOf(IndexOrDocValuesQuery.class));
         parsedQuery = ((IndexOrDocValuesQuery) parsedQuery).getIndexQuery();
         assertThat(parsedQuery, instanceOf(PointRangeQuery.class));
@@ -281,7 +281,7 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
                 "        }\n" +
                 "    }\n" +
                 "}";
-        expectThrows(ElasticsearchParseException.class, () -> parseQuery(invalidQuery).toQuery(createShardContext()));
+        expectThrows(ElasticsearchParseException.class, () -> parseQuery(invalidQuery).toQuery(createSearchExecutionContext()));
     }
 
     public void testDateRangeBoundaries() throws IOException {
@@ -293,7 +293,7 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
                 "        }\n" +
                 "    }\n" +
                 "}\n";
-        Query parsedQuery = parseQuery(query).toQuery(createShardContext());
+        Query parsedQuery = parseQuery(query).toQuery(createSearchExecutionContext());
         assertThat(parsedQuery, instanceOf(IndexOrDocValuesQuery.class));
         parsedQuery = ((IndexOrDocValuesQuery) parsedQuery).getIndexQuery();
         assertThat(parsedQuery, instanceOf(PointRangeQuery.class));
@@ -310,7 +310,7 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
                 "        }\n" +
                 "    }\n" +
                 "}";
-        parsedQuery = parseQuery(query).toQuery(createShardContext());
+        parsedQuery = parseQuery(query).toQuery(createSearchExecutionContext());
         assertThat(parsedQuery, instanceOf(IndexOrDocValuesQuery.class));
         parsedQuery = ((IndexOrDocValuesQuery) parsedQuery).getIndexQuery();
         assertThat(parsedQuery, instanceOf(PointRangeQuery.class));
@@ -330,7 +330,7 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
                 "        }\n" +
                 "    }\n" +
                 "}";
-        QueryShardContext context = createShardContext();
+        SearchExecutionContext context = createSearchExecutionContext();
         Query parsedQuery = parseQuery(query).toQuery(context);
         assertThat(parsedQuery, instanceOf(DateRangeIncludingNowQuery.class));
         parsedQuery = ((DateRangeIncludingNowQuery)parsedQuery).getQuery();
@@ -349,7 +349,7 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
                 "    }\n" +
                 "}";
         QueryBuilder queryBuilder = parseQuery(query);
-        queryBuilder.toQuery(createShardContext()); // no exception
+        queryBuilder.toQuery(createSearchExecutionContext()); // no exception
     }
 
     public void testFromJson() throws IOException {
@@ -401,8 +401,8 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
         DateTime queryToValue = new DateTime(2016, 1, 1, 0, 0, 0, ISOChronology.getInstanceUTC());
         query.from(queryFromValue);
         query.to(queryToValue);
-        QueryShardContext queryShardContext = createShardContext();
-        QueryBuilder rewritten = query.rewrite(queryShardContext);
+        SearchExecutionContext searchExecutionContext = createSearchExecutionContext();
+        QueryBuilder rewritten = query.rewrite(searchExecutionContext);
         assertThat(rewritten, instanceOf(RangeQueryBuilder.class));
         RangeQueryBuilder rewrittenRange = (RangeQueryBuilder) rewritten;
         assertThat(rewrittenRange.fieldName(), equalTo(fieldName));
@@ -410,17 +410,17 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
         assertThat(rewrittenRange.to(), equalTo(null));
 
         // Range query with open bounds rewrite to an exists query
-        Query luceneQuery = rewrittenRange.toQuery(queryShardContext);
+        Query luceneQuery = rewrittenRange.toQuery(searchExecutionContext);
         final Query expectedQuery;
-        if (queryShardContext.getFieldType(query.fieldName()).hasDocValues()) {
+        if (searchExecutionContext.getFieldType(query.fieldName()).hasDocValues()) {
             expectedQuery = new ConstantScoreQuery(new DocValuesFieldExistsQuery(query.fieldName()));
         } else {
             expectedQuery = new ConstantScoreQuery(new TermQuery(new Term(FieldNamesFieldMapper.NAME, query.fieldName())));
         }
         assertThat(luceneQuery, equalTo(expectedQuery));
 
-        QueryShardContext queryShardContextWithUnkType = createShardContextWithNoType();
-        luceneQuery  = rewrittenRange.toQuery(queryShardContextWithUnkType);
+        SearchExecutionContext searchExecutionContextWithUnkType = createShardContextWithNoType();
+        luceneQuery  = rewrittenRange.toQuery(searchExecutionContextWithUnkType);
         assertThat(luceneQuery, equalTo(new MatchNoDocsQuery("no mappings yet")));
     }
 
@@ -438,8 +438,8 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
         query.to(queryToValue);
         query.timeZone(randomZone().getId());
         query.format("yyyy-MM-dd");
-        QueryShardContext queryShardContext = createShardContext();
-        QueryBuilder rewritten = query.rewrite(queryShardContext);
+        SearchExecutionContext searchExecutionContext = createSearchExecutionContext();
+        QueryBuilder rewritten = query.rewrite(searchExecutionContext);
         assertThat(rewritten, instanceOf(RangeQueryBuilder.class));
         RangeQueryBuilder rewrittenRange = (RangeQueryBuilder) rewritten;
         assertThat(rewrittenRange.fieldName(), equalTo(fieldName));
@@ -461,8 +461,8 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
         DateTime queryToValue = new DateTime(2016, 1, 1, 0, 0, 0, ISOChronology.getInstanceUTC());
         query.from(queryFromValue);
         query.to(queryToValue);
-        QueryShardContext queryShardContext = createShardContext();
-        QueryBuilder rewritten = query.rewrite(queryShardContext);
+        SearchExecutionContext searchExecutionContext = createSearchExecutionContext();
+        QueryBuilder rewritten = query.rewrite(searchExecutionContext);
         assertThat(rewritten, instanceOf(MatchNoneQueryBuilder.class));
     }
 
@@ -478,8 +478,8 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
         DateTime queryToValue = new DateTime(2016, 1, 1, 0, 0, 0, ISOChronology.getInstanceUTC());
         query.from(queryFromValue);
         query.to(queryToValue);
-        QueryShardContext queryShardContext = createShardContext();
-        QueryBuilder rewritten = query.rewrite(queryShardContext);
+        SearchExecutionContext searchExecutionContext = createSearchExecutionContext();
+        QueryBuilder rewritten = query.rewrite(searchExecutionContext);
         assertThat(rewritten, sameInstance(query));
     }
 
@@ -491,8 +491,8 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
                 return Relation.INTERSECTS;
             }
         };
-        QueryShardContext queryShardContext = createShardContext();
-        QueryBuilder rewritten = query.rewrite(queryShardContext);
+        SearchExecutionContext searchExecutionContext = createSearchExecutionContext();
+        QueryBuilder rewritten = query.rewrite(searchExecutionContext);
         assertThat(rewritten, sameInstance(query));
     }
 
@@ -563,16 +563,16 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
     @Override
     public void testCacheability() throws IOException {
         RangeQueryBuilder queryBuilder = createTestQueryBuilder();
-        QueryShardContext context = createShardContext();
-        QueryBuilder rewriteQuery = rewriteQuery(queryBuilder, new QueryShardContext(context));
+        SearchExecutionContext context = createSearchExecutionContext();
+        QueryBuilder rewriteQuery = rewriteQuery(queryBuilder, new SearchExecutionContext(context));
         assertNotNull(rewriteQuery.toQuery(context));
         assertTrue("query should be cacheable: " + queryBuilder.toString(), context.isCacheable());
 
         // queries on date fields using "now" should not be cached
         queryBuilder = new RangeQueryBuilder(randomFrom(DATE_FIELD_NAME, DATE_RANGE_FIELD_NAME, DATE_ALIAS_FIELD_NAME));
         queryBuilder.to("now");
-        context = createShardContext();
-        rewriteQuery = rewriteQuery(queryBuilder, new QueryShardContext(context));
+        context = createSearchExecutionContext();
+        rewriteQuery = rewriteQuery(queryBuilder, new SearchExecutionContext(context));
         assertNotNull(rewriteQuery.toQuery(context));
         assertFalse("query should not be cacheable: " + queryBuilder.toString(), context.isCacheable());
     }

--- a/server/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTests.java
@@ -242,7 +242,8 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
     }
 
     public void testToQueryNumericField() throws IOException {
-        Query parsedQuery = rangeQuery(INT_FIELD_NAME).from(23).to(54).includeLower(true).includeUpper(false).toQuery(createSearchExecutionContext());
+        Query parsedQuery = rangeQuery(INT_FIELD_NAME).from(23).to(54).includeLower(true).includeUpper(false)
+            .toQuery(createSearchExecutionContext());
         // since age is automatically registered in data, we encode it as numeric
         assertThat(parsedQuery, instanceOf(IndexOrDocValuesQuery.class));
         parsedQuery = ((IndexOrDocValuesQuery) parsedQuery).getIndexQuery();

--- a/server/src/test/java/org/elasticsearch/index/query/RangeQueryRewriteTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/RangeQueryRewriteTests.java
@@ -40,7 +40,7 @@ public class RangeQueryRewriteTests extends ESSingleNodeTestCase {
     public void testRewriteMissingField() throws Exception {
         IndexService indexService = createIndex("test");
         IndexReader reader = new MultiReader();
-        QueryRewriteContext context = new QueryShardContext(
+        QueryRewriteContext context = new SearchExecutionContext(
             0,
             0,
             indexService.getIndexSettings(),
@@ -76,7 +76,7 @@ public class RangeQueryRewriteTests extends ESSingleNodeTestCase {
             .endObject().endObject());
         indexService.mapperService().merge("type",
                 new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE);
-        QueryRewriteContext context = new QueryShardContext(0, 0, indexService.getIndexSettings(), null, null,
+        QueryRewriteContext context = new SearchExecutionContext(0, 0, indexService.getIndexSettings(), null, null,
             indexService.mapperService(), indexService.mapperService().mappingLookup(), null, null, xContentRegistry(), writableRegistry(),
                 null, null, null, null, null, () -> true, null, emptyMap());
         RangeQueryBuilder range = new RangeQueryBuilder("foo");
@@ -96,7 +96,7 @@ public class RangeQueryRewriteTests extends ESSingleNodeTestCase {
         indexService.mapperService().merge("type",
                 new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE);
         IndexReader reader = new MultiReader();
-        QueryRewriteContext context = new QueryShardContext(
+        QueryRewriteContext context = new SearchExecutionContext(
             0,
             0,
             indexService.getIndexSettings(),

--- a/server/src/test/java/org/elasticsearch/index/query/RegexpQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/RegexpQueryBuilderTests.java
@@ -79,7 +79,7 @@ public class RegexpQueryBuilderTests extends AbstractQueryTestCase<RegexpQueryBu
     }
 
     @Override
-    protected void doAssertLuceneQuery(RegexpQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
+    protected void doAssertLuceneQuery(RegexpQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
         assertThat(query, instanceOf(RegexpQuery.class));
         RegexpQuery regexpQuery = (RegexpQuery) query;
 
@@ -120,7 +120,7 @@ public class RegexpQueryBuilderTests extends AbstractQueryTestCase<RegexpQueryBu
 
     public void testNumeric() throws Exception {
         RegexpQueryBuilder query = new RegexpQueryBuilder(INT_FIELD_NAME, "12");
-        QueryShardContext context = createShardContext();
+        SearchExecutionContext context = createSearchExecutionContext();
         QueryShardException e = expectThrows(QueryShardException.class, () -> query.toQuery(context));
         assertEquals("Can only use regexp queries on keyword and text fields - not on [mapped_int] which is of type [integer]",
                 e.getMessage());

--- a/server/src/test/java/org/elasticsearch/index/query/ScriptQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/ScriptQueryBuilderTests.java
@@ -51,7 +51,7 @@ public class ScriptQueryBuilderTests extends AbstractQueryTestCase<ScriptQueryBu
     }
 
     @Override
-    protected void doAssertLuceneQuery(ScriptQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
+    protected void doAssertLuceneQuery(ScriptQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
         assertThat(query, instanceOf(ScriptQueryBuilder.ScriptQuery.class));
     }
 
@@ -126,19 +126,19 @@ public class ScriptQueryBuilderTests extends AbstractQueryTestCase<ScriptQueryBu
     @Override
     public void testCacheability() throws IOException {
         ScriptQueryBuilder queryBuilder = createTestQueryBuilder();
-        QueryShardContext context = createShardContext();
-        QueryBuilder rewriteQuery = rewriteQuery(queryBuilder, new QueryShardContext(context));
+        SearchExecutionContext context = createSearchExecutionContext();
+        QueryBuilder rewriteQuery = rewriteQuery(queryBuilder, new SearchExecutionContext(context));
         assertNotNull(rewriteQuery.toQuery(context));
         assertFalse("query should not be cacheable: " + queryBuilder.toString(), context.isCacheable());
     }
 
     public void testDisallowExpensiveQueries() {
-        QueryShardContext queryShardContext = mock(QueryShardContext.class);
-        when(queryShardContext.allowExpensiveQueries()).thenReturn(false);
+        SearchExecutionContext searchExecutionContext = mock(SearchExecutionContext.class);
+        when(searchExecutionContext.allowExpensiveQueries()).thenReturn(false);
 
         ScriptQueryBuilder queryBuilder = doCreateTestQueryBuilder();
         ElasticsearchException e = expectThrows(ElasticsearchException.class,
-                () -> queryBuilder.toQuery(queryShardContext));
+                () -> queryBuilder.toQuery(searchExecutionContext));
         assertEquals("[script] queries cannot be executed when 'search.allow_expensive_queries' is set to false.",
                 e.getMessage());
     }

--- a/server/src/test/java/org/elasticsearch/index/query/ScriptScoreQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/ScriptScoreQueryBuilderTests.java
@@ -51,7 +51,7 @@ public class ScriptScoreQueryBuilderTests extends AbstractQueryTestCase<ScriptSc
     }
 
     @Override
-    protected void doAssertLuceneQuery(ScriptScoreQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
+    protected void doAssertLuceneQuery(ScriptScoreQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
         Query wrappedQuery = queryBuilder.query().rewrite(context).toQuery(context);
         if (wrappedQuery instanceof MatchNoDocsQuery) {
             assertThat(query, instanceOf(MatchNoDocsQuery.class));
@@ -102,15 +102,15 @@ public class ScriptScoreQueryBuilderTests extends AbstractQueryTestCase<ScriptSc
         ScriptScoreQueryBuilder queryBuilder = new ScriptScoreQueryBuilder(
             new TermQueryBuilder(KEYWORD_FIELD_NAME, "value"), script);
 
-        QueryShardContext context = createShardContext();
-        QueryBuilder rewriteQuery = rewriteQuery(queryBuilder, new QueryShardContext(context));
+        SearchExecutionContext context = createSearchExecutionContext();
+        QueryBuilder rewriteQuery = rewriteQuery(queryBuilder, new SearchExecutionContext(context));
         assertNotNull(rewriteQuery.toQuery(context));
         assertTrue("query should be cacheable: " + queryBuilder.toString(), context.isCacheable());
     }
 
     @Override
     public void testMustRewrite() throws IOException {
-        QueryShardContext context = createShardContext();
+        SearchExecutionContext context = createSearchExecutionContext();
         context.setAllowUnmappedFields(true);
         TermQueryBuilder termQueryBuilder = new TermQueryBuilder("unmapped_field", "foo");
         String scriptStr = "1";
@@ -124,17 +124,17 @@ public class ScriptScoreQueryBuilderTests extends AbstractQueryTestCase<ScriptSc
     public void testRewriteToMatchNone() throws IOException {
         Script script = new Script(ScriptType.INLINE, MockScriptEngine.NAME, "1", Collections.emptyMap());
         ScriptScoreQueryBuilder builder = new ScriptScoreQueryBuilder(new TermQueryBuilder("unmapped_field", "value"), script);
-        QueryBuilder rewrite = builder.rewrite(createShardContext());
+        QueryBuilder rewrite = builder.rewrite(createSearchExecutionContext());
         assertThat(rewrite, instanceOf(MatchNoneQueryBuilder.class));
     }
 
     public void testDisallowExpensiveQueries() {
-        QueryShardContext queryShardContext = mock(QueryShardContext.class);
-        when(queryShardContext.allowExpensiveQueries()).thenReturn(false);
+        SearchExecutionContext searchExecutionContext = mock(SearchExecutionContext.class);
+        when(searchExecutionContext.allowExpensiveQueries()).thenReturn(false);
 
         ScriptScoreQueryBuilder queryBuilder = doCreateTestQueryBuilder();
         ElasticsearchException e = expectThrows(ElasticsearchException.class,
-                () -> queryBuilder.toQuery(queryShardContext));
+                () -> queryBuilder.toQuery(searchExecutionContext));
         assertEquals("[script score] queries cannot be executed when 'search.allow_expensive_queries' is set to false.",
                 e.getMessage());
     }

--- a/server/src/test/java/org/elasticsearch/index/query/ScriptScoreQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/ScriptScoreQueryBuilderTests.java
@@ -51,7 +51,8 @@ public class ScriptScoreQueryBuilderTests extends AbstractQueryTestCase<ScriptSc
     }
 
     @Override
-    protected void doAssertLuceneQuery(ScriptScoreQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
+    protected void doAssertLuceneQuery(ScriptScoreQueryBuilder queryBuilder, Query query,
+                                       SearchExecutionContext context) throws IOException {
         Query wrappedQuery = queryBuilder.query().rewrite(context).toQuery(context);
         if (wrappedQuery instanceof MatchNoDocsQuery) {
             assertThat(query, instanceOf(MatchNoDocsQuery.class));

--- a/server/src/test/java/org/elasticsearch/index/query/SimpleQueryStringBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/SimpleQueryStringBuilderTests.java
@@ -260,7 +260,7 @@ public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQ
      * actual functionality of query parsing.
      */
     @Override
-    protected void doAssertLuceneQuery(SimpleQueryStringBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
+    protected void doAssertLuceneQuery(SimpleQueryStringBuilder queryBuilder, Query query, SearchExecutionContext context) {
         assertThat(query, notNullValue());
 
         if (queryBuilder.value().isEmpty()) {

--- a/server/src/test/java/org/elasticsearch/index/query/SimpleQueryStringBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/SimpleQueryStringBuilderTests.java
@@ -180,20 +180,20 @@ public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQ
     // Check operator handling, and default field handling.
     public void testDefaultOperatorHandling() throws IOException {
         SimpleQueryStringBuilder qb = new SimpleQueryStringBuilder("The quick brown fox.").field(TEXT_FIELD_NAME);
-        QueryShardContext shardContext = createShardContext();
-        shardContext.setAllowUnmappedFields(true); // to avoid occasional cases
+        SearchExecutionContext searchExecutionContext = createSearchExecutionContext();
+        searchExecutionContext.setAllowUnmappedFields(true); // to avoid occasional cases
                                                    // in setup where we didn't
                                                    // add types but strict field
                                                    // resolution
-        BooleanQuery boolQuery = (BooleanQuery) qb.toQuery(shardContext);
+        BooleanQuery boolQuery = (BooleanQuery) qb.toQuery(searchExecutionContext);
         assertThat(shouldClauses(boolQuery), is(4));
 
         qb.defaultOperator(Operator.AND);
-        boolQuery = (BooleanQuery) qb.toQuery(shardContext);
+        boolQuery = (BooleanQuery) qb.toQuery(searchExecutionContext);
         assertThat(shouldClauses(boolQuery), is(0));
 
         qb.defaultOperator(Operator.OR);
-        boolQuery = (BooleanQuery) qb.toQuery(shardContext);
+        boolQuery = (BooleanQuery) qb.toQuery(searchExecutionContext);
         assertThat(shouldClauses(boolQuery), is(4));
     }
 
@@ -246,9 +246,9 @@ public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQ
         assertThat(queryBuilder.value(), equalTo(query));
         assertThat(queryBuilder.fields(), notNullValue());
         assertThat(queryBuilder.fields().size(), equalTo(0));
-        QueryShardContext shardContext = createShardContext();
+        SearchExecutionContext searchExecutionContext = createSearchExecutionContext();
 
-        Query luceneQuery = queryBuilder.toQuery(shardContext);
+        Query luceneQuery = queryBuilder.toQuery(searchExecutionContext);
         assertThat(luceneQuery, anyOf(instanceOf(BooleanQuery.class), instanceOf(DisjunctionMaxQuery.class)));
     }
 
@@ -260,7 +260,7 @@ public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQ
      * actual functionality of query parsing.
      */
     @Override
-    protected void doAssertLuceneQuery(SimpleQueryStringBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
+    protected void doAssertLuceneQuery(SimpleQueryStringBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
         assertThat(query, notNullValue());
 
         if (queryBuilder.value().isEmpty()) {
@@ -313,10 +313,10 @@ public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQ
     }
 
     public void testToQueryBoost() throws IOException {
-        QueryShardContext shardContext = createShardContext();
+        SearchExecutionContext searchExecutionContext = createSearchExecutionContext();
         SimpleQueryStringBuilder simpleQueryStringBuilder = new SimpleQueryStringBuilder("test");
         simpleQueryStringBuilder.field(TEXT_FIELD_NAME, 5);
-        Query query = simpleQueryStringBuilder.toQuery(shardContext);
+        Query query = simpleQueryStringBuilder.toQuery(searchExecutionContext);
         assertThat(query, instanceOf(BoostQuery.class));
         BoostQuery boostQuery = (BoostQuery) query;
         assertThat(boostQuery.getBoost(), equalTo(5f));
@@ -325,7 +325,7 @@ public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQ
         simpleQueryStringBuilder = new SimpleQueryStringBuilder("test");
         simpleQueryStringBuilder.field(TEXT_FIELD_NAME, 5);
         simpleQueryStringBuilder.boost(2);
-        query = simpleQueryStringBuilder.toQuery(shardContext);
+        query = simpleQueryStringBuilder.toQuery(searchExecutionContext);
         boostQuery = (BoostQuery) query;
         assertThat(boostQuery.getBoost(), equalTo(2f));
         assertThat(boostQuery.getQuery(), instanceOf(BoostQuery.class));
@@ -377,7 +377,7 @@ public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQ
     }
 
     public void testMinimumShouldMatch() throws IOException {
-        QueryShardContext shardContext = createShardContext();
+        SearchExecutionContext searchExecutionContext = createSearchExecutionContext();
         int numberOfTerms = randomIntBetween(1, 4);
         StringBuilder queryString = new StringBuilder();
         for (int i = 0; i < numberOfTerms; i++) {
@@ -393,7 +393,7 @@ public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQ
         }
         int percent = randomIntBetween(1, 100);
         simpleQueryStringBuilder.minimumShouldMatch(percent + "%");
-        Query query = simpleQueryStringBuilder.toQuery(shardContext);
+        Query query = simpleQueryStringBuilder.toQuery(searchExecutionContext);
 
         // check special case: one term & one field should get simplified to a TermQuery
         if (numberOfFields * numberOfTerms == 1) {
@@ -416,25 +416,25 @@ public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQ
         Query query = new SimpleQueryStringBuilder("aBc*")
                 .field(TEXT_FIELD_NAME)
                 .analyzer("whitespace")
-                .toQuery(createShardContext());
+                .toQuery(createSearchExecutionContext());
         assertEquals(new PrefixQuery(new Term(TEXT_FIELD_NAME, "aBc")), query);
         query = new SimpleQueryStringBuilder("aBc*")
                 .field(TEXT_FIELD_NAME)
                 .analyzer("standard")
-                .toQuery(createShardContext());
+                .toQuery(createSearchExecutionContext());
         assertEquals(new PrefixQuery(new Term(TEXT_FIELD_NAME, "abc")), query);
 
         // Fuzzy
         query = new SimpleQueryStringBuilder("aBc~1")
                 .field(TEXT_FIELD_NAME)
                 .analyzer("whitespace")
-                .toQuery(createShardContext());
+                .toQuery(createSearchExecutionContext());
         FuzzyQuery expected = new FuzzyQuery(new Term(TEXT_FIELD_NAME, "aBc"), 1);
         assertEquals(expected, query);
         query = new SimpleQueryStringBuilder("aBc~1")
                 .field(TEXT_FIELD_NAME)
                 .analyzer("standard")
-                .toQuery(createShardContext());
+                .toQuery(createSearchExecutionContext());
         expected = new FuzzyQuery(new Term(TEXT_FIELD_NAME, "abc"), 1);
         assertEquals(expected, query);
     }
@@ -443,7 +443,7 @@ public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQ
         SimpleQueryStringQueryParser.Settings settings = new SimpleQueryStringQueryParser.Settings();
         settings.analyzeWildcard(true);
         SimpleQueryStringQueryParser parser = new SimpleQueryStringQueryParser(new StandardAnalyzer(),
-            Collections.singletonMap(TEXT_FIELD_NAME, 1.0f), -1, settings, createShardContext());
+            Collections.singletonMap(TEXT_FIELD_NAME, 1.0f), -1, settings, createSearchExecutionContext());
         for (Operator op : Operator.values()) {
             BooleanClause.Occur defaultOp = op.toBooleanClauseOccur();
             parser.setDefaultOperator(defaultOp);
@@ -466,7 +466,7 @@ public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQ
         SimpleQueryStringQueryParser.Settings settings = new SimpleQueryStringQueryParser.Settings();
         settings.analyzeWildcard(true);
         SimpleQueryStringQueryParser parser = new SimpleQueryStringQueryParser(new MockRepeatAnalyzer(),
-            Collections.singletonMap(TEXT_FIELD_NAME, 1.0f), -1, settings, createShardContext());
+            Collections.singletonMap(TEXT_FIELD_NAME, 1.0f), -1, settings, createSearchExecutionContext());
         for (Operator op : Operator.values()) {
             BooleanClause.Occur defaultOp = op.toBooleanClauseOccur();
             parser.setDefaultOperator(defaultOp);
@@ -497,7 +497,7 @@ public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQ
         SimpleQueryStringQueryParser.Settings settings = new SimpleQueryStringQueryParser.Settings();
         settings.analyzeWildcard(true);
         SimpleQueryStringQueryParser parser = new SimpleQueryStringQueryParser(new MockSynonymAnalyzer(),
-            Collections.singletonMap(TEXT_FIELD_NAME, 1.0f), -1, settings, createShardContext());
+            Collections.singletonMap(TEXT_FIELD_NAME, 1.0f), -1, settings, createSearchExecutionContext());
         for (Operator op : Operator.values()) {
             BooleanClause.Occur defaultOp = op.toBooleanClauseOccur();
             parser.setDefaultOperator(defaultOp);
@@ -551,20 +551,20 @@ public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQ
         settings.analyzeWildcard(true);
         settings.quoteFieldSuffix("_2");
         SimpleQueryStringQueryParser parser = new SimpleQueryStringQueryParser(new MockSynonymAnalyzer(),
-            Collections.singletonMap(TEXT_FIELD_NAME, 1.0f), -1, settings, createShardContext());
+            Collections.singletonMap(TEXT_FIELD_NAME, 1.0f), -1, settings, createSearchExecutionContext());
         assertEquals(new TermQuery(new Term(TEXT_FIELD_NAME, "bar")), parser.parse("bar"));
         assertEquals(new TermQuery(new Term(KEYWORD_FIELD_NAME, "bar")), parser.parse("\"bar\""));
 
         // Now check what happens if the quote field does not exist
         settings.quoteFieldSuffix(".quote");
         parser = new SimpleQueryStringQueryParser(new MockSynonymAnalyzer(),
-            Collections.singletonMap(TEXT_FIELD_NAME, 1.0f), -1, settings, createShardContext());
+            Collections.singletonMap(TEXT_FIELD_NAME, 1.0f), -1, settings, createSearchExecutionContext());
         assertEquals(new TermQuery(new Term(TEXT_FIELD_NAME, "bar")), parser.parse("bar"));
         assertEquals(new TermQuery(new Term(TEXT_FIELD_NAME, "bar")), parser.parse("\"bar\""));
     }
 
     public void testDefaultField() throws Exception {
-        QueryShardContext context = createShardContext();
+        SearchExecutionContext context = createSearchExecutionContext();
         // default value `*` sets leniency to true
         Query query = new SimpleQueryStringBuilder("hello")
             .toQuery(context);
@@ -603,7 +603,7 @@ public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQ
     }
 
     public void testAllFieldsWildcard() throws Exception {
-        QueryShardContext context = createShardContext();
+        SearchExecutionContext context = createSearchExecutionContext();
         Query query = new SimpleQueryStringBuilder("hello")
             .field("*")
             .toQuery(context);
@@ -623,7 +623,7 @@ public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQ
             .fuzzyPrefixLength(2)
             .fuzzyMaxExpansions(5)
             .fuzzyTranspositions(false)
-            .toQuery(createShardContext());
+            .toQuery(createSearchExecutionContext());
         FuzzyQuery expected = new FuzzyQuery(new Term(TEXT_FIELD_NAME, "text"), 2, 2, 5, false);
         assertEquals(expected, query);
     }
@@ -633,7 +633,7 @@ public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQ
             .field(DATE_FIELD_NAME)
             .field(TEXT_FIELD_NAME)
             .lenient(true)
-            .toQuery(createShardContext());
+            .toQuery(createSearchExecutionContext());
         List<Query> expectedQueries = new ArrayList<>();
         expectedQueries.add(new MatchNoDocsQuery(""));
         expectedQueries.add(new PrefixQuery(new Term(TEXT_FIELD_NAME, "t")));
@@ -645,7 +645,7 @@ public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQ
         Query query = new SimpleQueryStringBuilder("the quick fox")
             .field(TEXT_FIELD_NAME)
             .analyzer("stop")
-            .toQuery(createShardContext());
+            .toQuery(createSearchExecutionContext());
         Query expected = new BooleanQuery.Builder()
             .add(new TermQuery(new Term(TEXT_FIELD_NAME, "quick")), BooleanClause.Occur.SHOULD)
             .add(new TermQuery(new Term(TEXT_FIELD_NAME, "fox")), BooleanClause.Occur.SHOULD)
@@ -656,7 +656,7 @@ public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQ
             .field(TEXT_FIELD_NAME)
             .field(KEYWORD_FIELD_NAME)
             .analyzer("stop")
-            .toQuery(createShardContext());
+            .toQuery(createSearchExecutionContext());
         expected = new BooleanQuery.Builder()
             .add(new DisjunctionMaxQuery(
                 Arrays.asList(
@@ -675,7 +675,7 @@ public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQ
             .field(TEXT_FIELD_NAME)
             .field(KEYWORD_FIELD_NAME)
             .analyzer("stop")
-            .toQuery(createShardContext());
+            .toQuery(createSearchExecutionContext());
         assertEquals(new MatchNoDocsQuery(), query);
 
         query = new BoolQueryBuilder()
@@ -684,7 +684,7 @@ public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQ
                     .field(TEXT_FIELD_NAME)
                     .analyzer("stop")
             )
-            .toQuery(createShardContext());
+            .toQuery(createSearchExecutionContext());
         expected = new BooleanQuery.Builder()
             .add(new MatchNoDocsQuery(), BooleanClause.Occur.SHOULD)
             .build();
@@ -697,7 +697,7 @@ public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQ
                     .field(KEYWORD_FIELD_NAME)
                     .analyzer("stop")
             )
-            .toQuery(createShardContext());
+            .toQuery(createSearchExecutionContext());
         assertEquals(expected, query);
     }
 
@@ -705,7 +705,7 @@ public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQ
         Query query = new SimpleQueryStringBuilder("the* quick fox")
             .field(TEXT_FIELD_NAME)
             .analyzer("stop")
-            .toQuery(createShardContext());
+            .toQuery(createSearchExecutionContext());
         BooleanQuery expected = new BooleanQuery.Builder()
             .add(new PrefixQuery(new Term(TEXT_FIELD_NAME, "the")), BooleanClause.Occur.SHOULD)
             .add(new TermQuery(new Term(TEXT_FIELD_NAME, "quick")), BooleanClause.Occur.SHOULD)
@@ -726,7 +726,7 @@ public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQ
                 .field("unmapped")
                 .field("another_unmapped")
                 .defaultOperator(Operator.AND)
-                .toQuery(createShardContext());
+                .toQuery(createSearchExecutionContext());
         BooleanQuery expected = new BooleanQuery.Builder()
                 .add(new TermQuery(new Term(TEXT_FIELD_NAME, "first")), BooleanClause.Occur.MUST)
                 .add(new TermQuery(new Term(TEXT_FIELD_NAME, "second")), BooleanClause.Occur.MUST)
@@ -736,7 +736,7 @@ public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQ
             .field("unmapped")
             .field("another_unmapped")
             .defaultOperator(Operator.AND)
-            .toQuery(createShardContext());
+            .toQuery(createSearchExecutionContext());
         expected = new BooleanQuery.Builder()
             .add(new MatchNoDocsQuery(), BooleanClause.Occur.MUST)
             .add(new MatchNoDocsQuery(), BooleanClause.Occur.MUST)
@@ -750,7 +750,7 @@ public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQ
             () -> new SimpleQueryStringBuilder("the quick fox")
                 .field(TEXT_FIELD_NAME, -1.0f)
                 .field(KEYWORD_FIELD_NAME)
-                .toQuery(createShardContext()));
+                .toQuery(createSearchExecutionContext()));
         assertThat(exc.getMessage(), containsString("negative [boost]"));
     }
 
@@ -797,14 +797,14 @@ public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQ
     }
 
     private void assertQueryCachability(SimpleQueryStringBuilder qb, boolean cachingExpected) throws IOException {
-        QueryShardContext context = createShardContext();
+        SearchExecutionContext context = createSearchExecutionContext();
         assert context.isCacheable();
         /*
          * We use a private rewrite context here since we want the most realistic way of asserting that we are cacheable or not. We do it
          * this way in SearchService where we first rewrite the query with a private context, then reset the context and then build the
          * actual lucene query
          */
-        QueryBuilder rewritten = rewriteQuery(qb, new QueryShardContext(context));
+        QueryBuilder rewritten = rewriteQuery(qb, new SearchExecutionContext(context));
         assertNotNull(rewritten.toQuery(context));
         assertEquals("query should " + (cachingExpected ? "" : "not") + " be cacheable: " + qb.toString(), cachingExpected,
                 context.isCacheable());
@@ -812,7 +812,7 @@ public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQ
 
     public void testLenientFlag() throws Exception {
         SimpleQueryStringBuilder query = new SimpleQueryStringBuilder("test").field(BINARY_FIELD_NAME);
-        QueryShardContext context = createShardContext();
+        SearchExecutionContext context = createSearchExecutionContext();
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> query.toQuery(context));
         assertEquals("Field [mapped_binary] of type [binary] does not support match queries", e.getMessage());
         query.lenient(true);

--- a/server/src/test/java/org/elasticsearch/index/query/SpanContainingQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/SpanContainingQueryBuilderTests.java
@@ -37,7 +37,7 @@ public class SpanContainingQueryBuilderTests extends AbstractQueryTestCase<SpanC
     }
 
     @Override
-    protected void doAssertLuceneQuery(SpanContainingQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
+    protected void doAssertLuceneQuery(SpanContainingQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
         assertThat(query, instanceOf(SpanContainingQuery.class));
     }
 

--- a/server/src/test/java/org/elasticsearch/index/query/SpanContainingQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/SpanContainingQueryBuilderTests.java
@@ -37,7 +37,7 @@ public class SpanContainingQueryBuilderTests extends AbstractQueryTestCase<SpanC
     }
 
     @Override
-    protected void doAssertLuceneQuery(SpanContainingQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
+    protected void doAssertLuceneQuery(SpanContainingQueryBuilder queryBuilder, Query query, SearchExecutionContext context) {
         assertThat(query, instanceOf(SpanContainingQuery.class));
     }
 

--- a/server/src/test/java/org/elasticsearch/index/query/SpanFirstQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/SpanFirstQueryBuilderTests.java
@@ -41,7 +41,7 @@ public class SpanFirstQueryBuilderTests extends AbstractQueryTestCase<SpanFirstQ
     }
 
     @Override
-    protected void doAssertLuceneQuery(SpanFirstQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
+    protected void doAssertLuceneQuery(SpanFirstQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
         assertThat(query, instanceOf(SpanFirstQuery.class));
     }
 

--- a/server/src/test/java/org/elasticsearch/index/query/SpanGapQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/SpanGapQueryBuilderTests.java
@@ -58,7 +58,7 @@ public class SpanGapQueryBuilderTests extends AbstractQueryTestCase<SpanNearQuer
     }
 
     @Override
-    protected void doAssertLuceneQuery(SpanNearQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
+    protected void doAssertLuceneQuery(SpanNearQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
         assertThat(query, either(instanceOf(SpanNearQuery.class))
             .or(instanceOf(SpanTermQuery.class))
             .or(instanceOf(SpanBoostQuery.class))

--- a/server/src/test/java/org/elasticsearch/index/query/SpanMultiTermQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/SpanMultiTermQueryBuilderTests.java
@@ -85,7 +85,7 @@ public class SpanMultiTermQueryBuilderTests extends AbstractQueryTestCase<SpanMu
     }
 
     @Override
-    protected void doAssertLuceneQuery(SpanMultiTermQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
+    protected void doAssertLuceneQuery(SpanMultiTermQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
         if (query instanceof SpanMatchNoDocsQuery) {
             return;
         }
@@ -118,7 +118,7 @@ public class SpanMultiTermQueryBuilderTests extends AbstractQueryTestCase<SpanMu
 
     private static class TermMultiTermQueryBuilder implements MultiTermQueryBuilder {
         @Override
-        public Query toQuery(QueryShardContext context) throws IOException {
+        public Query toQuery(SearchExecutionContext context) throws IOException {
             return new TermQuery(new Term("foo", "bar"));
         }
 
@@ -178,19 +178,19 @@ public class SpanMultiTermQueryBuilderTests extends AbstractQueryTestCase<SpanMu
         MultiTermQueryBuilder query = new TermMultiTermQueryBuilder();
         SpanMultiTermQueryBuilder spanMultiTermQuery = new SpanMultiTermQueryBuilder(query);
         UnsupportedOperationException e = expectThrows(UnsupportedOperationException.class,
-                () -> spanMultiTermQuery.toQuery(createShardContext()));
+                () -> spanMultiTermQuery.toQuery(createSearchExecutionContext()));
         assertThat(e.getMessage(), startsWith("unsupported inner query"));
     }
 
     public void testToQueryInnerSpanMultiTerm() throws IOException {
-        Query query = new SpanOrQueryBuilder(createTestQueryBuilder()).toQuery(createShardContext());
+        Query query = new SpanOrQueryBuilder(createTestQueryBuilder()).toQuery(createSearchExecutionContext());
         //verify that the result is still a span query, despite the boost that might get set (SpanBoostQuery rather than BoostQuery)
         assertThat(query, instanceOf(SpanQuery.class));
     }
 
     public void testToQueryInnerTermQuery() throws IOException {
         String fieldName = randomFrom("prefix_field", "prefix_field_alias");
-        final QueryShardContext context = createShardContext();
+        final SearchExecutionContext context = createSearchExecutionContext();
         {
             Query query = new SpanMultiTermQueryBuilder(new PrefixQueryBuilder(fieldName, "foo")).toQuery(context);
             assertThat(query, instanceOf(FieldMaskingSpanQuery.class));
@@ -243,7 +243,7 @@ public class SpanMultiTermQueryBuilderTests extends AbstractQueryTestCase<SpanMu
 
     public void testDefaultMaxRewriteBuilder() throws Exception {
         Query query = QueryBuilders.spanMultiTermQueryBuilder(QueryBuilders.prefixQuery("body", "b"))
-            .toQuery(createShardContext());
+            .toQuery(createSearchExecutionContext());
 
         assertTrue(query instanceof SpanMultiTermQueryWrapper);
         if (query instanceof SpanMultiTermQueryWrapper) {
@@ -265,7 +265,7 @@ public class SpanMultiTermQueryBuilderTests extends AbstractQueryTestCase<SpanMu
                         QueryBuilder queryBuilder = new SpanMultiTermQueryBuilder(
                             QueryBuilders.prefixQuery("body", "bar")
                         );
-                        Query query = queryBuilder.toQuery(createShardContext(new IndexSearcher(reader)));
+                        Query query = queryBuilder.toQuery(createSearchExecutionContext(new IndexSearcher(reader)));
                         RuntimeException exc = expectThrows(RuntimeException.class, () -> query.rewrite(reader));
                         assertThat(exc.getMessage(), containsString("maxClauseCount"));
                     } finally {
@@ -279,7 +279,7 @@ public class SpanMultiTermQueryBuilderTests extends AbstractQueryTestCase<SpanMu
     public void testTopNMultiTermsRewriteInsideSpan() throws Exception {
         Query query = QueryBuilders.spanMultiTermQueryBuilder(
             QueryBuilders.prefixQuery("body", "b").rewrite("top_terms_boost_2000")
-        ).toQuery(createShardContext());
+        ).toQuery(createSearchExecutionContext());
 
         assertTrue(query instanceof SpanMultiTermQueryWrapper);
         if (query instanceof SpanMultiTermQueryWrapper) {

--- a/server/src/test/java/org/elasticsearch/index/query/SpanMultiTermQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/SpanMultiTermQueryBuilderTests.java
@@ -85,7 +85,8 @@ public class SpanMultiTermQueryBuilderTests extends AbstractQueryTestCase<SpanMu
     }
 
     @Override
-    protected void doAssertLuceneQuery(SpanMultiTermQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
+    protected void doAssertLuceneQuery(SpanMultiTermQueryBuilder queryBuilder, Query query,
+                                       SearchExecutionContext context) throws IOException {
         if (query instanceof SpanMatchNoDocsQuery) {
             return;
         }

--- a/server/src/test/java/org/elasticsearch/index/query/SpanNearQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/SpanNearQueryBuilderTests.java
@@ -49,7 +49,7 @@ public class SpanNearQueryBuilderTests extends AbstractQueryTestCase<SpanNearQue
     }
 
     @Override
-    protected void doAssertLuceneQuery(SpanNearQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
+    protected void doAssertLuceneQuery(SpanNearQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
         assertThat(query, either(instanceOf(SpanNearQuery.class))
             .or(instanceOf(SpanTermQuery.class))
             .or(instanceOf(SpanBoostQuery.class))

--- a/server/src/test/java/org/elasticsearch/index/query/SpanNotQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/SpanNotQueryBuilderTests.java
@@ -55,7 +55,7 @@ public class SpanNotQueryBuilderTests extends AbstractQueryTestCase<SpanNotQuery
     }
 
     @Override
-    protected void doAssertLuceneQuery(SpanNotQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
+    protected void doAssertLuceneQuery(SpanNotQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
         assertThat(query, instanceOf(SpanNotQuery.class));
         SpanNotQuery spanNotQuery = (SpanNotQuery) query;
         assertThat(spanNotQuery.getExclude(), equalTo(queryBuilder.excludeQuery().toQuery(context)));

--- a/server/src/test/java/org/elasticsearch/index/query/SpanOrQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/SpanOrQueryBuilderTests.java
@@ -43,7 +43,7 @@ public class SpanOrQueryBuilderTests extends AbstractQueryTestCase<SpanOrQueryBu
     }
 
     @Override
-    protected void doAssertLuceneQuery(SpanOrQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
+    protected void doAssertLuceneQuery(SpanOrQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
         assertThat(query, instanceOf(SpanOrQuery.class));
         SpanOrQuery spanOrQuery = (SpanOrQuery) query;
         assertThat(spanOrQuery.getClauses().length, equalTo(queryBuilder.clauses().size()));

--- a/server/src/test/java/org/elasticsearch/index/query/SpanTermQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/SpanTermQueryBuilderTests.java
@@ -58,7 +58,7 @@ public class SpanTermQueryBuilderTests extends AbstractTermQueryTestCase<SpanTer
     }
 
     @Override
-    protected void doAssertLuceneQuery(SpanTermQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
+    protected void doAssertLuceneQuery(SpanTermQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
         assertThat(query, instanceOf(SpanTermQuery.class));
         SpanTermQuery spanTermQuery = (SpanTermQuery) query;
 
@@ -126,7 +126,7 @@ public class SpanTermQueryBuilderTests extends AbstractTermQueryTestCase<SpanTer
     }
 
     public void testWithMetadataField() throws IOException {
-        QueryShardContext context = createShardContext();
+        SearchExecutionContext context = createSearchExecutionContext();
         for (String field : new String[]{"field1", "field2"}) {
             SpanTermQueryBuilder spanTermQueryBuilder = new SpanTermQueryBuilder(field, "toto");
             Query query = spanTermQueryBuilder.toQuery(context);

--- a/server/src/test/java/org/elasticsearch/index/query/SpanWithinQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/SpanWithinQueryBuilderTests.java
@@ -37,7 +37,7 @@ public class SpanWithinQueryBuilderTests extends AbstractQueryTestCase<SpanWithi
     }
 
     @Override
-    protected void doAssertLuceneQuery(SpanWithinQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
+    protected void doAssertLuceneQuery(SpanWithinQueryBuilder queryBuilder, Query query, SearchExecutionContext context) {
         assertThat(query, instanceOf(SpanWithinQuery.class));
     }
 

--- a/server/src/test/java/org/elasticsearch/index/query/SpanWithinQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/SpanWithinQueryBuilderTests.java
@@ -37,7 +37,7 @@ public class SpanWithinQueryBuilderTests extends AbstractQueryTestCase<SpanWithi
     }
 
     @Override
-    protected void doAssertLuceneQuery(SpanWithinQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
+    protected void doAssertLuceneQuery(SpanWithinQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
         assertThat(query, instanceOf(SpanWithinQuery.class));
     }
 

--- a/server/src/test/java/org/elasticsearch/index/query/TermQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/TermQueryBuilderTests.java
@@ -93,7 +93,7 @@ public class TermQueryBuilderTests extends AbstractTermQueryTestCase<TermQueryBu
     }
 
     @Override
-    protected void doAssertLuceneQuery(TermQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
+    protected void doAssertLuceneQuery(TermQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
         assertThat(query, either(instanceOf(TermQuery.class)).or(instanceOf(PointRangeQuery.class)).or(instanceOf(MatchNoDocsQuery.class))
             .or(instanceOf(AutomatonQuery.class)));
         MappedFieldType mapper = context.getFieldType(queryBuilder.fieldName());
@@ -148,7 +148,7 @@ public class TermQueryBuilderTests extends AbstractTermQueryTestCase<TermQueryBu
 
     public void testGeo() throws Exception {
         TermQueryBuilder query = new TermQueryBuilder(GEO_POINT_FIELD_NAME, "2,3");
-        QueryShardContext context = createShardContext();
+        SearchExecutionContext context = createSearchExecutionContext();
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> query.toQuery(context));
         assertEquals("Geometry fields do not support exact searching, "
                 + "use dedicated geometry queries instead: [mapped_geo_point]", e.getMessage());
@@ -192,27 +192,27 @@ public class TermQueryBuilderTests extends AbstractTermQueryTestCase<TermQueryBu
 
     public void testTypeField() throws IOException {
         TermQueryBuilder builder = QueryBuilders.termQuery("_type", "value1");
-        builder.doToQuery(createShardContext());
+        builder.doToQuery(createSearchExecutionContext());
         assertWarnings(TypeFieldType.TYPES_V7_DEPRECATION_MESSAGE);
     }
 
     public void testRewriteIndexQueryToMatchNone() throws IOException {
         TermQueryBuilder query = QueryBuilders.termQuery("_index", "does_not_exist");
-        QueryShardContext queryShardContext = createShardContext();
-        QueryBuilder rewritten = query.rewrite(queryShardContext);
+        SearchExecutionContext searchExecutionContext = createSearchExecutionContext();
+        QueryBuilder rewritten = query.rewrite(searchExecutionContext);
         assertThat(rewritten, instanceOf(MatchNoneQueryBuilder.class));
     }
 
     public void testRewriteIndexQueryToNotMatchNone() throws IOException {
         TermQueryBuilder query = QueryBuilders.termQuery("_index", getIndex().getName());
-        QueryShardContext queryShardContext = createShardContext();
-        QueryBuilder rewritten = query.rewrite(queryShardContext);
+        SearchExecutionContext searchExecutionContext = createSearchExecutionContext();
+        QueryBuilder rewritten = query.rewrite(searchExecutionContext);
         assertThat(rewritten, instanceOf(MatchAllQueryBuilder.class));
     }
 
     @Override
     public void testMustRewrite() throws IOException {
-        QueryShardContext context = createShardContext();
+        SearchExecutionContext context = createSearchExecutionContext();
         context.setAllowUnmappedFields(true);
         TermQueryBuilder queryBuilder = new TermQueryBuilder("unmapped_field", "foo");
         IllegalStateException e = expectThrows(IllegalStateException.class,

--- a/server/src/test/java/org/elasticsearch/index/query/TermsSetQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/TermsSetQueryBuilderTests.java
@@ -100,7 +100,7 @@ public class TermsSetQueryBuilderTests extends AbstractQueryTestCase<TermsSetQue
     }
 
     @Override
-    protected void doAssertLuceneQuery(TermsSetQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
+    protected void doAssertLuceneQuery(TermsSetQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
         if (queryBuilder.getValues().isEmpty()) {
             assertThat(query, instanceOf(MatchNoDocsQuery.class));
             MatchNoDocsQuery matchNoDocsQuery = (MatchNoDocsQuery) query;
@@ -118,8 +118,8 @@ public class TermsSetQueryBuilderTests extends AbstractQueryTestCase<TermsSetQue
         TermsSetQueryBuilder queryBuilder = createTestQueryBuilder();
         boolean isCacheable = queryBuilder.getMinimumShouldMatchField() != null ||
                 (queryBuilder.getMinimumShouldMatchScript() != null && queryBuilder.getValues().isEmpty());
-        QueryShardContext context = createShardContext();
-        rewriteQuery(queryBuilder, new QueryShardContext(context));
+        SearchExecutionContext context = createSearchExecutionContext();
+        rewriteQuery(queryBuilder, new SearchExecutionContext(context));
         assertNotNull(queryBuilder.doToQuery(context));
         assertEquals("query should " + (isCacheable ? "" : "not") + " be cacheable: " + queryBuilder.toString(), isCacheable,
                 context.isCacheable());
@@ -127,23 +127,23 @@ public class TermsSetQueryBuilderTests extends AbstractQueryTestCase<TermsSetQue
         // specifically trigger the two cases where query is cacheable
         queryBuilder = new TermsSetQueryBuilder(TEXT_FIELD_NAME, Collections.singletonList("foo"));
         queryBuilder.setMinimumShouldMatchField("m_s_m");
-        context = createShardContext();
-        rewriteQuery(queryBuilder, new QueryShardContext(context));
+        context = createSearchExecutionContext();
+        rewriteQuery(queryBuilder, new SearchExecutionContext(context));
         assertNotNull(queryBuilder.doToQuery(context));
         assertTrue("query should be cacheable: " + queryBuilder.toString(), context.isCacheable());
 
         queryBuilder = new TermsSetQueryBuilder(TEXT_FIELD_NAME, Collections.emptyList());
         queryBuilder.setMinimumShouldMatchScript(new Script(ScriptType.INLINE, MockScriptEngine.NAME, "_script", emptyMap()));
-        context = createShardContext();
-        rewriteQuery(queryBuilder, new QueryShardContext(context));
+        context = createSearchExecutionContext();
+        rewriteQuery(queryBuilder, new SearchExecutionContext(context));
         assertNotNull(queryBuilder.doToQuery(context));
         assertTrue("query should be cacheable: " + queryBuilder.toString(), context.isCacheable());
 
         // also test one case where query is not cacheable
         queryBuilder = new TermsSetQueryBuilder(TEXT_FIELD_NAME, Collections.singletonList("foo"));
         queryBuilder.setMinimumShouldMatchScript(new Script(ScriptType.INLINE, MockScriptEngine.NAME, "_script", emptyMap()));
-        context = createShardContext();
-        rewriteQuery(queryBuilder, new QueryShardContext(context));
+        context = createSearchExecutionContext();
+        rewriteQuery(queryBuilder, new SearchExecutionContext(context));
         assertNotNull(queryBuilder.doToQuery(context));
         assertFalse("query should be cacheable: " + queryBuilder.toString(), context.isCacheable());
     }
@@ -231,7 +231,7 @@ public class TermsSetQueryBuilderTests extends AbstractQueryTestCase<TermsSetQue
             }
 
             try (IndexReader ir = DirectoryReader.open(directory)) {
-                QueryShardContext context = createShardContext();
+                SearchExecutionContext context = createSearchExecutionContext();
                 Query query = new TermsSetQueryBuilder("message", Arrays.asList("c", "d"))
                         .setMinimumShouldMatchField("m_s_m").doToQuery(context);
                 IndexSearcher searcher = new IndexSearcher(ir);
@@ -276,7 +276,7 @@ public class TermsSetQueryBuilderTests extends AbstractQueryTestCase<TermsSetQue
             }
 
             try (IndexReader ir = DirectoryReader.open(directory)) {
-                QueryShardContext context = createShardContext();
+                SearchExecutionContext context = createSearchExecutionContext();
                 Script script = new Script(ScriptType.INLINE, MockScriptEngine.NAME, "_script", emptyMap());
                 Query query = new TermsSetQueryBuilder("message", Arrays.asList("a", "b", "c", "d"))
                         .setMinimumShouldMatchScript(script).doToQuery(context);
@@ -295,7 +295,7 @@ public class TermsSetQueryBuilderTests extends AbstractQueryTestCase<TermsSetQue
         TermsSetQueryBuilder queryBuilder = new TermsSetQueryBuilder(TEXT_ALIAS_FIELD_NAME, randomTerms)
             .setMinimumShouldMatchField("m_s_m");
 
-        QueryShardContext context = createShardContext();
+        SearchExecutionContext context = createSearchExecutionContext();
         List<Query> termQueries = queryBuilder.createTermQueries(context);
         assertEquals(randomTerms.size(), termQueries.size());
 

--- a/server/src/test/java/org/elasticsearch/index/query/WildcardQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/WildcardQueryBuilderTests.java
@@ -69,7 +69,7 @@ public class WildcardQueryBuilderTests extends AbstractQueryTestCase<WildcardQue
     }
 
     @Override
-    protected void doAssertLuceneQuery(WildcardQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
+    protected void doAssertLuceneQuery(WildcardQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
         String expectedFieldName = expectedFieldName(queryBuilder.fieldName());
 
         if (expectedFieldName.equals(TEXT_FIELD_NAME)) {
@@ -102,7 +102,7 @@ public class WildcardQueryBuilderTests extends AbstractQueryTestCase<WildcardQue
     }
 
     public void testEmptyValue() throws IOException {
-        QueryShardContext context = createShardContext();
+        SearchExecutionContext context = createSearchExecutionContext();
         context.setAllowUnmappedFields(true);
         WildcardQueryBuilder wildcardQueryBuilder = new WildcardQueryBuilder(TEXT_FIELD_NAME, "");
         assertEquals(wildcardQueryBuilder.toQuery(context).getClass(), WildcardQuery.class);
@@ -147,14 +147,14 @@ public class WildcardQueryBuilderTests extends AbstractQueryTestCase<WildcardQue
 
     public void testTypeField() throws IOException {
         WildcardQueryBuilder builder = QueryBuilders.wildcardQuery("_type", "doc*");
-        builder.doToQuery(createShardContext());
+        builder.doToQuery(createSearchExecutionContext());
         assertWarnings(TypeFieldType.TYPES_V7_DEPRECATION_MESSAGE);
     }
 
     public void testRewriteIndexQueryToMatchNone() throws IOException {
         WildcardQueryBuilder query = new WildcardQueryBuilder("_index", "does_not_exist");
-        QueryShardContext queryShardContext = createShardContext();
-        QueryBuilder rewritten = query.rewrite(queryShardContext);
+        SearchExecutionContext searchExecutionContext = createSearchExecutionContext();
+        QueryBuilder rewritten = query.rewrite(searchExecutionContext);
         assertThat(rewritten, instanceOf(MatchNoneQueryBuilder.class));
     }
 
@@ -162,14 +162,14 @@ public class WildcardQueryBuilderTests extends AbstractQueryTestCase<WildcardQue
         String fullIndexName = getIndex().getName();
         String firstHalfOfIndexName = fullIndexName.substring(0,fullIndexName.length()/2);
         WildcardQueryBuilder query = new WildcardQueryBuilder("_index", firstHalfOfIndexName +"*");
-        QueryShardContext queryShardContext = createShardContext();
-        QueryBuilder rewritten = query.rewrite(queryShardContext);
+        SearchExecutionContext searchExecutionContext = createSearchExecutionContext();
+        QueryBuilder rewritten = query.rewrite(searchExecutionContext);
         assertThat(rewritten, instanceOf(MatchAllQueryBuilder.class));
     }
 
     @Override
     public void testMustRewrite() throws IOException {
-        QueryShardContext context = createShardContext();
+        SearchExecutionContext context = createSearchExecutionContext();
         context.setAllowUnmappedFields(true);
         WildcardQueryBuilder queryBuilder = new WildcardQueryBuilder("unmapped_field", "foo");
         IllegalStateException e = expectThrows(IllegalStateException.class,

--- a/server/src/test/java/org/elasticsearch/index/query/WrapperQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/WrapperQueryBuilderTests.java
@@ -76,8 +76,8 @@ public class WrapperQueryBuilderTests extends AbstractQueryTestCase<WrapperQuery
     }
 
     @Override
-    protected void doAssertLuceneQuery(WrapperQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
-        QueryBuilder innerQuery = queryBuilder.rewrite(createShardContext());
+    protected void doAssertLuceneQuery(WrapperQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
+        QueryBuilder innerQuery = queryBuilder.rewrite(createSearchExecutionContext());
         Query expected = rewrite(innerQuery.toQuery(context));
         assertEquals(rewrite(query), expected);
     }
@@ -126,46 +126,46 @@ public class WrapperQueryBuilderTests extends AbstractQueryTestCase<WrapperQuery
     public void testMustRewrite() throws IOException {
         TermQueryBuilder tqb = new TermQueryBuilder(TEXT_FIELD_NAME, "bar");
         WrapperQueryBuilder qb = new WrapperQueryBuilder(tqb.toString());
-        UnsupportedOperationException e = expectThrows(UnsupportedOperationException.class, () -> qb.toQuery(createShardContext()));
+        UnsupportedOperationException e = expectThrows(UnsupportedOperationException.class, () -> qb.toQuery(createSearchExecutionContext()));
         assertEquals("this query must be rewritten first", e.getMessage());
-        QueryBuilder rewrite = qb.rewrite(createShardContext());
+        QueryBuilder rewrite = qb.rewrite(createSearchExecutionContext());
         assertEquals(tqb, rewrite);
     }
 
     public void testRewriteWithInnerName() throws IOException {
         QueryBuilder builder = new WrapperQueryBuilder("{ \"match_all\" : {\"_name\" : \"foobar\"}}");
-        QueryShardContext shardContext = createShardContext();
-        assertEquals(new MatchAllQueryBuilder().queryName("foobar"), builder.rewrite(shardContext));
+        SearchExecutionContext searchExecutionContext = createSearchExecutionContext();
+        assertEquals(new MatchAllQueryBuilder().queryName("foobar"), builder.rewrite(searchExecutionContext));
         builder = new WrapperQueryBuilder("{ \"match_all\" : {\"_name\" : \"foobar\"}}").queryName("outer");
         assertEquals(new BoolQueryBuilder().must(new MatchAllQueryBuilder().queryName("foobar")).queryName("outer"),
-            builder.rewrite(shardContext));
+            builder.rewrite(searchExecutionContext));
     }
 
     public void testRewriteWithInnerBoost() throws IOException {
         final TermQueryBuilder query = new TermQueryBuilder(TEXT_FIELD_NAME, "bar").boost(2);
         QueryBuilder builder = new WrapperQueryBuilder(query.toString());
-        QueryShardContext shardContext = createShardContext();
-        assertEquals(query, builder.rewrite(shardContext));
+        SearchExecutionContext searchExecutionContext = createSearchExecutionContext();
+        assertEquals(query, builder.rewrite(searchExecutionContext));
         builder = new WrapperQueryBuilder(query.toString()).boost(3);
-        assertEquals(new BoolQueryBuilder().must(query).boost(3), builder.rewrite(shardContext));
+        assertEquals(new BoolQueryBuilder().must(query).boost(3), builder.rewrite(searchExecutionContext));
     }
 
     public void testRewriteInnerQueryToo() throws IOException {
-        QueryShardContext shardContext = createShardContext();
+        SearchExecutionContext searchExecutionContext = createSearchExecutionContext();
 
         QueryBuilder qb = new WrapperQueryBuilder(
             new WrapperQueryBuilder(new TermQueryBuilder(TEXT_FIELD_NAME, "bar").toString()).toString()
         );
-        assertEquals(new TermQuery(new Term(TEXT_FIELD_NAME, "bar")), qb.rewrite(shardContext).toQuery(shardContext));
+        assertEquals(new TermQuery(new Term(TEXT_FIELD_NAME, "bar")), qb.rewrite(searchExecutionContext).toQuery(searchExecutionContext));
         qb = new WrapperQueryBuilder(
             new WrapperQueryBuilder(
                 new WrapperQueryBuilder(new TermQueryBuilder(TEXT_FIELD_NAME, "bar").toString()).toString()
             ).toString()
         );
-        assertEquals(new TermQuery(new Term(TEXT_FIELD_NAME, "bar")), qb.rewrite(shardContext).toQuery(shardContext));
+        assertEquals(new TermQuery(new Term(TEXT_FIELD_NAME, "bar")), qb.rewrite(searchExecutionContext).toQuery(searchExecutionContext));
 
         qb = new WrapperQueryBuilder(new BoolQueryBuilder().toString());
-        assertEquals(new MatchAllDocsQuery(), qb.rewrite(shardContext).toQuery(shardContext));
+        assertEquals(new MatchAllDocsQuery(), qb.rewrite(searchExecutionContext).toQuery(searchExecutionContext));
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/query/WrapperQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/WrapperQueryBuilderTests.java
@@ -126,7 +126,8 @@ public class WrapperQueryBuilderTests extends AbstractQueryTestCase<WrapperQuery
     public void testMustRewrite() throws IOException {
         TermQueryBuilder tqb = new TermQueryBuilder(TEXT_FIELD_NAME, "bar");
         WrapperQueryBuilder qb = new WrapperQueryBuilder(tqb.toString());
-        UnsupportedOperationException e = expectThrows(UnsupportedOperationException.class, () -> qb.toQuery(createSearchExecutionContext()));
+        UnsupportedOperationException e = expectThrows(UnsupportedOperationException.class,
+            () -> qb.toQuery(createSearchExecutionContext()));
         assertEquals("this query must be rewritten first", e.getMessage());
         QueryBuilder rewrite = qb.rewrite(createSearchExecutionContext());
         assertEquals(tqb, rewrite);

--- a/server/src/test/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilderTests.java
@@ -43,7 +43,7 @@ import org.elasticsearch.index.mapper.SeqNoFieldMapper;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.MatchNoneQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.RandomQueryBuilder;
 import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.index.query.WrapperQueryBuilder;
@@ -255,7 +255,7 @@ public class FunctionScoreQueryBuilderTests extends AbstractQueryTestCase<Functi
     }
 
     @Override
-    protected void doAssertLuceneQuery(FunctionScoreQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
+    protected void doAssertLuceneQuery(FunctionScoreQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
         Query wrappedQuery = queryBuilder.query().rewrite(context).toQuery(context);
         if (wrappedQuery instanceof MatchNoDocsQuery) {
             assertThat(query, CoreMatchers.instanceOf(MatchNoDocsQuery.class));
@@ -511,7 +511,7 @@ public class FunctionScoreQueryBuilderTests extends AbstractQueryTestCase<Functi
         assertThat(fieldValueFactorFunctionBuilder.getWeight(), equalTo(1f));
         assertThat(fieldValueFactorFunctionBuilder.missing(), nullValue());
 
-        Query luceneQuery = query.toQuery(createShardContext());
+        Query luceneQuery = query.toQuery(createSearchExecutionContext());
         assertThat(luceneQuery, instanceOf(FunctionScoreQuery.class));
         FunctionScoreQuery functionScoreQuery = (FunctionScoreQuery) luceneQuery;
         assertThat(functionScoreQuery.getFunctions().length, equalTo(1));
@@ -560,7 +560,7 @@ public class FunctionScoreQueryBuilderTests extends AbstractQueryTestCase<Functi
     }
 
     public void testCustomWeightFactorQueryBuilderWithFunctionScore() throws IOException {
-        QueryShardContext context = createShardContext();
+        SearchExecutionContext context = createSearchExecutionContext();
         Query parsedQuery = parseQuery(functionScoreQuery(termQuery(KEYWORD_FIELD_NAME, "banon"), weightFactorFunction(1.3f)))
                 .rewrite(context).toQuery(context);
         assertThat(parsedQuery, instanceOf(FunctionScoreQuery.class));
@@ -570,7 +570,7 @@ public class FunctionScoreQueryBuilderTests extends AbstractQueryTestCase<Functi
     }
 
     public void testCustomWeightFactorQueryBuilderWithFunctionScoreWithoutQueryGiven() throws IOException {
-        Query parsedQuery = parseQuery(functionScoreQuery(weightFactorFunction(1.3f))).toQuery(createShardContext());
+        Query parsedQuery = parseQuery(functionScoreQuery(weightFactorFunction(1.3f))).toQuery(createSearchExecutionContext());
         assertThat(parsedQuery, instanceOf(FunctionScoreQuery.class));
         FunctionScoreQuery functionScoreQuery = (FunctionScoreQuery) parsedQuery;
         assertThat(functionScoreQuery.getSubQuery() instanceof MatchAllDocsQuery, equalTo(true));
@@ -656,7 +656,7 @@ public class FunctionScoreQueryBuilderTests extends AbstractQueryTestCase<Functi
                 .scoreMode(FunctionScoreQuery.ScoreMode.SUM)
                 .setMinScore(1)
                 .maxBoost(100);
-        FunctionScoreQueryBuilder rewrite = (FunctionScoreQueryBuilder) functionScoreQueryBuilder.rewrite(createShardContext());
+        FunctionScoreQueryBuilder rewrite = (FunctionScoreQueryBuilder) functionScoreQueryBuilder.rewrite(createSearchExecutionContext());
         assertNotSame(functionScoreQueryBuilder, rewrite);
         assertEquals(rewrite.query(), new TermQueryBuilder(TEXT_FIELD_NAME, "bar"));
         assertEquals(rewrite.boostMode(), CombineFunction.REPLACE);
@@ -674,7 +674,7 @@ public class FunctionScoreQueryBuilderTests extends AbstractQueryTestCase<Functi
                 new FunctionScoreQueryBuilder.FilterFunctionBuilder[] {
                         new FunctionScoreQueryBuilder.FilterFunctionBuilder(firstFunction, new RandomScoreFunctionBuilder()),
                         new FunctionScoreQueryBuilder.FilterFunctionBuilder(secondFunction, new RandomScoreFunctionBuilder()) });
-        FunctionScoreQueryBuilder rewrite = (FunctionScoreQueryBuilder) functionScoreQueryBuilder.rewrite(createShardContext());
+        FunctionScoreQueryBuilder rewrite = (FunctionScoreQueryBuilder) functionScoreQueryBuilder.rewrite(createSearchExecutionContext());
         assertNotSame(functionScoreQueryBuilder, rewrite);
         assertEquals(rewrite.query(), new TermQueryBuilder(TEXT_FIELD_NAME, "bar"));
         assertEquals(rewrite.filterFunctionBuilders()[0].getFilter(), new TermQueryBuilder(KEYWORD_FIELD_NAME, "1"));
@@ -689,7 +689,7 @@ public class FunctionScoreQueryBuilderTests extends AbstractQueryTestCase<Functi
                 .setMinScore(1)
                 .maxBoost(100);
 
-        QueryBuilder rewrite = functionScoreQueryBuilder.rewrite(createShardContext());
+        QueryBuilder rewrite = functionScoreQueryBuilder.rewrite(createSearchExecutionContext());
         assertThat(rewrite, instanceOf(MatchNoneQueryBuilder.class));
     }
 
@@ -706,8 +706,8 @@ public class FunctionScoreQueryBuilderTests extends AbstractQueryTestCase<Functi
             builder.boostMode(randomFrom(CombineFunction.values()));
         }
 
-        QueryShardContext shardContext = createShardContext();
-        Query query = builder.rewrite(shardContext).toQuery(shardContext);
+        SearchExecutionContext searchExecutionContext = createSearchExecutionContext();
+        Query query = builder.rewrite(searchExecutionContext).toQuery(searchExecutionContext);
         assertThat(query, instanceOf(FunctionScoreQuery.class));
 
         CombineFunction expectedBoostMode = builder.boostMode() != null
@@ -827,8 +827,8 @@ public class FunctionScoreQueryBuilderTests extends AbstractQueryTestCase<Functi
     public void testCacheability() throws IOException {
         FunctionScoreQueryBuilder queryBuilder = createTestQueryBuilder();
         boolean isCacheable = isCacheable(queryBuilder);
-        QueryShardContext context = createShardContext();
-        QueryBuilder rewriteQuery = rewriteQuery(queryBuilder, new QueryShardContext(context));
+        SearchExecutionContext context = createSearchExecutionContext();
+        QueryBuilder rewriteQuery = rewriteQuery(queryBuilder, new SearchExecutionContext(context));
         assertNotNull(rewriteQuery.toQuery(context));
         // we occasionally need to update the expected "isCacheable" flag after rewrite for MatchNoneQueryBuilder
         if (rewriteQuery instanceof MatchNoneQueryBuilder) {
@@ -841,16 +841,16 @@ public class FunctionScoreQueryBuilderTests extends AbstractQueryTestCase<Functi
                 new Script(ScriptType.INLINE, MockScriptEngine.NAME, "1", Collections.emptyMap()));
         queryBuilder = new FunctionScoreQueryBuilder(new FilterFunctionBuilder[] {
             new FilterFunctionBuilder(RandomQueryBuilder.createQuery(random()), scriptScoreFunction) });
-        context = createShardContext();
-        rewriteQuery = rewriteQuery(queryBuilder, new QueryShardContext(context));
+        context = createSearchExecutionContext();
+        rewriteQuery = rewriteQuery(queryBuilder, new SearchExecutionContext(context));
         assertNotNull(rewriteQuery.toQuery(context));
         assertTrue("function script query should be cacheable" + queryBuilder.toString(), context.isCacheable());
 
         RandomScoreFunctionBuilder randomScoreFunctionBuilder = new RandomScoreFunctionBuilderWithFixedSeed();
         queryBuilder = new FunctionScoreQueryBuilder(new FilterFunctionBuilder[] {
             new FilterFunctionBuilder(RandomQueryBuilder.createQuery(random()), randomScoreFunctionBuilder) });
-        context = createShardContext();
-        rewriteQuery = rewriteQuery(queryBuilder, new QueryShardContext(context));
+        context = createSearchExecutionContext();
+        rewriteQuery = rewriteQuery(queryBuilder, new SearchExecutionContext(context));
         assertNotNull(rewriteQuery.toQuery(context));
         assertFalse("function random query should not be cacheable: " + queryBuilder.toString(), context.isCacheable());
     }
@@ -868,7 +868,7 @@ public class FunctionScoreQueryBuilderTests extends AbstractQueryTestCase<Functi
 
     @Override
     public void testMustRewrite() throws IOException {
-        QueryShardContext context = createShardContext();
+        SearchExecutionContext context = createSearchExecutionContext();
         context.setAllowUnmappedFields(true);
         TermQueryBuilder termQueryBuilder = new TermQueryBuilder("unmapped_field", "foo");
 

--- a/server/src/test/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilderTests.java
@@ -255,7 +255,8 @@ public class FunctionScoreQueryBuilderTests extends AbstractQueryTestCase<Functi
     }
 
     @Override
-    protected void doAssertLuceneQuery(FunctionScoreQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
+    protected void doAssertLuceneQuery(FunctionScoreQueryBuilder queryBuilder, Query query,
+                                       SearchExecutionContext context) throws IOException {
         Query wrappedQuery = queryBuilder.query().rewrite(context).toQuery(context);
         if (wrappedQuery instanceof MatchNoDocsQuery) {
             assertThat(query, CoreMatchers.instanceOf(MatchNoDocsQuery.class));

--- a/server/src/test/java/org/elasticsearch/index/query/functionscore/ScoreFunctionBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/functionscore/ScoreFunctionBuilderTests.java
@@ -28,7 +28,7 @@ import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.mapper.NumberFieldMapper.NumberType;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.test.ESTestCase;
 import org.mockito.Mockito;
@@ -54,7 +54,7 @@ public class ScoreFunctionBuilderTests extends ESTestCase {
     public void testRandomScoreFunctionWithSeedNoField() throws Exception {
         RandomScoreFunctionBuilder builder = new RandomScoreFunctionBuilder();
         builder.seed(42);
-        QueryShardContext context = Mockito.mock(QueryShardContext.class);
+        SearchExecutionContext context = Mockito.mock(SearchExecutionContext.class);
         Settings indexSettings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
                 .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1).build();
         IndexSettings settings = new IndexSettings(IndexMetadata.builder("index").settings(indexSettings).build(), Settings.EMPTY);
@@ -71,7 +71,7 @@ public class ScoreFunctionBuilderTests extends ESTestCase {
         RandomScoreFunctionBuilder builder = new RandomScoreFunctionBuilder();
         builder.setField("foo");
         builder.seed(42);
-        QueryShardContext context = Mockito.mock(QueryShardContext.class);
+        SearchExecutionContext context = Mockito.mock(SearchExecutionContext.class);
         Settings indexSettings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
             .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1).build();
         IndexSettings settings = new IndexSettings(IndexMetadata.builder("index").settings(indexSettings).build(), Settings.EMPTY);

--- a/server/src/test/java/org/elasticsearch/index/query/plugin/DummyQueryBuilder.java
+++ b/server/src/test/java/org/elasticsearch/index/query/plugin/DummyQueryBuilder.java
@@ -25,7 +25,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.query.AbstractQueryBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.plugin.DummyQueryParserPlugin.DummyQuery;
 
 import java.io.IOException;
@@ -57,7 +57,7 @@ public class DummyQueryBuilder extends AbstractQueryBuilder<DummyQueryBuilder> {
     }
 
     @Override
-    protected Query doToQuery(QueryShardContext context) throws IOException {
+    protected Query doToQuery(SearchExecutionContext context) throws IOException {
         return new DummyQuery();
     }
 

--- a/server/src/test/java/org/elasticsearch/index/search/MultiMatchQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/index/search/MultiMatchQueryTests.java
@@ -42,7 +42,7 @@ import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MockFieldMapper.FakeFieldType;
 import org.elasticsearch.index.query.MultiMatchQueryBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.search.MultiMatchQuery.FieldAndBoost;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESSingleNodeTestCase;
@@ -99,7 +99,7 @@ public class MultiMatchQueryTests extends ESSingleNodeTestCase {
     }
 
     public void testCrossFieldMultiMatchQuery() throws IOException {
-        QueryShardContext queryShardContext = indexService.newQueryShardContext(
+        SearchExecutionContext searchExecutionContext = indexService.newSearchExecutionContext(
                 randomInt(20),
             0,
             null,
@@ -107,7 +107,7 @@ public class MultiMatchQueryTests extends ESSingleNodeTestCase {
             null,
             emptyMap()
         );
-        queryShardContext.setAllowUnmappedFields(true);
+        searchExecutionContext.setAllowUnmappedFields(true);
         for (float tieBreaker : new float[] {0.0f, 0.5f}) {
             Query parsedQuery = multiMatchQuery("banon")
                 .field("name.first", 2)
@@ -115,7 +115,7 @@ public class MultiMatchQueryTests extends ESSingleNodeTestCase {
                 .field("foobar")
                 .type(MultiMatchQueryBuilder.Type.CROSS_FIELDS)
                 .tieBreaker(tieBreaker)
-                .toQuery(queryShardContext);
+                .toQuery(searchExecutionContext);
             try (Engine.Searcher searcher = indexService.getShard(0).acquireSearcher("test")) {
                 Query rewrittenQuery = searcher.rewrite(parsedQuery);
                 Query tq1 = new BoostQuery(new TermQuery(new Term("name.last", "banon")), 3);
@@ -133,7 +133,7 @@ public class MultiMatchQueryTests extends ESSingleNodeTestCase {
         float[] boosts = new float[] {2, 3};
         Query expected = BlendedTermQuery.dismaxBlendedQuery(terms, boosts, 1.0f);
         Query actual = MultiMatchQuery.blendTerm(
-            indexService.newQueryShardContext(
+            indexService.newSearchExecutionContext(
                 randomInt(20),
                 0,
                 null,
@@ -153,7 +153,7 @@ public class MultiMatchQueryTests extends ESSingleNodeTestCase {
         FakeFieldType ft1 = new FakeFieldType("foo");
         FakeFieldType ft2 = new FakeFieldType("bar") {
             @Override
-            public Query termQuery(Object value, QueryShardContext context) {
+            public Query termQuery(Object value, SearchExecutionContext context) {
                 throw new IllegalArgumentException();
             }
         };
@@ -164,7 +164,7 @@ public class MultiMatchQueryTests extends ESSingleNodeTestCase {
             BlendedTermQuery.dismaxBlendedQuery(terms, boosts, 1.0f)
         ), 1f);
         Query actual = MultiMatchQuery.blendTerm(
-            indexService.newQueryShardContext(
+            indexService.newSearchExecutionContext(
                 randomInt(20),
                 0,
                 null,
@@ -183,12 +183,12 @@ public class MultiMatchQueryTests extends ESSingleNodeTestCase {
     public void testBlendTermsUnsupportedValueWithoutLenient() {
         FakeFieldType ft = new FakeFieldType("bar") {
             @Override
-            public Query termQuery(Object value, QueryShardContext context) {
+            public Query termQuery(Object value, SearchExecutionContext context) {
                 throw new IllegalArgumentException();
             }
         };
         expectThrows(IllegalArgumentException.class, () -> MultiMatchQuery.blendTerm(
-            indexService.newQueryShardContext(
+            indexService.newSearchExecutionContext(
                 randomInt(20),
                 0,
                 null,
@@ -203,7 +203,7 @@ public class MultiMatchQueryTests extends ESSingleNodeTestCase {
         FakeFieldType ft1 = new FakeFieldType("foo");
         FakeFieldType ft2 = new FakeFieldType("bar") {
             @Override
-            public Query termQuery(Object value, QueryShardContext context) {
+            public Query termQuery(Object value, SearchExecutionContext context) {
                 return new MatchAllDocsQuery();
             }
         };
@@ -217,7 +217,7 @@ public class MultiMatchQueryTests extends ESSingleNodeTestCase {
                 expectedDisjunct1
             ), 1.0f);
         Query actual = MultiMatchQuery.blendTerm(
-            indexService.newQueryShardContext(
+            indexService.newSearchExecutionContext(
                 randomInt(20),
                 0,
                 null,
@@ -234,7 +234,7 @@ public class MultiMatchQueryTests extends ESSingleNodeTestCase {
     }
 
     public void testMultiMatchCrossFieldsWithSynonyms() throws IOException {
-        QueryShardContext queryShardContext = indexService.newQueryShardContext(
+        SearchExecutionContext searchExecutionContext = indexService.newSearchExecutionContext(
             randomInt(20),
             0,
             null,
@@ -243,7 +243,7 @@ public class MultiMatchQueryTests extends ESSingleNodeTestCase {
             emptyMap()
         );
 
-        MultiMatchQuery parser = new MultiMatchQuery(queryShardContext);
+        MultiMatchQuery parser = new MultiMatchQuery(searchExecutionContext);
         parser.setAnalyzer(new MockSynonymAnalyzer());
         Map<String, Float> fieldNames = new HashMap<>();
         fieldNames.put("name.first", 1.0f);
@@ -272,7 +272,7 @@ public class MultiMatchQueryTests extends ESSingleNodeTestCase {
     }
 
     public void testMultiMatchCrossFieldsWithSynonymsPhrase() throws IOException {
-        QueryShardContext queryShardContext = indexService.newQueryShardContext(
+        SearchExecutionContext searchExecutionContext = indexService.newSearchExecutionContext(
             randomInt(20),
             0,
             null,
@@ -280,7 +280,7 @@ public class MultiMatchQueryTests extends ESSingleNodeTestCase {
             null,
             emptyMap()
         );
-        MultiMatchQuery parser = new MultiMatchQuery(queryShardContext);
+        MultiMatchQuery parser = new MultiMatchQuery(searchExecutionContext);
         parser.setAnalyzer(new MockSynonymAnalyzer());
         Map<String, Float> fieldNames = new HashMap<>();
         fieldNames.put("name.first", 1.0f);
@@ -345,14 +345,14 @@ public class MultiMatchQueryTests extends ESSingleNodeTestCase {
                 .endObject()
             .endObject().endObject());
         mapperService.merge("type", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
-        QueryShardContext queryShardContext = indexService.newQueryShardContext(
+        SearchExecutionContext searchExecutionContext = indexService.newSearchExecutionContext(
             randomInt(20),
             0,
             null, () -> { throw new UnsupportedOperationException(); },
             null,
             emptyMap()
         );
-        MultiMatchQuery parser = new MultiMatchQuery(queryShardContext);
+        MultiMatchQuery parser = new MultiMatchQuery(searchExecutionContext);
         Map<String, Float> fieldNames = new HashMap<>();
         fieldNames.put("field", 1.0f);
         fieldNames.put("field_split", 1.0f);

--- a/server/src/test/java/org/elasticsearch/index/search/NestedHelperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/search/NestedHelperTests.java
@@ -36,7 +36,7 @@ import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.NestedQueryBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 
@@ -184,7 +184,7 @@ public class NestedHelperTests extends ESSingleNodeTestCase {
     }
 
     public void testRangeQuery() {
-        QueryShardContext context = createSearchContext(indexService).getQueryShardContext();
+        SearchExecutionContext context = createSearchContext(indexService).getSearchExecutionContext();
         Query rangeQuery = mapperService.fieldType("foo2").rangeQuery(2, 5, true, true, null, null, null, context);
         assertFalse(buildNestedHelper(mapperService).mightMatchNestedDocs(rangeQuery));
         assertTrue(buildNestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested1"));
@@ -335,7 +335,7 @@ public class NestedHelperTests extends ESSingleNodeTestCase {
     }
 
     public void testNested() throws IOException {
-        QueryShardContext context = indexService.newQueryShardContext(
+        SearchExecutionContext context = indexService.newSearchExecutionContext(
             0,
             0,
             new IndexSearcher(new MultiReader()),

--- a/server/src/test/java/org/elasticsearch/index/search/nested/NestedSortingTests.java
+++ b/server/src/test/java/org/elasticsearch/index/search/nested/NestedSortingTests.java
@@ -792,7 +792,8 @@ public class NestedSortingTests extends AbstractFieldDataTestCase {
         searcher.getIndexReader().close();
     }
 
-    private static TopFieldDocs search(QueryBuilder queryBuilder, FieldSortBuilder sortBuilder, SearchExecutionContext searchExecutionContext,
+    private static TopFieldDocs search(QueryBuilder queryBuilder, FieldSortBuilder sortBuilder,
+                                       SearchExecutionContext searchExecutionContext,
                                        IndexSearcher searcher) throws IOException {
         Query query = new BooleanQuery.Builder()
             .add(queryBuilder.toQuery(searchExecutionContext), Occur.MUST)

--- a/server/src/test/java/org/elasticsearch/index/search/nested/NestedSortingTests.java
+++ b/server/src/test/java/org/elasticsearch/index/search/nested/NestedSortingTests.java
@@ -58,7 +58,7 @@ import org.elasticsearch.index.fielddata.plain.PagedBytesIndexFieldData;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.NestedQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.index.shard.ShardId;
@@ -608,12 +608,12 @@ public class NestedSortingTests extends AbstractFieldDataTestCase {
         DirectoryReader reader = DirectoryReader.open(writer);
         reader = ElasticsearchDirectoryReader.wrap(reader, new ShardId(indexService.index(), 0));
         IndexSearcher searcher = new IndexSearcher(reader);
-        QueryShardContext queryShardContext = indexService.newQueryShardContext(0, 0, searcher, () -> 0L, null, emptyMap());
+        SearchExecutionContext searchExecutionContext = indexService.newSearchExecutionContext(0, 0, searcher, () -> 0L, null, emptyMap());
 
         FieldSortBuilder sortBuilder = new FieldSortBuilder("chapters.paragraphs.word_count");
         sortBuilder.setNestedSort(new NestedSortBuilder("chapters").setNestedSort(new NestedSortBuilder("chapters.paragraphs")));
         QueryBuilder queryBuilder = new MatchAllQueryBuilder();
-        TopFieldDocs topFields = search(queryBuilder, sortBuilder, queryShardContext, searcher);
+        TopFieldDocs topFields = search(queryBuilder, sortBuilder, searchExecutionContext, searcher);
         assertThat(topFields.totalHits.value, equalTo(5L));
         assertThat(searcher.doc(topFields.scoreDocs[0].doc).get("_id"), equalTo("2"));
         assertThat(((FieldDoc) topFields.scoreDocs[0]).fields[0], equalTo(76L));
@@ -629,25 +629,25 @@ public class NestedSortingTests extends AbstractFieldDataTestCase {
         // Specific genre
         {
             queryBuilder = new TermQueryBuilder("genre", "romance");
-            topFields = search(queryBuilder, sortBuilder, queryShardContext, searcher);
+            topFields = search(queryBuilder, sortBuilder, searchExecutionContext, searcher);
             assertThat(topFields.totalHits.value, equalTo(1L));
             assertThat(searcher.doc(topFields.scoreDocs[0].doc).get("_id"), equalTo("2"));
             assertThat(((FieldDoc) topFields.scoreDocs[0]).fields[0], equalTo(76L));
 
             queryBuilder = new TermQueryBuilder("genre", "science fiction");
-            topFields = search(queryBuilder, sortBuilder, queryShardContext, searcher);
+            topFields = search(queryBuilder, sortBuilder, searchExecutionContext, searcher);
             assertThat(topFields.totalHits.value, equalTo(1L));
             assertThat(searcher.doc(topFields.scoreDocs[0].doc).get("_id"), equalTo("1"));
             assertThat(((FieldDoc) topFields.scoreDocs[0]).fields[0], equalTo(234L));
 
             queryBuilder = new TermQueryBuilder("genre", "horror");
-            topFields = search(queryBuilder, sortBuilder, queryShardContext, searcher);
+            topFields = search(queryBuilder, sortBuilder, searchExecutionContext, searcher);
             assertThat(topFields.totalHits.value, equalTo(1L));
             assertThat(searcher.doc(topFields.scoreDocs[0].doc).get("_id"), equalTo("3"));
             assertThat(((FieldDoc) topFields.scoreDocs[0]).fields[0], equalTo(976L));
 
             queryBuilder = new TermQueryBuilder("genre", "cooking");
-            topFields = search(queryBuilder, sortBuilder, queryShardContext, searcher);
+            topFields = search(queryBuilder, sortBuilder, searchExecutionContext, searcher);
             assertThat(topFields.totalHits.value, equalTo(1L));
             assertThat(searcher.doc(topFields.scoreDocs[0].doc).get("_id"), equalTo("4"));
             assertThat(((FieldDoc) topFields.scoreDocs[0]).fields[0], equalTo(87L));
@@ -657,7 +657,7 @@ public class NestedSortingTests extends AbstractFieldDataTestCase {
         {
             sortBuilder.order(SortOrder.DESC);
             queryBuilder = new MatchAllQueryBuilder();
-            topFields = search(queryBuilder, sortBuilder, queryShardContext, searcher);
+            topFields = search(queryBuilder, sortBuilder, searchExecutionContext, searcher);
             assertThat(topFields.totalHits.value, equalTo(5L));
             assertThat(searcher.doc(topFields.scoreDocs[0].doc).get("_id"), equalTo("3"));
             assertThat(((FieldDoc) topFields.scoreDocs[0]).fields[0], equalTo(976L));
@@ -674,25 +674,25 @@ public class NestedSortingTests extends AbstractFieldDataTestCase {
         // Specific genre and reverse sort order
         {
             queryBuilder = new TermQueryBuilder("genre", "romance");
-            topFields = search(queryBuilder, sortBuilder, queryShardContext, searcher);
+            topFields = search(queryBuilder, sortBuilder, searchExecutionContext, searcher);
             assertThat(topFields.totalHits.value, equalTo(1L));
             assertThat(searcher.doc(topFields.scoreDocs[0].doc).get("_id"), equalTo("2"));
             assertThat(((FieldDoc) topFields.scoreDocs[0]).fields[0], equalTo(76L));
 
             queryBuilder = new TermQueryBuilder("genre", "science fiction");
-            topFields = search(queryBuilder, sortBuilder, queryShardContext, searcher);
+            topFields = search(queryBuilder, sortBuilder, searchExecutionContext, searcher);
             assertThat(topFields.totalHits.value, equalTo(1L));
             assertThat(searcher.doc(topFields.scoreDocs[0].doc).get("_id"), equalTo("1"));
             assertThat(((FieldDoc) topFields.scoreDocs[0]).fields[0], equalTo(849L));
 
             queryBuilder = new TermQueryBuilder("genre", "horror");
-            topFields = search(queryBuilder, sortBuilder, queryShardContext, searcher);
+            topFields = search(queryBuilder, sortBuilder, searchExecutionContext, searcher);
             assertThat(topFields.totalHits.value, equalTo(1L));
             assertThat(searcher.doc(topFields.scoreDocs[0].doc).get("_id"), equalTo("3"));
             assertThat(((FieldDoc) topFields.scoreDocs[0]).fields[0], equalTo(976L));
 
             queryBuilder = new TermQueryBuilder("genre", "cooking");
-            topFields = search(queryBuilder, sortBuilder, queryShardContext, searcher);
+            topFields = search(queryBuilder, sortBuilder, searchExecutionContext, searcher);
             assertThat(topFields.totalHits.value, equalTo(1L));
             assertThat(searcher.doc(topFields.scoreDocs[0].doc).get("_id"), equalTo("4"));
             assertThat(((FieldDoc) topFields.scoreDocs[0]).fields[0], equalTo(180L));
@@ -708,7 +708,7 @@ public class NestedSortingTests extends AbstractFieldDataTestCase {
                     .setNestedSort(new NestedSortBuilder("chapters.paragraphs"))
             );
             topFields = search(new NestedQueryBuilder("chapters", queryBuilder, ScoreMode.None),
-                sortBuilder, queryShardContext, searcher);
+                sortBuilder, searchExecutionContext, searcher);
             assertThat(topFields.totalHits.value, equalTo(2L));
             assertThat(searcher.doc(topFields.scoreDocs[0].doc).get("_id"), equalTo("2"));
             assertThat(((FieldDoc) topFields.scoreDocs[0]).fields[0], equalTo(76L));
@@ -717,7 +717,7 @@ public class NestedSortingTests extends AbstractFieldDataTestCase {
 
             sortBuilder.order(SortOrder.DESC);
             topFields = search(new NestedQueryBuilder("chapters", queryBuilder, ScoreMode.None),
-                sortBuilder, queryShardContext, searcher);
+                sortBuilder, searchExecutionContext, searcher);
             assertThat(topFields.totalHits.value, equalTo(2L));
             assertThat(searcher.doc(topFields.scoreDocs[0].doc).get("_id"), equalTo("4"));
             assertThat(((FieldDoc) topFields.scoreDocs[0]).fields[0], equalTo(87L));
@@ -738,7 +738,7 @@ public class NestedSortingTests extends AbstractFieldDataTestCase {
                     )
             );
             topFields = search(new NestedQueryBuilder("chapters", queryBuilder, ScoreMode.None),
-                sortBuilder, queryShardContext, searcher);
+                sortBuilder, searchExecutionContext, searcher);
             assertThat(topFields.totalHits.value, equalTo(2L));
             assertThat(searcher.doc(topFields.scoreDocs[0].doc).get("_id"), equalTo("4"));
             assertThat(((FieldDoc) topFields.scoreDocs[0]).fields[0], equalTo(87L));
@@ -747,7 +747,7 @@ public class NestedSortingTests extends AbstractFieldDataTestCase {
 
             sortBuilder.order(SortOrder.DESC);
             topFields = search(new NestedQueryBuilder("chapters", queryBuilder, ScoreMode.None),
-                sortBuilder, queryShardContext, searcher);
+                sortBuilder, searchExecutionContext, searcher);
             assertThat(topFields.totalHits.value, equalTo(2L));
             assertThat(searcher.doc(topFields.scoreDocs[0].doc).get("_id"), equalTo("4"));
             assertThat(((FieldDoc) topFields.scoreDocs[0]).fields[0], equalTo(87L));
@@ -765,25 +765,25 @@ public class NestedSortingTests extends AbstractFieldDataTestCase {
             );
 
             queryBuilder = new TermQueryBuilder("genre", "romance");
-            topFields = search(queryBuilder, sortBuilder, queryShardContext, searcher);
+            topFields = search(queryBuilder, sortBuilder, searchExecutionContext, searcher);
             assertThat(topFields.totalHits.value, equalTo(1L));
             assertThat(searcher.doc(topFields.scoreDocs[0].doc).get("_id"), equalTo("2"));
             assertThat(((FieldDoc) topFields.scoreDocs[0]).fields[0], equalTo(76L));
 
             queryBuilder = new TermQueryBuilder("genre", "science fiction");
-            topFields = search(queryBuilder, sortBuilder, queryShardContext, searcher);
+            topFields = search(queryBuilder, sortBuilder, searchExecutionContext, searcher);
             assertThat(topFields.totalHits.value, equalTo(1L));
             assertThat(searcher.doc(topFields.scoreDocs[0].doc).get("_id"), equalTo("1"));
             assertThat(((FieldDoc) topFields.scoreDocs[0]).fields[0], equalTo(Long.MAX_VALUE));
 
             queryBuilder = new TermQueryBuilder("genre", "horror");
-            topFields = search(queryBuilder, sortBuilder, queryShardContext, searcher);
+            topFields = search(queryBuilder, sortBuilder, searchExecutionContext, searcher);
             assertThat(topFields.totalHits.value, equalTo(1L));
             assertThat(searcher.doc(topFields.scoreDocs[0].doc).get("_id"), equalTo("3"));
             assertThat(((FieldDoc) topFields.scoreDocs[0]).fields[0], equalTo(Long.MAX_VALUE));
 
             queryBuilder = new TermQueryBuilder("genre", "cooking");
-            topFields = search(queryBuilder, sortBuilder, queryShardContext, searcher);
+            topFields = search(queryBuilder, sortBuilder, searchExecutionContext, searcher);
             assertThat(topFields.totalHits.value, equalTo(1L));
             assertThat(searcher.doc(topFields.scoreDocs[0].doc).get("_id"), equalTo("4"));
             assertThat(((FieldDoc) topFields.scoreDocs[0]).fields[0], equalTo(87L));
@@ -792,13 +792,13 @@ public class NestedSortingTests extends AbstractFieldDataTestCase {
         searcher.getIndexReader().close();
     }
 
-    private static TopFieldDocs search(QueryBuilder queryBuilder, FieldSortBuilder sortBuilder, QueryShardContext queryShardContext,
+    private static TopFieldDocs search(QueryBuilder queryBuilder, FieldSortBuilder sortBuilder, SearchExecutionContext searchExecutionContext,
                                        IndexSearcher searcher) throws IOException {
         Query query = new BooleanQuery.Builder()
-            .add(queryBuilder.toQuery(queryShardContext), Occur.MUST)
+            .add(queryBuilder.toQuery(searchExecutionContext), Occur.MUST)
             .add(Queries.newNonNestedFilter(), Occur.FILTER)
             .build();
-        Sort sort = new Sort(sortBuilder.build(queryShardContext).field);
+        Sort sort = new Sort(sortBuilder.build(searchExecutionContext).field);
         return searcher.search(query, 10, sort);
     }
 

--- a/server/src/test/java/org/elasticsearch/index/shard/SearchOperationListenerTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/SearchOperationListenerTests.java
@@ -18,7 +18,7 @@
  */
 package org.elasticsearch.index.shard;
 
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.internal.ReaderContext;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.test.ESTestCase;
@@ -140,7 +140,7 @@ public class SearchOperationListenerTests extends ESTestCase {
         Collections.shuffle(indexingOperationListeners, random());
         SearchOperationListener.CompositeListener compositeListener =
             new SearchOperationListener.CompositeListener(indexingOperationListeners, logger);
-        SearchContext ctx = new TestSearchContext((QueryShardContext) null);
+        SearchContext ctx = new TestSearchContext((SearchExecutionContext) null);
         compositeListener.onQueryPhase(ctx, timeInNanos.get());
         assertEquals(0, preFetch.get());
         assertEquals(0, preQuery.get());

--- a/server/src/test/java/org/elasticsearch/search/DefaultSearchContextTests.java
+++ b/server/src/test/java/org/elasticsearch/search/DefaultSearchContextTests.java
@@ -43,7 +43,7 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.AbstractQueryBuilder;
 import org.elasticsearch.index.query.ParsedQuery;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.search.internal.AliasFilter;
@@ -105,9 +105,9 @@ public class DefaultSearchContextTests extends ESTestCase {
         QueryCache queryCache = mock(QueryCache.class);
         when(indexCache.query()).thenReturn(queryCache);
         when(indexService.cache()).thenReturn(indexCache);
-        QueryShardContext queryShardContext = mock(QueryShardContext.class);
-        when(indexService.newQueryShardContext(eq(shardId.id()), eq(shardId.id()), anyObject(), anyObject(), anyString(), anyObject()))
-            .thenReturn(queryShardContext);
+        SearchExecutionContext searchExecutionContext = mock(SearchExecutionContext.class);
+        when(indexService.newSearchExecutionContext(eq(shardId.id()), eq(shardId.id()), anyObject(), anyObject(), anyString(), anyObject()))
+            .thenReturn(searchExecutionContext);
         MapperService mapperService = mock(MapperService.class);
         when(mapperService.hasNested()).thenReturn(randomBoolean());
         when(indexService.mapperService()).thenReturn(mapperService);
@@ -215,8 +215,8 @@ public class DefaultSearchContextTests extends ESTestCase {
             context3.sliceBuilder(null).parsedQuery(parsedQuery).preProcess(false);
             assertEquals(context3.query(), context3.buildFilteredQuery(parsedQuery.query()));
 
-            when(queryShardContext.getIndexSettings()).thenReturn(indexSettings);
-            when(queryShardContext.getFieldType(anyString())).thenReturn(mock(MappedFieldType.class));
+            when(searchExecutionContext.getIndexSettings()).thenReturn(indexSettings);
+            when(searchExecutionContext.getFieldType(anyString())).thenReturn(mock(MappedFieldType.class));
 
             readerContext.close();
             readerContext = new ReaderContext(newContextId(), indexService, indexShard,

--- a/server/src/test/java/org/elasticsearch/search/SearchModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchModuleTests.java
@@ -29,7 +29,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryRewriteContext;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.index.query.functionscore.GaussDecayFunctionBuilder;
 import org.elasticsearch.plugins.SearchPlugin;
@@ -500,7 +500,7 @@ public class SearchModuleTests extends ESTestCase {
         }
 
         @Override
-        public RescoreContext innerBuildContext(int windowSize, QueryShardContext context) throws IOException {
+        public RescoreContext innerBuildContext(int windowSize, SearchExecutionContext context) throws IOException {
             return null;
         }
     }
@@ -544,7 +544,7 @@ public class SearchModuleTests extends ESTestCase {
         }
 
         @Override
-        protected SuggestionSearchContext.SuggestionContext build(QueryShardContext context) throws IOException {
+        protected SuggestionSearchContext.SuggestionContext build(SearchExecutionContext context) throws IOException {
             return null;
         }
 

--- a/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
@@ -60,7 +60,7 @@ import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.MatchNoneQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryRewriteContext;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.index.search.stats.SearchStats;
 import org.elasticsearch.index.shard.IndexShard;
@@ -656,7 +656,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
 
         @Override
         protected QueryBuilder doRewrite(QueryRewriteContext queryRewriteContext) {
-            if (queryRewriteContext.convertToShardContext() != null) {
+            if (queryRewriteContext.convertToSearchExecutionContext() != null) {
                 throw new IllegalStateException("Fail on rewrite phase");
             }
             return this;
@@ -671,7 +671,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
         }
 
         @Override
-        protected Query doToQuery(QueryShardContext context) {
+        protected Query doToQuery(SearchExecutionContext context) {
             return null;
         }
 
@@ -931,9 +931,9 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
             0, indexService.numberOfShards(), AliasFilter.EMPTY, 1f, nowInMillis, clusterAlias);
         try (DefaultSearchContext searchContext = service.createSearchContext(request, new TimeValue(System.currentTimeMillis()))) {
             SearchShardTarget searchShardTarget = searchContext.shardTarget();
-            QueryShardContext queryShardContext = searchContext.getQueryShardContext();
+            SearchExecutionContext searchExecutionContext = searchContext.getSearchExecutionContext();
             String expectedIndexName = clusterAlias == null ? index : clusterAlias + ":" + index;
-            assertEquals(expectedIndexName, queryShardContext.getFullyQualifiedIndex().getName());
+            assertEquals(expectedIndexName, searchExecutionContext.getFullyQualifiedIndex().getName());
             assertEquals(expectedIndexName, searchShardTarget.getFullyQualifiedIndexName());
             assertEquals(clusterAlias, searchShardTarget.getClusterAlias());
             assertEquals(shardId, searchShardTarget.getShardId());

--- a/server/src/test/java/org/elasticsearch/search/aggregations/support/CoreValuesSourceTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/support/CoreValuesSourceTypeTests.java
@@ -72,7 +72,7 @@ public class CoreValuesSourceTypeTests extends MapperServiceTestCase {
         long max = randomLongBetween(min + 10, 100000000000L);
         MapperService mapperService = dateMapperService();
         Query query = mapperService.fieldType("field")
-            .rangeQuery(min, max, true, true, ShapeRelation.CONTAINS, null, null, createQueryShardContext(mapperService));
+            .rangeQuery(min, max, true, true, ShapeRelation.CONTAINS, null, null, createSearchExecutionContext(mapperService));
         withAggregationContext(null, mapperService, List.of(), query, context -> {
             Rounding rounding = mock(Rounding.class);
             CoreValuesSourceType.DATE.getField(context.buildFieldContext("field"), null, context).roundingPreparer().apply(rounding);
@@ -101,7 +101,7 @@ public class CoreValuesSourceTypeTests extends MapperServiceTestCase {
         }
         MapperService mapperService = dateMapperService();
         Query query = mapperService.fieldType("field")
-            .rangeQuery(minQuery, maxQuery, true, true, ShapeRelation.CONTAINS, null, null, createQueryShardContext(mapperService));
+            .rangeQuery(minQuery, maxQuery, true, true, ShapeRelation.CONTAINS, null, null, createSearchExecutionContext(mapperService));
         withAggregationContext(null, mapperService, docsWithDatesBetween(minDocs, maxDocs), query, context -> {
             Rounding rounding = mock(Rounding.class);
             CoreValuesSourceType.DATE.getField(context.buildFieldContext("field"), null, context).roundingPreparer().apply(rounding);

--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/FieldFetcherTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/FieldFetcherTests.java
@@ -32,7 +32,7 @@ import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MapperServiceTestCase;
 import org.elasticsearch.index.mapper.ParsedDocument;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.lookup.SourceLookup;
 
 import java.io.IOException;
@@ -704,7 +704,7 @@ public class FieldFetcherTests extends MapperServiceTestCase {
         SourceLookup sourceLookup = new SourceLookup();
         sourceLookup.setSource(BytesReference.bytes(source));
 
-        FieldFetcher fieldFetcher = FieldFetcher.create(newQueryShardContext(mapperService), null, fields);
+        FieldFetcher fieldFetcher = FieldFetcher.create(newSearchExecutionContext(mapperService), null, fields);
         return fieldFetcher.fetch(sourceLookup, ignoreFields != null ? ignoreFields : Collections.emptySet());
     }
 
@@ -730,14 +730,14 @@ public class FieldFetcherTests extends MapperServiceTestCase {
         return createMapperService(mapping);
     }
 
-    private static QueryShardContext newQueryShardContext(MapperService mapperService) {
+    private static SearchExecutionContext newSearchExecutionContext(MapperService mapperService) {
         Settings settings = Settings.builder().put("index.version.created", Version.CURRENT)
             .put("index.number_of_shards", 1)
             .put("index.number_of_replicas", 0)
             .put(IndexMetadata.SETTING_INDEX_UUID, "uuid").build();
         IndexMetadata indexMetadata = new IndexMetadata.Builder("index").settings(settings).build();
         IndexSettings indexSettings = new IndexSettings(indexMetadata, settings);
-        return new QueryShardContext(
+        return new SearchExecutionContext(
             0,
             0,
             indexSettings,

--- a/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTests.java
@@ -82,7 +82,7 @@ import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.query.ParsedQuery;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.search.ESToParentBlockJoinQuery;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.IndexShardTestCase;
@@ -675,9 +675,9 @@ public class QueryPhaseTests extends IndexShardTestCase {
         final String fieldNameDate = "date-field";
         MappedFieldType fieldTypeLong = new NumberFieldMapper.NumberFieldType(fieldNameLong, NumberFieldMapper.NumberType.LONG);
         MappedFieldType fieldTypeDate = new DateFieldMapper.DateFieldType(fieldNameDate);
-        QueryShardContext shardContext = mock(QueryShardContext.class);
-        when(shardContext.getFieldType(fieldNameLong)).thenReturn(fieldTypeLong);
-        when(shardContext.getFieldType(fieldNameDate)).thenReturn(fieldTypeDate);
+        SearchExecutionContext searchExecutionContext = mock(SearchExecutionContext.class);
+        when(searchExecutionContext.getFieldType(fieldNameLong)).thenReturn(fieldTypeLong);
+        when(searchExecutionContext.getFieldType(fieldNameDate)).thenReturn(fieldTypeDate);
         // enough docs to have a tree with several leaf nodes
         final int numDocs = 3500 * 20;
         Directory dir = newDirectory();
@@ -696,7 +696,7 @@ public class QueryPhaseTests extends IndexShardTestCase {
         writer.close();
         final IndexReader reader = DirectoryReader.open(dir);
 
-        TestSearchContext searchContext = spy(new TestSearchContext(shardContext, indexShard, newOptimizedContextSearcher(reader, 0)));
+        TestSearchContext searchContext = spy(new TestSearchContext(searchExecutionContext, indexShard, newOptimizedContextSearcher(reader, 0)));
 
         // 1. Test a sort on long field
         final SortField sortFieldLong = new SortField(fieldNameLong, SortField.Type.LONG);
@@ -954,10 +954,10 @@ public class QueryPhaseTests extends IndexShardTestCase {
 
     private static class TestSearchContextWithRewriteAndCancellation extends TestSearchContext {
 
-        private TestSearchContextWithRewriteAndCancellation(QueryShardContext queryShardContext,
+        private TestSearchContextWithRewriteAndCancellation(SearchExecutionContext searchExecutionContext,
                                                             IndexShard indexShard,
                                                             ContextIndexSearcher searcher) {
-            super(queryShardContext, indexShard, searcher);
+            super(searchExecutionContext, indexShard, searcher);
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTests.java
@@ -696,7 +696,8 @@ public class QueryPhaseTests extends IndexShardTestCase {
         writer.close();
         final IndexReader reader = DirectoryReader.open(dir);
 
-        TestSearchContext searchContext = spy(new TestSearchContext(searchExecutionContext, indexShard, newOptimizedContextSearcher(reader, 0)));
+        TestSearchContext searchContext = spy(new TestSearchContext(
+            searchExecutionContext, indexShard, newOptimizedContextSearcher(reader, 0)));
 
         // 1. Test a sort on long field
         final SortField sortFieldLong = new SortField(fieldNameLong, SortField.Type.LONG);

--- a/server/src/test/java/org/elasticsearch/search/sort/AbstractSortTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/sort/AbstractSortTestCase.java
@@ -46,7 +46,7 @@ import org.elasticsearch.index.mapper.ObjectMapper.Nested;
 import org.elasticsearch.index.query.IdsQueryBuilder;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.Rewriteable;
 import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.script.MockScriptEngine;
@@ -153,7 +153,7 @@ public abstract class AbstractSortTestCase<T extends SortBuilder<T>> extends EST
      * we would get when parsing the xContent the sort builder is rendering out
      */
     public void testBuildSortField() throws IOException {
-        QueryShardContext mockShardContext = createMockShardContext();
+        SearchExecutionContext mockShardContext = createMockSearchExecutionContext();
         for (int runs = 0; runs < NUMBER_OF_TESTBUILDERS; runs++) {
             T sortBuilder = createTestItem();
             SortFieldAndFormat sortField = Rewriteable.rewrite(sortBuilder, mockShardContext)
@@ -186,11 +186,11 @@ public abstract class AbstractSortTestCase<T extends SortBuilder<T>> extends EST
         }
     }
 
-    protected final QueryShardContext createMockShardContext() {
-        return createMockShardContext(null);
+    protected final SearchExecutionContext createMockSearchExecutionContext() {
+        return createMockSearchExecutionContext(null);
     }
 
-    protected final QueryShardContext createMockShardContext(IndexSearcher searcher) {
+    protected final SearchExecutionContext createMockSearchExecutionContext(IndexSearcher searcher) {
         Index index = new Index(randomAlphaOfLengthBetween(1, 10), "_na_");
         IndexSettings idxSettings = IndexSettingsModule.newIndexSettings(index,
             Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT).build());
@@ -200,7 +200,7 @@ public abstract class AbstractSortTestCase<T extends SortBuilder<T>> extends EST
             IndexFieldData.Builder builder = fieldType.fielddataBuilder(fieldIndexName, searchLookup);
             return builder.build(new IndexFieldDataCache.None(), null);
         };
-        return new QueryShardContext(0, 0, idxSettings, bitsetFilterCache, indexFieldDataLookup,
+        return new SearchExecutionContext(0, 0, idxSettings, bitsetFilterCache, indexFieldDataLookup,
                 null, null, null, scriptService, xContentRegistry(), namedWriteableRegistry, null, searcher,
                 () -> randomNonNegativeLong(), null, null, () -> true, null, emptyMap()) {
 

--- a/server/src/test/java/org/elasticsearch/search/sort/GeoDistanceSortBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/sort/GeoDistanceSortBuilderTests.java
@@ -528,13 +528,15 @@ public class GeoDistanceSortBuilderTests extends AbstractSortTestCase<GeoDistanc
         {
             GeoDistanceSortBuilder sortBuilder = new GeoDistanceSortBuilder("fieldName", -180.0, 0.0);
             sortBuilder.validation(GeoValidationMethod.STRICT);
-            ElasticsearchParseException ex = expectThrows(ElasticsearchParseException.class, () -> sortBuilder.build(searchExecutionContext));
+            ElasticsearchParseException ex = expectThrows(ElasticsearchParseException.class,
+                () -> sortBuilder.build(searchExecutionContext));
             assertEquals("illegal latitude value [-180.0] for [GeoDistanceSort] for field [fieldName].", ex.getMessage());
         }
         {
             GeoDistanceSortBuilder sortBuilder = new GeoDistanceSortBuilder("fieldName", 0.0, -360.0);
             sortBuilder.validation(GeoValidationMethod.STRICT);
-            ElasticsearchParseException ex = expectThrows(ElasticsearchParseException.class, () -> sortBuilder.build(searchExecutionContext));
+            ElasticsearchParseException ex = expectThrows(ElasticsearchParseException.class,
+                () -> sortBuilder.build(searchExecutionContext));
             assertEquals("illegal longitude value [-360.0] for [GeoDistanceSort] for field [fieldName].", ex.getMessage());
         }
     }

--- a/server/src/test/java/org/elasticsearch/search/sort/GeoDistanceSortBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/sort/GeoDistanceSortBuilderTests.java
@@ -43,7 +43,7 @@ import org.elasticsearch.index.query.MatchNoneQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.QueryRewriteContext;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.MultiValueMode;
@@ -374,7 +374,7 @@ public class GeoDistanceSortBuilderTests extends AbstractSortTestCase<GeoDistanc
         // make sure the below tests test something...
         assertFalse(SortField.class.equals(LatLonDocValuesField.newDistanceSort("random_field_name", 3.5, 2.1).getClass()));
 
-        QueryShardContext context = createMockShardContext();
+        SearchExecutionContext context = createMockSearchExecutionContext();
         // The common case should use LatLonDocValuesField.newDistanceSort
         GeoDistanceSortBuilder builder = new GeoDistanceSortBuilder("", new GeoPoint(3.5, 2.1));
         SortFieldAndFormat sort = builder.build(context);
@@ -410,25 +410,25 @@ public class GeoDistanceSortBuilderTests extends AbstractSortTestCase<GeoDistanc
      * Test that the sort builder order gets transferred correctly to the SortField
      */
     public void testBuildSortFieldOrder() throws IOException {
-        QueryShardContext shardContextMock = createMockShardContext();
+        SearchExecutionContext searchExecutionContext = createMockSearchExecutionContext();
         GeoDistanceSortBuilder geoDistanceSortBuilder = new GeoDistanceSortBuilder("fieldName", 1.0, 1.0);
-        assertEquals(false, geoDistanceSortBuilder.build(shardContextMock).field.getReverse());
+        assertEquals(false, geoDistanceSortBuilder.build(searchExecutionContext).field.getReverse());
 
         geoDistanceSortBuilder.order(SortOrder.ASC);
-        assertEquals(false, geoDistanceSortBuilder.build(shardContextMock).field.getReverse());
+        assertEquals(false, geoDistanceSortBuilder.build(searchExecutionContext).field.getReverse());
 
         geoDistanceSortBuilder.order(SortOrder.DESC);
-        assertEquals(true, geoDistanceSortBuilder.build(shardContextMock).field.getReverse());
+        assertEquals(true, geoDistanceSortBuilder.build(searchExecutionContext).field.getReverse());
     }
 
     /**
      * Test that the sort builder mode gets transferred correctly to the SortField
      */
     public void testMultiValueMode() throws IOException {
-        QueryShardContext shardContextMock = createMockShardContext();
+        SearchExecutionContext searchExecutionContext = createMockSearchExecutionContext();
         GeoDistanceSortBuilder geoDistanceSortBuilder = new GeoDistanceSortBuilder("fieldName", 1.0, 1.0);
         geoDistanceSortBuilder.sortMode(SortMode.MAX);
-        SortField sortField = geoDistanceSortBuilder.build(shardContextMock).field;
+        SortField sortField = geoDistanceSortBuilder.build(searchExecutionContext).field;
         assertThat(sortField.getComparatorSource(), instanceOf(XFieldComparatorSource.class));
         XFieldComparatorSource comparatorSource = (XFieldComparatorSource) sortField.getComparatorSource();
         assertEquals(MultiValueMode.MAX, comparatorSource.sortMode());
@@ -436,7 +436,7 @@ public class GeoDistanceSortBuilderTests extends AbstractSortTestCase<GeoDistanc
         // also use MultiValueMode.Max if no Mode set but order is DESC
         geoDistanceSortBuilder = new GeoDistanceSortBuilder("fieldName", 1.0, 1.0);
         geoDistanceSortBuilder.order(SortOrder.DESC);
-        sortField = geoDistanceSortBuilder.build(shardContextMock).field;
+        sortField = geoDistanceSortBuilder.build(searchExecutionContext).field;
         assertThat(sortField.getComparatorSource(), instanceOf(XFieldComparatorSource.class));
         comparatorSource = (XFieldComparatorSource) sortField.getComparatorSource();
         assertEquals(MultiValueMode.MAX, comparatorSource.sortMode());
@@ -445,7 +445,7 @@ public class GeoDistanceSortBuilderTests extends AbstractSortTestCase<GeoDistanc
         geoDistanceSortBuilder = new GeoDistanceSortBuilder("fieldName", 1.0, 1.0);
         // need to use distance unit other than Meters to not get back a LatLonPointSortField
         geoDistanceSortBuilder.order(SortOrder.ASC).unit(DistanceUnit.INCH);
-        sortField = geoDistanceSortBuilder.build(shardContextMock).field;
+        sortField = geoDistanceSortBuilder.build(searchExecutionContext).field;
         assertThat(sortField.getComparatorSource(), instanceOf(XFieldComparatorSource.class));
         comparatorSource = (XFieldComparatorSource) sortField.getComparatorSource();
         assertEquals(MultiValueMode.MIN, comparatorSource.sortMode());
@@ -453,19 +453,19 @@ public class GeoDistanceSortBuilderTests extends AbstractSortTestCase<GeoDistanc
         geoDistanceSortBuilder = new GeoDistanceSortBuilder("fieldName", 1.0, 1.0);
         // need to use distance unit other than Meters to not get back a LatLonPointSortField
         geoDistanceSortBuilder.sortMode(SortMode.MIN).unit(DistanceUnit.INCH);
-        sortField = geoDistanceSortBuilder.build(shardContextMock).field;
+        sortField = geoDistanceSortBuilder.build(searchExecutionContext).field;
         assertThat(sortField.getComparatorSource(), instanceOf(XFieldComparatorSource.class));
         comparatorSource = (XFieldComparatorSource) sortField.getComparatorSource();
         assertEquals(MultiValueMode.MIN, comparatorSource.sortMode());
 
         geoDistanceSortBuilder.sortMode(SortMode.AVG);
-        sortField = geoDistanceSortBuilder.build(shardContextMock).field;
+        sortField = geoDistanceSortBuilder.build(searchExecutionContext).field;
         assertThat(sortField.getComparatorSource(), instanceOf(XFieldComparatorSource.class));
         comparatorSource = (XFieldComparatorSource) sortField.getComparatorSource();
         assertEquals(MultiValueMode.AVG, comparatorSource.sortMode());
 
         geoDistanceSortBuilder.sortMode(SortMode.MEDIAN);
-        sortField = geoDistanceSortBuilder.build(shardContextMock).field;
+        sortField = geoDistanceSortBuilder.build(searchExecutionContext).field;
         assertThat(sortField.getComparatorSource(), instanceOf(XFieldComparatorSource.class));
         comparatorSource = (XFieldComparatorSource) sortField.getComparatorSource();
         assertEquals(MultiValueMode.MEDIAN, comparatorSource.sortMode());
@@ -475,11 +475,11 @@ public class GeoDistanceSortBuilderTests extends AbstractSortTestCase<GeoDistanc
      * Test that the sort builder nested object gets created in the SortField
      */
     public void testBuildNested() throws IOException {
-        QueryShardContext shardContextMock = createMockShardContext();
+        SearchExecutionContext searchExecutionContext = createMockSearchExecutionContext();
 
         GeoDistanceSortBuilder sortBuilder = new GeoDistanceSortBuilder("fieldName", 1.0, 1.0)
                 .setNestedSort(new NestedSortBuilder("path").setFilter(QueryBuilders.matchAllQuery()));
-        SortField sortField = sortBuilder.build(shardContextMock).field;
+        SortField sortField = sortBuilder.build(searchExecutionContext).field;
         assertThat(sortField.getComparatorSource(), instanceOf(XFieldComparatorSource.class));
         XFieldComparatorSource comparatorSource = (XFieldComparatorSource) sortField.getComparatorSource();
         Nested nested = comparatorSource.nested();
@@ -488,7 +488,7 @@ public class GeoDistanceSortBuilderTests extends AbstractSortTestCase<GeoDistanc
 
         sortBuilder = new GeoDistanceSortBuilder("fieldName", 1.0, 1.0)
             .setNestedSort(new NestedSortBuilder("path"));
-        sortField = sortBuilder.build(shardContextMock).field;
+        sortField = sortBuilder.build(searchExecutionContext).field;
         assertThat(sortField.getComparatorSource(), instanceOf(XFieldComparatorSource.class));
         comparatorSource = (XFieldComparatorSource) sortField.getComparatorSource();
         nested = comparatorSource.nested();
@@ -499,7 +499,7 @@ public class GeoDistanceSortBuilderTests extends AbstractSortTestCase<GeoDistanc
             .setNestedSort(new NestedSortBuilder("path")
                 .setFilter(QueryBuilders.matchAllQuery())
             );
-        sortField = sortBuilder.build(shardContextMock).field;
+        sortField = sortBuilder.build(searchExecutionContext).field;
         assertThat(sortField.getComparatorSource(), instanceOf(XFieldComparatorSource.class));
         comparatorSource = (XFieldComparatorSource) sortField.getComparatorSource();
         nested = comparatorSource.nested();
@@ -511,12 +511,12 @@ public class GeoDistanceSortBuilderTests extends AbstractSortTestCase<GeoDistanc
      * Test that if coercion is used, a point gets normalized but the original values in the builder are unchanged
      */
     public void testBuildCoerce() throws IOException {
-        QueryShardContext shardContextMock = createMockShardContext();
+        SearchExecutionContext searchExecutionContext = createMockSearchExecutionContext();
         GeoDistanceSortBuilder sortBuilder = new GeoDistanceSortBuilder("fieldName", -180.0, -360.0);
         sortBuilder.validation(GeoValidationMethod.COERCE);
         assertEquals(-180.0, sortBuilder.points()[0].getLat(), 0.0);
         assertEquals(-360.0, sortBuilder.points()[0].getLon(), 0.0);
-        SortField sortField = sortBuilder.build(shardContextMock).field;
+        SortField sortField = sortBuilder.build(searchExecutionContext).field;
         assertEquals(LatLonDocValuesField.newDistanceSort("fieldName", 0.0, 180.0), sortField);
     }
 
@@ -524,17 +524,17 @@ public class GeoDistanceSortBuilderTests extends AbstractSortTestCase<GeoDistanc
      * Test that if validation is strict, invalid points throw an error
      */
     public void testBuildInvalidPoints() throws IOException {
-        QueryShardContext shardContextMock = createMockShardContext();
+        SearchExecutionContext searchExecutionContext = createMockSearchExecutionContext();
         {
             GeoDistanceSortBuilder sortBuilder = new GeoDistanceSortBuilder("fieldName", -180.0, 0.0);
             sortBuilder.validation(GeoValidationMethod.STRICT);
-            ElasticsearchParseException ex = expectThrows(ElasticsearchParseException.class, () -> sortBuilder.build(shardContextMock));
+            ElasticsearchParseException ex = expectThrows(ElasticsearchParseException.class, () -> sortBuilder.build(searchExecutionContext));
             assertEquals("illegal latitude value [-180.0] for [GeoDistanceSort] for field [fieldName].", ex.getMessage());
         }
         {
             GeoDistanceSortBuilder sortBuilder = new GeoDistanceSortBuilder("fieldName", 0.0, -360.0);
             sortBuilder.validation(GeoValidationMethod.STRICT);
-            ElasticsearchParseException ex = expectThrows(ElasticsearchParseException.class, () -> sortBuilder.build(shardContextMock));
+            ElasticsearchParseException ex = expectThrows(ElasticsearchParseException.class, () -> sortBuilder.build(searchExecutionContext));
             assertEquals("illegal longitude value [-360.0] for [GeoDistanceSort] for field [fieldName].", ex.getMessage());
         }
     }
@@ -546,7 +546,7 @@ public class GeoDistanceSortBuilderTests extends AbstractSortTestCase<GeoDistanc
         GeoDistanceSortBuilder sortBuilder = new GeoDistanceSortBuilder("fieldName", 0.0, 0.0);
         RangeQueryBuilder rangeQuery = new RangeQueryBuilder("fieldName") {
             @Override
-            public QueryBuilder doRewrite(QueryRewriteContext queryShardContext) throws IOException {
+            public QueryBuilder doRewrite(QueryRewriteContext queryRewriteContext) throws IOException {
                 return new MatchNoneQueryBuilder();
             }
         };
@@ -554,7 +554,7 @@ public class GeoDistanceSortBuilderTests extends AbstractSortTestCase<GeoDistanc
             new NestedSortBuilder("path")
                 .setFilter(rangeQuery)
         );
-        GeoDistanceSortBuilder rewritten = sortBuilder.rewrite(createMockShardContext());
+        GeoDistanceSortBuilder rewritten = sortBuilder.rewrite(createMockSearchExecutionContext());
         assertNotSame(rangeQuery, rewritten.getNestedSort().getFilter());
     }
 
@@ -565,13 +565,13 @@ public class GeoDistanceSortBuilderTests extends AbstractSortTestCase<GeoDistanc
         GeoDistanceSortBuilder sortBuilder = new GeoDistanceSortBuilder("fieldName", 0.0, 0.0);
         RangeQueryBuilder rangeQuery = new RangeQueryBuilder("fieldName") {
             @Override
-            public QueryBuilder doRewrite(QueryRewriteContext queryShardContext) throws IOException {
+            public QueryBuilder doRewrite(QueryRewriteContext queryRewriteContext) throws IOException {
                 return new MatchNoneQueryBuilder();
             }
         };
         sortBuilder.setNestedSort(new NestedSortBuilder("path").setFilter(rangeQuery));
         GeoDistanceSortBuilder rewritten = (GeoDistanceSortBuilder) sortBuilder
-                .rewrite(createMockShardContext());
+                .rewrite(createMockSearchExecutionContext());
         assertNotSame(rangeQuery, rewritten.getNestedSort().getFilter());
     }
 

--- a/server/src/test/java/org/elasticsearch/search/sort/NestedSortBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/sort/NestedSortBuilderTests.java
@@ -150,7 +150,7 @@ public class NestedSortBuilderTests extends ESTestCase {
     public void testRewrite() throws IOException {
         QueryBuilder filterThatRewrites = new MatchNoneQueryBuilder() {
             @Override
-            protected QueryBuilder doRewrite(org.elasticsearch.index.query.QueryRewriteContext queryShardContext) throws IOException {
+            protected QueryBuilder doRewrite(org.elasticsearch.index.query.QueryRewriteContext queryRewriteContext) throws IOException {
                 return new MatchAllQueryBuilder();
             }
         };

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/FieldTypeTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/FieldTypeTestCase.java
@@ -18,7 +18,7 @@
  */
 package org.elasticsearch.index.mapper;
 
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.lookup.SourceLookup;
 import org.elasticsearch.test.ESTestCase;
 
@@ -33,17 +33,17 @@ import static org.mockito.Mockito.when;
 /** Base test case for subclasses of MappedFieldType */
 public abstract class FieldTypeTestCase extends ESTestCase {
 
-    public static final QueryShardContext MOCK_QSC = createMockQueryShardContext(true);
-    public static final QueryShardContext MOCK_QSC_DISALLOW_EXPENSIVE = createMockQueryShardContext(false);
+    public static final SearchExecutionContext MOCK_CONTEXT = createMockSearchExecutionContext(true);
+    public static final SearchExecutionContext MOCK_CONTEXT_DISALLOW_EXPENSIVE = createMockSearchExecutionContext(false);
 
-    protected QueryShardContext randomMockShardContext() {
-        return randomFrom(MOCK_QSC, MOCK_QSC_DISALLOW_EXPENSIVE);
+    protected SearchExecutionContext randomMockContext() {
+        return randomFrom(MOCK_CONTEXT, MOCK_CONTEXT_DISALLOW_EXPENSIVE);
     }
 
-    static QueryShardContext createMockQueryShardContext(boolean allowExpensiveQueries) {
-        QueryShardContext queryShardContext = mock(QueryShardContext.class);
-        when(queryShardContext.allowExpensiveQueries()).thenReturn(allowExpensiveQueries);
-        return queryShardContext;
+    private static SearchExecutionContext createMockSearchExecutionContext(boolean allowExpensiveQueries) {
+        SearchExecutionContext searchExecutionContext = mock(SearchExecutionContext.class);
+        when(searchExecutionContext.allowExpensiveQueries()).thenReturn(allowExpensiveQueries);
+        return searchExecutionContext;
     }
 
     public static List<?> fetchSourceValue(MappedFieldType fieldType, Object sourceValue) throws IOException {
@@ -52,10 +52,10 @@ public abstract class FieldTypeTestCase extends ESTestCase {
 
     public static List<?> fetchSourceValue(MappedFieldType fieldType, Object sourceValue, String format) throws IOException {
         String field = fieldType.name();
-        QueryShardContext queryShardContext = mock(QueryShardContext.class);
-        when(queryShardContext.sourcePath(field)).thenReturn(Set.of(field));
+        SearchExecutionContext searchExecutionContext = mock(SearchExecutionContext.class);
+        when(searchExecutionContext.sourcePath(field)).thenReturn(Set.of(field));
 
-        ValueFetcher fetcher = fieldType.valueFetcher(queryShardContext, format);
+        ValueFetcher fetcher = fieldType.valueFetcher(searchExecutionContext, format);
         SourceLookup lookup = new SourceLookup();
         lookup.setSource(Collections.singletonMap(field, sourceValue));
         return fetcher.fetchValues(lookup);

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperServiceTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperServiceTestCase.java
@@ -52,7 +52,7 @@ import org.elasticsearch.index.cache.bitset.BitsetFilterCache;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldDataCache;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.support.NestedScope;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.similarity.SimilarityService;
@@ -496,22 +496,22 @@ public abstract class MapperServiceTestCase extends ESTestCase {
         );
     }
 
-    protected QueryShardContext createQueryShardContext(MapperService mapperService) {
-        QueryShardContext queryShardContext = mock(QueryShardContext.class);
-        when(queryShardContext.getFieldType(anyString())).thenAnswer(inv -> mapperService.fieldType(inv.getArguments()[0].toString()));
-        when(queryShardContext.isFieldMapped(anyString()))
+    protected SearchExecutionContext createSearchExecutionContext(MapperService mapperService) {
+        SearchExecutionContext searchExecutionContext = mock(SearchExecutionContext.class);
+        when(searchExecutionContext.getFieldType(anyString())).thenAnswer(inv -> mapperService.fieldType(inv.getArguments()[0].toString()));
+        when(searchExecutionContext.isFieldMapped(anyString()))
             .thenAnswer(inv -> mapperService.fieldType(inv.getArguments()[0].toString()) != null);
-        when(queryShardContext.getIndexAnalyzers()).thenReturn(mapperService.getIndexAnalyzers());
-        when(queryShardContext.getIndexSettings()).thenReturn(mapperService.getIndexSettings());
-        when(queryShardContext.getObjectMapper(anyString())).thenAnswer(
+        when(searchExecutionContext.getIndexAnalyzers()).thenReturn(mapperService.getIndexAnalyzers());
+        when(searchExecutionContext.getIndexSettings()).thenReturn(mapperService.getIndexSettings());
+        when(searchExecutionContext.getObjectMapper(anyString())).thenAnswer(
             inv -> mapperService.getObjectMapper(inv.getArguments()[0].toString()));
-        when(queryShardContext.simpleMatchToIndexNames(anyObject())).thenAnswer(
+        when(searchExecutionContext.simpleMatchToIndexNames(anyObject())).thenAnswer(
             inv -> mapperService.simpleMatchToFullName(inv.getArguments()[0].toString())
         );
-        when(queryShardContext.allowExpensiveQueries()).thenReturn(true);
-        when(queryShardContext.lookup()).thenReturn(new SearchLookup(mapperService::fieldType, (ft, s) -> {
+        when(searchExecutionContext.allowExpensiveQueries()).thenReturn(true);
+        when(searchExecutionContext.lookup()).thenReturn(new SearchLookup(mapperService::fieldType, (ft, s) -> {
             throw new UnsupportedOperationException("search lookup not available");
         }));
-        return queryShardContext;
+        return searchExecutionContext;
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
@@ -40,7 +40,7 @@ import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldDataCache;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.lookup.SearchLookup;
@@ -103,9 +103,9 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
 
     protected void assertExistsQuery(MapperService mapperService) throws IOException {
         ParseContext.Document fields = mapperService.documentMapper().parse(source(this::writeField)).rootDoc();
-        QueryShardContext queryShardContext = createQueryShardContext(mapperService);
+        SearchExecutionContext searchExecutionContext = createSearchExecutionContext(mapperService);
         MappedFieldType fieldType = mapperService.fieldType("field");
-        Query query = fieldType.existsQuery(queryShardContext);
+        Query query = fieldType.existsQuery(searchExecutionContext);
         assertExistsQuery(fieldType, query, fields);
     }
 
@@ -453,8 +453,8 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
         if (fieldType.getTextSearchInfo() == TextSearchInfo.NONE) {
             expectThrows(IllegalArgumentException.class, () -> fieldType.termQuery(null, null));
         } else {
-            QueryShardContext queryShardContext = createQueryShardContext(mapperService);
-            assertNotNull(fieldType.termQuery(getSampleValueForQuery(), queryShardContext));
+            SearchExecutionContext searchExecutionContext = createSearchExecutionContext(mapperService);
+            assertNotNull(fieldType.termQuery(getSampleValueForQuery(), searchExecutionContext));
         }
         assertSearchable(fieldType);
         assertParseMinimalWarnings();

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MockFieldMapper.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MockFieldMapper.java
@@ -20,7 +20,7 @@
 package org.elasticsearch.index.mapper;
 
 import org.elasticsearch.index.analysis.NamedAnalyzer;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 
 import java.util.Collections;
 import java.util.List;
@@ -70,7 +70,7 @@ public class MockFieldMapper extends FieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             throw new UnsupportedOperationException();
         }
     }

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -94,7 +94,7 @@ import org.elasticsearch.index.mapper.RangeFieldMapper;
 import org.elasticsearch.index.mapper.RangeType;
 import org.elasticsearch.index.mapper.TextFieldMapper;
 import org.elasticsearch.index.query.QueryRewriteContext;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.Rewriteable;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
@@ -264,7 +264,7 @@ public abstract class AggregatorTestCase extends ESTestCase {
             @Override
             public void onCache(ShardId shardId, Accountable accountable) {}
         });
-        QueryShardContext queryShardContext = new QueryShardContext(
+        SearchExecutionContext searchExecutionContext = new SearchExecutionContext(
             0,
             -1,
             indexSettings,
@@ -288,13 +288,13 @@ public abstract class AggregatorTestCase extends ESTestCase {
 
         MultiBucketConsumer consumer = new MultiBucketConsumer(maxBucket, breakerService.getBreaker(CircuitBreaker.REQUEST));
         AggregationContext context = new ProductionAggregationContext(
-            queryShardContext,
+            searchExecutionContext,
             new MockBigArrays(new MockPageCacheRecycler(Settings.EMPTY), breakerService),
             bytesToPreallocate,
             () -> query,
             null,
             consumer,
-            () -> buildSubSearchContext(indexSettings, queryShardContext, bitsetFilterCache),
+            () -> buildSubSearchContext(indexSettings, searchExecutionContext, bitsetFilterCache),
             bitsetFilterCache,
             randomInt(),
             () -> 0L,
@@ -325,7 +325,7 @@ public abstract class AggregatorTestCase extends ESTestCase {
      */
     private SubSearchContext buildSubSearchContext(
         IndexSettings indexSettings,
-        QueryShardContext queryShardContext,
+        SearchExecutionContext searchExecutionContext,
         BitsetFilterCache bitsetFilterCache
     ) {
         SearchContext ctx = mock(SearchContext.class);
@@ -344,8 +344,8 @@ public abstract class AggregatorTestCase extends ESTestCase {
         try {
             when(ctx.searcher()).thenReturn(
                 new ContextIndexSearcher(
-                    queryShardContext.searcher().getIndexReader(),
-                    queryShardContext.searcher().getSimilarity(),
+                    searchExecutionContext.searcher().getIndexReader(),
+                    searchExecutionContext.searcher().getSimilarity(),
                     queryCache,
                     queryCachingPolicy,
                     false
@@ -361,10 +361,10 @@ public abstract class AggregatorTestCase extends ESTestCase {
          * don't try to fetch them which would require mocking a whole menagerie
          * of stuff.
          */
-        QueryShardContext subQSC = spy(queryShardContext);
+        SearchExecutionContext subContext = spy(searchExecutionContext);
         MappingLookup disableNestedLookup = new MappingLookup(Mapping.EMPTY, Set.of(), Set.of(), Set.of(), null, null, null);
-        doReturn(new NestedDocuments(disableNestedLookup, bitsetFilterCache::getBitSetProducer)).when(subQSC).getNestedDocuments();
-        when(ctx.getQueryShardContext()).thenReturn(subQSC);
+        doReturn(new NestedDocuments(disableNestedLookup, bitsetFilterCache::getBitSetProducer)).when(subContext).getNestedDocuments();
+        when(ctx.getSearchExecutionContext()).thenReturn(subContext);
 
         IndexShard indexShard = mock(IndexShard.class);
         when(indexShard.shardId()).thenReturn(new ShardId("test", "test", 0));

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractBuilderTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractBuilderTestCase.java
@@ -53,7 +53,7 @@ import org.elasticsearch.index.cache.bitset.BitsetFilterCache;
 import org.elasticsearch.index.fielddata.IndexFieldDataCache;
 import org.elasticsearch.index.fielddata.IndexFieldDataService;
 import org.elasticsearch.index.mapper.MapperService;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.similarity.SimilarityService;
 import org.elasticsearch.indices.IndicesModule;
@@ -252,24 +252,24 @@ public abstract class AbstractBuilderTestCase extends ESTestCase {
     }
 
     /**
-     * @return a new {@link QueryShardContext} with the provided searcher
+     * @return a new {@link SearchExecutionContext} with the provided searcher
      */
-    protected static QueryShardContext createShardContext(IndexSearcher searcher) {
+    protected static SearchExecutionContext createSearchExecutionContext(IndexSearcher searcher) {
         return serviceHolder.createShardContext(searcher);
     }
 
     /**
-     * @return a new {@link QueryShardContext} based on an index with no type registered
+     * @return a new {@link SearchExecutionContext} based on an index with no type registered
      */
-    protected static QueryShardContext createShardContextWithNoType() {
+    protected static SearchExecutionContext createShardContextWithNoType() {
         return serviceHolderWithNoType.createShardContext(null);
     }
 
     /**
-     * @return a new {@link QueryShardContext} based on the base test index and queryParserService
+     * @return a new {@link SearchExecutionContext} based on the base test index and queryParserService
      */
-    protected static QueryShardContext createShardContext() {
-        return createShardContext(null);
+    protected static SearchExecutionContext createSearchExecutionContext() {
+        return createSearchExecutionContext(null);
     }
 
     private static class ClientInvocationHandler implements InvocationHandler {
@@ -410,8 +410,8 @@ public abstract class AbstractBuilderTestCase extends ESTestCase {
         public void close() throws IOException {
         }
 
-        QueryShardContext createShardContext(IndexSearcher searcher) {
-            return new QueryShardContext(
+        SearchExecutionContext createShardContext(IndexSearcher searcher) {
+            return new SearchExecutionContext(
                 0,
                 0,
                 idxSettings,

--- a/test/framework/src/main/java/org/elasticsearch/test/TestSearchContext.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/TestSearchContext.java
@@ -28,7 +28,7 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.cache.bitset.BitsetFilterCache;
 import org.elasticsearch.index.query.ParsedQuery;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.search.SearchExtBuilder;
@@ -72,7 +72,7 @@ public class TestSearchContext extends SearchContext {
     final Map<Class<?>, Collector> queryCollectors = new HashMap<>();
     final IndexShard indexShard;
     final QuerySearchResult queryResult = new QuerySearchResult();
-    final QueryShardContext queryShardContext;
+    final SearchExecutionContext searchExecutionContext;
     ParsedQuery originalQuery;
     ParsedQuery postFilter;
     Query query;
@@ -95,23 +95,23 @@ public class TestSearchContext extends SearchContext {
         this.indexService = indexService;
         this.fixedBitSetFilterCache = indexService.cache().bitsetFilterCache();
         this.indexShard = indexService.getShardOrNull(0);
-        queryShardContext = indexService.newQueryShardContext(0, 0, null, () -> 0L, null, emptyMap());
+        searchExecutionContext = indexService.newSearchExecutionContext(0, 0, null, () -> 0L, null, emptyMap());
     }
 
-    public TestSearchContext(QueryShardContext queryShardContext) {
-        this(queryShardContext, null, null, null);
+    public TestSearchContext(SearchExecutionContext searchExecutionContext) {
+        this(searchExecutionContext, null, null, null);
     }
 
-    public TestSearchContext(QueryShardContext queryShardContext, IndexShard indexShard, ContextIndexSearcher searcher) {
-        this(queryShardContext, indexShard, searcher, null);
+    public TestSearchContext(SearchExecutionContext searchExecutionContext, IndexShard indexShard, ContextIndexSearcher searcher) {
+        this(searchExecutionContext, indexShard, searcher, null);
     }
 
-    public TestSearchContext(QueryShardContext queryShardContext, IndexShard indexShard,
+    public TestSearchContext(SearchExecutionContext searchExecutionContext, IndexShard indexShard,
                              ContextIndexSearcher searcher, ScrollContext scrollContext) {
         this.indexService = null;
         this.fixedBitSetFilterCache = null;
         this.indexShard = indexShard;
-        this.queryShardContext = queryShardContext;
+        this.searchExecutionContext = searchExecutionContext;
         this.searcher = searcher;
         this.scrollContext = scrollContext;
     }
@@ -516,8 +516,8 @@ public class TestSearchContext extends SearchContext {
     public Map<Class<?>, Collector> queryCollectors() {return queryCollectors;}
 
     @Override
-    public QueryShardContext getQueryShardContext() {
-        return queryShardContext;
+    public SearchExecutionContext getSearchExecutionContext() {
+        return searchExecutionContext;
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapper.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapper.java
@@ -39,7 +39,7 @@ import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.SourceValueFetcher;
 import org.elasticsearch.index.mapper.TextSearchInfo;
 import org.elasticsearch.index.mapper.ValueFetcher;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.search.lookup.SearchLookup;
@@ -134,7 +134,7 @@ public class HistogramFieldMapper extends FieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             return SourceValueFetcher.identity(name(), context, format);
         }
 
@@ -217,7 +217,7 @@ public class HistogramFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query termQuery(Object value, QueryShardContext context) {
+        public Query termQuery(Object value, SearchExecutionContext context) {
             throw new IllegalArgumentException("[" + CONTENT_TYPE + "] field do not support searching, " +
                 "use dedicated aggregations instead: [" + name() + "]");
         }

--- a/x-pack/plugin/async-search/qa/rest/src/main/java/org/elasticsearch/query/DeprecatedQueryBuilder.java
+++ b/x-pack/plugin/async-search/qa/rest/src/main/java/org/elasticsearch/query/DeprecatedQueryBuilder.java
@@ -16,7 +16,7 @@ import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.query.AbstractQueryBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 
 import java.io.IOException;
 
@@ -52,7 +52,7 @@ public class DeprecatedQueryBuilder extends AbstractQueryBuilder<DeprecatedQuery
     }
 
     @Override
-    protected Query doToQuery(QueryShardContext context) {
+    protected Query doToQuery(SearchExecutionContext context) {
         deprecationLogger.deprecate("to_query", "[deprecated] query");
         return new MatchAllDocsQuery();
     }

--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/BlockingQueryBuilder.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/BlockingQueryBuilder.java
@@ -14,7 +14,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.query.AbstractQueryBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -75,7 +75,7 @@ class BlockingQueryBuilder extends AbstractQueryBuilder<BlockingQueryBuilder> {
     }
 
     @Override
-    protected Query doToQuery(QueryShardContext context) {
+    protected Query doToQuery(SearchExecutionContext context) {
         final Query delegate = Queries.newMatchAllQuery();
         return new Query() {
             @Override

--- a/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/ThrowingQueryBuilder.java
+++ b/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/ThrowingQueryBuilder.java
@@ -14,7 +14,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.query.AbstractQueryBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 
 import java.io.IOException;
 
@@ -56,7 +56,7 @@ class ThrowingQueryBuilder extends AbstractQueryBuilder<ThrowingQueryBuilder> {
     }
 
     @Override
-    protected Query doToQuery(QueryShardContext context) {
+    protected Query doToQuery(SearchExecutionContext context) {
         final Query delegate = Queries.newMatchAllQuery();
         return new Query() {
             @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/index/query/PinnedQueryBuilder.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/index/query/PinnedQueryBuilder.java
@@ -11,7 +11,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.query.AbstractQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -27,7 +27,7 @@ import java.util.Objects;
 public class PinnedQueryBuilder extends AbstractQueryBuilder<PinnedQueryBuilder> {
     public static final String NAME = "pinned";
     protected final QueryBuilder organicQuery;
-    protected final List<String> ids;    
+    protected final List<String> ids;
     protected static final ParseField IDS_FIELD = new ParseField("ids");
     protected static final ParseField ORGANIC_QUERY_FIELD = new ParseField("organic");
 
@@ -49,7 +49,7 @@ public class PinnedQueryBuilder extends AbstractQueryBuilder<PinnedQueryBuilder>
       }
       this.ids = new ArrayList<>();
       Collections.addAll(this.ids, ids);
-      
+
     }
 
 
@@ -72,7 +72,7 @@ public class PinnedQueryBuilder extends AbstractQueryBuilder<PinnedQueryBuilder>
     public List<String> ids() {
         return Collections.unmodifiableList(this.ids);
     }
-    
+
 
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
@@ -91,7 +91,7 @@ public class PinnedQueryBuilder extends AbstractQueryBuilder<PinnedQueryBuilder>
     }
 
     @Override
-    protected Query doToQuery(QueryShardContext context) throws IOException {
+    protected Query doToQuery(SearchExecutionContext context) throws IOException {
         throw new UnsupportedOperationException("Client side-only class for use in HLRC");
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/SecurityIndexReaderWrapper.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/SecurityIndexReaderWrapper.java
@@ -14,7 +14,7 @@ import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.CheckedFunction;
 import org.elasticsearch.common.logging.LoggerMessageFormat;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.ShardUtils;
 import org.elasticsearch.license.XPackLicenseState;
@@ -44,17 +44,17 @@ import java.util.function.Function;
 public class SecurityIndexReaderWrapper implements CheckedFunction<DirectoryReader, DirectoryReader, IOException> {
     private static final Logger logger = LogManager.getLogger(SecurityIndexReaderWrapper.class);
 
-    private final Function<ShardId, QueryShardContext> queryShardContextProvider;
+    private final Function<ShardId, SearchExecutionContext> searchExecutionContextProvider;
     private final DocumentSubsetBitsetCache bitsetCache;
     private final XPackLicenseState licenseState;
     private final SecurityContext securityContext;
     private final ScriptService scriptService;
 
-    public SecurityIndexReaderWrapper(Function<ShardId, QueryShardContext> queryShardContextProvider,
+    public SecurityIndexReaderWrapper(Function<ShardId, SearchExecutionContext> searchExecutionContextProvider,
                                       DocumentSubsetBitsetCache bitsetCache, SecurityContext securityContext,
                                       XPackLicenseState licenseState, ScriptService scriptService) {
         this.scriptService = scriptService;
-        this.queryShardContextProvider = queryShardContextProvider;
+        this.searchExecutionContextProvider = searchExecutionContextProvider;
         this.bitsetCache = bitsetCache;
         this.securityContext = securityContext;
         this.licenseState = licenseState;
@@ -84,7 +84,7 @@ public class SecurityIndexReaderWrapper implements CheckedFunction<DirectoryRead
             DirectoryReader wrappedReader = reader;
             DocumentPermissions documentPermissions = permissions.getDocumentPermissions();
             if (documentPermissions != null && documentPermissions.hasDocumentLevelPermissions()) {
-                BooleanQuery filterQuery = documentPermissions.filter(getUser(), scriptService, shardId, queryShardContextProvider);
+                BooleanQuery filterQuery = documentPermissions.filter(getUser(), scriptService, shardId, searchExecutionContextProvider);
                 if (filterQuery != null) {
                     wrappedReader = DocumentSubsetReader.wrap(wrappedReader, bitsetCache, new ConstantScoreQuery(filterQuery));
                 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/DocumentPermissions.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/DocumentPermissions.java
@@ -14,7 +14,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryRewriteContext;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.Rewriteable;
 import org.elasticsearch.index.search.NestedHelper;
 import org.elasticsearch.index.shard.ShardId;
@@ -82,27 +82,27 @@ public final class DocumentPermissions {
      * @param user authenticated {@link User}
      * @param scriptService {@link ScriptService} for evaluating query templates
      * @param shardId {@link ShardId}
-     * @param queryShardContextProvider {@link QueryShardContext}
+     * @param searchExecutionContextProvider {@link SearchExecutionContext}
      * @return {@link BooleanQuery} for the filter
      * @throws IOException thrown if there is an exception during parsing
      */
     public BooleanQuery filter(User user, ScriptService scriptService, ShardId shardId,
-                                      Function<ShardId, QueryShardContext> queryShardContextProvider) throws IOException {
+                                      Function<ShardId, SearchExecutionContext> searchExecutionContextProvider) throws IOException {
         if (hasDocumentLevelPermissions()) {
             BooleanQuery.Builder filter;
             if (queries != null && limitedByQueries != null) {
                 filter = new BooleanQuery.Builder();
                 BooleanQuery.Builder scopedFilter = new BooleanQuery.Builder();
-                buildRoleQuery(user, scriptService, shardId, queryShardContextProvider, limitedByQueries, scopedFilter);
+                buildRoleQuery(user, scriptService, shardId, searchExecutionContextProvider, limitedByQueries, scopedFilter);
                 filter.add(scopedFilter.build(), FILTER);
 
-                buildRoleQuery(user, scriptService, shardId, queryShardContextProvider, queries, filter);
+                buildRoleQuery(user, scriptService, shardId, searchExecutionContextProvider, queries, filter);
             } else if (queries != null) {
                 filter = new BooleanQuery.Builder();
-                buildRoleQuery(user, scriptService, shardId, queryShardContextProvider, queries, filter);
+                buildRoleQuery(user, scriptService, shardId, searchExecutionContextProvider, queries, filter);
             } else if (limitedByQueries != null) {
                 filter = new BooleanQuery.Builder();
-                buildRoleQuery(user, scriptService, shardId, queryShardContextProvider, limitedByQueries, filter);
+                buildRoleQuery(user, scriptService, shardId, searchExecutionContextProvider, limitedByQueries, filter);
             } else {
                 return null;
             }
@@ -112,24 +112,25 @@ public final class DocumentPermissions {
     }
 
     private static void buildRoleQuery(User user, ScriptService scriptService, ShardId shardId,
-                                       Function<ShardId, QueryShardContext> queryShardContextProvider, Set<BytesReference> queries,
+                                       Function<ShardId, SearchExecutionContext> searchExecutionContextProvider,
+                                       Set<BytesReference> queries,
                                        BooleanQuery.Builder filter) throws IOException {
         for (BytesReference bytesReference : queries) {
-            QueryShardContext queryShardContext = queryShardContextProvider.apply(shardId);
+            SearchExecutionContext searchExecutionContext = searchExecutionContextProvider.apply(shardId);
             QueryBuilder queryBuilder = DLSRoleQueryValidator.evaluateAndVerifyRoleQuery(bytesReference, scriptService,
-                queryShardContext.getXContentRegistry(), user);
+                searchExecutionContext.getXContentRegistry(), user);
             if (queryBuilder != null) {
-                failIfQueryUsesClient(queryBuilder, queryShardContext);
-                Query roleQuery = queryShardContext.toQuery(queryBuilder).query();
+                failIfQueryUsesClient(queryBuilder, searchExecutionContext);
+                Query roleQuery = searchExecutionContext.toQuery(queryBuilder).query();
                 filter.add(roleQuery, SHOULD);
-                if (queryShardContext.hasNested()) {
-                    NestedHelper nestedHelper = new NestedHelper(queryShardContext::getObjectMapper, queryShardContext::isFieldMapped);
+                if (searchExecutionContext.hasNested()) {
+                    NestedHelper nestedHelper = new NestedHelper(searchExecutionContext::getObjectMapper, searchExecutionContext::isFieldMapped);
                     if (nestedHelper.mightMatchNestedDocs(roleQuery)) {
                         roleQuery = new BooleanQuery.Builder().add(roleQuery, FILTER)
                             .add(Queries.newNonNestedFilter(), FILTER).build();
                     }
                     // If access is allowed on root doc then also access is allowed on all nested docs of that root document:
-                    BitSetProducer rootDocs = queryShardContext
+                    BitSetProducer rootDocs = searchExecutionContext
                         .bitsetFilter(Queries.newNonNestedFilter());
                     ToChildBlockJoinQuery includeNestedDocs = new ToChildBlockJoinQuery(roleQuery, rootDocs);
                     filter.add(includeNestedDocs, SHOULD);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/DocumentSubsetBitsetCacheTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/DocumentSubsetBitsetCacheTests.java
@@ -108,7 +108,9 @@ public class DocumentSubsetBitsetCacheTests extends ESTestCase {
     public void testNullBitSetIsReturnedForNonMatchingQuery() throws Exception {
         final DocumentSubsetBitsetCache cache = newCache(Settings.EMPTY);
         runTestOnIndex((searchExecutionContext, leafContext) -> {
-            final Query query = QueryBuilders.termQuery("not-mapped", "any-value").rewrite(searchExecutionContext).toQuery(searchExecutionContext);
+            final Query query = QueryBuilders.termQuery("not-mapped", "any-value")
+                .rewrite(searchExecutionContext)
+                .toQuery(searchExecutionContext);
             final BitSet bitSet = cache.getBitSet(query, leafContext);
             assertThat(bitSet, nullValue());
         });

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/DocumentSubsetBitsetCacheTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/DocumentSubsetBitsetCacheTests.java
@@ -37,7 +37,7 @@ import org.elasticsearch.index.mapper.Mapping;
 import org.elasticsearch.index.mapper.MappingLookup;
 import org.elasticsearch.index.mapper.MockFieldMapper;
 import org.elasticsearch.index.query.QueryBuilders;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.ESTestCase;
@@ -92,12 +92,12 @@ public class DocumentSubsetBitsetCacheTests extends ESTestCase {
 
     public void testSameBitSetIsReturnedForIdenticalQuery() throws Exception {
         final DocumentSubsetBitsetCache cache = newCache(Settings.EMPTY);
-        runTestOnIndex((shardContext, leafContext) -> {
-            final Query query1 = QueryBuilders.termQuery("field-1", "value-1").toQuery(shardContext);
+        runTestOnIndex((searchExecutionContext, leafContext) -> {
+            final Query query1 = QueryBuilders.termQuery("field-1", "value-1").toQuery(searchExecutionContext);
             final BitSet bitSet1 = cache.getBitSet(query1, leafContext);
             assertThat(bitSet1, notNullValue());
 
-            final Query query2 = QueryBuilders.termQuery("field-1", "value-1").toQuery(shardContext);
+            final Query query2 = QueryBuilders.termQuery("field-1", "value-1").toQuery(searchExecutionContext);
             final BitSet bitSet2 = cache.getBitSet(query2, leafContext);
             assertThat(bitSet2, notNullValue());
 
@@ -107,8 +107,8 @@ public class DocumentSubsetBitsetCacheTests extends ESTestCase {
 
     public void testNullBitSetIsReturnedForNonMatchingQuery() throws Exception {
         final DocumentSubsetBitsetCache cache = newCache(Settings.EMPTY);
-        runTestOnIndex((shardContext, leafContext) -> {
-            final Query query = QueryBuilders.termQuery("not-mapped", "any-value").rewrite(shardContext).toQuery(shardContext);
+        runTestOnIndex((searchExecutionContext, leafContext) -> {
+            final Query query = QueryBuilders.termQuery("not-mapped", "any-value").rewrite(searchExecutionContext).toQuery(searchExecutionContext);
             final BitSet bitSet = cache.getBitSet(query, leafContext);
             assertThat(bitSet, nullValue());
         });
@@ -118,9 +118,9 @@ public class DocumentSubsetBitsetCacheTests extends ESTestCase {
         final DocumentSubsetBitsetCache cache = newCache(Settings.EMPTY);
         assertThat(cache.ramBytesUsed(), equalTo(0L));
 
-        runTestOnIndex((shardContext, leafContext) -> {
+        runTestOnIndex((searchExecutionContext, leafContext) -> {
             for (int i = 1; i <= randomIntBetween(3, 6); i++) {
-                final Query query = QueryBuilders.termQuery("dne-" + i, "dne- " + i).toQuery(shardContext);
+                final Query query = QueryBuilders.termQuery("dne-" + i, "dne- " + i).toQuery(searchExecutionContext);
                 final BitSet bitSet = cache.getBitSet(query, leafContext);
                 assertThat(bitSet, nullValue());
                 assertThat(cache.ramBytesUsed(), equalTo(0L));
@@ -143,12 +143,12 @@ public class DocumentSubsetBitsetCacheTests extends ESTestCase {
         assertThat(cache.entryCount(), equalTo(0));
         assertThat(cache.ramBytesUsed(), equalTo(0L));
 
-        runTestOnIndex((shardContext, leafContext) -> {
+        runTestOnIndex((searchExecutionContext, leafContext) -> {
             Query previousQuery = null;
             BitSet previousBitSet = null;
             for (int i = 1; i <= 5; i++) {
                 final TermQueryBuilder queryBuilder = QueryBuilders.termQuery("field-" + i, "value-" + i);
-                final Query query = queryBuilder.toQuery(shardContext);
+                final Query query = queryBuilder.toQuery(searchExecutionContext);
                 final BitSet bitSet = cache.getBitSet(query, leafContext);
                 assertThat(bitSet, notNullValue());
                 assertThat(bitSet.ramBytesUsed(), equalTo(expectedBytesPerBitSet));
@@ -167,7 +167,7 @@ public class DocumentSubsetBitsetCacheTests extends ESTestCase {
                 previousQuery = query;
                 previousBitSet = bitSet;
 
-                assertThat(cache.getBitSet(queryBuilder.toQuery(shardContext), leafContext), sameInstance(bitSet));
+                assertThat(cache.getBitSet(queryBuilder.toQuery(searchExecutionContext), leafContext), sameInstance(bitSet));
                 assertThat(cache.entryCount(), equalTo(expectedCount));
                 assertThat(cache.ramBytesUsed(), equalTo(expectedCount * expectedBytesPerBitSet));
             }
@@ -210,9 +210,9 @@ public class DocumentSubsetBitsetCacheTests extends ESTestCase {
                     " consider increasing the value of [xpack.security.dls.bitset.cache.size]"
             ));
 
-            runTestOnIndex((shardContext, leafContext) -> {
+            runTestOnIndex((searchExecutionContext, leafContext) -> {
                 final TermQueryBuilder queryBuilder = QueryBuilders.termQuery("field-1", "value-1");
-                final Query query = queryBuilder.toQuery(shardContext);
+                final Query query = queryBuilder.toQuery(searchExecutionContext);
                 final BitSet bitSet = cache.getBitSet(query, leafContext);
                 assertThat(bitSet, notNullValue());
                 assertThat(bitSet.ramBytesUsed(), equalTo(expectedBytesPerBitSet));
@@ -252,10 +252,10 @@ public class DocumentSubsetBitsetCacheTests extends ESTestCase {
                     " consider increasing the value of [xpack.security.dls.bitset.cache.size]"
             ));
 
-            runTestOnIndex((shardContext, leafContext) -> {
+            runTestOnIndex((searchExecutionContext, leafContext) -> {
                 for (int i = 1; i <= 3; i++) {
                     final TermQueryBuilder queryBuilder = QueryBuilders.termQuery("field-" + i, "value-" + i);
-                    final Query query = queryBuilder.toQuery(shardContext);
+                    final Query query = queryBuilder.toQuery(searchExecutionContext);
                     final BitSet bitSet = cache.getBitSet(query, leafContext);
                     assertThat(bitSet, notNullValue());
                     assertThat(bitSet.ramBytesUsed(), equalTo(expectedBytesPerBitSet));
@@ -277,12 +277,12 @@ public class DocumentSubsetBitsetCacheTests extends ESTestCase {
         assertThat(cache.entryCount(), equalTo(0));
         assertThat(cache.ramBytesUsed(), equalTo(0L));
 
-        runTestOnIndex((shardContext, leafContext) -> {
-            final Query query1 = QueryBuilders.termQuery("field-1", "value-1").toQuery(shardContext);
+        runTestOnIndex((searchExecutionContext, leafContext) -> {
+            final Query query1 = QueryBuilders.termQuery("field-1", "value-1").toQuery(searchExecutionContext);
             final BitSet bitSet1 = cache.getBitSet(query1, leafContext);
             assertThat(bitSet1, notNullValue());
 
-            final Query query2 = QueryBuilders.termQuery("field-2", "value-2").toQuery(shardContext);
+            final Query query2 = QueryBuilders.termQuery("field-2", "value-2").toQuery(searchExecutionContext);
             assertBusy(() -> {
                 // Force the cache to perform eviction
                 final BitSet bitSet2 = cache.getBitSet(query2, leafContext);
@@ -321,12 +321,12 @@ public class DocumentSubsetBitsetCacheTests extends ESTestCase {
         assertThat(cache.entryCount(), equalTo(0));
         assertThat(cache.ramBytesUsed(), equalTo(0L));
 
-        runTestOnIndex((shardContext, leafContext) -> {
-            final Query query1 = QueryBuilders.termQuery("field-1", "value-1").toQuery(shardContext);
+        runTestOnIndex((searchExecutionContext, leafContext) -> {
+            final Query query1 = QueryBuilders.termQuery("field-1", "value-1").toQuery(searchExecutionContext);
             final BitSet bitSet1 = cache.getBitSet(query1, leafContext);
             assertThat(bitSet1, notNullValue());
 
-            final Query query2 = QueryBuilders.termQuery("field-2", "value-2").toQuery(shardContext);
+            final Query query2 = QueryBuilders.termQuery("field-2", "value-2").toQuery(searchExecutionContext);
             final BitSet bitSet2 = cache.getBitSet(query2, leafContext);
             assertThat(bitSet2, notNullValue());
 
@@ -392,7 +392,7 @@ public class DocumentSubsetBitsetCacheTests extends ESTestCase {
                             for (int field = 1; field <= FIELD_COUNT; field++) {
                                 final TermQueryBuilder queryBuilder = QueryBuilders.termQuery("field-" + field, "value-" + field);
                                 final TestIndexContext randomContext = randomFrom(contexts);
-                                final Query query = queryBuilder.toQuery(randomContext.queryShardContext);
+                                final Query query = queryBuilder.toQuery(randomContext.searchExecutionContext);
                                 final BitSet bitSet = cache.getBitSet(query, randomContext.leafReaderContext);
                                 assertThat(bitSet, notNullValue());
                                 assertThat(bitSet.ramBytesUsed(), equalTo(expectedBytesPerBitSet));
@@ -431,11 +431,11 @@ public class DocumentSubsetBitsetCacheTests extends ESTestCase {
         final int iterations = randomIntBetween(3, 10);
         AtomicInteger counter = new AtomicInteger(0);
 
-        final CheckedBiConsumer<QueryShardContext, LeafReaderContext, Exception> consumer = new CheckedBiConsumer<>() {
+        final CheckedBiConsumer<SearchExecutionContext, LeafReaderContext, Exception> consumer = new CheckedBiConsumer<>() {
             @Override
-            public void accept(QueryShardContext shardContext, LeafReaderContext leafContext) throws Exception {
+            public void accept(SearchExecutionContext searchExecutionContext, LeafReaderContext leafContext) throws Exception {
                 final int count = counter.incrementAndGet();
-                final Query query = QueryBuilders.termQuery("field-1", "value-1").toQuery(shardContext);
+                final Query query = QueryBuilders.termQuery("field-1", "value-1").toQuery(searchExecutionContext);
                 final BitSet bitSet = cache.getBitSet(query, leafContext);
 
                 assertThat(bitSet, notNullValue());
@@ -456,9 +456,9 @@ public class DocumentSubsetBitsetCacheTests extends ESTestCase {
         assertThat(cache.ramBytesUsed(), equalTo(0L));
 
         for (int i = 1; i <= randomIntBetween(2, 5); i++) {
-            runTestOnIndex((shardContext, leafContext) -> {
+            runTestOnIndex((searchExecutionContext, leafContext) -> {
                 for (int j = 1; j <= randomIntBetween(2, 10); j++) {
-                    final Query query = QueryBuilders.termQuery("field-" + j, "value-1").toQuery(shardContext);
+                    final Query query = QueryBuilders.termQuery("field-" + j, "value-1").toQuery(searchExecutionContext);
                     final BitSet bitSet = cache.getBitSet(query, leafContext);
                     assertThat(bitSet, notNullValue());
                 }
@@ -507,10 +507,10 @@ public class DocumentSubsetBitsetCacheTests extends ESTestCase {
         }
     }
 
-    private void runTestOnIndex(CheckedBiConsumer<QueryShardContext, LeafReaderContext, Exception> body) throws Exception {
+    private void runTestOnIndex(CheckedBiConsumer<SearchExecutionContext, LeafReaderContext, Exception> body) throws Exception {
         runTestOnIndices(1, ctx -> {
             final TestIndexContext indexContext = ctx.get(0);
-            body.accept(indexContext.queryShardContext, indexContext.leafReaderContext);
+            body.accept(indexContext.searchExecutionContext, indexContext.leafReaderContext);
         });
     }
 
@@ -518,15 +518,15 @@ public class DocumentSubsetBitsetCacheTests extends ESTestCase {
         private final Directory directory;
         private final IndexWriter indexWriter;
         private final DirectoryReader directoryReader;
-        private final QueryShardContext queryShardContext;
+        private final SearchExecutionContext searchExecutionContext;
         private final LeafReaderContext leafReaderContext;
 
         private TestIndexContext(Directory directory, IndexWriter indexWriter, DirectoryReader directoryReader,
-                                 QueryShardContext queryShardContext, LeafReaderContext leafReaderContext) {
+                                 SearchExecutionContext searchExecutionContext, LeafReaderContext leafReaderContext) {
             this.directory = directory;
             this.indexWriter = indexWriter;
             this.directoryReader = directoryReader;
-            this.queryShardContext = queryShardContext;
+            this.searchExecutionContext = searchExecutionContext;
             this.leafReaderContext = leafReaderContext;
         }
 
@@ -565,11 +565,11 @@ public class DocumentSubsetBitsetCacheTests extends ESTestCase {
             directoryReader = DirectoryReader.open(directory);
             final LeafReaderContext leaf = directoryReader.leaves().get(0);
 
-            final QueryShardContext shardContext = new QueryShardContext(shardId.id(), 0, indexSettings,
+            final SearchExecutionContext searchExecutionContext = new SearchExecutionContext(shardId.id(), 0, indexSettings,
                 null, null, null, mappingLookup, null, null, xContentRegistry(), writableRegistry(),
                 client, new IndexSearcher(directoryReader), () -> nowInMillis, null, null, () -> true, null, emptyMap());
 
-            context = new TestIndexContext(directory, iw, directoryReader, shardContext, leaf);
+            context = new TestIndexContext(directory, iw, directoryReader, searchExecutionContext, leaf);
             return context;
         } finally {
             if (context == null) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/MockDeprecatedQueryBuilder.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/MockDeprecatedQueryBuilder.java
@@ -16,7 +16,7 @@ import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.query.AbstractQueryBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 
 import java.io.IOException;
 
@@ -70,7 +70,7 @@ public class MockDeprecatedQueryBuilder extends AbstractQueryBuilder<MockDepreca
     }
 
     @Override
-    protected Query doToQuery(QueryShardContext context) throws IOException {
+    protected Query doToQuery(SearchExecutionContext context) throws IOException {
         return Queries.newMatchAllQuery();
     }
 

--- a/x-pack/plugin/data-streams/src/main/java/org/elasticsearch/xpack/datastreams/mapper/DataStreamTimestampFieldMapper.java
+++ b/x-pack/plugin/data-streams/src/main/java/org/elasticsearch/xpack/datastreams/mapper/DataStreamTimestampFieldMapper.java
@@ -22,7 +22,7 @@ import org.elasticsearch.index.mapper.MetadataFieldMapper;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.TextSearchInfo;
 import org.elasticsearch.index.mapper.ValueFetcher;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -51,17 +51,17 @@ public class DataStreamTimestampFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
-        public Query termQuery(Object value, QueryShardContext context) {
+        public Query termQuery(Object value, SearchExecutionContext context) {
             throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] does not support term queries");
         }
 
         @Override
-        public Query existsQuery(QueryShardContext context) {
+        public Query existsQuery(SearchExecutionContext context) {
             throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] does not support exists queries");
         }
 
         @Override
-        public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             throw new UnsupportedOperationException();
         }
     }

--- a/x-pack/plugin/deprecation/qa/rest/src/main/java/org/elasticsearch/xpack/deprecation/TestDeprecatedQueryBuilder.java
+++ b/x-pack/plugin/deprecation/qa/rest/src/main/java/org/elasticsearch/xpack/deprecation/TestDeprecatedQueryBuilder.java
@@ -15,7 +15,7 @@ import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.query.AbstractQueryBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 
 import java.io.IOException;
 
@@ -64,7 +64,7 @@ public class TestDeprecatedQueryBuilder extends AbstractQueryBuilder<TestDepreca
     }
 
     @Override
-    protected Query doToQuery(QueryShardContext context) throws IOException {
+    protected Query doToQuery(SearchExecutionContext context) throws IOException {
         deprecationLogger.deprecate(NAME, "[{}] query is deprecated, but used on [{}] index", NAME, context.index().getName());
 
         return Queries.newMatchAllQuery();

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/EnrichShardMultiSearchAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/EnrichShardMultiSearchAction.java
@@ -50,7 +50,7 @@ import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.fieldvisitor.FieldsVisitor;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.IndicesService;
@@ -240,7 +240,7 @@ public class EnrichShardMultiSearchAction extends ActionType<MultiSearchResponse
                  * any.
                  */
                 Map<String, Object> runtimeFields = emptyMap();
-                final QueryShardContext context = indexService.newQueryShardContext(
+                final SearchExecutionContext context = indexService.newSearchExecutionContext(
                     shardId.id(),
                     0,
                     searcher,

--- a/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateDoubleMetricFieldMapper.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateDoubleMetricFieldMapper.java
@@ -295,7 +295,13 @@ public class AggregateDoubleMetricFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, SearchExecutionContext context) {
+        public Query rangeQuery(
+            Object lowerTerm,
+            Object upperTerm,
+            boolean includeLower,
+            boolean includeUpper,
+            SearchExecutionContext context
+        ) {
             return delegateFieldType().rangeQuery(lowerTerm, upperTerm, includeLower, includeUpper, context);
         }
 

--- a/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateDoubleMetricFieldMapper.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateDoubleMetricFieldMapper.java
@@ -33,7 +33,7 @@ import org.elasticsearch.index.mapper.SourceValueFetcher;
 import org.elasticsearch.index.mapper.TextSearchInfo;
 import org.elasticsearch.index.mapper.ValueFetcher;
 import org.elasticsearch.index.query.QueryRewriteContext;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.search.lookup.SearchLookup;
@@ -277,12 +277,12 @@ public class AggregateDoubleMetricFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query existsQuery(QueryShardContext context) {
+        public Query existsQuery(SearchExecutionContext context) {
             return delegateFieldType().existsQuery(context);
         }
 
         @Override
-        public Query termQuery(Object value, QueryShardContext context) {
+        public Query termQuery(Object value, SearchExecutionContext context) {
             if (value == null) {
                 throw new IllegalArgumentException("Cannot search for null.");
             }
@@ -290,12 +290,12 @@ public class AggregateDoubleMetricFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query termsQuery(List<?> values, QueryShardContext context) {
+        public Query termsQuery(List<?> values, SearchExecutionContext context) {
             return delegateFieldType().termsQuery(values, context);
         }
 
         @Override
-        public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, QueryShardContext context) {
+        public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, SearchExecutionContext context) {
             return delegateFieldType().rangeQuery(lowerTerm, upperTerm, includeLower, includeUpper, context);
         }
 
@@ -423,7 +423,7 @@ public class AggregateDoubleMetricFieldMapper extends FieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             if (format != null) {
                 throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
             }

--- a/x-pack/plugin/mapper-constant-keyword/src/main/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapper.java
+++ b/x-pack/plugin/mapper-constant-keyword/src/main/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapper.java
@@ -34,7 +34,7 @@ import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.ValueFetcher;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.lookup.SearchLookup;
 
@@ -130,7 +130,7 @@ public class ConstantKeywordFieldMapper extends FieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             if (format != null) {
                 throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
             }
@@ -141,7 +141,7 @@ public class ConstantKeywordFieldMapper extends FieldMapper {
         }
 
         @Override
-        protected boolean matches(String pattern, boolean caseInsensitive, QueryShardContext context) {
+        protected boolean matches(String pattern, boolean caseInsensitive, SearchExecutionContext context) {
             if (value == null) {
                 return false;
             }
@@ -149,7 +149,7 @@ public class ConstantKeywordFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query existsQuery(QueryShardContext context) {
+        public Query existsQuery(SearchExecutionContext context) {
             return value != null ? new MatchAllDocsQuery() : new MatchNoDocsQuery();
         }
 
@@ -158,7 +158,7 @@ public class ConstantKeywordFieldMapper extends FieldMapper {
                 Object lowerTerm, Object upperTerm,
                 boolean includeLower, boolean includeUpper,
                 ShapeRelation relation, ZoneId timeZone, DateMathParser parser,
-                QueryShardContext context) {
+                SearchExecutionContext context) {
             if (this.value == null) {
                 return new MatchNoDocsQuery();
             }
@@ -175,7 +175,7 @@ public class ConstantKeywordFieldMapper extends FieldMapper {
 
         @Override
         public Query fuzzyQuery(Object value, Fuzziness fuzziness, int prefixLength, int maxExpansions,
-                boolean transpositions, QueryShardContext context) {
+                boolean transpositions, SearchExecutionContext context) {
             if (this.value == null) {
                 return new MatchNoDocsQuery();
             }
@@ -205,7 +205,7 @@ public class ConstantKeywordFieldMapper extends FieldMapper {
 
         @Override
         public Query regexpQuery(String value, int syntaxFlags, int matchFlags, int maxDeterminizedStates,
-                MultiTermQuery.RewriteMethod method, QueryShardContext context) {
+                MultiTermQuery.RewriteMethod method, SearchExecutionContext context) {
             if (this.value == null) {
                 return new MatchNoDocsQuery();
             }

--- a/x-pack/plugin/mapper-flattened/src/main/java/org/elasticsearch/xpack/flattened/mapper/FlattenedFieldMapper.java
+++ b/x-pack/plugin/mapper-flattened/src/main/java/org/elasticsearch/xpack/flattened/mapper/FlattenedFieldMapper.java
@@ -39,7 +39,7 @@ import org.elasticsearch.index.mapper.StringFieldType;
 import org.elasticsearch.index.mapper.TextParams;
 import org.elasticsearch.index.mapper.TextSearchInfo;
 import org.elasticsearch.index.mapper.ValueFetcher;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.similarity.SimilarityProvider;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.search.DocValueFormat;
@@ -184,7 +184,7 @@ public final class FlattenedFieldMapper extends DynamicKeyFieldMapper {
         }
 
         @Override
-        public Query existsQuery(QueryShardContext context) {
+        public Query existsQuery(SearchExecutionContext context) {
             Term term = new Term(name(), FlattenedFieldParser.createKeyedValue(key, ""));
             return new PrefixQuery(term);
         }
@@ -194,7 +194,7 @@ public final class FlattenedFieldMapper extends DynamicKeyFieldMapper {
                                 Object upperTerm,
                                 boolean includeLower,
                                 boolean includeUpper,
-                                QueryShardContext context) {
+                                SearchExecutionContext context) {
 
             // We require range queries to specify both bounds because an unbounded query could incorrectly match
             // values from other keys. For example, a query on the 'first' key with only a lower bound would become
@@ -210,14 +210,14 @@ public final class FlattenedFieldMapper extends DynamicKeyFieldMapper {
 
         @Override
         public Query fuzzyQuery(Object value, Fuzziness fuzziness, int prefixLength, int maxExpansions,
-                                boolean transpositions, QueryShardContext context) {
+                                boolean transpositions, SearchExecutionContext context) {
             throw new UnsupportedOperationException("[fuzzy] queries are not currently supported on keyed " +
                 "[" + CONTENT_TYPE + "] fields.");
         }
 
         @Override
         public Query regexpQuery(String value, int syntaxFlags, int matchFlags, int maxDeterminizedStates,
-                                 MultiTermQuery.RewriteMethod method, QueryShardContext context) {
+                                 MultiTermQuery.RewriteMethod method, SearchExecutionContext context) {
             throw new UnsupportedOperationException("[regexp] queries are not currently supported on keyed " +
                 "[" + CONTENT_TYPE + "] fields.");
         }
@@ -226,13 +226,13 @@ public final class FlattenedFieldMapper extends DynamicKeyFieldMapper {
         public Query wildcardQuery(String value,
                                    MultiTermQuery.RewriteMethod method,
                                    boolean caseInsensitive,
-                                   QueryShardContext context) {
+                                   SearchExecutionContext context) {
             throw new UnsupportedOperationException("[wildcard] queries are not currently supported on keyed " +
                 "[" + CONTENT_TYPE + "] fields.");
         }
 
         @Override
-        public Query termQueryCaseInsensitive(Object value, QueryShardContext context) {
+        public Query termQueryCaseInsensitive(Object value, SearchExecutionContext context) {
             return AutomatonQueries.caseInsensitiveTermQuery(new Term(name(), indexedValueForSearch(value)));
         }
 
@@ -256,7 +256,7 @@ public final class FlattenedFieldMapper extends DynamicKeyFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             // This is an internal field but it can match a field pattern so we return an empty list.
             return lookup -> List.of();
         }
@@ -402,7 +402,7 @@ public final class FlattenedFieldMapper extends DynamicKeyFieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             return SourceValueFetcher.identity(name(), context, format);
         }
     }

--- a/x-pack/plugin/mapper-flattened/src/test/java/org/elasticsearch/xpack/flattened/mapper/KeyedFlattenedFieldTypeTests.java
+++ b/x-pack/plugin/mapper-flattened/src/test/java/org/elasticsearch/xpack/flattened/mapper/KeyedFlattenedFieldTypeTests.java
@@ -87,13 +87,13 @@ public class KeyedFlattenedFieldTypeTests extends FieldTypeTestCase {
         KeyedFlattenedFieldType ft = createFieldType();
 
         Query expected = new PrefixQuery(new Term("field", "key\0val"));
-        assertEquals(expected, ft.prefixQuery("val", MultiTermQuery.CONSTANT_SCORE_REWRITE, false, MOCK_QSC));
+        assertEquals(expected, ft.prefixQuery("val", MultiTermQuery.CONSTANT_SCORE_REWRITE, false, MOCK_CONTEXT));
 
         expected = AutomatonQueries.caseInsensitivePrefixQuery(new Term("field", "key\0vAl"));
-        assertEquals(expected, ft.prefixQuery("vAl", MultiTermQuery.CONSTANT_SCORE_REWRITE, true, MOCK_QSC));
+        assertEquals(expected, ft.prefixQuery("vAl", MultiTermQuery.CONSTANT_SCORE_REWRITE, true, MOCK_CONTEXT));
 
         ElasticsearchException ee = expectThrows(ElasticsearchException.class,
-                () -> ft.prefixQuery("val", MultiTermQuery.CONSTANT_SCORE_REWRITE, false, MOCK_QSC_DISALLOW_EXPENSIVE));
+                () -> ft.prefixQuery("val", MultiTermQuery.CONSTANT_SCORE_REWRITE, false, MOCK_CONTEXT_DISALLOW_EXPENSIVE));
         assertEquals("[prefix] queries cannot be executed when 'search.allow_expensive_queries' is set to false. " +
                 "For optimised prefix queries on text fields please enable [index_prefixes].", ee.getMessage());
     }
@@ -102,7 +102,7 @@ public class KeyedFlattenedFieldTypeTests extends FieldTypeTestCase {
         KeyedFlattenedFieldType ft = createFieldType();
 
         UnsupportedOperationException e = expectThrows(UnsupportedOperationException.class,
-            () -> ft.fuzzyQuery("value", Fuzziness.fromEdits(2), 1, 50, true, randomMockShardContext()));
+            () -> ft.fuzzyQuery("value", Fuzziness.fromEdits(2), 1, 50, true, randomMockContext()));
         assertEquals("[fuzzy] queries are not currently supported on keyed [flattened] fields.", e.getMessage());
     }
 
@@ -112,12 +112,12 @@ public class KeyedFlattenedFieldTypeTests extends FieldTypeTestCase {
         TermRangeQuery expected = new TermRangeQuery("field",
             new BytesRef("key\0lower"),
             new BytesRef("key\0upper"), false, false);
-        assertEquals(expected, ft.rangeQuery("lower", "upper", false, false, MOCK_QSC));
+        assertEquals(expected, ft.rangeQuery("lower", "upper", false, false, MOCK_CONTEXT));
 
         expected = new TermRangeQuery("field",
             new BytesRef("key\0lower"),
             new BytesRef("key\0upper"), true, true);
-        assertEquals(expected, ft.rangeQuery("lower", "upper", true, true, MOCK_QSC));
+        assertEquals(expected, ft.rangeQuery("lower", "upper", true, true, MOCK_CONTEXT));
 
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () ->
             ft.rangeQuery("lower", null, false, false, null));
@@ -125,12 +125,12 @@ public class KeyedFlattenedFieldTypeTests extends FieldTypeTestCase {
             e.getMessage());
 
         e = expectThrows(IllegalArgumentException.class, () ->
-            ft.rangeQuery(null, "upper", false, false, MOCK_QSC));
+            ft.rangeQuery(null, "upper", false, false, MOCK_CONTEXT));
         assertEquals("[range] queries on keyed [flattened] fields must include both an upper and a lower bound.",
             e.getMessage());
 
         ElasticsearchException ee = expectThrows(ElasticsearchException.class,
-                () -> ft.rangeQuery("lower", "upper", false, false, MOCK_QSC_DISALLOW_EXPENSIVE));
+                () -> ft.rangeQuery("lower", "upper", false, false, MOCK_CONTEXT_DISALLOW_EXPENSIVE));
         assertEquals("[range] queries on [text] or [keyword] fields cannot be executed when " +
                 "'search.allow_expensive_queries' is set to false.", ee.getMessage());
     }
@@ -139,7 +139,7 @@ public class KeyedFlattenedFieldTypeTests extends FieldTypeTestCase {
         KeyedFlattenedFieldType ft = createFieldType();
 
         UnsupportedOperationException e = expectThrows(UnsupportedOperationException.class,
-            () -> ft.regexpQuery("valu*", 0, 0, 10, null, randomMockShardContext()));
+            () -> ft.regexpQuery("valu*", 0, 0, 10, null, randomMockContext()));
         assertEquals("[regexp] queries are not currently supported on keyed [flattened] fields.", e.getMessage());
     }
 
@@ -147,7 +147,7 @@ public class KeyedFlattenedFieldTypeTests extends FieldTypeTestCase {
         KeyedFlattenedFieldType ft = createFieldType();
 
         UnsupportedOperationException e = expectThrows(UnsupportedOperationException.class,
-            () -> ft.wildcardQuery("valu*", null, false, randomMockShardContext()));
+            () -> ft.wildcardQuery("valu*", null, false, randomMockContext()));
         assertEquals("[wildcard] queries are not currently supported on keyed [flattened] fields.", e.getMessage());
     }
 

--- a/x-pack/plugin/mapper-flattened/src/test/java/org/elasticsearch/xpack/flattened/mapper/RootFlattenedFieldTypeTests.java
+++ b/x-pack/plugin/mapper-flattened/src/test/java/org/elasticsearch/xpack/flattened/mapper/RootFlattenedFieldTypeTests.java
@@ -72,12 +72,12 @@ public class RootFlattenedFieldTypeTests extends FieldTypeTestCase {
         RootFlattenedFieldType ft = createDefaultFieldType();
 
         Query expected = new FuzzyQuery(new Term("field", "value"), 2, 1, 50, true);
-        Query actual = ft.fuzzyQuery("value", Fuzziness.fromEdits(2), 1, 50, true, MOCK_QSC);
+        Query actual = ft.fuzzyQuery("value", Fuzziness.fromEdits(2), 1, 50, true, MOCK_CONTEXT);
         assertEquals(expected, actual);
 
         ElasticsearchException ee = expectThrows(ElasticsearchException.class,
                 () -> ft.fuzzyQuery("value", Fuzziness.AUTO, randomInt(10) + 1, randomInt(10) + 1,
-                        randomBoolean(), MOCK_QSC_DISALLOW_EXPENSIVE));
+                        randomBoolean(), MOCK_CONTEXT_DISALLOW_EXPENSIVE));
         assertEquals("[fuzzy] queries cannot be executed when 'search.allow_expensive_queries' is set to false.",
                 ee.getMessage());
     }
@@ -88,15 +88,15 @@ public class RootFlattenedFieldTypeTests extends FieldTypeTestCase {
         TermRangeQuery expected = new TermRangeQuery("field",
             new BytesRef("lower"),
             new BytesRef("upper"), false, false);
-        assertEquals(expected, ft.rangeQuery("lower", "upper", false, false, MOCK_QSC));
+        assertEquals(expected, ft.rangeQuery("lower", "upper", false, false, MOCK_CONTEXT));
 
         expected = new TermRangeQuery("field",
             new BytesRef("lower"),
             new BytesRef("upper"), true, true);
-        assertEquals(expected, ft.rangeQuery("lower", "upper", true, true, MOCK_QSC));
+        assertEquals(expected, ft.rangeQuery("lower", "upper", true, true, MOCK_CONTEXT));
 
         ElasticsearchException ee = expectThrows(ElasticsearchException.class,
-                () -> ft.rangeQuery("lower", "upper", true, true, MOCK_QSC_DISALLOW_EXPENSIVE));
+                () -> ft.rangeQuery("lower", "upper", true, true, MOCK_CONTEXT_DISALLOW_EXPENSIVE));
         assertEquals("[range] queries on [text] or [keyword] fields cannot be executed when " +
                 "'search.allow_expensive_queries' is set to false.", ee.getMessage());
     }
@@ -105,11 +105,11 @@ public class RootFlattenedFieldTypeTests extends FieldTypeTestCase {
         RootFlattenedFieldType ft = createDefaultFieldType();
 
         Query expected = new RegexpQuery(new Term("field", "val.*"));
-        Query actual = ft.regexpQuery("val.*", 0, 0, 10, null, MOCK_QSC);
+        Query actual = ft.regexpQuery("val.*", 0, 0, 10, null, MOCK_CONTEXT);
         assertEquals(expected, actual);
 
         ElasticsearchException ee = expectThrows(ElasticsearchException.class,
-                () -> ft.regexpQuery("val.*", randomInt(10), 0, randomInt(10) + 1, null, MOCK_QSC_DISALLOW_EXPENSIVE));
+                () -> ft.regexpQuery("val.*", randomInt(10), 0, randomInt(10) + 1, null, MOCK_CONTEXT_DISALLOW_EXPENSIVE));
         assertEquals("[regexp] queries cannot be executed when 'search.allow_expensive_queries' is set to false.",
                 ee.getMessage());
     }
@@ -118,10 +118,10 @@ public class RootFlattenedFieldTypeTests extends FieldTypeTestCase {
         RootFlattenedFieldType ft = createDefaultFieldType();
 
         Query expected = new WildcardQuery(new Term("field", new BytesRef("valu*")));
-        assertEquals(expected, ft.wildcardQuery("valu*", null, MOCK_QSC));
+        assertEquals(expected, ft.wildcardQuery("valu*", null, MOCK_CONTEXT));
 
         ElasticsearchException ee = expectThrows(ElasticsearchException.class,
-                () -> ft.wildcardQuery("valu*", null, MOCK_QSC_DISALLOW_EXPENSIVE));
+                () -> ft.wildcardQuery("valu*", null, MOCK_CONTEXT_DISALLOW_EXPENSIVE));
         assertEquals("[wildcard] queries cannot be executed when 'search.allow_expensive_queries' is set to false.",
                 ee.getMessage());
     }

--- a/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
@@ -191,7 +191,13 @@ public class UnsignedLongFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, SearchExecutionContext context) {
+        public Query rangeQuery(
+            Object lowerTerm,
+            Object upperTerm,
+            boolean includeLower,
+            boolean includeUpper,
+            SearchExecutionContext context
+        ) {
             failIfNotIndexed();
             long l = Long.MIN_VALUE;
             long u = Long.MAX_VALUE;

--- a/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
@@ -32,7 +32,7 @@ import org.elasticsearch.index.mapper.SimpleMappedFieldType;
 import org.elasticsearch.index.mapper.SourceValueFetcher;
 import org.elasticsearch.index.mapper.TextSearchInfo;
 import org.elasticsearch.index.mapper.ValueFetcher;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.lookup.SearchLookup;
 
@@ -160,7 +160,7 @@ public class UnsignedLongFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query termQuery(Object value, QueryShardContext context) {
+        public Query termQuery(Object value, SearchExecutionContext context) {
             failIfNotIndexed();
             Long longValue = parseTerm(value);
             if (longValue == null) {
@@ -170,7 +170,7 @@ public class UnsignedLongFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query termsQuery(List<?> values, QueryShardContext context) {
+        public Query termsQuery(List<?> values, SearchExecutionContext context) {
             failIfNotIndexed();
             long[] lvalues = new long[values.size()];
             int upTo = 0;
@@ -191,7 +191,7 @@ public class UnsignedLongFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, QueryShardContext context) {
+        public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, SearchExecutionContext context) {
             failIfNotIndexed();
             long l = Long.MIN_VALUE;
             long u = Long.MAX_VALUE;
@@ -231,7 +231,7 @@ public class UnsignedLongFieldMapper extends FieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             if (format != null) {
                 throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
             }

--- a/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/VersionStringFieldMapper.java
+++ b/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/VersionStringFieldMapper.java
@@ -42,7 +42,7 @@ import org.elasticsearch.index.mapper.SourceValueFetcher;
 import org.elasticsearch.index.mapper.TermBasedFieldType;
 import org.elasticsearch.index.mapper.TextSearchInfo;
 import org.elasticsearch.index.mapper.ValueFetcher;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.support.QueryParsers;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
@@ -131,17 +131,17 @@ public class VersionStringFieldMapper extends FieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             return SourceValueFetcher.toString(name(), context, format);
         }
 
         @Override
-        public Query existsQuery(QueryShardContext context) {
+        public Query existsQuery(SearchExecutionContext context) {
             return new DocValuesFieldExistsQuery(name());
         }
 
         @Override
-        public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive, QueryShardContext context) {
+        public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive, SearchExecutionContext context) {
             return wildcardQuery(value + "*", method, caseInsensitive, context);
         }
 
@@ -159,7 +159,7 @@ public class VersionStringFieldMapper extends FieldMapper {
             int matchFlags,
             int maxDeterminizedStates,
             @Nullable MultiTermQuery.RewriteMethod method,
-            QueryShardContext context
+            SearchExecutionContext context
         ) {
             if (context.allowExpensiveQueries() == false) {
                 throw new ElasticsearchException(
@@ -205,7 +205,7 @@ public class VersionStringFieldMapper extends FieldMapper {
             int prefixLength,
             int maxExpansions,
             boolean transpositions,
-            QueryShardContext context
+            SearchExecutionContext context
         ) {
             if (context.allowExpensiveQueries() == false) {
                 throw new ElasticsearchException(
@@ -240,7 +240,7 @@ public class VersionStringFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query wildcardQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive, QueryShardContext context) {
+        public Query wildcardQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive, SearchExecutionContext context) {
             if (context.allowExpensiveQueries() == false) {
                 throw new ElasticsearchException(
                     "[wildcard] queries cannot be executed when '" + ALLOW_EXPENSIVE_QUERIES.getKey() + "' is set to false."
@@ -293,7 +293,7 @@ public class VersionStringFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, QueryShardContext context) {
+        public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, SearchExecutionContext context) {
             BytesRef lower = lowerTerm == null ? null : indexedValueForSearch(lowerTerm);
             BytesRef upper = upperTerm == null ? null : indexedValueForSearch(upperTerm);
             return new TermRangeQuery(name(), lower, upper, includeLower, includeUpper);

--- a/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/VersionStringFieldMapper.java
+++ b/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/VersionStringFieldMapper.java
@@ -141,7 +141,12 @@ public class VersionStringFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive, SearchExecutionContext context) {
+        public Query prefixQuery(
+            String value,
+            MultiTermQuery.RewriteMethod method,
+            boolean caseInsensitive,
+            SearchExecutionContext context
+        ) {
             return wildcardQuery(value + "*", method, caseInsensitive, context);
         }
 
@@ -240,7 +245,12 @@ public class VersionStringFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query wildcardQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive, SearchExecutionContext context) {
+        public Query wildcardQuery(
+            String value,
+            MultiTermQuery.RewriteMethod method,
+            boolean caseInsensitive,
+            SearchExecutionContext context
+        ) {
             if (context.allowExpensiveQueries() == false) {
                 throw new ElasticsearchException(
                     "[wildcard] queries cannot be executed when '" + ALLOW_EXPENSIVE_QUERIES.getKey() + "' is set to false."
@@ -293,7 +303,13 @@ public class VersionStringFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, SearchExecutionContext context) {
+        public Query rangeQuery(
+            Object lowerTerm,
+            Object upperTerm,
+            boolean includeLower,
+            boolean includeUpper,
+            SearchExecutionContext context
+        ) {
             BytesRef lower = lowerTerm == null ? null : indexedValueForSearch(lowerTerm);
             BytesRef upper = upperTerm == null ? null : indexedValueForSearch(upperTerm);
             return new TermRangeQuery(name(), lower, upper, includeLower, includeUpper);

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerIndexingTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerIndexingTests.java
@@ -38,7 +38,7 @@ import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.AggregatorTestCase;
@@ -81,15 +81,15 @@ import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.hamcrest.number.OrderingComparison.greaterThan;
 
 public class RollupIndexerIndexingTests extends AggregatorTestCase {
-    private QueryShardContext queryShardContext;
+    private SearchExecutionContext searchExecutionContext;
     private IndexSettings settings;
 
     @Before
     private void setup() {
         settings = createIndexSettings();
-        queryShardContext = new QueryShardContext(0, 0, settings,
+        searchExecutionContext = new SearchExecutionContext(0, 0, settings,
             null, null, null, null, null, null,
-                null, null, null, null, () -> 0L, null, null, () -> true, null, emptyMap());
+            null, null, null, null, () -> 0L, null, null, () -> true, null, emptyMap());
     }
 
     public void testSimpleDateHisto() throws Exception {
@@ -642,7 +642,7 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
             RangeQueryBuilder range = (RangeQueryBuilder) request.source().query();
             final ZoneId timeZone = range.timeZone() != null ? ZoneId.of(range.timeZone()) : null;
             Query query = timestampField.rangeQuery(range.from(), range.to(), range.includeLower(), range.includeUpper(),
-                    null, timeZone, DateFormatter.forPattern(range.format()).toDateMathParser(), queryShardContext);
+                    null, timeZone, DateFormatter.forPattern(range.format()).toDateMathParser(), searchExecutionContext);
 
             // extract composite agg
             assertThat(request.source().aggregations().getAggregatorFactories().size(), equalTo(1));

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/AbstractScriptFieldType.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/AbstractScriptFieldType.java
@@ -26,7 +26,7 @@ import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.RuntimeFieldType;
 import org.elasticsearch.index.mapper.ValueFetcher;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.lookup.SearchLookup;
@@ -86,7 +86,7 @@ abstract class AbstractScriptFieldType<LeafFactory> extends RuntimeFieldType {
     /**
      * Create a script leaf factory for queries.
      */
-    protected final LeafFactory leafFactory(QueryShardContext context) {
+    protected final LeafFactory leafFactory(SearchExecutionContext context) {
         /*
          * Forking here causes us to count this field in the field data loop
          * detection code as though we were resolving field data for this field.
@@ -104,7 +104,7 @@ abstract class AbstractScriptFieldType<LeafFactory> extends RuntimeFieldType {
         ShapeRelation relation,
         ZoneId timeZone,
         DateMathParser parser,
-        QueryShardContext context
+        SearchExecutionContext context
     ) {
         if (relation == ShapeRelation.DISJOINT) {
             String message = "Runtime field [%s] of type [%s] does not support DISJOINT ranges";
@@ -120,7 +120,7 @@ abstract class AbstractScriptFieldType<LeafFactory> extends RuntimeFieldType {
         boolean includeUpper,
         ZoneId timeZone,
         DateMathParser parser,
-        QueryShardContext context
+        SearchExecutionContext context
     );
 
     @Override
@@ -130,18 +130,18 @@ abstract class AbstractScriptFieldType<LeafFactory> extends RuntimeFieldType {
         int prefixLength,
         int maxExpansions,
         boolean transpositions,
-        QueryShardContext context
+        SearchExecutionContext context
     ) {
         throw new IllegalArgumentException(unsupported("fuzzy", "keyword and text"));
     }
 
     @Override
-    public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive, QueryShardContext context) {
+    public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive, SearchExecutionContext context) {
         throw new IllegalArgumentException(unsupported("prefix", "keyword, text and wildcard"));
     }
 
     @Override
-    public Query wildcardQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive, QueryShardContext context) {
+    public Query wildcardQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive, SearchExecutionContext context) {
         throw new IllegalArgumentException(unsupported("wildcard", "keyword, text and wildcard"));
     }
 
@@ -152,7 +152,7 @@ abstract class AbstractScriptFieldType<LeafFactory> extends RuntimeFieldType {
         int matchFlags,
         int maxDeterminizedStates,
         MultiTermQuery.RewriteMethod method,
-        QueryShardContext context
+        SearchExecutionContext context
     ) {
         throw new IllegalArgumentException(unsupported("regexp", "keyword and text"));
     }
@@ -173,7 +173,7 @@ abstract class AbstractScriptFieldType<LeafFactory> extends RuntimeFieldType {
     }
 
     @Override
-    public SpanQuery spanPrefixQuery(String value, SpanMultiTermQueryWrapper.SpanRewriteMethod method, QueryShardContext context) {
+    public SpanQuery spanPrefixQuery(String value, SpanMultiTermQueryWrapper.SpanRewriteMethod method, SearchExecutionContext context) {
         throw new IllegalArgumentException(unsupported("span prefix", "text"));
     }
 
@@ -188,7 +188,7 @@ abstract class AbstractScriptFieldType<LeafFactory> extends RuntimeFieldType {
         );
     }
 
-    protected final void checkAllowExpensiveQueries(QueryShardContext context) {
+    protected final void checkAllowExpensiveQueries(SearchExecutionContext context) {
         if (context.allowExpensiveQueries() == false) {
             throw new ElasticsearchException(
                 "queries cannot be executed against runtime fields while [" + ALLOW_EXPENSIVE_QUERIES.getKey() + "] is set to [false]."
@@ -197,7 +197,7 @@ abstract class AbstractScriptFieldType<LeafFactory> extends RuntimeFieldType {
     }
 
     @Override
-    public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+    public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
         return new DocValueFetcher(docValueFormat(format, null), context.getForField(this));
     }
 

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/BooleanScriptFieldType.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/BooleanScriptFieldType.java
@@ -17,7 +17,7 @@ import org.elasticsearch.common.time.DateMathParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.mapper.BooleanFieldMapper;
 import org.elasticsearch.index.mapper.RuntimeFieldType;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.lookup.SearchLookup;
@@ -100,7 +100,7 @@ public final class BooleanScriptFieldType extends AbstractScriptFieldType<Boolea
     }
 
     @Override
-    public Query existsQuery(QueryShardContext context) {
+    public Query existsQuery(SearchExecutionContext context) {
         checkAllowExpensiveQueries(context);
         return new BooleanScriptFieldExistsQuery(script, leafFactory(context), name());
     }
@@ -113,7 +113,7 @@ public final class BooleanScriptFieldType extends AbstractScriptFieldType<Boolea
         boolean includeUpper,
         ZoneId timeZone,
         DateMathParser parser,
-        QueryShardContext context
+        SearchExecutionContext context
     ) {
         boolean trueAllowed;
         boolean falseAllowed;
@@ -171,19 +171,19 @@ public final class BooleanScriptFieldType extends AbstractScriptFieldType<Boolea
     }
 
     @Override
-    public Query termQueryCaseInsensitive(Object value, QueryShardContext context) {
+    public Query termQueryCaseInsensitive(Object value, SearchExecutionContext context) {
         checkAllowExpensiveQueries(context);
         return new BooleanScriptFieldTermQuery(script, leafFactory(context.lookup()), name(), toBoolean(value, true));
     }
 
     @Override
-    public Query termQuery(Object value, QueryShardContext context) {
+    public Query termQuery(Object value, SearchExecutionContext context) {
         checkAllowExpensiveQueries(context);
         return new BooleanScriptFieldTermQuery(script, leafFactory(context), name(), toBoolean(value, false));
     }
 
     @Override
-    public Query termsQuery(List<?> values, QueryShardContext context) {
+    public Query termsQuery(List<?> values, SearchExecutionContext context) {
         if (values.isEmpty()) {
             return Queries.newMatchNoDocsQuery("Empty terms query");
         }
@@ -199,7 +199,7 @@ public final class BooleanScriptFieldType extends AbstractScriptFieldType<Boolea
         return termsQuery(trueAllowed, falseAllowed, context);
     }
 
-    private Query termsQuery(boolean trueAllowed, boolean falseAllowed, QueryShardContext context) {
+    private Query termsQuery(boolean trueAllowed, boolean falseAllowed, SearchExecutionContext context) {
         if (trueAllowed) {
             if (falseAllowed) {
                 // Either true or false

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/DateScriptFieldType.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/DateScriptFieldType.java
@@ -22,7 +22,7 @@ import org.elasticsearch.index.mapper.DateFieldMapper.DateFieldType;
 import org.elasticsearch.index.mapper.DateFieldMapper.Resolution;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.RuntimeFieldType;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.lookup.SearchLookup;
@@ -152,7 +152,7 @@ public class DateScriptFieldType extends AbstractScriptFieldType<DateFieldScript
     }
 
     @Override
-    public Query distanceFeatureQuery(Object origin, String pivot, QueryShardContext context) {
+    public Query distanceFeatureQuery(Object origin, String pivot, SearchExecutionContext context) {
         checkAllowExpensiveQueries(context);
         return DateFieldType.handleNow(context, now -> {
             long originLong = DateFieldType.parseToLong(
@@ -175,7 +175,7 @@ public class DateScriptFieldType extends AbstractScriptFieldType<DateFieldScript
     }
 
     @Override
-    public Query existsQuery(QueryShardContext context) {
+    public Query existsQuery(SearchExecutionContext context) {
         checkAllowExpensiveQueries(context);
         return new LongScriptFieldExistsQuery(script, leafFactory(context)::newInstance, name());
     }
@@ -188,7 +188,7 @@ public class DateScriptFieldType extends AbstractScriptFieldType<DateFieldScript
         boolean includeUpper,
         ZoneId timeZone,
         @Nullable DateMathParser parser,
-        QueryShardContext context
+        SearchExecutionContext context
     ) {
         parser = parser == null ? this.dateMathParser : parser;
         checkAllowExpensiveQueries(context);
@@ -206,7 +206,7 @@ public class DateScriptFieldType extends AbstractScriptFieldType<DateFieldScript
     }
 
     @Override
-    public Query termQuery(Object value, QueryShardContext context) {
+    public Query termQuery(Object value, SearchExecutionContext context) {
         return DateFieldType.handleNow(context, now -> {
             long l = DateFieldType.parseToLong(value, false, null, this.dateMathParser, now, DateFieldMapper.Resolution.MILLISECONDS);
             checkAllowExpensiveQueries(context);
@@ -215,7 +215,7 @@ public class DateScriptFieldType extends AbstractScriptFieldType<DateFieldScript
     }
 
     @Override
-    public Query termsQuery(List<?> values, QueryShardContext context) {
+    public Query termsQuery(List<?> values, SearchExecutionContext context) {
         if (values.isEmpty()) {
             return Queries.newMatchAllQuery();
         }

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/DoubleScriptFieldType.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/DoubleScriptFieldType.java
@@ -15,7 +15,7 @@ import org.elasticsearch.common.time.DateMathParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.mapper.NumberFieldMapper.NumberType;
 import org.elasticsearch.index.mapper.RuntimeFieldType;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.lookup.SearchLookup;
@@ -90,7 +90,7 @@ public final class DoubleScriptFieldType extends AbstractScriptFieldType<DoubleF
     }
 
     @Override
-    public Query existsQuery(QueryShardContext context) {
+    public Query existsQuery(SearchExecutionContext context) {
         checkAllowExpensiveQueries(context);
         return new DoubleScriptFieldExistsQuery(script, leafFactory(context), name());
     }
@@ -103,7 +103,7 @@ public final class DoubleScriptFieldType extends AbstractScriptFieldType<DoubleF
         boolean includeUpper,
         ZoneId timeZone,
         DateMathParser parser,
-        QueryShardContext context
+        SearchExecutionContext context
     ) {
         checkAllowExpensiveQueries(context);
         return NumberType.doubleRangeQuery(
@@ -116,13 +116,13 @@ public final class DoubleScriptFieldType extends AbstractScriptFieldType<DoubleF
     }
 
     @Override
-    public Query termQuery(Object value, QueryShardContext context) {
+    public Query termQuery(Object value, SearchExecutionContext context) {
         checkAllowExpensiveQueries(context);
         return new DoubleScriptFieldTermQuery(script, leafFactory(context), name(), NumberType.objectToDouble(value));
     }
 
     @Override
-    public Query termsQuery(List<?> values, QueryShardContext context) {
+    public Query termsQuery(List<?> values, SearchExecutionContext context) {
         if (values.isEmpty()) {
             return Queries.newMatchAllQuery();
         }

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/GeoPointScriptFieldType.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/GeoPointScriptFieldType.java
@@ -20,7 +20,7 @@ import org.elasticsearch.geometry.MultiLine;
 import org.elasticsearch.index.mapper.GeoPointFieldMapper;
 import org.elasticsearch.index.mapper.GeoShapeQueryable;
 import org.elasticsearch.index.mapper.RuntimeFieldType;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.xpack.runtimefields.fielddata.GeoPointScriptFieldData;
@@ -80,13 +80,13 @@ public final class GeoPointScriptFieldType extends AbstractScriptFieldType<GeoPo
         boolean includeUpper,
         ZoneId timeZone,
         DateMathParser parser,
-        QueryShardContext context
+        SearchExecutionContext context
     ) {
         throw new IllegalArgumentException("Runtime field [" + name() + "] of type [" + typeName() + "] does not support range queries");
     }
 
     @Override
-    public Query termQuery(Object value, QueryShardContext context) {
+    public Query termQuery(Object value, SearchExecutionContext context) {
         throw new IllegalArgumentException(
             "Geometry fields do not support exact searching, use dedicated geometry queries instead: [" + name() + "]"
         );
@@ -98,13 +98,13 @@ public final class GeoPointScriptFieldType extends AbstractScriptFieldType<GeoPo
     }
 
     @Override
-    public Query existsQuery(QueryShardContext context) {
+    public Query existsQuery(SearchExecutionContext context) {
         checkAllowExpensiveQueries(context);
         return new GeoPointScriptFieldExistsQuery(script, leafFactory(context), name());
     }
 
     @Override
-    public Query geoShapeQuery(Geometry shape, String fieldName, ShapeRelation relation, QueryShardContext context) {
+    public Query geoShapeQuery(Geometry shape, String fieldName, ShapeRelation relation, SearchExecutionContext context) {
         if (shape == null) {
             return new MatchNoDocsQuery();
         }

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/IpScriptFieldType.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/IpScriptFieldType.java
@@ -21,7 +21,7 @@ import org.elasticsearch.common.util.BytesRefHash;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.mapper.IpFieldMapper;
 import org.elasticsearch.index.mapper.RuntimeFieldType;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.lookup.SearchLookup;
@@ -99,7 +99,7 @@ public final class IpScriptFieldType extends AbstractScriptFieldType<IpFieldScri
     }
 
     @Override
-    public Query existsQuery(QueryShardContext context) {
+    public Query existsQuery(SearchExecutionContext context) {
         checkAllowExpensiveQueries(context);
         return new IpScriptFieldExistsQuery(script, leafFactory(context), name());
     }
@@ -112,7 +112,7 @@ public final class IpScriptFieldType extends AbstractScriptFieldType<IpFieldScri
         boolean includeUpper,
         ZoneId timeZone,
         DateMathParser parser,
-        QueryShardContext context
+        SearchExecutionContext context
     ) {
         checkAllowExpensiveQueries(context);
         return IpFieldMapper.IpFieldType.rangeQuery(
@@ -131,7 +131,7 @@ public final class IpScriptFieldType extends AbstractScriptFieldType<IpFieldScri
     }
 
     @Override
-    public Query termQuery(Object value, QueryShardContext context) {
+    public Query termQuery(Object value, SearchExecutionContext context) {
         checkAllowExpensiveQueries(context);
         if (value instanceof InetAddress) {
             return inetAddressQuery((InetAddress) value, context);
@@ -144,12 +144,12 @@ public final class IpScriptFieldType extends AbstractScriptFieldType<IpFieldScri
         return inetAddressQuery(address, context);
     }
 
-    private Query inetAddressQuery(InetAddress address, QueryShardContext context) {
+    private Query inetAddressQuery(InetAddress address, SearchExecutionContext context) {
         return new IpScriptFieldTermQuery(script, leafFactory(context), name(), new BytesRef(InetAddressPoint.encode(address)));
     }
 
     @Override
-    public Query termsQuery(List<?> values, QueryShardContext context) {
+    public Query termsQuery(List<?> values, SearchExecutionContext context) {
         checkAllowExpensiveQueries(context);
         BytesRefHash terms = new BytesRefHash(values.size(), BigArrays.NON_RECYCLING_INSTANCE);
         List<Query> cidrQueries = null;
@@ -180,7 +180,7 @@ public final class IpScriptFieldType extends AbstractScriptFieldType<IpFieldScri
         return bool.build();
     }
 
-    private Query cidrQuery(String term, QueryShardContext context) {
+    private Query cidrQuery(String term, SearchExecutionContext context) {
         Tuple<InetAddress, Integer> cidr = InetAddresses.parseCidr(term);
         InetAddress addr = cidr.v1();
         int prefixLength = cidr.v2();

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/KeywordScriptFieldType.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/KeywordScriptFieldType.java
@@ -119,12 +119,7 @@ public final class KeywordScriptFieldType extends AbstractScriptFieldType<String
     }
 
     @Override
-    public Query prefixQuery(
-        String value,
-        RewriteMethod method,
-        boolean caseInsensitive,
-        SearchExecutionContext context
-    ) {
+    public Query prefixQuery(String value, RewriteMethod method, boolean caseInsensitive, SearchExecutionContext context) {
         checkAllowExpensiveQueries(context);
         return new StringScriptFieldPrefixQuery(script, leafFactory(context), name(), value, caseInsensitive);
     }

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/KeywordScriptFieldType.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/KeywordScriptFieldType.java
@@ -16,7 +16,7 @@ import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.RuntimeFieldType;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.xpack.runtimefields.fielddata.StringScriptFieldData;
@@ -92,7 +92,7 @@ public final class KeywordScriptFieldType extends AbstractScriptFieldType<String
     }
 
     @Override
-    public Query existsQuery(QueryShardContext context) {
+    public Query existsQuery(SearchExecutionContext context) {
         checkAllowExpensiveQueries(context);
         return new StringScriptFieldExistsQuery(script, leafFactory(context), name());
     }
@@ -104,7 +104,7 @@ public final class KeywordScriptFieldType extends AbstractScriptFieldType<String
         int prefixLength,
         int maxExpansions,
         boolean transpositions,
-        QueryShardContext context
+        SearchExecutionContext context
     ) {
         checkAllowExpensiveQueries(context);
         return StringScriptFieldFuzzyQuery.build(
@@ -123,7 +123,7 @@ public final class KeywordScriptFieldType extends AbstractScriptFieldType<String
         String value,
         RewriteMethod method,
         boolean caseInsensitive,
-        org.elasticsearch.index.query.QueryShardContext context
+        SearchExecutionContext context
     ) {
         checkAllowExpensiveQueries(context);
         return new StringScriptFieldPrefixQuery(script, leafFactory(context), name(), value, caseInsensitive);
@@ -137,7 +137,7 @@ public final class KeywordScriptFieldType extends AbstractScriptFieldType<String
         boolean includeUpper,
         ZoneId timeZone,
         DateMathParser parser,
-        QueryShardContext context
+        SearchExecutionContext context
     ) {
         checkAllowExpensiveQueries(context);
         return new StringScriptFieldRangeQuery(
@@ -158,7 +158,7 @@ public final class KeywordScriptFieldType extends AbstractScriptFieldType<String
         int matchFlags,
         int maxDeterminizedStates,
         RewriteMethod method,
-        QueryShardContext context
+        SearchExecutionContext context
     ) {
         checkAllowExpensiveQueries(context);
         if (matchFlags != 0) {
@@ -176,7 +176,7 @@ public final class KeywordScriptFieldType extends AbstractScriptFieldType<String
     }
 
     @Override
-    public Query termQueryCaseInsensitive(Object value, QueryShardContext context) {
+    public Query termQueryCaseInsensitive(Object value, SearchExecutionContext context) {
         checkAllowExpensiveQueries(context);
         return new StringScriptFieldTermQuery(
             script,
@@ -188,7 +188,7 @@ public final class KeywordScriptFieldType extends AbstractScriptFieldType<String
     }
 
     @Override
-    public Query termQuery(Object value, QueryShardContext context) {
+    public Query termQuery(Object value, SearchExecutionContext context) {
         checkAllowExpensiveQueries(context);
         return new StringScriptFieldTermQuery(
             script,
@@ -200,14 +200,14 @@ public final class KeywordScriptFieldType extends AbstractScriptFieldType<String
     }
 
     @Override
-    public Query termsQuery(List<?> values, QueryShardContext context) {
+    public Query termsQuery(List<?> values, SearchExecutionContext context) {
         checkAllowExpensiveQueries(context);
         Set<String> terms = values.stream().map(v -> BytesRefs.toString(Objects.requireNonNull(v))).collect(toSet());
         return new StringScriptFieldTermsQuery(script, leafFactory(context), name(), terms);
     }
 
     @Override
-    public Query wildcardQuery(String value, RewriteMethod method, boolean caseInsensitive, QueryShardContext context) {
+    public Query wildcardQuery(String value, RewriteMethod method, boolean caseInsensitive, SearchExecutionContext context) {
         checkAllowExpensiveQueries(context);
         return new StringScriptFieldWildcardQuery(script, leafFactory(context), name(), value, caseInsensitive);
     }

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/LongScriptFieldType.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/LongScriptFieldType.java
@@ -15,7 +15,7 @@ import org.elasticsearch.common.time.DateMathParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.mapper.NumberFieldMapper.NumberType;
 import org.elasticsearch.index.mapper.RuntimeFieldType;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.lookup.SearchLookup;
@@ -90,7 +90,7 @@ public final class LongScriptFieldType extends AbstractScriptFieldType<LongField
     }
 
     @Override
-    public Query existsQuery(QueryShardContext context) {
+    public Query existsQuery(SearchExecutionContext context) {
         checkAllowExpensiveQueries(context);
         return new LongScriptFieldExistsQuery(script, leafFactory(context)::newInstance, name());
     }
@@ -103,7 +103,7 @@ public final class LongScriptFieldType extends AbstractScriptFieldType<LongField
         boolean includeUpper,
         ZoneId timeZone,
         DateMathParser parser,
-        QueryShardContext context
+        SearchExecutionContext context
     ) {
         checkAllowExpensiveQueries(context);
         return NumberType.longRangeQuery(
@@ -116,7 +116,7 @@ public final class LongScriptFieldType extends AbstractScriptFieldType<LongField
     }
 
     @Override
-    public Query termQuery(Object value, QueryShardContext context) {
+    public Query termQuery(Object value, SearchExecutionContext context) {
         if (NumberType.hasDecimalPart(value)) {
             return Queries.newMatchNoDocsQuery("Value [" + value + "] has a decimal part");
         }
@@ -125,7 +125,7 @@ public final class LongScriptFieldType extends AbstractScriptFieldType<LongField
     }
 
     @Override
-    public Query termsQuery(List<?> values, QueryShardContext context) {
+    public Query termsQuery(List<?> values, SearchExecutionContext context) {
         if (values.isEmpty()) {
             return Queries.newMatchAllQuery();
         }

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/AbstractScriptFieldTypeTestCase.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/AbstractScriptFieldTypeTestCase.java
@@ -22,7 +22,7 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MapperServiceTestCase;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.ScriptPlugin;
 import org.elasticsearch.script.ScriptContext;
@@ -167,23 +167,23 @@ public abstract class AbstractScriptFieldTypeTestCase extends MapperServiceTestC
     @SuppressWarnings("unused")
     public abstract void testRangeQuery() throws IOException;
 
-    protected abstract Query randomRangeQuery(MappedFieldType ft, QueryShardContext ctx);
+    protected abstract Query randomRangeQuery(MappedFieldType ft, SearchExecutionContext ctx);
 
     @SuppressWarnings("unused")
     public abstract void testTermQuery() throws IOException;
 
-    protected abstract Query randomTermQuery(MappedFieldType ft, QueryShardContext ctx);
+    protected abstract Query randomTermQuery(MappedFieldType ft, SearchExecutionContext ctx);
 
     @SuppressWarnings("unused")
     public abstract void testTermsQuery() throws IOException;
 
-    protected abstract Query randomTermsQuery(MappedFieldType ft, QueryShardContext ctx);
+    protected abstract Query randomTermsQuery(MappedFieldType ft, SearchExecutionContext ctx);
 
-    protected static QueryShardContext mockContext() {
+    protected static SearchExecutionContext mockContext() {
         return mockContext(true);
     }
 
-    protected static QueryShardContext mockContext(boolean allowExpensiveQueries) {
+    protected static SearchExecutionContext mockContext(boolean allowExpensiveQueries) {
         return mockContext(allowExpensiveQueries, null);
     }
 
@@ -195,8 +195,8 @@ public abstract class AbstractScriptFieldTypeTestCase extends MapperServiceTestC
         return true;
     }
 
-    protected static QueryShardContext mockContext(boolean allowExpensiveQueries, MappedFieldType mappedFieldType) {
-        QueryShardContext context = mock(QueryShardContext.class);
+    protected static SearchExecutionContext mockContext(boolean allowExpensiveQueries, MappedFieldType mappedFieldType) {
+        SearchExecutionContext context = mock(SearchExecutionContext.class);
         if (mappedFieldType != null) {
             when(context.getFieldType(anyString())).thenReturn(mappedFieldType);
         }
@@ -293,7 +293,7 @@ public abstract class AbstractScriptFieldTypeTestCase extends MapperServiceTestC
         return reader.document(docId).getBinaryValue("_source").utf8ToString();
     }
 
-    protected final void checkExpensiveQuery(BiConsumer<MappedFieldType, QueryShardContext> queryBuilder) {
+    protected final void checkExpensiveQuery(BiConsumer<MappedFieldType, SearchExecutionContext> queryBuilder) {
         Exception e = expectThrows(ElasticsearchException.class, () -> queryBuilder.accept(simpleMappedFieldType(), mockContext(false)));
         assertThat(
             e.getMessage(),
@@ -301,7 +301,7 @@ public abstract class AbstractScriptFieldTypeTestCase extends MapperServiceTestC
         );
     }
 
-    protected final void checkLoop(BiConsumer<MappedFieldType, QueryShardContext> queryBuilder) {
+    protected final void checkLoop(BiConsumer<MappedFieldType, SearchExecutionContext> queryBuilder) {
         Exception e = expectThrows(IllegalArgumentException.class, () -> queryBuilder.accept(loopFieldType(), mockContext()));
         assertThat(e.getMessage(), equalTo("Cyclic dependency detected while resolving runtime fields: test -> test"));
     }

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/BooleanScriptFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/BooleanScriptFieldTypeTests.java
@@ -37,7 +37,7 @@ import org.elasticsearch.index.mapper.ContentPath;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.SourceToParse;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.plugins.ScriptPlugin;
 import org.elasticsearch.script.ScoreScript;
 import org.elasticsearch.script.Script;
@@ -129,7 +129,7 @@ public class BooleanScriptFieldTypeTests extends AbstractNonTextScriptFieldTypeT
             iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [false]}"))));
             try (DirectoryReader reader = iw.getReader()) {
                 IndexSearcher searcher = newSearcher(reader);
-                QueryShardContext qsc = mockContext(true, simpleMappedFieldType());
+                SearchExecutionContext searchContext = mockContext(true, simpleMappedFieldType());
                 assertThat(searcher.count(new ScriptScoreQuery(new MatchAllDocsQuery(), new Script("test"), new ScoreScript.LeafFactory() {
                     @Override
                     public boolean needs_score() {
@@ -138,7 +138,7 @@ public class BooleanScriptFieldTypeTests extends AbstractNonTextScriptFieldTypeT
 
                     @Override
                     public ScoreScript newInstance(LeafReaderContext ctx) {
-                        return new ScoreScript(Map.of(), qsc.lookup(), ctx) {
+                        return new ScoreScript(Map.of(), searchContext.lookup(), ctx) {
                             @Override
                             public double execute(ExplanationHolder explanation) {
                                 ScriptDocValues.Booleans booleans = (ScriptDocValues.Booleans) getDoc().get("test");
@@ -225,7 +225,7 @@ public class BooleanScriptFieldTypeTests extends AbstractNonTextScriptFieldTypeT
     }
 
     @Override
-    protected Query randomRangeQuery(MappedFieldType ft, QueryShardContext ctx) {
+    protected Query randomRangeQuery(MappedFieldType ft, SearchExecutionContext ctx) {
         // Builds a random range query that doesn't degenerate into match none
         switch (randomInt(2)) {
             case 0:
@@ -265,7 +265,7 @@ public class BooleanScriptFieldTypeTests extends AbstractNonTextScriptFieldTypeT
     }
 
     @Override
-    protected Query randomTermQuery(MappedFieldType ft, QueryShardContext ctx) {
+    protected Query randomTermQuery(MappedFieldType ft, SearchExecutionContext ctx) {
         return ft.termQuery(randomBoolean(), ctx);
     }
 
@@ -299,7 +299,7 @@ public class BooleanScriptFieldTypeTests extends AbstractNonTextScriptFieldTypeT
     }
 
     @Override
-    protected Query randomTermsQuery(MappedFieldType ft, QueryShardContext ctx) {
+    protected Query randomTermsQuery(MappedFieldType ft, SearchExecutionContext ctx) {
         switch (randomInt(2)) {
             case 0:
                 return ft.termsQuery(List.of(true), ctx);

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/DateScriptFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/DateScriptFieldTypeTests.java
@@ -38,7 +38,7 @@ import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.plugins.ScriptPlugin;
 import org.elasticsearch.script.ScoreScript;
 import org.elasticsearch.script.Script;
@@ -204,7 +204,7 @@ public class DateScriptFieldTypeTests extends AbstractNonTextScriptFieldTypeTest
             iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"timestamp\": [1595432181356]}"))));
             try (DirectoryReader reader = iw.getReader()) {
                 IndexSearcher searcher = newSearcher(reader);
-                QueryShardContext qsc = mockContext(true, simpleMappedFieldType());
+                SearchExecutionContext searchContext = mockContext(true, simpleMappedFieldType());
                 assertThat(searcher.count(new ScriptScoreQuery(new MatchAllDocsQuery(), new Script("test"), new ScoreScript.LeafFactory() {
                     @Override
                     public boolean needs_score() {
@@ -213,7 +213,7 @@ public class DateScriptFieldTypeTests extends AbstractNonTextScriptFieldTypeTest
 
                     @Override
                     public ScoreScript newInstance(LeafReaderContext ctx) throws IOException {
-                        return new ScoreScript(Map.of(), qsc.lookup(), ctx) {
+                        return new ScoreScript(Map.of(), searchContext.lookup(), ctx) {
                             @Override
                             public double execute(ExplanationHolder explanation) {
                                 ScriptDocValues.Dates dates = (ScriptDocValues.Dates) getDoc().get("test");
@@ -266,7 +266,7 @@ public class DateScriptFieldTypeTests extends AbstractNonTextScriptFieldTypeTest
         checkLoop(this::randomDistanceFeatureQuery);
     }
 
-    private Query randomDistanceFeatureQuery(MappedFieldType ft, QueryShardContext ctx) {
+    private Query randomDistanceFeatureQuery(MappedFieldType ft, SearchExecutionContext ctx) {
         return ft.distanceFeatureQuery(randomDate(), randomTimeValue(), ctx);
     }
 
@@ -353,7 +353,7 @@ public class DateScriptFieldTypeTests extends AbstractNonTextScriptFieldTypeTest
     }
 
     @Override
-    protected Query randomRangeQuery(MappedFieldType ft, QueryShardContext ctx) {
+    protected Query randomRangeQuery(MappedFieldType ft, SearchExecutionContext ctx) {
         long d1 = randomDate();
         long d2 = randomValueOtherThan(d1, DateScriptFieldTypeTests::randomDate);
         if (d1 > d2) {
@@ -386,7 +386,7 @@ public class DateScriptFieldTypeTests extends AbstractNonTextScriptFieldTypeTest
     }
 
     @Override
-    protected Query randomTermQuery(MappedFieldType ft, QueryShardContext ctx) {
+    protected Query randomTermQuery(MappedFieldType ft, SearchExecutionContext ctx) {
         return ft.termQuery(randomDate(), ctx);
     }
 
@@ -427,7 +427,7 @@ public class DateScriptFieldTypeTests extends AbstractNonTextScriptFieldTypeTest
     }
 
     @Override
-    protected Query randomTermsQuery(MappedFieldType ft, QueryShardContext ctx) {
+    protected Query randomTermsQuery(MappedFieldType ft, SearchExecutionContext ctx) {
         return ft.termsQuery(randomList(1, 100, DateScriptFieldTypeTests::randomDate), ctx);
     }
 

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/DoubleScriptFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/DoubleScriptFieldTypeTests.java
@@ -28,7 +28,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.plugins.ScriptPlugin;
 import org.elasticsearch.script.ScoreScript;
 import org.elasticsearch.script.Script;
@@ -127,7 +127,7 @@ public class DoubleScriptFieldTypeTests extends AbstractNonTextScriptFieldTypeTe
             iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [2.1]}"))));
             try (DirectoryReader reader = iw.getReader()) {
                 IndexSearcher searcher = newSearcher(reader);
-                QueryShardContext qsc = mockContext(true, simpleMappedFieldType());
+                SearchExecutionContext searchContext = mockContext(true, simpleMappedFieldType());
                 assertThat(searcher.count(new ScriptScoreQuery(new MatchAllDocsQuery(), new Script("test"), new ScoreScript.LeafFactory() {
                     @Override
                     public boolean needs_score() {
@@ -136,7 +136,7 @@ public class DoubleScriptFieldTypeTests extends AbstractNonTextScriptFieldTypeTe
 
                     @Override
                     public ScoreScript newInstance(LeafReaderContext ctx) {
-                        return new ScoreScript(Map.of(), qsc.lookup(), ctx) {
+                        return new ScoreScript(Map.of(), searchContext.lookup(), ctx) {
                             @Override
                             public double execute(ExplanationHolder explanation) {
                                 ScriptDocValues.Doubles doubles = (ScriptDocValues.Doubles) getDoc().get("test");
@@ -182,7 +182,7 @@ public class DoubleScriptFieldTypeTests extends AbstractNonTextScriptFieldTypeTe
     }
 
     @Override
-    protected Query randomRangeQuery(MappedFieldType ft, QueryShardContext ctx) {
+    protected Query randomRangeQuery(MappedFieldType ft, SearchExecutionContext ctx) {
         return ft.rangeQuery(randomLong(), randomLong(), randomBoolean(), randomBoolean(), null, null, null, ctx);
     }
 
@@ -202,7 +202,7 @@ public class DoubleScriptFieldTypeTests extends AbstractNonTextScriptFieldTypeTe
     }
 
     @Override
-    protected Query randomTermQuery(MappedFieldType ft, QueryShardContext ctx) {
+    protected Query randomTermQuery(MappedFieldType ft, SearchExecutionContext ctx) {
         return ft.termQuery(randomLong(), ctx);
     }
 
@@ -223,7 +223,7 @@ public class DoubleScriptFieldTypeTests extends AbstractNonTextScriptFieldTypeTe
     }
 
     @Override
-    protected Query randomTermsQuery(MappedFieldType ft, QueryShardContext ctx) {
+    protected Query randomTermsQuery(MappedFieldType ft, SearchExecutionContext ctx) {
         return ft.termsQuery(List.of(randomLong()), ctx);
     }
 

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/GeoPointScriptFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/GeoPointScriptFieldTypeTests.java
@@ -27,7 +27,7 @@ import org.elasticsearch.geo.GeometryTestUtils;
 import org.elasticsearch.index.fielddata.MultiGeoPointValues;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.plugins.ScriptPlugin;
 import org.elasticsearch.script.ScoreScript;
 import org.elasticsearch.script.Script;
@@ -116,7 +116,7 @@ public class GeoPointScriptFieldTypeTests extends AbstractNonTextScriptFieldType
             iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": {\"lat\": 0.0, \"lon\" : 0.0}}"))));
             try (DirectoryReader reader = iw.getReader()) {
                 IndexSearcher searcher = newSearcher(reader);
-                QueryShardContext qsc = mockContext(true, simpleMappedFieldType());
+                SearchExecutionContext searchContext = mockContext(true, simpleMappedFieldType());
                 assertThat(searcher.count(new ScriptScoreQuery(new MatchAllDocsQuery(), new Script("test"), new ScoreScript.LeafFactory() {
                     @Override
                     public boolean needs_score() {
@@ -125,7 +125,7 @@ public class GeoPointScriptFieldTypeTests extends AbstractNonTextScriptFieldType
 
                     @Override
                     public ScoreScript newInstance(LeafReaderContext ctx) {
-                        return new ScoreScript(Map.of(), qsc.lookup(), ctx) {
+                        return new ScoreScript(Map.of(), searchContext.lookup(), ctx) {
                             @Override
                             public double execute(ExplanationHolder explanation) {
                                 ScriptDocValues.GeoPoints points = (ScriptDocValues.GeoPoints) getDoc().get("test");
@@ -160,7 +160,7 @@ public class GeoPointScriptFieldTypeTests extends AbstractNonTextScriptFieldType
     }
 
     @Override
-    protected Query randomRangeQuery(MappedFieldType ft, QueryShardContext ctx) {
+    protected Query randomRangeQuery(MappedFieldType ft, SearchExecutionContext ctx) {
         throw new IllegalArgumentException("Unsupported");
     }
 
@@ -174,7 +174,7 @@ public class GeoPointScriptFieldTypeTests extends AbstractNonTextScriptFieldType
     }
 
     @Override
-    protected Query randomTermQuery(MappedFieldType ft, QueryShardContext ctx) {
+    protected Query randomTermQuery(MappedFieldType ft, SearchExecutionContext ctx) {
         throw new IllegalArgumentException("Unsupported");
     }
 
@@ -193,7 +193,7 @@ public class GeoPointScriptFieldTypeTests extends AbstractNonTextScriptFieldType
     }
 
     @Override
-    protected Query randomTermsQuery(MappedFieldType ft, QueryShardContext ctx) {
+    protected Query randomTermsQuery(MappedFieldType ft, SearchExecutionContext ctx) {
         return ft.termsQuery(randomList(100, GeometryTestUtils::randomPoint), mockContext());
     }
 

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/IpScriptFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/IpScriptFieldTypeTests.java
@@ -27,7 +27,7 @@ import org.elasticsearch.common.lucene.search.function.ScriptScoreQuery;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.plugins.ScriptPlugin;
 import org.elasticsearch.script.ScoreScript;
 import org.elasticsearch.script.Script;
@@ -139,7 +139,7 @@ public class IpScriptFieldTypeTests extends AbstractScriptFieldTypeTestCase {
             iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"192.168.0.2\"]}"))));
             try (DirectoryReader reader = iw.getReader()) {
                 IndexSearcher searcher = newSearcher(reader);
-                QueryShardContext qsc = mockContext(true, simpleMappedFieldType());
+                SearchExecutionContext searchContext = mockContext(true, simpleMappedFieldType());
                 assertThat(searcher.count(new ScriptScoreQuery(new MatchAllDocsQuery(), new Script("test"), new ScoreScript.LeafFactory() {
                     @Override
                     public boolean needs_score() {
@@ -148,7 +148,7 @@ public class IpScriptFieldTypeTests extends AbstractScriptFieldTypeTestCase {
 
                     @Override
                     public ScoreScript newInstance(LeafReaderContext ctx) {
-                        return new ScoreScript(Map.of(), qsc.lookup(), ctx) {
+                        return new ScoreScript(Map.of(), searchContext.lookup(), ctx) {
                             @Override
                             public double execute(ExplanationHolder explanation) {
                                 IpScriptFieldData.IpScriptDocValues bytes = (IpScriptFieldData.IpScriptDocValues) getDoc().get("test");
@@ -192,7 +192,7 @@ public class IpScriptFieldTypeTests extends AbstractScriptFieldTypeTestCase {
     }
 
     @Override
-    protected Query randomRangeQuery(MappedFieldType ft, QueryShardContext ctx) {
+    protected Query randomRangeQuery(MappedFieldType ft, SearchExecutionContext ctx) {
         return ft.rangeQuery("192.0.0.0", "200.0.0.0", randomBoolean(), randomBoolean(), null, null, null, ctx);
     }
 
@@ -214,7 +214,7 @@ public class IpScriptFieldTypeTests extends AbstractScriptFieldTypeTestCase {
     }
 
     @Override
-    protected Query randomTermQuery(MappedFieldType ft, QueryShardContext ctx) {
+    protected Query randomTermQuery(MappedFieldType ft, SearchExecutionContext ctx) {
         return ft.termQuery(randomIp(randomBoolean()), ctx);
     }
 
@@ -240,7 +240,7 @@ public class IpScriptFieldTypeTests extends AbstractScriptFieldTypeTestCase {
     }
 
     @Override
-    protected Query randomTermsQuery(MappedFieldType ft, QueryShardContext ctx) {
+    protected Query randomTermsQuery(MappedFieldType ft, SearchExecutionContext ctx) {
         return ft.termsQuery(randomList(100, () -> randomIp(randomBoolean())), ctx);
     }
 

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/LongScriptFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/LongScriptFieldTypeTests.java
@@ -29,7 +29,7 @@ import org.elasticsearch.common.lucene.search.function.ScriptScoreQuery;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.plugins.ScriptPlugin;
 import org.elasticsearch.script.ScoreScript;
 import org.elasticsearch.script.Script;
@@ -149,7 +149,7 @@ public class LongScriptFieldTypeTests extends AbstractNonTextScriptFieldTypeTest
             iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [2]}"))));
             try (DirectoryReader reader = iw.getReader()) {
                 IndexSearcher searcher = newSearcher(reader);
-                QueryShardContext qsc = mockContext(true, simpleMappedFieldType());
+                SearchExecutionContext searchContext = mockContext(true, simpleMappedFieldType());
                 assertThat(searcher.count(new ScriptScoreQuery(new MatchAllDocsQuery(), new Script("test"), new ScoreScript.LeafFactory() {
                     @Override
                     public boolean needs_score() {
@@ -158,7 +158,7 @@ public class LongScriptFieldTypeTests extends AbstractNonTextScriptFieldTypeTest
 
                     @Override
                     public ScoreScript newInstance(LeafReaderContext ctx) {
-                        return new ScoreScript(Map.of(), qsc.lookup(), ctx) {
+                        return new ScoreScript(Map.of(), searchContext.lookup(), ctx) {
                             @Override
                             public double execute(ExplanationHolder explanation) {
                                 ScriptDocValues.Longs longs = (ScriptDocValues.Longs) getDoc().get("test");
@@ -201,7 +201,7 @@ public class LongScriptFieldTypeTests extends AbstractNonTextScriptFieldTypeTest
     }
 
     @Override
-    protected Query randomRangeQuery(MappedFieldType ft, QueryShardContext ctx) {
+    protected Query randomRangeQuery(MappedFieldType ft, SearchExecutionContext ctx) {
         return ft.rangeQuery(randomLong(), randomLong(), randomBoolean(), randomBoolean(), null, null, null, ctx);
     }
 
@@ -221,7 +221,7 @@ public class LongScriptFieldTypeTests extends AbstractNonTextScriptFieldTypeTest
     }
 
     @Override
-    protected Query randomTermQuery(MappedFieldType ft, QueryShardContext ctx) {
+    protected Query randomTermQuery(MappedFieldType ft, SearchExecutionContext ctx) {
         return ft.termQuery(randomLong(), ctx);
     }
 
@@ -242,7 +242,7 @@ public class LongScriptFieldTypeTests extends AbstractNonTextScriptFieldTypeTest
     }
 
     @Override
-    protected Query randomTermsQuery(MappedFieldType ft, QueryShardContext ctx) {
+    protected Query randomTermsQuery(MappedFieldType ft, SearchExecutionContext ctx) {
         return ft.termsQuery(List.of(randomLong()), ctx);
     }
 

--- a/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/PinnedQueryBuilder.java
+++ b/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/PinnedQueryBuilder.java
@@ -27,7 +27,7 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.AbstractQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryRewriteContext;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -162,8 +162,8 @@ public class PinnedQueryBuilder extends AbstractQueryBuilder<PinnedQueryBuilder>
     }
 
     @Override
-    protected QueryBuilder doRewrite(QueryRewriteContext queryShardContext) throws IOException {
-        QueryBuilder newOrganicQuery = organicQuery.rewrite(queryShardContext);
+    protected QueryBuilder doRewrite(QueryRewriteContext queryRewriteContext) throws IOException {
+        QueryBuilder newOrganicQuery = organicQuery.rewrite(queryRewriteContext);
         if (newOrganicQuery != organicQuery) {
             PinnedQueryBuilder result = new PinnedQueryBuilder(newOrganicQuery, ids.toArray(String[]::new));
             result.boost(this.boost);
@@ -173,7 +173,7 @@ public class PinnedQueryBuilder extends AbstractQueryBuilder<PinnedQueryBuilder>
     }
 
     @Override
-    protected Query doToQuery(QueryShardContext context) throws IOException {
+    protected Query doToQuery(SearchExecutionContext context) throws IOException {
         MappedFieldType idField = context.getFieldType(IdFieldMapper.NAME);
         if (idField == null) {
             return new MatchNoDocsQuery("No mappings");

--- a/x-pack/plugin/search-business-rules/src/test/java/org/elasticsearch/xpack/searchbusinessrules/PinnedQueryBuilderTests.java
+++ b/x-pack/plugin/search-business-rules/src/test/java/org/elasticsearch/xpack/searchbusinessrules/PinnedQueryBuilderTests.java
@@ -18,7 +18,7 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.AbstractQueryTestCase;
@@ -90,7 +90,7 @@ public class PinnedQueryBuilderTests extends AbstractQueryTestCase<PinnedQueryBu
         }
 
     @Override
-    protected void doAssertLuceneQuery(PinnedQueryBuilder queryBuilder, Query query, QueryShardContext searchContext) throws IOException {
+    protected void doAssertLuceneQuery(PinnedQueryBuilder queryBuilder, Query query, SearchExecutionContext searchContext) throws IOException {
         if (queryBuilder.ids().size() == 0 && queryBuilder.organicQuery() == null) {
             assertThat(query, instanceOf(MatchNoDocsQuery.class));
         } else {
@@ -118,14 +118,14 @@ public class PinnedQueryBuilderTests extends AbstractQueryTestCase<PinnedQueryBu
             bigList[i] = String.valueOf(i);
         }
         expectThrows(IllegalArgumentException.class, () -> new PinnedQueryBuilder(new MatchAllQueryBuilder(), bigList));
-        
+
     }
 
     public void testEmptyPinnedQuery() throws Exception {
         XContentBuilder contentBuilder = XContentFactory.contentBuilder(randomFrom(XContentType.values()));
         contentBuilder.startObject().startObject("pinned").endObject().endObject();
         try (XContentParser xParser = createParser(contentBuilder)) {
-            expectThrows(ParsingException.class, () -> parseQuery(xParser).toQuery(createShardContext()));
+            expectThrows(ParsingException.class, () -> parseQuery(xParser).toQuery(createSearchExecutionContext()));
         }
     }
 
@@ -168,13 +168,13 @@ public class PinnedQueryBuilderTests extends AbstractQueryTestCase<PinnedQueryBu
 
     public void testRewrite() throws IOException {
         PinnedQueryBuilder pinnedQueryBuilder = new PinnedQueryBuilder(new TermQueryBuilder("foo", 1), "1");
-        QueryBuilder rewritten = pinnedQueryBuilder.rewrite(createShardContext());
+        QueryBuilder rewritten = pinnedQueryBuilder.rewrite(createSearchExecutionContext());
         assertThat(rewritten, instanceOf(PinnedQueryBuilder.class));
     }
 
     @Override
     public void testMustRewrite() throws IOException {
-        QueryShardContext context = createShardContext();
+        SearchExecutionContext context = createSearchExecutionContext();
         context.setAllowUnmappedFields(true);
         PinnedQueryBuilder queryBuilder = new PinnedQueryBuilder(new TermQueryBuilder("unmapped_field", "42"));
         IllegalStateException e = expectThrows(IllegalStateException.class,

--- a/x-pack/plugin/search-business-rules/src/test/java/org/elasticsearch/xpack/searchbusinessrules/PinnedQueryBuilderTests.java
+++ b/x-pack/plugin/search-business-rules/src/test/java/org/elasticsearch/xpack/searchbusinessrules/PinnedQueryBuilderTests.java
@@ -90,7 +90,7 @@ public class PinnedQueryBuilderTests extends AbstractQueryTestCase<PinnedQueryBu
         }
 
     @Override
-    protected void doAssertLuceneQuery(PinnedQueryBuilder queryBuilder, Query query, SearchExecutionContext searchContext) throws IOException {
+    protected void doAssertLuceneQuery(PinnedQueryBuilder queryBuilder, Query query, SearchExecutionContext searchContext) {
         if (queryBuilder.ids().size() == 0 && queryBuilder.organicQuery() == null) {
             assertThat(query, instanceOf(MatchNoDocsQuery.class));
         } else {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -729,7 +729,7 @@ public class Security extends Plugin implements SystemIndexPlugin, IngestPlugin,
                 assert dlsBitsetCache.get() != null;
                 module.setReaderWrapper(indexService ->
                         new SecurityIndexReaderWrapper(
-                                shardId -> indexService.newQueryShardContext(shardId.id(),
+                                shardId -> indexService.newSearchExecutionContext(shardId.id(),
                                 0,
                                 // we pass a null index reader, which is legal and will disable rewrite optimizations
                                 // based on index statistics, which is probably safer...

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapper.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapper.java
@@ -26,7 +26,7 @@ import org.elasticsearch.index.mapper.LegacyGeoShapeFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.ParseContext;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.VectorGeoShapeQueryProcessor;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.xpack.spatial.index.fielddata.plain.AbstractLatLonShapeIndexFieldData;
@@ -146,7 +146,7 @@ public class GeoShapeWithDocValuesFieldMapper extends AbstractShapeGeometryField
         }
 
         @Override
-        public Query geoShapeQuery(Geometry shape, String fieldName, ShapeRelation relation, QueryShardContext context) {
+        public Query geoShapeQuery(Geometry shape, String fieldName, ShapeRelation relation, SearchExecutionContext context) {
             return queryProcessor.geoShapeQuery(shape, fieldName, relation, context);
         }
     }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/PointFieldMapper.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/PointFieldMapper.java
@@ -19,7 +19,7 @@ import org.elasticsearch.index.mapper.ContentPath;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.ParseContext;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.xpack.spatial.common.CartesianPoint;
 import org.elasticsearch.xpack.spatial.index.mapper.PointFieldMapper.ParsedCartesianPoint;
 import org.elasticsearch.xpack.spatial.index.query.ShapeQueryPointProcessor;
@@ -166,7 +166,7 @@ public class PointFieldMapper extends AbstractPointGeometryFieldMapper<List<Pars
         }
 
         @Override
-        public Query shapeQuery(Geometry shape, String fieldName, ShapeRelation relation, QueryShardContext context) {
+        public Query shapeQuery(Geometry shape, String fieldName, ShapeRelation relation, SearchExecutionContext context) {
             return queryProcessor.shapeQuery(shape, fieldName, relation, context);
         }
     }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldMapper.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldMapper.java
@@ -19,7 +19,7 @@ import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.GeoShapeParser;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.ParseContext;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.xpack.spatial.index.query.ShapeQueryProcessor;
 
 import java.util.Arrays;
@@ -100,7 +100,7 @@ public class ShapeFieldMapper extends AbstractShapeGeometryFieldMapper<Geometry,
         }
 
         @Override
-        public Query shapeQuery(Geometry shape, String fieldName, ShapeRelation relation, QueryShardContext context) {
+        public Query shapeQuery(Geometry shape, String fieldName, ShapeRelation relation, SearchExecutionContext context) {
             return queryProcessor.shapeQuery(shape, fieldName, relation, context);
         }
 

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeQueryable.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeQueryable.java
@@ -8,7 +8,7 @@ package org.elasticsearch.xpack.spatial.index.mapper;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.geometry.Geometry;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 
 /**
  * Implemented by {@link org.elasticsearch.index.mapper.MappedFieldType} that support
@@ -16,5 +16,5 @@ import org.elasticsearch.index.query.QueryShardContext;
 */
 public interface ShapeQueryable {
 
-    Query shapeQuery(Geometry shape, String fieldName, ShapeRelation relation, QueryShardContext context);
+    Query shapeQuery(Geometry shape, String fieldName, ShapeRelation relation, SearchExecutionContext context);
 }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/query/ShapeQueryBuilder.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/query/ShapeQueryBuilder.java
@@ -17,7 +17,7 @@ import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.AbstractGeometryQueryBuilder;
 import org.elasticsearch.index.query.QueryRewriteContext;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.QueryShardException;
 import org.elasticsearch.xpack.spatial.index.mapper.ShapeQueryable;
 
@@ -101,7 +101,7 @@ public class ShapeQueryBuilder extends AbstractGeometryQueryBuilder<ShapeQueryBu
 
     @Override
     @SuppressWarnings({ "rawtypes" })
-    public Query buildShapeQuery(QueryShardContext context, MappedFieldType fieldType) {
+    public Query buildShapeQuery(SearchExecutionContext context, MappedFieldType fieldType) {
         if ((fieldType instanceof ShapeQueryable) == false) {
             throw new QueryShardException(context,
                 "Field [" + fieldName + "] is of unsupported type [" + fieldType.typeName() + "] for [" + NAME + "] query");

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/query/ShapeQueryPointProcessor.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/query/ShapeQueryPointProcessor.java
@@ -27,7 +27,7 @@ import org.elasticsearch.geometry.Polygon;
 import org.elasticsearch.geometry.Rectangle;
 import org.elasticsearch.geometry.ShapeType;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.QueryShardException;
 import org.elasticsearch.xpack.spatial.common.ShapeUtils;
 import org.elasticsearch.xpack.spatial.index.mapper.PointFieldMapper;
@@ -35,7 +35,7 @@ import org.elasticsearch.xpack.spatial.index.mapper.PointFieldMapper;
 
 public class ShapeQueryPointProcessor {
 
-    public Query shapeQuery(Geometry shape, String fieldName, ShapeRelation relation, QueryShardContext context) {
+    public Query shapeQuery(Geometry shape, String fieldName, ShapeRelation relation, SearchExecutionContext context) {
         validateIsPointFieldType(fieldName, context);
         // only the intersects relation is supported for indexed cartesian point types
         if (relation != ShapeRelation.INTERSECTS) {
@@ -46,7 +46,7 @@ public class ShapeQueryPointProcessor {
         return getVectorQueryFromShape(shape, fieldName, relation, context);
     }
 
-    private void validateIsPointFieldType(String fieldName, QueryShardContext context) {
+    private void validateIsPointFieldType(String fieldName, SearchExecutionContext context) {
         MappedFieldType fieldType = context.getFieldType(fieldName);
         if (fieldType instanceof PointFieldMapper.PointFieldType == false) {
             throw new QueryShardException(context, "Expected " + PointFieldMapper.CONTENT_TYPE
@@ -55,18 +55,18 @@ public class ShapeQueryPointProcessor {
     }
 
     protected Query getVectorQueryFromShape(
-        Geometry queryShape, String fieldName, ShapeRelation relation, QueryShardContext context) {
+        Geometry queryShape, String fieldName, ShapeRelation relation, SearchExecutionContext context) {
         ShapeVisitor shapeVisitor = new ShapeVisitor(context, fieldName, relation);
         return queryShape.visit(shapeVisitor);
     }
 
     private class ShapeVisitor implements GeometryVisitor<Query, RuntimeException> {
-        QueryShardContext context;
+        SearchExecutionContext context;
         MappedFieldType fieldType;
         String fieldName;
         ShapeRelation relation;
 
-        ShapeVisitor(QueryShardContext context, String fieldName, ShapeRelation relation) {
+        ShapeVisitor(SearchExecutionContext context, String fieldName, ShapeRelation relation) {
             this.context = context;
             this.fieldType = context.getFieldType(fieldName);
             this.fieldName = fieldName;

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/query/ShapeQueryProcessor.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/query/ShapeQueryProcessor.java
@@ -24,7 +24,7 @@ import org.elasticsearch.geometry.Point;
 import org.elasticsearch.geometry.Polygon;
 import org.elasticsearch.geometry.Rectangle;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.QueryShardException;
 import org.elasticsearch.xpack.spatial.common.ShapeUtils;
 import org.elasticsearch.xpack.spatial.index.mapper.ShapeFieldMapper;
@@ -35,7 +35,7 @@ import java.util.List;
 
 public class ShapeQueryProcessor  {
 
-    public Query shapeQuery(Geometry shape, String fieldName, ShapeRelation relation, QueryShardContext context) {
+    public Query shapeQuery(Geometry shape, String fieldName, ShapeRelation relation, SearchExecutionContext context) {
         validateIsShapeFieldType(fieldName, context);
         // CONTAINS queries are not supported by VECTOR strategy for indices created before version 7.5.0 (Lucene 8.3.0);
         if (relation == ShapeRelation.CONTAINS && context.indexVersionCreated().before(Version.V_7_5_0)) {
@@ -48,7 +48,7 @@ public class ShapeQueryProcessor  {
         return getVectorQueryFromShape(shape, fieldName, relation, context);
     }
 
-    private void validateIsShapeFieldType(String fieldName, QueryShardContext context) {
+    private void validateIsShapeFieldType(String fieldName, SearchExecutionContext context) {
         MappedFieldType fieldType = context.getFieldType(fieldName);
         if (fieldType instanceof ShapeFieldMapper.ShapeFieldType == false) {
             throw new QueryShardException(context, "Expected " + ShapeFieldMapper.CONTENT_TYPE
@@ -56,7 +56,7 @@ public class ShapeQueryProcessor  {
         }
     }
 
-    private Query getVectorQueryFromShape(Geometry queryShape, String fieldName, ShapeRelation relation, QueryShardContext context) {
+    private Query getVectorQueryFromShape(Geometry queryShape, String fieldName, ShapeRelation relation, SearchExecutionContext context) {
         final LuceneGeometryCollector visitor = new LuceneGeometryCollector(fieldName, context);
         queryShape.visit(visitor);
         final List<XYGeometry> geometries = visitor.geometries();
@@ -70,9 +70,9 @@ public class ShapeQueryProcessor  {
     private static class LuceneGeometryCollector implements GeometryVisitor<Void, RuntimeException> {
         private final List<XYGeometry> geometries = new ArrayList<>();
         private final String name;
-        private final QueryShardContext context;
+        private final SearchExecutionContext context;
 
-        private LuceneGeometryCollector(String name, QueryShardContext context) {
+        private LuceneGeometryCollector(String name, SearchExecutionContext context) {
             this.name = name;
             this.context = context;
         }

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/ShapeQueryBuilderOverShapeTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/ShapeQueryBuilderOverShapeTests.java
@@ -13,7 +13,7 @@ import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.geometry.ShapeType;
 import org.elasticsearch.index.mapper.MapperService;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.xpack.spatial.util.ShapeTestUtils;
 
 import java.io.IOException;
@@ -28,7 +28,7 @@ public class ShapeQueryBuilderOverShapeTests extends ShapeQueryBuilderTests {
 
     @Override
     protected ShapeRelation getShapeRelation(ShapeType type) {
-        QueryShardContext context = createShardContext();
+        SearchExecutionContext context = createSearchExecutionContext();
         if (context.indexVersionCreated().onOrAfter(Version.V_7_5_0)) { // CONTAINS is only supported from version 7.5
             if (type == ShapeType.LINESTRING || type == ShapeType.MULTILINESTRING) {
                 return randomFrom(ShapeRelation.DISJOINT, ShapeRelation.INTERSECTS, ShapeRelation.CONTAINS);

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/ShapeQueryBuilderTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/ShapeQueryBuilderTests.java
@@ -26,7 +26,7 @@ import org.elasticsearch.geometry.ShapeType;
 import org.elasticsearch.index.get.GetResult;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.QueryShardException;
 import org.elasticsearch.index.query.Rewriteable;
 import org.elasticsearch.plugins.Plugin;
@@ -119,7 +119,7 @@ public abstract class ShapeQueryBuilderTests extends AbstractQueryTestCase<Shape
     }
 
     @Override
-    protected void doAssertLuceneQuery(ShapeQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
+    protected void doAssertLuceneQuery(ShapeQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
         // Logic for doToQuery is complex and is hard to test here. Need to rely
         // on Integration tests to determine if created query is correct
         // TODO improve ShapeQueryBuilder.doToQuery() method to make it
@@ -174,9 +174,9 @@ public abstract class ShapeQueryBuilderTests extends AbstractQueryTestCase<Shape
     public void testMustRewrite() {
         ShapeQueryBuilder query = doCreateTestQueryBuilder(true);
 
-        UnsupportedOperationException e = expectThrows(UnsupportedOperationException.class, () -> query.toQuery(createShardContext()));
+        UnsupportedOperationException e = expectThrows(UnsupportedOperationException.class, () -> query.toQuery(createSearchExecutionContext()));
         assertEquals("query must be rewritten first", e.getMessage());
-        QueryBuilder rewrite = rewriteAndFetch(query, createShardContext());
+        QueryBuilder rewrite = rewriteAndFetch(query, createSearchExecutionContext());
         ShapeQueryBuilder geoShapeQueryBuilder = new ShapeQueryBuilder(fieldName(), indexedShapeToReturn);
         geoShapeQueryBuilder.relation(query.relation());
         assertEquals(geoShapeQueryBuilder, rewrite);
@@ -188,7 +188,7 @@ public abstract class ShapeQueryBuilderTests extends AbstractQueryTestCase<Shape
             .should(shape)
             .should(shape);
 
-        builder = rewriteAndFetch(builder, createShardContext());
+        builder = rewriteAndFetch(builder, createSearchExecutionContext());
 
         ShapeQueryBuilder expectedShape = new ShapeQueryBuilder(fieldName(), indexedShapeToReturn);
         expectedShape.relation(shape.relation());
@@ -202,29 +202,29 @@ public abstract class ShapeQueryBuilderTests extends AbstractQueryTestCase<Shape
         Geometry shape = getGeometry();
         final ShapeQueryBuilder queryBuilder = new ShapeQueryBuilder("unmapped", shape);
         queryBuilder.ignoreUnmapped(true);
-        Query query = queryBuilder.toQuery(createShardContext());
+        Query query = queryBuilder.toQuery(createSearchExecutionContext());
         assertThat(query, notNullValue());
         assertThat(query, instanceOf(MatchNoDocsQuery.class));
 
         final ShapeQueryBuilder failingQueryBuilder = new ShapeQueryBuilder("unmapped", shape);
         failingQueryBuilder.ignoreUnmapped(false);
-        QueryShardException e = expectThrows(QueryShardException.class, () -> failingQueryBuilder.toQuery(createShardContext()));
+        QueryShardException e = expectThrows(QueryShardException.class, () -> failingQueryBuilder.toQuery(createSearchExecutionContext()));
         assertThat(e.getMessage(), containsString("failed to find type for field [unmapped]"));
     }
 
     public void testWrongFieldType() {
         Geometry shape = getGeometry();
         final ShapeQueryBuilder queryBuilder = new ShapeQueryBuilder(TEXT_FIELD_NAME, shape);
-        QueryShardException e = expectThrows(QueryShardException.class, () -> queryBuilder.toQuery(createShardContext()));
+        QueryShardException e = expectThrows(QueryShardException.class, () -> queryBuilder.toQuery(createSearchExecutionContext()));
         assertThat(e.getMessage(), containsString("Field [mapped_string] is of unsupported type [text] for [shape] query"));
     }
 
     public void testSerializationFailsUnlessFetched() throws IOException {
         QueryBuilder builder = doCreateTestQueryBuilder(true);
-        QueryBuilder queryBuilder = Rewriteable.rewrite(builder, createShardContext());
+        QueryBuilder queryBuilder = Rewriteable.rewrite(builder, createSearchExecutionContext());
         IllegalStateException ise = expectThrows(IllegalStateException.class, () -> queryBuilder.writeTo(new BytesStreamOutput(10)));
         assertEquals(ise.getMessage(), "supplier must be null, can't serialize suppliers, missing a rewriteAndFetch?");
-        builder = rewriteAndFetch(builder, createShardContext());
+        builder = rewriteAndFetch(builder, createSearchExecutionContext());
         builder.writeTo(new BytesStreamOutput(10));
     }
 

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/ShapeQueryBuilderTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/ShapeQueryBuilderTests.java
@@ -174,7 +174,8 @@ public abstract class ShapeQueryBuilderTests extends AbstractQueryTestCase<Shape
     public void testMustRewrite() {
         ShapeQueryBuilder query = doCreateTestQueryBuilder(true);
 
-        UnsupportedOperationException e = expectThrows(UnsupportedOperationException.class, () -> query.toQuery(createSearchExecutionContext()));
+        UnsupportedOperationException e = expectThrows(UnsupportedOperationException.class,
+            () -> query.toQuery(createSearchExecutionContext()));
         assertEquals("query must be rewritten first", e.getMessage());
         QueryBuilder rewrite = rewriteAndFetch(query, createSearchExecutionContext());
         ShapeQueryBuilder geoShapeQueryBuilder = new ShapeQueryBuilder(fieldName(), indexedShapeToReturn);

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/ingest/CircleProcessorTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/ingest/CircleProcessorTests.java
@@ -30,7 +30,7 @@ import org.elasticsearch.geometry.utils.StandardValidator;
 import org.elasticsearch.geometry.utils.WellKnownText;
 import org.elasticsearch.index.mapper.GeoShapeIndexer;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.VectorGeoShapeQueryProcessor;
 import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.RandomDocumentPicks;
@@ -218,7 +218,7 @@ public class CircleProcessorTests extends ESTestCase {
             = new GeoShapeWithDocValuesFieldType(fieldName, true, false, ShapeBuilder.Orientation.RIGHT, null, Collections.emptyMap());
 
         VectorGeoShapeQueryProcessor processor = new VectorGeoShapeQueryProcessor();
-        QueryShardContext mockedContext = mock(QueryShardContext.class);
+        SearchExecutionContext mockedContext = mock(SearchExecutionContext.class);
         when(mockedContext.getFieldType(any())).thenReturn(shapeType);
         Query sameShapeQuery = processor.geoShapeQuery(geometry, fieldName, ShapeRelation.INTERSECTS, mockedContext);
         Query pointOnDatelineQuery = processor.geoShapeQuery(new Point(180, circle.getLat()), fieldName,
@@ -250,7 +250,7 @@ public class CircleProcessorTests extends ESTestCase {
         MappedFieldType shapeType = new ShapeFieldType(fieldName, true, ShapeBuilder.Orientation.RIGHT, null, Collections.emptyMap());
 
         ShapeQueryProcessor processor = new ShapeQueryProcessor();
-        QueryShardContext mockedContext = mock(QueryShardContext.class);
+        SearchExecutionContext mockedContext = mock(SearchExecutionContext.class);
         when(mockedContext.getFieldType(any())).thenReturn(shapeType);
         Query sameShapeQuery = processor.shapeQuery(geometry, fieldName, ShapeRelation.INTERSECTS, mockedContext);
         Query centerPointQuery = processor.shapeQuery(new Point(circle.getLon(), circle.getLat()), fieldName,

--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/mapper/DenseVectorFieldMapper.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/mapper/DenseVectorFieldMapper.java
@@ -22,7 +22,7 @@ import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.TextSearchInfo;
 import org.elasticsearch.index.mapper.ValueFetcher;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.lookup.SearchLookup;
@@ -109,7 +109,7 @@ public class DenseVectorFieldMapper extends FieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             if (format != null) {
                 throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
             }
@@ -138,7 +138,7 @@ public class DenseVectorFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query termQuery(Object value, QueryShardContext context) {
+        public Query termQuery(Object value, SearchExecutionContext context) {
             throw new IllegalArgumentException(
                 "Field [" + name() + "] of type [" + typeName() + "] doesn't support queries");
         }

--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/mapper/SparseVectorFieldMapper.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/mapper/SparseVectorFieldMapper.java
@@ -16,7 +16,7 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.TextSearchInfo;
 import org.elasticsearch.index.mapper.ValueFetcher;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.DocValueFormat;
 
 import java.time.ZoneId;
@@ -86,17 +86,17 @@ public class SparseVectorFieldMapper extends FieldMapper {
         }
 
         @Override
-        public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             throw new UnsupportedOperationException(ERROR_MESSAGE_7X);
         }
 
         @Override
-        public Query existsQuery(QueryShardContext context) {
+        public Query existsQuery(SearchExecutionContext context) {
             throw new UnsupportedOperationException(ERROR_MESSAGE_7X);
         }
 
         @Override
-        public Query termQuery(Object value, QueryShardContext context) {
+        public Query termQuery(Object value, SearchExecutionContext context) {
             throw new UnsupportedOperationException(ERROR_MESSAGE_7X);
         }
     }

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
@@ -886,7 +886,8 @@ public class WildcardFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive, SearchExecutionContext context) {
+        public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive,
+                                 SearchExecutionContext context) {
             return wildcardQuery(escapeWildcardSyntax(value) + "*", method, caseInsensitive, context);
         }
 

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
@@ -62,7 +62,7 @@ import org.elasticsearch.index.mapper.ParseContext.Document;
 import org.elasticsearch.index.mapper.SourceValueFetcher;
 import org.elasticsearch.index.mapper.TextSearchInfo;
 import org.elasticsearch.index.mapper.ValueFetcher;
-import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.lookup.SearchLookup;
 
@@ -264,7 +264,7 @@ public class WildcardFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query wildcardQuery(String wildcardPattern, RewriteMethod method, boolean caseInsensitive, QueryShardContext context) {
+        public Query wildcardQuery(String wildcardPattern, RewriteMethod method, boolean caseInsensitive, SearchExecutionContext context) {
 
             String ngramIndexPattern = addLineEndChars(wildcardPattern);
             // Break search term into tokens
@@ -345,7 +345,7 @@ public class WildcardFieldMapper extends FieldMapper {
 
         @Override
         public Query regexpQuery(String value, int syntaxFlags, int matchFlags, int maxDeterminizedStates,
-            RewriteMethod method, QueryShardContext context) {
+            RewriteMethod method, SearchExecutionContext context) {
             if (value.length() == 0) {
                 return new MatchNoDocsQuery();
             }
@@ -696,7 +696,7 @@ public class WildcardFieldMapper extends FieldMapper {
             ShapeRelation relation,
             ZoneId timeZone,
             DateMathParser parser,
-            QueryShardContext context
+            SearchExecutionContext context
         ) {
             BytesRef lower = lowerTerm == null ? null : BytesRefs.toBytesRef(lowerTerm);
             BytesRef upper = upperTerm == null ? null : BytesRefs.toBytesRef(upperTerm);
@@ -765,7 +765,7 @@ public class WildcardFieldMapper extends FieldMapper {
             int prefixLength,
             int maxExpansions,
             boolean transpositions,
-            QueryShardContext context
+            SearchExecutionContext context
         ) {
             String searchTerm = BytesRefs.toString(value);
             try {
@@ -859,7 +859,7 @@ public class WildcardFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query termQuery(Object value, QueryShardContext context) {
+        public Query termQuery(Object value, SearchExecutionContext context) {
             String searchTerm = BytesRefs.toString(value);
             return wildcardQuery(escapeWildcardSyntax(searchTerm),  MultiTermQuery.CONSTANT_SCORE_REWRITE, false, context);
         }
@@ -880,18 +880,18 @@ public class WildcardFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Query termQueryCaseInsensitive(Object value, QueryShardContext context) {
+        public Query termQueryCaseInsensitive(Object value, SearchExecutionContext context) {
             String searchTerm = BytesRefs.toString(value);
             return wildcardQuery(escapeWildcardSyntax(searchTerm), MultiTermQuery.CONSTANT_SCORE_REWRITE, true, context);
         }
 
         @Override
-        public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive, QueryShardContext context) {
+        public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive, SearchExecutionContext context) {
             return wildcardQuery(escapeWildcardSyntax(value) + "*", method, caseInsensitive, context);
         }
 
         @Override
-        public Query termsQuery(List<?> values, QueryShardContext context) {
+        public Query termsQuery(List<?> values, SearchExecutionContext context) {
             BooleanQuery.Builder bq = new BooleanQuery.Builder();
             for (Object value : values) {
                 bq.add(termQuery(value, context), Occur.SHOULD);
@@ -906,7 +906,7 @@ public class WildcardFieldMapper extends FieldMapper {
         }
 
          @Override
-         public ValueFetcher valueFetcher(QueryShardContext context, String format) {
+         public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
              if (format != null) {
                  throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
              }


### PR DESCRIPTION
We decided to rename `QueryShardContext` to clarify that it supports all parts
of search request execution. Before there was confusion over whether it should
only be used for building queries, or maybe only used in the query phase. This
PR also updates the javadocs.

Closes #64740.