### PR TITLE
Make ParsedMediaType truly immutable

### DIFF
--- a/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/ParsedMediaType.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/ParsedMediaType.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.common.xcontent;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -45,7 +44,7 @@ public class ParsedMediaType {
         this.originalHeaderValue = originalHeaderValue;
         this.type = type;
         this.subType = subType;
-        this.parameters = Collections.unmodifiableMap(parameters);
+        this.parameters = Map.copyOf(parameters);
     }
 
     /**

--- a/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/ParsedMediaType.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/ParsedMediaType.java
@@ -45,7 +45,7 @@ public class ParsedMediaType {
         this.originalHeaderValue = originalHeaderValue;
         this.type = type;
         this.subType = subType;
-        this.parameters = parameters;
+        this.parameters = Collections.unmodifiableMap(parameters);
     }
 
     /**
@@ -56,7 +56,7 @@ public class ParsedMediaType {
     }
 
     public Map<String, String> getParameters() {
-        return Collections.unmodifiableMap(parameters);
+        return parameters;
     }
 
     /**
@@ -108,8 +108,9 @@ public class ParsedMediaType {
 
     public static ParsedMediaType parseMediaType(XContentType requestContentType, Map<String, String> parameters) {
         ParsedMediaType parsedMediaType = requestContentType.toParsedMediaType();
-        parsedMediaType.parameters.putAll(parameters);
-        return parsedMediaType;
+
+        return new ParsedMediaType(parsedMediaType.originalHeaderValue,
+            parsedMediaType.type, parsedMediaType.subType, parameters);
     }
 
     // simplistic check for media ranges. do not validate if this is a correct header

--- a/libs/x-content/src/test/java/org/elasticsearch/common/xcontent/ParsedMediaTypeTests.java
+++ b/libs/x-content/src/test/java/org/elasticsearch/common/xcontent/ParsedMediaTypeTests.java
@@ -148,4 +148,48 @@ public class ParsedMediaTypeTests extends ESTestCase {
         ParsedMediaType parsedMediaType = ParsedMediaType.parseMediaType(mediaType);
         assertThat(parsedMediaType, equalTo(null));
     }
+
+    public void testParseMediaTypeFromXContentType() {
+
+        assertThat(ParsedMediaType.parseMediaType(XContentType.YAML, Collections.emptyMap())
+            .toMediaType(mediaTypeRegistry), equalTo(XContentType.YAML));
+        assertThat(ParsedMediaType.parseMediaType(XContentType.SMILE, Collections.emptyMap())
+            .toMediaType(mediaTypeRegistry), equalTo(XContentType.SMILE));
+        assertThat(ParsedMediaType.parseMediaType(XContentType.CBOR, Collections.emptyMap())
+            .toMediaType(mediaTypeRegistry), equalTo(XContentType.CBOR));
+
+        assertThat(ParsedMediaType.parseMediaType(XContentType.VND_JSON, Map.of("compatible-with", "7"))
+            .toMediaType(mediaTypeRegistry), equalTo(XContentType.VND_JSON));
+        assertThat(ParsedMediaType.parseMediaType(XContentType.VND_YAML, Map.of("compatible-with", "7"))
+            .toMediaType(mediaTypeRegistry), equalTo(XContentType.VND_YAML));
+        assertThat(ParsedMediaType.parseMediaType(XContentType.VND_SMILE, Map.of("compatible-with", "7"))
+            .toMediaType(mediaTypeRegistry), equalTo(XContentType.VND_SMILE));
+        assertThat(ParsedMediaType.parseMediaType(XContentType.VND_CBOR, Map.of("compatible-with", "7"))
+            .toMediaType(mediaTypeRegistry), equalTo(XContentType.VND_CBOR));
+    }
+
+    public void testResponseContentTypeHeader() {
+        assertThat(ParsedMediaType.parseMediaType(XContentType.JSON, Collections.emptyMap())
+            .responseContentTypeHeader(), equalTo("application/json"));
+        assertThat(ParsedMediaType.parseMediaType(XContentType.YAML, Collections.emptyMap())
+            .responseContentTypeHeader(), equalTo("application/yaml"));
+        assertThat(ParsedMediaType.parseMediaType(XContentType.SMILE, Collections.emptyMap())
+            .responseContentTypeHeader(), equalTo("application/smile"));
+        assertThat(ParsedMediaType.parseMediaType(XContentType.CBOR, Collections.emptyMap())
+            .responseContentTypeHeader(), equalTo("application/cbor"));
+
+        assertThat(ParsedMediaType.parseMediaType(XContentType.VND_JSON, Map.of("compatible-with", "7"))
+            .responseContentTypeHeader(), equalTo("application/vnd.elasticsearch+json;compatible-with=7"));
+        assertThat(ParsedMediaType.parseMediaType(XContentType.VND_YAML, Map.of("compatible-with", "7"))
+            .responseContentTypeHeader(), equalTo("application/vnd.elasticsearch+yaml;compatible-with=7"));
+        assertThat(ParsedMediaType.parseMediaType(XContentType.VND_SMILE, Map.of("compatible-with", "7"))
+            .responseContentTypeHeader(), equalTo("application/vnd.elasticsearch+smile;compatible-with=7"));
+        assertThat(ParsedMediaType.parseMediaType(XContentType.VND_CBOR, Map.of("compatible-with", "7"))
+            .responseContentTypeHeader(), equalTo("application/vnd.elasticsearch+cbor;compatible-with=7"));
+
+        assertThat(ParsedMediaType.parseMediaType(XContentType.JSON, Map.of("charset", "utf-8"))
+            .responseContentTypeHeader(), equalTo("application/json;charset=utf-8"));
+        assertThat(ParsedMediaType.parseMediaType(XContentType.JSON, Map.of("charset", "UTF-8"))
+            .responseContentTypeHeader(), equalTo("application/json;charset=UTF-8"));
+    }
 }

--- a/server/src/test/java/org/elasticsearch/common/xcontent/XContentTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/common/xcontent/XContentTypeTests.java
@@ -20,6 +20,7 @@ package org.elasticsearch.common.xcontent;
 
 import org.elasticsearch.test.ESTestCase;
 
+import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
@@ -163,6 +164,11 @@ public class XContentTypeTests extends ESTestCase {
 
         ParsedMediaType parsedMediaType = ParsedMediaType.parseMediaType(XContentType.JSON, Map.of("charset", "utf-8"));
         assertThat(xContentTypeJson.getParameters(), is(anEmptyMap()));
+        assertThat(parsedMediaType.getParameters(), equalTo(Map.of("charset","utf-8")));
+
+        Map<String, String> parameters = new HashMap<>(Map.of("charset", "utf-8"));
+        parsedMediaType = ParsedMediaType.parseMediaType(XContentType.JSON, parameters);
+        parameters.clear();
         assertThat(parsedMediaType.getParameters(), equalTo(Map.of("charset","utf-8")));
     }
 }

--- a/server/src/test/java/org/elasticsearch/common/xcontent/XContentTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/common/xcontent/XContentTypeTests.java
@@ -21,7 +21,9 @@ package org.elasticsearch.common.xcontent;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.Locale;
+import java.util.Map;
 
+import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
@@ -153,5 +155,14 @@ public class XContentTypeTests extends ESTestCase {
         // TODO do not allow parsing unrecognized parameter value https://github.com/elastic/elasticsearch/issues/63080
         // assertThat(XContentType.parseVersion("application/json;compatible-with=123"),
         //   is(nullValue()));
+    }
+
+    public void testParsedMediaTypeImmutability() {
+        ParsedMediaType xContentTypeJson = XContentType.JSON.toParsedMediaType();
+        assertThat(xContentTypeJson.getParameters(), is(anEmptyMap()));
+
+        ParsedMediaType parsedMediaType = ParsedMediaType.parseMediaType(XContentType.JSON, Map.of("charset", "utf-8"));
+        assertThat(xContentTypeJson.getParameters(), is(anEmptyMap()));
+        assertThat(parsedMediaType.getParameters(), equalTo(Map.of("charset","utf-8")));
     }
 }

--- a/server/src/test/java/org/elasticsearch/rest/RestControllerTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/RestControllerTests.java
@@ -643,7 +643,7 @@ public class RestControllerTests extends ESTestCase {
 
         final byte version = Version.CURRENT.minimumRestCompatibilityVersion().major;
 
-        final String mimeType = randomCompatibleMimeType(version);
+        final String mimeType = randomCompatibleMediaType(version);
         String content = randomAlphaOfLength((int) Math.round(BREAKER_LIMIT.getBytes() / inFlightRequestsBreaker.getOverhead()));
         final List<String> mimeTypeList = Collections.singletonList(mimeType);
         FakeRestRequest fakeRestRequest = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
@@ -679,7 +679,7 @@ public class RestControllerTests extends ESTestCase {
 
         final byte version = Version.CURRENT.minimumRestCompatibilityVersion().major;
 
-        final String mimeType = randomCompatibleMimeType(version);
+        final String mimeType = randomCompatibleMediaType(version);
         String content = randomAlphaOfLength((int) Math.round(BREAKER_LIMIT.getBytes() / inFlightRequestsBreaker.getOverhead()));
         final List<String> mimeTypeList = Collections.singletonList(mimeType);
         FakeRestRequest fakeRestRequest = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
@@ -729,7 +729,7 @@ public class RestControllerTests extends ESTestCase {
             }));
     }
 
-    private String randomCompatibleMimeType(byte version) {
+    private String randomCompatibleMediaType(byte version) {
         XContentType type = randomFrom(XContentType.VND_JSON, XContentType.VND_SMILE, XContentType.VND_CBOR, XContentType.VND_YAML);
         return type.toParsedMediaType()
             .responseContentTypeHeader(Map.of(MediaType.COMPATIBLE_WITH_PARAMETER_NAME, String.valueOf(version)));


### PR DESCRIPTION
By accident ParsedMediaType was not truly immutable and it was possible
to modify other ParsedMediaType's by accident when building.
ParsedMediaType#parseMediaType(XContentType,Map) was modifying
ParsedMediaTypes within XContentType. This should never happen.

This commit is addressing this by making Map of parameters immutable.

closes #67545