### PR TITLE
QL: Simplify the replaceChildren implementations (#66973)

### DIFF
--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/math/ToNumber.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/math/ToNumber.java
@@ -107,10 +107,6 @@ public class ToNumber extends ScalarFunction implements OptionalArgument {
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        if (newChildren.size() != 2) {
-            throw new IllegalArgumentException("expected [2] children but received [" + newChildren.size() + "]");
-        }
-
         return new ToNumber(source(), newChildren.get(0), newChildren.get(1));
     }
 }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/math/ToNumberFunctionPipe.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/math/ToNumberFunctionPipe.java
@@ -27,9 +27,6 @@ public class ToNumberFunctionPipe extends Pipe {
 
     @Override
     public final Pipe replaceChildren(List<Pipe> newChildren) {
-        if (newChildren.size() != 2) {
-            throw new IllegalArgumentException("expected [2] children but received [" + newChildren.size() + "]");
-        }
         return replaceChildren(newChildren.get(0), newChildren.get(1));
     }
 

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/Between.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/Between.java
@@ -146,10 +146,6 @@ public class Between extends ScalarFunction implements OptionalArgument {
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        if (newChildren.size() != 4) {
-            throw new IllegalArgumentException("expected [4] children but received [" + newChildren.size() + "]");
-        }
-
         return new Between(source(), newChildren.get(0), newChildren.get(1), newChildren.get(2), newChildren.get(3));
     }
 }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/BetweenFunctionPipe.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/BetweenFunctionPipe.java
@@ -30,9 +30,6 @@ public class BetweenFunctionPipe extends Pipe {
 
     @Override
     public final Pipe replaceChildren(List<Pipe> newChildren) {
-        if (newChildren.size() != 5) {
-            throw new IllegalArgumentException("expected [5] children but received [" + newChildren.size() + "]");
-        }
         return replaceChildren(newChildren.get(0), newChildren.get(1), newChildren.get(2), newChildren.get(3), newChildren.get(4));
     }
 

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/CIDRMatch.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/CIDRMatch.java
@@ -134,9 +134,6 @@ public class CIDRMatch extends ScalarFunction {
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        if (newChildren.size() < 2) {
-            throw new IllegalArgumentException("expected at least [2] children but received [" + newChildren.size() + "]");
-        }
         return new CIDRMatch(source(), newChildren.get(0), newChildren.subList(1, newChildren.size()));
     }
 }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/CIDRMatchFunctionPipe.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/CIDRMatchFunctionPipe.java
