### PR TITLE
Add assertion message when decrementing cache file

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/CacheFile.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/CacheFile.java
@@ -228,7 +228,21 @@ public class CacheFile {
 
     private void decrementRefCount() {
         final boolean released = refCounter.decRef();
-        assert released == false || (evicted.get() && Files.notExists(file));
+        assert assertRefCounted(released);
+    }
+
+    private boolean assertRefCounted(boolean isReleased) {
+        final boolean isEvicted = evicted.get();
+        final boolean notExists = Files.notExists(file);
+        assert isReleased == false || (isEvicted && notExists) : "fully released cache file should be deleted from disk but got ["
+            + "released="
+            + isReleased
+            + ", evicted="
+            + isEvicted
+            + ", file not exists="
+            + notExists
+            + ']';
+        return true;
     }
 
     /**
@@ -487,7 +501,7 @@ public class CacheFile {
                     }
                 }
             } finally {
-                refCounter.decRef();
+                decrementRefCount();
             }
         } else {
             assert evicted.get();


### PR DESCRIPTION
This assertion sometimes trips on CI on windows platforms (not seen yet on other OS):
```
Caused by:
        java.lang.AssertionError
            at __randomizedtesting.SeedInfo.seed([D42780D060BE4562]:0)
            at org.elasticsearch.index.store.cache.CacheFile.decrementRefCount(CacheFile.java:231)
            at org.elasticsearch.index.store.cache.CacheFile.startEviction(CacheFile.java:243)
            at org.elasticsearch.core.internal.io.IOUtils.close(IOUtils.java:74)
            at org.elasticsearch.core.internal.io.IOUtils.closeWhileHandlingException(IOUtils.java:164)
            at org.elasticsearch.xpack.searchablesnapshots.cache.CacheService.onCacheFileRemoval(CacheService.java:518)
            at org.elasticsearch.xpack.searchablesnapshots.cache.CacheService.lambda$new$1(CacheService.java:170)
            at org.elasticsearch.common.cache.Cache.delete(Cache.java:799)
            at org.elasticsearch.common.cache.Cache.lambda$new$6(Cache.java:499)
            at org.elasticsearch.common.cache.Cache$CacheSegment.remove(Cache.java:316)
            at org.elasticsearch.common.cache.Cache.invalidate(Cache.java:529)
            at org.elasticsearch.xpack.searchablesnapshots.cache.CacheService.processShardEviction(CacheService.java:429)
            at org.elasticsearch.xpack.searchablesnapshots.cache.CacheService$1.doRun(CacheService.java:365)
            at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:37)
            at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
            at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
            at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingRunnable.run(ThreadContext.java:680)
            at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
            at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
            at java.base/java.lang.Thread.run(Thread.java:834)
```

Examples of build scans where the assertion tripped:

- https://gradle-enterprise.elastic.co/s/b4kt7gmw7xujs
- https://gradle-enterprise.elastic.co/s/3gjo4ixeuwxsu

I'm not sure of what is happening but it is worth having a better description for this assertion. Also, when fsyncing is done and decrements the refcounter it is worth to also assert the result.