### PR TITLE
Remove unused typeText field from DocumentMapper

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -24,7 +24,6 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchGenerationException;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.compress.CompressedXContent;
-import org.elasticsearch.common.text.Text;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -92,7 +91,6 @@ public class DocumentMapper implements ToXContentFragment {
     }
 
     private final String type;
-    private final Text typeText;
     private final CompressedXContent mappingSource;
     private final DocumentParser documentParser;
     private final MappingLookup mappingLookup;
@@ -104,7 +102,6 @@ public class DocumentMapper implements ToXContentFragment {
                            DocumentParser documentParser,
                            Mapping mapping) {
         this.type = mapping.root().name();
-        this.typeText = new Text(this.type);
         this.documentParser = documentParser;
         this.mappingLookup = MappingLookup.fromMapping(mapping, documentParser, indexSettings, indexAnalyzers);
 
@@ -130,10 +127,6 @@ public class DocumentMapper implements ToXContentFragment {
 
     public String type() {
         return this.type;
-    }
-
-    public Text typeText() {
-        return this.typeText;
     }
 
     public Map<String, Object> meta() {


### PR DESCRIPTION
This is a leftover from types removal.