### PR TITLE
[7.10] [DOCS] Fix title abbrevs for API docs (#68118)

### DIFF
--- a/docs/reference/search/count.asciidoc
+++ b/docs/reference/search/count.asciidoc
@@ -1,5 +1,8 @@
 [[search-count]]
 === Count API
+++++
+<titleabbrev>Count</titleabbrev>
+++++
 
 Gets the number of matches for a search query.
 

--- a/docs/reference/search/explain.asciidoc
+++ b/docs/reference/search/explain.asciidoc
@@ -1,5 +1,8 @@
 [[search-explain]]
 === Explain API
+++++
+<titleabbrev>Explain</titleabbrev>
+++++
 
 Returns information about why a specific document matches (or doesn't match) a 
 query.

--- a/docs/reference/search/profile.asciidoc
+++ b/docs/reference/search/profile.asciidoc
@@ -1,5 +1,8 @@
 [[search-profile]]
 === Profile API
+++++
+<titleabbrev>Profile</titleabbrev>
+++++
 
 WARNING: The Profile API is a debugging tool and adds significant overhead to search execution.
 

--- a/docs/reference/search/search-shards.asciidoc
+++ b/docs/reference/search/search-shards.asciidoc
@@ -1,5 +1,8 @@
 [[search-shards]]
-=== Search Shards API
+=== Search shards API
+++++
+<titleabbrev>Search shards</titleabbrev>
+++++
 
 Returns the indices and shards that a search request would be executed against.
 

--- a/docs/reference/search/validate.asciidoc
+++ b/docs/reference/search/validate.asciidoc
@@ -1,5 +1,8 @@
 [[search-validate]]
 === Validate API
+++++
+<titleabbrev>Validate</titleabbrev>
+++++
 
 Validates a potentially expensive query without executing it.
 

--- a/x-pack/docs/en/rest-api/security/oidc-authenticate-api.asciidoc
+++ b/x-pack/docs/en/rest-api/security/oidc-authenticate-api.asciidoc
@@ -1,6 +1,9 @@
 [role="xpack"]
 [[security-api-oidc-authenticate]]
 === OpenID Connect authenticate API
+++++
+<titleabbrev>OpenID Connect authenticate</titleabbrev>
+++++
 
 Submits the response to an oAuth 2.0 authentication request for consumption from
 {es}. Upon successful validation, {es} will respond with an {es} internal Access

--- a/x-pack/docs/en/rest-api/security/oidc-logout-api.asciidoc
+++ b/x-pack/docs/en/rest-api/security/oidc-logout-api.asciidoc
@@ -1,6 +1,9 @@
 [role="xpack"]
 [[security-api-oidc-logout]]
 === OpenID Connect logout API
+++++
+<titleabbrev>OpenID Connect logout</titleabbrev>
+++++
 
 Submits a request to invalidate a refresh token and an access token that was
 generated as a response to a call to `/_security/oidc/authenticate`.

--- a/x-pack/docs/en/rest-api/security/oidc-prepare-authentication-api.asciidoc
+++ b/x-pack/docs/en/rest-api/security/oidc-prepare-authentication-api.asciidoc
@@ -1,6 +1,9 @@
 [role="xpack"]
 [[security-api-oidc-prepare-authentication]]
-=== OpenID Connect Prepare Authentication API
+=== OpenID Connect prepare authentication API
+++++
+<titleabbrev>OpenID Connect prepare authentication</titleabbrev>
+++++
 
 Creates an oAuth 2.0 authentication request as a URL string based on the
 configuration of the respective OpenID Connect authentication realm in {es}. 

--- a/x-pack/docs/en/rest-api/security/saml-authenticate-api.asciidoc
+++ b/x-pack/docs/en/rest-api/security/saml-authenticate-api.asciidoc
@@ -1,6 +1,9 @@
 [role="xpack"]
 [[security-api-saml-authenticate]]
 === SAML authenticate API
+++++
+<titleabbrev>SAML authenticate</titleabbrev>
+++++
 
 Submits a SAML `Response` message to {es} for consumption.
 

--- a/x-pack/docs/en/rest-api/security/saml-invalidate-api.asciidoc
+++ b/x-pack/docs/en/rest-api/security/saml-invalidate-api.asciidoc
@@ -1,6 +1,9 @@
 [role="xpack"]
 [[security-api-saml-invalidate]]
 === SAML invalidate API
+++++
+<titleabbrev>SAML invalidate</titleabbrev>
+++++
 
 Submits a SAML LogoutRequest message to {es} for consumption.
 

--- a/x-pack/docs/en/rest-api/security/saml-logout-api.asciidoc
+++ b/x-pack/docs/en/rest-api/security/saml-logout-api.asciidoc
@@ -1,6 +1,9 @@
 [role="xpack"]
 [[security-api-saml-logout]]
 === SAML logout API
+++++
+<titleabbrev>SAML logout</titleabbrev>
+++++
 
 Submits a request to invalidate an access token and refresh token.
 

--- a/x-pack/docs/en/rest-api/security/saml-prepare-authentication-api.asciidoc
+++ b/x-pack/docs/en/rest-api/security/saml-prepare-authentication-api.asciidoc
@@ -1,6 +1,9 @@
 [role="xpack"]
 [[security-api-saml-prepare-authentication]]
 === SAML prepare authentication API
+++++
+<titleabbrev>SAML prepare authentication</titleabbrev>
+++++
 
 Creates a SAML authentication request (`<AuthnRequest>`) as a URL string, based on the configuration of the respective SAML realm in {es}.
 


### PR DESCRIPTION
Backports the following commits to 7.10:
 - [DOCS] Fix title abbrevs for API docs (#68118)