### PR TITLE
Revert "Fix Azul identification in FIPS 140-2 CI (#67740) (#67753)"

### DIFF
--- a/gradle/fips.gradle
+++ b/gradle/fips.gradle
@@ -9,7 +9,7 @@ if (BuildParams.inFipsJvm) {
   allprojects {
     File fipsResourcesDir = new File(project.buildDir, 'fips-resources')
     boolean java8 = BuildParams.runtimeJavaVersion == JavaVersion.VERSION_1_8
-    boolean zulu8 = java8 && BuildParams.runtimeJavaDetails.toLowerCase().contains("azul")
+    boolean zulu8 = java8 && BuildParams.runtimeJavaDetails.contains("Zulu")
     File fipsSecurity;
     File fipsPolicy;
     if (java8) {


### PR DESCRIPTION
This reverts commit 7e26181a016789810966ed53c51caecd8cc1efd5.
The gradle 6.8 PR is not backported to 7.11 and as such the changes
in gradle/fips.gradle are not necessary in this branch.

relates: #67740