### PR TITLE
[7.11] Fix parsing empty value with brackets failed in Dissect ingest processor

### DIFF
--- a/libs/dissect/src/main/java/org/elasticsearch/dissect/DissectParser.java
+++ b/libs/dissect/src/main/java/org/elasticsearch/dissect/DissectParser.java
@@ -211,7 +211,7 @@ public final class DissectParser {
             int lookAheadMatches;
             //start walking the input string byte by byte, look ahead for matches where needed
             //if a match is found jump forward to the end of the match
-            for (; i < input.length; i++) {
+            while (i < input.length) {
                 lookAheadMatches = 0;
                 //potential match between delimiter and input string
                 if (delimiter.length > 0 && input[i] == delimiter[0]) {
@@ -263,7 +263,11 @@ public final class DissectParser {
                         delimiter = dissectPair.getDelimiter().getBytes(StandardCharsets.UTF_8);
                         //i is always one byte after the last found delimiter, aka the start of the next value
                         valueStart = i;
+                    } else {
+                        i++;
                     }
+                } else {
+                    i++;
                 }
             }
             //the last key, grab the rest of the input (unless consecutive delimiters already grabbed the last key)

--- a/libs/dissect/src/test/java/org/elasticsearch/dissect/DissectParserTests.java
+++ b/libs/dissect/src/test/java/org/elasticsearch/dissect/DissectParserTests.java
@@ -264,6 +264,11 @@ public class DissectParserTests extends ESTestCase {
         assertMatch(",%{a} %{b}", ",,foo bar", Arrays.asList("a", "b"), Arrays.asList(",foo", "bar"));
     }
 
+    public void testEmptyValueWithBrackets() {
+        assertMatch("(%{a}) [%{b}] -[%{c}]", "(foo) [] -[bar]", Arrays.asList("a", "b", "c"), Arrays.asList("foo", "", "bar"));
+        assertMatch("[%{a}] [%{b}]", "[] []", Arrays.asList("a", "b"), Arrays.asList("", ""));
+    }
+
     /**
      * Runtime errors
      */


### PR DESCRIPTION
Relates to #65080 .

The `DissectParser` cannot hanle the input string like `[][]` correctly, that's because when iterating over the input string, the cursor `i` cannot move to the next when `i += lookAheadMatches` has been executed.

This PR fix the bug and add a test for it.

Backport of #65524
