### PR TITLE
Update spotless to 5.9.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ plugins {
   id 'lifecycle-base'
   id 'elasticsearch.docker-support'
   id 'elasticsearch.global-build-info'
-  id "com.diffplug.spotless" version "5.6.1" apply false
+  id "com.diffplug.spotless" version "5.9.0" apply false
 }
 
 apply from: 'gradle/build-scan.gradle'

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/EnrichShardMultiSearchAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/EnrichShardMultiSearchAction.java
@@ -105,12 +105,8 @@ public class EnrichShardMultiSearchAction extends ActionType<MultiSearchResponse
         public Request(MultiSearchRequest multiSearchRequest) {
             super(multiSearchRequest.requests().get(0).indices()[0]);
             this.multiSearchRequest = multiSearchRequest;
-            assert multiSearchRequest.requests()
-                .stream()
-                .map(SearchRequest::indices)
-                .flatMap(Arrays::stream)
-                .distinct()
-                .count() == 1 : "action [" + NAME + "] cannot handle msearch request pointing to multiple indices";
+            assert multiSearchRequest.requests().stream().map(SearchRequest::indices).flatMap(Arrays::stream).distinct().count() == 1
+                : "action [" + NAME + "] cannot handle msearch request pointing to multiple indices";
             assert assertSearchSource();
         }
 

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/BaseSearchableSnapshotIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/BaseSearchableSnapshotIndexInput.java
@@ -42,11 +42,8 @@ public abstract class BaseSearchableSnapshotIndexInput extends BufferedIndexInpu
         this.blobContainer = Objects.requireNonNull(blobContainer);
         this.fileInfo = Objects.requireNonNull(fileInfo);
         this.context = Objects.requireNonNull(context);
-        assert fileInfo.metadata()
-            .hashEqualsContents() == false : "this method should only be used with blobs that are NOT stored in metadata's hash field "
-                + "(fileInfo: "
-                + fileInfo
-                + ')';
+        assert fileInfo.metadata().hashEqualsContents() == false
+            : "this method should only be used with blobs that are NOT stored in metadata's hash field " + "(fileInfo: " + fileInfo + ')';
         this.stats = Objects.requireNonNull(stats);
         this.offset = offset;
         this.length = length;

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/CacheFile.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/CacheFile.java
@@ -447,8 +447,8 @@ public class CacheFile {
         synchronized (listeners) {
             ensureOpen();
             reference = channelRef;
-            assert reference != null
-                && reference.refCount() > 0 : "impossible to run into a fully released channel reference under the listeners mutex";
+            assert reference != null && reference.refCount() > 0
+                : "impossible to run into a fully released channel reference under the listeners mutex";
             assert refCounter.refCount() > 0 : "file should not be fully released";
             reference.incRef();
         }

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotIndexEventListener.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotIndexEventListener.java
@@ -81,10 +81,8 @@ public class SearchableSnapshotIndexEventListener implements IndexEventListener 
             });
         }
         assert directory.listAll().length > 0 : "expecting directory listing to be non-empty";
-        assert success
-            || indexShard.routingEntry()
-                .recoverySource()
-                .getType() == RecoverySource.Type.PEER : "loading snapshot must not be called twice unless we are retrying a peer recovery";
+        assert success || indexShard.routingEntry().recoverySource().getType() == RecoverySource.Type.PEER
+            : "loading snapshot must not be called twice unless we are retrying a peer recovery";
     }
 
     private static void associateNewEmptyTranslogWithIndex(IndexShard indexShard) {

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheService.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheService.java
@@ -703,8 +703,8 @@ public class CacheService extends AbstractLifecycleComponent {
 
     private static boolean assertGenericThreadPool() {
         final String threadName = Thread.currentThread().getName();
-        assert threadName.contains('[' + ThreadPool.Names.GENERIC + ']')
-            || threadName.startsWith("TEST-") : "expected generic thread pool but got " + threadName;
+        assert threadName.contains('[' + ThreadPool.Names.GENERIC + ']') || threadName.startsWith("TEST-")
+            : "expected generic thread pool but got " + threadName;
         return true;
     }
 }


### PR DESCRIPTION
v5.9.0 of the spotless gradle plugin brings in the [assertion formatting changes that I contributed
upstream](https://bugs.eclipse.org/bugs/show_bug.cgi?id=118641), which resulted in a number of assertions being reformatted.