### PR TITLE
[DOCS] Fixes typo in decider docs

### DIFF
--- a/docs/reference/autoscaling/deciders/machine-learning-decider.asciidoc
+++ b/docs/reference/autoscaling/deciders/machine-learning-decider.asciidoc
@@ -22,8 +22,8 @@ of that type can be unassigned from a node due to the cluster being
 too small. Both settings are only considered for jobs that could
 eventually be fully opened given the current scale. If a job is too
 large for any node size or if a job couldn't ever be assigned without
-user intervention (for example, a user calling `_stop` against a real-time {anomaly-job}
-), the numbers are ignored for that particular job.
+user intervention (for example, a user calling `_stop` against a real-time 
+{anomaly-job}), the numbers are ignored for that particular job.
 
 `num_anomaly_jobs_in_queue`::
 (Optional, integer)


### PR DESCRIPTION
## Overview

This PR fixes a typo in the ML decider docs.

### Preview

[ML decider](https://elasticsearch_67743.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/autoscaling-machine-learning-decider.html)