### PR TITLE
Don't Deduplicate RepositoryData Loading When Caching is Disabled

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/CorruptedBlobStoreRepositoryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/CorruptedBlobStoreRepositoryIT.java
@@ -244,7 +244,6 @@ public class CorruptedBlobStoreRepositoryIT extends AbstractSnapshotIntegTestCas
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/67696")
     public void testMountCorruptedRepositoryData() throws Exception {
         disableRepoConsistencyCheck("This test intentionally corrupts the repository contents");
         Client client = client();

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -1372,7 +1372,10 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         } else {
             logger.trace("[{}] loading un-cached repository data with best known repository generation [{}]", metadata.name(),
                     latestKnownRepoGen);
-            if (bestEffortConsistency) {
+            // Don't deduplicate repo data loading if we don't have strong consistency guarantees between the repo and the cluster state
+            // Also, if we are not caching repository data (for tests) we assume that the contents of the repository data at a given
+            // generation may change
+            if (bestEffortConsistency || cacheRepositoryData == false) {
                 threadPool.generic().execute(ActionRunnable.wrap(listener, this::doGetRepositoryData));
             } else {
                 repoDataDeduplicator.executeOnce(metadata, listener, (metadata, l) ->


### PR DESCRIPTION
Deduplicating repository data loading when deactivating caching (which is effectively a test only
setting that allows us to change the repo data at a given generation in place).
In the corner case of the result deduplicator not removing the request from the `requests` map
quickly enough when we update the repository data in place this causes the old version to be loaded still,
thus breaking repo corruption tests.

Instead of complicating the tests, this commit just turns off deduplication if caching is off since
its always on in production anyway.

Closes #67696
