### PR TITLE
Disable ML on Darwin aarch64

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -1314,6 +1314,21 @@ public class Setting<T> implements ToXContentObject {
         return new Setting<>(key, defaultValueFn, b -> parseBoolean(b, key, isFiltered(properties)), properties);
     }
 
+    public static Setting<Boolean> boolSetting(
+        String key,
+        Function<Settings, String> defaultValueFn,
+        Validator<Boolean> validator,
+        Property... properties
+    ) {
+        return new Setting<>(
+            new SimpleKey(key),
+            defaultValueFn,
+            (String b) -> parseBoolean(b, key, isFiltered(properties)),
+            validator,
+            properties
+        );
+    }
+
     static boolean parseBoolean(String b, String key, boolean isFiltered) {
         try {
             return Booleans.parseBoolean(b);

--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -1314,21 +1314,6 @@ public class Setting<T> implements ToXContentObject {
         return new Setting<>(key, defaultValueFn, b -> parseBoolean(b, key, isFiltered(properties)), properties);
     }
 
-    public static Setting<Boolean> boolSetting(
-        String key,
-        Function<Settings, String> defaultValueFn,
-        Validator<Boolean> validator,
-        Property... properties
-    ) {
-        return new Setting<>(
-            new SimpleKey(key),
-            defaultValueFn,
-            (String b) -> parseBoolean(b, key, isFiltered(properties)),
-            validator,
-            properties
-        );
-    }
-
     static boolean parseBoolean(String b, String key, boolean isFiltered) {
         try {
             return Booleans.parseBoolean(b);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackSettings.java
@@ -32,6 +32,12 @@ import static org.elasticsearch.xpack.core.security.SecurityField.USER_SETTING;
  * A container for xpack setting constants.
  */
 public class XPackSettings {
+    private static final boolean IS_DARWIN_AARCH64;
+    static {
+        final String name = System.getProperty("os.name");
+        final String arch = System.getProperty("os.arch");
+        IS_DARWIN_AARCH64 = "aarch64".equals(arch) && name.startsWith("Mac OS X");
+    }
 
     private XPackSettings() {
         throw new IllegalStateException("Utility class should not be instantiated");
@@ -52,8 +58,15 @@ public class XPackSettings {
     public static final Setting<Boolean> GRAPH_ENABLED = Setting.boolSetting("xpack.graph.enabled", true, Setting.Property.NodeScope);
 
     /** Setting for enabling or disabling machine learning. Defaults to true. */
-    public static final Setting<Boolean> MACHINE_LEARNING_ENABLED = Setting.boolSetting("xpack.ml.enabled", true,
-            Setting.Property.NodeScope);
+    public static final Setting<Boolean> MACHINE_LEARNING_ENABLED = Setting.boolSetting(
+        "xpack.ml.enabled",
+        _settings -> Boolean.toString(IS_DARWIN_AARCH64 == false),
+        value -> {
+            if (value && IS_DARWIN_AARCH64) {
+                throw new IllegalArgumentException("[xpack.ml.enabled] can not be set to [true] on [Mac OS X/aarch64]");
+            }
+        },
+        Setting.Property.NodeScope);
 
     /** Setting for enabling or disabling auditing. Defaults to false. */
     public static final Setting<Boolean> AUDIT_ENABLED = Setting.boolSetting("xpack.security.audit.enabled", false,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackSettings.java
@@ -60,7 +60,7 @@ public class XPackSettings {
     /** Setting for enabling or disabling machine learning. Defaults to true. */
     public static final Setting<Boolean> MACHINE_LEARNING_ENABLED = Setting.boolSetting(
         "xpack.ml.enabled",
-        _settings -> Boolean.toString(IS_DARWIN_AARCH64 == false),
+        IS_DARWIN_AARCH64 == false,
         value -> {
             if (value && IS_DARWIN_AARCH64) {
                 throw new IllegalArgumentException("[xpack.ml.enabled] can not be set to [true] on [Mac OS X/aarch64]");


### PR DESCRIPTION
Until we have ML binaries available for darwin/aarch64, make sure ML is
disabled and stays disabled.