### PR TITLE
[7.x] Mark files stored in the PersistentCache as reused in RecoveryState

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
@@ -802,7 +802,7 @@ public class RecoveryState implements ToXContentFragment, Writeable {
     }
 
     public static class Index extends Timer implements ToXContentFragment, Writeable {
-        private final RecoveryFilesDetails fileDetails;
+        protected final RecoveryFilesDetails fileDetails;
 
         public static final long UNKNOWN = -1L;
 

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotRecoveryStateIntegrationTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotRecoveryStateIntegrationTests.java
@@ -7,30 +7,44 @@
 package org.elasticsearch.xpack.searchablesnapshots;
 
 import com.carrotsearch.hppc.ObjectContainer;
-import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResponse;
 import org.elasticsearch.action.admin.indices.recovery.RecoveryResponse;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
-import org.elasticsearch.common.Strings;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.SuppressForbidden;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.env.Environment;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexService;
+import org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot;
 import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.indices.recovery.RecoverySettings;
 import org.elasticsearch.indices.recovery.RecoveryState;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.plugins.RepositoryPlugin;
+import org.elasticsearch.repositories.IndexId;
+import org.elasticsearch.repositories.RepositoriesService;
+import org.elasticsearch.repositories.Repository;
+import org.elasticsearch.repositories.RepositoryData;
+import org.elasticsearch.repositories.blobstore.BlobStoreRepository;
+import org.elasticsearch.repositories.blobstore.ESBlobStoreRepositoryIntegTestCase;
+import org.elasticsearch.repositories.fs.FsRepository;
 import org.elasticsearch.snapshots.SnapshotInfo;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.xpack.core.searchablesnapshots.MountSearchableSnapshotAction;
-import org.elasticsearch.xpack.core.searchablesnapshots.MountSearchableSnapshotRequest;
 import org.elasticsearch.xpack.searchablesnapshots.cache.CacheService;
 
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -40,9 +54,15 @@ import java.util.stream.Stream;
 import static org.elasticsearch.index.IndexSettings.INDEX_SOFT_DELETES_SETTING;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 1)
 public class SearchableSnapshotRecoveryStateIntegrationTests extends BaseSearchableSnapshotsIntegTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return CollectionUtils.appendToCopy(super.nodePlugins(), TestRepositoryPlugin.class);
+    }
 
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {
@@ -70,18 +90,7 @@ public class SearchableSnapshotRecoveryStateIntegrationTests extends BaseSearcha
 
         assertAcked(client().admin().indices().prepareDelete(indexName));
 
-        final MountSearchableSnapshotRequest req = new MountSearchableSnapshotRequest(
-            restoredIndexName,
-            fsRepoName,
-            snapshotInfo.snapshotId().getName(),
-            indexName,
-            Settings.EMPTY,
-            Strings.EMPTY_ARRAY,
-            true
-        );
-
-        final RestoreSnapshotResponse restoreSnapshotResponse = client().execute(MountSearchableSnapshotAction.INSTANCE, req).get();
-        assertThat(restoreSnapshotResponse.getRestoreInfo().failedShards(), equalTo(0));
+        mountSnapshot(fsRepoName, snapshotName, indexName, restoredIndexName, Settings.EMPTY);
         ensureGreen(restoredIndexName);
 
         final Index restoredIndex = client().admin()
@@ -98,12 +107,7 @@ public class SearchableSnapshotRecoveryStateIntegrationTests extends BaseSearcha
         assertExecutorIsIdle(SearchableSnapshotsConstants.CACHE_PREWARMING_THREAD_POOL_NAME);
         assertExecutorIsIdle(SearchableSnapshotsConstants.CACHE_FETCH_ASYNC_THREAD_POOL_NAME);
 
-        final RecoveryResponse recoveryResponse = client().admin().indices().prepareRecoveries(restoredIndexName).get();
-        Map<String, List<RecoveryState>> shardRecoveries = recoveryResponse.shardRecoveryStates();
-        assertThat(shardRecoveries.containsKey(restoredIndexName), equalTo(true));
-        List<RecoveryState> recoveryStates = shardRecoveries.get(restoredIndexName);
-        assertThat(recoveryStates.size(), equalTo(1));
-        RecoveryState recoveryState = recoveryStates.get(0);
+        RecoveryState recoveryState = getRecoveryState(restoredIndexName);
 
         assertThat(recoveryState.getStage(), equalTo(RecoveryState.Stage.DONE));
 
@@ -112,8 +116,110 @@ public class SearchableSnapshotRecoveryStateIntegrationTests extends BaseSearcha
 
         assertThat("Physical cache size doesn't match with recovery state data", physicalCacheSize, equalTo(recoveredBytes));
         assertThat("Expected to recover 100% of files", recoveryState.getIndex().recoveredBytesPercent(), equalTo(100.0f));
+    }
 
