### PR TITLE
strict_date_optional_time to print nanoseconds

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/240_date_nanos.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/240_date_nanos.yml
@@ -102,7 +102,7 @@ setup:
   - length: { hits.hits: 2 }
   - match: { hits.hits.0._id: "date_ns_1" }
   - match: { hits.hits.1._id: "date_ms_1" }
-  - match: { hits.hits.0.fields.date: [ "2018-10-29T12:12:12.123Z", "1540815132123.456789", "2018-10-29T12:12:12.123456789Z" ] }
+  - match: { hits.hits.0.fields.date: [ "2018-10-29T12:12:12.123456789Z", "1540815132123.456789", "2018-10-29T12:12:12.123456789Z" ] }
   - match: { hits.hits.1.fields.date: [ "2018-10-29T12:12:12.987Z", "1540815132987", "2018-10-29T12:12:12.987000000Z" ] }
 
 ---

--- a/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
+++ b/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
@@ -103,7 +103,7 @@ public class DateFormatters {
         .appendLiteral(':')
         .appendValue(SECOND_OF_MINUTE, 2, 2, SignStyle.NOT_NEGATIVE)
         .optionalStart()
-        .appendFraction(NANO_OF_SECOND, 3, 3, true)
+        .appendFraction(NANO_OF_SECOND, 3, 9, true)
         .optionalEnd()
         .optionalEnd()
         .optionalStart()

--- a/server/src/test/java/org/elasticsearch/common/time/DateFormattersTests.java
+++ b/server/src/test/java/org/elasticsearch/common/time/DateFormattersTests.java
@@ -398,4 +398,23 @@ public class DateFormattersTests extends ESTestCase {
             assertThat(instant.getNano(), is(123_456_789));
         }
     }
+
+    public void testParsingDates() {
+        DateFormatter formatter = DateFormatters.forPattern("strict_date_optional_time");
+//        assertSameNanosOnParsedAndPrinted(formatter,"2016-01-01T00:00:01.000");
+        assertSameNanosOnParsedAndPrinted(formatter, "2018-05-15T17:14:56Z");
+        assertSameNanosOnParsedAndPrinted(formatter, "2018-05-15T17:14:56+0100");
+        assertSameNanosOnParsedAndPrinted(formatter, "2018-05-15T17:14:56+01:00");
+        assertSameNanosOnParsedAndPrinted(formatter, "2018-05-15T17:14:56.123456789Z");
+        assertSameNanosOnParsedAndPrinted(formatter, "2018-05-15T17:14:56.123456789+0100");
+        assertSameNanosOnParsedAndPrinted(formatter, "2018-05-15T17:14:56.123456789+01:00");
+    }
+
+    private void assertSameNanosOnParsedAndPrinted(DateFormatter formatter, String date) {
+        TemporalAccessor parse = formatter.parse(date);
+        Instant parsedInstant = Instant.from(parse);
+        String printed = formatter.format(parsedInstant);
+        Instant printedInstant = Instant.from(formatter.parse(printed));
+        assertThat(printedInstant.getNano(), equalTo(parsedInstant.getNano()));
+    }
 }

--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/watch/WatchStatusIntegrationTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/watch/WatchStatusIntegrationTests.java
@@ -54,7 +54,8 @@ public class WatchStatusIntegrationTests extends AbstractWatcherIntegrationTestC
 
         String lastChecked = source.getValue("status.last_checked");
         assertThat(lastChecked, WatcherTestUtils.isSameDate(getWatchResponse.getStatus().lastChecked()));
-        assertThat(getWatchResponse.getStatus().lastChecked(), isMillisResolution());
+        // TODO PG  nothing prevents us from having a  greater resolution ?
+        //   assertThat(getWatchResponse.getStatus().lastChecked(), isMillisResolution());
         // not started yet, so both nulls
         String lastMetCondition = source.getValue("status.last_met_condition");
         assertThat(lastMetCondition, is(nullValue()));


### PR DESCRIPTION
strict_date_optional_time is allowing to parse nanoseconds up to 9digis,
but is only printing up to 3digits.
This is enought for date field, but not sufficient for date_nanos
This commit is chaning the printer in `strict_date_optional_time` to
print up to 9 digits

closes #67063

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
