### PR TITLE
Teach runtime geopoint to parse all formats (#67924)

### DIFF
--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/GeoPointFieldScript.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/GeoPointFieldScript.java
@@ -7,6 +7,8 @@
 package org.elasticsearch.xpack.runtimefields.mapper;
 
 import org.apache.lucene.index.LeafReaderContext;
+import org.elasticsearch.common.geo.GeoPoint;
+import org.elasticsearch.common.geo.GeoUtils;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.painless.spi.Whitelist;
 import org.elasticsearch.painless.spi.WhitelistLoader;
@@ -52,20 +54,17 @@ public abstract class GeoPointFieldScript extends AbstractLongFieldScript {
         lookup,
         ctx
     ) {
+        private final GeoPoint scratch = new GeoPoint();
+
         @Override
         public void execute() {
-            Object v = XContentMapValues.extractValue(field, leafSearchLookup.source().loadSourceIfNeeded());
-            if (v instanceof Map == false) {
-                return;
+            try {
+                Object v = XContentMapValues.extractValue(field, leafSearchLookup.source().loadSourceIfNeeded());
+                GeoUtils.parseGeoPoint(v, scratch, true);
+                emit(scratch.lat(), scratch.lon());
+            } catch (Exception e) {
+                // ignore
             }
-            @SuppressWarnings("unchecked")
-            Map<String, ?> vs = (Map<String, ?>) v;
-            Object lat = vs.get("lat");
-            Object lon = vs.get("lon");
-            if (lat instanceof Number == false || lon instanceof Number == false) {
-                return;
-            }
-            emit(((Number) lat).doubleValue(), ((Number) lon).doubleValue());
         }
     };
 

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/101_geo_point_from_source.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/101_geo_point_from_source.yml
@@ -24,11 +24,11 @@ setup:
           {"index":{}}
           {"timestamp": "1998-04-30T14:30:17-05:00", "location" : {"lat": 13.5, "lon" : 34.89}}
           {"index":{}}
-          {"timestamp": "1998-04-30T14:30:53-05:00", "location" : {"lat": -7.9, "lon" : 120.78}}
+          {"timestamp": "1998-04-30T14:30:53-05:00", "location" : "-7.9, 120.78"}
           {"index":{}}
-          {"timestamp": "1998-04-30T14:31:12-05:00", "location" : {"lat": 45.78, "lon" : -173.45}}
+          {"timestamp": "1998-04-30T14:31:12-05:00", "location" : [-173.45, 45.78]}
           {"index":{}}
-          {"timestamp": "1998-04-30T14:31:19-05:00", "location" : {"lat": 32.45, "lon" : 45.6}}
+          {"timestamp": "1998-04-30T14:31:19-05:00", "location" : "POINT(45.6 32.45)"}
           {"index":{}}
           {"timestamp": "1998-04-30T14:31:22-05:00", "location" : {"lat": -63.24, "lon" : 31.0}}
           {"index":{}}
@@ -188,8 +188,7 @@ setup:
   - match: {hits.hits.0._source.location.lon: 0.0 }
   - match: {hits.hits.1._source.location.lat: 13.5 }
   - match: {hits.hits.1._source.location.lon: 34.89 }
-  - match: {hits.hits.2._source.location.lat: 32.45 }
-  - match: {hits.hits.2._source.location.lon: 45.6 }
+  - match: {hits.hits.2._source.location: "POINT(45.6 32.45)" }
   - match: {hits.hits.3._source.location.lat: -63.24 }
   - match: {hits.hits.3._source.location.lon: 31.0 }
 

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/102_geo_point_source_in_query.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/102_geo_point_source_in_query.yml
@@ -21,11 +21,11 @@ setup:
           {"index":{}}
           {"timestamp": "1998-04-30T14:30:17-05:00", "location" : {"lat": 13.5, "lon" : 34.89}}
           {"index":{}}
-          {"timestamp": "1998-04-30T14:30:53-05:00", "location" : {"lat": -7.9, "lon" : 120.78}}
+          {"timestamp": "1998-04-30T14:30:53-05:00", "location" : "-7.9, 120.78"}
           {"index":{}}
-          {"timestamp": "1998-04-30T14:31:12-05:00", "location" : {"lat": 45.78, "lon" : -173.45}}
+          {"timestamp": "1998-04-30T14:31:12-05:00", "location" : [-173.45, 45.78]}
           {"index":{}}
-          {"timestamp": "1998-04-30T14:31:19-05:00", "location" : {"lat": 32.45, "lon" : 45.6}}
+          {"timestamp": "1998-04-30T14:31:19-05:00", "location" : "POINT(45.6 32.45)"}
           {"index":{}}
           {"timestamp": "1998-04-30T14:31:22-05:00", "location" : {"lat": -63.24, "lon" : 31.0}}
           {"index":{}}
@@ -207,8 +207,7 @@ setup:
   - match: {hits.hits.0._source.location.lon: 0.0 }
   - match: {hits.hits.1._source.location.lat: 13.5 }
   - match: {hits.hits.1._source.location.lon: 34.89 }
-  - match: {hits.hits.2._source.location.lat: 32.45 }
-  - match: {hits.hits.2._source.location.lon: 45.6 }
+  - match: {hits.hits.2._source.location: "POINT(45.6 32.45)" }
   - match: {hits.hits.3._source.location.lat: -63.24 }
   - match: {hits.hits.3._source.location.lon: 31.0 }
 


### PR DESCRIPTION
Currently the default parser for geo_point runtime field expects data to come in object format. This PR makes the parser to be able to read points coming in all supported formats.

backport #67924