### PR TITLE
Adjust manage_follow_index privilege for promote data stream api

### DIFF
--- a/docs/reference/data-streams/promote-data-stream-api.asciidoc
+++ b/docs/reference/data-streams/promote-data-stream-api.asciidoc
@@ -32,7 +32,7 @@ POST /_data_stream/_promote/my-data-stream
 [[promote-data-stream-api-prereqs]]
 ==== {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have the `manage`
+* If the {es} {security-features} are enabled, you must have the `manage_follow_index`
 <<privileges-list-cluster,cluster privilege>> to use this API.
 
 [[promote-data-stream-api-path-params]]

--- a/x-pack/plugin/ccr/qa/security/follower-roles.yml
+++ b/x-pack/plugin/ccr/qa/security/follower-roles.yml
@@ -8,6 +8,7 @@ ccruser:
         - read
         - write
         - manage_follow_index
+        - view_index_metadata
     - names: [ 'clean-follower' ]
       privileges:
         - monitor

--- a/x-pack/plugin/ccr/qa/security/leader-roles.yml
+++ b/x-pack/plugin/ccr/qa/security/leader-roles.yml
@@ -7,3 +7,4 @@ ccruser:
         - monitor
         - read
         - manage_leader_index
+        - view_index_metadata

--- a/x-pack/plugin/ccr/qa/security/src/test/java/org/elasticsearch/xpack/ccr/FollowIndexSecurityIT.java
+++ b/x-pack/plugin/ccr/qa/security/src/test/java/org/elasticsearch/xpack/ccr/FollowIndexSecurityIT.java
@@ -17,8 +17,11 @@ import org.elasticsearch.index.seqno.ReplicationTracker;
 import org.elasticsearch.test.rest.yaml.ObjectPath;
 
 import java.io.IOException;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -252,6 +255,52 @@ public class FollowIndexSecurityIT extends ESCCRRestTestCase {
                 assertThat(tasks.size(), equalTo(0));
                 assertThat(countCcrNodeTasks(), equalTo(0));
             });
