### PR TITLE
[7.10] [DOCS] EQL: Add security privileges to EQL search docs (#68017)

### DIFF
--- a/docs/reference/eql/delete-async-eql-search-api.asciidoc
+++ b/docs/reference/eql/delete-async-eql-search-api.asciidoc
@@ -27,7 +27,10 @@ DELETE /_eql/search/FkpMRkJGS1gzVDRlM3g4ZzMyRGlLbkEaTXlJZHdNT09TU2VTZVBoNDM3cFZM
 [[delete-async-eql-search-api-prereqs]]
 ==== {api-prereq-title}
 
-See <<eql-required-fields>>.
+* If the {es} {security-features} are enabled, only the user who first submitted
+the EQL search can delete the search using this API.
+
+* See <<eql-required-fields>>.
 
 [[delete-async-eql-search-api-limitations]]
 ===== Limitations

--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -35,7 +35,11 @@ GET /my-index-000001/_eql/search
 [[eql-search-api-prereqs]]
 ==== {api-prereq-title}
 
-See <<eql-required-fields>>.
+* If the {es} {security-features} are enabled, you must have the `read`
+<<privileges-list-indices,index privilege>> for the target data stream, index,
+or index alias.
+
+* See <<eql-required-fields>>.
 
 [[eql-search-api-limitations]]
 ===== Limitations

--- a/docs/reference/eql/eql.asciidoc
+++ b/docs/reference/eql/eql.asciidoc
@@ -47,8 +47,10 @@ default.
 [[run-an-eql-search]]
 == Run an EQL search
 
-Use the <<eql-search-api,EQL search API>> to run a <<eql-basic-syntax,basic
-EQL query>>:
+Use the <<eql-search-api,EQL search API>> to run a <<eql-basic-syntax,basic EQL
+query>>. If the {es} {security-features} are enabled, you must have the `read`
+<<privileges-list-indices,index privilege>> for the target data stream, index,
+or index alias.
 
 [source,console]
 ----
@@ -494,7 +496,9 @@ requests.
 
 To check the progress of an async search, use the <<get-async-eql-search-api,get
 async EQL search API>> with the search ID. Specify how long you'd like for
-complete results in the `wait_for_completion_timeout` parameter.
+complete results in the `wait_for_completion_timeout` parameter. If the {es}
+{security-features} are enabled, only the user who first submitted the EQL
+search can retrieve the search using this API.
 
 [source,console]
 ----
@@ -554,7 +558,9 @@ GET /_eql/search/FmNJRUZ1YWZCU3dHY1BIOUhaenVSRkEaaXFlZ3h4c1RTWFNocDdnY2FSaERnUTo
 
 Use the <<delete-async-eql-search-api,delete async EQL search API>> to
 manually delete an async EQL search before the `keep_alive` period ends. If the
-search is still ongoing, {es} cancels the search request.
+search is still ongoing, {es} cancels the search request. If the {es}
+{security-features} are enabled, only the user who first submitted the EQL
+search can delete the search using this API.
 
 [source,console]
 ----

--- a/docs/reference/eql/get-async-eql-search-api.asciidoc
+++ b/docs/reference/eql/get-async-eql-search-api.asciidoc
@@ -27,7 +27,10 @@ GET /_eql/search/FkpMRkJGS1gzVDRlM3g4ZzMyRGlLbkEaTXlJZHdNT09TU2VTZVBoNDM3cFZMUTo
 [[get-async-eql-search-api-prereqs]]
 ==== {api-prereq-title}
 
-See <<eql-required-fields>>.
+* If the {es} {security-features} are enabled, only the user who first submitted
+the EQL search can retrieve the search using this API.
+
+* See <<eql-required-fields>>.
 
 [[get-async-eql-search-api-limitations]]
 ===== Limitations


### PR DESCRIPTION
Backports the following commits to 7.10:
 - [DOCS] EQL: Add security privileges to EQL search docs (#68017)