### PR TITLE
[DOCS] Add runtime fields to Painless Guide

### DIFF
--- a/docs/painless/painless-contexts.asciidoc
+++ b/docs/painless/painless-contexts.asciidoc
@@ -14,6 +14,9 @@ specialized code may define new ways to use a Painless script.
 |====
 | Name                              | Painless Documentation
                                     | Elasticsearch Documentation
+| Runtime field                     | <<painless-runtime-fields-context,Painless Documentation>>
+                                    | {ref}/runtime.html[Elasticsearch Documentation]
+
 | Ingest processor                  | <<painless-ingest-processor-context, Painless Documentation>>
                                     | {ref}/script-processor.html[Elasticsearch Documentation]
 | Update                            | <<painless-update-context, Painless Documentation>>

--- a/docs/painless/painless-contexts/index.asciidoc
+++ b/docs/painless/painless-contexts/index.asciidoc
@@ -1,5 +1,7 @@
 include::painless-context-examples.asciidoc[]
 
+include::painless-runtime-fields-context.asciidoc[]
+
 include::painless-ingest-processor-context.asciidoc[]
 
 include::painless-update-context.asciidoc[]

--- a/docs/painless/painless-contexts/painless-context-examples.asciidoc
+++ b/docs/painless/painless-contexts/painless-context-examples.asciidoc
@@ -10,6 +10,12 @@ data set contains booking information for a collection of plays. Each document
 represents a single seat for a play at a particular theater on a specific date
 and time.
 +
+[source,js]
+----
+curl https://download.elastic.co/demos/painless/contexts/seats.json --output seats.json
+----
+// NOTCONSOLE
++
 Each document contains the following fields:
 +
 `theatre` ({ref}/keyword.html[`keyword`])::
@@ -74,4 +80,3 @@ seat data is indexed.
 curl -XPOST "localhost:9200/seats/_bulk?pipeline=seats" -H "Content-Type: application/x-ndjson" --data-binary "@/<local-file-path>/seats.json"
 ----
 // NOTCONSOLE
-

--- a/docs/painless/painless-contexts/painless-runtime-fields-context.asciidoc
+++ b/docs/painless/painless-contexts/painless-runtime-fields-context.asciidoc
@@ -116,6 +116,14 @@ POST seats/_bulk?pipeline=seats
 ----
 // TEST[continued]
 
+Refresh the `seats` index:
+
+[source,console]
+----
+POST seats/_refresh
+----
+// TEST[continued]
+
 [[painless-runtime-fields-definition]]
 ==== Define a runtime field with a Painless script
 Run the following request to define a runtime field named `day_of_week`. This
@@ -208,6 +216,7 @@ defined in the mappings.
 }
 ----
 // TESTRESPONSE[s/\.\.\./"took" : $body.took,"timed_out" : $body.timed_out,"_shards" : $body._shards,/]
+// TESTRESPONSE[s/"value" : "11"/"value": $body.hits.total.value/]
 
 This is just one example of how you can use runtime fields. You can include
 Painless scripts in the context of runtime fields to override values for

--- a/docs/painless/painless-contexts/painless-runtime-fields-context.asciidoc
+++ b/docs/painless/painless-contexts/painless-runtime-fields-context.asciidoc
@@ -89,7 +89,7 @@ can ingest the full https://download.elastic.co/demos/painless/contexts/seats.js
 
 [source,console]
 ----
-POST seats/_bulk?pipeline=seats
+POST seats/_bulk?pipeline=seats&refresh=true
 {"create":{"_index":"seats","_id":"1"}}
 {"theatre":"Down Port","play":"Driving","actors":["James Holland","Krissy Smith","Joe Muir","Ryan Earns"],"date":"2018-4-1","time":"3:00PM","row":1,"number":1,"cost":30,"sold":false}
 {"create":{"_index":"seats","_id":"2"}}
@@ -113,14 +113,6 @@ POST seats/_bulk?pipeline=seats
 {"create":{"_index":"seats","_id":"11"}}
 {"theatre":"Down Port","play":"Driving","actors":["James Holland","Krissy Smith","Joe Muir","Ryan Earns"],"date":"2018-4-1","time":"3:00PM","row":1,"number":11,"cost":30,"sold":false}
 {"create":{"_index":"seats","_id":"12"}}
