### PR TITLE
[Transform] Log and audit a warning if all the group-by fields are runtime fields

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/SourceConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/SourceConfig.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import static java.util.stream.Collectors.toMap;
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
 
@@ -114,6 +115,12 @@ public class SourceConfig implements Writeable, ToXContentObject {
 
     public Map<String, Object> getRuntimeMappings() {
         return runtimeMappings;
+    }
+
+    public Map<String, Object> getScriptBasedRuntimeMappings() {
+        return getRuntimeMappings().entrySet().stream()
+            .filter(e -> e.getValue() instanceof Map<?, ?> && ((Map<?, ?>) e.getValue()).containsKey("script"))
+            .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     public boolean isValid() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/SourceConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/SourceConfigTests.java
@@ -11,11 +11,16 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.junit.Before;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Predicate;
 
+import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static java.util.stream.Collectors.toMap;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 public class SourceConfigTests extends AbstractSerializingTransformTestCase<SourceConfig> {
 
@@ -71,6 +76,37 @@ public class SourceConfigTests extends AbstractSerializingTransformTestCase<Sour
     @Override
     protected Reader<SourceConfig> instanceReader() {
         return SourceConfig::new;
+    }
+
+    public void testGetRuntimeMappings_EmptyRuntimeMappings() {
+        SourceConfig sourceConfig =
+            new SourceConfig(
+                generateRandomStringArray(10, 10, false, false),
+                QueryConfigTests.randomQueryConfig(),
+                emptyMap());
+        assertThat(sourceConfig.getRuntimeMappings(), is(anEmptyMap()));
+        assertThat(sourceConfig.getScriptBasedRuntimeMappings(), is(anEmptyMap()));
+    }
+
+    public void testGetRuntimeMappings_NonEmptyRuntimeMappings() {
+        Map<String, Object> runtimeMappings =
+            new HashMap<>() {{
+                put("field-A", singletonMap("type", "keyword"));
+                put("field-B", singletonMap("script", "some script"));
+                put("field-C", singletonMap("script", "some other script"));
+            }};
+        Map<String, Object> scriptBasedRuntimeMappings =
+            new HashMap<>() {{
+                put("field-B", singletonMap("script", "some script"));
+                put("field-C", singletonMap("script", "some other script"));
+            }};
+        SourceConfig sourceConfig =
+            new SourceConfig(
+                generateRandomStringArray(10, 10, false, false),
+                QueryConfigTests.randomQueryConfig(),
+                runtimeMappings);
+        assertThat(sourceConfig.getRuntimeMappings(), is(equalTo(runtimeMappings)));
+        assertThat(sourceConfig.getScriptBasedRuntimeMappings(), is(equalTo(scriptBasedRuntimeMappings)));
     }
 
     public void testRequiresRemoteCluster() {

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/LatestContinuousIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/LatestContinuousIT.java
@@ -25,11 +25,13 @@ import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregation.S
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static java.util.Collections.singletonMap;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -44,16 +46,27 @@ public class LatestContinuousIT extends ContinuousTestCase {
     private final String timestampField;
 
     public LatestContinuousIT() {
-        eventField = randomFrom(TERMS_FIELDS);
+        eventField = randomFrom("event", "event-upper", "event-upper-at-search");
         timestampField = randomFrom(TIMESTAMP_FIELDS);
     }
 
     @Override
     public TransformConfig createConfig() {
+        Map<String, Object> runtimeMappings =
+            new HashMap<>() {{
+                put("event-upper-at-search", new HashMap<>() {{
+                    put("type", "keyword");
+                    put("script", singletonMap("source", "if (params._source.event != null) {emit(params._source.event.toUpperCase())}"));
+                }});
+            }};
         TransformConfig.Builder transformConfigBuilder =
             new TransformConfig.Builder()
                 .setId(NAME)
-                .setSource(new SourceConfig(CONTINUOUS_EVENTS_SOURCE_INDEX))
+                .setSource(
+                    SourceConfig.builder()
+                        .setIndex(CONTINUOUS_EVENTS_SOURCE_INDEX)
+                        .setRuntimeMappings(runtimeMappings)
+                        .build())
                 .setDest(new DestConfig(NAME, INGEST_PIPELINE))
                 .setLatestConfig(
                     LatestConfig.builder()

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformProgressIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformProgressIT.java
@@ -154,7 +154,7 @@ public class TransformProgressIT extends ESRestTestCase {
         TransformConfig config =
             new TransformConfig(transformId, sourceConfig, destConfig, null, null, null, pivotConfig, null, null, null, null, null);
 
-        Pivot pivot = new Pivot(pivotConfig, transformId, new SettingsConfig(), Version.CURRENT);
+        Pivot pivot = new Pivot(pivotConfig, new SettingsConfig(), Version.CURRENT);
 
         TransformProgress progress = getProgress(pivot, getProgressQuery(pivot, config.getSource().getIndex(), null));
 
@@ -182,7 +182,7 @@ public class TransformProgressIT extends ESRestTestCase {
             Collections.singletonMap("every_50", new HistogramGroupSource("missing_field", null, missingBucket, 50.0))
         );
         pivotConfig = new PivotConfig(histgramGroupConfig, aggregationConfig, null);
-        pivot = new Pivot(pivotConfig, transformId, new SettingsConfig(), Version.CURRENT);
+        pivot = new Pivot(pivotConfig, new SettingsConfig(), Version.CURRENT);
 
         progress = getProgress(
             pivot,

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/Function.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/Function.java
@@ -153,6 +153,14 @@ public interface Function {
     void validateConfig(ActionListener<Boolean> listener);
 
     /**
+     * Returns names of fields that are critical to achieve good transform performance.
+     * Such fields should ideally be indexed, not runtime or script fields.
+     *
+     * @return list of fields names
+     */
+    List<String> getPerformanceCriticalFields();
+
+    /**
      * Runtime validation by querying the source and checking if source and config fit.
      *
      * @param client a client instance for querying the source

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/FunctionFactory.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/FunctionFactory.java
@@ -25,7 +25,7 @@ public final class FunctionFactory {
      */
     public static Function create(TransformConfig config) {
         if (config.getPivotConfig() != null) {
-            return new Pivot(config.getPivotConfig(), config.getId(), config.getSettings(), config.getVersion());
+            return new Pivot(config.getPivotConfig(), config.getSettings(), config.getVersion());
         } else if (config.getLatestConfig() != null) {
             return new Latest(config.getLatestConfig());
         } else {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
@@ -368,22 +368,24 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
         function = FunctionFactory.create(getConfig());
 
         if (isContinuous()) {
-            changeCollector = function.buildChangeCollector(getConfig().getSyncConfig().getField());
-
-            if (changeCollector.isOptimized() == false) {
-                logger.warn(
-                    new ParameterizedMessage(
-                        "[{}] could not find any optimizations for continuous execution, "
-                            + "this transform might run slowly, please check your configuration.",
-                        getJobId()
-                    )
-                );
-                auditor.warning(
-                    getJobId(),
-                    "could not find any optimizations for continuous execution, "
-                        + "this transform might run slowly, please check your configuration."
-                );
+            Map<String, Object> scriptBasedRuntimeFieldNames = transformConfig.getSource().getScriptBasedRuntimeMappings();
+            List<String> performanceCriticalFields = function.getPerformanceCriticalFields();
+            if (performanceCriticalFields.stream().allMatch(scriptBasedRuntimeFieldNames::containsKey)) {
+                String message = "all the group-by fields are script-based runtime fields, "
+                    + "this transform might run slowly, please check your configuration.";
+                logger.warn(new ParameterizedMessage("[{}] {}", getJobId(), message));
+                auditor.warning(getJobId(), message);
             }
+
+            changeCollector = function.buildChangeCollector(getConfig().getSyncConfig().getField());
+            if (changeCollector.isOptimized() == false) {
+                String message = "could not find any optimizations for continuous execution, "
+                    + "this transform might run slowly, please check your configuration.";
+                logger.warn(new ParameterizedMessage("[{}] {}", getJobId(), message));
+                auditor.warning(getJobId(), message);
+            }
+
+            // TODO: Report warnings in preview
         }
     }
 

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
@@ -377,6 +377,13 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
                 auditor.warning(getJobId(), message);
             }
 
+            if (scriptBasedRuntimeFieldNames.containsKey(transformConfig.getSyncConfig().getField())) {
+                String message = "sync time field is a script-based runtime field, "
+                    + "this transform might run slowly, please check your configuration.";
+                logger.warn(new ParameterizedMessage("[{}] {}", getJobId(), message));
+                auditor.warning(getJobId(), message);
+            }
+
             changeCollector = function.buildChangeCollector(getConfig().getSyncConfig().getField());
             if (changeCollector.isOptimized() == false) {
                 String message = "could not find any optimizations for continuous execution, "

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/latest/Latest.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/latest/Latest.java
@@ -6,8 +6,6 @@
 
 package org.elasticsearch.xpack.transform.transforms.latest;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.Client;
@@ -44,7 +42,6 @@ public class Latest extends AbstractCompositeAggFunction {
     public static final int DEFAULT_INITIAL_MAX_PAGE_SEARCH_SIZE = 5000;
 
     private static final String TOP_HITS_AGGREGATION_NAME = "_top_hits";
-    private static final Logger logger = LogManager.getLogger(Latest.class);
 
     private final LatestConfig config;
 
@@ -100,6 +97,11 @@ public class Latest extends AbstractCompositeAggFunction {
     @Override
     public void validateConfig(ActionListener<Boolean> listener) {
         listener.onResponse(true);
+    }
+
+    @Override
+    public List<String> getPerformanceCriticalFields() {
+        return config.getUniqueKey();
     }
 
     @Override

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/Pivot.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/Pivot.java
@@ -29,14 +29,17 @@ import org.elasticsearch.xpack.core.transform.transforms.SettingsConfig;
 import org.elasticsearch.xpack.core.transform.transforms.SourceConfig;
 import org.elasticsearch.xpack.core.transform.transforms.TransformIndexerStats;
 import org.elasticsearch.xpack.core.transform.transforms.pivot.PivotConfig;
+import org.elasticsearch.xpack.core.transform.transforms.pivot.SingleGroupSource;
 import org.elasticsearch.xpack.transform.Transform;
 import org.elasticsearch.xpack.transform.transforms.common.AbstractCompositeAggFunction;
 import org.elasticsearch.xpack.transform.transforms.common.DocumentConversionUtils;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
+import static java.util.stream.Collectors.toList;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 
 /**
@@ -52,11 +55,10 @@ public class Pivot extends AbstractCompositeAggFunction {
     /**
      * Create a new Pivot function
      * @param config A {@link PivotConfig} describing the function parameters
-     * @param transformId The referenced transform
      * @param settings Any miscellaneous settings for the function
      * @param version The version of the transform
      */
-    public Pivot(PivotConfig config, String transformId, SettingsConfig settings, Version version) {
+    public Pivot(PivotConfig config, SettingsConfig settings, Version version) {
         super(createCompositeAggregation(config));
         this.config = config;
         this.settings = settings;
@@ -75,6 +77,11 @@ public class Pivot extends AbstractCompositeAggFunction {
             }
         }
         listener.onResponse(true);
+    }
+
+    @Override
+    public List<String> getPerformanceCriticalFields() {
+        return config.getGroupConfig().getGroups().values().stream().map(SingleGroupSource::getField).collect(toList());
     }
 
     @Override

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/notifications/MockTransformAuditor.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/notifications/MockTransformAuditor.java
@@ -56,6 +56,10 @@ public class MockTransformAuditor extends TransformAuditor {
         expectations = new CopyOnWriteArrayList<>();
     }
 
+    /**
+     * Adds an audit expectation.
+     * Must be called *before* the code that uses auditor's {@code info}, {@code warning} or {@code error} methods.
+     */
     public void addExpectation(AuditExpectation expectation) {
         expectations.add(expectation);
     }

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerTests.java
@@ -504,7 +504,7 @@ public class TransformIndexerTests extends ESTestCase {
         auditor.assertAllExpectationsMatched();
     }
 
-    public void testInitializeFunction_WithWarning() {
+    public void testInitializeFunction_WithWarnings() {
         String transformId = randomAlphaOfLength(10);
         SourceConfig sourceConfig =
             new SourceConfig(
@@ -514,8 +514,9 @@ public class TransformIndexerTests extends ESTestCase {
                     put("field-A", singletonMap("script", "some script"));
                     put("field-B", singletonMap("script", "some script"));
                     put("field-C", singletonMap("script", "some script"));
+                    put("field-t", singletonMap("script", "some script"));
                 }});
-        SyncConfig syncConfig = new TimeSyncConfig("field", null);
+        SyncConfig syncConfig = new TimeSyncConfig("field-t", null);
         LatestConfig latestConfig = new LatestConfig(Arrays.asList("field-A", "field-B"), "sort");
         TransformConfig config =
             new TransformConfig(
@@ -528,6 +529,12 @@ public class TransformIndexerTests extends ESTestCase {
                 Level.WARNING,
                 transformId,
                 "all the group-by fields are script-based runtime fields"));
+        auditor.addExpectation(
+            new MockTransformAuditor.SeenAuditExpectation(
+                "warn when the sync time field is a script-based runtime field",
+                Level.WARNING,
+                transformId,
+                "sync time field is a script-based runtime field"));
         TransformContext.Listener contextListener = mock(TransformContext.Listener.class);
         TransformContext context = new TransformContext(TransformTaskState.STARTED, "", 0, contextListener);
         createMockIndexer(config, null, null, null, null, threadPool, ThreadPool.Names.GENERIC, auditor, context);

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerTests.java
@@ -28,14 +28,20 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.client.NoOpClient;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.core.common.notifications.Level;
 import org.elasticsearch.xpack.core.indexing.IndexerState;
 import org.elasticsearch.xpack.core.indexing.IterationResult;
+import org.elasticsearch.xpack.core.transform.transforms.QueryConfigTests;
 import org.elasticsearch.xpack.core.transform.transforms.SettingsConfig;
+import org.elasticsearch.xpack.core.transform.transforms.SourceConfig;
+import org.elasticsearch.xpack.core.transform.transforms.SyncConfig;
+import org.elasticsearch.xpack.core.transform.transforms.TimeSyncConfig;
 import org.elasticsearch.xpack.core.transform.transforms.TransformCheckpoint;
 import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
 import org.elasticsearch.xpack.core.transform.transforms.TransformIndexerPosition;
 import org.elasticsearch.xpack.core.transform.transforms.TransformIndexerStats;
 import org.elasticsearch.xpack.core.transform.transforms.TransformTaskState;
+import org.elasticsearch.xpack.core.transform.transforms.latest.LatestConfig;
 import org.elasticsearch.xpack.transform.Transform;
 import org.elasticsearch.xpack.transform.checkpoint.CheckpointProvider;
 import org.elasticsearch.xpack.transform.notifications.MockTransformAuditor;
@@ -46,7 +52,9 @@ import org.junit.Before;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -55,7 +63,9 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
 import static org.elasticsearch.xpack.core.transform.transforms.DestConfigTests.randomDestConfig;
 import static org.elasticsearch.xpack.core.transform.transforms.SourceConfigTests.randomSourceConfig;
 import static org.elasticsearch.xpack.core.transform.transforms.pivot.PivotConfigTests.randomPivotConfig;
@@ -462,6 +472,66 @@ public class TransformIndexerTests extends ESTestCase {
             failureMessage.get(),
             matchesRegex("Failed to execute script with error: \\[.*ArithmeticException: / by zero\\], stack trace: \\[stack\\]")
         );
+    }
+
+    public void testInitializeFunction_WithNoWarnings() {
+        String transformId = randomAlphaOfLength(10);
+        SourceConfig sourceConfig =
+            new SourceConfig(
+                generateRandomStringArray(10, 10, false, false),
+                QueryConfigTests.randomQueryConfig(),
+                new HashMap<>() {{
+                    put("field-A", singletonMap("script", "some script"));
+                    put("field-B", emptyMap());
+                    put("field-C", singletonMap("script", "some script"));
+                }});
+        SyncConfig syncConfig = new TimeSyncConfig("field", null);
+        LatestConfig latestConfig = new LatestConfig(Arrays.asList("field-A", "field-B"), "sort");
+        TransformConfig config =
+            new TransformConfig(
+                transformId, sourceConfig, randomDestConfig(), null, syncConfig, null, null, latestConfig, null, null, null, null);
+
+        MockTransformAuditor auditor = MockTransformAuditor.createMockAuditor();
+        auditor.addExpectation(
+            new MockTransformAuditor.UnseenAuditExpectation(
+                "warn when all the group-by fields are script-based runtime fields",
+                Level.WARNING,
+                transformId,
+                "all the group-by fields are script-based runtime fields"));
+        TransformContext.Listener contextListener = mock(TransformContext.Listener.class);
+        TransformContext context = new TransformContext(TransformTaskState.STARTED, "", 0, contextListener);
+        createMockIndexer(config, null, null, null, null, threadPool, ThreadPool.Names.GENERIC, auditor, context);
+        auditor.assertAllExpectationsMatched();
+    }
+
+    public void testInitializeFunction_WithWarning() {
+        String transformId = randomAlphaOfLength(10);
+        SourceConfig sourceConfig =
+            new SourceConfig(
+                generateRandomStringArray(10, 10, false, false),
+                QueryConfigTests.randomQueryConfig(),
+                new HashMap<>() {{
+                    put("field-A", singletonMap("script", "some script"));
+                    put("field-B", singletonMap("script", "some script"));
+                    put("field-C", singletonMap("script", "some script"));
+                }});
+        SyncConfig syncConfig = new TimeSyncConfig("field", null);
+        LatestConfig latestConfig = new LatestConfig(Arrays.asList("field-A", "field-B"), "sort");
+        TransformConfig config =
+            new TransformConfig(
+                transformId, sourceConfig, randomDestConfig(), null, syncConfig, null, null, latestConfig, null, null, null, null);
+
+        MockTransformAuditor auditor = MockTransformAuditor.createMockAuditor();
+        auditor.addExpectation(
+            new MockTransformAuditor.SeenAuditExpectation(
+                "warn when all the group-by fields are script-based runtime fields",
+                Level.WARNING,
+                transformId,
+                "all the group-by fields are script-based runtime fields"));
+        TransformContext.Listener contextListener = mock(TransformContext.Listener.class);
+        TransformContext context = new TransformContext(TransformTaskState.STARTED, "", 0, contextListener);
+        createMockIndexer(config, null, null, null, null, threadPool, ThreadPool.Names.GENERIC, auditor, context);
+        auditor.assertAllExpectationsMatched();
     }
 
     private MockedTransformIndexer createMockIndexer(

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/latest/LatestTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/latest/LatestTests.java
@@ -12,6 +12,9 @@ import org.elasticsearch.xpack.core.transform.transforms.latest.LatestConfig;
 import org.elasticsearch.xpack.core.transform.transforms.latest.LatestConfigTests;
 import org.elasticsearch.xpack.transform.transforms.Function;
 
+import java.util.Arrays;
+
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 
 public class LatestTests extends ESTestCase {
@@ -23,5 +26,11 @@ public class LatestTests extends ESTestCase {
             ActionListener.wrap(
                 isValid -> assertThat(isValid, is(true)),
                 e -> fail(e.getMessage())));
+    }
+
+    public void testGetPerformanceCriticalFields() {
+        LatestConfig latestConfig = new LatestConfig(Arrays.asList("field-A", "field-B"), "field-C");
+        Function latest = new Latest(latestConfig);
+        assertThat(latest.getPerformanceCriticalFields(), contains("field-A", "field-B"));
     }
 }

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/PivotTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/PivotTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.common.xcontent.DeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
@@ -32,6 +33,8 @@ import org.elasticsearch.test.client.NoOpClient;
 import org.elasticsearch.xpack.core.transform.transforms.SettingsConfig;
 import org.elasticsearch.xpack.core.transform.transforms.SourceConfig;
 import org.elasticsearch.xpack.core.transform.transforms.pivot.AggregationConfig;
+import org.elasticsearch.xpack.core.transform.transforms.pivot.AggregationConfigTests;
+import org.elasticsearch.xpack.core.transform.transforms.pivot.GroupConfig;
 import org.elasticsearch.xpack.core.transform.transforms.pivot.GroupConfigTests;
 import org.elasticsearch.xpack.core.transform.transforms.pivot.PivotConfig;
 import org.elasticsearch.xpack.transform.Transform;
@@ -54,6 +57,7 @@ import static java.util.Collections.emptyList;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 
@@ -94,14 +98,14 @@ public class PivotTests extends ESTestCase {
 
     public void testValidateExistingIndex() throws Exception {
         SourceConfig source = new SourceConfig("existing_source_index");
-        Function pivot = new Pivot(getValidPivotConfig(), randomAlphaOfLength(10), new SettingsConfig(), Version.CURRENT);
+        Function pivot = new Pivot(getValidPivotConfig(), new SettingsConfig(), Version.CURRENT);
 
         assertValidTransform(client, source, pivot);
     }
 
     public void testValidateNonExistingIndex() throws Exception {
         SourceConfig source = new SourceConfig("non_existing_source_index");
-        Function pivot = new Pivot(getValidPivotConfig(), randomAlphaOfLength(10), new SettingsConfig(), Version.CURRENT);
+        Function pivot = new Pivot(getValidPivotConfig(), new SettingsConfig(), Version.CURRENT);
 
         assertInvalidTransform(client, source, pivot);
     }
@@ -111,7 +115,6 @@ public class PivotTests extends ESTestCase {
 
         Function pivot = new Pivot(
             new PivotConfig(GroupConfigTests.randomGroupConfig(), getValidAggregationConfig(), expectedPageSize),
-            randomAlphaOfLength(10),
             new SettingsConfig(),
             Version.CURRENT
         );
@@ -119,7 +122,6 @@ public class PivotTests extends ESTestCase {
 
         pivot = new Pivot(
             new PivotConfig(GroupConfigTests.randomGroupConfig(), getValidAggregationConfig(), null),
-            randomAlphaOfLength(10),
             new SettingsConfig(),
             Version.CURRENT
         );
@@ -133,19 +135,19 @@ public class PivotTests extends ESTestCase {
         // search has failures although they might just be temporary
         SourceConfig source = new SourceConfig("existing_source_index_with_failing_shards");
 
-        Function pivot = new Pivot(getValidPivotConfig(), randomAlphaOfLength(10), new SettingsConfig(), Version.CURRENT);
+        Function pivot = new Pivot(getValidPivotConfig(), new SettingsConfig(), Version.CURRENT);
 
         assertInvalidTransform(client, source, pivot);
     }
 
     public void testValidateAllSupportedAggregations() throws Exception {
+        SourceConfig source = new SourceConfig("existing_source");
+
         for (String agg : supportedAggregations) {
             AggregationConfig aggregationConfig = getAggregationConfig(agg);
-            SourceConfig source = new SourceConfig("existing_source");
 
             Function pivot = new Pivot(
                 getValidPivotConfig(aggregationConfig),
-                randomAlphaOfLength(10),
                 new SettingsConfig(),
                 Version.CURRENT
             );
@@ -159,7 +161,6 @@ public class PivotTests extends ESTestCase {
 
             Function pivot = new Pivot(
                 getValidPivotConfig(aggregationConfig),
-                randomAlphaOfLength(10),
                 new SettingsConfig(),
                 Version.CURRENT
             );
@@ -169,6 +170,23 @@ public class PivotTests extends ESTestCase {
                 assertThat("expected aggregations to be unsupported, but they were", e, is(notNullValue()));
             }));
         }
+    }
+
+    public void testGetPerformanceCriticalFields() throws IOException {
+        String groupConfigJson = "{"
+            + "\"group-A\": { \"terms\": { \"field\": \"field-A\" } },"
+            + "\"group-B\": { \"terms\": { \"field\": \"field-B\" } },"
+            + "\"group-C\": { \"terms\": { \"field\": \"field-C\" } }"
+        + "}";
+        GroupConfig groupConfig;
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, groupConfigJson)) {
+            groupConfig = GroupConfig.fromXContent(parser, false);
+        }
+        assertThat(groupConfig.isValid(), is(true));
+
+        PivotConfig pivotConfig = new PivotConfig(groupConfig, AggregationConfigTests.randomAggregationConfig(), null);
+        Function pivot = new Pivot(pivotConfig, new SettingsConfig(), Version.CURRENT);
+        assertThat(pivot.getPerformanceCriticalFields(), contains("field-A", "field-B", "field-C"));
     }
 
     private class MyMockClient extends NoOpClient {


### PR DESCRIPTION
This PR adds logging and auditing for the case when all the fields that transform uses as group-by (in `pivot`) or unique key (in `latest`) are search runtime fields.

This PR is marked as `>non-issue` as it enhances an unreleased feature.

Relates https://github.com/elastic/elasticsearch/issues/65147