### PR TITLE
Object mapper: merge enabled flag only when explicitly set

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -19,17 +19,6 @@
 
 package org.elasticsearch.index.mapper;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-
 import org.apache.lucene.search.Query;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.Version;
@@ -41,6 +30,17 @@ import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.index.mapper.MapperService.MergeReason;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 
 public class ObjectMapper extends Mapper implements Cloneable {
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(ObjectMapper.class);
@@ -495,12 +495,12 @@ public class ObjectMapper extends Mapper implements Cloneable {
             this.dynamic = mergeWith.dynamic;
         }
 
-        if (reason == MergeReason.INDEX_TEMPLATE) {
-            if (mergeWith.enabled.explicit()) {
+        if (mergeWith.enabled.explicit()) {
+            if (reason == MergeReason.INDEX_TEMPLATE) {
                 this.enabled = mergeWith.enabled;
+            } else if (isEnabled() != mergeWith.isEnabled()){
+                throw new MapperException("the [enabled] parameter can't be updated for the object mapping [" + name() + "]");
             }
-        } else if (isEnabled() != mergeWith.isEnabled()) {
-            throw new MapperException("the [enabled] parameter can't be updated for the object mapping [" + name() + "]");
         }
 
         for (Mapper mergeWithMapper : mergeWith) {

--- a/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperMergeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperMergeTests.java
@@ -118,6 +118,8 @@ public class ObjectMapperMergeTests extends ESTestCase {
 
         RootObjectMapper merged = (RootObjectMapper) rootObjectMapper.merge(mergeWith);
         assertFalse(merged.isEnabled());
+        assertEquals(1, merged.runtimeFieldTypes().size());
+        assertEquals("test", merged.runtimeFieldTypes().iterator().next().name());
     }
 
     public void testMergeNested() {

--- a/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperMergeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperMergeTests.java
@@ -75,6 +75,17 @@ public class ObjectMapperMergeTests extends ESTestCase {
         assertEquals("the [enabled] parameter can't be updated for the object mapping [foo]", e.getMessage());
     }
 
+    public void testMergeDisabledField() {
+        // GIVEN a mapping with "foo" field disabled
+        Map<String, Mapper> mappers = new HashMap<>();
+        //the field is disabled, and we are not trying to re-enable it, hence merge should work
+        mappers.put("disabled", new ObjectMapper.Builder("disabled", Version.CURRENT).build(new ContentPath()));
+        RootObjectMapper mergeWith = createRootObjectMapper("type1", true, Collections.unmodifiableMap(mappers));
+
+        RootObjectMapper merged = (RootObjectMapper)rootObjectMapper.merge(mergeWith);
+        assertFalse(((ObjectMapper)merged.getMapper("disabled")).isEnabled());
+    }
+
     public void testMergeEnabled() {
         ObjectMapper mergeWith = createMapping(true, true, true, false);
 
@@ -95,6 +106,18 @@ public class ObjectMapperMergeTests extends ESTestCase {
 
         ObjectMapper result = firstMapper.merge(secondMapper, MapperService.MergeReason.INDEX_TEMPLATE);
         assertFalse(result.isEnabled());
+    }
+
+    public void testMergeDisabledRootMapper() {
+        String type = MapperService.SINGLE_MAPPING_NAME;
+        final RootObjectMapper rootObjectMapper =
+            (RootObjectMapper) new RootObjectMapper.Builder(type, Version.CURRENT).enabled(false).build(new ContentPath());
+        //the root is disabled, and we are not trying to re-enable it, but we do want to be able to add runtime fields
+        final RootObjectMapper mergeWith =
+            new RootObjectMapper.Builder(type, Version.CURRENT).addRuntime(new TestRuntimeField("test", "long")).build(new ContentPath());
+
+        RootObjectMapper merged = (RootObjectMapper) rootObjectMapper.merge(mergeWith);
+        assertFalse(merged.isEnabled());
     }
 
     public void testMergeNested() {


### PR DESCRIPTION
Currently, when merging an object through put mapping, the default value for enabled is applied, which is true. In case the object has been previously disabled, that is going to cause an error although the updated mapping does not attempt to change the value for the enabled flag.

What needs to happen instead is that the enabled flag is applied only when set explicitly.

Closes #67972