### PR TITLE
[DOCS] Added appendix to show dependencies

### DIFF
--- a/docs/reference/dependencies-versions.asciidoc
+++ b/docs/reference/dependencies-versions.asciidoc
@@ -1,0 +1,7 @@
+["appendix",id="dependencies-versions"]
+= Dependencies and versions
+
+[source, text]
+----
+include::{dependencies-dir}/version.properties[]
+----

--- a/docs/reference/index.asciidoc
+++ b/docs/reference/index.asciidoc
@@ -4,6 +4,7 @@
 :include-xpack:         true
 :es-test-dir:           {elasticsearch-root}/docs/src/test
 :plugins-examples-dir:  {elasticsearch-root}/plugins/examples
+:dependencies-dir:      {elasticsearch-root}/buildSrc
 :xes-repo-dir:          {elasticsearch-root}/x-pack/docs/{lang}
 :es-repo-dir:           {elasticsearch-root}/docs/reference
 
@@ -75,5 +76,7 @@ include::rest-api/index.asciidoc[]
 include::migration/index.asciidoc[]
 
 include::release-notes.asciidoc[]
+
+include::dependencies-versions.asciidoc[]
 
 include::redirects.asciidoc[]


### PR DESCRIPTION
Previously, we've only mentioned the JDK & Lucene versions in the release notes when the dependency changes. This PR adds an appendix that pulls in version.properties so you don't have to dig through past release notes to figure out what the versions are.

Preview: https://elasticsearch_67962.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/dependencies-versions.html