### PR TITLE
[7.11] Disable BWC tests for backport of index creation version stats backport (#68162)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -183,8 +183,8 @@ tasks.register("verifyVersions") {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = true
-String bwc_tests_disabled_issue = "" /* place a PR link here when committing bwc changes */
+boolean bwc_tests_enabled = false
+String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/68141" /* place a PR link here when committing bwc changes */
 /*
  * FIPS 140-2 behavior was fixed in 7.11.0. Before that there is no way to run elasticsearch in a
  * JVM that is properly configured to be in fips mode with BCFIPS. For now we need to disable


### PR DESCRIPTION
Backports the following commits to 7.11:
 - Disable BWC tests for backport of index creation version stats backport (#68162)