### PR TITLE
Introduce functional tests for new REST test plugins (#64186)

### DIFF
--- a/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/RestResourcesPluginFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/RestResourcesPluginFuncTest.groovy
@@ -1,0 +1,181 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.gradle
+
+import org.elasticsearch.gradle.fixtures.AbstractRestResourcesFuncTest
+import org.gradle.testkit.runner.TaskOutcome
+
+class RestResourcesPluginFuncTest extends AbstractRestResourcesFuncTest {
+
+    def "restResources does nothing when there are no tests"() {
+        given:
+        internalBuild()
+        buildFile << """
+            apply plugin: 'elasticsearch.rest-resources'
+            apply plugin: 'elasticsearch.java'
+        """
+
+        String api = "foo.json"
+        setupRestResources([api])
+
+        when:
+        def result = gradleRunner("copyRestApiSpecsTask").build()
+
+        then:
+        result.task(':copyRestApiSpecsTask').outcome == TaskOutcome.NO_SOURCE
+        result.task(':copyYamlTestsTask').outcome == TaskOutcome.NO_SOURCE
+    }
+
+    def "restResources copies API by default for projects with tests"() {
+        given:
+        internalBuild()
+        buildFile << """
+           apply plugin: 'elasticsearch.rest-resources'
+           apply plugin: 'elasticsearch.java'
+        """
+        String api = "foo.json"
+        setupRestResources([api])
+        addRestTestsToProject(["10_basic.yml"])
+
+        when:
+        def result = gradleRunner("copyRestApiSpecsTask").build()
+
+        then:
+        result.task(':copyRestApiSpecsTask').outcome == TaskOutcome.SUCCESS
+        result.task(':copyYamlTestsTask').outcome == TaskOutcome.NO_SOURCE
+        file("/build/resources/test/rest-api-spec/api/" + api).exists()
+    }
+
+    def "restResources copies all core API (but not x-pack) by default for projects with copied tests"() {
+        given:
+        internalBuild()
+        buildFile << """
+            apply plugin: 'elasticsearch.rest-resources'
+            apply plugin: 'elasticsearch.java'
+
+            restResources {
+                restTests {
+                    includeCore 'foo'
+                    includeXpack 'bar'
+                }
+            }
+        """
+        String apiCore1 = "foo1.json"
+        String apiCore2 = "foo2.json"
+        String apiXpack = "xpack.json"
+        String coreTest = "foo/10_basic.yml"
+        String xpackTest = "bar/10_basic.yml"
+        setupRestResources([apiCore1, apiCore2], [coreTest], [apiXpack], [xpackTest])
+        // intentionally not adding tests to project, they will be copied over via the plugin
+        // this tests that the test copy happens before the api copy since the api copy will only trigger if there are tests in the project
+
+        when:
+        def result = gradleRunner("copyRestApiSpecsTask").build()
+
+        then:
+        result.task(':copyRestApiSpecsTask').outcome == TaskOutcome.SUCCESS
+        result.task(':copyYamlTestsTask').outcome == TaskOutcome.SUCCESS
+        file("/build/resources/test/rest-api-spec/api/" + apiCore1).exists()
+        file("/build/resources/test/rest-api-spec/api/" + apiCore2).exists()
+        file("/build/resources/test/rest-api-spec/api/" + apiXpack).exists() == false //x-pack specs must be explicitly configured
+        file("/build/resources/test/rest-api-spec/test/" + coreTest).exists()
+        file("/build/resources/test/rest-api-spec/test/" + xpackTest).exists()
+    }
+
+    def "restResources copies API by configuration"() {
+        given:
+        internalBuild()
+        buildFile << """
+            apply plugin: 'elasticsearch.rest-resources'
+            apply plugin: 'elasticsearch.java'
+
+            restResources {
+                restApi {
+                    includeCore 'foo'
+                    includeXpack 'xpackfoo'
+                }
+            }
+        """
+        String apiFoo = "foo.json"
+        String apiXpackFoo = "xpackfoo.json"
+        String apiBar = "bar.json"
+        String apiXpackBar = "xpackbar.json"
+        setupRestResources([apiFoo, apiBar], [], [apiXpackFoo, apiXpackBar])
+        addRestTestsToProject(["10_basic.yml"])
+
+        when:
+        def result = gradleRunner("copyRestApiSpecsTask").build()
+
+        then:
+        result.task(':copyRestApiSpecsTask').outcome == TaskOutcome.SUCCESS
+        result.task(':copyYamlTestsTask').outcome == TaskOutcome.NO_SOURCE
+        file("/build/resources/test/rest-api-spec/api/" + apiFoo).exists()
+        file("/build/resources/test/rest-api-spec/api/" + apiXpackFoo).exists()
+        file("/build/resources/test/rest-api-spec/api/" + apiBar).exists() ==false
+        file("/build/resources/test/rest-api-spec/api/" + apiXpackBar).exists() == false
+    }
+
+    def "restResources copies Tests and API by configuration"() {
+        given:
+        internalBuild()
+        buildFile << """
+            apply plugin: 'elasticsearch.rest-resources'
+            apply plugin: 'elasticsearch.java'
+
+            restResources {
+                restApi {
+                    includeCore '*'
+                    includeXpack '*'
+                }
+                restTests {
+                    includeCore 'foo'
+                    includeXpack 'bar'
+                }
+            }
+        """
+        String apiCore1 = "foo1.json"
+        String apiCore2 = "foo2.json"
+        String apiXpack = "xpack.json"
+        String coreTest = "foo/10_basic.yml"
+        String xpackTest = "bar/10_basic.yml"
+        setupRestResources([apiCore1, apiCore2], [coreTest], [apiXpack], [xpackTest])
+        // intentionally not adding tests to project, they will be copied over via the plugin
+        // this tests that the test copy happens before the api copy since the api copy will only trigger if there are tests in the project
+
+        when:
+        def result = gradleRunner("copyRestApiSpecsTask").build()
+
+        then:
+        result.task(':copyRestApiSpecsTask').outcome == TaskOutcome.SUCCESS
+        result.task(':copyYamlTestsTask').outcome == TaskOutcome.SUCCESS
+        file("/build/resources/test/rest-api-spec/api/" + apiCore1).exists()
+        file("/build/resources/test/rest-api-spec/api/" + apiCore2).exists()
+        file("/build/resources/test/rest-api-spec/api/" + apiXpack).exists()
+        file("/build/resources/test/rest-api-spec/test/" + coreTest).exists()
+        file("/build/resources/test/rest-api-spec/test/" + xpackTest).exists()
+
+        when:
+        result = gradleRunner("copyRestApiSpecsTask").build()
+
+        then:
+        result.task(':copyRestApiSpecsTask').outcome == TaskOutcome.UP_TO_DATE
+        result.task(':copyYamlTestsTask').outcome == TaskOutcome.UP_TO_DATE
+    }
+}

--- a/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/YamlRestTestPluginFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/YamlRestTestPluginFuncTest.groovy
@@ -1,0 +1,87 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.gradle
+
+import org.elasticsearch.gradle.fixtures.AbstractRestResourcesFuncTest
+import org.gradle.testkit.runner.TaskOutcome
+
+class YamlRestTestPluginFuncTest extends AbstractRestResourcesFuncTest {
+
+    def "yamlRestTest does nothing when there are no tests"() {
+        given:
+        buildFile << """
+        plugins {
+          id 'elasticsearch.yaml-rest-test'
+        }
+        """
+
+        when:
+        def result = gradleRunner("yamlRestTest").build()
+
+        then:
+        result.task(':yamlRestTest').outcome == TaskOutcome.NO_SOURCE
+        result.task(':copyYamlTestsTask').outcome == TaskOutcome.NO_SOURCE
+        result.task(':copyRestApiSpecsTask').outcome == TaskOutcome.NO_SOURCE
+    }
+
+    def "yamlRestTest executes and copies api and tests to correct source set"() {
+        given:
+        internalBuild()
+        buildFile << """
+            apply plugin: 'elasticsearch.yaml-rest-test'
+
+            dependencies {
+               yamlRestTestImplementation "junit:junit:4.12"
+            }
+
+            // can't actually spin up test cluster from this test
+           tasks.withType(Test).configureEach{ enabled = false }
+        """
+        String api = "foo.json"
+        setupRestResources([api])
+        addRestTestsToProject(["10_basic.yml"], "yamlRestTest")
+        file("src/yamlRestTest/java/MockIT.java") << "import org.junit.Test;class MockIT { @Test public void doNothing() { }}"
+
+        when:
+        def result = gradleRunner("yamlRestTest").build()
+
+        then:
+        result.task(':yamlRestTest').outcome == TaskOutcome.SKIPPED
+        result.task(':copyRestApiSpecsTask').outcome == TaskOutcome.SUCCESS
+        result.task(':copyYamlTestsTask').outcome == TaskOutcome.NO_SOURCE
+
+        file("/build/resources/yamlRestTest/rest-api-spec/api/" + api).exists()
+        file("/build/resources/yamlRestTest/rest-api-spec/test/10_basic.yml").exists()
+        file("/build/classes/java/yamlRestTest/MockIT.class").exists()
+
+        //ensure we don't use the default test sourceset
+        file("/build/resources/test/rest-api-spec/api/" + api).exists() == false
+        file("/build/resources/test/rest-api-spec/test/10_basic.yml").exists() == false
+        file("/build/resources/test/rest-api-spec/MockIT.class").exists() == false
+
+        when:
+        result = gradleRunner("yamlRestTest").build()
+
+        then:
+        result.task(':yamlRestTest').outcome == TaskOutcome.SKIPPED
+        result.task(':copyRestApiSpecsTask').outcome == TaskOutcome.UP_TO_DATE
+        result.task(':copyYamlTestsTask').outcome == TaskOutcome.NO_SOURCE
+    }
+}

--- a/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
@@ -45,6 +45,12 @@ abstract class AbstractGradleFuncTest extends Specification {
         propertiesFile << "org.gradle.java.installations.fromEnv=JAVA_HOME,RUNTIME_JAVA_HOME,JAVA15_HOME,JAVA14_HOME,JAVA13_HOME,JAVA12_HOME,JAVA11_HOME,JAVA8_HOME"
     }
 
+    File addSubProject(String subProjectPath){
+        def subProjectBuild = file(subProjectPath.replace(":", "/") + "/build.gradle")
+        settingsFile << "include \"${subProjectPath}\"\n"
+        subProjectBuild
+    }
+
     GradleRunner gradleRunner(String... arguments) {
         return gradleRunner(testProjectDir.root, arguments)
     }
@@ -114,7 +120,7 @@ abstract class AbstractGradleFuncTest extends Specification {
                versionList.addAll(
             Arrays.asList(Version.fromString("$major"), Version.fromString("$minor"), Version.fromString("$bugfix"), currentVersion)
         )
-        
+
         BwcVersions versions = new BwcVersions(new TreeSet<>(versionList), currentVersion)
         BuildParams.init { it.setBwcVersions(versions) }
         """

--- a/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/fixtures/AbstractRestResourcesFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/fixtures/AbstractRestResourcesFuncTest.groovy
@@ -1,0 +1,67 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.gradle.fixtures;
+
+
+abstract class AbstractRestResourcesFuncTest extends AbstractGradleFuncTest {
+
+    void setupRestResources(List<String> apis, List<String> tests = [], List<String> xpackApis = [], List<String> xpackTests = []) {
+        addSubProject(":test:framework") << "apply plugin: 'elasticsearch.java'"
+        addSubProject(":distribution:archives:integ-test-zip") << "configurations { extracted }"
+        addSubProject(":rest-api-spec") << """
+        configurations { restSpecs\nrestTests }
+        artifacts {
+          restSpecs(new File(projectDir, "src/main/resources/rest-api-spec/api"))
+          restTests(new File(projectDir, "src/main/resources/rest-api-spec/test"))
+        }
+        """
+        addSubProject(":x-pack:plugin") << """
+        configurations { restXpackSpecs\nrestXpackTests }
+        artifacts {
+          //The api and tests need to stay at src/test/... since some external tooling depends on that exact file path.
+          restXpackSpecs(new File(projectDir, "src/test/resources/rest-api-spec/api"))
+          restXpackTests(new File(projectDir, "src/test/resources/rest-api-spec/test"))
+        }
+        """
+
+        xpackApis.each { api ->
+            file("x-pack/plugin/src/test/resources/rest-api-spec/api/" + api) << ""
+        }
+        xpackTests.each { test ->
+            file("x-pack/plugin/src/test/resources/rest-api-spec/test/" + test) << ""
+        }
+
+        apis.each { api ->
+            file("rest-api-spec/src/main/resources/rest-api-spec/api/" + api) << ""
+        }
+        tests.each { test ->
+            file("rest-api-spec/src/main/resources/rest-api-spec/test/" + test) << ""
+        }
+    }
+
+    void addRestTestsToProject(List<String> tests, String sourceSet = "test") {
+        // uses the test source set by default, but in practice it would be a custom source set set by another plugin
+        File testDir = new File(testProjectDir.root, "src/" + sourceSet + "/resources/rest-api-spec/test")
+        testDir.mkdirs();
+        tests.each { test ->
+            new File(testDir, test).createNewFile()
+        }
+    }
+}


### PR DESCRIPTION
This commit introduces 2 new Gradle plugin functional tests.
These tests make use of dummy subprojects to help satisfy the
inter dependencies of the projects in use. Helper methods
have been added to a new shared common parent.

