### PR TITLE
[Fleet] Allow Kibana system user to read and write to Fleet server indices

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -155,7 +155,7 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                                 RoleDescriptor.IndicesPrivileges.builder()
                                     .indices(".logs-endpoint.diagnostic.collection-*")
                                     .privileges("read").build(),
-                                // Fleet Server indices Kibana read and write to these indices to manage Elastic Agents
+                                // Fleet Server indices. Kibana read and write from these indices to manage Elastic Agents (add actions, reassign policies, ...)
                                 RoleDescriptor.IndicesPrivileges.builder()
                                     .indices(".fleet-agents")
                                     .privileges("read", "write").build(),
@@ -163,16 +163,17 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                                     .indices(".fleet-actions")
                                     .privileges("read", "write").build(),
                                 RoleDescriptor.IndicesPrivileges.builder()
-                                    .indices(".fleet-actions-results")
-                                    .privileges("read").build(),
-                                RoleDescriptor.IndicesPrivileges.builder()
                                     .indices(".fleet-enrollment-api-keys")
                                     .privileges("read", "write").build(),
                                 RoleDescriptor.IndicesPrivileges.builder()
                                     .indices(".fleet-policies")
                                     .privileges("read", "write").build(),
+                                // Fleet Server indices. Kibana read from these indices to manage Elastic Agents
                                 RoleDescriptor.IndicesPrivileges.builder()
                                     .indices(".fleet-servers")
+                                    .privileges("read").build(),
+                                RoleDescriptor.IndicesPrivileges.builder()
+                                    .indices(".fleet-actions-results")
                                     .privileges("read").build(),
                         },
                         null,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -156,15 +156,19 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                                     .indices(".logs-endpoint.diagnostic.collection-*")
                                     .privileges("read").build(),
                                 // Fleet Server indices. Kibana read and write from these indices to manage Elastic Agents.
+                                // Kibana write to this indice to reassign agent policy or perform force unenroll
                                 RoleDescriptor.IndicesPrivileges.builder()
                                     .indices(".fleet-agents")
                                     .privileges("read", "write").build(),
+                                // Kibana write to this indice to add action to an agent, upgrade, unenroll, ...
                                 RoleDescriptor.IndicesPrivileges.builder()
                                     .indices(".fleet-actions")
                                     .privileges("read", "write").build(),
+                                // Kibana write to this indice new enrollment api key
                                 RoleDescriptor.IndicesPrivileges.builder()
                                     .indices(".fleet-enrollment-api-keys")
                                     .privileges("read", "write").build(),
+                                // Kibana write to this indice every policy change
                                 RoleDescriptor.IndicesPrivileges.builder()
                                     .indices(".fleet-policies")
                                     .privileges("read", "write").build(),

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -155,6 +155,25 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                                 RoleDescriptor.IndicesPrivileges.builder()
                                     .indices(".logs-endpoint.diagnostic.collection-*")
                                     .privileges("read").build(),
+                                // Fleet Server indices Kibana read and write to these indices to manage Elastic Agents
+                                RoleDescriptor.IndicesPrivileges.builder()
+                                    .indices(".fleet-agents")
+                                    .privileges("read", "write").build(),
+                                RoleDescriptor.IndicesPrivileges.builder()
+                                    .indices(".fleet-actions")
+                                    .privileges("read", "write").build(),
+                                RoleDescriptor.IndicesPrivileges.builder()
+                                    .indices(".fleet-actions-results")
+                                    .privileges("read", "write").build(),
+                                RoleDescriptor.IndicesPrivileges.builder()
+                                    .indices(".fleet-enrollment-api-keys")
+                                    .privileges("read", "write").build(),
+                                RoleDescriptor.IndicesPrivileges.builder()
+                                    .indices(".fleet-policies")
+                                    .privileges("read", "write").build(),
+                                RoleDescriptor.IndicesPrivileges.builder()
+                                    .indices(".fleet-servers")
+                                    .privileges("read", "write").build(),
                         },
                         null,
                         new ConfigurableClusterPrivilege[] { new ManageApplicationPrivileges(Collections.singleton("kibana-*")) },

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -164,7 +164,7 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                                     .privileges("read", "write").build(),
                                 RoleDescriptor.IndicesPrivileges.builder()
                                     .indices(".fleet-actions-results")
