### PR TITLE
Extend async search keep alive (#67877)

### DIFF
--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchActionIT.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchActionIT.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.search;
 
 import org.apache.lucene.store.AlreadyClosedException;
 import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
@@ -343,7 +344,7 @@ public class AsyncSearchActionIT extends AsyncSearchIntegTestCase {
         assertThat(response.getSearchResponse().getSuccessfulShards(), equalTo(0));
         assertThat(response.getSearchResponse().getFailedShards(), equalTo(0));
 
-        response = getAsyncSearch(response.getId(), TimeValue.timeValueDays(10));
+        response = getAsyncSearch(response.getId(), TimeValue.timeValueDays(6));
         assertThat(response.getExpirationTime(), greaterThan(expirationTime));
 
         assertTrue(response.isRunning());
@@ -362,8 +363,13 @@ public class AsyncSearchActionIT extends AsyncSearchIntegTestCase {
         assertEquals(0, statusResponse.getSkippedShards());
         assertEquals(null, statusResponse.getCompletionStatus());
 
-        response = getAsyncSearch(response.getId(), TimeValue.timeValueMillis(1));
-        assertThat(response.getExpirationTime(), lessThan(expirationTime));
+        expirationTime = response.getExpirationTime();
+        response = getAsyncSearch(response.getId(), TimeValue.timeValueMinutes(between(1, 24 * 60)));
+        assertThat(response.getExpirationTime(), equalTo(expirationTime));
+        response = getAsyncSearch(response.getId(), TimeValue.timeValueDays(10));
+        assertThat(response.getExpirationTime(), greaterThan(expirationTime));
+
+        deleteAsyncSearch(response.getId());
         ensureTaskNotRunning(response.getId());
         ensureTaskRemoval(response.getId());
     }
@@ -389,8 +395,9 @@ public class AsyncSearchActionIT extends AsyncSearchIntegTestCase {
         assertThat(response.getSearchResponse().getSuccessfulShards(), equalTo(numShards));
         assertThat(response.getSearchResponse().getFailedShards(), equalTo(0));
 
-        response = getAsyncSearch(response.getId(), TimeValue.timeValueDays(10));
+        response = getAsyncSearch(response.getId(), TimeValue.timeValueDays(8));
         assertThat(response.getExpirationTime(), greaterThan(expirationTime));
+        expirationTime = response.getExpirationTime();
 
         assertFalse(response.isRunning());
         assertThat(response.getSearchResponse().getTotalShards(), equalTo(numShards));
@@ -398,7 +405,11 @@ public class AsyncSearchActionIT extends AsyncSearchIntegTestCase {
         assertThat(response.getSearchResponse().getFailedShards(), equalTo(0));
 
         response = getAsyncSearch(response.getId(), TimeValue.timeValueMillis(1));
-        assertThat(response.getExpirationTime(), lessThan(expirationTime));
+        assertThat(response.getExpirationTime(), equalTo(expirationTime));
+        response = getAsyncSearch(response.getId(), TimeValue.timeValueDays(10));
+        assertThat(response.getExpirationTime(), greaterThan(expirationTime));
+
+        deleteAsyncSearch(response.getId());
         ensureTaskNotRunning(response.getId());
         ensureTaskRemoval(response.getId());
     }
@@ -425,22 +436,24 @@ public class AsyncSearchActionIT extends AsyncSearchIntegTestCase {
             ExceptionsHelper.unwrapCause(exc.getCause()) : ExceptionsHelper.unwrapCause(exc);
         assertThat(ExceptionsHelper.status(cause).getStatus(), equalTo(404));
 
-        SubmitAsyncSearchRequest newReq = new SubmitAsyncSearchRequest(indexName);
+        SubmitAsyncSearchRequest newReq = new SubmitAsyncSearchRequest(indexName) {
+            @Override
+            public ActionRequestValidationException validate() {
+                return null; // to use a small keep_alive
+            }
+        };
         newReq.getSearchRequest().source(
             new SearchSourceBuilder().aggregation(new CancellingAggregationBuilder("test", randomLong()))
         );
-        newReq.setWaitForCompletionTimeout(TimeValue.timeValueMillis(1));
+        newReq.setWaitForCompletionTimeout(TimeValue.timeValueMillis(1)).setKeepAlive(TimeValue.timeValueSeconds(5));
         AsyncSearchResponse newResp = submitAsyncSearch(newReq);
         assertNotNull(newResp.getSearchResponse());
         assertTrue(newResp.isRunning());
         assertThat(newResp.getSearchResponse().getTotalShards(), equalTo(numShards));
         assertThat(newResp.getSearchResponse().getSuccessfulShards(), equalTo(0));
         assertThat(newResp.getSearchResponse().getFailedShards(), equalTo(0));
-        long expirationTime = newResp.getExpirationTime();
 
         // check garbage collection
-        newResp = getAsyncSearch(newResp.getId(), TimeValue.timeValueMillis(1));
-        assertThat(newResp.getExpirationTime(), lessThan(expirationTime));
         ensureTaskNotRunning(newResp.getId());
         ensureTaskRemoval(newResp.getId());
     }

--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchIntegTestCase.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchIntegTestCase.java
@@ -23,6 +23,7 @@ import org.elasticsearch.index.reindex.ReindexPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.script.MockScriptPlugin;
 import org.elasticsearch.search.aggregations.bucket.filter.InternalFilter;
 import org.elasticsearch.search.builder.PointInTimeBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
@@ -59,11 +60,15 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
 
 import static org.elasticsearch.xpack.core.XPackPlugin.ASYNC_RESULTS_INDEX;
 import static org.elasticsearch.xpack.core.async.AsyncTaskMaintenanceService.ASYNC_SEARCH_CLEANUP_INTERVAL_SETTING;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
@@ -95,6 +100,44 @@ public abstract class AsyncSearchIntegTestCase extends ESIntegTestCase {
         }
     }
 
+    public static class ExpirationTimeScriptPlugin extends MockScriptPlugin {
+        @Override
+        public String pluginScriptLang() {
+            return "painless";
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        protected Map<String, Function<Map<String, Object>, Object>> pluginScripts() {
+            final String fieldName = "expiration_time";
+            final String script =
+                " if (ctx._source.expiration_time < params.expiration_time) { " +
+                "     ctx._source.expiration_time = params.expiration_time; " +
+                " } else { " +
+                "     ctx.op = \"noop\"; " +
+                " }";
+            return Collections.singletonMap(
+                script, vars -> {
+                    Map<String, Object> params = (Map<String, Object>) vars.get("params");
+                    assertNotNull(params);
+                    assertThat(params.keySet(), contains(fieldName));
+                    long updatingValue = (long) params.get(fieldName);
+
+                    Map<String, Object> ctx = (Map<String, Object>) vars.get("ctx");
+                    assertNotNull(ctx);
+                    Map<String, Object> source = (Map<String, Object>) ctx.get("_source");
+                    long currentValue = (long) source.get(fieldName);
+                    if (currentValue < updatingValue) {
+                        source.put(fieldName, updatingValue);
+                    } else {
+                        ctx.put("op", "noop");
+                    }
+                    return ctx;
+                }
+            );
+        }
+    }
+
     @Before
     public void startMaintenanceService() {
         for (AsyncTaskMaintenanceService service : internalCluster().getDataNodeInstances(AsyncTaskMaintenanceService.class)) {
@@ -122,7 +165,7 @@ public abstract class AsyncSearchIntegTestCase extends ESIntegTestCase {
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
         return Arrays.asList(LocalStateCompositeXPackPlugin.class, AsyncSearch.class, AsyncResultsIndexPlugin.class, IndexLifecycle.class,
-            SearchTestPlugin.class, ReindexPlugin.class);
+            SearchTestPlugin.class, ReindexPlugin.class, ExpirationTimeScriptPlugin.class);
     }
 
     @Override
@@ -202,7 +245,7 @@ public abstract class AsyncSearchIntegTestCase extends ESIntegTestCase {
                     throw exc;
                 }
             }
-        });
+        }, 30, TimeUnit.SECONDS);
     }
 
     /**
@@ -220,7 +263,7 @@ public abstract class AsyncSearchIntegTestCase extends ESIntegTestCase {
                     throw exc;
                 }
             }
-        });
+        }, 30, TimeUnit.SECONDS);
     }
 
     /**

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/AsyncSearchTask.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/AsyncSearchTask.java
@@ -38,6 +38,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -62,7 +63,7 @@ final class AsyncSearchTask extends SearchTask implements AsyncTask {
     private final List<Runnable> initListeners = new ArrayList<>();
     private final Map<Long, Consumer<AsyncSearchResponse>> completionListeners = new HashMap<>();
 
-    private volatile long expirationTimeMillis;
+    private final AtomicLong expirationTimeMillis;
     private final AtomicBoolean isCancelling = new AtomicBoolean(false);
 
     private final AtomicReference<MutableSearchResponse> searchResponse = new AtomicReference<>();
@@ -93,7 +94,7 @@ final class AsyncSearchTask extends SearchTask implements AsyncTask {
                     ThreadPool threadPool,
                     Supplier<InternalAggregation.ReduceContext> aggReduceContextSupplier) {
         super(id, type, action, () -> "async_search{" + descriptionSupplier.get() + "}", parentTaskId, taskHeaders);
-        this.expirationTimeMillis = getStartTime() + keepAlive.getMillis();
+        this.expirationTimeMillis = new AtomicLong(getStartTime() + keepAlive.getMillis());
         this.originHeaders = originHeaders;
         this.searchId = searchId;
         this.client = client;
@@ -127,8 +128,8 @@ final class AsyncSearchTask extends SearchTask implements AsyncTask {
      * Update the expiration time of the (partial) response.
      */
     @Override
