### PR TITLE
[7.11] [DOCS] Add security privileges to data stream API docs (#67612)

### DIFF
--- a/docs/reference/data-streams/promote-data-stream-api.asciidoc
+++ b/docs/reference/data-streams/promote-data-stream-api.asciidoc
@@ -29,6 +29,11 @@ POST /_data_stream/_promote/my-data-stream
 
 `POST /_data_stream/_promote/<data-stream>`
 
+[[promote-data-stream-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `manage`
+<<privileges-list-cluster,cluster privilege>> to use this API.
 
 [[promote-data-stream-api-path-params]]
 ==== {api-path-parms-title}

--- a/docs/reference/indices/create-data-stream.asciidoc
+++ b/docs/reference/indices/create-data-stream.asciidoc
@@ -41,6 +41,12 @@ DELETE /_index_template/template
 
 `PUT /_data_stream/<data-stream>`
 
+[[indices-create-data-stream-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `create_index`
+or `manage` <<privileges-list-indices,index privilege>> for the data stream.
+
 [[indices-create-data-stream-api-path-params]]
 ==== {api-path-parms-title}
 

--- a/docs/reference/indices/data-stream-stats.asciidoc
+++ b/docs/reference/indices/data-stream-stats.asciidoc
@@ -52,6 +52,12 @@ DELETE /_index_template/*
 GET /_data_stream/my-data-stream/_stats
 ----
 
+[[data-stream-stats-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the
+`monitor` or `manage` <<privileges-list-indices,index privilege>>
+for the data stream.
 
 [[data-stream-stats-api-request]]
 ==== {api-request-title}

--- a/docs/reference/indices/delete-data-stream.asciidoc
+++ b/docs/reference/indices/delete-data-stream.asciidoc
@@ -40,6 +40,12 @@ DELETE /_index_template/template
 
 `DELETE /_data_stream/<data-stream>`
 
+[[delete-data-stream-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `delete_index`
+or `manage` <<privileges-list-indices,index privilege>> for the data stream.
+
 
 [[delete-data-stream-api-path-params]]
 ==== {api-path-parms-title}

--- a/docs/reference/indices/get-data-stream.asciidoc
+++ b/docs/reference/indices/get-data-stream.asciidoc
@@ -75,6 +75,13 @@ GET /_data_stream/my-data-stream
 
 `GET /_data_stream/<data-stream>`
 
+[[get-data-stream-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the
+`view_index_metadata` or `manage` <<privileges-list-indices,index privilege>>
+for the data stream.
+
 [[get-data-stream-api-path-params]]
 ==== {api-path-parms-title}
 

--- a/docs/reference/indices/migrate-to-data-stream.asciidoc
+++ b/docs/reference/indices/migrate-to-data-stream.asciidoc
@@ -72,6 +72,12 @@ DELETE /_index_template/template
 
 `POST /_data_stream/_migrate/<alias>`
 
+[[indices-migrate-to-data-stream-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `manage`
+<<privileges-list-indices,index privilege>> for the index alias.
+
 [[indices-migrate-to-data-stream-api-path-params]]
 ==== {api-path-parms-title}
 


### PR DESCRIPTION
Backports the following commits to 7.11:
 - [DOCS] Add security privileges to data stream API docs (#67612)