### PR TITLE
Allow searchable snapshots to work on source-only repositories

### DIFF
--- a/server/src/main/java/org/elasticsearch/repositories/FilterRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/FilterRepository.java
@@ -51,6 +51,10 @@ public class FilterRepository implements Repository {
         this.in = in;
     }
 
+    public Repository getDelegate() {
+        return in;
+    }
+
     @Override
     public RepositoryMetadata getMetadata() {
         return in.getMetadata();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/snapshots/SourceOnlySnapshotRepository.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/snapshots/SourceOnlySnapshotRepository.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.env.ShardLock;
+import org.elasticsearch.index.engine.EngineConfig;
 import org.elasticsearch.index.engine.EngineFactory;
 import org.elasticsearch.index.engine.ReadOnlyEngine;
 import org.elasticsearch.index.mapper.MapperService;
@@ -172,13 +173,17 @@ public final class SourceOnlySnapshotRepository extends FilterRepository {
      */
     public static EngineFactory getEngineFactory() {
         return config -> new ReadOnlyEngine(config, null, new TranslogStats(0, 0, 0, 0, 0), true,
-            reader -> {
-                try {
-                    return SeqIdGeneratingFilterReader.wrap(reader, config.getPrimaryTermSupplier().getAsLong());
-                } catch (IOException e) {
-                    throw new UncheckedIOException(e);
-                }
-            }, true);
+            readerWrapper(config), true);
+    }
+
+    public static Function<DirectoryReader, DirectoryReader> readerWrapper(EngineConfig engineConfig) {
+        return reader -> {
+            try {
+                return SeqIdGeneratingFilterReader.wrap(reader, engineConfig.getPrimaryTermSupplier().getAsLong());
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        };
     }
 
     /**

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackPlugin.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackPlugin.java
@@ -86,6 +86,7 @@ import org.elasticsearch.xpack.core.ssl.SSLConfiguration;
 import org.elasticsearch.xpack.core.ssl.SSLConfigurationReloader;
 import org.elasticsearch.xpack.core.ssl.SSLService;
 import org.elasticsearch.xpack.core.watcher.WatcherMetadata;
+import org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsConstants;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -363,7 +364,8 @@ public class XPackPlugin extends XPackClientPlugin implements ExtensiblePlugin, 
 
     @Override
     public Optional<EngineFactory> getEngineFactory(IndexSettings indexSettings) {
-        if (indexSettings.getValue(SourceOnlySnapshotRepository.SOURCE_ONLY)) {
+        if (indexSettings.getValue(SourceOnlySnapshotRepository.SOURCE_ONLY) &&
+            SearchableSnapshotsConstants.isSearchableSnapshotStore(indexSettings.getSettings()) == false) {
             return Optional.of(SourceOnlySnapshotRepository.getEngineFactory());
         }
 

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/SearchableSnapshotDirectory.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/SearchableSnapshotDirectory.java
@@ -53,6 +53,7 @@ import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.repositories.Repository;
 import org.elasticsearch.repositories.blobstore.BlobStoreRepository;
 import org.elasticsearch.snapshots.SnapshotId;
+import org.elasticsearch.snapshots.SourceOnlySnapshotRepository;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsConstants;
 import org.elasticsearch.xpack.searchablesnapshots.cache.CacheService;
@@ -563,7 +564,10 @@ public class SearchableSnapshotDirectory extends BaseDirectory {
         }
 
         final String repositoryName = SNAPSHOT_REPOSITORY_SETTING.get(indexSettings.getSettings());
-        final Repository repository = repositories.repository(repositoryName);
+        Repository repository = repositories.repository(repositoryName);
+        if (repository instanceof SourceOnlySnapshotRepository) {
+            repository = ((SourceOnlySnapshotRepository) repository).getDelegate();
+        }
         if (repository instanceof BlobStoreRepository == false) {
             throw new IllegalArgumentException("Repository [" + repository + "] is not searchable");
         }

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
@@ -55,6 +55,7 @@ import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestHandler;
 import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.snapshots.SourceOnlySnapshotRepository;
 import org.elasticsearch.threadpool.ExecutorBuilder;
 import org.elasticsearch.threadpool.ScalingExecutorBuilder;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -301,7 +302,10 @@ public class SearchableSnapshots extends Plugin implements IndexStorePlugin, Eng
         if (SearchableSnapshotsConstants.isSearchableSnapshotStore(indexSettings.getSettings())
             && indexSettings.getSettings().getAsBoolean("index.frozen", false) == false) {
             return Optional.of(
-                engineConfig -> new ReadOnlyEngine(engineConfig, null, new TranslogStats(), false, Function.identity(), false)
+                engineConfig -> new ReadOnlyEngine(engineConfig, null, new TranslogStats(), false,
+                    indexSettings.getValue(SourceOnlySnapshotRepository.SOURCE_ONLY)
+                        ? SourceOnlySnapshotRepository.readerWrapper(engineConfig)
+                        : Function.identity(), false)
             );
         }
         return Optional.empty();

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
@@ -302,10 +302,16 @@ public class SearchableSnapshots extends Plugin implements IndexStorePlugin, Eng
         if (SearchableSnapshotsConstants.isSearchableSnapshotStore(indexSettings.getSettings())
             && indexSettings.getSettings().getAsBoolean("index.frozen", false) == false) {
             return Optional.of(
-                engineConfig -> new ReadOnlyEngine(engineConfig, null, new TranslogStats(), false,
+                engineConfig -> new ReadOnlyEngine(
+                    engineConfig,
+                    null,
+                    new TranslogStats(),
+                    false,
                     indexSettings.getValue(SourceOnlySnapshotRepository.SOURCE_ONLY)
                         ? SourceOnlySnapshotRepository.readerWrapper(engineConfig)
-                        : Function.identity(), false)
+                        : Function.identity(),
+                    false
+                )
             );
         }
         return Optional.empty();

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsRestTestCase.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsRestTestCase.java
@@ -47,11 +47,18 @@ public abstract class AbstractSearchableSnapshotsRestTestCase extends ESRestTest
     protected abstract Settings repositorySettings();
 
     private void runSearchableSnapshotsTest(SearchableSnapshotsTestCaseBody testCaseBody) throws Exception {
+        runSearchableSnapshotsTest(testCaseBody, false);
+    }
+
+    private void runSearchableSnapshotsTest(SearchableSnapshotsTestCaseBody testCaseBody, boolean sourceOnly) throws Exception {
         final String repositoryType = repositoryType();
-        final Settings repositorySettings = repositorySettings();
+        Settings repositorySettings = repositorySettings();
+        if (sourceOnly) {
+            repositorySettings = Settings.builder().put("delegate_type", repositoryType).put(repositorySettings).build();
+        }
 
         logger.info("creating repository [{}] of type [{}]", REPOSITORY_NAME, repositoryType);
-        registerRepository(REPOSITORY_NAME, repositoryType, true, repositorySettings);
+        registerRepository(REPOSITORY_NAME, sourceOnly ? "source" : repositoryType, true, repositorySettings);
 
         final String indexName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
         final int numberOfShards = randomIntBetween(1, 5);
@@ -138,6 +145,20 @@ public abstract class AbstractSearchableSnapshotsRestTestCase extends ESRestTest
                 assertSearchResults(restoredIndexName, numDocs, Boolean.FALSE);
             }
         });
+    }
+
+    public void testSourceOnlyRepository() throws Exception {
+        runSearchableSnapshotsTest((indexName, numDocs) -> {
+            for (int i = 0; i < 10; i++) {
+                if (randomBoolean()) {
+                    logger.info("clearing searchable snapshots cache for [{}] before search", indexName);
+                    clearCache(indexName);
+                }
+                Map<String, Object> searchResults =
+                    search(indexName, QueryBuilders.matchAllQuery(), randomFrom(Boolean.TRUE, Boolean.FALSE, null));
+                assertThat(extractValue(searchResults, "hits.total.value"), equalTo(numDocs));
+            }
+        }, true);
     }
 
     public void testCloseAndReopen() throws Exception {

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsRestTestCase.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsRestTestCase.java
@@ -154,8 +154,11 @@ public abstract class AbstractSearchableSnapshotsRestTestCase extends ESRestTest
                     logger.info("clearing searchable snapshots cache for [{}] before search", indexName);
                     clearCache(indexName);
                 }
-                Map<String, Object> searchResults =
-                    search(indexName, QueryBuilders.matchAllQuery(), randomFrom(Boolean.TRUE, Boolean.FALSE, null));
+                Map<String, Object> searchResults = search(
+                    indexName,
+                    QueryBuilders.matchAllQuery(),
+                    randomFrom(Boolean.TRUE, Boolean.FALSE, null)
+                );
                 assertThat(extractValue(searchResults, "hits.total.value"), equalTo(numDocs));
             }
         }, true);


### PR DESCRIPTION
Searchable snapshots currently do not mix well with source-only repositories, see https://github.com/elastic/elasticsearch/issues/67936.
Fixing this is relatively straight-forward, and gives us support to fully mount (cold tier) or partially mount (frozen tier) a source only snapshot.

This PR provides the ability to mount a snapshot from a source-only repository as a searchable snapshot. This allows combining the space benefits of source-only snapshots with the query capabilities of searchable snapshots and runtime fields.