### PR TITLE
[Test] Refix testTemplateExists in FIPS for 7.x

### DIFF
--- a/modules/transport-netty4/src/javaRestTest/java/org/elasticsearch/rest/Netty4HeadBodyIsEmptyIT.java
+++ b/modules/transport-netty4/src/javaRestTest/java/org/elasticsearch/rest/Netty4HeadBodyIsEmptyIT.java
@@ -126,7 +126,6 @@ public class Netty4HeadBodyIsEmptyIT extends ESRestTestCase {
     }
 
     public void testTemplateExists() throws IOException {
-        assumeFalse("fails in FIPS mode: https://github.com/elastic/elasticsearch/issues/66820", inFipsJvm());
         try (XContentBuilder builder = jsonBuilder()) {
             builder.startObject();
             {
@@ -143,10 +142,10 @@ public class Netty4HeadBodyIsEmptyIT extends ESRestTestCase {
             if (inFipsJvm()) {
                 request.setOptions(expectWarnings(
                     "legacy template [template] has index patterns [*] matching patterns from existing composable templates " +
-                    "[.deprecation-indexing-template,.slm-history,.triggered_watches,.watch-history-14,.watches,ilm-history,logs," +
+                    "[.deprecation-indexing-template,.slm-history,.triggered_watches,.watch-history-13,.watches,ilm-history,logs," +
                     "metrics,synthetics] with patterns (.deprecation-indexing-template => [.logs-deprecation-elasticsearch]," +
                     ".slm-history => [.slm-history-5*],.triggered_watches => [.triggered_watches*]," +
-                    ".watch-history-14 => [.watcher-history-14*],.watches => [.watches*],ilm-history => [ilm-history-5*]," +
+                    ".watch-history-13 => [.watcher-history-13*],.watches => [.watches*],ilm-history => [ilm-history-5*]," +
                     "logs => [logs-*-*],metrics => [metrics-*-*],synthetics => [synthetics-*-*]" +
                     "); this template [template] may be ignored in favor of a composable template at index creation time"));
             }


### PR DESCRIPTION
The latest index template version is 13 instead of 14 for branch 7.x.

Resolves: #66820