### PR TITLE
[7.10] [DOCS] Add security privileges to cat API docs (#67467)

### DIFF
--- a/docs/reference/cat/alias.asciidoc
+++ b/docs/reference/cat/alias.asciidoc
@@ -15,6 +15,13 @@ filter and routing information.
 
 `GET /_cat/aliases`
 
+[[cat-alias-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the
+`view_index_metadata` or `manage` <<privileges-list-indices,index privilege>>
+for any alias you retrieve.
+
 [[cat-alias-api-path-params]]
 ==== {api-path-parms-title}
 

--- a/docs/reference/cat/allocation.asciidoc
+++ b/docs/reference/cat/allocation.asciidoc
@@ -16,6 +16,12 @@ and their disk space.
 
 `GET /_cat/allocation`
 
+[[cat-allocation-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `monitor` or
+`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
+
 [[cat-allocation-api-path-params]]
 ==== {api-path-parms-title}
 

--- a/docs/reference/cat/count.asciidoc
+++ b/docs/reference/cat/count.asciidoc
@@ -18,6 +18,12 @@ which have not yet been removed by the merge process.
 
 `GET /_cat/count`
 
+[[cat-count-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `read`
+<<privileges-list-indices,index privilege>> for any data stream, index, or index
+alias you retrieve.
 
 [[cat-count-api-path-params]]
 ==== {api-path-parms-title}

--- a/docs/reference/cat/fielddata.asciidoc
+++ b/docs/reference/cat/fielddata.asciidoc
@@ -15,6 +15,11 @@ Returns the amount of heap memory currently used by the
 
 `GET /_cat/fielddata`
 
+[[cat-fielddata-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `monitor` or
+`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
 
 [[cat-fielddata-api-path-params]]
 ==== {api-path-parms-title}

--- a/docs/reference/cat/health.asciidoc
+++ b/docs/reference/cat/health.asciidoc
@@ -13,6 +13,11 @@ health>> API.
 
 `GET /_cat/health`
 
+[[cat-health-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `monitor` or
+`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
 
 [[cat-health-api-desc]]
 ==== {api-description-title}

--- a/docs/reference/cat/indices.asciidoc
+++ b/docs/reference/cat/indices.asciidoc
@@ -15,6 +15,13 @@ indices for data streams.
 
 `GET /_cat/indices`
 
+[[cat-indices-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `monitor` or
+`manage` <<privileges-list-cluster,cluster privilege>> to use this API. You must
+also have the `monitor` or `manage` <<privileges-list-indices,index privilege>>
+for any data stream, index, or index alias you retrieve.
 
 [[cat-indices-api-desc]]
 ==== {api-description-title}

--- a/docs/reference/cat/master.asciidoc
+++ b/docs/reference/cat/master.asciidoc
@@ -13,6 +13,11 @@ and name.
 
 `GET /_cat/master`
 
+[[cat-master-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `monitor` or
+`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
 
 [[cat-master-api-query-params]]
 ==== {api-query-parms-title}

--- a/docs/reference/cat/nodeattrs.asciidoc
+++ b/docs/reference/cat/nodeattrs.asciidoc
@@ -11,6 +11,12 @@ Returns information about custom node attributes.
 
 `GET /_cat/nodeattrs`
 
+[[cat-nodeattrs-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `monitor` or
+`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
+
 [[cat-nodeattrs-api-query-params]]
 ==== {api-query-parms-title}
 

--- a/docs/reference/cat/nodes.asciidoc
+++ b/docs/reference/cat/nodes.asciidoc
@@ -11,6 +11,12 @@ Returns information about a cluster's nodes.
 
 `GET /_cat/nodes`
 
+[[cat-nodes-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `monitor` or
+`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
+
 [[cat-nodes-api-query-params]]
 ==== {api-query-parms-title}
 

--- a/docs/reference/cat/pending_tasks.asciidoc
+++ b/docs/reference/cat/pending_tasks.asciidoc
@@ -12,6 +12,12 @@ Returns cluster-level changes that have not yet been executed, similar to the
 
 `GET /_cat/pending_tasks`
 
+[[cat-pending-tasks-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `monitor` or
+`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
+
 [[cat-pending-tasks-api-query-params]]
 ==== {api-query-parms-title}
 

--- a/docs/reference/cat/plugins.asciidoc
+++ b/docs/reference/cat/plugins.asciidoc
@@ -7,13 +7,18 @@
 Returns a list of plugins running on each node of a cluster.
 
 
-[[cat-plugins-tasks-api-request]]
+[[cat-plugins-api-request]]
 ==== {api-request-title}
 
 `GET /_cat/plugins`
 
+[[cat-plugins-api-prereqs]]
+==== {api-prereq-title}
 
-[[cat-plugins-tasks-api-query-params]]
+* If the {es} {security-features} are enabled, you must have the `monitor` or
+`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
+
+[[cat-plugins-api-query-params]]
 ==== {api-query-parms-title}
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=http-format]

--- a/docs/reference/cat/recovery.asciidoc
+++ b/docs/reference/cat/recovery.asciidoc
@@ -18,6 +18,13 @@ indices.
 
 `GET /_cat/recovery`
 
+[[cat-recovery-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `monitor` or
+`manage` <<privileges-list-cluster,cluster privilege>> to use this API. You must
+also have the `monitor` or `manage` <<privileges-list-indices,index privilege>>
+for any data stream, index, or index alias you retrieve.
 
 [[cat-recovery-api-desc]]
 ==== {api-description-title}

--- a/docs/reference/cat/repositories.asciidoc
+++ b/docs/reference/cat/repositories.asciidoc
@@ -12,6 +12,12 @@ Returns the <<snapshots-repositories,snapshot repositories>> for a cluster.
 
 `GET /_cat/repositories`
 
+[[cat-repositories-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the
+`monitor_snapshot`, `create_snapshot`, or `manage`
+<<privileges-list-cluster,cluster privilege>> to use this API.
 
 [[cat-repositories-query-params]]
 ==== {api-query-parms-title}

--- a/docs/reference/cat/segments.asciidoc
+++ b/docs/reference/cat/segments.asciidoc
@@ -18,6 +18,13 @@ indices.
 
 `GET /_cat/segments`
 
+[[cat-segments-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `monitor` or
+`manage` <<privileges-list-cluster,cluster privilege>> to use this API. You must
+also have the `monitor` or `manage` <<privileges-list-indices,index privilege>>
+for any data stream, index, or index alias you retrieve.
 
 [[cat-segments-path-params]]
 ==== {api-path-parms-title}

--- a/docs/reference/cat/shards.asciidoc
+++ b/docs/reference/cat/shards.asciidoc
@@ -19,6 +19,13 @@ indices.
 
 `GET /_cat/shards`
 
+[[cat-shards-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `monitor` or
+`manage` <<privileges-list-cluster,cluster privilege>> to use this API. You must
+also have the `monitor` or `manage` <<privileges-list-indices,index privilege>>
+for any data stream, index, or index alias you retrieve.
 
 [[cat-shards-path-params]]
 ==== {api-path-parms-title}

--- a/docs/reference/cat/snapshots.asciidoc
+++ b/docs/reference/cat/snapshots.asciidoc
@@ -13,6 +13,13 @@ more repositories. A snapshot is a backup of an index or running {es} cluster.
 
 `GET /_cat/snapshots/<repository>`
 
+[[cat-snapshots-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the
+`monitor_snapshot`, `create_snapshot`, or `manage`
+<<privileges-list-cluster,cluster privilege>> to use this API.
+
 
 [[cat-snapshots-path-params]]
 ==== {api-path-parms-title}

--- a/docs/reference/cat/tasks.asciidoc
+++ b/docs/reference/cat/tasks.asciidoc
@@ -15,6 +15,11 @@ similar to the <<tasks,task management>> API.
 
 `GET /_cat/tasks`
 
+[[cat-tasks-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `monitor` or
+`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
 
 [[cat-tasks-api-desc]]
 ==== {api-description-title}

--- a/docs/reference/cat/templates.asciidoc
+++ b/docs/reference/cat/templates.asciidoc
@@ -16,6 +16,11 @@ and <<mapping,field mappings>> to new indices at creation.
 
 `GET /_cat/templates`
 
+[[cat-templates-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `monitor` or
+`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
 
 [[cat-templates-path-params]]
 ==== {api-path-parms-title}

--- a/docs/reference/cat/thread_pool.asciidoc
+++ b/docs/reference/cat/thread_pool.asciidoc
@@ -16,6 +16,11 @@ pools.
 
 `GET /_cat/thread_pool`
 
+[[cat-thread-pool-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `monitor` or
+`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
 
 [[cat-thread-pool-path-params]]
 ==== {api-path-parms-title}


### PR DESCRIPTION
Backports the following commits to 7.10:
 - [DOCS] Add security privileges to cat API docs (#67467)