### PR TITLE
Remove unnecessary code when reading CacheFile

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/CachedBlobContainerIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/CachedBlobContainerIndexInput.java
@@ -288,7 +288,9 @@ public class CachedBlobContainerIndexInput extends BaseSearchableSnapshotIndexIn
                 + (position + length)
                 + "] vs "
                 + rangeToWrite;
+
             final Tuple<Long, Long> rangeToRead = Tuple.tuple(position, position + length);
+            assert rangeToRead.v2() - rangeToRead.v1() == b.remaining() : b.remaining() + " vs " + rangeToRead;
 
             final Future<Integer> populateCacheFuture = cacheFile.populateAndRead(
                 rangeToWrite,


### PR DESCRIPTION
The code that is removed in pull request has been introduced when Lucene was upgrade to 8.6.0, in which `BufferedIndexInput` read method is changed to use a `ByteBuffer` instead of a fixed buffer.

The range to read here is computed from the ByteBuffer position and remaining bytes so it should never exceed the ByteBuffer's remaining bytes. Also, Lucene guarantees that the `ByteBuffer` [never read more bytes than the file total length](https://github.com/apache/lucene-solr/blob/branch_8_8/lucene/core/src/java/org/apache/lucene/store/BufferedIndexInput.java#L150-L151) so I think we can safely remove this unnecessary code.