### PR TITLE
Permit wait_for_active_shards warnings in master

### DIFF
--- a/plugins/repository-hdfs/src/test/resources/rest-api-spec/test/hdfs_repository/40_restore.yml
+++ b/plugins/repository-hdfs/src/test/resources/rest-api-spec/test/hdfs_repository/40_restore.yml
@@ -4,6 +4,8 @@
 #
 ---
 "Create a snapshot and then restore it":
+  - skip:
+      features: ["allowed_warnings"]
 
   # Create repository
   - do:
@@ -47,6 +49,8 @@
   - do:
       indices.close:
         index : test_index
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
   # Restore index
   - do:

--- a/plugins/repository-hdfs/src/test/resources/rest-api-spec/test/secure_hdfs_repository/40_restore.yml
+++ b/plugins/repository-hdfs/src/test/resources/rest-api-spec/test/secure_hdfs_repository/40_restore.yml
@@ -4,6 +4,8 @@
 #
 ---
 "Create a snapshot and then restore it":
+  - skip:
+      features: ["allowed_warnings"]
 
   # Create repository
   - do:
@@ -49,6 +51,8 @@
   - do:
       indices.close:
         index : test_index
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
   # Restore index
   - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.aliases/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.aliases/10_basic.yml
@@ -388,6 +388,7 @@
   - skip:
       version: " - 7.3.99"
       reason:  "is_write_index is shown in cat.aliases starting version 7.4.0"
+      features: ["allowed_warnings"]
 
   - do:
       indices.create:
@@ -399,6 +400,8 @@
   - do:
       indices.close:
         index: test_index
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
   - do:
       cat.aliases:
@@ -419,7 +422,7 @@
 "Alias against closed index (pre 7.4.0)":
   - skip:
       version: "7.4.0 - "
-      features: node_selector
+      features: ["node_selector", "allowed_warnings"]
       reason:  "is_write_index is shown in cat.aliases starting version 7.4.0"
 
   - do:
@@ -432,6 +435,8 @@
   - do:
       indices.close:
         index: test_index
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
   - do:
       node_selector:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.indices/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.indices/10_basic.yml
@@ -54,6 +54,7 @@
   - skip:
       version: "7.2.0 - "
       reason:  "closed indices are replicated starting version 7.2.0"
+      features: ["allowed_warnings"]
 
   - do:
       indices.create:
@@ -66,6 +67,8 @@
   - do:
       indices.close:
         index: index-2
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
   - is_true: acknowledged
 
   - do:
@@ -95,6 +98,7 @@
   - skip:
       version: " - 7.1.99"
       reason:  "closed indices are replicated starting version 7.2.0"
+      features: ["allowed_warnings"]
 
   - do:
       indices.create:
@@ -107,6 +111,8 @@
   - do:
       indices.close:
         index: index-2
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
   - is_true: acknowledged
 
   - do:
@@ -221,6 +227,8 @@
 
 ---
 "Test cat indices sort":
+  - skip:
+      features: ["allowed_warnings"]
 
   - do:
       indices.create:
@@ -249,6 +257,8 @@
   - do:
       indices.close:
         index: bar
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
   - do:
       cat.indices:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.recovery/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.recovery/10_basic.yml
@@ -84,6 +84,7 @@
   - skip:
       version: " - 7.99.99"
       reason: format of bytes output changed in 8.0.0
+      features: ["allowed_warnings"]
 
   - do:
       indices.create:
@@ -96,6 +97,8 @@
   - do:
       indices.close:
         index: index2
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
   - is_true: acknowledged
 
   - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.segments/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.segments/10_basic.yml
@@ -83,6 +83,8 @@
 
 ---
 "Test cat segments on closed index behaviour":
+  - skip:
+      features: ["allowed_warnings"]
 
   - do:
       indices.create:
@@ -95,6 +97,8 @@
   - do:
       indices.close:
         index: index1
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
   - do:
       catch: bad_request

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.allocation_explain/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.allocation_explain/10_basic.yml
@@ -52,6 +52,7 @@
   - skip:
       version: " - 7.1.99"
       reason: closed indices are replicated starting version 7.2.0
+      features: ["allowed_warnings"]
 
   - do:
       indices.create:
@@ -68,6 +69,8 @@
   - do:
       indices.close:
         index: test_closed
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
   - match: { acknowledged: true }
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.health/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.health/10_basic.yml
@@ -134,6 +134,7 @@
   - skip:
       version: "7.2.0 - "
       reason:  "closed indices are replicated starting version 7.2.0"
+      features: ["allowed_warnings"]
 
   - do:
       indices.create:
@@ -180,6 +181,8 @@
   - do:
       indices.close:
         index: index-2
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
   - is_true: acknowledged
 
   # closing the index-2 turns the cluster health back to green
