### PR TITLE
Reinstate BWC snapshot tests

### DIFF
--- a/qa/mixed-cluster/src/test/java/org/elasticsearch/backwards/IndexingIT.java
+++ b/qa/mixed-cluster/src/test/java/org/elasticsearch/backwards/IndexingIT.java
@@ -232,7 +232,6 @@ public class IndexingIT extends ESRestTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/pull/67829") // backporting
     public void testUpdateSnapshotStatus() throws Exception {
         Nodes nodes = buildNodeAndVersions();
         assumeFalse("new nodes is empty", nodes.getNewNodes().isEmpty());

--- a/qa/repository-multi-version/src/test/java/org/elasticsearch/upgrades/MultiVersionRepositoryAccessIT.java
+++ b/qa/repository-multi-version/src/test/java/org/elasticsearch/upgrades/MultiVersionRepositoryAccessIT.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.upgrades;
 
-import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.admin.cluster.repositories.put.PutRepositoryRequest;
 import org.elasticsearch.action.admin.cluster.snapshots.delete.DeleteSnapshotRequest;
@@ -64,7 +63,6 @@ import static org.hamcrest.Matchers.is;
  *     <li>Run against the current version cluster from the second step: {@link TestStep#STEP4_NEW_CLUSTER}</li>
  * </ul>
  */
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/pull/67829") // backporting
 public class MultiVersionRepositoryAccessIT extends ESRestTestCase {
 
     private enum TestStep {

--- a/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/10_basic.yml
+++ b/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/10_basic.yml
@@ -13,11 +13,10 @@
 
 ---
 "Verify custom cluster metadata still exists during upgrade":
-# Skipping this for backport of #67829
-#  - do:
-#      snapshot.get_repository:
-#        repository: my_repo
-#  - is_true: my_repo
+  - do:
+      snapshot.get_repository:
+        repository: my_repo
+  - is_true: my_repo
 
   - do:
       ingest.get_pipeline:

--- a/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/10_basic.yml
+++ b/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/10_basic.yml
@@ -1,15 +1,14 @@
 ---
 "Create things in the cluster state that we'll validate are there after the upgrade":
-# Skipping this for backport of #67829
-#  - do:
-#      snapshot.create_repository:
-#        repository: my_repo
-#        verify: false
-#        body:
-#          type: url
-#          settings:
-#            url: "http://snapshot.test"
-#  - match: { "acknowledged": true }
+  - do:
+      snapshot.create_repository:
+        repository: my_repo
+        verify: false
+        body:
+          type: url
+          settings:
+            url: "http://snapshot.test"
+  - match: { "acknowledged": true }
 
   - do:
       ingest.put_pipeline:

--- a/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/10_basic.yml
+++ b/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/10_basic.yml
@@ -13,11 +13,10 @@
 
 ---
 "Verify custom cluster metadata still exists after rolling upgrade":
-# Skipping this for backport of #67829
-#  - do:
-#      snapshot.get_repository:
-#        repository: my_repo
-#  - is_true: my_repo
+  - do:
+      snapshot.get_repository:
+        repository: my_repo
+  - is_true: my_repo
 
   - do:
       ingest.get_pipeline:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.repositories/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.repositories/10_basic.yml
@@ -11,9 +11,6 @@
                $/
 ---
 "Test cat repositories output":
-  - skip:
-      version: " - 7.99.99"
-      reason:  "backporting #67829"
 
   - do:
       cat.repositories: {}
@@ -49,10 +46,6 @@
 
 ---
 "Test cat repositories sort":
-  - skip:
-      version: " - 7.99.99"
-      reason:  "backporting #67829"
-
   - do:
       snapshot.create_repository:
         repository: test_cat_repo_1

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.clone/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.clone/10_basic.yml
@@ -1,8 +1,5 @@
 ---
 setup:
-  - skip:
-      version: " - 7.99.99"
-      reason:  "backporting #67829"
 
   - do:
       snapshot.create_repository:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.create/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.create/10_basic.yml
@@ -1,8 +1,5 @@
 ---
 setup:
-  - skip:
-      version: " - 7.99.99"
-      reason:  "backporting #67829"
 
   - do:
       snapshot.create_repository:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.get/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.get/10_basic.yml
@@ -1,8 +1,5 @@
 ---
 setup:
-  - skip:
-      version: " - 7.99.99"
-      reason:  "backporting #67829"
 
   - do:
       snapshot.create_repository:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.get_repository/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.get_repository/10_basic.yml
@@ -1,8 +1,5 @@
 ---
 setup:
-  - skip:
-      version: " - 7.99.99"
-      reason:  "backporting #67829"
 
   - do:
       snapshot.create_repository:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.get_repository/20_repository_uuid.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.get_repository/20_repository_uuid.yml
@@ -1,8 +1,8 @@
 ---
 "Get repository returns UUID":
   - skip:
-      version: " - 7.99.99"
-      reason:  "backporting #67829"
+      version: " - 7.12.99"
+      reason:  repository UUIDs introduced in 7.12.0
 
   - do:
       snapshot.create_repository:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.restore/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.restore/10_basic.yml
@@ -1,8 +1,5 @@
 ---
 setup:
-  - skip:
-      version: " - 7.99.99"
-      reason:  "backporting #67829"
 
   - do:
       snapshot.create_repository:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.status/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.status/10_basic.yml
@@ -1,8 +1,5 @@
 ---
 setup:
-  - skip:
-      version: " - 7.99.99"
-      reason:  "backporting #67829"
 
   - do:
       snapshot.create_repository:


### PR DESCRIPTION
This commit mostly reverts #67934, except for the change to the version
constant `REPOSITORY_UUID_IN_REPO_DATA_VERSION`.

Completes the backport of #67829 via #67899