### PR TITLE
[DOCS] EQL: Add security privileges to EQL search docs

### DIFF
--- a/docs/reference/eql/delete-async-eql-search-api.asciidoc
+++ b/docs/reference/eql/delete-async-eql-search-api.asciidoc
@@ -25,7 +25,10 @@ DELETE /_eql/search/FkpMRkJGS1gzVDRlM3g4ZzMyRGlLbkEaTXlJZHdNT09TU2VTZVBoNDM3cFZM
 [[delete-async-eql-search-api-prereqs]]
 ==== {api-prereq-title}
 
-See <<eql-required-fields>>.
+* If the {es} {security-features} are enabled, only the user who first submitted
+the EQL search can delete the search using this API.
+
+* See <<eql-required-fields>>.
 
 [[delete-async-eql-search-api-limitations]]
 ===== Limitations

--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -33,7 +33,11 @@ GET /my-index-000001/_eql/search
 [[eql-search-api-prereqs]]
 ==== {api-prereq-title}
 
-See <<eql-required-fields>>.
+* If the {es} {security-features} are enabled, you must have the `read`
+<<privileges-list-indices,index privilege>> for the target data stream, index,
+or index alias.
+
+* See <<eql-required-fields>>.
 
 [[eql-search-api-limitations]]
 ===== Limitations

--- a/docs/reference/eql/eql.asciidoc
+++ b/docs/reference/eql/eql.asciidoc
@@ -497,7 +497,7 @@ To check the progress of an async search, use the <<get-async-eql-search-api,get
 async EQL search API>> with the search ID. Specify how long you'd like for
 complete results in the `wait_for_completion_timeout` parameter. If the {es}
 {security-features} are enabled, only the user who first submitted the EQL
-search can retrieve the search.
+search can retrieve the search using this API.
 
 [source,console]
 ----
@@ -559,7 +559,7 @@ Use the <<delete-async-eql-search-api,delete async EQL search API>> to
 manually delete an async EQL search before the `keep_alive` period ends. If the
 search is still ongoing, {es} cancels the search request. If the {es}
 {security-features} are enabled, only the user who first submitted the EQL
-search can delete the search.
+search can delete the search using this API.
 
 [source,console]
 ----

--- a/docs/reference/eql/eql.asciidoc
+++ b/docs/reference/eql/eql.asciidoc
@@ -45,8 +45,10 @@ default.
 [[run-an-eql-search]]
 == Run an EQL search
 
-Use the <<eql-search-api,EQL search API>> to run a <<eql-basic-syntax,basic
-EQL query>>:
+Use the <<eql-search-api,EQL search API>> to run a <<eql-basic-syntax,basic EQL
+query>>. If the {es} {security-features} are enabled, you must have the `read`
+<<privileges-list-indices,index privilege>> for the target data stream, index,
+or index alias.
 
 [source,console]
 ----
@@ -493,7 +495,9 @@ requests.
 
 To check the progress of an async search, use the <<get-async-eql-search-api,get
 async EQL search API>> with the search ID. Specify how long you'd like for
-complete results in the `wait_for_completion_timeout` parameter.
+complete results in the `wait_for_completion_timeout` parameter. If the {es}
+{security-features} are enabled, only the user who first submitted the EQL
+search can retrieve the search.
 
 [source,console]
 ----
@@ -553,7 +557,9 @@ GET /_eql/search/FmNJRUZ1YWZCU3dHY1BIOUhaenVSRkEaaXFlZ3h4c1RTWFNocDdnY2FSaERnUTo
 
 Use the <<delete-async-eql-search-api,delete async EQL search API>> to
 manually delete an async EQL search before the `keep_alive` period ends. If the
-search is still ongoing, {es} cancels the search request.
+search is still ongoing, {es} cancels the search request. If the {es}
+{security-features} are enabled, only the user who first submitted the EQL
+search can delete the search.
 
 [source,console]
 ----

--- a/docs/reference/eql/get-async-eql-search-api.asciidoc
+++ b/docs/reference/eql/get-async-eql-search-api.asciidoc
@@ -25,7 +25,10 @@ GET /_eql/search/FkpMRkJGS1gzVDRlM3g4ZzMyRGlLbkEaTXlJZHdNT09TU2VTZVBoNDM3cFZMUTo
 [[get-async-eql-search-api-prereqs]]
 ==== {api-prereq-title}
 
-See <<eql-required-fields>>.
+* If the {es} {security-features} are enabled, only the user who first submitted
+the EQL search can retrieve the search using this API.
+
+* See <<eql-required-fields>>.
 
 [[get-async-eql-search-api-limitations]]
 ===== Limitations


### PR DESCRIPTION
Updates the EQL docs to note required security privileges.

Relates to #66212


### Previews:
- Run an EQL search: https://elasticsearch_68017.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/eql.html#run-an-eql-search
- Run an EQL async search: https://elasticsearch_68017.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/eql.html#eql-search-async
- Change the search retention period: https://elasticsearch_68017.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/eql.html#eql-search-store-async-eql-search
- EQL search API: https://elasticsearch_68017.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/eql-search-api.html#eql-search-api-prereqs
- Get async EQL search API: https://elasticsearch_68017.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/get-async-eql-search-api.html#get-async-eql-search-api-prereqs
- Delete async EQL search API: https://elasticsearch_68017.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/delete-async-eql-search-api.html#delete-async-eql-search-api-prereqs