### PR TITLE
QL: Refactor function resolution strategy (#67672)

### DIFF
--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/ExpressionBuilder.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/ExpressionBuilder.java
@@ -24,6 +24,7 @@ import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.Literal;
 import org.elasticsearch.xpack.ql.expression.UnresolvedAttribute;
 import org.elasticsearch.xpack.ql.expression.function.Function;
+import org.elasticsearch.xpack.ql.expression.function.FunctionResolutionStrategy;
 import org.elasticsearch.xpack.ql.expression.function.UnresolvedFunction;
 import org.elasticsearch.xpack.ql.expression.predicate.Predicates;
 import org.elasticsearch.xpack.ql.expression.predicate.logical.And;
@@ -199,7 +200,7 @@ public class ExpressionBuilder extends IdentifierBuilder {
         String name = ctx.name.getText();
         List<Expression> arguments = expressions(ctx.expression());
 
-        return new UnresolvedFunction(source, name, UnresolvedFunction.ResolutionType.STANDARD, arguments);
+        return new UnresolvedFunction(source, name, FunctionResolutionStrategy.DEFAULT, arguments);
     }
 
     @Override

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/parser/ExpressionTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/parser/ExpressionTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.Literal;
 import org.elasticsearch.xpack.ql.expression.UnresolvedAttribute;
+import org.elasticsearch.xpack.ql.expression.function.FunctionResolutionStrategy;
 import org.elasticsearch.xpack.ql.expression.function.UnresolvedFunction;
 import org.elasticsearch.xpack.ql.expression.predicate.logical.And;
 import org.elasticsearch.xpack.ql.expression.predicate.logical.Not;
@@ -274,8 +275,8 @@ public class ExpressionTests extends ESTestCase {
             new UnresolvedAttribute(null, "some.field"),
             new Literal(null, "test string", DataTypes.KEYWORD)
         );
-        UnresolvedFunction.ResolutionType resolutionType = UnresolvedFunction.ResolutionType.STANDARD;
-        Expression expected = new UnresolvedFunction(null, "concat", resolutionType, arguments);
+        FunctionResolutionStrategy resolutionStrategy = FunctionResolutionStrategy.DEFAULT;
+        Expression expected = new UnresolvedFunction(null, "concat", resolutionStrategy, arguments);
 
         assertEquals(expected, expr("concat(some.field, \"test string\")"));
     }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/function/FunctionDefinition.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/function/FunctionDefinition.java
