### PR TITLE
Introduce `RestCompatTestTransformTask` 

### DIFF
--- a/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/YamlRestCompatTestPluginFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/YamlRestCompatTestPluginFuncTest.groovy
@@ -92,7 +92,7 @@ class YamlRestCompatTestPluginFuncTest extends AbstractRestResourcesFuncTest {
         file("distribution/bwc/minor/checkoutDir/src/yamlRestTest/resources/rest-api-spec/test/" + test) << ""
 
         when:
-        def result = gradleRunner("yamlRestCompatTest").build()
+        def result = gradleRunner("yamlRestCompatTest", "--info").build()
 
         then:
         result.task(':yamlRestCompatTest').outcome == TaskOutcome.SKIPPED
@@ -112,14 +112,14 @@ class YamlRestCompatTestPluginFuncTest extends AbstractRestResourcesFuncTest {
         result.task(':copyYamlTestsTask').outcome == TaskOutcome.NO_SOURCE
 
         when:
-        result = gradleRunner("yamlRestCompatTest").build()
+        result = gradleRunner("yamlRestCompatTest", "--info").build()
 
         then:
         result.task(':yamlRestCompatTest').outcome == TaskOutcome.SKIPPED
         result.task(':copyRestApiCompatSpecsTask').outcome == TaskOutcome.UP_TO_DATE
         result.task(':copyRestApiCompatTestTask').outcome == TaskOutcome.UP_TO_DATE
     }
-    
+
     def "yamlRestCompatTest is wired into check and checkRestCompat"() {
         given:
 

--- a/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/YamlRestCompatTestPluginFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/YamlRestCompatTestPluginFuncTest.groovy
@@ -20,9 +20,12 @@
 package org.elasticsearch.gradle
 
 import org.elasticsearch.gradle.fixtures.AbstractRestResourcesFuncTest
+import org.elasticsearch.gradle.internal.rest.compat.YamlRestCompatTestPlugin
 import org.gradle.testkit.runner.TaskOutcome
 
 class YamlRestCompatTestPluginFuncTest extends AbstractRestResourcesFuncTest {
+
+    def intermediateDir = YamlRestCompatTestPlugin.TEST_INTERMEDIATE_DIR_NAME;
 
     def "yamlRestCompatTest does nothing when there are no tests"() {
         given:
@@ -47,6 +50,7 @@ class YamlRestCompatTestPluginFuncTest extends AbstractRestResourcesFuncTest {
         result.task(':yamlRestCompatTest').outcome == TaskOutcome.NO_SOURCE
         result.task(':copyRestApiCompatSpecsTask').outcome == TaskOutcome.NO_SOURCE
         result.task(':copyRestApiCompatTestTask').outcome == TaskOutcome.NO_SOURCE
+        result.task(':transformCompatTests').outcome == TaskOutcome.NO_SOURCE
     }
 
     def "yamlRestCompatTest executes and copies api and tests from :bwc:minor"() {
@@ -92,32 +96,38 @@ class YamlRestCompatTestPluginFuncTest extends AbstractRestResourcesFuncTest {
         file("distribution/bwc/minor/checkoutDir/src/yamlRestTest/resources/rest-api-spec/test/" + test) << ""
 
         when:
-        def result = gradleRunner("yamlRestCompatTest", "--info").build()
+        def result = gradleRunner("yamlRestCompatTest").build()
 
         then:
         result.task(':yamlRestCompatTest').outcome == TaskOutcome.SKIPPED
         result.task(':copyRestApiCompatSpecsTask').outcome == TaskOutcome.SUCCESS
         result.task(':copyRestApiCompatTestTask').outcome == TaskOutcome.SUCCESS
+        result.task(':transformCompatTests').outcome == TaskOutcome.SUCCESS
 
         file("/build/resources/yamlRestCompatTest/rest-api-spec/api/" + api).exists()
         file("/build/resources/yamlRestCompatTest/rest-api-spec/test/" + test).exists()
+        file("/build/resources/yamlRestCompatTest/" + intermediateDir + "/rest-api-spec/test/" + test).exists()
         file("/build/resources/yamlRestCompatTest/rest-api-spec/test/" + additionalTest).exists()
+        //additionalTest is not copied from the prior version, and thus not in the intermediate directory
+        file("/build/resources/yamlRestCompatTest/" + intermediateDir + "/rest-api-spec/test/" + additionalTest).exists() == false
 
         file("/build/classes/java/yamlRestTest/MockIT.class").exists() //The "standard" runner is used to execute the compat test
 
         file("/build/resources/yamlRestCompatTest/rest-api-spec/api/" + wrongApi).exists() == false
+        file("/build/resources/yamlRestCompatTest/" + intermediateDir + "/rest-api-spec/test/" + wrongTest).exists() == false
         file("/build/resources/yamlRestCompatTest/rest-api-spec/test/" + wrongTest).exists() == false
 
         result.task(':copyRestApiSpecsTask').outcome == TaskOutcome.NO_SOURCE
         result.task(':copyYamlTestsTask').outcome == TaskOutcome.NO_SOURCE
 
         when:
-        result = gradleRunner("yamlRestCompatTest", "--info").build()
+        result = gradleRunner("yamlRestCompatTest").build()
 
         then:
         result.task(':yamlRestCompatTest').outcome == TaskOutcome.SKIPPED
         result.task(':copyRestApiCompatSpecsTask').outcome == TaskOutcome.UP_TO_DATE
         result.task(':copyRestApiCompatTestTask').outcome == TaskOutcome.UP_TO_DATE
+        result.task(':transformCompatTests').outcome == TaskOutcome.UP_TO_DATE
     }
 
     def "yamlRestCompatTest is wired into check and checkRestCompat"() {
@@ -146,6 +156,7 @@ class YamlRestCompatTestPluginFuncTest extends AbstractRestResourcesFuncTest {
         result.task(':yamlRestCompatTest').outcome == TaskOutcome.NO_SOURCE
         result.task(':copyRestApiCompatSpecsTask').outcome == TaskOutcome.NO_SOURCE
         result.task(':copyRestApiCompatTestTask').outcome == TaskOutcome.NO_SOURCE
+        result.task(':transformCompatTests').outcome == TaskOutcome.NO_SOURCE
 
         when:
         buildFile << """
@@ -159,5 +170,7 @@ class YamlRestCompatTestPluginFuncTest extends AbstractRestResourcesFuncTest {
         result.task(':yamlRestCompatTest').outcome == TaskOutcome.SKIPPED
         result.task(':copyRestApiCompatSpecsTask').outcome == TaskOutcome.SKIPPED
         result.task(':copyRestApiCompatTestTask').outcome == TaskOutcome.SKIPPED
+        result.task(':transformCompatTests').outcome == TaskOutcome.SKIPPED
+
     }
 }

--- a/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/YamlRestCompatTestPluginFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/YamlRestCompatTestPluginFuncTest.groovy
@@ -53,50 +53,6 @@ class YamlRestCompatTestPluginFuncTest extends AbstractRestResourcesFuncTest {
         result.task(':transformCompatTests').outcome == TaskOutcome.NO_SOURCE
     }
 
-    def "yamlRestCompatTest is wired into check and checkRestCompat"() {
-        given:
-
-        addSubProject(":distribution:bwc:minor") << """
-        configurations { checkout }
-        artifacts {
-            checkout(new File(projectDir, "checkoutDir"))
-        }
-        """
-
-        buildFile << """
-        plugins {
-          id 'elasticsearch.yaml-rest-compat-test'
-        }
-
-        """
-
-        when:
-        def result = gradleRunner("check").build()
-
-        then:
-        result.task(':check').outcome == TaskOutcome.UP_TO_DATE
-        result.task(':checkRestCompat').outcome == TaskOutcome.UP_TO_DATE
-        result.task(':yamlRestCompatTest').outcome == TaskOutcome.NO_SOURCE
-        result.task(':copyRestApiCompatSpecsTask').outcome == TaskOutcome.NO_SOURCE
-        result.task(':copyRestApiCompatTestTask').outcome == TaskOutcome.NO_SOURCE
-        result.task(':transformCompatTests').outcome == TaskOutcome.NO_SOURCE
-
-        when:
-        buildFile << """
-         ext.bwc_tests_enabled = false
-        """
-        result = gradleRunner("check").build()
-
-        then:
-        result.task(':check').outcome == TaskOutcome.UP_TO_DATE
-        result.task(':checkRestCompat').outcome == TaskOutcome.UP_TO_DATE
-        result.task(':yamlRestCompatTest').outcome == TaskOutcome.SKIPPED
-        result.task(':copyRestApiCompatSpecsTask').outcome == TaskOutcome.SKIPPED
-        result.task(':copyRestApiCompatTestTask').outcome == TaskOutcome.SKIPPED
-        result.task(':transformCompatTests').outcome == TaskOutcome.SKIPPED
-
-    }
-
     def "yamlRestCompatTest executes and copies api and transforms tests from :bwc:minor"() {
         given:
         internalBuild()
@@ -175,5 +131,49 @@ class YamlRestCompatTestPluginFuncTest extends AbstractRestResourcesFuncTest {
         result.task(':copyRestApiCompatSpecsTask').outcome == TaskOutcome.UP_TO_DATE
         result.task(':copyRestApiCompatTestTask').outcome == TaskOutcome.UP_TO_DATE
         result.task(':transformCompatTests').outcome == TaskOutcome.UP_TO_DATE
+    }
+
+    def "yamlRestCompatTest is wired into check and checkRestCompat"() {
+        given:
+
+        addSubProject(":distribution:bwc:minor") << """
+        configurations { checkout }
+        artifacts {
+            checkout(new File(projectDir, "checkoutDir"))
+        }
+        """
+
+        buildFile << """
+        plugins {
+          id 'elasticsearch.yaml-rest-compat-test'
+        }
+
+        """
+
+        when:
+        def result = gradleRunner("check").build()
+
+        then:
+        result.task(':check').outcome == TaskOutcome.UP_TO_DATE
+        result.task(':checkRestCompat').outcome == TaskOutcome.UP_TO_DATE
+        result.task(':yamlRestCompatTest').outcome == TaskOutcome.NO_SOURCE
+        result.task(':copyRestApiCompatSpecsTask').outcome == TaskOutcome.NO_SOURCE
+        result.task(':copyRestApiCompatTestTask').outcome == TaskOutcome.NO_SOURCE
+        result.task(':transformCompatTests').outcome == TaskOutcome.NO_SOURCE
+
+        when:
+        buildFile << """
+         ext.bwc_tests_enabled = false
+        """
+        result = gradleRunner("check").build()
+
+        then:
+        result.task(':check').outcome == TaskOutcome.UP_TO_DATE
+        result.task(':checkRestCompat').outcome == TaskOutcome.UP_TO_DATE
+        result.task(':yamlRestCompatTest').outcome == TaskOutcome.SKIPPED
+        result.task(':copyRestApiCompatSpecsTask').outcome == TaskOutcome.SKIPPED
+        result.task(':copyRestApiCompatTestTask').outcome == TaskOutcome.SKIPPED
+        result.task(':transformCompatTests').outcome == TaskOutcome.SKIPPED
+
     }
 }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/internal/rest/compat/RestCompatTestTransformTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/internal/rest/compat/RestCompatTestTransformTask.java
@@ -67,7 +67,7 @@ public class RestCompatTestTransformTask extends DefaultTask {
         "application/vnd.elasticsearch+json;compatible-with=7"
     );
 
-    private String sourceSetName;
+    private SourceSet sourceSet;
     private static final String REST_TEST_PREFIX = "rest-api-spec/test";
 
     private final PatternFilterable testPatternSet;
@@ -86,15 +86,11 @@ public class RestCompatTestTransformTask extends DefaultTask {
         throw new UnsupportedOperationException();
     }
 
-    @Input
-    public String getSourceSetName() {
-        return sourceSetName;
-    }
 
     @OutputDirectory
     public File getOutputDir() {
         return new File(
-            getSourceSet().orElseThrow(() -> new IllegalArgumentException("could not find source set [" + sourceSetName + "]"))
+            sourceSet
                 .getOutput()
                 .getResourcesDir(),
             REST_TEST_PREFIX
@@ -107,8 +103,7 @@ public class RestCompatTestTransformTask extends DefaultTask {
         return getProject().files(
             new File(
                 new File(
-                    getSourceSet().orElseThrow(() -> new IllegalArgumentException("could not find source set [" + sourceSetName + "]"))
-                        .getOutput()
+                    sourceSet                        .getOutput()
                         .getResourcesDir(),
                     inputResourceParent
                 ),
@@ -138,15 +133,8 @@ public class RestCompatTestTransformTask extends DefaultTask {
         }
     }
 
-    private Optional<SourceSet> getSourceSet() {
-        Project project = getProject();
-        return project.getConvention().findPlugin(JavaPluginConvention.class) == null
-            ? Optional.empty()
-            : Optional.ofNullable(GradleUtils.getJavaSourceSets(project).findByName(getSourceSetName()));
-    }
-
-    public void setSourceSetName(String sourceSetName) {
-        this.sourceSetName = sourceSetName;
+    public void setSourceSet(SourceSet sourceSet) {
+        this.sourceSet = sourceSet;
     }
 
     public void setInputResourceParent(String inputResourceParent) {

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/internal/rest/compat/RestCompatTestTransformTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/internal/rest/compat/RestCompatTestTransformTask.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.gradle.internal.rest.compat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SequenceWriter;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLParser;
+import org.elasticsearch.gradle.test.rest.transform.InjectHeaders;
+import org.elasticsearch.gradle.test.rest.transform.RestTestTransform;
+import org.elasticsearch.gradle.test.rest.transform.RestTestTransformer;
+import org.elasticsearch.gradle.util.GradleUtils;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.Project;
+import org.gradle.api.file.FileTree;
+import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.util.PatternFilterable;
+import org.gradle.api.tasks.util.PatternSet;
+import org.gradle.internal.Factory;
+
+import javax.inject.Inject;
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class RestCompatTestTransformTask extends DefaultTask {
+
+    private static final YAMLFactory yaml = new YAMLFactory();
+    private static final ObjectMapper mapper = new ObjectMapper(yaml);
+
+    private static final Map<String, String> headers = Map.of(
+        "Content-Type",
+        "application/vnd.elasticsearch+json;compatible-with=7",
+        "Accept",
+        "application/vnd.elasticsearch+json;compatible-with=7"
+    );
+
+
+    String sourceSetName;
+    private static final String REST_TEST_PREFIX = "rest-api-spec/test";
+
+    private final PatternFilterable testPatternSet;
+    private final List<RestTestTransform<?>> transformations;
+
+    public RestCompatTestTransformTask() {
+        testPatternSet = getPatternSetFactory().create();
+        testPatternSet.include("/**/*.yml");
+        transformations = Collections.singletonList(new InjectHeaders(headers));
+    }
+
+    @Inject
+    protected Factory<PatternSet> getPatternSetFactory() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Input
+    public String getSourceSetName() {
+        return sourceSetName;
+    }
+
+    @OutputDirectory
+    public File getOutputDir() {
+        return new File(
+            getSourceSet().orElseThrow(() -> new IllegalArgumentException("could not find source set [" + sourceSetName + "]"))
+                .getOutput()
+                .getResourcesDir(),
+            REST_TEST_PREFIX
+        );
+    }
+
+    @InputFiles
+    public FileTree getTestFiles() {
+        return getProject().files(getOutputDir()).getAsFileTree().matching(testPatternSet);
+    }
+
+    @TaskAction
+    public void transform() throws IOException {
+        RestTestTransformer transformer = new RestTestTransformer();
+        for (File file : getTestFiles().getFiles()) {
+            YAMLParser yamlParser = yaml.createParser(file);
+            List<ObjectNode> tests = mapper.readValues(yamlParser, ObjectNode.class).readAll();
+            List<ObjectNode> transformRestTests = transformer.transformRestTests(new LinkedList<>(tests), transformations);
+            try (SequenceWriter sequenceWriter = mapper.writer().writeValues(file)) {
+                for (ObjectNode transformedTest : transformRestTests) {
+                    sequenceWriter.write(transformedTest);
+                }
+            }
+        }
+    }
+
+    private Optional<SourceSet> getSourceSet() {
+        Project project = getProject();
+        return project.getConvention().findPlugin(JavaPluginConvention.class) == null
+            ? Optional.empty()
+            : Optional.ofNullable(GradleUtils.getJavaSourceSets(project).findByName(getSourceSetName()));
+    }
+}

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/internal/rest/compat/RestCompatTestTransformTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/internal/rest/compat/RestCompatTestTransformTask.java
@@ -32,6 +32,7 @@ import org.elasticsearch.gradle.test.rest.transform.RestTestTransformer;
 import org.elasticsearch.gradle.util.GradleUtils;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Project;
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.Input;
@@ -68,6 +69,8 @@ public class RestCompatTestTransformTask extends DefaultTask {
     );
 
     private SourceSet sourceSet;
+    private FileCollection input;
+    private File output;
     private static final String REST_TEST_PREFIX = "rest-api-spec/test";
 
     private final PatternFilterable testPatternSet;
@@ -100,16 +103,7 @@ public class RestCompatTestTransformTask extends DefaultTask {
     @SkipWhenEmpty
     @InputFiles
     public FileTree getTestFiles() {
-        return getProject().files(
-            new File(
-                new File(
-                    sourceSet                        .getOutput()
-                        .getResourcesDir(),
-                    inputResourceParent
-                ),
-                REST_TEST_PREFIX
-            )
-        ).getAsFileTree().matching(testPatternSet);
+        return input.getAsFileTree().matching(testPatternSet);
     }
 
     @TaskAction
@@ -135,6 +129,14 @@ public class RestCompatTestTransformTask extends DefaultTask {
 
     public void setSourceSet(SourceSet sourceSet) {
         this.sourceSet = sourceSet;
+    }
+
+    public void setInput(FileCollection input) {
+        this.input = input;
+    }
+
+    public void setOutput(File output) {
+        this.output = output;
     }
 
     public void setInputResourceParent(String inputResourceParent) {

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/internal/rest/compat/RestCompatTestTransformTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/internal/rest/compat/RestCompatTestTransformTask.java
@@ -63,7 +63,7 @@ public class RestCompatTestTransformTask extends DefaultTask {
         "application/vnd.elasticsearch+json;compatible-with=7"
     );
 
-    String sourceSetName;
+    private String sourceSetName;
     private static final String REST_TEST_PREFIX = "rest-api-spec/test";
 
     private final PatternFilterable testPatternSet;
@@ -73,7 +73,7 @@ public class RestCompatTestTransformTask extends DefaultTask {
 
     public RestCompatTestTransformTask() {
         testPatternSet = getPatternSetFactory().create();
-        testPatternSet.include("/*" + "*/*.yml"); // to keep build from thinking this is a java comment
+        testPatternSet.include("/*" + "*/*.yml"); // concat these strings to keep build from thinking this is invalid javadoc
         transformations = Collections.singletonList(new InjectHeaders(headers));
     }
 
@@ -139,6 +139,10 @@ public class RestCompatTestTransformTask extends DefaultTask {
         return project.getConvention().findPlugin(JavaPluginConvention.class) == null
             ? Optional.empty()
             : Optional.ofNullable(GradleUtils.getJavaSourceSets(project).findByName(getSourceSetName()));
+    }
+
+    public void setSourceSetName(String sourceSetName) {
+        this.sourceSetName = sourceSetName;
     }
 
     public void setInputResourceParent(String inputResourceParent) {

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/internal/rest/compat/RestCompatTestTransformTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/internal/rest/compat/RestCompatTestTransformTask.java
@@ -62,7 +62,6 @@ public class RestCompatTestTransformTask extends DefaultTask {
         "application/vnd.elasticsearch+json;compatible-with=7"
     );
 
-
     String sourceSetName;
     private static final String REST_TEST_PREFIX = "rest-api-spec/test";
 
@@ -71,7 +70,7 @@ public class RestCompatTestTransformTask extends DefaultTask {
 
     public RestCompatTestTransformTask() {
         testPatternSet = getPatternSetFactory().create();
-        testPatternSet.include("/**/*.yml");
+        testPatternSet.include("/*" + "*/*.yml"); // to keep build from thinking this is a java comment
         transformations = Collections.singletonList(new InjectHeaders(headers));
     }
 

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/internal/rest/compat/RestCompatTestTransformTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/internal/rest/compat/RestCompatTestTransformTask.java
@@ -69,7 +69,6 @@ public class RestCompatTestTransformTask extends DefaultTask {
     private final PatternFilterable testPatternSet;
     private final List<RestTestTransform<?>> transformations;
 
-
     private String inputResourceParent = "";
 
     public RestCompatTestTransformTask() {
@@ -101,13 +100,17 @@ public class RestCompatTestTransformTask extends DefaultTask {
     @SkipWhenEmpty
     @InputFiles
     public FileTree getTestFiles() {
-        return getProject().files(new File(new File(
-            getSourceSet().orElseThrow(() -> new IllegalArgumentException("could not find source set [" + sourceSetName + "]"))
-                .getOutput()
-                .getResourcesDir(),
-            inputResourceParent),
-            REST_TEST_PREFIX
-        )).getAsFileTree().matching(testPatternSet);
+        return getProject().files(
+            new File(
+                new File(
+                    getSourceSet().orElseThrow(() -> new IllegalArgumentException("could not find source set [" + sourceSetName + "]"))
+                        .getOutput()
+                        .getResourcesDir(),
+                    inputResourceParent
+                ),
+                REST_TEST_PREFIX
+            )
+        ).getAsFileTree().matching(testPatternSet);
     }
 
     @TaskAction
@@ -117,9 +120,9 @@ public class RestCompatTestTransformTask extends DefaultTask {
             YAMLParser yamlParser = yaml.createParser(file);
             List<ObjectNode> tests = mapper.readValues(yamlParser, ObjectNode.class).readAll();
             List<ObjectNode> transformRestTests = transformer.transformRestTests(new LinkedList<>(tests), transformations);
-            //convert to url to ensure forward slashes
+            // convert to url to ensure forward slashes
             String[] testFileParts = file.toURI().toURL().getPath().split(REST_TEST_PREFIX);
-            assert testFileParts.length == 2; //before and after the REST_TEST_PREFIX
+            assert testFileParts.length == 2; // before and after the REST_TEST_PREFIX
             try (SequenceWriter sequenceWriter = mapper.writer().writeValues(new File(getOutputDir(), testFileParts[1]))) {
                 for (ObjectNode transformedTest : transformRestTests) {
                     sequenceWriter.write(transformedTest);

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/internal/rest/compat/RestCompatTestTransformTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/internal/rest/compat/RestCompatTestTransformTask.java
@@ -123,7 +123,10 @@ public class RestCompatTestTransformTask extends DefaultTask {
             // convert to url to ensure forward slashes
             String[] testFileParts = file.toURI().toURL().getPath().split(REST_TEST_PREFIX);
             assert testFileParts.length == 2; // before and after the REST_TEST_PREFIX
-            try (SequenceWriter sequenceWriter = mapper.writer().writeValues(new File(getOutputDir(), testFileParts[1]))) {
+            File output = new File(getOutputDir(), testFileParts[1]);
+            boolean mkdirs = output.getParentFile().mkdirs();
+            assert mkdirs : "could not make directories for " + output;
+            try (SequenceWriter sequenceWriter = mapper.writer().writeValues(output)) {
                 for (ObjectNode transformedTest : transformRestTests) {
                     sequenceWriter.write(transformedTest);
                 }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/internal/rest/compat/RestCompatTestTransformTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/internal/rest/compat/RestCompatTestTransformTask.java
@@ -69,7 +69,6 @@ public class RestCompatTestTransformTask extends DefaultTask {
     private final PatternFilterable testPatternSet;
     private final List<RestTestTransform<?>> transformations;
 
-
     @Inject
     public RestCompatTestTransformTask(Factory<PatternSet> patternSetFactory) {
         this.testPatternSet = patternSetFactory.create();

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/internal/rest/compat/YamlRestCompatTestPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/internal/rest/compat/YamlRestCompatTestPlugin.java
@@ -156,6 +156,7 @@ public class YamlRestCompatTestPlugin implements Plugin<Project> {
                 task.sourceSetName = SOURCE_SET_NAME;
                 task.dependsOn(copyCompatYamlTestTask);
                 task.dependsOn(yamlCompatTestSourceSet.getProcessResourcesTaskName());
+//                task.setEnabled(false);
             });
 
         // setup the yamlRestTest task

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/internal/rest/compat/YamlRestCompatTestPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/internal/rest/compat/YamlRestCompatTestPlugin.java
@@ -166,8 +166,6 @@ public class YamlRestCompatTestPlugin implements Plugin<Project> {
                 task.setInput(project.files(new File(intermediateDir, RELATIVE_TEST_PATH.toString())));
                 task.setOutput(new File(resourceDir, RELATIVE_TEST_PATH.toString()));
 
-
-
                 task.onlyIf(t -> isEnabled(project));
             });
 

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/internal/rest/compat/YamlRestCompatTestPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/internal/rest/compat/YamlRestCompatTestPlugin.java
@@ -152,7 +152,7 @@ public class YamlRestCompatTestPlugin implements Plugin<Project> {
                     )
                 );
                 task.dependsOn(copyCompatYamlSpecTask);
-                task.setOutputResourceParent(TEST_INTERMEDIATE_DIR_NAME);
+                task.setOutputResourceRoot(TEST_INTERMEDIATE_DIR_NAME);
                 task.onlyIf(t -> isEnabled(project));
             });
 
@@ -163,6 +163,13 @@ public class YamlRestCompatTestPlugin implements Plugin<Project> {
                 task.dependsOn(copyCompatYamlTestTask);
                 task.dependsOn(yamlCompatTestSourceSet.getProcessResourcesTaskName());
                 task.setInputResourceParent(TEST_INTERMEDIATE_DIR_NAME);
+                File resourceDir = yamlCompatTestSourceSet.getOutput().getResourcesDir();
+                File intermediateDir = new File(resourceDir, TEST_INTERMEDIATE_DIR_NAME);
+                task.setInput(project.files(new File(intermediateDir,RELATIVE_TEST_PATH.toString())));
+
+
+
+
                 task.onlyIf(t -> isEnabled(project));
             });
 

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/internal/rest/compat/YamlRestCompatTestPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/internal/rest/compat/YamlRestCompatTestPlugin.java
@@ -66,8 +66,9 @@ public class YamlRestCompatTestPlugin implements Plugin<Project> {
     private static final Path RELATIVE_REST_API_RESOURCES = Path.of("rest-api-spec/src/main/resources");
     private static final Path RELATIVE_REST_XPACK_RESOURCES = Path.of("x-pack/plugin/src/test/resources");
     private static final Path RELATIVE_REST_PROJECT_RESOURCES = Path.of("src/yamlRestTest/resources");
-    public static final String TEST_INTERMEDIATE_DIR_NAME =
-        "v" + (Version.fromString(VersionProperties.getVersions().get("elasticsearch")).getMajor() - 1) + "restTests";
+    public static final String TEST_INTERMEDIATE_DIR_NAME = "v"
+        + (Version.fromString(VersionProperties.getVersions().get("elasticsearch")).getMajor() - 1)
+        + "restTests";
 
     @Override
     public void apply(Project project) {

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/internal/rest/compat/YamlRestCompatTestPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/internal/rest/compat/YamlRestCompatTestPlugin.java
@@ -20,6 +20,8 @@
 package org.elasticsearch.gradle.internal.rest.compat;
 
 import org.elasticsearch.gradle.ElasticsearchJavaPlugin;
+import org.elasticsearch.gradle.Version;
+import org.elasticsearch.gradle.VersionProperties;
 import org.elasticsearch.gradle.test.RestIntegTestTask;
 import org.elasticsearch.gradle.test.RestTestBasePlugin;
 import org.elasticsearch.gradle.test.rest.CopyRestApiTask;
@@ -64,6 +66,8 @@ public class YamlRestCompatTestPlugin implements Plugin<Project> {
     private static final Path RELATIVE_REST_API_RESOURCES = Path.of("rest-api-spec/src/main/resources");
     private static final Path RELATIVE_REST_XPACK_RESOURCES = Path.of("x-pack/plugin/src/test/resources");
     private static final Path RELATIVE_REST_PROJECT_RESOURCES = Path.of("src/yamlRestTest/resources");
+    public static final String TEST_INTERMEDIATE_DIR_NAME =
+        "v" + (Version.fromString(VersionProperties.getVersions().get("elasticsearch")).getMajor() - 1) + "restTests";
 
     @Override
     public void apply(Project project) {
@@ -147,6 +151,7 @@ public class YamlRestCompatTestPlugin implements Plugin<Project> {
                     )
                 );
                 task.dependsOn(copyCompatYamlSpecTask);
+                task.setOutputResourceParent(TEST_INTERMEDIATE_DIR_NAME);
                 task.onlyIf(t -> isEnabled(project));
             });
 
@@ -156,7 +161,8 @@ public class YamlRestCompatTestPlugin implements Plugin<Project> {
                 task.sourceSetName = SOURCE_SET_NAME;
                 task.dependsOn(copyCompatYamlTestTask);
                 task.dependsOn(yamlCompatTestSourceSet.getProcessResourcesTaskName());
-//                task.setEnabled(false);
+                task.setInputResourceParent(TEST_INTERMEDIATE_DIR_NAME);
+                task.onlyIf(t -> isEnabled(project));
             });
 
         // setup the yamlRestTest task

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/internal/rest/compat/YamlRestCompatTestPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/internal/rest/compat/YamlRestCompatTestPlugin.java
@@ -159,7 +159,7 @@ public class YamlRestCompatTestPlugin implements Plugin<Project> {
         // transform the copied tests task
         TaskProvider<RestCompatTestTransformTask> transformCompatTestTask = project.getTasks()
             .register("transformCompatTests", RestCompatTestTransformTask.class, task -> {
-                task.sourceSetName = SOURCE_SET_NAME;
+                task.setSourceSetName(SOURCE_SET_NAME);
                 task.dependsOn(copyCompatYamlTestTask);
                 task.dependsOn(yamlCompatTestSourceSet.getProcessResourcesTaskName());
                 task.setInputResourceParent(TEST_INTERMEDIATE_DIR_NAME);

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/internal/rest/compat/YamlRestCompatTestPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/internal/rest/compat/YamlRestCompatTestPlugin.java
@@ -159,14 +159,12 @@ public class YamlRestCompatTestPlugin implements Plugin<Project> {
         // transform the copied tests task
         TaskProvider<RestCompatTestTransformTask> transformCompatTestTask = project.getTasks()
             .register("transformCompatTests", RestCompatTestTransformTask.class, task -> {
-                task.setSourceSet(yamlCompatTestSourceSet);
                 task.dependsOn(copyCompatYamlTestTask);
                 task.dependsOn(yamlCompatTestSourceSet.getProcessResourcesTaskName());
-                task.setInputResourceParent(TEST_INTERMEDIATE_DIR_NAME);
                 File resourceDir = yamlCompatTestSourceSet.getOutput().getResourcesDir();
                 File intermediateDir = new File(resourceDir, TEST_INTERMEDIATE_DIR_NAME);
-                task.setInput(project.files(new File(intermediateDir,RELATIVE_TEST_PATH.toString())));
-
+                task.setInput(project.files(new File(intermediateDir, RELATIVE_TEST_PATH.toString())));
+                task.setOutput(new File(resourceDir, RELATIVE_TEST_PATH.toString()));
 
 
 

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/internal/rest/compat/YamlRestCompatTestPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/internal/rest/compat/YamlRestCompatTestPlugin.java
@@ -159,7 +159,7 @@ public class YamlRestCompatTestPlugin implements Plugin<Project> {
         // transform the copied tests task
         TaskProvider<RestCompatTestTransformTask> transformCompatTestTask = project.getTasks()
             .register("transformCompatTests", RestCompatTestTransformTask.class, task -> {
-                task.setSourceSetName(SOURCE_SET_NAME);
+                task.setSourceSet(yamlCompatTestSourceSet);
                 task.dependsOn(copyCompatYamlTestTask);
                 task.dependsOn(yamlCompatTestSourceSet.getProcessResourcesTaskName());
                 task.setInputResourceParent(TEST_INTERMEDIATE_DIR_NAME);

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/CopyRestTestsTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/CopyRestTestsTask.java
@@ -140,11 +140,13 @@ public class CopyRestTestsTask extends DefaultTask {
 
     @OutputDirectory
     public File getOutputDir() {
-        return new File(new File(
-            getSourceSet().orElseThrow(() -> new IllegalArgumentException("could not find source set [" + sourceSetName + "]"))
-                .getOutput()
-                .getResourcesDir(),
-            outputResourceParent),
+        return new File(
+            new File(
+                getSourceSet().orElseThrow(() -> new IllegalArgumentException("could not find source set [" + sourceSetName + "]"))
+                    .getOutput()
+                    .getResourcesDir(),
+                outputResourceParent
+            ),
             REST_TEST_PREFIX
         );
     }
@@ -170,8 +172,9 @@ public class CopyRestTestsTask extends DefaultTask {
                 getFileSystemOperations().copy(c -> {
                     c.from(getArchiveOperations().zipTree(coreConfig.getSingleFile())); // jar file
                     // this ends up as the same dir as outputDir
-                    c.into(new File(Objects.requireNonNull(getSourceSet().orElseThrow().getOutput().getResourcesDir()),
-                        outputResourceParent));
+                    c.into(
+                        new File(Objects.requireNonNull(getSourceSet().orElseThrow().getOutput().getResourcesDir()), outputResourceParent)
+                    );
                     c.include(
                         includeCore.get().stream().map(prefix -> REST_TEST_PREFIX + "/" + prefix + "*/**").collect(Collectors.toList())
                     );

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/CopyRestTestsTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/CopyRestTestsTask.java
@@ -68,6 +68,7 @@ public class CopyRestTestsTask extends DefaultTask {
     private Function<FileCollection, FileTree> coreConfigToFileTree = FileCollection::getAsFileTree;
     private Function<FileCollection, FileTree> xpackConfigToFileTree = FileCollection::getAsFileTree;
     private Function<FileCollection, FileTree> additionalConfigToFileTree = FileCollection::getAsFileTree;
+    private String outputResourceParent = "";
 
     private final PatternFilterable corePatternSet;
     private final PatternFilterable xpackPatternSet;
@@ -139,10 +140,11 @@ public class CopyRestTestsTask extends DefaultTask {
 
     @OutputDirectory
     public File getOutputDir() {
-        return new File(
+        return new File(new File(
             getSourceSet().orElseThrow(() -> new IllegalArgumentException("could not find source set [" + sourceSetName + "]"))
                 .getOutput()
                 .getResourcesDir(),
+            outputResourceParent),
             REST_TEST_PREFIX
         );
     }
@@ -168,7 +170,8 @@ public class CopyRestTestsTask extends DefaultTask {
                 getFileSystemOperations().copy(c -> {
                     c.from(getArchiveOperations().zipTree(coreConfig.getSingleFile())); // jar file
                     // this ends up as the same dir as outputDir
-                    c.into(Objects.requireNonNull(getSourceSet().orElseThrow().getOutput().getResourcesDir()));
+                    c.into(new File(Objects.requireNonNull(getSourceSet().orElseThrow().getOutput().getResourcesDir()),
+                        outputResourceParent));
                     c.include(
                         includeCore.get().stream().map(prefix -> REST_TEST_PREFIX + "/" + prefix + "*/**").collect(Collectors.toList())
                     );
@@ -226,6 +229,10 @@ public class CopyRestTestsTask extends DefaultTask {
 
     public void setAdditionalConfigToFileTree(Function<FileCollection, FileTree> additionalConfigToFileTree) {
         this.additionalConfigToFileTree = additionalConfigToFileTree;
+    }
+
+    public void setOutputResourceParent(String outputResourceParent) {
+        this.outputResourceParent = outputResourceParent;
     }
 
     @Internal

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/CopyRestTestsTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/CopyRestTestsTask.java
@@ -68,7 +68,7 @@ public class CopyRestTestsTask extends DefaultTask {
     private Function<FileCollection, FileTree> coreConfigToFileTree = FileCollection::getAsFileTree;
     private Function<FileCollection, FileTree> xpackConfigToFileTree = FileCollection::getAsFileTree;
     private Function<FileCollection, FileTree> additionalConfigToFileTree = FileCollection::getAsFileTree;
-    private String outputResourceParent = "";
+    private String outputResourceRoot = "";
 
     private final PatternFilterable corePatternSet;
     private final PatternFilterable xpackPatternSet;
@@ -145,7 +145,7 @@ public class CopyRestTestsTask extends DefaultTask {
                 getSourceSet().orElseThrow(() -> new IllegalArgumentException("could not find source set [" + sourceSetName + "]"))
                     .getOutput()
                     .getResourcesDir(),
-                outputResourceParent
+                outputResourceRoot
             ),
             REST_TEST_PREFIX
         );
@@ -173,7 +173,7 @@ public class CopyRestTestsTask extends DefaultTask {
                     c.from(getArchiveOperations().zipTree(coreConfig.getSingleFile())); // jar file
                     // this ends up as the same dir as outputDir
                     c.into(
-                        new File(Objects.requireNonNull(getSourceSet().orElseThrow().getOutput().getResourcesDir()), outputResourceParent)
+                        new File(Objects.requireNonNull(getSourceSet().orElseThrow().getOutput().getResourcesDir()), outputResourceRoot)
                     );
                     c.include(
                         includeCore.get().stream().map(prefix -> REST_TEST_PREFIX + "/" + prefix + "*/**").collect(Collectors.toList())
@@ -234,8 +234,8 @@ public class CopyRestTestsTask extends DefaultTask {
         this.additionalConfigToFileTree = additionalConfigToFileTree;
     }
 
-    public void setOutputResourceParent(String outputResourceParent) {
-        this.outputResourceParent = outputResourceParent;
+    public void setOutputResourceRoot(String outputResourceRoot) {
+        this.outputResourceRoot = outputResourceRoot;
     }
 
     @Internal

--- a/buildSrc/src/main/resources/META-INF/gradle-plugins/elasticsearch.yaml-rest-compat-test.properties
+++ b/buildSrc/src/main/resources/META-INF/gradle-plugins/elasticsearch.yaml-rest-compat-test.properties
@@ -17,4 +17,4 @@
 # under the License.
 #
 
-implementation-class=org.elasticsearch.gradle.internal.YamlRestCompatTestPlugin
+implementation-class=org.elasticsearch.gradle.internal.rest.compat.YamlRestCompatTestPlugin

--- a/buildSrc/src/test/java/org/elasticsearch/gradle/test/rest/transform/InjectHeaderTests.java
+++ b/buildSrc/src/test/java/org/elasticsearch/gradle/test/rest/transform/InjectHeaderTests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.gradle.test.rest.transform;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.SequenceWriter;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -45,8 +46,10 @@ import java.util.stream.Collectors;
 
 public class InjectHeaderTests extends GradleUnitTestCase {
 
-    private static final YAMLFactory yaml = new YAMLFactory();
-    private static final ObjectMapper mapper = new ObjectMapper(yaml);
+    private static final YAMLFactory YAML_FACTORY = new YAMLFactory();
+    private static final ObjectMapper MAPPER = new ObjectMapper(YAML_FACTORY);
+    private static final ObjectReader READER = MAPPER.readerFor(ObjectNode.class);
+
     private static final Map<String, String> headers = Map.of(
         "Content-Type",
         "application/vnd.elasticsearch+json;compatible-with=7",
@@ -62,8 +65,8 @@ public class InjectHeaderTests extends GradleUnitTestCase {
     public void testInjectHeadersWithoutSetupBlock() throws Exception {
         String testName = "/rest/header_inject/no_setup.yml";
         File testFile = new File(getClass().getResource(testName).toURI());
-        YAMLParser yamlParser = yaml.createParser(testFile);
-        List<ObjectNode> tests = mapper.readValues(yamlParser, ObjectNode.class).readAll();
+        YAMLParser yamlParser = YAML_FACTORY.createParser(testFile);
+        List<ObjectNode> tests = READER.<ObjectNode>readValues(yamlParser).readAll();
         RestTestTransformer transformer = new RestTestTransformer();
         // validate no setup
         assertThat(tests.stream().filter(node -> node.get("setup") != null).count(), CoreMatchers.equalTo(0L));
@@ -96,8 +99,8 @@ public class InjectHeaderTests extends GradleUnitTestCase {
     public void testInjectHeadersWithSetupBlock() throws Exception {
         String testName = "/rest/header_inject/with_setup.yml";
         File testFile = new File(getClass().getResource(testName).toURI());
-        YAMLParser yamlParser = yaml.createParser(testFile);
-        List<ObjectNode> tests = mapper.readValues(yamlParser, ObjectNode.class).readAll();
+        YAMLParser yamlParser = YAML_FACTORY.createParser(testFile);
+        List<ObjectNode> tests = READER.<ObjectNode>readValues(yamlParser).readAll();
         RestTestTransformer transformer = new RestTestTransformer();
 
         // validate setup exists
@@ -131,8 +134,8 @@ public class InjectHeaderTests extends GradleUnitTestCase {
     public void testInjectHeadersWithSkipBlock() throws Exception {
         String testName = "/rest/header_inject/with_skip.yml";
         File testFile = new File(getClass().getResource(testName).toURI());
-        YAMLParser yamlParser = yaml.createParser(testFile);
-        List<ObjectNode> tests = mapper.readValues(yamlParser, ObjectNode.class).readAll();
+        YAMLParser yamlParser = YAML_FACTORY.createParser(testFile);
+        List<ObjectNode> tests = READER.<ObjectNode>readValues(yamlParser).readAll();
         RestTestTransformer transformer = new RestTestTransformer();
 
         // validate setup exists
@@ -178,8 +181,8 @@ public class InjectHeaderTests extends GradleUnitTestCase {
     public void testInjectHeadersWithFeaturesBlock() throws Exception {
         String testName = "/rest/header_inject/with_features.yml";
         File testFile = new File(getClass().getResource(testName).toURI());
-        YAMLParser yamlParser = yaml.createParser(testFile);
-        List<ObjectNode> tests = mapper.readValues(yamlParser, ObjectNode.class).readAll();
+        YAMLParser yamlParser = YAML_FACTORY.createParser(testFile);
+        List<ObjectNode> tests = READER.<ObjectNode>readValues(yamlParser).readAll();
         RestTestTransformer transformer = new RestTestTransformer();
 
         // validate setup exists
@@ -224,8 +227,8 @@ public class InjectHeaderTests extends GradleUnitTestCase {
     public void testInjectHeadersWithHeadersBlock() throws Exception {
         String testName = "/rest/header_inject/with_headers.yml";
         File testFile = new File(getClass().getResource(testName).toURI());
-        YAMLParser yamlParser = yaml.createParser(testFile);
-        List<ObjectNode> tests = mapper.readValues(yamlParser, ObjectNode.class).readAll();
+        YAMLParser yamlParser = YAML_FACTORY.createParser(testFile);
+        List<ObjectNode> tests = READER.<ObjectNode>readValues(yamlParser).readAll();
         RestTestTransformer transformer = new RestTestTransformer();
 
         // validate setup exists
@@ -346,7 +349,7 @@ public class InjectHeaderTests extends GradleUnitTestCase {
     private void printTest(String testName, List<ObjectNode> tests) {
         if (humanDebug) {
             System.out.println("\n************* " + testName + " *************");
-            try (SequenceWriter sequenceWriter = mapper.writer().writeValues(System.out)) {
+            try (SequenceWriter sequenceWriter = MAPPER.writer().writeValues(System.out)) {
                 for (ObjectNode transformedTest : tests) {
                     sequenceWriter.write(transformedTest);
                 }

--- a/modules/reindex/build.gradle
+++ b/modules/reindex/build.gradle
@@ -26,6 +26,7 @@ import org.elasticsearch.gradle.test.AntFixture
 apply plugin: 'elasticsearch.test-with-dependencies'
 apply plugin: 'elasticsearch.jdk-download'
 apply plugin: 'elasticsearch.yaml-rest-test'
+apply plugin: 'elasticsearch.yaml-rest-compat-test'
 apply plugin: 'elasticsearch.java-rest-test'
 apply plugin: 'elasticsearch.internal-cluster-test'
 

--- a/modules/reindex/build.gradle
+++ b/modules/reindex/build.gradle
@@ -26,7 +26,6 @@ import org.elasticsearch.gradle.test.AntFixture
 apply plugin: 'elasticsearch.test-with-dependencies'
 apply plugin: 'elasticsearch.jdk-download'
 apply plugin: 'elasticsearch.yaml-rest-test'
-apply plugin: 'elasticsearch.yaml-rest-compat-test'
 apply plugin: 'elasticsearch.java-rest-test'
 apply plugin: 'elasticsearch.internal-cluster-test'
 


### PR DESCRIPTION
Introduce `RestCompatTestTransformTask` to execute in transformations 
needed for REST compatibility testing. 

This new task is part of the execution graph for `yamlRestCompatTest` 
such that when that task is run it now copy the bwc:minor rest 
tests to an intermediate location (e.g. build/resources/yamlRestCompatTest/v7restTests/rest-api-spec/test)
Then this new task will read from that location, transform the tests as
necessary and output to the location that test runner expects 
(e.g. build/resources/yamlRestCompatTest/rest-api-spec/test)

Currently only the compatibility headers are injected via the 
transformation(s), but future additional transformations are possible and this
commit contains only the gradle hooks needed to ensure that all transforms are
executed and result in the correct location on disk for the test runner. 