### PR TITLE
[DOCS] Add security privileges to document API docs

### DIFF
--- a/docs/reference/docs/bulk.asciidoc
+++ b/docs/reference/docs/bulk.asciidoc
@@ -26,6 +26,32 @@ POST _bulk
 
 `POST /<target>/_bulk`
 
+[[docs-bulk-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the following
+<<privileges-list-indices,index privileges>> for the target data stream, index,
+or index alias:
+
+** To use the `create` action, you must have the `create_doc`, `create`,
+`index`, or `write` index privilege. Data streams support only the `create`
+action.
+
+** To use the `index` action, you must have the `create`, `index`, or `write`
+index privilege.
+
+** To use the `delete` action, you must have the `delete` or `write` index
+privilege.
+
+** To use the `update` action, you must have the `index` or `write` index
+privilege.
+
+** To automatically create a data stream or index with a bulk API request, you
+must have the `auto_configure`, `create_index`, or `manage` index privilege.
+
+* Automatic data stream creation requires a matching index template with data
+stream enabled. See <<set-up-a-data-stream>>.
+
 [[docs-bulk-api-desc]]
 ==== {api-description-title}
 

--- a/docs/reference/docs/delete-by-query.asciidoc
+++ b/docs/reference/docs/delete-by-query.asciidoc
@@ -49,6 +49,16 @@ POST /my-index-000001/_delete_by_query
 
 `POST /<target>/_delete_by_query`
 
+[[docs-delete-by-query-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the following
+<<privileges-list-indices,index privileges>> for the target data stream, index,
+or index alias:
+
+** `read`
+** `delete` or `write`
+
 [[docs-delete-by-query-api-desc]]
 ==== {api-description-title}
 

--- a/docs/reference/docs/delete.asciidoc
+++ b/docs/reference/docs/delete.asciidoc
@@ -11,6 +11,13 @@ Removes a JSON document from the specified index.
 
 `DELETE /<index>/_doc/<_id>`
 
+[[docs-delete-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `delete` or
+`write` <<privileges-list-indices,index privilege>> for the target index or
+index alias.
+
 [[docs-delete-api-desc]]
 ==== {api-description-title}
 

--- a/docs/reference/docs/get.asciidoc
+++ b/docs/reference/docs/get.asciidoc
@@ -23,6 +23,12 @@ GET my-index-000001/_doc/0
 
 `HEAD <index>/_source/<_id>`
 
+[[docs-get-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `read`
+<<privileges-list-indices,index privilege>> for the target index or index alias.
+
 [[docs-get-api-desc]]
 ==== {api-description-title}
 You use GET to retrieve a document and its source or stored fields from a

--- a/docs/reference/docs/index_.asciidoc
+++ b/docs/reference/docs/index_.asciidoc
@@ -30,6 +30,27 @@ IMPORTANT: You cannot add new documents to a data stream using the
 `PUT /<target>/_create/<_id>` format instead. See
 <<add-documents-to-a-data-stream>>.
 
+[[docs-index-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the following
+<<privileges-list-indices,index privileges>> for the target data stream, index,
+or index alias:
+
+** To add or overwrite a document using the `PUT /<target>/_doc/<_id>` request
+format, you must have the `create`, `index`, or `write` index privilege.
+
+** To add a document using the `POST /<target>/_doc/`,
+`PUT /<target>/_create/<_id>`, or `POST /<target>/_create/<_id>` request
+formats, you must have the `create_doc`, `create`, `index`, or `write` index
+privilege.
+
+** To automatically create a data stream or index with an index API request, you
+must have the `auto_configure`, `create_index`, or `manage` index privilege.
+
+* Automatic data stream creation requires a matching index template with data
+stream enabled. See <<set-up-a-data-stream>>.
+
 [[docs-index-api-path-params]]
 ==== {api-path-parms-title}
 

--- a/docs/reference/docs/multi-get.asciidoc
+++ b/docs/reference/docs/multi-get.asciidoc
@@ -31,6 +31,12 @@ GET /_mget
 
 `GET /<index>/_mget`
 
+[[docs-multi-get-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `read`
+<<privileges-list-indices,index privilege>> for the target index or index alias.
+
 [[docs-multi-get-api-desc]]
 ==== {api-description-title}
 

--- a/docs/reference/docs/multi-termvectors.asciidoc
+++ b/docs/reference/docs/multi-termvectors.asciidoc
@@ -35,6 +35,12 @@ POST /_mtermvectors
 
 `POST /<index>/_mtermvectors`
 
+[[docs-multi-termvectors-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `read`
+<<privileges-list-indices,index privilege>> for the target index or index alias.
+
 [[docs-multi-termvectors-api-desc]]
 ==== {api-description-title}
 

--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -68,6 +68,33 @@ POST _reindex
 
 `POST /_reindex`
 
+[[docs-reindex-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the the following
+security privileges:
+
+** The `read` <<privileges-list-indices,index privilege>> for the source data
+stream, index, or index alias.
+
+** The `write` index privilege for the destination data stream, index, or index
+alias.
+
+** To automatically create a data stream or index with an reindex API request,
+you must have the `auto_configure`, `create_index`, or `manage` index
+privilege for the destination data stream, index, or index alias.
+
+** If reindexing from a remote cluster, the `source.remote.user` must have the
+`monitor` <<privileges-list-cluster,cluster privilege>> and the `read` index
+privilege for the source data stream, index, or index alias.
+
+* If reindexing from a remote cluster, you must explicitly allow the remote host
+in the `reindex.remote.whitelist` setting of `elasticsearch.yml`. See
+<<reindex-from-remote>>.
+
+* Automatic data stream creation requires a matching index template with data
+stream enabled. See <<set-up-a-data-stream>>.
+
 [[docs-reindex-api-desc]]
 ==== {api-description-title}
 

--- a/docs/reference/docs/termvectors.asciidoc
+++ b/docs/reference/docs/termvectors.asciidoc
@@ -17,6 +17,12 @@ GET /my-index-000001/_termvectors/1
 
 `GET /<index>/_termvectors/<_id>`
 
+[[docs-termvectors-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `read`
+<<privileges-list-indices,index privilege>> for the target index or index alias.
+
 [[docs-termvectors-api-desc]]
 ==== {api-description-title}
 

--- a/docs/reference/docs/update-by-query.asciidoc
+++ b/docs/reference/docs/update-by-query.asciidoc
@@ -46,6 +46,16 @@ POST my-index-000001/_update_by_query?conflicts=proceed
 
 `POST /<target>/_update_by_query`
 
+[[docs-update-by-query-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the following
+<<privileges-list-indices,index privileges>> for the target data stream, index,
+or index alias:
+
+** `read`
+** `index` or `write`
+
 [[docs-update-by-query-api-desc]]
 ==== {api-description-title}
 

--- a/docs/reference/docs/update.asciidoc
+++ b/docs/reference/docs/update.asciidoc
@@ -11,6 +11,13 @@ Updates a document using the specified script.
 
 `POST /<index>/_update/<_id>`
 
+[[docs-update-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `index` or
+`write` <<privileges-list-indices,index privilege>> for the target index or
+index alias.
+
 [[update-api-desc]]
 ==== {api-description-title}
 


### PR DESCRIPTION
Updates the document API docs to note required security privileges.

Relates to #66212

### Previews
- Bulk API: https://elasticsearch_67843.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/docs-bulk.html#docs-bulk-api-prereqs
- Delete by query API: https://elasticsearch_67843.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html#docs-delete-by-query-api-prereqs
- Delete API: https://elasticsearch_67843.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/docs-delete.html#docs-delete-api-prereqs
- Get API: https://elasticsearch_67843.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/docs-get.html#docs-get-api-prereqs
- Index API: https://elasticsearch_67843.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/docs-index_.html#docs-index-api-prereqs
- mget API: https://elasticsearch_67843.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/docs-multi-get.html#docs-multi-get-api-prereqs
- Multi term vectors API: https://elasticsearch_67843.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html#docs-multi-termvectors-api-prereqs
- Reindex API: https://elasticsearch_67843.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/docs-reindex.html#docs-reindex-api-prereqs
- Term vectors API: https://elasticsearch_67843.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/docs-termvectors.html#docs-termvectors-api-prereqs
- Update by query API: https://elasticsearch_67843.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html#docs-update-by-query-api-prereqs
- Update API: https://elasticsearch_67843.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/docs-update.html#docs-update-api-prereqs