### PR TITLE
[7.x][ML] Re-enable temporarily muted integration tests (#67818)

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DetectionRulesIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DetectionRulesIT.java
@@ -122,7 +122,6 @@ public class DetectionRulesIT extends MlNativeAutodetectIntegTestCase {
         assertThat(records.get(0).getByFieldValue(), equalTo("low"));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/ml-cpp/issues/1253")
     public void testScope() throws Exception {
         MlFilter safeIps = MlFilter.builder("safe_ips").setItems("111.111.111.111", "222.222.222.222").build();
         assertThat(putMlFilter(safeIps).getFilter(), equalTo(safeIps));

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ScheduledEventsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ScheduledEventsIT.java
@@ -195,7 +195,6 @@ public class ScheduledEventsIT extends MlNativeAutodetectIntegTestCase {
     /**
      * Test an open job picks up changes to scheduled events/calendars
      */
-    @AwaitsFix(bugUrl = "https://github.com/elastic/ml-cpp/issues/1253")
     public void testAddEventsToOpenJob() throws Exception {
         TimeValue bucketSpan = TimeValue.timeValueMinutes(30);
         Job.Builder job = createJob("scheduled-events-add-events-to-open-job", bucketSpan);
@@ -264,7 +263,6 @@ public class ScheduledEventsIT extends MlNativeAutodetectIntegTestCase {
     /**
      * An open job that later gets added to a calendar, should take the scheduled events into account
      */
-    @AwaitsFix(bugUrl = "https://github.com/elastic/ml-cpp/issues/1253")
     public void testAddOpenedJobToGroupWithCalendar() throws Exception {
         TimeValue bucketSpan = TimeValue.timeValueMinutes(30);
         String groupName = "opened-calendar-job-group";


### PR DESCRIPTION
Unmute tests that were temporarily disabled in order to change how the
Java ML process communicates with the C++ backend.

Backports #67818 