### PR TITLE
[7.x] [DOCS] Fix explain API anchors (#68007)

### DIFF
--- a/docs/reference/search/explain.asciidoc
+++ b/docs/reference/search/explain.asciidoc
@@ -16,14 +16,14 @@ GET /my-index-000001/_explain/0
 // TEST[setup:messages]
 
 
-[[sample-api-request]]
+[[search-explain-api-request]]
 ==== {api-request-title}
 
 `GET /<index>/_explain/<id>`
 
 `POST /<index>/_explain/<id>`
 
-[[sample-api-desc]]
+[[search-explain-api-desc]]
 ==== {api-description-title}
 
 The explain API computes a score explanation for a query and a specific
@@ -31,7 +31,7 @@ document. This can give useful feedback whether a document matches or
 didn't match a specific query.
 
 
-[[sample-api-path-params]]
+[[search-explain-api-path-params]]
 ==== {api-path-parms-title}
 
 `<id>`::
@@ -47,7 +47,7 @@ Only a single index name can be provided to this parameter.
 --
 
 
-[[sample-api-query-params]]
+[[search-explain-api-query-params]]
 ==== {api-query-parms-title}
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=analyzer]
@@ -77,13 +77,13 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=source_excludes]
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=source_includes]
 
 
-[[sample-api-request-body]]
+[[search-explain-api-request-body]]
 ==== {api-request-body-title}
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=query]
 
 
-[[sample-api-example]]
+[[search-explain-api-example]]
 ==== {api-examples-title}
 
 [source,console]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Fix explain API anchors (#68007)