### PR TITLE
Improve error message on incompatible repo format

### DIFF
--- a/server/src/main/java/org/elasticsearch/repositories/RepositoryData.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoryData.java
@@ -453,11 +453,27 @@ public final class RepositoryData {
      * Writes the snapshots metadata and the related indices metadata to x-content.
      */
     public XContentBuilder snapshotsToXContent(final XContentBuilder builder, final Version repoMetaVersion) throws IOException {
-        builder.startObject();
-        // write the snapshots list
-        builder.startArray(SNAPSHOTS);
+
         final boolean shouldWriteIndexGens = SnapshotsService.useIndexGenerations(repoMetaVersion);
         final boolean shouldWriteShardGens = SnapshotsService.useShardGenerations(repoMetaVersion);
+
+        assert Boolean.compare(shouldWriteIndexGens, shouldWriteShardGens) <= 0;
+
+        builder.startObject();
+
+        if (shouldWriteShardGens) {
+            // Add min version field to make it impossible for older ES versions to deserialize this object
+            final Version minVersion;
+            if (shouldWriteIndexGens) {
+                minVersion = SnapshotsService.INDEX_GEN_IN_REPO_DATA_VERSION;
+            } else {
+                minVersion = SnapshotsService.SHARD_GEN_IN_REPO_DATA_VERSION;
+            }
+            builder.field(MIN_VERSION, minVersion.toString());
+        }
+
+        // write the snapshots list
+        builder.startArray(SNAPSHOTS);
         for (final SnapshotId snapshot : getSnapshotIds()) {
             builder.startObject();
             builder.field(NAME, snapshot.getName());
@@ -482,6 +498,7 @@ public final class RepositoryData {
             builder.endObject();
         }
         builder.endArray();
+
         // write the indices map
         builder.startObject(INDICES);
         for (final IndexId indexId : getIndices().values()) {
@@ -504,14 +521,13 @@ public final class RepositoryData {
             builder.endObject();
         }
         builder.endObject();
+
         if (shouldWriteIndexGens) {
-            builder.field(MIN_VERSION, SnapshotsService.INDEX_GEN_IN_REPO_DATA_VERSION.toString());
             builder.field(INDEX_METADATA_IDENTIFIERS, indexMetaDataGenerations.identifiers);
-        } else if (shouldWriteShardGens) {
-            // Add min version field to make it impossible for older ES versions to deserialize this object
-            builder.field(MIN_VERSION, SnapshotsService.SHARD_GEN_IN_REPO_DATA_VERSION.toString());
         }
+
         builder.endObject();
+
         return builder;
     }
 
@@ -554,6 +570,10 @@ public final class RepositoryData {
                     XContentParserUtils.ensureExpectedToken(XContentParser.Token.VALUE_STRING, parser.nextToken(), parser);
                     final Version version = Version.fromString(parser.text());
                     assert SnapshotsService.useShardGenerations(version);
+                    if (version.after(Version.CURRENT)) {
+                        throw new IllegalStateException(
+                                "this snapshot repository format requires Elasticsearch version [" + version + "] or later");
+                    }
                     break;
                 default:
                     XContentParserUtils.throwUnknownField(field, parser.getTokenLocation());

--- a/server/src/test/java/org/elasticsearch/repositories/RepositoryDataTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/RepositoryDataTests.java
@@ -330,6 +330,25 @@ public class RepositoryDataTests extends ESTestCase {
         assertEquals(newRepoData.indexMetaDataToRemoveAfterRemovingSnapshots(Collections.singleton(otherSnapshotId)), removeFromOther);
     }
 
+    public void testFailsIfMinVersionNotSatisfied() throws IOException {
+        final Version futureVersion = Version.fromString((Version.CURRENT.major + 1) + ".0.0");
+
+        final XContentBuilder builder = XContentBuilder.builder(randomFrom(XContentType.JSON).xContent());
+        builder.startObject();
+        {
+            builder.field("min_version", futureVersion);
+            builder.field("junk", "should not get this far");
+        }
+        builder.endObject();
+
+        try (XContentParser xParser = createParser(builder)) {
+            IllegalStateException e = expectThrows(IllegalStateException.class, () ->
+                    RepositoryData.snapshotsFromXContent(xParser, randomNonNegativeLong(), randomBoolean()));
+            assertThat(e.getMessage(), equalTo(
+                    "this snapshot repository format requires Elasticsearch version [" + futureVersion + "] or later"));
+        }
+    }
+
     public static RepositoryData generateRandomRepoData() {
         final int numIndices = randomIntBetween(1, 30);
         final List<IndexId> indices = new ArrayList<>(numIndices);


### PR DESCRIPTION
Today the `min_version` field is written near the end of the repository
metadata blob, so if you try reading the blob with the wrong version you
likely get an opaque parse error.

This commit moves the `min_version` field to the top of the blob so it's
parsed first, and adds parse-time validation that bails out with a more
useful error message if the current version is too old.