@@ -31,9 +31,6 @@ public class CIDRMatchFunctionPipe extends Pipe {
 
     @Override
     public final Pipe replaceChildren(List<Pipe> newChildren) {
-        if (newChildren.size() < 2) {
-            throw new IllegalArgumentException("expected at least [2] children but received [" + newChildren.size() + "]");
-        }
         return replaceChildren(newChildren.get(0), newChildren.subList(1, newChildren.size()));
     }
 

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/ConcatFunctionPipe.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/ConcatFunctionPipe.java
@@ -41,7 +41,7 @@ public class ConcatFunctionPipe extends Pipe {
             return this;
         }
 
-        return replaceChildren(newValues);
+        return replaceChildrenSameSize(newValues);
     }
 
     @Override

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/EndsWith.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/EndsWith.java
@@ -126,10 +126,6 @@ public class EndsWith extends CaseSensitiveScalarFunction {
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        if (newChildren.size() != 2) {
-            throw new IllegalArgumentException("expected [2] children but received [" + newChildren.size() + "]");
-        }
-
         return new EndsWith(source(), newChildren.get(0), newChildren.get(1), configuration());
     }
 

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/EndsWithFunctionPipe.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/EndsWithFunctionPipe.java
@@ -29,9 +29,6 @@ public class EndsWithFunctionPipe extends Pipe {
 
     @Override
     public final Pipe replaceChildren(List<Pipe> newChildren) {
-        if (newChildren.size() != 2) {
-            throw new IllegalArgumentException("expected [2] children but received [" + newChildren.size() + "]");
-        }
         return replaceChildren(newChildren.get(0), newChildren.get(1));
     }
 

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/IndexOf.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/IndexOf.java
@@ -130,10 +130,6 @@ public class IndexOf extends CaseSensitiveScalarFunction implements OptionalArgu
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        if (newChildren.size() != 3) {
-            throw new IllegalArgumentException("expected [3] children but received [" + newChildren.size() + "]");
-        }
-
         return new IndexOf(source(), newChildren.get(0), newChildren.get(1), newChildren.get(2), configuration());
     }
 

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/IndexOfFunctionPipe.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/IndexOfFunctionPipe.java
@@ -30,9 +30,6 @@ public class IndexOfFunctionPipe extends Pipe {
 
     @Override
     public final Pipe replaceChildren(List<Pipe> newChildren) {
-        if (newChildren.size() != 3) {
-            throw new IllegalArgumentException("expected [3] children but received [" + newChildren.size() + "]");
-        }
         return replaceChildren(newChildren.get(0), newChildren.get(1), newChildren.get(2));
     }
 

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/Length.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/Length.java
@@ -96,10 +96,6 @@ public class Length extends ScalarFunction {
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        if (newChildren.size() != 1) {
-            throw new IllegalArgumentException("expected [1] children but received [" + newChildren.size() + "]");
-        }
-
         return new Length(source(), newChildren.get(0));
     }
 

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/LengthFunctionPipe.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/LengthFunctionPipe.java
@@ -26,9 +26,6 @@ public class LengthFunctionPipe extends Pipe {
 
     @Override
     public final Pipe replaceChildren(List<Pipe> newChildren) {
-        if (newChildren.size() != 1) {
-            throw new IllegalArgumentException("expected [1] children but received [" + newChildren.size() + "]");
-        }
         return replaceChildren(newChildren.get(0));
     }
 

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/Match.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/Match.java
@@ -52,9 +52,6 @@ public class Match extends BaseSurrogateFunction {
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        if (newChildren.size() < 2) {
-            throw new IllegalArgumentException("expected at least [2] children but received [" + newChildren.size() + "]");
-        }
         return new Match(source(), newChildren);
     }
 

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/StringContains.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/StringContains.java
@@ -119,10 +119,6 @@ public class StringContains extends CaseSensitiveScalarFunction {
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        if (newChildren.size() != 2) {
-            throw new IllegalArgumentException("expected [2] children but received [" + newChildren.size() + "]");
-        }
-
         return new StringContains(source(), newChildren.get(0), newChildren.get(1), eqlConfiguration());
     }
 

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/StringContainsFunctionPipe.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/StringContainsFunctionPipe.java
@@ -30,9 +30,6 @@ public class StringContainsFunctionPipe extends Pipe {
 
     @Override
     public final Pipe replaceChildren(List<Pipe> newChildren) {
-        if (newChildren.size() != 2) {
-            throw new IllegalArgumentException("expected [2] children but received [" + newChildren.size() + "]");
-        }
         return replaceChildren(newChildren.get(0), newChildren.get(1));
     }
 

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/Substring.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/Substring.java
@@ -121,10 +121,6 @@ public class Substring extends ScalarFunction implements OptionalArgument {
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        if (newChildren.size() != 3) {
-            throw new IllegalArgumentException("expected [3] children but received [" + newChildren.size() + "]");
-        }
-
         return new Substring(source(), newChildren.get(0), newChildren.get(1), newChildren.get(2));
     }
 }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/SubstringFunctionPipe.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/SubstringFunctionPipe.java
@@ -28,9 +28,6 @@ public class SubstringFunctionPipe extends Pipe {
 
     @Override
     public final Pipe replaceChildren(List<Pipe> newChildren) {
-        if (newChildren.size() != 3) {
-            throw new IllegalArgumentException("expected [3] children but received [" + newChildren.size() + "]");
-        }
         return replaceChildren(newChildren.get(0), newChildren.get(1), newChildren.get(2));
     }
 

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/ToString.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/ToString.java
@@ -95,10 +95,6 @@ public class ToString extends ScalarFunction {
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        if (newChildren.size() != 1) {
-            throw new IllegalArgumentException("expected [1] children but received [" + newChildren.size() + "]");
-        }
-
         return new ToString(source(), newChildren.get(0));
     }
 }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/ToStringFunctionPipe.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/ToStringFunctionPipe.java
@@ -26,9 +26,6 @@ public class ToStringFunctionPipe extends Pipe {
 
     @Override
     public final ToStringFunctionPipe replaceChildren(List<Pipe> newChildren) {
-        if (newChildren.size() != 1) {
-            throw new IllegalArgumentException("expected [1] children but received [" + newChildren.size() + "]");
-        }
         return new ToStringFunctionPipe(source(), expression(), newChildren.get(0));
     }
 

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/Wildcard.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/Wildcard.java
@@ -49,10 +49,6 @@ public class Wildcard extends BaseSurrogateFunction {
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        if (newChildren.size() < 2) {
-            throw new IllegalArgumentException("expected at least [2] children but received [" + newChildren.size() + "]");
-        }
-
         return new Wildcard(source(), newChildren.get(0), newChildren.subList(1, newChildren.size()));
     }
 

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/optimizer/Optimizer.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/optimizer/Optimizer.java
@@ -184,7 +184,7 @@ public class Optimizer extends RuleExecutor<LogicalPlan> {
                 plan = new Filter(f.source(), f.child(), new And(f.source(), f.condition(), filter.condition()));
             } else if (child instanceof UnaryPlan) {
                 UnaryPlan up = (UnaryPlan) child;
-                plan = child.replaceChildren(singletonList(new Filter(filter.source(), up.child(), filter.condition())));
+                plan = child.replaceChildrenSameSize(singletonList(new Filter(filter.source(), up.child(), filter.condition())));
             }
 
             return plan;
@@ -426,13 +426,13 @@ public class Optimizer extends RuleExecutor<LogicalPlan> {
                         // preserve the order for the base query, everything else needs to be ascending
                         List<Order> pushedOrder = baseFilter ? orderBy.order() : ascendingOrders;
                         OrderBy order = new OrderBy(filter.source(), filter.child(), pushedOrder);
-                        orderedQueries.add((KeyedFilter) filter.replaceChildren(singletonList(order)));
+                        orderedQueries.add((KeyedFilter) filter.replaceChildrenSameSize(singletonList(order)));
                         baseFilter = false;
                     }
 
                     KeyedFilter until = join.until();
                     OrderBy order = new OrderBy(until.source(), until.child(), ascendingOrders);
-                    until = (KeyedFilter) until.replaceChildren(singletonList(order));
+                    until = (KeyedFilter) until.replaceChildrenSameSize(singletonList(order));
 
                     OrderDirection direction = orderBy.order().get(0).direction();
                     plan = join.with(orderedQueries, until, direction);

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/LogicalPlanBuilder.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/LogicalPlanBuilder.java
@@ -123,7 +123,7 @@ public abstract class LogicalPlanBuilder extends ExpressionBuilder {
                 } else {
                     previous = new Tail(defaultLimitSource, defaultSize, previous);
                 }
-                plan = plan.replaceChildren(singletonList(previous));
+                plan = plan.replaceChildrenSameSize(singletonList(previous));
             }
             previous = plan;
         }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plan/logical/Join.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plan/logical/Join.java
@@ -6,7 +6,6 @@
 
 package org.elasticsearch.xpack.eql.plan.logical;
 
-import org.elasticsearch.xpack.eql.EqlIllegalArgumentException;
 import org.elasticsearch.xpack.ql.capabilities.Resolvables;
 import org.elasticsearch.xpack.ql.expression.Attribute;
 import org.elasticsearch.xpack.ql.expression.Expressions;
@@ -77,9 +76,6 @@ public class Join extends LogicalPlan {
 
     @Override
     public Join replaceChildren(List<LogicalPlan> newChildren) {
-        if (newChildren.size() < 2) {
-            throw new EqlIllegalArgumentException("expected at least [2] children but received [{}]", newChildren.size());
-        }
         int lastIndex = newChildren.size() - 1;
         return new Join(source(), newChildren.subList(0, lastIndex), newChildren.get(lastIndex), timestamp, tiebreaker, direction);
     }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plan/logical/Sequence.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plan/logical/Sequence.java
@@ -7,7 +7,6 @@
 package org.elasticsearch.xpack.eql.plan.logical;
 
 import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.xpack.eql.EqlIllegalArgumentException;
 import org.elasticsearch.xpack.ql.expression.Attribute;
 import org.elasticsearch.xpack.ql.expression.Order.OrderDirection;
 import org.elasticsearch.xpack.ql.plan.logical.LogicalPlan;
@@ -52,9 +51,6 @@ public class Sequence extends Join {
 
     @Override
     public Join replaceChildren(List<LogicalPlan> newChildren) {
-        if (newChildren.size() < 2) {
-            throw new EqlIllegalArgumentException("expected at least [2] children but received [{}]", newChildren.size());
-        }
         int lastIndex = newChildren.size() - 1;
         return new Sequence(source(), newChildren.subList(0, lastIndex), newChildren.get(lastIndex), maxSpan, timestamp(), tiebreaker(),
                 direction());

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plan/physical/SequenceExec.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plan/physical/SequenceExec.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.eql.plan.physical;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.xpack.eql.EqlIllegalArgumentException;
 import org.elasticsearch.xpack.eql.execution.assembler.ExecutionManager;
 import org.elasticsearch.xpack.eql.execution.search.Limit;
 import org.elasticsearch.xpack.eql.session.EqlSession;
@@ -72,11 +71,6 @@ public class SequenceExec extends PhysicalPlan {
 
     @Override
     public PhysicalPlan replaceChildren(List<PhysicalPlan> newChildren) {
-        if (newChildren.size() != children().size()) {
-            throw new EqlIllegalArgumentException("Expected the same number of children [{}] but got [{}]",
-                    children().size(),
-                    newChildren.size());
-        }
         return new SequenceExec(source(), newChildren, keys, timestamp, tiebreaker, limit, direction, maxSpan);
     }
 

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plan/physical/UnaryExec.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plan/physical/UnaryExec.java
@@ -23,9 +23,6 @@ public abstract class UnaryExec extends PhysicalPlan {
 
     @Override
     public final PhysicalPlan replaceChildren(List<PhysicalPlan> newChildren) {
-        if (newChildren.size() != 1) {
-            throw new IllegalArgumentException("expected [1] child but received [" + newChildren.size() + "]");
-        }
         return replaceChild(newChildren.get(0));
     }
 

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/ConcatFunctionPipeTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/ConcatFunctionPipeTests.java
@@ -68,8 +68,8 @@ public class ConcatFunctionPipeTests extends AbstractNodeTestCase<ConcatFunction
         List<Pipe> newValues = mutateOneValue(b.values());
 
         ConcatFunctionPipe newB = new ConcatFunctionPipe(b.source(), b.expression(), b.values());
-        ConcatFunctionPipe transformed = newB.replaceChildren(newValues);
-
+        ConcatFunctionPipe transformed = (ConcatFunctionPipe) newB.replaceChildrenSameSize(newValues);
+        
         assertEquals(transformed.values(), newValues);
         assertEquals(transformed.source(), b.source());
         assertEquals(transformed.expression(), b.expression());

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/Alias.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/Alias.java
@@ -57,9 +57,6 @@ public class Alias extends NamedExpression {
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        if (newChildren.size() != 1) {
-            throw new IllegalArgumentException("expected [1] child but received [" + newChildren.size() + "]");
-        }
         return new Alias(source(), name(), qualifier, newChildren.get(0), id(), synthetic());
     }
 

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/Order.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/Order.java
@@ -58,9 +58,6 @@ public class Order extends Expression {
 
     @Override
     public Order replaceChildren(List<Expression> newChildren) {
-        if (newChildren.size() != 1) {
-            throw new IllegalArgumentException("expected [1] child but received [" + newChildren.size() + "]");
-        }
         return new Order(source(), newChildren.get(0), direction, nulls);
     }
 

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/UnaryExpression.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/UnaryExpression.java
@@ -24,9 +24,6 @@ public abstract class UnaryExpression extends Expression {
 
     @Override
     public final UnaryExpression replaceChildren(List<Expression> newChildren) {
-        if (newChildren.size() != 1) {
-            throw new IllegalArgumentException("expected [1] child but received [" + newChildren.size() + "]");
-        }
         return replaceChild(newChildren.get(0));
     }
     protected abstract UnaryExpression replaceChild(Expression newChild);

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/UnresolvedAlias.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/UnresolvedAlias.java
@@ -30,9 +30,6 @@ public class UnresolvedAlias extends UnresolvedNamedExpression {
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        if (newChildren.size() != 1) {
-            throw new IllegalArgumentException("expected [1] child but received [" + newChildren.size() + "]");
-        }
         return new UnresolvedAlias(source(), newChildren.get(0));
     }
 

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/function/aggregate/Count.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/function/aggregate/Count.java
@@ -35,9 +35,6 @@ public class Count extends AggregateFunction {
 
     @Override
     public Count replaceChildren(List<Expression> newChildren) {
-        if (newChildren.size() != 1) {
-            throw new IllegalArgumentException("expected [1] child but received [" + newChildren.size() + "]");
-        }
         return new Count(source(), newChildren.get(0), distinct);
     }
 

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/function/scalar/BinaryScalarFunction.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/function/scalar/BinaryScalarFunction.java
@@ -28,9 +28,6 @@ public abstract class BinaryScalarFunction extends ScalarFunction {
 
     @Override
     public final BinaryScalarFunction replaceChildren(List<Expression> newChildren) {
-        if (newChildren.size() != 2) {
-            throw new IllegalArgumentException("expected [2] children but received [" + newChildren.size() + "]");
-        }
         Expression newLeft = newChildren.get(0);
         Expression newRight = newChildren.get(1);
 

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/function/scalar/UnaryScalarFunction.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/function/scalar/UnaryScalarFunction.java
@@ -33,9 +33,6 @@ public abstract class UnaryScalarFunction extends ScalarFunction {
 
     @Override
     public final UnaryScalarFunction replaceChildren(List<Expression> newChildren) {
-        if (newChildren.size() != 1) {
-            throw new IllegalArgumentException("expected [1] child but received [" + newChildren.size() + "]");
-        }
         return replaceChild(newChildren.get(0));
     }
 

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/function/scalar/string/StartsWith.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/function/scalar/string/StartsWith.java
@@ -122,10 +122,6 @@ public class StartsWith extends CaseSensitiveScalarFunction {
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        if (newChildren.size() != 2) {
-            throw new IllegalArgumentException("expected [2] children but received [" + newChildren.size() + "]");
-        }
-
         return new StartsWith(source(), newChildren.get(0), newChildren.get(1), configuration());
     }
 

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/function/scalar/string/StartsWithFunctionPipe.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/function/scalar/string/StartsWithFunctionPipe.java
@@ -30,9 +30,6 @@ public class StartsWithFunctionPipe extends Pipe {
 
     @Override
     public final Pipe replaceChildren(List<Pipe> newChildren) {
-        if (newChildren.size() != 2) {
-            throw new IllegalArgumentException("expected [2] children but received [" + newChildren.size() + "]");
-        }
         return replaceChildren(newChildren.get(0), newChildren.get(1));
     }
 

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/gen/pipeline/BinaryPipe.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/gen/pipeline/BinaryPipe.java
@@ -25,9 +25,6 @@ public abstract class BinaryPipe extends Pipe {
 
     @Override
     public final Pipe replaceChildren(List<Pipe> newChildren) {
-        if (newChildren.size() != 2) {
-            throw new IllegalArgumentException("expected [2] children but received [" + newChildren.size() + "]");
-        }
         return replaceChildren(newChildren.get(0), newChildren.get(1));
     }
 

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/gen/pipeline/Pipe.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/gen/pipeline/Pipe.java
@@ -71,7 +71,7 @@ public abstract class Pipe extends Node<Pipe> implements FieldExtraction, Resolv
             newPipes.add(p.resolveAttributes(resolver));
         }
 
-        return children().equals(newPipes) ? this : replaceChildren(newPipes);
+        return children().equals(newPipes) ? this : replaceChildrenSameSize(newPipes);
     }
 
     public interface AttributeResolver {

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/gen/pipeline/UnaryPipe.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/gen/pipeline/UnaryPipe.java
@@ -35,9 +35,6 @@ public final class UnaryPipe extends Pipe {
 
     @Override
     public Pipe replaceChildren(List<Pipe> newChildren) {
-        if (newChildren.size() != 1) {
-            throw new IllegalArgumentException("expected [1] child but received [" + newChildren.size() + "]");
-        }
         return new UnaryPipe(source(), expression(), newChildren.get(0), action);
     }
 

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/Range.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/Range.java
@@ -56,9 +56,6 @@ public class Range extends ScalarFunction {
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        if (newChildren.size() != 3) {
-            throw new IllegalArgumentException("expected [3] children but received [" + newChildren.size() + "]");
-        }
         return new Range(source(), newChildren.get(0), newChildren.get(1), includeLower, newChildren.get(2), includeUpper, zoneId);
     }
 

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/fulltext/MatchQueryPredicate.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/fulltext/MatchQueryPredicate.java
@@ -30,9 +30,6 @@ public class MatchQueryPredicate extends FullTextPredicate {
 
     @Override
     public MatchQueryPredicate replaceChildren(List<Expression> newChildren) {
-        if (newChildren.size() != 1) {
-            throw new IllegalArgumentException("expected [1] child but received [" + newChildren.size() + "]");
-        }
         return new MatchQueryPredicate(source(), newChildren.get(0), query(), options());
     }
 

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/comparison/In.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/comparison/In.java
@@ -55,9 +55,6 @@ public class In extends ScalarFunction {
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        if (newChildren.size() < 2) {
-            throw new IllegalArgumentException("expected at least [2] children but received [" + newChildren.size() + "]");
-        }
         return new In(source(), newChildren.get(newChildren.size() - 1), newChildren.subList(0, newChildren.size() - 1), zoneId());
     }
 

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/comparison/InPipe.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/comparison/InPipe.java
@@ -23,9 +23,6 @@ public class InPipe extends MultiPipe {
 
     @Override
     public final Pipe replaceChildren(List<Pipe> newChildren) {
-        if (newChildren.size() < 2) {
-            throw new IllegalArgumentException("expected at least [2] children but received [" + newChildren.size() + "]");
-        }
         return new InPipe(source(), expression(), newChildren);
     }
 

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/plan/logical/UnaryPlan.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/plan/logical/UnaryPlan.java
@@ -27,9 +27,6 @@ public abstract class UnaryPlan extends LogicalPlan {
 
     @Override
     public final UnaryPlan replaceChildren(List<LogicalPlan> newChildren) {
-        if (newChildren.size() != 1) {
-            throw new IllegalArgumentException("expected [1] child but received [" + newChildren.size() + "]");
-        }
         return replaceChild(newChildren.get(0));
     }
 

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/tree/Node.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/tree/Node.java
@@ -217,12 +217,17 @@ public abstract class Node<T extends Node<T>> {
             transformedChildren.add(next);
         }
 
-        return (childrenChanged ? replaceChildren(transformedChildren) : (T) this);
+        return (childrenChanged ? replaceChildrenSameSize(transformedChildren) : (T) this);
     }
 
-    /**
-     * Replace the children of this node.
-     */
+     public final T replaceChildrenSameSize(List<T> newChildren) {
+        if (newChildren.size() != children.size()) {
+            throw new QlIllegalArgumentException(
+                "Expected the same number of children [" + children.size() + "], but received [" + newChildren.size() + "]");
+        }
+        return replaceChildren(newChildren);
+    }
+
     public abstract T replaceChildren(List<T> newChildren);
 
     //

--- a/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/expression/LiteralTests.java
+++ b/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/expression/LiteralTests.java
@@ -105,7 +105,7 @@ public class LiteralTests extends AbstractNodeTestCase<Literal, Expression> {
 
     @Override
     public void testReplaceChildren() {
-        Exception e = expectThrows(UnsupportedOperationException.class, () -> randomInstance().replaceChildren(emptyList()));
+        Exception e = expectThrows(UnsupportedOperationException.class, () -> randomInstance().replaceChildrenSameSize(emptyList()));
         assertEquals("this type of node doesn't have any children to replace", e.getMessage());
     }
 

--- a/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/tree/AbstractNodeTestCase.java
+++ b/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/tree/AbstractNodeTestCase.java
@@ -8,6 +8,8 @@ package org.elasticsearch.xpack.ql.tree;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.EqualsHashCodeTestUtils;
 
+import java.util.List;
+
 /**
  * Superclass for tests of subclasses of {@link Node}.
  */
@@ -32,7 +34,7 @@ public abstract class AbstractNodeTestCase<T extends B, B extends Node<B>> exten
      */
     public abstract void testTransform();
     /**
-     * Test this subclass's implementation of {@link Node#replaceChildren}.
+     * Test this subclass's implementation of {@link Node#replaceChildren(List)}.
      */
     public abstract void testReplaceChildren();
 

--- a/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/tree/NodeSubclassTests.java
+++ b/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/tree/NodeSubclassTests.java
@@ -155,7 +155,7 @@ public class NodeSubclassTests<T extends B, B extends Node<B>> extends ESTestCas
     }
 
     /**
-     * Test {@link Node#replaceChildren} implementation on {@link #subclass}.
+     * Test {@link Node#replaceChildren(List)} implementation on {@link #subclass}.
      */
     public void testReplaceChildren() throws Exception {
         Constructor<T> ctor = longestCtor(subclass);

--- a/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/tree/NodeTests.java
+++ b/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/tree/NodeTests.java
@@ -94,9 +94,6 @@ public class NodeTests extends ESTestCase {
 
         @Override
         public AChildIsAProperty replaceChildren(List<Dummy> newChildren) {
-            if (newChildren.size() != 1) {
-                throw new IllegalArgumentException("expected [1] child but received [" + newChildren.size() + "]");
-            }
             return new AChildIsAProperty(source(), newChildren.get(0), thing());
         }
 

--- a/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/tree/TestCompoundAggregate.java
+++ b/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/tree/TestCompoundAggregate.java
@@ -27,9 +27,6 @@ public class TestCompoundAggregate extends AggregateFunction implements Compound
 
     @Override
     public TestCompoundAggregate replaceChildren(List<Expression> newChildren) {
-        if (newChildren.size() != 1) {
-            throw new IllegalArgumentException("expected [1] child but received [" + newChildren.size() + "]");
-        }
         return new TestCompoundAggregate(source(), newChildren.get(0));
     }
 

--- a/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/tree/TestEnclosedAgg.java
+++ b/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/tree/TestEnclosedAgg.java
@@ -27,9 +27,6 @@ public class TestEnclosedAgg extends AggregateFunction implements EnclosedAgg {
 
     @Override
     public TestEnclosedAgg replaceChildren(List<Expression> newChildren) {
-        if (newChildren.size() != 1) {
-            throw new IllegalArgumentException("expected [1] child but received [" + newChildren.size() + "]");
-        }
         return new TestEnclosedAgg(source(), newChildren.get(0));
     }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Analyzer.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Analyzer.java
@@ -781,7 +781,7 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
 
             // LeafPlans are tables and BinaryPlans are joins so pushing can only happen on unary
             if (plan instanceof UnaryPlan) {
-                return plan.replaceChildren(singletonList(propagateMissing(((UnaryPlan) plan).child(), missing, failed)));
+                return plan.replaceChildrenSameSize(singletonList(propagateMissing(((UnaryPlan) plan).child(), missing, failed)));
             }
 
             failed.addAll(missing);
@@ -1209,7 +1209,7 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
                     }
                     left = l == common ? left : new Cast(left.source(), left, common);
                     right = r == common ? right : new Cast(right.source(), right, common);
-                    return e.replaceChildren(Arrays.asList(left, right));
+                    return e.replaceChildrenSameSize(Arrays.asList(left, right));
                 }
             }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/Avg.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/Avg.java
@@ -30,9 +30,6 @@ public class Avg extends NumericAggregate implements EnclosedAgg {
 
     @Override
     public Avg replaceChildren(List<Expression> newChildren) {
-        if (newChildren.size() != 1) {
-            throw new IllegalArgumentException("expected [1] child but received [" + newChildren.size() + "]");
-        }
         return new Avg(source(), newChildren.get(0));
     }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/ExtendedStats.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/ExtendedStats.java
@@ -24,9 +24,6 @@ public class ExtendedStats extends CompoundNumericAggregate {
 
     @Override
     public ExtendedStats replaceChildren(List<Expression> newChildren) {
-        if (newChildren.size() != 1) {
-            throw new IllegalArgumentException("expected [1] child but received [" + newChildren.size() + "]");
-        }
         return new ExtendedStats(source(), newChildren.get(0));
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/First.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/First.java
@@ -27,9 +27,6 @@ public class First extends TopHits {
 
     @Override
     public First replaceChildren(List<Expression> newChildren) {
-        if (newChildren.size() > 2) {
-            throw new IllegalArgumentException("expected one or two children but received [" + newChildren.size() + "]");
-        }
         return new First(source(), newChildren.get(0), newChildren.size() > 1 ? newChildren.get(1) : null);
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/Kurtosis.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/Kurtosis.java
@@ -24,9 +24,6 @@ public class Kurtosis extends NumericAggregate implements MatrixStatsEnclosed {
 
     @Override
     public Kurtosis replaceChildren(List<Expression> newChildren) {
-        if (newChildren.size() != 1) {
-            throw new IllegalArgumentException("expected [1] child but received [" + newChildren.size() + "]");
-        }
         return new Kurtosis(source(), newChildren.get(0));
     }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/Last.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/Last.java
@@ -27,9 +27,6 @@ public class Last extends TopHits {
 
     @Override
     public Last replaceChildren(List<Expression> newChildren) {
-        if (newChildren.size() > 2) {
-            throw new IllegalArgumentException("expected one or two children but received [" + newChildren.size() + "]");
-        }
         return new Last(source(), newChildren.get(0), newChildren.size() > 1 ? newChildren.get(1) : null);
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/MatrixStats.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/MatrixStats.java
@@ -24,9 +24,6 @@ public class MatrixStats extends CompoundNumericAggregate {
 
     @Override
     public MatrixStats replaceChildren(List<Expression> newChildren) {
-        if (newChildren.size() != 1) {
-            throw new IllegalArgumentException("expected [1] child but received [" + newChildren.size() + "]");
-        }
         return new MatrixStats(source(), newChildren.get(0));
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/MedianAbsoluteDeviation.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/MedianAbsoluteDeviation.java
@@ -27,9 +27,6 @@ public class MedianAbsoluteDeviation extends NumericAggregate {
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        if (newChildren.size() != 1) {
-            throw new IllegalArgumentException("expected [1] child but received [" + newChildren.size() + "]");
-        }
         return new MedianAbsoluteDeviation(source(), newChildren.get(0));
     }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/Min.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/Min.java
@@ -34,9 +34,6 @@ public class Min extends NumericAggregate implements EnclosedAgg {
 
     @Override
     public Min replaceChildren(List<Expression> newChildren) {
-        if (newChildren.size() != 1) {
-            throw new IllegalArgumentException("expected [1] child but received [" + newChildren.size() + "]");
-        }
         return new Min(source(), newChildren.get(0));
     }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/Percentile.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/Percentile.java
@@ -24,9 +24,6 @@ public class Percentile extends PercentileAggregate {
 
     @Override
     public Percentile replaceChildren(List<Expression> newChildren) {
-        if (newChildren.size() != 2) {
-            throw new IllegalArgumentException("expected [2] children but received [" + newChildren.size() + "]");
-        }
         return new Percentile(source(), newChildren.get(0), newChildren.get(1), method(), methodParameter());
     }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/PercentileRank.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/PercentileRank.java
@@ -24,9 +24,6 @@ public class PercentileRank extends PercentileAggregate {
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        if (newChildren.size() != 2) {
-            throw new IllegalArgumentException("expected [2] children but received [" + newChildren.size() + "]");
-        }
         return new PercentileRank(source(), newChildren.get(0), newChildren.get(1), method(), methodParameter());
     }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/PercentileRanks.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/PercentileRanks.java
@@ -25,9 +25,6 @@ public class PercentileRanks extends PercentileCompoundAggregate {
 
     @Override
     public PercentileRanks replaceChildren(List<Expression> newChildren) {
-        if (newChildren.size() < 2) {
-            throw new IllegalArgumentException("expected at least [2] children but received [" + newChildren.size() + "]");
-        }
         return new PercentileRanks(source(), newChildren.get(0), newChildren.subList(1, newChildren.size()), percentilesConfig);
     }
     

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/Percentiles.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/Percentiles.java
@@ -25,9 +25,6 @@ public class Percentiles extends PercentileCompoundAggregate {
 
     @Override
     public Percentiles replaceChildren(List<Expression> newChildren) {
-        if (newChildren.size() < 2) {
-            throw new IllegalArgumentException("expected at least [2] children but received [" + newChildren.size() + "]");
-        }
         return new Percentiles(source(), newChildren.get(0), newChildren.subList(1, newChildren.size()), percentilesConfig());
     }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/Skewness.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/Skewness.java
@@ -24,9 +24,6 @@ public class Skewness extends NumericAggregate implements MatrixStatsEnclosed {
 
     @Override
     public Skewness replaceChildren(List<Expression> newChildren) {
-        if (newChildren.size() != 1) {
-            throw new IllegalArgumentException("expected [1] child but received [" + newChildren.size() + "]");
-        }
         return new Skewness(source(), newChildren.get(0));
     }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/Stats.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/Stats.java
@@ -24,9 +24,6 @@ public class Stats extends CompoundNumericAggregate {
 
     @Override
     public Stats replaceChildren(List<Expression> newChildren) {
-        if (newChildren.size() != 1) {
-            throw new IllegalArgumentException("expected [1] child but received [" + newChildren.size() + "]");
-        }
         return new Stats(source(), newChildren.get(0));
     }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/StddevPop.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/StddevPop.java
@@ -24,9 +24,6 @@ public class StddevPop extends NumericAggregate implements ExtendedStatsEnclosed
 
     @Override
     public StddevPop replaceChildren(List<Expression> newChildren) {
-        if (newChildren.size() != 1) {
-            throw new IllegalArgumentException("expected [1] child but received [" + newChildren.size() + "]");
-        }
         return new StddevPop(source(), newChildren.get(0));
     }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/StddevSamp.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/StddevSamp.java
@@ -24,9 +24,6 @@ public class StddevSamp extends NumericAggregate implements ExtendedStatsEnclose
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        if (newChildren.size() != 1) {
-            throw new IllegalArgumentException("expected [1] child but received [" + newChildren.size() + "]");
-        }
         return new StddevSamp(source(), newChildren.get(0));
     }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/Sum.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/Sum.java
@@ -29,9 +29,6 @@ public class Sum extends NumericAggregate implements EnclosedAgg {
 
     @Override
     public Sum replaceChildren(List<Expression> newChildren) {
-        if (newChildren.size() != 1) {
-            throw new IllegalArgumentException("expected [1] child but received [" + newChildren.size() + "]");
-        }
         return new Sum(source(), newChildren.get(0));
     }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/SumOfSquares.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/SumOfSquares.java
@@ -24,9 +24,6 @@ public class SumOfSquares extends NumericAggregate implements ExtendedStatsEnclo
 
     @Override
     public SumOfSquares replaceChildren(List<Expression> newChildren) {
-        if (newChildren.size() != 1) {
-            throw new IllegalArgumentException("expected [1] child but received [" + newChildren.size() + "]");
-        }
         return new SumOfSquares(source(), newChildren.get(0));
     }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/VarPop.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/VarPop.java
@@ -24,9 +24,6 @@ public class VarPop extends NumericAggregate implements ExtendedStatsEnclosed {
 
     @Override
     public VarPop replaceChildren(List<Expression> newChildren) {
-        if (newChildren.size() != 1) {
-            throw new IllegalArgumentException("expected [1] child but received [" + newChildren.size() + "]");
-        }
         return new VarPop(source(), newChildren.get(0));
     }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/VarSamp.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/VarSamp.java
@@ -24,9 +24,6 @@ public class VarSamp extends NumericAggregate implements ExtendedStatsEnclosed {
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        if (newChildren.size() != 1) {
-            throw new IllegalArgumentException("expected [1] child but received [" + newChildren.size() + "]");
-        }
         return new VarSamp(source(), newChildren.get(0));
     }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/grouping/Histogram.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/grouping/Histogram.java
@@ -64,9 +64,6 @@ public class Histogram extends GroupingFunction {
     
     @Override
     public final GroupingFunction replaceChildren(List<Expression> newChildren) {
-        if (newChildren.size() != 2) {
-            throw new IllegalArgumentException("expected [2] children but received [" + newChildren.size() + "]");
-        }
         return new Histogram(source(), newChildren.get(0), newChildren.get(1), zoneId);
     }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/ThreeArgsDateTimeFunction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/ThreeArgsDateTimeFunction.java
@@ -53,9 +53,6 @@ public abstract class ThreeArgsDateTimeFunction extends ScalarFunction {
 
     @Override
     public final ThreeArgsDateTimeFunction replaceChildren(List<Expression> newChildren) {
-        if (newChildren.size() != 3) {
-            throw new IllegalArgumentException("expected [3] children but received [" + newChildren.size() + "]");
-        }
         return replaceChildren(newChildren.get(0), newChildren.get(1), newChildren.get(2));
     }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/ThreeArgsDateTimePipe.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/ThreeArgsDateTimePipe.java
@@ -46,9 +46,6 @@ public abstract class ThreeArgsDateTimePipe extends Pipe {
 
     @Override
     public final Pipe replaceChildren(List<Pipe> newChildren) {
-        if (newChildren.size() != 3) {
-            throw new IllegalArgumentException("expected [3] children but received [" + newChildren.size() + "]");
-        }
         return replaceChildren(newChildren.get(0), newChildren.get(1), newChildren.get(2));
     }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/math/BinaryOptionalMathPipe.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/math/BinaryOptionalMathPipe.java
@@ -31,11 +31,7 @@ public class BinaryOptionalMathPipe extends Pipe {
 
     @Override
     public final Pipe replaceChildren(List<Pipe> newChildren) {
-        int childrenSize = newChildren.size();
-        if (childrenSize > 2 || childrenSize < 1) {
-            throw new IllegalArgumentException("expected [1 or 2] children but received [" + newChildren.size() + "]");
-        }
-        return replaceChildren(newChildren.get(0), childrenSize == 1 ? null : newChildren.get(1));
+        return replaceChildren(newChildren.get(0), newChildren.size() == 1 ? null : newChildren.get(1));
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/math/BinaryOptionalNumericFunction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/math/BinaryOptionalNumericFunction.java
@@ -75,12 +75,6 @@ public abstract class BinaryOptionalNumericFunction extends ScalarFunction {
     
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        if (right() != null && newChildren.size() != 2) {
-            throw new IllegalArgumentException("expected [2] children but received [" + newChildren.size() + "]");
-        } else if (right() == null && newChildren.size() != 1) {
-            throw new IllegalArgumentException("expected [1] child but received [" + newChildren.size() + "]");
-        }
-
         return replacedChildrenInstance(newChildren);
     }
     

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/Insert.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/Insert.java
@@ -134,10 +134,6 @@ public class Insert extends ScalarFunction {
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        if (newChildren.size() != 4) {
-            throw new IllegalArgumentException("expected [4] children but received [" + newChildren.size() + "]");
-        }
-
         return new Insert(source(), newChildren.get(0), newChildren.get(1), newChildren.get(2), newChildren.get(3));
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/InsertFunctionPipe.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/InsertFunctionPipe.java
@@ -31,9 +31,6 @@ public class InsertFunctionPipe extends Pipe {
 
     @Override
     public final Pipe replaceChildren(List<Pipe> newChildren) {
-        if (newChildren.size() != 4) {
-            throw new IllegalArgumentException("expected [4] children but received [" + newChildren.size() + "]");
-        }
         return replaceChildren(newChildren.get(0), newChildren.get(1), newChildren.get(2), newChildren.get(3));
     }
     

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/Locate.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/Locate.java
@@ -136,12 +136,6 @@ public class Locate extends ScalarFunction implements OptionalArgument {
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        if (start != null && newChildren.size() != 3) {
-            throw new IllegalArgumentException("expected [3] children but received [" + newChildren.size() + "]");
-        } else if (start == null && newChildren.size() != 2) {
-            throw new IllegalArgumentException("expected [2] children but received [" + newChildren.size() + "]");
-        }
-
         return new Locate(source(), newChildren.get(0), newChildren.get(1), start == null ? null : newChildren.get(2));
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/LocateFunctionPipe.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/LocateFunctionPipe.java
@@ -28,11 +28,7 @@ public class LocateFunctionPipe extends Pipe {
 
     @Override
     public final Pipe replaceChildren(List<Pipe> newChildren) {
-        int childrenSize = newChildren.size();
-        if (childrenSize > 3 || childrenSize < 2) {
-            throw new IllegalArgumentException("expected [2 or 3] children but received [" + newChildren.size() + "]");
-        }
-        return replaceChildren(newChildren.get(0), newChildren.get(1), childrenSize == 2 ? null : newChildren.get(2));
+        return replaceChildren(newChildren.get(0), newChildren.get(1), newChildren.size() == 2 ? null : newChildren.get(2));
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/Replace.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/Replace.java
@@ -121,10 +121,6 @@ public class Replace extends ScalarFunction {
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        if (newChildren.size() != 3) {
-            throw new IllegalArgumentException("expected [3] children but received [" + newChildren.size() + "]");
-        }
-
         return new Replace(source(), newChildren.get(0), newChildren.get(1), newChildren.get(2));
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/ReplaceFunctionPipe.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/ReplaceFunctionPipe.java
@@ -28,9 +28,6 @@ public class ReplaceFunctionPipe extends Pipe {
 
     @Override
     public final Pipe replaceChildren(List<Pipe> newChildren) {
-        if (newChildren.size() != 3) {
-            throw new IllegalArgumentException("expected [3] children but received [" + newChildren.size() + "]");
-        }
         return replaceChildren(newChildren.get(0), newChildren.get(1), newChildren.get(2));
     }
     

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/Substring.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/Substring.java
@@ -118,10 +118,6 @@ public class Substring extends ScalarFunction {
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        if (newChildren.size() != 3) {
-            throw new IllegalArgumentException("expected [3] children but received [" + newChildren.size() + "]");
-        }
-
         return new Substring(source(), newChildren.get(0), newChildren.get(1), newChildren.get(2));
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/SubstringFunctionPipe.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/SubstringFunctionPipe.java
@@ -28,9 +28,6 @@ public class SubstringFunctionPipe extends Pipe {
 
     @Override
     public final Pipe replaceChildren(List<Pipe> newChildren) {
-        if (newChildren.size() != 3) {
-            throw new IllegalArgumentException("expected [3] children but received [" + newChildren.size() + "]");
-        }
         return replaceChildren(newChildren.get(0), newChildren.get(1), newChildren.get(2));
     }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/conditional/IfConditional.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/conditional/IfConditional.java
@@ -50,9 +50,6 @@ public class IfConditional extends Expression {
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        if (newChildren.size() < 2) {
-            throw new IllegalArgumentException("expected at least [2] children but received [" + newChildren.size() + "]");
-        }
         return new IfConditional(source(), newChildren.get(0), newChildren.get(1));
     }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/operator/comparison/In.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/operator/comparison/In.java
@@ -34,9 +34,6 @@ public class In extends org.elasticsearch.xpack.ql.expression.predicate.operator
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        if (newChildren.size() < 2) {
-            throw new IllegalArgumentException("expected at least [2] children but received [" + newChildren.size() + "]");
-        }
         return new In(source(), newChildren.get(newChildren.size() - 1), newChildren.subList(0, newChildren.size() - 1), zoneId());
     }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/Join.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/Join.java
@@ -46,9 +46,6 @@ public class Join extends BinaryPlan {
 
     @Override
     public LogicalPlan replaceChildren(List<LogicalPlan> newChildren) {
-        if (newChildren.size() != 2) {
-            throw new IllegalArgumentException("expected [2] children but received [" + newChildren.size() + "]");
-        }
         return new Join(source(), newChildren.get(0), newChildren.get(1), type, condition);
     }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/physical/BinaryExec.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/physical/BinaryExec.java
@@ -23,9 +23,6 @@ abstract class BinaryExec extends PhysicalPlan {
 
     @Override
     public final BinaryExec replaceChildren(List<PhysicalPlan> newChildren) {
-        if (newChildren.size() != 2) {
-            throw new IllegalArgumentException("expected [2] children but received [" + newChildren.size() + "]");
-        }
         return replaceChildren(newChildren.get(0), newChildren.get(1));
     }
     protected abstract BinaryExec replaceChildren(PhysicalPlan newLeft, PhysicalPlan newRight);

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/physical/UnaryExec.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/physical/UnaryExec.java
@@ -23,9 +23,6 @@ public abstract class UnaryExec extends PhysicalPlan {
 
     @Override
     public final PhysicalPlan replaceChildren(List<PhysicalPlan> newChildren) {
-        if (newChildren.size() != 1) {
-            throw new IllegalArgumentException("expected [1] child but received [" + newChildren.size() + "]");
-        }
         return replaceChild(newChildren.get(0));
     }
 


### PR DESCRIPTION
Most of the `Node` transformations calling `Node.replaceChildren`
does not change the size of the children list, hence it is enough to 
check this property once in the `Node` class instead of checking it
in each implementation of the `replaceChildren` method.

Modification:
* All of the tree transformation rules with the exception of the
`Case` and `ArbitraryConditionalFunction` transformations expect the
children count to be the same before and after the transformation, hence
I moved the check for this invariant into the
`final Node.replaceChildrenSameSize(List)` method.
* Removed a few hundred lines from `Node.replaceChildren`
implementations that check the size of the children list
* Switched most of the `replaceChildren()` calls to 
 `replaceChildrenSameSize()` with the exception of the 
 `ArbitraryConditionalFunction` and `Case` Optimizer rules