### PR TITLE
[7.10] [DOCS] Fix typo (#68129)

### DIFF
--- a/docs/reference/rollup/overview.asciidoc
+++ b/docs/reference/rollup/overview.asciidoc
@@ -39,7 +39,7 @@ such as hourly or daily trends.
 If we compress the 43 million documents into hourly summaries, we can save vast amounts of space.  The Rollup feature
 automates this process of summarizing historical data.
 
-Details about setting up and configuring Rollup are covered in <<rollup-put-job,Create Job API>>
+Details about setting up and configuring Rollup are covered in <<rollup-put-job,Create Job API>>.
 
 [discrete]
 ==== Rollup uses standard query DSL


### PR DESCRIPTION
Backports the following commits to 7.10:
 - [DOCS] Fix typo (#68129)