### PR TITLE
HttpCertificateCommand PKCS12 filetype auto-detect in JDK16

### DIFF
--- a/x-pack/plugin/security/cli/src/main/java/org/elasticsearch/xpack/security/cli/HttpCertificateCommand.java
+++ b/x-pack/plugin/security/cli/src/main/java/org/elasticsearch/xpack/security/cli/HttpCertificateCommand.java
@@ -105,6 +105,7 @@ class HttpCertificateCommand extends EnvironmentAwareCommand {
      * Magic bytes for an empty PKCS#12 file
      */
     private static final byte[] MAGIC_BYTES2_PKCS12 = new byte[] { (byte) 0x30, (byte) 0x56 };
+    private static final byte[] MAGIC_BYTES2_JDK16_PKCS12 = new byte[] { (byte) 0x30, (byte) 0x65 };
     /**
      * Magic bytes for a JKS keystore
      */
@@ -1097,7 +1098,9 @@ class HttpCertificateCommand extends EnvironmentAwareCommand {
                 // No supported file type has less than 2 bytes
                 return FileType.UNRECOGNIZED;
             }
-            if (Arrays.equals(leadingBytes, MAGIC_BYTES1_PKCS12) || Arrays.equals(leadingBytes, MAGIC_BYTES2_PKCS12)) {
+            if (Arrays.equals(leadingBytes, MAGIC_BYTES1_PKCS12) ||
+                    Arrays.equals(leadingBytes, MAGIC_BYTES2_PKCS12) ||
+                    Arrays.equals(leadingBytes, MAGIC_BYTES2_JDK16_PKCS12)) {
                 return FileType.PKCS12;
             }
             if (Arrays.equals(leadingBytes, MAGIC_BYTES_JKS)) {


### PR DESCRIPTION
[JDK16](https://jdk.java.net/16/release-notes) updated the default encryption and MAC algorithms used in PKCS#12.
Because of it, the empty keystore fingerprint (the first two bytes) has changed.
This PR updates the PKCS12 detection rule so that the http certificate command identifies empty keystores created in JDK16.

Build scan of failure https://gradle-enterprise.elastic.co/s/glhmvrx532q3q

Tested with:
```
RUNTIME_JAVA_HOME=$JAVA16_HOME ./gradlew ':x-pack:plugin:security:cli:test' --tests "org.elasticsearch.xpack.security.cli.HttpCertificateCommandTests" -Dtests.iters=16
RUNTIME_JAVA_HOME=$JAVA15_HOME ./gradlew ':x-pack:plugin:security:cli:test' --tests "org.elasticsearch.xpack.security.cli.HttpCertificateCommandTests" -Dtests.iters=16
RUNTIME_JAVA_HOME=$JAVA14_HOME ./gradlew ':x-pack:plugin:security:cli:test' --tests "org.elasticsearch.xpack.security.cli.HttpCertificateCommandTests" -Dtests.iters=16
RUNTIME_JAVA_HOME=$JAVA13_HOME ./gradlew ':x-pack:plugin:security:cli:test' --tests "org.elasticsearch.xpack.security.cli.HttpCertificateCommandTests" -Dtests.iters=16
```