### PR TITLE
[7.x] add the ability to retrieve the fieldnames an aggregation creates from the builder

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregationBuilder.java
@@ -33,6 +33,8 @@ import org.elasticsearch.search.aggregations.support.AggregationContext;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 /**
  * A factory that knows how to create an {@link Aggregator} of a specific type.
@@ -64,6 +66,18 @@ public abstract class AggregationBuilder
     /** Return this aggregation's name. */
     public String getName() {
         return name;
+    }
+
+    /**
+     * Return the field names this aggregation creates.
+     *
+     * This method is a optional helper for clients that need to know the output field names.
+     *
+     * @return The set of output field names this aggregation produces or Optional.empty() if not implemented or Optional.of(emptySet())
+     *         if the fields are not known.
+     */
+    public Optional<Set<String>> getOutputFieldNames() {
+        return Optional.empty();
     }
 
     /** Internal: build an {@link AggregatorFactory} based on the configuration of this builder. */

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalExtendedStats.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalExtendedStats.java
@@ -25,9 +25,13 @@ import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class InternalExtendedStats extends InternalStats implements ExtendedStats {
     enum Metrics {
@@ -40,6 +44,10 @@ public class InternalExtendedStats extends InternalStats implements ExtendedStat
             return Metrics.valueOf(name);
         }
     }
+
+    private static final Set<String> METRIC_NAMES = Collections.unmodifiableSet(
+        Stream.of(Metrics.values()).map(Metrics::name).collect(Collectors.toSet())
+    );
 
     private final double sumOfSqrs;
     private final double sigma;
@@ -113,6 +121,11 @@ public class InternalExtendedStats extends InternalStats implements ExtendedStat
             return getStdDeviationBound(Bounds.LOWER_SAMPLING);
         }
         return super.value(name);
+    }
+
+    @Override
+    public Iterable<String> valueNames() {
+        return METRIC_NAMES;
     }
 
     public double getSigma() {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalStats.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalStats.java
@@ -25,9 +25,11 @@ import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -41,7 +43,9 @@ public class InternalStats extends InternalNumericMetricsAggregation.MultiValue 
         }
     }
 
-    public static List<String> metricNames = Stream.of(Metrics.values()).map(Metrics::name).collect(Collectors.toList());
+    static final Set<String> METRIC_NAMES = Collections.unmodifiableSet(
+        Stream.of(Metrics.values()).map(Metrics::name).collect(Collectors.toSet())
+    );
 
     protected final long count;
     protected final double min;
