### PR TITLE
Ensure snapshot repo directory is cleaned out prior to docs integ tests

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -95,6 +95,12 @@ testClusters.matching { it.name == "integTest"}.configureEach {
   }
 }
 
+tasks.named("integTest").configure {
+  doFirst {
+    delete("${buildDir}/cluster/shared/repo")
+  }
+}
+
 ext.docsFileTree = fileTree(projectDir) {
   // No snippets in here!
   exclude 'build.gradle'


### PR DESCRIPTION
When explicitly configuring a `repo.path` on test clusters, we need to also ensure that location is cleaned up between test runs. In CI generally this isn't a problem due to our use of ephermal workers, but for local development we don't want to reuse stale data from previous test executions.