### PR TITLE
ILM: skip rollover if the data stream is rolled over already

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/RolloverStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/RolloverStepTests.java
@@ -29,6 +29,7 @@ import java.util.Locale;
 import static org.elasticsearch.cluster.DataStreamTestHelper.createTimestampField;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.verifyZeroInteractions;
 
 public class RolloverStepTests extends AbstractStepMasterTimeoutTestCase<RolloverStep> {
 
@@ -158,6 +159,46 @@ public class RolloverStepTests extends AbstractStepMasterTimeoutTestCase<Rollove
         Mockito.verify(client, Mockito.only()).admin();
         Mockito.verify(adminClient, Mockito.only()).indices();
         Mockito.verify(indicesClient, Mockito.only()).rolloverIndex(Mockito.any(), Mockito.any());
+    }
+
+    public void testSkipRolloverIfDataStreamIsAlreadyRolledOver() {
+        String dataStreamName = "test-datastream";
+        IndexMetadata firstGenerationIndex = IndexMetadata.builder(DataStream.getDefaultBackingIndexName(dataStreamName, 1))
+            .settings(settings(Version.CURRENT))
+            .numberOfShards(randomIntBetween(1, 5)).numberOfReplicas(randomIntBetween(0, 5)).build();
+
+        IndexMetadata writeIndex = IndexMetadata.builder(DataStream.getDefaultBackingIndexName(dataStreamName, 2))
+            .settings(settings(Version.CURRENT))
+            .numberOfShards(randomIntBetween(1, 5)).numberOfReplicas(randomIntBetween(0, 5)).build();
+        RolloverStep step = createRandomInstance();
+
+        SetOnce<Boolean> actionCompleted = new SetOnce<>();
+        ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT)
+            .metadata(
+                Metadata.builder().put(firstGenerationIndex, true)
+                    .put(writeIndex, true)
+                    .put(new DataStream(dataStreamName, createTimestampField("@timestamp"),
+                        List.of(firstGenerationIndex.getIndex(), writeIndex.getIndex())))
+            )
+            .build();
+        step.performAction(firstGenerationIndex, clusterState, null, new AsyncActionStep.Listener() {
+
+            @Override
+            public void onResponse(boolean complete) {
+                actionCompleted.set(complete);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                throw new AssertionError("Unexpected method call", e);
+            }
+        });
+
+        assertEquals(true, actionCompleted.get());
+
+        verifyZeroInteractions(client);
+        verifyZeroInteractions(adminClient);
+        verifyZeroInteractions(indicesClient);
     }
 
     private void mockClientRolloverCall(String rolloverTarget) {


### PR DESCRIPTION
The rollover action would perform a datastream rollover irrespective if the
managed index was the write index or not. This could lead to multiple rollovers
being executed eg. a manual call rolls over the datastream and later an ILM
managed index, the previous write index, will do so too. There are similar
scenarios possible if the `rollover` step failed (due to various reasons including
`Concurrent modification of alias`) and succeded when retried.

Fixes #67777