### PR TITLE
[7.x] Fix vendor identification in FIPS 140-2 CI (#67551)

### DIFF
--- a/gradle/fips.gradle
+++ b/gradle/fips.gradle
@@ -23,7 +23,7 @@ if (BuildParams.inFipsJvm) {
       }
     } else {
       fipsSecurity = new File(fipsResourcesDir,
-        BuildParams.runtimeJavaDetails.toLowerCase().contains()('oracle') ? 'fips_java_oracle.security' : 'fips_java_bcjsse_11.security')
+        BuildParams.runtimeJavaDetails.toLowerCase().contains('oracle') ? 'fips_java_oracle.security' : 'fips_java_bcjsse_11.security')
       fipsPolicy = new File(fipsResourcesDir, "fips_java_bcjsse_11.policy")
     }
     File fipsTrustStore = new File(fipsResourcesDir, 'cacerts.bcfks')

--- a/gradle/fips.gradle
+++ b/gradle/fips.gradle
@@ -23,7 +23,7 @@ if (BuildParams.inFipsJvm) {
       }
     } else {
       fipsSecurity = new File(fipsResourcesDir,
-        BuildParams.runtimeJavaDetails.startsWith('Oracle') ? 'fips_java_oracle.security' : 'fips_java_bcjsse_11.security')
+        BuildParams.runtimeJavaDetails.toLowerCase().contains()('oracle') ? 'fips_java_oracle.security' : 'fips_java_bcjsse_11.security')
       fipsPolicy = new File(fipsResourcesDir, "fips_java_bcjsse_11.policy")
     }
     File fipsTrustStore = new File(fipsResourcesDir, 'cacerts.bcfks')


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fix vendor identification in FIPS 140-2 CI (#67551)