### PR TITLE
[DOCS] Expands feature processors property description and adds a link of conceptual docs

### DIFF
--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -574,9 +574,14 @@ tag::dfas-feature-processors[]
 A collection of feature preprocessors that modify one or more included fields.
 The analysis uses the resulting one or more features instead of the
 original document field. Multiple `feature_processors` entries can refer to the
-same document fields.
-Note, automatic categorical {ml-docs}/ml-feature-encoding.html[feature encoding] 
-still occurs.
+same document fields. Note, automatic categorical 
+{ml-docs}/ml-feature-encoding.html[feature encoding] still occurs for the fields 
+that are unprocessed by a custom processor or that have categorical values.
+Advanced configuration option. Only use this if you want to override the 
+automatic feature encoding of the specified fields.
+Refer to 
+{ml-docs}/ml-feature-processors.html[{dfanalytics} feature processors] to 
+learn more.
 end::dfas-feature-processors[]
 
 tag::dfas-feature-processors-feat-name[]

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -571,17 +571,17 @@ candidate split.
 end::dfas-feature-bag-fraction[]
 
 tag::dfas-feature-processors[]
+Advanced configuration option.
 A collection of feature preprocessors that modify one or more included fields.
 The analysis uses the resulting one or more features instead of the
 original document field. Multiple `feature_processors` entries can refer to the
 same document fields. Automatic categorical 
 {ml-docs}/ml-feature-encoding.html[feature encoding] still occurs for the fields 
 that are unprocessed by a custom processor or that have categorical values.
-Advanced configuration option. Only use this if you want to override the 
-automatic feature encoding of the specified fields.
-Refer to 
-{ml-docs}/ml-feature-processors.html[{dfanalytics} feature processors] to 
-learn more.
+Only use this if you want to override the automatic feature encoding of the 
+specified fields. Refer to 
+{ml-docs}/ml-feature-processors.html[{dfanalytics} feature processors] to learn 
+more.
 end::dfas-feature-processors[]
 
 tag::dfas-feature-processors-feat-name[]

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -574,7 +574,7 @@ tag::dfas-feature-processors[]
 A collection of feature preprocessors that modify one or more included fields.
 The analysis uses the resulting one or more features instead of the
 original document field. Multiple `feature_processors` entries can refer to the
-same document fields. Note, automatic categorical 
+same document fields. Automatic categorical 
 {ml-docs}/ml-feature-encoding.html[feature encoding] still occurs for the fields 
 that are unprocessed by a custom processor or that have categorical values.
 Advanced configuration option. Only use this if you want to override the 


### PR DESCRIPTION
## Overview

This PR expands the description of the `feature.processors` property of the PUT DFA API and adds a link that points to the conceptual docs of the custom feature processors.

### Preview

[PUT DFA API docs](https://elasticsearch_68213.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/put-dfanalytics.html)

### Notes

The docs build CI will pass after https://github.com/elastic/stack-docs/pull/1540 is merged.