### PR TITLE
Fix ChangePolicyforIndexIT.testChangePolicyForIndex

### DIFF
--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/ChangePolicyforIndexIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/ChangePolicyforIndexIT.java
@@ -64,8 +64,10 @@ public class ChangePolicyforIndexIT extends ESRestTestCase {
         Map<String, Phase> phases2 = new HashMap<>();
         phases2.put("hot", new Phase("hot", TimeValue.ZERO, singletonMap(RolloverAction.NAME, new RolloverAction(null, null, 1000L))));
         phases2.put("warm", new Phase("warm", TimeValue.ZERO,
-                singletonMap(AllocateAction.NAME, new AllocateAction(1, singletonMap("_name", "javaRestTest-1,javaRestTest-2"), null, null))));
-        LifecyclePolicy lifecyclePolicy2 = new LifecyclePolicy("policy_1", phases2);
+                singletonMap(AllocateAction.NAME,
+                    new AllocateAction(1, singletonMap("_name", "javaRestTest-0,javaRestTest-1,javaRestTest-2,javaRestTest-3"),
+                        null, null))));
+        LifecyclePolicy lifecyclePolicy2 = new LifecyclePolicy("policy_2", phases2);
         // PUT policy_1 and policy_2
         XContentBuilder builder1 = jsonBuilder();
         lifecyclePolicy1.toXContent(builder1, null);
@@ -118,7 +120,7 @@ public class ChangePolicyforIndexIT extends ESRestTestCase {
         // Check index is allocated on javaRestTest-1 and javaRestTest-2 as per policy_2
         Map<String, Object> indexSettings = getIndexSettingsAsMap(indexName);
         String includesAllocation = (String) indexSettings.get("index.routing.allocation.include._name");
-        assertEquals("javaRestTest-1,javaRestTest-2", includesAllocation);
+        assertEquals("javaRestTest-0,javaRestTest-1,javaRestTest-2,javaRestTest-3", includesAllocation);
     }
 
     private void assertStep(String indexName, StepKey expectedStep) throws IOException {


### PR DESCRIPTION
This test was doing some sophisticated policy switching to test phase caching and updated policies,
but as part of it, it was unnecessarily restricting where an index could be allocated.

This change relaxes those restrictions and fixes an issue where the second policy was
misnamed (leading to some confusing log messages)

Resolves #66960
