### PR TITLE
Add ability to trace executions of outstanding tasks

### DIFF
--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/TransportRethrottleActionTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/TransportRethrottleActionTests.java
@@ -103,7 +103,7 @@ public class TransportRethrottleActionTests extends ESTestCase {
         for (int i = 0; i < slices; i++) {
             BulkByScrollTask.Status status = believeableInProgressStatus(i);
             tasks.add(new TaskInfo(new TaskId("test", 123), "test", "test", "test", status, 0, 0, true, new TaskId("test", task.getId()),
-                Collections.emptyMap()));
+                Collections.emptyMap(), List.of()));
             sliceStatuses.add(new BulkByScrollTask.StatusOrException(status));
         }
         rethrottleTestCase(slices,
@@ -124,7 +124,7 @@ public class TransportRethrottleActionTests extends ESTestCase {
         for (int i = succeeded; i < slices; i++) {
             BulkByScrollTask.Status status = believeableInProgressStatus(i);
             tasks.add(new TaskInfo(new TaskId("test", 123), "test", "test", "test", status, 0, 0, true, new TaskId("test", task.getId()),
-                Collections.emptyMap()));
+                Collections.emptyMap(), List.of()));
             sliceStatuses.add(new BulkByScrollTask.StatusOrException(status));
         }
         rethrottleTestCase(slices - succeeded,

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/get/TransportGetTaskAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/get/TransportGetTaskAction.java
@@ -131,7 +131,8 @@ public class TransportGetTaskAction extends HandledTransportAction<GetTaskReques
                     @Override
                     protected void doRun() {
                         taskManager.waitForTaskCompletion(runningTask, waitForCompletionTimeout(request.getTimeout()));
-                        waitedForCompletion(thisTask, request, runningTask.taskInfo(clusterService.localNode().getId(), true), listener);
+                        waitedForCompletion(
+                            thisTask, request, runningTask.taskInfo(clusterService.localNode().getId(), true, true), listener);
                     }
 
                     @Override
@@ -140,7 +141,7 @@ public class TransportGetTaskAction extends HandledTransportAction<GetTaskReques
                     }
                 });
             } else {
-                TaskInfo info = runningTask.taskInfo(clusterService.localNode().getId(), true);
+                TaskInfo info = runningTask.taskInfo(clusterService.localNode().getId(), true, true);
                 listener.onResponse(new GetTaskResponse(new TaskResult(false, info)));
             }
         }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/list/TransportListTasksAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/list/TransportListTasksAction.java
