### PR TITLE
Use proper skip versions after #68138

### DIFF
--- a/x-pack/plugin/watcher/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/watcher/put_watch/92_put_watch_with_indices_options.yml
+++ b/x-pack/plugin/watcher/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/watcher/put_watch/92_put_watch_with_indices_options.yml
@@ -53,8 +53,8 @@ setup:
 ---
 "Test put watch with expand wildcards":
   - skip:
-      version: "7.10.1 - 7.99.99"
-      reason: "watch parsing with partial indices options was broken in 7.10.1"
+      version: "7.10.1 - 7.10.2"
+      reason: "watch parsing with partial indices options was broken in 7.10.1 and 7.10.2"
   - do:
       watcher.put_watch:
         id: "my_watch_expand_wildcards"
@@ -99,8 +99,8 @@ setup:
 ---
 "Test put watch with ignore unavailable":
   - skip:
-      version: "7.10.1 - 7.99.99"
-      reason: "watch parsing with partial indices options was broken in 7.10.1"
+      version: "7.10.1 - 7.10.2"
+      reason: "watch parsing with partial indices options was broken in 7.10.1 and 7.10.2"
   - do:
       watcher.put_watch:
         id: "my_watch_ignore_unavailable"


### PR DESCRIPTION
This commit updates the skip versions used in tests that put watches
with partial indices options to only skip 7.10.1 and 7.10.2 now that
the fix has been backported.