### PR TITLE
Ensure IndexingPressure memory is re-adjusted once

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/IndexingPressureTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexingPressureTests.java
@@ -140,9 +140,7 @@ public class IndexingPressureTests extends ESTestCase {
             assertEquals(1, indexingPressure.stats().getReplicaRejections());
             assertEquals(1024 * 14, indexingPressure.stats().getCurrentReplicaBytes());
             forced.close();
-
             replica2.close();
-            forced.close();
         }
 
         assertEquals(1024 * 14, indexingPressure.stats().getTotalReplicaBytes());


### PR DESCRIPTION
We have seen a case where the memory of IndexingPressure was re-adjusted twice. With this commit, we will log that error with a stack trace so that we can figure out the source of the issue.


```
java.lang.IllegalArgumentException: Values less than -1 bytes are not supported: -103362b
        at org.elasticsearch.common.unit.ByteSizeValue.<init>(ByteSizeValue.java:79) ~[elasticsearch-7.10.0.jar:7.10.0]
        at org.elasticsearch.common.unit.ByteSizeValue.<init>(ByteSizeValue.java:74) ~[elasticsearch-7.10.0.jar:7.10.0]
        at org.elasticsearch.index.stats.IndexingPressureStats.toXContent(IndexingPressureStats.java:175) ~[elasticsearch-7.10.0.jar:7.10.0]
        at org.elasticsearch.action.admin.cluster.node.stats.NodeStats.toXContent(NodeStats.java:366) ~[elasticsearch-7.10.0.jar:7.10.0]
        at org.elasticsearch.action.admin.cluster.node.stats.NodesStatsResponse.toXContent(NodesStatsResponse.java:61) ~[elasticsearch-7.10.0.jar:7.10.0]
        at org.elasticsearch.rest.action.RestActions.nodesResponse(RestActions.java:184) ~[elasticsearch-7.10.0.jar:7.10.0]
        at org.elasticsearch.rest.action.RestActions$NodesResponseRestListener.buildResponse(RestActions.java:237) ~[elasticsearch-7.10.0.jar:7.10.0]
        at org.elasticsearch.rest.action.RestActions$NodesResponseRestListener.buildResponse(RestActions.java:228) ~[elasticsearch-7.10.0.jar:7.10.0]
        at org.elasticsearch.rest.action.RestBuilderListener.buildResponse(RestBuilderListener.java:38) ~[elasticsearch-7.10.0.jar:7.10.0]
        at org.elasticsearch.rest.action.RestResponseListener.processResponse(RestResponseListener.java:37) ~[elasticsearch-7.10.0.jar:7.10.0]
        at org.elasticsearch.rest.action.RestActionListener.onResponse(RestActionListener.java:47) [elasticsearch-7.10.0.jar:7.10.0]
        at org.elasticsearch.action.support.TransportAction$1.onResponse(TransportAction.java:89) [elasticsearch-7.10.0.jar:7.10.0]
        at org.elasticsearch.action.support.TransportAction$1.onResponse(TransportAction.java:83) [elasticsearch-7.10.0.jar:7.10.0]
        at org.elasticsearch.action.support.ContextPreservingActionListener.onResponse(ContextPreservingActionListener.java:43) [elasticsearch-7.10.0.jar:7.10.0]
        at org.elasticsearch.action.ActionRunnable.lambda$supply$0(ActionRunnable.java:58) [elasticsearch-7.10.0.jar:7.10.0]
        at org.elasticsearch.action.ActionRunnable$2.doRun(ActionRunnable.java:73) [elasticsearch-7.10.0.jar:7.10.0]
        at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:37) [elasticsearch-7.10.0.jar:7.10.0]
        at org.elasticsearch.common.util.concurrent.EsExecutors$DirectExecutorService.execute(EsExecutors.java:224) [elasticsearch-7.10.0.jar:7.10.0]
        at org.elasticsearch.action.support.nodes.TransportNodesAction$AsyncAction.finishHim(TransportNodesAction.java:263) [elasticsearch-7.10.0.jar:7.10.0]
        at org.elasticsearch.action.support.nodes.TransportNodesAction$AsyncAction.onOperation(TransportNodesAction.java:248) [elasticsearch-7.10.0.jar:7.10.0]
        at org.elasticsearch.action.support.nodes.TransportNodesAction$AsyncAction.access$000(TransportNodesAction.java:177) [elasticsearch-7.10.0.jar:7.10.0]
        at org.elasticsearch.action.support.nodes.TransportNodesAction$AsyncAction$1.handleResponse(TransportNodesAction.java:226) [elasticsearch-7.10.0.jar:7.10.0]
        at org.elasticsearch.action.support.nodes.TransportNodesAction$AsyncAction$1.handleResponse(TransportNodesAction.java:218) [elasticsearch-7.10.0.jar:7.10.0]
        at org.elasticsearch.transport.TransportService$6.handleResponse(TransportService.java:634) [elasticsearch-7.10.0.jar:7.10.0]
        at org.elasticsearch.transport.TransportService$ContextRestoreResponseHandler.handleResponse(TransportService.java:1171) [elasticsearch-7.10.0.jar:7.10.0]
        at org.elasticsearch.transport.TransportService$DirectResponseChannel.processResponse(TransportService.java:1249) [elasticsearch-7.10.0.jar:7.10.0]
        at org.elasticsearch.transport.TransportService$DirectResponseChannel.sendResponse(TransportService.java:1229) [elasticsearch-7.10.0.jar:7.10.0]
        at org.elasticsearch.transport.TaskTransportChannel.sendResponse(TaskTransportChannel.java:52) [elasticsearch-7.10.0.jar:7.10.0]
```