-----
-// TEST[continued]
-
-Refresh the `seats` index:
-
-[source,console]
-----
-POST seats/_refresh
 ----
 // TEST[continued]
 

--- a/docs/painless/painless-contexts/painless-runtime-fields-context.asciidoc
+++ b/docs/painless/painless-contexts/painless-runtime-fields-context.asciidoc
@@ -1,0 +1,273 @@
+[[painless-runtime-fields-context]]
+=== Runtime fields context
+
+Use a Painless script to return a calculated value for a
+<<painless-runtime-fields,runtime field>>, defined either in the mappings or as
+part of a query. You can also use runtime fields to override values for indexed
+fields.
+
+See the {ref}/runtime.html[runtime field] documentation for more.
+
+*Variables*
+
+`params` (`Map`, read-only)::
+        User-defined parameters passed in as part of the query.
+
+`doc` (`Map`, read-only)::
+        Contains the fields of the specified document where each field is a
+        `List` of values.
+
+{ref}/mapping-source-field.html[`params['_source']`] (`Map`, read-only)::
+        Contains extracted JSON in a `Map` and `List` structure for the fields
+        existing in a stored document.
+
+*Return*
+
+`void`::
+        No expected return value.
+
+*API*
+
+Both the standard <<painless-api-reference-shared, Painless API>> and
+<<painless-api-reference-field, Specialized Field API>> are available.
+
+
+*Example*
+
+To run this example, follow the steps in
+<<painless-context-examples, context examples>>. Let's break down each of those
+steps to understand how runtime fields work within the context of Painless.
+
+[[painless-runtime-fields-mapping]]
+==== Create the index mappings
+The following request creates the mappings for the sample data:
+
+[source,console]
+----
+PUT /seats
+{
+  "mappings": {
+    "properties": {
+      "theatre":  { "type": "keyword" },
+      "play":     { "type": "keyword" },
+      "actors":   { "type": "text"    },
+      "row":      { "type": "integer" },
+      "number":   { "type": "integer" },
+      "cost":     { "type": "double"  },
+      "sold":     { "type": "boolean" },
+      "datetime": { "type": "date"    },
+      "date":     { "type": "keyword" },
+      "time":     { "type": "keyword" }
+    }
+  }
+}
+----
+// TESTSETUP
+
+[[painless-runtime-fields-ingest]]
+==== Ingest some sample data
+You can ingest the full https://download.elastic.co/demos/painless/contexts/seats.json[seat sample data], but we'll only use a subset of that data:
+
+[source,console]
+----
+POST seats/_bulk?pipeline=seats
+{"create":{"_index":"seats","_id":"1"}}
+{"theatre":"Down Port","play":"Driving","actors":["James Holland","Krissy Smith","Joe Muir","Ryan Earns"],"date":"2018-4-1","time":"3:00PM","row":1,"number":1,"cost":30,"sold":false}
+{"create":{"_index":"seats","_id":"2"}}
+{"theatre":"Down Port","play":"Driving","actors":["James Holland","Krissy Smith","Joe Muir","Ryan Earns"],"date":"2018-4-1","time":"3:00PM","row":1,"number":2,"cost":30,"sold":false}
+{"create":{"_index":"seats","_id":"3"}}
+{"theatre":"Down Port","play":"Driving","actors":["James Holland","Krissy Smith","Joe Muir","Ryan Earns"],"date":"2018-4-1","time":"3:00PM","row":1,"number":3,"cost":30,"sold":true}
+{"create":{"_index":"seats","_id":"4"}}
+{"theatre":"Down Port","play":"Driving","actors":["James Holland","Krissy Smith","Joe Muir","Ryan Earns"],"date":"2018-4-1","time":"3:00PM","row":1,"number":4,"cost":30,"sold":false}
+{"create":{"_index":"seats","_id":"5"}}
+{"theatre":"Down Port","play":"Driving","actors":["James Holland","Krissy Smith","Joe Muir","Ryan Earns"],"date":"2018-4-1","time":"3:00PM","row":1,"number":5,"cost":30,"sold":false}
+{"create":{"_index":"seats","_id":"6"}}
+{"theatre":"Down Port","play":"Driving","actors":["James Holland","Krissy Smith","Joe Muir","Ryan Earns"],"date":"2018-4-1","time":"3:00PM","row":1,"number":6,"cost":30,"sold":true}
+{"create":{"_index":"seats","_id":"7"}}
+{"theatre":"Down Port","play":"Driving","actors":["James Holland","Krissy Smith","Joe Muir","Ryan Earns"],"date":"2018-4-1","time":"3:00PM","row":1,"number":7,"cost":30,"sold":true}
+{"create":{"_index":"seats","_id":"8"}}
+{"theatre":"Down Port","play":"Driving","actors":["James Holland","Krissy Smith","Joe Muir","Ryan Earns"],"date":"2018-4-1","time":"3:00PM","row":1,"number":8,"cost":30,"sold":false}
+{"create":{"_index":"seats","_id":"9"}}
+{"theatre":"Down Port","play":"Driving","actors":["James Holland","Krissy Smith","Joe Muir","Ryan Earns"],"date":"2018-4-1","time":"3:00PM","row":1,"number":9,"cost":30,"sold":true}
+{"create":{"_index":"seats","_id":"10"}}
+{"theatre":"Down Port","play":"Driving","actors":["James Holland","Krissy Smith","Joe Muir","Ryan Earns"],"date":"2018-4-1","time":"3:00PM","row":1,"number":10,"cost":30,"sold":false}
+{"create":{"_index":"seats","_id":"11"}}
+{"theatre":"Down Port","play":"Driving","actors":["James Holland","Krissy Smith","Joe Muir","Ryan Earns"],"date":"2018-4-1","time":"3:00PM","row":1,"number":11,"cost":30,"sold":false}
+{"create":{"_index":"seats","_id":"12"}}
+----
+// TEST[continued]
+
+[[painless-runtime-fields-processor]]
+==== Run the ingest processor
+The following request sets up a script ingest processor used on each document
+as the seat data is indexed:
+
+[source,console]
+----
+PUT _ingest/pipeline/seats
+{
+  "description": "use index:seats",
+  "processors": [
+    {
+      "script": {
+        "source": """
+          String[] dateSplit = ctx.date.splitOnToken("-");
+String year = dateSplit[0].trim();
+String month = dateSplit[1].trim();
+
+if (month.length() == 1) {
+    month = "0" + month;
+}
+
+String day = dateSplit[2].trim();
+
+if (day.length() == 1) {
+    day = "0" + day;
+}
+
+boolean pm = ctx.time.substring(ctx.time.length() - 2).equals("PM");
+String[] timeSplit = ctx.time.substring(0,
+        ctx.time.length() - 2).splitOnToken(":");
+int hours = Integer.parseInt(timeSplit[0].trim());
+int minutes = Integer.parseInt(timeSplit[1].trim());
+
+if (pm) {
+    hours += 12;
+}
+
+String dts = year + "-" + month + "-" + day + "T" +
+        (hours < 10 ? "0" + hours : "" + hours) + ":" +
+        (minutes < 10 ? "0" + minutes : "" + minutes) +
+        ":00+08:00";
+
+ZonedDateTime dt = ZonedDateTime.parse(
+         dts, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+ctx.datetime = dt.getLong(ChronoField.INSTANT_SECONDS)*1000L;
+        """
+      }
+    }
+  ]
+}
+----
+// TEST[continued]
+
+[[painless-runtime-fields-definition]]
+==== Define a runtime field with a Painless script
+The following request defines a runtime field named `day_of_week`. This field
+contains a script with the same source defined in
+<<painless-field-context,Field context>>, but also uses an `emit` function
+that runtime fields require when defining a Painless script.
+
+Because `day_of_week` is a runtime field, it isn't indexed, and the included
+script only runs at query time.
+
+[source,console]
+----
+PUT seats/_mapping
+{
+    "dynamic": "runtime",
+    "runtime": {
+      "day_of_week": {
+        "type": "date",
+        "script": {
+          "source": "emit(doc['datetime'].value.getDayOfWeek())"
+        }
+      }
+    }
+}
+----
+// TEST[continued]
+
+After defining the runtime field and script in the mappings, you can run a
+query that includes `day_of_week`. When the query runs, {es} evaluates the
+included Painless script and dynamically generates a value based on the script
+definition:
+
+[source,console]
+----
+GET seats/_search
+{
+  "fields": [
+    "@timestamp",
+    "day_of_week"
+  ],
+  "_source": false
+}
+----
+// TEST[continued]
+
+The response includes `day_of_week` for each hit. {es} calculates the value for
+this field dynamically at search time by operating on the `datetime` field
+defined in the mappings.
+
+[source,console-result]
+----
+{
+  ...
+  "hits" : {
+    "total" : {
+      "value" : 11,
+      "relation" : "eq"
+    },
+    "max_score" : 1.0,
+    "hits" : [
+      {
+        "_index" : "seats",
+        "_type" : "_doc",
+        "_id" : "1",
+        "_score" : 1.0,
+        "fields" : {
+          "time" : [
+            "3:00PM"
+          ],
+          "day_of_week" : [
+            "1970-01-01T00:00:00.007Z"
+          ]
+        }
+      },
+      {
+        "_index" : "seats",
+        "_type" : "_doc",
+        "_id" : "2",
+        "_score" : 1.0,
+        "fields" : {
+          "time" : [
+            "3:00PM"
+          ],
+          "day_of_week" : [
+            "1970-01-01T00:00:00.007Z"
+          ]
+        }
+      }
+    ]
+  }
+}
+----
+// TESTRESPONSE[s/\.\.\./"took" : $body.took,"timed_out" : $body.timed_out,"_shards" : $body._shards,/]
+// TESTRESPONSE[s/"_id" : "1"/"_id": $body.hits.hits.0._id/]
+// TESTRESPONSE[s/"_id" : "2"/"_id": $body.hits.hits.1._id/]
+// TESTRESPONSE[s/"day_of_week" : "1970-01-01T00:00:00.007Z"/"day_of_week": $body.hits.hits.0.fields.day_of_week/]
+// TESTRESPONSE[s/"day_of_week" : "1970-01-01T00:00:00.007Z"/"day_of_week": $body.hits.hits.1.fields.day_of_week/]
+
+You can then use these two example scripts to compute custom information
+for each search hit and output it to two new fields.
+
+The first script gets the doc value for the `datetime` field and calls
+the `getDayOfWeek` function to determine the corresponding day of the week.
+
+[source,Painless]
+----
+doc['datetime'].value.getDayOfWeek();
+----
+
+The second script calculates the number of actors. Actors' names are stored
+as a text array in the `actors` field.
+
+[source,Painless]
+----
+params['_source']['actors'].length;                        <1>
+----
+
+<1> By default, doc values are not available for text fields. However,
+    you can still calculate the number of actors by extracting actors
+    from `_source`. Note that `params['_source']['actors']` is a list.

