### PR TITLE
Ensure consistent disabling of transitive dependency resolution

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchJavaPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchJavaPlugin.java
@@ -55,7 +55,6 @@ import java.io.File;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
-import java.util.stream.Stream;
 
 import static org.elasticsearch.gradle.util.Util.toStringable;
 

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchJavaPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchJavaPlugin.java
@@ -24,6 +24,7 @@ import nebula.plugin.info.InfoBrokerPlugin;
 import org.elasticsearch.gradle.info.BuildParams;
 import org.elasticsearch.gradle.info.GlobalBuildInfoPlugin;
 import org.elasticsearch.gradle.precommit.PrecommitTaskPlugin;
+import org.elasticsearch.gradle.util.GradleUtils;
 import org.elasticsearch.gradle.util.Util;
 import org.gradle.api.Action;
 import org.gradle.api.JavaVersion;
@@ -39,6 +40,7 @@ import org.gradle.api.plugins.JavaLibraryPlugin;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.Jar;
 import org.gradle.api.tasks.compile.AbstractCompile;
@@ -53,6 +55,7 @@ import java.io.File;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 
 import static org.elasticsearch.gradle.util.Util.toStringable;
 
@@ -127,11 +130,10 @@ public class ElasticsearchJavaPlugin implements Plugin<Project> {
                 }
             });
         };
-        disableTransitiveDeps.accept(JavaPlugin.API_CONFIGURATION_NAME);
-        disableTransitiveDeps.accept(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME);
-        disableTransitiveDeps.accept(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME);
-        disableTransitiveDeps.accept(JavaPlugin.RUNTIME_ONLY_CONFIGURATION_NAME);
-        disableTransitiveDeps.accept(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME);
+
+        SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
+        GradleUtils.disableTransitiveDependenciesForSourceSet(project, sourceSets.getByName("main"));
+        GradleUtils.disableTransitiveDependenciesForSourceSet(project, sourceSets.getByName("test"));
     }
 
     /**
@@ -284,9 +286,9 @@ public class ElasticsearchJavaPlugin implements Plugin<Project> {
 
         TaskProvider<Javadoc> javadoc = project.getTasks().withType(Javadoc.class).named("javadoc");
         javadoc.configure(doc ->
-        // remove compiled classes from the Javadoc classpath:
-        // http://mail.openjdk.java.net/pipermail/javadoc-dev/2018-January/000400.html
-        doc.setClasspath(Util.getJavaMainSourceSet(project).get().getCompileClasspath()));
+            // remove compiled classes from the Javadoc classpath:
+            // http://mail.openjdk.java.net/pipermail/javadoc-dev/2018-January/000400.html
+            doc.setClasspath(Util.getJavaMainSourceSet(project).get().getCompileClasspath()));
 
         // ensure javadoc task is run with 'check'
         project.getTasks().named(LifecycleBasePlugin.CHECK_TASK_NAME).configure(t -> t.dependsOn(javadoc));

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchJavaPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchJavaPlugin.java
@@ -284,10 +284,10 @@ public class ElasticsearchJavaPlugin implements Plugin<Project> {
         });
 
         TaskProvider<Javadoc> javadoc = project.getTasks().withType(Javadoc.class).named("javadoc");
-        javadoc.configure(doc ->
-            // remove compiled classes from the Javadoc classpath:
-            // http://mail.openjdk.java.net/pipermail/javadoc-dev/2018-January/000400.html
-            doc.setClasspath(Util.getJavaMainSourceSet(project).get().getCompileClasspath()));
+
+        // remove compiled classes from the Javadoc classpath:
+        // http://mail.openjdk.java.net/pipermail/javadoc-dev/2018-January/000400.html
+        javadoc.configure(doc -> doc.setClasspath(Util.getJavaMainSourceSet(project).get().getCompileClasspath()));
 
         // ensure javadoc task is run with 'check'
         project.getTasks().named(LifecycleBasePlugin.CHECK_TASK_NAME).configure(t -> t.dependsOn(javadoc));

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/JavaRestTestPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/JavaRestTestPlugin.java
@@ -53,6 +53,9 @@ public class JavaRestTestPlugin implements Plugin<Project> {
         SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
         SourceSet javaTestSourceSet = sourceSets.create(SOURCE_SET_NAME);
 
+        // disable transitive dependency management
+        GradleUtils.disableTransitiveDependenciesForSourceSet(project, javaTestSourceSet);
+
         // create the test cluster container
         createTestCluster(project, javaTestSourceSet);
 

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/YamlRestTestPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/YamlRestTestPlugin.java
@@ -54,6 +54,9 @@ public class YamlRestTestPlugin implements Plugin<Project> {
         SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
         SourceSet yamlTestSourceSet = sourceSets.create(SOURCE_SET_NAME);
 
+        // disable transitive dependency management
+        GradleUtils.disableTransitiveDependenciesForSourceSet(project, yamlTestSourceSet);
+
         // create the test cluster container
         createTestCluster(project, yamlTestSourceSet);
 

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/util/GradleUtils.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/util/GradleUtils.java
@@ -26,6 +26,8 @@ import org.gradle.api.Task;
 import org.gradle.api.UnknownTaskException;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.ModuleDependency;
+import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.provider.Provider;
@@ -46,7 +48,9 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 public abstract class GradleUtils {
 
@@ -138,6 +142,8 @@ public abstract class GradleUtils {
         extendSourceSet(project, SourceSet.MAIN_SOURCE_SET_NAME, sourceSetName);
 
         setupIdeForTestSourceSet(project, testSourceSet);
+
+        disableTransitiveDependenciesForSourceSet(project, testSourceSet);
 
         // add to the check task
         project.getTasks().named(JavaBasePlugin.CHECK_TASK_NAME).configure(check -> check.dependsOn(testTask));
@@ -231,5 +237,27 @@ public abstract class GradleUtils {
         return projectPath.contains("modules:")
             || projectPath.startsWith(":x-pack:plugin")
             || projectPath.startsWith(":x-pack:quota-aware-fs");
+    }
+
+    public static void disableTransitiveDependenciesForSourceSet(Project project, SourceSet sourceSet) {
+        Stream.of(
+            sourceSet.getApiConfigurationName(),
+            sourceSet.getImplementationConfigurationName(),
+            sourceSet.getCompileOnlyConfigurationName(),
+            sourceSet.getRuntimeOnlyConfigurationName()
+        )
+            .map(name -> project.getConfigurations().findByName(name))
+            .filter(Objects::nonNull)
+            .forEach(GradleUtils::disableTransitiveDependencies);
+    }
+
+    private static void disableTransitiveDependencies(Configuration config) {
+        config.getDependencies().all(dep -> {
+            if (dep instanceof ModuleDependency
+                && dep instanceof ProjectDependency == false
+                && dep.getGroup().startsWith("org.elasticsearch") == false) {
+                ((ModuleDependency) dep).setTransitive(false);
+            }
+        });
     }
 }


### PR DESCRIPTION
By convention we don't rely on transitive dependency resolution in Gradle (yet). This PR makes this consistent across all source sets, such as YAML and REST tests, in addition to the existing `main` and `test` source set dependencies.