### PR TITLE
[ML] Remove DFA job states reindexing and analyzing from docs

### DIFF
--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
@@ -515,8 +515,7 @@ percentage.
 
 `state`:::
 (string) The status of the {dfanalytics-job}, which can be one of the following
-values: `analyzing`, `failed`, `reindexing`, `started`, `starting`,`stopping`, 
-`stopped`.
+values: `failed`, `started`, `starting`,`stopping`, `stopped`.
 ====
 //End of data_frame_analytics
 


### PR DESCRIPTION
These states do no longer exist as of #67423
