### PR TITLE
Allow partial indices options in watches

### DIFF
--- a/x-pack/docs/en/watcher/transform/search.asciidoc
+++ b/x-pack/docs/en/watcher/transform/search.asciidoc
@@ -68,8 +68,9 @@ The following table lists all available settings for the search
                                                                                   a REST `_search` request. The body can be static text
                                                                                   or include `mustache` <<templates,templates>>.
 
-| `request.indices_options.expand_wildcards`    | no        | `open`            | Determines how to expand indices wildcards. Can be one
-                                                                                  of `open`, `closed`, `none` or `all`
+| `request.indices_options.expand_wildcards`    | no        | `open`            | Determines how to expand indices wildcards. An array
+                                                                                  consisting of a combination of `open`, `closed`,
+                                                                                  and `hidden`. Alternatively a value of `none` or `all`.
                                                                                   (see <<multi-index,multi-index support>>)
 
 | `request.indices_options.ignore_unavailable`  | no        | `true`            | A boolean value that determines whether the search

--- a/x-pack/plugin/watcher/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/watcher/put_watch/92_put_watch_with_indices_options.yml
+++ b/x-pack/plugin/watcher/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/watcher/put_watch/92_put_watch_with_indices_options.yml
@@ -1,0 +1,143 @@
+---
+setup:
+  - do:
+      cluster.health:
+        wait_for_status: yellow
+
+---
+"Test put watch with allow no indices":
+  - skip:
+      version: "7.10.1 - 7.99.99"
+      reason: "watch parsing with partial indices options was broken in 7.10.1"
+  - do:
+      watcher.put_watch:
+        id: "my_watch_allow_no_indices"
+        body:  >
+          {
+            "trigger": {
+              "schedule" : { "cron" : "0 0 0 1 * ? 2099" }
+            },
+            "input": {
+              "search" : {
+                "request" : {
+                  "indices" : [ "my_test_index" ],
+                  "rest_total_hits_as_int": false,
+                  "body" : {
+                    "query": {
+                      "match_all" : {}
+                    }
+                  },
+                  "indices_options" : {
+                    "allow_no_indices" : false
+                  }
+                }
+              }
+            },
+            "actions": {
+              "test_index": {
+                "index": {
+                  "index": "test"
+                }
+              }
+            }
+          }
+  - match: { _id: "my_watch_allow_no_indices" }
+
+  - do:
+      watcher.get_watch:
+        id: "my_watch_allow_no_indices"
+  - match: { found : true}
+  - match: { _id: "my_watch_allow_no_indices" }
+  - match: { watch.input.search.request.indices_options.allow_no_indices: false }
+
+---
+"Test put watch with expand wildcards":
+  - skip:
+      version: "7.10.1 - 7.99.99"
+      reason: "watch parsing with partial indices options was broken in 7.10.1"
+  - do:
+      watcher.put_watch:
+        id: "my_watch_expand_wildcards"
+        body:  >
+          {
+            "trigger": {
+              "schedule" : { "cron" : "0 0 0 1 * ? 2099" }
+            },
+            "input": {
+              "search" : {
+                "request" : {
+                  "indices" : [ "my_test_index" ],
+                  "rest_total_hits_as_int": false,
+                  "body" : {
+                    "query": {
+                      "match_all" : {}
+                    }
+                  },
+                  "indices_options" : {
+                    "expand_wildcards" : [ "open", "hidden" ]
+                  }
+                }
+              }
+            },
+            "actions": {
+              "test_index": {
+                "index": {
+                  "index": "test"
+                }
+              }
+            }
+          }
+  - match: { _id: "my_watch_expand_wildcards" }
+
+  - do:
+      watcher.get_watch:
+        id: "my_watch_expand_wildcards"
+  - match: { found : true}
+  - match: { _id: "my_watch_expand_wildcards" }
+  - match: { watch.input.search.request.indices_options.expand_wildcards: [ "open", "hidden" ] }
+
+---
+"Test put watch with ignore unavailable":
+  - skip:
+      version: "7.10.1 - 7.99.99"
+      reason: "watch parsing with partial indices options was broken in 7.10.1"
+  - do:
+      watcher.put_watch:
+        id: "my_watch_ignore_unavailable"
+        body:  >
+          {
+            "trigger": {
+              "schedule" : { "cron" : "0 0 0 1 * ? 2099" }
+            },
+            "input": {
+              "search" : {
+                "request" : {
+                  "indices" : [ "my_test_index" ],
+                  "rest_total_hits_as_int": false,
+                  "body" : {
+                    "query": {
+                      "match_all" : {}
+                    }
+                  },
+                  "indices_options" : {
+                    "ignore_unavailable" : false
+                  }
+                }
+              }
+            },
+            "actions": {
+              "test_index": {
+                "index": {
+                  "index": "test"
+                }
+              }
+            }
+          }
+  - match: { _id: "my_watch_ignore_unavailable" }
+
+  - do:
+      watcher.get_watch:
+        id: "my_watch_ignore_unavailable"
+  - match: { found : true}
+  - match: { _id: "my_watch_ignore_unavailable" }
+  - match: { watch.input.search.request.indices_options.ignore_unavailable: false }

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/support/search/WatcherSearchTemplateRequest.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/support/search/WatcherSearchTemplateRequest.java
@@ -188,7 +188,7 @@ public class WatcherSearchTemplateRequest implements ToXContentObject {
                         searchSource = BytesReference.bytes(builder);
                     }
                 } else if (INDICES_OPTIONS_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
-                    indicesOptions = IndicesOptions.fromXContent(parser);
+                    indicesOptions = IndicesOptions.fromXContent(parser, DEFAULT_INDICES_OPTIONS);
                 } else if (TEMPLATE_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                     template = Script.parse(parser, Script.DEFAULT_TEMPLATE_LANG);
                 } else {


### PR DESCRIPTION
Partially defined indices options have always been allowed in watches,
but the cleanup in #65332 removed this ability and made the definition
of indices options within a watch require all fields. This change fixes
this by updating the parsing to accept a default indices options and
add test coverage for this scenario.

Closes #68022