### PR TITLE
EQL: Remove the duplicated readSpec() utility function

### DIFF
--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/planner/QueryFolderOkTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/planner/QueryFolderOkTests.java
@@ -7,16 +7,8 @@
 package org.elasticsearch.xpack.eql.planner;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.xpack.eql.plan.physical.EsQueryExec;
 import org.elasticsearch.xpack.eql.plan.physical.PhysicalPlan;
-
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.Map;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
@@ -36,75 +28,6 @@ public class QueryFolderOkTests extends AbstractQueryFolderTestCase {
     @ParametersFactory(shuffle = false, argumentFormatting = "%1$s")
     public static Iterable<Object[]> parameters() throws Exception {
         return QueriesUtils.readSpec("/queryfolder_tests.txt");
-    }
-
-    public static Iterable<Object[]> readSpec(String url) throws Exception {
-        ArrayList<Object[]> arr = new ArrayList<>();
-        Map<String, Integer> testNames = new LinkedHashMap<>();
-
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(
-                QueryFolderOkTests.class.getResourceAsStream(url), StandardCharsets.UTF_8))) {
-            int lineNumber = 0;
-            String line;
-            String name = null;
-            String query = null;
-            ArrayList<Object> expectations = new ArrayList<>(8);
-
-            StringBuilder sb = new StringBuilder();
-
-            while ((line = reader.readLine()) != null) {
-                lineNumber++;
-                line = line.trim();
-
-                if (line.isEmpty() || line.startsWith("//")) {
-                    continue;
-                }
-
-                if (name == null) {
-                    name = line;
-                    Integer previousName = testNames.put(name, lineNumber);
-                    if (previousName != null) {
-                        throw new IllegalArgumentException("Duplicate test name '" + line + "' at line " + lineNumber
-                                + " (previously seen at line " + previousName + ")");
-                    }
-                } else if (query == null) {
-                    sb.append(line);
-                    if (line.endsWith(";")) {
-                        sb.setLength(sb.length() - 1);
-                        query = sb.toString();
-                        sb.setLength(0);
-                    }
-                } else {
-                    boolean done = false;
-                    if (line.endsWith(";")) {
-                        line = line.substring(0, line.length() - 1);
-                        done = true;
-                    }
-                    // no expectation
-                    if (line.equals("null") == false) {
-                        expectations.add(line);
-                    }
-                    if (done) {
-                        // Add and zero out for the next spec
-                        addSpec(arr, name, query, expectations.isEmpty() ? null : expectations.toArray());
-                        name = null;
-                        query = null;
-                        expectations.clear();
-                    }
-                }
-            }
-
-            if (name != null) {
-                throw new IllegalStateException("Read a test [" + name + "] without a body at the end of [" + url + "]");
-            }
-        }
-        return arr;
-    }
-
-    private static void addSpec(ArrayList<Object[]> arr, String name, String query, Object[] expectations) {
-        if ((Strings.isNullOrEmpty(name) == false) && (Strings.isNullOrEmpty(query) == false)) {
-            arr.add(new Object[]{name, query, expectations});
-        }
     }
 
     public void test() {


### PR DESCRIPTION
The unused `org.elasticsearch.xpack.eql.planner.QueryFolderOkTests.readSpec()` is the duplicate of `org.elasticsearch.xpack.eql.planner.QueriesUtils.readSpec()`.