@@ -61,7 +61,7 @@ public class TransportListTasksAction extends TransportTasksAction<Task, ListTas
 
     @Override
     protected void taskOperation(ListTasksRequest request, Task task, ActionListener<TaskInfo> listener) {
-        listener.onResponse(task.taskInfo(clusterService.localNode().getId(), request.getDetailed()));
+        listener.onResponse(task.taskInfo(clusterService.localNode().getId(), request.getDetailed(), request.getDetailed()));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -68,6 +68,7 @@ import org.elasticsearch.search.profile.ProfileShardResult;
 import org.elasticsearch.search.profile.SearchProfileShardResults;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskId;
+import org.elasticsearch.tasks.TaskSpan;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.RemoteClusterAware;
 import org.elasticsearch.transport.RemoteClusterService;
@@ -224,8 +225,8 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
     }
 
     public interface SinglePhaseSearchAction {
-        void executeOnShardTarget(SearchTask searchTask, SearchShardTarget target, Transport.Connection connection,
-                                  ActionListener<SearchPhaseResult> listener);
+        void executeOnShardTarget(SearchTask searchTask, TaskSpan taskSpan, SearchShardTarget target,
+                                  Transport.Connection connection, ActionListener<SearchPhaseResult> listener);
     }
 
     public void executeRequest(Task task, SearchRequest searchRequest, String actionName,
@@ -244,10 +245,10 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                     executor, searchRequest, listener, shardsIts, timeProvider, clusterState, task,
                     new ArraySearchPhaseResults<>(shardsIts.size()), 1, clusters) {
                     @Override
-                    protected void executePhaseOnShard(SearchShardIterator shardIt, SearchShardTarget shard,
+                    protected void executePhaseOnShard(TaskSpan taskSpan, SearchShardIterator shardIt, SearchShardTarget shard,
                                                        SearchActionListener<SearchPhaseResult> listener) {
                         final Transport.Connection connection = getConnection(shard.getClusterAlias(), shard.getNodeId());
-                        phaseSearchAction.executeOnShardTarget(task, shard, connection, listener);
+                        phaseSearchAction.executeOnShardTarget(task, taskSpan, shard, connection, listener);
                     }
 
                     @Override

--- a/server/src/main/java/org/elasticsearch/index/reindex/BulkByScrollTask.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/BulkByScrollTask.java
@@ -108,7 +108,7 @@ public class BulkByScrollTask extends CancellableTask {
             sliceStatuses.set(status.getSliceId(), new BulkByScrollTask.StatusOrException(status));
         }
         Status status = leaderState.getStatus(sliceStatuses);
-        return taskInfo(localNodeId, getDescription(), status);
+        return taskInfo(localNodeId, getDescription(), status, List.of());
     }
 
     private BulkByScrollTask.Status emptyStatus() {

--- a/server/src/main/java/org/elasticsearch/tasks/TaskSpan.java
+++ b/server/src/main/java/org/elasticsearch/tasks/TaskSpan.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.tasks;
+
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Represents a unit of execution of a task on the current node or a remote node
+ */
+public final class TaskSpan {
+    public static final String REMOTE_NODE = "remote_node";
+    public static final String REMOTE_ACTION = "remote_action";
+    public static final String SHARD_ID = "shard_id";
+    public static final String THREAD_NAME = "thread_name";
+
+    private final long startTimeInMillis;
+    private long endTimeInMillis = -1L;
+    private Exception failure = null;
+    private Map<String, Object> attributes;
+    private List<TaskSpan> childSpans;
+
+    public TaskSpan() {
+        this.startTimeInMillis = System.currentTimeMillis();
+    }
+
+    synchronized TaskSpanInfo getSpanInfo() {
+        final List<TaskSpanInfo> childInfos;
+        if (childSpans == null) {
+            childInfos = List.of();
+        } else {
+            childInfos = childSpans.stream().map(TaskSpan::getSpanInfo).collect(Collectors.toList());
+        }
+        final Map<String, Object> serializableAttributes;
+        if (attributes != null) {
+            serializableAttributes = new HashMap<>(attributes.size());
+            for (Map.Entry<String, Object> e : attributes.entrySet()) {
+                if (e.getValue() instanceof WeakReference) {
+                    final Object v = ((WeakReference<?>) e.getValue()).get();
+                    if (v != null) {
+                        final String str;
+                        if (v instanceof TaskAwareRequest) {
+                            str = ((TaskAwareRequest) v).getDescription();
+                        } else {
+                            str = v.toString();
+                        }
+                        serializableAttributes.put(e.getKey(), str);
+                    }
+                } else {
+                    serializableAttributes.put(e.getKey(), e.getValue());
+                }
+            }
+        } else {
+            serializableAttributes = Map.of();
+        }
+        final long runningTime = (endTimeInMillis != -1L ? endTimeInMillis : System.currentTimeMillis()) - startTimeInMillis;
+        return new TaskSpanInfo(startTimeInMillis, runningTime, isDone(), failure, serializableAttributes, childInfos);
+    }
+
+    public synchronized TaskSpan newChildSpan() {
+        if (isDone()) {
+            throw new IllegalStateException("Task span is completed already");
+        }
+        if (childSpans == null) {
+            childSpans = new ArrayList<>();
+        } else {
+            int size = childSpans.size();
+            final Iterator<TaskSpan> it = childSpans.iterator();
+            while (size > 1000 && it.hasNext()) {
+                final TaskSpan span = it.next();
+                if (span.isDone()) {
+                    it.remove();
+                    --size;
+                }
+            }
+        }
+        final TaskSpan sub = new TaskSpan();
+        childSpans.add(sub);
+        return sub;
+    }
+
+    public TaskSpan addAttribute(String tag, String value) {
+        return innerAddAttribute(tag, value);
+    }
+
+    public TaskSpan addAttribute(String tag, boolean value) {
+        return innerAddAttribute(tag, value);
+    }
+
+    public TaskSpan addAttribute(String tag, int value) {
+        return innerAddAttribute(tag, value);
+    }
+
+    public TaskSpan addAttribute(String tag, Object value) {
+        return innerAddAttribute(tag, new WeakReference<>(value));
+    }
+
+    public synchronized void removeAttribute(String tag) {
+        if (attributes != null) {
+            attributes.remove(tag);
+        }
+    }
+
+    private synchronized TaskSpan innerAddAttribute(String tag, Object value) {
+        if (attributes == null) {
+            attributes = new HashMap<>();
+        }
+        attributes.put(tag, value);
+        return this;
+    }
+
+    public synchronized Object getAttribute(String tag) {
+        return attributes.get(tag);
+    }
+
+    public synchronized void markAsFailure(Exception failure) {
+        this.failure = Objects.requireNonNull(failure);
+        this.endTimeInMillis = System.currentTimeMillis();
+    }
+
+    public synchronized void markAsComplete() {
+        this.endTimeInMillis = System.currentTimeMillis();
+    }
+
+    synchronized boolean isDone() {
+        return this.endTimeInMillis != -1L;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/tasks/TaskSpanInfo.java
+++ b/server/src/main/java/org/elasticsearch/tasks/TaskSpanInfo.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.tasks;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public final class TaskSpanInfo implements ToXContentObject, Writeable {
+    private final long startTimeInMillis;
+    private final long runningTimeInMillis;
+    private final boolean completed;
+    private final Exception failure;
+    private final Map<String, Object> attributes;
+    private final List<TaskSpanInfo> subSpans;
+
+    TaskSpanInfo(long startTimeInMillis, long runningTimeInMillis, boolean completed,
+                 Exception failure, Map<String, Object> attributes, List<TaskSpanInfo> subSpans) {
+        this.startTimeInMillis = startTimeInMillis;
+        this.runningTimeInMillis = runningTimeInMillis;
+        this.completed = completed;
+        this.failure = failure;
+        this.attributes = Objects.requireNonNull(attributes);
+        this.subSpans = Objects.requireNonNull(subSpans);
+    }
+
+    TaskSpanInfo(StreamInput in) throws IOException {
+        this.startTimeInMillis = in.readLong();
+        this.runningTimeInMillis = in.readLong();
+        this.completed = in.readBoolean();
+        this.failure = in.readException();
+        this.attributes = in.readMap(StreamInput::readString, StreamInput::readGenericValue);
+        this.subSpans = in.readList(TaskSpanInfo::new);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeLong(startTimeInMillis);
+        out.writeLong(runningTimeInMillis);
+        out.writeBoolean(completed);
+        out.writeException(failure);
+        out.writeMap(attributes, StreamOutput::writeString, StreamOutput::writeGenericValue);
+        out.writeList(subSpans);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        if (completed) {
+            if (failure != null) {
+                builder.field("status", "failed");
+                builder.startObject("failure");
+                ElasticsearchException.generateThrowableXContent(builder, params, failure);
+                builder.endObject();
+            } else {
+                builder.field("status", "completed");
+            }
+        } else {
+            if (attributes.containsKey(TaskSpan.REMOTE_ACTION)) {
+                builder.field("status", "waiting");
+            } else {
+                builder.field("status", "running");
+            }
+        }
+        builder.field("start_time_in_millis", startTimeInMillis);
+        builder.field("running_time_in_millis", runningTimeInMillis);
+        for (Map.Entry<String, Object> e : attributes.entrySet()) {
+            builder.field(e.getKey(), e.getValue());
+        }
+        if (subSpans.isEmpty() == false) {
+            builder.field("children", subSpans);
+        }
+        builder.endObject();
+        return builder;
+    }
+}

--- a/server/src/test/java/org/elasticsearch/action/search/AbstractSearchAsyncActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/AbstractSearchAsyncActionTests.java
@@ -35,6 +35,8 @@ import org.elasticsearch.search.internal.AliasFilter;
 import org.elasticsearch.search.internal.InternalSearchResponse;
 import org.elasticsearch.search.internal.ShardSearchContextId;
 import org.elasticsearch.search.internal.ShardSearchRequest;
+import org.elasticsearch.tasks.TaskId;
+import org.elasticsearch.tasks.TaskSpan;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.transport.Transport;
 
@@ -42,6 +44,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.TimeUnit;
@@ -83,15 +86,16 @@ public class AbstractSearchAsyncActionTests extends ESTestCase {
             resolvedNodes.add(Tuple.tuple(cluster, node));
             return null;
         };
+        final SearchTask task = new SearchTask(1, "type", "action", () -> "", TaskId.EMPTY_TASK_ID, Map.of());
 
         return new AbstractSearchAsyncAction<SearchPhaseResult>("test", logger, null, nodeIdToConnection,
                 Collections.singletonMap("foo", new AliasFilter(new MatchAllQueryBuilder())), Collections.singletonMap("foo", 2.0f),
-            null, request, listener,
+                null, request, listener,
                 new GroupShardsIterator<>(
                     Collections.singletonList(
                         new SearchShardIterator(null, null, Collections.emptyList(), null)
                     )
-                ), timeProvider, ClusterState.EMPTY_STATE, null,
+                ), timeProvider, ClusterState.EMPTY_STATE, task,
                 results, request.getMaxConcurrentShardRequests(),
                 SearchResponse.Clusters.EMPTY) {
             @Override
@@ -100,8 +104,8 @@ public class AbstractSearchAsyncActionTests extends ESTestCase {
             }
 
             @Override
-            protected void executePhaseOnShard(final SearchShardIterator shardIt, final SearchShardTarget shard,
-                                               final SearchActionListener<SearchPhaseResult> listener) {
+            protected void executePhaseOnShard(TaskSpan taskSpan, SearchShardIterator shardIt, SearchShardTarget shard,
+                                               SearchActionListener<SearchPhaseResult> listener) {
             }
 
             @Override

--- a/server/src/test/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhaseTests.java
@@ -54,6 +54,8 @@ import org.elasticsearch.search.internal.ShardSearchRequest;
 import org.elasticsearch.search.sort.MinAndMax;
 import org.elasticsearch.search.sort.SortBuilders;
 import org.elasticsearch.search.sort.SortOrder;
+import org.elasticsearch.tasks.TaskId;
+import org.elasticsearch.tasks.TaskSpan;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.transport.Transport;
 
@@ -91,8 +93,8 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
         Map<String, Transport.Connection> lookup = new ConcurrentHashMap<>();
         DiscoveryNode primaryNode = new DiscoveryNode("node_1", buildNewFakeTransportAddress(), Version.CURRENT);
         DiscoveryNode replicaNode = new DiscoveryNode("node_2", buildNewFakeTransportAddress(), Version.CURRENT);
-        lookup.put("node1", new SearchAsyncActionTests.MockConnection(primaryNode));
-        lookup.put("node2", new SearchAsyncActionTests.MockConnection(replicaNode));
+        lookup.put("node_1", new SearchAsyncActionTests.MockConnection(primaryNode));
+        lookup.put("node_2", new SearchAsyncActionTests.MockConnection(replicaNode));
         final boolean shard1 = randomBoolean();
         final boolean shard2 = randomBoolean();
 
@@ -118,7 +120,8 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
             (clusterAlias, node) -> lookup.get(node),
             Collections.singletonMap("_na_", new AliasFilter(null, Strings.EMPTY_ARRAY)),
             Collections.emptyMap(), EsExecutors.newDirectExecutorService(),
-            searchRequest, null, shardsIter, timeProvider, ClusterState.EMPTY_STATE, null,
+            searchRequest, null, shardsIter, timeProvider, ClusterState.EMPTY_STATE,
+            new SearchTask(1, "type", "action", () -> "", TaskId.EMPTY_TASK_ID, Map.of()),
             (iter) -> new SearchPhase("test") {
                     @Override
                     public void run() throws IOException {
@@ -150,8 +153,8 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
         Map<String, Transport.Connection> lookup = new ConcurrentHashMap<>();
         DiscoveryNode primaryNode = new DiscoveryNode("node_1", buildNewFakeTransportAddress(), Version.CURRENT);
         DiscoveryNode replicaNode = new DiscoveryNode("node_2", buildNewFakeTransportAddress(), Version.CURRENT);
-        lookup.put("node1", new SearchAsyncActionTests.MockConnection(primaryNode));
-        lookup.put("node2", new SearchAsyncActionTests.MockConnection(replicaNode));
+        lookup.put("node_1", new SearchAsyncActionTests.MockConnection(primaryNode));
+        lookup.put("node_2", new SearchAsyncActionTests.MockConnection(replicaNode));
         final boolean shard1 = randomBoolean();
         SearchTransportService searchTransportService = new SearchTransportService(null, null, null) {
             @Override
@@ -186,7 +189,8 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
             (clusterAlias, node) -> lookup.get(node),
             Collections.singletonMap("_na_", new AliasFilter(null, Strings.EMPTY_ARRAY)),
             Collections.emptyMap(), EsExecutors.newDirectExecutorService(),
-            searchRequest, null, shardsIter, timeProvider, ClusterState.EMPTY_STATE, null,
+            searchRequest, null, shardsIter, timeProvider, ClusterState.EMPTY_STATE,
+            new SearchTask(1, "type", "action", () -> "", TaskId.EMPTY_TASK_ID, Map.of()),
             (iter) -> new SearchPhase("test") {
                 @Override
                 public void run() throws IOException {
@@ -214,8 +218,8 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
         final Map<String, Transport.Connection> lookup = new ConcurrentHashMap<>();
         final DiscoveryNode primaryNode = new DiscoveryNode("node_1", buildNewFakeTransportAddress(), Version.CURRENT);
         final DiscoveryNode replicaNode = new DiscoveryNode("node_2", buildNewFakeTransportAddress(), Version.CURRENT);
-        lookup.put("node1", new SearchAsyncActionTests.MockConnection(primaryNode));
-        lookup.put("node2", new SearchAsyncActionTests.MockConnection(replicaNode));
+        lookup.put("node_1", new SearchAsyncActionTests.MockConnection(primaryNode));
+        lookup.put("node_2", new SearchAsyncActionTests.MockConnection(replicaNode));
 
 
         final SearchTransportService searchTransportService =
@@ -253,7 +257,7 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
             shardsIter,
             timeProvider,
             ClusterState.EMPTY_STATE,
-            null,
+            new SearchTask(1, "type", "action", () -> "", TaskId.EMPTY_TASK_ID, Map.of()),
             (iter) -> new AbstractSearchAsyncAction<>(
                 "test",
                 logger,
@@ -270,7 +274,7 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
                 iter,
                 new TransportSearchAction.SearchTimeProvider(0, 0, () -> 0),
                 ClusterState.EMPTY_STATE,
-                null,
+                new SearchTask(1, "type", "action", () -> "", TaskId.EMPTY_TASK_ID, Map.of()),
                 new ArraySearchPhaseResults<>(iter.size()),
                 randomIntBetween(1, 32),
                 SearchResponse.Clusters.EMPTY) {
@@ -287,6 +291,7 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
 
                 @Override
                 protected void executePhaseOnShard(
+                    final TaskSpan taskSpan,
                     final SearchShardIterator shardIt,
                     final SearchShardTarget shard,
                     final SearchActionListener<SearchPhaseResult> listener) {
@@ -310,8 +315,8 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
         Map<String, Transport.Connection> lookup = new ConcurrentHashMap<>();
         DiscoveryNode primaryNode = new DiscoveryNode("node_1", buildNewFakeTransportAddress(), Version.CURRENT);
         DiscoveryNode replicaNode = new DiscoveryNode("node_2", buildNewFakeTransportAddress(), Version.CURRENT);
-        lookup.put("node1", new SearchAsyncActionTests.MockConnection(primaryNode));
-        lookup.put("node2", new SearchAsyncActionTests.MockConnection(replicaNode));
+        lookup.put("node_1", new SearchAsyncActionTests.MockConnection(primaryNode));
+        lookup.put("node_2", new SearchAsyncActionTests.MockConnection(replicaNode));
 
         for (SortOrder order : SortOrder.values()) {
             List<ShardId> shardIds = new ArrayList<>();
@@ -351,7 +356,8 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
                 (clusterAlias, node) -> lookup.get(node),
                 Collections.singletonMap("_na_", new AliasFilter(null, Strings.EMPTY_ARRAY)),
                 Collections.emptyMap(), EsExecutors.newDirectExecutorService(),
-                searchRequest, null, shardsIter, timeProvider, ClusterState.EMPTY_STATE, null,
+                searchRequest, null, shardsIter, timeProvider, ClusterState.EMPTY_STATE,
+                new SearchTask(1, "type", "action", () -> "", TaskId.EMPTY_TASK_ID, Map.of()),
                 (iter) -> new SearchPhase("test") {
                     @Override
                     public void run() {
@@ -383,8 +389,8 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
         Map<String, Transport.Connection> lookup = new ConcurrentHashMap<>();
         DiscoveryNode primaryNode = new DiscoveryNode("node_1", buildNewFakeTransportAddress(), Version.CURRENT);
         DiscoveryNode replicaNode = new DiscoveryNode("node_2", buildNewFakeTransportAddress(), Version.CURRENT);
-        lookup.put("node1", new SearchAsyncActionTests.MockConnection(primaryNode));
-        lookup.put("node2", new SearchAsyncActionTests.MockConnection(replicaNode));
+        lookup.put("node_1", new SearchAsyncActionTests.MockConnection(primaryNode));
+        lookup.put("node_2", new SearchAsyncActionTests.MockConnection(replicaNode));
 
         for (SortOrder order : SortOrder.values()) {
             int numShards = randomIntBetween(2, 20);
@@ -428,7 +434,8 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
                 (clusterAlias, node) -> lookup.get(node),
                 Collections.singletonMap("_na_", new AliasFilter(null, Strings.EMPTY_ARRAY)),
                 Collections.emptyMap(), EsExecutors.newDirectExecutorService(),
-                searchRequest, null, shardsIter, timeProvider, ClusterState.EMPTY_STATE, null,
+                searchRequest, null, shardsIter, timeProvider, ClusterState.EMPTY_STATE,
+                new SearchTask(1, "type", "action", () -> "", TaskId.EMPTY_TASK_ID, Map.of()),
                 (iter) -> new SearchPhase("test") {
                     @Override
                     public void run() {
@@ -641,8 +648,8 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
         Map<String, Transport.Connection> lookup = new ConcurrentHashMap<>();
         DiscoveryNode primaryNode = new DiscoveryNode("node_1", buildNewFakeTransportAddress(), Version.CURRENT);
         DiscoveryNode replicaNode = new DiscoveryNode("node_2", buildNewFakeTransportAddress(), Version.CURRENT);
-        lookup.put("node1", new SearchAsyncActionTests.MockConnection(primaryNode));
-        lookup.put("node2", new SearchAsyncActionTests.MockConnection(replicaNode));
+        lookup.put("node_1", new SearchAsyncActionTests.MockConnection(primaryNode));
+        lookup.put("node_2", new SearchAsyncActionTests.MockConnection(replicaNode));
 
         List<String> indicesToSearch = new ArrayList<>();
         indicesToSearch.add(dataStream.getName());
@@ -737,7 +744,7 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
             shardsIter,
             timeProvider,
             ClusterState.EMPTY_STATE,
-            null,
+            new SearchTask(1, "type", "action", () -> "", TaskId.EMPTY_TASK_ID, Map.of()),
             (iter) -> new SearchPhase("test") {
                 @Override
                 public void run() throws IOException {

--- a/server/src/test/java/org/elasticsearch/action/search/SearchAsyncActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchAsyncActionTests.java
@@ -37,6 +37,8 @@ import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.search.internal.AliasFilter;
 import org.elasticsearch.search.internal.InternalSearchResponse;
 import org.elasticsearch.search.internal.ShardSearchContextId;
+import org.elasticsearch.tasks.TaskId;
+import org.elasticsearch.tasks.TaskSpan;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.TransportException;
@@ -114,13 +116,13 @@ public class SearchAsyncActionTests extends ESTestCase {
                 shardsIter,
                 new TransportSearchAction.SearchTimeProvider(0, 0, () -> 0),
                 ClusterState.EMPTY_STATE,
-                null,
+                new SearchTask(1, "type", "action", () -> "", TaskId.EMPTY_TASK_ID, Map.of()),
                 new ArraySearchPhaseResults<>(shardsIter.size()),
                 request.getMaxConcurrentShardRequests(),
                 SearchResponse.Clusters.EMPTY) {
 
                 @Override
-                protected void executePhaseOnShard(SearchShardIterator shardIt, SearchShardTarget shard,
+                protected void executePhaseOnShard(TaskSpan taskSpan, SearchShardIterator shardIt, SearchShardTarget shard,
                                                    SearchActionListener<TestSearchPhaseResult> listener) {
                     seenShard.computeIfAbsent(shard.getShardId(), (i) -> {
                         numRequests.incrementAndGet(); // only count this once per replica
@@ -219,13 +221,13 @@ public class SearchAsyncActionTests extends ESTestCase {
                 shardsIter,
                 new TransportSearchAction.SearchTimeProvider(0, 0, () -> 0),
                 ClusterState.EMPTY_STATE,
-                null,
+                new SearchTask(1, "type", "action", () -> "", TaskId.EMPTY_TASK_ID, Map.of()),
                 new ArraySearchPhaseResults<>(shardsIter.size()),
                 request.getMaxConcurrentShardRequests(),
                 SearchResponse.Clusters.EMPTY) {
 
                 @Override
-                protected void executePhaseOnShard(SearchShardIterator shardIt, SearchShardTarget shard,
+                protected void executePhaseOnShard(TaskSpan taskSpan, SearchShardIterator shardIt, SearchShardTarget shard,
                                                    SearchActionListener<TestSearchPhaseResult> listener) {
                     seenShard.computeIfAbsent(shard.getShardId(), (i) -> {
                         numRequests.incrementAndGet(); // only count this once per shard copy
@@ -321,14 +323,14 @@ public class SearchAsyncActionTests extends ESTestCase {
                         shardsIter,
                         new TransportSearchAction.SearchTimeProvider(0, 0, () -> 0),
                         ClusterState.EMPTY_STATE,
-                        null,
+                        new SearchTask(1, "type", "action", () -> "", TaskId.EMPTY_TASK_ID, Map.of()),
                         new ArraySearchPhaseResults<>(shardsIter.size()),
                         request.getMaxConcurrentShardRequests(),
                         SearchResponse.Clusters.EMPTY) {
             TestSearchResponse response = new TestSearchResponse();
 
             @Override
-            protected void executePhaseOnShard(SearchShardIterator shardIt, SearchShardTarget shard,
+            protected void executePhaseOnShard(TaskSpan taskSpan, SearchShardIterator shardIt, SearchShardTarget shard,
                                                SearchActionListener<TestSearchPhaseResult> listener) {
                 assertTrue("shard: " + shard.getShardId() + " has been queried twice", response.queried.add(shard.getShardId()));
                 Transport.Connection connection = getConnection(null, shard.getNodeId());
@@ -430,14 +432,15 @@ public class SearchAsyncActionTests extends ESTestCase {
                 shardsIter,
                 new TransportSearchAction.SearchTimeProvider(0, 0, () -> 0),
                 ClusterState.EMPTY_STATE,
-                null,
+                new SearchTask(1, "type", "action", () -> "", TaskId.EMPTY_TASK_ID, Map.of()),
                 new ArraySearchPhaseResults<>(shardsIter.size()),
                 request.getMaxConcurrentShardRequests(),
                 SearchResponse.Clusters.EMPTY) {
                 TestSearchResponse response = new TestSearchResponse();
 
                 @Override
-                protected void executePhaseOnShard(SearchShardIterator shardIt,
+                protected void executePhaseOnShard(TaskSpan taskSpan,
+                                                   SearchShardIterator shardIt,
                                                    SearchShardTarget shard,
                                                    SearchActionListener<TestSearchPhaseResult> listener) {
                     assertTrue("shard: " + shard.getShardId() + " has been queried twice", response.queried.add(shard.getShardId()));
@@ -530,13 +533,13 @@ public class SearchAsyncActionTests extends ESTestCase {
                 shardsIter,
                 new TransportSearchAction.SearchTimeProvider(0, 0, () -> 0),
                 ClusterState.EMPTY_STATE,
-                null,
+                new SearchTask(1, "type", "action", () -> "", TaskId.EMPTY_TASK_ID, Map.of()),
                 new ArraySearchPhaseResults<>(shardsIter.size()),
                 request.getMaxConcurrentShardRequests(),
                 SearchResponse.Clusters.EMPTY) {
 
                 @Override
-                protected void executePhaseOnShard(SearchShardIterator shardIt, SearchShardTarget shard,
+                protected void executePhaseOnShard(TaskSpan taskSpan, SearchShardIterator shardIt, SearchShardTarget shard,
                                                    SearchActionListener<TestSearchPhaseResult> listener) {
                     seenShard.computeIfAbsent(shard.getShardId(), (i) -> {
                         numRequests.incrementAndGet(); // only count this once per shard copy
@@ -617,13 +620,13 @@ public class SearchAsyncActionTests extends ESTestCase {
                 shardsIter,
                 new TransportSearchAction.SearchTimeProvider(0, 0, () -> 0),
                 ClusterState.EMPTY_STATE,
-                null,
+                new SearchTask(1, "type", "action", () -> "", TaskId.EMPTY_TASK_ID, Map.of()),
                 new ArraySearchPhaseResults<>(shardsIter.size()),
                 request.getMaxConcurrentShardRequests(),
                 SearchResponse.Clusters.EMPTY) {
 
                 @Override
-                protected void executePhaseOnShard(SearchShardIterator shardIt, SearchShardTarget shard,
+                protected void executePhaseOnShard(TaskSpan taskSpan, SearchShardIterator shardIt, SearchShardTarget shard,
                                                    SearchActionListener<TestSearchPhaseResult> listener) {
                     assert false : "Expected to skip all shards";
                 }

--- a/server/src/test/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncActionTests.java
@@ -241,13 +241,13 @@ public class SearchQueryThenFetchAsyncActionTests extends ESTestCase {
         routingNewVersionShard = routingNewVersionShard.initialize(newVersionNode.getId(), "p0", 0);
         routingNewVersionShard.started();
         list.add(new SearchShardIterator(null, new ShardId(new Index("idx", "_na_"), 0), singletonList(routingNewVersionShard), idx));
-        
+
         ShardRouting routingOldVersionShard = ShardRouting.newUnassigned(new ShardId(new Index("idx", "_na_"), 1), true,
             RecoverySource.EmptyStoreRecoverySource.INSTANCE, new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "foobar"));
         routingOldVersionShard = routingOldVersionShard.initialize(oldVersionNode.getId(), "p1", 0);
         routingOldVersionShard.started();
         list.add(new SearchShardIterator(null, new ShardId(new Index("idx", "_na_"), 1), singletonList(routingOldVersionShard), idx));
-        
+
         GroupShardsIterator<SearchShardIterator> shardsIter = new GroupShardsIterator<>(list);
         final SearchRequest searchRequest = new SearchRequest(minVersion);
         searchRequest.setMaxConcurrentShardRequests(numConcurrent);
@@ -291,7 +291,7 @@ public class SearchQueryThenFetchAsyncActionTests extends ESTestCase {
         Version newVersion = Version.CURRENT;
         Version oldVersion = VersionUtils.randomPreviousCompatibleVersion(random(), newVersion);
         Version minVersion = oldVersion;
-        
+
         final TransportSearchAction.SearchTimeProvider timeProvider =
             new TransportSearchAction.SearchTimeProvider(0, System.nanoTime(), System::nanoTime);
         AtomicInteger successfulOps = new AtomicInteger();
@@ -309,13 +309,13 @@ public class SearchQueryThenFetchAsyncActionTests extends ESTestCase {
         routingNewVersionShard = routingNewVersionShard.initialize(newVersionNode.getId(), "p0", 0);
         routingNewVersionShard.started();
         list.add(new SearchShardIterator(null, new ShardId(new Index("idx", "_na_"), 0), singletonList(routingNewVersionShard), idx));
-        
+
         ShardRouting routingOldVersionShard = ShardRouting.newUnassigned(new ShardId(new Index("idx", "_na_"), 1), true,
             RecoverySource.EmptyStoreRecoverySource.INSTANCE, new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "foobar"));
         routingOldVersionShard = routingOldVersionShard.initialize(oldVersionNode.getId(), "p1", 0);
         routingOldVersionShard.started();
         list.add(new SearchShardIterator(null, new ShardId(new Index("idx", "_na_"), 1), singletonList(routingOldVersionShard), idx));
-        
+
         GroupShardsIterator<SearchShardIterator> shardsIter = new GroupShardsIterator<>(list);
         final SearchRequest searchRequest = new SearchRequest(minVersion);
         searchRequest.allowPartialSearchResults(false);
@@ -390,7 +390,7 @@ public class SearchQueryThenFetchAsyncActionTests extends ESTestCase {
         Version newVersion = Version.CURRENT;
         Version oldVersion = VersionUtils.randomPreviousCompatibleVersion(random(), newVersion);
         Version minVersion = newVersion;
-        
+
         final TransportSearchAction.SearchTimeProvider timeProvider =
             new TransportSearchAction.SearchTimeProvider(0, System.nanoTime(), System::nanoTime);
         AtomicInteger successfulOps = new AtomicInteger();
@@ -410,13 +410,13 @@ public class SearchQueryThenFetchAsyncActionTests extends ESTestCase {
         routingNewVersionShard1 = routingNewVersionShard1.initialize(newVersionNode1.getId(), "p0", 0);
         routingNewVersionShard1.started();
         list.add(new SearchShardIterator(null, new ShardId(new Index("idx", "_na_"), 0), singletonList(routingNewVersionShard1), idx));
-        
+
         ShardRouting routingNewVersionShard2 = ShardRouting.newUnassigned(new ShardId(new Index("idx", "_na_"), 1), true,
             RecoverySource.EmptyStoreRecoverySource.INSTANCE, new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "foobar"));
         routingNewVersionShard2 = routingNewVersionShard2.initialize(newVersionNode2.getId(), "p1", 0);
         routingNewVersionShard2.started();
         list.add(new SearchShardIterator(null, new ShardId(new Index("idx", "_na_"), 1), singletonList(routingNewVersionShard2), idx));
-        
+
         GroupShardsIterator<SearchShardIterator> shardsIter = new GroupShardsIterator<>(list);
         final SearchRequest searchRequest = new SearchRequest(minVersion);
         searchRequest.allowPartialSearchResults(false);
@@ -495,11 +495,12 @@ public class SearchQueryThenFetchAsyncActionTests extends ESTestCase {
         SearchActionListener<SearchPhaseResult> listener = new SearchActionListener<SearchPhaseResult>(searchShardTarget, 0) {
             @Override
             public void onFailure(Exception e) { }
-            
+
             @Override
             protected void innerOnResponse(SearchPhaseResult response) { }
         };
-        Exception e = expectThrows(VersionMismatchException.class, () -> action.executePhaseOnShard(shardIt, searchShardTarget, listener));
+        Exception e = expectThrows(VersionMismatchException.class,
+            () -> action.executePhaseOnShard(task.newSpan(), shardIt, searchShardTarget, listener));
         assertThat(e.getMessage(), equalTo("One of the shards is incompatible with the required minimum version [" + minVersion + "]"));
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/TransportOpenPointInTimeAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/TransportOpenPointInTimeAction.java
@@ -79,7 +79,7 @@ public class TransportOpenPointInTimeAction extends HandledTransportAction<OpenP
             searchRequest,
             "open_search_context",
             true,
-            (searchTask, shardTarget, connection, phaseListener) -> {
+            (searchTask, taskSpan, shardTarget, connection, phaseListener) -> {
                 final ShardOpenReaderRequest shardRequest = new ShardOpenReaderRequest(
                     shardTarget.getShardId(),
                     shardTarget.getOriginalIndices(),

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/EnrichStatsResponseTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/EnrichStatsResponseTests.java
@@ -60,6 +60,18 @@ public class EnrichStatsResponseTests extends AbstractWireSerializingTestCase<En
         Map<String, String> headers = randomBoolean()
             ? Collections.emptyMap()
             : Collections.singletonMap(randomAlphaOfLength(5), randomAlphaOfLength(5));
-        return new TaskInfo(taskId, type, action, description, null, startTime, runningTimeNanos, cancellable, parentTaskId, headers);
+        return new TaskInfo(
+            taskId,
+            type,
+            action,
+            description,
+            null,
+            startTime,
+            runningTimeNanos,
+            cancellable,
+            parentTaskId,
+            headers,
+            List.of()
+        );
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlDailyMaintenanceServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlDailyMaintenanceServiceTests.java
@@ -36,6 +36,7 @@ import org.junit.Before;
 import org.mockito.stubbing.Answer;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -163,7 +164,8 @@ public class MlDailyMaintenanceServiceTests extends ESTestCase {
                 0,
                 true,
                 new TaskId("test", 456),
-                Collections.emptyMap());
+                Collections.emptyMap(),
+                List.of());
 
         when(clusterService.state()).thenReturn(createClusterState(false));
         doAnswer(withResponse(new DeleteExpiredDataAction.Response(true)))


### PR DESCRIPTION
Sample output from `GET /_tasks?detailed` with remote executions:

```json
"XZASbZrBSHGvjp5CqcOnYQ:270": {
    "node": "XZASbZrBSHGvjp5CqcOnYQ",
    "id": 270,
    "type": "transport",
    "action": "indices:data/read/search",
    "description": "indices[], search_type[QUERY_THEN_FETCH], source[{\"size\":100}]",
    "start_time_in_millis": 1611867972293,
    "running_time_in_nanos": 697426025,
    "cancellable": true,
    "headers": {},
    "spans": [
        {
            "status": "running",
            "start_time_in_millis": 1611867972293,
            "running_time_in_millis": 697,
            "phase": "query",
            "total_shards": 2,
            "skip_shards": 0,
            "children": [
                {
                    "status": "waiting",
                    "start_time_in_millis": 1611867972293,
                    "running_time_in_millis": 697,
                    "remote_action": "indices:data/read/search[phase/query]",
                    "shard-index": 0,
                    "remote_node": "runTask-0",
                    "target": "[XZASbZrBSHGvjp5CqcOnYQ][index-1][0]"
                },
                {
                    "status": "waiting",
                    "start_time_in_millis": 1611867972294,
                    "running_time_in_millis": 696,
                    "remote_action": "indices:data/read/search[phase/query]",
                    "shard-index": 1,
                    "remote_node": "runTask-0",
                    "target": "[XZASbZrBSHGvjp5CqcOnYQ][index-2][0]"
                }
            ]
        }
    ]
}
````


With local executions:

```json
"XZASbZrBSHGvjp5CqcOnYQ:271": {
    "node": "XZASbZrBSHGvjp5CqcOnYQ",
    "id": 271,
    "type": "direct",
    "action": "indices:data/read/search[phase/query]",
    "description": "shardId[[index-1][0]]",
    "start_time_in_millis": 1611867972293,
    "running_time_in_nanos": 696930850,
    "cancellable": true,
    "parent_task_id": "XZASbZrBSHGvjp5CqcOnYQ:270",
    "headers": {},
    "spans": [
        {
            "status": "completed",
            "start_time_in_millis": 1611867972293,
            "running_time_in_millis": 1,
            "shard_id": "[index-1][0]",
            "step": "rewrite_and_fetch"
        },
        {
            "status": "completed",
            "start_time_in_millis": 1611867972294,
            "running_time_in_millis": 0,
            "shard_id": "[index-1][0]",
            "step": "await_shard_search_active"
        },
        {
            "status": "running",
            "start_time_in_millis": 1611867972294,
            "running_time_in_millis": 696,
            "can_cache": false,
            "thread_name": "elasticsearch[runTask-0][search][T#16]",
            "step": "query"
        }
    ]
}
 ```