### PR TITLE
SQL: Update supported version for date_nanos

### DIFF
--- a/x-pack/plugin/sql/qa/jdbc/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/JdbcTestUtils.java
+++ b/x-pack/plugin/sql/qa/jdbc/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/JdbcTestUtils.java
@@ -104,6 +104,6 @@ final class JdbcTestUtils {
     }
 
     static boolean versionSupportsDateNanos() {
-        return JDBC_DRIVER_VERSION.onOrAfter(Version.V_8_0_0);
+        return JDBC_DRIVER_VERSION.onOrAfter(Version.V_7_12_0);
     }
 }

--- a/x-pack/plugin/sql/sql-proto/src/main/java/org/elasticsearch/xpack/sql/proto/SqlVersion.java
+++ b/x-pack/plugin/sql/sql-proto/src/main/java/org/elasticsearch/xpack/sql/proto/SqlVersion.java
@@ -30,8 +30,8 @@ public class SqlVersion implements Comparable<SqlVersion>{
     public static final int MAJOR_MULTIPLIER = REVISION_MULTIPLIER * MINOR_MULTIPLIER;
 
     public static final SqlVersion V_7_7_0 = new SqlVersion(7, 7, 0);
-    public static final SqlVersion V_8_0_0 = new SqlVersion(8, 0, 0);
-    public static final SqlVersion DATE_NANOS_SUPPORT_VERSION = V_8_0_0;
+    public static final SqlVersion V_7_12_0 = new SqlVersion(7, 12, 0);
+    public static final SqlVersion DATE_NANOS_SUPPORT_VERSION = V_7_12_0;
 
     public SqlVersion(byte major, byte minor, byte revision) {
         this(toString(major, minor, revision), major, minor, revision);


### PR DESCRIPTION
With #68198 merged, the supported version for date_nanos is updated to 7.12.0
    
Follows: #67666