@@ -23,18 +23,22 @@ public class FunctionDefinition {
     private final String name;
     private final List<String> aliases;
     private final Class<? extends Function> clazz;
+    private final Builder builder;
+
     /**
      * Is this a datetime function compatible with {@code EXTRACT}.
      */
+    // TODO: needs refactoring so that specific function properties (per language) are isolated from QL
     private final boolean extractViable;
-    private final Builder builder;
 
-    FunctionDefinition(String name, List<String> aliases, Class<? extends Function> clazz, boolean datetime, Builder builder) {
+
+    protected FunctionDefinition(String name, List<String> aliases, Class<? extends Function> clazz, boolean dateTime, Builder builder) {
         this.name = name;
         this.aliases = aliases;
         this.clazz = clazz;
-        this.extractViable = datetime;
         this.builder = builder;
+
+        this.extractViable = dateTime;
     }
 
     public String name() {
@@ -49,14 +53,14 @@ public class FunctionDefinition {
         return clazz;
     }
 
-    Builder builder() {
+    public Builder builder() {
         return builder;
     }
 
     /**
      * Is this a datetime function compatible with {@code EXTRACT}.
      */
-    boolean extractViable() {
+    public boolean extractViable() {
         return extractViable;
     }
 

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/function/FunctionResolutionStrategy.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/function/FunctionResolutionStrategy.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.ql.expression.function;
+
+import org.elasticsearch.xpack.ql.session.Configuration;
+
+
+/**
+ * Strategy indicating the type of resolution to apply for resolving the actual function definition in a pluggable way.
+ */
+public interface FunctionResolutionStrategy {
+
+    /**
+     * Default behavior of standard function calls like {@code ABS(col)}.
+     */
+    FunctionResolutionStrategy DEFAULT = new FunctionResolutionStrategy() {
+    };
+
+    /**
+     * Build the real function from this one and resolution metadata.
+     */
+    default Function buildResolved(UnresolvedFunction uf, Configuration cfg, FunctionDefinition def) {
+        return def.builder().build(uf, false, cfg);
+    }
+
+    /**
+     * The kind of strategy being applied. Used when
+     * building the error message sent back to the user when
+     * they specify a function that doesn't exist.
+     */
+    default String kind() {
+        return "function";
+    }
+
+    /**
+     * Is {@code def} a valid alternative for function invocations
+     * of this kind. Used to filter the list of "did you mean"
+     * options sent back to the user when they specify a missing
+     * function.
+     */
+    default boolean isValidAlternative(FunctionDefinition def) {
+        return true;
+    }
+}

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/function/UnresolvedFunction.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/function/UnresolvedFunction.java
@@ -8,33 +8,25 @@ package org.elasticsearch.xpack.ql.expression.function;
 import org.elasticsearch.xpack.ql.capabilities.Unresolvable;
 import org.elasticsearch.xpack.ql.capabilities.UnresolvedException;
 import org.elasticsearch.xpack.ql.expression.Expression;
-import org.elasticsearch.xpack.ql.expression.Literal;
 import org.elasticsearch.xpack.ql.expression.Nullability;
-import org.elasticsearch.xpack.ql.expression.function.aggregate.Count;
 import org.elasticsearch.xpack.ql.expression.gen.script.ScriptTemplate;
 import org.elasticsearch.xpack.ql.session.Configuration;
 import org.elasticsearch.xpack.ql.tree.NodeInfo;
 import org.elasticsearch.xpack.ql.tree.Source;
 import org.elasticsearch.xpack.ql.type.DataType;
-import org.elasticsearch.xpack.ql.type.DataTypes;
 import org.elasticsearch.xpack.ql.util.StringUtils;
 
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
 
-import static java.util.Collections.singletonList;
-
 public class UnresolvedFunction extends Function implements Unresolvable {
+
     private final String name;
     private final String unresolvedMsg;
-    /**
-     * How the resolution should be performed. This is changed depending
-     * on how the function was called.
-     */
-    private final ResolutionType resolutionType;
+    private final FunctionResolutionStrategy resolution;
+
     /**
      * Flag to indicate analysis has been applied and there's no point in
      * doing it again this is an optimization to prevent searching for a
@@ -42,48 +34,45 @@ public class UnresolvedFunction extends Function implements Unresolvable {
      */
     private final boolean analyzed;
 
-    public UnresolvedFunction(Source source, String name, ResolutionType resolutionType, List<Expression> children) {
-        this(source, name, resolutionType, children, false, null);
+    public UnresolvedFunction(Source source, String name, FunctionResolutionStrategy resolutionStrategy, List<Expression> children) {
+        this(source, name, resolutionStrategy, children, false, null);
     }
 
     /**
      * Constructor used for specifying a more descriptive message (typically
      * 'did you mean') instead of the default one.
+     *
      * @see #withMessage(String)
      */
-    UnresolvedFunction(Source source, String name, ResolutionType resolutionType, List<Expression> children,
-            boolean analyzed, String unresolvedMessage) {
+    UnresolvedFunction(Source source, String name, FunctionResolutionStrategy resolutionStrategy, List<Expression> children,
+                       boolean analyzed, String unresolvedMessage) {
         super(source, children);
         this.name = name;
-        this.resolutionType = resolutionType;
+        this.resolution = resolutionStrategy;
         this.analyzed = analyzed;
-        this.unresolvedMsg = unresolvedMessage == null ? "Unknown " + resolutionType.type() + " [" + name + "]" : unresolvedMessage;
+        this.unresolvedMsg = unresolvedMessage == null ? "Unknown " + resolutionStrategy.kind() + " [" + name + "]" : unresolvedMessage;
     }
 
     @Override
     protected NodeInfo<UnresolvedFunction> info() {
         return NodeInfo.create(this, UnresolvedFunction::new,
-            name, resolutionType, children(), analyzed, unresolvedMsg);
+            name, resolution, children(), analyzed, unresolvedMsg);
     }
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        return new UnresolvedFunction(source(), name, resolutionType, newChildren, analyzed, unresolvedMsg);
+        return new UnresolvedFunction(source(), name, resolution, newChildren, analyzed, unresolvedMsg);
     }
 
     public UnresolvedFunction withMessage(String message) {
-        return new UnresolvedFunction(source(), name(), resolutionType, children(), true, message);
-    }
-
-    public UnresolvedFunction preprocessStar() {
-        return resolutionType.preprocessStar(this);
+        return new UnresolvedFunction(source(), name(), resolution, children(), true, message);
     }
 
     /**
      * Build a function to replace this one after resolving the function.
      */
     public Function buildResolved(Configuration configuration, FunctionDefinition def) {
-        return resolutionType.buildResolved(this, configuration, def);
+        return resolution.buildResolved(this, configuration, def);
     }
 
     /**
@@ -94,7 +83,7 @@ public class UnresolvedFunction extends Function implements Unresolvable {
         // try to find alternatives
         Set<String> names = new LinkedHashSet<>();
         for (FunctionDefinition def : alternatives) {
-            if (resolutionType.isValidAlternative(def)) {
+            if (resolution.isValidAlternative(def)) {
                 names.add(def.name());
                 names.addAll(def.aliases());
             }
@@ -105,7 +94,7 @@ public class UnresolvedFunction extends Function implements Unresolvable {
             return this;
         }
         String matchesMessage = matches.size() == 1 ? "[" + matches.get(0) + "]" : "any of " + matches;
-        return withMessage("Unknown " + resolutionType.type() + " [" + name + "], did you mean " + matchesMessage + "?");
+        return withMessage("Unknown " + resolution.kind() + " [" + name + "], did you mean " + matchesMessage + "?");
     }
 
     @Override
@@ -117,20 +106,12 @@ public class UnresolvedFunction extends Function implements Unresolvable {
         return name;
     }
 
-    ResolutionType resolutionType() {
-        return resolutionType;
+    public FunctionResolutionStrategy resolutionStrategy() {
+        return resolution;
     }
 
     public boolean analyzed() {
         return analyzed;
-    }
-    
-    public boolean sameAs(Count count) {
-        if (this.resolutionType == ResolutionType.DISTINCT && count.distinct()
-                || this.resolutionType == ResolutionType.STANDARD && count.distinct() == false) {
-            return true;
-        }
-        return false;
     }
 
     @Override
@@ -170,7 +151,7 @@ public class UnresolvedFunction extends Function implements Unresolvable {
         }
         UnresolvedFunction other = (UnresolvedFunction) obj;
         return name.equals(other.name)
-            && resolutionType.equals(other.resolutionType)
+            && resolution.equals(other.resolution)
             && children().equals(other.children())
             && analyzed == other.analyzed
             && Objects.equals(unresolvedMsg, other.unresolvedMsg);
@@ -178,111 +159,6 @@ public class UnresolvedFunction extends Function implements Unresolvable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, resolutionType, children(), analyzed, unresolvedMsg);
-    }
-
-    /**
-     * Customize how function resolution works based on
-     * where the function appeared in the grammar.
-     */
-    public enum ResolutionType {
-        /**
-         * Behavior of standard function calls like {@code ABS(col)}.
-         */
-        STANDARD {
-            @Override
-            public UnresolvedFunction preprocessStar(UnresolvedFunction uf) {
-                // TODO: might be removed
-                // dedicated count optimization
-                if (uf.name.toUpperCase(Locale.ROOT).equals("COUNT")) {
-                    return new UnresolvedFunction(uf.source(), uf.name(), uf.resolutionType,
-                            singletonList(new Literal(uf.arguments().get(0).source(), Integer.valueOf(1), DataTypes.INTEGER)));
-                }
-                return uf;
-            }
-            @Override
-            public Function buildResolved(UnresolvedFunction uf, Configuration cfg, FunctionDefinition def) {
-                return def.builder().build(uf, false, cfg);
-            }
-            @Override
-            protected boolean isValidAlternative(FunctionDefinition def) {
-                return true;
-            }
-            @Override
-            protected String type() {
-                return "function";
-            }
-        },
-        /**
-         * Behavior of DISTINCT like {@code COUNT DISTINCT(col)}.
-         */
-        DISTINCT {
-            @Override
-            public UnresolvedFunction preprocessStar(UnresolvedFunction uf) {
-                return uf.withMessage("* is not valid with DISTINCT");
-            }
-            @Override
-            public Function buildResolved(UnresolvedFunction uf, Configuration cfg, FunctionDefinition def) {
-                return def.builder().build(uf, true, cfg);
-            }
-            @Override
-            protected boolean isValidAlternative(FunctionDefinition def) {
-                return false; // think about this later.
-            }
-            @Override
-            protected String type() {
-                return "function";
-            }
-        },
-        /**
-         * Behavior of EXTRACT function calls like {@code EXTRACT(DAY FROM col)}.
-         */
-        EXTRACT {
-            @Override
-            public UnresolvedFunction preprocessStar(UnresolvedFunction uf) {
-                return uf.withMessage("Can't extract from *");
-            }
-            @Override
-            public Function buildResolved(UnresolvedFunction uf, Configuration cfg, FunctionDefinition def) {
-                if (def.extractViable()) {
-                    return def.builder().build(uf, false, cfg);
-                }
-                return uf.withMessage("Invalid datetime field [" + uf.name() + "]. Use any datetime function.");
-            }
-            @Override
-            protected boolean isValidAlternative(FunctionDefinition def) {
-                return def.extractViable();
-            }
-            @Override
-            protected String type() {
-                return "datetime field";
-            }
-        };
-        /**
-         * Preprocess a function that contains a star to some other
-         * form before attempting to resolve it. For example,
-         * {@code DISTINCT} doesn't support {@code *} so it converts
-         * this function into a dead end, unresolveable function.
-         * Or {@code COUNT(*)} can be rewritten to {@code COUNT(1)}
-         * so we don't have to resolve {@code *}.
-         */
-        protected abstract UnresolvedFunction preprocessStar(UnresolvedFunction uf);
-        /**
-         * Build the real function from this one and resolution metadata.
-         */
-        protected abstract Function buildResolved(UnresolvedFunction uf, Configuration cfg, FunctionDefinition def);
-        /**
-         * Is {@code def} a valid alternative for function invocations
-         * of this kind. Used to filter the list of "did you mean"
-         * options sent back to the user when they specify a missing
-         * function.
-         */
-        protected abstract boolean isValidAlternative(FunctionDefinition def);
-        /**
-         * The name of the kind of thing being resolved. Used when
-         * building the error message sent back to the user when
-         * they specify a function that doesn't exist.
-         */
-        protected abstract String type();
+        return Objects.hash(name, resolution, children(), analyzed, unresolvedMsg);
     }
 }

--- a/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/expression/function/FunctionRegistryTests.java
+++ b/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/expression/function/FunctionRegistryTests.java
@@ -12,22 +12,18 @@ import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.function.scalar.ScalarFunction;
 import org.elasticsearch.xpack.ql.expression.gen.pipeline.Pipe;
 import org.elasticsearch.xpack.ql.expression.gen.script.ScriptTemplate;
-import org.elasticsearch.xpack.ql.session.Configuration;
 import org.elasticsearch.xpack.ql.tree.NodeInfo;
 import org.elasticsearch.xpack.ql.tree.Source;
 import org.elasticsearch.xpack.ql.tree.SourceTests;
 import org.elasticsearch.xpack.ql.type.DataType;
 
-import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.List;
 
 import static java.util.Collections.emptyList;
 import static org.elasticsearch.xpack.ql.TestUtils.randomConfiguration;
 import static org.elasticsearch.xpack.ql.expression.function.FunctionRegistry.def;
-import static org.elasticsearch.xpack.ql.expression.function.UnresolvedFunction.ResolutionType.DISTINCT;
-import static org.elasticsearch.xpack.ql.expression.function.UnresolvedFunction.ResolutionType.EXTRACT;
-import static org.elasticsearch.xpack.ql.expression.function.UnresolvedFunction.ResolutionType.STANDARD;
+import static org.elasticsearch.xpack.ql.expression.function.FunctionResolutionStrategy.DEFAULT;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
@@ -35,24 +31,14 @@ import static org.mockito.Mockito.mock;
 public class FunctionRegistryTests extends ESTestCase {
 
     public void testNoArgFunction() {
-        UnresolvedFunction ur = uf(STANDARD);
+        UnresolvedFunction ur = uf(DEFAULT);
         FunctionRegistry r = new FunctionRegistry(def(DummyFunction.class, DummyFunction::new, "DUMMY_FUNCTION"));
         FunctionDefinition def = r.resolveFunction(ur.name());
         assertEquals(ur.source(), ur.buildResolved(randomConfiguration(), def).source());
-
-        // Distinct isn't supported
-        ParsingException e = expectThrows(ParsingException.class, () ->
-                uf(DISTINCT).buildResolved(randomConfiguration(), def));
-        assertThat(e.getMessage(), endsWith("does not support DISTINCT yet it was specified"));
-
-        // Any children aren't supported
-        e = expectThrows(ParsingException.class, () ->
-                uf(STANDARD, mock(Expression.class)).buildResolved(randomConfiguration(), def));
-        assertThat(e.getMessage(), endsWith("expects no arguments"));
     }
 
     public void testUnaryFunction() {
-        UnresolvedFunction ur = uf(STANDARD, mock(Expression.class));
+        UnresolvedFunction ur = uf(DEFAULT, mock(Expression.class));
         FunctionRegistry r = new FunctionRegistry(def(DummyFunction.class, (Source l, Expression e) -> {
             assertSame(e, ur.children().get(0));
             return new DummyFunction(l);
@@ -61,131 +47,68 @@ public class FunctionRegistryTests extends ESTestCase {
         assertFalse(def.extractViable());
         assertEquals(ur.source(), ur.buildResolved(randomConfiguration(), def).source());
 
-        // Distinct isn't supported
-        ParsingException e = expectThrows(ParsingException.class, () ->
-                uf(DISTINCT, mock(Expression.class)).buildResolved(randomConfiguration(), def));
-        assertThat(e.getMessage(), endsWith("does not support DISTINCT yet it was specified"));
-
         // No children aren't supported
-        e = expectThrows(ParsingException.class, () ->
-                uf(STANDARD).buildResolved(randomConfiguration(), def));
+        ParsingException e = expectThrows(ParsingException.class, () ->
+            uf(DEFAULT).buildResolved(randomConfiguration(), def));
         assertThat(e.getMessage(), endsWith("expects exactly one argument"));
 
         // Multiple children aren't supported
         e = expectThrows(ParsingException.class, () ->
-            uf(STANDARD, mock(Expression.class), mock(Expression.class)).buildResolved(randomConfiguration(), def));
-        assertThat(e.getMessage(), endsWith("expects exactly one argument"));
-    }
-
-    public void testUnaryDistinctAwareFunction() {
-        boolean urIsDistinct = randomBoolean();
-        UnresolvedFunction ur = uf(urIsDistinct ? DISTINCT : STANDARD, mock(Expression.class));
-        FunctionRegistry r = new FunctionRegistry(def(DummyFunction.class, (Source l, Expression e, boolean distinct) -> {
-                    assertEquals(urIsDistinct, distinct);
-                    assertSame(e, ur.children().get(0));
-                    return new DummyFunction(l);
-        }, "DUMMY_FUNCTION"));
-        FunctionDefinition def = r.resolveFunction(ur.name());
-        assertEquals(ur.source(), ur.buildResolved(randomConfiguration(), def).source());
-        assertFalse(def.extractViable());
-
-        // No children aren't supported
-        ParsingException e = expectThrows(ParsingException.class, () ->
-                uf(STANDARD).buildResolved(randomConfiguration(), def));
-        assertThat(e.getMessage(), endsWith("expects exactly one argument"));
-
-        // Multiple children aren't supported
-        e = expectThrows(ParsingException.class, () ->
-                uf(STANDARD, mock(Expression.class), mock(Expression.class)).buildResolved(randomConfiguration(), def));
-        assertThat(e.getMessage(), endsWith("expects exactly one argument"));
-    }
-
-    public void testDateTimeFunction() {
-        boolean urIsExtract = randomBoolean();
-        UnresolvedFunction ur = uf(urIsExtract ? EXTRACT : STANDARD, mock(Expression.class));
-        ZoneId providedTimeZone = randomZone().normalized();
-        Configuration providedConfiguration = randomConfiguration(providedTimeZone);
-        FunctionRegistry r = new FunctionRegistry(def(DummyFunction.class, (Source l, Expression e, ZoneId zi) -> {
-                    assertEquals(providedTimeZone, zi);
-                    assertSame(e, ur.children().get(0));
-                    return new DummyFunction(l);
-        }, "DUMMY_FUNCTION"));
-        FunctionDefinition def = r.resolveFunction(ur.name());
-        assertEquals(ur.source(), ur.buildResolved(providedConfiguration, def).source());
-        assertTrue(def.extractViable());
-
-        // Distinct isn't supported
-        ParsingException e = expectThrows(ParsingException.class, () ->
-                uf(DISTINCT, mock(Expression.class)).buildResolved(randomConfiguration(), def));
-        assertThat(e.getMessage(), endsWith("does not support DISTINCT yet it was specified"));
-
-        // No children aren't supported
-        e = expectThrows(ParsingException.class, () ->
-                uf(STANDARD).buildResolved(randomConfiguration(), def));
-        assertThat(e.getMessage(), endsWith("expects exactly one argument"));
-
-        // Multiple children aren't supported
-        e = expectThrows(ParsingException.class, () ->
-                uf(STANDARD, mock(Expression.class), mock(Expression.class)).buildResolved(randomConfiguration(), def));
+            uf(DEFAULT, mock(Expression.class), mock(Expression.class)).buildResolved(randomConfiguration(), def));
         assertThat(e.getMessage(), endsWith("expects exactly one argument"));
     }
 
     public void testBinaryFunction() {
-        UnresolvedFunction ur = uf(STANDARD, mock(Expression.class), mock(Expression.class));
+        UnresolvedFunction ur = uf(DEFAULT, mock(Expression.class), mock(Expression.class));
         FunctionRegistry r = new FunctionRegistry(def(DummyFunction.class, (Source l, Expression lhs, Expression rhs) -> {
-                    assertSame(lhs, ur.children().get(0));
-                    assertSame(rhs, ur.children().get(1));
-                    return new DummyFunction(l);
+            assertSame(lhs, ur.children().get(0));
+            assertSame(rhs, ur.children().get(1));
+            return new DummyFunction(l);
         }, "DUMMY_FUNCTION"));
         FunctionDefinition def = r.resolveFunction(ur.name());
         assertEquals(ur.source(), ur.buildResolved(randomConfiguration(), def).source());
         assertFalse(def.extractViable());
 
-        // Distinct isn't supported
-        ParsingException e = expectThrows(ParsingException.class, () ->
-                uf(DISTINCT, mock(Expression.class), mock(Expression.class)).buildResolved(randomConfiguration(), def));
-        assertThat(e.getMessage(), endsWith("does not support DISTINCT yet it was specified"));
-
         // No children aren't supported
-        e = expectThrows(ParsingException.class, () ->
-                uf(STANDARD).buildResolved(randomConfiguration(), def));
+        ParsingException e = expectThrows(ParsingException.class, () ->
+            uf(DEFAULT).buildResolved(randomConfiguration(), def));
         assertThat(e.getMessage(), endsWith("expects exactly two arguments"));
 
         // One child isn't supported
         e = expectThrows(ParsingException.class, () ->
-                uf(STANDARD, mock(Expression.class)).buildResolved(randomConfiguration(), def));
+            uf(DEFAULT, mock(Expression.class)).buildResolved(randomConfiguration(), def));
         assertThat(e.getMessage(), endsWith("expects exactly two arguments"));
 
         // Many children aren't supported
         e = expectThrows(ParsingException.class, () ->
-                uf(STANDARD, mock(Expression.class), mock(Expression.class), mock(Expression.class))
-                    .buildResolved(randomConfiguration(), def));
+            uf(DEFAULT, mock(Expression.class), mock(Expression.class), mock(Expression.class))
+                .buildResolved(randomConfiguration(), def));
         assertThat(e.getMessage(), endsWith("expects exactly two arguments"));
     }
-    
+
     public void testAliasNameIsTheSameAsAFunctionName() {
         FunctionRegistry r = new FunctionRegistry(def(DummyFunction.class, DummyFunction::new, "DUMMY_FUNCTION", "ALIAS"));
         QlIllegalArgumentException iae = expectThrows(QlIllegalArgumentException.class, () ->
-                r.register(def(DummyFunction2.class, DummyFunction2::new, "DUMMY_FUNCTION2", "DUMMY_FUNCTION")));
+            r.register(def(DummyFunction2.class, DummyFunction2::new, "DUMMY_FUNCTION2", "DUMMY_FUNCTION")));
         assertEquals("alias [DUMMY_FUNCTION] is used by [DUMMY_FUNCTION] and [DUMMY_FUNCTION2]", iae.getMessage());
     }
-    
+
     public void testDuplicateAliasInTwoDifferentFunctionsFromTheSameBatch() {
         QlIllegalArgumentException iae = expectThrows(QlIllegalArgumentException.class, () ->
-                new FunctionRegistry(def(DummyFunction.class, DummyFunction::new, "DUMMY_FUNCTION", "ALIAS"),
-                        def(DummyFunction2.class, DummyFunction2::new, "DUMMY_FUNCTION2", "ALIAS")));
+            new FunctionRegistry(def(DummyFunction.class, DummyFunction::new, "DUMMY_FUNCTION", "ALIAS"),
+                def(DummyFunction2.class, DummyFunction2::new, "DUMMY_FUNCTION2", "ALIAS")));
         assertEquals("alias [ALIAS] is used by [DUMMY_FUNCTION(ALIAS)] and [DUMMY_FUNCTION2]", iae.getMessage());
     }
-    
+
     public void testDuplicateAliasInTwoDifferentFunctionsFromTwoDifferentBatches() {
         FunctionRegistry r = new FunctionRegistry(def(DummyFunction.class, DummyFunction::new, "DUMMY_FUNCTION", "ALIAS"));
         QlIllegalArgumentException iae = expectThrows(QlIllegalArgumentException.class, () ->
-                r.register(def(DummyFunction2.class, DummyFunction2::new, "DUMMY_FUNCTION2", "ALIAS")));
+            r.register(def(DummyFunction2.class, DummyFunction2::new, "DUMMY_FUNCTION2", "ALIAS")));
         assertEquals("alias [ALIAS] is used by [DUMMY_FUNCTION] and [DUMMY_FUNCTION2]", iae.getMessage());
     }
 
     public void testFunctionResolving() {
-        UnresolvedFunction ur = uf(STANDARD, mock(Expression.class));
+        UnresolvedFunction ur = uf(DEFAULT, mock(Expression.class));
         FunctionRegistry r = new FunctionRegistry(def(DummyFunction.class, (Source l, Expression e) -> {
             assertSame(e, ur.children().get(0));
             return new DummyFunction(l);
@@ -226,10 +149,10 @@ public class FunctionRegistryTests extends ESTestCase {
             is("Cannot find function DUMMYFUNCTION; this should have been caught during analysis"));
     }
 
-    private UnresolvedFunction uf(UnresolvedFunction.ResolutionType resolutionType, Expression... children) {
-        return new UnresolvedFunction(SourceTests.randomSource(), "DUMMY_FUNCTION", resolutionType, Arrays.asList(children));
+    public static UnresolvedFunction uf(FunctionResolutionStrategy resolutionStrategy, Expression... children) {
+        return new UnresolvedFunction(SourceTests.randomSource(), "DUMMY_FUNCTION", resolutionStrategy, Arrays.asList(children));
     }
-    
+
     public static class DummyFunction extends ScalarFunction {
         public DummyFunction(Source source) {
             super(source, emptyList());
@@ -260,7 +183,7 @@ public class FunctionRegistryTests extends ESTestCase {
             return null;
         }
     }
-    
+
     public static class DummyFunction2 extends DummyFunction {
         public DummyFunction2(Source source) {
             super(source);

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Analyzer.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Analyzer.java
@@ -18,6 +18,7 @@ import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.Expressions;
 import org.elasticsearch.xpack.ql.expression.FieldAttribute;
 import org.elasticsearch.xpack.ql.expression.Foldables;
+import org.elasticsearch.xpack.ql.expression.Literal;
 import org.elasticsearch.xpack.ql.expression.NamedExpression;
 import org.elasticsearch.xpack.ql.expression.Order;
 import org.elasticsearch.xpack.ql.expression.ReferenceAttribute;
@@ -27,6 +28,7 @@ import org.elasticsearch.xpack.ql.expression.UnresolvedStar;
 import org.elasticsearch.xpack.ql.expression.function.Function;
 import org.elasticsearch.xpack.ql.expression.function.FunctionDefinition;
 import org.elasticsearch.xpack.ql.expression.function.FunctionRegistry;
+import org.elasticsearch.xpack.ql.expression.function.FunctionResolutionStrategy;
 import org.elasticsearch.xpack.ql.expression.function.Functions;
 import org.elasticsearch.xpack.ql.expression.function.UnresolvedFunction;
 import org.elasticsearch.xpack.ql.expression.predicate.operator.arithmetic.ArithmeticOperation;
@@ -49,6 +51,7 @@ import org.elasticsearch.xpack.ql.type.UnsupportedEsField;
 import org.elasticsearch.xpack.ql.util.CollectionUtils;
 import org.elasticsearch.xpack.ql.util.Holder;
 import org.elasticsearch.xpack.sql.expression.SubQueryExpression;
+import org.elasticsearch.xpack.sql.expression.function.SqlFunctionResolution;
 import org.elasticsearch.xpack.sql.expression.function.scalar.Cast;
 import org.elasticsearch.xpack.sql.plan.logical.Join;
 import org.elasticsearch.xpack.sql.plan.logical.LocalRelation;
@@ -62,6 +65,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -880,7 +884,17 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
                 String name = uf.name();
 
                 if (hasStar(uf.arguments())) {
-                    uf = uf.preprocessStar();
+                    FunctionResolutionStrategy strategy = uf.resolutionStrategy();
+                    if (SqlFunctionResolution.DISTINCT == strategy) {
+                        uf = uf.withMessage("* is not valid with DISTINCT");
+                    } else if (SqlFunctionResolution.EXTRACT == strategy) {
+                        uf = uf.withMessage("Can't extract from *");
+                    } else {
+                        if (uf.name().toUpperCase(Locale.ROOT).equals("COUNT")) {
+                            uf = new UnresolvedFunction(uf.source(), uf.name(), strategy,
+                                singletonList(new Literal(uf.arguments().get(0).source(), Integer.valueOf(1), DataTypes.INTEGER)));
+                        }
+                    }
                     if (uf.analyzed()) {
                         return uf;
                     }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/SqlFunctionResolution.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/SqlFunctionResolution.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.sql.expression.function;
+
+import org.elasticsearch.xpack.ql.expression.function.Function;
+import org.elasticsearch.xpack.ql.expression.function.FunctionDefinition;
+import org.elasticsearch.xpack.ql.expression.function.FunctionResolutionStrategy;
+import org.elasticsearch.xpack.ql.expression.function.UnresolvedFunction;
+import org.elasticsearch.xpack.ql.session.Configuration;
+
+public enum SqlFunctionResolution implements FunctionResolutionStrategy {
+
+    /**
+     * Behavior of DISTINCT like {@code COUNT DISTINCT(col)}.
+     */
+    DISTINCT {
+        @Override
+        public Function buildResolved(UnresolvedFunction uf, Configuration cfg, FunctionDefinition def) {
+            return def.builder().build(uf, true, cfg);
+        }
+
+        @Override
+        public boolean isValidAlternative(FunctionDefinition def) {
+            return false; // think about this later.
+        }
+    },
+    /**
+     * Behavior of EXTRACT function calls like {@code EXTRACT(DAY FROM col)}.
+     */
+    EXTRACT {
+        @Override
+        public Function buildResolved(UnresolvedFunction uf, Configuration cfg, FunctionDefinition def) {
+            if (def.extractViable()) {
+                return def.builder().build(uf, false, cfg);
+            }
+            return uf.withMessage("Invalid datetime field [" + uf.name() + "]. Use any datetime function.");
+        }
+
+        @Override
+        public boolean isValidAlternative(FunctionDefinition def) {
+            return def.extractViable();
+        }
+
+        @Override
+        public String kind() {
+            return "datetime field";
+        }
+    }
+}

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/SqlFunctionRegistryTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/SqlFunctionRegistryTests.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.sql.expression.function;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.ql.ParsingException;
+import org.elasticsearch.xpack.ql.expression.Expression;
+import org.elasticsearch.xpack.ql.expression.function.FunctionDefinition;
+import org.elasticsearch.xpack.ql.expression.function.FunctionRegistry;
+import org.elasticsearch.xpack.ql.expression.function.FunctionRegistryTests;
+import org.elasticsearch.xpack.ql.expression.function.FunctionRegistryTests.DummyFunction;
+import org.elasticsearch.xpack.ql.expression.function.UnresolvedFunction;
+import org.elasticsearch.xpack.ql.session.Configuration;
+import org.elasticsearch.xpack.ql.tree.Source;
+
+import java.time.ZoneId;
+
+import static org.elasticsearch.xpack.ql.TestUtils.randomConfiguration;
+import static org.elasticsearch.xpack.ql.expression.function.FunctionRegistry.def;
+import static org.elasticsearch.xpack.ql.expression.function.FunctionRegistryTests.uf;
+import static org.elasticsearch.xpack.ql.expression.function.FunctionResolutionStrategy.DEFAULT;
+import static org.elasticsearch.xpack.sql.expression.function.SqlFunctionResolution.DISTINCT;
+import static org.elasticsearch.xpack.sql.expression.function.SqlFunctionResolution.EXTRACT;
+import static org.hamcrest.Matchers.endsWith;
+import static org.mockito.Mockito.mock;
+
+public class SqlFunctionRegistryTests extends ESTestCase {
+
+    public void testNoArgFunction() {
+        UnresolvedFunction ur = uf(DEFAULT);
+        FunctionRegistry r = new FunctionRegistry(def(DummyFunction.class, DummyFunction::new, "DUMMY_FUNCTION"));
+        FunctionDefinition def = r.resolveFunction(ur.name());
+
+        // Distinct isn't supported
+        ParsingException e = expectThrows(ParsingException.class, () ->
+            uf(DISTINCT).buildResolved(randomConfiguration(), def));
+        assertThat(e.getMessage(), endsWith("does not support DISTINCT yet it was specified"));
+
+        // Any children aren't supported
+        e = expectThrows(ParsingException.class, () ->
+            uf(DEFAULT, mock(Expression.class)).buildResolved(randomConfiguration(), def));
+        assertThat(e.getMessage(), endsWith("expects no arguments"));
+    }
+
+    public void testUnaryFunction() {
+        UnresolvedFunction ur = uf(DEFAULT, mock(Expression.class));
+        FunctionRegistry r = new FunctionRegistry(def(DummyFunction.class, (Source l, Expression e) -> {
+            assertSame(e, ur.children().get(0));
+            return new DummyFunction(l);
+        }, "DUMMY_FUNCTION"));
+        FunctionDefinition def = r.resolveFunction(ur.name());
+
+        // Distinct isn't supported
+        ParsingException e = expectThrows(ParsingException.class, () ->
+            uf(DISTINCT, mock(Expression.class)).buildResolved(randomConfiguration(), def));
+        assertThat(e.getMessage(), endsWith("does not support DISTINCT yet it was specified"));
+
+        // No children aren't supported
+        e = expectThrows(ParsingException.class, () ->
+            uf(DEFAULT).buildResolved(randomConfiguration(), def));
+        assertThat(e.getMessage(), endsWith("expects exactly one argument"));
+
+        // Multiple children aren't supported
+        e = expectThrows(ParsingException.class, () ->
+            uf(DEFAULT, mock(Expression.class), mock(Expression.class)).buildResolved(randomConfiguration(), def));
+        assertThat(e.getMessage(), endsWith("expects exactly one argument"));
+    }
+
+    public void testUnaryDistinctAwareFunction() {
+        boolean urIsDistinct = randomBoolean();
+        UnresolvedFunction ur = uf(urIsDistinct ? DISTINCT : DEFAULT, mock(Expression.class));
+        FunctionRegistry r = new FunctionRegistry(
+            def(FunctionRegistryTests.DummyFunction.class, (Source l, Expression e, boolean distinct) -> {
+                assertEquals(urIsDistinct, distinct);
+                assertSame(e, ur.children().get(0));
+                return new FunctionRegistryTests.DummyFunction(l);
+            }, "DUMMY_FUNCTION"));
+        FunctionDefinition def = r.resolveFunction(ur.name());
+        assertEquals(ur.source(), ur.buildResolved(randomConfiguration(), def).source());
+        assertFalse(def.extractViable());
+
+        // No children aren't supported
+        ParsingException e = expectThrows(ParsingException.class, () ->
+            uf(DEFAULT).buildResolved(randomConfiguration(), def));
+        assertThat(e.getMessage(), endsWith("expects exactly one argument"));
+
+        // Multiple children aren't supported
+        e = expectThrows(ParsingException.class, () ->
+            uf(DEFAULT, mock(Expression.class), mock(Expression.class)).buildResolved(randomConfiguration(), def));
+        assertThat(e.getMessage(), endsWith("expects exactly one argument"));
+    }
+
+    public void testDateTimeFunction() {
+        boolean urIsExtract = randomBoolean();
+        UnresolvedFunction ur = uf(urIsExtract ? EXTRACT : DEFAULT, mock(Expression.class));
+        ZoneId providedTimeZone = randomZone().normalized();
+        Configuration providedConfiguration = randomConfiguration(providedTimeZone);
+        FunctionRegistry r = new FunctionRegistry(def(FunctionRegistryTests.DummyFunction.class, (Source l, Expression e, ZoneId zi) -> {
+            assertEquals(providedTimeZone, zi);
+            assertSame(e, ur.children().get(0));
+            return new FunctionRegistryTests.DummyFunction(l);
+        }, "DUMMY_FUNCTION"));
+        FunctionDefinition def = r.resolveFunction(ur.name());
+        assertEquals(ur.source(), ur.buildResolved(providedConfiguration, def).source());
+        assertTrue(def.extractViable());
+
+        // Distinct isn't supported
+        ParsingException e = expectThrows(ParsingException.class, () ->
+            uf(DISTINCT, mock(Expression.class)).buildResolved(randomConfiguration(), def));
+        assertThat(e.getMessage(), endsWith("does not support DISTINCT yet it was specified"));
+
+        // No children aren't supported
+        e = expectThrows(ParsingException.class, () ->
+            uf(DEFAULT).buildResolved(randomConfiguration(), def));
+        assertThat(e.getMessage(), endsWith("expects exactly one argument"));
+
+        // Multiple children aren't supported
+        e = expectThrows(ParsingException.class, () ->
+            uf(DEFAULT, mock(Expression.class), mock(Expression.class)).buildResolved(randomConfiguration(), def));
+        assertThat(e.getMessage(), endsWith("expects exactly one argument"));
+    }
+}
+

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/SqlUnresolvedFunctionTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/SqlUnresolvedFunctionTests.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.sql.expression.function.scalar;
+
+import org.elasticsearch.xpack.ql.expression.function.FunctionResolutionStrategy;
+import org.elasticsearch.xpack.ql.expression.function.UnresolvedFunctionTests;
+import org.elasticsearch.xpack.sql.expression.function.SqlFunctionResolution;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class SqlUnresolvedFunctionTests extends UnresolvedFunctionTests {
+
+    @Override
+    protected List<FunctionResolutionStrategy> resolutionStrategies() {
+        return Arrays.asList(FunctionResolutionStrategy.DEFAULT, SqlFunctionResolution.DISTINCT, SqlFunctionResolution.EXTRACT);
+    }
+}


### PR DESCRIPTION
Backports the following commits to 7.x:
 - QL: Refactor function resolution strategy (#67672)