### PR TITLE
Skip translog phase on recovery state for searchable snapshots

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
@@ -101,6 +101,11 @@ public class RecoveryState implements ToXContentFragment, Writeable {
         }
     }
 
+    public enum IndexType {
+        REGULAR,
+        SEARCHABLE_SNAPSHOT;
+    }
+
     private Stage stage;
 
     private final Index index;
@@ -177,6 +182,9 @@ public class RecoveryState implements ToXContentFragment, Writeable {
         return this.stage;
     }
 
+    public IndexType getIndexType() {
+        return IndexType.REGULAR;
+    }
 
     protected void validateAndSetStage(Stage expected, Stage next) {
         if (stage != expected) {

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsRelocationIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsRelocationIntegTests.java
@@ -89,7 +89,7 @@ public class SearchableSnapshotsRelocationIntegTests extends BaseSearchableSnaps
             assertEquals(secondDataNode, shardRecoveryState.getTargetNode().getName());
         });
 
-        assertBusy(() -> assertSame(RecoveryState.Stage.TRANSLOG, getActiveRelocations(restoredIndex).get(0).getStage()));
+        assertBusy(() -> assertSame(RecoveryState.Stage.FINALIZE, getActiveRelocations(restoredIndex).get(0).getStage()));
         final Index restoredIdx = clusterAdmin().prepareState().get().getState().metadata().index(restoredIndex).getIndex();
         final IndicesService indicesService = internalCluster().getInstance(IndicesService.class, secondDataNode);
         assertEquals(1, indicesService.indexService(restoredIdx).getShard(0).outstandingCleanFilesConditions());
@@ -123,9 +123,7 @@ public class SearchableSnapshotsRelocationIntegTests extends BaseSearchableSnaps
             .shardRecoveryStates()
             .get(restoredIndex)
             .stream()
-            // filter for relocations that are not in stage FINALIZE (they could end up in this stage without progress for good if the
-            // target node does not have enough cache space available to hold the primary completely
-            .filter(recoveryState -> recoveryState.getSourceNode() != null && recoveryState.getStage() != RecoveryState.Stage.FINALIZE)
+            .filter(recoveryState -> recoveryState.getSourceNode() != null)
             .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
This commit introduces a change where searchable snapshots
skip the TRANSLOG stage. Since #65531 was introduced, the
cleanFiles peer recovery stage is blocked until pre-warming
completes (this is done to avoid search latency spikes due to a cold
cache). In that phase, the RecoveryState stage is
TRANSLOG which can be confusing as we don't replay
any ops during searchable snapshots recoveries. In order
to avoid that confusion we transition directly to a new stage named
PRE_WARMING only used for searchable snapshots.
