### PR TITLE
[7.x] [DOCS] Add security privileges to repositories monitoring API docs (#67944)

### DIFF
--- a/docs/reference/repositories-metering-api/apis/clear-repositories-metering-archive.asciidoc
+++ b/docs/reference/repositories-metering-api/apis/clear-repositories-metering-archive.asciidoc
@@ -13,6 +13,12 @@ Removes the archived repositories metering information present in the cluster.
 
 `DELETE /_nodes/<node_id>/_repositories_metering/<max_version_to_clear>`
 
+[[clear-repositories-metering-archive-ap-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `monitor` or
+`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
+
 [[clear-repositories-metering-archive-api-desc]]
 ==== {api-description-title}
 

--- a/docs/reference/repositories-metering-api/apis/get-repositories-metering.asciidoc
+++ b/docs/reference/repositories-metering-api/apis/get-repositories-metering.asciidoc
@@ -13,6 +13,12 @@ Returns cluster repositories metering information.
 
 `GET /_nodes/<node_id>/_repositories_metering`
 
+[[get-repositories-metering-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `monitor` or
+`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
+
 [[get-repositories-metering-api-desc]]
 ==== {api-description-title}
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Add security privileges to repositories monitoring API docs (#67944)