### PR TITLE
Clarify bootstrap check failure messages

### DIFF
--- a/server/src/main/java/org/elasticsearch/bootstrap/BootstrapChecks.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/BootstrapChecks.java
@@ -158,9 +158,10 @@ final class BootstrapChecks {
 
         if (!errors.isEmpty()) {
             final List<String> messages = new ArrayList<>(1 + errors.size());
-            messages.add("[" + errors.size() + "] bootstrap checks failed");
+            messages.add("[" + errors.size() + "] bootstrap checks failed. You must address the points described in the following ["
+                    + errors.size() + "] lines before starting Elasticsearch.");
             for (int i = 0; i < errors.size(); i++) {
-                messages.add("[" + (i + 1) + "]: " + errors.get(i));
+                messages.add("bootstrap check failure [" + (i + 1) + "] of [" + errors.size() + "]: " + errors.get(i));
             }
             final NodeValidationException ne = new NodeValidationException(String.join("\n", messages));
             errors.stream().map(IllegalStateException::new).forEach(ne::addSuppressed);

--- a/server/src/test/java/org/elasticsearch/bootstrap/BootstrapChecksTests.java
+++ b/server/src/test/java/org/elasticsearch/bootstrap/BootstrapChecksTests.java
@@ -137,7 +137,14 @@ public class BootstrapChecksTests extends AbstractBootstrapCheckTestCase {
         final NodeValidationException e =
                 expectThrows(NodeValidationException.class,
                     () -> BootstrapChecks.check(emptyContext, true, checks));
-        assertThat(e, hasToString(allOf(containsString("bootstrap checks failed"), containsString("first"), containsString("second"))));
+        assertThat(e, hasToString(allOf(
+                containsString("[2] bootstrap checks failed"),
+                containsString("You must address the points described in the following [2] lines before starting Elasticsearch"),
+                containsString("bootstrap check failure [1] of [2]:"),
+                containsString("first"),
+                containsString("bootstrap check failure [2] of [2]:"),
+                containsString("second")
+        )));
         final Throwable[] suppressed = e.getSuppressed();
         assertThat(suppressed.length, equalTo(2));
         assertThat(suppressed[0], instanceOf(IllegalStateException.class));


### PR DESCRIPTION
Today a bootstrap check failure results in a multi-line log message, for
example:

    [ERROR][o.e.b.Bootstrap ] node validation exception
    [2] bootstrap checks failed
    [1]: system call filters failed to install; check the logs and fix your configuration or disable system call filters at your own risk
    [2]: the default discovery settings are unsuitable for production use; at least one of [discovery.seed_hosts, discovery.seed_providers, cluster.initial_master_nodes] must be configured

We get frequent questions about bootstrap check failures that indicate
some users see the `bootstrap checks failed` message but struggle to see
that the actionable details are on the following lines.

This commit adds extra information to this message to help link the
lines together and lead users more explicitly from the top-level failure
down to the actions they need to take:

    [ERROR][o.e.b.Bootstrap ] node validation exception
    [2] bootstrap checks failed. You must address the points described in the following [2] lines before starting Elasticsearch.
    bootstrap check failure [1] of [2]: system call filters failed to install; check the logs and fix your configuration or disable system call filters at your own risk
    bootstrap check failure [2] of [2]: the default discovery settings are unsuitable for production use; at least one of [discovery.seed_hosts, discovery.seed_providers, cluster.initial_master_nodes] must be configured