--- a/docs/painless/painless-contexts/painless-runtime-fields-context.asciidoc
+++ b/docs/painless/painless-contexts/painless-runtime-fields-context.asciidoc
@@ -1,6 +1,6 @@
 [[painless-runtime-fields-context]]
 === Runtime fields context
-
+beta::[]
 Use a Painless script to return a calculated value for a
 <<painless-runtime-fields,runtime field>>, defined either in the mappings or as
 part of a query. You can also use runtime fields to override values for indexed
@@ -38,7 +38,7 @@ To run this example, follow the steps in
 <<painless-context-examples, context examples>>. Let's break down each of those
 steps to understand how runtime fields work within the context of Painless.
 
-[[painless-runtime-fields-mapping]]
+[[painless-runtime-fields-mappings]]
 ==== Create the index mappings
 The following request creates the mappings for the sample data:
 
@@ -62,7 +62,6 @@ PUT /seats
   }
 }
 ----
-// TESTSETUP
 
 [[painless-runtime-fields-ingest]]
 ==== Ingest some sample data

--- a/docs/painless/painless-contexts/painless-runtime-fields-context.asciidoc
+++ b/docs/painless/painless-contexts/painless-runtime-fields-context.asciidoc
@@ -6,8 +6,6 @@ Use a Painless script to return a calculated value for a
 part of a query. You can also use runtime fields to override values for indexed
 fields.
 
