### PR TITLE
Fix painless build in eclipse

### DIFF
--- a/modules/lang-painless/build.gradle
+++ b/modules/lang-painless/build.gradle
@@ -88,6 +88,14 @@ dependencies {
   docImplementation project(':server')
   docImplementation project(':modules:lang-painless')
   docImplementation 'com.github.javaparser:javaparser-core:3.18.0'
+  if (isEclipse) {
+    /*
+     * Eclipse isn't quite "with it" enough to understand the different
+     * source sets. This adds the dependency to all source sets so it
+     * can compile the doc java files.
+     */
+    implementation 'com.github.javaparser:javaparser-core:3.18.0'
+  }
 }
 
 testClusters {


### PR DESCRIPTION
Painless now has a `doc` source which has its own dependencies. That's
lovely for everything but Eclipse doesn't understand that sort of thing.
This adds the docs dependencies to the regular build path when building
with Eclipse.
