### PR TITLE
Handle correctly runtime geo_point null values

### DIFF
--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/GeoPointFieldScript.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/GeoPointFieldScript.java
@@ -57,9 +57,6 @@ public abstract class GeoPointFieldScript extends AbstractLongFieldScript {
         public void execute() {
             try {
                 Object value = XContentMapValues.extractValue(field, leafSearchLookup.source().loadSourceIfNeeded());
-                if (value == null) {
-                    return;
-                }
                 if (value instanceof List<?>) {
                     List<?> values = (List<?>) value;
                     if (values.size() > 0 && values.get(0) instanceof Number) {

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/GeoPointFieldScript.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/GeoPointFieldScript.java
@@ -57,6 +57,9 @@ public abstract class GeoPointFieldScript extends AbstractLongFieldScript {
         public void execute() {
             try {
                 Object value = XContentMapValues.extractValue(field, leafSearchLookup.source().loadSourceIfNeeded());
+                if (value == null) {
+                    return;
+                }
                 if (value instanceof List<?>) {
                     List<?> values = (List<?>) value;
                     if (values.size() > 0 && values.get(0) instanceof Number) {
@@ -75,8 +78,10 @@ public abstract class GeoPointFieldScript extends AbstractLongFieldScript {
         }
 
         private void parsePoint(Object point) {
-            GeoUtils.parseGeoPoint(point, scratch, true);
-            emit(scratch.lat(), scratch.lon());
+            if (point != null) {
+                GeoUtils.parseGeoPoint(point, scratch, true);
+                emit(scratch.lat(), scratch.lon());
+            }
         }
     };
 

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/GeoPointScriptFieldGeoShapeQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/GeoPointScriptFieldGeoShapeQuery.java
@@ -98,7 +98,8 @@ public class GeoPointScriptFieldGeoShapeQuery extends AbstractGeoPointScriptFiel
                             return false;
                         }
                     }
-                    return true;
+                    // return true iff there is at least one point
+                    return count > 0;
                 };
             }
             case WITHIN: {
@@ -114,7 +115,8 @@ public class GeoPointScriptFieldGeoShapeQuery extends AbstractGeoPointScriptFiel
                             return false;
                         }
                     }
-                    return true;
+                    // return true iff there is at least one point
+                    return count > 0;
                 };
             }
             case CONTAINS: {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/101_geo_point_from_source.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/101_geo_point_from_source.yml
@@ -28,6 +28,8 @@ setup:
           {"index":{}}
           {"timestamp": "1998-04-30T14:30:53-05:00", "location" : "-7.9, 120.78"}
           {"index":{}}
+           {"timestamp": "1998-04-30T14:30:54-05:00"}
+          {"index":{}}
           {"timestamp": "1998-04-30T14:30:55-05:00", "location" : ["-8, 120", "-7, 121.0"]}
           {"index":{}}
           {"timestamp": "1998-04-30T14:31:12-05:00", "location" : [-173.45, 45.78]}
@@ -59,7 +61,7 @@ setup:
         body:
           sort: timestamp
           fields: [location]
-  - match: {hits.total.value: 10}
+  - match: {hits.total.value: 11}
   - match: {hits.hits.0.fields.location: ["13.499999991618097, 34.889999935403466"] }
 
 ---
@@ -174,7 +176,7 @@ setup:
               geo_bounds:
                 field: "location"
                 wrap_longitude: false
-  - match: {hits.total.value: 10}
+  - match: {hits.total.value: 11}
   - match: {aggregations.bounds.bounds.top_left.lat: 46.77999998442829 }
   - match: {aggregations.bounds.bounds.top_left.lon: -174.45000001229346 }
   - match: {aggregations.bounds.bounds.bottom_right.lat: -63.240000014193356 }
@@ -191,7 +193,7 @@ setup:
               location:
                 lat: 0.0
                 lon: 0.0
-  - match: {hits.total.value: 10}
+  - match: {hits.total.value: 11}
   - match: {hits.hits.0._source.location.lat: 0.0 }
   - match: {hits.hits.0._source.location.lon: 0.0 }
   - match: {hits.hits.1._source.location.0.0: -174.45 }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/102_geo_point_source_in_query.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/102_geo_point_source_in_query.yml
@@ -21,6 +21,8 @@ setup:
           {"index":{}}
           {"timestamp": "1998-04-30T14:30:17-05:00", "location" : {"lat": 13.5, "lon" : 34.89}}
           {"index":{}}
+          {"timestamp": "1998-04-30T14:30:20-05:00"}
+          {"index":{}}
           {"timestamp": "1998-04-30T14:30:27-05:00", "location" : [{"lat": 13.0, "lon" : 34.0}, {"lat": 14.0, "lon" : 35.0}]}
           {"index":{}}
           {"timestamp": "1998-04-30T14:30:53-05:00", "location" : "-7.9, 120.78"}
@@ -50,7 +52,7 @@ setup:
               type: geo_point
           sort: timestamp
           fields: [location]
-  - match: {hits.total.value: 10}
+  - match: {hits.total.value: 11}
   - match: {hits.hits.0.fields.location: ["13.499999991618097, 34.889999935403466"] }
 
 ---
@@ -189,7 +191,7 @@ setup:
               geo_bounds:
                 field: "location"
                 wrap_longitude: false
-  - match: {hits.total.value: 10}
+  - match: {hits.total.value: 11}
   - match: {aggregations.bounds.bounds.top_left.lat: 46.77999998442829 }
   - match: {aggregations.bounds.bounds.top_left.lon: -174.45000001229346 }
   - match: {aggregations.bounds.bounds.bottom_right.lat: -63.240000014193356 }
@@ -209,7 +211,7 @@ setup:
               location:
                 lat: 0.0
                 lon: 0.0
-  - match: {hits.total.value: 10}
+  - match: {hits.total.value: 11}
   - match: {hits.hits.0._source.location.lat: 0.0 }
   - match: {hits.hits.0._source.location.lon: 0.0 }
   - match: {hits.hits.1._source.location.0.0: -174.45 }


### PR DESCRIPTION
Fix a bug where we the runtime geo_point default parser emits wrong values when a document has null values.

label as non-issue as it has not been released.