### PR TITLE
[7.11] [Autoscaling] fixing random autoscaling test generation (#67607)

### DIFF
--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/action/TransportPutAutoscalingPolicyActionIT.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/action/TransportPutAutoscalingPolicyActionIT.java
@@ -37,13 +37,15 @@ public class TransportPutAutoscalingPolicyActionIT extends AutoscalingIntegTestC
         assertThat(metadata.policies().get(policy.name()).policy(), equalTo(policy));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/67620")
     public void testUpdatePolicy() {
         final AutoscalingPolicy policy = putRandomAutoscalingPolicy();
         final AutoscalingPolicy updatedPolicy = new AutoscalingPolicy(
             policy.name(),
             new TreeSet<>(
-                randomSubsetOf(org.elasticsearch.common.collect.List.of("data", "data_content", "data_hot", "data_warm", "data_cold"))
+                randomSubsetOf(
+                    randomIntBetween(1, 5),
+                    org.elasticsearch.common.collect.List.of("data", "data_content", "data_hot", "data_warm", "data_cold")
+                )
             ),
             mutateAutoscalingDeciders(policy.deciders())
         );


### PR DESCRIPTION
Backports the following commits to 7.11:
 - [Autoscaling] fixing random autoscaling test generation (#67607)