### PR TITLE
Async search keep alive validation

### DIFF
--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchActionIT.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchActionIT.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.search;
 
 import org.apache.lucene.store.AlreadyClosedException;
 import org.elasticsearch.ExceptionsHelper;
-import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
@@ -438,16 +437,11 @@ public class AsyncSearchActionIT extends AsyncSearchIntegTestCase {
             ExceptionsHelper.unwrapCause(exc.getCause()) : ExceptionsHelper.unwrapCause(exc);
         assertThat(ExceptionsHelper.status(cause).getStatus(), equalTo(404));
 
-        SubmitAsyncSearchRequest newReq = new SubmitAsyncSearchRequest(indexName) {
-            @Override
-            public ActionRequestValidationException validate() {
-                return null; // to use a small keep_alive
-            }
-        };
+        SubmitAsyncSearchRequest newReq = new SubmitAsyncSearchRequest(indexName);
         newReq.getSearchRequest().source(
             new SearchSourceBuilder().aggregation(new CancellingAggregationBuilder("test", randomLong()))
         );
-        newReq.setWaitForCompletionTimeout(TimeValue.timeValueMillis(1)).setKeepAlive(TimeValue.timeValueSeconds(5));
+        newReq.setWaitForCompletionTimeout(TimeValue.timeValueMillis(1)).setKeepAlive(TimeValue.timeValueSeconds(1));
         AsyncSearchResponse newResp = submitAsyncSearch(newReq);
         assertNotNull(newResp.getSearchResponse());
         assertTrue(newResp.isRunning());

--- a/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/SubmitAsyncSearchRequestTests.java
+++ b/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/SubmitAsyncSearchRequestTests.java
@@ -98,7 +98,7 @@ public class SubmitAsyncSearchRequestTests extends AbstractWireSerializingTransf
 
     public void testValidateKeepAlive() {
         SubmitAsyncSearchRequest req = new SubmitAsyncSearchRequest();
-        req.setKeepAlive(TimeValue.timeValueSeconds(randomIntBetween(1, 59)));
+        req.setKeepAlive(TimeValue.timeValueMillis(randomIntBetween(1, 999)));
         ActionRequestValidationException exc = req.validate();
         assertNotNull(exc);
         assertThat(exc.validationErrors().size(), equalTo(1));

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/SubmitAsyncSearchRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/SubmitAsyncSearchRequest.java
@@ -135,7 +135,8 @@ public class SubmitAsyncSearchRequest extends ActionRequest {
         }
         if (keepAlive.getMillis() < MIN_KEEP_ALIVE) {
             validationException =
-                addValidationError("[keep_alive] must be greater than 1 second, got:" + keepAlive.toString(), validationException);
+                addValidationError("[keep_alive] must be greater or equals than 1 second, got:" +
+                    keepAlive.toString(), validationException);
         }
         if (request.isCcsMinimizeRoundtrips()) {
             validationException =

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/SubmitAsyncSearchRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/SubmitAsyncSearchRequest.java
@@ -28,7 +28,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
  * @see AsyncSearchResponse
  */
 public class SubmitAsyncSearchRequest extends ActionRequest {
-    public static long MIN_KEEP_ALIVE = TimeValue.timeValueMinutes(1).millis();
+    public static long MIN_KEEP_ALIVE = TimeValue.timeValueSeconds(1).millis();
 
     private TimeValue waitForCompletionTimeout = TimeValue.timeValueSeconds(1);
     private boolean keepOnCompletion = false;
@@ -135,7 +135,7 @@ public class SubmitAsyncSearchRequest extends ActionRequest {
         }
         if (keepAlive.getMillis() < MIN_KEEP_ALIVE) {
             validationException =
-                addValidationError("[keep_alive] must be greater than 1 minute, got:" + keepAlive.toString(), validationException);
+                addValidationError("[keep_alive] must be greater than 1 second, got:" + keepAlive.toString(), validationException);
         }
         if (request.isCcsMinimizeRoundtrips()) {
             validationException =


### PR DESCRIPTION
This commit changes the minimum value for the keep_alive option of async searches to 1s.

Closes #67974