-                                    .privileges("read", "write").build(),
+                                    .privileges("read").build(),
                                 RoleDescriptor.IndicesPrivileges.builder()
                                     .indices(".fleet-enrollment-api-keys")
                                     .privileges("read", "write").build(),
@@ -173,7 +173,7 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                                     .privileges("read", "write").build(),
                                 RoleDescriptor.IndicesPrivileges.builder()
                                     .indices(".fleet-servers")
-                                    .privileges("read", "write").build(),
+                                    .privileges("read").build(),
                         },
                         null,
                         new ConfigurableClusterPrivilege[] { new ManageApplicationPrivileges(Collections.singleton("kibana-*")) },

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -155,7 +155,7 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                                 RoleDescriptor.IndicesPrivileges.builder()
                                     .indices(".logs-endpoint.diagnostic.collection-*")
                                     .privileges("read").build(),
-                                // Fleet Server indices. Kibana read and write from these indices to manage Elastic Agents (add actions, reassign policies, ...)
+                                // Fleet Server indices. Kibana read and write from these indices to manage Elastic Agents.
                                 RoleDescriptor.IndicesPrivileges.builder()
                                     .indices(".fleet-agents")
                                     .privileges("read", "write").build(),

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -485,10 +485,8 @@ public class ReservedRolesStoreTests extends ESTestCase {
         Arrays.asList(
             ".fleet-agents",
             ".fleet-actions",
-            ".fleet-actions-results",
             ".fleet-enrollment-api-keys",
-            ".fleet-policies",
-            ".fleet-servers"
+            ".fleet-policies"
         ).forEach((index) -> {
             assertThat(kibanaRole.indices().allowedIndicesMatcher("indices:foo").test(mockIndexAbstraction(index)), is(false));
             assertThat(kibanaRole.indices().allowedIndicesMatcher("indices:bar").test(mockIndexAbstraction(index)), is(false));
@@ -497,11 +495,29 @@ public class ReservedRolesStoreTests extends ESTestCase {
             assertThat(kibanaRole.indices().allowedIndicesMatcher(CreateIndexAction.NAME).test(mockIndexAbstraction(index)), is(false));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(IndexAction.NAME).test(mockIndexAbstraction(index)), is(true));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(DeleteAction.NAME).test(mockIndexAbstraction(index)), is(true));
-            assertThat(kibanaRole.indices().allowedIndicesMatcher(UpdateSettingsAction.NAME).test(mockIndexAbstraction(index)), is(true));
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(UpdateSettingsAction.NAME).test(mockIndexAbstraction(index)), is(false));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(SearchAction.NAME).test(mockIndexAbstraction(index)), is(true));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(MultiSearchAction.NAME).test(mockIndexAbstraction(index)), is(true));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(GetAction.NAME).test(mockIndexAbstraction(index)), is(true));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(READ_CROSS_CLUSTER_NAME).test(mockIndexAbstraction(index)), is(true));
+        });
+        // readonly indices for Fleet Server
+        Arrays.asList(
+            ".fleet-actions-results",
+            ".fleet-servers"
+        ).forEach((index) -> {
+            assertThat(kibanaRole.indices().allowedIndicesMatcher("indices:foo").test(mockIndexAbstraction(index)), is(false));
+            assertThat(kibanaRole.indices().allowedIndicesMatcher("indices:bar").test(mockIndexAbstraction(index)), is(false));
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(DeleteIndexAction.NAME).test(mockIndexAbstraction(index)), is(false));
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(GetIndexAction.NAME).test(mockIndexAbstraction(index)), is(true));
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(CreateIndexAction.NAME).test(mockIndexAbstraction(index)), is(false));
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(IndexAction.NAME).test(mockIndexAbstraction(index)), is(false));
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(DeleteAction.NAME).test(mockIndexAbstraction(index)), is(false));
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(UpdateSettingsAction.NAME).test(mockIndexAbstraction(index)), is(false));
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(SearchAction.NAME).test(mockIndexAbstraction(index)), is(true));
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(MultiSearchAction.NAME).test(mockIndexAbstraction(index)), is(true));
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(GetAction.NAME).test(mockIndexAbstraction(index)), is(true));
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(READ_CROSS_CLUSTER_NAME).test(mockIndexAbstraction(index)), is(false));
         });
 
         // Data telemetry reads mappings, metadata and stats of indices

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -481,6 +481,28 @@ public class ReservedRolesStoreTests extends ESTestCase {
             assertThat(kibanaRole.indices().allowedIndicesMatcher(READ_CROSS_CLUSTER_NAME).test(mockIndexAbstraction(index)), is(false));
         });
 
