### PR TITLE
Fix AbstractClient#execute Listener Leak (#65415) 

### DIFF
--- a/server/src/main/java/org/elasticsearch/client/node/NodeClient.java
+++ b/server/src/main/java/org/elasticsearch/client/node/NodeClient.java
@@ -30,6 +30,7 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.tasks.TaskListener;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.RemoteClusterService;
@@ -72,13 +73,23 @@ public class NodeClient extends AbstractClient {
     public <Request extends ActionRequest, Response extends ActionResponse>
     void doExecute(ActionType<Response> action, Request request, ActionListener<Response> listener) {
         // Discard the task because the Client interface doesn't use it.
-        executeLocally(action, request, listener);
+        try {
+            executeLocally(action, request, listener);
+        } catch (TaskCancelledException | IllegalArgumentException | IllegalStateException e) {
+            // #executeLocally returns the task and throws TaskCancelledException if it fails to register the task because the parent
+            // task has been cancelled, IllegalStateException if the client was not in a state to execute the request because it was not
+            // yet properly initialized or IllegalArgumentException if header validation fails we forward them to listener since this API
+            // does not concern itself with the specifics of the task handling
+            listener.onFailure(e);
+        }
     }
 
     /**
      * Execute an {@link ActionType} locally, returning that {@link Task} used to track it, and linking an {@link ActionListener}.
      * Prefer this method if you don't need access to the task when listening for the response. This is the method used to implement
      * the {@link Client} interface.
+     *
+     * @throws TaskCancelledException if the request's parent task has been cancelled already
      */
     public <    Request extends ActionRequest,
                 Response extends ActionResponse
@@ -87,8 +98,10 @@ public class NodeClient extends AbstractClient {
     }
 
     /**
-     * Execute an {@link ActionType} locally, returning that {@link Task} used to track it, and linking an {@link TaskListener}. Prefer this
-     * method if you need access to the task when listening for the response.
+     * Execute an {@link ActionType} locally, returning that {@link Task} used to track it, and linking an {@link TaskListener}.
+     * Prefer this method if you need access to the task when listening for the response.
+     *
+     * @throws TaskCancelledException if the request's parent task has been cancelled already
      */
     public <    Request extends ActionRequest,
                 Response extends ActionResponse

--- a/server/src/main/java/org/elasticsearch/client/support/AbstractClient.java
+++ b/server/src/main/java/org/elasticsearch/client/support/AbstractClient.java
@@ -408,8 +408,13 @@ public abstract class AbstractClient implements Client {
     @Override
     public final <Request extends ActionRequest, Response extends ActionResponse> void execute(
         ActionType<Response> action, Request request, ActionListener<Response> listener) {
-        listener = threadedWrapper.wrap(listener);
-        doExecute(action, request, listener);
+        try {
+            listener = threadedWrapper.wrap(listener);
+            doExecute(action, request, listener);
+        } catch (Exception e) {
+            assert false : new AssertionError(e);
+            listener.onFailure(e);
+        }
     }
 
     protected abstract <Request extends ActionRequest, Response extends ActionResponse>

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
@@ -246,7 +246,14 @@ public final class RemoteClusterService extends RemoteClusterAware implements Cl
      * will invoke the listener immediately.
      */
     void ensureConnected(String clusterAlias, ActionListener<Void> listener) {
-        getRemoteClusterConnection(clusterAlias).ensureConnected(listener);
+        final RemoteClusterConnection remoteClusterConnection;
+        try {
+            remoteClusterConnection = getRemoteClusterConnection(clusterAlias);
+        } catch (NoSuchRemoteClusterException e) {
+            listener.onFailure(e);
+            return;
+        }
+        remoteClusterConnection.ensureConnected(listener);
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/shrink/TransportResizeActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/shrink/TransportResizeActionTests.java
@@ -74,12 +74,12 @@ public class TransportResizeActionTests extends ESTestCase {
     }
 
     public void testErrorCondition() {
-        ClusterState state = createClusterState("source", randomIntBetween(2, 42), randomIntBetween(0, 10),
-            Settings.builder().put("index.blocks.write", true).build());
+        IndexMetadata state = createClusterState("source", randomIntBetween(2, 42), randomIntBetween(0, 10),
+            Settings.builder().put("index.blocks.write", true).build()).metadata().index("source");
         assertTrue(
             expectThrows(IllegalStateException.class, () ->
                 TransportResizeAction.prepareCreateIndexRequest(new ResizeRequest("target", "source"), state,
-                (i) -> new DocsStats(Integer.MAX_VALUE, between(1, 1000), between(1, 100)), "source", "target")
+                (i) -> new DocsStats(Integer.MAX_VALUE, between(1, 1000), between(1, 100)), "target")
         ).getMessage().startsWith("Can't merge index with more than [2147483519] docs - too many documents in shards "));
 
 
@@ -87,11 +87,11 @@ public class TransportResizeActionTests extends ESTestCase {
             expectThrows(IllegalStateException.class, () -> {
                 ResizeRequest req = new ResizeRequest("target", "source");
                 req.getTargetIndexRequest().settings(Settings.builder().put("index.number_of_shards", 4));
-                ClusterState clusterState = createClusterState("source", 8, 1,
-                    Settings.builder().put("index.blocks.write", true).build());
-                    TransportResizeAction.prepareCreateIndexRequest(req, clusterState,
+                    TransportResizeAction.prepareCreateIndexRequest(req,
+                            createClusterState("source", 8, 1,
+                                    Settings.builder().put("index.blocks.write", true).build()).metadata().index("source"),
                         (i) -> i == 2 || i == 3 ? new DocsStats(Integer.MAX_VALUE / 2, between(1, 1000), between(1, 10000)) : null
-                        , "source", "target");
+                        , "target");
                 }
             ).getMessage().startsWith("Can't merge index with more than [2147483519] docs - too many documents in shards "));
 
@@ -99,10 +99,11 @@ public class TransportResizeActionTests extends ESTestCase {
         IllegalArgumentException softDeletesError = expectThrows(IllegalArgumentException.class, () -> {
             ResizeRequest req = new ResizeRequest("target", "source");
             req.getTargetIndexRequest().settings(Settings.builder().put("index.soft_deletes.enabled", false));
-            ClusterState clusterState = createClusterState("source", 8, 1,
-                Settings.builder().put("index.blocks.write", true).put("index.soft_deletes.enabled", true).build());
-            TransportResizeAction.prepareCreateIndexRequest(req, clusterState,
-                (i) -> new DocsStats(between(10, 1000), between(1, 10), between(1, 10000)), "source", "target");
+            TransportResizeAction.prepareCreateIndexRequest(req,
+                    createClusterState("source", 8, 1,
+                            Settings.builder().put("index.blocks.write", true).put("index.soft_deletes.enabled", true).build())
+                            .metadata().index("source"),
+                (i) -> new DocsStats(between(10, 1000), between(1, 10), between(1, 10000)), "target");
         });
         assertThat(softDeletesError.getMessage(), equalTo("Can't disable [index.soft_deletes.enabled] setting on resize"));
 
@@ -121,8 +122,8 @@ public class TransportResizeActionTests extends ESTestCase {
         routingTable = ESAllocationTestCase.startInitializingShardsAndReroute(service, clusterState, "source").routingTable();
         clusterState = ClusterState.builder(clusterState).routingTable(routingTable).build();
 
-        TransportResizeAction.prepareCreateIndexRequest(new ResizeRequest("target", "source"), clusterState,
-            (i) -> new DocsStats(between(1, 1000), between(1, 1000), between(0, 10000)), "source", "target");
+        TransportResizeAction.prepareCreateIndexRequest(new ResizeRequest("target", "source"), clusterState.metadata().index("source"),
+            (i) -> new DocsStats(between(1, 1000), between(1, 1000), between(0, 10000)), "target");
     }
 
     public void testPassNumRoutingShards() {
@@ -144,14 +145,15 @@ public class TransportResizeActionTests extends ESTestCase {
         resizeRequest.setResizeType(ResizeType.SPLIT);
         resizeRequest.getTargetIndexRequest()
             .settings(Settings.builder().put("index.number_of_shards", 2).build());
-        TransportResizeAction.prepareCreateIndexRequest(resizeRequest, clusterState, null, "source", "target");
+        IndexMetadata indexMetadata = clusterState.metadata().index("source");
+        TransportResizeAction.prepareCreateIndexRequest(resizeRequest, indexMetadata, null, "target");
 
         resizeRequest.getTargetIndexRequest()
             .settings(Settings.builder()
                 .put("index.number_of_routing_shards", randomIntBetween(2, 10))
                 .put("index.number_of_shards", 2)
                 .build());
-        TransportResizeAction.prepareCreateIndexRequest(resizeRequest, clusterState, null, "source", "target");
+        TransportResizeAction.prepareCreateIndexRequest(resizeRequest, indexMetadata, null, "target");
     }
 
     public void testPassNumRoutingShardsAndFail() {
@@ -174,7 +176,7 @@ public class TransportResizeActionTests extends ESTestCase {
         resizeRequest.setResizeType(ResizeType.SPLIT);
         resizeRequest.getTargetIndexRequest()
             .settings(Settings.builder().put("index.number_of_shards", numShards * 2).build());
-        TransportResizeAction.prepareCreateIndexRequest(resizeRequest, clusterState, null, "source", "target");
+        TransportResizeAction.prepareCreateIndexRequest(resizeRequest, clusterState.metadata().index("source"), null, "target");
 
         resizeRequest.getTargetIndexRequest()
             .settings(Settings.builder()
@@ -182,7 +184,7 @@ public class TransportResizeActionTests extends ESTestCase {
                 .put("index.number_of_routing_shards", numShards * 2).build());
         ClusterState finalState = clusterState;
         IllegalArgumentException iae = expectThrows(IllegalArgumentException.class,
-            () -> TransportResizeAction.prepareCreateIndexRequest(resizeRequest, finalState, null, "source", "target"));
+            () -> TransportResizeAction.prepareCreateIndexRequest(resizeRequest, finalState.metadata().index("source"), null, "target"));
         assertEquals("cannot provide index.number_of_routing_shards on resize", iae.getMessage());
     }
 
@@ -210,7 +212,7 @@ public class TransportResizeActionTests extends ESTestCase {
         final ActiveShardCount activeShardCount = randomBoolean() ? ActiveShardCount.ALL : ActiveShardCount.ONE;
         target.setWaitForActiveShards(activeShardCount);
         CreateIndexClusterStateUpdateRequest request = TransportResizeAction.prepareCreateIndexRequest(
-            target, clusterState, (i) -> stats, indexName, "target");
+            target, clusterState.metadata().index(indexName), (i) -> stats, "target");
         assertNotNull(request.recoverFrom());
         assertEquals(indexName, request.recoverFrom().getName());
         assertEquals("1", request.settings().get("index.number_of_shards"));

--- a/server/src/test/java/org/elasticsearch/client/transport/TransportClientTests.java
+++ b/server/src/test/java/org/elasticsearch/client/transport/TransportClientTests.java
@@ -49,7 +49,7 @@ public class TransportClientTests extends ESTestCase {
         final TransportClient client =  new MockTransportClient(Settings.EMPTY);
         client.close();
         final IllegalStateException e =
-            expectThrows(IllegalStateException.class, () -> client.admin().cluster().health(new ClusterHealthRequest()).get());
+            expectThrows(IllegalStateException.class, () -> client.admin().cluster().health(new ClusterHealthRequest()).actionGet());
         assertThat(e, hasToString(containsString("transport client is closed")));
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/RestActionTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/RestActionTestCase.java
@@ -37,6 +37,7 @@ import org.junit.After;
 import org.junit.Before;
 
 import java.util.Collections;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 
@@ -95,6 +96,11 @@ public abstract class RestActionTestCase extends ESTestCase {
             reset();
         }
 
+        @Override
+        public String getLocalNodeId() {
+            return "test_node_id";
+        }
+
         /**
          * Clears any previously set verifier functions set by {@link #setExecuteVerifier(BiFunction)} and/or
          * {@link #setExecuteLocallyVerifier(BiFunction)}. These functions are replaced with functions which will throw an
@@ -131,15 +137,18 @@ public abstract class RestActionTestCase extends ESTestCase {
          * @param verifier A function which is called in place of {@link #executeLocally(ActionType, ActionRequest, TaskListener)}
          */
         public <Request extends ActionRequest, Response extends ActionResponse>
-        void setExecuteLocallyVerifier(BiFunction<ActionType<Response>, Request, Void> verifier) {
+        void setExecuteLocallyVerifier(BiFunction<ActionType<Response>, Request, Response> verifier) {
             executeLocallyVerifier.set(verifier);
         }
+
+        private static final AtomicLong taskIdGenerator = new AtomicLong(0L);
 
         @Override
         public <Request extends ActionRequest, Response extends ActionResponse>
         Task executeLocally(ActionType<Response> action, Request request, ActionListener<Response> listener) {
             listener.onResponse((Response) executeLocallyVerifier.get().apply(action, request));
-            return null;
+            return new Task(taskIdGenerator.incrementAndGet(), "transport", action.name(), "", request.getParentTask(),
+                    Collections.emptyMap());
         }
 
         @Override

--- a/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/RestSubmitAsyncSearchActionTests.java
+++ b/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/RestSubmitAsyncSearchActionTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.test.rest.FakeRestChannel;
 import org.elasticsearch.test.rest.FakeRestRequest;
 import org.elasticsearch.test.rest.RestActionTestCase;
+import org.elasticsearch.xpack.core.search.action.AsyncSearchResponse;
 import org.elasticsearch.xpack.core.search.action.SubmitAsyncSearchRequest;
 import org.junit.Before;
 
@@ -89,7 +90,7 @@ public class RestSubmitAsyncSearchActionTests extends RestActionTestCase {
             assertThat(request, instanceOf(SubmitAsyncSearchRequest.class));
             assertThat(valueAccessor.apply((SubmitAsyncSearchRequest) request), equalTo(expectedValue));
             executeCalled.set(true);
-            return null;
+            return new AsyncSearchResponse("", randomBoolean(), randomBoolean(), 0L, 0L);
         });
         Map<String, String> params = new HashMap<>();
         params.put(paramName, paramValue);

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunner.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunner.java
@@ -124,7 +124,12 @@ public class EnrichPolicyRunner implements Runnable {
         client.admin().indices().getIndex(getIndexRequest, new ActionListener<GetIndexResponse>() {
             @Override
             public void onResponse(GetIndexResponse getIndexResponse) {
-                validateMappings(getIndexResponse);
+                try {
+                    validateMappings(getIndexResponse);
+                } catch (Exception e) {
+                    listener.onFailure(e);
+                    return;
+                }
                 prepareAndCreateEnrichIndex();
             }
 

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/history/ILMHistoryStore.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/history/ILMHistoryStore.java
@@ -33,6 +33,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -90,7 +91,8 @@ public class ILMHistoryStore implements Closeable {
                     if (response.hasFailures()) {
                         Map<String, String> failures = Arrays.stream(response.getItems())
                             .filter(BulkItemResponse::isFailed)
-                            .collect(Collectors.toMap(BulkItemResponse::getId, BulkItemResponse::getFailureMessage));
+                            .collect(Collectors.toMap(BulkItemResponse::getId, BulkItemResponse::getFailureMessage,
+                                    (msg1, msg2) -> Objects.equals(msg1, msg2) ? msg1 : msg1 + "," + msg2));
                         logger.error("failures: [{}]", failures);
                     }
                 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/utils/persistence/ResultsPersisterServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/utils/persistence/ResultsPersisterServiceTests.java
@@ -62,7 +62,6 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -138,7 +137,7 @@ public class ResultsPersisterServiceTests extends ESTestCase {
     }
 
     public void testSearchWithRetries_SuccessAfterRetryDueToException() {
-        doThrow(new IndexPrimaryShardNotAllocatedException(new Index("my-index", "UUID")))
+        doAnswer(withFailure(new IndexPrimaryShardNotAllocatedException(new Index("my-index", "UUID"))))
             .doAnswer(withResponse(SEARCH_RESPONSE_SUCCESS))
             .when(client).execute(eq(SearchAction.INSTANCE), eq(SEARCH_REQUEST), any());
 


### PR DESCRIPTION
This was observed in #65405 due to trying to locally execute a
task whose parent was already cancelled but is a general issue.

We should not throw from APIs that consume a listener as this may
like in this case leak the listener in that case.
Rather than fixing the specific case of #65405 this fixes the
abstract client overall to avoid other such leaks.

Closes #65405

backport of #65415 