### PR TITLE
[DOCS] Add security privileges to API docs

### DIFF
--- a/docs/reference/indices/apis/reload-analyzers.asciidoc
+++ b/docs/reference/indices/apis/reload-analyzers.asciidoc
@@ -29,6 +29,13 @@ IMPORTANT: After reloading the search analyzers you should clear the request
 
 `GET /<target>/_reload_search_analyzers`
 
+[discrete]
+[[indices-reload-analyzers-api-prereqs]]
+=== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `manage`
+<<privileges-list-indices,index privilege>> for the target data stream, index,
+or index alias.
 
 [discrete]
 [[indices-reload-analyzers-api-desc]]

--- a/docs/reference/migration/apis/deprecation.asciidoc
+++ b/docs/reference/migration/apis/deprecation.asciidoc
@@ -22,6 +22,12 @@ be removed or changed in the next major version.
 
 `GET /<target>/_migration/deprecations`
 
+[[migration-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `manage`
+<<privileges-list-cluster,cluster privilege>> to use this API.
+
 [[migration-api-path-params]]
 ==== {api-path-parms-title}
 

--- a/docs/reference/rest-api/info.asciidoc
+++ b/docs/reference/rest-api/info.asciidoc
@@ -12,6 +12,13 @@ Provides general information about the installed {xpack} features.
 `GET /_xpack`
 
 [discrete]
+[[info-api-prereqs]]
+=== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `monitor` or
+`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
+
+[discrete]
 [[info-api-desc]]
 === {api-description-title}
 

--- a/docs/reference/rest-api/usage.asciidoc
+++ b/docs/reference/rest-api/usage.asciidoc
@@ -12,6 +12,13 @@ Provides usage information about the installed {xpack} features.
 `GET /_xpack/usage`
 
 [discrete]
+[[usage-api-prereqs]]
+=== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `monitor` or
+`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
+
+[discrete]
 [[usage-api-desc]]
 === {api-description-title}
 


### PR DESCRIPTION
Updates several API docs to note required security privileges.

Relates to #66212

### Preview
- Reload search analyzers API: https://elasticsearch_67939.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/indices-reload-analyzers.html
- Info API: https://elasticsearch_67939.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/info-api.html
- Deprecation info API: https://elasticsearch_67939.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/migration-api-deprecation.html
- Usage API: https://elasticsearch_67939.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/usage-api.html