### PR TITLE
Extend default probe connect/handshake timeouts

### DIFF
--- a/docs/reference/modules/discovery/discovery-settings.asciidoc
+++ b/docs/reference/modules/discovery/discovery-settings.asciidoc
@@ -73,12 +73,12 @@ Defaults to `1s`.
 `discovery.probe.connect_timeout`::
 (<<static-cluster-setting,Static>>)
 Sets how long to wait when attempting to connect to each address. Defaults to
-`3s`.
+`30s`.
 
 `discovery.probe.handshake_timeout`::
 (<<static-cluster-setting,Static>>)
 Sets how long to wait when attempting to identify the remote node via a
-handshake. Defaults to `1s`.
+handshake. Defaults to `30s`.
 
 `discovery.request_peers_timeout`::
 (<<static-cluster-setting,Static>>)

--- a/server/src/main/java/org/elasticsearch/discovery/HandshakingTransportAddressConnector.java
+++ b/server/src/main/java/org/elasticsearch/discovery/HandshakingTransportAddressConnector.java
@@ -51,11 +51,11 @@ public class HandshakingTransportAddressConnector implements TransportAddressCon
     // connection timeout for probes
     public static final Setting<TimeValue> PROBE_CONNECT_TIMEOUT_SETTING =
         Setting.timeSetting("discovery.probe.connect_timeout",
-            TimeValue.timeValueMillis(3000), TimeValue.timeValueMillis(1), Setting.Property.NodeScope);
+            TimeValue.timeValueSeconds(30), TimeValue.timeValueMillis(1), Setting.Property.NodeScope);
     // handshake timeout for probes
     public static final Setting<TimeValue> PROBE_HANDSHAKE_TIMEOUT_SETTING =
         Setting.timeSetting("discovery.probe.handshake_timeout",
-            TimeValue.timeValueMillis(1000), TimeValue.timeValueMillis(1), Setting.Property.NodeScope);
+            TimeValue.timeValueSeconds(30), TimeValue.timeValueMillis(1), Setting.Property.NodeScope);
 
     private final TransportService transportService;
     private final TimeValue probeConnectTimeout;


### PR DESCRIPTION
Today the discovery phase has a short 1-second timeout for handshaking
with a remote node after connecting, which allows it to quickly move on
and retry in the case of connecting to something that doesn't respond
straight away (e.g. it isn't an Elasticsearch node).

This short timeout was necessary when the component was first developed
because each connection attempt would block a thread. Since #42636 the
connection attempt is now nonblocking so we can apply a more relaxed
timeout.

If transport security is enabled then our handshake timeout applies to
the TLS handshake followed by the Elasticsearch handshake. If the TLS
handshake alone takes over a second then the whole handshake times out
with a `ConnectTransportException`, but this does not tell us which of
the two individual handshakes took so long.

TLS handshakes have their own 10-second timeout, which if reached yields
a `SslHandshakeTimeoutException` that allows us to distinguish a problem
at the TLS level from one at the Elasticsearch level. Therefore this
commit extends the discovery probe timeouts.