### PR TITLE
Avoid exception in in SetStepInfoUpdateTask#onFailure

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/ClusterStateTaskListener.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterStateTaskListener.java
@@ -25,13 +25,20 @@ import java.util.List;
 public interface ClusterStateTaskListener {
 
     /**
-     * A callback called when execute fails.
+     * A callback for when task execution fails.
+     *
+     * Implementations of this callback should not throw exceptions: an exception thrown here is logged by the master service at {@code
+     * ERROR} level and otherwise ignored. If log-and-ignore is the right behaviour then implementations should do so themselves, typically
+     * using a more specific logger and at a less dramatic log level.
      */
     void onFailure(String source, Exception e);
 
     /**
-     * called when the task was rejected because the local node is no longer master.
-     * Used only for tasks submitted to {@link MasterService}.
+     * A callback for when the task was rejected because the processing node is no longer the elected master.
+     *
+     * Implementations of this callback should not throw exceptions: an exception thrown here is logged by the master service at {@code
+     * ERROR} level and otherwise ignored. If log-and-ignore is the right behaviour then implementations should do so themselves, typically
+     * using a more specific logger and at a less dramatic log level.
      */
     default void onNoLongerMaster(String source) {
         onFailure(source, new NotMasterException("no longer master. source: [" + source + "]"));
@@ -40,6 +47,10 @@ public interface ClusterStateTaskListener {
     /**
      * Called when the result of the {@link ClusterStateTaskExecutor#execute(ClusterState, List)} have been processed
      * properly by all listeners.
+     *
+     * Implementations of this callback should not throw exceptions: an exception thrown here is logged by the master service at {@code
+     * ERROR} level and otherwise ignored. If log-and-ignore is the right behaviour then implementations should do so themselves, typically
+     * using a more specific logger and at a less dramatic log level.
      */
     default void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
     }

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterStateTaskListener.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterStateTaskListener.java
@@ -18,8 +18,6 @@
  */
 package org.elasticsearch.cluster;
 
-import org.elasticsearch.cluster.service.MasterService;
-
 import java.util.List;
 
 public interface ClusterStateTaskListener {

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterStateUpdateTask.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterStateUpdateTask.java
@@ -72,7 +72,11 @@ public abstract class ClusterStateUpdateTask
     public abstract ClusterState execute(ClusterState currentState) throws Exception;
 
     /**
-     * A callback called when execute fails.
+     * A callback for when task execution fails.
+     *
+     * Implementations of this callback should not throw exceptions: an exception thrown here is logged by the master service at {@code
+     * ERROR} level and otherwise ignored. If log-and-ignore is the right behaviour then implementations should do so themselves, typically
+     * using a more specific logger and at a less dramatic log level.
      */
     public abstract void onFailure(String source, Exception e);
 

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/SetStepInfoUpdateTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/SetStepInfoUpdateTask.java
@@ -6,6 +6,9 @@
 
 package org.elasticsearch.xpack.ilm;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
@@ -22,10 +25,13 @@ import java.io.IOException;
 import java.util.Objects;
 
 public class SetStepInfoUpdateTask extends ClusterStateUpdateTask {
+
+    private static final Logger logger = LogManager.getLogger(SetStepInfoUpdateTask.class);
+
     private final Index index;
     private final String policy;
     private final Step.StepKey currentStepKey;
-    private ToXContentObject stepInfo;
+    private final ToXContentObject stepInfo;
 
     public SetStepInfoUpdateTask(Index index, String policy, Step.StepKey currentStepKey, ToXContentObject stepInfo) {
         this.index = index;
@@ -72,8 +78,8 @@ public class SetStepInfoUpdateTask extends ClusterStateUpdateTask {
 
     @Override
     public void onFailure(String source, Exception e) {
-        throw new ElasticsearchException("policy [" + policy + "] for index [" + index.getName()
-                + "] failed trying to set step info for step [" + currentStepKey + "].", e);
+        logger.warn(new ParameterizedMessage("policy [{}] for index [{}] failed trying to set step info for step [{}].",
+                policy, index.getName(), currentStepKey), e);
     }
 
     public static class ExceptionWrapper implements ToXContentObject {

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/SetStepInfoUpdateTaskTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/SetStepInfoUpdateTaskTests.java
@@ -6,13 +6,16 @@
 
 package org.elasticsearch.xpack.ilm;
 
-import org.elasticsearch.ElasticsearchException;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.ToXContentObject;
@@ -20,6 +23,8 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.xpack.core.ilm.LifecycleExecutionState;
 import org.elasticsearch.xpack.core.ilm.LifecycleSettings;
 import org.elasticsearch.xpack.core.ilm.Step.StepKey;
@@ -104,19 +109,34 @@ public class SetStepInfoUpdateTaskTests extends ESTestCase {
         assertThat(newState, sameInstance(clusterState));
     }
 
-    public void testOnFailure() {
+    @TestLogging(reason = "logging test", value="logger.org.elasticsearch.xpack.ilm.SetStepInfoUpdateTask:WARN")
+    public void testOnFailure() throws IllegalAccessException {
         StepKey currentStepKey = new StepKey("current-phase", "current-action", "current-name");
         ToXContentObject stepInfo = getRandomStepInfo();
 
         setStateToKey(currentStepKey);
 
         SetStepInfoUpdateTask task = new SetStepInfoUpdateTask(index, policy, currentStepKey, stepInfo);
-        Exception expectedException = new RuntimeException();
-        ElasticsearchException exception = expectThrows(ElasticsearchException.class,
-                () -> task.onFailure(randomAlphaOfLength(10), expectedException));
-        assertEquals("policy [" + policy + "] for index [" + index.getName() + "] failed trying to set step info for step ["
-                + currentStepKey + "].", exception.getMessage());
-        assertSame(expectedException, exception.getCause());
+
+        final MockLogAppender mockAppender = new MockLogAppender();
+        mockAppender.start();
+        mockAppender.addExpectation(
+                new MockLogAppender.SeenEventExpectation(
+                        "warning",
+                        SetStepInfoUpdateTask.class.getCanonicalName(),
+                        Level.WARN,
+                        "*policy [" + policy + "] for index [" + index.getName() + "] failed trying to set step info for step ["
+                                + currentStepKey + "]."));
+
+        final Logger taskLogger = LogManager.getLogger(SetStepInfoUpdateTask.class);
+        Loggers.addAppender(taskLogger, mockAppender);
+        try {
+            task.onFailure(randomAlphaOfLength(10), new RuntimeException("test exception"));
+            mockAppender.assertAllExpectationsMatched();
+        } finally {
+            Loggers.removeAppender(taskLogger, mockAppender);
+            mockAppender.stop();
+        }
     }
 
     private void setStatePolicy(String policy) {


### PR DESCRIPTION
Exceptions thrown by the various `ClusterStateTaskListener` methods are
logged as an `ERROR` by the `MasterService` and otherwise ignored. It's
preferable for implementations to log their own messages.

This commit adjusts the implementation to log a message itself, and adds
Javadoc to clarify that other implementations should do the same.