### PR TITLE
[DOCS] Clarifies default ML and transform node settings

### DIFF
--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -68,9 +68,6 @@ A node that has `xpack.ml.enabled` and the `ml` role, which is the default
 behavior in the {es} {default-dist}. If you want to use {ml-features}, there
 must be at least one {ml} node in your cluster. For more information about
 {ml-features}, see {ml-docs}/index.html[Machine learning in the {stack}].
-+
-IMPORTANT: If you use the {oss-dist}, do not add the `ml` role. Otherwise, the
-node fails to start.
 
 <<transform-node,{transform-cap} node>>::
 
@@ -325,7 +322,7 @@ requests. If `xpack.ml.enabled` is set to `true` and the node does not have the
 If you want to use {ml-features} in your cluster, you must enable {ml}
 (set `xpack.ml.enabled` to `true`) on all master-eligible nodes. If you want to
 use {ml-features} in clients (including {kib}), it must also be enabled on all
-coordinating nodes. If you have the {oss-dist}, do not use these settings.
+coordinating nodes.
 
 For more information about these settings, see <<ml-settings>>.
 
@@ -343,9 +340,8 @@ Otherwise, {ccs} fails when used in {ml} jobs or {dfeeds}. See <<remote-node>>.
 [[transform-node]]
 ==== [xpack]#{transform-cap} node#
 
-{transform-cap} nodes run {transforms} and handle {transform} API requests. If
-you have the {oss-dist}, do not use these settings. For more information, see
-<<transform-settings>>.
+{transform-cap} nodes run {transforms} and handle {transform} API requests. For
+more information, see <<transform-settings>>.
 
 To create a dedicated {transform} node in the {default-dist}, set:
 

--- a/docs/reference/settings/ml-settings.asciidoc
+++ b/docs/reference/settings/ml-settings.asciidoc
@@ -25,9 +25,8 @@ hardware, you must disable {ml} (by setting `xpack.ml.enabled` to `false`).
 the node as a _{ml} node_. If you want to run {ml} jobs, there must be at least
 one {ml} node in your cluster. 
 +
-By default, every node is a {ml} node. If you set `node.roles`, however,
-you must explicitly specify all the required roles for the node. To learn more, 
-refer to <<modules-node>>.
+If you set `node.roles`, you must explicitly specify all the required roles for
+the node. To learn more, refer to <<modules-node>>.
 +
 [IMPORTANT]
 ====

--- a/docs/reference/settings/transform-settings.asciidoc
+++ b/docs/reference/settings/transform-settings.asciidoc
@@ -19,9 +19,8 @@ default.
 identify the node as a _transform node_. If you want to run {transforms}, there 
 must be at least one {transform} node in your cluster.
 +
-By default, every node is a {transform} node. If you set `node.roles`, however,
-you must explicitly specify all the required roles for the node. To learn more, 
-refer to <<modules-node>>.
+If you set `node.roles`, you must explicitly specify all the required roles for
+the node. To learn more, refer to <<modules-node>>.
 + 
 IMPORTANT: It is strongly recommended that dedicated {transform} nodes also have 
 the `remote_cluster_client` role; otherwise, {ccs} fails when used in 


### PR DESCRIPTION
This PR addresses comments in https://github.com/elastic/elasticsearch/pull/66616#issuecomment-762382596

It also removes obsolete references to `{oss-dist}` in the details about machine learning and transform nodes.