### PR TITLE
Introduce repository UUIDs

### DIFF
--- a/docs/reference/snapshot-restore/apis/get-repo-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/get-repo-api.asciidoc
@@ -124,9 +124,11 @@ The API returns the following response:
 {
   "my_repository" : {
     "type" : "fs",
+    "uuid" : "0JLknrXbSUiVPuLakHjBrQ",
     "settings" : {
       "location" : "my_backup_location"
     }
   }
 }
 ----
+// TESTRESPONSE[s/"uuid" : "0JLknrXbSUiVPuLakHjBrQ"/"uuid" : $body.my_repository.uuid/]

--- a/docs/reference/snapshot-restore/register-repository.asciidoc
+++ b/docs/reference/snapshot-restore/register-repository.asciidoc
@@ -51,12 +51,14 @@ This request returns the following response:
 {
   "my_backup": {
     "type": "fs",
+    "uuid": "0JLknrXbSUiVPuLakHjBrQ",
     "settings": {
       "location": "my_backup_location"
     }
   }
 }
 -----------------------------------
+// TESTRESPONSE[s/"uuid": "0JLknrXbSUiVPuLakHjBrQ"/"uuid": $body.my_backup.uuid/]
 
 To retrieve information about multiple repositories, specify a comma-delimited
 list of repositories. You can also use a wildcard (`*`) when

