### PR TITLE
Fix Leaked SnapshotsService State on Failed Delete

### DIFF
--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -1938,7 +1938,11 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
 
             @Override
             public void onFailure(String source, Exception e) {
-                listener.onFailure(e);
+                if (deleteFromRepoTask == null) {
+                    listener.onFailure(e);
+                } else {
+                    deleteFromRepoTask.onFailure(source, e);
+                }
             }
 
             @Override


### PR DESCRIPTION
Fixing leaked snapshots service state on a failed delete/abort task that marked some snapshots as ending (it adds noop snapshot aborts to `endingSnapshots`) while computing the updated cluster state. If the update fails for any reason we must remove the snapshot from the `endingSnapshots` field again which is done in the `deleteFromRepoTask` instead of just failing the listener. Otherwise we get stuck aborted snapshots.

This needs to only go into into 7.x and 7.11 where we use this indirect way of computing the cluster state update task, in master this weird workaround is not necessary.

Relates to most visible cases of https://github.com/elastic/elasticsearch/issues/66663 but there's another issue left that will be resolved by a different PR to master.