### PR TITLE
Align JSON logs better with ECS

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/logging/ClusterIdConverter.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/ClusterIdConverter.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.logging;
+
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.pattern.ConverterKeys;
+import org.apache.logging.log4j.core.pattern.LogEventPatternConverter;
+import org.apache.logging.log4j.core.pattern.PatternConverter;
+
+/**
+ * Pattern converter to format the cluster_id variable into JSON fields <code>cluster.id</code>.
+ */
+@Plugin(category = PatternConverter.CATEGORY, name = "ClusterIdConverter")
+@ConverterKeys({"cluster_id"})
+public final class ClusterIdConverter extends LogEventPatternConverter {
+    /**
+     * Called by log4j2 to initialize this converter.
+     */
+    public static ClusterIdConverter newInstance(@SuppressWarnings("unused") final String[] options) {
+        return new ClusterIdConverter();
+    }
+
+    public ClusterIdConverter() {
+        super("cluster_id", "cluster_id");
+    }
+
+    /**
+     * Formats the cluster.uuid into json fields.
+     *
+     * @param event - a log event is ignored in this method as it uses the clusterId value
+     *              from <code>NodeAndClusterIdStateListener</code> to format
+     */
+    @Override
+    public void format(LogEvent event, StringBuilder toAppendTo) {
+        if (NodeAndClusterIdStateListener.nodeAndClusterId.get() != null) {
+            toAppendTo.append(NodeAndClusterIdStateListener.nodeAndClusterId.get().v2());
+        }
+        // nodeId/clusterUuid not received yet, not appending
+    }
+
+}

--- a/server/src/main/java/org/elasticsearch/common/logging/ClusterIdConverter.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/ClusterIdConverter.java
@@ -27,6 +27,8 @@ import org.apache.logging.log4j.core.pattern.PatternConverter;
 
 /**
  * Pattern converter to format the cluster_id variable into JSON fields <code>cluster.id</code>.
+ * <p>
+ * This is used in `EcsJsonLayout`, which does not use {@link NodeAndClusterIdConverter}.
  */
 @Plugin(category = PatternConverter.CATEGORY, name = "ClusterIdConverter")
 @ConverterKeys({"cluster_id"})

--- a/server/src/main/java/org/elasticsearch/common/logging/DeprecatedMessage.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/DeprecatedMessage.java
@@ -19,10 +19,10 @@
 
 package org.elasticsearch.common.logging;
 
