### PR TITLE
[7.11] Add missing space in installing modules log message (#67593)

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -655,7 +655,7 @@ public class ElasticsearchNode implements TestClusterConfiguration {
     }
 
     private void installModules() {
-        logToProcessStdout("Installing " + modules.size() + "modules");
+        logToProcessStdout("Installing " + modules.size() + " modules");
         for (Provider<File> module : modules) {
             Path destination = getDistroDir().resolve("modules")
                 .resolve(module.get().getName().replace(".zip", "").replace("-" + getVersion(), "").replace("-SNAPSHOT", ""));


### PR DESCRIPTION
Adds a missing space in the "Installing x modules" log
message that appears on node startup.

Backport of #67593