-See the {ref}/runtime.html[runtime field] documentation for more.
-
 *Variables*
 
 `params` (`Map`, read-only)::
@@ -34,13 +32,13 @@ Both the standard <<painless-api-reference-shared, Painless API>> and
 
 *Example*
 
-To run this example, follow the steps in
-<<painless-context-examples, context examples>>. Let's break down each of those
-steps to understand how runtime fields work within the context of Painless.
+Let's break down each of the steps from the
+<<painless-context-examples,context examples>> to understand how runtime fields
+work within the context of Painless.
 
 [[painless-runtime-fields-mappings]]
 ==== Create the index mappings
-The following request creates the mappings for the sample data:
+First, create the mappings for the sample data:
 
 [source,console]
 ----
@@ -63,9 +61,31 @@ PUT /seats
 }
 ----
 
+[[painless-runtime-fields-processor]]
+==== Run the ingest processor
+Next, run the request from the <<painless-ingest-processor-context,Painless ingest processor context>> to configure a script ingest processor that parses
+each document as the `seat` data is indexed:
+
+[source,console]
+----
+PUT /_ingest/pipeline/seats
+{
+  "description": "update datetime for seats",
+  "processors": [
+    {
+      "script": {
+        "source": "String[] dateSplit = ctx.date.splitOnToken('-'); String year = dateSplit[0].trim(); String month = dateSplit[1].trim(); if (month.length() == 1) { month = '0' + month; } String day = dateSplit[2].trim(); if (day.length() == 1) { day = '0' + day; } boolean pm = ctx.time.substring(ctx.time.length() - 2).equals('PM'); String[] timeSplit = ctx.time.substring(0, ctx.time.length() - 2).splitOnToken(':'); int hours = Integer.parseInt(timeSplit[0].trim()); int minutes = Integer.parseInt(timeSplit[1].trim()); if (pm) { hours += 12; } String dts = year + '-' + month + '-' + day + 'T' + (hours < 10 ? '0' + hours : '' + hours) + ':' + (minutes < 10 ? '0' + minutes : '' + minutes) + ':00+08:00'; ZonedDateTime dt = ZonedDateTime.parse(dts, DateTimeFormatter.ISO_OFFSET_DATE_TIME); ctx.datetime = dt.getLong(ChronoField.INSTANT_SECONDS)*1000L;"
+      }
+    }
+  ]
+}
+----
+// TEST[continued]
+
 [[painless-runtime-fields-ingest]]
 ==== Ingest some sample data
