### PR TITLE
[backport] Resolves Rollup Action cluster privileges (#68024)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ClusterPrivilegeResolver.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ClusterPrivilegeResolver.java
@@ -78,7 +78,7 @@ public class ClusterPrivilegeResolver {
     private static final Set<String> READ_PIPELINE_PATTERN = Collections.unmodifiableSet(Sets.newHashSet(GetPipelineAction.NAME,
         SimulatePipelineAction.NAME));
     private static final Set<String> MANAGE_ROLLUP_PATTERN = Collections.unmodifiableSet(
-        Sets.newHashSet("cluster:admin/xpack/rollup/*", "cluster:monitor/xpack/rollup/*", "indices:admin/xpack/rollup"));
+        Sets.newHashSet("cluster:admin/xpack/rollup/*", "cluster:monitor/xpack/rollup/*"));
     private static final Set<String> MANAGE_CCR_PATTERN =
         Collections.unmodifiableSet(Sets.newHashSet("cluster:admin/xpack/ccr/*", ClusterStateAction.NAME, HasPrivilegesAction.NAME));
     private static final Set<String> CREATE_SNAPSHOT_PATTERN = Collections.unmodifiableSet(


### PR DESCRIPTION
There is a problem with MANAGE_ROLLUP cluster privilege role
where it was not included within the MANAGE role

this commit removes the rollup action from the manage_rollup patterns

relates https://github.com/elastic/kibana/issues/89180.