### PR TITLE
Fix Azul identification in FIPS 140-2 CI

### DIFF
--- a/gradle/fips.gradle
+++ b/gradle/fips.gradle
@@ -9,7 +9,7 @@ if (BuildParams.inFipsJvm) {
   allprojects {
     File fipsResourcesDir = new File(project.buildDir, 'fips-resources')
     boolean java8 = BuildParams.runtimeJavaVersion == JavaVersion.VERSION_1_8
-    boolean zulu8 = java8 && BuildParams.runtimeJavaDetails.contains("Zulu")
+    boolean zulu8 = java8 && BuildParams.runtimeJavaDetails.toLowerCase().contains("azul")
     File fipsSecurity;
     File fipsPolicy;
     if (java8) {


### PR DESCRIPTION
Vendor is now reported as Azul, adjust our matching.

Backport of  #67740