### PR TITLE
Prevent cache file synchronization to add evicted cache files back in the persistent cache

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/PersistentCache.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/PersistentCache.java
@@ -75,11 +75,13 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.IntPredicate;
+import java.util.function.Predicate;
 
 import static java.util.Collections.synchronizedMap;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.unmodifiableSortedSet;
 import static org.elasticsearch.xpack.searchablesnapshots.cache.CacheService.getShardCachePath;
+import static org.elasticsearch.xpack.searchablesnapshots.cache.CacheService.resolveSnapshotCache;
 
 public class PersistentCache implements Closeable {
 
@@ -140,8 +142,17 @@ public class PersistentCache implements Closeable {
     }
 
     public long getCacheSize(ShardId shardId, SnapshotId snapshotId) {
+        return getCacheSize(shardId, snapshotId, Files::exists);
+    }
+
+    // pkg private for tests
+    long getCacheSize(ShardId shardId, SnapshotId snapshotId, Predicate<Path> predicate) {
         long aggregateSize = 0L;
         for (CacheIndexWriter writer : writers) {
+            final Path snapshotCacheDir = resolveSnapshotCache(writer.nodePath().resolve(shardId)).resolve(snapshotId.getUUID());
+            if (Files.exists(snapshotCacheDir) == false) {
+                continue; // searchable snapshot shard is not present on this node path, not need to run a query
+            }
             try (IndexReader indexReader = DirectoryReader.open(writer.indexWriter)) {
                 final IndexSearcher searcher = new IndexSearcher(indexReader);
                 searcher.setQueryCache(null);
@@ -165,8 +176,11 @@ public class PersistentCache implements Closeable {
                         while (docIdSetIterator.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
                             if (isLiveDoc.test(docIdSetIterator.docID())) {
                                 final Document document = leafReaderContext.reader().document(docIdSetIterator.docID());
-                                for (Tuple<Long, Long> range : buildCacheFileRanges(document)) {
-                                    aggregateSize += range.v2() - range.v1();
+                                final String cacheFileId = getValue(document, CACHE_ID_FIELD);
+                                if (predicate.test(snapshotCacheDir.resolve(cacheFileId))) {
+                                    final long size = buildCacheFileRanges(document).stream().mapToLong(range -> range.v2() - range.v1()).sum();
+                                    logger.trace("cache file [{}] has size [{}]", cacheFileId, size);
+                                    aggregateSize += size;
                                 }
                             }
                         }
@@ -291,16 +305,6 @@ public class PersistentCache implements Closeable {
                 logger.warn("failed to close persistent cache index", e);
             }
         }
-    }
-
-    public boolean hasDeletions() {
-        ensureOpen();
-        for (CacheIndexWriter writer : writers) {
-            if (writer.indexWriter.hasDeletions()) {
-                return true;
-            }
-        }
-        return false;
     }
 
     public long getNumDocs() {

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/PersistentCache.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/PersistentCache.java
@@ -178,7 +178,7 @@ public class PersistentCache implements Closeable {
                                 final Document document = leafReaderContext.reader().document(docIdSetIterator.docID());
                                 final String cacheFileId = getValue(document, CACHE_ID_FIELD);
                                 if (predicate.test(snapshotCacheDir.resolve(cacheFileId))) {
-                                    final long size = buildCacheFileRanges(document).stream().mapToLong(range -> range.v2() - range.v1()).sum();
+                                    long size = buildCacheFileRanges(document).stream().mapToLong(range -> range.v2() - range.v1()).sum();
                                     logger.trace("cache file [{}] has size [{}]", cacheFileId, size);
                                     aggregateSize += size;
                                 }

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/CacheFileTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/CacheFileTests.java
@@ -5,13 +5,13 @@
  */
 package org.elasticsearch.index.store.cache;
 
+import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.cluster.coordination.DeterministicTaskQueue;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.io.PathUtils;
 import org.elasticsearch.common.io.PathUtilsForTesting;
-import org.elasticsearch.common.util.concurrent.RunOnce;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.store.cache.CacheFile.EvictionListener;
 import org.elasticsearch.index.store.cache.TestUtils.FSyncTrackingFileSystemProvider;
@@ -25,13 +25,15 @@ import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.Set;
 import java.util.SortedSet;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.elasticsearch.common.settings.Settings.builder;
 import static org.elasticsearch.index.store.cache.TestUtils.randomPopulateAndReads;
@@ -39,6 +41,7 @@ import static org.elasticsearch.node.Node.NODE_NAME_SETTING;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -46,7 +49,14 @@ import static org.hamcrest.Matchers.sameInstance;
 
 public class CacheFileTests extends ESTestCase {
 
-    private static final Runnable NOOP = () -> {};
+    private static final CacheFile.ModificationListener NOOP = new CacheFile.ModificationListener() {
+        @Override
+        public void onCacheFileNeedsFsync(CacheFile cacheFile) {}
+
+        @Override
+        public void onCacheFileDelete(CacheFile cacheFile) {}
+    };
+
     private static final CacheKey CACHE_KEY = new CacheKey("_snap_uuid", "_snap_index", new ShardId("_name", "_uuid", 0), "_filename");
 
     public void testGetCacheKey() throws Exception {
@@ -63,7 +73,9 @@ public class CacheFileTests extends ESTestCase {
 
     public void testAcquireAndRelease() throws Exception {
         final Path file = createTempDir().resolve("file.cache");
-        final CacheFile cacheFile = new CacheFile(CACHE_KEY, randomLongBetween(1, 100), file, NOOP);
+        final TestCacheFileModificationListener updatesListener = new TestCacheFileModificationListener();
+        final CacheFile cacheFile = new CacheFile(CACHE_KEY, randomLongBetween(1, 100), file, updatesListener);
+        assertFalse(updatesListener.containsDelete(cacheFile));
 
         assertThat("Cache file is not acquired: no channel exists", cacheFile.getChannel(), nullValue());
         assertThat("Cache file is not acquired: file does not exist", Files.exists(file), is(false));
@@ -94,15 +106,18 @@ public class CacheFileTests extends ESTestCase {
         assertThat("Cache file is evicted but not fully released: channel still exists", cacheFile.getChannel(), notNullValue());
         assertThat("Cache file is evicted but not fully released: channel is open", cacheFile.getChannel().isOpen(), is(true));
         assertThat("Channel didn't change after eviction", cacheFile.getChannel(), sameInstance(fileChannel));
+        assertFalse(updatesListener.containsDelete(cacheFile));
 
         cacheFile.release(listener);
         assertThat("Cache file evicted and fully released: channel does not exist", cacheFile.getChannel(), nullValue());
         assertThat("Cache file has been deleted", Files.exists(file), is(false));
+        assertTrue(updatesListener.containsDelete(cacheFile));
     }
 
     public void testCacheFileNotAcquired() throws IOException {
         final Path file = createTempDir().resolve("file.cache");
-        final CacheFile cacheFile = new CacheFile(CACHE_KEY, randomLongBetween(1, 100), file, NOOP);
+        final TestCacheFileModificationListener updatesListener = new TestCacheFileModificationListener();
+        final CacheFile cacheFile = new CacheFile(CACHE_KEY, randomLongBetween(1, 100), file, updatesListener);
 
         assertThat(Files.exists(file), is(false));
         assertThat(cacheFile.getChannel(), nullValue());
@@ -117,14 +132,20 @@ public class CacheFileTests extends ESTestCase {
             cacheFile.release(listener);
         }
 
+        assertFalse(updatesListener.containsUpdate(cacheFile));
+        assertFalse(updatesListener.containsDelete(cacheFile));
+
         cacheFile.startEviction();
+
         assertThat(cacheFile.getChannel(), nullValue());
         assertFalse(Files.exists(file));
+        assertTrue(updatesListener.containsDelete(cacheFile));
     }
 
     public void testDeleteOnCloseAfterLastRelease() throws Exception {
         final Path file = createTempDir().resolve("file.cache");
-        final CacheFile cacheFile = new CacheFile(CACHE_KEY, randomLongBetween(1, 100), file, NOOP);
+        final TestCacheFileModificationListener updatesListener = new TestCacheFileModificationListener();
+        final CacheFile cacheFile = new CacheFile(CACHE_KEY, randomLongBetween(1, 100), file, updatesListener);
 
         final List<TestEvictionListener> acquiredListeners = new ArrayList<>();
         for (int i = 0; i < randomIntBetween(1, 20); i++) {
@@ -151,12 +172,14 @@ public class CacheFileTests extends ESTestCase {
         acquiredListeners.forEach(l -> assertTrue("Released listeners after cache file eviction are called", l.isCalled()));
         acquiredListeners.forEach(cacheFile::release);
 
+        assertTrue(updatesListener.containsDelete(cacheFile));
         assertFalse(Files.exists(file));
     }
 
     public void testConcurrentAccess() throws Exception {
         final Path file = createTempDir().resolve("file.cache");
-        final CacheFile cacheFile = new CacheFile(CACHE_KEY, randomLongBetween(1, 100), file, NOOP);
+        final TestCacheFileModificationListener updatesListener = new TestCacheFileModificationListener();
+        final CacheFile cacheFile = new CacheFile(CACHE_KEY, randomLongBetween(1, 100), file, updatesListener);
 
         final TestEvictionListener evictionListener = new TestEvictionListener();
         cacheFile.acquire(evictionListener);
@@ -191,28 +214,32 @@ public class CacheFileTests extends ESTestCase {
         deterministicTaskQueue.scheduleNow(() -> cacheFile.release(evictionListener));
         deterministicTaskQueue.runAllRunnableTasks();
         if (populateAndReadFuture != null) {
-            assertTrue(populateAndReadFuture.isDone());
+            try {
+                assertTrue(populateAndReadFuture.isDone());
+                populateAndReadFuture.get();
+                assertTrue(updatesListener.containsUpdate(cacheFile));
+            } catch (ExecutionException e) {
+                assertThat(e.getCause(), instanceOf(AlreadyClosedException.class));
+                assertFalse(updatesListener.containsUpdate(cacheFile));
+                assertTrue(updatesListener.containsDelete(cacheFile));
+            }
         }
         if (readIfAvailableFuture != null) {
             assertTrue(readIfAvailableFuture.isDone());
         }
         if (evicted) {
             assertFalse(Files.exists(file));
+            assertTrue(updatesListener.containsDelete(cacheFile));
         }
     }
 
     public void testFSync() throws Exception {
         final FSyncTrackingFileSystemProvider fileSystem = setupFSyncCountingFileSystem();
         try {
-            final AtomicBoolean needsFSyncCalled = new AtomicBoolean();
-            final CacheFile cacheFile = new CacheFile(
-                CACHE_KEY,
-                randomLongBetween(0L, 1000L),
-                fileSystem.resolve("test"),
-                () -> assertFalse(needsFSyncCalled.getAndSet(true))
-            );
+            final TestCacheFileModificationListener updatesListener = new TestCacheFileModificationListener();
+            final CacheFile cacheFile = new CacheFile(CACHE_KEY, randomLongBetween(0L, 1000L), fileSystem.resolve("test"), updatesListener);
             assertFalse(cacheFile.needsFsync());
-            assertFalse(needsFSyncCalled.get());
+            assertFalse(updatesListener.containsUpdate(cacheFile));
 
             final TestEvictionListener listener = new TestEvictionListener();
             cacheFile.acquire(listener);
@@ -223,23 +250,24 @@ public class CacheFileTests extends ESTestCase {
                     assertNumberOfFSyncs(cacheFile.getFile(), equalTo(0));
                     assertThat(completedRanges, hasSize(0));
                     assertFalse(cacheFile.needsFsync());
-                    assertFalse(needsFSyncCalled.get());
+                    assertFalse(updatesListener.containsUpdate(cacheFile));
                 }
 
                 final SortedSet<Tuple<Long, Long>> expectedCompletedRanges = randomPopulateAndReads(cacheFile);
                 if (expectedCompletedRanges.isEmpty() == false) {
                     assertTrue(cacheFile.needsFsync());
-                    assertTrue(needsFSyncCalled.getAndSet(false));
+                    assertTrue(updatesListener.containsUpdate(cacheFile));
+                    updatesListener.reset();
                 } else {
                     assertFalse(cacheFile.needsFsync());
-                    assertFalse(needsFSyncCalled.get());
+                    assertFalse(updatesListener.containsUpdate(cacheFile));
                 }
 
                 final SortedSet<Tuple<Long, Long>> completedRanges = cacheFile.fsync();
                 assertNumberOfFSyncs(cacheFile.getFile(), equalTo(expectedCompletedRanges.isEmpty() ? 0 : 1));
                 assertArrayEquals(completedRanges.toArray(new Tuple<?, ?>[0]), expectedCompletedRanges.toArray(new Tuple<?, ?>[0]));
                 assertFalse(cacheFile.needsFsync());
-                assertFalse(needsFSyncCalled.get());
+                assertFalse(updatesListener.containsUpdate(cacheFile));
             } finally {
                 cacheFile.release(listener);
             }
@@ -251,49 +279,55 @@ public class CacheFileTests extends ESTestCase {
     public void testFSyncOnEvictedFile() throws Exception {
         final FSyncTrackingFileSystemProvider fileSystem = setupFSyncCountingFileSystem();
         try {
-            final AtomicBoolean needsFSyncCalled = new AtomicBoolean();
-            final CacheFile cacheFile = new CacheFile(
-                CACHE_KEY,
-                randomLongBetween(0L, 1000L),
-                fileSystem.resolve("test"),
-                () -> assertFalse(needsFSyncCalled.getAndSet(true))
-            );
+            final TestCacheFileModificationListener updatesListener = new TestCacheFileModificationListener();
+            final CacheFile cacheFile = new CacheFile(CACHE_KEY, randomLongBetween(0L, 1000L), fileSystem.resolve("test"), updatesListener);
             assertFalse(cacheFile.needsFsync());
-            assertFalse(needsFSyncCalled.get());
+            assertFalse(updatesListener.containsUpdate(cacheFile));
+            assertFalse(updatesListener.containsDelete(cacheFile));
 
             final TestEvictionListener listener = new TestEvictionListener();
             cacheFile.acquire(listener);
 
-            final RunOnce releaseOnce = new RunOnce(() -> cacheFile.release(listener));
+            boolean released = false;
             try {
                 final SortedSet<Tuple<Long, Long>> expectedCompletedRanges = randomPopulateAndReads(cacheFile);
                 if (expectedCompletedRanges.isEmpty() == false) {
                     assertTrue(cacheFile.needsFsync());
-                    assertTrue(needsFSyncCalled.getAndSet(false));
+                    assertTrue(updatesListener.containsUpdate(cacheFile));
+                    updatesListener.reset();
 
                     final SortedSet<Tuple<Long, Long>> completedRanges = cacheFile.fsync();
                     assertArrayEquals(completedRanges.toArray(new Tuple<?, ?>[0]), expectedCompletedRanges.toArray(new Tuple<?, ?>[0]));
                     assertNumberOfFSyncs(cacheFile.getFile(), equalTo(1));
                 }
                 assertFalse(cacheFile.needsFsync());
-                assertFalse(needsFSyncCalled.get());
+                assertFalse(updatesListener.containsUpdate(cacheFile));
+                updatesListener.reset();
 
                 cacheFile.startEviction();
+                assertFalse(updatesListener.containsDelete(cacheFile));
 
                 if (rarely()) {
                     assertThat("New ranges should not be written after cache file eviction", randomPopulateAndReads(cacheFile), hasSize(0));
                 }
                 if (randomBoolean()) {
-                    releaseOnce.run();
+                    cacheFile.release(listener);
+                    assertTrue(updatesListener.containsDelete(cacheFile));
+                    released = true;
                 }
+                updatesListener.reset();
 
                 final SortedSet<Tuple<Long, Long>> completedRangesAfterEviction = cacheFile.fsync();
                 assertNumberOfFSyncs(cacheFile.getFile(), equalTo(expectedCompletedRanges.isEmpty() ? 0 : 1));
                 assertThat(completedRangesAfterEviction, hasSize(0));
                 assertFalse(cacheFile.needsFsync());
-                assertFalse(needsFSyncCalled.get());
+                assertFalse(updatesListener.containsUpdate(cacheFile));
+                updatesListener.reset();
             } finally {
-                releaseOnce.run();
+                if (released == false) {
+                    cacheFile.release(listener);
+                    assertTrue(updatesListener.containsDelete(cacheFile));
+                }
             }
         } finally {
             fileSystem.tearDown();
@@ -305,15 +339,11 @@ public class CacheFileTests extends ESTestCase {
         try {
             fileSystem.failFSyncs(true);
 
-            final AtomicBoolean needsFSyncCalled = new AtomicBoolean();
-            final CacheFile cacheFile = new CacheFile(
-                CACHE_KEY,
-                randomLongBetween(0L, 1000L),
-                fileSystem.resolve("test"),
-                () -> assertFalse(needsFSyncCalled.getAndSet(true))
-            );
+            final TestCacheFileModificationListener updatesListener = new TestCacheFileModificationListener();
+            final CacheFile cacheFile = new CacheFile(CACHE_KEY, randomLongBetween(0L, 1000L), fileSystem.resolve("test"), updatesListener);
             assertFalse(cacheFile.needsFsync());
-            assertFalse(needsFSyncCalled.get());
+            assertFalse(updatesListener.containsUpdate(cacheFile));
+            assertFalse(updatesListener.containsDelete(cacheFile));
 
             final TestEvictionListener listener = new TestEvictionListener();
             cacheFile.acquire(listener);
@@ -322,11 +352,14 @@ public class CacheFileTests extends ESTestCase {
                 final SortedSet<Tuple<Long, Long>> expectedCompletedRanges = randomPopulateAndReads(cacheFile);
                 if (expectedCompletedRanges.isEmpty() == false) {
                     assertTrue(cacheFile.needsFsync());
-                    assertTrue(needsFSyncCalled.getAndSet(false));
+                    assertTrue(updatesListener.containsUpdate(cacheFile));
+                    updatesListener.reset();
+
                     IOException exception = expectThrows(IOException.class, cacheFile::fsync);
                     assertThat(exception.getMessage(), containsString("simulated"));
                     assertTrue(cacheFile.needsFsync());
-                    assertTrue(needsFSyncCalled.getAndSet(false));
+                    assertTrue(updatesListener.containsUpdate(cacheFile));
+                    updatesListener.reset();
                 } else {
                     assertFalse(cacheFile.needsFsync());
                     final SortedSet<Tuple<Long, Long>> completedRanges = cacheFile.fsync();
@@ -340,7 +373,9 @@ public class CacheFileTests extends ESTestCase {
                 assertArrayEquals(completedRanges.toArray(new Tuple<?, ?>[0]), expectedCompletedRanges.toArray(new Tuple<?, ?>[0]));
                 assertNumberOfFSyncs(cacheFile.getFile(), equalTo(expectedCompletedRanges.isEmpty() ? 0 : 1));
                 assertFalse(cacheFile.needsFsync());
-                assertFalse(needsFSyncCalled.get());
+                assertFalse(updatesListener.containsUpdate(cacheFile));
+                assertFalse(updatesListener.containsDelete(cacheFile));
+                updatesListener.reset();
             } finally {
                 cacheFile.release(listener);
             }
@@ -364,6 +399,35 @@ public class CacheFileTests extends ESTestCase {
         @Override
         public void onEviction(CacheFile evictedCacheFile) {
             evicted.set(Objects.requireNonNull(evictedCacheFile));
+        }
+    }
+
+    private static class TestCacheFileModificationListener implements CacheFile.ModificationListener {
+
+        private final Set<CacheFile> updates = new HashSet<>();
+        private final Set<CacheFile> deletes = new HashSet<>();
+
+        @Override
+        public synchronized void onCacheFileNeedsFsync(CacheFile cacheFile) {
+            assertTrue(updates.add(cacheFile));
+        }
+
+        synchronized boolean containsUpdate(CacheFile cacheFile) {
+            return updates.contains(cacheFile);
+        }
+
+        @Override
+        public synchronized void onCacheFileDelete(CacheFile cacheFile) {
+            assertTrue(deletes.add(cacheFile));
+        }
+
+        synchronized boolean containsDelete(CacheFile cacheFile) {
+            return deletes.contains(cacheFile);
+        }
+
+        synchronized void reset() {
+            updates.clear();
+            deletes.clear();
         }
     }
 

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/TestUtils.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/TestUtils.java
@@ -176,6 +176,10 @@ public final class TestUtils {
         assertThat(timedCounter.totalNanoseconds(), equalTo(totalNanoseconds));
     }
 
+    public static long sumOfCompletedRangesLengths(CacheFile cacheFile) {
+        return cacheFile.getCompletedRanges().stream().mapToLong(range -> range.v2() - range.v1()).sum();
+    }
+
     /**
      * A {@link BlobContainer} that can read a single in-memory blob.
      * Any attempt to read a different blob will throw a {@link FileNotFoundException}

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/PersistentCacheTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/PersistentCacheTests.java
@@ -9,30 +9,52 @@ package org.elasticsearch.xpack.searchablesnapshots.cache;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.StringField;
+import org.apache.lucene.mockfile.FilterFileChannel;
+import org.apache.lucene.mockfile.FilterFileSystemProvider;
+import org.apache.lucene.mockfile.FilterPath;
+import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.io.PathUtils;
+import org.elasticsearch.common.io.PathUtilsForTesting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.core.internal.io.IOUtils;
+import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.index.store.cache.CacheFile;
+import org.elasticsearch.index.store.cache.CacheKey;
+import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.xpack.searchablesnapshots.AbstractSearchableSnapshotsTestCase;
 
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.file.FileSystem;
 import java.nio.file.Files;
+import java.nio.file.OpenOption;
 import java.nio.file.Path;
+import java.nio.file.attribute.FileAttribute;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedSet;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.cluster.node.DiscoveryNodeRole.BUILT_IN_ROLES;
 import static org.elasticsearch.cluster.node.DiscoveryNodeRole.DATA_ROLE;
 import static org.elasticsearch.index.store.cache.TestUtils.assertCacheFileEquals;
+import static org.elasticsearch.index.store.cache.TestUtils.randomPopulateAndReads;
+import static org.elasticsearch.index.store.cache.TestUtils.sumOfCompletedRangesLengths;
 import static org.elasticsearch.node.NodeRoleSettings.NODE_ROLES_SETTING;
 import static org.elasticsearch.xpack.searchablesnapshots.cache.PersistentCache.createCacheIndexWriter;
 import static org.elasticsearch.xpack.searchablesnapshots.cache.PersistentCache.resolveCacheIndexFolder;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -171,5 +193,236 @@ public class PersistentCacheTests extends AbstractSearchableSnapshotsTestCase {
         assertTrue(cacheFiles.stream().allMatch(Files::exists));
         PersistentCache.cleanUp(nodeSettings, nodeEnvironment);
         assertTrue(cacheFiles.stream().noneMatch(Files::exists));
+    }
+
+    public void testFSyncDoesNotAddDocumentsBackInPersistentCacheWhenShardIsEvicted() throws Exception {
+        IOUtils.close(nodeEnvironment); // this test uses a specific filesystem to block fsync
+
+        final FSyncBlockingFileSystemProvider fileSystem = setupFSyncBlockingFileSystemProvider();
+        try {
+            nodeEnvironment = newNodeEnvironment(
+                Settings.builder()
+                    .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toAbsolutePath())
+                    .putList(Environment.PATH_DATA_SETTING.getKey(), tmpPaths())
+                    .build()
+            );
+
+            try (
+                PersistentCache persistentCache = new PersistentCache(nodeEnvironment);
+                CacheService cacheService = new CacheService(Settings.EMPTY, clusterService, threadPool, persistentCache)
+            ) {
+                cacheService.setCacheSyncInterval(TimeValue.ZERO);
+                cacheService.start();
+
+                logger.debug("creating cache files");
+                final List<CacheFile> cacheFiles = randomCacheFiles(cacheService);
+                assertThat(cacheService.getCacheFilesEventsQueueSize(), equalTo((long) cacheFiles.size()));
+                assertThat(cacheService.getNumberOfCacheFilesEvents(), equalTo((long) cacheFiles.size()));
+
+                final CacheFile randomCacheFile = randomFrom(cacheFiles);
+                final CacheKey cacheKey = randomCacheFile.getCacheKey();
+
+                final SnapshotId snapshotId = new SnapshotId("_ignored_", cacheKey.getSnapshotUUID());
+                if (randomBoolean()) {
+                    final Tuple<Long, Long> absent = randomCacheFile.getAbsentRangeWithin(0L, randomCacheFile.getLength());
+                    if (absent != null) {
+                        assertThat(
+                            "Persistent cache should not contain any cached data",
+                            persistentCache.getCacheSize(cacheKey.getShardId(), snapshotId),
+                            equalTo(0L)
+                        );
+
+                        cacheService.synchronizeCache();
+
+                        assertThat(cacheService.getCacheFilesEventsQueueSize(), equalTo(0L));
+                        assertThat(cacheService.getNumberOfCacheFilesEvents(), equalTo(0L));
+
+                        final long sizeInCache = persistentCache.getCacheSize(cacheKey.getShardId(), snapshotId);
+                        final long sizeInCacheFile = sumOfCompletedRangesLengths(randomCacheFile);
+                        assertThat(
+                            "Persistent cache should contain cached data for at least 1 cache file",
+                            sizeInCache,
+                            greaterThanOrEqualTo(sizeInCacheFile)
+                        );
+
+                        final CacheFile.EvictionListener listener = evictedCacheFile -> {};
+                        randomCacheFile.acquire(listener);
+                        try {
+                            SortedSet<Tuple<Long, Long>> ranges = null;
+                            while (ranges == null || ranges.isEmpty()) {
+                                ranges = randomPopulateAndReads(randomCacheFile);
+                            }
+                            assertTrue(cacheService.isCacheFileToSync(randomCacheFile));
+                            assertThat(cacheService.getCacheFilesEventsQueueSize(), equalTo(1L));
+                            assertThat(cacheService.getNumberOfCacheFilesEvents(), equalTo(1L));
+                        } finally {
+                            randomCacheFile.release(listener);
+                        }
+
+                        assertThat(
+                            "Persistent cache should contain cached data for at least 1 cache file",
+                            persistentCache.getCacheSize(cacheKey.getShardId(), snapshotId),
+                            equalTo(sizeInCache)
+                        );
+                    }
+                }
+
+                final boolean fsyncFailure = randomBoolean();
+                logger.debug("blocking fsync for cache file [{}] with failure [{}]", randomCacheFile.getFile(), fsyncFailure);
+                fileSystem.blockFSyncForPath(randomCacheFile.getFile(), fsyncFailure);
+
+                logger.debug("starting synchronization of cache files");
+                final Thread fsyncThread = new Thread(cacheService::synchronizeCache);
+                fsyncThread.start();
+
+                logger.debug("waiting for synchronization of cache files to be blocked");
+                fileSystem.waitForBlock();
+
+                logger.debug("starting eviction of shard [{}]", cacheKey);
+                cacheService.markShardAsEvictedInCache(cacheKey.getSnapshotUUID(), cacheKey.getSnapshotIndexName(), cacheKey.getShardId());
+
+                logger.debug("waiting for shard eviction to be processed");
+                cacheService.waitForCacheFilesEvictionIfNeeded(
+                    cacheKey.getSnapshotUUID(),
+                    cacheKey.getSnapshotIndexName(),
+                    cacheKey.getShardId()
+                );
+
+                logger.debug("unblocking synchronization of cache files");
+                fileSystem.unblock();
+                fsyncThread.join();
+
+                assertThat(
+                    "Persistent cache should not report any cached data for the evicted shard",
+                    persistentCache.getCacheSize(cacheKey.getShardId(), new SnapshotId("_ignored_", cacheKey.getSnapshotUUID())),
+                    equalTo(0L)
+                );
+
+                logger.debug("triggering one more cache synchronization in case all cache files deletions were not processed before");
+                cacheService.synchronizeCache();
+
+                assertThat(
+                    "Persistent cache should not report any cached data for the evicted shard (ignoring deleted files)",
+                    persistentCache.getCacheSize(
+                        cacheKey.getShardId(),
+                        new SnapshotId("_ignored_", cacheKey.getSnapshotUUID()),
+                        path -> true
+                    ),
+                    equalTo(0L)
+                );
+
+                assertThat(cacheService.getCacheFilesEventsQueueSize(), equalTo(0L));
+                assertThat(cacheService.getNumberOfCacheFilesEvents(), equalTo(0L));
+            }
+        } finally {
+            fileSystem.tearDown();
+        }
+    }
+
+    public void testGetCacheSizeIgnoresDeletedCacheFiles() throws Exception {
+        try (CacheService cacheService = defaultCacheService()) {
+            cacheService.setCacheSyncInterval(TimeValue.ZERO);
+            cacheService.start();
+
+            final CacheFile cacheFile = randomFrom(randomCacheFiles(cacheService));
+            final long sizeOfCacheFileInCache = sumOfCompletedRangesLengths(cacheFile);
+
+            final Supplier<Long> cacheSizeSupplier = () -> cacheService.getPersistentCache()
+                .getCacheSize(cacheFile.getCacheKey().getShardId(), new SnapshotId("_ignored_", cacheFile.getCacheKey().getSnapshotUUID()));
+            assertThat(cacheSizeSupplier.get(), equalTo(0L));
+
+            cacheService.synchronizeCache();
+
+            final long sizeOfShardInCache = cacheSizeSupplier.get();
+            assertThat(sizeOfShardInCache, greaterThanOrEqualTo(sizeOfCacheFileInCache));
+
+            final CacheFile.EvictionListener listener = evictedCacheFile -> {};
+            cacheFile.acquire(listener);
+            try {
+                cacheService.removeFromCache(cacheFile.getCacheKey());
+                assertThat(cacheSizeSupplier.get(), equalTo(sizeOfShardInCache));
+            } finally {
+                cacheFile.release(listener);
+            }
+            assertThat(cacheSizeSupplier.get(), equalTo(sizeOfShardInCache - sizeOfCacheFileInCache));
+        }
+    }
+
+    private static FSyncBlockingFileSystemProvider setupFSyncBlockingFileSystemProvider() {
+        final FileSystem defaultFileSystem = PathUtils.getDefaultFileSystem();
+        final FSyncBlockingFileSystemProvider provider = new FSyncBlockingFileSystemProvider(defaultFileSystem, createTempDir());
+        PathUtilsForTesting.installMock(provider.getFileSystem(null));
+        return provider;
+    }
+
+    /**
+     * {@link FilterFileSystemProvider} that can block fsync for a specified {@link Path}.
+     */
+    public static class FSyncBlockingFileSystemProvider extends FilterFileSystemProvider {
+
+        private final AtomicReference<Path> pathToBlock = new AtomicReference<>();
+        private final AtomicBoolean failFSync = new AtomicBoolean();
+        private final CountDownLatch blockingLatch = new CountDownLatch(1);
+        private final CountDownLatch releasingLatch = new CountDownLatch(1);
+
+        private final FileSystem delegateInstance;
+        private final Path rootDir;
+
+        public FSyncBlockingFileSystemProvider(FileSystem delegate, Path rootDir) {
+            super("fsyncblocking://", delegate);
+            this.rootDir = new FilterPath(rootDir, this.fileSystem);
+            this.delegateInstance = delegate;
+        }
+
+        public Path resolve(String other) {
+            return rootDir.resolve(other);
+        }
+
+        @Override
+        public FileChannel newFileChannel(Path path, Set<? extends OpenOption> options, FileAttribute<?>... attrs) throws IOException {
+            return new FilterFileChannel(super.newFileChannel(path, options, attrs)) {
+
+                @Override
+                public void force(boolean metaData) throws IOException {
+                    final Path blockedPath = pathToBlock.get();
+                    if (blockedPath == null || blockedPath.equals(path.toAbsolutePath()) == false) {
+                        super.force(metaData);
+                        return;
+                    }
+                    try {
+                        blockingLatch.countDown();
+                        releasingLatch.await();
+                        if (failFSync.get()) {
+                            throw new IOException("Simulated");
+                        } else {
+                            super.force(metaData);
+                        }
+                    } catch (InterruptedException e) {
+                        throw new AssertionError(e);
+                    }
+                }
+            };
+        }
+
+        public void blockFSyncForPath(Path path, boolean failure) {
+            pathToBlock.set(path.toAbsolutePath());
+            failFSync.set(failure);
+        }
+
+        public void waitForBlock() {
+            try {
+                blockingLatch.await();
+            } catch (InterruptedException e) {
+                throw new AssertionError(e);
+            }
+        }
+
+        public void unblock() {
+            releasingLatch.countDown();
+        }
+
+        public void tearDown() {
+            PathUtilsForTesting.installMock(delegateInstance);
+        }
     }
 }


### PR DESCRIPTION
This commit changes how cache files synchronization interacts with
the persistent cacge in searchable snapshots. Before this change it
was possible that synchronization reintroduces information about
an evicted cache file in the persistent cache Lucene index.

This commit introduces an queue of cache file events that are
periodically processed by the cache synchronization method. The
events refer to a specific cache file and a type of event (deletion or
fsync needed) that must be processed by the cache synchronization
method, which in turn applies the appropriate logic to the persistent
cache Lucene. This commit changes how the event are inserted into
the events queue by guaranteeing that no need fsync/update event
come after a delete event.
index.

Backport of #67694