-import java.util.Map;
-
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.MapBuilder;
+
+import java.util.Map;
 
 /**
  * A logger message used by {@link DeprecationLogger}.

--- a/server/src/main/java/org/elasticsearch/common/logging/NodeAndClusterIdStateListener.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/NodeAndClusterIdStateListener.java
@@ -21,9 +21,11 @@ package org.elasticsearch.common.logging;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateObserver;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 
@@ -34,6 +36,7 @@ import org.elasticsearch.common.util.concurrent.ThreadContext;
  */
 public class NodeAndClusterIdStateListener implements ClusterStateObserver.Listener {
     private static final Logger logger = LogManager.getLogger(NodeAndClusterIdStateListener.class);
+    static final SetOnce<Tuple<String,String>> nodeAndClusterId = new SetOnce<>();
 
     private NodeAndClusterIdStateListener() {}
 
@@ -67,6 +70,11 @@ public class NodeAndClusterIdStateListener implements ClusterStateObserver.Liste
 
         logger.debug("Received cluster state update. Setting nodeId=[{}] and clusterUuid=[{}]", nodeId, clusterUUID);
         NodeAndClusterIdConverter.setNodeIdAndClusterId(nodeId, clusterUUID);
+        setNodeIdAndClusterId(nodeId, clusterUUID);
+    }
+
+    void setNodeIdAndClusterId(String nodeId, String clusterUUID){
+        nodeAndClusterId.set(Tuple.tuple(nodeId,clusterUUID));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/common/logging/NodeIdConverter.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/NodeIdConverter.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.logging;
+
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.pattern.ConverterKeys;
+import org.apache.logging.log4j.core.pattern.LogEventPatternConverter;
+import org.apache.logging.log4j.core.pattern.PatternConverter;
+
+/**
+ * Pattern converter to format the node_id variable into JSON fields <code>node.id</code> .
+ */
+@Plugin(category = PatternConverter.CATEGORY, name = "NodeIdConverter")
+@ConverterKeys({"node_id"})
+public final class NodeIdConverter extends LogEventPatternConverter {
+    /**
+     * Called by log4j2 to initialize this converter.
+     */
+    public static NodeIdConverter newInstance(@SuppressWarnings("unused") final String[] options) {
+        return new NodeIdConverter();
+    }
+
+    public NodeIdConverter() {
+        super("node_id", "node_id");
+    }
+
+    /**
+     * Formats the node.id into json fields.
+     *
+     * @param event - a log event is ignored in this method as it uses the clusterId value
+     *              from <code>NodeAndClusterIdStateListener</code> to format
+     */
+    @Override
+    public void format(LogEvent event, StringBuilder toAppendTo) {
+        if (NodeAndClusterIdStateListener.nodeAndClusterId.get() != null) {
+            toAppendTo.append(NodeAndClusterIdStateListener.nodeAndClusterId.get().v1());
+        }
+        // nodeId/clusterUuid not received yet, not appending
+    }
+}

--- a/server/src/main/java/org/elasticsearch/common/logging/NodeIdConverter.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/NodeIdConverter.java
@@ -27,6 +27,8 @@ import org.apache.logging.log4j.core.pattern.PatternConverter;
 
 /**
  * Pattern converter to format the node_id variable into JSON fields <code>node.id</code> .
+ * <p>
+ * This is used in `EcsJsonLayout`, which does not use {@link NodeAndClusterIdConverter}.
  */
 @Plugin(category = PatternConverter.CATEGORY, name = "NodeIdConverter")
 @ConverterKeys({"node_id"})

--- a/x-pack/plugin/deprecation/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/deprecation/DeprecationHttpIT.java
+++ b/x-pack/plugin/deprecation/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/deprecation/DeprecationHttpIT.java
@@ -63,16 +63,16 @@ public class DeprecationHttpIT extends ESRestTestCase {
             .startObject("transient")
             .field(
                 TestDeprecationHeaderRestAction.TEST_DEPRECATED_SETTING_TRUE1.getKey(),
-                !TestDeprecationHeaderRestAction.TEST_DEPRECATED_SETTING_TRUE1.getDefault(Settings.EMPTY)
+                TestDeprecationHeaderRestAction.TEST_DEPRECATED_SETTING_TRUE1.getDefault(Settings.EMPTY) == false
             )
             .field(
                 TestDeprecationHeaderRestAction.TEST_DEPRECATED_SETTING_TRUE2.getKey(),
-                !TestDeprecationHeaderRestAction.TEST_DEPRECATED_SETTING_TRUE2.getDefault(Settings.EMPTY)
+                TestDeprecationHeaderRestAction.TEST_DEPRECATED_SETTING_TRUE2.getDefault(Settings.EMPTY) == false
             )
             // There should be no warning for this field
             .field(
                 TestDeprecationHeaderRestAction.TEST_NOT_DEPRECATED_SETTING.getKey(),
-                !TestDeprecationHeaderRestAction.TEST_NOT_DEPRECATED_SETTING.getDefault(Settings.EMPTY)
+                TestDeprecationHeaderRestAction.TEST_NOT_DEPRECATED_SETTING.getDefault(Settings.EMPTY) == false
             )
             .endObject()
             .endObject();
@@ -276,35 +276,37 @@ public class DeprecationHttpIT extends ESRestTestCase {
                     hasItems(
                         allOf(
                             hasKey("@timestamp"),
-                            hasKey("cluster.name"),
-                            hasKey("cluster.uuid"),
-                            hasKey("component"),
-                            hasEntry("data_stream.dataset", "deprecation.elasticsearch"),
+                            hasKey("elasticsearch.cluster.name"),
+                            hasKey("elasticsearch.cluster.uuid"),
+                            hasEntry("elasticsearch.http.request.x_opaque_id", "some xid"),
+                            hasKey("elasticsearch.node.id"),
+                            hasKey("elasticsearch.node.name"),
+                            hasEntry("data_stream.dataset", "elasticsearch.deprecation"),
                             hasEntry("data_stream.namespace", "default"),
                             hasEntry("data_stream.type", "logs"),
-                            hasEntry("ecs.version", "1.6"),
-                            hasEntry("key", "deprecated_settings"),
-                            hasEntry("level", "DEPRECATION"),
-                            hasEntry("message", "[deprecated_settings] usage is deprecated. use [settings] instead"),
-                            hasKey("node.id"),
-                            hasKey("node.name"),
-                            hasEntry("x-opaque-id", "some xid")
+                            hasEntry("ecs.version", "1.7"),
+                            hasEntry("event.code", "deprecated_settings"),
+                            hasEntry("event.dataset", "elasticsearch.deprecation"),
+                            hasEntry("log.level", "DEPRECATION"),
+                            hasKey("log.logger"),
+                            hasEntry("message", "[deprecated_settings] usage is deprecated. use [settings] instead")
                         ),
                         allOf(
                             hasKey("@timestamp"),
-                            hasKey("cluster.name"),
-                            hasKey("cluster.uuid"),
-                            hasKey("component"),
-                            hasEntry("data_stream.dataset", "deprecation.elasticsearch"),
+                            hasKey("elasticsearch.cluster.name"),
+                            hasKey("elasticsearch.cluster.uuid"),
+                            hasEntry("elasticsearch.http.request.x_opaque_id", "some xid"),
+                            hasKey("elasticsearch.node.id"),
+                            hasKey("elasticsearch.node.name"),
+                            hasEntry("data_stream.dataset", "elasticsearch.deprecation"),
                             hasEntry("data_stream.namespace", "default"),
                             hasEntry("data_stream.type", "logs"),
-                            hasEntry("ecs.version", "1.6"),
-                            hasEntry("key", "deprecated_route"),
-                            hasEntry("level", "DEPRECATION"),
-                            hasEntry("message", "[/_test_cluster/deprecated_settings] exists for deprecated tests"),
-                            hasKey("node.id"),
-                            hasKey("node.name"),
-                            hasEntry("x-opaque-id", "some xid")
+                            hasEntry("ecs.version", "1.7"),
+                            hasEntry("event.code", "deprecated_route"),
+                            hasEntry("event.dataset", "elasticsearch.deprecation"),
+                            hasEntry("log.level", "DEPRECATION"),
+                            hasKey("log.logger"),
+                            hasEntry("message", "[/_test_cluster/deprecated_settings] exists for deprecated tests")
                         )
                     )
                 );

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/logging/DeprecationIndexingComponent.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/logging/DeprecationIndexingComponent.java
@@ -6,11 +6,6 @@
 
 package org.elasticsearch.xpack.deprecation.logging;
 
-import java.util.Arrays;
-import java.util.Map;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
@@ -37,6 +32,11 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.xpack.core.ClientHelper;
 
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
 /**
  * This component manages the construction and lifecycle of the {@link DeprecationIndexingAppender}.
  * It also starts and stops the appender
@@ -62,14 +62,14 @@ public class DeprecationIndexingComponent extends AbstractLifecycleComponent imp
         final LoggerContext context = (LoggerContext) LogManager.getContext(false);
         final Configuration configuration = context.getConfiguration();
 
-        final EcsJsonLayout layout = EcsJsonLayout.newBuilder()
-            .setType("deprecation")
+        final EcsJsonLayout ecsLayout = EcsJsonLayout.newBuilder()
+            .setDataset("elasticsearch.deprecation")
             .setESMessageFields("key,x-opaque-id")
             .setConfiguration(configuration)
             .build();
 
         this.filter = new RateLimitingFilter();
-        this.appender = new DeprecationIndexingAppender("deprecation_indexing_appender", filter, layout, consumer);
+        this.appender = new DeprecationIndexingAppender("deprecation_indexing_appender", filter, ecsLayout, consumer);
     }
 
     @Override

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/logging/EcsJsonLayout.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/logging/EcsJsonLayout.java
@@ -6,14 +6,6 @@
 
 package org.elasticsearch.xpack.deprecation.logging;
 
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.config.Node;
@@ -27,13 +19,22 @@ import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.logging.ESJsonLayout;
 
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 /**
- * This is in essense a fork of {@link ESJsonLayout}, with tweaks to align the output more closely
+ * This is in essence a fork of {@link ESJsonLayout}, with tweaks to align the output more closely
  * with ECS. This will be removed in the next major release of ES.
  */
 @Plugin(name = "EcsJsonLayout", category = Node.CATEGORY, elementType = Layout.ELEMENT_TYPE, printObject = true)
 public class EcsJsonLayout extends AbstractStringLayout {
-    private static final String ECS_VERSION = "1.6";
+    private static final String ECS_VERSION = "1.7";
 
     private final PatternLayout patternLayout;
 
@@ -45,26 +46,33 @@ public class EcsJsonLayout extends AbstractStringLayout {
                                           .build();
     }
 
-    protected String pattern(String type, String[] esMessageFields) {
-        if (Strings.isEmpty(type)) {
-            throw new IllegalArgumentException("layout parameter 'type_name' cannot be empty");
+    protected String pattern(String dataset, String[] esMessageFields) {
+        if (Strings.isEmpty(dataset)) {
+            throw new IllegalArgumentException("layout parameter 'dataset' cannot be empty");
         }
         Map<String, Object> map = new LinkedHashMap<>();
-        map.put("type", inQuotes(type));
+        map.put("event.dataset", inQuotes(dataset));
         map.put("@timestamp", inQuotes("%d{yyyy-MM-dd'T'HH:mm:ss,SSSZZ}"));
-        map.put("level", inQuotes("%p"));
-        map.put("component", inQuotes("%c"));
-        map.put("cluster.name", inQuotes("${sys:es.logs.cluster_name}"));
-        map.put("node.name", inQuotes("%node_name"));
+        map.put("log.level", inQuotes("%p"));
+        map.put("log.logger", inQuotes("%c"));
+        map.put("elasticsearch.cluster.name", inQuotes("${sys:es.logs.cluster_name}"));
+        map.put("elasticsearch.cluster.uuid", inQuotes("%cluster_id"));
+        map.put("elasticsearch.node.id", inQuotes("%node_id"));
+        map.put("elasticsearch.node.name", inQuotes("%node_name"));
         map.put("message", inQuotes("%notEmpty{%enc{%marker}{JSON} }%enc{%.-10000m}{JSON}"));
         map.put("data_stream.type", inQuotes("logs"));
-        map.put("data_stream.dataset", inQuotes("deprecation.elasticsearch"));
+        map.put("data_stream.dataset", inQuotes("elasticsearch.deprecation"));
         map.put("data_stream.namespace", inQuotes("default"));
         map.put("ecs.version", inQuotes(ECS_VERSION));
 
+        Map<String, String> ecsKeyReplacements = new HashMap<>();
+        ecsKeyReplacements.put("x-opaque-id", "elasticsearch.http.request.x_opaque_id");
+        ecsKeyReplacements.put("key", "event.code");
+
         for (String key : esMessageFields) {
-            map.put(key, inQuotes("%ESMessageField{" + key + "}"));
+            map.put(ecsKeyReplacements.getOrDefault(key, key), inQuotes("%ESMessageField{" + key + "}"));
         }
+
         return createPattern(map, Stream.of(esMessageFields).collect(Collectors.toSet()));
     }
 
@@ -87,7 +95,6 @@ public class EcsJsonLayout extends AbstractStringLayout {
 
             separator = ", ";
         }
-        sb.append(notEmpty(", %node_and_cluster_id "));
         sb.append("%exceptionAsJson ");
         sb.append("}");
         sb.append(System.lineSeparator());
@@ -98,10 +105,6 @@ public class EcsJsonLayout extends AbstractStringLayout {
     private void appendField(StringBuilder sb, Map.Entry<String, Object> entry) {
         sb.append(jsonKey(entry.getKey()));
         sb.append(entry.getValue().toString());
-    }
-
-    private String notEmpty(String value) {
-        return "%notEmpty{" + value + "}";
     }
 
     private CharSequence jsonKey(String s) {
@@ -126,8 +129,8 @@ public class EcsJsonLayout extends AbstractStringLayout {
     public static class Builder<B extends EcsJsonLayout.Builder<B>> extends AbstractStringLayout.Builder<B>
         implements org.apache.logging.log4j.core.util.Builder<EcsJsonLayout> {
 
-        @PluginAttribute("type_name")
-        String type;
+        @PluginAttribute("dataset")
+        String dataset;
 
         @PluginAttribute(value = "charset", defaultString = "UTF-8")
         Charset charset;
@@ -142,7 +145,7 @@ public class EcsJsonLayout extends AbstractStringLayout {
         @Override
         public EcsJsonLayout build() {
             String[] split = Strings.isNullOrEmpty(esMessageFields) ? new String[]{} : esMessageFields.split(",");
-            return EcsJsonLayout.createLayout(type, charset, split);
+            return EcsJsonLayout.createLayout(dataset, charset, split);
         }
 
         public Charset getCharset() {
@@ -154,12 +157,12 @@ public class EcsJsonLayout extends AbstractStringLayout {
             return asBuilder();
         }
 
-        public String getType() {
-            return type;
+        public String getDataset() {
+            return dataset;
         }
 
-        public B setType(final String type) {
-            this.type = type;
+        public B setDataset(final String dataset) {
+            this.dataset = dataset;
             return asBuilder();
         }
 


### PR DESCRIPTION
Backport / reimplementation of #67266.

The JSON logs that Elasticsearch produces are roughly in an ECS shape. This PR improves
that alignment. Since `7.x` has it's own version of `EcsJsonLayout`, most of the changes are there, though I also had to backport `ClusterIdConverter` and `NodeIdConverter`.