### PR TITLE
Temporarily suppress BWC snapshot tests

### DIFF
--- a/qa/mixed-cluster/src/test/java/org/elasticsearch/backwards/IndexingIT.java
+++ b/qa/mixed-cluster/src/test/java/org/elasticsearch/backwards/IndexingIT.java
@@ -232,6 +232,7 @@ public class IndexingIT extends ESRestTestCase {
         }
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/pull/67829") // backporting
     public void testUpdateSnapshotStatus() throws Exception {
         Nodes nodes = buildNodeAndVersions();
         assumeFalse("new nodes is empty", nodes.getNewNodes().isEmpty());

--- a/qa/repository-multi-version/src/test/java/org/elasticsearch/upgrades/MultiVersionRepositoryAccessIT.java
+++ b/qa/repository-multi-version/src/test/java/org/elasticsearch/upgrades/MultiVersionRepositoryAccessIT.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.upgrades;
 
+import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.admin.cluster.repositories.put.PutRepositoryRequest;
 import org.elasticsearch.action.admin.cluster.snapshots.delete.DeleteSnapshotRequest;
@@ -63,6 +64,7 @@ import static org.hamcrest.Matchers.is;
  *     <li>Run against the current version cluster from the second step: {@link TestStep#STEP4_NEW_CLUSTER}</li>
  * </ul>
  */
+@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/pull/67829") // backporting
 public class MultiVersionRepositoryAccessIT extends ESRestTestCase {
 
     private enum TestStep {

--- a/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/10_basic.yml
+++ b/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/10_basic.yml
@@ -13,10 +13,11 @@
 
 ---
 "Verify custom cluster metadata still exists during upgrade":
-  - do:
-      snapshot.get_repository:
-        repository: my_repo
-  - is_true: my_repo
+# Skipping this for backport of #67829
+#  - do:
+#      snapshot.get_repository:
+#        repository: my_repo
+#  - is_true: my_repo
 
   - do:
       ingest.get_pipeline:

--- a/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/10_basic.yml
+++ b/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/10_basic.yml
@@ -1,14 +1,15 @@
 ---
 "Create things in the cluster state that we'll validate are there after the upgrade":
-  - do:
-      snapshot.create_repository:
-        repository: my_repo
-        verify: false
-        body:
-          type: url
-          settings:
-            url: "http://snapshot.test"
-  - match: { "acknowledged": true }
+# Skipping this for backport of #67829
+#  - do:
+#      snapshot.create_repository:
+#        repository: my_repo
+#        verify: false
+#        body:
+#          type: url
+#          settings:
+#            url: "http://snapshot.test"
+#  - match: { "acknowledged": true }
 
   - do:
       ingest.put_pipeline:

--- a/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/10_basic.yml
+++ b/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/10_basic.yml
@@ -13,10 +13,11 @@
 
 ---
 "Verify custom cluster metadata still exists after rolling upgrade":
-  - do:
-      snapshot.get_repository:
-        repository: my_repo
-  - is_true: my_repo
+# Skipping this for backport of #67829
+#  - do:
+#      snapshot.get_repository:
+#        repository: my_repo
+#  - is_true: my_repo
 
   - do:
       ingest.get_pipeline:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.repositories/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.repositories/10_basic.yml
@@ -11,6 +11,9 @@
                $/
 ---
 "Test cat repositories output":
+  - skip:
+      version: " - 7.99.99"
+      reason:  "backporting #67829"
 
   - do:
       cat.repositories: {}
@@ -46,6 +49,10 @@
 
 ---
 "Test cat repositories sort":
+  - skip:
+      version: " - 7.99.99"
+      reason:  "backporting #67829"
+
   - do:
       snapshot.create_repository:
         repository: test_cat_repo_1

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.clone/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.clone/10_basic.yml
@@ -1,5 +1,8 @@
 ---
 setup:
+  - skip:
+      version: " - 7.99.99"
+      reason:  "backporting #67829"
 
   - do:
       snapshot.create_repository:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.create/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.create/10_basic.yml
@@ -1,5 +1,8 @@
 ---
 setup:
+  - skip:
+      version: " - 7.99.99"
+      reason:  "backporting #67829"
 
   - do:
       snapshot.create_repository:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.get/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.get/10_basic.yml
@@ -1,5 +1,8 @@
 ---
 setup:
+  - skip:
+      version: " - 7.99.99"
+      reason:  "backporting #67829"
 
   - do:
       snapshot.create_repository:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.get_repository/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.get_repository/10_basic.yml
@@ -1,5 +1,8 @@
 ---
 setup:
+  - skip:
+      version: " - 7.99.99"
+      reason:  "backporting #67829"
 
   - do:
       snapshot.create_repository:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.get_repository/20_repository_uuid.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.get_repository/20_repository_uuid.yml
@@ -2,7 +2,7 @@
 "Get repository returns UUID":
   - skip:
       version: " - 7.99.99"
-      reason:  repository UUIDs introduced in 8.0.0
+      reason:  "backporting #67829"
 
   - do:
       snapshot.create_repository:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.restore/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.restore/10_basic.yml
@@ -1,5 +1,8 @@
 ---
 setup:
+  - skip:
+      version: " - 7.99.99"
+      reason:  "backporting #67829"
 
   - do:
       snapshot.create_repository:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.status/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.status/10_basic.yml
@@ -1,5 +1,8 @@
 ---
 setup:
+  - skip:
+      version: " - 7.99.99"
+      reason:  "backporting #67829"
 
   - do:
       snapshot.create_repository:

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -132,7 +132,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
 
     public static final Version INDEX_GEN_IN_REPO_DATA_VERSION = Version.V_7_9_0;
 
-    public static final Version REPOSITORY_UUID_IN_REPO_DATA_VERSION = Version.V_8_0_0; // TODO adjust after backport
+    public static final Version REPOSITORY_UUID_IN_REPO_DATA_VERSION = Version.V_7_12_0;
 
     public static final Version OLD_SNAPSHOT_FORMAT = Version.V_7_5_0;
 


### PR DESCRIPTION
This commit suppresses any BWC tests related to snapshots in `master` so
that #67899 can be merged to `7.x`. It will mostly be reverted after the
merge of #67899 is complete.

Relates #66431
