### PR TITLE
[7.10] [DOCS] Add security privileges to API docs (#67939)

### DIFF
--- a/docs/reference/indices/apis/reload-analyzers.asciidoc
+++ b/docs/reference/indices/apis/reload-analyzers.asciidoc
@@ -21,6 +21,13 @@ POST /my-index-000001/_reload_search_analyzers
 
 `GET /<target>/_reload_search_analyzers`
 
+[discrete]
+[[indices-reload-analyzers-api-prereqs]]
+=== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `manage`
+<<privileges-list-indices,index privilege>> for the target data stream, index,
+or index alias.
 
 [discrete]
 [[indices-reload-analyzers-api-desc]]

--- a/docs/reference/migration/apis/deprecation.asciidoc
+++ b/docs/reference/migration/apis/deprecation.asciidoc
@@ -22,6 +22,12 @@ be removed or changed in the next major version.
 
 `GET /<target>/_migration/deprecations`
 
+[[migration-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `manage`
+<<privileges-list-cluster,cluster privilege>> to use this API.
+
 [[migration-api-path-params]]
 ==== {api-path-parms-title}
 

--- a/docs/reference/rest-api/info.asciidoc
+++ b/docs/reference/rest-api/info.asciidoc
@@ -12,6 +12,13 @@ Provides general information about the installed {xpack} features.
 `GET /_xpack`
 
 [discrete]
+[[info-api-prereqs]]
+=== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `monitor` or
+`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
+
+[discrete]
 [[info-api-desc]]
 === {api-description-title}
 

--- a/docs/reference/rest-api/usage.asciidoc
+++ b/docs/reference/rest-api/usage.asciidoc
@@ -12,6 +12,13 @@ Provides usage information about the installed {xpack} features.
 `GET /_xpack/usage`
 
 [discrete]
+[[usage-api-prereqs]]
+=== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `monitor` or
+`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
+
+[discrete]
 [[usage-api-desc]]
 === {api-description-title}
 


### PR DESCRIPTION
Backports the following commits to 7.10:
 - [DOCS] Add security privileges to API docs (#67939)