### PR TITLE
Fix painless tests in eclipse

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/api/Augmentation.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/api/Augmentation.java
@@ -695,14 +695,14 @@ public class Augmentation {
         return receiver.split(new LimitedCharSequence(input, receiver, limitFactor));
     }
 
-    public static String[] split​(Pattern receiver, int limitFactor, CharSequence input, int limit) {
+    public static String[] split(Pattern receiver, int limitFactor, CharSequence input, int limit) {
         if (limitFactor == UNLIMITED_PATTERN_FACTOR) {
             return receiver.split(input, limit);
         }
         return receiver.split(new LimitedCharSequence(input, receiver, limitFactor), limit);
     }
 
-    public static Stream<String> splitAsStream​(Pattern receiver, int limitFactor, CharSequence input) {
+    public static Stream<String> splitAsStream(Pattern receiver, int limitFactor, CharSequence input) {
         if (limitFactor == UNLIMITED_PATTERN_FACTOR) {
             return receiver.splitAsStream(input);
         }

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/RegexTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/RegexTests.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.painless;
 
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.script.ScriptException;
 
 import java.nio.CharBuffer;
@@ -30,15 +29,6 @@ import java.util.regex.Pattern;
 import static java.util.Collections.singletonMap;
 
 public class RegexTests extends ScriptTestCase {
-
-    @Override
-    protected Settings scriptEngineSettings() {
-        // Enable regexes just for this test. They are disabled by default.
-        return Settings.builder()
-                .put(CompilerSettings.REGEX_ENABLED.getKey(), true)
-                .build();
-    }
-
     public void testPatternAfterReturn() {
         assertEquals(true, exec("return 'foo' ==~ /foo/"));
         assertEquals(false, exec("return 'bar' ==~ /foo/"));
@@ -151,6 +141,10 @@ public class RegexTests extends ScriptTestCase {
     // Make sure some methods on Pattern are whitelisted
     public void testSplit() {
         assertArrayEquals(new String[] {"cat", "dog"}, (String[]) exec("/,/.split('cat,dog')"));
+    }
+
+    public void testSplitWithLimit() {
+        assertArrayEquals(new String[] {"cat", "dog,pig"}, (String[]) exec("/,/.split('cat,dog,pig', 2)"));
     }
 
     public void testSplitAsStream() {


### PR DESCRIPTION
`Augmentation.java` had a zero width space [1] in two method
definitions:
```
    public static String[] split(Pattern receiver, int limitFactor, CharSequence input, int limit) {
                                ^------- Right before the ( character
    public static Stream<String> splitAsStream(Pattern receiver, int limitFactor, CharSequence input) {
                                              ^ Right before the ( here too
```

Sadly, Eclipse and javac treat this character differently. Eclipse seems
to include it in the method name and javac seems to treat it as regular
space. This caused all the unit tests for painless to fail to load
because they couldn't find the `split` and `splitAsStream`
augmentations. But if you listed all of the methods they looked like
they were there. If you crack open the line in a hex editor you can see
it.

Eclipse is tracking [2] similar issues. This is an Eclipse bug but we really
probably don't want the zero width space in the source anyway.....

[1]: https://en.wikipedia.org/wiki/Zero-width_space
[2]: https://bugs.eclipse.org/bugs/show_bug.cgi?id=547601
