### PR TITLE
[7.x][ML] Add new hyperparams to config index mappings (#68103)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/ReservedFieldNames.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/ReservedFieldNames.java
@@ -337,12 +337,18 @@ public final class ReservedFieldNames {
             Classification.NUM_TOP_CLASSES.getPreferredName(),
             Classification.TRAINING_PERCENT.getPreferredName(),
             Classification.FEATURE_PROCESSORS.getPreferredName(),
+            BoostedTreeParams.ALPHA.getPreferredName(),
+            BoostedTreeParams.DOWNSAMPLE_FACTOR.getPreferredName(),
             BoostedTreeParams.LAMBDA.getPreferredName(),
             BoostedTreeParams.GAMMA.getPreferredName(),
             BoostedTreeParams.ETA.getPreferredName(),
+            BoostedTreeParams.ETA_GROWTH_RATE_PER_TREE.getPreferredName(),
+            BoostedTreeParams.MAX_OPTIMIZATION_ROUNDS_PER_HYPERPARAMETER.getPreferredName(),
             BoostedTreeParams.MAX_TREES.getPreferredName(),
             BoostedTreeParams.FEATURE_BAG_FRACTION.getPreferredName(),
             BoostedTreeParams.NUM_TOP_FEATURE_IMPORTANCE_VALUES.getPreferredName(),
+            BoostedTreeParams.SOFT_TREE_DEPTH_LIMIT.getPreferredName(),
+            BoostedTreeParams.SOFT_TREE_DEPTH_TOLERANCE.getPreferredName(),
 
             ElasticsearchMappings.CONFIG_TYPE,
 

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/core/ml/config_index_mappings.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/core/ml/config_index_mappings.json
@@ -25,10 +25,19 @@
         "properties" : {
           "classification" : {
             "properties" : {
+              "alpha" : {
+                "type" : "double"
+              },
               "dependent_variable" : {
                 "type" : "keyword"
               },
+              "downsample_factor" : {
+                "type" : "double"
+              },
               "eta" : {
+                "type" : "double"
+              },
+              "eta_growth_rate_per_tree" : {
                 "type" : "double"
               },
               "feature_bag_fraction" : {
@@ -42,6 +51,9 @@
               },
               "lambda" : {
                 "type" : "double"
+              },
+              "max_optimization_rounds_per_hyperparameter" : {
+                "type" : "integer"
               },
               "max_trees" : {
                 "type" : "integer"
@@ -57,6 +69,12 @@
               },
               "prediction_field_name" : {
                 "type" : "keyword"
+              },
+              "soft_tree_depth_limit" : {
+                "type" : "double"
+              },
+              "soft_tree_depth_tolerance" : {
+                "type" : "double"
               },
               "training_percent" : {
                 "type" : "double"
@@ -78,10 +96,19 @@
           },
           "regression" : {
             "properties" : {
+              "alpha" : {
+                "type" : "double"
+              },
               "dependent_variable" : {
                 "type" : "keyword"
               },
+              "downsample_factor" : {
+                "type" : "double"
+              },
               "eta" : {
+                "type" : "double"
+              },
+              "eta_growth_rate_per_tree" : {
                 "type" : "double"
               },
               "feature_bag_fraction" : {
@@ -102,6 +129,9 @@
               "loss_function_parameter" : {
                 "type" : "double"
               },
+              "max_optimization_rounds_per_hyperparameter" : {
+                "type" : "integer"
+              },
               "max_trees" : {
                 "type" : "integer"
               },
@@ -110,6 +140,12 @@
               },
               "prediction_field_name" : {
                 "type" : "keyword"
+              },
+              "soft_tree_depth_limit" : {
+                "type" : "double"
+              },
+              "soft_tree_depth_tolerance" : {
+                "type" : "double"
               },
               "training_percent" : {
                 "type" : "double"


### PR DESCRIPTION
This is a follow-up PR adding mappings for the hyperparams
that were added in #67950

Backport of #68103
