### PR TITLE
[7.x] ILM: ShrinkStep ignores the isAcknowledged flag on the response (#67591)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ShrinkStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ShrinkStep.java
@@ -62,7 +62,10 @@ public class ShrinkStep extends AsyncActionStep {
         resizeRequest.getTargetIndexRequest().settings(relevantTargetSettings);
 
         getClient().admin().indices().resizeIndex(resizeRequest, ActionListener.wrap(response -> {
-            listener.onResponse(response.isAcknowledged());
+            // Hard coding this to true as the resize request was executed and the corresponding cluster change was committed, so the
+            // eventual retry will not be able to succeed anymore (shrunk index was created already)
+            // The next step in the ShrinkAction will wait for the shrunk index to be created and for the shards to be allocated.
+            listener.onResponse(true);
         }, listener::onFailure));
 
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ShrinkStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ShrinkStepTests.java
@@ -124,7 +124,7 @@ public class ShrinkStepTests extends AbstractStepTestCase<ShrinkStep> {
         Mockito.verify(indicesClient, Mockito.only()).resizeIndex(Mockito.any(), Mockito.any());
     }
 
-    public void testPerformActionNotComplete() throws Exception {
+    public void testPerformActionIsCompleteForUnAckedRequests() throws Exception {
         LifecycleExecutionState.Builder lifecycleState = LifecycleExecutionState.builder();
         lifecycleState.setIndexCreationDate(randomNonNegativeLong());
         IndexMetadata indexMetadata = IndexMetadata.builder(randomAlphaOfLength(10)).settings(settings(Version.CURRENT))
@@ -153,7 +153,7 @@ public class ShrinkStepTests extends AbstractStepTestCase<ShrinkStep> {
             }
         });
 
-        assertEquals(false, actionCompleted.get());
+        assertEquals(true, actionCompleted.get());
 
         Mockito.verify(client, Mockito.only()).admin();
         Mockito.verify(adminClient, Mockito.only()).indices();


### PR DESCRIPTION
The ShrinkStep only reported complete if the resize request was acked. If the isAcknowledged
flag is false though, ILM will not move to the next step, but remain on the ShrinkStep
 and it will attempt to re-execute the step on a master failover. However, the resize request
 was executed and the corresponding cluster change was committed, so the eventual retry will
not be able to succeed anymore.

This change makes the ShrinkStep report as complete when a successful (acked or not) `ResizeResponse`
is received. The following step in the ShrinkAction, `shrunk-shards-allocated`, will
wait for the shrunk index to be created and for the shards to be allocated.

(cherry picked from commit 931bb0f87369a6cada9e73583958b96010307b0a)
Signed-off-by: Andrei Dan <andrei.dan@elastic.co>

Backport of #67591
