### PR TITLE
[7.x][Transform] report last search time in transform stats (#66718)

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/transform/transforms/TransformCheckpointingInfo.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/transform/transforms/TransformCheckpointingInfo.java
@@ -35,46 +35,69 @@ public class TransformCheckpointingInfo {
     public static final ParseField NEXT_CHECKPOINT = new ParseField("next", "in_progress");
     public static final ParseField OPERATIONS_BEHIND = new ParseField("operations_behind");
     public static final ParseField CHANGES_LAST_DETECTED_AT = new ParseField("changes_last_detected_at");
+    public static final ParseField LAST_SEARCH_TIME = new ParseField("last_search_time");
 
     private final TransformCheckpointStats last;
     private final TransformCheckpointStats next;
     private final long operationsBehind;
     private final Instant changesLastDetectedAt;
+    private final Instant lastSearchTime;
 
-    private static final ConstructingObjectParser<TransformCheckpointingInfo, Void> LENIENT_PARSER =
-            new ConstructingObjectParser<>(
-                "transform_checkpointing_info",
-                true,
-                a -> {
-                        long behind = a[2] == null ? 0L : (Long) a[2];
-                        Instant changesLastDetectedAt = (Instant)a[3];
-                        return new TransformCheckpointingInfo(
-                            a[0] == null ? TransformCheckpointStats.EMPTY : (TransformCheckpointStats) a[0],
-                            a[1] == null ? TransformCheckpointStats.EMPTY : (TransformCheckpointStats) a[1],
-                            behind,
-                            changesLastDetectedAt);
-                    });
+    private static final ConstructingObjectParser<TransformCheckpointingInfo, Void> LENIENT_PARSER = new ConstructingObjectParser<>(
+        "transform_checkpointing_info",
+        true,
+        a -> {
+            long behind = a[2] == null ? 0L : (Long) a[2];
+            Instant changesLastDetectedAt = (Instant) a[3];
+            Instant lastSearchTime = (Instant) a[4];
+            return new TransformCheckpointingInfo(
+                a[0] == null ? TransformCheckpointStats.EMPTY : (TransformCheckpointStats) a[0],
+                a[1] == null ? TransformCheckpointStats.EMPTY : (TransformCheckpointStats) a[1],
+                behind,
+                changesLastDetectedAt,
+                lastSearchTime
+            );
+        }
+    );
 
     static {
-        LENIENT_PARSER.declareObject(ConstructingObjectParser.optionalConstructorArg(),
-                (p, c) -> TransformCheckpointStats.fromXContent(p), LAST_CHECKPOINT);
-        LENIENT_PARSER.declareObject(ConstructingObjectParser.optionalConstructorArg(),
-                (p, c) -> TransformCheckpointStats.fromXContent(p), NEXT_CHECKPOINT);
+        LENIENT_PARSER.declareObject(
+            ConstructingObjectParser.optionalConstructorArg(),
+            (p, c) -> TransformCheckpointStats.fromXContent(p),
+            LAST_CHECKPOINT
+        );
+        LENIENT_PARSER.declareObject(
+            ConstructingObjectParser.optionalConstructorArg(),
+            (p, c) -> TransformCheckpointStats.fromXContent(p),
+            NEXT_CHECKPOINT
+        );
         LENIENT_PARSER.declareLong(ConstructingObjectParser.optionalConstructorArg(), OPERATIONS_BEHIND);
-        LENIENT_PARSER.declareField(ConstructingObjectParser.optionalConstructorArg(),
+        LENIENT_PARSER.declareField(
+            ConstructingObjectParser.optionalConstructorArg(),
             p -> TimeUtil.parseTimeFieldToInstant(p, CHANGES_LAST_DETECTED_AT.getPreferredName()),
             CHANGES_LAST_DETECTED_AT,
-            ObjectParser.ValueType.VALUE);
+            ObjectParser.ValueType.VALUE
+        );
+        LENIENT_PARSER.declareField(
+            ConstructingObjectParser.optionalConstructorArg(),
+            p -> TimeUtil.parseTimeFieldToInstant(p, LAST_SEARCH_TIME.getPreferredName()),
+            LAST_SEARCH_TIME,
+            ObjectParser.ValueType.VALUE
+        );
     }
 
-    public TransformCheckpointingInfo(TransformCheckpointStats last,
-                                      TransformCheckpointStats next,
-                                      long operationsBehind,
-                                      Instant changesLastDetectedAt) {
+    public TransformCheckpointingInfo(
+        TransformCheckpointStats last,
+        TransformCheckpointStats next,
+        long operationsBehind,
+        Instant changesLastDetectedAt,
+        Instant lastSearchTime
+    ) {
         this.last = Objects.requireNonNull(last);
         this.next = Objects.requireNonNull(next);
         this.operationsBehind = operationsBehind;
         this.changesLastDetectedAt = changesLastDetectedAt;
+        this.lastSearchTime = lastSearchTime;
     }
 
     public TransformCheckpointStats getLast() {
@@ -94,13 +117,18 @@ public class TransformCheckpointingInfo {
         return changesLastDetectedAt;
     }
 
+    @Nullable
+    public Instant getLastSearchTime() {
+        return lastSearchTime;
+    }
+
     public static TransformCheckpointingInfo fromXContent(XContentParser p) {
         return LENIENT_PARSER.apply(p, null);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(last, next, operationsBehind, changesLastDetectedAt);
+        return Objects.hash(last, next, operationsBehind, changesLastDetectedAt, lastSearchTime);
     }
 
     @Override
@@ -115,10 +143,11 @@ public class TransformCheckpointingInfo {
 
         TransformCheckpointingInfo that = (TransformCheckpointingInfo) other;
 
-        return Objects.equals(this.last, that.last) &&
-            Objects.equals(this.next, that.next) &&
-            this.operationsBehind == that.operationsBehind &&
-            Objects.equals(this.changesLastDetectedAt, that.changesLastDetectedAt);
+        return Objects.equals(this.last, that.last)
+            && Objects.equals(this.next, that.next)
+            && this.operationsBehind == that.operationsBehind
+            && Objects.equals(this.changesLastDetectedAt, that.changesLastDetectedAt)
+            && Objects.equals(this.lastSearchTime, that.lastSearchTime);
     }
 
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/transform/transforms/TransformCheckpointingInfoTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/transform/transforms/TransformCheckpointingInfoTests.java
@@ -30,12 +30,12 @@ import static org.elasticsearch.test.AbstractXContentTestCase.xContentTester;
 public class TransformCheckpointingInfoTests extends ESTestCase {
 
     public void testFromXContent() throws IOException {
-        xContentTester(this::createParser,
+        xContentTester(
+            this::createParser,
             TransformCheckpointingInfoTests::randomTransformCheckpointingInfo,
             TransformCheckpointingInfoTests::toXContent,
-            TransformCheckpointingInfo::fromXContent)
-                .supportsUnknownFields(false)
-                .test();
+            TransformCheckpointingInfo::fromXContent
+        ).supportsUnknownFields(false).test();
     }
 
     public static TransformCheckpointingInfo randomTransformCheckpointingInfo() {
@@ -43,7 +43,9 @@ public class TransformCheckpointingInfoTests extends ESTestCase {
             TransformCheckpointStatsTests.randomTransformCheckpointStats(),
             TransformCheckpointStatsTests.randomTransformCheckpointStats(),
             randomLongBetween(0, 10000),
-            randomBoolean() ? null : Instant.ofEpochMilli(randomNonNegativeLong()));
+            randomBoolean() ? null : Instant.ofEpochMilli(randomNonNegativeLong()),
+            randomBoolean() ? null : Instant.ofEpochMilli(randomNonNegativeLong())
+        );
     }
 
     public static void toXContent(TransformCheckpointingInfo info, XContentBuilder builder) throws IOException {
@@ -59,6 +61,9 @@ public class TransformCheckpointingInfoTests extends ESTestCase {
         builder.field(TransformCheckpointingInfo.OPERATIONS_BEHIND.getPreferredName(), info.getOperationsBehind());
         if (info.getChangesLastDetectedAt() != null) {
             builder.field(TransformCheckpointingInfo.CHANGES_LAST_DETECTED_AT.getPreferredName(), info.getChangesLastDetectedAt());
+        }
+        if (info.getLastSearchTime() != null) {
+            builder.field(TransformCheckpointingInfo.LAST_SEARCH_TIME.getPreferredName(), info.getLastSearchTime());
         }
         builder.endObject();
     }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/transform/transforms/hlrc/TransformCheckpointingInfoTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/transform/transforms/hlrc/TransformCheckpointingInfoTests.java
@@ -31,19 +31,22 @@ import static org.elasticsearch.client.transform.transforms.hlrc.TransformStatsT
 
 public class TransformCheckpointingInfoTests extends AbstractResponseTestCase<
     org.elasticsearch.xpack.core.transform.transforms.TransformCheckpointingInfo,
-        TransformCheckpointingInfo> {
+    TransformCheckpointingInfo> {
 
     public static org.elasticsearch.xpack.core.transform.transforms.TransformCheckpointingInfo randomTransformCheckpointingInfo() {
         return new org.elasticsearch.xpack.core.transform.transforms.TransformCheckpointingInfo(
             TransformCheckpointStatsTests.randomTransformCheckpointStats(),
             TransformCheckpointStatsTests.randomTransformCheckpointStats(),
             randomNonNegativeLong(),
-            randomBoolean() ? null : Instant.ofEpochMilli(randomNonNegativeLong()));
+            randomBoolean() ? null : Instant.ofEpochMilli(randomNonNegativeLong()),
+            randomBoolean() ? null : Instant.ofEpochMilli(randomNonNegativeLong())
+        );
     }
 
     @Override
-    protected org.elasticsearch.xpack.core.transform.transforms.TransformCheckpointingInfo
-    createServerTestInstance(XContentType xContentType) {
+    protected org.elasticsearch.xpack.core.transform.transforms.TransformCheckpointingInfo createServerTestInstance(
+        XContentType xContentType
+    ) {
         return randomTransformCheckpointingInfo();
     }
 
@@ -53,8 +56,10 @@ public class TransformCheckpointingInfoTests extends AbstractResponseTestCase<
     }
 
     @Override
-    protected void assertInstances(org.elasticsearch.xpack.core.transform.transforms.TransformCheckpointingInfo serverTestInstance,
-                                   TransformCheckpointingInfo clientInstance) {
+    protected void assertInstances(
+        org.elasticsearch.xpack.core.transform.transforms.TransformCheckpointingInfo serverTestInstance,
+        TransformCheckpointingInfo clientInstance
+    ) {
         assertTransformCheckpointInfo(serverTestInstance, clientInstance);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformCheckpointingInfo.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformCheckpointingInfo.java
@@ -231,7 +231,7 @@ public class TransformCheckpointingInfo implements Writeable, ToXContentObject {
         } else {
             changesLastDetectedAt = null;
         }
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) { // todo: V_7_12_0
+        if (in.getVersion().onOrAfter(Version.V_7_12_0)) {
             lastSearchTime = in.readOptionalInstant();
         } else {
             lastSearchTime = null;
@@ -294,7 +294,7 @@ public class TransformCheckpointingInfo implements Writeable, ToXContentObject {
         if (out.getVersion().onOrAfter(Version.V_7_4_0)) {
             out.writeOptionalInstant(changesLastDetectedAt);
         }
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) { // todo: V_7_12_0
+        if (out.getVersion().onOrAfter(Version.V_7_12_0)) {
             out.writeOptionalInstant(lastSearchTime);
         }
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformCheckpointingInfo.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformCheckpointingInfo.java
@@ -41,6 +41,7 @@ public class TransformCheckpointingInfo implements Writeable, ToXContentObject {
         private TransformCheckpoint nextCheckpoint;
         private TransformCheckpoint sourceCheckpoint;
         private Instant changesLastDetectedAt;
+        private Instant lastSearchTime;
         private long operationsBehind;
 
         public TransformCheckpointingInfoBuilder() {}
@@ -76,7 +77,8 @@ public class TransformCheckpointingInfo implements Writeable, ToXContentObject {
                     nextCheckpoint.getTimeUpperBound()
                 ),
                 operationsBehind,
-                changesLastDetectedAt
+                changesLastDetectedAt,
+                lastSearchTime
             );
         }
 
@@ -122,6 +124,11 @@ public class TransformCheckpointingInfo implements Writeable, ToXContentObject {
             return this;
         }
 
+        public TransformCheckpointingInfoBuilder setLastSearchTime(Instant lastSearchTime) {
+            this.lastSearchTime = lastSearchTime;
+            return this;
+        }
+
         public TransformCheckpointingInfoBuilder setOperationsBehind(long operationsBehind) {
             this.operationsBehind = operationsBehind;
             return this;
@@ -133,6 +140,7 @@ public class TransformCheckpointingInfo implements Writeable, ToXContentObject {
         TransformCheckpointStats.EMPTY,
         TransformCheckpointStats.EMPTY,
         0L,
+        null,
         null
     );
 
@@ -140,10 +148,12 @@ public class TransformCheckpointingInfo implements Writeable, ToXContentObject {
     public static final ParseField NEXT_CHECKPOINT = new ParseField("next");
     public static final ParseField OPERATIONS_BEHIND = new ParseField("operations_behind");
     public static final ParseField CHANGES_LAST_DETECTED_AT = new ParseField("changes_last_detected_at");
+    public static final ParseField LAST_SEARCH_TIME = new ParseField("last_search_time");
     private final TransformCheckpointStats last;
     private final TransformCheckpointStats next;
     private final long operationsBehind;
     private final Instant changesLastDetectedAt;
+    private final Instant lastSearchTime;
 
     private static final ConstructingObjectParser<TransformCheckpointingInfo, Void> LENIENT_PARSER = new ConstructingObjectParser<>(
         "data_frame_transform_checkpointing_info",
@@ -151,11 +161,13 @@ public class TransformCheckpointingInfo implements Writeable, ToXContentObject {
         a -> {
             long behind = a[2] == null ? 0L : (Long) a[2];
             Instant changesLastDetectedAt = (Instant) a[3];
+            Instant lastSearchTime = (Instant) a[4];
             return new TransformCheckpointingInfo(
                 a[0] == null ? TransformCheckpointStats.EMPTY : (TransformCheckpointStats) a[0],
                 a[1] == null ? TransformCheckpointStats.EMPTY : (TransformCheckpointStats) a[1],
                 behind,
-                changesLastDetectedAt
+                changesLastDetectedAt,
+                lastSearchTime
             );
         }
     );
@@ -178,6 +190,12 @@ public class TransformCheckpointingInfo implements Writeable, ToXContentObject {
             CHANGES_LAST_DETECTED_AT,
             ObjectParser.ValueType.VALUE
         );
+        LENIENT_PARSER.declareField(
+            ConstructingObjectParser.optionalConstructorArg(),
+            p -> TimeUtils.parseTimeFieldToInstant(p, LAST_SEARCH_TIME.getPreferredName()),
+            LAST_SEARCH_TIME,
+            ObjectParser.ValueType.VALUE
+        );
     }
 
     /**
@@ -187,18 +205,21 @@ public class TransformCheckpointingInfo implements Writeable, ToXContentObject {
      * @param last stats of the last checkpoint
      * @param next stats of the next checkpoint
      * @param operationsBehind counter of operations the current checkpoint is behind source
-     * @param changesLastDetectedAt the last time the source indices were checked for changes
+     * @param changesLastDetectedAt the last time the source indices changes have been found
+     * @param lastSearchTime the last time the source indices were searched
      */
     public TransformCheckpointingInfo(
         TransformCheckpointStats last,
         TransformCheckpointStats next,
         long operationsBehind,
-        Instant changesLastDetectedAt
+        Instant changesLastDetectedAt,
+        Instant lastSearchTime
     ) {
         this.last = Objects.requireNonNull(last);
         this.next = Objects.requireNonNull(next);
         this.operationsBehind = operationsBehind;
-        this.changesLastDetectedAt = changesLastDetectedAt == null ? null : Instant.ofEpochMilli(changesLastDetectedAt.toEpochMilli());
+        this.changesLastDetectedAt = changesLastDetectedAt;
+        this.lastSearchTime = lastSearchTime;
     }
 
     public TransformCheckpointingInfo(StreamInput in) throws IOException {
@@ -209,6 +230,11 @@ public class TransformCheckpointingInfo implements Writeable, ToXContentObject {
             changesLastDetectedAt = in.readOptionalInstant();
         } else {
             changesLastDetectedAt = null;
+        }
+        if (in.getVersion().onOrAfter(Version.V_8_0_0)) { // todo: V_7_12_0
+            lastSearchTime = in.readOptionalInstant();
+        } else {
+            lastSearchTime = null;
         }
     }
 
@@ -228,6 +254,10 @@ public class TransformCheckpointingInfo implements Writeable, ToXContentObject {
         return changesLastDetectedAt;
     }
 
+    public Instant getLastSearchTime() {
+        return lastSearchTime;
+    }
+
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
@@ -245,6 +275,13 @@ public class TransformCheckpointingInfo implements Writeable, ToXContentObject {
                 changesLastDetectedAt.toEpochMilli()
             );
         }
+        if (lastSearchTime != null) {
+            builder.timeField(
+                LAST_SEARCH_TIME.getPreferredName(),
+                LAST_SEARCH_TIME.getPreferredName() + "_string",
+                lastSearchTime.toEpochMilli()
+            );
+        }
         builder.endObject();
         return builder;
     }
@@ -257,6 +294,9 @@ public class TransformCheckpointingInfo implements Writeable, ToXContentObject {
         if (out.getVersion().onOrAfter(Version.V_7_4_0)) {
             out.writeOptionalInstant(changesLastDetectedAt);
         }
+        if (out.getVersion().onOrAfter(Version.V_8_0_0)) { // todo: V_7_12_0
+            out.writeOptionalInstant(lastSearchTime);
+        }
     }
 
     public static TransformCheckpointingInfo fromXContent(XContentParser p) {
@@ -265,7 +305,7 @@ public class TransformCheckpointingInfo implements Writeable, ToXContentObject {
 
     @Override
     public int hashCode() {
-        return Objects.hash(last, next, operationsBehind, changesLastDetectedAt);
+        return Objects.hash(last, next, operationsBehind, changesLastDetectedAt, lastSearchTime);
     }
 
     @Override
@@ -283,7 +323,8 @@ public class TransformCheckpointingInfo implements Writeable, ToXContentObject {
         return Objects.equals(this.last, that.last)
             && Objects.equals(this.next, that.next)
             && this.operationsBehind == that.operationsBehind
-            && Objects.equals(this.changesLastDetectedAt, that.changesLastDetectedAt);
+            && Objects.equals(this.changesLastDetectedAt, that.changesLastDetectedAt)
+            && Objects.equals(this.lastSearchTime, that.lastSearchTime);
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformCheckpointingInfoTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformCheckpointingInfoTests.java
@@ -22,6 +22,7 @@ public class TransformCheckpointingInfoTests extends AbstractSerializingTransfor
             TransformCheckpointStatsTests.randomTransformCheckpointStats(),
             TransformCheckpointStatsTests.randomTransformCheckpointStats(),
             randomNonNegativeLong(),
+            randomBoolean() ? null : Instant.ofEpochMilli(randomLongBetween(1, 100000)),
             randomBoolean() ? null : Instant.ofEpochMilli(randomLongBetween(1, 100000))
         );
     }
@@ -46,7 +47,8 @@ public class TransformCheckpointingInfoTests extends AbstractSerializingTransfor
             TransformCheckpointStats.EMPTY,
             TransformCheckpointStats.EMPTY,
             randomNonNegativeLong(),
-            // changesLastDetectedAt is not serialized to past values, so when it is pulled back in, it will be null
+            // changesLastDetectedAt, lastSearchTime is not serialized to past values, so when it is pulled back in, it will be null
+            null,
             null
         );
         try (BytesStreamOutput output = new BytesStreamOutput()) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformStatsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformStatsTests.java
@@ -75,6 +75,7 @@ public class TransformStatsTests extends AbstractSerializingTestCase<TransformSt
                     new TransformCheckpointStats(0, null, null, 100, 1000),
                     // changesLastDetectedAt aren't serialized back
                     100,
+                    null,
                     null
                 )
             );
@@ -103,6 +104,7 @@ public class TransformStatsTests extends AbstractSerializingTestCase<TransformSt
                     new TransformCheckpointStats(0, null, null, 100, 1000),
                     // changesLastDetectedAt aren't serialized back
                     100,
+                    null,
                     null
                 )
             );

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/ContinuousTestCase.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/ContinuousTestCase.java
@@ -42,6 +42,7 @@ import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
 
 public abstract class ContinuousTestCase extends ESRestTestCase {
 
+    public static final TimeValue SYNC_DELAY = new TimeValue(1, TimeUnit.SECONDS);
     public static final String CONTINUOUS_EVENTS_SOURCE_INDEX = "test-transform-continuous-events";
     public static final String INGEST_PIPELINE = "transform-ingest";
     public static final String MAX_RUN_FIELD = "run.max";
@@ -89,7 +90,7 @@ public abstract class ContinuousTestCase extends ESRestTestCase {
     protected TransformConfig.Builder addCommonBuilderParameters(TransformConfig.Builder builder) {
         return builder.setSyncConfig(getSyncConfig())
             .setSettings(addCommonSetings(new SettingsConfig.Builder()).build())
-            .setFrequency(new TimeValue(1, TimeUnit.SECONDS));
+            .setFrequency(SYNC_DELAY);
     }
 
     protected AggregatorFactories.Builder addCommonAggregations(AggregatorFactories.Builder builder) {
@@ -134,6 +135,6 @@ public abstract class ContinuousTestCase extends ESRestTestCase {
     }
 
     private SyncConfig getSyncConfig() {
-        return new TimeSyncConfig("timestamp", new TimeValue(1, TimeUnit.SECONDS));
+        return new TimeSyncConfig("timestamp", SYNC_DELAY);
     }
 }

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TransformContinuousIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TransformContinuousIT.java
@@ -271,9 +271,7 @@ public class TransformContinuousIT extends ESRestTestCase {
             // start all transforms, wait until the processed all data and stop them
             startTransforms();
 
-            // at random we added between 0 and 999_999ns == (1ms - 1ns) to every data point, so we add 1ms, so every data point is before
-            // the checkpoint
-            waitUntilTransformsReachedUpperBound(runDate.toEpochMilli() + 1, run);
+            waitUntilTransformsProcessedNewData(ContinuousTestCase.SYNC_DELAY, run);
             stopTransforms();
 
             // TODO: the transform dest index requires a refresh, see gh#51154
@@ -487,11 +485,12 @@ public class TransformContinuousIT extends ESRestTestCase {
         }
     }
 
-    private void waitUntilTransformsReachedUpperBound(long timeStampUpperBoundMillis, int iteration) throws Exception {
+    private void waitUntilTransformsProcessedNewData(TimeValue delay, int iteration) throws Exception {
+        Instant waitUntil = Instant.now().plusMillis(delay.getMillis());
         logger.info(
-            "wait until transform reaches timestamp_millis: {} iteration: {}",
-            ContinuousTestCase.STRICT_DATE_OPTIONAL_TIME_PRINTER_NANOS.withZone(ZoneId.of("UTC"))
-                .format(Instant.ofEpochMilli(timeStampUpperBoundMillis)),
+            "wait until transform reaches timestamp_millis: {} (takes into account the delay: {}) iteration: {}",
+            ContinuousTestCase.STRICT_DATE_OPTIONAL_TIME_PRINTER_NANOS.withZone(ZoneId.of("UTC")).format(waitUntil),
+            delay,
             iteration
         );
         for (ContinuousTestCase testCase : transformTestCases) {
@@ -504,8 +503,8 @@ public class TransformContinuousIT extends ESRestTestCase {
                         + stats.getState()
                         + ", reason: "
                         + stats.getReason(),
-                    stats.getCheckpointingInfo().getLast().getTimeUpperBoundMillis(),
-                    greaterThan(timeStampUpperBoundMillis)
+                    stats.getCheckpointingInfo().getLastSearchTime(),
+                    greaterThan(waitUntil)
                 );
             }, 20, TimeUnit.SECONDS);
         }

--- a/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/checkpoint/TransformCheckpointServiceNodeTests.java
+++ b/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/checkpoint/TransformCheckpointServiceNodeTests.java
@@ -266,7 +266,8 @@ public class TransformCheckpointServiceNodeTests extends TransformSingleNodeTest
             new TransformCheckpointStats(1, null, null, timestamp, 0L),
             new TransformCheckpointStats(2, position, progress, timestamp + 100L, 0L),
             30L,
-            Instant.ofEpochMilli(timestamp)
+            Instant.ofEpochMilli(timestamp),
+            null
         );
 
         assertAsync(
@@ -281,7 +282,8 @@ public class TransformCheckpointServiceNodeTests extends TransformSingleNodeTest
             new TransformCheckpointStats(1, null, null, timestamp, 0L),
             new TransformCheckpointStats(2, position, progress, timestamp + 100L, 0L),
             63L,
-            Instant.ofEpochMilli(timestamp)
+            Instant.ofEpochMilli(timestamp),
+            null
         );
         assertAsync(
             listener -> getCheckpoint(transformCheckpointService, transformId, 1, position, progress, listener),
@@ -296,7 +298,8 @@ public class TransformCheckpointServiceNodeTests extends TransformSingleNodeTest
             new TransformCheckpointStats(1, null, null, timestamp, 0L),
             new TransformCheckpointStats(2, position, progress, timestamp + 100L, 0L),
             0L,
-            Instant.ofEpochMilli(timestamp)
+            Instant.ofEpochMilli(timestamp),
+            null
         );
         assertAsync(
             listener -> getCheckpoint(transformCheckpointService, transformId, 1, position, progress, listener),

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformContext.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformContext.java
@@ -29,6 +29,7 @@ class TransformContext {
     private volatile int numFailureRetries = Transform.DEFAULT_FAILURE_RETRIES;
     private final AtomicInteger failureCount;
     private volatile Instant changesLastDetectedAt;
+    private volatile Instant lastSearchTime;
     private volatile boolean shouldStopAtCheckpoint;
 
     // the checkpoint of this transform, storing the checkpoint until data indexing from source to dest is _complete_
@@ -107,6 +108,14 @@ class TransformContext {
         return changesLastDetectedAt;
     }
 
+    void setLastSearchTime(Instant time) {
+        lastSearchTime = time;
+    }
+
+    Instant getLastSearchTime() {
+        return lastSearchTime;
+    }
+
     public boolean shouldStopAtCheckpoint() {
         return shouldStopAtCheckpoint;
     }
@@ -120,18 +129,16 @@ class TransformContext {
     }
 
     void markAsFailed(String failureMessage) {
-        taskListener
-            .fail(
-                failureMessage,
-                ActionListener
-                    .wrap(
-                        r -> {
-                            // Successfully marked as failed, reset counter so that task can be restarted
-                            failureCount.set(0);
-                        },
-                        e -> {}
-                    )
-            );
+        taskListener.fail(
+            failureMessage,
+            ActionListener.wrap(
+                r -> {
+                    // Successfully marked as failed, reset counter so that task can be restarted
+                    failureCount.set(0);
+                },
+                e -> {}
+            )
+        );
     }
 
 }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
@@ -174,6 +174,9 @@ public class TransformTask extends AllocatedPersistentTask implements SchedulerE
             if (context.getChangesLastDetectedAt() != null) {
                 infoBuilder.setChangesLastDetectedAt(context.getChangesLastDetectedAt());
             }
+            if (context.getLastSearchTime() != null) {
+                infoBuilder.setLastSearchTime(context.getLastSearchTime());
+            }
             listener.onResponse(infoBuilder.build());
         }, listener::onFailure);
 

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransportGetTransformStatsActionTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransportGetTransformStatsActionTests.java
@@ -45,6 +45,7 @@ public class TransportGetTransformStatsActionTests extends ESTestCase {
             new TransformCheckpointStats(1, null, null, 1, 1),
             new TransformCheckpointStats(2, null, null, 2, 5),
             2,
+            Instant.now(),
             Instant.now()
         );
 
@@ -81,6 +82,7 @@ public class TransportGetTransformStatsActionTests extends ESTestCase {
             new TransformCheckpointStats(1, null, null, 1, 1),
             new TransformCheckpointStats(2, null, null, 2, 5),
             2,
+            Instant.now(),
             Instant.now()
         );
 
@@ -126,6 +128,7 @@ public class TransportGetTransformStatsActionTests extends ESTestCase {
             new TransformCheckpointStats(1, null, null, 1, 1),
             new TransformCheckpointStats(2, null, null, 2, 5),
             2,
+            Instant.now(),
             Instant.now()
         );
 


### PR DESCRIPTION
transforms reports the the last time changes where detected with changes_last_detected_at, however
that doesn't tell a user it searched for changes, this PR adds a field last_search_time to report
when transform searched for changes the last time.

fixes #66410
relates #66367
backport #66718
