### PR TITLE
[7.x][ML] Improve resuming a DFA job stopped during inference (#67623)

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -750,7 +750,6 @@ public class MachineLearning extends Plugin implements SystemIndexPlugin,
             analyticsProcessFactory,
             dataFrameAnalyticsAuditor,
             trainedModelProvider,
-            modelLoadingService,
             resultsPersisterService,
             EsExecutors.allocatedProcessors(settings));
         MemoryUsageEstimationProcessManager memoryEstimationProcessManager =
@@ -759,8 +758,9 @@ public class MachineLearning extends Plugin implements SystemIndexPlugin,
         DataFrameAnalyticsConfigProvider dataFrameAnalyticsConfigProvider = new DataFrameAnalyticsConfigProvider(client, xContentRegistry,
             dataFrameAnalyticsAuditor);
         assert client instanceof NodeClient;
-        DataFrameAnalyticsManager dataFrameAnalyticsManager = new DataFrameAnalyticsManager((NodeClient) client, clusterService,
-            dataFrameAnalyticsConfigProvider, analyticsProcessManager, dataFrameAnalyticsAuditor, indexNameExpressionResolver);
+        DataFrameAnalyticsManager dataFrameAnalyticsManager = new DataFrameAnalyticsManager(settings, (NodeClient) client, threadPool,
+            clusterService, dataFrameAnalyticsConfigProvider, analyticsProcessManager, dataFrameAnalyticsAuditor,
+            indexNameExpressionResolver, resultsPersisterService, modelLoadingService);
         this.dataFrameAnalyticsManager.set(dataFrameAnalyticsManager);
 
         // Components shared by anomaly detection and data frame analytics

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsAction.java
@@ -268,6 +268,7 @@ public class TransportStartDataFrameAnalyticsAction
                         break;
                     case RESUMING_REINDEXING:
                     case RESUMING_ANALYZING:
