### PR TITLE
[7.11] Mute testClusterWithTwoMlNodes_RunsDatafeed_GivenOriginalNodeGoesDown (#67757)

### DIFF
--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlDistributedFailureIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlDistributedFailureIT.java
@@ -466,6 +466,7 @@ public class MlDistributedFailureIT extends BaseMlIntegTestCase {
         });
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/67756")
     public void testClusterWithTwoMlNodes_RunsDatafeed_GivenOriginalNodeGoesDown() throws Exception {
         internalCluster().ensureAtMostNumDataNodes(0);
         logger.info("Starting dedicated master node...");


### PR DESCRIPTION
Backports the following commits to 7.11:
 - Mute testClusterWithTwoMlNodes_RunsDatafeed_GivenOriginalNodeGoesDown (#67757)