### PR TITLE
[7.x] [DOCS] Fix metric requirements in rollup V2 API docs (#67922)

### DIFF
--- a/docs/reference/rollup/apis/rollup-api.asciidoc
+++ b/docs/reference/rollup/apis/rollup-api.asciidoc
@@ -154,19 +154,19 @@ increase the size of the resulting rollup index.
 =====
 
 `metrics`::
-(Optional, array of objects)
-Collects and stores metrics for <<number,numeric>> fields.
+(Required, array of objects)
+Collects and stores metrics for <<number,numeric>> fields. You must specify at
+least one `metrics` object.
 +
 .Properties of `metrics` objects
 [%collapsible%open]
 =====
 `field`::
-(Required*, string)
-<<number,Numeric>> field to collect metrics for. If you specify a `metrics`
-object, this property is required.
+(Required, string)
+<<number,Numeric>> field to collect metrics for.
 
 `metrics`::
-(Required*, array of strings)
+(Required, array of strings)
 Array of metrics to collect. Each value corresponds to a
 <<search-aggregations-metrics,metric aggregation>>. Valid values are
 <<search-aggregations-metrics-min-aggregation,`min`>>,
@@ -174,8 +174,7 @@ Array of metrics to collect. Each value corresponds to a
 <<search-aggregations-metrics-sum-aggregation,`sum`>>,
 <<search-aggregations-metrics-avg-aggregation,`avg`>>, and
 <<search-aggregations-metrics-valuecount-aggregation,`value_count`>>. You must
-specify at least one value. If you specify a `metrics` object, this property is
-required.
+specify at least one value.
 +
 NOTE: The rollup index stores these metrics in an
 <<aggregate-metric-double,`aggregate_metric_double`>> field. The `avg` metric


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Fix metric requirements in rollup V2 API docs (#67922)