### PR TITLE
[7.x] [DOCS] Add test subs for rollover API docs (#67615)

### DIFF
--- a/docs/reference/rollup/apis/rollup-api.asciidoc
+++ b/docs/reference/rollup/apis/rollup-api.asciidoc
@@ -38,6 +38,9 @@ POST /my-index-000001/_rollup/rollup-my-index-000001
 }
 ----
 // TEST[setup:my_index]
+// TEST[s/my-keyword-field/http.request.method/]
+// TEST[s/my-other-keyword-field/user.id/]
+// TEST[s/my-numeric-field/http.response.bytes/]
 
 
 [[rollup-api-request]]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Add test subs for rollover API docs (#67615)