### PR TITLE
Add runtime geo_point distance_feature query (#68094)

### DIFF
--- a/x-pack/plugin/runtime-fields/qa/build.gradle
+++ b/x-pack/plugin/runtime-fields/qa/build.gradle
@@ -60,8 +60,6 @@ subprojects {
           'field_caps/30_filter/Field caps with index filter', // We don't support filtering field caps on runtime fields. What should we do?
           'search.aggregation/220_filters_bucket/cache', // runtime keyword does not support split_queries_on_whitespace
           'search/140_pre_filter_search_shards/pre_filter_shard_size with shards that have no hit',
-          //distance feature query needs to be implemented for geo_point runtime field: https://github.com/elastic/elasticsearch/issues/67910
-          'search/250_distance_feature/test distance_feature query on geo_point type',
           //completion suggester does not return options when the context field is a geo_point runtime field
           'suggest/30_context/Multi contexts should work',
           /////// TO FIX ///////

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/GeoPointScriptFieldDistanceFeatureQuery.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/query/GeoPointScriptFieldDistanceFeatureQuery.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.geo.GeoEncodingUtils;
+import org.apache.lucene.geo.GeoUtils;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.Explanation;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.TwoPhaseIterator;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.util.SloppyMath;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.xpack.runtimefields.mapper.AbstractLongFieldScript;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+
+public final class GeoPointScriptFieldDistanceFeatureQuery extends AbstractScriptFieldQuery<AbstractLongFieldScript> {
+    private final double originLat;
+    private final double originLon;
+    private final double pivotDistance;
+
+    public GeoPointScriptFieldDistanceFeatureQuery(
+        Script script,
+        Function<LeafReaderContext, AbstractLongFieldScript> leafFactory,
+        String fieldName,
+        double originLat,
+        double originLon,
+        double pivotDistance
+    ) {
+        super(script, fieldName, leafFactory);
+        GeoUtils.checkLatitude(originLat);
+        GeoUtils.checkLongitude(originLon);
+        this.originLon = originLon;
+        this.originLat = originLat;
+        if (pivotDistance <= 0) {
+            throw new IllegalArgumentException("pivotDistance must be > 0, got " + pivotDistance);
+        }
+        this.pivotDistance = pivotDistance;
+    }
+
+    double lat() {
+        return originLat;
+    }
+
+    double lon() {
+        return originLon;
+    }
+
+    double pivot() {
+        return pivotDistance;
+    }
+
+    @Override
+    protected boolean matches(AbstractLongFieldScript scriptContext, int docId) {
+        scriptContext.runForDoc(docId);
+        return scriptContext.count() > 0;
+    }
+
+    @Override
+    public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) {
+        return new Weight(this) {
+            @Override
+            public boolean isCacheable(LeafReaderContext ctx) {
+                return false;
+            }
+
+            @Override
+            public void extractTerms(Set<Term> terms) {}
+
+            @Override
+            public Scorer scorer(LeafReaderContext context) {
+                return new DistanceScorer(this, scriptContextFunction().apply(context), context.reader().maxDoc(), boost);
+            }
+
+            @Override
+            public Explanation explain(LeafReaderContext context, int doc) {
+                AbstractLongFieldScript script = scriptContextFunction().apply(context);
+                script.runForDoc(doc);
+                long encoded = valueWithMinAbsoluteDistance(script);
+                int latitudeBits = (int) (encoded >> 32);
+                int longitudeBits = (int) (encoded & 0xFFFFFFFF);
+                double lat = GeoEncodingUtils.decodeLatitude(latitudeBits);
+                double lon = GeoEncodingUtils.decodeLongitude(longitudeBits);
+                double distance = SloppyMath.haversinMeters(originLat, originLon, lat, lon);
+                float score = (float) (boost * (pivotDistance / (pivotDistance + distance)));
+                return Explanation.match(
+                    score,
+                    "Distance score, computed as weight * pivotDistance / (pivotDistance + abs(distance)) from:",
+                    Explanation.match(boost, "weight"),
+                    Explanation.match(pivotDistance, "pivotDistance"),
+                    Explanation.match(originLat, "originLat"),
+                    Explanation.match(originLon, "originLon"),
+                    Explanation.match(lat, "current lat"),
+                    Explanation.match(lon, "current lon"),
+                    Explanation.match(distance, "distance")
+                );
+            }
+        };
+    }
+
+    private class DistanceScorer extends Scorer {
+
+        private final AbstractLongFieldScript script;
+        private final TwoPhaseIterator twoPhase;
+        private final DocIdSetIterator disi;
+        private final float weight;
+        private double maxDistance = GeoUtils.EARTH_MEAN_RADIUS_METERS * Math.PI;
+
+        protected DistanceScorer(Weight weight, AbstractLongFieldScript script, int maxDoc, float boost) {
+            super(weight);
+            this.script = script;
+            twoPhase = new TwoPhaseIterator(DocIdSetIterator.all(maxDoc)) {
+                @Override
+                public boolean matches() {
+                    return GeoPointScriptFieldDistanceFeatureQuery.this.matches(script, approximation.docID());
+                }
+
+                @Override
+                public float matchCost() {
+                    return MATCH_COST;
+                }
+            };
+            disi = TwoPhaseIterator.asDocIdSetIterator(twoPhase);
+            this.weight = boost;
+        }
+
+        @Override
+        public int docID() {
+            return disi.docID();
+        }
+
+        @Override
+        public float score() throws IOException {
+            if (script.count() == 0) {
+                return 0;
+            }
+            return GeoPointScriptFieldDistanceFeatureQuery.this.score(weight, getDistance(script));
+        }
+
+        @Override
+        public float getMaxScore(int upTo) {
+            return weight;
+        }
+
+        @Override
+        public DocIdSetIterator iterator() {
+            return disi;
+        }
+
+        @Override
+        public TwoPhaseIterator twoPhaseIterator() {
+            return twoPhase;
+        }
+    }
+
+    private double getDistance(AbstractLongFieldScript script) {
+        double minDistance = Double.POSITIVE_INFINITY;
+        for (int i = 0; i < script.count(); i++) {
+            minDistance = Math.min(minDistance, getDistanceFromEncoded(script.values()[i]));
+        }
+        return minDistance;
+    }
+
+    private double getDistanceFromEncoded(long encoded) {
+        int latitudeBits = (int) (encoded >> 32);
+        int longitudeBits = (int) (encoded & 0xFFFFFFFF);
+        double lat = GeoEncodingUtils.decodeLatitude(latitudeBits);
+        double lon = GeoEncodingUtils.decodeLongitude(longitudeBits);
+        return SloppyMath.haversinMeters(originLat, originLon, lat, lon);
+    }
+
+    long valueWithMinAbsoluteDistance(AbstractLongFieldScript script) {
+        double minDistance = Double.POSITIVE_INFINITY;
+        long minDistanceValue = Long.MAX_VALUE;
+        for (int i = 0; i < script.count(); i++) {
+            double distance = getDistanceFromEncoded(script.values()[i]);
+            if (distance < minDistance) {
+                minDistance = distance;
+                minDistanceValue = script.values()[i];
+            }
+        }
+        return minDistanceValue;
+    }
+
+    float score(float weight, double distance) {
+        return (float) (weight * (pivotDistance / (pivotDistance + distance)));
+    }
+
+    @Override
+    public String toString(String field) {
+        StringBuilder b = new StringBuilder();
+        if (false == fieldName().equals(field)) {
+            b.append(fieldName()).append(":");
+        }
+        b.append(getClass().getSimpleName());
+        b.append("(lat=").append(originLat);
+        b.append(",lon=").append(originLon);
+        b.append(",pivot=").append(pivotDistance).append(")");
+        return b.toString();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), originLat, originLon, pivotDistance);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (false == super.equals(obj)) {
+            return false;
+        }
+        GeoPointScriptFieldDistanceFeatureQuery other = (GeoPointScriptFieldDistanceFeatureQuery) obj;
+        return originLon == other.originLon && originLat == other.originLat && pivotDistance == other.pivotDistance;
+    }
+
+    @Override
+    public void visit(QueryVisitor visitor) {
+        if (visitor.acceptField(fieldName())) {
+            visitor.visitLeaf(this);
+        }
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/GeoPointScriptFieldDistanceFeatureQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/GeoPointScriptFieldDistanceFeatureQueryTests.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.query;
+
+import org.apache.lucene.document.StoredField;
+import org.apache.lucene.geo.GeoTestUtil;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.RandomIndexWriter;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.geo.GeoPoint;
+import org.elasticsearch.common.geo.GeoUtils;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.search.lookup.SearchLookup;
+import org.elasticsearch.xpack.runtimefields.mapper.AbstractLongFieldScript;
+import org.elasticsearch.xpack.runtimefields.mapper.GeoPointFieldScript;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class GeoPointScriptFieldDistanceFeatureQueryTests extends AbstractScriptFieldQueryTestCase<
+    GeoPointScriptFieldDistanceFeatureQuery> {
+    private final Function<LeafReaderContext, AbstractLongFieldScript> leafFactory = ctx -> null;
+
+    @Override
+    protected GeoPointScriptFieldDistanceFeatureQuery createTestInstance() {
+        double lat = GeoTestUtil.nextLatitude();
+        double lon = GeoTestUtil.nextLongitude();
+        double pivot = randomDouble() * GeoUtils.EARTH_EQUATOR;
+        return new GeoPointScriptFieldDistanceFeatureQuery(randomScript(), leafFactory, randomAlphaOfLength(5), lat, lon, pivot);
+    }
+
+    @Override
+    protected GeoPointScriptFieldDistanceFeatureQuery copy(GeoPointScriptFieldDistanceFeatureQuery orig) {
+        return new GeoPointScriptFieldDistanceFeatureQuery(
+            orig.script(),
+            leafFactory,
+            orig.fieldName(),
+            orig.lat(),
+            orig.lon(),
+            orig.pivot()
+        );
+    }
+
+    @Override
+    protected GeoPointScriptFieldDistanceFeatureQuery mutate(GeoPointScriptFieldDistanceFeatureQuery orig) {
+        Script script = orig.script();
+        String fieldName = orig.fieldName();
+        double lat = orig.lat();
+        double lon = orig.lon();
+        double pivot = orig.pivot();
+        switch (randomInt(4)) {
+            case 0:
+                script = randomValueOtherThan(script, this::randomScript);
+                break;
+            case 1:
+                fieldName += "modified";
+                break;
+            case 2:
+                lat = randomValueOtherThan(lat, GeoTestUtil::nextLatitude);
+                break;
+            case 3:
+                lon = randomValueOtherThan(lon, GeoTestUtil::nextLongitude);
+                break;
+            case 4:
+                pivot = randomValueOtherThan(pivot, () -> randomDouble() * GeoUtils.EARTH_EQUATOR);
+                break;
+            default:
+                fail();
+        }
+        return new GeoPointScriptFieldDistanceFeatureQuery(script, leafFactory, fieldName, lat, lon, pivot);
+    }
+
+    @Override
+    public void testMatches() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"location\": [34, 6]}"))));
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"location\": [-3.56, -45.98]}"))));
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                SearchLookup searchLookup = new SearchLookup(null, null);
+                Function<LeafReaderContext, AbstractLongFieldScript> leafFactory = ctx -> new GeoPointFieldScript(
+                    "test",
+                    Map.of(),
+                    searchLookup,
+                    ctx
+                ) {
+                    final GeoPoint point = new GeoPoint();
+
+                    @Override
+                    public void execute() {
+                        GeoUtils.parseGeoPoint(searchLookup.source().get("location"), point, true);
+                        emit(point.lat(), point.lon());
+                    }
+                };
+                GeoPointScriptFieldDistanceFeatureQuery query = new GeoPointScriptFieldDistanceFeatureQuery(
+                    randomScript(),
+                    leafFactory,
+                    "test",
+                    0,
+                    0,
+                    30000
+                );
+                TopDocs td = searcher.search(query, 2);
+                assertThat(td.scoreDocs[0].score, equalTo(0.0077678584F));
+                assertThat(td.scoreDocs[0].doc, equalTo(0));
+                assertThat(td.scoreDocs[1].score, equalTo(0.005820022F));
+                assertThat(td.scoreDocs[1].doc, equalTo(1));
+            }
+        }
+    }
+
+    public void testMaxScore() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(List.of());
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                GeoPointScriptFieldDistanceFeatureQuery query = createTestInstance();
+                float boost = randomFloat();
+                assertThat(
+                    query.createWeight(searcher, ScoreMode.COMPLETE, boost).scorer(reader.leaves().get(0)).getMaxScore(randomInt()),
+                    equalTo(boost)
+                );
+            }
+        }
+    }
+
+    @Override
+    protected void assertToString(GeoPointScriptFieldDistanceFeatureQuery query) {
+        assertThat(
+            query.toString(query.fieldName()),
+            equalTo("GeoPointScriptFieldDistanceFeatureQuery(lat=" + query.lat() + ",lon=" + query.lon() + ",pivot=" + query.pivot() + ")")
+        );
+    }
+
+    @Override
+    public final void testVisit() {
+        assertEmptyVisit();
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/GeoPointScriptFieldDistanceFeatureQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/GeoPointScriptFieldDistanceFeatureQueryTests.java
@@ -24,8 +24,7 @@ import org.elasticsearch.xpack.runtimefields.mapper.AbstractLongFieldScript;
 import org.elasticsearch.xpack.runtimefields.mapper.GeoPointFieldScript;
 
 import java.io.IOException;
-import java.util.List;
-import java.util.Map;
+import java.util.Collections;
 import java.util.function.Function;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -86,14 +85,14 @@ public class GeoPointScriptFieldDistanceFeatureQueryTests extends AbstractScript
     @Override
     public void testMatches() throws IOException {
         try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"location\": [34, 6]}"))));
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"location\": [-3.56, -45.98]}"))));
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"location\": [34, 6]}"))));
+            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"location\": [-3.56, -45.98]}"))));
             try (DirectoryReader reader = iw.getReader()) {
                 IndexSearcher searcher = newSearcher(reader);
                 SearchLookup searchLookup = new SearchLookup(null, null);
                 Function<LeafReaderContext, AbstractLongFieldScript> leafFactory = ctx -> new GeoPointFieldScript(
                     "test",
-                    Map.of(),
+                    Collections.emptyMap(),
                     searchLookup,
                     ctx
                 ) {
@@ -124,7 +123,7 @@ public class GeoPointScriptFieldDistanceFeatureQueryTests extends AbstractScript
 
     public void testMaxScore() throws IOException {
         try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
-            iw.addDocument(List.of());
+            iw.addDocument(Collections.emptyList());
             try (DirectoryReader reader = iw.getReader()) {
                 IndexSearcher searcher = newSearcher(reader);
                 GeoPointScriptFieldDistanceFeatureQuery query = createTestInstance();

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/GeoPointScriptFieldDistanceFeatureQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/GeoPointScriptFieldDistanceFeatureQueryTests.java
@@ -86,7 +86,9 @@ public class GeoPointScriptFieldDistanceFeatureQueryTests extends AbstractScript
     public void testMatches() throws IOException {
         try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
             iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"location\": [34, 6]}"))));
-            iw.addDocument(org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"location\": [-3.56, -45.98]}"))));
+            iw.addDocument(
+                org.elasticsearch.common.collect.List.of(new StoredField("_source", new BytesRef("{\"location\": [-3.56, -45.98]}")))
+            );
             try (DirectoryReader reader = iw.getReader()) {
                 IndexSearcher searcher = newSearcher(reader);
                 SearchLookup searchLookup = new SearchLookup(null, null);

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/100_geo_point.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/100_geo_point.yml
@@ -178,3 +178,27 @@ setup:
   - match: {hits.hits.3._source.location.lat: -63.24 }
   - match: {hits.hits.3._source.location.lon: 31.0 }
 
+---
+"distance_feature query":
+  - do:
+      search:
+        index: locations
+        body:
+          query:
+            bool:
+              should:
+                distance_feature:
+                  field: "location"
+                  pivot: "1000km"
+                  origin: [0.0, 0.0]
+
+  - match: {hits.total.value: 6}
+  - match: {hits.hits.0._source.location.lat: 0.0 }
+  - match: {hits.hits.0._source.location.lon: 0.0 }
+  - match: {hits.hits.1._source.location.lat: 13.5 }
+  - match: {hits.hits.1._source.location.lon: 34.89 }
+  - match: {hits.hits.2._source.location.lat: 32.45 }
+  - match: {hits.hits.2._source.location.lon: 45.6 }
+  - match: {hits.hits.3._source.location.lat: -63.24 }
+  - match: {hits.hits.3._source.location.lon: 31.0 }
+

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/101_geo_point_from_source.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/101_geo_point_from_source.yml
@@ -209,3 +209,32 @@ setup:
   - match: {hits.hits.4._source.location.0: "POINT(46.5 33.45)" }
   - match: {hits.hits.4._source.location.1: "POINT(45.4 32.75)" }
 
+---
+"distance_feature query":
+  - do:
+      search:
+        index: locations
+        body:
+          query:
+            bool:
+              should:
+                distance_feature:
+                  field: "location"
+                  pivot: "1000km"
+                  origin: [0.0, 0.0]
+  - match: {hits.total.value: 10}
+  - match: {hits.hits.0._source.location.lat: 0.0 }
+  - match: {hits.hits.0._source.location.lon: 0.0 }
+  - match: {hits.hits.1._source.location.0.0: -174.45 }
+  - match: {hits.hits.1._source.location.0.1: 46.78 }
+  - match: {hits.hits.1._source.location.1.0: 0.0 }
+  - match: {hits.hits.1._source.location.1.1: 1.0 }
+  - match: {hits.hits.2._source.location.0.lat: 13.0 }
+  - match: {hits.hits.2._source.location.0.lon: 34.0 }
+  - match: {hits.hits.2._source.location.1.lat: 14.0 }
+  - match: {hits.hits.2._source.location.1.lon: 35.0 }
+  - match: {hits.hits.3._source.location.lat: 13.5 }
+  - match: {hits.hits.3._source.location.lon: 34.89 }
+  - match: {hits.hits.4._source.location.0: "POINT(46.5 33.45)" }
+  - match: {hits.hits.4._source.location.1: "POINT(45.4 32.75)" }
+

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/102_geo_point_source_in_query.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/102_geo_point_source_in_query.yml
@@ -227,3 +227,35 @@ setup:
   - match: {hits.hits.4._source.location.0: "POINT(46.5 33.45)" }
   - match: {hits.hits.4._source.location.1: "POINT(45.4 32.75)" }
 
+---
+"distance_feature query":
+  - do:
+      search:
+        index: locations
+        body:
+          runtime_mappings:
+            location:
+              type: geo_point
+          query:
+            bool:
+              should:
+                distance_feature:
+                  field: "location"
+                  pivot: "1000km"
+                  origin: [0.0, 0.0]
+  - match: {hits.total.value: 10}
+  - match: {hits.hits.0._source.location.lat: 0.0 }
+  - match: {hits.hits.0._source.location.lon: 0.0 }
+  - match: {hits.hits.1._source.location.0.0: -174.45 }
+  - match: {hits.hits.1._source.location.0.1: 46.78 }
+  - match: {hits.hits.1._source.location.1.0: 0.0 }
+  - match: {hits.hits.1._source.location.1.1: 1.0 }
+  - match: {hits.hits.2._source.location.0.lat: 13.0 }
+  - match: {hits.hits.2._source.location.0.lon: 34.0 }
+  - match: {hits.hits.2._source.location.1.lat: 14.0 }
+  - match: {hits.hits.2._source.location.1.lon: 35.0 }
+  - match: {hits.hits.3._source.location.lat: 13.5 }
+  - match: {hits.hits.3._source.location.lon: 34.89 }
+  - match: {hits.hits.4._source.location.0: "POINT(46.5 33.45)" }
+  - match: {hits.hits.4._source.location.1: "POINT(45.4 32.75)" }
+


### PR DESCRIPTION
Add support for distance_feature query for runtime geo_point field. This was an oversight when initially added the field.

backport #68094