--- a/plugins/repository-s3/src/internalClusterTest/java/org/elasticsearch/repositories/s3/S3BlobStoreRepositoryTests.java
+++ b/plugins/repository-s3/src/internalClusterTest/java/org/elasticsearch/repositories/s3/S3BlobStoreRepositoryTests.java
@@ -158,7 +158,7 @@ public class S3BlobStoreRepositoryTests extends ESMockAPIBasedRepositoryIntegTes
         final BlobStoreRepository repository = (BlobStoreRepository) repositoriesService.repository(repoName);
         final RepositoryData repositoryData = getRepositoryData(repository);
         final RepositoryData modifiedRepositoryData = repositoryData.withVersions(Collections.singletonMap(fakeOldSnapshot,
-            SnapshotsService.SHARD_GEN_IN_REPO_DATA_VERSION.minimumCompatibilityVersion()));
+            SnapshotsService.SHARD_GEN_IN_REPO_DATA_VERSION.minimumCompatibilityVersion())).withoutUuid();
         final BytesReference serialized = BytesReference.bytes(modifiedRepositoryData.snapshotsToXContent(XContentFactory.jsonBuilder(),
             SnapshotsService.OLD_SNAPSHOT_FORMAT));
         PlainActionFuture.get(f -> repository.threadPool().generic().execute(ActionRunnable.run(f, () ->

--- a/qa/repository-multi-version/src/test/java/org/elasticsearch/upgrades/MultiVersionRepositoryAccessIT.java
+++ b/qa/repository-multi-version/src/test/java/org/elasticsearch/upgrades/MultiVersionRepositoryAccessIT.java
@@ -218,7 +218,7 @@ public class MultiVersionRepositoryAccessIT extends ESRestTestCase {
                     ensureSnapshotRestoreWorks(repoName, "snapshot-2", shards);
                 }
             } else {
-                if (SnapshotsService.useIndexGenerations(minimumNodeVersion()) == false) {
+                if (SnapshotsService.includesRepositoryUuid(minimumNodeVersion()) == false) {
                     assertThat(TEST_STEP, is(TestStep.STEP3_OLD_CLUSTER));
                     final List<Class<? extends Exception>> expectedExceptions =
                         Arrays.asList(ResponseException.class, ElasticsearchStatusException.class);

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.get_repository/20_repository_uuid.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.get_repository/20_repository_uuid.yml
@@ -1,0 +1,72 @@
+---
+"Get repository returns UUID":
+  - skip:
+      version: " - 7.11.99"
+      reason:  repository UUIDs introduced in 7.12.0
+
+  - do:
+      snapshot.create_repository:
+        repository: test_repo_uuid_1
+        body:
+          type: fs
+          settings:
+            location: "test_repo_uuid_1_loc"
+
+  - do:
+      indices.create:
+        index: test_index
+        body:
+          settings:
+            number_of_shards:   1
+            number_of_replicas: 0
+
+  - do:
+      snapshot.create:
+        repository: test_repo_uuid_1
+        snapshot: test_snapshot
+        wait_for_completion: true
+
+  - do:
+      snapshot.get_repository: {}
+
+  - match: { test_repo_uuid_1.type: fs }
+  - is_true: test_repo_uuid_1.uuid
+  - set: { test_repo_uuid_1.uuid: repo_uuid }
+  - match: { test_repo_uuid_1.settings.location: "test_repo_uuid_1_loc" }
+  - is_false: test_repo_uuid_1.generation
+  - is_false: test_repo_uuid_1.pending_generation
+
+  - do:
+      snapshot.delete_repository:
+        repository: test_repo_uuid_1
+
+  - do:
+      snapshot.create_repository:
+        repository: test_repo_uuid_1_copy
+        body:
+          type: fs
+          settings:
+            location: "test_repo_uuid_1_loc"
+
+  - do:
+      snapshot.get_repository: {}
+
+  - match: { test_repo_uuid_1_copy.uuid: $repo_uuid }
+
+  - do:
+      snapshot.delete_repository:
+        repository: test_repo_uuid_1_copy
+
+  - do:
+      snapshot.create_repository:
+        repository: test_repo_uuid_1_ro
+        body:
+          type: fs
+          settings:
+            location: "test_repo_uuid_1_loc"
+            read_only: true
+
+  - do:
+      snapshot.get_repository: {}
+
+  - match: { test_repo_uuid_1_ro.uuid: $repo_uuid }

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/MultiClusterRepoAccessIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/MultiClusterRepoAccessIT.java
@@ -41,6 +41,8 @@ import java.util.function.Function;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
 
 public class MultiClusterRepoAccessIT extends AbstractSnapshotIntegTestCase {
 
@@ -83,8 +85,6 @@ public class MultiClusterRepoAccessIT extends AbstractSnapshotIntegTestCase {
 
         secondCluster.startMasterOnlyNode();
         secondCluster.startDataOnlyNode();
-        secondCluster.client().admin().cluster().preparePutRepository(repoNameOnSecondCluster).setType("fs")
-                .setSettings(Settings.builder().put("location", repoPath)).get();
 
         createIndexWithRandomDocs("test-idx-1", randomIntBetween(1, 100));
         createFullSnapshot(repoNameOnFirstCluster, "snap-1");
@@ -93,6 +93,8 @@ public class MultiClusterRepoAccessIT extends AbstractSnapshotIntegTestCase {
         createIndexWithRandomDocs("test-idx-3", randomIntBetween(1, 100));
         createFullSnapshot(repoNameOnFirstCluster, "snap-3");
 
+        secondCluster.client().admin().cluster().preparePutRepository(repoNameOnSecondCluster).setType("fs")
+                .setSettings(Settings.builder().put("location", repoPath)).get();
         secondCluster.client().admin().cluster().prepareDeleteSnapshot(repoNameOnSecondCluster, "snap-1").get();
         secondCluster.client().admin().cluster().prepareDeleteSnapshot(repoNameOnSecondCluster, "snap-2").get();
 
@@ -106,5 +108,39 @@ public class MultiClusterRepoAccessIT extends AbstractSnapshotIntegTestCase {
         assertAcked(client().admin().cluster().prepareDeleteRepository(repoNameOnFirstCluster).get());
         createRepository(repoNameOnFirstCluster, "fs", repoPath);
         createFullSnapshot(repoNameOnFirstCluster, "snap-5");
+    }
+
+    @SuppressWarnings("OptionalGetWithoutIsPresent") // we want it to throw if absent
+    public void testConcurrentWipeAndRecreateFromOtherCluster() throws InterruptedException, IOException {
+        internalCluster().startMasterOnlyNode();
+        internalCluster().startDataOnlyNode();
+        final String repoName = "test-repo";
+        createRepository(repoName, "fs", repoPath);
+
+        createIndexWithRandomDocs("test-idx-1", randomIntBetween(1, 100));
+        createFullSnapshot(repoName, "snap-1");
+        final String repoUuid = client().admin().cluster().prepareGetRepositories(repoName).get().repositories()
+                .stream().filter(r -> r.name().equals(repoName)).findFirst().get().uuid();
+
+        secondCluster.startMasterOnlyNode();
+        secondCluster.startDataOnlyNode();
+        assertAcked(secondCluster.client().admin().cluster().preparePutRepository(repoName)
+                .setType("fs")
+                .setSettings(Settings.builder().put("location", repoPath).put("read_only", true)));
+        assertThat(secondCluster.client().admin().cluster().prepareGetRepositories(repoName).get().repositories()
+                .stream().filter(r -> r.name().equals(repoName)).findFirst().get().uuid(), equalTo(repoUuid));
+
+        assertAcked(client().admin().cluster().prepareDeleteRepository(repoName));
+        IOUtils.rm(internalCluster().getCurrentMasterNodeInstance(Environment.class).resolveRepoFile(repoPath.toString()));
+        createRepository(repoName, "fs", repoPath);
+        createFullSnapshot(repoName, "snap-1");
+
+        final String newRepoUuid = client().admin().cluster().prepareGetRepositories(repoName).get().repositories()
+                .stream().filter(r -> r.name().equals(repoName)).findFirst().get().uuid();
+        assertThat(newRepoUuid, not(equalTo((repoUuid))));
+
+        secondCluster.client().admin().cluster().prepareGetSnapshots(repoName).get(); // force another read of the repo data
+        assertThat(secondCluster.client().admin().cluster().prepareGetRepositories(repoName).get().repositories()
+                .stream().filter(r -> r.name().equals(repoName)).findFirst().get().uuid(), equalTo(newRepoUuid));
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotStatusApisIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotStatusApisIT.java
@@ -267,7 +267,7 @@ public class SnapshotStatusApisIT extends AbstractSnapshotIntegTestCase {
 
     public void testSnapshotStatusOnFailedSnapshot() throws Exception {
         String repoName = "test-repo";
-        createRepository(repoName, "fs");
+        createRepositoryNoVerify(repoName, "fs"); // mustn't load the repository data before we inject the broken snapshot
         final String snapshot = "test-snap-1";
         addBwCFailedSnapshot(repoName, snapshot, Collections.emptyMap());
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/RepositoryMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/RepositoryMetadata.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.repositories.RepositoryData;
+import org.elasticsearch.snapshots.SnapshotsService;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -36,6 +37,7 @@ public class RepositoryMetadata implements Writeable {
     public static final Version REPO_GEN_IN_CS_VERSION = Version.V_7_6_0;
 
     private final String name;
+    private final String uuid;
     private final String type;
     private final Settings settings;
 
@@ -57,15 +59,16 @@ public class RepositoryMetadata implements Writeable {
      * @param settings repository settings
      */
     public RepositoryMetadata(String name, String type, Settings settings) {
-        this(name, type, settings, RepositoryData.UNKNOWN_REPO_GEN, RepositoryData.EMPTY_REPO_GEN);
+        this(name, RepositoryData.MISSING_UUID, type, settings, RepositoryData.UNKNOWN_REPO_GEN, RepositoryData.EMPTY_REPO_GEN);
     }
 
     public RepositoryMetadata(RepositoryMetadata metadata, long generation, long pendingGeneration) {
-        this(metadata.name, metadata.type, metadata.settings, generation, pendingGeneration);
+        this(metadata.name, metadata.uuid, metadata.type, metadata.settings, generation, pendingGeneration);
     }
 
-    public RepositoryMetadata(String name, String type, Settings settings, long generation, long pendingGeneration) {
+    public RepositoryMetadata(String name, String uuid, String type, Settings settings, long generation, long pendingGeneration) {
         this.name = name;
+        this.uuid = uuid;
         this.type = type;
         this.settings = settings;
         this.generation = generation;
@@ -90,6 +93,19 @@ public class RepositoryMetadata implements Writeable {
      */
     public String type() {
         return this.type;
+    }
+
+    /**
+     * Return the repository UUID, if set and known. The repository UUID is stored in the repository and typically populated here when the
+     * repository is registered or when we write to it. It may not be set if the repository is maintaining support for versions before
+     * {@link SnapshotsService#REPOSITORY_UUID_IN_REPO_DATA_VERSION}. It may not be known if the repository was registered with {@code
+     * ?verify=false} and has had no subsequent writes. Consumers may, if desired, try and fill in a missing value themselves by retrieving
+     * the {@link RepositoryData} and calling {@link org.elasticsearch.repositories.RepositoriesService#updateRepositoryUuidInMetadata}.
+     *
+     * @return repository UUID, or {@link RepositoryData#MISSING_UUID} if the UUID is not set or not known.
+     */
+    public String uuid() {
+        return this.uuid;
     }
 
     /**
@@ -127,6 +143,11 @@ public class RepositoryMetadata implements Writeable {
 
     public RepositoryMetadata(StreamInput in) throws IOException {
         name = in.readString();
+        if (in.getVersion().onOrAfter(SnapshotsService.REPOSITORY_UUID_IN_REPO_DATA_VERSION)) {
+            uuid = in.readString();
+        } else {
+            uuid = RepositoryData.MISSING_UUID;
+        }
         type = in.readString();
         settings = Settings.readSettingsFromStream(in);
         if (in.getVersion().onOrAfter(REPO_GEN_IN_CS_VERSION)) {
@@ -146,6 +167,9 @@ public class RepositoryMetadata implements Writeable {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(name);
+        if (out.getVersion().onOrAfter(SnapshotsService.REPOSITORY_UUID_IN_REPO_DATA_VERSION)) {
+            out.writeString(uuid);
+        }
         out.writeString(type);
         Settings.writeSettingsToStream(settings, out);
         if (out.getVersion().onOrAfter(REPO_GEN_IN_CS_VERSION)) {
@@ -161,7 +185,7 @@ public class RepositoryMetadata implements Writeable {
      * @return {@code true} if both instances equal in all fields but the generation fields
      */
     public boolean equalsIgnoreGenerations(RepositoryMetadata other) {
-        return name.equals(other.name) && type.equals(other.type()) && settings.equals(other.settings());
+        return name.equals(other.name) && uuid.equals(other.uuid()) && type.equals(other.type()) && settings.equals(other.settings());
     }
 
     @Override
@@ -172,6 +196,7 @@ public class RepositoryMetadata implements Writeable {
         RepositoryMetadata that = (RepositoryMetadata) o;
 
         if (!name.equals(that.name)) return false;
+        if (!uuid.equals(that.uuid)) return false;
         if (!type.equals(that.type)) return false;
         if (generation != that.generation) return false;
         if (pendingGeneration != that.pendingGeneration) return false;
@@ -180,11 +205,16 @@ public class RepositoryMetadata implements Writeable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, type, settings, generation, pendingGeneration);
+        return Objects.hash(name, uuid, type, settings, generation, pendingGeneration);
     }
 
     @Override
     public String toString() {
-        return "RepositoryMetadata{" + name + "}{" + type + "}{" + settings + "}{" + generation + "}{" + pendingGeneration + "}";
+        return "RepositoryMetadata{" + name + "}{" + uuid + "}{" + type + "}{" + settings + "}{"
+                + generation + "}{" + pendingGeneration + "}";
+    }
+
+    public RepositoryMetadata withUuid(String uuid) {
+        return new RepositoryMetadata(name, uuid, type, settings, generation, pendingGeneration);
     }
 }

--- a/server/src/main/java/org/elasticsearch/repositories/RepositoryData.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoryData.java
@@ -68,9 +68,15 @@ public final class RepositoryData {
     public static final long CORRUPTED_REPO_GEN = -3L;
 
     /**
+     * Sentinel value for the repository UUID indicating that it is not set.
+     */
+    public static final String MISSING_UUID = "_na_";
+
+    /**
      * An instance initialized for an empty repository.
      */
     public static final RepositoryData EMPTY = new RepositoryData(
+            MISSING_UUID,
             EMPTY_REPO_GEN,
             Collections.emptyMap(),
             Collections.emptyMap(),
@@ -79,6 +85,11 @@ public final class RepositoryData {
             Collections.emptyMap(),
             ShardGenerations.EMPTY,
             IndexMetaDataGenerations.EMPTY);
+
+    /**
+     * A UUID that identifies this repository.
+     */
+    private final String uuid;
 
     /**
      * The generational id of the index file from which the repository data was read.
@@ -114,6 +125,7 @@ public final class RepositoryData {
     private final ShardGenerations shardGenerations;
 
     public RepositoryData(
+            String uuid,
             long genId,
             Map<String, SnapshotId> snapshotIds,
             Map<String, SnapshotState> snapshotStates,
@@ -122,6 +134,7 @@ public final class RepositoryData {
             ShardGenerations shardGenerations,
             IndexMetaDataGenerations indexMetaDataGenerations) {
         this(
+                uuid,
                 genId,
                 Collections.unmodifiableMap(snapshotIds),
                 Collections.unmodifiableMap(snapshotStates),
@@ -134,6 +147,7 @@ public final class RepositoryData {
     }
 
     private RepositoryData(
+            String uuid,
             long genId,
             Map<String, SnapshotId> snapshotIds,
             Map<String, SnapshotState> snapshotStates,
@@ -142,6 +156,7 @@ public final class RepositoryData {
             Map<IndexId, List<SnapshotId>> indexSnapshots,
             ShardGenerations shardGenerations,
             IndexMetaDataGenerations indexMetaDataGenerations) {
+        this.uuid = Objects.requireNonNull(uuid);
         this.genId = genId;
         this.snapshotIds = snapshotIds;
         this.snapshotStates = snapshotStates;
@@ -158,6 +173,7 @@ public final class RepositoryData {
 
     protected RepositoryData copy() {
         return new RepositoryData(
+                uuid,
                 genId,
                 snapshotIds,
                 snapshotStates,
@@ -180,6 +196,7 @@ public final class RepositoryData {
         final Map<String, Version> newVersions = new HashMap<>(snapshotVersions);
         versions.forEach((id, version) -> newVersions.put(id.getUUID(), version));
         return new RepositoryData(
+                uuid,
                 genId,
                 snapshotIds,
                 snapshotStates,
@@ -192,6 +209,14 @@ public final class RepositoryData {
 
     public ShardGenerations shardGenerations() {
         return shardGenerations;
+    }
+
+    /**
+     * @return The UUID of this repository, or {@link RepositoryData#MISSING_UUID} if this repository has no UUID because it still
+     * supports access from versions earlier than {@link SnapshotsService#REPOSITORY_UUID_IN_REPO_DATA_VERSION}.
+     */
+    public String getUuid() {
+        return uuid;
     }
 
     /**
@@ -334,6 +359,7 @@ public final class RepositoryData {
         }
 
         return new RepositoryData(
+                uuid,
                 genId,
                 snapshots,
                 newSnapshotStates,
@@ -354,7 +380,42 @@ public final class RepositoryData {
             return this;
         }
         return new RepositoryData(
+                uuid,
                 newGeneration,
+                snapshotIds,
+                snapshotStates,
+                snapshotVersions,
+                indices,
+                indexSnapshots,
+                shardGenerations,
+                indexMetaDataGenerations);
+    }
+
+    /**
+     * Make a copy of this instance with the given UUID and all other fields unchanged.
+     */
+    public RepositoryData withUuid(String uuid) {
+        assert this.uuid.equals(MISSING_UUID) : this.uuid;
+        assert uuid.equals(MISSING_UUID) == false;
+        return new RepositoryData(
+                uuid,
+                genId,
+                snapshotIds,
+                snapshotStates,
+                snapshotVersions,
+                indices,
+                indexSnapshots,
+                shardGenerations,
+                indexMetaDataGenerations);
+    }
+
+    /**
+     * For test purposes, make a copy of this instance with the UUID removed and all other fields unchanged, as if from an older version.
+     */
+    public RepositoryData withoutUuid() {
+        return new RepositoryData(
+                MISSING_UUID,
+                genId,
                 snapshotIds,
                 snapshotStates,
                 snapshotVersions,
@@ -402,6 +463,7 @@ public final class RepositoryData {
         }
 
         return new RepositoryData(
+                uuid,
                 genId,
                 newSnapshotIds,
                 newSnapshotStates,
@@ -505,10 +567,24 @@ public final class RepositoryData {
      * Writes the snapshots metadata and the related indices metadata to x-content.
      */
     public XContentBuilder snapshotsToXContent(final XContentBuilder builder, final Version repoMetaVersion) throws IOException {
+        return snapshotsToXContent(builder, repoMetaVersion, false);
+    }
 
+    /**
+     * Writes the snapshots metadata and the related indices metadata to x-content.
+     * @param permitMissingUuid indicates whether we permit the repository UUID to be missing, e.g. we are serializing for the in-memory
+     *                          cache or running tests
+     */
+    public XContentBuilder snapshotsToXContent(
+            final XContentBuilder builder,
+            final Version repoMetaVersion,
+            boolean permitMissingUuid) throws IOException {
+
+        final boolean shouldWriteRepoUuid = SnapshotsService.includesRepositoryUuid(repoMetaVersion);
         final boolean shouldWriteIndexGens = SnapshotsService.useIndexGenerations(repoMetaVersion);
         final boolean shouldWriteShardGens = SnapshotsService.useShardGenerations(repoMetaVersion);
 
+        assert Boolean.compare(shouldWriteRepoUuid, shouldWriteIndexGens) <= 0;
         assert Boolean.compare(shouldWriteIndexGens, shouldWriteShardGens) <= 0;
 
         builder.startObject();
@@ -516,12 +592,24 @@ public final class RepositoryData {
         if (shouldWriteShardGens) {
             // Add min version field to make it impossible for older ES versions to deserialize this object
             final Version minVersion;
-            if (shouldWriteIndexGens) {
+            if (shouldWriteRepoUuid) {
+                minVersion = SnapshotsService.REPOSITORY_UUID_IN_REPO_DATA_VERSION;
+            } else if (shouldWriteIndexGens) {
                 minVersion = SnapshotsService.INDEX_GEN_IN_REPO_DATA_VERSION;
             } else {
                 minVersion = SnapshotsService.SHARD_GEN_IN_REPO_DATA_VERSION;
             }
             builder.field(MIN_VERSION, minVersion.toString());
+        }
+
+        if (shouldWriteRepoUuid) {
+            if (uuid.equals(MISSING_UUID)) {
+                assert permitMissingUuid : "missing uuid";
+            } else {
+                builder.field(UUID, uuid);
+            }
+        } else {
+            assert uuid.equals(MISSING_UUID) : "lost uuid " + uuid;
         }
 
         // write the snapshots list
@@ -606,6 +694,7 @@ public final class RepositoryData {
         final ShardGenerations.Builder shardGenerations = ShardGenerations.builder();
         final Map<SnapshotId, Map<String, String>> indexMetaLookup = new HashMap<>();
         Map<String, String> indexMetaIdentifiers = null;
+        String uuid = MISSING_UUID;
         while (parser.nextToken() == XContentParser.Token.FIELD_NAME) {
             final String field = parser.currentName();
             switch (field) {
@@ -628,6 +717,11 @@ public final class RepositoryData {
                                 "this snapshot repository format requires Elasticsearch version [" + version + "] or later");
                     }
                     break;
+                case UUID:
+                    XContentParserUtils.ensureExpectedToken(XContentParser.Token.VALUE_STRING, parser.nextToken(), parser);
+                    uuid = parser.text();
+                    assert uuid.equals(MISSING_UUID) == false;
+                    break;
                 default:
                     XContentParserUtils.throwUnknownField(field, parser.getTokenLocation());
             }
@@ -637,6 +731,7 @@ public final class RepositoryData {
         XContentParserUtils.ensureExpectedToken(null, parser.nextToken(), parser);
 
         return new RepositoryData(
+                uuid,
                 genId,
                 snapshots,
                 snapshotStates,

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -40,6 +40,7 @@ import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.StepListener;
 import org.elasticsearch.action.support.GroupedActionListener;
 import org.elasticsearch.action.support.PlainListenableActionFuture;
+import org.elasticsearch.action.support.ThreadedActionListener;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.RepositoryCleanupInProgress;
@@ -103,6 +104,7 @@ import org.elasticsearch.indices.recovery.RecoverySettings;
 import org.elasticsearch.indices.recovery.RecoveryState;
 import org.elasticsearch.repositories.IndexId;
 import org.elasticsearch.repositories.IndexMetaDataGenerations;
+import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.repositories.Repository;
 import org.elasticsearch.repositories.RepositoryCleanupResult;
 import org.elasticsearch.repositories.RepositoryData;
@@ -147,6 +149,7 @@ import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
 import static org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot.FileInfo.canonicalName;
+import static org.elasticsearch.repositories.RepositoryData.MISSING_UUID;
 
 /**
  * BlobStore - based implementation of Snapshot Repository
@@ -1504,21 +1507,34 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
             }
             try {
                 final CachedRepositoryData cached = latestKnownRepositoryData.get();
-                final RepositoryData loaded;
                 // Caching is not used with #bestEffortConsistency see docs on #cacheRepositoryData for details
                 if (bestEffortConsistency == false && cached.generation() == genToLoad && cached.hasData()) {
-                    loaded = cached.repositoryData();
+                    listener.onResponse(cached.repositoryData());
                 } else {
-                    loaded = getRepositoryData(genToLoad);
+                    final RepositoryData loaded = getRepositoryData(genToLoad);
                     if (cached == null || cached.generation() < genToLoad) {
                         // We can cache serialized in the most recent version here without regard to the actual repository metadata version
                         // since we're only caching the information that we just wrote and thus won't accidentally cache any information
                         // that isn't safe
                         cacheRepositoryData(compressRepoDataForCache(BytesReference.bytes(
-                                loaded.snapshotsToXContent(XContentFactory.jsonBuilder(), Version.CURRENT))), genToLoad);
+                                loaded.snapshotsToXContent(XContentFactory.jsonBuilder(), Version.CURRENT, true))), genToLoad);
+                    }
+                    if (loaded.getUuid().equals(metadata.uuid())) {
+                        listener.onResponse(loaded);
+                    } else {
+                        // someone switched the repo contents out from under us
+                        RepositoriesService.updateRepositoryUuidInMetadata(
+                                clusterService,
+                                metadata.name(),
+                                loaded,
+                                new ThreadedActionListener<>(
+                                        logger,
+                                        threadPool,
+                                        ThreadPool.Names.GENERIC,
+                                        listener.map(v -> loaded),
+                                        false));
                     }
                 }
-                listener.onResponse(loaded);
                 return;
             } catch (RepositoryException e) {
                 // If the generation to load changed concurrently and we didn't just try loading the same generation before we retry
@@ -1796,7 +1812,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         })), listener::onFailure);
         filterRepositoryDataStep.whenComplete(filteredRepositoryData -> {
             final long newGen = setPendingStep.result();
-            final RepositoryData newRepositoryData = filteredRepositoryData.withGenId(newGen);
+            final RepositoryData newRepositoryData = updateRepositoryData(filteredRepositoryData, version, newGen);
             if (latestKnownRepoGen.get() >= newGen) {
                 throw new IllegalArgumentException(
                     "Tried writing generation [" + newGen + "] but repository is at least at generation [" + latestKnownRepoGen.get()
@@ -1834,10 +1850,14 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                                 "Tried to update from unexpected pending repo generation [" + meta.pendingGeneration() +
                                     "] after write to generation [" + newGen + "]");
                         }
-                        return updateRepositoryGenerationsIfNecessary(stateFilter.apply(ClusterState.builder(currentState)
-                                .metadata(Metadata.builder(currentState.getMetadata()).putCustom(RepositoriesMetadata.TYPE,
-                                        currentState.metadata().<RepositoriesMetadata>custom(RepositoriesMetadata.TYPE)
-                                                .withUpdatedGeneration(metadata.name(), newGen, newGen))).build()), expectedGen, newGen);
+                        final RepositoriesMetadata currentMetadata = currentState.metadata().custom(RepositoriesMetadata.TYPE);
+                        final RepositoriesMetadata withGenerations = currentMetadata.withUpdatedGeneration(metadata.name(), newGen, newGen);
+                        final RepositoriesMetadata withUuid = meta.uuid().equals(newRepositoryData.getUuid())
+                                ? withGenerations
+                                : withGenerations.withUuid(metadata.name(), newRepositoryData.getUuid());
+                        final ClusterState newClusterState = stateFilter.apply(ClusterState.builder(currentState).metadata(
+                                Metadata.builder(currentState.getMetadata()).putCustom(RepositoriesMetadata.TYPE, withUuid)).build());
+                        return updateRepositoryGenerationsIfNecessary(newClusterState, expectedGen, newGen);
                     }
 
                     @Override
@@ -1868,6 +1888,14 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                     }
                 });
         }, listener::onFailure);
+    }
+
+    private RepositoryData updateRepositoryData(RepositoryData repositoryData, Version repositoryMetaversion, long newGen) {
+        if (SnapshotsService.includesRepositoryUuid(repositoryMetaversion) && repositoryData.getUuid().equals(MISSING_UUID)) {
+            return repositoryData.withGenId(newGen).withUuid(UUIDs.randomBase64UUID());
+        } else {
+            return repositoryData.withGenId(newGen);
+        }
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -139,6 +139,8 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
 
     public static final Version INDEX_GEN_IN_REPO_DATA_VERSION = Version.V_7_9_0;
 
+    public static final Version REPOSITORY_UUID_IN_REPO_DATA_VERSION = Version.V_7_12_0;
+
     public static final Version OLD_SNAPSHOT_FORMAT = Version.V_7_5_0;
 
     public static final Version MULTI_DELETE_VERSION = Version.V_7_8_0;
@@ -2294,6 +2296,16 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
      */
     public static boolean useIndexGenerations(Version repositoryMetaVersion) {
         return repositoryMetaVersion.onOrAfter(INDEX_GEN_IN_REPO_DATA_VERSION);
+    }
+
+    /**
+     * Checks whether the metadata version supports writing {@link ShardGenerations} to the repository.
+     *
+     * @param repositoryMetaVersion version to check
+     * @return true if version supports {@link ShardGenerations}
+     */
+    public static boolean includesRepositoryUuid(Version repositoryMetaVersion) {
+        return repositoryMetaVersion.onOrAfter(REPOSITORY_UUID_IN_REPO_DATA_VERSION);
     }
 
     /** Deletes snapshot from repository

--- a/server/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryTests.java
@@ -258,6 +258,7 @@ public class BlobStoreRepositoryTests extends ESSingleNodeTestCase {
             client.admin().cluster().preparePutRepository(repositoryName)
                                     .setType(REPO_TYPE)
                                     .setSettings(Settings.builder().put(node().settings()).put("location", location))
+                                    .setVerify(false) // prevent eager reading of repo data
                                     .get();
         assertThat(putRepositoryResponse.isAcknowledged(), equalTo(true));
 

--- a/server/src/test/java/org/elasticsearch/snapshots/RepositoriesMetadataSerializationTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/RepositoriesMetadataSerializationTests.java
@@ -44,8 +44,13 @@ public class RepositoriesMetadataSerializationTests extends AbstractDiffableSeri
         for (int i = 0; i < numberOfRepositories; i++) {
             // divide by 2 to not overflow when adding to this number for the pending generation below
             final long generation = randomNonNegativeLong() / 2L;
-            entries.add(new RepositoryMetadata(randomAlphaOfLength(10), randomAlphaOfLength(10), randomSettings(), generation,
-                generation + randomLongBetween(0, generation)));
+            entries.add(new RepositoryMetadata(
+                    randomAlphaOfLength(10),
+                    randomAlphaOfLength(10),
+                    randomAlphaOfLength(10),
+                    randomSettings(),
+                    generation,
+                    generation + randomLongBetween(0, generation)));
         }
         entries.sort(Comparator.comparing(RepositoryMetadata::name));
         return new RepositoriesMetadata(entries);

--- a/test/framework/src/main/java/org/elasticsearch/index/shard/RestoreOnlyRepository.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/shard/RestoreOnlyRepository.java
@@ -49,6 +49,7 @@ import java.util.function.Function;
 
 import static java.util.Collections.emptyList;
 import static org.elasticsearch.repositories.RepositoryData.EMPTY_REPO_GEN;
+import static org.elasticsearch.repositories.RepositoryData.MISSING_UUID;
 
 /** A dummy repository for testing which just needs restore overridden */
 public abstract class RestoreOnlyRepository extends AbstractLifecycleComponent implements Repository {
@@ -94,6 +95,7 @@ public abstract class RestoreOnlyRepository extends AbstractLifecycleComponent i
     public void getRepositoryData(ActionListener<RepositoryData> listener) {
         final IndexId indexId = new IndexId(indexName, "blah");
         listener.onResponse(new RepositoryData(
+                MISSING_UUID,
                 EMPTY_REPO_GEN,
                 Collections.emptyMap(),
                 Collections.emptyMap(),

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
@@ -106,6 +106,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.index.seqno.RetentionLeaseActions.RETAIN_ALL;
+import static org.elasticsearch.repositories.RepositoryData.MISSING_UUID;
 import static org.elasticsearch.xpack.ccr.CcrRetentionLeases.retentionLeaseId;
 import static org.elasticsearch.xpack.ccr.CcrRetentionLeases.syncAddRetentionLease;
 import static org.elasticsearch.xpack.ccr.CcrRetentionLeases.syncRenewRetentionLease;
@@ -261,6 +262,7 @@ public class CcrRepository extends AbstractLifecycleComponent implements Reposit
                 indexSnapshots.put(new IndexId(indexName, index.getUUID()), Collections.singletonList(snapshotId));
             }
             return new RepositoryData(
+                    MISSING_UUID,
                     1,
                     copiedSnapshotIds,
                     snapshotStates,

--- a/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/slm/SLMSnapshotBlockingIntegTests.java
+++ b/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/slm/SLMSnapshotBlockingIntegTests.java
@@ -295,7 +295,7 @@ public class SLMSnapshotBlockingIntegTests extends AbstractSnapshotIntegTestCase
         final SnapshotState expectedUnsuccessfulState = partialSuccess ? SnapshotState.PARTIAL : SnapshotState.FAILED;
         // Setup
         createAndPopulateIndex(indexName);
-        createRepository(REPO, "mock");
+        createRepositoryNoVerify(REPO, "mock");
 
         createSnapshotPolicy(policyId, "snap", NEVER_EXECUTE_CRON_SCHEDULE, REPO, indexName, true,
             partialSuccess, new SnapshotRetentionConfiguration(null, 1, 2));

--- a/x-pack/plugin/repository-encrypted/src/internalClusterTest/java/org/elasticsearch/repositories/encrypted/EncryptedFSBlobStoreRepositoryIntegTests.java
+++ b/x-pack/plugin/repository-encrypted/src/internalClusterTest/java/org/elasticsearch/repositories/encrypted/EncryptedFSBlobStoreRepositoryIntegTests.java
@@ -115,7 +115,6 @@ public final class EncryptedFSBlobStoreRepositoryIntegTests extends ESFsBasedRep
         client().admin().cluster().prepareCreateSnapshot(repoName, snapshotName).setWaitForCompletion(true).setIndices("other*").get();
 
         assertAcked(client().admin().cluster().prepareDeleteRepository(repoName));
-        createRepository(repoName, Settings.builder().put(repoSettings).put("readonly", randomBoolean()).build(), randomBoolean());
 
         try (Stream<Path> rootContents = Files.list(repoPath.resolve(EncryptedRepository.DEK_ROOT_CONTAINER))) {
             // tamper all DEKs
@@ -136,22 +135,40 @@ public final class EncryptedFSBlobStoreRepositoryIntegTests extends ESFsBasedRep
                     throw new UncheckedIOException(e);
                 }
             });
-            final BlobStoreRepository blobStoreRepository = (BlobStoreRepository) internalCluster().getCurrentMasterNodeInstance(
-                RepositoriesService.class
-            ).repository(repoName);
-            RepositoryException e = expectThrows(
+        }
+
+        final Settings settings = Settings.builder().put(repoSettings).put("readonly", randomBoolean()).build();
+        final boolean verifyOnCreate = randomBoolean();
+
+        if (verifyOnCreate) {
+            assertThat(
+                expectThrows(RepositoryException.class, () -> createRepository(repoName, settings, true)).getMessage(),
+                containsString("the encryption metadata in the repository has been corrupted")
+            );
+            // it still creates the repository even if verification failed
+        } else {
+            createRepository(repoName, settings, false);
+        }
+
+        final BlobStoreRepository blobStoreRepository = (BlobStoreRepository) internalCluster().getCurrentMasterNodeInstance(
+            RepositoriesService.class
+        ).repository(repoName);
+        assertThat(
+            expectThrows(
                 RepositoryException.class,
                 () -> PlainActionFuture.<RepositoryData, Exception>get(
                     f -> blobStoreRepository.threadPool().generic().execute(ActionRunnable.wrap(f, blobStoreRepository::getRepositoryData))
                 )
-            );
-            assertThat(e.getMessage(), containsString("the encryption metadata in the repository has been corrupted"));
-            e = expectThrows(
+            ).getMessage(),
+            containsString("the encryption metadata in the repository has been corrupted")
+        );
+        assertThat(
+            expectThrows(
                 RepositoryException.class,
                 () -> client().admin().cluster().prepareRestoreSnapshot(repoName, snapshotName).setWaitForCompletion(true).get()
-            );
-            assertThat(e.getMessage(), containsString("the encryption metadata in the repository has been corrupted"));
-        }
+            ).getMessage(),
+            containsString("the encryption metadata in the repository has been corrupted")
+        );
     }
 
 }


### PR DESCRIPTION
Today a snapshot repository does not have a well-defined identity. It
can be reregistered with a different cluster under a different name, and
can even be registered with multiple clusters in readonly mode.

This presents problems for cases where we need to refer to a specific
snapshot in a globally-unique fashion. Today we rely on the repository
being registered under the same name on every cluster, but this is not a
safe assumption.

This commit adds a UUID that can be used to uniquely identify a
repository. The UUID is stored in the top-level index blob, represented
by `RepositoryData`, and is also usually copied into the
`RepositoryMetadata` that represents the repository in the cluster
state. The repository UUID is exposed in the get-repositories API; other
more meaningful consumers will be added in due course.

Backport of #67829