### PR TITLE
[7.x] doc: data stream api move template to prereq (#67787)

### DIFF
--- a/docs/reference/indices/create-data-stream.asciidoc
+++ b/docs/reference/indices/create-data-stream.asciidoc
@@ -7,9 +7,6 @@
 
 Creates a new <<data-streams,data stream>>.
 
-Data streams require a matching <<index-templates,index template>>.
-See <<set-up-a-data-stream>>.
-
 ////
 [source,console]
 ----
@@ -46,6 +43,9 @@ DELETE /_index_template/template
 
 * If the {es} {security-features} are enabled, you must have the `create_index`
 or `manage` <<privileges-list-indices,index privilege>> for the data stream.
+
+* A matching <<index-templates,index template>> with data stream enabled.
+See <<set-up-a-data-stream>>.
 
 [[indices-create-data-stream-api-path-params]]
 ==== {api-path-parms-title}

--- a/docs/reference/indices/migrate-to-data-stream.asciidoc
+++ b/docs/reference/indices/migrate-to-data-stream.asciidoc
@@ -7,9 +7,6 @@
 
 Converts an <<indices-aliases,index alias>> to a <<data-streams,data stream>>.
 
-Data streams require a matching <<index-templates,index template>>.
-See <<set-up-a-data-stream>>.
-
 ////
 [source,console]
 ----
@@ -77,6 +74,9 @@ DELETE /_index_template/template
 
 * If the {es} {security-features} are enabled, you must have the `manage`
 <<privileges-list-indices,index privilege>> for the index alias.
+
+* A matching <<index-templates,index template>> with data stream enabled.
+See <<set-up-a-data-stream>>.
 
 [[indices-migrate-to-data-stream-api-path-params]]
 ==== {api-path-parms-title}


### PR DESCRIPTION
Backports the following commits to 7.x:
 - doc: data stream api move template to prereq (#67787)