@@ -208,6 +211,7 @@
   - skip:
       version: " - 7.1.99"
       reason:  "closed indices are replicated starting version 7.2.0"
+      features: ["allowed_warnings"]
 
   - do:
       indices.create:
@@ -255,6 +259,8 @@
   - do:
       indices.close:
         index: index-2
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
   - is_true: acknowledged
 
   - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.health/30_indices_options.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.health/30_indices_options.yml
@@ -1,4 +1,6 @@
 setup:
+  - skip:
+      features: ["allowed_warnings"]
 
   - do:
       indices.create:
@@ -23,6 +25,8 @@ setup:
   - do:
       indices.close:
         index: index-2
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
   - do:
       cluster.health:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.state/30_expand_wildcards.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.state/30_expand_wildcards.yml
@@ -1,4 +1,6 @@
 setup:
+  - skip:
+      features: ["allowed_warnings"]
 
   - do:
       indices.create:
@@ -25,6 +27,8 @@ setup:
   - do:
       indices.close:
         index: test_close_index
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
 ---
 "Test expand_wildcards parameter on closed, open indices and both":

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get/10_basic.yml
@@ -1,5 +1,7 @@
 ---
 setup:
+  - skip:
+      features: ["allowed_warnings"]
 
   - do:
       indices.create:
@@ -38,6 +40,8 @@ setup:
   - do:
       indices.close:
         index: test_index_3
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
   - do:
       cluster.health:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_alias/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_alias/10_basic.yml
@@ -1,6 +1,5 @@
 ---
 setup:
-
   - do:
       indices.create:
         index: test_index
@@ -303,10 +302,14 @@ setup:
 
 ---
 "Get alias against closed indices":
+  - skip:
+      features: ["allowed_warnings"]
 
   - do:
       indices.close:
         index: test_index_2
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
   - do:
       indices.get_alias:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_mapping/50_wildcard_expansion.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_mapping/50_wildcard_expansion.yml
@@ -1,5 +1,8 @@
 ---
 setup:
+  - skip:
+      features: ["allowed_warnings"]
+
   - do:
         indices.create:
           index: test-xxx
@@ -52,6 +55,8 @@ setup:
   - do:
       indices.close:
         index: test-xyy
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
   - do:
         cluster.health:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.open/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.open/10_basic.yml
@@ -1,5 +1,8 @@
 ---
 "Basic test for index open/close":
+  - skip:
+      features: ["allowed_warnings"]
+
   - do:
       indices.create:
         index: test_index
@@ -14,6 +17,8 @@
   - do:
       indices.close:
         index: test_index
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
   - is_true: acknowledged
 
   - do:
@@ -38,6 +43,8 @@
 
 ---
 "Open index with wait_for_active_shards set to all":
+  - skip:
+      features: ["allowed_warnings"]
 
   - do:
       indices.create:
@@ -49,6 +56,8 @@
   - do:
       indices.close:
         index: test_index
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
   - is_true: acknowledged
 
   - do:
@@ -81,6 +90,9 @@
   - match: { shards_acknowledged: true }
 ---
 "Close index response with result per index":
+  - skip:
+      features: ["allowed_warnings"]
+
   - do:
       indices.create:
         index: index_1
@@ -105,6 +117,8 @@
   - do:
       indices.close:
         index: "index_*"
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
   - match: { acknowledged: true }
   - match: { shards_acknowledged: true }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.open/20_multiple_indices.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.open/20_multiple_indices.yml
@@ -23,9 +23,14 @@ setup:
 
 ---
 "All indices":
+  - skip:
+      features: ["allowed_warnings"]
+
   - do:
       indices.close:
         index: _all
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
   - is_true: acknowledged
 
   - do:
@@ -50,9 +55,14 @@ setup:
 
 ---
 "Trailing wildcard":
+  - skip:
+      features: ["allowed_warnings"]
+
   - do:
       indices.close:
         index: test_*
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
   - is_true: acknowledged
 
   - do:
@@ -77,9 +87,14 @@ setup:
 
 ---
 "Only wildcard":
+  - skip:
+      features: ["allowed_warnings"]
+
   - do:
       indices.close:
         index: '*'
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
   - is_true: acknowledged
 
   - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_settings/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_settings/10_basic.yml
@@ -56,6 +56,9 @@ setup:
 
 ---
 "Test preserve_existing settings":
+  - skip:
+      features: ["allowed_warnings"]
+
   - do:
       indices.put_settings:
         index: test-index
@@ -89,6 +92,8 @@ setup:
   - do:
       indices.close:
         index: test-index
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
   - do:
       indices.put_settings:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.recovery/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.recovery/10_basic.yml
