### PR TITLE
Add doc values restriction for wildcard fields

### DIFF
--- a/docs/reference/mapping/params/doc-values.asciidoc
+++ b/docs/reference/mapping/params/doc-values.asciidoc
@@ -42,4 +42,5 @@ PUT my-index-000001
 <1> The `status_code` field has `doc_values` enabled by default.
 <2> The `session_id` has `doc_values` disabled, but can still be queried.
 
-Doc values cannot be disabled for `wildcard` fields.
+NOTE: You cannot disable doc values for <<wildcard-field-type,`wildcard`>>
+fields.

--- a/docs/reference/mapping/params/doc-values.asciidoc
+++ b/docs/reference/mapping/params/doc-values.asciidoc
@@ -42,3 +42,4 @@ PUT my-index-000001
 <1> The `status_code` field has `doc_values` enabled by default.
 <2> The `session_id` has `doc_values` disabled, but can still be queried.
 
+Doc values cannot be disabled for `wildcard` fields.


### PR DESCRIPTION
Adding a small note that you cannot disable doc values for wildcard fields

