### PR TITLE
Drop gateway.recover_after_nodes from default conf

### DIFF
--- a/distribution/src/config/elasticsearch.yml
+++ b/distribution/src/config/elasticsearch.yml
@@ -73,14 +73,6 @@ ${path.logs}
 #
 # For more information, consult the discovery and cluster formation module documentation.
 #
-# ---------------------------------- Gateway -----------------------------------
-#
-# Block initial recovery after a full cluster restart until N nodes are started:
-#
-#gateway.recover_after_nodes: 3
-#
-# For more information, consult the gateway module documentation.
-#
 # ---------------------------------- Various -----------------------------------
 #
 # Require explicit names when deleting indices:


### PR DESCRIPTION
The `gateway.recover_after_nodes` setting is one of the lucky few that
gets a mention in the default `elasticsearch.yml` config file. This
setting was deprecated in favour of `gateway.recover_after_data_nodes`
in #53646, but neither of these settings is really important enough to
warrant a place in the default config so this commit removes it.