@@ -44,6 +44,7 @@
   - skip:
       version: " - 7.1.99"
       reason: closed indices are replicated starting version 7.2.0
+      features: ["allowed_warnings"]
 
   - do:
       indices.create:
@@ -56,6 +57,8 @@
   - do:
       indices.close:
         index: test_2
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
   - is_true: acknowledged
 
   - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.resolve_index/10_basic_resolve_index.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.resolve_index/10_basic_resolve_index.yml
@@ -24,6 +24,8 @@ setup:
   - do:
       indices.close:
         index: test_index2
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
   - do:
       indices.create:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.segments/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.segments/10_basic.yml
@@ -42,6 +42,9 @@
 
 ---
 "closed segments test":
+  - skip:
+      features: ["allowed_warnings"]
+
   - do:
       indices.create:
         index: index1
@@ -58,6 +61,8 @@
   - do:
       indices.close:
         index: index1
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
   - do:
       catch: bad_request

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/80_indices_options.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/80_indices_options.yml
@@ -27,6 +27,9 @@
 ---
 "Closed index":
 
+  - skip:
+      features: ["allowed_warnings"]
+
   - do:
       indices.create:
           index:  index_closed
@@ -34,6 +37,8 @@
   - do:
       indices.close:
           index:  index_closed
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
   - do:
       catch:  /index_closed_exception/

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.restore/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.restore/10_basic.yml
@@ -24,6 +24,9 @@ setup:
 ---
 "Create a snapshot and then restore it":
 
+  - skip:
+      features: ["allowed_warnings"]
+
   - do:
       snapshot.create:
         repository: test_repo_restore_1
@@ -40,6 +43,8 @@ setup:
   - do:
       indices.close:
         index : test_index
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
   - do:
       snapshot.restore:

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -1216,8 +1216,19 @@ public abstract class ESRestTestCase extends ESTestCase {
         return RestStatus.OK.getStatus() == response.getStatusLine().getStatusCode();
     }
 