@@ -149,7 +153,7 @@ public class InternalStats extends InternalNumericMetricsAggregation.MultiValue 
 
     @Override
     public Iterable<String> valueNames() {
-        return metricNames;
+        return METRIC_NAMES;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedStats.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedStats.java
@@ -32,7 +32,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.elasticsearch.search.aggregations.metrics.InternalStats.metricNames;
+import static org.elasticsearch.search.aggregations.metrics.InternalStats.METRIC_NAMES;
 
 public class ParsedStats extends ParsedAggregation implements Stats {
 
@@ -105,7 +105,7 @@ public class ParsedStats extends ParsedAggregation implements Stats {
 
     @Override
     public Iterable<String> valueNames() {
-        return metricNames;
+        return METRIC_NAMES;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/StatsAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/StatsAggregationBuilder.java
@@ -36,6 +36,8 @@ import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 public class StatsAggregationBuilder extends ValuesSourceAggregationBuilder.LeafOnly<ValuesSource.Numeric, StatsAggregationBuilder> {
     public static final String NAME = "stats";
@@ -107,5 +109,10 @@ public class StatsAggregationBuilder extends ValuesSourceAggregationBuilder.Leaf
     @Override
     protected ValuesSourceRegistry.RegistryKey<?> getRegistryKey() {
         return REGISTRY_KEY;
+    }
+
+    @Override
+    public Optional<Set<String>> getOutputFieldNames() {
+        return Optional.of(InternalStats.METRIC_NAMES);
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsAggregatorTests.java
@@ -22,11 +22,8 @@ package org.elasticsearch.search.aggregations.metrics;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.SortedNumericDocValuesField;
-import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.RandomIndexWriter;
-import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
-import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.NumericUtils;
 import org.elasticsearch.common.CheckedConsumer;
 import org.elasticsearch.index.mapper.MappedFieldType;
@@ -258,18 +255,11 @@ public class ExtendedStatsAggregatorTests extends AggregatorTestCase {
     public void testCase(MappedFieldType ft,
                          CheckedConsumer<RandomIndexWriter, IOException> buildIndex,
                          Consumer<InternalExtendedStats> verify) throws IOException {
-        try (Directory directory = newDirectory();
-             RandomIndexWriter indexWriter = new RandomIndexWriter(random(), directory)) {
-            buildIndex.accept(indexWriter);
-            try (IndexReader reader = indexWriter.getReader()) {
-                IndexSearcher searcher = new IndexSearcher(reader);
-                ExtendedStatsAggregationBuilder aggBuilder = new ExtendedStatsAggregationBuilder("my_agg")
-                    .field("field")
-                    .sigma(randomDoubleBetween(0, 10, true));
-                InternalExtendedStats stats = searchAndReduce(searcher, new MatchAllDocsQuery(), aggBuilder, ft);
-                verify.accept(stats);
-            }
-        }
+        ExtendedStatsAggregationBuilder aggBuilder = new ExtendedStatsAggregationBuilder("my_agg")
+            .field("field")
+            .sigma(randomDoubleBetween(0, 10, true));
+
+        testCase(aggBuilder, new MatchAllDocsQuery(), buildIndex, verify, ft);
     }
 
     static class ExtendedSimpleStatsAggregator extends StatsAggregatorTests.SimpleStatsAggregator {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/StatsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/StatsAggregatorTests.java
@@ -50,7 +50,6 @@ import org.elasticsearch.search.lookup.LeafDocLookup;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -88,7 +87,7 @@ public class StatsAggregatorTests extends AggregatorTestCase {
                 assertEquals(Double.NEGATIVE_INFINITY, stats.getMax(), 0);
                 assertFalse(AggregationInspectionHelper.hasValue(stats));
             },
-            singleton(ft)
+            ft
         );
     }
 
@@ -119,7 +118,7 @@ public class StatsAggregatorTests extends AggregatorTestCase {
                 assertEquals(expected.sum / expected.count, stats.getAvg(), TOLERANCE);
                 assertTrue(AggregationInspectionHelper.hasValue(stats));
             },
-            singleton(ft)
+            ft
         );
     }
 
@@ -203,7 +202,7 @@ public class StatsAggregatorTests extends AggregatorTestCase {
                 assertEquals(expectedMin, stats.getMin(), 0d);
                 assertTrue(AggregationInspectionHelper.hasValue(stats));
             },
-            singleton(ft)
+            ft
         );
         testCase(
             stats("_name").field(ft.name()),
@@ -220,7 +219,7 @@ public class StatsAggregatorTests extends AggregatorTestCase {
                 assertEquals(expectedMin, stats.getMin(), 0d);
                 assertTrue(AggregationInspectionHelper.hasValue(stats));
             },
-            singleton(ft)
+            ft
         );
     }
 
@@ -400,7 +399,7 @@ public class StatsAggregatorTests extends AggregatorTestCase {
                 assertEquals(expected.sum / expected.count, stats.getAvg(), TOLERANCE);
                 assertTrue(AggregationInspectionHelper.hasValue(stats));
             },
-            singleton(ft)
+            ft
         );
     }
 
@@ -445,24 +444,15 @@ public class StatsAggregatorTests extends AggregatorTestCase {
             builder,
             iw -> iw.addDocuments(docs),
             stats -> verify.accept(expected, stats),
-            singleton(ft)
+            ft
         );
     }
 
     private void testCase(StatsAggregationBuilder builder,
                           CheckedConsumer<RandomIndexWriter, IOException> buildIndex,
                           Consumer<InternalStats> verify,
-                          Collection<MappedFieldType> fieldTypes) throws IOException {
-        try (Directory directory = newDirectory();
-            RandomIndexWriter indexWriter = new RandomIndexWriter(random(), directory)) {
-            buildIndex.accept(indexWriter);
-            try (IndexReader reader = indexWriter.getReader()) {
-                IndexSearcher searcher = new IndexSearcher(reader);
-                final MappedFieldType[] fieldTypesArray = fieldTypes.toArray(new MappedFieldType[0]);
-                final InternalStats stats = searchAndReduce(searcher, new MatchAllDocsQuery(), builder, fieldTypesArray);
-                verify.accept(stats);
-            }
-        }
+                          MappedFieldType... fieldTypes) throws IOException {
+        testCase(builder, new MatchAllDocsQuery(), buildIndex, verify, fieldTypes);
     }
 
     static class SimpleStatsAggregator {

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -111,6 +111,7 @@ import org.elasticsearch.search.aggregations.AggregatorFactories.Builder;
 import org.elasticsearch.search.aggregations.MultiBucketConsumerService.MultiBucketConsumer;
 import org.elasticsearch.search.aggregations.bucket.nested.NestedAggregationBuilder;
 import org.elasticsearch.search.aggregations.metrics.MetricsAggregator;
+import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregation;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator.PipelineTree;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
@@ -136,8 +137,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -537,6 +540,8 @@ public abstract class AggregatorTestCase extends ESTestCase {
 
                 V agg = searchAndReduce(indexSearcher, query, aggregationBuilder, fieldTypes);
                 verify.accept(agg);
+
+                verifyOutputFieldNames(aggregationBuilder, agg);
             }
         }
     }
