### PR TITLE
Replace NOT operator with explicit `false` check

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/IndicesRequestIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/IndicesRequestIT.java
@@ -604,7 +604,7 @@ public class IndicesRequestIT extends ESIntegTestCase {
     private static void assertSameIndices(IndicesRequest originalRequest, boolean optional, String... actions) {
         for (String action : actions) {
             List<TransportRequest> requests = consumeTransportRequests(action);
-            if (!optional) {
+            if (optional == false) {
                 assertThat("no internal requests intercepted for action [" + action + "]", requests.size(), greaterThan(0));
             }
             for (TransportRequest internalRequest : requests) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/aliases/IndexAliasesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/aliases/IndexAliasesIT.java
@@ -631,7 +631,7 @@ public class IndexAliasesIT extends ESIntegTestCase {
         executor.shutdown();
         boolean done = executor.awaitTermination(20, TimeUnit.SECONDS);
         assertThat(done, equalTo(true));
-        if (!done) {
+        if (done == false) {
             executor.shutdownNow();
         }
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/bwcompat/RecoveryWithUnsupportedIndicesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/bwcompat/RecoveryWithUnsupportedIndicesIT.java
@@ -56,7 +56,7 @@ public class RecoveryWithUnsupportedIndicesIT extends ESIntegTestCase {
         try (DirectoryStream<Path> stream = Files.newDirectoryStream(dataDir)) {
             List<Path> dirs = new ArrayList<>();
             for (Path p : stream) {
-                if (!p.getFileName().toString().startsWith("extra")) {
+                if (p.getFileName().toString().startsWith("extra") == false) {
                     dirs.add(p);
                 }
             }

--- a/server/src/internalClusterTest/java/org/elasticsearch/discovery/ClusterDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/discovery/ClusterDisruptionIT.java
@@ -147,10 +147,10 @@ public class ClusterDisruptionIT extends AbstractDisruptionTestCase {
                 final String name = "indexer_" + indexers.size();
                 final int numPrimaries = getNumShards("test").numPrimaries;
                 Thread thread = new Thread(() -> {
-                    while (!stop.get()) {
+                    while (stop.get() == false) {
                         String id = null;
                         try {
-                            if (!semaphore.tryAcquire(10, TimeUnit.SECONDS)) {
+                            if (semaphore.tryAcquire(10, TimeUnit.SECONDS) == false) {
                                 continue;
                             }
                             logger.info("[{}] Acquired semaphore and it has {} permits left", name, semaphore.availablePermits());

--- a/server/src/internalClusterTest/java/org/elasticsearch/discovery/MasterDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/discovery/MasterDisruptionIT.java
@@ -202,10 +202,10 @@ public class MasterDisruptionIT extends AbstractDisruptionTestCase {
             if (nodeState.nodes().getMasterNode() == null) {
                 success = false;
             }
-            if (!nodeState.blocks().global().isEmpty()) {
+            if (nodeState.blocks().global().isEmpty() == false) {
                 success = false;
             }
-            if (!success) {
+            if (success == false) {
                 fail("node [" + node + "] has no master or has blocks, despite of being on the right side of the partition. State dump:\n"
                         + nodeState);
             }

--- a/server/src/internalClusterTest/java/org/elasticsearch/discovery/StableMasterDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/discovery/StableMasterDisruptionIT.java
@@ -194,7 +194,7 @@ public class StableMasterDisruptionIT extends ESIntegTestCase {
             internalCluster().getInstance(ClusterService.class, node).addListener(event -> {
                 DiscoveryNode previousMaster = event.previousState().nodes().getMasterNode();
                 DiscoveryNode currentMaster = event.state().nodes().getMasterNode();
-                if (!Objects.equals(previousMaster, currentMaster)) {
+                if (Objects.equals(previousMaster, currentMaster) == false) {
                     logger.info("--> node {} received new cluster state: {} \n and had previous cluster state: {}", node, event.state(),
                         event.previousState());
                     String previousMasterNodeName = previousMaster != null ? previousMaster.getName() : null;

--- a/server/src/internalClusterTest/java/org/elasticsearch/gateway/RecoveryFromGatewayIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/gateway/RecoveryFromGatewayIT.java
@@ -216,7 +216,7 @@ public class RecoveryFromGatewayIT extends ESIntegTestCase {
             assertHitCount(client().prepareSearch().setSize(0).setQuery(termQuery("field", "value2")).get(), value2Docs);
             assertHitCount(client().prepareSearch().setSize(0).setQuery(termQuery("num", 179)).get(), value1Docs);
         }
-        if (!indexToAllShards) {
+        if (indexToAllShards == false) {
             // we have to verify primaries are started for them to be restored
             logger.info("Ensure all primaries have been started");
             ensureYellow();

--- a/server/src/internalClusterTest/java/org/elasticsearch/recovery/RelocationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/recovery/RelocationIT.java
@@ -254,7 +254,7 @@ public class RelocationIT extends ESIntegTestCase {
                         IntHashSet set = IntHashSet.from(hitIds);
                         for (SearchHit hit : hits.getHits()) {
                             int id = Integer.parseInt(hit.getId());
-                            if (!set.remove(id)) {
+                            if (set.remove(id) == false) {
                                 logger.error("Extra id [{}]", id);
                             }
                         }
@@ -266,7 +266,7 @@ public class RelocationIT extends ESIntegTestCase {
                     logger.info("--> DONE search test round {}", i + 1);
 
             }
-            if (!ranOnce) {
+            if (ranOnce == false) {
                 fail();
             }
         }
@@ -404,7 +404,7 @@ public class RelocationIT extends ESIntegTestCase {
         ClusterService clusterService = internalCluster().getInstance(ClusterService.class, p_node);
         MockTransportService mockTransportService = (MockTransportService) internalCluster().getInstance(TransportService.class, p_node);
         for (DiscoveryNode node : clusterService.state().nodes()) {
-            if (!node.equals(clusterService.localNode())) {
+            if (node.equals(clusterService.localNode()) == false) {
                 mockTransportService.addSendBehavior(internalCluster().getInstance(TransportService.class, node.getName()),
                         new RecoveryCorruption(corruptionCount));
             }

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/RestoreSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/RestoreSnapshotIT.java
@@ -611,7 +611,7 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
             Settings initialSettings = initialSettingsBuilder.build();
             logger.info("--> using initial block settings {}", initialSettings);
 
-            if (!initialSettings.isEmpty()) {
+            if (initialSettings.isEmpty() == false) {
                 logger.info("--> apply initial blocks to index");
                 client().admin().indices().prepareUpdateSettings("test-idx").setSettings(initialSettingsBuilder).get();
             }

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
@@ -132,7 +132,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
                     indicesToFlush.add("test-idx-" + i);
                 }
             }
-            if (!indicesToFlush.isEmpty()) {
+            if (indicesToFlush.isEmpty() == false) {
                 logger.info("--> starting asynchronous flush for indices {}", indicesToFlush);
                 flushResponseFuture = client().admin().indices().prepareFlush(indicesToFlush.toArray(Strings.EMPTY_ARRAY)).execute();
             }

--- a/server/src/internalClusterTest/java/org/elasticsearch/update/UpdateIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/update/UpdateIT.java
@@ -755,7 +755,7 @@ public class UpdateIT extends ESIntegTestCase {
             }
 
             private void incrementMapValue(int j, Map<Integer,Integer> map) {
-                if (!map.containsKey(j)) {
+                if (map.containsKey(j) == false) {
                     map.put(j, 0);
                 }
                 map.put(j, map.get(j) + 1);

--- a/server/src/main/java/org/elasticsearch/Build.java
+++ b/server/src/main/java/org/elasticsearch/Build.java
@@ -296,11 +296,11 @@ public class Build {
 
         Build build = (Build) o;
 
-        if (!flavor.equals(build.flavor)) {
+        if (flavor.equals(build.flavor) == false) {
             return false;
         }
 
-        if (!type.equals(build.type)) {
+        if (type.equals(build.type) == false) {
             return false;
         }
 

--- a/server/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/server/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -1165,7 +1165,7 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
         for (int i = 0; i < value.length(); i++) {
             char c = value.charAt(i);
             if (Character.isUpperCase(c)) {
-                if (!changed) {
+                if (changed == false) {
                     // copy it over here
                     for (int j = 0; j < i; j++) {
                         sb.append(value.charAt(j));
@@ -1187,7 +1187,7 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
                 }
             }
         }
-        if (!changed) {
+        if (changed == false) {
             return value;
         }
         return sb.toString();

--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -192,7 +192,7 @@ public class Version implements Comparable<Version>, ToXContentFragment {
      * Returns the version given its string representation, current version if the argument is null or empty
      */
     public static Version fromString(String version) {
-        if (!Strings.hasLength(version)) {
+        if (Strings.hasLength(version) == false) {
             return Version.CURRENT;
         }
         final Version cached = stringToVersion.get(version);

--- a/server/src/main/java/org/elasticsearch/action/bulk/BackoffPolicy.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BackoffPolicy.java
@@ -158,7 +158,7 @@ public abstract class BackoffPolicy implements Iterable<TimeValue> {
 
         @Override
         public TimeValue next() {
-            if (!hasNext()) {
+            if (hasNext() == false) {
                 throw new NoSuchElementException("Only up to " + numberOfElements + " elements");
             }
             int result = start + 10 * ((int) Math.exp(0.8d * (currentlyConsumed)) - 1);
@@ -201,7 +201,7 @@ public abstract class BackoffPolicy implements Iterable<TimeValue> {
 
         @Override
         public TimeValue next() {
-            if (!hasNext()) {
+            if (hasNext() == false) {
                 throw new NoSuchElementException();
             }
             curr++;

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkProcessor.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkProcessor.java
@@ -426,7 +426,7 @@ public class BulkProcessor implements Closeable {
     // needs to be executed under a lock
     private Tuple<BulkRequest,Long> newBulkRequestIfNeeded(){
         ensureOpen();
-        if (!isOverTheLimit()) {
+        if (isOverTheLimit() == false) {
             return null;
         }
         final BulkRequest bulkRequest = this.bulkRequest;

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkRequestParser.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkRequestParser.java
@@ -179,7 +179,7 @@ public final class BulkRequestParser {
                             currentFieldName = parser.currentName();
                         } else if (token.isValue()) {
                             if (INDEX.match(currentFieldName, parser.getDeprecationHandler())) {
-                                if (!allowExplicitIndex) {
+                                if (allowExplicitIndex == false) {
                                     throw new IllegalArgumentException("explicit index in bulk is not allowed");
                                 }
                                 index = stringDeduplicator.computeIfAbsent(parser.text(), Function.identity());

--- a/server/src/main/java/org/elasticsearch/action/bulk/Retry.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/Retry.java
@@ -102,7 +102,7 @@ public class Retry {
 
         @Override
         public void onResponse(BulkResponse bulkItemResponses) {
-            if (!bulkItemResponses.hasFailures()) {
+            if (bulkItemResponses.hasFailures() == false) {
                 // we're done here, include all responses
                 addResponses(bulkItemResponses, (r -> true));
                 finishHim();
@@ -152,7 +152,7 @@ public class Retry {
         }
 
         private boolean canRetry(BulkResponse bulkItemResponses) {
-            if (!backoff.hasNext()) {
+            if (backoff.hasNext() == false) {
                 return false;
             }
             for (BulkItemResponse bulkItemResponse : bulkItemResponses) {

--- a/server/src/main/java/org/elasticsearch/action/explain/TransportExplainAction.java
+++ b/server/src/main/java/org/elasticsearch/action/explain/TransportExplainAction.java
@@ -111,7 +111,7 @@ public class TransportExplainAction extends TransportSingleShardAction<ExplainRe
         try {
             // No need to check the type, IndexShard#get does it for us
             result = context.indexShard().get(new Engine.Get(false, false, request.id()));
-            if (!result.exists()) {
+            if (result.exists() == false) {
                 return new ExplainResponse(shardId.getIndexName(), request.id(), false);
             }
             context.parsedQuery(context.getSearchExecutionContext().toQuery(request.query()));

--- a/server/src/main/java/org/elasticsearch/bootstrap/BootstrapChecks.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/BootstrapChecks.java
@@ -144,7 +144,7 @@ final class BootstrapChecks {
         for (final BootstrapCheck check : checks) {
             final BootstrapCheck.BootstrapCheckResult result = check.check(context);
             if (result.isFailure()) {
-                if (!(enforceLimits || enforceBootstrapChecks) && !check.alwaysEnforce()) {
+                if ((enforceLimits || enforceBootstrapChecks) && !check.alwaysEnforce() == false) {
                     ignoredErrors.add(result.getMessage());
                 } else {
                     errors.add(result.getMessage());
@@ -152,11 +152,11 @@ final class BootstrapChecks {
             }
         }
 
-        if (!ignoredErrors.isEmpty()) {
+        if (ignoredErrors.isEmpty() == false) {
             ignoredErrors.forEach(error -> log(logger, error));
         }
 
-        if (!errors.isEmpty()) {
+        if (errors.isEmpty() == false) {
             final List<String> messages = new ArrayList<>(1 + errors.size());
             messages.add("[" + errors.size() + "] bootstrap checks failed. You must address the points described in the following ["
                     + errors.size() + "] lines before starting Elasticsearch.");

--- a/server/src/main/java/org/elasticsearch/bootstrap/BootstrapChecks.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/BootstrapChecks.java
@@ -144,7 +144,7 @@ final class BootstrapChecks {
         for (final BootstrapCheck check : checks) {
             final BootstrapCheck.BootstrapCheckResult result = check.check(context);
             if (result.isFailure()) {
-                if ((enforceLimits || enforceBootstrapChecks) && !check.alwaysEnforce() == false) {
+                if (enforceLimits == false && enforceBootstrapChecks == false && check.alwaysEnforce() == false) {
                     ignoredErrors.add(result.getMessage());
                 } else {
                     errors.add(result.getMessage());

--- a/server/src/main/java/org/elasticsearch/bootstrap/JNANatives.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/JNANatives.java
@@ -184,7 +184,7 @@ class JNANatives {
             // Thus, we need to first increase the working set size of the JVM by
             // the amount of memory we wish to lock, plus a small overhead (1MB).
             SizeT size = new SizeT(JvmInfo.jvmInfo().getMem().getHeapInit().getBytes() + (1024 * 1024));
-            if (!kernel.SetProcessWorkingSetSize(process, size, size)) {
+            if (kernel.SetProcessWorkingSetSize(process, size, size) == false) {
                 logger.warn("Unable to lock JVM memory. Failed to set working set size. Error code {}", Native.getLastError());
             } else {
                 JNAKernel32Library.MemoryBasicInformation memInfo = new JNAKernel32Library.MemoryBasicInformation();

--- a/server/src/main/java/org/elasticsearch/bootstrap/Natives.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Natives.java
@@ -53,7 +53,7 @@ final class Natives {
     }
 
     static void tryMlockall() {
-        if (!JNA_AVAILABLE) {
+        if (JNA_AVAILABLE == false) {
             logger.warn("cannot mlockall because JNA is not available");
             return;
         }
@@ -61,7 +61,7 @@ final class Natives {
     }
 
     static boolean definitelyRunningAsRoot() {
-        if (!JNA_AVAILABLE) {
+        if (JNA_AVAILABLE == false) {
             logger.warn("cannot check if running as root because JNA is not available");
             return false;
         }
@@ -69,7 +69,7 @@ final class Natives {
     }
 
     static void tryVirtualLock() {
-        if (!JNA_AVAILABLE) {
+        if (JNA_AVAILABLE == false) {
             logger.warn("cannot virtual lock because JNA is not available");
             return;
         }
@@ -83,7 +83,7 @@ final class Natives {
      * @return the short path name (or the original path if getting the short path name fails for any reason)
      */
     static String getShortPathName(final String path) {
-        if (!JNA_AVAILABLE) {
+        if (JNA_AVAILABLE == false) {
             logger.warn("cannot obtain short path for [{}] because JNA is not available", path);
             return path;
         }
@@ -91,7 +91,7 @@ final class Natives {
     }
 
     static void addConsoleCtrlHandler(ConsoleCtrlHandler handler) {
-        if (!JNA_AVAILABLE) {
+        if (JNA_AVAILABLE == false) {
             logger.warn("cannot register console handler because JNA is not available");
             return;
         }
@@ -99,14 +99,14 @@ final class Natives {
     }
 
     static boolean isMemoryLocked() {
-        if (!JNA_AVAILABLE) {
+        if (JNA_AVAILABLE == false) {
             return false;
         }
         return JNANatives.LOCAL_MLOCKALL;
     }
 
     static void tryInstallSystemCallFilter(Path tmpFile) {
-        if (!JNA_AVAILABLE) {
+        if (JNA_AVAILABLE == false) {
             logger.warn("cannot install system call filter because JNA is not available");
             return;
         }
@@ -114,7 +114,7 @@ final class Natives {
     }
 
     static void trySetMaxNumberOfThreads() {
-        if (!JNA_AVAILABLE) {
+        if (JNA_AVAILABLE == false) {
             logger.warn("cannot getrlimit RLIMIT_NPROC because JNA is not available");
             return;
         }
@@ -122,7 +122,7 @@ final class Natives {
     }
 
     static void trySetMaxSizeVirtualMemory() {
-        if (!JNA_AVAILABLE) {
+        if (JNA_AVAILABLE == false) {
             logger.warn("cannot getrlimit RLIMIT_AS because JNA is not available");
             return;
         }
@@ -130,7 +130,7 @@ final class Natives {
     }
 
     static void trySetMaxFileSize() {
-        if (!JNA_AVAILABLE) {
+        if (JNA_AVAILABLE == false) {
             logger.warn("cannot getrlimit RLIMIT_FSIZE because JNA is not available");
             return;
         }
@@ -138,7 +138,7 @@ final class Natives {
     }
 
     static boolean isSystemCallFilterInstalled() {
-        if (!JNA_AVAILABLE) {
+        if (JNA_AVAILABLE == false) {
             return false;
         }
         return JNANatives.LOCAL_SYSTEM_CALL_FILTER;

--- a/server/src/main/java/org/elasticsearch/bootstrap/Security.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Security.java
@@ -223,7 +223,7 @@ final class Security {
              */
             try {
                 final Path realPath = path.toRealPath();
-                if (!dataFilesPaths.add(realPath)) {
+                if (dataFilesPaths.add(realPath) == false) {
                     throw new IllegalStateException("path [" + realPath + "] is duplicated by [" + path + "]");
                 }
             } catch (final IOException e) {

--- a/server/src/main/java/org/elasticsearch/bootstrap/Spawner.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Spawner.java
@@ -61,10 +61,10 @@ final class Spawner implements Closeable {
      * @throws IOException if an I/O error occurs reading the module or spawning a native process
      */
     void spawnNativeControllers(final Environment environment, final boolean inheritIo) throws IOException {
-        if (!spawned.compareAndSet(false, true)) {
+        if (spawned.compareAndSet(false, true) == false) {
             throw new IllegalStateException("native controllers already spawned");
         }
-        if (!Files.exists(environment.modulesFile())) {
+        if (Files.exists(environment.modulesFile()) == false) {
             throw new IllegalStateException("modules directory [" + environment.modulesFile() + "] not found");
         }
         /*
@@ -75,10 +75,10 @@ final class Spawner implements Closeable {
         for (final Path modules : paths) {
             final PluginInfo info = PluginInfo.readFromProperties(modules);
             final Path spawnPath = Platforms.nativeControllerPath(modules);
-            if (!Files.isRegularFile(spawnPath)) {
+            if (Files.isRegularFile(spawnPath) == false) {
                 continue;
             }
-            if (!info.hasNativeController()) {
+            if (info.hasNativeController() == false) {
                 final String message = String.format(
                     Locale.ROOT,
                     "module [%s] does not have permission to fork native controller",

--- a/server/src/main/java/org/elasticsearch/bootstrap/SystemCallFilter.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/SystemCallFilter.java
@@ -564,7 +564,7 @@ final class SystemCallFilter {
     // windows impl via job ActiveProcessLimit
 
     static void windowsImpl() {
-        if (!Constants.WINDOWS) {
+        if (Constants.WINDOWS == false) {
             throw new IllegalStateException("bug: should not be trying to initialize ActiveProcessLimit for an unsupported OS");
         }
 
@@ -581,7 +581,7 @@ final class SystemCallFilter {
             int clazz = JNAKernel32Library.JOBOBJECT_BASIC_LIMIT_INFORMATION_CLASS;
             JNAKernel32Library.JOBOBJECT_BASIC_LIMIT_INFORMATION limits = new JNAKernel32Library.JOBOBJECT_BASIC_LIMIT_INFORMATION();
             limits.write();
-            if (!lib.QueryInformationJobObject(job, clazz, limits.getPointer(), limits.size(), null)) {
+            if (lib.QueryInformationJobObject(job, clazz, limits.getPointer(), limits.size(), null) == false) {
                 throw new UnsupportedOperationException("QueryInformationJobObject: " + Native.getLastError());
             }
             limits.read();
@@ -589,11 +589,11 @@ final class SystemCallFilter {
             limits.ActiveProcessLimit = 1;
             limits.LimitFlags = JNAKernel32Library.JOB_OBJECT_LIMIT_ACTIVE_PROCESS;
             limits.write();
-            if (!lib.SetInformationJobObject(job, clazz, limits.getPointer(), limits.size())) {
+            if (lib.SetInformationJobObject(job, clazz, limits.getPointer(), limits.size()) == false) {
                 throw new UnsupportedOperationException("SetInformationJobObject: " + Native.getLastError());
             }
             // assign ourselves to the job
-            if (!lib.AssignProcessToJobObject(job, lib.GetCurrentProcess())) {
+            if (lib.AssignProcessToJobObject(job, lib.GetCurrentProcess()) == false) {
                 throw new UnsupportedOperationException("AssignProcessToJobObject: " + Native.getLastError());
             }
         } finally {

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterChangedEvent.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterChangedEvent.java
@@ -97,7 +97,7 @@ public class ClusterChangedEvent {
      */
     public boolean indexRoutingTableChanged(String index) {
         Objects.requireNonNull(index, "index must not be null");
-        if (!state.routingTable().hasIndex(index) && !previousState.routingTable().hasIndex(index)) {
+        if (state.routingTable().hasIndex(index) == false && previousState.routingTable().hasIndex(index) == false) {
             return false;
         }
         if (state.routingTable().hasIndex(index) && previousState.routingTable().hasIndex(index)) {
@@ -110,13 +110,13 @@ public class ClusterChangedEvent {
      * Returns the indices created in this event
      */
     public List<String> indicesCreated() {
-        if (!metadataChanged()) {
+        if (metadataChanged() == false) {
             return Collections.emptyList();
         }
         List<String> created = null;
         for (ObjectCursor<String> cursor : state.metadata().indices().keys()) {
             String index = cursor.value;
-            if (!previousState.metadata().hasIndex(index)) {
+            if (previousState.metadata().hasIndex(index) == false) {
                 if (created == null) {
                     created = new ArrayList<>();
                 }

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterState.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterState.java
@@ -347,7 +347,7 @@ public class ClusterState implements ToXContentFragment, Diffable<ClusterState> 
                 }
                 Metric m = valueToEnum.get(metric);
                 if (m == null) {
-                    if (!ignoreUnknown) {
+                    if (ignoreUnknown == false) {
                         throw new IllegalArgumentException("Unknown metric [" + metric + "]");
                     }
                 } else {
@@ -382,7 +382,7 @@ public class ClusterState implements ToXContentFragment, Diffable<ClusterState> 
         if (metrics.contains(Metric.BLOCKS)) {
             builder.startObject("blocks");
 
-            if (!blocks().global().isEmpty()) {
+            if (blocks().global().isEmpty() == false) {
                 builder.startObject("global");
                 for (ClusterBlock block : blocks().global()) {
                     block.toXContent(builder, params);
@@ -390,7 +390,7 @@ public class ClusterState implements ToXContentFragment, Diffable<ClusterState> 
                 builder.endObject();
             }
 
-            if (!blocks().indices().isEmpty()) {
+            if (blocks().indices().isEmpty() == false) {
                 builder.startObject("indices");
                 for (ObjectObjectCursor<String, Set<ClusterBlock>> entry : blocks().indices()) {
                     builder.startObject(entry.key);

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterStateObserver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterStateObserver.java
@@ -170,7 +170,7 @@ public class ClusterStateObserver {
         } else {
             logger.trace("observer: sampled state rejected by predicate ({}). adding listener to ClusterService", newState);
             final ObservingContext context = new ObservingContext(listener, statePredicate);
-            if (!observingContext.compareAndSet(null, context)) {
+            if (observingContext.compareAndSet(null, context) == false) {
                 throw new ElasticsearchException("already waiting for a cluster state change");
             }
             clusterApplierService.addTimeoutListener(timeoutTimeLeftMS == null ?

--- a/server/src/main/java/org/elasticsearch/cluster/DiffableUtils.java
+++ b/server/src/main/java/org/elasticsearch/cluster/DiffableUtils.java
@@ -182,7 +182,7 @@ public final class DiffableUtils {
             assert after != null && before != null;
 
             for (K key : before.keySet()) {
-                if (!after.containsKey(key)) {
+                if (after.containsKey(key) == false) {
                     deletes.add(key);
                 }
             }
@@ -243,7 +243,7 @@ public final class DiffableUtils {
             assert after != null && before != null;
 
             for (ObjectCursor<K> key : before.keys()) {
-                if (!after.containsKey(key.value)) {
+                if (after.containsKey(key.value) == false) {
                     deletes.add(key.value);
                 }
             }
@@ -315,7 +315,7 @@ public final class DiffableUtils {
             assert after != null && before != null;
 
             for (IntCursor key : before.keys()) {
-                if (!after.containsKey(key.value)) {
+                if (after.containsKey(key.value) == false) {
                     deletes.add(key.value);
                 }
             }

--- a/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
+++ b/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
@@ -399,10 +399,10 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
             if (includeGlobalState != entry.includeGlobalState) return false;
             if (partial != entry.partial) return false;
             if (startTime != entry.startTime) return false;
-            if (!indices.equals(entry.indices)) return false;
-            if (!dataStreams.equals(entry.dataStreams)) return false;
-            if (!shards.equals(entry.shards)) return false;
-            if (!snapshot.equals(entry.snapshot)) return false;
+            if (indices.equals(entry.indices) == false) return false;
+            if (dataStreams.equals(entry.dataStreams) == false) return false;
+            if (shards.equals(entry.shards) == false) return false;
+            if (snapshot.equals(entry.snapshot) == false) return false;
             if (state != entry.state) return false;
             if (repositoryStateId != entry.repositoryStateId) return false;
             if (Objects.equals(failure, ((Entry) o).failure) == false) return false;

--- a/server/src/main/java/org/elasticsearch/cluster/block/ClusterBlockException.java
+++ b/server/src/main/java/org/elasticsearch/cluster/block/ClusterBlockException.java
@@ -63,7 +63,7 @@ public class ClusterBlockException extends ElasticsearchException {
 
     public boolean retryable() {
         for (ClusterBlock block : blocks) {
-            if (!block.retryable()) {
+            if (block.retryable() == false) {
                 return false;
             }
         }

--- a/server/src/main/java/org/elasticsearch/cluster/block/ClusterBlocks.java
+++ b/server/src/main/java/org/elasticsearch/cluster/block/ClusterBlocks.java
@@ -337,7 +337,7 @@ public class ClusterBlocks extends AbstractDiffable<ClusterBlocks> {
         public Builder blocks(ClusterBlocks blocks) {
             global.addAll(blocks.global());
             for (ObjectObjectCursor<String, Set<ClusterBlock>> entry : blocks.indices()) {
-                if (!indices.containsKey(entry.key)) {
+                if (indices.containsKey(entry.key) == false) {
                     indices.put(entry.key, new HashSet<>());
                 }
                 indices.get(entry.key).addAll(entry.value);
@@ -391,7 +391,7 @@ public class ClusterBlocks extends AbstractDiffable<ClusterBlocks> {
 
 
         public Builder addIndexBlock(String index, ClusterBlock block) {
-            if (!indices.containsKey(index)) {
+            if (indices.containsKey(index) == false) {
                 indices.put(index, new HashSet<>());
             }
             indices.get(index).add(block);
@@ -399,7 +399,7 @@ public class ClusterBlocks extends AbstractDiffable<ClusterBlocks> {
         }
 
         public Builder removeIndexBlocks(String index) {
-            if (!indices.containsKey(index)) {
+            if (indices.containsKey(index) == false) {
                 return this;
             }
             indices.remove(index);
@@ -411,7 +411,7 @@ public class ClusterBlocks extends AbstractDiffable<ClusterBlocks> {
         }
 
         public Builder removeIndexBlock(String index, ClusterBlock block) {
-            if (!indices.containsKey(index)) {
+            if (indices.containsKey(index) == false) {
                 return this;
             }
             indices.get(index).remove(block);

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationState.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationState.java
@@ -555,11 +555,11 @@ public class CoordinationState {
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (!(o instanceof VoteCollection)) return false;
+            if ((o instanceof VoteCollection) == false) return false;
 
             VoteCollection that = (VoteCollection) o;
 
-            if (!nodes.equals(that.nodes)) return false;
+            if (nodes.equals(that.nodes) == false) return false;
             return joins.equals(that.joins);
         }
 

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinRequest.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinRequest.java
@@ -93,12 +93,12 @@ public class JoinRequest extends TransportRequest {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof JoinRequest)) return false;
+        if ((o instanceof JoinRequest) == false) return false;
 
         JoinRequest that = (JoinRequest) o;
 
         if (minimumTerm != that.minimumTerm) return false;
-        if (!sourceNode.equals(that.sourceNode)) return false;
+        if (sourceNode.equals(that.sourceNode) == false) return false;
         return optionalJoin.equals(that.optionalJoin);
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/NodeRemovalClusterStateTaskExecutor.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/NodeRemovalClusterStateTaskExecutor.java
@@ -80,7 +80,7 @@ public class NodeRemovalClusterStateTaskExecutor implements ClusterStateTaskExec
             }
         }
 
-        if (!removed) {
+        if (removed == false) {
             // no nodes to remove, keep the current cluster state
             return ClusterTasksResult.<Task>builder().successes(tasks).build(currentState);
         }

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/PublishRequest.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/PublishRequest.java
@@ -41,7 +41,7 @@ public class PublishRequest {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof PublishRequest)) return false;
+        if ((o instanceof PublishRequest) == false) return false;
 
         PublishRequest that = (PublishRequest) o;
 

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/PublishWithJoinResponse.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/PublishWithJoinResponse.java
@@ -60,11 +60,11 @@ public class PublishWithJoinResponse extends TransportResponse {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof PublishWithJoinResponse)) return false;
+        if ((o instanceof PublishWithJoinResponse) == false) return false;
 
         PublishWithJoinResponse that = (PublishWithJoinResponse) o;
 
-        if (!publishResponse.equals(that.publishResponse)) return false;
+        if (publishResponse.equals(that.publishResponse) == false) return false;
         return optionalJoin.equals(that.optionalJoin);
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/StartJoinRequest.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/StartJoinRequest.java
@@ -71,7 +71,7 @@ public class StartJoinRequest extends TransportRequest {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof StartJoinRequest)) return false;
+        if ((o instanceof StartJoinRequest) == false) return false;
 
         StartJoinRequest that = (StartJoinRequest) o;
 

--- a/server/src/main/java/org/elasticsearch/cluster/health/ClusterShardHealth.java
+++ b/server/src/main/java/org/elasticsearch/cluster/health/ClusterShardHealth.java
@@ -245,7 +245,7 @@ public final class ClusterShardHealth implements Writeable, ToXContentFragment {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof ClusterShardHealth)) return false;
+        if ((o instanceof ClusterShardHealth) == false) return false;
         ClusterShardHealth that = (ClusterShardHealth) o;
         return shardId == that.shardId &&
                 activeShards == that.activeShards &&

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/AliasMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/AliasMetadata.java
@@ -274,7 +274,7 @@ public class AliasMetadata extends AbstractDiffable<AliasMetadata> implements To
         }
 
         public Builder filter(String filter) {
-            if (!Strings.hasLength(filter)) {
+            if (Strings.hasLength(filter) == false) {
                 this.filter = null;
                 return this;
             }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/AliasValidator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/AliasValidator.java
@@ -86,7 +86,7 @@ public class AliasValidator {
     public void validateAlias(String alias, String index, @Nullable String indexRouting, Function<String, IndexMetadata> indexLookup) {
         validateAliasStandalone(alias, indexRouting);
 
-        if (!Strings.hasText(index)) {
+        if (Strings.hasText(index) == false) {
             throw new IllegalArgumentException("index name is required");
         }
 
@@ -97,7 +97,7 @@ public class AliasValidator {
     }
 
     void validateAliasStandalone(String alias, String indexRouting) {
-        if (!Strings.hasText(alias)) {
+        if (Strings.hasText(alias) == false) {
             throw new IllegalArgumentException("alias name is required");
         }
         MetadataCreateIndexService.validateIndexOrAliasName(alias, InvalidAliasNameException::new);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -646,22 +646,22 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             return false;
         }
 
-        if (!aliases.equals(that.aliases)) {
+        if (aliases.equals(that.aliases) == false) {
             return false;
         }
-        if (!index.equals(that.index)) {
+        if (index.equals(that.index) == false) {
             return false;
         }
-        if (!mappings.equals(that.mappings)) {
+        if (mappings.equals(that.mappings) == false) {
             return false;
         }
-        if (!settings.equals(that.settings)) {
+        if (settings.equals(that.settings) == false) {
             return false;
         }
         if (state != that.state) {
             return false;
         }
-        if (!customData.equals(that.customData)) {
+        if (customData.equals(that.customData) == false) {
             return false;
         }
         if (routingNumShards != that.routingNumShards) {
@@ -673,7 +673,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         if (Arrays.equals(primaryTerms, that.primaryTerms) == false) {
             return false;
         }
-        if (!inSyncAllocationIds.equals(that.inSyncAllocationIds)) {
+        if (inSyncAllocationIds.equals(that.inSyncAllocationIds) == false) {
             return false;
         }
         if (rolloverInfos.equals(that.rolloverInfos) == false) {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -218,7 +218,7 @@ public class IndexNameExpressionResolver {
         }
 
         if (expressions.isEmpty()) {
-            if (!options.allowNoIndices()) {
+            if (options.allowNoIndices() == false) {
                 IndexNotFoundException infe;
                 if (indexExpressions.length == 1) {
                     if (indexExpressions[0].equals(Metadata.ALL)) {
@@ -566,8 +566,8 @@ public class IndexNameExpressionResolver {
                 for (IndexMetadata index : indexAbstraction.getIndices()) {
                     String concreteIndex = index.getIndex().getName();
                     AliasMetadata aliasMetadata = index.getAliases().get(indexAbstraction.getName());
-                    if (!norouting.contains(concreteIndex)) {
-                        if (!aliasMetadata.searchRoutingValues().isEmpty()) {
+                    if (norouting.contains(concreteIndex) == false) {
+                        if (aliasMetadata.searchRoutingValues().isEmpty() == false) {
                             // Routing alias
                             if (routings == null) {
                                 routings = new HashMap<>();
@@ -586,7 +586,7 @@ public class IndexNameExpressionResolver {
                             }
                         } else {
                             // Non-routing alias
-                            if (!norouting.contains(concreteIndex)) {
+                            if (norouting.contains(concreteIndex) == false) {
                                 norouting.add(concreteIndex);
                                 if (paramRouting != null) {
                                     Set<String> r = new HashSet<>(paramRouting);
@@ -605,7 +605,7 @@ public class IndexNameExpressionResolver {
                 }
             } else {
                 // Index
-                if (!norouting.contains(expression)) {
+                if (norouting.contains(expression) == false) {
                     norouting.add(expression);
                     if (paramRouting != null) {
                         Set<String> r = new HashSet<>(paramRouting);
@@ -1118,7 +1118,7 @@ public class IndexNameExpressionResolver {
                         case LEFT_BOUND:
                             if (inDateFormat && escapedChar) {
                                 inPlaceHolderSb.append(c);
-                            } else if (!inDateFormat) {
+                            } else if (inDateFormat == false) {
                                 inDateFormat = true;
                                 inPlaceHolderSb.append(c);
                             } else {
@@ -1192,7 +1192,7 @@ public class IndexNameExpressionResolver {
                             break;
 
                         case RIGHT_BOUND:
-                            if (!escapedChar) {
+                            if (escapedChar == false) {
                                 throw new ElasticsearchParseException("invalid dynamic name expression [{}]." +
                                     " invalid character at position [{}]. `{` and `}` are reserved characters and" +
                                     " should be escaped when used as part of the index name using `\\` (e.g. `\\{text\\}`)",

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetadata.java
@@ -164,10 +164,10 @@ public class IndexTemplateMetadata extends AbstractDiffable<IndexTemplateMetadat
         IndexTemplateMetadata that = (IndexTemplateMetadata) o;
 
         if (order != that.order) return false;
-        if (!mappings.equals(that.mappings)) return false;
-        if (!name.equals(that.name)) return false;
-        if (!settings.equals(that.settings)) return false;
-        if (!patterns.equals(that.patterns)) return false;
+        if (mappings.equals(that.mappings) == false) return false;
+        if (name.equals(that.name) == false) return false;
+        if (settings.equals(that.settings) == false) return false;
+        if (patterns.equals(that.patterns) == false) return false;
 
         return Objects.equals(aliases, that.aliases) &&
             Objects.equals(version, that.version);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MappingMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MappingMetadata.java
@@ -171,9 +171,9 @@ public class MappingMetadata extends AbstractDiffable<MappingMetadata> {
 
         MappingMetadata that = (MappingMetadata) o;
 
-        if (!Objects.equals(this.routingRequired, that.routingRequired)) return false;
-        if (!source.equals(that.source)) return false;
-        if (!type.equals(that.type)) return false;
+        if (Objects.equals(this.routingRequired, that.routingRequired) == false) return false;
+        if (source.equals(that.source) == false) return false;
+        if (type.equals(that.type) == false) return false;
 
         return true;
     }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -590,7 +590,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
                     aliasMd.getIndexRouting() + "] that resolved to several routing values, rejecting operation");
             }
             if (routing != null) {
-                if (!routing.equals(aliasMd.indexRouting())) {
+                if (routing.equals(aliasMd.indexRouting()) == false) {
                     throw new IllegalArgumentException("Alias [" + aliasOrIndex + "] has index routing associated with it [" +
                         aliasMd.indexRouting() + "], and was provided with routing value [" + routing + "], rejecting operation");
                 }
@@ -752,19 +752,19 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
     }
 
     public static boolean isGlobalStateEquals(Metadata metadata1, Metadata metadata2) {
-        if (!metadata1.coordinationMetadata.equals(metadata2.coordinationMetadata)) {
+        if (metadata1.coordinationMetadata.equals(metadata2.coordinationMetadata) == false) {
             return false;
         }
-        if (!metadata1.persistentSettings.equals(metadata2.persistentSettings)) {
+        if (metadata1.persistentSettings.equals(metadata2.persistentSettings) == false) {
             return false;
         }
-        if (!metadata1.hashesOfConsistentSettings.equals(metadata2.hashesOfConsistentSettings)) {
+        if (metadata1.hashesOfConsistentSettings.equals(metadata2.hashesOfConsistentSettings) == false) {
             return false;
         }
-        if (!metadata1.templates.equals(metadata2.templates())) {
+        if (metadata1.templates.equals(metadata2.templates()) == false) {
             return false;
         }
-        if (!metadata1.clusterUUID.equals(metadata2.clusterUUID)) {
+        if (metadata1.clusterUUID.equals(metadata2.clusterUUID) == false) {
             return false;
         }
         if (metadata1.clusterUUIDCommitted != metadata2.clusterUUIDCommitted) {
@@ -774,7 +774,9 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
         int customCount1 = 0;
         for (ObjectObjectCursor<String, Custom> cursor : metadata1.customs) {
             if (cursor.value.context().contains(XContentContext.GATEWAY)) {
-                if (!cursor.value.equals(metadata2.custom(cursor.key))) return false;
+                if (cursor.value.equals(metadata2.custom(cursor.key)) == false) {
+                    return false;
+                }
                 customCount1++;
             }
         }
@@ -784,7 +786,9 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
                 customCount2++;
             }
         }
-        if (customCount1 != customCount2) return false;
+        if (customCount1 != customCount2) {
+            return false;
+        }
         return true;
     }
 
@@ -1531,7 +1535,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
             // we might get here after the meta-data element, or on a fresh parser
             XContentParser.Token token = parser.currentToken();
             String currentFieldName = parser.currentName();
-            if (!"meta-data".equals(currentFieldName)) {
+            if ("meta-data".equals(currentFieldName) == false) {
                 token = parser.nextToken();
                 if (token == XContentParser.Token.START_OBJECT) {
                     // move to the field name (meta-data)
@@ -1545,7 +1549,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
                 currentFieldName = parser.currentName();
             }
 
-            if (!"meta-data".equals(parser.currentName())) {
+            if ("meta-data".equals(parser.currentName()) == false) {
                 throw new IllegalArgumentException("Expected [meta-data] as a field name but got " + currentFieldName);
             }
             if (token != XContentParser.Token.START_OBJECT) {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -178,7 +178,7 @@ public class MetadataCreateIndexService {
      */
     public void validateIndexName(String index, ClusterState state) {
         validateIndexOrAliasName(index, InvalidIndexNameException::new);
-        if (!index.toLowerCase(Locale.ROOT).equals(index)) {
+        if (index.toLowerCase(Locale.ROOT).equals(index) == false) {
             throw new InvalidIndexNameException(index, "must be lowercase");
         }
 
@@ -224,7 +224,7 @@ public class MetadataCreateIndexService {
      * Validate the name for an index or alias against some static rules.
      */
     public static void validateIndexOrAliasName(String index, BiFunction<String, String, ? extends RuntimeException> exceptionCtor) {
-        if (!Strings.validFileName(index)) {
+        if (Strings.validFileName(index) == false) {
             throw exceptionCtor.apply(index, "must not contain the following characters " + Strings.INVALID_FILENAME_CHARS);
         }
         if (index.contains("#")) {
@@ -897,7 +897,7 @@ public class MetadataCreateIndexService {
 
     private static ClusterBlocks.Builder createClusterBlocksBuilder(ClusterState currentState, String index, Set<ClusterBlock> blocks) {
         ClusterBlocks.Builder blocksBuilder = ClusterBlocks.builder().blocks(currentState.blocks());
-        if (!blocks.isEmpty()) {
+        if (blocks.isEmpty() == false) {
             for (ClusterBlock block : blocks) {
                 blocksBuilder.addIndexBlock(index, block);
             }
@@ -911,7 +911,7 @@ public class MetadataCreateIndexService {
                                                              @Nullable IndexMetadata sourceMetadata) throws IOException {
         MapperService mapperService = indexService.mapperService();
         for (Map<String, Object> mapping : mappings) {
-            if (!mapping.isEmpty()) {
+            if (mapping.isEmpty() == false) {
                 mapperService.merge(MapperService.SINGLE_MAPPING_NAME, mapping, MergeReason.INDEX_TEMPLATE);
             }
         }
@@ -986,7 +986,7 @@ public class MetadataCreateIndexService {
     private static List<String> validateIndexCustomPath(Settings settings, @Nullable Path sharedDataPath) {
         String customPath = IndexMetadata.INDEX_DATA_PATH_SETTING.get(settings);
         List<String> validationErrors = new ArrayList<>();
-        if (!Strings.isEmpty(customPath)) {
+        if (Strings.isEmpty(customPath) == false) {
             if (sharedDataPath == null) {
                 validationErrors.add("path.shared_data must be set in order to use custom data paths");
             } else {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexAliasesService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexAliasesService.java
@@ -173,7 +173,7 @@ public class MetadataIndexAliasesService {
                 ClusterState updatedState = ClusterState.builder(currentState).metadata(metadata).build();
                 // even though changes happened, they resulted in 0 actual changes to metadata
                 // i.e. remove and add the same alias to the same index
-                if (!updatedState.metadata().equalsAliases(currentState.metadata())) {
+                if (updatedState.metadata().equalsAliases(currentState.metadata()) == false) {
                     return updatedState;
                 }
             }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataMappingService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataMappingService.java
@@ -163,7 +163,7 @@ public class MetadataMappingService {
             }
         }
 
-        if (!dirty) {
+        if (dirty == false) {
             return currentState;
         }
         return ClusterState.builder(currentState).metadata(mdBuilder).build();

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpdateSettingsService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpdateSettingsService.java
@@ -137,7 +137,7 @@ public class MetadataUpdateSettingsService {
                     }
                 }
 
-                if (!skippedSettings.isEmpty() && !openIndices.isEmpty()) {
+                if (skippedSettings.isEmpty() == false && openIndices.isEmpty() == false) {
                     throw new IllegalArgumentException(String.format(Locale.ROOT,
                             "Can't update non dynamic settings [%s] for open indices %s", skippedSettings, openIndices));
                 }
@@ -168,7 +168,7 @@ public class MetadataUpdateSettingsService {
                     }
                 }
 
-                if (!openIndices.isEmpty()) {
+                if (openIndices.isEmpty() == false) {
                     for (Index index : openIndices) {
                         IndexMetadata indexMetadata = metadataBuilder.getSafe(index);
                         Settings.Builder updates = Settings.builder();
@@ -197,7 +197,7 @@ public class MetadataUpdateSettingsService {
                     }
                 }
 
-                if (!closeIndices.isEmpty()) {
+                if (closeIndices.isEmpty() == false) {
                     for (Index index : closeIndices) {
                         IndexMetadata indexMetadata = metadataBuilder.getSafe(index);
                         Settings.Builder updates = Settings.builder();

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/RepositoryMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/RepositoryMetadata.java
@@ -185,9 +185,9 @@ public class RepositoryMetadata implements Writeable {
 
         RepositoryMetadata that = (RepositoryMetadata) o;
 
-        if (!name.equals(that.name)) return false;
-        if (!uuid.equals(that.uuid)) return false;
-        if (!type.equals(that.type)) return false;
+        if (name.equals(that.name) == false) return false;
+        if (uuid.equals(that.uuid) == false) return false;
+        if (type.equals(that.type) == false) return false;
         if (generation != that.generation) return false;
         if (pendingGeneration != that.pendingGeneration) return false;
         return settings.equals(that.settings);

--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
@@ -429,7 +429,7 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
             roles.stream().map(DiscoveryNodeRole::roleNameAbbreviation).sorted().forEach(sb::append);
             sb.append('}');
         }
-        if (!attributes.isEmpty()) {
+        if (attributes.isEmpty() == false) {
             sb.append(attributes);
         }
         return sb.toString();

--- a/server/src/main/java/org/elasticsearch/cluster/routing/AllocationId.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/AllocationId.java
@@ -170,7 +170,7 @@ public class AllocationId implements ToXContentObject, Writeable {
             return false;
         }
         AllocationId that = (AllocationId) o;
-        if (!id.equals(that.id)) {
+        if (id.equals(that.id) == false) {
             return false;
         }
         return !(relocationId != null ? !relocationId.equals(that.relocationId) : that.relocationId != null);

--- a/server/src/main/java/org/elasticsearch/cluster/routing/IndexRoutingTable.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/IndexRoutingTable.java
@@ -95,7 +95,7 @@ public class IndexRoutingTable extends AbstractDiffable<IndexRoutingTable> imple
 
     boolean validate(Metadata metadata) {
         // check index exists
-        if (!metadata.hasIndex(index.getName())) {
+        if (metadata.hasIndex(index.getName()) == false) {
             throw new IllegalStateException(index + " exists in routing does not exists in metadata");
         }
         IndexMetadata indexMetadata = metadata.index(index.getName());
@@ -124,7 +124,7 @@ public class IndexRoutingTable extends AbstractDiffable<IndexRoutingTable> imple
                                  "], got [" + routingNumberOfReplicas + "]");
             }
             for (ShardRouting shardRouting : indexShardRoutingTable) {
-                if (!shardRouting.index().equals(index)) {
+                if (shardRouting.index().equals(index) == false) {
                     throw new IllegalStateException("shard routing has an index [" + shardRouting.index() + "] that is different " +
                                                     "from the routing table");
                 }
@@ -182,7 +182,7 @@ public class IndexRoutingTable extends AbstractDiffable<IndexRoutingTable> imple
                             }
                         }
                     }
-                    if (!excluded) {
+                    if (excluded == false) {
                         nodes.add(currentNodeId);
                     }
                 }
@@ -275,8 +275,8 @@ public class IndexRoutingTable extends AbstractDiffable<IndexRoutingTable> imple
 
         IndexRoutingTable that = (IndexRoutingTable) o;
 
-        if (!index.equals(that.index)) return false;
-        if (!shards.equals(that.shards)) return false;
+        if (index.equals(that.index) == false) return false;
+        if (shards.equals(that.shards) == false) return false;
 
         return true;
     }
@@ -387,7 +387,7 @@ public class IndexRoutingTable extends AbstractDiffable<IndexRoutingTable> imple
         private Builder initializeAsRestore(IndexMetadata indexMetadata, SnapshotRecoverySource recoverySource, IntSet ignoreShards,
                                             boolean asNew, UnassignedInfo unassignedInfo) {
             assert indexMetadata.getIndex().equals(index);
-            if (!shards.isEmpty()) {
+            if (shards.isEmpty() == false) {
                 throw new IllegalStateException("trying to initialize an index with fresh shards, but already has shards created");
             }
             for (int shardNumber = 0; shardNumber < indexMetadata.getNumberOfShards(); shardNumber++) {
@@ -414,7 +414,7 @@ public class IndexRoutingTable extends AbstractDiffable<IndexRoutingTable> imple
          */
         private Builder initializeEmpty(IndexMetadata indexMetadata, UnassignedInfo unassignedInfo) {
             assert indexMetadata.getIndex().equals(index);
-            if (!shards.isEmpty()) {
+            if (shards.isEmpty() == false) {
                 throw new IllegalStateException("trying to initialize an index with fresh shards, but already has shards created");
             }
             for (int shardNumber = 0; shardNumber < indexMetadata.getNumberOfShards(); shardNumber++) {
@@ -471,15 +471,15 @@ public class IndexRoutingTable extends AbstractDiffable<IndexRoutingTable> imple
                 // first check if there is one that is not assigned to a node, and remove it
                 boolean removed = false;
                 for (ShardRouting shardRouting : indexShard) {
-                    if (!shardRouting.primary() && !shardRouting.assignedToNode()) {
+                    if (shardRouting.primary() == false && shardRouting.assignedToNode() == false) {
                         builder.removeShard(shardRouting);
                         removed = true;
                         break;
                     }
                 }
-                if (!removed) {
+                if (removed == false) {
                     for (ShardRouting shardRouting : indexShard) {
-                        if (!shardRouting.primary()) {
+                        if (shardRouting.primary() == false) {
                             builder.removeShard(shardRouting);
                             break;
                         }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/IndexShardRoutingTable.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/IndexShardRoutingTable.java
@@ -472,7 +472,7 @@ public class IndexShardRoutingTable implements Iterable<ShardRouting> {
             }
         }
         preferred.addAll(notPreferred);
-        if (!allInitializingShards.isEmpty()) {
+        if (allInitializingShards.isEmpty() == false) {
             preferred.addAll(allInitializingShards);
         }
         return new PlainShardIterator(shardId, preferred);
@@ -485,8 +485,8 @@ public class IndexShardRoutingTable implements Iterable<ShardRouting> {
 
         IndexShardRoutingTable that = (IndexShardRoutingTable) o;
 
-        if (!shardId.equals(that.shardId)) return false;
-        if (!shards.equals(that.shards)) return false;
+        if (shardId.equals(that.shardId) == false) return false;
+        if (shards.equals(that.shards) == false) return false;
 
         return true;
     }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/OperationRouting.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/OperationRouting.java
@@ -157,7 +157,7 @@ public class OperationRouting {
                         break;
                     }
                 }
-                if (!found) {
+                if (found == false) {
                     return null;
                 }
                 // no more preference

--- a/server/src/main/java/org/elasticsearch/cluster/routing/RoutingNode.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/RoutingNode.java
@@ -269,7 +269,7 @@ public class RoutingNode implements Iterable<ShardRouting> {
         }
 
         for (ShardRouting shardEntry : this) {
-            if (!shardEntry.getIndexName().equals(index)) {
+            if (shardEntry.getIndexName().equals(index) == false) {
                 continue;
             }
             for (ShardRoutingState state : states) {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
@@ -351,7 +351,7 @@ public class RoutingNodes implements Iterable<RoutingNode> {
             return false; // if we are empty nothing is active if we have less than total at least one is unassigned
         }
         for (ShardRouting shard : shards) {
-            if (!shard.active()) {
+            if (shard.active() == false) {
                 return false;
             }
         }
@@ -543,7 +543,7 @@ public class RoutingNodes implements Iterable<RoutingNode> {
             if (assignedShards.isEmpty() == false) {
                 // copy list to prevent ConcurrentModificationException
                 for (ShardRouting routing : new ArrayList<>(assignedShards)) {
-                    if (!routing.primary() && routing.initializing()) {
+                    if (routing.primary() == false && routing.initializing()) {
                         // re-resolve replica as earlier iteration could have changed source/target of replica relocation
                         ShardRouting replicaShard = getByAllocationId(routing.shardId(), routing.allocationId().getId());
                         assert replicaShard != null : "failed to re-resolve " + routing + " when failing replicas";
@@ -1141,7 +1141,7 @@ public class RoutingNodes implements Iterable<RoutingNode> {
         }
         return new Iterator<ShardRouting>() {
             public boolean hasNext() {
-                while (!queue.isEmpty()) {
+                while (queue.isEmpty() == false) {
                     if (queue.peek().hasNext()) {
                         return true;
                     }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/ShardRouting.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/ShardRouting.java
@@ -438,7 +438,7 @@ public final class ShardRouting implements Writeable, ToXContentObject {
      */
     public ShardRouting moveUnassignedFromPrimary() {
         assert state == ShardRoutingState.UNASSIGNED : "expected an unassigned shard " + this;
-        if (!primary) {
+        if (primary == false) {
             throw new IllegalShardRoutingStateException(this, "Not primary, can't move to replica");
         }
         return new ShardRouting(shardId, currentNodeId, relocatingNodeId, false, state, PeerRecoverySource.INSTANCE, unassignedInfo,

--- a/server/src/main/java/org/elasticsearch/cluster/service/ClusterApplierService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/ClusterApplierService.java
@@ -326,7 +326,7 @@ public class ClusterApplierService extends AbstractLifecycleComponent implements
     private void submitStateUpdateTask(final String source, final ClusterStateTaskConfig config,
                                        final Function<ClusterState, ClusterState> executor,
                                        final ClusterApplyListener listener) {
-        if (!lifecycle.started()) {
+        if (lifecycle.started() == false) {
             return;
         }
         final ThreadContext threadContext = threadPool.getThreadContext();
@@ -345,7 +345,7 @@ public class ClusterApplierService extends AbstractLifecycleComponent implements
         } catch (EsRejectedExecutionException e) {
             // ignore cases where we are shutting down..., there is really nothing interesting
             // to be done here...
-            if (!lifecycle.stoppedOrClosed()) {
+            if (lifecycle.stoppedOrClosed() == false) {
                 throw e;
             }
         }
@@ -377,7 +377,7 @@ public class ClusterApplierService extends AbstractLifecycleComponent implements
     }
 
     private void runTask(UpdateTask task) {
-        if (!lifecycle.started()) {
+        if (lifecycle.started() == false) {
             logger.debug("processing [{}]: ignoring, cluster applier service not started", task.source);
             return;
         }

--- a/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
@@ -196,7 +196,7 @@ public class MasterService extends AbstractLifecycleComponent {
 
     private void runTasks(TaskInputs taskInputs) {
         final String summary = taskInputs.summary;
-        if (!lifecycle.started()) {
+        if (lifecycle.started() == false) {
             logger.debug("processing [{}]: ignoring, master service not started", summary);
             return;
         }
@@ -204,7 +204,7 @@ public class MasterService extends AbstractLifecycleComponent {
         logger.debug("executing cluster state update for [{}]", summary);
         final ClusterState previousClusterState = state();
 
-        if (!previousClusterState.nodes().isLocalNodeElectedMaster() && taskInputs.runOnlyWhenMaster()) {
+        if (previousClusterState.nodes().isLocalNodeElectedMaster() == false && taskInputs.runOnlyWhenMaster()) {
             logger.debug("failing [{}]: local node is no longer master", summary);
             taskInputs.onNoLongerMaster();
             return;
@@ -779,7 +779,7 @@ public class MasterService extends AbstractLifecycleComponent {
     public <T> void submitStateUpdateTasks(final String source,
                                            final Map<T, ClusterStateTaskListener> tasks, final ClusterStateTaskConfig config,
                                            final ClusterStateTaskExecutor<T> executor) {
-        if (!lifecycle.started()) {
+        if (lifecycle.started() == false) {
             return;
         }
         final ThreadContext threadContext = threadPool.getThreadContext();
@@ -794,7 +794,7 @@ public class MasterService extends AbstractLifecycleComponent {
         } catch (EsRejectedExecutionException e) {
             // ignore cases where we are shutting down..., there is really nothing interesting
             // to be done here...
-            if (!lifecycle.stoppedOrClosed()) {
+            if (lifecycle.stoppedOrClosed() == false) {
                 throw e;
             }
         }

--- a/server/src/main/java/org/elasticsearch/common/MacAddressProvider.java
+++ b/server/src/main/java/org/elasticsearch/common/MacAddressProvider.java
@@ -30,7 +30,7 @@ public class MacAddressProvider {
         if (en != null) {
             while (en.hasMoreElements()) {
                 NetworkInterface nint = en.nextElement();
-                if (!nint.isLoopback()) {
+                if (nint.isLoopback() == false) {
                     // Pick the first valid non loopback address we find
                     byte[] address = nint.getHardwareAddress();
                     if (isValidAddress(address)) {
@@ -63,7 +63,7 @@ public class MacAddressProvider {
             // address will be set below
         }
 
-        if (!isValidAddress(address)) {
+        if (isValidAddress(address) == false) {
             address = constructDummyMulticastAddress();
         }
 

--- a/server/src/main/java/org/elasticsearch/common/StopWatch.java
+++ b/server/src/main/java/org/elasticsearch/common/StopWatch.java
@@ -130,7 +130,7 @@ public class StopWatch {
      * @see #start()
      */
     public StopWatch stop() throws IllegalStateException {
-        if (!this.running) {
+        if (this.running == false) {
             throw new IllegalStateException("Can't stop StopWatch: it's not running");
         }
         long lastTimeNS = System.nanoTime() - this.startTimeNS;

--- a/server/src/main/java/org/elasticsearch/common/Strings.java
+++ b/server/src/main/java/org/elasticsearch/common/Strings.java
@@ -89,8 +89,12 @@ public class Strings {
 
             char ch = s.charAt(pos++);
             if (ch == '\\') {
-                if (!decode) sb.append(ch);
-                if (pos >= end) break;  // ERROR, or let it go?
+                if (decode == false) {
+                    sb.append(ch);
+                }
+                if (pos >= end) {
+                    break;  // ERROR, or let it go?
+                }
                 ch = s.charAt(pos++);
                 if (decode) {
                     switch (ch) {
@@ -207,12 +211,12 @@ public class Strings {
      * @see java.lang.Character#isWhitespace
      */
     public static boolean hasText(CharSequence str) {
-        if (!hasLength(str)) {
+        if (hasLength(str) == false) {
             return false;
         }
         int strLen = str.length();
         for (int i = 0; i < strLen; i++) {
-            if (!Character.isWhitespace(str.charAt(i))) {
+            if (Character.isWhitespace(str.charAt(i)) == false) {
                 return true;
             }
         }
@@ -241,7 +245,7 @@ public class Strings {
      * @return the trimmed String
      */
     public static String trimLeadingCharacter(String str, char leadingCharacter) {
-        if (!hasLength(str)) {
+        if (hasLength(str) == false) {
             return str;
         }
         StringBuilder sb = new StringBuilder(str);
@@ -279,7 +283,7 @@ public class Strings {
      * @return a String with the replacements
      */
     public static String replace(String inString, String oldPattern, String newPattern) {
-        if (!hasLength(inString) || !hasLength(oldPattern) || newPattern == null) {
+        if (hasLength(inString) == false || hasLength(oldPattern) == false || newPattern == null) {
             return inString;
         }
         StringBuilder sb = new StringBuilder();
@@ -318,7 +322,7 @@ public class Strings {
      * @return the resulting String
      */
     public static String deleteAny(String inString, String charsToDelete) {
-        if (!hasLength(inString) || !hasLength(charsToDelete)) {
+        if (hasLength(inString) == false || hasLength(charsToDelete) == false) {
             return inString;
         }
         StringBuilder sb = new StringBuilder();
@@ -464,7 +468,7 @@ public class Strings {
      *         or <code>null</code> if the delimiter wasn't found in the given input String
      */
     public static String[] split(String toSplit, String delimiter) {
-        if (!hasLength(toSplit) || !hasLength(delimiter)) {
+        if (hasLength(toSplit) == false || hasLength(delimiter) == false) {
             return null;
         }
         int offset = toSplit.indexOf(delimiter);

--- a/server/src/main/java/org/elasticsearch/common/Table.java
+++ b/server/src/main/java/org/elasticsearch/common/Table.java
@@ -129,7 +129,7 @@ public class Table {
         if (currentCells == null) {
             throw new IllegalStateException("no block started...");
         }
-        if (!inHeaders) {
+        if (inHeaders == false) {
             if (currentCells.size() == headers.size()) {
                 throw new IllegalStateException("can't add more cells to a row than the header");
             }
@@ -144,7 +144,7 @@ public class Table {
             }
         } else {
             mAttr = new HashMap<>();
-            if (!inHeaders) {
+            if (inHeaders == false) {
                 // get the attributes of the header cell we are going to add
                 mAttr.putAll(headers.get(currentCells.size()).attr);
             }
@@ -163,7 +163,7 @@ public class Table {
         currentCells.add(cell);
 
         // If we're in a value row, also populate the named column.
-        if (!inHeaders) {
+        if (inHeaders == false) {
             String hdr = (String) headers.get(cellIndex).value;
             map.get(hdr).add(cell);
         }

--- a/server/src/main/java/org/elasticsearch/common/collect/CopyOnWriteHashMap.java
+++ b/server/src/main/java/org/elasticsearch/common/collect/CopyOnWriteHashMap.java
@@ -309,7 +309,7 @@ public final class CopyOnWriteHashMap<K, V> extends AbstractMap<K, V> {
         @Override
         V get(Object key, int hash) {
             final int hash6 = hash & HASH_MASK;
-            if (!exists(hash6)) {
+            if (exists(hash6) == false) {
                 return null;
             }
             final int slot = slot(hash6);
@@ -397,7 +397,7 @@ public final class CopyOnWriteHashMap<K, V> extends AbstractMap<K, V> {
         @Override
         InnerNode<K, V> remove(Object key, int hash) {
             final int hash6 = hash & HASH_MASK;
-            if (!exists(hash6)) {
+            if (exists(hash6) == false) {
                 return this;
             }
             final int slot = slot(hash6);

--- a/server/src/main/java/org/elasticsearch/common/collect/ImmutableOpenIntMap.java
+++ b/server/src/main/java/org/elasticsearch/common/collect/ImmutableOpenIntMap.java
@@ -164,7 +164,7 @@ public final class ImmutableOpenIntMap<VType> implements Iterable<IntObjectCurso
 
         ImmutableOpenIntMap that = (ImmutableOpenIntMap) o;
 
-        if (!map.equals(that.map)) return false;
+        if (map.equals(that.map) == false) return false;
 
         return true;
     }

--- a/server/src/main/java/org/elasticsearch/common/collect/ImmutableOpenMap.java
+++ b/server/src/main/java/org/elasticsearch/common/collect/ImmutableOpenMap.java
@@ -187,7 +187,7 @@ public final class ImmutableOpenMap<KType, VType> implements Iterable<ObjectObje
 
         ImmutableOpenMap that = (ImmutableOpenMap) o;
 
-        if (!map.equals(that.map)) return false;
+        if (map.equals(that.map) == false) return false;
 
         return true;
     }

--- a/server/src/main/java/org/elasticsearch/common/collect/Iterators.java
+++ b/server/src/main/java/org/elasticsearch/common/collect/Iterators.java
@@ -60,7 +60,7 @@ public class Iterators {
 
         @Override
         public T next() {
-            if (!hasNext()) {
+            if (hasNext() == false) {
                 throw new NoSuchElementException();
             }
             return iterators[index].next();

--- a/server/src/main/java/org/elasticsearch/common/component/AbstractLifecycleComponent.java
+++ b/server/src/main/java/org/elasticsearch/common/component/AbstractLifecycleComponent.java
@@ -50,7 +50,7 @@ public abstract class AbstractLifecycleComponent implements LifecycleComponent {
     @Override
     public void start() {
         synchronized (lifecycle) {
-            if (!lifecycle.canMoveToStarted()) {
+            if (lifecycle.canMoveToStarted() == false) {
                 return;
             }
             for (LifecycleListener listener : listeners) {
@@ -69,7 +69,7 @@ public abstract class AbstractLifecycleComponent implements LifecycleComponent {
     @Override
     public void stop() {
         synchronized (lifecycle) {
-            if (!lifecycle.canMoveToStopped()) {
+            if (lifecycle.canMoveToStopped() == false) {
                 return;
             }
             for (LifecycleListener listener : listeners) {
@@ -91,7 +91,7 @@ public abstract class AbstractLifecycleComponent implements LifecycleComponent {
             if (lifecycle.started()) {
                 stop();
             }
-            if (!lifecycle.canMoveToClosed()) {
+            if (lifecycle.canMoveToClosed() == false) {
                 return;
             }
             for (LifecycleListener listener : listeners) {

--- a/server/src/main/java/org/elasticsearch/common/component/Lifecycle.java
+++ b/server/src/main/java/org/elasticsearch/common/component/Lifecycle.java
@@ -32,7 +32,7 @@ package org.elasticsearch.common.component;
  * following logic can be applied:
  * <pre>
  * public void stop() {
- *  if (!lifecycleState.moveToStopped()) {
+ *  if (lifecycleState.moveToStopped() == false) {
  *      return;
  *  }
  * // continue with stop logic
@@ -52,7 +52,7 @@ package org.elasticsearch.common.component;
  *      if (lifecycleState.started()) {
  *          stop();
  *      }
- *      if (!lifecycleState.moveToClosed()) {
+ *      if (lifecycleState.moveToClosed() == false) {
  *          return;
  *      }
  *  }

--- a/server/src/main/java/org/elasticsearch/common/geo/GeoLineDecomposer.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeoLineDecomposer.java
@@ -133,7 +133,7 @@ public class GeoLineDecomposer {
     private static double calculateShift(double lon, boolean include180) {
         double normalized = GeoUtils.centeredModulus(lon, 360);
         double shift = Math.round(normalized - lon);
-        if (!include180 && normalized == 180.0) {
+        if (include180 == false && normalized == 180.0) {
             shift = shift - 360;
         }
         return shift;

--- a/server/src/main/java/org/elasticsearch/common/geo/GeoPolygonDecomposer.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeoPolygonDecomposer.java
@@ -346,7 +346,7 @@ public class GeoPolygonDecomposer {
             if (direction) {
                 edges[edgeOffset + i] = new Edge(nextPoint, edges[edgeOffset + i - 1]);
                 edges[edgeOffset + i].component = component;
-            } else if (!edges[edgeOffset + i - 1].coordinate.equals(nextPoint)) {
+            } else if (edges[edgeOffset + i - 1].coordinate.equals(nextPoint) == false) {
                 edges[edgeOffset + i - 1].next = edges[edgeOffset + i] = new Edge(nextPoint, null);
                 edges[edgeOffset + i - 1].component = component;
             } else {
@@ -385,7 +385,7 @@ public class GeoPolygonDecomposer {
             edges[i].intersect = Edge.MAX_COORDINATE;
 
             double position = intersection(p1.getX(), p2.getX(), dateline);
-            if (!Double.isNaN(position)) {
+            if (Double.isNaN(position) == false) {
                 edges[i].intersection(position);
                 numIntersections++;
                 maxComponent = Math.max(maxComponent, edges[i].component);
@@ -577,7 +577,7 @@ public class GeoPolygonDecomposer {
                         prev.component = visitID;
                         prev = visitedEdge.get(prev.coordinate).v1();
                         ++splitIndex;
-                    } while (!current.coordinate.equals(prev.coordinate));
+                    } while (current.coordinate.equals(prev.coordinate) == false);
                     ++connectedComponents;
                 } else {
                     visitedEdge.put(current.coordinate, new Tuple<Edge, Edge>(prev, current));

--- a/server/src/main/java/org/elasticsearch/common/geo/GeoShapeType.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeoShapeType.java
@@ -168,8 +168,8 @@ public enum GeoShapeType {
                     coordinates.children.size(), numValidPts);
             }
             // close linear ring iff coerce is set and ring is open, otherwise throw parse exception
-            if (!coordinates.children.get(0).coordinate.equals(
-                coordinates.children.get(coordinates.children.size() - 1).coordinate)) {
+            if (coordinates.children.get(0).coordinate.equals(
+                coordinates.children.get(coordinates.children.size() - 1).coordinate) == false) {
                 if (coerce) {
                     coordinates.children.add(coordinates.children.get(0));
                 } else {

--- a/server/src/main/java/org/elasticsearch/common/inject/EncounterImpl.java
+++ b/server/src/main/java/org/elasticsearch/common/inject/EncounterImpl.java
@@ -59,7 +59,7 @@ final class EncounterImpl<T> implements TypeEncounter<T> {
 
     @Override
     public void register(MembersInjector<? super T> membersInjector) {
-        if (!valid) {
+        if (valid == false) {
             throw new IllegalStateException("Encounters may not be used after hear() returns.");
         }
 
@@ -72,7 +72,7 @@ final class EncounterImpl<T> implements TypeEncounter<T> {
 
     @Override
     public void register(InjectionListener<? super T> injectionListener) {
-        if (!valid) {
+        if (valid == false) {
             throw new IllegalStateException("Encounters may not be used after hear() returns.");
         }
 
@@ -85,7 +85,7 @@ final class EncounterImpl<T> implements TypeEncounter<T> {
 
     @Override
     public void addError(String message, Object... arguments) {
-        if (!valid) {
+        if (valid == false) {
             throw new IllegalStateException("Encounters may not be used after hear() returns.");
         }
         errors.addMessage(message, arguments);
@@ -93,7 +93,7 @@ final class EncounterImpl<T> implements TypeEncounter<T> {
 
     @Override
     public void addError(Throwable t) {
-        if (!valid) {
+        if (valid == false) {
             throw new IllegalStateException("Encounters may not be used after hear() returns.");
         }
         errors.errorInUserCode(t, "An exception was caught and reported. Message: %s", t.getMessage());
@@ -101,7 +101,7 @@ final class EncounterImpl<T> implements TypeEncounter<T> {
 
     @Override
     public void addError(Message message) {
-        if (!valid) {
+        if (valid == false) {
             throw new IllegalStateException("Encounters may not be used after hear() returns.");
         }
         errors.addMessage(message);
@@ -109,7 +109,7 @@ final class EncounterImpl<T> implements TypeEncounter<T> {
 
     @Override
     public <T> Provider<T> getProvider(Key<T> key) {
-        if (!valid) {
+        if (valid == false) {
             throw new IllegalStateException("Encounters may not be used after hear() returns.");
         }
         return lookups.getProvider(key);
@@ -122,7 +122,7 @@ final class EncounterImpl<T> implements TypeEncounter<T> {
 
     @Override
     public <T> MembersInjector<T> getMembersInjector(TypeLiteral<T> typeLiteral) {
-        if (!valid) {
+        if (valid == false) {
             throw new IllegalStateException("Encounters may not be used after hear() returns.");
         }
         return lookups.getMembersInjector(typeLiteral);

--- a/server/src/main/java/org/elasticsearch/common/inject/Initializer.java
+++ b/server/src/main/java/org/elasticsearch/common/inject/Initializer.java
@@ -102,7 +102,7 @@ class Initializer {
             }
         }
 
-        if (!pendingInjection.isEmpty()) {
+        if (pendingInjection.isEmpty() == false) {
             throw new AssertionError("Failed to satisfy " + pendingInjection);
         }
 

--- a/server/src/main/java/org/elasticsearch/common/inject/InjectorBuilder.java
+++ b/server/src/main/java/org/elasticsearch/common/inject/InjectorBuilder.java
@@ -128,7 +128,7 @@ class InjectorBuilder {
         stopwatch.resetAndLog("Provider verification");
 
         for (InjectorShell shell : shells) {
-            if (!shell.getElements().isEmpty()) {
+            if (shell.getElements().isEmpty() == false) {
                 throw new AssertionError("Failed to execute " + shell.getElements());
             }
         }

--- a/server/src/main/java/org/elasticsearch/common/inject/InjectorImpl.java
+++ b/server/src/main/java/org/elasticsearch/common/inject/InjectorImpl.java
@@ -153,7 +153,7 @@ class InjectorImpl implements Injector, Lookups {
     private <T> BindingImpl<MembersInjector<T>> createMembersInjectorBinding(
             Key<MembersInjector<T>> key, Errors errors) throws ErrorsException {
         Type membersInjectorType = key.getTypeLiteral().getType();
-        if (!(membersInjectorType instanceof ParameterizedType)) {
+        if ((membersInjectorType instanceof ParameterizedType) == false) {
             throw errors.cannotInjectRawMembersInjector().toException();
         }
 
@@ -179,7 +179,7 @@ class InjectorImpl implements Injector, Lookups {
         Type providerType = key.getTypeLiteral().getType();
 
         // If the Provider has no type parameter (raw Provider)...
-        if (!(providerType instanceof ParameterizedType)) {
+        if ((providerType instanceof ParameterizedType) == false) {
             throw errors.cannotInjectRawProvider().toException();
         }
 
@@ -274,7 +274,7 @@ class InjectorImpl implements Injector, Lookups {
                         .toException();
             }
 
-            if (!type.getRawType().isInstance(converted)) {
+            if (type.getRawType().isInstance(converted) == false) {
                 throw errors.conversionTypeError(stringValue, source, type, matchingConverter, converted)
                         .toException();
             }
@@ -356,7 +356,7 @@ class InjectorImpl implements Injector, Lookups {
                 ((ConstructorBindingImpl) binding).initialize(this, errors);
                 successful = true;
             } finally {
-                if (!successful) {
+                if (successful == false) {
                     jitBindings.remove(key);
                 }
             }
@@ -410,7 +410,7 @@ class InjectorImpl implements Injector, Lookups {
             throw errors.cannotInjectInnerClass(rawType).toException();
         }
 
-        if (!scoping.isExplicitlyScoped()) {
+        if (scoping.isExplicitlyScoped() == false) {
             Class<? extends Annotation> scopeAnnotation = findScopeAnnotation(errors, rawType);
             if (scopeAnnotation != null) {
                 scoping = Scopes.makeInjectable(Scoping.forAnnotation(scopeAnnotation),
@@ -428,7 +428,7 @@ class InjectorImpl implements Injector, Lookups {
     private <T> BindingImpl<TypeLiteral<T>> createTypeLiteralBinding(
             Key<TypeLiteral<T>> key, Errors errors) throws ErrorsException {
         Type typeLiteralType = key.getTypeLiteral().getType();
-        if (!(typeLiteralType instanceof ParameterizedType)) {
+        if ((typeLiteralType instanceof ParameterizedType) == false) {
             throw errors.cannotInjectRawTypeLiteral().toException();
         }
 
@@ -437,9 +437,9 @@ class InjectorImpl implements Injector, Lookups {
 
         // this is unfortunate. We don't support building TypeLiterals for type variable like 'T'. If
         // this proves problematic, we can probably fix TypeLiteral to support type variables
-        if (!(innerType instanceof Class)
-                && !(innerType instanceof GenericArrayType)
-                && !(innerType instanceof ParameterizedType)) {
+        if ((innerType instanceof Class) == false
+                && (innerType instanceof GenericArrayType) == false
+                && (innerType instanceof ParameterizedType) == false) {
             throw errors.cannotInjectTypeLiteralOf(innerType).toException();
         }
 
@@ -516,7 +516,7 @@ class InjectorImpl implements Injector, Lookups {
         }
 
         // Make sure implementationType extends type.
-        if (!rawType.isAssignableFrom(implementationType)) {
+        if (rawType.isAssignableFrom(implementationType) == false) {
             throw errors.notASubtype(implementationType, rawType).toException();
         }
 

--- a/server/src/main/java/org/elasticsearch/common/inject/Key.java
+++ b/server/src/main/java/org/elasticsearch/common/inject/Key.java
@@ -184,7 +184,7 @@ public class Key<T> {
         if (o == this) {
             return true;
         }
-        if (!(o instanceof Key<?>)) {
+        if ((o instanceof Key<?>) == false) {
             return false;
         }
         Key<?> other = (Key<?>) o;
@@ -364,7 +364,7 @@ public class Key<T> {
 
     private static void ensureRetainedAtRuntime(
             Class<? extends Annotation> annotationType) {
-        if (!Annotations.isRetainedAtRuntime(annotationType)) {
+        if (Annotations.isRetainedAtRuntime(annotationType) == false) {
             throw new IllegalArgumentException(
                     annotationType.getName() + " is not retained at runtime. Please annotate it with @Retention(RUNTIME)."
             );
@@ -373,7 +373,7 @@ public class Key<T> {
 
     private static void ensureIsBindingAnnotation(
             Class<? extends Annotation> annotationType) {
-        if (!isBindingAnnotation(annotationType)) {
+        if (isBindingAnnotation(annotationType) == false) {
             throw new IllegalArgumentException(
                     annotationType.getName() + " is not a binding annotation. Please annotate it with @BindingAnnotation."
             );
@@ -440,7 +440,7 @@ public class Key<T> {
 
         @Override
         public boolean equals(Object o) {
-            if (!(o instanceof AnnotationInstanceStrategy)) {
+            if ((o instanceof AnnotationInstanceStrategy) == false) {
                 return false;
             }
 
@@ -494,7 +494,7 @@ public class Key<T> {
 
         @Override
         public boolean equals(Object o) {
-            if (!(o instanceof AnnotationTypeStrategy)) {
+            if ((o instanceof AnnotationTypeStrategy) == false) {
                 return false;
             }
 

--- a/server/src/main/java/org/elasticsearch/common/inject/ScopeBindingProcessor.java
+++ b/server/src/main/java/org/elasticsearch/common/inject/ScopeBindingProcessor.java
@@ -40,12 +40,12 @@ class ScopeBindingProcessor extends AbstractProcessor {
         Scope scope = command.getScope();
         Class<? extends Annotation> annotationType = command.getAnnotationType();
 
-        if (!Annotations.isScopeAnnotation(annotationType)) {
+        if (Annotations.isScopeAnnotation(annotationType) == false) {
             errors.withSource(annotationType).missingScopeAnnotation();
             // Go ahead and bind anyway so we don't get collateral errors.
         }
 
-        if (!Annotations.isRetainedAtRuntime(annotationType)) {
+        if (Annotations.isRetainedAtRuntime(annotationType) == false) {
             errors.withSource(annotationType)
                     .missingRuntimeRetention(command.getSource());
             // Go ahead and bind anyway so we don't get collateral errors.

--- a/server/src/main/java/org/elasticsearch/common/inject/SingleMethodInjector.java
+++ b/server/src/main/java/org/elasticsearch/common/inject/SingleMethodInjector.java
@@ -46,7 +46,7 @@ class SingleMethodInjector implements SingleMemberInjector {
 
         // We can't use FastMethod if the method is private.
         int modifiers = method.getModifiers();
-        if (!Modifier.isPrivate(modifiers) && !Modifier.isProtected(modifiers)) {
+        if (Modifier.isPrivate(modifiers) == false && Modifier.isProtected(modifiers) == false) {
         }
 
         return new MethodInvoker() {

--- a/server/src/main/java/org/elasticsearch/common/inject/TypeConverterBindingProcessor.java
+++ b/server/src/main/java/org/elasticsearch/common/inject/TypeConverterBindingProcessor.java
@@ -159,7 +159,7 @@ class TypeConverterBindingProcessor extends AbstractProcessor {
             @Override
             public boolean matches(TypeLiteral<?> typeLiteral) {
                 Type type = typeLiteral.getType();
-                if (!(type instanceof Class)) {
+                if ((type instanceof Class) == false) {
                     return false;
                 }
                 Class<?> clazz = (Class<?>) type;

--- a/server/src/main/java/org/elasticsearch/common/inject/TypeLiteral.java
+++ b/server/src/main/java/org/elasticsearch/common/inject/TypeLiteral.java
@@ -218,7 +218,7 @@ public class TypeLiteral<T> {
                 for (int t = 0, length = args.length; t < length; t++) {
                     Type resolvedTypeArgument = resolveType(args[t]);
                     if (resolvedTypeArgument != args[t]) {
-                        if (!changed) {
+                        if (changed == false) {
                             args = args.clone();
                             changed = true;
                         }
@@ -263,7 +263,7 @@ public class TypeLiteral<T> {
      * @since 2.0
      */
     public TypeLiteral<?> getSupertype(Class<?> supertype) {
-        if (!supertype.isAssignableFrom(rawType)) {
+        if (supertype.isAssignableFrom(rawType) == false) {
             throw new IllegalArgumentException(supertype + " is not a supertype of " + type);
         }
         return resolve(MoreTypes.getGenericSupertype(type, rawType, supertype));
@@ -276,7 +276,7 @@ public class TypeLiteral<T> {
      * @since 2.0
      */
     public TypeLiteral<?> getFieldType(Field field) {
-        if (!field.getDeclaringClass().isAssignableFrom(rawType)) {
+        if (field.getDeclaringClass().isAssignableFrom(rawType) == false) {
             throw new IllegalArgumentException(field + " is not defined by a supertype of " + type);
         }
         return resolve(field.getGenericType());
@@ -293,14 +293,14 @@ public class TypeLiteral<T> {
 
         if (methodOrConstructor instanceof Method) {
             Method method = (Method) methodOrConstructor;
-            if (!method.getDeclaringClass().isAssignableFrom(rawType)) {
+            if (method.getDeclaringClass().isAssignableFrom(rawType) == false) {
                 throw new IllegalArgumentException(method + " is not defined by a supertype of " + type);
             }
             genericParameterTypes = method.getGenericParameterTypes();
 
         } else if (methodOrConstructor instanceof Constructor) {
             Constructor constructor = (Constructor) methodOrConstructor;
-            if (!constructor.getDeclaringClass().isAssignableFrom(rawType)) {
+            if (constructor.getDeclaringClass().isAssignableFrom(rawType) == false) {
                 throw new IllegalArgumentException(constructor + " does not construct a supertype of " + type);
             }
 
@@ -324,7 +324,7 @@ public class TypeLiteral<T> {
 
         if (methodOrConstructor instanceof Method) {
             Method method = (Method) methodOrConstructor;
-            if (!method.getDeclaringClass().isAssignableFrom(rawType)) {
+            if (method.getDeclaringClass().isAssignableFrom(rawType) == false) {
                 throw new IllegalArgumentException(method + " is not defined by a supertype of " + type);
             }
 
@@ -332,7 +332,7 @@ public class TypeLiteral<T> {
 
         } else if (methodOrConstructor instanceof Constructor) {
             Constructor<?> constructor = (Constructor<?>) methodOrConstructor;
-            if (!constructor.getDeclaringClass().isAssignableFrom(rawType)) {
+            if (constructor.getDeclaringClass().isAssignableFrom(rawType) == false) {
                 throw new IllegalArgumentException(constructor + " does not construct a supertype of " + type);
             }
             genericExceptionTypes = constructor.getGenericExceptionTypes();
@@ -351,7 +351,7 @@ public class TypeLiteral<T> {
      * @since 2.0
      */
     public TypeLiteral<?> getReturnType(Method method) {
-        if (!method.getDeclaringClass().isAssignableFrom(rawType)) {
+        if (method.getDeclaringClass().isAssignableFrom(rawType) == false) {
             throw new IllegalArgumentException(method + " is not defined by a supertype of " + type);
         }
 

--- a/server/src/main/java/org/elasticsearch/common/io/FileSystemUtils.java
+++ b/server/src/main/java/org/elasticsearch/common/io/FileSystemUtils.java
@@ -113,15 +113,15 @@ public final class FileSystemUtils {
     public static boolean isAccessibleDirectory(Path directory, Logger logger) {
         assert directory != null && logger != null;
 
-        if (!Files.exists(directory)) {
+        if (Files.exists(directory) == false) {
             logger.debug("[{}] directory does not exist.", directory.toAbsolutePath());
             return false;
         }
-        if (!Files.isDirectory(directory)) {
+        if (Files.isDirectory(directory) == false) {
             logger.debug("[{}] should be a directory but is not.", directory.toAbsolutePath());
             return false;
         }
-        if (!Files.isReadable(directory)) {
+        if (Files.isReadable(directory) == false) {
             logger.debug("[{}] directory is not readable.", directory.toAbsolutePath());
             return false;
         }

--- a/server/src/main/java/org/elasticsearch/common/joda/JodaDateMathParser.java
+++ b/server/src/main/java/org/elasticsearch/common/joda/JodaDateMathParser.java
@@ -102,7 +102,7 @@ public class JodaDateMathParser implements DateMathParser {
             }
 
             final int num;
-            if (!Character.isDigit(mathString.charAt(i))) {
+            if (Character.isDigit(mathString.charAt(i)) == false) {
                 num = 1;
             } else {
                 int numFrom = i;

--- a/server/src/main/java/org/elasticsearch/common/logging/LoggerMessageFormat.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/LoggerMessageFormat.java
@@ -69,7 +69,7 @@ public class LoggerMessageFormat {
                 }
             } else {
                 if (isEscapedDelimiter(messagePattern, j)) {
-                    if (!isDoubleEscaped(messagePattern, j)) {
+                    if (isDoubleEscaped(messagePattern, j) == false) {
                         L--; // DELIM_START was escaped, thus should not be incremented
                         sbuf.append(messagePattern.substring(i, j - 1));
                         sbuf.append(DELIM_START);
@@ -122,7 +122,7 @@ public class LoggerMessageFormat {
             sbuf.append("null");
             return;
         }
-        if (!o.getClass().isArray()) {
+        if (o.getClass().isArray() == false) {
             safeObjectAppend(sbuf, o);
         } else {
             // check for primitive array types because they
@@ -161,7 +161,7 @@ public class LoggerMessageFormat {
 
     private static void objectArrayAppend(StringBuilder sbuf, Object[] a, Set<Object[]> seen) {
         sbuf.append('[');
-        if (!seen.contains(a)) {
+        if (seen.contains(a) == false) {
             seen.add(a);
             final int len = a.length;
             for (int i = 0; i < len; i++) {

--- a/server/src/main/java/org/elasticsearch/common/lucene/Lucene.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/Lucene.java
@@ -538,7 +538,7 @@ public class Lucene {
     }
 
     public static void writeScoreDoc(StreamOutput out, ScoreDoc scoreDoc) throws IOException {
-        if (!scoreDoc.getClass().equals(ScoreDoc.class)) {
+        if (scoreDoc.getClass().equals(ScoreDoc.class) == false) {
             throw new IllegalArgumentException("This method can only be used to serialize a ScoreDoc, not a " + scoreDoc.getClass());
         }
         out.writeVInt(scoreDoc.doc);

--- a/server/src/main/java/org/elasticsearch/common/lucene/MinimumScoreCollector.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/MinimumScoreCollector.java
@@ -44,7 +44,7 @@ public class MinimumScoreCollector extends SimpleCollector {
 
     @Override
     public void setScorer(Scorable scorer) throws IOException {
-        if (!(scorer instanceof ScoreCachingWrappingScorer)) {
+        if ((scorer instanceof ScoreCachingWrappingScorer) == false) {
             scorer = new ScoreCachingWrappingScorer(scorer);
         }
         this.scorer = scorer;

--- a/server/src/main/java/org/elasticsearch/common/lucene/ShardCoreKeyMap.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/ShardCoreKeyMap.java
@@ -153,7 +153,7 @@ public final class ShardCoreKeyMap {
     }
 
     private synchronized boolean assertSize() {
-        if (!Assertions.ENABLED) {
+        if (Assertions.ENABLED == false) {
             throw new AssertionError("only run this if assertions are enabled");
         }
         Collection<Set<IndexReader.CacheKey>> values = indexToCoreKey.values();

--- a/server/src/main/java/org/elasticsearch/common/network/IfConfig.java
+++ b/server/src/main/java/org/elasticsearch/common/network/IfConfig.java
@@ -61,7 +61,7 @@ public final class IfConfig {
             msg.append(System.lineSeparator());
 
             // display name (e.g. on windows)
-            if (!nic.getName().equals(nic.getDisplayName())) {
+            if (nic.getName().equals(nic.getDisplayName()) == false) {
                 msg.append(INDENT);
                 msg.append(nic.getDisplayName());
                 msg.append(System.lineSeparator());

--- a/server/src/main/java/org/elasticsearch/common/network/InetAddresses.java
+++ b/server/src/main/java/org/elasticsearch/common/network/InetAddresses.java
@@ -160,7 +160,7 @@ public class InetAddresses {
         // If we found a ::, then we must have skipped at least one part.
         // Otherwise, we must have exactly the right number of parts.
         int partsSkipped = IPV6_PART_COUNT - (partsHi + partsLo);
-        if (!(skipIndex >= 0 ? partsSkipped >= 1 : partsSkipped == 0)) {
+        if ((skipIndex >= 0 ? partsSkipped >= 1 : partsSkipped == 0) == false) {
             return null;
         }
 
@@ -249,7 +249,7 @@ public class InetAddresses {
             byte[] bytes = ip.getAddress();
             return (bytes[0] & 0xff) + "." + (bytes[1] & 0xff) + "." + (bytes[2] & 0xff) + "." + (bytes[3] & 0xff);
         }
-        if (!(ip instanceof Inet6Address)) {
+        if ((ip instanceof Inet6Address) == false) {
             throw new IllegalArgumentException("ip");
         }
         byte[] bytes = ip.getAddress();

--- a/server/src/main/java/org/elasticsearch/common/network/NetworkUtils.java
+++ b/server/src/main/java/org/elasticsearch/common/network/NetworkUtils.java
@@ -45,7 +45,7 @@ public abstract class NetworkUtils {
 
     /** no instantiation */
     private NetworkUtils() {}
-    
+
     /**
      * By default we bind to any addresses on an interface/name, unless restricted by :ipv4 etc.
      * This property is unrelated to that, this is about what we *publish*. Today the code pretty much
@@ -79,14 +79,14 @@ public abstract class NetworkUtils {
         }
         SUPPORTS_V6 = v;
     }
-    
+
     /** Sorts an address by preference. This way code like publishing can just pick the first one */
     static int sortKey(InetAddress address, boolean prefer_v6) {
         int key = address.getAddress().length;
         if (prefer_v6) {
             key = -key;
         }
-        
+
         if (address.isAnyLocalAddress()) {
             key += 5;
         }
@@ -106,7 +106,7 @@ public abstract class NetworkUtils {
         return key;
     }
 
-    /** 
+    /**
      * Sorts addresses by order of preference. This is used to pick the first one for publishing
      * @deprecated remove this when multihoming is really correct
      */
@@ -124,7 +124,7 @@ public abstract class NetworkUtils {
             }
         });
     }
-    
+
     /** Return all interfaces (and subinterfaces) on the system */
     static List<NetworkInterface> getInterfaces() throws SocketException {
         List<NetworkInterface> all = new ArrayList<>();
@@ -137,17 +137,17 @@ public abstract class NetworkUtils {
         });
         return all;
     }
-    
+
     /** Helper for getInterfaces, recursively adds subinterfaces to {@code target} */
     private static void addAllInterfaces(List<NetworkInterface> target, List<NetworkInterface> level) {
-        if (!level.isEmpty()) {
+        if (level.isEmpty() == false) {
             target.addAll(level);
             for (NetworkInterface intf : level) {
                 addAllInterfaces(target, Collections.list(intf.getSubInterfaces()));
             }
         }
     }
-    
+
     /** Returns system default for SO_REUSEADDR */
     public static boolean defaultReuseAddress() {
         return Constants.WINDOWS ? false : true;
@@ -185,12 +185,12 @@ public abstract class NetworkUtils {
     static InetAddress[] getLoopbackAddresses() throws IOException {
         return filterAllAddresses(InetAddress::isLoopbackAddress, "no up-and-running loopback addresses found");
     }
-    
+
     /** Returns all site-local scope (private) addresses for interfaces that are up. */
     static InetAddress[] getSiteLocalAddresses() throws IOException {
         return filterAllAddresses(InetAddress::isSiteLocalAddress, "No up-and-running site-local (private) addresses found");
     }
-    
+
     /** Returns all global scope addresses for interfaces that are up. */
     static InetAddress[] getGlobalAddresses() throws IOException {
         return filterAllAddresses(
@@ -199,8 +199,8 @@ public abstract class NetworkUtils {
                         && address.isLinkLocalAddress() == false,
                 "no up-and-running global-scope (public) addresses found");
     }
-    
-    /** Returns all addresses (any scope) for interfaces that are up. 
+
+    /** Returns all addresses (any scope) for interfaces that are up.
      *  This is only used to pick a publish address, when the user set network.host to a wildcard */
     static InetAddress[] getAllAddresses() throws IOException {
         return filterAllAddresses(address -> true, "no up-and-running addresses found");
@@ -219,7 +219,7 @@ public abstract class NetworkUtils {
                     getInterfaces().stream().map(otherInterface -> "_" + otherInterface.getName() + suffix + "_")
                             .collect(Collectors.joining(", ")) + "]");
         }
-        if (!networkInterface.get().isUp()) {
+        if (networkInterface.get().isUp() == false) {
             throw new IllegalArgumentException("setting [" + settingValue + "] matched network interface [" +
                     networkInterface.get().getName() + "] but this interface is not up and running");
         }
@@ -230,7 +230,7 @@ public abstract class NetworkUtils {
         }
         return list.toArray(new InetAddress[list.size()]);
     }
-    
+
     /** Returns only the IPV4 addresses in {@code addresses} */
     static InetAddress[] filterIPV4(InetAddress addresses[]) {
         List<InetAddress> list = new ArrayList<>();
@@ -244,7 +244,7 @@ public abstract class NetworkUtils {
         }
         return list.toArray(new InetAddress[list.size()]);
     }
-    
+
     /** Returns only the IPV6 addresses in {@code addresses} */
     static InetAddress[] filterIPV6(InetAddress addresses[]) {
         List<InetAddress> list = new ArrayList<>();

--- a/server/src/main/java/org/elasticsearch/common/recycler/ConcurrentDequeRecycler.java
+++ b/server/src/main/java/org/elasticsearch/common/recycler/ConcurrentDequeRecycler.java
@@ -53,7 +53,7 @@ public class ConcurrentDequeRecycler<T> extends DequeRecycler<T> {
 
     @Override
     protected void afterRelease(boolean recycled) {
-        if (!recycled) {
+        if (recycled == false) {
             size.decrementAndGet();
         }
     }

--- a/server/src/main/java/org/elasticsearch/common/settings/PropertyPlaceholder.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/PropertyPlaceholder.java
@@ -78,7 +78,7 @@ class PropertyPlaceholder {
             int endIndex = findPlaceholderEndIndex(buf, startIndex);
             if (endIndex != -1) {
                 String placeholder = buf.substring(startIndex + this.placeholderPrefix.length(), endIndex);
-                if (!visitedPlaceholders.add(placeholder)) {
+                if (visitedPlaceholders.add(placeholder) == false) {
                     throw new IllegalArgumentException(
                             "Circular placeholder reference '" + placeholder + "' in property definitions");
                 }

--- a/server/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -429,7 +429,7 @@ public final class Settings implements ToXContentFragment {
      * Returns group settings for the given setting prefix.
      */
     public Map<String, Settings> getGroups(String settingPrefix, boolean ignoreNonGrouped) throws SettingsException {
-        if (!Strings.hasLength(settingPrefix)) {
+        if (Strings.hasLength(settingPrefix) == false) {
             throw new IllegalArgumentException("illegal setting prefix " + settingPrefix);
         }
         if (settingPrefix.charAt(settingPrefix.length() - 1) != '.') {
@@ -558,7 +558,7 @@ public final class Settings implements ToXContentFragment {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         Settings settings = SettingsFilter.filterSettings(params, this);
-        if (!params.paramAsBoolean("flat_settings", false)) {
+        if (params.paramAsBoolean("flat_settings", false) == false) {
             for (Map.Entry<String, Object> entry : settings.getAsStructuredMap().entrySet()) {
                 builder.field(entry.getKey(), entry.getValue());
             }
@@ -591,7 +591,7 @@ public final class Settings implements ToXContentFragment {
             // ensure we reached the end of the stream
             XContentParser.Token lastToken = null;
             try {
-                while (!parser.isClosed() && (lastToken = parser.nextToken()) == null) ;
+                while (parser.isClosed() == false && (lastToken = parser.nextToken()) == null) ;
             } catch (Exception e) {
                 throw new ElasticsearchParseException(
                     "malformed, expected end of settings but encountered additional content starting at line number: [{}], "

--- a/server/src/main/java/org/elasticsearch/common/settings/SettingsFilter.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/SettingsFilter.java
@@ -99,7 +99,7 @@ public final class SettingsFilter {
                 builder.remove(pattern);
             }
         }
-        if (!simpleMatchPatternList.isEmpty()) {
+        if (simpleMatchPatternList.isEmpty() == false) {
             String[] simpleMatchPatterns = simpleMatchPatternList.toArray(new String[simpleMatchPatternList.size()]);
             builder.keys().removeIf(key -> Regex.simpleMatch(simpleMatchPatterns, key));
         }

--- a/server/src/main/java/org/elasticsearch/common/time/JavaDateMathParser.java
+++ b/server/src/main/java/org/elasticsearch/common/time/JavaDateMathParser.java
@@ -109,7 +109,7 @@ public class JavaDateMathParser implements DateMathParser {
             }
 
             final int num;
-            if (!Character.isDigit(mathString.charAt(i))) {
+            if (Character.isDigit(mathString.charAt(i)) == false) {
                 num = 1;
             } else {
                 int numFrom = i;

--- a/server/src/main/java/org/elasticsearch/common/util/BigArrays.java
+++ b/server/src/main/java/org/elasticsearch/common/util/BigArrays.java
@@ -461,7 +461,7 @@ public class BigArrays {
             adjustBreaker(array.ramBytesUsed(), true);
             success = true;
         } finally {
-            if (!success) {
+            if (success == false) {
                 Releasables.closeWhileHandlingException(array);
             }
         }

--- a/server/src/main/java/org/elasticsearch/common/util/CollectionUtils.java
+++ b/server/src/main/java/org/elasticsearch/common/util/CollectionUtils.java
@@ -83,7 +83,7 @@ public class CollectionUtils {
             sort(array);
             int uniqueCount = 1;
             for (int i = 1; i < len; ++i) {
-                if (!Arrays.equals(array.get(i), array.get(i - 1))) {
+                if (Arrays.equals(array.get(i), array.get(i - 1)) == false) {
                     array.set(uniqueCount++, array.get(i));
                 }
             }
@@ -191,7 +191,7 @@ public class CollectionUtils {
             if (distance < 0 || distance >= list.size()) {
                 throw new IllegalArgumentException();
             }
-            if (!(list instanceof RandomAccess)) {
+            if ((list instanceof RandomAccess) == false) {
                 throw new IllegalArgumentException();
             }
             this.in = list;
@@ -256,7 +256,7 @@ public class CollectionUtils {
         bytes.get(previous, indices[0]);
         for (int i = 1; i < numValues; ++i) {
             bytes.get(current, indices[i]);
-            if (!previous.get().equals(current.get())) {
+            if (previous.get().equals(current.get()) == false) {
                 indices[uniqueCount++] = indices[i];
             }
             BytesRefBuilder tmp = previous;

--- a/server/src/main/java/org/elasticsearch/common/util/LongObjectPagedHashMap.java
+++ b/server/src/main/java/org/elasticsearch/common/util/LongObjectPagedHashMap.java
@@ -140,7 +140,7 @@ public class LongObjectPagedHashMap<T> extends AbstractPagedHashMap implements I
 
             @Override
             public boolean hasNext() {
-                if (!cached) {
+                if (cached == false) {
                     while (true) {
                         ++cursor.index;
                         if (cursor.index >= capacity()) {
@@ -158,7 +158,7 @@ public class LongObjectPagedHashMap<T> extends AbstractPagedHashMap implements I
 
             @Override
             public Cursor<T> next() {
-                if (!hasNext()) {
+                if (hasNext() == false) {
                     throw new NoSuchElementException();
                 }
                 cached = false;

--- a/server/src/main/java/org/elasticsearch/common/xcontent/XContentHelper.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/XContentHelper.java
@@ -252,7 +252,7 @@ public class XContentHelper {
     public static boolean update(Map<String, Object> source, Map<String, Object> changes, boolean checkUpdatesAreUnequal) {
         boolean modified = false;
         for (Map.Entry<String, Object> changesEntry : changes.entrySet()) {
-            if (!source.containsKey(changesEntry.getKey())) {
+            if (source.containsKey(changesEntry.getKey()) == false) {
                 // safe to copy, change does not exist in source
                 source.put(changesEntry.getKey(), changesEntry.getValue());
                 modified = true;
@@ -270,7 +270,7 @@ public class XContentHelper {
             if (modified) {
                 continue;
             }
-            if (!checkUpdatesAreUnequal) {
+            if (checkUpdatesAreUnequal == false) {
                 modified = true;
                 continue;
             }
@@ -285,7 +285,7 @@ public class XContentHelper {
      */
     public static void mergeDefaults(Map<String, Object> content, Map<String, Object> defaults) {
         for (Map.Entry<String, Object> defaultEntry : defaults.entrySet()) {
-            if (!content.containsKey(defaultEntry.getKey())) {
+            if (content.containsKey(defaultEntry.getKey()) == false) {
                 // copy it over, it does not exists in the content
                 content.put(defaultEntry.getKey(), defaultEntry.getValue());
             } else {
@@ -322,7 +322,7 @@ public class XContentHelper {
                         List<Object> mergedList = new ArrayList<>(defaultList);
 
                         for (Object o : contentList) {
-                            if (!mergedList.contains(o)) {
+                            if (mergedList.contains(o) == false) {
                                 mergedList.add(o);
                             }
                         }
@@ -335,7 +335,7 @@ public class XContentHelper {
 
     private static boolean allListValuesAreMapsOfOne(List<Object> list) {
         for (Object o : list) {
-            if (!(o instanceof Map)) {
+            if ((o instanceof Map) == false) {
                 return false;
             }
             if (((Map) o).size() != 1) {

--- a/server/src/main/java/org/elasticsearch/discovery/SeedHostsResolver.java
+++ b/server/src/main/java/org/elasticsearch/discovery/SeedHostsResolver.java
@@ -117,7 +117,7 @@ public class SeedHostsResolver extends AbstractLifecycleComponent implements Con
         for (final Future<TransportAddress[]> future : futures.get()) {
             assert future.isDone();
             final String hostname = it.next();
-            if (!future.isCancelled()) {
+            if (future.isCancelled() == false) {
                 try {
                     final TransportAddress[] addresses = future.get();
                     logger.trace("resolved host [{}] to {}", hostname, addresses);

--- a/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -1144,7 +1144,7 @@ public final class NodeEnvironment  implements Closeable {
 
 
     private void assertEnvIsLocked() {
-        if (!closed.get() && locks != null) {
+        if (closed.get() == false && locks != null) {
             for (Lock lock : locks) {
                 try {
                     lock.ensureValid();

--- a/server/src/main/java/org/elasticsearch/gateway/LocalAllocateDangledIndices.java
+++ b/server/src/main/java/org/elasticsearch/gateway/LocalAllocateDangledIndices.java
@@ -167,7 +167,7 @@ public class LocalAllocateDangledIndices {
                         sb.append("[").append(upgradedIndexMetadata.getIndex()).append("/").append(upgradedIndexMetadata.getState())
                             .append("]");
                     }
-                    if (!importNeeded) {
+                    if (importNeeded == false) {
                         return currentState;
                     }
                     logger.info("importing dangled indices {} from [{}]", sb.toString(), request.fromNode);

--- a/server/src/main/java/org/elasticsearch/http/AbstractHttpServerTransport.java
+++ b/server/src/main/java/org/elasticsearch/http/AbstractHttpServerTransport.java
@@ -185,7 +185,7 @@ public abstract class AbstractHttpServerTransport extends AbstractLifecycleCompo
             }
             return true;
         });
-        if (!success) {
+        if (success == false) {
             throw new BindHttpException(
                 "Failed to bind to " + NetworkAddress.format(hostAddress, port),
                 lastException.get()

--- a/server/src/main/java/org/elasticsearch/http/CorsHandler.java
+++ b/server/src/main/java/org/elasticsearch/http/CorsHandler.java
@@ -108,7 +108,7 @@ public class CorsHandler {
     }
 
     public void setCorsResponseHeaders(final HttpRequest httpRequest, final HttpResponse httpResponse) {
-        if (!config.isCorsSupportEnabled()) {
+        if (config.isCorsSupportEnabled() == false) {
             return;
         }
         if (setOrigin(httpRequest, httpResponse)) {
@@ -154,7 +154,7 @@ public class CorsHandler {
 
     private boolean setOrigin(final HttpRequest request, final HttpResponse response) {
         String origin = getOrigin(request);
-        if (!Strings.isNullOrEmpty(origin)) {
+        if (Strings.isNullOrEmpty(origin) == false) {
             if (config.isAnyOriginSupported()) {
                 if (config.isCredentialsAllowed()) {
                     setAllowOrigin(response, origin);

--- a/server/src/main/java/org/elasticsearch/index/MergePolicyConfig.java
+++ b/server/src/main/java/org/elasticsearch/index/MergePolicyConfig.java
@@ -228,7 +228,7 @@ public final class MergePolicyConfig {
 
     private int adjustMaxMergeAtOnceIfNeeded(int maxMergeAtOnce, double segmentsPerTier) {
         // fixing maxMergeAtOnce, see TieredMergePolicy#setMaxMergeAtOnce
-        if ((segmentsPerTier >= maxMergeAtOnce) == false) {
+        if (segmentsPerTier < maxMergeAtOnce) {
             int newMaxMergeAtOnce = (int) segmentsPerTier;
             // max merge at once should be at least 2
             if (newMaxMergeAtOnce <= 1) {

--- a/server/src/main/java/org/elasticsearch/index/MergePolicyConfig.java
+++ b/server/src/main/java/org/elasticsearch/index/MergePolicyConfig.java
@@ -228,7 +228,7 @@ public final class MergePolicyConfig {
 
     private int adjustMaxMergeAtOnceIfNeeded(int maxMergeAtOnce, double segmentsPerTier) {
         // fixing maxMergeAtOnce, see TieredMergePolicy#setMaxMergeAtOnce
-        if (!(segmentsPerTier >= maxMergeAtOnce)) {
+        if ((segmentsPerTier >= maxMergeAtOnce) == false) {
             int newMaxMergeAtOnce = (int) segmentsPerTier;
             // max merge at once should be at least 2
             if (newMaxMergeAtOnce <= 1) {

--- a/server/src/main/java/org/elasticsearch/indices/IndicesRequestCache.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesRequestCache.java
@@ -123,7 +123,7 @@ public final class IndicesRequestCache implements RemovalListener<IndicesRequest
             key.entity.onMiss();
             // see if its the first time we see this reader, and make sure to register a cleanup key
             CleanupKey cleanupKey = new CleanupKey(cacheEntity, reader.getReaderCacheHelper().getKey());
-            if (!registeredClosedListeners.containsKey(cleanupKey)) {
+            if (registeredClosedListeners.containsKey(cleanupKey) == false) {
                 Boolean previous = registeredClosedListeners.putIfAbsent(cleanupKey, Boolean.TRUE);
                 if (previous == null) {
                     ElasticsearchDirectoryReader.addReaderCloseListener(reader, cleanupKey);
@@ -250,8 +250,8 @@ public final class IndicesRequestCache implements RemovalListener<IndicesRequest
             Key key = (Key) o;
             if (mappingCacheKey.equals(key.mappingCacheKey) == false) return false;
             if (readerCacheKey.equals(key.readerCacheKey) == false) return false;
-            if (!entity.getCacheIdentity().equals(key.entity.getCacheIdentity())) return false;
-            if (!value.equals(key.value)) return false;
+            if (entity.getCacheIdentity().equals(key.entity.getCacheIdentity()) == false) return false;
+            if (value.equals(key.value) == false) return false;
             return true;
         }
 
@@ -290,7 +290,7 @@ public final class IndicesRequestCache implements RemovalListener<IndicesRequest
             }
             CleanupKey that = (CleanupKey) o;
             if (Objects.equals(readerCacheKey, that.readerCacheKey) == false) return false;
-            if (!entity.getCacheIdentity().equals(that.entity.getCacheIdentity())) return false;
+            if (entity.getCacheIdentity().equals(that.entity.getCacheIdentity()) == false) return false;
             return true;
         }
 
@@ -319,7 +319,7 @@ public final class IndicesRequestCache implements RemovalListener<IndicesRequest
                 currentKeysToClean.add(cleanupKey);
             }
         }
-        if (!currentKeysToClean.isEmpty() || !currentFullClean.isEmpty()) {
+        if (currentKeysToClean.isEmpty() == false || currentFullClean.isEmpty() == false) {
             for (Iterator<Key> iterator = cache.keys().iterator(); iterator.hasNext(); ) {
                 Key key = iterator.next();
                 if (currentFullClean.contains(key.entity.getCacheIdentity())) {

--- a/server/src/main/java/org/elasticsearch/indices/NodeIndicesStats.java
+++ b/server/src/main/java/org/elasticsearch/indices/NodeIndicesStats.java
@@ -199,7 +199,7 @@ public class NodeIndicesStats implements Writeable, ToXContentFragment {
         final String level = params.param("level", "node");
         final boolean isLevelValid =
             "indices".equalsIgnoreCase(level) || "node".equalsIgnoreCase(level) || "shards".equalsIgnoreCase(level);
-        if (!isLevelValid) {
+        if (isLevelValid == false) {
             throw new IllegalArgumentException("level parameter must be one of [indices] or [node] or [shards] but was [" + level + "]");
         }
 
@@ -239,7 +239,7 @@ public class NodeIndicesStats implements Writeable, ToXContentFragment {
     private Map<Index, CommonStats> createStatsByIndex() {
         Map<Index, CommonStats> statsMap = new HashMap<>();
         for (Map.Entry<Index, List<IndexShardStats>> entry : statsByShard.entrySet()) {
-            if (!statsMap.containsKey(entry.getKey())) {
+            if (statsMap.containsKey(entry.getKey()) == false) {
                 statsMap.put(entry.getKey(), new CommonStats());
             }
 

--- a/server/src/main/java/org/elasticsearch/indices/analysis/HunspellService.java
+++ b/server/src/main/java/org/elasticsearch/indices/analysis/HunspellService.java
@@ -103,7 +103,7 @@ public class HunspellService {
                 throw new IllegalStateException("failed to load hunspell dictionary for locale: " + locale, e);
             }
         };
-        if (!HUNSPELL_LAZY_LOAD.get(settings)) {
+        if (HUNSPELL_LAZY_LOAD.get(settings) == false) {
             scanAndLoadDictionaries();
         }
 

--- a/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -209,7 +209,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
 
     @Override
     public synchronized void applyClusterState(final ClusterChangedEvent event) {
-        if (!lifecycle.started()) {
+        if (lifecycle.started() == false) {
             return;
         }
 
@@ -521,7 +521,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
     }
 
     private void updateIndices(ClusterChangedEvent event) {
-        if (!event.metadataChanged()) {
+        if (event.metadataChanged() == false) {
             return;
         }
         final ClusterState state = event.state();
@@ -669,7 +669,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
     private static DiscoveryNode findSourceNodeForPeerRecovery(Logger logger, RoutingTable routingTable, DiscoveryNodes nodes,
                                                                ShardRouting shardRouting) {
         DiscoveryNode sourceNode = null;
-        if (!shardRouting.primary()) {
+        if (shardRouting.primary() == false) {
             ShardRouting primary = routingTable.shardRoutingTable(shardRouting.shardId()).primaryShard();
             // only recover from started primary, if we can't find one, we will do it next round
             if (primary.active()) {

--- a/server/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
+++ b/server/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
@@ -121,7 +121,7 @@ public class IndicesStore implements ClusterStateListener, Closeable {
 
     @Override
     public void clusterChanged(ClusterChangedEvent event) {
-        if (!event.routingTableChanged()) {
+        if (event.routingTableChanged() == false) {
             return;
         }
 
@@ -364,7 +364,7 @@ public class IndicesStore implements ClusterStateListener, Closeable {
 
         private IndexShard getShard(ShardActiveRequest request) {
             ClusterName thisClusterName = clusterService.getClusterName();
-            if (!thisClusterName.equals(request.clusterName)) {
+            if (thisClusterName.equals(request.clusterName) == false) {
                 logger.trace("shard exists request meant for cluster[{}], but this is cluster[{}], ignoring request",
                     request.clusterName, thisClusterName);
                 return null;

--- a/server/src/main/java/org/elasticsearch/ingest/PipelineConfiguration.java
+++ b/server/src/main/java/org/elasticsearch/ingest/PipelineConfiguration.java
@@ -143,7 +143,7 @@ public final class PipelineConfiguration extends AbstractDiffable<PipelineConfig
 
         PipelineConfiguration that = (PipelineConfiguration) o;
 
-        if (!id.equals(that.id)) return false;
+        if (id.equals(that.id) == false) return false;
         return getConfigAsMap().equals(that.getConfigAsMap());
 
     }

--- a/server/src/main/java/org/elasticsearch/monitor/fs/FsInfo.java
+++ b/server/src/main/java/org/elasticsearch/monitor/fs/FsInfo.java
@@ -454,7 +454,7 @@ public class FsInfo implements Iterable<FsInfo.Path>, Writeable, ToXContentFragm
         Set<String> seenDevices = new HashSet<>(paths.length);
         for (Path subPath : paths) {
             if (subPath.path != null) {
-                if (!seenDevices.add(subPath.path)) {
+                if (seenDevices.add(subPath.path) == false) {
                     continue; // already added numbers for this device;
                 }
             }

--- a/server/src/main/java/org/elasticsearch/monitor/fs/FsProbe.java
+++ b/server/src/main/java/org/elasticsearch/monitor/fs/FsProbe.java
@@ -49,7 +49,7 @@ public class FsProbe {
     }
 
     public FsInfo stats(FsInfo previous) throws IOException {
-        if (!nodeEnv.hasNodeFile()) {
+        if (nodeEnv.hasNodeFile() == false) {
             return new FsInfo(System.currentTimeMillis(), null, new FsInfo.Path[0]);
         }
         NodePath[] dataLocations = nodeEnv.nodePaths();
@@ -83,12 +83,12 @@ public class FsProbe {
             List<FsInfo.DeviceStats> devicesStats = new ArrayList<>();
 
             List<String> lines = readProcDiskStats();
-            if (!lines.isEmpty()) {
+            if (lines.isEmpty() == false) {
                 for (String line : lines) {
                     String fields[] = line.trim().split("\\s+");
                     final int majorDeviceNumber = Integer.parseInt(fields[0]);
                     final int minorDeviceNumber = Integer.parseInt(fields[1]);
-                    if (!devicesNumbers.contains(Tuple.tuple(majorDeviceNumber, minorDeviceNumber))) {
+                    if (devicesNumbers.contains(Tuple.tuple(majorDeviceNumber, minorDeviceNumber)) == false) {
                         continue;
                     }
                     final String deviceName = fields[2];

--- a/server/src/main/java/org/elasticsearch/monitor/jvm/DeadlockAnalyzer.java
+++ b/server/src/main/java/org/elasticsearch/monitor/jvm/DeadlockAnalyzer.java
@@ -80,7 +80,7 @@ public class DeadlockAnalyzer {
                 cycle.add(t);
             }
 
-            if (!cycles.contains(cycle)) {
+            if (cycles.contains(cycle) == false) {
                 cycles.add(cycle);
             }
         }
@@ -100,7 +100,7 @@ public class DeadlockAnalyzer {
                     if (cycle.contains(threadInfoMap.get(Long.valueOf(threadInfo.getLockOwnerId())))) {
                         LinkedHashSet<ThreadInfo> chain = new LinkedHashSet<>();
                         ThreadInfo node = threadInfo;
-                        while (!chain.contains(node)) {
+                        while (chain.contains(node) == false) {
                             chain.add(node);
                             node = threadInfoMap.get(Long.valueOf(node.getLockOwnerId()));
                         }

--- a/server/src/main/java/org/elasticsearch/monitor/jvm/JvmGcMonitorService.java
+++ b/server/src/main/java/org/elasticsearch/monitor/jvm/JvmGcMonitorService.java
@@ -192,7 +192,7 @@ public class JvmGcMonitorService extends AbstractLifecycleComponent {
 
     @Override
     protected void doStart() {
-        if (!enabled) {
+        if (enabled == false) {
             return;
         }
         scheduledFuture = threadPool.scheduleWithFixedDelay(new JvmMonitor(gcThresholds, gcOverheadThreshold) {
@@ -343,7 +343,7 @@ public class JvmGcMonitorService extends AbstractLifecycleComponent {
 
     @Override
     protected void doStop() {
-        if (!enabled) {
+        if (enabled == false) {
             return;
         }
         scheduledFuture.cancel();

--- a/server/src/main/java/org/elasticsearch/monitor/jvm/JvmInfo.java
+++ b/server/src/main/java/org/elasticsearch/monitor/jvm/JvmInfo.java
@@ -349,7 +349,7 @@ public class JvmInfo implements ReportingService.Info {
             int i = 0;
             StringBuilder sVersion = new StringBuilder();
             for (; i < version.length(); i++) {
-                if (!Character.isDigit(version.charAt(i)) && version.charAt(i) != '.') {
+                if (Character.isDigit(version.charAt(i)) == false && version.charAt(i) != '.') {
                     break;
                 }
                 if (version.charAt(i) != '.') {
@@ -370,7 +370,7 @@ public class JvmInfo implements ReportingService.Info {
             int i = 0;
             StringBuilder sVersion = new StringBuilder();
             for (; i < version.length(); i++) {
-                if (!Character.isDigit(version.charAt(i)) && version.charAt(i) != '.') {
+                if (Character.isDigit(version.charAt(i)) == false && version.charAt(i) != '.') {
                     break;
                 }
                 if (version.charAt(i) != '.') {
@@ -393,7 +393,7 @@ public class JvmInfo implements ReportingService.Info {
                 return -1;
             }
             for (; i < version.length(); i++) {
-                if (!Character.isDigit(version.charAt(i)) && version.charAt(i) != '.') {
+                if (Character.isDigit(version.charAt(i)) == false && version.charAt(i) != '.') {
                     break;
                 }
             }

--- a/server/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
+++ b/server/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
@@ -497,16 +497,16 @@ public class OsProbe {
      */
     @SuppressForbidden(reason = "access /proc/self/cgroup, /sys/fs/cgroup/cpu, /sys/fs/cgroup/cpuacct and /sys/fs/cgroup/memory")
     boolean areCgroupStatsAvailable() {
-        if (!Files.exists(PathUtils.get("/proc/self/cgroup"))) {
+        if (Files.exists(PathUtils.get("/proc/self/cgroup")) == false) {
             return false;
         }
-        if (!Files.exists(PathUtils.get("/sys/fs/cgroup/cpu"))) {
+        if (Files.exists(PathUtils.get("/sys/fs/cgroup/cpu")) == false) {
             return false;
         }
-        if (!Files.exists(PathUtils.get("/sys/fs/cgroup/cpuacct"))) {
+        if (Files.exists(PathUtils.get("/sys/fs/cgroup/cpuacct")) == false) {
             return false;
         }
-        if (!Files.exists(PathUtils.get("/sys/fs/cgroup/memory"))) {
+        if (Files.exists(PathUtils.get("/sys/fs/cgroup/memory")) == false) {
             return false;
         }
         return true;
@@ -519,7 +519,7 @@ public class OsProbe {
      */
     private OsStats.Cgroup getCgroup() {
         try {
-            if (!areCgroupStatsAvailable()) {
+            if (areCgroupStatsAvailable() == false) {
                 return null;
             } else {
                 final Map<String, String> controllerMap = getControlGroups();

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -735,7 +735,7 @@ public class Node implements Closeable {
         } catch (IOException ex) {
             throw new ElasticsearchException("failed to bind service", ex);
         } finally {
-            if (!success) {
+            if (success == false) {
                 IOUtils.closeWhileHandlingException(resourcesToClose);
             }
         }
@@ -802,7 +802,7 @@ public class Node implements Closeable {
      * Start the node. If the node is already started, this method is no-op.
      */
     public Node start() throws NodeValidationException {
-        if (!lifecycle.moveToStarted()) {
+        if (lifecycle.moveToStarted() == false) {
             return this;
         }
 
@@ -931,7 +931,7 @@ public class Node implements Closeable {
     }
 
     private Node stop() {
-        if (!lifecycle.moveToStopped()) {
+        if (lifecycle.moveToStopped() == false) {
             return this;
         }
         logger.info("stopping ...");
@@ -975,7 +975,7 @@ public class Node implements Closeable {
             if (lifecycle.started()) {
                 stop();
             }
-            if (!lifecycle.moveToClosed()) {
+            if (lifecycle.moveToClosed() == false) {
                 return;
             }
         }

--- a/server/src/main/java/org/elasticsearch/plugins/PluginInfo.java
+++ b/server/src/main/java/org/elasticsearch/plugins/PluginInfo.java
@@ -236,7 +236,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
 
     private static String getClassname(String name, PluginType type, String classname) {
         if (type == PluginType.BOOTSTRAP) {
-            if (!Strings.isNullOrEmpty(classname)) {
+            if (Strings.isNullOrEmpty(classname) == false) {
                 throw new IllegalArgumentException(
                     "property [classname] can only have a value when [type] is set to [bootstrap] for plugin [" + name + "]"
                 );
@@ -395,7 +395,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
 
         PluginInfo that = (PluginInfo) o;
 
-        if (!name.equals(that.name)) return false;
+        if (name.equals(that.name) == false) return false;
         // TODO: since the plugins are unique by their directory name, this should only be a name check, version should not matter?
         if (version != null ? !version.equals(that.version) : that.version != null) return false;
 

--- a/server/src/main/java/org/elasticsearch/plugins/PluginSecurity.java
+++ b/server/src/main/java/org/elasticsearch/plugins/PluginSecurity.java
@@ -66,10 +66,10 @@ class PluginSecurity {
     }
 
     private static void prompt(final Terminal terminal, final boolean batch) throws UserException {
-        if (!batch) {
+        if (batch == false) {
             terminal.println(Verbosity.NORMAL, "");
             String text = terminal.readText("Continue with installation? [y/N]");
-            if (!text.equalsIgnoreCase("y")) {
+            if (text.equalsIgnoreCase("y") == false) {
                 throw new UserException(ExitCodes.DATA_ERROR, "installation aborted by user");
             }
         }

--- a/server/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/server/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -172,11 +172,11 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
         if (mandatoryPlugins.isEmpty() == false) {
             Set<String> missingPlugins = new HashSet<>();
             for (String mandatoryPlugin : mandatoryPlugins) {
-                if (!pluginsNames.contains(mandatoryPlugin) && !missingPlugins.contains(mandatoryPlugin)) {
+                if (pluginsNames.contains(mandatoryPlugin) == false && missingPlugins.contains(mandatoryPlugin) == false) {
                     missingPlugins.add(mandatoryPlugin);
                 }
             }
-            if (!missingPlugins.isEmpty()) {
+            if (missingPlugins.isEmpty() == false) {
                 final String message = String.format(
                         Locale.ROOT,
                         "missing mandatory plugins [%s], found plugins [%s]",

--- a/server/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
@@ -199,7 +199,7 @@ public class RepositoriesService extends AbstractLifecycleComponent implements C
                             repositoriesMetadata.add(repositoryMetadata);
                         }
                     }
-                    if (!found) {
+                    if (found == false) {
                         logger.info("put repository [{}]", request.name());
                         repositoriesMetadata.add(new RepositoryMetadata(request.name(), request.type(), request.settings()));
                     } else {

--- a/server/src/main/java/org/elasticsearch/rest/BaseRestHandler.java
+++ b/server/src/main/java/org/elasticsearch/rest/BaseRestHandler.java
@@ -85,7 +85,7 @@ public abstract class BaseRestHandler implements RestHandler {
             request.unconsumedParams().stream().filter(p -> !responseParams().contains(p)).collect(Collectors.toCollection(TreeSet::new));
 
         // validate the non-response params
-        if (!unconsumedParams.isEmpty()) {
+        if (unconsumedParams.isEmpty() == false) {
             final Set<String> candidateParams = new HashSet<>();
             candidateParams.addAll(request.consumedParams());
             candidateParams.addAll(responseParams());

--- a/server/src/main/java/org/elasticsearch/rest/RestUtils.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestUtils.java
@@ -143,7 +143,7 @@ public class RestUtils {
             return "";
         }
         final int size = s.length();
-        if (!decodingNeeded(s, size, plusAsSpace)) {
+        if (decodingNeeded(s, size, plusAsSpace) == false) {
             return s;
         }
         final byte[] buf = new byte[size];

--- a/server/src/main/java/org/elasticsearch/script/Script.java
+++ b/server/src/main/java/org/elasticsearch/script/Script.java
@@ -652,7 +652,7 @@ public final class Script implements ToXContentObject, Writeable {
             builder.field(OPTIONS_PARSE_FIELD.getPreferredName(), options);
         }
 
-        if (!params.isEmpty()) {
+        if (params.isEmpty() == false) {
             builder.field(PARAMS_PARSE_FIELD.getPreferredName(), params);
         }
 
@@ -709,7 +709,7 @@ public final class Script implements ToXContentObject, Writeable {
 
         if (type != script.type) return false;
         if (lang != null ? !lang.equals(script.lang) : script.lang != null) return false;
-        if (!idOrCode.equals(script.idOrCode)) return false;
+        if (idOrCode.equals(script.idOrCode) == false) return false;
         if (options != null ? !options.equals(script.options) : script.options != null) return false;
         return params.equals(script.params);
 

--- a/server/src/main/java/org/elasticsearch/script/ScriptContextInfo.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptContextInfo.java
@@ -340,7 +340,7 @@ public class ScriptContextInfo implements ToXContentObject, Writeable {
                     throw new IllegalArgumentException("Could not find field [" + parametersFieldName + "] on instance class [" +
                         clazz.getName() + "] but method [" + name + "] has [" + parameterTypes.length + "] parameters");
                 }
-                if (!parameterNamesField.getType().equals(String[].class)) {
+                if (parameterNamesField.getType().equals(String[].class) == false) {
                     throw new IllegalArgumentException("Expected a constant [String[] PARAMETERS] on instance class [" +
                         clazz.getName() + "] for method [" + name + "] with [" + parameterTypes.length + "] parameters, found [" +
                         parameterNamesField.getType().getTypeName() + "]");
@@ -370,10 +370,10 @@ public class ScriptContextInfo implements ToXContentObject, Writeable {
             // See ScriptClassInfo(PainlessLookup painlessLookup, Class<?> baseClass)
             HashSet<ScriptMethodInfo> getters = new HashSet<>();
             for (java.lang.reflect.Method m : clazz.getMethods()) {
-                if (!m.isDefault() &&
+                if (m.isDefault() == false &&
                     m.getName().startsWith("get") &&
-                    !m.getName().equals("getClass") &&
-                    !Modifier.isStatic(m.getModifiers()) &&
+                    m.getName().equals("getClass") == false &&
+                    Modifier.isStatic(m.getModifiers()) == false &&
                     m.getParameters().length == 0) {
                     getters.add(new ScriptMethodInfo(m.getName(), m.getReturnType().getTypeName(), new ArrayList<>()));
                 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregationPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregationPhase.java
@@ -54,7 +54,7 @@ public class AggregationPhase {
                     }
                 }
                 context.aggregations().aggregators(aggregators);
-                if (!collectors.isEmpty()) {
+                if (collectors.isEmpty() == false) {
                     Collector collector = MultiBucketCollector.wrap(collectors);
                     ((BucketCollector)collector).preCollection();
                     if (context.getProfilers() != null) {
@@ -90,7 +90,7 @@ public class AggregationPhase {
         }
 
         // optimize the global collector based execution
-        if (!globals.isEmpty()) {
+        if (globals.isEmpty() == false) {
             BucketCollector globalsCollector = MultiBucketCollector.wrap(globals);
             Query query = context.buildFilteredQuery(Queries.newMatchAllQuery());
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactories.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactories.java
@@ -84,7 +84,7 @@ public class AggregatorFactories {
                         "Unexpected token " + token + " in [aggs]: aggregations definitions must start with the name of the aggregation.");
             }
             final String aggregationName = parser.currentName();
-            if (!validAggMatcher.reset(aggregationName).matches()) {
+            if (validAggMatcher.reset(aggregationName).matches() == false) {
                 throw new ParsingException(parser.getTokenLocation(), "Invalid aggregation name [" + aggregationName
                         + "]. Aggregation names can contain any character except '[', ']', and '>'");
             }
@@ -295,7 +295,7 @@ public class AggregatorFactories {
         }
 
         public Builder addAggregator(AggregationBuilder factory) {
-            if (!names.add(factory.name)) {
+            if (names.add(factory.name) == false) {
                 throw new IllegalArgumentException("Two sibling aggregations cannot have the same name: [" + factory.name + "]");
             }
             aggregationBuilders.add(factory);
@@ -372,7 +372,7 @@ public class AggregatorFactories {
             List<PipelineAggregationBuilder> orderedPipelineAggregatorrs = new LinkedList<>();
             List<PipelineAggregationBuilder> unmarkedBuilders = new ArrayList<>(pipelineAggregatorBuilders);
             Collection<PipelineAggregationBuilder> temporarilyMarked = new HashSet<>();
-            while (!unmarkedBuilders.isEmpty()) {
+            while (unmarkedBuilders.isEmpty() == false) {
                 PipelineAggregationBuilder builder = unmarkedBuilders.get(0);
                 resolvePipelineAggregatorOrder(aggBuildersMap, pipelineAggregatorBuildersMap, orderedPipelineAggregatorrs, unmarkedBuilders,
                         temporarilyMarked, builder);
@@ -414,7 +414,7 @@ public class AggregatorFactories {
                                     }
                                 }
                                 // Check the pipeline sub-aggregator factories
-                                if (!foundSubBuilder && (i == bucketsPathElements.size() - 1)) {
+                                if (foundSubBuilder == false && (i == bucketsPathElements.size() - 1)) {
                                     Collection<PipelineAggregationBuilder> subPipelineBuilders = aggBuilder.factoriesBuilder
                                             .pipelineAggregatorBuilders;
                                     for (PipelineAggregationBuilder subFactory : subPipelineBuilders) {
@@ -424,7 +424,7 @@ public class AggregatorFactories {
                                         }
                                     }
                                 }
-                                if (!foundSubBuilder) {
+                                if (foundSubBuilder == false) {
                                     throw new IllegalArgumentException("No aggregation [" + aggName + "] found for path [" + bucketsPath
                                             + "]");
                                 }
@@ -506,9 +506,9 @@ public class AggregatorFactories {
                 return false;
             Builder other = (Builder) obj;
 
-            if (!Objects.equals(aggregationBuilders, other.aggregationBuilders))
+            if (Objects.equals(aggregationBuilders, other.aggregationBuilders) == false)
                 return false;
-            if (!Objects.equals(pipelineAggregatorBuilders, other.pipelineAggregatorBuilders))
+            if (Objects.equals(pipelineAggregatorBuilders, other.pipelineAggregatorBuilders) == false)
                 return false;
             return true;
         }

--- a/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -1362,7 +1362,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
             builder.field(SLICE.getPreferredName(), sliceBuilder);
         }
 
-        if (!indexBoosts.isEmpty()) {
+        if (indexBoosts.isEmpty() == false) {
             builder.startArray(INDICES_BOOST_FIELD.getPreferredName());
             for (IndexBoost ib : indexBoosts) {
                 builder.startObject();

--- a/server/src/main/java/org/elasticsearch/search/collapse/CollapseBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/collapse/CollapseBuilder.java
@@ -186,7 +186,7 @@ public class CollapseBuilder implements Writeable, ToXContentObject {
         CollapseBuilder that = (CollapseBuilder) o;
 
         if (maxConcurrentGroupRequests != that.maxConcurrentGroupRequests) return false;
-        if (!field.equals(that.field)) return false;
+        if (field.equals(that.field) == false) return false;
         return Objects.equals(innerHits, that.innerHits);
     }
 

--- a/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
@@ -205,7 +205,7 @@ public class FetchPhase {
 
         if (storedFieldsContext == null) {
             // no fields specified, default to return source if no explicit indication
-            if (!context.hasScriptFields() && !context.hasFetchSourceContext()) {
+            if (context.hasScriptFields() == false && context.hasFetchSourceContext() == false) {
                 context.fetchSourceContext(new FetchSourceContext(true));
             }
             boolean loadSource = sourceRequired(context);

--- a/server/src/main/java/org/elasticsearch/search/searchafter/SearchAfterBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/searchafter/SearchAfterBuilder.java
@@ -276,7 +276,7 @@ public class SearchAfterBuilder implements ToXContentObject, Writeable {
 
     @Override
     public boolean equals(Object other) {
-        if ( (other instanceof SearchAfterBuilder) == false) {
+        if ((other instanceof SearchAfterBuilder) == false) {
             return false;
         }
         return Arrays.equals(sortValues, ((SearchAfterBuilder) other).sortValues);

--- a/server/src/main/java/org/elasticsearch/search/searchafter/SearchAfterBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/searchafter/SearchAfterBuilder.java
@@ -276,7 +276,7 @@ public class SearchAfterBuilder implements ToXContentObject, Writeable {
 
     @Override
     public boolean equals(Object other) {
-        if (! (other instanceof SearchAfterBuilder)) {
+        if ( (other instanceof SearchAfterBuilder) == false) {
             return false;
         }
         return Arrays.equals(sortValues, ((SearchAfterBuilder) other).sortValues);

--- a/server/src/main/java/org/elasticsearch/search/slice/SliceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/slice/SliceBuilder.java
@@ -177,7 +177,7 @@ public class SliceBuilder implements Writeable, ToXContentObject {
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof SliceBuilder)) {
+        if ((other instanceof SliceBuilder) == false) {
             return false;
         }
 

--- a/server/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortBuilder.java
@@ -657,14 +657,14 @@ public class GeoDistanceSortBuilder extends SortBuilder<GeoDistanceSortBuilder> 
     }
 
     static void parseGeoPoints(XContentParser parser, List<GeoPoint> geoPoints) throws IOException {
-        while (!parser.nextToken().equals(XContentParser.Token.END_ARRAY)) {
+        while (parser.nextToken().equals(XContentParser.Token.END_ARRAY) == false) {
             if (parser.currentToken() == XContentParser.Token.VALUE_NUMBER) {
                 // we might get here if the geo point is " number, number] " and the parser already moved over the
                 // opening bracket in this case we cannot use GeoUtils.parseGeoPoint(..) because this expects an opening
                 // bracket
                 double lon = parser.doubleValue();
                 parser.nextToken();
-                if (!parser.currentToken().equals(XContentParser.Token.VALUE_NUMBER)) {
+                if (parser.currentToken().equals(XContentParser.Token.VALUE_NUMBER) == false) {
                     throw new ElasticsearchParseException(
                             "geo point parsing: expected second number but got [{}] instead",
                             parser.currentToken());

--- a/server/src/main/java/org/elasticsearch/search/sort/SortBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/sort/SortBuilder.java
@@ -158,7 +158,7 @@ public abstract class SortBuilder<T extends SortBuilder<T>> implements NamedWrit
             sortFields.add(sf.field);
             sortFormats.add(sf.format);
         }
-        if (!sortFields.isEmpty()) {
+        if (sortFields.isEmpty() == false) {
             // optimize if we just sort on score non reversed, we don't really
             // need sorting
             boolean sort;

--- a/server/src/main/java/org/elasticsearch/search/suggest/Suggest.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/Suggest.java
@@ -439,7 +439,7 @@ public class Suggest implements Iterable<Suggest.Suggestion<? extends Entry<? ex
                 final Map<O, O> entries = new HashMap<>();
                 Entry<O> leader = toReduce.get(0);
                 for (Entry<O> entry : toReduce) {
-                    if (!leader.text.equals(entry.text)) {
+                    if (leader.text.equals(entry.text) == false) {
                         throw new IllegalStateException("Can't merge suggest entries, this might be caused by suggest calls " +
                                 "across multiple indices with different analysis chains. Suggest entries have different text actual [" +
                                 entry.text + "] expected [" + leader.text +"]");

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -343,7 +343,7 @@ public class RestoreService implements ClusterStateApplier {
                                         .put(IndexMetadata.SETTING_INDEX_UUID, UUIDs.randomBase64UUID()))
                                         .timestampRange(IndexLongFieldRange.NO_SHARDS);
                                     shardLimitValidator.validateShardLimit(snapshotIndexMetadata.getSettings(), currentState);
-                                    if (!request.includeAliases() && !snapshotIndexMetadata.getAliases().isEmpty()) {
+                                    if (request.includeAliases() == false && snapshotIndexMetadata.getAliases().isEmpty() == false) {
                                         // Remove all aliases - they shouldn't be restored
                                         indexMdBuilder.removeAllAliases();
                                     } else {
@@ -381,9 +381,9 @@ public class RestoreService implements ClusterStateApplier {
                                             Math.max(snapshotIndexMetadata.primaryTerm(shard), currentIndexMetadata.primaryTerm(shard)));
                                     }
 
-                                    if (!request.includeAliases()) {
+                                    if (request.includeAliases() == false) {
                                         // Remove all snapshot aliases
-                                        if (!snapshotIndexMetadata.getAliases().isEmpty()) {
+                                        if (snapshotIndexMetadata.getAliases().isEmpty() == false) {
                                             indexMdBuilder.removeAllAliases();
                                         }
                                         /// Add existing aliases
@@ -407,7 +407,7 @@ public class RestoreService implements ClusterStateApplier {
                                 }
 
                                 for (int shard = 0; shard < snapshotIndexMetadata.getNumberOfShards(); shard++) {
-                                    if (!ignoreShards.contains(shard)) {
+                                    if (ignoreShards.contains(shard) == false) {
                                         shardsBuilder.put(new ShardId(renamedIndex, shard),
                                             new RestoreInProgress.ShardRestoreStatus(clusterService.state().nodes().getLocalNodeId()));
                                     } else {
@@ -556,7 +556,7 @@ public class RestoreService implements ClusterStateApplier {
                         Set<String> keyFilters = new HashSet<>();
                         List<String> simpleMatchPatterns = new ArrayList<>();
                         for (String ignoredSetting : ignoreSettings) {
-                            if (!Regex.isSimpleMatchPattern(ignoredSetting)) {
+                            if (Regex.isSimpleMatchPattern(ignoredSetting) == false) {
                                 if (UNREMOVABLE_SETTINGS.contains(ignoredSetting)) {
                                     throw new SnapshotRestoreException(
                                         snapshot, "cannot remove setting [" + ignoredSetting + "] on restore");
@@ -853,7 +853,7 @@ public class RestoreService implements ClusterStateApplier {
                                                         ImmutableOpenMap<ShardId, RestoreInProgress.ShardRestoreStatus> shards) {
         boolean hasFailed = false;
         for (ObjectCursor<RestoreInProgress.ShardRestoreStatus> status : shards.values()) {
-            if (!status.value.state().completed()) {
+            if (status.value.state().completed() == false) {
                 return nonCompletedState;
             }
             if (status.value.state() == RestoreInProgress.State.FAILURE) {
@@ -869,7 +869,7 @@ public class RestoreService implements ClusterStateApplier {
 
     public static boolean completed(ImmutableOpenMap<ShardId, RestoreInProgress.ShardRestoreStatus> shards) {
         for (ObjectCursor<RestoreInProgress.ShardRestoreStatus> status : shards.values()) {
-            if (!status.value.state().completed()) {
+            if (status.value.state().completed() == false) {
                 return false;
             }
         }
@@ -922,7 +922,7 @@ public class RestoreService implements ClusterStateApplier {
      * @param snapshotInfo    snapshot metadata
      */
     private static void validateSnapshotRestorable(final String repository, final SnapshotInfo snapshotInfo) {
-        if (!snapshotInfo.state().restorable()) {
+        if (snapshotInfo.state().restorable() == false) {
             throw new SnapshotRestoreException(new Snapshot(repository, snapshotInfo.snapshotId()),
                                                "unsupported snapshot state [" + snapshotInfo.state() + "]");
         }

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotUtils.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotUtils.java
@@ -49,7 +49,7 @@ public class SnapshotUtils {
         for (int i = 0; i < selectedIndices.length; i++) {
             String indexOrPattern = selectedIndices[i];
             boolean add = true;
-            if (!indexOrPattern.isEmpty()) {
+            if (indexOrPattern.isEmpty() == false) {
                 if (availableIndices.contains(indexOrPattern)) {
                     if (result == null) {
                         result = new HashSet<>();
@@ -74,8 +74,8 @@ public class SnapshotUtils {
                 }
             }
             if (indexOrPattern.isEmpty() || !Regex.isSimpleMatchPattern(indexOrPattern)) {
-                if (!availableIndices.contains(indexOrPattern)) {
-                    if (!indicesOptions.ignoreUnavailable()) {
+                if (availableIndices.contains(indexOrPattern) == false) {
+                    if (indicesOptions.ignoreUnavailable() == false) {
                         throw new IndexNotFoundException(indexOrPattern);
                     } else {
                         if (result == null) {
@@ -109,7 +109,7 @@ public class SnapshotUtils {
                     }
                 }
             }
-            if (!found && !indicesOptions.allowNoIndices()) {
+            if (found == false && indicesOptions.allowNoIndices() == false) {
                 throw new IndexNotFoundException(indexOrPattern);
             }
         }

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -2189,7 +2189,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                     } else if (primary.relocating() || primary.initializing()) {
                         shardSnapshotStatus = new ShardSnapshotStatus(
                             primary.currentNodeId(), ShardState.WAITING, shardRepoGeneration);
-                    } else if (!primary.started()) {
+                    } else if (primary.started() == false) {
                         shardSnapshotStatus =
                             new ShardSnapshotStatus(primary.currentNodeId(), ShardState.MISSING,
                                 "primary shard hasn't been started yet", shardRepoGeneration);

--- a/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -345,7 +345,7 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
     @Override
     public ScheduledCancellable schedule(Runnable command, TimeValue delay, String executor) {
         command = threadContext.preserveContext(command);
-        if (!Names.SAME.equals(executor)) {
+        if (Names.SAME.equals(executor) == false) {
             command = new ThreadedRunnable(command, executor(executor));
         }
         return new ScheduledCancellableAdapter(scheduler.schedule(command, delay.millis(), TimeUnit.MILLISECONDS));

--- a/server/src/main/java/org/elasticsearch/transport/InboundHandler.java
+++ b/server/src/main/java/org/elasticsearch/transport/InboundHandler.java
@@ -319,7 +319,7 @@ public class InboundHandler {
     }
 
     private void handleException(final TransportResponseHandler<?> handler, Throwable error) {
-        if (!(error instanceof RemoteTransportException)) {
+        if ((error instanceof RemoteTransportException) == false) {
             error = new RemoteTransportException(error.getMessage(), error);
         }
         final RemoteTransportException rtx = (RemoteTransportException) error;

--- a/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -396,7 +396,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
                 }
                 return true;
             });
-            if (!success) {
+            if (success == false) {
                 throw new BindTransportException(
                     "Failed to bind to " + NetworkAddress.format(hostAddress, portsRange),
                     lastException.get()
@@ -510,7 +510,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
         if (hostPortString.startsWith("[")) {
             // Parse a bracketed host, typically an IPv6 literal.
             Matcher matcher = BRACKET_PATTERN.matcher(hostPortString);
-            if (!matcher.matches()) {
+            if (matcher.matches() == false) {
                 throw new IllegalArgumentException("Invalid bracketed host/port range: " + hostPortString);
             }
             host = matcher.group(1);
@@ -596,7 +596,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
 
     // exposed for tests
     static void handleException(TcpChannel channel, Exception e, Lifecycle lifecycle, OutboundHandler outboundHandler) {
-        if (!lifecycle.started()) {
+        if (lifecycle.started() == false) {
             // just close and ignore - we are already stopped and just need to make sure we release all resources
             CloseableChannel.closeChannel(channel);
             return;

--- a/server/src/main/java/org/elasticsearch/watcher/AbstractResourceWatcher.java
+++ b/server/src/main/java/org/elasticsearch/watcher/AbstractResourceWatcher.java
@@ -32,7 +32,7 @@ public abstract class AbstractResourceWatcher<Listener> implements ResourceWatch
 
     @Override
     public void init() throws IOException {
-        if (!initialized) {
+        if (initialized == false) {
             doInit();
             initialized = true;
         }

--- a/server/src/test/java/org/elasticsearch/ExceptionsHelperTests.java
+++ b/server/src/test/java/org/elasticsearch/ExceptionsHelperTests.java
@@ -64,7 +64,7 @@ public class ExceptionsHelperTests extends ESTestCase {
         for (int i = 0; i < depth; i++) {
             final int length = randomIntBetween(1, 4);
             for (int j = 0; j < length; j++) {
-                if (!fatal && rarely()) {
+                if (fatal == false && rarely()) {
                     error = new Error();
                     cause.addSuppressed(error);
                     fatal = true;
@@ -72,7 +72,7 @@ public class ExceptionsHelperTests extends ESTestCase {
                     cause.addSuppressed(new Exception());
                 }
             }
-            if (!fatal && rarely()) {
+            if (fatal == false && rarely()) {
                 cause = error = new Error(cause);
                 fatal = true;
             } else {

--- a/server/src/test/java/org/elasticsearch/http/DefaultRestChannelTests.java
+++ b/server/src/test/java/org/elasticsearch/http/DefaultRestChannelTests.java
@@ -247,7 +247,7 @@ public class DefaultRestChannelTests extends ESTestCase {
             }
         } else {
             httpRequest = new TestHttpRequest(HttpRequest.HttpVersion.HTTP_1_0, RestRequest.Method.GET, "/");
-            if (!close) {
+            if (close == false) {
                 httpRequest.getHeaders().put(DefaultRestChannel.CONNECTION, Collections.singletonList(DefaultRestChannel.KEEP_ALIVE));
             }
         }

--- a/server/src/test/java/org/elasticsearch/search/MultiValueModeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/MultiValueModeTests.java
@@ -68,7 +68,7 @@ public class MultiValueModeTests extends ESTestCase {
     private static FixedBitSet randomInnerDocs(FixedBitSet rootDocs) {
         FixedBitSet innerDocs = new FixedBitSet(rootDocs.length());
         for (int i = 0; i < innerDocs.length(); ++i) {
-            if (!rootDocs.get(i) && randomBoolean()) {
+            if (rootDocs.get(i) == false && randomBoolean()) {
                 innerDocs.set(i);
             }
         }


### PR DESCRIPTION
Part 2.

We have an in-house rule to compare explicitly against `false` instead
of using the logical not operator (`!`). However, this hasn't
historically been enforced, meaning that there are many violations in
the source at present.

We now have a Checkstyle rule that can detect these cases, but before we
can turn it on, we need to fix the existing violations. This is being
done over a series of PRs, since there are a lot to fix.