### PR TITLE
Fix vendor identification in FIPS 140-2 CI

### DIFF
--- a/gradle/fips.gradle
+++ b/gradle/fips.gradle
@@ -6,7 +6,7 @@ import org.elasticsearch.gradle.testclusters.TestDistribution
 if (BuildParams.inFipsJvm) {
 
   allprojects {
-    String javaSecurityFilename = BuildParams.runtimeJavaDetails.startsWith('oracle') ? 'fips_java_oracle.security' : 'fips_java.security'
+    String javaSecurityFilename = BuildParams.runtimeJavaDetails.toLowerCase().contains('oracle') ? 'fips_java_oracle.security' : 'fips_java.security'
     File fipsResourcesDir = new File(project.buildDir, 'fips-resources')
     File fipsSecurity = new File(fipsResourcesDir, javaSecurityFilename)
     File fipsPolicy = new File(fipsResourcesDir, 'fips_java.policy')


### PR DESCRIPTION
We would attempt to match a string that starts with lower case
'oracle' but runtimeJavaDetails is ORACLE/Oracle Corporation.
Changed the matching to be a little more inclusive so that it will
not easily break by future changes to our build tooling or jdk
reported vendor string.

resolves: #66821
