### PR TITLE
[Transform] finalize backport of last_search_time

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -175,8 +175,8 @@ tasks.register("verifyVersions") {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = false
-String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/67779" /* place a PR link here when committing bwc changes */
+boolean bwc_tests_enabled = true
+String bwc_tests_disabled_issue = "" /* place a PR link here when committing bwc changes */
 /*
  * FIPS 140-2 behavior was fixed in 7.11.0. Before that there is no way to run elasticsearch in a
  * JVM that is properly configured to be in fips mode with BCFIPS. For now we need to disable

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformCheckpointingInfo.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformCheckpointingInfo.java
@@ -231,7 +231,7 @@ public class TransformCheckpointingInfo implements Writeable, ToXContentObject {
         } else {
             changesLastDetectedAt = null;
         }
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) { // todo: V_7_12_0
+        if (in.getVersion().onOrAfter(Version.V_7_12_0)) {
             lastSearchTime = in.readOptionalInstant();
         } else {
             lastSearchTime = null;
@@ -294,7 +294,7 @@ public class TransformCheckpointingInfo implements Writeable, ToXContentObject {
         if (out.getVersion().onOrAfter(Version.V_7_4_0)) {
             out.writeOptionalInstant(changesLastDetectedAt);
         }
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) { // todo: V_7_12_0
+        if (out.getVersion().onOrAfter(Version.V_7_12_0)) {
             out.writeOptionalInstant(lastSearchTime);
         }
     }


### PR DESCRIPTION
adjusts the version after the backport of #66718 and re-enables BWC