### PR TITLE
[ML] Unmuting snapshot upgrader bwc tests when upgrading from 6.8

### DIFF
--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlJobSnapshotUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlJobSnapshotUpgradeIT.java
@@ -88,7 +88,6 @@ public class MlJobSnapshotUpgradeIT extends AbstractUpgradeTestCase {
      * index mappings when it is assigned to an upgraded node even if no other ML endpoint is called after the upgrade
      */
     public void testSnapshotUpgrader() throws Exception {
-        assumeTrue("Mute due: https://github.com/elastic/elasticsearch/issues/67728", UPGRADE_FROM_VERSION.onOrAfter(Version.V_7_0_0));
         hlrc = new HLRC(client()).machineLearning();
         Request adjustLoggingLevels = new Request("PUT", "/_cluster/settings");
         adjustLoggingLevels.setJsonEntity(


### PR DESCRIPTION
Following elastic/ml-cpp#1680 they should work now.

Backport of #67774