### PR TITLE
removing extra double quote from example

### DIFF
--- a/x-pack/docs/en/watcher/trigger/schedule/cron.asciidoc
+++ b/x-pack/docs/en/watcher/trigger/schedule/cron.asciidoc
@@ -48,7 +48,7 @@ minute during the weekend:
   "trigger" : {
     "schedule" : {
       "cron" : [
-        "0 0/2 * ? * MON-FRI"",
+        "0 0/2 * ? * MON-FRI",
         "0 1-59/2 * ? * SAT-SUN"
       ]
     }


### PR DESCRIPTION
fixing a typo in the example