### PR TITLE
[ML] Return status 400 for grok_pattern errors in find_structure

### DIFF
--- a/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/GrokPatternCreator.java
+++ b/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/GrokPatternCreator.java
@@ -822,8 +822,11 @@ public final class GrokPatternCreator {
             TimeoutChecker timeoutChecker
         ) {
 
-            explanation.add("A full message Grok pattern [" + grokPattern.substring(2, grokPattern.length() - 1) + "] looks appropriate");
-
+            if (grokPattern.startsWith("%{") && grokPattern.endsWith("}")) {
+                explanation.add(
+                    "A full message Grok pattern [" + grokPattern.substring(2, grokPattern.length() - 1) + "] looks appropriate"
+                );
+            }
             if (mappings != null || fieldStats != null) {
                 Map<String, Collection<String>> valuesPerField = new HashMap<>();
 

--- a/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/TextLogFileStructureFinder.java
+++ b/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/TextLogFileStructureFinder.java
@@ -9,6 +9,7 @@ import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.xpack.core.textstructure.action.FindStructureAction;
 import org.elasticsearch.xpack.core.textstructure.structurefinder.FieldStats;
 import org.elasticsearch.xpack.core.textstructure.structurefinder.TextStructure;
+import org.joni.exception.SyntaxException;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -158,7 +159,12 @@ public class TextLogFileStructureFinder implements FileStructureFinder {
             if (interimTimestampField == null) {
                 interimTimestampField = "timestamp";
             }
-            grokPatternCreator.validateFullLineGrokPattern(grokPattern, interimTimestampField);
+            // Since this Grok pattern came from the end user, it might contain a syntax error
+            try {
+                grokPatternCreator.validateFullLineGrokPattern(grokPattern, interimTimestampField);
+            } catch (SyntaxException e) {
+                throw new IllegalArgumentException("Supplied Grok pattern [" + grokPattern + "] cannot be converted to a valid regex", e);
+            }
         } else {
             Tuple<String, String> timestampFieldAndFullMatchGrokPattern = grokPatternCreator.findFullLineGrokPattern(interimTimestampField);
             if (timestampFieldAndFullMatchGrokPattern != null) {

--- a/x-pack/plugin/text-structure/src/test/java/org/elasticsearch/xpack/textstructure/structurefinder/TextLogTextStructureFinderTests.java
+++ b/x-pack/plugin/text-structure/src/test/java/org/elasticsearch/xpack/textstructure/structurefinder/TextLogTextStructureFinderTests.java
@@ -278,6 +278,33 @@ public class TextLogTextStructureFinderTests extends TextStructureTestCase {
         );
     }
 
+    public void testCreateConfigsGivenElasticsearchLogAndInvalidGrokPatternOverride() {
+
+        // This Grok pattern has a low-level syntax error
+        FileStructureOverrides overrides = FileStructureOverrides.builder().setGrokPattern("[").build();
+
+        assertTrue(factory.canCreateFromSample(explanation, TEXT_SAMPLE, 0.0));
+
+        String charset = randomFrom(POSSIBLE_CHARSETS);
+        Boolean hasByteOrderMarker = randomHasByteOrderMarker(charset);
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> factory.createFromSample(
+                explanation,
+                TEXT_SAMPLE,
+                charset,
+                hasByteOrderMarker,
+                FileStructureFinderManager.DEFAULT_LINE_MERGE_SIZE_LIMIT,
+                overrides,
+                NOOP_TIMEOUT_CHECKER
+            )
+        );
+
+        assertEquals("Supplied Grok pattern [[] cannot be converted to a valid regex", e.getMessage());
+        assertNotNull(e.getCause());
+        assertEquals("premature end of char-class", e.getCause().getMessage());
+    }
+
     public void testErrorOnIncorrectMessageFormation() {
 
         // This sample causes problems because the (very weird) primary timestamp format


### PR DESCRIPTION
The _text_structure/find_structure endpoint should return a
400 error if an invalid grok_pattern override is supplied.
Previously this was happening in the case of high-level
errors, like named patterns that didn't exist, but in the
case of low-level errors in the regex structure 500 errors
were being returned. This change rectifies the mistake, so
that now both high-level and low-level errors in grok_pattern
overrides return status 400.

Fixes #68132