### PR TITLE
Remove unregistered discovery settings from old docs

### DIFF
--- a/docs/reference/modules/discovery/discovery-settings.asciidoc
+++ b/docs/reference/modules/discovery/discovery-settings.asciidoc
@@ -74,16 +74,6 @@ or may become unstable or intolerant of certain failures.
     Sets how long a node will wait before attempting another discovery round.
     Defaults to `1s`.
 
-`discovery.probe.connect_timeout`::
-
-    Sets how long to wait when attempting to connect to each address. Defaults
-    to `3s`.
-
-`discovery.probe.handshake_timeout`::
-
-    Sets how long to wait when attempting to identify the remote node via a
-    handshake. Defaults to `1s`.
-
 `discovery.request_peers_timeout`::
 
     Sets how long a node will wait after asking its peers again before


### PR DESCRIPTION
The following settings are not exposed to users in 7.6 and earlier:

- `discovery.probe.connect_timeout`
- `discovery.probe.handshake_timeout`

This was addressed in 7.7 (#51304) but the docs for older versions
suggest incorrectly that these settings are available. This commit
removes the docs for these settings in the affected versions to avoid
confusion.