-    public void setExpirationTime(long expirationTimeMillis) {
-        this.expirationTimeMillis = expirationTimeMillis;
+    public void extendExpirationTime(long newExpirationTimeMillis) {
+        this.expirationTimeMillis.updateAndGet(curr -> Math.max(curr, newExpirationTimeMillis));
     }
 
     @Override
@@ -330,11 +331,11 @@ final class AsyncSearchTask extends SearchTask implements AsyncTask {
         checkCancellation();
         AsyncSearchResponse asyncSearchResponse;
         try {
-            asyncSearchResponse = mutableSearchResponse.toAsyncSearchResponse(this, expirationTimeMillis, restoreResponseHeaders);
+            asyncSearchResponse = mutableSearchResponse.toAsyncSearchResponse(this, expirationTimeMillis.get(), restoreResponseHeaders);
         } catch(Exception e) {
             ElasticsearchException exception = new ElasticsearchStatusException("Async search: error while reducing partial results",
                 ExceptionsHelper.status(e), e);
-            asyncSearchResponse = mutableSearchResponse.toAsyncSearchResponse(this, expirationTimeMillis, exception);
+            asyncSearchResponse = mutableSearchResponse.toAsyncSearchResponse(this, expirationTimeMillis.get(), exception);
        }
        return asyncSearchResponse;
     }
@@ -342,7 +343,7 @@ final class AsyncSearchTask extends SearchTask implements AsyncTask {
     // checks if the search task should be cancelled
     private synchronized void checkCancellation() {
         long now = System.currentTimeMillis();
-        if (hasCompleted == false && expirationTimeMillis < now) {
+        if (hasCompleted == false && expirationTimeMillis.get() < now) {
             // we cancel expired search task even if they are still running
             cancelTask(() -> {}, "async search has expired");
         }
@@ -354,7 +355,7 @@ final class AsyncSearchTask extends SearchTask implements AsyncTask {
     public AsyncStatusResponse getStatusResponse() {
         MutableSearchResponse mutableSearchResponse = searchResponse.get();
         assert mutableSearchResponse != null;
-        return mutableSearchResponse.toStatusResponse(searchId.getEncoded(), getStartTime(), expirationTimeMillis);
+        return mutableSearchResponse.toStatusResponse(searchId.getEncoded(), getStartTime(), expirationTimeMillis.get());
     }
 
     class Listener extends SearchProgressActionListener {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncResultsService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncResultsService.java
@@ -81,7 +81,7 @@ public class AsyncResultsService<Task extends AsyncTask, Response extends AsyncR
             // EQL doesn't store initial or intermediate results so we only need to update expiration time in store for only in case of
             // async search
             if (updateInitialResultsInStore & expirationTime > 0) {
-                store.updateExpirationTime(searchId.getDocId(), expirationTime,
+                store.extendExpirationTime(searchId.getDocId(), expirationTime,
                     ActionListener.wrap(
                         p -> getSearchResponseFromTask(searchId, request, nowInMillis, expirationTime, listener),
                         exc -> {
@@ -123,7 +123,7 @@ public class AsyncResultsService<Task extends AsyncTask, Response extends AsyncR
             }
 
             if (expirationTimeMillis != -1) {
-                task.setExpirationTime(expirationTimeMillis);
+                task.extendExpirationTime(expirationTimeMillis);
             }
             addCompletionListener.apply(task, new ActionListener<Response>() {
                 @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncTask.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncTask.java
@@ -30,9 +30,9 @@ public interface AsyncTask {
     boolean isCancelled();
 
     /**
-     * Update the expiration time of the (partial) response.
+     * Extends the expiration time of the (partial) response if needed
      */
-    void setExpirationTime(long expirationTimeMillis);
+    void extendExpirationTime(long newExpirationTimeMillis);
 
     /**
      * Performs necessary checks, cancels the task and calls the runnable upon completion

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncTaskIndexService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncTaskIndexService.java
@@ -35,6 +35,8 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskManager;
 import org.elasticsearch.xpack.core.search.action.AsyncSearchResponse;
@@ -65,6 +67,13 @@ public final class AsyncTaskIndexService<R extends AsyncResponse<R>> {
     public static final String HEADERS_FIELD = "headers";
     public static final String RESPONSE_HEADERS_FIELD = "response_headers";
     public static final String EXPIRATION_TIME_FIELD = "expiration_time";
+    public static final String EXPIRATION_TIME_SCRIPT =
+        " if (ctx._source.expiration_time < params.expiration_time) { " +
+        "     ctx._source.expiration_time = params.expiration_time; " +
+        " } else { " +
+        "     ctx.op = \"noop\"; " +
+        " }";
+
     public static final String RESULT_FIELD = "result";
 
     static Settings settings() {
@@ -208,16 +217,15 @@ public final class AsyncTaskIndexService<R extends AsyncResponse<R>> {
     }
 
     /**
-     * Updates the expiration time of the provided <code>docId</code> if the place-holder
-     * document is still present (update).
+     * Extends the expiration time of the provided <code>docId</code> if the place-holder document is still present (update).
      */
-    public void updateExpirationTime(String docId,
-                              long expirationTimeMillis,
-                              ActionListener<UpdateResponse> listener) {
-        Map<String, Object> source = Collections.singletonMap(EXPIRATION_TIME_FIELD, expirationTimeMillis);
-        UpdateRequest request = new UpdateRequest().index(index)
+    public void extendExpirationTime(String docId, long expirationTimeMillis, ActionListener<UpdateResponse> listener) {
+        Script script = new Script(ScriptType.INLINE, "painless", EXPIRATION_TIME_SCRIPT,
+            Collections.singletonMap(EXPIRATION_TIME_FIELD, expirationTimeMillis));
+        UpdateRequest request = new UpdateRequest()
+            .index(index)
             .id(docId)
-            .doc(source, XContentType.JSON)
+            .script(script)
             .retryOnConflict(5);
         // updates create the index automatically if it doesn't exist so we force the creation
         // preemptively.

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/async/AsyncTaskServiceTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/async/AsyncTaskServiceTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.elasticsearch.transport.TransportService;
@@ -24,6 +25,7 @@ import org.elasticsearch.xpack.core.security.user.User;
 import org.junit.Before;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Collections;
 
 // TODO: test CRUD operations
@@ -39,6 +41,11 @@ public class AsyncTaskServiceTests extends ESSingleNodeTestCase {
         indexService = new AsyncTaskIndexService<>(index, clusterService,
             transportService.getThreadPool().getThreadContext(),
             client(), "test_origin", AsyncSearchResponse::new, writableRegistry());
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return pluginList(ExpirationTimeScriptPlugin.class);
     }
 
     public void testEnsuredAuthenticatedUserIsSame() throws IOException {
@@ -136,7 +143,7 @@ public class AsyncTaskServiceTests extends ESSingleNodeTestCase {
         assertTrue(ack.isAcknowledged());
         {
             PlainActionFuture<UpdateResponse> future = PlainActionFuture.newFuture();
-            indexService.updateExpirationTime("0", 10L, future);
+            indexService.extendExpirationTime("0", 10L, future);
             expectThrows(Exception.class, () -> future.get());
             assertSettings();
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/async/ExpirationTimeScriptPlugin.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/async/ExpirationTimeScriptPlugin.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.xpack.core.async;
+
+import org.elasticsearch.script.MockScriptPlugin;
+import org.junit.Assert;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Function;
+
+import static org.hamcrest.Matchers.contains;
+
+public class ExpirationTimeScriptPlugin extends MockScriptPlugin {
+    @Override
+    public String pluginScriptLang() {
+        return "painless";
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Map<String, Function<Map<String, Object>, Object>> pluginScripts() {
+        final String fieldName = "expiration_time";
+        final String script =
+            " if (ctx._source.expiration_time < params.expiration_time) { " +
+            "     ctx._source.expiration_time = params.expiration_time; " +
+            " } else { " +
+            "     ctx.op = \"noop\"; " +
+            " }";
+        return Collections.singletonMap(
+            script, vars -> {
+                Map<String, Object> params = (Map<String, Object>) vars.get("params");
+                Assert.assertNotNull(params);
+                Assert.assertThat(params.keySet(), contains(fieldName));
+                long updatingValue = (long) params.get(fieldName);
+
+                Map<String, Object> ctx = (Map<String, Object>) vars.get("ctx");
+                Assert.assertNotNull(ctx);
+                Map<String, Object> source = (Map<String, Object>) ctx.get("_source");
+                long currentValue = (long) source.get(fieldName);
+                if (currentValue < updatingValue) {
+                    source.put(fieldName, updatingValue);
+                } else {
+                    ctx.put("op", "noop");
+                }
+                return ctx;
+            }
+        );
+    }
+}

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/async/StoredAsyncTask.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/async/StoredAsyncTask.java
@@ -18,13 +18,14 @@ import org.elasticsearch.xpack.core.async.AsyncTask;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
 
 
 public abstract class StoredAsyncTask<Response extends ActionResponse> extends CancellableTask implements AsyncTask {
 
     private final AsyncExecutionId asyncExecutionId;
     private final Map<String, String> originHeaders;
-    private volatile long expirationTimeMillis;
+    private final AtomicLong expirationTimeMillis;
     private final List<ActionListener<Response>> completionListeners;
 
     public StoredAsyncTask(long id, String type, String action, String description, TaskId parentTaskId,
@@ -33,7 +34,7 @@ public abstract class StoredAsyncTask<Response extends ActionResponse> extends C
         super(id, type, action, description, parentTaskId, headers);
         this.asyncExecutionId = asyncExecutionId;
         this.originHeaders = originHeaders;
-        this.expirationTimeMillis = getStartTime() + keepAlive.getMillis();
+        this.expirationTimeMillis = new AtomicLong(getStartTime() + keepAlive.getMillis());
         this.completionListeners = new ArrayList<>();
     }
 
@@ -51,12 +52,12 @@ public abstract class StoredAsyncTask<Response extends ActionResponse> extends C
      * Update the expiration time of the (partial) response.
      */
     @Override
-    public void setExpirationTime(long expirationTimeMillis) {
-        this.expirationTimeMillis = expirationTimeMillis;
+    public void extendExpirationTime(long newExpirationTimeMillis) {
+        this.expirationTimeMillis.updateAndGet(curr -> Math.max(curr, newExpirationTimeMillis));
     }
 
     public long getExpirationTimeMillis() {
-        return expirationTimeMillis;
+        return expirationTimeMillis.get();
     }
 
     public synchronized void addCompletionListener(ActionListener<Response> listener) {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/async_search/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/async_search/10_basic.yml
@@ -77,6 +77,43 @@
   - match:  { response.hits.hits.0._source.max: 1 }
   - match:  { response.aggregations.max.value:  3.0 }
 
+  - do:
+      async_search.submit:
+        index: test-*
+        batched_reduce_size: 2
+        wait_for_completion_timeout: 10s
+        keep_alive: 10m
+        keep_on_completion: true
+        body:
+          aggs:
+            max:
+              max:
+                field: max
+          sort: max
+
+  - set:    { id:                                  id }
+  - set:    { expiration_time_in_millis: expiration_time_in_millis }
+
+  - do:
+      async_search.get:
+        id: "$id"
+        keep_alive: 5m
+
+  - match: { expiration_time_in_millis: $expiration_time_in_millis }
+
+  - do:
+      async_search.get:
+        id: "$id"
+        keep_alive: 30m
+
+  - gt:  { expiration_time_in_millis: $expiration_time_in_millis }
+
+  - do:
+      async_search.delete:
+        id: "$id"
+
+  - match: { acknowledged:   true }
+
   # test with typed_keys:
   - do:
       async_search.submit:


### PR DESCRIPTION
There can be a race between two GET async search requests, and the one
with a lower keep_alive parameter wins the race. This scenario is not
desirable as we should retain the search result for all requests. This
commit ensures the keep_alive is extended and never goes backward.

Backport of #67877