@@ -559,6 +564,24 @@ public abstract class AggregatorTestCase extends ESTestCase {
                 verify.accept(searcher, createAggregator(aggregationBuilder, context));
             }
         }
+    }
+
+    protected <T extends AggregationBuilder, V extends InternalAggregation> void verifyOutputFieldNames(T aggregationBuilder, V agg)
+        throws IOException {
+        if (aggregationBuilder.getOutputFieldNames().isPresent() == false) {
+            // aggregation does not support output field names yet
+            return;
+        }
+
+        assert agg instanceof NumericMetricsAggregation.MultiValue : "only multi value aggs are supported";
+
+        NumericMetricsAggregation.MultiValue multiValueAgg = (NumericMetricsAggregation.MultiValue) agg;
+        Set<String> valueNames = new HashSet<>();
+        for (String name : multiValueAgg.valueNames()) {
+            valueNames.add(name);
+        }
+
+        assertEquals(aggregationBuilder.getOutputFieldNames().get(), valueNames);
     }
 
     /**

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/boxplot/BoxplotAggregationBuilder.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/boxplot/BoxplotAggregationBuilder.java
@@ -25,6 +25,8 @@ import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 
 import static org.elasticsearch.search.aggregations.metrics.PercentilesMethod.COMPRESSION_FIELD;
 
@@ -142,6 +144,12 @@ public class BoxplotAggregationBuilder extends ValuesSourceAggregationBuilder.Le
     @Override
     protected ValuesSourceRegistry.RegistryKey<?> getRegistryKey() {
         return REGISTRY_KEY;
+    }
+
+
+    @Override
+    public Optional<Set<String>> getOutputFieldNames() {
+        return Optional.of(InternalBoxplot.METRIC_NAMES);
     }
 }
 

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/boxplot/InternalBoxplot.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/boxplot/InternalBoxplot.java
@@ -17,10 +17,12 @@ import org.elasticsearch.search.aggregations.metrics.InternalNumericMetricsAggre
 import org.elasticsearch.search.aggregations.metrics.TDigestState;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -164,9 +166,9 @@ public class InternalBoxplot extends InternalNumericMetricsAggregation.MultiValu
         return results;
     }
 
-    public static List<String> metricNames = Stream.of(Metrics.values())
-        .map(m -> m.name().toLowerCase(Locale.ROOT))
-        .collect(Collectors.toList());
+    static final Set<String> METRIC_NAMES = Collections.unmodifiableSet(
+        Stream.of(Metrics.values()).map(m -> m.name().toLowerCase(Locale.ROOT)).collect(Collectors.toSet())
+    );
 
     private final TDigestState state;
 
@@ -253,7 +255,7 @@ public class InternalBoxplot extends InternalNumericMetricsAggregation.MultiValu
 
     @Override
     public Iterable<String> valueNames() {
-        return metricNames;
+        return METRIC_NAMES;
     }
 
     // for testing only

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/TopMetricsAggregationBuilder.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/TopMetricsAggregationBuilder.java
@@ -27,6 +27,9 @@ import org.elasticsearch.search.sort.SortBuilder;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
@@ -190,5 +193,10 @@ public class TopMetricsAggregationBuilder extends AbstractAggregationBuilder<Top
 
     List<MultiValuesSourceFieldConfig> getMetricFields() {
         return metricFields;
+    }
+
+    @Override
+    public Optional<Set<String>> getOutputFieldNames() {
+        return Optional.of(metricFields.stream().map(mf -> mf.getFieldName()).collect(Collectors.toSet()));
     }
 }

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/topmetrics/TopMetricsAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/topmetrics/TopMetricsAggregatorTests.java
@@ -518,7 +518,9 @@ public class TopMetricsAggregatorTests extends AggregatorTestCase {
 
             try (IndexReader indexReader = DirectoryReader.open(directory)) {
                 IndexSearcher indexSearcher = newSearcher(indexReader, true, true);
-                return searchAndReduce(indexSearcher, query, builder, fields);
+                InternalAggregation agg = searchAndReduce(indexSearcher, query, builder, fields);
+                verifyOutputFieldNames(builder, agg);
+                return agg;
             }
         }
     }


### PR DESCRIPTION
Add a getOutputFieldNames method to aggregationbuilder to retrieve the names of the fields the
aggregation produces. Implementation is optional and provided for a set of multi value aggregations
as a start.

backport of #65139