### PR TITLE
[ML] fixing ml autoscaling decider bugs around requested node size and tier size

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsState.java
@@ -44,4 +44,11 @@ public enum DataFrameAnalyticsState implements Writeable {
     public boolean isAnyOf(DataFrameAnalyticsState... candidates) {
         return Arrays.stream(candidates).anyMatch(candidate -> this == candidate);
     }
+
+    /**
+     * @return {@code false} if state matches any of the given {@code candidates}
+     */
+    public boolean isNoneOf(DataFrameAnalyticsState... candidates) {
+        return Arrays.stream(candidates).noneMatch(candidate -> this == candidate);
+    }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/JobState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/JobState.java
@@ -48,6 +48,13 @@ public enum JobState implements Writeable {
         return Arrays.stream(candidates).anyMatch(candidate -> this == candidate);
     }
 
+    /**
+     * @return {@code false} if state matches any of the given {@code candidates}
+     */
+    public boolean isNoneOf(JobState... candidates) {
+        return Arrays.stream(candidates).noneMatch(candidate -> this == candidate);
+    }
+
     @Override
     public String toString() {
         return name().toLowerCase(Locale.ROOT);

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/AutoscalingIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/AutoscalingIT.java
@@ -99,7 +99,7 @@ public class AutoscalingIT extends MlNativeAutodetectIntegTestCase {
             .collect(Collectors.toList());
         NativeMemoryCapacity currentScale = MlAutoscalingDeciderService.currentScale(mlNodes, 30, false);
         expectedTierBytes = (long)Math.ceil(
-            (ByteSizeValue.ofMb(50_000 + BASIC_REQUIREMENT_MB + 60_000 + BASIC_REQUIREMENT_MB).getBytes()
+            (ByteSizeValue.ofMb(50_000 + BASIC_REQUIREMENT_MB + 60_000 + BASELINE_OVERHEAD_MB).getBytes()
                 + currentScale.getTier()
             ) * 100 / 30.0
         );

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlScalingReason.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlScalingReason.java
@@ -126,7 +126,7 @@ public class MlScalingReason implements AutoscalingDeciderResult.Reason {
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         builder.field(WAITING_ANALYTICS_JOBS, waitingAnalyticsJobs);
-        builder.field(WAITING_ANOMALY_JOBS, waitingAnalyticsJobs);
+        builder.field(WAITING_ANOMALY_JOBS, waitingAnomalyJobs);
         builder.startObject(CONFIGURATION).value(passedConfiguration).endObject();
         if (largestWaitingAnalyticsJob != null) {
             builder.field(LARGEST_WAITING_ANALYTICS_JOB, largestWaitingAnalyticsJob);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/NativeMemoryCapacity.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/NativeMemoryCapacity.java
@@ -63,8 +63,11 @@ public class NativeMemoryCapacity  {
             useAuto
         ));
         double inverseScale = memoryPercentForMl <= 0 ? 0 : 100.0 / memoryPercentForMl;
+        long actualTier = (long)Math.ceil(tier * inverseScale);
         return new AutoscalingCapacity(
-            new AutoscalingCapacity.AutoscalingResources(null, ByteSizeValue.ofBytes((long)Math.ceil(tier * inverseScale))),
+            // Tier should always be AT LEAST the largest node size.
+            // This Math.max catches any strange rounding errors or weird input.
+            new AutoscalingCapacity.AutoscalingResources(null, ByteSizeValue.ofBytes(Math.max(actualTier, actualNodeSize))),
             new AutoscalingCapacity.AutoscalingResources(null, ByteSizeValue.ofBytes(actualNodeSize))
         );
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/NodeLoad.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/NodeLoad.java
@@ -21,6 +21,16 @@ import java.util.Objects;
 
 public class NodeLoad {
 
+    public static boolean taskStateFilter(JobState jobState) {
+        return jobState == null || jobState.isNoneOf(JobState.CLOSED, JobState.FAILED);
+    }
+
+    public static boolean taskStateFilter(DataFrameAnalyticsState dataFrameAnalyticsState) {
+        // Don't count stopped and failed df-analytics tasks as they don't consume native memory
+        return dataFrameAnalyticsState == null
+            || dataFrameAnalyticsState.isNoneOf(DataFrameAnalyticsState.STOPPED, DataFrameAnalyticsState.FAILED);
+    }
+
     private static final Logger logger = LogManager.getLogger(NodeLoadDetector.class);
 
     private final long maxMemory;
@@ -205,7 +215,7 @@ public class NodeLoad {
         void adjustForAnomalyJob(JobState jobState,
                                  String jobId,
                                  MlMemoryTracker mlMemoryTracker) {
-            if ((jobState.isAnyOf(JobState.CLOSED, JobState.FAILED) == false) && jobId != null) {
+            if (taskStateFilter(jobState) && jobId != null) {
                 // Don't count CLOSED or FAILED jobs, as they don't consume native memory
                 ++numAssignedJobs;
                 if (jobState == JobState.OPENING) {
@@ -228,8 +238,7 @@ public class NodeLoad {
                                    MlMemoryTracker mlMemoryTracker) {
             DataFrameAnalyticsState dataFrameAnalyticsState = MlTasks.getDataFrameAnalyticsState(assignedTask);
 
-            // Don't count stopped and failed df-analytics tasks as they don't consume native memory
-            if (dataFrameAnalyticsState.isAnyOf(DataFrameAnalyticsState.STOPPED, DataFrameAnalyticsState.FAILED) == false) {
+            if (taskStateFilter(dataFrameAnalyticsState)) {
                 // The native process is only running in the ANALYZING and STOPPING states, but in the STARTED
                 // and REINDEXING states we're committed to using the memory soon, so account for it here
                 ++numAssignedJobs;

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingDeciderServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingDeciderServiceTests.java
@@ -7,26 +7,44 @@
 package org.elasticsearch.xpack.ml.autoscaling;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterInfo;
+import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
+import org.elasticsearch.snapshots.SnapshotShardSizeInfo;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingCapacity;
 import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingDeciderContext;
 import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingDeciderResult;
+import org.elasticsearch.xpack.core.ml.MlTasks;
+import org.elasticsearch.xpack.core.ml.action.OpenJobAction;
+import org.elasticsearch.xpack.core.ml.action.StartDataFrameAnalyticsAction;
+import org.elasticsearch.xpack.core.ml.action.StartDatafeedAction;
+import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsState;
+import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsTaskState;
+import org.elasticsearch.xpack.core.ml.job.config.JobState;
+import org.elasticsearch.xpack.core.ml.job.config.JobTaskState;
 import org.elasticsearch.xpack.ml.MachineLearning;
 import org.elasticsearch.xpack.ml.job.NodeLoad;
 import org.elasticsearch.xpack.ml.job.NodeLoadDetector;
+import org.elasticsearch.xpack.ml.job.task.OpenJobPersistentTasksExecutorTests;
 import org.elasticsearch.xpack.ml.process.MlMemoryTracker;
+import org.elasticsearch.xpack.ml.utils.NativeMemoryCalculator;
 import org.junit.Before;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -34,8 +52,12 @@ import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.xpack.ml.job.JobNodeSelector.AWAITING_LAZY_ASSIGNMENT;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyInt;
@@ -45,7 +67,7 @@ import static org.mockito.Mockito.when;
 
 public class MlAutoscalingDeciderServiceTests extends ESTestCase {
 
-    private static final long DEFAULT_NODE_SIZE = ByteSizeValue.ofGb(2).getBytes();
+    private static final long DEFAULT_NODE_SIZE = ByteSizeValue.ofGb(20).getBytes();
     private static final long DEFAULT_JVM_SIZE = ByteSizeValue.ofMb((long)(DEFAULT_NODE_SIZE * 0.25)).getBytes();
     private static final long DEFAULT_JOB_SIZE = ByteSizeValue.ofMb(200).getBytes();
     private static final long OVERHEAD = ByteSizeValue.ofMb(30).getBytes();
@@ -53,10 +75,12 @@ public class MlAutoscalingDeciderServiceTests extends ESTestCase {
     private ClusterService clusterService;
     private Settings settings;
     private Supplier<Long> timeSupplier;
+    private MlMemoryTracker mlMemoryTracker;
 
     @Before
     public void setup() {
-        MlMemoryTracker mlMemoryTracker = mock(MlMemoryTracker.class);
+        mlMemoryTracker = mock(MlMemoryTracker.class);
+        when(mlMemoryTracker.isRecentlyRefreshed(any())).thenReturn(true);
         when(mlMemoryTracker.asyncRefresh()).thenReturn(true);
         when(mlMemoryTracker.getAnomalyDetectorJobMemoryRequirement(any())).thenReturn(DEFAULT_JOB_SIZE);
         when(mlMemoryTracker.getDataFrameAnalyticsJobMemoryRequirement(any())).thenReturn(DEFAULT_JOB_SIZE);
@@ -95,6 +119,51 @@ public class MlAutoscalingDeciderServiceTests extends ESTestCase {
             equalTo(Optional.empty()));
     }
 
+    public void testScaleUp_withWaitingJobsAndAutoMemory() {
+        when(mlMemoryTracker.getAnomalyDetectorJobMemoryRequirement(any())).thenReturn(ByteSizeValue.ofGb(2).getBytes());
+        when(mlMemoryTracker.getDataFrameAnalyticsJobMemoryRequirement(any())).thenReturn(ByteSizeValue.ofGb(2).getBytes());
+        List<String> jobTasks = Arrays.asList("waiting_job", "waiting_job_2");
+        List<String> analytics = Arrays.asList("analytics_waiting");
+        MlScalingReason.Builder reasonBuilder = new MlScalingReason.Builder()
+            .setPassedConfiguration(Settings.EMPTY)
+            .setCurrentMlCapacity(AutoscalingCapacity.ZERO);
+        MlAutoscalingDeciderService service = buildService();
+        service.setUseAuto(true);
+        { // No time in queue
+            Optional<AutoscalingDeciderResult> decision = service.checkForScaleUp(0, 0,
+                jobTasks,
+                analytics,
+                null,
+                NativeMemoryCapacity.ZERO,
+                reasonBuilder);
+            assertFalse(decision.isEmpty());
+            assertThat(decision.get().requiredCapacity().node().memory().getBytes(), equalTo(3512729601L));
+            assertThat(decision.get().requiredCapacity().total().memory().getBytes(), equalTo(9382475687L));
+        }
+        { // we allow one job in the analytics queue
+            Optional<AutoscalingDeciderResult> decision = service.checkForScaleUp(0, 1,
+                jobTasks,
+                analytics,
+                null,
+                NativeMemoryCapacity.ZERO,
+                reasonBuilder);
+            assertFalse(decision.isEmpty());
+            assertThat(decision.get().requiredCapacity().node().memory().getBytes(), equalTo(3512729601L));
+            assertThat(decision.get().requiredCapacity().total().memory().getBytes(), equalTo(6270180545L));
+        }
+        { // we allow one job in the anomaly queue and analytics queue
+            Optional<AutoscalingDeciderResult> decision = service.checkForScaleUp(1, 1,
+                jobTasks,
+                analytics,
+                null,
+                NativeMemoryCapacity.ZERO,
+                reasonBuilder);
+            assertFalse(decision.isEmpty());
+            assertThat(decision.get().requiredCapacity().node().memory().getBytes(), equalTo(3512729601L));
+            assertThat(decision.get().requiredCapacity().total().memory().getBytes(), equalTo(3512729601L));
+        }
+    }
+
     public void testScaleUp_withWaitingJobs() {
         List<String> jobTasks = Arrays.asList("waiting_job", "waiting_job_2");
         List<String> analytics = Arrays.asList("analytics_waiting");
@@ -112,7 +181,8 @@ public class MlAutoscalingDeciderServiceTests extends ESTestCase {
                 reasonBuilder);
             assertFalse(decision.isEmpty());
             assertThat(decision.get().requiredCapacity().node().memory().getBytes(), equalTo((DEFAULT_JOB_SIZE + OVERHEAD) * 4));
-            assertThat(decision.get().requiredCapacity().total().memory().getBytes(), equalTo(12 * DEFAULT_JOB_SIZE));
+            assertThat(decision.get().requiredCapacity().total().memory().getBytes(),
+                equalTo(4 * (3 * DEFAULT_JOB_SIZE + OVERHEAD)));
         }
         { // we allow one job in the analytics queue
             Optional<AutoscalingDeciderResult> decision = service.checkForScaleUp(0, 1,
@@ -123,7 +193,8 @@ public class MlAutoscalingDeciderServiceTests extends ESTestCase {
                 reasonBuilder);
             assertFalse(decision.isEmpty());
             assertThat(decision.get().requiredCapacity().node().memory().getBytes(), equalTo(4 * (DEFAULT_JOB_SIZE + OVERHEAD)));
-            assertThat(decision.get().requiredCapacity().total().memory().getBytes(), equalTo(8 * DEFAULT_JOB_SIZE));
+            assertThat(decision.get().requiredCapacity().total().memory().getBytes(),
+                equalTo(4 * (2 * DEFAULT_JOB_SIZE + OVERHEAD)));
         }
         { // we allow one job in the anomaly queue and analytics queue
             Optional<AutoscalingDeciderResult> decision = service.checkForScaleUp(1, 1,
@@ -134,7 +205,7 @@ public class MlAutoscalingDeciderServiceTests extends ESTestCase {
                 reasonBuilder);
             assertFalse(decision.isEmpty());
             assertThat(decision.get().requiredCapacity().node().memory().getBytes(), equalTo(4 * (DEFAULT_JOB_SIZE + OVERHEAD)));
-            assertThat(decision.get().requiredCapacity().total().memory().getBytes(), equalTo(4 * DEFAULT_JOB_SIZE));
+            assertThat(decision.get().requiredCapacity().total().memory().getBytes(), equalTo(4 * (DEFAULT_JOB_SIZE + OVERHEAD)));
         }
     }
 
@@ -263,8 +334,137 @@ public class MlAutoscalingDeciderServiceTests extends ESTestCase {
         }
     }
 
+    public void testFutureAvailableCapacity() {
+        nodeLoadDetector = new NodeLoadDetector(mlMemoryTracker);
+        MlAutoscalingDeciderService service = buildService();
+        service.onMaster();
+        service.setUseAuto(true);
+        boolean waitingAnalytics = randomBoolean();
+        boolean waitingAnomalyJobs = !waitingAnalytics || randomBoolean();
+        int maxWaitingAnalytics = randomIntBetween(1, 2);
+        int maxWaitingAnomaly = randomIntBetween(1, 2);
+        List<String> assignedAnomalyJobs = randomList(0, 2, () -> randomAlphaOfLength(10));
+        List<String> batchAnomalyJobs = randomList(0, 2, () -> randomAlphaOfLength(10));
+        List<String> assignedAnalyticsJobs = randomList(0, 2, () -> randomAlphaOfLength(10));
+        ClusterState clusterState = clusterState(
+            assignedAnomalyJobs,
+            batchAnomalyJobs,
+            assignedAnalyticsJobs,
+            waitingAnomalyJobs ? randomList(1, maxWaitingAnomaly, () -> randomAlphaOfLength(10)) : Collections.emptyList(),
+            waitingAnalytics ? randomList(1, maxWaitingAnalytics, () -> randomAlphaOfLength(10)) : Collections.emptyList()
+        );
+
+        Optional<NativeMemoryCapacity> nativeMemoryCapacity = service.calculateFutureAvailableCapacity(
+            clusterState.metadata().custom(PersistentTasksCustomMetadata.TYPE),
+            Duration.ofMillis(10),
+            clusterState.getNodes().mastersFirstStream().collect(Collectors.toList()),
+            clusterState
+        );
+        assertThat(nativeMemoryCapacity.isEmpty(), is(false));
+        assertThat(nativeMemoryCapacity.get().getNode(), greaterThanOrEqualTo(DEFAULT_JOB_SIZE));
+        assertThat(nativeMemoryCapacity.get().getNode(),
+            lessThanOrEqualTo(NativeMemoryCalculator.allowedBytesForMl(DEFAULT_NODE_SIZE, 20, true)));
+        assertThat(nativeMemoryCapacity.get().getTier(),
+            greaterThanOrEqualTo(DEFAULT_JOB_SIZE * (assignedAnomalyJobs.size() + batchAnomalyJobs.size())));
+        assertThat(nativeMemoryCapacity.get().getTier(),
+            lessThanOrEqualTo(3 * (NativeMemoryCalculator.allowedBytesForMl(DEFAULT_NODE_SIZE, 20, true))));
+    }
+
+    public void testScale_WithNoScaleUpButWaitingJobs() {
+        nodeLoadDetector = new NodeLoadDetector(mlMemoryTracker);
+        MlAutoscalingDeciderService service = buildService();
+        service.onMaster();
+        service.setUseAuto(true);
+        boolean waitingAnalytics = randomBoolean();
+        boolean waitingAnomalyJobs = !waitingAnalytics || randomBoolean();
+        int maxWaitingAnalytics = randomIntBetween(1, 2);
+        int maxWaitingAnomaly = randomIntBetween(1, 2);
+        ClusterState clusterState = clusterState(
+            randomList(0, 2, () -> randomAlphaOfLength(10)),
+            randomList(0, 2, () -> randomAlphaOfLength(10)),
+            randomList(0, 2, () -> randomAlphaOfLength(10)),
+            waitingAnomalyJobs ? randomList(1, maxWaitingAnomaly, () -> randomAlphaOfLength(10)) : Collections.emptyList(),
+            waitingAnalytics ? randomList(1, maxWaitingAnalytics, () -> randomAlphaOfLength(10)) : Collections.emptyList()
+        );
+
+        Settings settings = Settings.builder()
+            .put(MlAutoscalingDeciderService.NUM_ANALYTICS_JOBS_IN_QUEUE.getKey(), maxWaitingAnalytics)
+            .put(MlAutoscalingDeciderService.NUM_ANOMALY_JOBS_IN_QUEUE.getKey(), maxWaitingAnalytics)
+            .build();
+        AutoscalingCapacity autoscalingCapacity = new AutoscalingCapacity(
+            new AutoscalingCapacity.AutoscalingResources(ByteSizeValue.ofGb(1), ByteSizeValue.ofGb(1)),
+            new AutoscalingCapacity.AutoscalingResources(ByteSizeValue.ofGb(1), ByteSizeValue.ofGb(1))
+        );
+
+        DeciderContext deciderContext = new DeciderContext(clusterState, autoscalingCapacity);
+
+        AutoscalingDeciderResult result = service.scale(settings, deciderContext);
+        assertThat(result.reason().summary(),
+            containsString("Passing currently perceived capacity as there are analytics and anomaly jobs in the queue"));
+        assertThat(result.requiredCapacity(), equalTo(autoscalingCapacity));
+    }
+
     private MlAutoscalingDeciderService buildService() {
         return new MlAutoscalingDeciderService(nodeLoadDetector, settings, clusterService, timeSupplier);
+    }
+
+    private static ClusterState clusterState(List<String> anomalyTasks,
+                                             List<String> batchAnomalyTasks,
+                                             List<String> analyticsTasks,
+                                             List<String> waitingAnomalyTasks,
+                                             List<String> waitingAnalyticsTasks) {
+        List<String> nodeNames = Arrays.asList("_node_id1", "_node_id2", "_node_id3");
+        List<DiscoveryNode> nodeList = withMlNodes(nodeNames.toArray(String[]::new));
+        DiscoveryNodes.Builder nodesBuilder = DiscoveryNodes.builder();
+        for (DiscoveryNode node : nodeList) {
+            nodesBuilder.add(node);
+        };
+        PersistentTasksCustomMetadata.Builder tasksBuilder = PersistentTasksCustomMetadata.builder();
+        for (String jobId : anomalyTasks) {
+            OpenJobPersistentTasksExecutorTests.addJobTask(jobId,
+                randomFrom(nodeNames),
+                randomFrom(JobState.CLOSING, JobState.OPENED, JobState.OPENING, (JobState)null),
+                tasksBuilder);
+        }
+        for (String jobId : batchAnomalyTasks) {
+            String nodeAssignment = randomFrom(nodeNames);
+            OpenJobPersistentTasksExecutorTests.addJobTask(jobId,
+                nodeAssignment,
+                randomFrom(JobState.CLOSING, JobState.OPENED, JobState.OPENING, (JobState)null),
+                tasksBuilder);
+            StartDatafeedAction.DatafeedParams dfParams =new StartDatafeedAction.DatafeedParams(jobId + "-datafeed", 0);
+            dfParams.setEndTime(new Date().getTime());
+            tasksBuilder.addTask(
+                MlTasks.datafeedTaskId(jobId + "-datafeed"),
+                MlTasks.DATAFEED_TASK_NAME,
+                dfParams,
+                new PersistentTasksCustomMetadata.Assignment(nodeAssignment, "test"));
+        }
+        for (String analyticsId : analyticsTasks) {
+            addAnalyticsTask(analyticsId,
+                randomFrom(nodeNames),
+                randomFrom(
+                    DataFrameAnalyticsState.STARTED,
+                    DataFrameAnalyticsState.REINDEXING,
+                    DataFrameAnalyticsState.ANALYZING,
+                    DataFrameAnalyticsState.STOPPING,
+                    DataFrameAnalyticsState.STARTING
+                ),
+                tasksBuilder);
+        }
+        for (String job : waitingAnalyticsTasks) {
+            addAnalyticsTask(job, null, null, tasksBuilder);
+        }
+        for (String job : waitingAnomalyTasks) {
+            addJobTask(job, null, null, tasksBuilder);
+        }
+        PersistentTasksCustomMetadata tasks = tasksBuilder.build();
+        ClusterState.Builder cs = ClusterState.builder(new ClusterName("_name"));
+        cs.nodes(nodesBuilder);
+        Metadata.Builder metadata = Metadata.builder();
+        metadata.putCustom(PersistentTasksCustomMetadata.TYPE, tasks);
+        cs.metadata(metadata);
+        return cs.build();
     }
 
     private static List<DiscoveryNode> withMlNodes(String... nodeName) {
@@ -275,10 +475,80 @@ public class MlAutoscalingDeciderServiceTests extends ESTestCase {
                 MapBuilder.<String, String>newMapBuilder()
                     .put(MachineLearning.MACHINE_MEMORY_NODE_ATTR, String.valueOf(DEFAULT_NODE_SIZE))
                     .put(MachineLearning.MAX_JVM_SIZE_NODE_ATTR, String.valueOf(DEFAULT_JVM_SIZE))
+                    .put(MachineLearning.MAX_OPEN_JOBS_NODE_ATTR, String.valueOf(10))
                     .map(),
                 new HashSet<>(Arrays.asList(DiscoveryNodeRole.MASTER_ROLE)),
                 Version.CURRENT))
             .collect(Collectors.toList());
+    }
+
+    public static void addAnalyticsTask(String jobId,
+                                        String nodeId,
+                                        DataFrameAnalyticsState jobState,
+                                        PersistentTasksCustomMetadata.Builder builder) {
+        builder.addTask(
+            MlTasks.dataFrameAnalyticsTaskId(jobId),
+            MlTasks.DATA_FRAME_ANALYTICS_TASK_NAME,
+            new StartDataFrameAnalyticsAction.TaskParams(jobId, Version.CURRENT, Collections.emptyList(), true),
+            nodeId == null ? AWAITING_LAZY_ASSIGNMENT : new PersistentTasksCustomMetadata.Assignment(nodeId, "test assignment")
+        );
+        if (jobState != null) {
+            builder.updateTaskState(
+                MlTasks.dataFrameAnalyticsTaskId(jobId),
+                new DataFrameAnalyticsTaskState(jobState, builder.getLastAllocationId(), null)
+            );
+        }
+    }
+
+    public static void addJobTask(String jobId,
+                                  String nodeId,
+                                  JobState jobState,
+                                  PersistentTasksCustomMetadata.Builder builder) {
+        builder.addTask(
+            MlTasks.jobTaskId(jobId),
+            MlTasks.JOB_TASK_NAME,
+            new OpenJobAction.JobParams(jobId),
+            nodeId == null ? AWAITING_LAZY_ASSIGNMENT : new PersistentTasksCustomMetadata.Assignment(nodeId, "test assignment"));
+        if (jobState != null) {
+            builder.updateTaskState(MlTasks.jobTaskId(jobId),
+                new JobTaskState(jobState, builder.getLastAllocationId(), null));
+        }
+    }
+
+    static class DeciderContext implements AutoscalingDeciderContext {
+
+        private final ClusterState state;
+        private final AutoscalingCapacity capacity;
+
+        DeciderContext(ClusterState state, AutoscalingCapacity capacity) {
+            this.state = state;
+            this.capacity = capacity;
+        }
+
+        @Override
+        public ClusterState state() {
+            return state;
+        }
+
+        @Override
+        public AutoscalingCapacity currentCapacity() {
+            return capacity;
+        }
+
+        @Override
+        public Set<DiscoveryNode> nodes() {
+            return null;
+        }
+
+        @Override
+        public ClusterInfo info() {
+            return null;
+        }
+
+        @Override
+        public SnapshotShardSizeInfo snapshotShardSizeInfo() {
+            return null;
+        }
     }
 
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingDeciderServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingDeciderServiceTests.java
@@ -365,7 +365,7 @@ public class MlAutoscalingDeciderServiceTests extends ESTestCase {
         assertThat(nativeMemoryCapacity.get().getNode(),
             lessThanOrEqualTo(NativeMemoryCalculator.allowedBytesForMl(DEFAULT_NODE_SIZE, 20, true)));
         assertThat(nativeMemoryCapacity.get().getTier(),
-            greaterThanOrEqualTo(DEFAULT_JOB_SIZE * (assignedAnomalyJobs.size() + batchAnomalyJobs.size())));
+            greaterThanOrEqualTo(DEFAULT_JOB_SIZE * (assignedAnalyticsJobs.size() + batchAnomalyJobs.size())));
         assertThat(nativeMemoryCapacity.get().getTier(),
             lessThanOrEqualTo(3 * (NativeMemoryCalculator.allowedBytesForMl(DEFAULT_NODE_SIZE, 20, true))));
     }
@@ -389,7 +389,7 @@ public class MlAutoscalingDeciderServiceTests extends ESTestCase {
 
         Settings settings = Settings.builder()
             .put(MlAutoscalingDeciderService.NUM_ANALYTICS_JOBS_IN_QUEUE.getKey(), maxWaitingAnalytics)
-            .put(MlAutoscalingDeciderService.NUM_ANOMALY_JOBS_IN_QUEUE.getKey(), maxWaitingAnalytics)
+            .put(MlAutoscalingDeciderService.NUM_ANOMALY_JOBS_IN_QUEUE.getKey(), maxWaitingAnomaly)
             .build();
         AutoscalingCapacity autoscalingCapacity = new AutoscalingCapacity(
             new AutoscalingCapacity.AutoscalingResources(ByteSizeValue.ofGb(1), ByteSizeValue.ofGb(1)),

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/NativeMemoryCapacityTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/NativeMemoryCapacityTests.java
@@ -9,12 +9,19 @@ package org.elasticsearch.xpack.ml.autoscaling;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingCapacity;
+import org.elasticsearch.xpack.ml.utils.NativeMemoryCalculator;
+
+import java.util.function.BiConsumer;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
 public class NativeMemoryCapacityTests extends ESTestCase {
+
+    private static final int NUM_TEST_RUNS = 10;
 
     public void testMerge() {
         NativeMemoryCapacity capacity = new NativeMemoryCapacity(ByteSizeValue.ofGb(1).getBytes(),
@@ -63,8 +70,53 @@ public class NativeMemoryCapacityTests extends ESTestCase {
             assertThat(autoscalingCapacity.node().memory().getBytes(), equalTo(2566914048L));
             assertThat(autoscalingCapacity.total().memory().getBytes(), equalTo(6507526207L));
         }
-
     }
 
+    public void testAutoscalingCapacityConsistency() {
+        final BiConsumer<NativeMemoryCapacity, Integer> consistentAutoAssertions = (nativeMemory, memoryPercentage) -> {
+            AutoscalingCapacity autoscalingCapacity = nativeMemory.autoscalingCapacity(25, true);
+            assertThat(autoscalingCapacity.total().memory().getBytes(), greaterThan(nativeMemory.getTier()));
+            assertThat(autoscalingCapacity.node().memory().getBytes(), greaterThan(nativeMemory.getNode()));
+            assertThat(autoscalingCapacity.total().memory().getBytes(),
+                greaterThanOrEqualTo(autoscalingCapacity.node().memory().getBytes()));
+        };
+
+        { // 0 memory
+            assertThat(NativeMemoryCalculator.calculateApproxNecessaryNodeSize(
+                0L,
+                randomLongBetween(0L, ByteSizeValue.ofGb(100).getBytes()),
+                randomIntBetween(0, 100),
+                randomBoolean()
+                ),
+                equalTo(0L));
+            assertThat(
+                NativeMemoryCalculator.calculateApproxNecessaryNodeSize(0L, null, randomIntBetween(0, 100), randomBoolean()),
+                equalTo(0L));
+        }
+        for (int i = 0; i < NUM_TEST_RUNS; i++) {
+            int memoryPercentage = randomIntBetween(5, 200);
+            { // tiny memory
+                long nodeMemory = randomLongBetween(ByteSizeValue.ofKb(100).getBytes(), ByteSizeValue.ofMb(500).getBytes());
+                consistentAutoAssertions.accept(
+                    new NativeMemoryCapacity(randomLongBetween(nodeMemory, nodeMemory * 4), nodeMemory),
+                    memoryPercentage
+                );
+            }
+            { // normal-ish memory
+                long nodeMemory = randomLongBetween(ByteSizeValue.ofMb(500).getBytes(), ByteSizeValue.ofGb(4).getBytes());
+                consistentAutoAssertions.accept(
+                    new NativeMemoryCapacity(randomLongBetween(nodeMemory, nodeMemory * 4), nodeMemory),
+                    memoryPercentage
+                );
+            }
+            { // huge memory
+                long nodeMemory = randomLongBetween(ByteSizeValue.ofGb(30).getBytes(), ByteSizeValue.ofGb(60).getBytes());
+                consistentAutoAssertions.accept(
+                    new NativeMemoryCapacity(randomLongBetween(nodeMemory, nodeMemory * 4), nodeMemory),
+                    memoryPercentage
+                );
+            }
+        }
+    }
 
 }


### PR DESCRIPTION
Three bugs with the ML autoscaler service are corrected in this PR:

- The XContent serialized information around waiting jobs is corrected in the verbose scaling reason
- Tier will never be below the requested node size
- Anomaly and analytics task state are now appropriately checked (using same logic as node load detection)