-        assertAcked(client().admin().indices().prepareDelete(restoredIndexName));
+    public void testFilesStoredInThePersistentCacheAreMarkedAsReusedInRecoveryState() throws Exception {
+        final String fsRepoName = randomAlphaOfLength(10);
+        final String indexName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
+        final String restoredIndexName = randomBoolean() ? indexName : randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
+        final String snapshotName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
+
+        createRepository(fsRepoName, "test-fs");
+        int numberOfShards = 1;
+
+        assertAcked(
+            prepareCreate(
+                indexName,
+                Settings.builder()
+                    .put(INDEX_SOFT_DELETES_SETTING.getKey(), true)
+                    .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, numberOfShards)
+            )
+        );
+        ensureGreen(indexName);
+
+        final int documentCount = randomIntBetween(1000, 3000);
+        populateIndex(indexName, documentCount);
+
+        final SnapshotInfo snapshotInfo = createFullSnapshot(fsRepoName, snapshotName);
+
+        assertAcked(client().admin().indices().prepareDelete(indexName));
+
+        mountSnapshot(fsRepoName, snapshotName, indexName, restoredIndexName, Settings.EMPTY);
+        ensureGreen(restoredIndexName);
+        assertBusy(() -> assertThat(getRecoveryState(restoredIndexName).getStage(), equalTo(RecoveryState.Stage.DONE)));
+
+        for (CacheService cacheService : internalCluster().getDataNodeInstances(CacheService.class)) {
+            cacheService.synchronizeCache();
+        }
+
+        internalCluster().restartRandomDataNode();
+        ensureGreen(restoredIndexName);
+
+        final Index restoredIndex = client().admin()
+            .cluster()
+            .prepareState()
+            .clear()
+            .setMetadata(true)
+            .get()
+            .getState()
+            .metadata()
+            .index(restoredIndexName)
+            .getIndex();
+
+        assertExecutorIsIdle(SearchableSnapshotsConstants.CACHE_PREWARMING_THREAD_POOL_NAME);
+        assertExecutorIsIdle(SearchableSnapshotsConstants.CACHE_FETCH_ASYNC_THREAD_POOL_NAME);
+
+        RecoveryState recoveryState = getRecoveryState(restoredIndexName);
+
+        assertThat(recoveryState.getStage(), equalTo(RecoveryState.Stage.DONE));
+
+        long recoveredBytes = recoveryState.getIndex().recoveredBytes();
+        long physicalCacheSize = getPhysicalCacheSize(restoredIndex, snapshotInfo.snapshotId().getUUID());
+
+        assertThat("Expected to reuse all data from the persistent cache but it didn't", 0L, equalTo(recoveredBytes));
+
+        final Repository repository = internalCluster().getDataNodeInstance(RepositoriesService.class).repository(fsRepoName);
+        assertThat(repository, instanceOf(BlobStoreRepository.class));
+        final BlobStoreRepository blobStoreRepository = (BlobStoreRepository) repository;
+
+        final RepositoryData repositoryData = ESBlobStoreRepositoryIntegTestCase.getRepositoryData(repository);
+        final IndexId indexId = repositoryData.resolveIndexId(indexName);
+        long inMemoryCacheSize = 0;
+        long expectedPhysicalCacheSize = 0;
+        for (int shardId = 0; shardId < numberOfShards; shardId++) {
+            final BlobStoreIndexShardSnapshot snapshot = blobStoreRepository.loadShardSnapshot(
+                blobStoreRepository.shardContainer(indexId, shardId),
+                snapshotInfo.snapshotId()
+            );
+            inMemoryCacheSize += snapshot.indexFiles()
+                .stream()
+                .filter(f -> f.metadata().hashEqualsContents())
+                .mapToLong(BlobStoreIndexShardSnapshot.FileInfo::length)
+                .sum();
+
+            expectedPhysicalCacheSize += snapshot.indexFiles()
+                .stream()
+                .filter(f -> f.metadata().hashEqualsContents() == false)
+                .mapToLong(BlobStoreIndexShardSnapshot.FileInfo::length)
+                .sum();
+        }
+
+        assertThat(physicalCacheSize, equalTo(expectedPhysicalCacheSize));
+        assertThat(physicalCacheSize + inMemoryCacheSize, equalTo(recoveryState.getIndex().reusedBytes()));
+        assertThat("Expected to recover 100% of files", recoveryState.getIndex().recoveredBytesPercent(), equalTo(100.0f));
+
+        for (RecoveryState.FileDetail fileDetail : recoveryState.getIndex().fileDetails()) {
+            assertThat(fileDetail.name() + " wasn't mark as reused", fileDetail.reused(), equalTo(true));
+        }
+    }
+
+    private RecoveryState getRecoveryState(String indexName) {
+        final RecoveryResponse recoveryResponse = client().admin().indices().prepareRecoveries(indexName).get();
+        Map<String, List<RecoveryState>> shardRecoveries = recoveryResponse.shardRecoveryStates();
+        assertThat(shardRecoveries.containsKey(indexName), equalTo(true));
+        List<RecoveryState> recoveryStates = shardRecoveries.get(indexName);
+        assertThat(recoveryStates.size(), equalTo(1));
+        return recoveryStates.get(0);
     }
 
     @SuppressForbidden(reason = "Uses FileSystem APIs")
