### PR TITLE
[DOCS] Remove experimental tag from find structure API

### DIFF
--- a/docs/java-rest/high-level/textstructure/find-structure.asciidoc
+++ b/docs/java-rest/high-level/textstructure/find-structure.asciidoc
@@ -7,8 +7,6 @@
 [id="{upid}-{api}"]
 === Find structure API
 
-experimental::[]
-
 Determines the structure of text and other information that will be
 useful to import its contents to an {es} index. It accepts a +{request}+ object
 and responds with a +{response}+ object.
@@ -28,7 +26,7 @@ include-tagged::{doc-tests-file}[{api}-request]
 
 ==== Optional arguments
 
-The following arguments are optional.
+The following arguments are optional:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------


### PR DESCRIPTION
This PR removes the "experimental" designation from the find structure API in the Java high level REST client documentation [(java-rest-high-text-structure-find-structure.html)](https://www.elastic.co/guide/en/elasticsearch/client/java-rest/master/java-rest-high-text-structure-find-structure.html).  It also includes one minor edit.

