### PR TITLE
Autoscaling storage scale empty tier

### DIFF
--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingCalculateCapacityService.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingCalculateCapacityService.java
@@ -257,6 +257,11 @@ public class AutoscalingCalculateCapacityService implements PolicyValidator {
             return currentNodes;
         }
 
+        @Override
+        public Set<DiscoveryNodeRole> roles() {
+            return roles;
+        }
+
         private boolean calculateCurrentCapacityAccurate() {
             return currentNodes.stream().allMatch(this::nodeHasAccurateCapacity);
         }

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingDeciderContext.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingDeciderContext.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.autoscaling.capacity;
 import org.elasticsearch.cluster.ClusterInfo;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.snapshots.SnapshotShardSizeInfo;
 
 import java.util.Set;
@@ -29,6 +30,11 @@ public interface AutoscalingDeciderContext {
      * Return the nodes governed by the policy.
      */
     Set<DiscoveryNode> nodes();
+
+    /**
+     * Return the set of roles required for nodes governed by the policy.
+     */
+    Set<DiscoveryNodeRole> roles();
 
     /**
      * The cluster info to use when calculating a capacity. This represents the storage use on nodes including per shard usage.

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/storage/ProactiveStorageDeciderService.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/storage/ProactiveStorageDeciderService.java
@@ -20,6 +20,7 @@ import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingCapacity;
 import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingDeciderContext;
 import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingDeciderResult;
 import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingDeciderService;
+import org.elasticsearch.xpack.cluster.routing.allocation.DataTierAllocationDecider;
 import org.elasticsearch.xpack.core.DataTier;
 
 import java.io.IOException;
@@ -32,9 +33,11 @@ public class ProactiveStorageDeciderService implements AutoscalingDeciderService
 
     private final DiskThresholdSettings diskThresholdSettings;
     private final AllocationDeciders allocationDeciders;
+    private final DataTierAllocationDecider dataTierAllocationDecider;
 
     public ProactiveStorageDeciderService(Settings settings, ClusterSettings clusterSettings, AllocationDeciders allocationDeciders) {
         this.diskThresholdSettings = new DiskThresholdSettings(settings, clusterSettings);
+        this.dataTierAllocationDecider = new DataTierAllocationDecider(settings, clusterSettings);
         this.allocationDeciders = allocationDeciders;
     }
 
@@ -61,7 +64,8 @@ public class ProactiveStorageDeciderService implements AutoscalingDeciderService
         ReactiveStorageDeciderService.AllocationState allocationState = new ReactiveStorageDeciderService.AllocationState(
             context,
             diskThresholdSettings,
-            allocationDeciders
+            allocationDeciders,
+            dataTierAllocationDecider
         );
         long unassignedBytesBeforeForecast = allocationState.storagePreventsAllocation();
         assert unassignedBytesBeforeForecast >= 0;

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderService.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderService.java
@@ -260,7 +260,7 @@ public class ReactiveStorageDeciderService implements AutoscalingDeciderService 
                 && Strings.hasText(
                     DataTierAllocationDecider.INDEX_ROUTING_PREFER_SETTING.get(indexMetadata(shard, allocation).getSettings())
                 )) {
-                // THe data tier decider allows a shard to remain on a lower preference tier when no nodes exists on higher preference
+                // The data tier decider allows a shard to remain on a lower preference tier when no nodes exists on higher preference
                 // tiers.
                 // Here we ensure that if our policy governs the highest preference tier, we assume the shard needs to move to that tier
                 // once a node is started for it.

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderService.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderService.java
@@ -17,6 +17,7 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.RoutingNodes;
 import org.elasticsearch.cluster.routing.RoutingTable;
@@ -27,6 +28,7 @@ import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision;
 import org.elasticsearch.cluster.routing.allocation.decider.DiskThresholdDecider;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -42,6 +44,7 @@ import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingCapacity;
 import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingDeciderContext;
 import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingDeciderResult;
 import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingDeciderService;
+import org.elasticsearch.xpack.cluster.routing.allocation.DataTierAllocationDecider;
 import org.elasticsearch.xpack.core.DataTier;
 
 import java.io.IOException;
@@ -51,6 +54,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -61,10 +65,12 @@ public class ReactiveStorageDeciderService implements AutoscalingDeciderService 
     public static final String NAME = "reactive_storage";
 
     private final DiskThresholdSettings diskThresholdSettings;
+    private final DataTierAllocationDecider dataTierAllocationDecider;
     private final AllocationDeciders allocationDeciders;
 
     public ReactiveStorageDeciderService(Settings settings, ClusterSettings clusterSettings, AllocationDeciders allocationDeciders) {
         this.diskThresholdSettings = new DiskThresholdSettings(settings, clusterSettings);
+        this.dataTierAllocationDecider = new DataTierAllocationDecider(settings, clusterSettings);
         this.allocationDeciders = allocationDeciders;
     }
 
@@ -96,7 +102,12 @@ public class ReactiveStorageDeciderService implements AutoscalingDeciderService 
             return new AutoscalingDeciderResult(null, new ReactiveReason("current capacity not available", -1, -1));
         }
 
-        AllocationState allocationState = new AllocationState(context, diskThresholdSettings, allocationDeciders);
+        AllocationState allocationState = new AllocationState(
+            context,
+            diskThresholdSettings,
+            allocationDeciders,
+            dataTierAllocationDecider
+        );
         long unassignedBytes = allocationState.storagePreventsAllocation();
         long assignedBytes = allocationState.storagePreventsRemainOrMove();
         long maxShardSize = allocationState.maxShardSize();
@@ -130,44 +141,53 @@ public class ReactiveStorageDeciderService implements AutoscalingDeciderService 
     public static class AllocationState {
         private final ClusterState state;
         private final AllocationDeciders allocationDeciders;
+        private final DataTierAllocationDecider dataTierAllocationDecider;
         private final DiskThresholdSettings diskThresholdSettings;
         private final ClusterInfo info;
         private final SnapshotShardSizeInfo shardSizeInfo;
         private final Predicate<DiscoveryNode> nodeTierPredicate;
         private final Set<DiscoveryNode> nodes;
         private final Set<String> nodeIds;
+        private final Set<DiscoveryNodeRole> roles;
 
         AllocationState(
             AutoscalingDeciderContext context,
             DiskThresholdSettings diskThresholdSettings,
-            AllocationDeciders allocationDeciders
+            AllocationDeciders allocationDeciders,
+            DataTierAllocationDecider dataTierAllocationDecider
         ) {
             this(
                 context.state(),
                 allocationDeciders,
+                dataTierAllocationDecider,
                 diskThresholdSettings,
                 context.info(),
                 context.snapshotShardSizeInfo(),
-                context.nodes()
+                context.nodes(),
+                context.roles()
             );
         }
 
         AllocationState(
             ClusterState state,
             AllocationDeciders allocationDeciders,
+            DataTierAllocationDecider dataTierAllocationDecider,
             DiskThresholdSettings diskThresholdSettings,
             ClusterInfo info,
             SnapshotShardSizeInfo shardSizeInfo,
-            Set<DiscoveryNode> nodes
+            Set<DiscoveryNode> nodes,
+            Set<DiscoveryNodeRole> roles
         ) {
             this.state = state;
             this.allocationDeciders = allocationDeciders;
+            this.dataTierAllocationDecider = dataTierAllocationDecider;
             this.diskThresholdSettings = diskThresholdSettings;
             this.info = info;
             this.shardSizeInfo = shardSizeInfo;
             this.nodes = nodes;
             this.nodeIds = nodes.stream().map(DiscoveryNode::getId).collect(Collectors.toSet());
             this.nodeTierPredicate = nodes::contains;
+            this.roles = roles;
         }
 
         public long storagePreventsAllocation() {
@@ -200,7 +220,7 @@ public class ReactiveStorageDeciderService implements AutoscalingDeciderService 
             List<ShardRouting> candidates = state.getRoutingNodes()
                 .shardsWithState(ShardRoutingState.STARTED)
                 .stream()
-                .filter(shard -> allocationDeciders.canRemain(shard, routingNodes.node(shard.currentNodeId()), allocation) == Decision.NO)
+                .filter(shard -> canRemainOnlyHighestTierPreference(shard, allocation) == false)
                 .filter(shard -> canAllocate(shard, allocation) == false)
                 .collect(Collectors.toList());
 
@@ -225,6 +245,31 @@ public class ReactiveStorageDeciderService implements AutoscalingDeciderService 
             return unallocatableBytes + unmovableBytes;
         }
 
+        /**
+         * Check if shard can remain where it is, with the additional check that the DataTierAllocationDecider did not allow it to stay
+         * on a node in a lower preference tier.
+         */
+        public boolean canRemainOnlyHighestTierPreference(ShardRouting shard, RoutingAllocation allocation) {
+            boolean result = allocationDeciders.canRemain(
+                shard,
+                allocation.routingNodes().node(shard.currentNodeId()),
+                allocation
+            ) != Decision.NO;
+            if (result
+                && nodes.isEmpty()
+                && Strings.hasText(
+                    DataTierAllocationDecider.INDEX_ROUTING_PREFER_SETTING.get(indexMetadata(shard, allocation).getSettings())
+                )) {
+                // THe data tier decider allows a shard to remain on a lower preference tier when no nodes exists on higher preference
+                // tiers.
+                // Here we ensure that if our policy governs the highest preference tier, we assume the shard needs to move to that tier
+                // once a node is started for it.
+                // In the case of overlapping policies, this is consistent with double accounting of unassigned.
+                return isAssignedToTier(shard, allocation) == false;
+            }
+            return result;
+        }
+
         private boolean allocatedToTier(ShardRouting s, RoutingAllocation allocation) {
             return nodeTierPredicate.test(allocation.routingNodes().node(s.currentNodeId()).node());
         }
@@ -234,6 +279,9 @@ public class ReactiveStorageDeciderService implements AutoscalingDeciderService 
          * @return true if and only if a node exists in the tier where only disk decider prevents allocation
          */
         private boolean cannotAllocateDueToStorage(ShardRouting shard, RoutingAllocation allocation) {
+            if (nodeIds.isEmpty() && isAssignedToTier(shard, allocation)) {
+                return true;
+            }
             assert allocation.debugDecision() == false;
             // enable debug decisions to see all decisions and preserve the allocation decision label
             allocation.debugDecision(true);
@@ -266,6 +314,21 @@ public class ReactiveStorageDeciderService implements AutoscalingDeciderService 
             return nodesInTier(allocation.routingNodes()).anyMatch(
                 node -> allocationDeciders.canAllocate(shard, node, allocation) != Decision.NO
             );
+        }
+
+        private boolean isAssignedToTier(ShardRouting shard, RoutingAllocation allocation) {
+            IndexMetadata indexMetadata = indexMetadata(shard, allocation);
+            return dataTierAllocationDecider.shouldFilter(indexMetadata, roles, this::highestPreferenceTier, allocation) != Decision.NO;
+        }
+
+        private IndexMetadata indexMetadata(ShardRouting shard, RoutingAllocation allocation) {
+            return allocation.metadata().getIndexSafe(shard.index());
+        }
+
+        private Optional<String> highestPreferenceTier(String tierPreference, DiscoveryNodes nodes) {
+            String[] preferredTiers = DataTierAllocationDecider.parseTierList(tierPreference);
+            assert preferredTiers.length > 0;
+            return Optional.of(preferredTiers[0]);
         }
 
         public long maxShardSize() {
@@ -377,7 +440,16 @@ public class ReactiveStorageDeciderService implements AutoscalingDeciderService 
             ClusterState forecastClusterState = ClusterState.builder(state).metadata(metadataBuilder).routingTable(routingTable).build();
             ClusterInfo forecastInfo = new ExtendedClusterInfo(sizeBuilder.build(), AllocationState.this.info);
 
-            return new AllocationState(forecastClusterState, allocationDeciders, diskThresholdSettings, forecastInfo, shardSizeInfo, nodes);
+            return new AllocationState(
+                forecastClusterState,
+                allocationDeciders,
+                dataTierAllocationDecider,
+                diskThresholdSettings,
+                forecastInfo,
+                shardSizeInfo,
+                nodes,
+                roles
+            );
         }
 
         private SingleForecast forecast(IndexAbstraction.DataStream stream, long forecastWindow, long now) {

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ProactiveStorageDeciderServiceTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ProactiveStorageDeciderServiceTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.cluster.metadata.IndexAbstraction;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.RoutingNodes;
 import org.elasticsearch.cluster.routing.RoutingTable;
@@ -38,6 +39,7 @@ import org.elasticsearch.xpack.autoscaling.AutoscalingTestCase;
 import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingCapacity;
 import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingDeciderContext;
 import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingDeciderResult;
+import org.elasticsearch.xpack.cluster.routing.allocation.DataTierAllocationDeciderTests;
 import org.hamcrest.Matchers;
 
 import java.util.ArrayList;
@@ -77,7 +79,7 @@ public class ProactiveStorageDeciderServiceTests extends AutoscalingTestCase {
         );
         ClusterState interimState = stateBuilder.build();
         final ClusterState state = startAll(interimState);
-        final ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        final ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, DataTierAllocationDeciderTests.ALL_SETTINGS);
         Collection<AllocationDecider> allocationDecidersList = new ArrayList<>(
             ClusterModule.createAllocationDeciders(Settings.EMPTY, clusterSettings, Collections.emptyList())
         );
@@ -105,6 +107,11 @@ public class ProactiveStorageDeciderServiceTests extends AutoscalingTestCase {
             @Override
             public Set<DiscoveryNode> nodes() {
                 return Sets.newHashSet(state.nodes());
+            }
+
+            @Override
+            public Set<DiscoveryNodeRole> roles() {
+                return Set.of(DiscoveryNodeRole.DATA_ROLE);
             }
 
             @Override
@@ -161,6 +168,8 @@ public class ProactiveStorageDeciderServiceTests extends AutoscalingTestCase {
             null,
             null,
             null,
+            null,
+            Set.of(),
             Set.of()
         );
 
@@ -190,9 +199,11 @@ public class ProactiveStorageDeciderServiceTests extends AutoscalingTestCase {
             state,
             null,
             null,
+            null,
             randomClusterInfo(state),
             null,
-            Sets.newHashSet(state.nodes())
+            Sets.newHashSet(state.nodes()),
+            Set.of()
         );
 
         assertThat(allocationState.forecast(0, lastCreated + between(-3, 1)), Matchers.sameInstance(allocationState));
@@ -230,9 +241,11 @@ public class ProactiveStorageDeciderServiceTests extends AutoscalingTestCase {
             state,
             null,
             null,
+            null,
             info,
             null,
-            Sets.newHashSet(state.nodes())
+            Sets.newHashSet(state.nodes()),
+            Set.of()
         );
 
         for (int window = 0; window < between(1, 20); ++window) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDecider.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDecider.java
@@ -115,7 +115,8 @@ public class DataTierAllocationDecider extends AllocationDecider {
         Optional<String> apply(String tierPreference, DiscoveryNodes nodes);
     }
 
-    public Decision shouldFilter(IndexMetadata indexMd, Set<DiscoveryNodeRole> roles, PreferredTierFunction preferredTierFunction, RoutingAllocation allocation) {
+    public Decision shouldFilter(IndexMetadata indexMd, Set<DiscoveryNodeRole> roles,
+                                 PreferredTierFunction preferredTierFunction, RoutingAllocation allocation) {
         Decision decision = shouldClusterFilter(roles, allocation);
         if (decision != null) {
             return decision;
@@ -134,7 +135,8 @@ public class DataTierAllocationDecider extends AllocationDecider {
         return allocation.decision(Decision.YES, NAME, "node passes include/exclude/require/prefer tier filters");
     }
 
-    private Decision shouldIndexPreferTier(IndexMetadata indexMetadata, Set<DiscoveryNodeRole> roles, PreferredTierFunction preferredTierFunction, RoutingAllocation allocation) {
+    private Decision shouldIndexPreferTier(IndexMetadata indexMetadata, Set<DiscoveryNodeRole> roles,
+                                           PreferredTierFunction preferredTierFunction, RoutingAllocation allocation) {
         Settings indexSettings = indexMetadata.getSettings();
         String tierPreference = INDEX_ROUTING_PREFER_SETTING.get(indexSettings);
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDecider.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDecider.java
@@ -90,7 +90,7 @@ public class DataTierAllocationDecider extends AllocationDecider {
 
     @Override
     public Decision canAllocate(IndexMetadata indexMetadata, RoutingNode node, RoutingAllocation allocation) {
-        return shouldFilter(indexMetadata, node.node(), allocation);
+        return shouldFilter(indexMetadata, node.node().getRoles(), allocation);
     }
 
     @Override
@@ -100,36 +100,33 @@ public class DataTierAllocationDecider extends AllocationDecider {
 
     @Override
     public Decision shouldAutoExpandToNode(IndexMetadata indexMetadata, DiscoveryNode node, RoutingAllocation allocation) {
-        Decision decision = shouldClusterFilter(node, allocation);
-        if (decision != null) {
-            return decision;
-        }
-
-        decision = shouldIndexFilter(indexMetadata, node, allocation);
-        if (decision != null) {
-            return decision;
-        }
-
-        decision = shouldIndexPreferTier(indexMetadata, node, allocation);
-        if (decision != null) {
-            return decision;
-        }
-
-        return allocation.decision(Decision.YES, NAME, "node passes include/exclude/require/prefer tier filters");
+        return shouldFilter(indexMetadata, node.getRoles(), allocation);
     }
 
     private Decision shouldFilter(ShardRouting shardRouting, DiscoveryNode node, RoutingAllocation allocation) {
-        Decision decision = shouldClusterFilter(node, allocation);
+        return shouldFilter(allocation.metadata().getIndexSafe(shardRouting.index()), node.getRoles(), allocation);
+    }
+
+    public Decision shouldFilter(IndexMetadata indexMd, Set<DiscoveryNodeRole> roles, RoutingAllocation allocation) {
+        return shouldFilter(indexMd, roles, DataTierAllocationDecider::preferredAvailableTier, allocation);
+    }
+
+    public interface PreferredTierFunction {
+        Optional<String> apply(String tierPreference, DiscoveryNodes nodes);
+    }
+
+    public Decision shouldFilter(IndexMetadata indexMd, Set<DiscoveryNodeRole> roles, PreferredTierFunction preferredTierFunction, RoutingAllocation allocation) {
+        Decision decision = shouldClusterFilter(roles, allocation);
         if (decision != null) {
             return decision;
         }
 
-        decision = shouldIndexFilter(allocation.metadata().getIndexSafe(shardRouting.index()), node, allocation);
+        decision = shouldIndexFilter(indexMd, roles, allocation);
         if (decision != null) {
             return decision;
         }
 
-        decision = shouldIndexPreferTier(allocation.metadata().getIndexSafe(shardRouting.index()), node, allocation);
+        decision = shouldIndexPreferTier(indexMd, roles, preferredTierFunction, allocation);
         if (decision != null) {
             return decision;
         }
@@ -137,36 +134,17 @@ public class DataTierAllocationDecider extends AllocationDecider {
         return allocation.decision(Decision.YES, NAME, "node passes include/exclude/require/prefer tier filters");
     }
 
-    private Decision shouldFilter(IndexMetadata indexMd, DiscoveryNode node, RoutingAllocation allocation) {
-        Decision decision = shouldClusterFilter(node, allocation);
-        if (decision != null) {
-            return decision;
-        }
-
-        decision = shouldIndexFilter(indexMd, node, allocation);
-        if (decision != null) {
-            return decision;
-        }
-
-        decision = shouldIndexPreferTier(indexMd, node, allocation);
-        if (decision != null) {
-            return decision;
-        }
-
-        return allocation.decision(Decision.YES, NAME, "node passes include/exclude/require/prefer tier filters");
-    }
-
-    private Decision shouldIndexPreferTier(IndexMetadata indexMetadata, DiscoveryNode node, RoutingAllocation allocation) {
+    private Decision shouldIndexPreferTier(IndexMetadata indexMetadata, Set<DiscoveryNodeRole> roles, PreferredTierFunction preferredTierFunction, RoutingAllocation allocation) {
         Settings indexSettings = indexMetadata.getSettings();
         String tierPreference = INDEX_ROUTING_PREFER_SETTING.get(indexSettings);
 
         if (Strings.hasText(tierPreference)) {
-            Optional<String> tier = preferredAvailableTier(tierPreference, allocation.nodes());
+            Optional<String> tier = preferredTierFunction.apply(tierPreference, allocation.nodes());
             if (tier.isPresent()) {
                 String tierName = tier.get();
                 // The OpType doesn't actually matter here, because we have
                 // selected only a single tier as our "preferred" tier
-                if (allocationAllowed(OpType.AND, tierName, node)) {
+                if (allocationAllowed(OpType.AND, tierName, roles)) {
                     return allocation.decision(Decision.YES, NAME,
                         "index has a preference for tiers [%s] and node has tier [%s]", tierPreference, tierName);
                 } else {
@@ -181,26 +159,26 @@ public class DataTierAllocationDecider extends AllocationDecider {
         return null;
     }
 
-    private Decision shouldIndexFilter(IndexMetadata indexMd, DiscoveryNode node, RoutingAllocation allocation) {
+    private Decision shouldIndexFilter(IndexMetadata indexMd, Set<DiscoveryNodeRole> roles, RoutingAllocation allocation) {
         Settings indexSettings = indexMd.getSettings();
         String indexRequire = INDEX_ROUTING_REQUIRE_SETTING.get(indexSettings);
         String indexInclude = INDEX_ROUTING_INCLUDE_SETTING.get(indexSettings);
         String indexExclude = INDEX_ROUTING_EXCLUDE_SETTING.get(indexSettings);
 
         if (Strings.hasText(indexRequire)) {
-            if (allocationAllowed(OpType.AND, indexRequire, node) == false) {
+            if (allocationAllowed(OpType.AND, indexRequire, roles) == false) {
                 return allocation.decision(Decision.NO, NAME, "node does not match all index setting [%s] tier filters [%s]",
                     INDEX_ROUTING_REQUIRE, indexRequire);
             }
         }
         if (Strings.hasText(indexInclude)) {
-            if (allocationAllowed(OpType.OR, indexInclude, node) == false) {
+            if (allocationAllowed(OpType.OR, indexInclude, roles) == false) {
                 return allocation.decision(Decision.NO, NAME, "node does not match any index setting [%s] tier filters [%s]",
                     INDEX_ROUTING_INCLUDE, indexInclude);
             }
         }
         if (Strings.hasText(indexExclude)) {
-            if (allocationAllowed(OpType.OR, indexExclude, node)) {
+            if (allocationAllowed(OpType.OR, indexExclude, roles)) {
                 return allocation.decision(Decision.NO, NAME, "node matches any index setting [%s] tier filters [%s]",
                     INDEX_ROUTING_EXCLUDE, indexExclude);
             }
@@ -208,21 +186,21 @@ public class DataTierAllocationDecider extends AllocationDecider {
         return null;
     }
 
-    private Decision shouldClusterFilter(DiscoveryNode node, RoutingAllocation allocation) {
+    private Decision shouldClusterFilter(Set<DiscoveryNodeRole> roles, RoutingAllocation allocation) {
         if (Strings.hasText(clusterRequire)) {
-            if (allocationAllowed(OpType.AND, clusterRequire, node) == false) {
+            if (allocationAllowed(OpType.AND, clusterRequire, roles) == false) {
                 return allocation.decision(Decision.NO, NAME, "node does not match all cluster setting [%s] tier filters [%s]",
                     CLUSTER_ROUTING_REQUIRE, clusterRequire);
             }
         }
         if (Strings.hasText(clusterInclude)) {
-            if (allocationAllowed(OpType.OR, clusterInclude, node) == false) {
+            if (allocationAllowed(OpType.OR, clusterInclude, roles) == false) {
                 return allocation.decision(Decision.NO, NAME, "node does not match any cluster setting [%s] tier filters [%s]",
                     CLUSTER_ROUTING_INCLUDE, clusterInclude);
             }
         }
         if (Strings.hasText(clusterExclude)) {
-            if (allocationAllowed(OpType.OR, clusterExclude, node)) {
+            if (allocationAllowed(OpType.OR, clusterExclude, roles)) {
                 return allocation.decision(Decision.NO, NAME, "node matches any cluster setting [%s] tier filters [%s]",
                     CLUSTER_ROUTING_EXCLUDE, clusterExclude);
             }
@@ -242,8 +220,12 @@ public class DataTierAllocationDecider extends AllocationDecider {
      * {@code Optional<String>}.
      */
     public static Optional<String> preferredAvailableTier(String prioritizedTiers, DiscoveryNodes nodes) {
-        String[] tiers = Strings.tokenizeToStringArray(prioritizedTiers, ",");
+        String[] tiers = parseTierList(prioritizedTiers);
         return Arrays.stream(tiers).filter(tier -> tierNodesPresent(tier, nodes)).findFirst();
+    }
+
+    public static String[] parseTierList(String tiers) {
+        return Strings.tokenizeToStringArray(tiers, ",");
     }
 
     static boolean tierNodesPresent(String singleTier, DiscoveryNodes nodes) {
@@ -260,12 +242,12 @@ public class DataTierAllocationDecider extends AllocationDecider {
     }
 
 
-    private static boolean allocationAllowed(OpType opType, String tierSetting, DiscoveryNode node) {
-        String[] values = Strings.tokenizeToStringArray(tierSetting, ",");
+    private static boolean allocationAllowed(OpType opType, String tierSetting, Set<DiscoveryNodeRole> roles) {
+        String[] values = parseTierList(tierSetting);
         for (String value : values) {
             // generic "data" roles are considered to have all tiers
-            if (node.getRoles().contains(DiscoveryNodeRole.DATA_ROLE) ||
-                node.getRoles().stream().map(DiscoveryNodeRole::roleName).collect(Collectors.toSet()).contains(value)) {
+            if (roles.contains(DiscoveryNodeRole.DATA_ROLE) ||
+                roles.stream().map(DiscoveryNodeRole::roleName).collect(Collectors.toSet()).contains(value)) {
                 if (opType == OpType.OR) {
                     return true;
                 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDeciderTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDeciderTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision;
 import org.elasticsearch.cluster.routing.allocation.decider.ReplicaAfterPrimaryActiveAllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.SameShardAllocationDecider;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
@@ -46,7 +47,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class DataTierAllocationDeciderTests extends ESAllocationTestCase {
 
-    private static final Set<Setting<?>> ALL_SETTINGS;
+    public static final Set<Setting<?>> ALL_SETTINGS;
     private static final DiscoveryNode HOT_NODE = newNode("node-hot", Collections.singleton(DataTier.DATA_HOT_NODE_ROLE));
     private static final DiscoveryNode WARM_NODE = newNode("node-warm", Collections.singleton(DataTier.DATA_WARM_NODE_ROLE));
     private static final DiscoveryNode COLD_NODE = newNode("node-cold", Collections.singleton(DataTier.DATA_COLD_NODE_ROLE));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDeciderTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDeciderTests.java
@@ -26,7 +26,6 @@ import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision;
 import org.elasticsearch.cluster.routing.allocation.decider.ReplicaAfterPrimaryActiveAllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.SameShardAllocationDecider;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingDeciderServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingDeciderServiceTests.java
@@ -541,6 +541,11 @@ public class MlAutoscalingDeciderServiceTests extends ESTestCase {
         }
 
         @Override
+        public Set<DiscoveryNodeRole> roles() {
+            return null;
+        }
+
+        @Override
         public ClusterInfo info() {
             return null;
         }


### PR DESCRIPTION
Fixed storage autoscaling to also calculate a capacity in the case where
the policy governs no nodes currently (0-1 case).
