### PR TITLE
[7.x] Allow population of Enrich indices to work with System Index protections (#67406)

### DIFF
--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/AbstractAsyncBulkByScrollAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/AbstractAsyncBulkByScrollAction.java
@@ -103,7 +103,8 @@ public abstract class AbstractAsyncBulkByScrollAction<Request extends AbstractBu
     private final AtomicLong startTime = new AtomicLong(-1);
     private final Set<String> destinationIndices = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
-    private final ParentTaskAssigningClient client;
+    private final ParentTaskAssigningClient searchClient;
+    private final ParentTaskAssigningClient bulkClient;
     private final ActionListener<BulkByScrollResponse> listener;
     private final Retry bulkRetry;
     private final ScrollableHitSource scrollSource;
@@ -120,6 +121,14 @@ public abstract class AbstractAsyncBulkByScrollAction<Request extends AbstractBu
                                     boolean needsSourceDocumentSeqNoAndPrimaryTerm, Logger logger, ParentTaskAssigningClient client,
                                     ThreadPool threadPool, Request mainRequest, ActionListener<BulkByScrollResponse> listener,
                                     @Nullable ScriptService scriptService, @Nullable ReindexSslConfig sslConfig) {
+        this(task, needsSourceDocumentVersions, needsSourceDocumentSeqNoAndPrimaryTerm, logger, client, client, threadPool, mainRequest,
+            listener, scriptService, sslConfig);
+    }
+    AbstractAsyncBulkByScrollAction(BulkByScrollTask task, boolean needsSourceDocumentVersions,
+                                    boolean needsSourceDocumentSeqNoAndPrimaryTerm, Logger logger, ParentTaskAssigningClient searchClient,
+                                    ParentTaskAssigningClient bulkClient, ThreadPool threadPool, Request mainRequest,
+                                    ActionListener<BulkByScrollResponse> listener, @Nullable ScriptService scriptService,
+                                    @Nullable ReindexSslConfig sslConfig) {
         this.task = task;
         this.scriptService = scriptService;
         this.sslConfig = sslConfig;
@@ -129,7 +138,8 @@ public abstract class AbstractAsyncBulkByScrollAction<Request extends AbstractBu
         this.worker = task.getWorkerState();
 
         this.logger = logger;
-        this.client = client;
+        this.searchClient = searchClient;
+        this.bulkClient = bulkClient;
         this.threadPool = threadPool;
         this.mainRequest = mainRequest;
         this.listener = listener;
@@ -215,7 +225,7 @@ public abstract class AbstractAsyncBulkByScrollAction<Request extends AbstractBu
 
     protected ScrollableHitSource buildScrollableResultSource(BackoffPolicy backoffPolicy) {
         return new ClientScrollableHitSource(logger, backoffPolicy, threadPool, worker::countSearchRetry,
-            this::onScrollResponse, this::finishHim, client,
+            this::onScrollResponse, this::finishHim, searchClient,
                 mainRequest.getSearchRequest());
     }
 
@@ -349,7 +359,7 @@ public abstract class AbstractAsyncBulkByScrollAction<Request extends AbstractBu
             finishHim(null);
             return;
         }