+    /**
+     * Deprecation message emitted since {@link Version#V_7_12_0} for the rest of the 7.x series. Can be removed in v9 since it is not
+     * emitted in v8. Note that this message is also permitted in certain YAML test cases, it can be removed there too.
+     * See https://github.com/elastic/elasticsearch/issues/66419 for more details.
+     */
+    private static final String WAIT_FOR_ACTIVE_SHARDS_DEFAULT_DEPRECATION_MESSAGE = "the default value for the ?wait_for_active_shards " +
+            "parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' " +
+            "to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour";
+
     protected static void closeIndex(String index) throws IOException {
-        assertOK(client().performRequest(new Request(HttpPost.METHOD_NAME, "/" + index + "/_close")));
+        final Request closeRequest = new Request(HttpPost.METHOD_NAME, "/" + index + "/_close");
+        closeRequest.setOptions(expectVersionSpecificWarnings(v -> v.compatible(WAIT_FOR_ACTIVE_SHARDS_DEFAULT_DEPRECATION_MESSAGE)));
+        assertOK(client().performRequest(closeRequest));
     }
 
     protected static void openIndex(String index) throws IOException {

--- a/x-pack/plugin/ccr/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/ccr/follow_and_unfollow.yml
+++ b/x-pack/plugin/ccr/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/ccr/follow_and_unfollow.yml
@@ -1,5 +1,8 @@
 ---
 "Test follow and unfollow an existing index":
+  - skip:
+      features: ["allowed_warnings"]
+
   - do:
       cluster.state: {}
 
@@ -62,6 +65,8 @@
   - do:
       indices.close:
         index: bar
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
   - is_true: acknowledged
 
   - do:

--- a/x-pack/plugin/ccr/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/ccr/forget_follower.yml
+++ b/x-pack/plugin/ccr/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/ccr/forget_follower.yml
@@ -1,5 +1,8 @@
 ---
 "Test forget follower":
+  - skip:
+      features: ["allowed_warnings"]
+
   - do:
       cluster.state: {}
 
@@ -72,6 +75,8 @@
   - do:
       indices.close:
         index: follower_index
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
   - is_true: acknowledged
 
   - do:

--- a/x-pack/plugin/ccr/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/ccr/index_directly_into_follower_index.yml
+++ b/x-pack/plugin/ccr/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/ccr/index_directly_into_follower_index.yml
@@ -1,5 +1,8 @@
 ---
 "Test indexing direcly into a follower index":
+  - skip:
+      features: ["allowed_warnings"]
+
   - do:
       cluster.state: {}
 
@@ -58,6 +61,8 @@
   - do:
       indices.close:
         index: bar
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
   - is_true: acknowledged
 
   - do:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/data_stream/20_unsupported_apis.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/data_stream/20_unsupported_apis.yml
@@ -45,6 +45,8 @@
   - do:
       indices.close:
         index: logs-*
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
   - is_true: acknowledged
   - length: { indices: 0 }
 
@@ -165,6 +167,8 @@
       catch: bad_request
       indices.close:
         index: ".ds-simple-data-stream1-*000001"
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
   - do:
       indices.delete_data_stream:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/data_stream/40_supported_apis.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/data_stream/40_supported_apis.yml
@@ -230,6 +230,8 @@ teardown:
   - do:
       indices.close:
         index: ".ds-simple-data-stream1-*000001,.ds-simple-data-stream1-*000002"
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
   - is_true: acknowledged
 
   - do:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/data_stream/80_resolve_index_data_streams.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/data_stream/80_resolve_index_data_streams.yml
@@ -54,6 +54,8 @@ setup:
   - do:
       indices.close:
         index: test_index2
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
   - do:
       indices.create:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/indices.freeze/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/indices.freeze/10_basic.yml
@@ -79,6 +79,10 @@
 
 ---
 "Test index options":
+
+- skip:
+    features: ["allowed_warnings"]
+
 - do:
     index:
       index: test
@@ -94,6 +98,8 @@
 - do:
     indices.close:
       index: test-close
+    allowed_warnings:
+      - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
 - do:
     indices.freeze:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_crud.yml
@@ -1215,6 +1215,8 @@
 
 ---
 "Test put job after closing results index":
+  - skip:
+      features: ["allowed_warnings"]
 
   - do:
       indices.create:
@@ -1223,6 +1225,8 @@
   - do:
       indices.close:
         index: ".ml-anomalies-shared"
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
   - do:
       catch: /Cannot create job \[closed-results-job\] as it requires closed index \[\.ml-anomalies-shared\]/
@@ -1242,6 +1246,8 @@
 
 ---
 "Test put job after closing state index":
+  - skip:
+      features: ["allowed_warnings"]
 
   - do:
       indices.create:
@@ -1250,6 +1256,8 @@
   - do:
       indices.close:
         index: ".ml-state-000001"
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
   - do:
       catch: /Cannot create job \[closed-results-job\] as it requires closed index \[\.ml-state-000001\]/

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/monitoring/bulk/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/monitoring/bulk/10_basic.yml
@@ -174,6 +174,7 @@
   - skip:
       version: "all"
       reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/30101"
+      features: ["allowed_warnings"]
 
   - do:
       monitoring.bulk:
@@ -206,6 +207,8 @@
   - do:
       indices.close:
         index: .monitoring-beats-*
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
   - do:
       catch: /export_exception/

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/security/authz/14_cat_indices.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/security/authz/14_cat_indices.yml
@@ -1,7 +1,7 @@
 ---
 setup:
   - skip:
-      features: headers
+      features: ["headers", "allowed_warnings"]
 
   - do:
       cluster.health:
@@ -55,6 +55,8 @@ setup:
   - do:
       indices.close:
         index:  index3
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
 ---
 teardown:
@@ -120,6 +122,7 @@ teardown:
   - skip:
       version: "all"
       reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/47875"
+      features: ["allowed_warnings"]
 
   - do:
       indices.create:
@@ -150,6 +153,8 @@ teardown:
   - do:
       indices.close:
         index:  index_to_monitor
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
   - do:
       headers: { Authorization: "Basic Y2F0X3VzZXI6Y2F0X3NlY3JldF9wYXNzd29yZA==" } # cat_user

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/snapshot/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/snapshot/10_basic.yml
@@ -24,6 +24,8 @@ setup:
 
 ---
 "Create a source only snapshot and then restore it":
+  - skip:
+      features: ["allowed_warnings"]
 
   - do:
       index:
@@ -52,6 +54,8 @@ setup:
   - do:
       indices.close:
         index : test_index
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
   - do:
       snapshot.restore:

--- a/x-pack/qa/multi-cluster-search-security/src/test/resources/rest-api-spec/test/remote_cluster/10_basic.yml
+++ b/x-pack/qa/multi-cluster-search-security/src/test/resources/rest-api-spec/test/remote_cluster/10_basic.yml
@@ -106,6 +106,8 @@ setup:
   - do:
       indices.close:
         index: closed_index
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
   - do:
         indices.create:


### PR DESCRIPTION
Part of the fixes for #66419, this commit permits nodes to emit the
deprecation warning regarding not specifying `?wait_for_active_shards`
when closing an index in 7.x versions for x ≥ 12. This change is
required on `master` too since the BWC tests encounter these warnings.

Relates #67246, which is the 7.x part of this change.