### PR TITLE
Wait for events, rather than just cluster health

### DIFF
--- a/x-pack/plugin/stack/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/stack/10_basic.yml
+++ b/x-pack/plugin/stack/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/stack/10_basic.yml
@@ -2,7 +2,7 @@
 setup:
   - do:
       cluster.health:
-        wait_for_status: yellow
+        wait_for_events: languid
 
 ---
 "Test stack template installation":


### PR DESCRIPTION
Fixes #67676

My read of things is that waiting for the cluster health isn't enough, we get online with no shards before we load in the system policies, etc.

```
=== Standard output of node `node{:x-pack:plugin:stack:qa:rest:yamlRestTest-0}` ===

»    ↓ errors and warnings from /Users/joegallo/Code/elastic/elasticsearch/x-pack/plugin/stack/qa/rest/build/testclusters/yamlRestTest-0/logs/es.stdout.log ↓
» WARN ][o.e.d.FileBasedSeedHostsProvider] [yamlRestTest-0] expected, but did not find, a dynamic hosts list at [/Users/joegallo/Code/elastic/elasticsearch/x-pack/plugin/stack/qa/rest/build/testclusters/yamlRestTest-0/config/unicast_hosts.txt]
»   ↓ last 40 non error or warning messages from /Users/joegallo/Code/elastic/elasticsearch/x-pack/plugin/stack/qa/rest/build/testclusters/yamlRestTest-0/logs/es.stdout.log ↓
» [2021-01-25T13:37:58,512][INFO ][o.e.c.c.Coordinator      ] [yamlRestTest-0] setting initial configuration to VotingConfiguration{6ziAq8nESe2U4GURe27jsA}
» [2021-01-25T13:37:58,628][INFO ][o.e.h.AbstractHttpServerTransport] [yamlRestTest-0] publish_address {127.0.0.1:59050}, bound_addresses {[::1]:59049}, {127.0.0.1:59050}
» [2021-01-25T13:37:58,629][INFO ][o.e.n.Node               ] [yamlRestTest-0] started
» [2021-01-25T13:37:58,755][INFO ][o.e.c.s.MasterService    ] [yamlRestTest-0] elected-as-master ([1] nodes joined)[{yamlRestTest-0}{6ziAq8nESe2U4GURe27jsA}{3C1VNaYtQt-tGE-UoraNSg}{127.0.0.1}{127.0.0.1:59048}{cdhimrstw}{xpack.installed=true, transform.node=true, testattr=test} elect leader, _BECOME_MASTER_TASK_, _FINISH_ELECTION_], term: 1, version: 1, delta: ma
ster node changed {previous [], current [{yamlRestTest-0}{6ziAq8nESe2U4GURe27jsA}{3C1VNaYtQt-tGE-UoraNSg}{127.0.0.1}{127.0.0.1:59048}{cdhimrstw}{xpack.installed=true, transform.node=true, testattr=test}]}
» [2021-01-25T13:37:58,842][INFO ][o.e.c.c.CoordinationState] [yamlRestTest-0] cluster UUID set to [nWox6JFNTtuxWdpvPv7C_g]
» [2021-01-25T13:37:58,921][INFO ][o.e.c.s.ClusterApplierService] [yamlRestTest-0] master node changed {previous [], current [{yamlRestTest-0}{6ziAq8nESe2U4GURe27jsA}{3C1VNaYtQt-tGE-UoraNSg}{127.0.0.1}{127.0.0.1:59048}{cdhimrstw}{xpack.installed=true, transform.node=true, testattr=test}]}, term: 1, version: 1, reason: Publication{term=1, version=1}
» [2021-01-25T13:37:59,074][INFO ][o.e.g.GatewayService     ] [yamlRestTest-0] recovered [0] indices into cluster_state
» [2021-01-25T13:37:59,192][INFO ][o.e.c.m.MetadataIndexTemplateService] [yamlRestTest-0] adding component template [logs-mappings]
» [2021-01-25T13:37:59,302][INFO ][o.e.c.m.MetadataIndexTemplateService] [yamlRestTest-0] adding component template [synthetics-settings]
» [2021-01-25T13:37:59,411][INFO ][o.e.c.m.MetadataIndexTemplateService] [yamlRestTest-0] adding component template [synthetics-mappings]
» [2021-01-25T13:37:59,501][INFO ][o.e.c.m.MetadataIndexTemplateService] [yamlRestTest-0] adding component template [metrics-settings]
» [2021-01-25T13:37:59,608][INFO ][o.e.c.m.MetadataIndexTemplateService] [yamlRestTest-0] adding component template [metrics-mappings]
» [2021-01-25T13:37:59,729][INFO ][o.e.c.m.MetadataIndexTemplateService] [yamlRestTest-0] adding component template [logs-settings]
» [2021-01-25T13:37:59,892][INFO ][o.e.c.m.MetadataIndexTemplateService] [yamlRestTest-0] adding index template [.triggered_watches] for index patterns [.triggered_watches*]
» [2021-01-25T13:38:00,006][INFO ][o.e.c.m.MetadataIndexTemplateService] [yamlRestTest-0] adding index template [.watch-history-14] for index patterns [.watcher-history-14*]
» [2021-01-25T13:38:00,096][INFO ][o.e.c.m.MetadataIndexTemplateService] [yamlRestTest-0] adding index template [.watches] for index patterns [.watches*]
» [2021-01-25T13:38:00,205][INFO ][o.e.c.m.MetadataIndexTemplateService] [yamlRestTest-0] adding index template [ilm-history] for index patterns [ilm-history-5*]
» [2021-01-25T13:38:00,293][INFO ][o.e.c.m.MetadataIndexTemplateService] [yamlRestTest-0] adding index template [.slm-history] for index patterns [.slm-history-5*]
» [2021-01-25T13:38:00,380][INFO ][o.e.c.m.MetadataIndexTemplateService] [yamlRestTest-0] adding component template [.deprecation-indexing-settings]
» [2021-01-25T13:38:00,487][INFO ][o.e.c.m.MetadataIndexTemplateService] [yamlRestTest-0] adding component template [.deprecation-indexing-mappings]
» [2021-01-25T13:38:00,575][INFO ][o.e.c.m.MetadataIndexTemplateService] [yamlRestTest-0] adding template [.monitoring-alerts-7] for index patterns [.monitoring-alerts-7]
» [2021-01-25T13:38:00,679][INFO ][o.e.c.m.MetadataIndexTemplateService] [yamlRestTest-0] adding template [.monitoring-es] for index patterns [.monitoring-es-7-*]
» [2021-01-25T13:38:00,810][INFO ][o.e.c.m.MetadataIndexTemplateService] [yamlRestTest-0] adding template [.monitoring-kibana] for index patterns [.monitoring-kibana-7-*]
» [2021-01-25T13:38:00,904][INFO ][o.e.c.m.MetadataIndexTemplateService] [yamlRestTest-0] adding template [.monitoring-logstash] for index patterns [.monitoring-logstash-7-*]
» [2021-01-25T13:38:01,000][INFO ][o.e.c.m.MetadataIndexTemplateService] [yamlRestTest-0] adding template [.monitoring-beats] for index patterns [.monitoring-beats-7-*]
» [2021-01-25T13:38:01,091][INFO ][o.e.c.m.MetadataIndexTemplateService] [yamlRestTest-0] adding index template [synthetics] for index patterns [synthetics-*-*]
» [2021-01-25T13:38:01,179][INFO ][o.e.c.m.MetadataIndexTemplateService] [yamlRestTest-0] adding index template [metrics] for index patterns [metrics-*-*]
» [2021-01-25T13:38:01,272][INFO ][o.e.c.m.MetadataIndexTemplateService] [yamlRestTest-0] adding index template [logs] for index patterns [logs-*-*]
» [2021-01-25T13:38:01,382][INFO ][o.e.c.m.MetadataIndexTemplateService] [yamlRestTest-0] adding index template [.deprecation-indexing-template] for index patterns [.logs-deprecation-elasticsearch]
» [2021-01-25T13:38:01,471][INFO ][o.e.x.i.a.TransportPutLifecycleAction] [yamlRestTest-0] adding index lifecycle policy [logs]
» [2021-01-25T13:38:01,586][INFO ][o.e.x.i.a.TransportPutLifecycleAction] [yamlRestTest-0] adding index lifecycle policy [synthetics]
» [2021-01-25T13:38:01,671][INFO ][o.e.x.i.a.TransportPutLifecycleAction] [yamlRestTest-0] adding index lifecycle policy [metrics]
» [2021-01-25T13:38:01,754][INFO ][o.e.x.i.a.TransportPutLifecycleAction] [yamlRestTest-0] adding index lifecycle policy [watch-history-ilm-policy]
» [2021-01-25T13:38:01,839][INFO ][o.e.x.i.a.TransportPutLifecycleAction] [yamlRestTest-0] adding index lifecycle policy [ilm-history-ilm-policy]
» [2021-01-25T13:38:01,926][INFO ][o.e.x.i.a.TransportPutLifecycleAction] [yamlRestTest-0] adding index lifecycle policy [slm-history-ilm-policy]
» [2021-01-25T13:38:02,017][INFO ][o.e.x.i.a.TransportPutLifecycleAction] [yamlRestTest-0] adding index lifecycle policy [.deprecation-indexing-ilm-policy]
» [2021-01-25T13:38:02,226][INFO ][o.e.l.LicenseService     ] [yamlRestTest-0] license [7bb9e08f-bb73-4a7c-9335-5a1875a6aac1] mode [trial] - valid
» [2021-01-25T13:38:02,226][INFO ][o.e.x.s.s.SecurityStatusChangeListener] [yamlRestTest-0] Active license is now [TRIAL]; Security is enabled
» [2021-01-25T18:38:02.710003Z] [BUILD] Stopping node
```