### PR TITLE
Improve performance of terms query for non-decimal numbers (#66909)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -751,6 +751,12 @@ public class NumberFieldMapper extends FieldMapper {
          * Returns true if the object is a number and has a decimal part
          */
         public static boolean hasDecimalPart(Object number) {
+            if (number instanceof Byte
+                || number instanceof Short
+                || number instanceof Integer
+                || number instanceof Long) {
+                return false;
+            }
             if (number instanceof Number) {
                 double doubleValue = ((Number) number).doubleValue();
                 return doubleValue % 1 != 0;


### PR DESCRIPTION
Benchmarking terms query (10000+ terms) on long type,
shows that the code part costing most CPU is when trying to judge
whether terms have a decimal part because a double mod is executed
for each number, regardless of if it has a decimal part.

Adding a check before the mod take place to exclude non-decimal
numbers.

(cherry picked from commit c32f8b1c09c67df0a706f9c98cf5a20edbc4677e)
