### PR TITLE
Extend async search keep alive

### DIFF
--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchIntegTestCase.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchIntegTestCase.java
@@ -23,6 +23,7 @@ import org.elasticsearch.index.reindex.ReindexPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.script.MockScriptPlugin;
 import org.elasticsearch.search.aggregations.bucket.filter.InternalFilter;
 import org.elasticsearch.search.builder.PointInTimeBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
@@ -57,11 +58,15 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
 
 import static org.elasticsearch.xpack.core.XPackPlugin.ASYNC_RESULTS_INDEX;
 import static org.elasticsearch.xpack.core.async.AsyncTaskMaintenanceService.ASYNC_SEARCH_CLEANUP_INTERVAL_SETTING;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
@@ -93,6 +98,37 @@ public abstract class AsyncSearchIntegTestCase extends ESIntegTestCase {
         }
     }
 
+    public static class ExpirationTimeScriptPlugin extends MockScriptPlugin {
+        @Override
+        public String pluginScriptLang() {
+            return "painless";
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        protected Map<String, Function<Map<String, Object>, Object>> pluginScripts() {
+            final String fieldName = "expiration_time";
+            final String script =
+                "if (ctx._source.expiration_time < params.expiration_time) ctx._source.expiration_time = params.expiration_time";
+            return Map.of(
+                script, vars -> {
+                    Map<String, Object> params = (Map<String, Object>) vars.get("params");
+                    assertNotNull(params);
+                    assertThat(params.keySet(), contains(fieldName));
+                    long updatingValue = (long) params.get(fieldName);
+
+                    Map<String, Object> ctx = (Map<String, Object>) vars.get("ctx");
+                    assertNotNull(ctx);
+                    Map<String, Object> source = (Map<String, Object>) ctx.get("_source");
+                    long currentValue = (long) source.get(fieldName);
+
+                    source.put(fieldName, Math.max(currentValue, updatingValue));
+                    return ctx;
+                }
+            );
+        }
+    }
+
     @Before
     public void startMaintenanceService() {
         for (AsyncTaskMaintenanceService service : internalCluster().getDataNodeInstances(AsyncTaskMaintenanceService.class)) {
@@ -120,7 +156,7 @@ public abstract class AsyncSearchIntegTestCase extends ESIntegTestCase {
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
         return Arrays.asList(LocalStateCompositeXPackPlugin.class, AsyncSearch.class, AsyncResultsIndexPlugin.class, IndexLifecycle.class,
-            SearchTestPlugin.class, ReindexPlugin.class);
+            SearchTestPlugin.class, ReindexPlugin.class, ExpirationTimeScriptPlugin.class);
     }
 
     @Override
@@ -189,7 +225,7 @@ public abstract class AsyncSearchIntegTestCase extends ESIntegTestCase {
                     throw exc;
                 }
             }
-        });
+        }, 30, TimeUnit.SECONDS);
     }
 
     /**
@@ -207,7 +243,7 @@ public abstract class AsyncSearchIntegTestCase extends ESIntegTestCase {
                     throw exc;
                 }
             }
-        });
+        }, 30, TimeUnit.SECONDS);
     }
 
     /**

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/AsyncSearchTask.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/AsyncSearchTask.java
@@ -128,8 +128,8 @@ final class AsyncSearchTask extends SearchTask implements AsyncTask {
      * Update the expiration time of the (partial) response.
      */
     @Override
