### PR TITLE
[7.x] [DOCS] Add xrefs to rollup overview (#68119)

### DIFF
--- a/docs/reference/glossary.asciidoc
+++ b/docs/reference/glossary.asciidoc
@@ -424,6 +424,7 @@ ifdef::permanently-unreleased-branch[]
 // tag::rollup-def[]
 Aggregates an index's time series data and stores the results in a new read-only
 index. For example, you can roll up hourly data into daily or weekly summaries.
+See {ref}/xpack-rollup.html[Roll up your data].
 // end::rollup-def[]
 
 endif::[]

--- a/docs/reference/rollup/apis/put-job.asciidoc
+++ b/docs/reference/rollup/apis/put-job.asciidoc
@@ -11,8 +11,8 @@ ifdef::permanently-unreleased-branch[]
 
 // tag::legacy-rollup-admon[]
 WARNING: This documentation is about legacy rollups. Legacy rollups are
-deprecated and will be replaced by new rollup functionality introduced in {es}
-7.x.
+deprecated and will be replaced by <<xpack-rollup,new rollup functionality>>
+introduced in {es} 7.x.
 // end::legacy-rollup-admon[]
 
 Creates a legacy {rollup-job}.


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Add xrefs to rollup overview (#68119)