### PR TITLE
Add Security Advisory to 7.10.2 release notes

### DIFF
--- a/docs/reference/release-notes/7.10.asciidoc
+++ b/docs/reference/release-notes/7.10.asciidoc
@@ -3,6 +3,18 @@
 
 Also see <<breaking-changes-7.10,Breaking changes in 7.10>>.
 
+[float]
+[[security-updates-7.9.0]]
+=== Security updates
+
+* An information disclosure flaw was found in the Elasticsearch async search API.
+Users who execute an async search will store the HTTP headers.
+An Elasticsearch user with the ability to read the .tasks index could obtain
+sensitive request headers of other users in the cluster.
+All versions of {es} between 7.7.0 and 7.10.1 are affected by this flaw.
+You must upgrade to {es} version 7.10.2 to obtain the fix.
+https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-22132[CVE-2021-22132]
+
 [[bug-7.10.2]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/7.10.asciidoc
+++ b/docs/reference/release-notes/7.10.asciidoc
@@ -7,9 +7,9 @@ Also see <<breaking-changes-7.10,Breaking changes in 7.10>>.
 [[security-updates-7.10.2]]
 === Security updates
 
-* An information disclosure flaw was found in the Elasticsearch async search API.
+* An information disclosure flaw was found in the {es} async search API.
 Users who execute an async search will store the HTTP headers.
-An Elasticsearch user with the ability to read the .tasks index could obtain
+A user with the ability to read the `.tasks` index could obtain
 sensitive request headers of other users in the cluster.
 All versions of {es} between 7.7.0 and 7.10.1 are affected by this flaw.
 You must upgrade to {es} version 7.10.2 to obtain the fix.

--- a/docs/reference/release-notes/7.10.asciidoc
+++ b/docs/reference/release-notes/7.10.asciidoc
@@ -3,7 +3,7 @@
 
 Also see <<breaking-changes-7.10,Breaking changes in 7.10>>.
 
-[float]
+[discrete]
 [[security-updates-7.10.2]]
 === Security updates
 

--- a/docs/reference/release-notes/7.10.asciidoc
+++ b/docs/reference/release-notes/7.10.asciidoc
@@ -4,7 +4,7 @@
 Also see <<breaking-changes-7.10,Breaking changes in 7.10>>.
 
 [float]
-[[security-updates-7.9.0]]
+[[security-updates-7.10.2]]
 === Security updates
 
 * An information disclosure flaw was found in the Elasticsearch async search API.


### PR DESCRIPTION
This adds a security advisory about https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-22132 to the 7.10.2 release notes