### PR TITLE
[7.x] [DOCS] Fix the data stream stats api url in the doc (#64200)

### DIFF
--- a/docs/reference/indices/data-stream-stats.asciidoc
+++ b/docs/reference/indices/data-stream-stats.asciidoc
@@ -56,7 +56,7 @@ GET /_data_stream/my-data-stream/_stats
 [[data-stream-stats-api-request]]
 ==== {api-request-title}
 
-`GET /_data_stream/<data-stream>`
+`GET /_data_stream/<data-stream>/_stats`
 
 
 [[data-stream-stats-api-path-params]]


### PR DESCRIPTION
The data stream stats api's URL is not correct in the doc.

Backport of #64200.
