### PR TITLE
Limit thread pool sizes for test clusters to avoid resource contention

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -1138,6 +1138,7 @@ public class ElasticsearchNode implements TestClusterConfiguration {
         if (nodeName != null) {
             baseConfig.put("node.name", nodeName);
         }
+        baseConfig.put("node.processors", "2"); // limit thread pool sizes since we are running loads of parallel es instances
         baseConfig.put("path.repo", confPathRepo.toAbsolutePath().toString());
         baseConfig.put("path.data", confPathData.toAbsolutePath().toString());
         baseConfig.put("path.logs", confPathLogs.toAbsolutePath().toString());


### PR DESCRIPTION
Some experimentation around resource contention in parallel test execution. 

We limit the number of ES nodes we spin up in proportion to the number of configured build workers, but the nodes themselves all assume they have exclusive access to all available processors. This might be causing issues and contributing to test suite timeouts even when worker count is lowered.

Stable builds > faster builds.