### PR TITLE
[ML] updating 7.11 breaking changes doc (#67377)

### DIFF
--- a/docs/reference/migration/migrate_7_11.asciidoc
+++ b/docs/reference/migration/migrate_7_11.asciidoc
@@ -18,6 +18,17 @@ See also <<release-highlights>> and <<es-release-notes>>.
 //tag::notable-breaking-changes[]
 
 [discrete]
+[[breaking_711_ml_changes]]
+=== Machine learning changes
+.The trained models API parameter `for_export` is now renamed to `exclude_generated`.
+[%collapsible]
+====
+*Details* +
+The {ref}/get-trained-models.html[get trained models API] no longer accepts `for_export`.
+Use `exclude_generated` instead.
+====
+
+[discrete]
 [[breaking_711_search_changes]]
 === Search changes
 


### PR DESCRIPTION
Updates breaking changes doc for ML to include changes to the trained models API.

forward port of: https://github.com/elastic/elasticsearch/pull/67377