### PR TITLE
Fix terms serialization on older versions

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/query/TermsQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/TermsQueryBuilder.java
@@ -552,7 +552,7 @@ public class TermsQueryBuilder extends AbstractQueryBuilder<TermsQueryBuilder> {
             if (out.getVersion().onOrAfter(VERSION_STORE_VALUES_AS_BYTES_REFERENCE)) {
                 out.writeBytesReference(valueRef);
             } else {
-                valueRef.writeTo(out);
+                out.writeGenericValue(new ArrayList(this));
             }
         }
 

--- a/server/src/test/java/org/elasticsearch/index/query/TermsQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/TermsQueryBuilderTests.java
@@ -27,6 +27,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermInSetQuery;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.common.ParsingException;
@@ -40,6 +41,7 @@ import org.elasticsearch.index.get.GetResult;
 import org.elasticsearch.index.mapper.TypeFieldType;
 import org.elasticsearch.indices.TermsLookup;
 import org.elasticsearch.test.AbstractQueryTestCase;
+import org.elasticsearch.test.VersionUtils;
 import org.hamcrest.CoreMatchers;
 import org.junit.Before;
 
@@ -313,6 +315,14 @@ public class TermsQueryBuilderTests extends AbstractQueryTestCase<TermsQueryBuil
         SearchExecutionContext searchExecutionContext = createSearchExecutionContext();
         QueryBuilder rewritten = query.rewrite(searchExecutionContext);
         assertThat(rewritten, instanceOf(MatchAllQueryBuilder.class));
+    }
+
+    public void testSerialization() throws IOException {
+        for (int i = 0; i < 5; i++) {
+            Version version = VersionUtils.randomCompatibleVersion(random(), Version.CURRENT);
+            TermsQueryBuilder cand = doCreateTestQueryBuilder();
+            assertSerialization(cand, version);
+        }
     }
 
     @Override


### PR DESCRIPTION
This commit fixes a serialization bug introduced in #67223.
It is not part of any release hence the `>non-issue` tag.