### PR TITLE
Make RepositoryData Parsing Stricter (#67699)

### DIFF
--- a/server/src/main/java/org/elasticsearch/repositories/RepositoryData.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoryData.java
@@ -560,6 +560,9 @@ public final class RepositoryData {
             }
         }
 
+        // ensure we drained the stream completely
+        XContentParserUtils.ensureExpectedToken(null, parser.nextToken(), parser);
+
         return new RepositoryData(genId, snapshots, snapshotStates, snapshotVersions, indexSnapshots, shardGenerations.build(),
                 buildIndexMetaGenerations(indexMetaLookup, indexLookup, indexMetaIdentifiers));
     }


### PR DESCRIPTION
We should not accept random bytes after the actual repository
data bytes. Not validating for this was causing e.g. `{}abc` to be parsed
as empty repository data instead of throwing.

closes #67696

backport of #67699 