### PR TITLE
Relax CacheFile.decrementRefCount() assertion

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/CacheFile.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/CacheFile.java
@@ -240,14 +240,14 @@ public class CacheFile {
 
     private boolean assertRefCounted(boolean isReleased) {
         final boolean isEvicted = evicted.get();
-        final boolean notExists = Files.notExists(file);
-        assert isReleased == false || (isEvicted && notExists) : "fully released cache file should be deleted from disk but got ["
+        final boolean fileExists = Files.exists(file);
+        assert isReleased == false || (isEvicted && fileExists == false) : "fully released cache file should be deleted from disk but got ["
             + "released="
             + isReleased
             + ", evicted="
             + isEvicted
-            + ", file not exists="
-            + notExists
+            + ", file exists="
+            + fileExists
             + ']';
         return true;
     }


### PR DESCRIPTION
Some searchable snapshots related tests failed recently on CI for 
Windows platforms (#67579) with the following assertion tripping:

java.lang.AssertionError: fully released cache file should be 
deleted from disk but got [released=true, evicted=true, file not exists=false]
 at __randomizedtesting.SeedInfo.seed([F459F30E820622D8]:0)
  at org.elasticsearch.index.store.cache.CacheFile.assertRefCounted(CacheFile.java:244)
 at org.elasticsearch.index.store.cache.CacheFile.decrementRefCount(CacheFile.java:238)

In #67561 we improved the description of the assertion to show 
more information about the released/evicted/file status. It confirms 
that Files.notExists(file) sometimes returns false on Windows 
platforms. The assertion never tripped on non-Windows platforms
 so far.

The false value does not necessary means that the file exists; this 
value is also returned when the JVM cannot determine the status 
of the file. Since some cache files are evicted soon after the parent's 
directory is deleted (shard was removed from disk) it seems that on 
Windows it is not possible to be sure of the file non-existence.

I think it's simpler to check if the file exists and fails if it's true.

Close #67633
Backport of #67633 for 7.12.0
