### PR TITLE
[DOCS] Add security privileges to ingest API docs

### DIFF
--- a/docs/reference/ingest/apis/delete-pipeline.asciidoc
+++ b/docs/reference/ingest/apis/delete-pipeline.asciidoc
@@ -35,6 +35,12 @@ DELETE /_ingest/pipeline/my-pipeline-id
 
 `DELETE /_ingest/pipeline/<pipeline>`
 
+[[delete-pipeline-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the
+`manage_pipeline`, `manage_ingest_pipelines`, or `manage`
+<<privileges-list-cluster,cluster privilege>> to use this API.
 
 [[delete-pipeline-api-path-params]]
 ==== {api-path-parms-title}

--- a/docs/reference/ingest/apis/get-pipeline.asciidoc
+++ b/docs/reference/ingest/apis/get-pipeline.asciidoc
@@ -41,6 +41,12 @@ GET /_ingest/pipeline/my-pipeline-id
 
 `GET /_ingest/pipeline`
 
+[[get-pipeline-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the
+`read_pipeline`, `manage_pipeline`, `manage_ingest_pipelines`, or `manage`
+<<privileges-list-cluster,cluster privilege>> to use this API.
 
 [[get-pipeline-api-path-params]]
 ==== {api-path-parms-title}

--- a/docs/reference/ingest/apis/put-pipeline.asciidoc
+++ b/docs/reference/ingest/apis/put-pipeline.asciidoc
@@ -29,6 +29,13 @@ PUT _ingest/pipeline/my-pipeline-id
 
 `PUT /_ingest/pipeline/<pipeline>`
 
+[[put-pipeline-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the
+`manage_pipeline`, `manage_ingest_pipelines`, or `manage`
+<<privileges-list-cluster,cluster privilege>> to use this API.
+
 
 [[put-pipeline-api-path-params]]
 ==== {api-path-parms-title}

--- a/docs/reference/ingest/apis/simulate-pipeline.asciidoc
+++ b/docs/reference/ingest/apis/simulate-pipeline.asciidoc
@@ -62,6 +62,12 @@ POST /_ingest/pipeline/my-pipeline-id/_simulate
 
 `GET /_ingest/pipeline/_simulate`
 
+[[simulate-pipeline-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the
+`read_pipeline`, `manage_pipeline`, `manage_ingest_pipelines`, or `manage`
+<<privileges-list-cluster,cluster privilege>> to use this API.
 
 [[simulate-pipeline-api-desc]]
 ==== {api-description-title}


### PR DESCRIPTION
Updates the ingest API docs to note required security privileges.

Relates to #66212

### Previews
- Delete pipeline API: https://elasticsearch_67845.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/delete-pipeline-api.html#delete-pipeline-api-prereqs
- Get pipeline API: https://elasticsearch_67845.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/get-pipeline-api.html#get-pipeline-api-prereqs
- Put pipeline API: https://elasticsearch_67845.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/put-pipeline-api.html#put-pipeline-api-prereqs
- Simulate pipeline API: https://elasticsearch_67845.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/simulate-pipeline-api.html#simulate-pipeline-api-prereqs