### PR TITLE
Warn of change of default of wait_for_active_shards

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/IndicesRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/IndicesRequestConverters.java
@@ -38,6 +38,7 @@ import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest
 import org.elasticsearch.action.admin.indices.shrink.ResizeType;
 import org.elasticsearch.action.admin.indices.template.delete.DeleteIndexTemplateRequest;
 import org.elasticsearch.action.admin.indices.validate.query.ValidateQueryRequest;
+import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.client.indices.AnalyzeRequest;
 import org.elasticsearch.client.indices.CloseIndexRequest;
 import org.elasticsearch.client.indices.CreateDataStreamRequest;
@@ -140,6 +141,13 @@ final class IndicesRequestConverters {
         parameters.withTimeout(closeIndexRequest.timeout());
         parameters.withMasterTimeout(closeIndexRequest.masterNodeTimeout());
         parameters.withIndicesOptions(closeIndexRequest.indicesOptions());
+
+        final ActiveShardCount activeShardCount = closeIndexRequest.waitForActiveShards();
+        if (activeShardCount == ActiveShardCount.DEFAULT) {
+            request.addParameter("wait_for_active_shards", "index-setting");
+        } else {
+            parameters.withWaitForActiveShards(activeShardCount);
+        }
         request.addParameters(parameters.asMap());
         return request;
     }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/CloseIndexRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/CloseIndexRequest.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.client.indices;
 
-import org.elasticsearch.action.admin.indices.open.OpenIndexResponse;
 import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.TimedRequest;
