### PR TITLE
[Fleet] Allow Kibana system user to create Fleet system indices

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -159,19 +159,19 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                                 // Kibana write to this indice to reassign agent policy or perform force unenroll
                                 RoleDescriptor.IndicesPrivileges.builder()
                                     .indices(".fleet-agents")
-                                    .privileges("read", "write").build(),
+                                    .privileges("read", "write", "create_index").build(),
                                 // Kibana write to this indice to add action to an agent, upgrade, unenroll, ...
                                 RoleDescriptor.IndicesPrivileges.builder()
                                     .indices(".fleet-actions")
-                                    .privileges("read", "write").build(),
+                                    .privileges("read", "write", "create_index").build(),
                                 // Kibana write to this indice new enrollment api key
                                 RoleDescriptor.IndicesPrivileges.builder()
                                     .indices(".fleet-enrollment-api-keys")
-                                    .privileges("read", "write").build(),
+                                    .privileges("read", "write", "create_index").build(),
                                 // Kibana write to this indice every policy change
                                 RoleDescriptor.IndicesPrivileges.builder()
                                     .indices(".fleet-policies")
-                                    .privileges("read", "write").build(),
+                                    .privileges("read", "write", "create_index").build(),
                                 // Fleet Server indices. Kibana read from these indices to manage Elastic Agents
                                 RoleDescriptor.IndicesPrivileges.builder()
                                     .indices(".fleet-servers")

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -492,7 +492,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
             assertThat(kibanaRole.indices().allowedIndicesMatcher("indices:bar").test(mockIndexAbstraction(index)), is(false));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(DeleteIndexAction.NAME).test(mockIndexAbstraction(index)), is(false));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(GetIndexAction.NAME).test(mockIndexAbstraction(index)), is(true));
-            assertThat(kibanaRole.indices().allowedIndicesMatcher(CreateIndexAction.NAME).test(mockIndexAbstraction(index)), is(false));
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(CreateIndexAction.NAME).test(mockIndexAbstraction(index)), is(true));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(IndexAction.NAME).test(mockIndexAbstraction(index)), is(true));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(DeleteAction.NAME).test(mockIndexAbstraction(index)), is(true));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(UpdateSettingsAction.NAME).test(mockIndexAbstraction(index)), is(false));


### PR DESCRIPTION
## Description 

In https://github.com/elastic/elasticsearch/pull/67726 we give the permission to read and write to `.fleet` indices to the Kibana user we missed the `created_index` permission.

Installing the package Fleet Server in Kibana will create the index template for the Fleet server system indices. 

Creating these indices will be done by kibana when trying to write we are missing the permission for now this PR fix it.

Related to https://github.com/elastic/kibana/issues/87372