+        }
+    }
+
+    public void testUnPromoteAndFollowDataStream() throws Exception {
+        if ("follow".equals(targetCluster) == false) {
+            return;
+        }
+
+        int numDocs = 64;
+        String dataStreamName = "logs-eu-monitor1";
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'hh:mm:ss", Locale.ROOT);
+
+        // Setup
+        {
+            createAutoFollowPattern(adminClient(), "test_pattern", "logs-eu*", "leader_cluster");
+        }
+        // Create data stream and ensure that is is auto followed
+        {
+            try (RestClient leaderClient = buildLeaderClient()) {
+                for (int i = 0; i < numDocs; i++) {
+                    Request indexRequest = new Request("POST", "/" + dataStreamName + "/_doc");
+                    indexRequest.addParameter("refresh", "true");
+                    indexRequest.setJsonEntity("{\"@timestamp\": \"" + dateFormat.format(new Date()) + "\",\"message\":\"abc\"}");
+                    assertOK(leaderClient.performRequest(indexRequest));
+                }
+                verifyDataStream(leaderClient, dataStreamName, backingIndexName(dataStreamName, 1));
+                verifyDocuments(leaderClient, dataStreamName, numDocs);
+            }
+            assertBusy(() -> {
+                verifyDataStream(client(), dataStreamName, backingIndexName(dataStreamName, 1));
+                ensureYellow(dataStreamName);
+                verifyDocuments(client(), dataStreamName, numDocs);
+            });
+        }
+        // promote and unfollow
+        {
+            Request promoteRequest = new Request("POST", "/_data_stream/_promote/" + dataStreamName);
+            assertOK(client().performRequest(promoteRequest));
+            // Now that the data stream is a non replicated data stream, rollover.
+            Request rolloverRequest = new Request("POST", "/" +  dataStreamName + "/_rollover");
+            assertOK(client().performRequest(rolloverRequest));
+            // Unfollow .ds-logs-eu-monitor1-000001,
+            // which is now possible because this index can now be closed as it is no longer the write index.
+            pauseFollow(backingIndexName(dataStreamName, 1));
+            closeIndex(backingIndexName(dataStreamName, 1));
+            unfollow(backingIndexName(dataStreamName, 1));
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/PromoteDataStreamAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/PromoteDataStreamAction.java
@@ -8,6 +8,8 @@ package org.elasticsearch.xpack.core.action;
 
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.action.support.master.MasterNodeRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -27,9 +29,9 @@ public class PromoteDataStreamAction extends ActionType<AcknowledgedResponse> {
         super(NAME, AcknowledgedResponse::readFrom);
     }
 
-    public static class Request extends MasterNodeRequest<PromoteDataStreamAction.Request> {
+    public static class Request extends MasterNodeRequest<PromoteDataStreamAction.Request> implements IndicesRequest {
 
-        private String name;
+        private final String name;
 
         public Request(String name) {
             this.name = Objects.requireNonNull(name);
@@ -51,6 +53,16 @@ public class PromoteDataStreamAction extends ActionType<AcknowledgedResponse> {
         public Request(StreamInput in) throws IOException {
             super(in);
             this.name = in.readString();
+        }
+
+        @Override
+        public String[] indices() {
+            return new String[]{name};
+        }
+
+        @Override
+        public IndicesOptions indicesOptions() {
+            return IndicesOptions.strictSingleIndexNoExpandForbidClosed();
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/IndexPrivilege.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/IndexPrivilege.java
@@ -22,6 +22,7 @@ import org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsAction
 import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsAction;
 import org.elasticsearch.action.admin.indices.mapping.put.AutoPutMappingAction;
 import org.elasticsearch.action.admin.indices.resolve.ResolveIndexAction;
+import org.elasticsearch.action.admin.indices.rollover.RolloverAction;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsAction;
 import org.elasticsearch.action.admin.indices.validate.query.ValidateQueryAction;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesAction;
@@ -29,6 +30,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.xpack.core.action.CreateDataStreamAction;
 import org.elasticsearch.xpack.core.action.DeleteDataStreamAction;
 import org.elasticsearch.xpack.core.action.GetDataStreamAction;
+import org.elasticsearch.xpack.core.action.PromoteDataStreamAction;
 import org.elasticsearch.xpack.core.ccr.action.ForgetFollowerAction;
 import org.elasticsearch.xpack.core.ccr.action.PutFollowAction;
 import org.elasticsearch.xpack.core.ccr.action.UnfollowAction;
@@ -76,7 +78,7 @@ public final class IndexPrivilege extends Privilege {
         ClusterSearchShardsAction.NAME, TypesExistsAction.NAME, ValidateQueryAction.NAME + "*", GetSettingsAction.NAME,
         ExplainLifecycleAction.NAME, GetDataStreamAction.NAME, ResolveIndexAction.NAME, FieldCapabilitiesAction.NAME + "*");
     private static final Automaton MANAGE_FOLLOW_INDEX_AUTOMATON = patterns(PutFollowAction.NAME, UnfollowAction.NAME,
-        CloseIndexAction.NAME + "*");
+        CloseIndexAction.NAME + "*", PromoteDataStreamAction.NAME, RolloverAction.NAME);
     private static final Automaton MANAGE_LEADER_INDEX_AUTOMATON = patterns(ForgetFollowerAction.NAME + "*");
     private static final Automaton MANAGE_ILM_AUTOMATON = patterns("indices:admin/ilm/*");
     private static final Automaton MAINTENANCE_AUTOMATON = patterns("indices:admin/refresh*", "indices:admin/flush*",


### PR DESCRIPTION
Backport #67773 to 7.x branch.

This fixes the manage_follow_index builtin privilege so that it can be used
for managing data streams in a follower cluster. In order to successfully
unfollow a data stream the promote data stream and rollover APIs need to be
executed. (This is additional to the close and unfollow APIs).