@@ -147,5 +253,29 @@ public class SearchableSnapshotRecoveryStateIntegrationTests extends BaseSearcha
 
     private DiscoveryNodes getDiscoveryNodes() {
         return client().admin().cluster().prepareState().clear().setNodes(true).get().getState().nodes();
+    }
+
+    /**
+     * A fs repository plugin that allows using its methods from any thread
+     */
+    public static class TestRepositoryPlugin extends Plugin implements RepositoryPlugin {
+        @Override
+        public Map<String, Repository.Factory> getRepositories(
+            Environment env,
+            NamedXContentRegistry namedXContentRegistry,
+            ClusterService clusterService,
+            BigArrays bigArrays,
+            RecoverySettings recoverySettings
+        ) {
+            return Collections.singletonMap(
+                "test-fs",
+                (metadata) -> new FsRepository(metadata, env, namedXContentRegistry, clusterService, bigArrays, recoverySettings) {
+                    @Override
+                    protected void assertSnapshotOrGenericThread() {
+                        // ignore
+                    }
+                }
+            );
+        }
     }
 }

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/CacheFile.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/CacheFile.java
@@ -163,6 +163,13 @@ public class CacheFile {
         return tracker.getCompletedRanges();
     }
 
+    /**
+     * Number of bytes that were present on the persistent when this cache file was created
+     */
+    public long getInitialLength() {
+        return tracker.getInitialLength();
+    }
+
     public void acquire(final EvictionListener listener) throws IOException {
         assert listener != null;
 

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/CachedBlobContainerIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/CachedBlobContainerIndexInput.java
@@ -435,8 +435,9 @@ public class CachedBlobContainerIndexInput extends BaseSearchableSnapshotIndexIn
 
     /**
      * Prefetches a complete part and writes it in cache. This method is used to prewarm the cache.
+     * @return a tuple with {@code Tuple<Persistent Cache Length, Prefetched Length>} values
      */
-    public void prefetchPart(final int part) throws IOException {
+    public Tuple<Long, Long> prefetchPart(final int part) throws IOException {
         ensureContext(ctx -> ctx == CACHE_WARMING_CONTEXT);
         if (part >= fileInfo.numberOfParts()) {
             throw new IllegalArgumentException("Unexpected part number [" + part + "]");
@@ -456,7 +457,7 @@ public class CachedBlobContainerIndexInput extends BaseSearchableSnapshotIndexIn
                     partRange.v2(),
                     cacheFileReference
                 );
-                return;
+                return Tuple.tuple(cacheFile.getInitialLength(), 0L);
             }
 
             final long rangeStart = range.v1();
@@ -511,6 +512,7 @@ public class CachedBlobContainerIndexInput extends BaseSearchableSnapshotIndexIn
                 stats.addCachedBytesWritten(totalBytesWritten.get(), endTimeNanos - startTimeNanos);
             }
             assert totalBytesRead == rangeLength;
+            return Tuple.tuple(cacheFile.getInitialLength(), rangeLength);
         } catch (final Exception e) {
             throw new IOException("Failed to prefetch file part in cache", e);
         }

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/SparseFileTracker.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/SparseFileTracker.java
@@ -38,6 +38,12 @@ public class SparseFileTracker {
     private final long length;
 
     /**
+     * Number of bytes that were initially present in the case where the sparse file tracker was initialized with some completed ranges.
+     * See {@link #SparseFileTracker(String, long, SortedSet)}
+     */
+    private final long initialLength;
+
+    /**
      * Creates a new empty {@link SparseFileTracker}
      *
      * @param description a description for the sparse file tracker
@@ -60,6 +66,7 @@ public class SparseFileTracker {
         if (length < 0) {
             throw new IllegalArgumentException("Length [" + length + "] must be equal to or greater than 0 for [" + description + "]");
         }
+        long initialLength = 0;
         if (ranges.isEmpty() == false) {
             synchronized (mutex) {
                 Range previous = null;
@@ -77,10 +84,12 @@ public class SparseFileTracker {
                     final boolean added = this.ranges.add(range);
                     assert added : range + " already exist in " + this.ranges;
                     previous = range;
+                    initialLength += range.end - range.start;
                 }
                 assert invariant();
             }
         }
+        this.initialLength = initialLength;
     }
 
     public long getLength() {
@@ -102,6 +111,15 @@ public class SparseFileTracker {
             }
         }
         return completedRanges == null ? Collections.emptySortedSet() : completedRanges;
+    }
+
+    /**
+     * Returns the number of bytes that were initially present in the case where the sparse file tracker was initialized with some
+     * completed ranges.
+     * See {@link #SparseFileTracker(String, long, SortedSet)}
+     */
+    public long getInitialLength() {
+        return initialLength;
     }
 
     /**

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/indices/recovery/SearchableSnapshotRecoveryState.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/indices/recovery/SearchableSnapshotRecoveryState.java
@@ -60,6 +60,11 @@ public final class SearchableSnapshotRecoveryState extends RecoveryState {
         index.addFileToIgnore(name);
     }
 
+    public synchronized void markIndexFileAsReused(String name) {
+        SearchableSnapshotRecoveryState.Index index = (Index) getIndex();
+        index.markFileAsReused(name);
+    }
+
     private static final class Index extends RecoveryState.Index {
         // We ignore the files that won't be part of the pre-warming
         // phase since the information for those files won't be
@@ -84,6 +89,10 @@ public final class SearchableSnapshotRecoveryState extends RecoveryState {
             }
 
             super.addFileDetail(name, length, reused);
+        }
+
+        private synchronized void markFileAsReused(String name) {
+            ((SearchableSnapshotRecoveryFilesDetails) fileDetails).markFileAsReused(name);
         }
 
         // We have to bypass all the calls to the timer
@@ -118,6 +127,12 @@ public final class SearchableSnapshotRecoveryState extends RecoveryState {
                 + "] and ["
                 + length
                 + "]";
+        }
+
+        void markFileAsReused(String name) {
+            final FileDetail fileDetail = fileDetails.get(name);
+            assert fileDetail != null;
+            fileDetails.put(name, new FileDetail(fileDetail.name(), fileDetail.length(), true));
         }
 
         @Override


### PR DESCRIPTION
Before this commit we were marking all files as recovered during searchable
snapshots pre-warm phase. After introducing the persistent cache, it's possible
that some of these files are already on disk and are in fact reused. This commit
takes that fact into account and mark files that are in the persistent cache as
reused.

Backport of #67425
