### PR TITLE
Apply `isSystem` flag correctly when applying IndexMetadata diffs (#67851)

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -894,7 +894,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             builder.customMetadata.putAll(customData.apply(part.customData));
             builder.inSyncAllocationIds.putAll(inSyncAllocationIds.apply(part.inSyncAllocationIds));
             builder.rolloverInfos.putAll(rolloverInfos.apply(part.rolloverInfos));
-            builder.system(part.isSystem);
+            builder.system(isSystem);
             builder.timestampMillisRange(timestampMillisRange);
             return builder.build();
         }


### PR DESCRIPTION
Backports the following commits to 7.11:
 - Apply `isSystem` flag correctly when applying IndexMetadata diffs (#67851)