### PR TITLE
[TEST] Enable geo_point in runtime fields qa tests (#67915)

### DIFF
--- a/x-pack/plugin/runtime-fields/qa/build.gradle
+++ b/x-pack/plugin/runtime-fields/qa/build.gradle
@@ -55,16 +55,23 @@ subprojects {
       systemProperty 'tests.rest.blacklist',
         [
           /////// TO FIX ///////
-          'search/115_multiple_field_collapsing/two levels fields collapsing', // Broken. Gotta fix.
+          'search.aggregation/40_range/Date range', //source only date field should also emit values for numbers, it expects strings only
+          'search/115_multiple_field_collapsing/two levels fields collapsing', // Field collapsing on a runtime field does not work
           'field_caps/30_filter/Field caps with index filter', // We don't support filtering field caps on runtime fields. What should we do?
           'search.aggregation/220_filters_bucket/cache', // runtime keyword does not support split_queries_on_whitespace
           'search/140_pre_filter_search_shards/pre_filter_shard_size with shards that have no hit',
+          //distance feature query needs to be implemented for geo_point runtime field: https://github.com/elastic/elasticsearch/issues/67910
+          'search/250_distance_feature/test distance_feature query on geo_point type',
+          //completion suggester does not return options when the context field is a geo_point runtime field
+          'suggest/30_context/Multi contexts should work',
           /////// TO FIX ///////
 
           /////// NOT SUPPORTED ///////
           'search.highlight/40_keyword_ignore/Plain Highligher should skip highlighting ignored keyword values', // The plain highlighter is incompatible with the prefix queries that we make for runtime fields, use unified highlighter instead.
           'search.aggregation/280_rare_terms/*', // Requires an index and we won't have it
-          'search.aggregation/10_histogram/*', // Runtime fields don't support sub-fields
+          // Runtime fields don't support sub-fields
+          'search.aggregation/10_histogram/*',
+          'suggest/50_completion_with_multi_fields/Search by suggestion on geofield-hash on sub field should work',
           // Runtime fields don't have global ords
           'search.aggregation/20_terms/string profiler via global ordinals',
           'search.aggregation/20_terms/Global ordinals are loaded with the global_ordinals execution hint',

--- a/x-pack/plugin/runtime-fields/qa/src/main/java/org/elasticsearch/xpack/runtimefields/test/CoreTestTranslater.java
+++ b/x-pack/plugin/runtime-fields/qa/src/main/java/org/elasticsearch/xpack/runtimefields/test/CoreTestTranslater.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.mapper.BooleanFieldMapper;
 import org.elasticsearch.index.mapper.DateFieldMapper;
+import org.elasticsearch.index.mapper.GeoPointFieldMapper;
 import org.elasticsearch.index.mapper.IpFieldMapper;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.NumberFieldMapper.NumberType;
@@ -76,16 +77,14 @@ public abstract class CoreTestTranslater {
 
     protected abstract Suite suite(ClientYamlTestCandidate candidate);
 
-    // TODO geo_points are missing
-    private static final Set<String> RUNTIME_TYPES = new HashSet<>(
-        Arrays.asList(
-            BooleanFieldMapper.CONTENT_TYPE,
-            DateFieldMapper.CONTENT_TYPE,
-            NumberType.DOUBLE.typeName(),
-            KeywordFieldMapper.CONTENT_TYPE,
-            IpFieldMapper.CONTENT_TYPE,
-            NumberType.LONG.typeName()
-        )
+    private static final Set<String> RUNTIME_TYPES = org.elasticsearch.common.collect.Set.of(
+        BooleanFieldMapper.CONTENT_TYPE,
+        DateFieldMapper.CONTENT_TYPE,
+        NumberType.DOUBLE.typeName(),
+        KeywordFieldMapper.CONTENT_TYPE,
+        IpFieldMapper.CONTENT_TYPE,
+        GeoPointFieldMapper.CONTENT_TYPE,
+        NumberType.LONG.typeName()
     );
 
     protected abstract Map<String, Object> dynamicTemplateFor();
@@ -117,12 +116,14 @@ public abstract class CoreTestTranslater {
                     /*
                      * It would be great to use dynamic:runtime rather than dynamic templates.
                      * Unfortunately, string gets dynamically mapped as a multi-field (text + keyword) which we can't mimic as
-                     * runtime fields don't support text, and from a dynamic template a field can either be runtime of concrete.
+                     * runtime fields don't support text, and from a dynamic template a field can either be runtime or concrete.
                      * We would like to define a keyword sub-field under runtime and leave the main field under properties but that
                      * is not possible. What we do for now is skip strings: we register a dynamic template for each type besides string.
-                     * Ip fields never get dynamically mapped so they'll just look like strings.
+                     * Ip and geo_point fields never get dynamically mapped so they'll just look like strings.
                      */
-                    if (type.equals(IpFieldMapper.CONTENT_TYPE) || type.equals(KeywordFieldMapper.CONTENT_TYPE)) {
+                    if (type.equals(IpFieldMapper.CONTENT_TYPE)
+                        || type.equals(GeoPointFieldMapper.CONTENT_TYPE)
+                        || type.equals(KeywordFieldMapper.CONTENT_TYPE)) {
                         continue;
                     }
                     HashMap<String, Object> map = new HashMap<>();

--- a/x-pack/plugin/runtime-fields/qa/src/main/java/org/elasticsearch/xpack/runtimefields/test/CoreTestTranslater.java
+++ b/x-pack/plugin/runtime-fields/qa/src/main/java/org/elasticsearch/xpack/runtimefields/test/CoreTestTranslater.java
@@ -31,10 +31,8 @@ import org.elasticsearch.test.rest.yaml.section.SetupSection;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;


### PR DESCRIPTION
Mapped geo_point fields are replaced with source only runtime fields and tested. This has caught a couple of bugs that have now their corresponding issues.