-        bulkRetry.withBackoff(client::bulk, request, new ActionListener<BulkResponse>() {
+        bulkRetry.withBackoff(bulkClient::bulk, request, new ActionListener<BulkResponse>() {
             @Override
             public void onResponse(BulkResponse response) {
                 onBulkResponse(response, onSuccess);
@@ -451,7 +461,7 @@ public abstract class AbstractAsyncBulkByScrollAction<Request extends AbstractBu
         RefreshRequest refresh = new RefreshRequest();
         refresh.indices(destinationIndices.toArray(new String[destinationIndices.size()]));
         logger.debug("[{}]: refreshing", task.getId());
-        client.admin().indices().refresh(refresh, new ActionListener<RefreshResponse>() {
+        bulkClient.admin().indices().refresh(refresh, new ActionListener<RefreshResponse>() {
             @Override
             public void onResponse(RefreshResponse response) {
                 finishHim(null, indexingFailures, searchFailures, timedOut);

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/ReindexSslConfig.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/ReindexSslConfig.java
@@ -54,7 +54,7 @@ import static org.elasticsearch.common.settings.Setting.simpleString;
  * Loads "reindex.ssl.*" configuration from Settings, and makes the applicable configuration (trust manager / key manager / hostname
  * verification / cipher-suites) available for reindex-from-remote.
  */
-class ReindexSslConfig {
+public class ReindexSslConfig {
 
     private static final Map<String, Setting<?>> SETTINGS = new HashMap<>();
     private static final Map<String, Setting<SecureString>> SECURE_SETTINGS = new HashMap<>();
@@ -89,7 +89,7 @@ class ReindexSslConfig {
         return settings;
     }
 
-    ReindexSslConfig(Settings settings, Environment environment, ResourceWatcherService resourceWatcher) {
+    public ReindexSslConfig(Settings settings, Environment environment, ResourceWatcherService resourceWatcher) {
         final SslConfigurationLoader loader = new SslConfigurationLoader("reindex.ssl.") {
 
             @Override

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/ReindexValidator.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/ReindexValidator.java
@@ -41,7 +41,7 @@ import org.elasticsearch.search.builder.SearchSourceBuilder;
 
 import java.util.List;
 
-class ReindexValidator {
+public class ReindexValidator {
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(ReindexValidator.class);
     static final String SORT_DEPRECATED_MESSAGE = "The sort option in reindex is deprecated. " +
         "Instead consider using query filtering to find the desired subset of data.";
@@ -59,7 +59,7 @@ class ReindexValidator {
         this.autoCreateIndex = autoCreateIndex;
     }
 
-    void initialValidation(ReindexRequest request) {
+    public void initialValidation(ReindexRequest request) {
         checkRemoteWhitelist(remoteWhitelist, request.getRemoteInfo());
         ClusterState state = clusterService.state();
         validateAgainstAliases(request.getSearchRequest(), request.getDestination(), request.getRemoteInfo(), resolver, autoCreateIndex,

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/TransportReindexAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/TransportReindexAction.java
@@ -19,6 +19,11 @@
 
 package org.elasticsearch.index.reindex;
 
+import static java.util.Collections.emptyList;
+
+import java.util.List;
+import java.util.function.Function;
+
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.AutoCreateIndex;
@@ -35,35 +40,41 @@ import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
-import java.util.List;
-import java.util.function.Function;
-
-import static java.util.Collections.emptyList;
-
 public class TransportReindexAction extends HandledTransportAction<ReindexRequest, BulkByScrollResponse> {
     public static final Setting<List<String>> REMOTE_CLUSTER_WHITELIST =
             Setting.listSetting("reindex.remote.whitelist", emptyList(), Function.identity(), Property.NodeScope);
 
-    private final ReindexValidator reindexValidator;
+    protected final ReindexValidator reindexValidator;
     private final Reindexer reindexer;
+
+    protected final Client client;
 
     @Inject
     public TransportReindexAction(Settings settings, ThreadPool threadPool, ActionFilters actionFilters,
             IndexNameExpressionResolver indexNameExpressionResolver, ClusterService clusterService, ScriptService scriptService,
             AutoCreateIndex autoCreateIndex, Client client, TransportService transportService, ReindexSslConfig sslConfig) {
-        super(ReindexAction.NAME, transportService, actionFilters, ReindexRequest::new);
+        this(ReindexAction.NAME, settings, threadPool, actionFilters, indexNameExpressionResolver, clusterService, scriptService,
+            autoCreateIndex, client, transportService, sslConfig);
+    }
+
+    protected TransportReindexAction(String name, Settings settings, ThreadPool threadPool, ActionFilters actionFilters,
+                                     IndexNameExpressionResolver indexNameExpressionResolver, ClusterService clusterService,
+                                     ScriptService scriptService, AutoCreateIndex autoCreateIndex, Client client,
+                                     TransportService transportService, ReindexSslConfig sslConfig) {
+        super(name, transportService, actionFilters, ReindexRequest::new);
+        this.client = client;
         this.reindexValidator = new ReindexValidator(settings, clusterService, indexNameExpressionResolver, autoCreateIndex);
         this.reindexer = new Reindexer(clusterService, client, threadPool, scriptService, sslConfig);
     }
 
     @Override
     protected void doExecute(Task task, ReindexRequest request, ActionListener<BulkByScrollResponse> listener) {
-        reindexValidator.initialValidation(request);
+        validate(request);
         BulkByScrollTask bulkByScrollTask = (BulkByScrollTask) task;
         reindexer.initTask(bulkByScrollTask, request, new ActionListener<Void>() {
             @Override
             public void onResponse(Void v) {
-                reindexer.execute(bulkByScrollTask, request, listener);
+                reindexer.execute(bulkByScrollTask, request, getBulkClient(), listener);
             }
 
             @Override
@@ -71,5 +82,22 @@ public class TransportReindexAction extends HandledTransportAction<ReindexReques
                 listener.onFailure(e);
             }
         });
+    }
+
+    /**
+     * This method can be overridden to specify a different {@link Client} to be used for indexing than that used for the search/input
+     * part of the reindex. For example, a {@link org.elasticsearch.client.FilterClient} can be provided to transform bulk index requests
+     * before they are fully performed.
+     */
+    protected Client getBulkClient() {
+        return client;
+    }
+
+    /**
+     * This method can be overridden if different than usual validation is needed. This method should throw an exception if validation
+     * fails.
+     */
+    protected void validate(ReindexRequest request) {
+        reindexValidator.initialValidation(request);
     }
 }

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/ReindexMetadataTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/ReindexMetadataTests.java
@@ -76,7 +76,7 @@ public class ReindexMetadataTests extends AbstractAsyncBulkByScrollActionMetadat
 
     private class TestAction extends Reindexer.AsyncIndexBySearchAction {
         TestAction() {
-            super(ReindexMetadataTests.this.task, ReindexMetadataTests.this.logger, null, ReindexMetadataTests.this.threadPool,
+            super(ReindexMetadataTests.this.task, ReindexMetadataTests.this.logger, null, null, ReindexMetadataTests.this.threadPool,
                 null, null, request(), listener());
         }
 

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/ReindexScriptTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/ReindexScriptTests.java
@@ -105,6 +105,6 @@ public class ReindexScriptTests extends AbstractAsyncBulkByScrollActionScriptTes
     @Override
     protected Reindexer.AsyncIndexBySearchAction action(ScriptService scriptService, ReindexRequest request) {
         ReindexSslConfig sslConfig = Mockito.mock(ReindexSslConfig.class);
-        return new Reindexer.AsyncIndexBySearchAction(task, logger, null, threadPool, scriptService, sslConfig, request, listener());
+        return new Reindexer.AsyncIndexBySearchAction(task, logger, null, null, threadPool, scriptService, sslConfig, request, listener());
     }
 }

--- a/x-pack/plugin/enrich/build.gradle
+++ b/x-pack/plugin/enrich/build.gradle
@@ -10,6 +10,7 @@ archivesBaseName = 'x-pack-enrich'
 
 dependencies {
   compileOnly project(path: xpackModule('core'), configuration: 'default')
+  api project(path: ':modules:reindex')
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
   testImplementation project(path: ':modules:ingest-common')
   testImplementation project(path: ':modules:lang-mustache')

--- a/x-pack/plugin/enrich/qa/common/src/main/java/org/elasticsearch/test/enrich/CommonEnrichRestTestCase.java
+++ b/x-pack/plugin/enrich/qa/common/src/main/java/org/elasticsearch/test/enrich/CommonEnrichRestTestCase.java
@@ -182,11 +182,11 @@ public abstract class CommonEnrichRestTestCase extends ESRestTestCase {
             + "}";
     }
 
-    private static Map<String, Object> toMap(Response response) throws IOException {
+    protected static Map<String, Object> toMap(Response response) throws IOException {
         return toMap(EntityUtils.toString(response.getEntity()));
     }
 
-    private static Map<String, Object> toMap(String response) {
+    protected static Map<String, Object> toMap(String response) {
         return XContentHelper.convertToMap(JsonXContent.jsonXContent, response, false);
     }
 

--- a/x-pack/plugin/enrich/qa/rest-with-advanced-security/build.gradle
+++ b/x-pack/plugin/enrich/qa/rest-with-advanced-security/build.gradle
@@ -1,0 +1,18 @@
+apply plugin: 'elasticsearch.java-rest-test'
+
+import org.elasticsearch.gradle.info.BuildParams
+
+dependencies {
+  javaRestTestImplementation project(path: xpackModule('core'))
+  javaRestTestImplementation project(path: xpackModule('enrich:qa:common'))
+}
+
+testClusters.all {
+  testDistribution = 'DEFAULT'
+  extraConfigFile 'roles.yml', file('roles.yml')
+  user username: "test_admin", password: "x-pack-test-password", role: "superuser"
+  user username: "test_enrich", password: "x-pack-test-password", role: "integ_test_role"
+  setting 'xpack.license.self_generated.type', 'trial'
+  setting 'xpack.security.enabled', 'true'
+  setting 'xpack.monitoring.collection.enabled', 'true'
+}

--- a/x-pack/plugin/enrich/qa/rest-with-advanced-security/roles.yml
+++ b/x-pack/plugin/enrich/qa/rest-with-advanced-security/roles.yml
@@ -1,0 +1,29 @@
+integ_test_role:
+  cluster:
+    - manage_enrich
+    - manage_ingest_pipelines
+    - monitor
+  indices:
+    - names: [ 'my-index', 'my-source-index' ]
+      privileges:
+        - manage
+        - read
+        - write
+    - names: [ 'fls-source-index' ]
+      privileges:
+        - read
+        - create_index
+        - view_index_metadata
+      field_security:
+        grant:
+          - host
+          - tld
+          - tldRank
+    - names: [ 'dls-source-index' ]
+      privileges:
+        - read
+        - create_index
+        - view_index_metadata
+      query:
+        match:
+          host: elastic.co

--- a/x-pack/plugin/enrich/qa/rest-with-advanced-security/src/javaRestTest/java/org/elasticsearch/xpack/enrich/EnrichAdvancedSecurityIT.java
+++ b/x-pack/plugin/enrich/qa/rest-with-advanced-security/src/javaRestTest/java/org/elasticsearch/xpack/enrich/EnrichAdvancedSecurityIT.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.enrich;
+
+import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.basicAuthHeaderValue;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.elasticsearch.client.Request;
+import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.test.enrich.CommonEnrichRestTestCase;
+
+public class EnrichAdvancedSecurityIT extends CommonEnrichRestTestCase {
+
+    @Override
+    protected Settings restClientSettings() {
+        String token = basicAuthHeaderValue("test_enrich", new SecureString("x-pack-test-password".toCharArray()));
+        return Settings.builder().put(ThreadContext.PREFIX + ".Authorization", token).build();
+    }
+
+    @Override
+    protected Settings restAdminSettings() {
+        String token = basicAuthHeaderValue("test_admin", new SecureString("x-pack-test-password".toCharArray()));
+        return Settings.builder().put(ThreadContext.PREFIX + ".Authorization", token).build();
+    }
+
+    public void testEnrichEnforcesDLS() throws IOException {
+        // Create the index and policy using the admin client
+        final String sourceIndexName = "dls-source-index";
+        setupSourceIndexAndPolicy(sourceIndexName);
+
+        // Add another doc that doesn't match the DLS filter
+        Request sourceDocIndexReq = new Request("PUT", "/" + sourceIndexName + "/_doc/example.com");
+        sourceDocIndexReq.setJsonEntity("{\"host\": \"example.com\",\"globalRank\": 42,\"tldRank\": 7,\"tld\": \"com\"}");
+        assertOK(adminClient().performRequest(sourceDocIndexReq));
+        Request refreshRequest = new Request("POST", "/" + sourceIndexName + "/_refresh");
+        assertOK(adminClient().performRequest(refreshRequest));
+
+        // Execute the policy:
+        Request executePolicyRequest = new Request("POST", "/_enrich/policy/my_policy/_execute");
+        assertOK(client().performRequest(executePolicyRequest));
+
+        // Create pipeline
+        Request putPipelineRequest = new Request("PUT", "/_ingest/pipeline/my_pipeline");
+        putPipelineRequest.setJsonEntity(
+            "{\"processors\":[" + "{\"enrich\":{\"policy_name\":\"my_policy\",\"field\":\"host\",\"target_field\":\"entry\"}}" + "]}"
+        );
+        assertOK(client().performRequest(putPipelineRequest));
+
+        // Verify that the pipeline works as expected for the source doc included in the DLS filter
+        {
+            // Index document using pipeline with enrich processor:
+            Request indexRequest = new Request("PUT", "/my-index/_doc/1");
+            indexRequest.addParameter("pipeline", "my_pipeline");
+            indexRequest.setJsonEntity("{\"host\": \"elastic.co\"}");
+            assertOK(client().performRequest(indexRequest));
+
+            // Check if document has been enriched
+            Request getRequest = new Request("GET", "/my-index/_doc/1");
+            Map<String, Object> response = toMap(client().performRequest(getRequest));
+            Map<?, ?> entry = (Map<?, ?>) ((Map<?, ?>) response.get("_source")).get("entry");
+            assertThat(entry.size(), equalTo(4));
+            assertThat(entry.get("host"), equalTo("elastic.co"));
+            assertThat(entry.get("tld"), equalTo("co"));
+            assertThat(entry.get("globalRank"), equalTo(25));
+            assertThat(entry.get("tldRank"), equalTo(7));
+        }
+
+        // Verify that we don't leak the source doc that isn't included in the DLS filter
+        {
+            // Index document using pipeline with enrich processor:
+            Request indexRequest = new Request("PUT", "/my-index/_doc/2");
+            indexRequest.addParameter("pipeline", "my_pipeline");
+            indexRequest.setJsonEntity("{\"host\": \"example.com\"}");
+            assertOK(client().performRequest(indexRequest));
+
+            // Check if document has been enriched
+            Request getRequest = new Request("GET", "/my-index/_doc/2");
+            Map<String, Object> response = toMap(client().performRequest(getRequest));
+            Map<?, ?> entry = (Map<?, ?>) ((Map<?, ?>) response.get("_source")).get("entry");
+            assertThat("the document should not have been enriched", entry, nullValue());
+        }
+
+        // delete the pipeline so the policies can be deleted
+        client().performRequest(new Request("DELETE", "/_ingest/pipeline/my_pipeline"));
+    }
+
+    public void testEnrichEnforcesFLS() throws IOException {
+        // Create the index and policy using the admin client
+        setupSourceIndexAndPolicy("fls-source-index");
+
+        // Execute the policy:
+        Request executePolicyRequest = new Request("POST", "/_enrich/policy/my_policy/_execute");
+        assertOK(client().performRequest(executePolicyRequest));
+
+        // Create pipeline
+        Request putPipelineRequest = new Request("PUT", "/_ingest/pipeline/my_pipeline");
+        putPipelineRequest.setJsonEntity(
+            "{\"processors\":[" + "{\"enrich\":{\"policy_name\":\"my_policy\",\"field\":\"host\",\"target_field\":\"entry\"}}" + "]}"
+        );
+        assertOK(client().performRequest(putPipelineRequest));
+
+        // Index document using pipeline with enrich processor:
+        Request indexRequest = new Request("PUT", "/my-index/_doc/1");
+        indexRequest.addParameter("pipeline", "my_pipeline");
+        indexRequest.setJsonEntity("{\"host\": \"elastic.co\"}");
+        assertOK(client().performRequest(indexRequest));
+
+        // Check if document has been enriched
+        Request getRequest = new Request("GET", "/my-index/_doc/1");
+        Map<String, Object> response = toMap(client().performRequest(getRequest));
+        Map<?, ?> entry = (Map<?, ?>) ((Map<?, ?>) response.get("_source")).get("entry");
+        assertThat(entry.size(), equalTo(3));
+        assertThat(entry.get("host"), equalTo("elastic.co"));
+        assertThat(entry.get("tld"), equalTo("co"));
+        assertThat(entry.get("tldRank"), equalTo(7));
+        assertThat("Field [globalRank] should not be present due to FLS restrictions", entry.get("globalRank"), nullValue());
+
+        // delete the pipeline so the policies can be deleted
+        client().performRequest(new Request("DELETE", "/_ingest/pipeline/my_pipeline"));
+    }
+
+    private void setupSourceIndexAndPolicy(String sourceIndexName) throws IOException {
+        // Create source index:
+        createSourceIndex(sourceIndexName);
+        // Create the policy:
+        Request putPolicyRequest = new Request("PUT", "/_enrich/policy/my_policy");
+        putPolicyRequest.setJsonEntity(generatePolicySource(sourceIndexName));
+        assertOK(adminClient().performRequest(putPolicyRequest));
+
+        // Add entry to source index and then refresh:
+        Request indexRequest = new Request("PUT", "/" + sourceIndexName + "/_doc/elastic.co");
+        indexRequest.setJsonEntity("{\"host\": \"elastic.co\",\"globalRank\": 25,\"tldRank\": 7,\"tld\": \"co\"}");
+        assertOK(adminClient().performRequest(indexRequest));
+        Request refreshRequest = new Request("POST", "/" + sourceIndexName + "/_refresh");
+        assertOK(adminClient().performRequest(refreshRequest));
+    }
+}

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPlugin.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPlugin.java
@@ -46,8 +46,10 @@ import org.elasticsearch.xpack.core.enrich.action.PutEnrichPolicyAction;
 import org.elasticsearch.xpack.enrich.action.EnrichCoordinatorProxyAction;
 import org.elasticsearch.xpack.enrich.action.EnrichCoordinatorStatsAction;
 import org.elasticsearch.xpack.core.enrich.EnrichFeatureSet;
+import org.elasticsearch.xpack.enrich.action.EnrichReindexAction;
 import org.elasticsearch.xpack.enrich.action.EnrichShardMultiSearchAction;
 import org.elasticsearch.xpack.enrich.action.TransportDeleteEnrichPolicyAction;
+import org.elasticsearch.xpack.enrich.action.TransportEnrichReindexAction;
 import org.elasticsearch.xpack.enrich.action.TransportEnrichStatsAction;
 import org.elasticsearch.xpack.enrich.action.TransportExecuteEnrichPolicyAction;
 import org.elasticsearch.xpack.enrich.action.TransportGetEnrichPolicyAction;
@@ -151,7 +153,8 @@ public class EnrichPlugin extends Plugin implements SystemIndexPlugin, IngestPlu
             new ActionHandler<>(EnrichStatsAction.INSTANCE, TransportEnrichStatsAction.class),
             new ActionHandler<>(EnrichCoordinatorProxyAction.INSTANCE, EnrichCoordinatorProxyAction.TransportAction.class),
             new ActionHandler<>(EnrichShardMultiSearchAction.INSTANCE, EnrichShardMultiSearchAction.TransportAction.class),
-            new ActionHandler<>(EnrichCoordinatorStatsAction.INSTANCE, EnrichCoordinatorStatsAction.TransportAction.class)
+            new ActionHandler<>(EnrichCoordinatorStatsAction.INSTANCE, EnrichCoordinatorStatsAction.TransportAction.class),
+            new ActionHandler<>(EnrichReindexAction.INSTANCE, TransportEnrichReindexAction.class)
         );
     }
 

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunner.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunner.java
@@ -5,6 +5,16 @@
  */
 package org.elasticsearch.xpack.enrich;
 
+import static org.elasticsearch.xpack.core.ClientHelper.ENRICH_ORIGIN;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.LongSupplier;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
@@ -29,7 +39,6 @@ import org.elasticsearch.action.admin.indices.segments.IndicesSegmentsRequest;
 import org.elasticsearch.action.admin.indices.segments.ShardSegments;
 import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest;
 import org.elasticsearch.action.bulk.BulkItemResponse;
-import org.elasticsearch.action.support.ContextPreservingActionListener;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.OriginSettingClient;
@@ -49,22 +58,12 @@ import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.reindex.BulkByScrollResponse;
-import org.elasticsearch.index.reindex.ReindexAction;
 import org.elasticsearch.index.reindex.ReindexRequest;
 import org.elasticsearch.index.reindex.ScrollableHitSource;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.xpack.core.enrich.EnrichPolicy;
 import org.elasticsearch.xpack.core.enrich.action.ExecuteEnrichPolicyStatus;
-
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.function.LongSupplier;
-
-import static org.elasticsearch.xpack.core.ClientHelper.ENRICH_ORIGIN;
+import org.elasticsearch.xpack.enrich.action.EnrichReindexAction;
 
 public class EnrichPolicyRunner implements Runnable {
 
@@ -363,79 +362,67 @@ public class EnrichPolicyRunner implements Runnable {
         reindexRequest.getDestination().routing("discard");
         reindexRequest.getDestination().setPipeline(EnrichPolicyReindexPipeline.pipelineName());
 
-        // The ContextPreservingActionListener here is for the purpose of dropping the response headers, as we need this reindex to run
-        // in the security context of the user (rather than Enrich's security context) to ensure that DLS/FLS is correctly applied, but
-        // the reindex needs to access the `.enrich` index, which causes a deprecation warning. Since we drop the response headers,
-        // the deprecation warning is also dropped - but this is a hack and will not work once full protections of system indices are
-        // enabled.
-        client.execute(
-            ReindexAction.INSTANCE,
-            reindexRequest,
-            new ContextPreservingActionListener<>(
-                client.threadPool().getThreadContext().newRestorableContext(false),
-                new ActionListener<BulkByScrollResponse>() {
-                    @Override
-                    public void onResponse(BulkByScrollResponse bulkByScrollResponse) {
-                        // Do we want to fail the request if there were failures during the reindex process?
-                        if (bulkByScrollResponse.getBulkFailures().size() > 0) {
-                            logger.warn(
-                                "Policy [{}]: encountered [{}] bulk failures. Turn on DEBUG logging for details.",
-                                policyName,
-                                bulkByScrollResponse.getBulkFailures().size()
+        client.execute(EnrichReindexAction.INSTANCE, reindexRequest, new ActionListener<BulkByScrollResponse>() {
+            @Override
+            public void onResponse(BulkByScrollResponse bulkByScrollResponse) {
+                // Do we want to fail the request if there were failures during the reindex process?
+                if (bulkByScrollResponse.getBulkFailures().size() > 0) {
+                    logger.warn(
+                        "Policy [{}]: encountered [{}] bulk failures. Turn on DEBUG logging for details.",
+                        policyName,
+                        bulkByScrollResponse.getBulkFailures().size()
+                    );
+                    if (logger.isDebugEnabled()) {
+                        for (BulkItemResponse.Failure failure : bulkByScrollResponse.getBulkFailures()) {
+                            logger.debug(
+                                new ParameterizedMessage(
+                                    "Policy [{}]: bulk index failed for index [{}], id [{}]",
+                                    policyName,
+                                    failure.getIndex(),
+                                    failure.getId()
+                                ),
+                                failure.getCause()
                             );
-                            if (logger.isDebugEnabled()) {
-                                for (BulkItemResponse.Failure failure : bulkByScrollResponse.getBulkFailures()) {
-                                    logger.debug(
-                                        new ParameterizedMessage(
-                                            "Policy [{}]: bulk index failed for index [{}], id [{}]",
-                                            policyName,
-                                            failure.getIndex(),
-                                            failure.getId()
-                                        ),
-                                        failure.getCause()
-                                    );
-                                }
-                            }
-                            listener.onFailure(new ElasticsearchException("Encountered bulk failures during reindex process"));
-                        } else if (bulkByScrollResponse.getSearchFailures().size() > 0) {
-                            logger.warn(
-                                "Policy [{}]: encountered [{}] search failures. Turn on DEBUG logging for details.",
-                                policyName,
-                                bulkByScrollResponse.getSearchFailures().size()
-                            );
-                            if (logger.isDebugEnabled()) {
-                                for (ScrollableHitSource.SearchFailure failure : bulkByScrollResponse.getSearchFailures()) {
-                                    logger.debug(
-                                        new ParameterizedMessage(
-                                            "Policy [{}]: search failed for index [{}], shard [{}] on node [{}]",
-                                            policyName,
-                                            failure.getIndex(),
-                                            failure.getShardId(),
-                                            failure.getNodeId()
-                                        ),
-                                        failure.getReason()
-                                    );
-                                }
-                            }
-                            listener.onFailure(new ElasticsearchException("Encountered search failures during reindex process"));
-                        } else {
-                            logger.info(
-                                "Policy [{}]: Transferred [{}] documents to enrich index [{}]",
-                                policyName,
-                                bulkByScrollResponse.getCreated(),
-                                destinationIndexName
-                            );
-                            forceMergeEnrichIndex(destinationIndexName, 1);
                         }
                     }
-
-                    @Override
-                    public void onFailure(Exception e) {
-                        listener.onFailure(e);
+                    listener.onFailure(new ElasticsearchException("Encountered bulk failures during reindex process"));
+                } else if (bulkByScrollResponse.getSearchFailures().size() > 0) {
+                    logger.warn(
+                        "Policy [{}]: encountered [{}] search failures. Turn on DEBUG logging for details.",
+                        policyName,
+                        bulkByScrollResponse.getSearchFailures().size()
+                    );
+                    if (logger.isDebugEnabled()) {
+                        for (ScrollableHitSource.SearchFailure failure : bulkByScrollResponse.getSearchFailures()) {
+                            logger.debug(
+                                new ParameterizedMessage(
+                                    "Policy [{}]: search failed for index [{}], shard [{}] on node [{}]",
+                                    policyName,
+                                    failure.getIndex(),
+                                    failure.getShardId(),
+                                    failure.getNodeId()
+                                ),
+                                failure.getReason()
+                            );
+                        }
                     }
+                    listener.onFailure(new ElasticsearchException("Encountered search failures during reindex process"));
+                } else {
+                    logger.info(
+                        "Policy [{}]: Transferred [{}] documents to enrich index [{}]",
+                        policyName,
+                        bulkByScrollResponse.getCreated(),
+                        destinationIndexName
+                    );
+                    forceMergeEnrichIndex(destinationIndexName, 1);
                 }
-            )
-        );
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                listener.onFailure(e);
+            }
+        });
     }
 
     private void forceMergeEnrichIndex(final String destinationIndexName, final int attempt) {

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/EnrichReindexAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/EnrichReindexAction.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.enrich.action;
+
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.index.reindex.BulkByScrollResponse;
+
+/**
+ * This class exists only to support {@link TransportEnrichReindexAction}.
+ */
+public class EnrichReindexAction extends ActionType<BulkByScrollResponse> {
+
+    public static final String NAME = "cluster:admin/xpack/enrich/reindex";
+    public static final EnrichReindexAction INSTANCE = new EnrichReindexAction();
+
+    private EnrichReindexAction() {
+        super(NAME, BulkByScrollResponse::new);
+    }
+}

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/TransportEnrichReindexAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/TransportEnrichReindexAction.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.enrich.action;
+
+import static org.elasticsearch.xpack.core.ClientHelper.ENRICH_ORIGIN;
+
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.AutoCreateIndex;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.client.OriginSettingClient;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.index.reindex.ReindexRequest;
+import org.elasticsearch.index.reindex.ReindexSslConfig;
+import org.elasticsearch.index.reindex.TransportReindexAction;
+import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.watcher.ResourceWatcherService;
+
+/**
+ * A specialized version of {@link TransportReindexAction} which performs the search part of the reindex in the security context of the
+ * current user, but the indexing part of the reindex in the security context of the Enrich plugin. This is necessary as Enrich indices are
+ * protected system indices, and typically cannot be accessed directly by users.
+ */
+public class TransportEnrichReindexAction extends TransportReindexAction {
+
+    private final Client bulkClient;
+
+    @Inject
+    public TransportEnrichReindexAction(
+        Settings settings,
+        ThreadPool threadPool,
+        ActionFilters actionFilters,
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        ClusterService clusterService,
+        ScriptService scriptService,
+        AutoCreateIndex autoCreateIndex,
+        Client client,
+        TransportService transportService,
+        Environment environment,
+        ResourceWatcherService watcherService
+    ) {
+        super(
+            EnrichReindexAction.NAME,
+            settings,
+            threadPool,
+            actionFilters,
+            indexNameExpressionResolver,
+            clusterService,
+            scriptService,
+            autoCreateIndex,
+            client,
+            transportService,
+            new ReindexSslConfig(settings, environment, watcherService)
+        );
+        this.bulkClient = new OriginSettingClient(client, ENRICH_ORIGIN);
+    }
+
+    @Override
+    protected Client getBulkClient() {
+        return bulkClient;
+    }
+
+    @Override
+    protected void validate(ReindexRequest request) {
+        // Validate the request in Enrich's security context, to be sure the validation can access system indices
+        try (ThreadContext.StoredContext ctx = client.threadPool().getThreadContext().stashWithOrigin(ENRICH_ORIGIN)) {
+            reindexValidator.initialValidation(request);
+        }
+    }
+}

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunnerTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunnerTests.java
@@ -84,7 +84,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
 
     @Override
     protected Collection<Class<? extends Plugin>> getPlugins() {
-        return Arrays.asList(ReindexPlugin.class, IngestCommonPlugin.class, GeoPlugin.class);
+        return Arrays.asList(ReindexPlugin.class, IngestCommonPlugin.class, GeoPlugin.class, LocalStateEnrich.class);
     }
 
     private static ThreadPool testThreadPool;

--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
@@ -100,6 +100,7 @@ public class Constants {
         "cluster:admin/xpack/enrich/execute",
         "cluster:admin/xpack/enrich/get",
         "cluster:admin/xpack/enrich/put",
+        "cluster:admin/xpack/enrich/reindex",
         "cluster:admin/xpack/license/basic_status",
         // "cluster:admin/xpack/license/delete",
         "cluster:admin/xpack/license/feature_usage",


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Allow population of Enrich indices to work with System Index protections (#67406)