### PR TITLE
Add deprecation warnings handling to GET /index requests in tests.

### DIFF
--- a/qa/mixed-cluster/src/test/java/org/elasticsearch/backwards/SearchWithMinCompatibleSearchNodeIT.java
+++ b/qa/mixed-cluster/src/test/java/org/elasticsearch/backwards/SearchWithMinCompatibleSearchNodeIT.java
@@ -66,7 +66,7 @@ public class SearchWithMinCompatibleSearchNodeIT extends ESRestTestCase {
         bwcVersion = bwcNodes.get(0).getVersion();
         newVersion = newNodes.get(0).getVersion();
 
-        if (client().performRequest(new Request("HEAD", "/" + index)).getStatusLine().getStatusCode() == 404) {
+        if (indexExists(index) == false) {
             createIndex(index, Settings.builder()
                 .put(IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), numShards)
                 .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, numReplicas).build());

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -1252,7 +1252,15 @@ public abstract class ESRestTestCase extends ESTestCase {
     }
 
     protected static boolean indexExists(String index) throws IOException {
-        Response response = client().performRequest(new Request("HEAD", "/" + index));
+        final Request getRequest = new Request("HEAD", "/" + index);
+        getRequest.setOptions(expectVersionSpecificWarnings(v -> {
+            final String typesWarning = "[types removal] The parameter include_type_name should be explicitly specified in get indices " +
+                "requests to prepare for 7.0. In 7.0 include_type_name will default to 'false', which means responses will omit the type " +
+                "name in mapping definitions.";
+            v.current(typesWarning);
+            v.compatible(typesWarning);
+        }));
+        Response response = client().performRequest(getRequest);
         return RestStatus.OK.getStatus() == response.getStatusLine().getStatusCode();
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -1257,7 +1257,6 @@ public abstract class ESRestTestCase extends ESTestCase {
             final String typesWarning = "[types removal] The parameter include_type_name should be explicitly specified in get indices " +
                 "requests to prepare for 7.0. In 7.0 include_type_name will default to 'false', which means responses will omit the type " +
                 "name in mapping definitions.";
-            v.current(typesWarning);
             v.compatible(typesWarning);
         }));
         Response response = client().performRequest(getRequest);


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/67571