### PR TITLE
Rename CacheService.processAllPendingShardsEvictions() method

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheService.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheService.java
@@ -215,7 +215,7 @@ public class CacheService extends AbstractLifecycleComponent {
             cacheSyncTask.close();
         } finally {
             try {
-                processAllPendingShardsEvictions();
+                waitForAllPendingShardsEvictions();
             } finally {
                 try {
                     persistentCache.close();
@@ -450,9 +450,9 @@ public class CacheService extends AbstractLifecycleComponent {
     }
 
     /**
-     * Processes and waits for all pending shard evictions to complete.
+     * Waits for all pending shard evictions to complete.
      */
-    private void processAllPendingShardsEvictions() {
+    private void waitForAllPendingShardsEvictions() {
         synchronized (shardsEvictionsMutex) {
             allowShardsEvictions = false;
         }


### PR DESCRIPTION
The method `processAllPendingShardsEvictions` is confusing as it does not process anything but rather waits for pending shard eviction to complete. This commit renames that method.