### PR TITLE
[ML] [DOCS] adding missing fields to the get trained models API docs

### DIFF
--- a/docs/reference/ml/df-analytics/apis/get-trained-models.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-trained-models.asciidoc
@@ -151,23 +151,23 @@ Classification configuration for inference.
 .Properties of classification inference
 [%collapsible%open]
 ======
-`num_top_classes`:::::
+`num_top_classes`::::
 (integer)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-classification-num-top-classes]
 
-`num_top_feature_importance_values`:::::
+`num_top_feature_importance_values`::::
 (integer)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-classification-num-top-feature-importance-values]
 
-`prediction_field_type`:::::
+`prediction_field_type`::::
 (string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-classification-prediction-field-type]
 
-`results_field`:::::
+`results_field`::::
 (string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-results-field]
 
-`top_classes_results_field`:::::
+`top_classes_results_field`::::
 (string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-classification-top-classes-results-field]
 ======
@@ -178,11 +178,11 @@ Regression configuration for inference.
 .Properties of regression inference
 [%collapsible%open]
 ======
-`num_top_feature_importance_values`:::::
+`num_top_feature_importance_values`::::
 (integer)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-regression-num-top-feature-importance-values]
 
-`results_field`:::::
+`results_field`::::
 (string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-results-field]
 ======

--- a/docs/reference/ml/df-analytics/apis/get-trained-models.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-trained-models.asciidoc
@@ -113,10 +113,6 @@ Information on the creator of the trained model.
 (<<time-units,time units>>)
 The time when the trained model was created.
 
-`description`:::
-(string)
-The free-text description of the trained model.
-
 `default_field_map` :::
 (object)
 A string to string object that contains the default field map to use
@@ -126,6 +122,10 @@ The analytics job would then supply a default field map entry for
 `"foo" : "foo.keyword"`.
 +
 Any field map described in the inference configuration takes precedence.
+
+`description`:::
+(string)
+The free-text description of the trained model.
 
 `estimated_heap_memory_usage_bytes`:::
 (integer)
@@ -144,22 +144,6 @@ or `classification` configuration. It must match the underlying
 .Properties of `inference_config`
 [%collapsible%open]
 =====
-`regression`::::
-(object)
-Regression configuration for inference.
-+
-.Properties of regression inference
-[%collapsible%open]
-======
-`num_top_feature_importance_values`:::::
-(integer)
-include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-regression-num-top-feature-importance-values]
-
-`results_field`:::::
-(string)
-include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-results-field]
-======
-
 `classification`::::
 (object)
 Classification configuration for inference.
@@ -187,8 +171,22 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-results-field]
 (string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-classification-top-classes-results-field]
 ======
-=====
+`regression`::::
+(object)
+Regression configuration for inference.
++
+.Properties of regression inference
+[%collapsible%open]
+======
+`num_top_feature_importance_values`:::::
+(integer)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-regression-num-top-feature-importance-values]
 
+`results_field`:::::
+(string)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-results-field]
+======
+=====
 
 `input`:::
 (object)

--- a/docs/reference/ml/df-analytics/apis/get-trained-models.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-trained-models.asciidoc
@@ -151,23 +151,23 @@ Classification configuration for inference.
 .Properties of classification inference
 [%collapsible%open]
 ======
-`num_top_classes`::::
+`num_top_classes`:::
 (integer)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-classification-num-top-classes]
 
-`num_top_feature_importance_values`::::
+`num_top_feature_importance_values`:::
 (integer)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-classification-num-top-feature-importance-values]
 
-`prediction_field_type`::::
+`prediction_field_type`:::
 (string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-classification-prediction-field-type]
 
-`results_field`::::
+`results_field`:::
 (string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-results-field]
 
-`top_classes_results_field`::::
+`top_classes_results_field`:::
 (string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-classification-top-classes-results-field]
 ======
@@ -178,11 +178,11 @@ Regression configuration for inference.
 .Properties of regression inference
 [%collapsible%open]
 ======
-`num_top_feature_importance_values`::::
+`num_top_feature_importance_values`:::
 (integer)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-regression-num-top-feature-importance-values]
 
-`results_field`::::
+`results_field`:::
 (string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-results-field]
 ======

--- a/docs/reference/ml/df-analytics/apis/get-trained-models.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-trained-models.asciidoc
@@ -113,6 +113,10 @@ Information on the creator of the trained model.
 (<<time-units,time units>>)
 The time when the trained model was created.
 
+`description`:::
+(string)
+The free-text description of the trained model.
+
 `default_field_map` :::
 (object)
 A string to string object that contains the default field map to use
@@ -130,6 +134,73 @@ The estimated heap usage in bytes to keep the trained model in memory.
 `estimated_operations`:::
 (integer)
 The estimated number of operations to use the trained model.
+
+`inference_config`:::
+(object)
+The default configuration for inference. This can be either a `regression`
+or `classification` configuration. It must match the underlying
+`definition.trained_model`'s `target_type`.
++
+.Properties of `inference_config`
+[%collapsible%open]
+=====
+`regression`::::
+(object)
+Regression configuration for inference.
++
+.Properties of regression inference
+[%collapsible%open]
+======
+`num_top_feature_importance_values`:::::
+(integer)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-regression-num-top-feature-importance-values]
+
+`results_field`:::::
+(string)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-results-field]
+======
+
+`classification`::::
+(object)
+Classification configuration for inference.
++
+.Properties of classification inference
+[%collapsible%open]
+======
+`num_top_classes`:::::
+(integer)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-classification-num-top-classes]
+
+`num_top_feature_importance_values`:::::
+(integer)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-classification-num-top-feature-importance-values]
+
+`prediction_field_type`:::::
+(string)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-classification-prediction-field-type]
+
+`results_field`:::::
+(string)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-results-field]
+
+`top_classes_results_field`:::::
+(string)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-classification-top-classes-results-field]
+======
+=====
+
+
+`input`:::
+(object)
+The input field names for the model definition.+
++
+.Properties of `input`
+[%collapsible%open]
+=====
+`field_names`::::
+(string)
+An array of input field names for the model.
+=====
 
 `license_level`:::
 (string)
@@ -272,6 +343,7 @@ A comma delimited string of tags. A trained model can have many tags, or none.
 `version`:::
 (string)
 The {es} version number in which the trained model was created.
+
 ====
 
 


### PR DESCRIPTION
Adds missing fields `description`, `inference_config`, and `input` to the GET trained models API documentation