### PR TITLE
[7.11] [DOCS] Fix response typo in transport message listener (#68125)

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/TransportMessageListener.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportMessageListener.java
@@ -61,7 +61,7 @@ public interface TransportMessageListener {
 
     /**
      * Called for every response received
-     * @param requestId the request id for this reponse
+     * @param requestId the request id for this response
      * @param context the response context or null if the context was already processed ie. due to a timeout.
      */
     default void onResponseReceived(long requestId, Transport.ResponseContext context) {}


### PR DESCRIPTION
Backports the following commits to 7.11:
 - [DOCS] Fix response typo in transport message listener (#68125)