### PR TITLE
[7.x] Add requested headers to YAML REST error stash (#67378)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestExecutionContext.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestExecutionContext.java
@@ -114,6 +114,9 @@ public class ClientYamlTestExecutionContext {
             Object responseBody = response != null ? response.getBody() : null;
             //we always stash the last response body
             stash.stashValue("body", responseBody);
+            if(requestHeaders.isEmpty() == false) {
+                stash.stashValue("request_headers", requestHeaders);
+            }
         }
     }
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add requested headers to YAML REST error stash (#67378)