### PR TITLE
SQL: Fix elasticsearch-sql-cli under docker (#67737)

### DIFF
--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/SqlCliTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/SqlCliTests.java
@@ -24,14 +24,12 @@ import org.elasticsearch.packaging.util.Shell;
 import org.junit.Before;
 
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
 
 public class SqlCliTests extends PackagingTestCase {
     @Before
     public void filterDistros() {
         assumeTrue("only default distro", distribution.flavor == Distribution.Flavor.DEFAULT);
-        assumeFalse("no docker", distribution.isDocker());
     }
 
     public void test010Install() throws Exception {

--- a/x-pack/plugin/sql/src/main/bin/elasticsearch-sql-cli
+++ b/x-pack/plugin/sql/src/main/bin/elasticsearch-sql-cli
@@ -4,6 +4,8 @@
 # or more contributor license agreements. Licensed under the Elastic License;
 # you may not use this file except in compliance with the Elastic License.
 
+CLI_PARAMETERS="$@"
+
 source "`dirname "$0"`"/elasticsearch-env
 
 source "$ES_HOME"/bin/x-pack-env
@@ -14,4 +16,4 @@ exec \
   "$JAVA" \
   "$XSHARE" \
   -jar "$CLI_JAR" \
-  "$@"
+  $CLI_PARAMETERS


### PR DESCRIPTION
Calling `./bin/elasticsearch-sql-cli http://localhost:9200`under
docker failed with `ERROR: E is not a recognized option` error
message.

The root cause is that under docker the environmental variables are
automatically appended to the arguments of the sql cli. `"$@"` will
contain `-Evar=value` strings added by the `elasticsearch-env`
(line 122). This change uses the original argument list (saves it
before it is modified) when the sql cli is called.

Fixes #57744

(cherry-pick from 4b36ab9ca21915bd172dffe3a09d96bd065f7d23)