### PR TITLE
[7.x] Fix typo in autoscaling policy doc (#67575)

### DIFF
--- a/docs/reference/autoscaling/apis/delete-autoscaling-policy.asciidoc
+++ b/docs/reference/autoscaling/apis/delete-autoscaling-policy.asciidoc
@@ -47,7 +47,7 @@ This API deletes an autoscaling policy with the provided name.
 [[autoscaling-delete-autoscaling-policy-examples]]
 ==== {api-examples-title}
 
-This example deletes an autoscaling policy named `my_autosaling_policy`.
+This example deletes an autoscaling policy named `my_autoscaling_policy`.
 
 [source,console]
 --------------------------------------------------

--- a/docs/reference/autoscaling/apis/get-autoscaling-policy.asciidoc
+++ b/docs/reference/autoscaling/apis/get-autoscaling-policy.asciidoc
@@ -58,7 +58,7 @@ This API gets an autoscaling policy with the provided name.
 [[autoscaling-get-autoscaling-policy-examples]]
 ==== {api-examples-title}
 
-This example gets an autoscaling policy named `my_autosaling_policy`.
+This example gets an autoscaling policy named `my_autoscaling_policy`.
 
 [source,console]
 --------------------------------------------------


### PR DESCRIPTION
Backports the following commits to 7.x:
- Fix typo in autoscaling policy doc (#67575)