### PR TITLE
[7.x][ML] Unmute RegressionIT.testSingleNumericFeatureAndMixedTrainingAndNonTrainingRows

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RegressionIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RegressionIT.java
@@ -70,10 +70,23 @@ public class RegressionIT extends MlNativeDataFrameAnalyticsIntegTestCase {
     private String sourceIndex;
     private String destIndex;
 
+    @Before
+    public void setupLogging() {
+        client().admin().cluster()
+            .prepareUpdateSettings()
+            .setTransientSettings(Settings.builder()
+                .put("logger.org.elasticsearch.xpack.ml.process.logging.CppLogMessageHandler", "DEBUG"))
+            .get();
+    }
 
     @After
     public void cleanup() {
         cleanUp();
+        client().admin().cluster()
+        .prepareUpdateSettings()
+        .setTransientSettings(Settings.builder()
+            .putNull("logger.org.elasticsearch.xpack.ml.process.logging.CppLogMessageHandler"))
+        .get();
     }
 
     @Override
@@ -85,7 +98,6 @@ public class RegressionIT extends MlNativeDataFrameAnalyticsIntegTestCase {
         return new NamedXContentRegistry(entries);
     }
 
-    @AwaitsFix( bugUrl = "https://github.com/elastic/elasticsearch/issues/59413")
     public void testSingleNumericFeatureAndMixedTrainingAndNonTrainingRows() throws Exception {
         initialize("regression_single_numeric_feature_and_mixed_data_set");
         String predictedClassField = DEPENDENT_VARIABLE_FIELD + "_prediction";


### PR DESCRIPTION
Besides unmuting the test I added debug-level logging to facilitate finding the root cause of the test failure.

Backport of #67904.