@@ -35,7 +34,7 @@ public class CloseIndexRequest extends TimedRequest implements Validatable {
 
     private String[] indices;
     private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpen();
-    private ActiveShardCount waitForActiveShards = ActiveShardCount.DEFAULT;
+    private ActiveShardCount waitForActiveShards = null;
 
     /**
      * Creates a new close index request
@@ -82,16 +81,14 @@ public class CloseIndexRequest extends TimedRequest implements Validatable {
     }
 
     /**
-     * Sets the number of shard copies that should be active for indices opening to return.
-     * Defaults to {@link ActiveShardCount#DEFAULT}, which will wait for one shard copy
-     * (the primary) to become active. Set this value to {@link ActiveShardCount#ALL} to
-     * wait for all shards (primary and all replicas) to be active before returning.
-     * Otherwise, use {@link ActiveShardCount#from(int)} to set this value to any
-     * non-negative integer, up to the number of copies per shard (number of replicas + 1),
-     * to wait for the desired amount of shard copies to become active before returning.
-     * Indices opening will only wait up until the timeout value for the number of shard copies
-     * to be active before returning.  Check {@link OpenIndexResponse#isShardsAcknowledged()} to
-     * determine if the requisite shard copies were all started before returning or timing out.
+     * Sets the number of shard copies that should be active before a close-index request returns. Defaults to {@code null}, which means not
+     * to wait. However the default behaviour is deprecated and will change in version 8. You can opt-in to the new default behaviour now by
+     * setting this to {@link ActiveShardCount#DEFAULT}, which will wait according to the setting {@code index.write.wait_for_active_shards}
+     * which by default will wait for one shard, the primary. Set this value to {@link ActiveShardCount#ALL} to wait for all shards (primary
+     * and all replicas) to be active before returning. Otherwise, use {@link ActiveShardCount#from(int)} to set this value to any
+     * non-negative integer up to the number of copies per shard (number of replicas + 1), to wait for the desired amount of shard copies
+     * to become active before returning. To explicitly preserve today's default behaviour and suppress the deprecation warning, set this
+     * property to {@code ActiveShardCount.from(0)}.
      *
      * @param waitForActiveShards number of active shard copies to wait on
      */

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/CCRIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/CCRIT.java
@@ -188,6 +188,7 @@ public class CCRIT extends ESRestHighLevelClientTestCase {
 
         // Need to close index prior to unfollowing it:
         CloseIndexRequest closeIndexRequest = new CloseIndexRequest("follower");
+        closeIndexRequest.waitForActiveShards(ActiveShardCount.from(0));
         org.elasticsearch.action.support.master.AcknowledgedResponse closeIndexReponse =
             highLevelClient().indices().close(closeIndexRequest, RequestOptions.DEFAULT);
         assertThat(closeIndexReponse.isAcknowledged(), is(true));

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesClientIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesClientIT.java
@@ -50,6 +50,7 @@ import org.elasticsearch.action.admin.indices.template.delete.DeleteIndexTemplat
 import org.elasticsearch.action.admin.indices.validate.query.ValidateQueryRequest;
 import org.elasticsearch.action.admin.indices.validate.query.ValidateQueryResponse;
 import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.action.support.broadcast.BroadcastResponse;
@@ -904,6 +905,7 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
         }
 
         CloseIndexRequest closeIndexRequest = new CloseIndexRequest(indices);
+        closeIndexRequest.waitForActiveShards(ActiveShardCount.from(0));
         CloseIndexResponse closeIndexResponse = execute(closeIndexRequest,
             highLevelClient().indices()::close, highLevelClient().indices()::closeAsync);
         assertTrue(closeIndexResponse.isAcknowledged());
@@ -926,6 +928,7 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
         assertFalse(indexExists(nonExistentIndex));
 
         CloseIndexRequest closeIndexRequest = new CloseIndexRequest(nonExistentIndex);
+        closeIndexRequest.waitForActiveShards(ActiveShardCount.from(0));
         ElasticsearchException exception = expectThrows(ElasticsearchException.class,
                 () -> execute(closeIndexRequest, highLevelClient().indices()::close, highLevelClient().indices()::closeAsync));
         assertEquals(RestStatus.NOT_FOUND, exception.status());
@@ -934,6 +937,7 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
     public void testCloseEmptyOrNullIndex() {
         String[] indices = randomBoolean() ? Strings.EMPTY_ARRAY : null;
         CloseIndexRequest closeIndexRequest = new CloseIndexRequest(indices);
+        closeIndexRequest.waitForActiveShards(ActiveShardCount.from(0));
         org.elasticsearch.client.ValidationException exception = expectThrows(org.elasticsearch.client.ValidationException.class,
             () -> execute(closeIndexRequest, highLevelClient().indices()::close, highLevelClient().indices()::closeAsync));
         assertThat(exception.validationErrors().get(0), equalTo("index is missing"));

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesRequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesRequestConvertersTests.java
@@ -41,6 +41,7 @@ import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest
 import org.elasticsearch.action.admin.indices.shrink.ResizeType;
 import org.elasticsearch.action.admin.indices.template.delete.DeleteIndexTemplateRequest;
 import org.elasticsearch.action.admin.indices.validate.query.ValidateQueryRequest;
+import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.client.indices.AnalyzeRequest;
 import org.elasticsearch.client.indices.CloseIndexRequest;
@@ -641,6 +642,22 @@ public class IndicesRequestConvertersTests extends ESTestCase {
         RequestConvertersTests.setRandomMasterTimeout(closeIndexRequest, expectedParams);
         RequestConvertersTests.setRandomIndicesOptions(closeIndexRequest::indicesOptions, closeIndexRequest::indicesOptions,
             expectedParams);
+        switch (between(0, 3)) {
+            case 0:
+                break;
+            case 1:
+                closeIndexRequest.waitForActiveShards(ActiveShardCount.DEFAULT);
+                expectedParams.put("wait_for_active_shards", "index-setting");
+                break;
+            case 2:
+                closeIndexRequest.waitForActiveShards(ActiveShardCount.ALL);
+                expectedParams.put("wait_for_active_shards", "all");
+                break;
+            case 3:
+                closeIndexRequest.waitForActiveShards(ActiveShardCount.from(1));
+                expectedParams.put("wait_for_active_shards", "1");
+                break;
+        }
 
         Request request = IndicesRequestConverters.closeIndex(closeIndexRequest);
         StringJoiner endpoint = new StringJoiner("/", "/", "").add(String.join(",", indices)).add("_close");

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RankEvalIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RankEvalIT.java
@@ -108,7 +108,7 @@ public class RankEvalIT extends ESRestHighLevelClientTestCase {
         }
 
         // now try this when test2 is closed
-        client().performRequest(new Request("POST", "index2/_close"));
+        closeIndex("index2");
         rankEvalRequest.indicesOptions(IndicesOptions.fromParameters(null, "true", null, "false", SearchRequest.DEFAULT_INDICES_OPTIONS));
         response = execute(rankEvalRequest, highLevelClient()::rankEval, highLevelClient()::rankEvalAsync);
     }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/CCRDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/CCRDocumentationIT.java
@@ -321,6 +321,7 @@ public class CCRDocumentationIT extends ESRestHighLevelClientTestCase {
             assertThat(unfollowResponse.isAcknowledged(), is(true));
 
             CloseIndexRequest closeIndexRequest = new CloseIndexRequest(followIndex);
+            closeIndexRequest.waitForActiveShards(ActiveShardCount.from(0));
             assertThat(client.indices().close(closeIndexRequest, RequestOptions.DEFAULT).isAcknowledged(), is(true));
         }
 
@@ -353,6 +354,7 @@ public class CCRDocumentationIT extends ESRestHighLevelClientTestCase {
             assertThat(unfollowResponse.isAcknowledged(), is(true));
 
             CloseIndexRequest closeIndexRequest = new CloseIndexRequest(followIndex);
+            closeIndexRequest.waitForActiveShards(ActiveShardCount.from(0));
             assertThat(client.indices().close(closeIndexRequest, RequestOptions.DEFAULT).isAcknowledged(), is(true));
         }
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/IndicesClientDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/IndicesClientDocumentationIT.java
@@ -1469,6 +1469,8 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             CloseIndexRequest request = new CloseIndexRequest("index"); // <1>
             // end::close-index-request
 
+            request.waitForActiveShards(ActiveShardCount.from(0));
+
             // tag::close-index-request-timeout
             request.setTimeout(TimeValue.timeValueMinutes(2)); // <1>
             // end::close-index-request-timeout

--- a/distribution/archives/integ-test-zip/src/test/java/org/elasticsearch/test/rest/WaitForRefreshAndCloseIT.java
+++ b/distribution/archives/integ-test-zip/src/test/java/org/elasticsearch/test/rest/WaitForRefreshAndCloseIT.java
@@ -97,7 +97,9 @@ public class WaitForRefreshAndCloseIT extends ESRestTestCase {
         });
 
         // Close the index. That should flush the listener.
-        client().performRequest(new Request("POST", "/test/_close"));
+        final Request closeRequest = new Request("POST", "/test/_close");
+        closeRequest.addParameter("wait_for_active_shards", "0");
+        client().performRequest(closeRequest);
 
         /*
          * The request may fail, but we really, really, really want to make

--- a/docs/reference/ccr/apis/follow/post-unfollow.asciidoc
+++ b/docs/reference/ccr/apis/follow/post-unfollow.asciidoc
@@ -23,7 +23,7 @@ PUT /follower_index/_ccr/follow?wait_for_active_shards=1
 
 POST /follower_index/_ccr/pause_follow
 
-POST /follower_index/_close
+POST /follower_index/_close?wait_for_active_shards=0
 --------------------------------------------------
 // TESTSETUP
 // TEST[setup:remote_cluster_and_leader_index]

--- a/docs/reference/ccr/getting-started.asciidoc
+++ b/docs/reference/ccr/getting-started.asciidoc
@@ -243,7 +243,7 @@ replication
 --------------------------------------------------
 POST /server-metrics-follower/_ccr/pause_follow
 
-POST /server-metrics-follower/_close
+POST /server-metrics-follower/_close?wait_for_active_shards=0
 
 POST /server-metrics-follower/_ccr/unfollow
 --------------------------------------------------

--- a/docs/reference/ccr/managing.asciidoc
+++ b/docs/reference/ccr/managing.asciidoc
@@ -127,7 +127,7 @@ process. Then, close the follower index and recreate it. For example:
 ----------------------------------------------------------------------
 POST /follower_index/_ccr/pause_follow
 
-POST /follower_index/_close
+POST /follower_index/_close?wait_for_active_shards=0
 
 PUT /follower_index/_ccr/follow?wait_for_active_shards=1
 {

--- a/docs/reference/index-modules/similarity.asciidoc
+++ b/docs/reference/index-modules/similarity.asciidoc
@@ -540,7 +540,7 @@ request and <<indices-open-close,open>> it again afterwards:
 
 [source,console]
 --------------------------------------------------
-POST /index/_close
+POST /index/_close?wait_for_active_shards=0
 
 PUT /index/_settings
 {

--- a/docs/reference/indices/close.asciidoc
+++ b/docs/reference/indices/close.asciidoc
@@ -11,6 +11,7 @@ Closes an index.
 POST /my-index-000001/_close
 --------------------------------------------------
 // TEST[setup:my_index]
+// TEST[warning:the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour]
 
 
 [[close-index-api-request]]
@@ -52,7 +53,18 @@ Defaults to `open`.
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards]
+`wait_for_active_shards`::
++
+--
+(Optional, string) The number of shard copies that must be active before
+proceeding with the operation. Set to `all`, `index-setting`, or any positive
+integer up to the total number of shards in the index (`number_of_replicas+1`).
+The value `index-setting` means to wait according to the index setting
+`index.write.wait_for_active_shards`. Default: `0`, meaning do not wait for any
+shards to be ready.
+
+See <<index-wait-for-active-shards>>.
+--
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
@@ -66,7 +78,8 @@ The following example shows how to close an index:
 --------------------------------------------------
 POST /my-index-000001/_close
 --------------------------------------------------
-// TEST[s/^/PUT my-index-000001\n/]
+// TEST[setup:my_index]
+// TEST[warning:the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour]
 
 The API returns following response:
 

--- a/docs/reference/indices/open-close.asciidoc
+++ b/docs/reference/indices/open-close.asciidoc
@@ -12,7 +12,7 @@ opens any closed backing indices.
 POST /my-index-000001/_open
 --------------------------------------------------
 // TEST[setup:my_index]
-// TEST[s/^/POST \/my-index-000001\/_close\n/]
+// TEST[s/^/POST \/my-index-000001\/_close?wait_for_active_shards=0\n/]
 
 
 [[open-index-api-request]]
@@ -122,7 +122,7 @@ The following request re-opens a closed index named `my-index-000001`.
 --------------------------------------------------
 POST /my-index-000001/_open
 --------------------------------------------------
-// TEST[s/^/PUT my-index-000001\nPOST my-index-000001\/_close\n/]
+// TEST[s/^/PUT my-index-000001\nPOST my-index-000001\/_close?wait_for_active_shards=0\n/]
 
 The API returns the following response:
 

--- a/docs/reference/indices/resolve.asciidoc
+++ b/docs/reference/indices/resolve.asciidoc
@@ -13,7 +13,7 @@ supported.
 ----
 PUT /foo_closed
 
-POST /foo_closed/_close
+POST /foo_closed/_close?wait_for_active_shards=0
 
 PUT /remotecluster-bar-01
 

--- a/docs/reference/indices/update-settings.asciidoc
+++ b/docs/reference/indices/update-settings.asciidoc
@@ -167,7 +167,7 @@ the following commands add the `content` analyzer to the `my-index-000001` index
 
 [source,console]
 --------------------------------------------------
-POST /my-index-000001/_close
+POST /my-index-000001/_close?wait_for_active_shards=0
 
 PUT /my-index-000001/_settings
 {

--- a/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
@@ -38,13 +38,13 @@ PUT _snapshot/my_repository/snapshot_2?wait_for_completion=true
   }
 }
 
-POST /index_1/_close
+POST /index_1/_close?wait_for_active_shards=0
 
-POST /index_2/_close
+POST /index_2/_close?wait_for_active_shards=0
 
-POST /index_3/_close
+POST /index_3/_close?wait_for_active_shards=0
 
-POST /index_4/_close
+POST /index_4/_close?wait_for_active_shards=0
 
 ----
 // TESTSETUP

--- a/plugins/repository-hdfs/src/test/resources/rest-api-spec/test/hdfs_repository/40_restore.yml
+++ b/plugins/repository-hdfs/src/test/resources/rest-api-spec/test/hdfs_repository/40_restore.yml
@@ -4,6 +4,8 @@
 #
 ---
 "Create a snapshot and then restore it":
+  - skip:
+      features: ["allowed_warnings"]
 
   # Create repository
   - do:
@@ -47,6 +49,8 @@
   - do:
       indices.close:
         index : test_index
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
   # Restore index
   - do:

--- a/plugins/repository-hdfs/src/test/resources/rest-api-spec/test/secure_hdfs_repository/40_restore.yml
+++ b/plugins/repository-hdfs/src/test/resources/rest-api-spec/test/secure_hdfs_repository/40_restore.yml
@@ -4,6 +4,8 @@
 #
 ---
 "Create a snapshot and then restore it":
+  - skip:
+      features: ["allowed_warnings"]
 
   # Create repository
   - do:
@@ -49,6 +51,8 @@
   - do:
       indices.close:
         index : test_index
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
   # Restore index
   - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.close.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.close.json
@@ -56,7 +56,7 @@
       },
       "wait_for_active_shards":{
         "type":"string",
-        "description":"Sets the number of active shards to wait for before the operation returns."
+        "description":"Sets the number of active shards to wait for before the operation returns. Set to `index-setting` to wait according to the index setting `index.write.wait_for_active_shards`, or `all` to wait for all shards, or an integer. Defaults to `0`."
       }
     }
   }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.aliases/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.aliases/10_basic.yml
@@ -388,6 +388,7 @@
   - skip:
       version: " - 7.3.99"
       reason:  "is_write_index is shown in cat.aliases starting version 7.4.0"
+      features: ["allowed_warnings"]
 
   - do:
       indices.create:
@@ -399,6 +400,8 @@
   - do:
       indices.close:
         index: test_index
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
   - do:
       cat.aliases:
@@ -419,7 +422,7 @@
 "Alias against closed index (pre 7.4.0)":
   - skip:
       version: "7.4.0 - "
-      features: node_selector
+      features: ["node_selector", "allowed_warnings"]
       reason:  "is_write_index is shown in cat.aliases starting version 7.4.0"
 
   - do:
@@ -432,6 +435,8 @@
   - do:
       indices.close:
         index: test_index
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
   - do:
       node_selector:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.indices/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.indices/10_basic.yml
@@ -54,6 +54,7 @@
   - skip:
       version: "7.2.0 - "
       reason:  "closed indices are replicated starting version 7.2.0"
+      features: ["allowed_warnings"]
 
   - do:
       indices.create:
@@ -66,6 +67,8 @@
   - do:
       indices.close:
         index: index-2
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
   - is_true: acknowledged
 
   - do:
@@ -95,6 +98,7 @@
   - skip:
       version: " - 7.1.99"
       reason:  "closed indices are replicated starting version 7.2.0"
+      features: ["allowed_warnings"]
 
   - do:
       indices.create:
@@ -107,6 +111,8 @@
   - do:
       indices.close:
         index: index-2
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
   - is_true: acknowledged
 
   - do:
@@ -221,6 +227,8 @@
 
 ---
 "Test cat indices sort":
+  - skip:
+      features: ["allowed_warnings"]
 
   - do:
       indices.create:
@@ -249,6 +257,8 @@
   - do:
       indices.close:
         index: bar
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
   - do:
       cat.indices:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.recovery/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.recovery/10_basic.yml
@@ -81,6 +81,7 @@
   - skip:
       version: " - 7.1.99"
       reason: closed indices are replicated starting version 7.2.0
+      features: ["allowed_warnings"]
 
   - do:
       indices.create:
@@ -93,6 +94,8 @@
   - do:
       indices.close:
         index: index2
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
   - is_true: acknowledged
 
   - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.segments/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.segments/10_basic.yml
@@ -83,6 +83,8 @@
 
 ---
 "Test cat segments on closed index behaviour":
+  - skip:
+      features: ["allowed_warnings"]
 
   - do:
       indices.create:
@@ -95,6 +97,8 @@
   - do:
       indices.close:
         index: index1
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
   - do:
       catch: bad_request

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.allocation_explain/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.allocation_explain/10_basic.yml
@@ -52,6 +52,7 @@
   - skip:
       version: " - 7.1.99"
       reason: closed indices are replicated starting version 7.2.0
+      features: ["allowed_warnings"]
 
   - do:
       indices.create:
@@ -68,6 +69,8 @@
   - do:
       indices.close:
         index: test_closed
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
   - match: { acknowledged: true }
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.health/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.health/10_basic.yml
@@ -137,6 +137,7 @@
   - skip:
       version: "7.2.0 - "
       reason:  "closed indices are replicated starting version 7.2.0"
+      features: ["allowed_warnings"]
 
   - do:
       indices.create:
@@ -183,6 +184,8 @@
   - do:
       indices.close:
         index: index-2
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
   - is_true: acknowledged
 
   # closing the index-2 turns the cluster health back to green
@@ -211,6 +214,7 @@
   - skip:
       version: " - 7.1.99"
       reason:  "closed indices are replicated starting version 7.2.0"
+      features: ["allowed_warnings"]
 
   - do:
       indices.create:
@@ -258,6 +262,8 @@
   - do:
       indices.close:
         index: index-2
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
   - is_true: acknowledged
 
   - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.health/30_indices_options.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.health/30_indices_options.yml
@@ -1,4 +1,6 @@
 setup:
+  - skip:
+      features: ["allowed_warnings"]
 
   - do:
       indices.create:
@@ -23,6 +25,8 @@ setup:
   - do:
       indices.close:
         index: index-2
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
   - do:
       cluster.health:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.state/30_expand_wildcards.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.state/30_expand_wildcards.yml
@@ -1,4 +1,6 @@
 setup:
+  - skip:
+      features: ["allowed_warnings"]
 
   - do:
       indices.create:
@@ -25,6 +27,8 @@ setup:
   - do:
       indices.close:
         index: test_close_index
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
 ---
 "Test expand_wildcards parameter on closed, open indices and both":

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get/10_basic.yml
@@ -1,5 +1,7 @@
 ---
 setup:
+  - skip:
+      features: ["allowed_warnings"]
 
   - do:
       indices.create:
@@ -38,6 +40,8 @@ setup:
   - do:
       indices.close:
         index: test_index_3
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
   - do:
       cluster.health:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get/11_basic_with_types.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get/11_basic_with_types.yml
@@ -1,5 +1,7 @@
 ---
 setup:
+  - skip:
+      features: ["allowed_warnings"]
 
   - do:
       indices.create:
@@ -37,6 +39,8 @@ setup:
   - do:
       indices.close:
         index: test_index_3
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
   - do:
       cluster.health:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_alias/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_alias/10_basic.yml
@@ -1,6 +1,5 @@
 ---
 setup:
-
   - do:
       indices.create:
         index: test_index
@@ -303,10 +302,14 @@ setup:
 
 ---
 "Get alias against closed indices":
+  - skip:
+      features: ["allowed_warnings"]
 
   - do:
       indices.close:
         index: test_index_2
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
   - do:
       indices.get_alias:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_mapping/50_wildcard_expansion.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_mapping/50_wildcard_expansion.yml
@@ -1,5 +1,8 @@
 ---
 setup:
+  - skip:
+      features: ["allowed_warnings"]
+
   - do:
         indices.create:
           index: test-xxx
@@ -52,6 +55,8 @@ setup:
   - do:
       indices.close:
         index: test-xyy
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
   - do:
         cluster.health:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.open/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.open/10_basic.yml
@@ -1,5 +1,8 @@
 ---
 "Basic test for index open/close":
+  - skip:
+      features: ["allowed_warnings"]
+
   - do:
       indices.create:
         index: test_index
@@ -14,6 +17,8 @@
   - do:
       indices.close:
         index: test_index
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
   - is_true: acknowledged
 
   - do:
@@ -39,8 +44,7 @@
 ---
 "Open index with wait_for_active_shards set to all":
   - skip:
-      version: " - 6.0.99"
-      reason: wait_for_active_shards parameter was added in 6.1.0
+      features: ["allowed_warnings"]
 
   - do:
       indices.create:
@@ -52,6 +56,8 @@
   - do:
       indices.close:
         index: test_index
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
   - is_true: acknowledged
 
   - do:
@@ -87,6 +93,7 @@
   - skip:
       version: " - 7.2.99"
       reason: "close index response reports result per index starting version 7.3.0"
+      features: ["allowed_warnings"]
 
   - do:
       indices.create:
@@ -112,9 +119,54 @@
   - do:
       indices.close:
         index: "index_*"
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
   - match: { acknowledged: true }
   - match: { shards_acknowledged: true }
   - match: { indices.index_1.closed: true }
   - match: { indices.index_2.closed: true }
   - match: { indices.index_3.closed: true }
+
+---
+"?wait_for_active_shards=index-setting":
+  - skip:
+      version: " - 7.11.99"
+      reason: "?wait_for_active_shards=index-setting support added in 7.12"
+      features: ["node_selector"]
+
+  - do:
+      indices.create:
+        index: index_1
+        body:
+          settings:
+            number_of_replicas: 0
+
+  - do:
+      indices.close:
+        index: "index_*"
+        wait_for_active_shards: "index-setting"
+      node_selector:
+        version: "7.12.0 - "
+
+---
+"?wait_for_active_shards default is deprecated":
+  - skip:
+      version: " - 7.11.99"
+      reason: "required deprecation warning is only emitted in 7.12 and later"
+      features: ["warnings", "node_selector"]
+
+  - do:
+      indices.create:
+        index: index_1
+        body:
+          settings:
+            number_of_replicas: 0
+
+  - do:
+      indices.close:
+        index: "index_*"
+      node_selector:
+        version: "7.12.0 - "
+      warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.open/20_multiple_indices.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.open/20_multiple_indices.yml
@@ -23,9 +23,14 @@ setup:
 
 ---
 "All indices":
+  - skip:
+      features: ["allowed_warnings"]
+
   - do:
       indices.close:
         index: _all
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
   - is_true: acknowledged
 
   - do:
@@ -50,9 +55,14 @@ setup:
 
 ---
 "Trailing wildcard":
+  - skip:
+      features: ["allowed_warnings"]
+
   - do:
       indices.close:
         index: test_*
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
   - is_true: acknowledged
 
   - do:
@@ -77,9 +87,14 @@ setup:
 
 ---
 "Only wildcard":
+  - skip:
+      features: ["allowed_warnings"]
+
   - do:
       indices.close:
         index: '*'
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
   - is_true: acknowledged
 
   - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_settings/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_settings/10_basic.yml
@@ -56,6 +56,9 @@ setup:
 
 ---
 "Test preserve_existing settings":
+  - skip:
+      features: ["allowed_warnings"]
+
   - do:
       indices.put_settings:
         index: test-index
@@ -89,6 +92,8 @@ setup:
   - do:
       indices.close:
         index: test-index
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
   - do:
       indices.put_settings:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.recovery/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.recovery/10_basic.yml
@@ -44,6 +44,7 @@
   - skip:
       version: " - 7.1.99"
       reason: closed indices are replicated starting version 7.2.0
+      features: ["allowed_warnings"]
 
   - do:
       indices.create:
@@ -56,6 +57,8 @@
   - do:
       indices.close:
         index: test_2
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
   - is_true: acknowledged
 
   - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.resolve_index/10_basic_resolve_index.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.resolve_index/10_basic_resolve_index.yml
@@ -24,6 +24,8 @@ setup:
   - do:
       indices.close:
         index: test_index2
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
   - do:
       indices.create:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.segments/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.segments/10_basic.yml
@@ -43,6 +43,9 @@
 
 ---
 "closed segments test":
+  - skip:
+      features: ["allowed_warnings"]
+
   - do:
       indices.create:
         index: index1
@@ -60,6 +63,8 @@
   - do:
       indices.close:
         index: index1
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
   - do:
       catch: bad_request

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/80_indices_options.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/80_indices_options.yml
@@ -27,6 +27,9 @@
 ---
 "Closed index":
 
+  - skip:
+      features: ["allowed_warnings"]
+
   - do:
       indices.create:
           index:  index_closed
@@ -34,6 +37,8 @@
   - do:
       indices.close:
           index:  index_closed
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
   - do:
       catch:  /index_closed_exception/

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.restore/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.restore/10_basic.yml
@@ -24,6 +24,9 @@ setup:
 ---
 "Create a snapshot and then restore it":
 
+  - skip:
+      features: ["allowed_warnings"]
+
   - do:
       snapshot.create:
         repository: test_repo_restore_1
@@ -40,6 +43,8 @@ setup:
   - do:
       indices.close:
         index : test_index
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
   - do:
       snapshot.restore:

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestCloseIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestCloseIndexAction.java
@@ -24,6 +24,7 @@ import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
@@ -36,6 +37,12 @@ import static java.util.Collections.unmodifiableList;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 
 public class RestCloseIndexAction extends BaseRestHandler {
+
+    private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(RestCloseIndexAction.class);
+
+    public static final String WAIT_FOR_ACTIVE_SHARDS_DEFAULT_DEPRECATION_MESSAGE = "the default value for the ?wait_for_active_shards " +
+            "parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' " +
+            "to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour";
 
     @Override
     public List<Route> routes() {
@@ -56,7 +63,11 @@ public class RestCloseIndexAction extends BaseRestHandler {
         closeIndexRequest.timeout(request.paramAsTime("timeout", closeIndexRequest.timeout()));
         closeIndexRequest.indicesOptions(IndicesOptions.fromRequest(request, closeIndexRequest.indicesOptions()));
         String waitForActiveShards = request.param("wait_for_active_shards");
-        if (waitForActiveShards != null) {
+        if (waitForActiveShards == null) {
+            deprecationLogger.deprecate("close-index-wait_for_active_shards-default", WAIT_FOR_ACTIVE_SHARDS_DEFAULT_DEPRECATION_MESSAGE);
+        } else if ("index-setting".equalsIgnoreCase(waitForActiveShards)) {
+            closeIndexRequest.waitForActiveShards(ActiveShardCount.DEFAULT);
+        } else {
             closeIndexRequest.waitForActiveShards(ActiveShardCount.parseString(waitForActiveShards));
         }
         return channel -> client.admin().indices().close(closeIndexRequest, new RestToXContentListener<>(channel));

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -103,6 +103,7 @@ import java.util.stream.Collectors;
 
 import static java.util.Collections.sort;
 import static java.util.Collections.unmodifiableList;
+import static org.elasticsearch.rest.action.admin.indices.RestCloseIndexAction.WAIT_FOR_ACTIVE_SHARDS_DEFAULT_DEPRECATION_MESSAGE;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsString;
@@ -1256,8 +1257,12 @@ public abstract class ESRestTestCase extends ESTestCase {
     }
 
     protected static void closeIndex(String index) throws IOException {
-        Response response = client().performRequest(new Request("POST", "/" + index + "/_close"));
-        assertThat(response.getStatusLine().getStatusCode(), equalTo(RestStatus.OK.getStatus()));
+        final Request closeRequest = new Request(HttpPost.METHOD_NAME, "/" + index + "/_close");
+        closeRequest.setOptions(expectVersionSpecificWarnings(v -> {
+            v.current(WAIT_FOR_ACTIVE_SHARDS_DEFAULT_DEPRECATION_MESSAGE);
+            v.compatible(WAIT_FOR_ACTIVE_SHARDS_DEFAULT_DEPRECATION_MESSAGE);
+        }));
+        assertOK(client().performRequest(closeRequest));
     }
 
     protected static void openIndex(String index) throws IOException {

--- a/x-pack/plugin/ccr/qa/multi-cluster/src/test/java/org/elasticsearch/xpack/ccr/FollowIndexIT.java
+++ b/x-pack/plugin/ccr/qa/multi-cluster/src/test/java/org/elasticsearch/xpack/ccr/FollowIndexIT.java
@@ -81,7 +81,7 @@ public class FollowIndexIT extends ESCCRRestTestCase {
             assertBusy(() -> verifyCcrMonitoring(leaderIndexName, followIndexName), 30, TimeUnit.SECONDS);
 
             pauseFollow(followIndexName);
-            assertOK(client().performRequest(new Request("POST", "/" + followIndexName + "/_close")));
+            closeIndex(followIndexName);
             assertOK(client().performRequest(new Request("POST", "/" + followIndexName + "/_ccr/unfollow")));
             Exception e = expectThrows(ResponseException.class, () -> resumeFollow(followIndexName));
             assertThat(e.getMessage(), containsString("follow index [" + followIndexName + "] does not have ccr metadata"));

--- a/x-pack/plugin/ccr/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/ccr/follow_and_unfollow.yml
+++ b/x-pack/plugin/ccr/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/ccr/follow_and_unfollow.yml
@@ -1,5 +1,8 @@
 ---
 "Test follow and unfollow an existing index":
+  - skip:
+      features: ["allowed_warnings"]
+
   - do:
       cluster.state: {}
 
@@ -62,6 +65,8 @@
   - do:
       indices.close:
         index: bar
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
   - is_true: acknowledged
 
   - do:

--- a/x-pack/plugin/ccr/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/ccr/forget_follower.yml
+++ b/x-pack/plugin/ccr/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/ccr/forget_follower.yml
@@ -1,5 +1,8 @@
 ---
 "Test forget follower":
+  - skip:
+      features: ["allowed_warnings"]
+
   - do:
       cluster.state: {}
 
@@ -72,6 +75,8 @@
   - do:
       indices.close:
         index: follower_index
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
   - is_true: acknowledged
 
   - do:

--- a/x-pack/plugin/ccr/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/ccr/index_directly_into_follower_index.yml
+++ b/x-pack/plugin/ccr/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/ccr/index_directly_into_follower_index.yml
@@ -1,5 +1,8 @@
 ---
 "Test indexing direcly into a follower index":
+  - skip:
+      features: ["allowed_warnings"]
+
   - do:
       cluster.state: {}
 
@@ -58,6 +61,8 @@
   - do:
       indices.close:
         index: bar
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
   - is_true: acknowledged
 
   - do:

--- a/x-pack/plugin/ccr/qa/security/src/test/java/org/elasticsearch/xpack/ccr/FollowIndexSecurityIT.java
+++ b/x-pack/plugin/ccr/qa/security/src/test/java/org/elasticsearch/xpack/ccr/FollowIndexSecurityIT.java
@@ -89,7 +89,7 @@ public class FollowIndexSecurityIT extends ESCCRRestTestCase {
                 assertThat(countCcrNodeTasks(), equalTo(0));
             });
 
-            assertOK(client().performRequest(new Request("POST", "/" + allowedIndex + "/_close")));
+            closeIndex(allowedIndex);
             assertOK(client().performRequest(new Request("POST", "/" + allowedIndex + "/_ccr/unfollow")));
             Exception e = expectThrows(ResponseException.class, () -> resumeFollow(allowedIndex));
             assertThat(e.getMessage(), containsString("follow index [" + allowedIndex + "] does not have ccr metadata"));
@@ -124,7 +124,9 @@ public class FollowIndexSecurityIT extends ESCCRRestTestCase {
             e = expectThrows(ResponseException.class,
                 () -> client().performRequest(new Request("POST", "/" + unallowedIndex + "/_ccr/unfollow")));
             assertThat(e.getMessage(), containsString("action [indices:admin/xpack/ccr/unfollow] is unauthorized for user [test_ccr]"));
-            assertOK(adminClient().performRequest(new Request("POST", "/" + unallowedIndex + "/_close")));
+            final Request closeIndexRequest = new Request("POST", "/" + unallowedIndex + "/_close");
+            closeIndexRequest.addParameter("wait_for_active_shards", "0");
+            assertOK(adminClient().performRequest(closeIndexRequest));
             assertOK(adminClient().performRequest(new Request("POST", "/" + unallowedIndex + "/_ccr/unfollow")));
             assertBusy(() -> assertThat(countCcrNodeTasks(), equalTo(0)));
         }

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsRestTestCase.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsRestTestCase.java
@@ -142,8 +142,7 @@ public abstract class AbstractSearchableSnapshotsRestTestCase extends ESRestTest
 
     public void testCloseAndReopen() throws Exception {
         runSearchableSnapshotsTest((restoredIndexName, numDocs) -> {
-            final Request closeRequest = new Request(HttpPost.METHOD_NAME, restoredIndexName + "/_close");
-            assertOK(client().performRequest(closeRequest));
+            closeIndex(restoredIndexName);
             ensureGreen(restoredIndexName);
 
             final Request openRequest = new Request(HttpPost.METHOD_NAME, restoredIndexName + "/_open");

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/data_stream/20_unsupported_apis.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/data_stream/20_unsupported_apis.yml
@@ -45,6 +45,8 @@
   - do:
       indices.close:
         index: logs-*
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
   - is_true: acknowledged
   - length: { indices: 0 }
 
@@ -165,6 +167,8 @@
       catch: bad_request
       indices.close:
         index: ".ds-simple-data-stream1-*000001"
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
   - do:
       indices.delete_data_stream:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/data_stream/40_supported_apis.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/data_stream/40_supported_apis.yml
@@ -230,6 +230,8 @@ teardown:
   - do:
       indices.close:
         index: ".ds-simple-data-stream1-*000001,.ds-simple-data-stream1-*000002"
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
   - is_true: acknowledged
 
   - do:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/data_stream/80_resolve_index_data_streams.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/data_stream/80_resolve_index_data_streams.yml
@@ -54,6 +54,8 @@ setup:
   - do:
       indices.close:
         index: test_index2
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
   - do:
       indices.create:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/indices.freeze/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/indices.freeze/10_basic.yml
@@ -88,6 +88,7 @@
 - skip:
     version: " - 6.99.99"
     reason: types are required in requests before 7.0.0
+    features: ["allowed_warnings"]
 
 - do:
     index:
@@ -104,6 +105,8 @@
 - do:
     indices.close:
       index: test-close
+    allowed_warnings:
+      - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
 - do:
     indices.freeze:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_crud.yml
@@ -1215,6 +1215,8 @@
 
 ---
 "Test put job after closing results index":
+  - skip:
+      features: ["allowed_warnings"]
 
   - do:
       indices.create:
@@ -1223,6 +1225,8 @@
   - do:
       indices.close:
         index: ".ml-anomalies-shared"
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
   - do:
       catch: /Cannot create job \[closed-results-job\] as it requires closed index \[\.ml-anomalies-shared\]/
@@ -1242,6 +1246,8 @@
 
 ---
 "Test put job after closing state index":
+  - skip:
+      features: ["allowed_warnings"]
 
   - do:
       indices.create:
@@ -1250,6 +1256,8 @@
   - do:
       indices.close:
         index: ".ml-state-000001"
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
   - do:
       catch: /Cannot create job \[closed-results-job\] as it requires closed index \[\.ml-state-000001\]/

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/monitoring/bulk/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/monitoring/bulk/10_basic.yml
@@ -174,6 +174,7 @@
   - skip:
       version: "all"
       reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/30101"
+      features: ["allowed_warnings"]
 
   - do:
       monitoring.bulk:
@@ -206,6 +207,8 @@
   - do:
       indices.close:
         index: .monitoring-beats-*
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
   - do:
       catch: /export_exception/

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/security/authz/14_cat_indices.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/security/authz/14_cat_indices.yml
@@ -1,7 +1,7 @@
 ---
 setup:
   - skip:
-      features: headers
+      features: ["headers", "allowed_warnings"]
 
   - do:
       cluster.health:
@@ -55,6 +55,8 @@ setup:
   - do:
       indices.close:
         index:  index3
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
 ---
 teardown:
@@ -120,6 +122,7 @@ teardown:
   - skip:
       version: "all"
       reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/47875"
+      features: ["allowed_warnings"]
 
   - do:
       indices.create:
@@ -150,6 +153,8 @@ teardown:
   - do:
       indices.close:
         index:  index_to_monitor
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
   - do:
       headers: { Authorization: "Basic Y2F0X3VzZXI6Y2F0X3NlY3JldF9wYXNzd29yZA==" } # cat_user

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/snapshot/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/snapshot/10_basic.yml
@@ -24,6 +24,8 @@ setup:
 
 ---
 "Create a source only snapshot and then restore it":
+  - skip:
+      features: ["allowed_warnings"]
 
   - do:
       index:
@@ -53,6 +55,8 @@ setup:
   - do:
       indices.close:
         index : test_index
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
   - do:
       snapshot.restore:

--- a/x-pack/qa/multi-cluster-search-security/src/test/resources/rest-api-spec/test/remote_cluster/10_basic.yml
+++ b/x-pack/qa/multi-cluster-search-security/src/test/resources/rest-api-spec/test/remote_cluster/10_basic.yml
@@ -106,6 +106,8 @@ setup:
   - do:
       indices.close:
         index: closed_index
+      allowed_warnings:
+        - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 
   - do:
         indices.create:


### PR DESCRIPTION
In 7.x the close indices API defaults to `?wait_for_active_shards=0` but
from 8.0 it will default to respecting the index settings instead. This
commit introduces the `index-setting` value for this parameter on this
API allowing users to opt-in to the future behaviour today, and starts
to emit a deprecation warning for users that use the default.

Relates #67158
Retry of #67246 now that #67498 is merged to `master`
Closes #66419