### PR TITLE
[7.x] Adjust serialization version and re-enable BWC

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -183,8 +183,8 @@ tasks.register("verifyVersions") {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = false
-String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/68141" /* place a PR link here when committing bwc changes */
+boolean bwc_tests_enabled = true
+String bwc_tests_disabled_issue = "" /* place a PR link here when committing bwc changes */
 /*
  * FIPS 140-2 behavior was fixed in 7.11.0. Before that there is no way to run elasticsearch in a
  * JVM that is properly configured to be in fips mode with BCFIPS. For now we need to disable

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsResponse.java
@@ -58,7 +58,7 @@ public class ClusterStatsResponse extends BaseNodesResponse<ClusterStatsNodeResp
             analysisStats = in.readOptionalWriteable(AnalysisStats::new);
         }
         VersionStats versionStats = null;
-        if (in.getVersion().onOrAfter(Version.V_7_12_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_11_0)) {
             versionStats = in.readOptionalWriteable(VersionStats::new);
         }
         this.clusterUUID = clusterUUID;
@@ -122,7 +122,7 @@ public class ClusterStatsResponse extends BaseNodesResponse<ClusterStatsNodeResp
             out.writeOptionalWriteable(indicesStats.getMappings());
             out.writeOptionalWriteable(indicesStats.getAnalysis());
         }
-        if (out.getVersion().onOrAfter(Version.V_7_12_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_11_0)) {
             out.writeOptionalWriteable(indicesStats.getVersions());
         }
     }


### PR DESCRIPTION
Adjusts the ClusterStatsResponse serialization after #68173 has been merged, re-enabling BWC
testing.

Relates to #68141, #68161, and #68173