+                    case RESUMING_INFERENCE:
                         toValidateMappingsListener.onResponse(startContext);
                         break;
                     case FINISHED:

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsTask.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsTask.java
@@ -287,7 +287,7 @@ public class DataFrameAnalyticsTask extends AllocatedPersistentTask implements S
      * {@code FINISHED} means the job had finished.
      */
     public enum StartingState {
-        FIRST_TIME, RESUMING_REINDEXING, RESUMING_ANALYZING, FINISHED
+        FIRST_TIME, RESUMING_REINDEXING, RESUMING_ANALYZING, RESUMING_INFERENCE, FINISHED
     }
 
     public StartingState determineStartingState() {
@@ -312,6 +312,9 @@ public class DataFrameAnalyticsTask extends AllocatedPersistentTask implements S
 
         if (ProgressTracker.REINDEXING.equals(lastIncompletePhase.getPhase())) {
             return lastIncompletePhase.getProgressPercent() == 0 ? StartingState.FIRST_TIME : StartingState.RESUMING_REINDEXING;
+        }
+        if (ProgressTracker.INFERENCE.equals(lastIncompletePhase.getPhase())) {
+            return StartingState.RESUMING_INFERENCE;
         }
         return StartingState.RESUMING_ANALYZING;
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/DataFrameDataExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/DataFrameDataExtractor.java
@@ -99,7 +99,7 @@ public class DataFrameDataExtractor {
     }
 
     public void cancel() {
-        LOGGER.debug("[{}] Data extractor was cancelled", context.jobId);
+        LOGGER.debug(() -> new ParameterizedMessage("[{}] Data extractor was cancelled", context.jobId));
         isCancelled = true;
     }
 
@@ -127,7 +127,7 @@ public class DataFrameDataExtractor {
             // We've set allow_partial_search_results to false which means if something
             // goes wrong the request will throw.
             SearchResponse searchResponse = request.get();
-            LOGGER.debug("[{}] Search response was obtained", context.jobId);
+            LOGGER.trace(() -> new ParameterizedMessage("[{}] Search response was obtained", context.jobId));
 
             List<Row> rows = processSearchResponse(searchResponse);
 
@@ -153,7 +153,7 @@ public class DataFrameDataExtractor {
         long from = lastSortKey + 1;
         long to = from + context.scrollSize;
 
-        LOGGER.debug(() -> new ParameterizedMessage(
+        LOGGER.trace(() -> new ParameterizedMessage(
             "[{}] Searching docs with [{}] in [{}, {})", context.jobId, DestinationIndex.INCREMENTAL_ID, from, to));
 
         SearchRequestBuilder searchRequestBuilder = new SearchRequestBuilder(client, SearchAction.INSTANCE)
@@ -283,7 +283,7 @@ public class DataFrameDataExtractor {
         }
         boolean isTraining = trainTestSplitter.get().isTraining(extractedValues);
         Row row = new Row(extractedValues, hit, isTraining);
-        LOGGER.debug(() -> new ParameterizedMessage("[{}] Extracted row: sort key = [{}], is_training = [{}], values = {}",
+        LOGGER.trace(() -> new ParameterizedMessage("[{}] Extracted row: sort key = [{}], is_training = [{}], values = {}",
             context.jobId, row.getSortKey(), isTraining, Arrays.toString(row.values)));
         return row;
     }
@@ -306,7 +306,7 @@ public class DataFrameDataExtractor {
         SearchRequestBuilder searchRequestBuilder = buildDataSummarySearchRequestBuilder();
         SearchResponse searchResponse = executeSearchRequest(searchRequestBuilder);
         long rows = searchResponse.getHits().getTotalHits().value;
-        LOGGER.debug("[{}] Data summary rows [{}]", context.jobId, rows);
+        LOGGER.debug(() -> new ParameterizedMessage("[{}] Data summary rows [{}]", context.jobId, rows));
         return new DataSummary(rows, organicFeatures.length + processedFeatures.length);
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/stats/ProgressTracker.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/stats/ProgressTracker.java
@@ -55,6 +55,9 @@ public class ProgressTracker {
         assert progressPercentPerPhase.containsKey(REINDEXING);
         assert progressPercentPerPhase.containsKey(LOADING_DATA);
         assert progressPercentPerPhase.containsKey(WRITING_RESULTS);
+        // If there is inference it should be the last phase otherwise there
+        // are assumptions that do not hold.
+        assert progressPercentPerPhase.containsKey(INFERENCE) == false || INFERENCE.equals(phasesInOrder[phasesInOrder.length - 1]);
     }
 
     public void updateReindexingProgress(int progressPercent) {
@@ -95,6 +98,32 @@ public class ProgressTracker {
 
     private void updatePhase(String phase, int progress) {
         progressPercentPerPhase.computeIfPresent(phase, (k, v) -> Math.max(v, progress));
+    }
+
+    /**
+     * Resets progress to reflect all phases are complete except for inference
+     * which is set to zero.
+     */
+    public void resetForInference() {
+        for (Map.Entry<String, Integer> phaseProgress : progressPercentPerPhase.entrySet()) {
+            if (phaseProgress.getKey().equals(INFERENCE)) {
+                progressPercentPerPhase.put(phaseProgress.getKey(), 0);
+            } else {
+                progressPercentPerPhase.put(phaseProgress.getKey(), 100);
+            }
+        }
+    }
+
+    /**
+     * Returns whether all phases before inference are complete
+     */
+    public boolean areAllPhasesExceptInferenceComplete() {
+        for (Map.Entry<String, Integer> phaseProgress : progressPercentPerPhase.entrySet()) {
+            if (phaseProgress.getKey().equals(INFERENCE) == false && phaseProgress.getValue() < 100) {
+                return false;
+            }
+        }
+        return true;
     }
 
     public List<PhaseProgress> report() {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/steps/AbstractDataFrameAnalyticsStep.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/steps/AbstractDataFrameAnalyticsStep.java
@@ -58,7 +58,7 @@ abstract class AbstractDataFrameAnalyticsStep implements DataFrameAnalyticsStep 
     public final void execute(ActionListener<StepResponse> listener) {
         logger.debug(() -> new ParameterizedMessage("[{}] Executing step [{}]", config.getId(), name()));
         if (task.isStopping()) {
-            logger.debug(() -> new ParameterizedMessage("[{}] task is stopping before starting [{}]", config.getId(), name()));
+            logger.debug(() -> new ParameterizedMessage("[{}] task is stopping before starting [{}] step", config.getId(), name()));
             listener.onResponse(new StepResponse(true));
             return;
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/steps/DataFrameAnalyticsStep.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/steps/DataFrameAnalyticsStep.java
@@ -14,7 +14,7 @@ import java.util.Locale;
 public interface DataFrameAnalyticsStep {
 
     enum Name {
-        REINDEXING, ANALYSIS;
+        REINDEXING, ANALYSIS, INFERENCE, FINAL;
 
         @Override
         public String toString() {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/steps/FinalStep.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/steps/FinalStep.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.ml.dataframe.steps;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
+import org.elasticsearch.action.admin.indices.refresh.RefreshResponse;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.client.ParentTaskAssigningClient;
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.xpack.core.ml.MlStatsIndex;
+import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfig;
+import org.elasticsearch.xpack.core.ml.dataframe.stats.common.DataCounts;
+import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
+import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
+import org.elasticsearch.xpack.core.ml.utils.ToXContentParams;
+import org.elasticsearch.xpack.ml.dataframe.DataFrameAnalyticsTask;
+import org.elasticsearch.xpack.ml.notifications.DataFrameAnalyticsAuditor;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
+
+/**
+ * The final step of a data frame analytics job.
+ * Allows the job to perform finalizing tasks like refresh indices,
+ * persist stats, etc.
+ */
+public class FinalStep extends AbstractDataFrameAnalyticsStep {
+
+    private static final Logger LOGGER = LogManager.getLogger(FinalStep.class);
+
+    public FinalStep(NodeClient client, DataFrameAnalyticsTask task, DataFrameAnalyticsAuditor auditor, DataFrameAnalyticsConfig config) {
+        super(client, task, auditor, config);
+    }
+
+    @Override
+    public Name name() {
+        return Name.FINAL;
+    }
+
+    @Override
+    protected void doExecute(ActionListener<StepResponse> listener) {
+
+        ActionListener<RefreshResponse> refreshListener = ActionListener.wrap(
+            refreshResponse -> listener.onResponse(new StepResponse(true)),
+            listener::onFailure
+        );
+
+        ActionListener<IndexResponse> dataCountsIndexedListener = ActionListener.wrap(
+            indexResponse -> refreshIndices(refreshListener),
+            listener::onFailure
+        );
+
+        indexDataCounts(dataCountsIndexedListener);
+    }
+
+    private void indexDataCounts(ActionListener<IndexResponse> listener) {
+        DataCounts dataCounts = task.getStatsHolder().getDataCountsTracker().report(config.getId());
+        try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
+            dataCounts.toXContent(builder, new ToXContent.MapParams(
+                Collections.singletonMap(ToXContentParams.FOR_INTERNAL_STORAGE, "true")));
+            IndexRequest indexRequest = new IndexRequest(MlStatsIndex.writeAlias())
+                .id(DataCounts.documentId(config.getId()))
+                .setRequireAlias(true)
+                .source(builder);
+            parentTaskClient().index(indexRequest, listener);
+        } catch (IOException e) {
+            listener.onFailure(ExceptionsHelper.serverError("[{}] Error persisting final data counts", e, config.getId()));
+        }
+    }
+
+    private void refreshIndices(ActionListener<RefreshResponse> listener) {
+        RefreshRequest refreshRequest = new RefreshRequest(
+            AnomalyDetectorsIndex.jobStateIndexPattern(),
+            MlStatsIndex.indexPattern(),
+            config.getDest().getIndex()
+        );
+        refreshRequest.indicesOptions(IndicesOptions.lenientExpandOpen());
+
+        LOGGER.debug(() -> new ParameterizedMessage("[{}] Refreshing indices {}", config.getId(),
+            Arrays.toString(refreshRequest.indices())));
+
+        ParentTaskAssigningClient parentTaskClient = parentTaskClient();
+        try (ThreadContext.StoredContext ignore = parentTaskClient.threadPool().getThreadContext().stashWithOrigin(ML_ORIGIN)) {
+            parentTaskClient.admin().indices().refresh(refreshRequest, listener);
+        }
+    }
+
+    @Override
+    public void cancel(String reason, TimeValue timeout) {
+        // Not cancellable
+    }
+
+    @Override
+    public void updateProgress(ActionListener<Void> listener) {
+        // No progress to update
+        listener.onResponse(null);
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/steps/InferenceStep.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/steps/InferenceStep.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.ml.dataframe.steps;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.elasticsearch.ResourceNotFoundException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.refresh.RefreshResponse;
+import org.elasticsearch.action.search.SearchAction;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.sort.SortOrder;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfig;
+import org.elasticsearch.xpack.core.ml.inference.TrainedModelConfig;
+import org.elasticsearch.xpack.core.ml.inference.persistence.InferenceIndexConstants;
+import org.elasticsearch.xpack.ml.MachineLearning;
+import org.elasticsearch.xpack.ml.dataframe.DataFrameAnalyticsTask;
+import org.elasticsearch.xpack.ml.dataframe.inference.InferenceRunner;
+import org.elasticsearch.xpack.ml.notifications.DataFrameAnalyticsAuditor;
+
+import java.util.Objects;
+
+import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
+import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
+
+public class InferenceStep extends AbstractDataFrameAnalyticsStep {
+
+    private static final Logger LOGGER = LogManager.getLogger(InferenceStep.class);
+
+    private final ThreadPool threadPool;
+    private final InferenceRunner inferenceRunner;
+
+    public InferenceStep(NodeClient client, DataFrameAnalyticsTask task, DataFrameAnalyticsAuditor auditor, DataFrameAnalyticsConfig config,
+                         ThreadPool threadPool, InferenceRunner inferenceRunner) {
+        super(client, task, auditor, config);
+        this.threadPool = Objects.requireNonNull(threadPool);
+        this.inferenceRunner = Objects.requireNonNull(inferenceRunner);
+    }
+
+    @Override
+    public Name name() {
+        return Name.INFERENCE;
+    }
+
+    @Override
+    protected void doExecute(ActionListener<StepResponse> listener) {
+        if (config.getAnalysis().supportsInference() == false) {
+            LOGGER.debug(() -> new ParameterizedMessage(
+                "[{}] Inference step completed immediately as analysis does not support inference", config.getId()));
+            listener.onResponse(new StepResponse(false));
+            return;
+        }
+
+        ActionListener<String> modelIdListener = ActionListener.wrap(
+            modelId -> runInference(modelId, listener),
+            listener::onFailure
+        );
+
+        ActionListener<RefreshResponse> refreshDestListener = ActionListener.wrap(
+            refreshResponse -> getModelId(modelIdListener),
+            listener::onFailure
+        );
+
+        refreshDestAsync(refreshDestListener);
+    }
+
+    private void runInference(String modelId, ActionListener<StepResponse> listener) {
+        threadPool.executor(MachineLearning.UTILITY_THREAD_POOL_NAME).execute(() -> {
+            try {
+                inferenceRunner.run(modelId);
+                listener.onResponse(new StepResponse(isTaskStopping()));
+            } catch (Exception e) {
+                if (task.isStopping()) {
+                    listener.onResponse(new StepResponse(false));
+                } else {
+                    listener.onFailure(e);
+                }
+            }
+        });
+    }
+
+    private void getModelId(ActionListener<String> listener) {
+        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+        searchSourceBuilder.size(1);
+        searchSourceBuilder.fetchSource(false);
+        searchSourceBuilder.query(QueryBuilders.boolQuery()
+            .filter(QueryBuilders.termQuery(TrainedModelConfig.TAGS.getPreferredName(), config.getId()))
+        );
+        searchSourceBuilder.sort(TrainedModelConfig.CREATE_TIME.getPreferredName(), SortOrder.DESC);
+        SearchRequest searchRequest = new SearchRequest(InferenceIndexConstants.INDEX_PATTERN);
+        searchRequest.source(searchSourceBuilder);
+
+        executeAsyncWithOrigin(client, ML_ORIGIN, SearchAction.INSTANCE, searchRequest, ActionListener.wrap(
+            searchResponse -> {
+                SearchHit[] hits = searchResponse.getHits().getHits();
+                if (hits.length == 0) {
+                    listener.onFailure(new ResourceNotFoundException("No model could be found to perform inference"));
+                } else {
+                    listener.onResponse(hits[0].getId());
+                }
+            },
+            listener::onFailure
+        ));
+    }
+
+    @Override
+    public void cancel(String reason, TimeValue timeout) {
+        inferenceRunner.cancel();
+    }
+
+    @Override
+    public void updateProgress(ActionListener<Void> listener) {
+        // Inference runner updates progress directly
+        listener.onResponse(null);
+    }
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsTaskTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsTaskTests.java
@@ -117,6 +117,18 @@ public class DataFrameAnalyticsTaskTests extends ESTestCase {
         assertThat(startingState, equalTo(StartingState.RESUMING_ANALYZING));
     }
 
+    public void testDetermineStartingState_GivenInferenceIsIncomplete() {
+        List<PhaseProgress> progress = Arrays.asList(new PhaseProgress("reindexing", 100),
+            new PhaseProgress("loading_data", 100),
+            new PhaseProgress("analyzing", 100),
+            new PhaseProgress("writing_results", 100),
+            new PhaseProgress("inference", 40));
+
+        StartingState startingState = DataFrameAnalyticsTask.determineStartingState("foo", progress);
+
+        assertThat(startingState, equalTo(StartingState.RESUMING_INFERENCE));
+    }
+
     public void testDetermineStartingState_GivenFinished() {
         List<PhaseProgress> progress = Arrays.asList(new PhaseProgress("reindexing", 100),
             new PhaseProgress("loading_data", 100),

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsProcessManagerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsProcessManagerTests.java
@@ -113,9 +113,8 @@ public class AnalyticsProcessManagerTests extends ESTestCase {
         when(dataExtractorFactory.getExtractedFields()).thenReturn(mock(ExtractedFields.class));
 
         resultsPersisterService = mock(ResultsPersisterService.class);
-        modelLoadingService = mock(ModelLoadingService.class);
         processManager = new AnalyticsProcessManager(Settings.EMPTY, client, executorServiceForJob, executorServiceForProcess,
-            processFactory, auditor, trainedModelProvider, modelLoadingService, resultsPersisterService, 1);
+            processFactory, auditor, trainedModelProvider, resultsPersisterService, 1);
     }
 
     public void testRunJob_TaskIsStopping() {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/process/DataFrameAnalyticsManagerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/process/DataFrameAnalyticsManagerTests.java
@@ -8,10 +8,14 @@ package org.elasticsearch.xpack.ml.dataframe.process;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.ml.dataframe.DataFrameAnalyticsManager;
 import org.elasticsearch.xpack.ml.dataframe.persistence.DataFrameAnalyticsConfigProvider;
+import org.elasticsearch.xpack.ml.inference.loadingservice.ModelLoadingService;
 import org.elasticsearch.xpack.ml.notifications.DataFrameAnalyticsAuditor;
+import org.elasticsearch.xpack.ml.utils.persistence.ResultsPersisterService;
 
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
@@ -21,12 +25,16 @@ public class DataFrameAnalyticsManagerTests extends ESTestCase {
     public void testNodeShuttingDown() {
         DataFrameAnalyticsManager manager =
             new DataFrameAnalyticsManager(
+                Settings.EMPTY,
                 mock(NodeClient.class),
+                mock(ThreadPool.class),
                 mock(ClusterService.class),
                 mock(DataFrameAnalyticsConfigProvider.class),
                 mock(AnalyticsProcessManager.class),
                 mock(DataFrameAnalyticsAuditor.class),
-                mock(IndexNameExpressionResolver.class));
+                mock(IndexNameExpressionResolver.class),
+                mock(ResultsPersisterService.class),
+                mock(ModelLoadingService.class));
         assertThat(manager.isNodeShuttingDown(), is(false));
 
         manager.markNodeAsShuttingDown();

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/stats/StatsHolderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/stats/StatsHolderTests.java
@@ -123,6 +123,32 @@ public class StatsHolderTests extends ESTestCase {
         assertThat(phaseProgresses.get(4).getProgressPercent(), equalTo(0));
     }
 
+    public void testAdjustProgressTracker_GivenAllPhasesCompleteExceptInference() {
+        List<PhaseProgress> phases = Collections.unmodifiableList(
+            Arrays.asList(
+                new PhaseProgress("reindexing", 100),
+                new PhaseProgress("loading_data", 100),
+                new PhaseProgress("a", 100),
+                new PhaseProgress("writing_results", 100),
+                new PhaseProgress("inference", 20)
+            )
+        );
+        StatsHolder statsHolder = new StatsHolder(phases);
+
+        statsHolder.adjustProgressTracker(Arrays.asList("a", "b"), true);
+
+        List<PhaseProgress> phaseProgresses = statsHolder.getProgressTracker().report();
+
+        assertThat(phaseProgresses, contains(
+            new PhaseProgress("reindexing", 100),
+            new PhaseProgress("loading_data", 100),
+            new PhaseProgress("a", 100),
+            new PhaseProgress("b", 100),
+            new PhaseProgress("writing_results", 100),
+            new PhaseProgress("inference", 0)
+        ));
+    }
+
     public void testResetProgressTracker() {
         List<PhaseProgress> phases = Collections.unmodifiableList(
             Arrays.asList(


### PR DESCRIPTION
If a DFA job is stopped while in the inference phase, after
resuming we should start inference immediately. However, this
is currently not the case. Inference is tied in `AnalyticsProcessManager`
and thus we start a process, load data, restore state, etc., until
we get to start inference.

This commit gets rid of this unnecessary delay by factoring inference
out as an independent step and ensuring we can resume straight from
that phase upon restarting a job.

Backport of #67623
