### PR TITLE
Autoscaling hide test setup in docs

### DIFF
--- a/docs/reference/autoscaling/apis/delete-autoscaling-policy.asciidoc
+++ b/docs/reference/autoscaling/apis/delete-autoscaling-policy.asciidoc
@@ -13,6 +13,7 @@ Delete autoscaling policy.
 [[autoscaling-delete-autoscaling-policy-request]]
 ==== {api-request-title}
 
+//////////////////////////
 [source,console]
 --------------------------------------------------
 PUT /_autoscaling/policy/my_autoscaling_policy
@@ -25,6 +26,7 @@ PUT /_autoscaling/policy/my_autoscaling_policy
 }
 --------------------------------------------------
 // TESTSETUP
+//////////////////////////
 
 [source,console]
 --------------------------------------------------

--- a/docs/reference/autoscaling/apis/get-autoscaling-policy.asciidoc
+++ b/docs/reference/autoscaling/apis/get-autoscaling-policy.asciidoc
@@ -13,6 +13,7 @@ Get autoscaling policy.
 [[autoscaling-get-autoscaling-policy-request]]
 ==== {api-request-title}
 
+//////////////////////////
 [source,console]
 --------------------------------------------------
 PUT /_autoscaling/policy/my_autoscaling_policy
@@ -26,7 +27,6 @@ PUT /_autoscaling/policy/my_autoscaling_policy
 --------------------------------------------------
 // TESTSETUP
 
-//////////////////////////
 
 [source,console]
 --------------------------------------------------


### PR DESCRIPTION
Two APIs showed the test setup in docs, now hidden.

