### PR TITLE
Simplify non transitive setup on sourceSet configs

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/JavaRestTestPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/JavaRestTestPlugin.java
@@ -53,9 +53,6 @@ public class JavaRestTestPlugin implements Plugin<Project> {
         SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
         SourceSet javaTestSourceSet = sourceSets.create(SOURCE_SET_NAME);
 
-        // disable transitive dependency management
-        GradleUtils.disableTransitiveDependenciesForSourceSet(project, javaTestSourceSet);
-
         // create the test cluster container
         createTestCluster(project, javaTestSourceSet);
 

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/YamlRestTestPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/YamlRestTestPlugin.java
@@ -54,9 +54,6 @@ public class YamlRestTestPlugin implements Plugin<Project> {
         SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
         SourceSet yamlTestSourceSet = sourceSets.create(SOURCE_SET_NAME);
 
-        // disable transitive dependency management
-        GradleUtils.disableTransitiveDependenciesForSourceSet(project, yamlTestSourceSet);
-
         // create the test cluster container
         createTestCluster(project, yamlTestSourceSet);
 

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/util/GradleUtils.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/util/GradleUtils.java
@@ -48,9 +48,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.Function;
-import java.util.stream.Stream;
 
 public abstract class GradleUtils {
 
@@ -142,8 +140,6 @@ public abstract class GradleUtils {
         extendSourceSet(project, SourceSet.MAIN_SOURCE_SET_NAME, sourceSetName);
 
         setupIdeForTestSourceSet(project, testSourceSet);
-
-        disableTransitiveDependenciesForSourceSet(project, testSourceSet);
 
         // add to the check task
         project.getTasks().named(JavaBasePlugin.CHECK_TASK_NAME).configure(check -> check.dependsOn(testTask));
@@ -239,19 +235,7 @@ public abstract class GradleUtils {
             || projectPath.startsWith(":x-pack:quota-aware-fs");
     }
 
-    public static void disableTransitiveDependenciesForSourceSet(Project project, SourceSet sourceSet) {
-        Stream.of(
-            sourceSet.getApiConfigurationName(),
-            sourceSet.getImplementationConfigurationName(),
-            sourceSet.getCompileOnlyConfigurationName(),
-            sourceSet.getRuntimeOnlyConfigurationName()
-        )
-            .map(name -> project.getConfigurations().findByName(name))
-            .filter(Objects::nonNull)
-            .forEach(GradleUtils::disableTransitiveDependencies);
-    }
-
-    private static void disableTransitiveDependencies(Configuration config) {
+    public static void disableTransitiveDependencies(Configuration config) {
         config.getDependencies().all(dep -> {
             if (dep instanceof ModuleDependency
                 && dep instanceof ProjectDependency == false


### PR DESCRIPTION
This simplifies how transitive dependency resolution for configurations linked to sourceSets
is configured.

A follow up on https://github.com/elastic/elasticsearch/pull/68019