+        // read and write indices for Fleet Server
+        Arrays.asList(
+            ".fleet-agents",
+            ".fleet-actions",
+            ".fleet-actions-results",
+            ".fleet-enrollment-api-keys",
+            ".fleet-policies",
+            ".fleet-servers"
+        ).forEach((index) -> {
+            assertThat(kibanaRole.indices().allowedIndicesMatcher("indices:foo").test(mockIndexAbstraction(index)), is(false));
+            assertThat(kibanaRole.indices().allowedIndicesMatcher("indices:bar").test(mockIndexAbstraction(index)), is(false));
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(DeleteIndexAction.NAME).test(mockIndexAbstraction(index)), is(false));
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(GetIndexAction.NAME).test(mockIndexAbstraction(index)), is(true));
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(CreateIndexAction.NAME).test(mockIndexAbstraction(index)), is(false));
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(IndexAction.NAME).test(mockIndexAbstraction(index)), is(true));
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(DeleteAction.NAME).test(mockIndexAbstraction(index)), is(true));
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(UpdateSettingsAction.NAME).test(mockIndexAbstraction(index)), is(true));
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(SearchAction.NAME).test(mockIndexAbstraction(index)), is(true));
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(MultiSearchAction.NAME).test(mockIndexAbstraction(index)), is(true));
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(GetAction.NAME).test(mockIndexAbstraction(index)), is(true));
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(READ_CROSS_CLUSTER_NAME).test(mockIndexAbstraction(index)), is(true));
+        });
 
         // Data telemetry reads mappings, metadata and stats of indices
         Arrays.asList(randomAlphaOfLengthBetween(8, 24), "packetbeat-*", "logs-*").forEach((index) -> {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -499,7 +499,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
             assertThat(kibanaRole.indices().allowedIndicesMatcher(SearchAction.NAME).test(mockIndexAbstraction(index)), is(true));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(MultiSearchAction.NAME).test(mockIndexAbstraction(index)), is(true));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(GetAction.NAME).test(mockIndexAbstraction(index)), is(true));
-            assertThat(kibanaRole.indices().allowedIndicesMatcher(READ_CROSS_CLUSTER_NAME).test(mockIndexAbstraction(index)), is(true));
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(READ_CROSS_CLUSTER_NAME).test(mockIndexAbstraction(index)), is(false));
         });
         // readonly indices for Fleet Server
         Arrays.asList(


### PR DESCRIPTION
## Description 

To allow to migrate from Kibana saved object to new indices for Fleet server we need to add `read` and `write` permissions to the following indices:
* `.fleet-agents`
* `.fleet-actions`
* `.fleet-actions-results`
* `.fleet-enrollment-api-keys`
* `.fleet-policies`
* `.fleet-servers`

The indices will be created via an integration package with the current user permissions.

Related to https://github.com/elastic/kibana/issues/87372