### PR TITLE
BACKPORT 712 HttpCertificateCommand PKCS12 filetype auto-detect in JDK16 (#68072)

### DIFF
--- a/x-pack/plugin/security/cli/src/main/java/org/elasticsearch/xpack/security/cli/HttpCertificateCommand.java
+++ b/x-pack/plugin/security/cli/src/main/java/org/elasticsearch/xpack/security/cli/HttpCertificateCommand.java
@@ -108,6 +108,7 @@ class HttpCertificateCommand extends EnvironmentAwareCommand {
      * Magic bytes for an empty PKCS#12 file
      */
     private static final byte[] MAGIC_BYTES2_PKCS12 = new byte[] { (byte) 0x30, (byte) 0x56 };
+    private static final byte[] MAGIC_BYTES2_JDK16_PKCS12 = new byte[] { (byte) 0x30, (byte) 0x65 };
     /**
      * Magic bytes for a JKS keystore
      */
@@ -1103,7 +1104,9 @@ class HttpCertificateCommand extends EnvironmentAwareCommand {
                 // No supported file type has less than 2 bytes
                 return FileType.UNRECOGNIZED;
             }
-            if (Arrays.equals(leadingBytes, MAGIC_BYTES1_PKCS12) || Arrays.equals(leadingBytes, MAGIC_BYTES2_PKCS12)) {
+            if (Arrays.equals(leadingBytes, MAGIC_BYTES1_PKCS12) ||
+                    Arrays.equals(leadingBytes, MAGIC_BYTES2_PKCS12) ||
+                    Arrays.equals(leadingBytes, MAGIC_BYTES2_JDK16_PKCS12)) {
                 return FileType.PKCS12;
             }
             if (Arrays.equals(leadingBytes, MAGIC_BYTES_JKS)) {


### PR DESCRIPTION
Backport of https://github.com/elastic/elasticsearch/pull/68072

JDK16 updated the default encryption and MAC algorithms used in PKCS#12.
Because of it, the empty keystore fingerprint (the first two bytes) has changed.
This PR updates the PKCS12 detection rule so that the http certificate command
identifies empty keystores created in JDK16.