### PR TITLE
[7.x][ML] Refactor data frame analytics framework in steps (#67423)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsState.java
@@ -16,6 +16,9 @@ import java.util.Locale;
 
 public enum DataFrameAnalyticsState implements Writeable {
 
+    // States reindexing and analyzing are no longer used.
+    // However, we need to keep them for BWC as tasks may be
+    // awaiting assignment in older versioned nodes.
     STARTED, REINDEXING, ANALYZING, STOPPING, STOPPED, FAILED, STARTING;
 
     public static DataFrameAnalyticsState fromString(String name) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/MlTasksTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/MlTasksTests.java
@@ -203,46 +203,6 @@ public class MlTasksTests extends ESTestCase {
         assertThat(state, equalTo(DataFrameAnalyticsState.STARTING));
     }
 
-    public void testGetDataFrameAnalyticsState_GivenTaskWithReindexingState() {
-        String jobId = "foo";
-        PersistentTasksCustomMetadata.PersistentTask<?> task = createDataFrameAnalyticsTask(jobId, "test_node",
-            DataFrameAnalyticsState.REINDEXING, false);
-
-        DataFrameAnalyticsState state = MlTasks.getDataFrameAnalyticsState(task);
-
-        assertThat(state, equalTo(DataFrameAnalyticsState.REINDEXING));
-    }
-
-    public void testGetDataFrameAnalyticsState_GivenStaleTaskWithReindexingState() {
-        String jobId = "foo";
-        PersistentTasksCustomMetadata.PersistentTask<?> task = createDataFrameAnalyticsTask(jobId, "test_node",
-            DataFrameAnalyticsState.REINDEXING, true);
-
-        DataFrameAnalyticsState state = MlTasks.getDataFrameAnalyticsState(task);
-
-        assertThat(state, equalTo(DataFrameAnalyticsState.STARTING));
-    }
-
-    public void testGetDataFrameAnalyticsState_GivenTaskWithAnalyzingState() {
-        String jobId = "foo";
-        PersistentTasksCustomMetadata.PersistentTask<?> task = createDataFrameAnalyticsTask(jobId, "test_node",
-            DataFrameAnalyticsState.ANALYZING, false);
-
-        DataFrameAnalyticsState state = MlTasks.getDataFrameAnalyticsState(task);
-
-        assertThat(state, equalTo(DataFrameAnalyticsState.ANALYZING));
-    }
-
-    public void testGetDataFrameAnalyticsState_GivenStaleTaskWithAnalyzingState() {
-        String jobId = "foo";
-        PersistentTasksCustomMetadata.PersistentTask<?> task = createDataFrameAnalyticsTask(jobId, "test_node",
-            DataFrameAnalyticsState.ANALYZING, true);
-
-        DataFrameAnalyticsState state = MlTasks.getDataFrameAnalyticsState(task);
-
-        assertThat(state, equalTo(DataFrameAnalyticsState.STARTING));
-    }
-
     public void testGetDataFrameAnalyticsState_GivenTaskWithStoppingState() {
         String jobId = "foo";
         PersistentTasksCustomMetadata.PersistentTask<?> task = createDataFrameAnalyticsTask(jobId, "test_node",

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ClassificationIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ClassificationIT.java
@@ -49,6 +49,7 @@ import org.elasticsearch.xpack.core.ml.inference.MlInferenceNamedXContentProvide
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelConfig;
 import org.elasticsearch.xpack.core.ml.inference.preprocessing.OneHotEncoding;
 import org.elasticsearch.xpack.core.ml.inference.preprocessing.PreProcessor;
+import org.elasticsearch.xpack.core.ml.utils.PhaseProgress;
 import org.junit.After;
 import org.junit.Before;
 
@@ -497,15 +498,10 @@ public class ClassificationIT extends MlNativeDataFrameAnalyticsIntegTestCase {
         NodeAcknowledgedResponse response = startAnalytics(jobId);
         assertThat(response.getNode(), not(emptyString()));
 
-        // Wait until state is one of REINDEXING or ANALYZING, or until it is STOPPED.
+        // Wait until progress for first phase is over 1
         assertBusy(() -> {
-            DataFrameAnalyticsState state = getAnalyticsStats(jobId).getState();
-            assertThat(
-                state,
-                is(anyOf(
-                    equalTo(DataFrameAnalyticsState.REINDEXING),
-                    equalTo(DataFrameAnalyticsState.ANALYZING),
-                    equalTo(DataFrameAnalyticsState.STOPPED))));
+            List<PhaseProgress> progress = getAnalyticsStats(jobId).getProgress();
+            assertThat(progress.get(0).getProgressPercent(), greaterThan(1));
         });
         stopAnalytics(jobId);
         waitUntilAnalyticsIsStopped(jobId);

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RunDataFrameAnalyticsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RunDataFrameAnalyticsIT.java
@@ -28,6 +28,7 @@ import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsDest;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsSource;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsState;
 import org.elasticsearch.xpack.core.ml.dataframe.analyses.OutlierDetection;
+import org.elasticsearch.xpack.core.ml.utils.PhaseProgress;
 import org.junit.After;
 import org.junit.Before;
 
@@ -611,11 +612,10 @@ public class RunDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsIntegTest
         NodeAcknowledgedResponse response = startAnalytics(id);
         assertThat(response.getNode(), not(emptyString()));
 
-        // Wait until state is one of REINDEXING or ANALYZING, or until it is STOPPED.
+        // Wait until progress for first phase is over 1
         assertBusy(() -> {
-            DataFrameAnalyticsState state = getAnalyticsStats(id).getState();
-            assertThat(state, is(anyOf(equalTo(DataFrameAnalyticsState.REINDEXING), equalTo(DataFrameAnalyticsState.ANALYZING),
-                equalTo(DataFrameAnalyticsState.STOPPED))));
+            List<PhaseProgress> progress = getAnalyticsStats(id).getProgress();
+            assertThat(progress.get(0).getProgressPercent(), greaterThan(1));
         });
         stopAnalytics(id);
         waitUntilAnalyticsIsStopped(id);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -759,7 +759,7 @@ public class MachineLearning extends Plugin implements SystemIndexPlugin,
         DataFrameAnalyticsConfigProvider dataFrameAnalyticsConfigProvider = new DataFrameAnalyticsConfigProvider(client, xContentRegistry,
             dataFrameAnalyticsAuditor);
         assert client instanceof NodeClient;
-        DataFrameAnalyticsManager dataFrameAnalyticsManager = new DataFrameAnalyticsManager((NodeClient) client,
+        DataFrameAnalyticsManager dataFrameAnalyticsManager = new DataFrameAnalyticsManager((NodeClient) client, clusterService,
             dataFrameAnalyticsConfigProvider, analyticsProcessManager, dataFrameAnalyticsAuditor, indexNameExpressionResolver);
         this.dataFrameAnalyticsManager.set(dataFrameAnalyticsManager);
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDataFrameAnalyticsStatsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDataFrameAnalyticsStatsAction.java
@@ -105,7 +105,7 @@ public class TransportGetDataFrameAnalyticsStatsAction
                                  ActionListener<QueryPage<Stats>> listener) {
         logger.debug("Get stats for running task [{}]", task.getParams().getId());
 
-        ActionListener<Void> reindexingProgressListener = ActionListener.wrap(
+        ActionListener<Void> updateProgressListener = ActionListener.wrap(
             aVoid -> {
                 Stats stats = buildStats(
                     task.getParams().getId(),
@@ -120,7 +120,7 @@ public class TransportGetDataFrameAnalyticsStatsAction
         );
 
         // We must update the progress of the reindexing task as it might be stale
-        task.updateReindexTaskProgress(reindexingProgressListener);
+        task.updateTaskProgress(updateProgressListener);
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsAction.java
@@ -14,7 +14,9 @@ import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.SearchAction;
 import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
@@ -29,6 +31,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.license.License;
 import org.elasticsearch.license.LicenseUtils;
 import org.elasticsearch.license.XPackLicenseState;
@@ -38,6 +41,7 @@ import org.elasticsearch.persistent.PersistentTaskState;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.persistent.PersistentTasksService;
 import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -68,6 +72,7 @@ import org.elasticsearch.xpack.ml.dataframe.DataFrameAnalyticsManager;
 import org.elasticsearch.xpack.ml.dataframe.DataFrameAnalyticsTask;
 import org.elasticsearch.xpack.ml.dataframe.MappingsMerger;
 import org.elasticsearch.xpack.ml.dataframe.SourceDestValidations;
+import org.elasticsearch.xpack.ml.dataframe.StoredProgress;
 import org.elasticsearch.xpack.ml.dataframe.extractor.DataFrameDataExtractorFactory;
 import org.elasticsearch.xpack.ml.dataframe.extractor.ExtractedFieldsDetectorFactory;
 import org.elasticsearch.xpack.ml.dataframe.persistence.DataFrameAnalyticsConfigProvider;
@@ -76,6 +81,7 @@ import org.elasticsearch.xpack.ml.job.JobNodeSelector;
 import org.elasticsearch.xpack.ml.notifications.DataFrameAnalyticsAuditor;
 import org.elasticsearch.xpack.ml.process.MlMemoryTracker;
 import org.elasticsearch.xpack.ml.task.AbstractJobPersistentTasksExecutor;
+import org.elasticsearch.xpack.ml.utils.persistence.MlParserUtils;
 
 import java.util.List;
 import java.util.Map;
@@ -142,6 +148,7 @@ public class TransportStartDataFrameAnalyticsAction
     @Override
     protected void masterOperation(StartDataFrameAnalyticsAction.Request request, ClusterState state,
                                    ActionListener<NodeAcknowledgedResponse> listener) {
+        logger.debug(() -> new ParameterizedMessage("[{}] received start request", request.getId()));
         if (licenseState.checkFeature(XPackLicenseState.Feature.MACHINE_LEARNING) == false) {
             listener.onFailure(LicenseUtils.newComplianceException(XPackField.MACHINE_LEARNING));
             return;
@@ -526,8 +533,6 @@ public class TransportStartDataFrameAnalyticsAction
             DataFrameAnalyticsState analyticsState = taskState == null ? DataFrameAnalyticsState.STOPPED : taskState.getState();
             switch (analyticsState) {
                 case STARTED:
-                case REINDEXING:
-                case ANALYZING:
                     node = persistentTask.getExecutorNode();
                     return true;
                 case STOPPING:
@@ -581,7 +586,6 @@ public class TransportStartDataFrameAnalyticsAction
     public static class TaskExecutor extends AbstractJobPersistentTasksExecutor<TaskParams> {
 
         private final Client client;
-        private final ClusterService clusterService;
         private final DataFrameAnalyticsManager manager;
         private final DataFrameAnalyticsAuditor auditor;
         private final IndexTemplateConfig inferenceIndexTemplate;
@@ -598,7 +602,6 @@ public class TransportStartDataFrameAnalyticsAction
                 memoryTracker,
                 resolver);
             this.client = Objects.requireNonNull(client);
-            this.clusterService = Objects.requireNonNull(clusterService);
             this.manager = Objects.requireNonNull(manager);
             this.auditor = Objects.requireNonNull(auditor);
             this.inferenceIndexTemplate = Objects.requireNonNull(inferenceIndexTemplate);
@@ -611,7 +614,7 @@ public class TransportStartDataFrameAnalyticsAction
             PersistentTasksCustomMetadata.PersistentTask<TaskParams> persistentTask,
             Map<String, String> headers) {
             return new DataFrameAnalyticsTask(
-                id, type, action, parentTaskId, headers, client, clusterService, manager, auditor, persistentTask.getParams());
+                id, type, action, parentTaskId, headers, client, manager, auditor, persistentTask.getParams());
         }
 
         @Override
@@ -645,8 +648,10 @@ public class TransportStartDataFrameAnalyticsAction
 
         @Override
         protected void nodeOperation(AllocatedPersistentTask task, TaskParams params, PersistentTaskState state) {
+            DataFrameAnalyticsTask dfaTask = (DataFrameAnalyticsTask) task;
             DataFrameAnalyticsTaskState analyticsTaskState = (DataFrameAnalyticsTaskState) state;
-            DataFrameAnalyticsState analyticsState = analyticsTaskState == null ? null : analyticsTaskState.getState();
+            DataFrameAnalyticsState analyticsState = analyticsTaskState == null ? DataFrameAnalyticsState.STOPPED
+                : analyticsTaskState.getState();
             logger.info("[{}] Starting data frame analytics from state [{}]", params.getId(), analyticsState);
 
             // If we are "stopping" there is nothing to do and we should stop
@@ -660,8 +665,26 @@ public class TransportStartDataFrameAnalyticsAction
                 return;
             }
 
+            ActionListener<StoredProgress> progressListener = ActionListener.wrap(
+                storedProgress -> {
+                    if (storedProgress != null) {
+                        dfaTask.getStatsHolder().setProgressTracker(storedProgress.get());
+                    }
+                    executeTask(dfaTask);
+                },
+                dfaTask::setFailed
+            );
+
             ActionListener<Boolean> templateCheckListener = ActionListener.wrap(
-                ok -> executeTask(analyticsTaskState, task),
+                ok -> {
+                    if (analyticsState != DataFrameAnalyticsState.STOPPED) {
+                        // If the state is not stopped it means the task is reassigning and
+                        // we need to update the progress from the last stored progress doc.
+                        searchProgressFromIndex(params.getId(), progressListener);
+                    } else {
+                        progressListener.onResponse(null);
+                    }
+                },
                 error -> {
                     Throwable cause = ExceptionsHelper.unwrapCause(error);
                     logger.error(
@@ -670,23 +693,44 @@ public class TransportStartDataFrameAnalyticsAction
                             params.getId(),
                             inferenceIndexTemplate.getTemplateName()),
                         cause);
-                    task.markAsFailed(error);
+                    dfaTask.setFailed(error);
                 }
             );
 
             MlIndexAndAlias.installIndexTemplateIfRequired(clusterState, client, inferenceIndexTemplate, templateCheckListener);
         }
 
-        private void executeTask(DataFrameAnalyticsTaskState analyticsTaskState, AllocatedPersistentTask task) {
-            if (analyticsTaskState == null) {
-                DataFrameAnalyticsTaskState startedState = new DataFrameAnalyticsTaskState(DataFrameAnalyticsState.STARTED,
-                    task.getAllocationId(), null);
-                task.updatePersistentTaskState(startedState, ActionListener.wrap(
-                    response -> manager.execute((DataFrameAnalyticsTask) task, DataFrameAnalyticsState.STARTED, clusterState),
-                    task::markAsFailed));
-            } else {
-                manager.execute((DataFrameAnalyticsTask) task, analyticsTaskState.getState(), clusterState);
-            }
+        private void searchProgressFromIndex(String jobId, ActionListener<StoredProgress> listener) {
+            SearchRequest searchRequest = new SearchRequest(AnomalyDetectorsIndex.jobStateIndexPattern());
+            searchRequest.indicesOptions(IndicesOptions.lenientExpandOpen());
+            searchRequest.source().size(1);
+            searchRequest.source().query(QueryBuilders.idsQuery().addIds(StoredProgress.documentId(jobId)));
+            searchRequest.allowPartialSearchResults(false);
+
+            ActionListener<SearchResponse> searchListener = ActionListener.wrap(
+                searchResponse -> {
+                    SearchHit[] hits = searchResponse.getHits().getHits();
+                    if (hits.length == 0) {
+                        logger.debug(() -> new ParameterizedMessage("[{}] No stored progress found", jobId));
+                        listener.onResponse(null);
+                    } else {
+                        StoredProgress storedProgress = MlParserUtils.parse(hits[0], StoredProgress.PARSER);
+                        logger.debug(() -> new ParameterizedMessage("[{}] Found stored progress {}", jobId, storedProgress.get().get(0)));
+                        listener.onResponse(storedProgress);
+                    }
+                },
+                listener::onFailure
+            );
+
+            executeAsyncWithOrigin(client, ML_ORIGIN, SearchAction.INSTANCE, searchRequest, searchListener);
+        }
+
+        private void executeTask(DataFrameAnalyticsTask task) {
+            DataFrameAnalyticsTaskState startedState = new DataFrameAnalyticsTaskState(DataFrameAnalyticsState.STARTED,
+                task.getAllocationId(), null);
+            task.updatePersistentTaskState(startedState, ActionListener.wrap(
+                response -> manager.execute(task, clusterState),
+                task::markAsFailed));
         }
 
         public static String nodeFilter(DiscoveryNode node, TaskParams params) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsManager.java
@@ -8,19 +8,9 @@ package org.elasticsearch.xpack.ml.dataframe;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
-import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexAction;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
-import org.elasticsearch.action.admin.indices.get.GetIndexAction;
-import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
-import org.elasticsearch.action.admin.indices.get.GetIndexResponse;
-import org.elasticsearch.action.admin.indices.refresh.RefreshAction;
-import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
-import org.elasticsearch.action.admin.indices.refresh.RefreshResponse;
-import org.elasticsearch.action.bulk.BulkItemResponse;
-import org.elasticsearch.action.support.ContextPreservingActionListener;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.ParentTaskAssigningClient;
 import org.elasticsearch.client.node.NodeClient;
@@ -28,40 +18,26 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
-import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.index.IndexNotFoundException;
-import org.elasticsearch.index.mapper.SeqNoFieldMapper;
-import org.elasticsearch.index.reindex.BulkByScrollResponse;
-import org.elasticsearch.index.reindex.ReindexAction;
-import org.elasticsearch.index.reindex.ReindexRequest;
-import org.elasticsearch.script.Script;
-import org.elasticsearch.search.sort.SortOrder;
-import org.elasticsearch.tasks.Task;
-import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.ml.MlStatsIndex;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfig;
-import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsState;
-import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsTaskState;
-import org.elasticsearch.xpack.core.ml.job.messages.Messages;
 import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
 import org.elasticsearch.xpack.core.ml.job.persistence.ElasticsearchMappings;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
-import org.elasticsearch.xpack.ml.dataframe.extractor.DataFrameDataExtractorFactory;
 import org.elasticsearch.xpack.ml.dataframe.persistence.DataFrameAnalyticsConfigProvider;
 import org.elasticsearch.xpack.ml.dataframe.process.AnalyticsProcessManager;
+import org.elasticsearch.xpack.ml.dataframe.steps.AnalysisStep;
+import org.elasticsearch.xpack.ml.dataframe.steps.DataFrameAnalyticsStep;
+import org.elasticsearch.xpack.ml.dataframe.steps.ReindexingStep;
+import org.elasticsearch.xpack.ml.dataframe.steps.StepResponse;
 import org.elasticsearch.xpack.ml.notifications.DataFrameAnalyticsAuditor;
 
-import java.time.Clock;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Supplier;
 
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
-import static org.elasticsearch.xpack.core.ClientHelper.executeWithHeadersAsync;
 
 public class DataFrameAnalyticsManager {
 
@@ -71,6 +47,7 @@ public class DataFrameAnalyticsManager {
      * We need a {@link NodeClient} to get the reindexing task and be able to report progress
      */
     private final NodeClient client;
+    private final ClusterService clusterService;
     private final DataFrameAnalyticsConfigProvider configProvider;
     private final AnalyticsProcessManager processManager;
     private final DataFrameAnalyticsAuditor auditor;
@@ -78,17 +55,18 @@ public class DataFrameAnalyticsManager {
     /** Indicates whether the node is shutting down. */
     private final AtomicBoolean nodeShuttingDown = new AtomicBoolean();
 
-    public DataFrameAnalyticsManager(NodeClient client, DataFrameAnalyticsConfigProvider configProvider,
+    public DataFrameAnalyticsManager(NodeClient client, ClusterService clusterService, DataFrameAnalyticsConfigProvider configProvider,
                                      AnalyticsProcessManager processManager, DataFrameAnalyticsAuditor auditor,
                                      IndexNameExpressionResolver expressionResolver) {
         this.client = Objects.requireNonNull(client);
+        this.clusterService = Objects.requireNonNull(clusterService);
         this.configProvider = Objects.requireNonNull(configProvider);
         this.processManager = Objects.requireNonNull(processManager);
         this.auditor = Objects.requireNonNull(auditor);
         this.expressionResolver = Objects.requireNonNull(expressionResolver);
     }
 
-    public void execute(DataFrameAnalyticsTask task, DataFrameAnalyticsState currentState, ClusterState clusterState) {
+    public void execute(DataFrameAnalyticsTask task, ClusterState clusterState) {
         // With config in hand, determine action to take
         ActionListener<DataFrameAnalyticsConfig> configListener = ActionListener.wrap(
             config -> {
@@ -104,12 +82,7 @@ public class DataFrameAnalyticsManager {
                             DestinationIndex.MIN_COMPATIBLE_VERSION);
                         task.getStatsHolder().resetProgressTracker(config.getAnalysis().getProgressPhases(),
                             config.getAnalysis().supportsInference());
-                        DataFrameAnalyticsTaskState reindexingState = new DataFrameAnalyticsTaskState(DataFrameAnalyticsState.REINDEXING,
-                            task.getAllocationId(), "destination index was out of date");
-                        task.updatePersistentTaskState(reindexingState, ActionListener.wrap(
-                            updatedTask -> executeJobInMiddleOfReindexing(task, config),
-                            task::setFailed
-                        ));
+                        executeJobInMiddleOfReindexing(task, config);
                         return;
                     }
                 }
@@ -117,27 +90,7 @@ public class DataFrameAnalyticsManager {
                 task.getStatsHolder().adjustProgressTracker(config.getAnalysis().getProgressPhases(),
                     config.getAnalysis().supportsInference());
 
-                switch(currentState) {
-                    // If we are STARTED, it means the job was started because the start API was called.
-                    // We should determine the job's starting state based on its previous progress.
-                    case STARTED:
-                        executeStartingJob(task, config);
-                        break;
-                    // The task has fully reindexed the documents and we should continue on with our analyses
-                    case ANALYZING:
-                        LOGGER.debug("[{}] Reassigning job that was analyzing", config.getId());
-                        startAnalytics(task, config);
-                        break;
-                    // If we are already at REINDEXING, we are not 100% sure if we reindexed ALL the docs.
-                    // We will delete the destination index, recreate, reindex
-                    case REINDEXING:
-                        LOGGER.debug("[{}] Reassigning job that was reindexing", config.getId());
-                        executeJobInMiddleOfReindexing(task, config);
-                        break;
-                    default:
-                        task.setFailed(ExceptionsHelper.serverError("Cannot execute analytics task [" + config.getId() +
-                            "] as it is in unknown state [" + currentState + "]. Must be one of [STARTED, REINDEXING, ANALYZING]"));
-                }
+                determineProgressAndResume(task, config);
 
             },
             task::setFailed
@@ -174,38 +127,53 @@ public class DataFrameAnalyticsManager {
         MlStatsIndex.createStatsIndexAndAliasIfNecessary(client, clusterState, expressionResolver, createIndexListener);
     }
 
-    private void executeStartingJob(DataFrameAnalyticsTask task, DataFrameAnalyticsConfig config) {
-        if (task.isStopping()) {
-            LOGGER.debug("[{}] task is stopping. Marking as complete before starting job.", task.getParams().getId());
-            task.markAsCompleted();
-            return;
-        }
-        DataFrameAnalyticsTaskState reindexingState = new DataFrameAnalyticsTaskState(DataFrameAnalyticsState.REINDEXING,
-            task.getAllocationId(), null);
-        DataFrameAnalyticsTask.StartingState startingState = DataFrameAnalyticsTask.determineStartingState(
-            config.getId(), task.getParams().getProgressOnStart());
+    private void determineProgressAndResume(DataFrameAnalyticsTask task, DataFrameAnalyticsConfig config) {
+        DataFrameAnalyticsTask.StartingState startingState = task.determineStartingState();
 
-        LOGGER.debug("[{}] Starting job from state [{}]", config.getId(), startingState);
+        LOGGER.debug(() -> new ParameterizedMessage("[{}] Starting job from state [{}]", config.getId(), startingState));
         switch (startingState) {
             case FIRST_TIME:
-                task.updatePersistentTaskState(reindexingState, ActionListener.wrap(
-                    updatedTask -> reindexDataframeAndStartAnalysis(task, config),
-                    task::setFailed
-                ));
+                executeStep(task, config, new ReindexingStep(clusterService, client, task, auditor, config));
                 break;
             case RESUMING_REINDEXING:
-                task.updatePersistentTaskState(reindexingState, ActionListener.wrap(
-                    updatedTask -> executeJobInMiddleOfReindexing(task, config),
-                    task::setFailed
-                ));
+                executeJobInMiddleOfReindexing(task, config);
                 break;
             case RESUMING_ANALYZING:
-                startAnalytics(task, config);
+                executeStep(task, config, new AnalysisStep(client, task, auditor, config, processManager));
                 break;
             case FINISHED:
             default:
                 task.setFailed(ExceptionsHelper.serverError("Unexpected starting state [" + startingState + "]"));
         }
+    }
+
+    private void executeStep(DataFrameAnalyticsTask task, DataFrameAnalyticsConfig config, DataFrameAnalyticsStep step) {
+        task.setStep(step);
+
+        ActionListener<StepResponse> stepListener = ActionListener.wrap(
+            stepResponse -> {
+                if (stepResponse.isTaskComplete()) {
+                    LOGGER.info("[{}] Marking task completed", config.getId());
+                    task.markAsCompleted();
+                    return;
+                }
+                switch (step.name()) {
+                    case REINDEXING:
+                        executeStep(task, config, new AnalysisStep(client, task, auditor, config, processManager));
+                        break;
+                    case ANALYSIS:
+                        // This is the last step
+                        LOGGER.info("[{}] Marking task completed", config.getId());
+                        task.markAsCompleted();
+                        break;
+                    default:
+                        task.markAsFailed(ExceptionsHelper.serverError("Unknown step [{}]", step));
+                }
+            },
+            task::setFailed
+        );
+
+        step.execute(stepListener);
     }
 
     private void executeJobInMiddleOfReindexing(DataFrameAnalyticsTask task, DataFrameAnalyticsConfig config) {
@@ -219,223 +187,16 @@ public class DataFrameAnalyticsManager {
             DeleteIndexAction.INSTANCE,
             new DeleteIndexRequest(config.getDest().getIndex()),
             ActionListener.wrap(
-                r-> reindexDataframeAndStartAnalysis(task, config),
+                r-> executeStep(task, config, new ReindexingStep(clusterService, client, task, auditor, config)),
                 e -> {
                     Throwable cause = ExceptionsHelper.unwrapCause(e);
                     if (cause instanceof IndexNotFoundException) {
-                        reindexDataframeAndStartAnalysis(task, config);
+                        executeStep(task, config, new ReindexingStep(clusterService, client, task, auditor, config));
                     } else {
                         task.setFailed(e);
                     }
                 }
             ));
-    }
-
-    private void reindexDataframeAndStartAnalysis(DataFrameAnalyticsTask task, DataFrameAnalyticsConfig config) {
-        if (task.isStopping()) {
-            LOGGER.debug("[{}] task is stopping. Marking as complete before starting reindexing and analysis.",
-                task.getParams().getId());
-            task.markAsCompleted();
-            return;
-        }
-
-        final ParentTaskAssigningClient parentTaskClient = new ParentTaskAssigningClient(client, task.getParentTaskId());
-
-        // Reindexing is complete; start analytics
-        ActionListener<BulkByScrollResponse> reindexCompletedListener = ActionListener.wrap(
-            reindexResponse -> {
-
-                // If the reindex task is canceled, this listener is called.
-                // Consequently, we should not signal reindex completion.
-                if (task.isStopping()) {
-                    LOGGER.debug("[{}] task is stopping. Marking as complete before marking reindex as finished.",
-                        task.getParams().getId());
-                    task.markAsCompleted();
-                    return;
-                }
-
-                task.setReindexingTaskId(null);
-
-                Exception reindexError = getReindexError(task.getParams().getId(), reindexResponse);
-                if (reindexError != null) {
-                    task.setFailed(reindexError);
-                    return;
-                }
-
-                LOGGER.debug("[{}] Reindex completed; created [{}]; retries [{}]", task.getParams().getId(),
-                    reindexResponse.getCreated(), reindexResponse.getBulkRetries());
-
-                auditor.info(
-                    config.getId(),
-                    Messages.getMessage(Messages.DATA_FRAME_ANALYTICS_AUDIT_FINISHED_REINDEXING, config.getDest().getIndex(),
-                        reindexResponse.getTook()));
-                startAnalytics(task, config);
-            },
-            error -> {
-                if (task.isStopping() && isTaskCancelledException(error)) {
-                    LOGGER.debug(new ParameterizedMessage("[{}] Caught task cancelled exception while task is stopping",
-                        config.getId()), error);
-                    task.markAsCompleted();
-                } else {
-                    task.setFailed(error);
-                }
-            }
-        );
-
-        // Reindex
-        ActionListener<CreateIndexResponse> copyIndexCreatedListener = ActionListener.wrap(
-            createIndexResponse -> {
-                ReindexRequest reindexRequest = new ReindexRequest();
-                reindexRequest.setRefresh(true);
-                reindexRequest.setSourceIndices(config.getSource().getIndex());
-                reindexRequest.setSourceQuery(config.getSource().getParsedQuery());
-                reindexRequest.getSearchRequest().allowPartialSearchResults(false);
-                reindexRequest.getSearchRequest().source().fetchSource(config.getSource().getSourceFiltering());
-                reindexRequest.getSearchRequest().source().sort(SeqNoFieldMapper.NAME, SortOrder.ASC);
-                reindexRequest.setDestIndex(config.getDest().getIndex());
-
-                // We explicitly set slices to 1 as we cannot parallelize in order to have the incremental id
-                reindexRequest.setSlices(1);
-                Map<String, Object> counterValueParam = new HashMap<>();
-                counterValueParam.put("value", -1);
-                reindexRequest.setScript(
-                    new Script(
-                        Script.DEFAULT_SCRIPT_TYPE,
-                        Script.DEFAULT_SCRIPT_LANG,
-                        // We use indirection here because top level params are immutable.
-                        // This is a work around at the moment but the plan is to make this a feature of reindex API.
-                        "ctx._source." + DestinationIndex.INCREMENTAL_ID + " = ++params.counter.value",
-                        Collections.singletonMap("counter", counterValueParam)
-                    )
-                );
-
-                reindexRequest.setParentTask(task.getParentTaskId());
-
-                final ThreadContext threadContext = parentTaskClient.threadPool().getThreadContext();
-                final Supplier<ThreadContext.StoredContext> supplier = threadContext.newRestorableContext(false);
-                try (ThreadContext.StoredContext ignore = threadContext.stashWithOrigin(ML_ORIGIN)) {
-                    LOGGER.info("[{}] Started reindexing", config.getId());
-                    Task reindexTask = client.executeLocally(ReindexAction.INSTANCE, reindexRequest,
-                        new ContextPreservingActionListener<>(supplier, reindexCompletedListener));
-                    task.setReindexingTaskId(reindexTask.getId());
-                    auditor.info(config.getId(),
-                        Messages.getMessage(Messages.DATA_FRAME_ANALYTICS_AUDIT_STARTED_REINDEXING, config.getDest().getIndex()));
-                }
-            },
-            reindexCompletedListener::onFailure
-        );
-
-        // Create destination index if it does not exist
-        ActionListener<GetIndexResponse> destIndexListener = ActionListener.wrap(
-            indexResponse -> {
-                auditor.info(
-                    config.getId(),
-                    Messages.getMessage(Messages.DATA_FRAME_ANALYTICS_AUDIT_REUSING_DEST_INDEX, indexResponse.indices()[0]));
-                LOGGER.info("[{}] Using existing destination index [{}]", config.getId(), indexResponse.indices()[0]);
-                DestinationIndex.updateMappingsToDestIndex(parentTaskClient, config, indexResponse, ActionListener.wrap(
-                    acknowledgedResponse -> copyIndexCreatedListener.onResponse(null),
-                    copyIndexCreatedListener::onFailure
-                ));
-            },
-            e -> {
-                if (ExceptionsHelper.unwrapCause(e) instanceof IndexNotFoundException) {
-                    auditor.info(
-                        config.getId(),
-                        Messages.getMessage(Messages.DATA_FRAME_ANALYTICS_AUDIT_CREATING_DEST_INDEX, config.getDest().getIndex()));
-                    LOGGER.info("[{}] Creating destination index [{}]", config.getId(), config.getDest().getIndex());
-                    DestinationIndex.createDestinationIndex(parentTaskClient, Clock.systemUTC(), config, copyIndexCreatedListener);
-                } else {
-                    copyIndexCreatedListener.onFailure(e);
-                }
-            }
-        );
-
-        ClientHelper.executeWithHeadersAsync(config.getHeaders(), ML_ORIGIN, parentTaskClient, GetIndexAction.INSTANCE,
-                new GetIndexRequest().indices(config.getDest().getIndex()), destIndexListener);
-    }
-
-    private static Exception getReindexError(String jobId, BulkByScrollResponse reindexResponse) {
-        if (reindexResponse.getBulkFailures().isEmpty() == false) {
-            LOGGER.error("[{}] reindexing encountered {} failures", jobId,
-                reindexResponse.getBulkFailures().size());
-            for (BulkItemResponse.Failure failure : reindexResponse.getBulkFailures()) {
-                LOGGER.error("[{}] reindexing failure: {}", jobId, failure);
-            }
-            return ExceptionsHelper.serverError("reindexing encountered " + reindexResponse.getBulkFailures().size() + " failures");
-        }
-        if (reindexResponse.getReasonCancelled() != null) {
-            LOGGER.error("[{}] reindex task got cancelled with reason [{}]", jobId, reindexResponse.getReasonCancelled());
-            return ExceptionsHelper.serverError("reindex task got cancelled with reason [" + reindexResponse.getReasonCancelled() + "]");
-        }
-        if (reindexResponse.isTimedOut()) {
-            LOGGER.error("[{}] reindex task timed out after [{}]", jobId, reindexResponse.getTook().getStringRep());
-            return ExceptionsHelper.serverError("reindex task timed out after [" + reindexResponse.getTook().getStringRep() + "]");
-        }
-        return null;
-    }
-
-    private static boolean isTaskCancelledException(Exception error) {
-        return ExceptionsHelper.unwrapCause(error) instanceof TaskCancelledException
-            || ExceptionsHelper.unwrapCause(error.getCause()) instanceof TaskCancelledException;
-    }
-
-    private void startAnalytics(DataFrameAnalyticsTask task, DataFrameAnalyticsConfig config) {
-        if (task.isStopping()) {
-            LOGGER.debug("[{}] task is stopping. Marking as complete before starting analysis.", task.getParams().getId());
-            task.markAsCompleted();
-            return;
-        }
-
-        final ParentTaskAssigningClient parentTaskClient = new ParentTaskAssigningClient(client, task.getParentTaskId());
-        // Update state to ANALYZING and start process
-        ActionListener<DataFrameDataExtractorFactory> dataExtractorFactoryListener = ActionListener.wrap(
-            dataExtractorFactory -> {
-                DataFrameAnalyticsTaskState analyzingState = new DataFrameAnalyticsTaskState(DataFrameAnalyticsState.ANALYZING,
-                    task.getAllocationId(), null);
-                task.updatePersistentTaskState(analyzingState, ActionListener.wrap(
-                    updatedTask -> {
-                        if (task.isStopping()) {
-                            LOGGER.debug("[{}] task is stopping. Marking as complete before starting native process.",
-                                task.getParams().getId());
-                            task.markAsCompleted();
-                            return;
-                        }
-                        processManager.runJob(task, config, dataExtractorFactory);
-                    },
-                    error -> {
-                        Throwable cause = ExceptionsHelper.unwrapCause(error);
-                        if (cause instanceof ResourceNotFoundException) {
-                            // Task has stopped
-                        } else {
-                            task.setFailed(error);
-                        }
-                    }
-                ));
-            },
-            task::setFailed
-        );
-
-        ActionListener<RefreshResponse> refreshListener = ActionListener.wrap(
-            refreshResponse -> {
-                // Now we can ensure reindexing progress is complete
-                task.setReindexingFinished();
-
-                // TODO This could fail with errors. In that case we get stuck with the copied index.
-                // We could delete the index in case of failure or we could try building the factory before reindexing
-                // to catch the error early on.
-                DataFrameDataExtractorFactory.createForDestinationIndex(parentTaskClient, config, dataExtractorFactoryListener);
-            },
-            dataExtractorFactoryListener::onFailure
-        );
-
-        // First we need to refresh the dest index to ensure data is searchable in case the job
-        // was stopped after reindexing was complete but before the index was refreshed.
-        executeWithHeadersAsync(config.getHeaders(), ML_ORIGIN, parentTaskClient, RefreshAction.INSTANCE,
-            new RefreshRequest(config.getDest().getIndex()), refreshListener);
-    }
-
-    public void stop(DataFrameAnalyticsTask task) {
-        processManager.stop(task);
     }
 
     public boolean isNodeShuttingDown() {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsTask.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsTask.java
@@ -8,11 +8,7 @@ package org.elasticsearch.xpack.ml.dataframe;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
-import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.admin.cluster.node.tasks.cancel.CancelTasksRequest;
-import org.elasticsearch.action.admin.cluster.node.tasks.cancel.CancelTasksResponse;
-import org.elasticsearch.action.admin.cluster.node.tasks.get.GetTaskRequest;
 import org.elasticsearch.action.index.IndexAction;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
@@ -22,20 +18,15 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.ParentTaskAssigningClient;
-import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.query.IdsQueryBuilder;
-import org.elasticsearch.index.reindex.BulkByScrollTask;
 import org.elasticsearch.persistent.AllocatedPersistentTask;
 import org.elasticsearch.persistent.PersistentTasksService;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.tasks.TaskManager;
-import org.elasticsearch.tasks.TaskResult;
 import org.elasticsearch.xpack.core.ml.MlTasks;
 import org.elasticsearch.xpack.core.ml.action.StartDataFrameAnalyticsAction;
 import org.elasticsearch.xpack.core.ml.action.StopDataFrameAnalyticsAction;
@@ -48,6 +39,7 @@ import org.elasticsearch.xpack.core.ml.utils.PhaseProgress;
 import org.elasticsearch.xpack.core.watcher.watch.Payload;
 import org.elasticsearch.xpack.ml.dataframe.stats.ProgressTracker;
 import org.elasticsearch.xpack.ml.dataframe.stats.StatsHolder;
+import org.elasticsearch.xpack.ml.dataframe.steps.DataFrameAnalyticsStep;
 import org.elasticsearch.xpack.ml.notifications.DataFrameAnalyticsAuditor;
 import org.elasticsearch.xpack.ml.utils.persistence.MlParserUtils;
 
@@ -63,40 +55,31 @@ public class DataFrameAnalyticsTask extends AllocatedPersistentTask implements S
     private static final Logger LOGGER = LogManager.getLogger(DataFrameAnalyticsTask.class);
 
     private final Client client;
-    private final ClusterService clusterService;
     private final DataFrameAnalyticsManager analyticsManager;
     private final DataFrameAnalyticsAuditor auditor;
     private final StartDataFrameAnalyticsAction.TaskParams taskParams;
-    @Nullable
-    private volatile Long reindexingTaskId;
-    private volatile boolean isReindexingFinished;
     private volatile boolean isStopping;
     private volatile boolean isMarkAsCompletedCalled;
     private final StatsHolder statsHolder;
+    private volatile DataFrameAnalyticsStep currentStep;
 
     public DataFrameAnalyticsTask(long id, String type, String action, TaskId parentTask, Map<String, String> headers,
-                                  Client client, ClusterService clusterService, DataFrameAnalyticsManager analyticsManager,
-                                  DataFrameAnalyticsAuditor auditor, StartDataFrameAnalyticsAction.TaskParams taskParams) {
+                                  Client client, DataFrameAnalyticsManager analyticsManager, DataFrameAnalyticsAuditor auditor,
+                                  StartDataFrameAnalyticsAction.TaskParams taskParams) {
         super(id, type, action, MlTasks.DATA_FRAME_ANALYTICS_TASK_ID_PREFIX + taskParams.getId(), parentTask, headers);
         this.client = new ParentTaskAssigningClient(Objects.requireNonNull(client), parentTask);
-        this.clusterService = Objects.requireNonNull(clusterService);
         this.analyticsManager = Objects.requireNonNull(analyticsManager);
         this.auditor = Objects.requireNonNull(auditor);
         this.taskParams = Objects.requireNonNull(taskParams);
         this.statsHolder = new StatsHolder(taskParams.getProgressOnStart());
     }
 
+    public void setStep(DataFrameAnalyticsStep step) {
+        currentStep = step;
+    }
+
     public StartDataFrameAnalyticsAction.TaskParams getParams() {
         return taskParams;
-    }
-
-    public void setReindexingTaskId(Long reindexingTaskId) {
-        LOGGER.debug("[{}] Setting reindexing task id to [{}] from [{}]", taskParams.getId(), reindexingTaskId, this.reindexingTaskId);
-        this.reindexingTaskId = reindexingTaskId;
-    }
-
-    public void setReindexingFinished() {
-        isReindexingFinished = true;
     }
 
     public boolean isStopping() {
@@ -152,59 +135,21 @@ public class DataFrameAnalyticsTask extends AllocatedPersistentTask implements S
     public void stop(String reason, TimeValue timeout) {
         isStopping = true;
 
-        ActionListener<Void> reindexProgressListener = ActionListener.wrap(
-            aVoid -> doStop(reason, timeout),
+        LOGGER.debug(() -> new ParameterizedMessage("[{}] Stopping task due to reason [{}]", getParams().getId(), reason));
+
+        DataFrameAnalyticsStep cachedCurrentStep = currentStep;
+        ActionListener<Void> stepProgressListener = ActionListener.wrap(
+            aVoid -> cachedCurrentStep.cancel(reason, timeout),
             e -> {
-                LOGGER.error(new ParameterizedMessage("[{}] Error updating reindexing progress", taskParams.getId()), e);
+                LOGGER.error(new ParameterizedMessage("[{}] Error updating progress for step [{}]",
+                    taskParams.getId(), cachedCurrentStep.name()), e);
                 // We should log the error but it shouldn't stop us from stopping the task
-                doStop(reason, timeout);
+                cachedCurrentStep.cancel(reason, timeout);
             }
         );
 
-        // We need to update reindexing progress before we cancel the task
-        updateReindexTaskProgress(reindexProgressListener);
-    }
-
-    private void doStop(String reason, TimeValue timeout) {
-        if (reindexingTaskId != null) {
-            cancelReindexingTask(reason, timeout);
-        }
-        analyticsManager.stop(this);
-    }
-
-    private void cancelReindexingTask(String reason, TimeValue timeout) {
-        TaskId reindexTaskId = new TaskId(clusterService.localNode().getId(), reindexingTaskId);
-        LOGGER.debug("[{}] Cancelling reindex task [{}]", taskParams.getId(), reindexTaskId);
-
-        CancelTasksRequest cancelReindex = new CancelTasksRequest();
-        cancelReindex.setTaskId(reindexTaskId);
-        cancelReindex.setReason(reason);
-        cancelReindex.setTimeout(timeout);
-
-        // We need to cancel the reindexing task within context with ML origin as we started the task
-        // from the same context
-        CancelTasksResponse cancelReindexResponse = cancelTaskWithinMlOriginContext(cancelReindex);
-
-        Throwable firstError = null;
-        if (cancelReindexResponse.getNodeFailures().isEmpty() == false) {
-            firstError = cancelReindexResponse.getNodeFailures().get(0).getRootCause();
-        }
-        if (cancelReindexResponse.getTaskFailures().isEmpty() == false) {
-            firstError = cancelReindexResponse.getTaskFailures().get(0).getCause();
-        }
-        // There is a chance that the task is finished by the time we cancel it in which case we'll get
-        // a ResourceNotFoundException which we can ignore.
-        if (firstError != null && ExceptionsHelper.unwrapCause(firstError) instanceof ResourceNotFoundException == false) {
-            throw ExceptionsHelper.serverError("[" + taskParams.getId() + "] Error cancelling reindex task", firstError);
-        } else {
-            LOGGER.debug("[{}] Reindex task was successfully cancelled", taskParams.getId());
-        }
-    }
-
-    private CancelTasksResponse cancelTaskWithinMlOriginContext(CancelTasksRequest cancelTasksRequest) {
-        final ThreadContext threadContext = client.threadPool().getThreadContext();
-        try (ThreadContext.StoredContext ignore = threadContext.stashWithOrigin(ML_ORIGIN)) {
-            return client.admin().cluster().cancelTasks(cancelTasksRequest).actionGet();
+        if (cachedCurrentStep != null) {
+            cachedCurrentStep.updateProgress(stepProgressListener);
         }
     }
 
@@ -236,53 +181,8 @@ public class DataFrameAnalyticsTask extends AllocatedPersistentTask implements S
         });
     }
 
-    public void updateReindexTaskProgress(ActionListener<Void> listener) {
-        getReindexTaskProgress(ActionListener.wrap(
-            // We set reindexing progress at least to 1 for a running process to be able to
-            // distinguish a job that is running for the first time against a job that is restarting.
-            reindexTaskProgress -> {
-                statsHolder.getProgressTracker().updateReindexingProgress(Math.max(1, reindexTaskProgress));
-                listener.onResponse(null);
-            },
-            listener::onFailure
-        ));
-    }
-
-    private void getReindexTaskProgress(ActionListener<Integer> listener) {
-        TaskId reindexTaskId = getReindexTaskId();
-        if (reindexTaskId == null) {
-            listener.onResponse(isReindexingFinished ? 100 : 0);
-            return;
-        }
-
-        GetTaskRequest getTaskRequest = new GetTaskRequest();
-        getTaskRequest.setTaskId(reindexTaskId);
-        client.admin().cluster().getTask(getTaskRequest, ActionListener.wrap(
-            taskResponse -> {
-                TaskResult taskResult = taskResponse.getTask();
-                BulkByScrollTask.Status taskStatus = (BulkByScrollTask.Status) taskResult.getTask().getStatus();
-                int progress = (int) (taskStatus.getCreated() * 100.0 / taskStatus.getTotal());
-                listener.onResponse(progress);
-            },
-            error -> {
-                if (ExceptionsHelper.unwrapCause(error) instanceof ResourceNotFoundException) {
-                    // The task is not present which means either it has not started yet or it finished.
-                    listener.onResponse(isReindexingFinished ? 100 : 0);
-                } else {
-                    listener.onFailure(error);
-                }
-            }
-        ));
-    }
-
-    @Nullable
-    private TaskId getReindexTaskId() {
-        try {
-            return new TaskId(clusterService.localNode().getId(), reindexingTaskId);
-        } catch (NullPointerException e) {
-            // This may happen if there is no reindexing task id set which means we either never started the task yet or we're finished
-            return null;
-        }
+    public void persistProgress() {
+        persistProgress(client, taskParams.getId(), () -> {});
     }
 
     // Visible for testing
@@ -323,7 +223,8 @@ public class DataFrameAnalyticsTask extends AllocatedPersistentTask implements S
                 List<PhaseProgress> progress = statsHolder.getProgressTracker().report();
                 final StoredProgress progressToStore = new StoredProgress(progress);
                 if (progressToStore.equals(previous)) {
-                    LOGGER.debug("[{}] new progress is the same as previously persisted progress. Skipping storage.", jobId);
+                    LOGGER.debug(() -> new ParameterizedMessage(
+                        "[{}] new progress is the same as previously persisted progress. Skipping storage.", jobId));
                     runnable.run();
                     return;
                 }
@@ -333,7 +234,7 @@ public class DataFrameAnalyticsTask extends AllocatedPersistentTask implements S
                     .setRequireAlias(AnomalyDetectorsIndex.jobStateIndexWriteAlias().equals(indexOrAlias))
                     .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
                 try (XContentBuilder jsonBuilder = JsonXContent.contentBuilder()) {
-                    LOGGER.debug("[{}] Persisting progress is: {}", jobId, progress);
+                    LOGGER.debug(() -> new ParameterizedMessage("[{}] Persisting progress is: {}", jobId, progress));
                     progressToStore.toXContent(jsonBuilder, Payload.XContent.EMPTY_PARAMS);
                     indexRequest.source(jsonBuilder);
                 }
@@ -347,7 +248,7 @@ public class DataFrameAnalyticsTask extends AllocatedPersistentTask implements S
         );
 
         // Step 2: Search for existing progress document in .ml-state*
-        ActionListener<Void> reindexProgressUpdateListener = ActionListener.wrap(
+        ActionListener<Void> stepProgressUpdateListener = ActionListener.wrap(
             aVoid -> {
                 SearchRequest searchRequest =
                     new SearchRequest(AnomalyDetectorsIndex.jobStateIndexPattern())
@@ -359,13 +260,23 @@ public class DataFrameAnalyticsTask extends AllocatedPersistentTask implements S
             },
             e -> {
                 LOGGER.error(new ParameterizedMessage(
-                    "[{}] cannot persist progress as an error occurred while updating reindexing task progress", taskParams.getId()), e);
+                    "[{}] cannot persist progress as an error occurred while updating task progress", taskParams.getId()), e);
                 runnable.run();
             }
         );
 
         // Step 1: Update reindexing progress as it could be stale
-        updateReindexTaskProgress(reindexProgressUpdateListener);
+        updateTaskProgress(stepProgressUpdateListener);
+    }
+
+    public void updateTaskProgress(ActionListener<Void> updateProgressListener) {
+        synchronized (this) {
+            if (currentStep != null) {
+                currentStep.updateProgress(updateProgressListener);
+            } else {
+                updateProgressListener.onResponse(null);
+            }
+        }
     }
 
     /**
@@ -377,6 +288,10 @@ public class DataFrameAnalyticsTask extends AllocatedPersistentTask implements S
      */
     public enum StartingState {
         FIRST_TIME, RESUMING_REINDEXING, RESUMING_ANALYZING, FINISHED
+    }
+
+    public StartingState determineStartingState() {
+        return determineStartingState(taskParams.getId(), statsHolder.getProgressTracker().report());
     }
 
     public static StartingState determineStartingState(String jobId, List<PhaseProgress> progressOnStart) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/stats/StatsHolder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/stats/StatsHolder.java
@@ -30,14 +30,19 @@ public class StatsHolder {
         dataCountsTracker = new DataCountsTracker();
     }
 
+    public void setProgressTracker(List<PhaseProgress> progress) {
+        progressTracker = new ProgressTracker(progress);
+    }
+
     public void adjustProgressTracker(List<String> analysisPhases, boolean hasInferencePhase) {
         int reindexingProgressPercent = progressTracker.getReindexingProgressPercent();
         progressTracker = ProgressTracker.fromZeroes(analysisPhases, hasInferencePhase);
 
-        // If reindexing progress was less than 100 (ie not complete) we reset it to 1
+        // If reindexing progress was more than 0 and less than 100 (ie not complete) we reset it to 1
         // as we will have to do reindexing from scratch and at the same time we want
         // to differentiate from a job that has never started before.
-        progressTracker.updateReindexingProgress(reindexingProgressPercent < 100 ? 1 : reindexingProgressPercent);
+        progressTracker.updateReindexingProgress(
+            (reindexingProgressPercent > 0 && reindexingProgressPercent < 100) ? 1 : reindexingProgressPercent);
     }
 
     public void resetProgressTracker(List<String> analysisPhases, boolean hasInferencePhase) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/steps/AbstractDataFrameAnalyticsStep.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/steps/AbstractDataFrameAnalyticsStep.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.ml.dataframe.steps;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.refresh.RefreshAction;
+import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
+import org.elasticsearch.action.admin.indices.refresh.RefreshResponse;
+import org.elasticsearch.client.ParentTaskAssigningClient;
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.tasks.TaskId;
+import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfig;
+import org.elasticsearch.xpack.ml.dataframe.DataFrameAnalyticsTask;
+import org.elasticsearch.xpack.ml.notifications.DataFrameAnalyticsAuditor;
+
+import java.util.Objects;
+
+import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
+import static org.elasticsearch.xpack.core.ClientHelper.executeWithHeadersAsync;
+
+abstract class AbstractDataFrameAnalyticsStep implements DataFrameAnalyticsStep {
+
+    private static final Logger logger = LogManager.getLogger(AbstractDataFrameAnalyticsStep.class);
+
+    protected final NodeClient client;
+    protected final DataFrameAnalyticsTask task;
+    protected final DataFrameAnalyticsAuditor auditor;
+    protected final DataFrameAnalyticsConfig config;
+
+    AbstractDataFrameAnalyticsStep(NodeClient client, DataFrameAnalyticsTask task, DataFrameAnalyticsAuditor auditor,
+                                   DataFrameAnalyticsConfig config) {
+        this.client = Objects.requireNonNull(client);
+        this.task = Objects.requireNonNull(task);
+        this.auditor = Objects.requireNonNull(auditor);
+        this.config = Objects.requireNonNull(config);
+    }
+
+    protected boolean isTaskStopping() {
+        return task.isStopping();
+    }
+
+    protected ParentTaskAssigningClient parentTaskClient() {
+        return new ParentTaskAssigningClient(client, task.getParentTaskId());
+    }
+
+    protected TaskId getParentTaskId() {
+        return task.getParentTaskId();
+    }
+
+    @Override
+    public final void execute(ActionListener<StepResponse> listener) {
+        logger.debug(() -> new ParameterizedMessage("[{}] Executing step [{}]", config.getId(), name()));
+        if (task.isStopping()) {
+            logger.debug(() -> new ParameterizedMessage("[{}] task is stopping before starting [{}]", config.getId(), name()));
+            listener.onResponse(new StepResponse(true));
+            return;
+        }
+        doExecute(listener);
+
+        // We persist progress at the end of each step to ensure we do not have
+        // to repeat the step in case the node goes down without getting a chance to persist progress.
+        task.persistProgress();
+    }
+
+    protected abstract void doExecute(ActionListener<StepResponse> listener);
+
+    protected void refreshDestAsync(ActionListener<RefreshResponse> refreshListener) {
+        ParentTaskAssigningClient parentTaskClient = parentTaskClient();
+        executeWithHeadersAsync(config.getHeaders(), ML_ORIGIN, parentTaskClient, RefreshAction.INSTANCE,
+            new RefreshRequest(config.getDest().getIndex()), refreshListener);
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/steps/AnalysisStep.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/steps/AnalysisStep.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.ml.dataframe.steps;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.refresh.RefreshResponse;
+import org.elasticsearch.client.ParentTaskAssigningClient;
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfig;
+import org.elasticsearch.xpack.ml.dataframe.DataFrameAnalyticsTask;
+import org.elasticsearch.xpack.ml.dataframe.extractor.DataFrameDataExtractorFactory;
+import org.elasticsearch.xpack.ml.dataframe.process.AnalyticsProcessManager;
+import org.elasticsearch.xpack.ml.notifications.DataFrameAnalyticsAuditor;
+
+import java.util.Objects;
+
+public class AnalysisStep extends AbstractDataFrameAnalyticsStep {
+
+    private final AnalyticsProcessManager processManager;
+
+    public AnalysisStep(NodeClient client, DataFrameAnalyticsTask task, DataFrameAnalyticsAuditor auditor, DataFrameAnalyticsConfig config,
+                        AnalyticsProcessManager processManager) {
+        super(client, task, auditor, config);
+        this.processManager = Objects.requireNonNull(processManager);
+    }
+
+    @Override
+    public Name name() {
+        return Name.ANALYSIS;
+    }
+
+    @Override
+    public void cancel(String reason, TimeValue timeout) {
+        processManager.stop(task);
+    }
+
+    @Override
+    public void updateProgress(ActionListener<Void> listener) {
+        // Progress for the analysis step gets handled by the c++ process reporting it and the
+        // results processor parsing the value in memory.
+        listener.onResponse(null);
+    }
+
+    @Override
+    protected void doExecute(ActionListener<StepResponse> listener) {
+        final ParentTaskAssigningClient parentTaskClient = parentTaskClient();
+        // Update state to ANALYZING and start process
+        ActionListener<DataFrameDataExtractorFactory> dataExtractorFactoryListener = ActionListener.wrap(
+            dataExtractorFactory -> processManager.runJob(task, config, dataExtractorFactory, listener),
+            listener::onFailure
+        );
+
+        ActionListener<RefreshResponse> refreshListener = ActionListener.wrap(
+            refreshResponse -> {
+                // TODO This could fail with errors. In that case we get stuck with the copied index.
+                // We could delete the index in case of failure or we could try building the factory before reindexing
+                // to catch the error early on.
+                DataFrameDataExtractorFactory.createForDestinationIndex(parentTaskClient, config, dataExtractorFactoryListener);
+            },
+            dataExtractorFactoryListener::onFailure
+        );
+
+        // First we need to refresh the dest index to ensure data is searchable in case the job
+        // was stopped after reindexing was complete but before the index was refreshed.
+        refreshDestAsync(refreshListener);
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/steps/DataFrameAnalyticsStep.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/steps/DataFrameAnalyticsStep.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.ml.dataframe.steps;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.unit.TimeValue;
+
+import java.util.Locale;
+
+public interface DataFrameAnalyticsStep {
+
+    enum Name {
+        REINDEXING, ANALYSIS;
+
+        @Override
+        public String toString() {
+            return name().toLowerCase(Locale.ROOT);
+        }
+    }
+
+    Name name();
+
+    void execute(ActionListener<StepResponse> listener);
+
+    void cancel(String reason, TimeValue timeout);
+
+    void updateProgress(ActionListener<Void> listener);
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/steps/ReindexingStep.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/steps/ReindexingStep.java
@@ -1,0 +1,329 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.ml.dataframe.steps;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.elasticsearch.ResourceNotFoundException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.cluster.node.tasks.cancel.CancelTasksRequest;
+import org.elasticsearch.action.admin.cluster.node.tasks.cancel.CancelTasksResponse;
+import org.elasticsearch.action.admin.cluster.node.tasks.get.GetTaskRequest;
+import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
+import org.elasticsearch.action.admin.indices.get.GetIndexAction;
+import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
+import org.elasticsearch.action.admin.indices.get.GetIndexResponse;
+import org.elasticsearch.action.bulk.BulkItemResponse;
+import org.elasticsearch.action.support.ContextPreservingActionListener;
+import org.elasticsearch.client.ParentTaskAssigningClient;
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.index.mapper.SeqNoFieldMapper;
+import org.elasticsearch.index.reindex.BulkByScrollResponse;
+import org.elasticsearch.index.reindex.BulkByScrollTask;
+import org.elasticsearch.index.reindex.ReindexAction;
+import org.elasticsearch.index.reindex.ReindexRequest;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.search.sort.SortOrder;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskCancelledException;
+import org.elasticsearch.tasks.TaskId;
+import org.elasticsearch.tasks.TaskResult;
+import org.elasticsearch.xpack.core.ClientHelper;
+import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfig;
+import org.elasticsearch.xpack.core.ml.job.messages.Messages;
+import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
+import org.elasticsearch.xpack.ml.dataframe.DataFrameAnalyticsTask;
+import org.elasticsearch.xpack.ml.dataframe.DestinationIndex;
+import org.elasticsearch.xpack.ml.notifications.DataFrameAnalyticsAuditor;
+
+import java.time.Clock;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
+
+public class ReindexingStep extends AbstractDataFrameAnalyticsStep {
+
+    private static final Logger LOGGER = LogManager.getLogger(ReindexingStep.class);
+
+    private final ClusterService clusterService;
+    @Nullable
+    private volatile Long reindexingTaskId;
+    private volatile boolean isReindexingFinished;
+
+    public ReindexingStep(ClusterService clusterService, NodeClient client, DataFrameAnalyticsTask task, DataFrameAnalyticsAuditor auditor,
+                          DataFrameAnalyticsConfig config) {
+        super(client, task, auditor, config);
+        this.clusterService = Objects.requireNonNull(clusterService);
+    }
+
+    @Override
+    public Name name() {
+        return Name.REINDEXING;
+    }
+
+    @Override
+    protected void doExecute(ActionListener<StepResponse> listener) {
+        task.getStatsHolder().getProgressTracker().updateReindexingProgress(1);
+
+        final ParentTaskAssigningClient parentTaskClient = parentTaskClient();
+
+        // Reindexing is complete
+        ActionListener<BulkByScrollResponse> reindexCompletedListener = ActionListener.wrap(
+            reindexResponse -> {
+
+                // If the reindex task is canceled, this listener is called.
+                // Consequently, we should not signal reindex completion.
+                if (isTaskStopping()) {
+                    LOGGER.debug("[{}] task is stopping. Stopping reindexing before it is finished.", config.getId());
+                    listener.onResponse(new StepResponse(true));
+                    return;
+                }
+
+                synchronized (this) {
+                    reindexingTaskId = null;
+                }
+
+                Exception reindexError = getReindexError(config.getId(), reindexResponse);
+                if (reindexError != null) {
+                    listener.onFailure(reindexError);
+                    return;
+                }
+
+                auditor.info(
+                    config.getId(),
+                    Messages.getMessage(Messages.DATA_FRAME_ANALYTICS_AUDIT_FINISHED_REINDEXING, config.getDest().getIndex(),
+                        reindexResponse.getTook()));
+
+                isReindexingFinished = true;
+                task.getStatsHolder().getProgressTracker().updateReindexingProgress(100);
+
+                LOGGER.debug("[{}] Reindex completed; created [{}]; retries [{}]", config.getId(), reindexResponse.getCreated(),
+                    reindexResponse.getBulkRetries());
+
+                listener.onResponse(new StepResponse(false));
+            },
+            error -> {
+                if (isTaskStopping() && isTaskCancelledException(error)) {
+                    LOGGER.debug(new ParameterizedMessage("[{}] Caught task cancelled exception while task is stopping",
+                        config.getId()), error);
+                    listener.onResponse(new StepResponse(true));
+                } else {
+                    listener.onFailure(error);
+                }
+            }
+        );
+
+        // Reindex
+        ActionListener<CreateIndexResponse> copyIndexCreatedListener = ActionListener.wrap(
+            createIndexResponse -> {
+                ReindexRequest reindexRequest = new ReindexRequest();
+                reindexRequest.setRefresh(true);
+                reindexRequest.setSourceIndices(config.getSource().getIndex());
+                reindexRequest.setSourceQuery(config.getSource().getParsedQuery());
+                reindexRequest.getSearchRequest().allowPartialSearchResults(false);
+                reindexRequest.getSearchRequest().source().fetchSource(config.getSource().getSourceFiltering());
+                reindexRequest.getSearchRequest().source().sort(SeqNoFieldMapper.NAME, SortOrder.ASC);
+                reindexRequest.setDestIndex(config.getDest().getIndex());
+
+                // We explicitly set slices to 1 as we cannot parallelize in order to have the incremental id
+                reindexRequest.setSlices(1);
+                Map<String, Object> counterValueParam = new HashMap<>();
+                counterValueParam.put("value", -1);
+                reindexRequest.setScript(
+                    new Script(
+                        Script.DEFAULT_SCRIPT_TYPE,
+                        Script.DEFAULT_SCRIPT_LANG,
+                        // We use indirection here because top level params are immutable.
+                        // This is a work around at the moment but the plan is to make this a feature of reindex API.
+                        "ctx._source." + DestinationIndex.INCREMENTAL_ID + " = ++params.counter.value",
+                        Collections.singletonMap("counter", counterValueParam)
+                    )
+                );
+
+                reindexRequest.setParentTask(getParentTaskId());
+
+                final ThreadContext threadContext = parentTaskClient.threadPool().getThreadContext();
+                final Supplier<ThreadContext.StoredContext> supplier = threadContext.newRestorableContext(false);
+                try (ThreadContext.StoredContext ignore = threadContext.stashWithOrigin(ML_ORIGIN)) {
+                    synchronized (this) {
+                        if (isTaskStopping()) {
+                            LOGGER.debug("[{}] task is stopping. Stopping reindexing before it is finished.", config.getId());
+                            listener.onResponse(new StepResponse(true));
+                            return;
+                        }
+                        LOGGER.info("[{}] Started reindexing", config.getId());
+                        Task reindexTask = client.executeLocally(ReindexAction.INSTANCE, reindexRequest,
+                            new ContextPreservingActionListener<>(supplier, reindexCompletedListener));
+                        reindexingTaskId = reindexTask.getId();
+                    }
+                    auditor.info(config.getId(),
+                        Messages.getMessage(Messages.DATA_FRAME_ANALYTICS_AUDIT_STARTED_REINDEXING, config.getDest().getIndex()));
+                }
+            },
+            reindexCompletedListener::onFailure
+        );
+
+        // Create destination index if it does not exist
+        ActionListener<GetIndexResponse> destIndexListener = ActionListener.wrap(
+            indexResponse -> {
+                auditor.info(
+                    config.getId(),
+                    Messages.getMessage(Messages.DATA_FRAME_ANALYTICS_AUDIT_REUSING_DEST_INDEX, indexResponse.indices()[0]));
+                LOGGER.info("[{}] Using existing destination index [{}]", config.getId(), indexResponse.indices()[0]);
+                DestinationIndex.updateMappingsToDestIndex(parentTaskClient, config, indexResponse, ActionListener.wrap(
+                    acknowledgedResponse -> copyIndexCreatedListener.onResponse(null),
+                    copyIndexCreatedListener::onFailure
+                ));
+            },
+            e -> {
+                if (ExceptionsHelper.unwrapCause(e) instanceof IndexNotFoundException) {
+                    auditor.info(
+                        config.getId(),
+                        Messages.getMessage(Messages.DATA_FRAME_ANALYTICS_AUDIT_CREATING_DEST_INDEX, config.getDest().getIndex()));
+                    LOGGER.info("[{}] Creating destination index [{}]", config.getId(), config.getDest().getIndex());
+                    DestinationIndex.createDestinationIndex(parentTaskClient, Clock.systemUTC(), config, copyIndexCreatedListener);
+                } else {
+                    copyIndexCreatedListener.onFailure(e);
+                }
+            }
+        );
+
+        ClientHelper.executeWithHeadersAsync(config.getHeaders(), ML_ORIGIN, parentTaskClient, GetIndexAction.INSTANCE,
+            new GetIndexRequest().indices(config.getDest().getIndex()), destIndexListener);
+    }
+
+    private static Exception getReindexError(String jobId, BulkByScrollResponse reindexResponse) {
+        if (reindexResponse.getBulkFailures().isEmpty() == false) {
+            LOGGER.error("[{}] reindexing encountered {} failures", jobId,
+                reindexResponse.getBulkFailures().size());
+            for (BulkItemResponse.Failure failure : reindexResponse.getBulkFailures()) {
+                LOGGER.error("[{}] reindexing failure: {}", jobId, failure);
+            }
+            return ExceptionsHelper.serverError("reindexing encountered " + reindexResponse.getBulkFailures().size() + " failures");
+        }
+        if (reindexResponse.getReasonCancelled() != null) {
+            LOGGER.error("[{}] reindex task got cancelled with reason [{}]", jobId, reindexResponse.getReasonCancelled());
+            return ExceptionsHelper.serverError("reindex task got cancelled with reason [" + reindexResponse.getReasonCancelled() + "]");
+        }
+        if (reindexResponse.isTimedOut()) {
+            LOGGER.error("[{}] reindex task timed out after [{}]", jobId, reindexResponse.getTook().getStringRep());
+            return ExceptionsHelper.serverError("reindex task timed out after [" + reindexResponse.getTook().getStringRep() + "]");
+        }
+        return null;
+    }
+
+    private static boolean isTaskCancelledException(Exception error) {
+        return ExceptionsHelper.unwrapCause(error) instanceof TaskCancelledException
+            || ExceptionsHelper.unwrapCause(error.getCause()) instanceof TaskCancelledException;
+    }
+
+    @Override
+    public void cancel(String reason, TimeValue timeout) {
+        TaskId reindexTaskId = null;
+        synchronized (this) {
+            if (reindexingTaskId != null) {
+                reindexTaskId = new TaskId(clusterService.localNode().getId(), reindexingTaskId);
+            }
+        }
+        if (reindexTaskId == null) {
+            return;
+        }
+
+        LOGGER.debug("[{}] Cancelling reindex task [{}]", config.getId(), reindexTaskId);
+
+        CancelTasksRequest cancelReindex = new CancelTasksRequest();
+        cancelReindex.setTaskId(reindexTaskId);
+        cancelReindex.setReason(reason);
+        cancelReindex.setTimeout(timeout);
+
+        // We need to cancel the reindexing task within context with ML origin as we started the task
+        // from the same context
+        CancelTasksResponse cancelReindexResponse = cancelTaskWithinMlOriginContext(cancelReindex);
+
+        Throwable firstError = null;
+        if (cancelReindexResponse.getNodeFailures().isEmpty() == false) {
+            firstError = cancelReindexResponse.getNodeFailures().get(0).getRootCause();
+        }
+        if (cancelReindexResponse.getTaskFailures().isEmpty() == false) {
+            firstError = cancelReindexResponse.getTaskFailures().get(0).getCause();
+        }
+        // There is a chance that the task is finished by the time we cancel it in which case we'll get
+        // a ResourceNotFoundException which we can ignore.
+        if (firstError != null && ExceptionsHelper.unwrapCause(firstError) instanceof ResourceNotFoundException == false) {
+            throw ExceptionsHelper.serverError("[" + config.getId() + "] Error cancelling reindex task", firstError);
+        } else {
+            LOGGER.debug("[{}] Reindex task was successfully cancelled", config.getId());
+        }
+    }
+
+    private CancelTasksResponse cancelTaskWithinMlOriginContext(CancelTasksRequest cancelTasksRequest) {
+        final ThreadContext threadContext = client.threadPool().getThreadContext();
+        try (ThreadContext.StoredContext ignore = threadContext.stashWithOrigin(ML_ORIGIN)) {
+            return client.admin().cluster().cancelTasks(cancelTasksRequest).actionGet();
+        }
+    }
+
+    @Override
+    public void updateProgress(ActionListener<Void> listener) {
+        getReindexTaskProgress(ActionListener.wrap(
+            // We set reindexing progress at least to 1 for a running process to be able to
+            // distinguish a job that is running for the first time against a job that is restarting.
+            reindexTaskProgress -> {
+                task.getStatsHolder().getProgressTracker().updateReindexingProgress(Math.max(1, reindexTaskProgress));
+                listener.onResponse(null);
+            },
+            listener::onFailure
+        ));
+    }
+
+    private void getReindexTaskProgress(ActionListener<Integer> listener) {
+        TaskId reindexTaskId = getReindexTaskId();
+        if (reindexTaskId == null) {
+            listener.onResponse(isReindexingFinished ? 100 : 0);
+            return;
+        }
+
+        GetTaskRequest getTaskRequest = new GetTaskRequest();
+        getTaskRequest.setTaskId(reindexTaskId);
+        client.admin().cluster().getTask(getTaskRequest, ActionListener.wrap(
+            taskResponse -> {
+                TaskResult taskResult = taskResponse.getTask();
+                BulkByScrollTask.Status taskStatus = (BulkByScrollTask.Status) taskResult.getTask().getStatus();
+                int progress = (int) (taskStatus.getCreated() * 100.0 / taskStatus.getTotal());
+                listener.onResponse(progress);
+            },
+            error -> {
+                if (ExceptionsHelper.unwrapCause(error) instanceof ResourceNotFoundException) {
+                    // The task is not present which means either it has not started yet or it finished.
+                    listener.onResponse(isReindexingFinished ? 100 : 0);
+                } else {
+                    listener.onFailure(error);
+                }
+            }
+        ));
+    }
+
+    @Nullable
+    private TaskId getReindexTaskId() {
+        try {
+            return new TaskId(clusterService.localNode().getId(), reindexingTaskId);
+        } catch (NullPointerException e) {
+            // This may happen if there is no reindexing task id set which means we either never started the task yet or we're finished
+            return null;
+        }
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/steps/StepResponse.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/steps/StepResponse.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.ml.dataframe.steps;
+
+public final class StepResponse {
+
+    private final boolean isTaskComplete;
+
+    public StepResponse(boolean isTaskComplete) {
+        this.isTaskComplete = isTaskComplete;
+    }
+
+    /**
+     * Returns whether the entire task has completed after this step was done
+     * @return whether the entire task has completed after this step was done
+     */
+    public boolean isTaskComplete() {
+        return isTaskComplete;
+    }
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsTaskTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsTaskTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.DeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
@@ -34,6 +35,8 @@ import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
 import org.elasticsearch.xpack.core.ml.utils.PhaseProgress;
 import org.elasticsearch.xpack.ml.dataframe.DataFrameAnalyticsTask.StartingState;
 import org.elasticsearch.xpack.ml.dataframe.stats.ProgressTracker;
+import org.elasticsearch.xpack.ml.dataframe.steps.DataFrameAnalyticsStep;
+import org.elasticsearch.xpack.ml.dataframe.steps.StepResponse;
 import org.elasticsearch.xpack.ml.notifications.DataFrameAnalyticsAuditor;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
@@ -163,7 +166,7 @@ public class DataFrameAnalyticsTaskTests extends ESTestCase {
 
         DataFrameAnalyticsTask task =
             new DataFrameAnalyticsTask(
-                123, "type", "action", null, Collections.emptyMap(), client, clusterService, analyticsManager, auditor, taskParams);
+                123, "type", "action", null, Collections.emptyMap(), client, analyticsManager, auditor, taskParams);
         task.init(persistentTasksService, taskManager, "task-id", 42);
 
         task.persistProgress(client, "task_id", runnable);
@@ -241,9 +244,9 @@ public class DataFrameAnalyticsTaskTests extends ESTestCase {
 
         DataFrameAnalyticsTask task =
             new DataFrameAnalyticsTask(
-                123, "type", "action", null, Collections.emptyMap(), client, clusterService, analyticsManager, auditor, taskParams);
+                123, "type", "action", null, Collections.emptyMap(), client, analyticsManager, auditor, taskParams);
         task.init(persistentTasksService, taskManager, "task-id", 42);
-        task.setReindexingFinished();
+        task.setStep(new StubReindexingStep(task.getStatsHolder().getProgressTracker()));
         Exception exception = new Exception("some exception");
 
         task.setFailed(exception);
@@ -285,5 +288,33 @@ public class DataFrameAnalyticsTaskTests extends ESTestCase {
             listener.onResponse(response);
             return null;
         };
+    }
+
+    private class StubReindexingStep implements DataFrameAnalyticsStep {
+
+        private final ProgressTracker progressTracker;
+
+        StubReindexingStep(ProgressTracker progressTracker) {
+            this.progressTracker = progressTracker;
+        }
+
+        @Override
+        public Name name() {
+            return Name.REINDEXING;
+        }
+
+        @Override
+        public void execute(ActionListener<StepResponse> listener) {
+        }
+
+        @Override
+        public void cancel(String reason, TimeValue timeout) {
+        }
+
+        @Override
+        public void updateProgress(ActionListener<Void> listener) {
+            progressTracker.updateReindexingProgress(100);
+            listener.onResponse(null);
+        }
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsProcessManagerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsProcessManagerTests.java
@@ -7,6 +7,7 @@ package org.elasticsearch.xpack.ml.dataframe.process;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionFuture;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
@@ -30,7 +31,6 @@ import org.elasticsearch.xpack.ml.inference.persistence.TrainedModelProvider;
 import org.elasticsearch.xpack.ml.notifications.DataFrameAnalyticsAuditor;
 import org.elasticsearch.xpack.ml.utils.persistence.ResultsPersisterService;
 import org.junit.Before;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 
 import java.util.Arrays;
@@ -45,7 +45,6 @@ import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
@@ -124,71 +123,88 @@ public class AnalyticsProcessManagerTests extends ESTestCase {
         when(task.getParams()).thenReturn(
             new StartDataFrameAnalyticsAction.TaskParams("data_frame_id", Version.CURRENT, Collections.emptyList(), false));
 
-        processManager.runJob(task, dataFrameAnalyticsConfig, dataExtractorFactory);
-        assertThat(processManager.getProcessContextCount(), equalTo(0));
+        processManager.runJob(task, dataFrameAnalyticsConfig, dataExtractorFactory, ActionListener.wrap(
+            stepResponse -> {
+                assertThat(processManager.getProcessContextCount(), equalTo(0));
+                assertThat(stepResponse.isTaskComplete(), is(true));
 
-        InOrder inOrder = inOrder(task);
-        inOrder.verify(task).isStopping();
-        inOrder.verify(task).getParams();
-        inOrder.verify(task).markAsCompleted();
-        verifyNoMoreInteractions(task);
+                InOrder inOrder = inOrder(task);
+                inOrder.verify(task).isStopping();
+                inOrder.verify(task).getParams();
+                verifyNoMoreInteractions(task);
+            },
+            e -> fail(e.getMessage())
+        ));
     }
 
     public void testRunJob_ProcessContextAlreadyExists() {
-        processManager.runJob(task, dataFrameAnalyticsConfig, dataExtractorFactory);
+        processManager.runJob(task, dataFrameAnalyticsConfig, dataExtractorFactory, ActionListener.wrap(
+            stepResponse -> {},
+            e -> fail(e.getMessage()) // First run should not error
+        ));
         assertThat(processManager.getProcessContextCount(), equalTo(1));
-        processManager.runJob(task, dataFrameAnalyticsConfig, dataExtractorFactory);
-        assertThat(processManager.getProcessContextCount(), equalTo(1));
+        processManager.runJob(task, dataFrameAnalyticsConfig, dataExtractorFactory, ActionListener.wrap(
+            stepResponse -> fail("Expected error but listener got a response instead"),
+            e -> {
+                assertThat(processManager.getProcessContextCount(), equalTo(1));
 
-        InOrder inOrder = inOrder(task);
-        inOrder.verify(task).isStopping();
-        inOrder.verify(task).getAllocationId();
-        inOrder.verify(task).isStopping();
-        inOrder.verify(task).getParentTaskId();
-        inOrder.verify(task).getStatsHolder();
-        inOrder.verify(task).isStopping();
-        inOrder.verify(task).getAllocationId();
+                InOrder inOrder = inOrder(task);
+                inOrder.verify(task).isStopping();
+                inOrder.verify(task).getAllocationId();
+                inOrder.verify(task).isStopping();
+                inOrder.verify(task).getParentTaskId();
+                inOrder.verify(task).getStatsHolder();
+                inOrder.verify(task).isStopping();
+                inOrder.verify(task).getAllocationId();
 
-        ArgumentCaptor<Exception> failureCaptor = ArgumentCaptor.forClass(Exception.class);
-        inOrder.verify(task).setFailed(failureCaptor.capture());
-        assertThat(failureCaptor.getValue().getMessage(), equalTo("[config-id] Could not create process as one already exists"));
-
-        verifyNoMoreInteractions(task);
+                assertThat(e.getMessage(), equalTo("[config-id] Could not create process as one already exists"));
+            })
+        );
     }
 
     public void testRunJob_EmptyDataFrame() {
         when(dataExtractor.collectDataSummary()).thenReturn(new DataFrameDataExtractor.DataSummary(0, NUM_COLS));
 
-        processManager.runJob(task, dataFrameAnalyticsConfig, dataExtractorFactory);
-        assertThat(processManager.getProcessContextCount(), equalTo(0));  // Make sure the process context did not leak
+        processManager.runJob(task, dataFrameAnalyticsConfig, dataExtractorFactory, ActionListener.wrap(
+            stepResponse -> {
+                assertThat(processManager.getProcessContextCount(), equalTo(0));  // Make sure the process context did not leak
+                assertThat(stepResponse.isTaskComplete(), is(true));
 
-        InOrder inOrder = inOrder(dataExtractor, executorServiceForProcess, process, task);
-        inOrder.verify(task).isStopping();
-        inOrder.verify(task).getAllocationId();
-        inOrder.verify(task).isStopping();
-        inOrder.verify(dataExtractor).collectDataSummary();
-        inOrder.verify(dataExtractor).getCategoricalFields(dataFrameAnalyticsConfig.getAnalysis());
-        inOrder.verify(task).getAllocationId();
-        inOrder.verify(task).markAsCompleted();
-        verifyNoMoreInteractions(dataExtractor, executorServiceForProcess, process, task);
+                InOrder inOrder = inOrder(dataExtractor, executorServiceForProcess, process, task);
+                inOrder.verify(task).isStopping();
+                inOrder.verify(task).getAllocationId();
+                inOrder.verify(task).isStopping();
+                inOrder.verify(dataExtractor).collectDataSummary();
+                inOrder.verify(dataExtractor).getCategoricalFields(dataFrameAnalyticsConfig.getAnalysis());
+                inOrder.verify(task).getAllocationId();
+                verifyNoMoreInteractions(dataExtractor, executorServiceForProcess, process, task);
+            },
+            e -> fail(e.getMessage())
+        ));
     }
 
     public void testRunJob_Ok() {
-        processManager.runJob(task, dataFrameAnalyticsConfig, dataExtractorFactory);
-        assertThat(processManager.getProcessContextCount(), equalTo(1));
+        processManager.runJob(task, dataFrameAnalyticsConfig, dataExtractorFactory,
+            ActionListener.wrap(
+                stepResponse -> {
+                    assertThat(processManager.getProcessContextCount(), equalTo(1));
+                    assertThat(stepResponse.isTaskComplete(), is(true));
 
-        InOrder inOrder = inOrder(dataExtractor, executorServiceForProcess, process, task);
-        inOrder.verify(task).isStopping();
-        inOrder.verify(task).getAllocationId();
-        inOrder.verify(task).isStopping();
-        inOrder.verify(dataExtractor).collectDataSummary();
-        inOrder.verify(dataExtractor).getCategoricalFields(dataFrameAnalyticsConfig.getAnalysis());
-        inOrder.verify(process).isProcessAlive();
-        inOrder.verify(task).getParentTaskId();
-        inOrder.verify(task).getStatsHolder();
-        inOrder.verify(dataExtractor).getExtractedFields();
-        inOrder.verify(executorServiceForProcess, times(2)).execute(any());  // 'processData' and 'processResults' threads
-        verifyNoMoreInteractions(dataExtractor, executorServiceForProcess, process, task);
+                    InOrder inOrder = inOrder(dataExtractor, executorServiceForProcess, process, task);
+                    inOrder.verify(task).isStopping();
+                    inOrder.verify(task).getAllocationId();
+                    inOrder.verify(task).isStopping();
+                    inOrder.verify(dataExtractor).collectDataSummary();
+                    inOrder.verify(dataExtractor).getCategoricalFields(dataFrameAnalyticsConfig.getAnalysis());
+                    inOrder.verify(process).isProcessAlive();
+                    inOrder.verify(task).getParentTaskId();
+                    inOrder.verify(task).getStatsHolder();
+                    inOrder.verify(dataExtractor).getExtractedFields();
+                    inOrder.verify(executorServiceForProcess, times(2)).execute(any());  // 'processData' and 'processResults' threads
+                    verifyNoMoreInteractions(dataExtractor, executorServiceForProcess, process, task);
+                },
+                e -> fail(e.getMessage())
+        ));
     }
 
     public void testRunJob_ProcessNotAliveAfterStart() {
@@ -196,13 +212,13 @@ public class AnalyticsProcessManagerTests extends ESTestCase {
         when(task.getParams()).thenReturn(
             new StartDataFrameAnalyticsAction.TaskParams("data_frame_id", Version.CURRENT, Collections.emptyList(), false));
 
-        processManager.runJob(task, dataFrameAnalyticsConfig, dataExtractorFactory);
-        assertThat(processManager.getProcessContextCount(), equalTo(1));
-
-        ArgumentCaptor<Exception> errorCaptor = ArgumentCaptor.forClass(Exception.class);
-        verify(task).setFailed(errorCaptor.capture());
-
-        assertThat(errorCaptor.getValue().getMessage(), equalTo("Failed to start data frame analytics process"));
+        processManager.runJob(task, dataFrameAnalyticsConfig, dataExtractorFactory, ActionListener.wrap(
+            stepResponse -> fail("Expected error but listener got a response instead"),
+            e -> {
+                assertThat(processManager.getProcessContextCount(), equalTo(0));
+                assertThat(e.getMessage(), equalTo("Failed to start data frame analytics process"));
+            }
+        ));
     }
 
     public void testProcessContext_GetSetFailureReason() {
@@ -247,6 +263,7 @@ public class AnalyticsProcessManagerTests extends ESTestCase {
     }
 
     public void testProcessContext_StartAndStop() throws Exception {
+
         AnalyticsProcessManager.ProcessContext processContext = processManager.new ProcessContext(dataFrameAnalyticsConfig);
         assertThat(processContext.startProcess(dataExtractorFactory, task, false), is(true));
         processContext.stop();

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/process/DataFrameAnalyticsManagerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/process/DataFrameAnalyticsManagerTests.java
@@ -7,6 +7,7 @@ package org.elasticsearch.xpack.ml.dataframe.process;
 
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.ml.dataframe.DataFrameAnalyticsManager;
 import org.elasticsearch.xpack.ml.dataframe.persistence.DataFrameAnalyticsConfigProvider;
@@ -21,6 +22,7 @@ public class DataFrameAnalyticsManagerTests extends ESTestCase {
         DataFrameAnalyticsManager manager =
             new DataFrameAnalyticsManager(
                 mock(NodeClient.class),
+                mock(ClusterService.class),
                 mock(DataFrameAnalyticsConfigProvider.class),
                 mock(AnalyticsProcessManager.class),
                 mock(DataFrameAnalyticsAuditor.class),

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/stats/StatsHolderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/stats/StatsHolderTests.java
@@ -19,13 +19,39 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class StatsHolderTests extends ESTestCase {
 
+    public void testAdjustProgressTracker_GivenZeroProgress() {
+        List<PhaseProgress> phases = Collections.unmodifiableList(
+            Arrays.asList(
+                new PhaseProgress("reindexing", 0),
+                new PhaseProgress("loading_data", 0),
+                new PhaseProgress("a", 0),
+                new PhaseProgress("b", 0),
+                new PhaseProgress("writing_results", 0)
+            )
+        );
+        StatsHolder statsHolder = new StatsHolder(phases);
+
+        statsHolder.adjustProgressTracker(Arrays.asList("a", "b"), false);
+
+        List<PhaseProgress> phaseProgresses = statsHolder.getProgressTracker().report();
+
+        assertThat(phaseProgresses.size(), equalTo(5));
+        assertThat(phaseProgresses.stream().map(PhaseProgress::getPhase).collect(Collectors.toList()),
+            contains("reindexing", "loading_data", "a", "b", "writing_results"));
+        assertThat(phaseProgresses.get(0).getProgressPercent(), equalTo(0));
+        assertThat(phaseProgresses.get(1).getProgressPercent(), equalTo(0));
+        assertThat(phaseProgresses.get(2).getProgressPercent(), equalTo(0));
+        assertThat(phaseProgresses.get(3).getProgressPercent(), equalTo(0));
+        assertThat(phaseProgresses.get(4).getProgressPercent(), equalTo(0));
+    }
+
     public void testAdjustProgressTracker_GivenSameAnalysisPhases() {
         List<PhaseProgress> phases = Collections.unmodifiableList(
             Arrays.asList(
-                new org.elasticsearch.xpack.core.ml.utils.PhaseProgress("reindexing", 100),
-                new org.elasticsearch.xpack.core.ml.utils.PhaseProgress("loading_data", 20),
-                new org.elasticsearch.xpack.core.ml.utils.PhaseProgress("a", 30),
-                new org.elasticsearch.xpack.core.ml.utils.PhaseProgress("b", 40),
+                new PhaseProgress("reindexing", 100),
+                new PhaseProgress("loading_data", 20),
+                new PhaseProgress("a", 30),
+                new PhaseProgress("b", 40),
                 new PhaseProgress("writing_results", 50)
             )
         );
@@ -48,10 +74,10 @@ public class StatsHolderTests extends ESTestCase {
     public void testAdjustProgressTracker_GivenDifferentAnalysisPhases() {
         List<PhaseProgress> phases = Collections.unmodifiableList(
             Arrays.asList(
-                new org.elasticsearch.xpack.core.ml.utils.PhaseProgress("reindexing", 100),
-                new org.elasticsearch.xpack.core.ml.utils.PhaseProgress("loading_data", 20),
-                new org.elasticsearch.xpack.core.ml.utils.PhaseProgress("a", 30),
-                new org.elasticsearch.xpack.core.ml.utils.PhaseProgress("b", 40),
+                new PhaseProgress("reindexing", 100),
+                new PhaseProgress("loading_data", 20),
+                new PhaseProgress("a", 30),
+                new PhaseProgress("b", 40),
                 new PhaseProgress("writing_results", 50)
             )
         );
@@ -74,10 +100,10 @@ public class StatsHolderTests extends ESTestCase {
     public void testAdjustProgressTracker_GivenReindexingProgressIncomplete() {
         List<PhaseProgress> phases = Collections.unmodifiableList(
             Arrays.asList(
-                new org.elasticsearch.xpack.core.ml.utils.PhaseProgress("reindexing", 42),
-                new org.elasticsearch.xpack.core.ml.utils.PhaseProgress("loading_data", 20),
-                new org.elasticsearch.xpack.core.ml.utils.PhaseProgress("a", 30),
-                new org.elasticsearch.xpack.core.ml.utils.PhaseProgress("b", 40),
+                new PhaseProgress("reindexing", 42),
+                new PhaseProgress("loading_data", 20),
+                new PhaseProgress("a", 30),
+                new PhaseProgress("b", 40),
                 new PhaseProgress("writing_results", 50)
             )
         );
@@ -100,10 +126,10 @@ public class StatsHolderTests extends ESTestCase {
     public void testResetProgressTracker() {
         List<PhaseProgress> phases = Collections.unmodifiableList(
             Arrays.asList(
-                new org.elasticsearch.xpack.core.ml.utils.PhaseProgress("reindexing", 100),
-                new org.elasticsearch.xpack.core.ml.utils.PhaseProgress("loading_data", 20),
-                new org.elasticsearch.xpack.core.ml.utils.PhaseProgress("a", 30),
-                new org.elasticsearch.xpack.core.ml.utils.PhaseProgress("b", 40),
+                new PhaseProgress("reindexing", 100),
+                new PhaseProgress("loading_data", 20),
+                new PhaseProgress("a", 30),
+                new PhaseProgress("b", 40),
                 new PhaseProgress("writing_results", 50)
             )
         );


### PR DESCRIPTION
This commit improves the design of the code that manages
and runs data frame analytics jobs.

First, it splits the code into asynchronous steps. At the moment,
there are only two steps: the reindexing step and the analysis
step. However, splitting the task into steps allows us to
factor out running inference into its own step which in turn
allows us to properly resume a job that failed during inference
without having to start a c++ process. I will follow with this
improvement in a follow up PR.

The other main improvement this commit does is that it simplifies
the state of a DFA task by getting rid of `reindexing` and `analyzing`
states. Now, once the task goes to `started` it stays there until
it finishes or gets stopped. The removed states are no longer useful.
They used to be useful in order to know how to resume a job before
progress was added. But currently they serve no purpose at all.

Backport of #67423