-You can ingest the full https://download.elastic.co/demos/painless/contexts/seats.json[seat sample data], but we'll only use a subset of that data:
+Use the ingest pipeline you defined to ingest some sample data. You
+can ingest the full https://download.elastic.co/demos/painless/contexts/seats.json[seat sample data], but we'll only use a subset for this example:
 
 [source,console]
 ----
@@ -96,69 +116,15 @@ POST seats/_bulk?pipeline=seats
 ----
 // TEST[continued]
 
-[[painless-runtime-fields-processor]]
-==== Run the ingest processor
-The following request sets up a script ingest processor used on each document
-as the seat data is indexed:
-
-[source,console]
-----
-PUT _ingest/pipeline/seats
-{
-  "description": "use index:seats",
-  "processors": [
-    {
-      "script": {
-        "source": """
-          String[] dateSplit = ctx.date.splitOnToken("-");
-String year = dateSplit[0].trim();
-String month = dateSplit[1].trim();
-
-if (month.length() == 1) {
-    month = "0" + month;
-}
-
-String day = dateSplit[2].trim();
-
-if (day.length() == 1) {
-    day = "0" + day;
-}
-
-boolean pm = ctx.time.substring(ctx.time.length() - 2).equals("PM");
-String[] timeSplit = ctx.time.substring(0,
-        ctx.time.length() - 2).splitOnToken(":");
-int hours = Integer.parseInt(timeSplit[0].trim());
-int minutes = Integer.parseInt(timeSplit[1].trim());
-
-if (pm) {
-    hours += 12;
-}
-
-String dts = year + "-" + month + "-" + day + "T" +
-        (hours < 10 ? "0" + hours : "" + hours) + ":" +
-        (minutes < 10 ? "0" + minutes : "" + minutes) +
-        ":00+08:00";
-
-ZonedDateTime dt = ZonedDateTime.parse(
-         dts, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
-ctx.datetime = dt.getLong(ChronoField.INSTANT_SECONDS)*1000L;
-        """
-      }
-    }
-  ]
-}
-----
-// TEST[continued]
-
 [[painless-runtime-fields-definition]]
 ==== Define a runtime field with a Painless script
