### PR TITLE
[7.x][ML] Remove DFA job states reindexing and analyzing from docs (#…

### DIFF
--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
@@ -516,8 +516,7 @@ percentage.
 
 `state`:::
 (string) The status of the {dfanalytics-job}, which can be one of the following
-values: `analyzing`, `failed`, `reindexing`, `started`, `starting`, `stopped`,
-`stopping`.
+values: `failed`, `started`, `starting`,`stopping`, `stopped`.
 ====
 //End of data_frame_analytics
 


### PR DESCRIPTION
…67658)

These states do no longer exist as of #67423

Backport of #67658
