### PR TITLE
[ML] fix multi_encoding test failure

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/inference/preprocessing/MultiTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/inference/preprocessing/MultiTests.java
@@ -80,7 +80,7 @@ public class MultiTests extends AbstractXContentTestCase<Multi> {
                     OneHotEncodingTests.createRandom(),
                     NGramTests.createRandom()
                 )
-            ).limit(randomIntBetween(1, 10)).collect(Collectors.toList());
+            ).limit(randomIntBetween(2, 10)).collect(Collectors.toList());
         }
         return new Multi(processors, isCustom);
     }


### PR DESCRIPTION
needs to be at least two processors for multi_encoding definitions. 