### PR TITLE
[7.11] [DOCS] Add security privileges to cluster API docs (#67589)

### DIFF
--- a/docs/reference/cluster/allocation-explain.asciidoc
+++ b/docs/reference/cluster/allocation-explain.asciidoc
@@ -12,6 +12,11 @@ Provides explanations for shard allocations in the cluster.
 
 `GET /_cluster/allocation/explain`
 
+[[cluster-allocation-explain-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `monitor` or
+`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
 
 [[cluster-allocation-explain-api-desc]]
 ==== {api-description-title}

--- a/docs/reference/cluster/get-settings.asciidoc
+++ b/docs/reference/cluster/get-settings.asciidoc
@@ -11,6 +11,12 @@ Returns cluster-wide settings.
 GET /_cluster/settings
 ----
 
+[[cluster-get-settings-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `monitor` or
+`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
+
 [[cluster-get-settings-api-request]]
 ==== {api-request-title}
 

--- a/docs/reference/cluster/health.asciidoc
+++ b/docs/reference/cluster/health.asciidoc
@@ -9,7 +9,13 @@ Returns the health status of a cluster.
 [[cluster-health-api-request]]
 ==== {api-request-title}
 
-`GET _cluster/health/<target>`
+`GET /_cluster/health/<target>`
+
+[[cluster-health-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `monitor` or
+`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
 
 [[cluster-health-api-desc]]
 ==== {api-description-title}

--- a/docs/reference/cluster/nodes-hot-threads.asciidoc
+++ b/docs/reference/cluster/nodes-hot-threads.asciidoc
@@ -14,6 +14,11 @@ Returns the hot threads on each selected node in the cluster.
 
 `GET /_nodes/<node_id>/hot_threads`
 
+[[cluster-nodes-hot-threads-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `monitor` or
+`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
 
 [[cluster-nodes-hot-threads-api-desc]]
 ==== {api-description-title}

--- a/docs/reference/cluster/nodes-info.asciidoc
+++ b/docs/reference/cluster/nodes-info.asciidoc
@@ -18,6 +18,12 @@ Returns cluster nodes information.
 
 `GET /_nodes/<node_id>/<metric>`
 
+[[cluster-nodes-info-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `monitor` or
+`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
+
 
 [[cluster-nodes-info-api-desc]]
 ==== {api-description-title}

--- a/docs/reference/cluster/nodes-reload-secure-settings.asciidoc
+++ b/docs/reference/cluster/nodes-reload-secure-settings.asciidoc
@@ -9,8 +9,14 @@ Reloads the keystore on nodes in the cluster.
 [[cluster-nodes-reload-secure-settings-api-request]]
 ==== {api-request-title}
 
-`POST _nodes/reload_secure_settings` +
-`POST _nodes/<node_id>/reload_secure_settings`
+`POST /_nodes/reload_secure_settings` +
+`POST /_nodes/<node_id>/reload_secure_settings`
+
+[[cluster-nodes-reload-secure-settings-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `manage`
+<<privileges-list-cluster,cluster privilege>> to use this API.
 
 [[cluster-nodes-reload-secure-settings-api-desc]]
 ==== {api-description-title}

--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -21,6 +21,11 @@ Returns cluster nodes statistics.
 
 `GET /_nodes/<node_id>/stats/<metric>/<index_metric>`
 
+[[cluster-nodes-stats-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `monitor` or
+`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
 
 [[cluster-nodes-stats-api-desc]]
 ==== {api-description-title}

--- a/docs/reference/cluster/nodes-usage.asciidoc
+++ b/docs/reference/cluster/nodes-usage.asciidoc
@@ -18,6 +18,11 @@ Returns information on the usage of features.
 
 `GET /_nodes/<node_id>/usage/<metric>`
 
+[[cluster-nodes-usage-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `monitor` or
+`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
 
 [[cluster-nodes-usage-api-desc]]
 ==== {api-description-title}

--- a/docs/reference/cluster/pending.asciidoc
+++ b/docs/reference/cluster/pending.asciidoc
@@ -12,6 +12,11 @@ Returns cluster-level changes that have not yet been executed.
 
 `GET /_cluster/pending_tasks`
 
+[[cluster-pending-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `monitor` or
+`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
 
 [[cluster-pending-api-desc]]
 ==== {api-description-title}

--- a/docs/reference/cluster/remote-info.asciidoc
+++ b/docs/reference/cluster/remote-info.asciidoc
@@ -12,6 +12,11 @@ Returns configured remote cluster information.
 
 `GET /_remote/info`
 
+[[cluster-remote-info-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `monitor` or
+`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
 
 [[cluster-remote-info-api-desc]]
 ==== {api-description-title}

--- a/docs/reference/cluster/reroute.asciidoc
+++ b/docs/reference/cluster/reroute.asciidoc
@@ -12,6 +12,12 @@ Changes the allocation of shards in a cluster.
 
 `POST /_cluster/reroute`
 
+[[cluster-reroute-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `manage`
+<<privileges-list-cluster,cluster privilege>> to use this API.
+
 [[cluster-reroute-api-desc]]
 ==== {api-description-title}
 

--- a/docs/reference/cluster/state.asciidoc
+++ b/docs/reference/cluster/state.asciidoc
@@ -11,6 +11,12 @@ Returns metadata about the state of the cluster.
 
 `GET /_cluster/state/<metrics>/<target>`
 
+[[cluster-state-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `monitor` or
+`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
+
 [[cluster-state-api-desc]]
 ==== {api-description-title}
 

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -14,6 +14,11 @@ Returns cluster statistics.
 
 `GET /_cluster/stats/nodes/<node_filter>`
 
+[[cluster-stats-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `monitor` or
+`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
 
 [[cluster-stats-api-desc]]
 ==== {api-description-title}

--- a/docs/reference/cluster/tasks.asciidoc
+++ b/docs/reference/cluster/tasks.asciidoc
@@ -15,6 +15,11 @@ Returns information about the tasks currently executing in the cluster.
 
 `GET /_tasks`
 
+[[tasks-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `monitor` or
+`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
 
 [[tasks-api-desc]]
 ==== {api-description-title}

--- a/docs/reference/cluster/update-settings.asciidoc
+++ b/docs/reference/cluster/update-settings.asciidoc
@@ -12,6 +12,11 @@ Updates cluster-wide settings.
 
 `PUT /_cluster/settings`
 
+[[cluster-update-settings-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `manage`
+<<privileges-list-cluster,cluster privilege>> to use this API.
 
 [[cluster-update-settings-api-desc]]
 ==== {api-description-title}

--- a/docs/reference/cluster/voting-exclusions.asciidoc
+++ b/docs/reference/cluster/voting-exclusions.asciidoc
@@ -11,12 +11,17 @@ Adds or removes master-eligible nodes from the
 [[voting-config-exclusions-api-request]]
 ==== {api-request-title}
 
-`POST _cluster/voting_config_exclusions?node_names=<node_names>` +
+`POST /_cluster/voting_config_exclusions?node_names=<node_names>` +
 
-`POST _cluster/voting_config_exclusions?node_ids=<node_ids>` +
+`POST /_cluster/voting_config_exclusions?node_ids=<node_ids>` +
 
-`DELETE _cluster/voting_config_exclusions`
+`DELETE /_cluster/voting_config_exclusions`
 
+[[voting-config-exclusions-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `manage`
+<<privileges-list-cluster,cluster privilege>> to use this API.
 
 [[voting-config-exclusions-api-desc]]
 ==== {api-description-title}


### PR DESCRIPTION
Backports the following commits to 7.11:
 - [DOCS] Add security privileges to cluster API docs (#67589)