### PR TITLE
Stop ignoring exceptions in mock loggers

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/MockLogAppender.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/MockLogAppender.java
@@ -41,7 +41,7 @@ public class MockLogAppender extends AbstractAppender {
     private List<LoggingExpectation> expectations;
 
     public MockLogAppender() throws IllegalAccessException {
-        super("mock", RegexFilter.createFilter(".*(\n.*)*", new String[0], false, null, null), null);
+        super("mock", RegexFilter.createFilter(".*(\n.*)*", new String[0], false, null, null), null, false);
         /*
          * We use a copy-on-write array list since log messages could be appended while we are setting up expectations. When that occurs,
          * we would run into a concurrent modification exception from the iteration over the expectations in #append, concurrent with a


### PR DESCRIPTION
Today when testing loggers we use `MockLogAppender` which is configured
to ignore exceptions encountered during logging. These exceptions are
captured by the `StatusLogger` and ultimately cause tests to fail, but
the failure lacks the context we need to diagnose the problem.

This commit sets the `ignoreExceptions` flag to `false` on all
`MockLogAppender` objects so that exceptions are thrown to the caller
for a more informative debugging experience.

Relates #66630
Relates #67117