-    public void setExpirationTime(long expirationTimeMillis) {
-        this.expirationTimeMillis.updateAndGet(curr -> Math.max(curr, expirationTimeMillis));
+    public void extendExpirationTime(long newExpirationTimeMillis) {
+        this.expirationTimeMillis.updateAndGet(curr -> Math.max(curr, newExpirationTimeMillis));
     }
 
     @Override

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/AsyncSearchTask.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/AsyncSearchTask.java
@@ -38,6 +38,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -62,7 +63,7 @@ final class AsyncSearchTask extends SearchTask implements AsyncTask {
     private final List<Runnable> initListeners = new ArrayList<>();
     private final Map<Long, Consumer<AsyncSearchResponse>> completionListeners = new HashMap<>();
 
-    private volatile long expirationTimeMillis;
+    private final AtomicLong expirationTimeMillis;
     private final AtomicBoolean isCancelling = new AtomicBoolean(false);
 
     private final AtomicReference<MutableSearchResponse> searchResponse = new AtomicReference<>();
@@ -93,7 +94,7 @@ final class AsyncSearchTask extends SearchTask implements AsyncTask {
                     ThreadPool threadPool,
                     Supplier<InternalAggregation.ReduceContext> aggReduceContextSupplier) {
         super(id, type, action, () -> "async_search{" + descriptionSupplier.get() + "}", parentTaskId, taskHeaders);
-        this.expirationTimeMillis = getStartTime() + keepAlive.getMillis();
+        this.expirationTimeMillis = new AtomicLong(getStartTime() + keepAlive.getMillis());
         this.originHeaders = originHeaders;
         this.searchId = searchId;
         this.client = client;
@@ -128,7 +129,7 @@ final class AsyncSearchTask extends SearchTask implements AsyncTask {
      */
     @Override
     public void setExpirationTime(long expirationTimeMillis) {
-        this.expirationTimeMillis = expirationTimeMillis;
+        this.expirationTimeMillis.updateAndGet(curr -> Math.max(curr, expirationTimeMillis));
     }
 
     @Override
@@ -330,11 +331,11 @@ final class AsyncSearchTask extends SearchTask implements AsyncTask {
         checkCancellation();
         AsyncSearchResponse asyncSearchResponse;
         try {
-            asyncSearchResponse = mutableSearchResponse.toAsyncSearchResponse(this, expirationTimeMillis, restoreResponseHeaders);
+            asyncSearchResponse = mutableSearchResponse.toAsyncSearchResponse(this, expirationTimeMillis.get(), restoreResponseHeaders);
         } catch(Exception e) {
             ElasticsearchException exception = new ElasticsearchStatusException("Async search: error while reducing partial results",
                 ExceptionsHelper.status(e), e);
-            asyncSearchResponse = mutableSearchResponse.toAsyncSearchResponse(this, expirationTimeMillis, exception);
+            asyncSearchResponse = mutableSearchResponse.toAsyncSearchResponse(this, expirationTimeMillis.get(), exception);
        }
        return asyncSearchResponse;
     }
@@ -342,7 +343,7 @@ final class AsyncSearchTask extends SearchTask implements AsyncTask {
     // checks if the search task should be cancelled
     private synchronized void checkCancellation() {
         long now = System.currentTimeMillis();
-        if (hasCompleted == false && expirationTimeMillis < now) {
+        if (hasCompleted == false && expirationTimeMillis.get() < now) {
             // we cancel expired search task even if they are still running
             cancelTask(() -> {}, "async search has expired");
         }
@@ -354,7 +355,7 @@ final class AsyncSearchTask extends SearchTask implements AsyncTask {
     public AsyncStatusResponse getStatusResponse() {
         MutableSearchResponse mutableSearchResponse = searchResponse.get();
         assert mutableSearchResponse != null;
-        return mutableSearchResponse.toStatusResponse(searchId.getEncoded(), getStartTime(), expirationTimeMillis);
+        return mutableSearchResponse.toStatusResponse(searchId.getEncoded(), getStartTime(), expirationTimeMillis.get());
     }
 
     class Listener extends SearchProgressActionListener {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncResultsService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncResultsService.java
@@ -81,7 +81,7 @@ public class AsyncResultsService<Task extends AsyncTask, Response extends AsyncR
             // EQL doesn't store initial or intermediate results so we only need to update expiration time in store for only in case of
             // async search
             if (updateInitialResultsInStore & expirationTime > 0) {
-                store.updateExpirationTime(searchId.getDocId(), expirationTime,
+                store.extendExpirationTime(searchId.getDocId(), expirationTime,
                     ActionListener.wrap(
                         p -> getSearchResponseFromTask(searchId, request, nowInMillis, expirationTime, listener),
                         exc -> {
@@ -123,7 +123,7 @@ public class AsyncResultsService<Task extends AsyncTask, Response extends AsyncR
             }
 
             if (expirationTimeMillis != -1) {
-                task.setExpirationTime(expirationTimeMillis);
+                task.extendExpirationTime(expirationTimeMillis);
             }
             addCompletionListener.apply(task, new ActionListener<>() {
                 @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncTask.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncTask.java
@@ -30,9 +30,9 @@ public interface AsyncTask {
     boolean isCancelled();
 
     /**
-     * Update the expiration time of the (partial) response.
+     * Extends the expiration time of the (partial) response if needed
      */
-    void setExpirationTime(long expirationTimeMillis);
+    void extendExpirationTime(long newExpirationTimeMillis);
 
     /**
      * Performs necessary checks, cancels the task and calls the runnable upon completion

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncTaskIndexService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncTaskIndexService.java
@@ -202,12 +202,9 @@ public final class AsyncTaskIndexService<R extends AsyncResponse<R>> {
     }
 
     /**
-     * Updates the expiration time of the provided <code>docId</code> if the place-holder
-     * document is still present (update).
+     * Extends the expiration time of the provided <code>docId</code> if the place-holder document is still present (update).
      */
-    public void updateExpirationTime(String docId,
-                              long expirationTimeMillis,
-                              ActionListener<UpdateResponse> listener) {
+    public void extendExpirationTime(String docId, long expirationTimeMillis, ActionListener<UpdateResponse> listener) {
         Script script = new Script(ScriptType.INLINE, "painless", EXPIRATION_TIME_SCRIPT,
             Map.of(EXPIRATION_TIME_FIELD, expirationTimeMillis));
         UpdateRequest request = new UpdateRequest()

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncTaskIndexService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncTaskIndexService.java
@@ -49,7 +49,6 @@ import java.nio.ByteBuffer;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.function.BiFunction;
 
@@ -66,9 +65,12 @@ public final class AsyncTaskIndexService<R extends AsyncResponse<R>> {
     public static final String HEADERS_FIELD = "headers";
     public static final String RESPONSE_HEADERS_FIELD = "response_headers";
     public static final String EXPIRATION_TIME_FIELD = "expiration_time";
-    public static final String EXPIRATION_TIME_SCRIPT = String.format(Locale.ROOT,
-        "if (ctx._source.%s < params.%s) ctx._source.%s = params.%s",
-        EXPIRATION_TIME_FIELD, EXPIRATION_TIME_FIELD, EXPIRATION_TIME_FIELD, EXPIRATION_TIME_FIELD);
+    public static final String EXPIRATION_TIME_SCRIPT =
+        " if (ctx._source.expiration_time < params.expiration_time) { " +
+        "     ctx._source.expiration_time = params.expiration_time; " +
+        " } else { " +
+        "     ctx.op = \"noop\"; " +
+        " }";
 
     public static final String RESULT_FIELD = "result";
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/async/AsyncResultsServiceTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/async/AsyncResultsServiceTests.java
@@ -70,8 +70,8 @@ public class AsyncResultsServiceTests extends ESSingleNodeTestCase {
         }
 
         @Override
-        public void setExpirationTime(long expirationTimeMillis) {
-            this.expirationTimeMillis = expirationTimeMillis;
+        public void extendExpirationTime(long newExpirationTimeMillis) {
+            this.expirationTimeMillis = newExpirationTimeMillis;
         }
 
         @Override
@@ -157,7 +157,7 @@ public class AsyncResultsServiceTests extends ESSingleNodeTestCase {
         try {
             boolean shouldExpire = randomBoolean();
             long expirationTime = System.currentTimeMillis() + randomLongBetween(100000, 1000000) * (shouldExpire ? -1 : 1);
-            task.setExpirationTime(expirationTime);
+            task.extendExpirationTime(expirationTime);
 
             if (updateInitialResultsInStore) {
                 // we need to store initial result
@@ -199,7 +199,7 @@ public class AsyncResultsServiceTests extends ESSingleNodeTestCase {
         TestTask task = (TestTask) taskManager.register("test", "test", request);
         try {
             long startTime = System.currentTimeMillis();
-            task.setExpirationTime(startTime + TimeValue.timeValueMinutes(1).getMillis());
+            task.extendExpirationTime(startTime + TimeValue.timeValueMinutes(1).getMillis());
 
             if (updateInitialResultsInStore) {
                 // we need to store initial result
@@ -237,7 +237,7 @@ public class AsyncResultsServiceTests extends ESSingleNodeTestCase {
         TestTask task = (TestTask) taskManager.register("test", "test", request);
         try {
             long startTime = System.currentTimeMillis();
-            task.setExpirationTime(startTime + TimeValue.timeValueMinutes(1).getMillis());
+            task.extendExpirationTime(startTime + TimeValue.timeValueMinutes(1).getMillis());
 
             if (updateInitialResultsInStore) {
                 // we need to store initial result

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/async/AsyncResultsServiceTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/async/AsyncResultsServiceTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskId;
@@ -23,6 +24,7 @@ import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.async.AsyncSearchIndexServiceTests.TestAsyncResponse;
 import org.junit.Before;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -272,5 +274,10 @@ public class AsyncResultsServiceTests extends ESSingleNodeTestCase {
         deleteListener = new PlainActionFuture<>();
         deleteService.deleteResult(new DeleteAsyncResultRequest(task.getExecutionId().getEncoded()), deleteListener);
         assertFutureThrows(deleteListener, ResourceNotFoundException.class);
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return pluginList(ExpirationTimeScriptPlugin.class);
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/async/AsyncTaskServiceTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/async/AsyncTaskServiceTests.java
@@ -155,7 +155,7 @@ public class AsyncTaskServiceTests extends ESSingleNodeTestCase {
         // And so does updating the expiration time
         {
             PlainActionFuture<UpdateResponse> future = PlainActionFuture.newFuture();
-            indexService.updateExpirationTime("0", 10L, future);
+            indexService.extendExpirationTime("0", 10L, future);
             expectThrows(Exception.class, future::get);
             assertSettings();
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/async/AsyncTaskServiceTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/async/AsyncTaskServiceTests.java
@@ -51,6 +51,7 @@ public class AsyncTaskServiceTests extends ESSingleNodeTestCase {
     protected Collection<Class<? extends Plugin>> getPlugins() {
         List<Class<? extends Plugin>> plugins = new ArrayList<>(super.getPlugins());
         plugins.add(TestPlugin.class);
+        plugins.add(ExpirationTimeScriptPlugin.class);
         return plugins;
     }
 
@@ -175,4 +176,6 @@ public class AsyncTaskServiceTests extends ESSingleNodeTestCase {
         Settings expected = AsyncTaskIndexService.settings();
         assertEquals(expected, settings.filter(expected::hasValue));
     }
+
+
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/async/ExpirationTimeScriptPlugin.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/async/ExpirationTimeScriptPlugin.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.xpack.core.async;
+
+import org.elasticsearch.script.MockScriptPlugin;
+import org.junit.Assert;
+
+import java.util.Map;
+import java.util.function.Function;
+
+import static org.hamcrest.Matchers.contains;
+
+public class ExpirationTimeScriptPlugin extends MockScriptPlugin {
+    @Override
+    public String pluginScriptLang() {
+        return "painless";
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Map<String, Function<Map<String, Object>, Object>> pluginScripts() {
+        final String fieldName = "expiration_time";
+        final String script =
+            "if (ctx._source.expiration_time < params.expiration_time) ctx._source.expiration_time = params.expiration_time";
+        return Map.of(
+            script, vars -> {
+                Map<String, Object> params = (Map<String, Object>) vars.get("params");
+                Assert.assertNotNull(params);
+                Assert.assertThat(params.keySet(), contains(fieldName));
+                long updatingValue = (long) params.get(fieldName);
+
+                Map<String, Object> ctx = (Map<String, Object>) vars.get("ctx");
+                Assert.assertNotNull(ctx);
+                Map<String, Object> source = (Map<String, Object>) ctx.get("_source");
+                long currentValue = (long) source.get(fieldName);
+
+                source.put(fieldName, Math.max(currentValue, updatingValue));
+                return ctx;
+            }
+        );
+    }
+}

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/async/StoredAsyncTask.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/async/StoredAsyncTask.java
@@ -52,8 +52,8 @@ public abstract class StoredAsyncTask<Response extends ActionResponse> extends C
      * Update the expiration time of the (partial) response.
      */
     @Override
-    public void setExpirationTime(long expirationTimeMillis) {
-        this.expirationTimeMillis.updateAndGet(curr -> Math.max(curr, expirationTimeMillis));
+    public void extendExpirationTime(long newExpirationTimeMillis) {
+        this.expirationTimeMillis.updateAndGet(curr -> Math.max(curr, newExpirationTimeMillis));
     }
 
     public long getExpirationTimeMillis() {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/async_search/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/async_search/10_basic.yml
@@ -77,6 +77,43 @@
   - match:  { response.hits.hits.0._source.max: 1 }
   - match:  { response.aggregations.max.value:  3.0 }
 
+  - do:
+      async_search.submit:
+        index: test-*
+        batched_reduce_size: 2
+        wait_for_completion_timeout: 10s
+        keep_alive: 10m
+        keep_on_completion: true
+        body:
+          aggs:
+            max:
+              max:
+                field: max
+          sort: max
+
+  - set:    { id:                                  id }
+  - set:    { expiration_time_in_millis: expiration_time_in_millis }
+
+  - do:
+      async_search.get:
+        id: "$id"
+        keep_alive: 5m
+
+  - match: { expiration_time_in_millis: $expiration_time_in_millis }
+
+  - do:
+      async_search.get:
+        id: "$id"
+        keep_alive: 30m
+
+  - gt:  { expiration_time_in_millis: $expiration_time_in_millis }
+
+  - do:
+      async_search.delete:
+        id: "$id"
+
+  - match: { acknowledged:   true }
+
   # test with typed_keys:
   - do:
       async_search.submit:


### PR DESCRIPTION
There can be a race between two GET async search requests, and the one with a lower keep_alive parameter wins the race. This scenario is not desirable as we should retain the search result for all requests. This commit ensures the keep_alive is extended and never goes backward.


Relates https://github.com/elastic/kibana/issues/88599