### PR TITLE
Only populate snapshot repo once in docs tests (#68013)

### DIFF
--- a/docs/src/test/java/org/elasticsearch/smoketest/DocsClientYamlTestSuiteIT.java
+++ b/docs/src/test/java/org/elasticsearch/smoketest/DocsClientYamlTestSuiteIT.java
@@ -108,8 +108,15 @@ public class DocsClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
         }
     }
 
+    private static boolean snapshotRepositoryPopulated;
+
     @Before
     public void populateSnapshotRepository() throws IOException {
+
+        if (snapshotRepositoryPopulated) {
+            return;
+        }
+
         // The repository UUID is only created on the first write to the repo, so it may or may not exist when running the tests. However to
         // include the output from the put-repository and get-repositories APIs in the docs we must be sure whether the UUID is returned or
         // not, so we prepare by taking a snapshot first to ensure that the UUID really has been created.
@@ -128,6 +135,8 @@ public class DocsClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
 
         final Request deleteRepoRequest = new Request("DELETE", "/_snapshot/test_setup_repo");
         assertOK(adminClient().performRequest(deleteRepoRequest));
+
+        snapshotRepositoryPopulated = true;
     }
 
     @After


### PR DESCRIPTION
In #67829 we introduced a `@Before` method to set up the repository for
the docs tests. In fact this only needs to run once for the whole suite,
not once per test.

Relates #67853

backport of #68013 