-The following request defines a runtime field named `day_of_week`. This field
-contains a script with the same source defined in
+Run the following request to define a runtime field named `day_of_week`. This
+field contains a script with the same `source` defined in
 <<painless-field-context,Field context>>, but also uses an `emit` function
 that runtime fields require when defining a Painless script.
 
 Because `day_of_week` is a runtime field, it isn't indexed, and the included
-script only runs at query time.
+script only runs at query time:
 
 [source,console]
 ----
@@ -169,7 +135,7 @@ PUT seats/_mapping
       "day_of_week": {
         "type": "date",
         "script": {
-          "source": "emit(doc['datetime'].value.getDayOfWeek())"
+          "source": "emit(doc['datetime'].value.getDayOfWeekEnum().getValue())"
         }
       }
     }
@@ -186,8 +152,9 @@ definition:
 ----
 GET seats/_search
 {
+  "size": 2,
   "fields": [
-    "@timestamp",
+    "time",
     "day_of_week"
   ],
   "_source": false
@@ -212,7 +179,6 @@ defined in the mappings.
     "hits" : [
       {
         "_index" : "seats",
-        "_type" : "_doc",
         "_id" : "1",
         "_score" : 1.0,
         "fields" : {
@@ -226,7 +192,6 @@ defined in the mappings.
       },
       {
         "_index" : "seats",
-        "_type" : "_doc",
         "_id" : "2",
         "_score" : 1.0,
         "fields" : {
@@ -243,30 +208,10 @@ defined in the mappings.
 }
 ----
 // TESTRESPONSE[s/\.\.\./"took" : $body.took,"timed_out" : $body.timed_out,"_shards" : $body._shards,/]
-// TESTRESPONSE[s/"_id" : "1"/"_id": $body.hits.hits.0._id/]
-// TESTRESPONSE[s/"_id" : "2"/"_id": $body.hits.hits.1._id/]
-// TESTRESPONSE[s/"day_of_week" : "1970-01-01T00:00:00.007Z"/"day_of_week": $body.hits.hits.0.fields.day_of_week/]
-// TESTRESPONSE[s/"day_of_week" : "1970-01-01T00:00:00.007Z"/"day_of_week": $body.hits.hits.1.fields.day_of_week/]
 
-You can then use these two example scripts to compute custom information
-for each search hit and output it to two new fields.
+This is just one example of how you can use runtime fields. You can include
+Painless scripts in the context of runtime fields to override values for
+indexed fields or create fields that exist only as part of the query.
 
-The first script gets the doc value for the `datetime` field and calls
-the `getDayOfWeek` function to determine the corresponding day of the week.
-
-[source,Painless]
-----
-doc['datetime'].value.getDayOfWeek();
-----
-
-The second script calculates the number of actors. Actors' names are stored
-as a text array in the `actors` field.
-
-[source,Painless]
-----
-params['_source']['actors'].length;                        <1>
-----
-
-<1> By default, doc values are not available for text fields. However,
-    you can still calculate the number of actors by extracting actors
-    from `_source`. Note that `params['_source']['actors']` is a list.
+See the {ref}/runtime.html[runtime fields] documentation for more information
+about how to use runtime fields.

--- a/docs/painless/painless-contexts/painless-runtime-fields-context.asciidoc
+++ b/docs/painless/painless-contexts/painless-runtime-fields-context.asciidoc
@@ -1,10 +1,11 @@
 [[painless-runtime-fields-context]]
 === Runtime fields context
 beta::[]
-Use a Painless script to return a calculated value for a
-<<painless-runtime-fields,runtime field>>, defined either in the mappings or as
-part of a query. You can also use runtime fields to override values for indexed
-fields.
+Use a Painless script to calculate and emit
+<<painless-runtime-fields,runtime field>> values.
+
+See the {ref}/runtime.html[runtime fields] documentation for more information
+about how to use runtime fields.
 
 *Variables*
 
@@ -130,34 +131,40 @@ script only runs at query time:
 ----
 PUT seats/_mapping
 {
-    "dynamic": "runtime",
-    "runtime": {
-      "day_of_week": {
-        "type": "date",
-        "script": {
-          "source": "emit(doc['datetime'].value.getDayOfWeekEnum().getValue())"
-        }
+  "runtime": {
+    "day_of_week": {
+      "type": "date",
+      "script": {
+        "source": "emit(doc['datetime'].value.getDayOfWeekEnum().getValue())"
       }
     }
+  }
 }
 ----
 // TEST[continued]
 
 After defining the runtime field and script in the mappings, you can run a
-query that includes `day_of_week`. When the query runs, {es} evaluates the
-included Painless script and dynamically generates a value based on the script
-definition:
+query that includes a terms aggregation for `day_of_week`. When the query runs,
+{es} evaluates the included Painless script and dynamically generates a value
+based on the script definition:
 
 [source,console]
 ----
 GET seats/_search
 {
-  "size": 2,
+  "size": 0,
   "fields": [
     "time",
     "day_of_week"
-  ],
-  "_source": false
+    ],
+    "aggs": {
+      "day_of_week": {
+        "terms": {
+          "field": "day_of_week",
+          "size": 10
+        }
+      }
+    }
 }
 ----
 // TEST[continued]
@@ -175,44 +182,23 @@ defined in the mappings.
       "value" : 11,
       "relation" : "eq"
     },
-    "max_score" : 1.0,
-    "hits" : [
-      {
-        "_index" : "seats",
-        "_id" : "1",
-        "_score" : 1.0,
-        "fields" : {
-          "time" : [
-            "3:00PM"
-          ],
-          "day_of_week" : [
-            "1970-01-01T00:00:00.007Z"
-          ]
+    "max_score" : null,
+    "hits" : [ ]
+  },
+  "aggregations" : {
+    "day_of_week" : {
+      "doc_count_error_upper_bound" : 0,
+      "sum_other_doc_count" : 0,
+      "buckets" : [
+        {
+          "key" : 7,
+          "key_as_string" : "1970-01-01T00:00:00.007Z",
+          "doc_count" : 11
         }
-      },
-      {
-        "_index" : "seats",
-        "_id" : "2",
-        "_score" : 1.0,
-        "fields" : {
-          "time" : [
-            "3:00PM"
-          ],
-          "day_of_week" : [
-            "1970-01-01T00:00:00.007Z"
-          ]
-        }
-      }
-    ]
+      ]
+    }
   }
 }
 ----
 // TESTRESPONSE[s/\.\.\./"took" : $body.took,"timed_out" : $body.timed_out,"_shards" : $body._shards,/]
 // TESTRESPONSE[s/"value" : "11"/"value": $body.hits.total.value/]
-
-This is just one example of how you can use runtime fields. You can include
-Painless scripts in the context of runtime fields to override values for
-indexed fields or create fields that exist only as part of the query.
-
-See the {ref}/runtime.html[runtime fields] documentation for more information
-about how to use runtime fields.

--- a/docs/painless/painless-guide/painless-runtime-fields.asciidoc
+++ b/docs/painless/painless-guide/painless-runtime-fields.asciidoc
@@ -1,5 +1,6 @@
 [[painless-runtime-fields]]
 === Use Painless scripts in runtime fields
+beta::[]
 A runtime field is a field that is evaluated at query time. When you define a
 runtime field, you can immediately use it in search requests, aggregations,
 filtering, and sorting.

--- a/docs/reference/mapping/runtime.asciidoc
+++ b/docs/reference/mapping/runtime.asciidoc
@@ -1,5 +1,7 @@
 [[runtime]]
 == Runtime fields
+beta::[]
+
 A _runtime field_ is a field that is evaluated at query time. Runtime fields
 enable you to:
 
@@ -70,6 +72,7 @@ against runtime fields.
 
 [[runtime-mapping-fields]]
 === Map a runtime field
+beta::[]
 You map runtime fields by adding a `runtime` section under the mapping
 definition and defining
 <<modules-scripting-using,a Painless script>>. This script has access to the
@@ -154,6 +157,7 @@ to `boolean`.
 
 [[runtime-search-request]]
 === Define runtime fields in a search request
+beta::[]
 You can specify a `runtime_mappings` section in a search request to create
 runtime fields that exist only as part of the query. You specify a script
 as part of the `runtime_mappings` section, just as you would if adding a
@@ -221,6 +225,7 @@ PUT my-index/
 
 [[runtime-override-values]]
 === Override field values at query time
+beta::[]
 If you create a runtime field with the same name as a field that
 already exists in the mapping, the runtime field shadows the mapped field. At
 query time, {es} evaluates the runtime field, calculates a value based on the
@@ -407,6 +412,7 @@ which still returns in the response:
 
 [[runtime-retrieving-fields]]
 === Retrieve a runtime field
+beta::[]
 Use the <<search-fields,`fields`>> parameter on the `_search` API to retrieve
 the values of runtime fields. Runtime fields won't display in `_source`, but
 the `fields` API works for all fields, even those that were not sent as part of
@@ -585,6 +591,7 @@ address.
 
 [[runtime-examples]]
 === Explore your data with runtime fields
+beta::[]
 Consider a large set of log data that you want to extract fields from.
 Indexing the data is time consuming and uses a lot of disk space, and you just
 want to explore the data structure without committing to a schema up front.

--- a/docs/reference/mapping/runtime.asciidoc
+++ b/docs/reference/mapping/runtime.asciidoc
@@ -1,6 +1,5 @@
 [[runtime]]
 == Runtime fields
-beta::[]
 
 A _runtime field_ is a field that is evaluated at query time. Runtime fields
 enable you to:
@@ -72,7 +71,6 @@ against runtime fields.
 
 [[runtime-mapping-fields]]
 === Map a runtime field
-beta::[]
 You map runtime fields by adding a `runtime` section under the mapping
 definition and defining
 <<modules-scripting-using,a Painless script>>. This script has access to the
@@ -157,7 +155,6 @@ to `boolean`.
 
 [[runtime-search-request]]
 === Define runtime fields in a search request
-beta::[]
 You can specify a `runtime_mappings` section in a search request to create
 runtime fields that exist only as part of the query. You specify a script
 as part of the `runtime_mappings` section, just as you would if adding a
@@ -225,7 +222,6 @@ PUT my-index/
 
 [[runtime-override-values]]
 === Override field values at query time
-beta::[]
 If you create a runtime field with the same name as a field that
 already exists in the mapping, the runtime field shadows the mapped field. At
 query time, {es} evaluates the runtime field, calculates a value based on the
@@ -412,7 +408,6 @@ which still returns in the response:
 
 [[runtime-retrieving-fields]]
 === Retrieve a runtime field
-beta::[]
 Use the <<search-fields,`fields`>> parameter on the `_search` API to retrieve
 the values of runtime fields. Runtime fields won't display in `_source`, but
 the `fields` API works for all fields, even those that were not sent as part of
@@ -591,7 +586,6 @@ address.
 
 [[runtime-examples]]
 === Explore your data with runtime fields
-beta::[]
 Consider a large set of log data that you want to extract fields from.
 Indexing the data is time consuming and uses a lot of disk space, and you just
 want to explore the data structure without committing to a schema up front.


### PR DESCRIPTION
This PR:
* Adds a new page in the Painless guide for [using runtime fields](https://elasticsearch_67781.docs-preview.app.elstc.co/guide/en/elasticsearch/painless/master/painless-runtime-fields.html)
* Adds a new page for [runtime fields context](https://elasticsearch_67781.docs-preview.app.elstc.co/guide/en/elasticsearch/painless/master/painless-runtime-fields-context.html) in Painless