### PR TITLE
Rename mime_type configuration option to media_type

### DIFF
--- a/docs/reference/ingest/processors/set.asciidoc
+++ b/docs/reference/ingest/processors/set.asciidoc
@@ -17,7 +17,7 @@ its value will be replaced with the provided one.
 | `copy_from` | no       | -       | The origin field which will be copied to `field`, cannot set `value` simultaneously. Supported data types are `boolean`, `number`, `array`, `object`, `string`, `date`, etc.
 | `override`  | no       | `true`  | If processor will update fields with pre-existing non-null-valued field. When set to `false`, such fields will not be touched.
 | `ignore_empty_value` | no | `false` | If `true` and `value` is a <<accessing-template-fields,template snippet>> that evaluates to `null` or the empty string, the processor quietly exits without modifying the document
-| `mime_type` | no       | `application/json` | The MIME type for encoding `value`. Applies only when `value` is a <<accessing-template-fields,template snippet>>. Must be one of `application/json`, `text/plain`, or `application/x-www-form-urlencoded`.
+| `media_type` | no       | `application/json` | The media type for encoding `value`. Applies only when `value` is a <<accessing-template-fields,template snippet>>. Must be one of `application/json`, `text/plain`, or `application/x-www-form-urlencoded`.
 include::common-options.asciidoc[]
 |======
 

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/SetProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/SetProcessor.java
@@ -111,11 +111,11 @@ public final class SetProcessor extends AbstractProcessor {
                                    String description, Map<String, Object> config) throws Exception {
             String field = ConfigurationUtils.readStringProperty(TYPE, processorTag, config, "field");
             String copyFrom = ConfigurationUtils.readOptionalStringProperty(TYPE, processorTag, config, "copy_from");
-            String mimeType = ConfigurationUtils.readMimeTypeProperty(TYPE, processorTag, config, "mime_type", "application/json");
+            String mediaType = ConfigurationUtils.readMediaTypeProperty(TYPE, processorTag, config, "media_type", "application/json");
             ValueSource valueSource = null;
             if (copyFrom == null) {
                 Object value = ConfigurationUtils.readObject(TYPE, processorTag, config, "value");
-                valueSource = ValueSource.wrap(value, scriptService, Map.of(Script.CONTENT_TYPE_OPTION, mimeType));
+                valueSource = ValueSource.wrap(value, scriptService, Map.of(Script.CONTENT_TYPE_OPTION, mediaType));
             } else {
                 Object value = config.remove("value");
                 if (value != null) {

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/SetProcessorFactoryTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/SetProcessorFactoryTests.java
@@ -137,25 +137,25 @@ public class SetProcessorFactoryTests extends ESTestCase {
         assertThat(exception.getMessage(), equalTo("[copy_from] cannot set both `copy_from` and `value` in the same processor"));
     }
 
-    public void testMimeType() throws Exception {
-        // valid mime type
-        String expectedMimeType = randomFrom(ConfigurationUtils.VALID_MEDIA_TYPES);
+    public void testMediaType() throws Exception {
+        // valid media type
+        String expectedMediaType = randomFrom(ConfigurationUtils.VALID_MEDIA_TYPES);
         Map<String, Object> config = new HashMap<>();
         config.put("field", "field1");
         config.put("value", "value1");
-        config.put("mime_type", expectedMimeType);
+        config.put("media_type", expectedMediaType);
         String processorTag = randomAlphaOfLength(10);
         SetProcessor setProcessor = factory.create(null, processorTag, null, config);
         assertThat(setProcessor.getTag(), equalTo(processorTag));
 
-        // invalid mime type
-        expectedMimeType = randomValueOtherThanMany(m -> Arrays.asList(ConfigurationUtils.VALID_MEDIA_TYPES).contains(m),
+        // invalid media type
+        expectedMediaType = randomValueOtherThanMany(m -> Arrays.asList(ConfigurationUtils.VALID_MEDIA_TYPES).contains(m),
             () -> randomAlphaOfLengthBetween(5, 9));
         final Map<String, Object> config2 = new HashMap<>();
         config2.put("field", "field1");
         config2.put("value", "value1");
-        config2.put("mime_type", expectedMimeType);
+        config2.put("media_type", expectedMediaType);
         ElasticsearchException e = expectThrows(ElasticsearchException.class, () -> factory.create(null, processorTag, null, config2));
-        assertThat(e.getMessage(), containsString("property does not contain a supported MIME type [" + expectedMimeType + "]"));
+        assertThat(e.getMessage(), containsString("property does not contain a supported media type [" + expectedMediaType + "]"));
     }
 }

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/SetProcessorFactoryTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/SetProcessorFactoryTests.java
@@ -139,7 +139,7 @@ public class SetProcessorFactoryTests extends ESTestCase {
 
     public void testMimeType() throws Exception {
         // valid mime type
-        String expectedMimeType = randomFrom(ConfigurationUtils.VALID_MIME_TYPES);
+        String expectedMimeType = randomFrom(ConfigurationUtils.VALID_MEDIA_TYPES);
         Map<String, Object> config = new HashMap<>();
         config.put("field", "field1");
         config.put("value", "value1");
@@ -149,7 +149,7 @@ public class SetProcessorFactoryTests extends ESTestCase {
         assertThat(setProcessor.getTag(), equalTo(processorTag));
 
         // invalid mime type
-        expectedMimeType = randomValueOtherThanMany(m -> Arrays.asList(ConfigurationUtils.VALID_MIME_TYPES).contains(m),
+        expectedMimeType = randomValueOtherThanMany(m -> Arrays.asList(ConfigurationUtils.VALID_MEDIA_TYPES).contains(m),
             () -> randomAlphaOfLengthBetween(5, 9));
         final Map<String, Object> config2 = new HashMap<>();
         config2.put("field", "field1");

--- a/server/src/main/java/org/elasticsearch/ingest/ConfigurationUtils.java
+++ b/server/src/main/java/org/elasticsearch/ingest/ConfigurationUtils.java
@@ -49,7 +49,7 @@ public final class ConfigurationUtils {
 
     public static final String TAG_KEY = "tag";
     public static final String DESCRIPTION_KEY = "description";
-    public static final String[] VALID_MIME_TYPES = {"application/json", "text/plain", "application/x-www-form-urlencoded"};
+    public static final String[] VALID_MEDIA_TYPES = {"application/json", "text/plain", "application/x-www-form-urlencoded"};
 
     private ConfigurationUtils() {
     }
@@ -306,16 +306,16 @@ public final class ConfigurationUtils {
         return value;
     }
 
-    public static String readMimeTypeProperty(String processorType, String processorTag, Map<String, Object> configuration,
+    public static String readMediaTypeProperty(String processorType, String processorTag, Map<String, Object> configuration,
         String propertyName, String defaultValue) {
-        String mimeType = readStringProperty(processorType, processorTag, configuration, propertyName, defaultValue);
+        String mediaType = readStringProperty(processorType, processorTag, configuration, propertyName, defaultValue);
 
-        if (Arrays.asList(VALID_MIME_TYPES).contains(mimeType) == false) {
+        if (Arrays.asList(VALID_MEDIA_TYPES).contains(mediaType) == false) {
             throw newConfigurationException(processorType, processorTag, propertyName,
-                "property does not contain a supported MIME type [" + mimeType + "]");
+                "property does not contain a supported media type [" + mediaType + "]");
         }
 
-        return mimeType;
+        return mediaType;
     }
 
     public static ElasticsearchException newConfigurationException(String processorType, String processorTag,

--- a/server/src/test/java/org/elasticsearch/ingest/ConfigurationUtilsTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/ConfigurationUtilsTests.java
@@ -116,34 +116,36 @@ public class ConfigurationUtilsTests extends ESTestCase {
         }
     }
 
-    public void testReadMimeProperty() {
-        // valid mime type
-        String expectedMimeType = randomFrom(ConfigurationUtils.VALID_MIME_TYPES);
-        config.put("mime_type", expectedMimeType);
-        String readMimeType = ConfigurationUtils.readMimeTypeProperty(null, null, config, "mime_type", "");
-        assertThat(readMimeType, equalTo(expectedMimeType));
+    public void testReadMediaProperty() {
+        // valid media type
+        String expectedMediaType = randomFrom(ConfigurationUtils.VALID_MEDIA_TYPES);
+        config.put("media_type", expectedMediaType);
+        String readMediaType = ConfigurationUtils.readMediaTypeProperty(null, null, config, "media_type", "");
+        assertThat(readMediaType, equalTo(expectedMediaType));
 
-        // missing mime type with valid default
-        expectedMimeType = randomFrom(ConfigurationUtils.VALID_MIME_TYPES);
-        config.remove("mime_type");
-        readMimeType = ConfigurationUtils.readMimeTypeProperty(null, null, config, "mime_type", expectedMimeType);
-        assertThat(readMimeType, equalTo(expectedMimeType));
+        // missing media type with valid default
+        expectedMediaType = randomFrom(ConfigurationUtils.VALID_MEDIA_TYPES);
+        config.remove("media_type");
+        readMediaType = ConfigurationUtils.readMediaTypeProperty(null, null, config, "media_type", expectedMediaType);
+        assertThat(readMediaType, equalTo(expectedMediaType));
 
-        // invalid mime type
-        expectedMimeType = randomValueOtherThanMany(m -> Arrays.asList(ConfigurationUtils.VALID_MIME_TYPES).contains(m),
+        // invalid media type
+        expectedMediaType = randomValueOtherThanMany(m -> Arrays.asList(ConfigurationUtils.VALID_MEDIA_TYPES).contains(m),
             () -> randomAlphaOfLengthBetween(5, 9));
-        config.put("mime_type", expectedMimeType);
+        config.put("media_type", expectedMediaType);
         ElasticsearchException e = expectThrows(ElasticsearchException.class,
-            () -> ConfigurationUtils.readMimeTypeProperty(null, null, config, "mime_type", ""));
-        assertThat(e.getMessage(), containsString("property does not contain a supported MIME type [" + expectedMimeType + "]"));
+            () -> ConfigurationUtils.readMediaTypeProperty(null, null, config, "media_type", ""));
+        assertThat(e.getMessage(), containsString("property does not contain a supported media type [" + expectedMediaType + "]"));
 
-        // missing mime type with invalid default
-        final String invalidDefaultMimeType = randomValueOtherThanMany(m -> Arrays.asList(ConfigurationUtils.VALID_MIME_TYPES).contains(m),
-            () -> randomAlphaOfLengthBetween(5, 9));
-        config.remove("mime_type");
+        // missing media type with invalid default
+        final String invalidDefaultMediaType = randomValueOtherThanMany(
+            m -> Arrays.asList(ConfigurationUtils.VALID_MEDIA_TYPES).contains(m),
+            () -> randomAlphaOfLengthBetween(5, 9)
+        );
+        config.remove("media_type");
         e = expectThrows(ElasticsearchException.class,
-            () -> ConfigurationUtils.readMimeTypeProperty(null, null, config, "mime_type", invalidDefaultMimeType));
-        assertThat(e.getMessage(), containsString("property does not contain a supported MIME type [" + invalidDefaultMimeType + "]"));
+            () -> ConfigurationUtils.readMediaTypeProperty(null, null, config, "media_type", invalidDefaultMediaType));
+        assertThat(e.getMessage(), containsString("property does not contain a supported media type [" + invalidDefaultMediaType + "]"));
     }
 
     public void testReadProcessors() throws Exception {


### PR DESCRIPTION
Follow-up on #65314 to address the comment there: https://github.com/elastic/elasticsearch/pull/65314#discussion_r553387513. Since #66857 which would have provided further means of improvement has been closed in favor of a more limited #67677, I believe renaming the configuration option is the only improvement that can be made here.

Non-issue since the original code has yet to be released.
