### PR TITLE
[ML] Rename "file" to "text"

### DIFF
--- a/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/rest/RestFindStructureAction.java
+++ b/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/rest/RestFindStructureAction.java
@@ -13,7 +13,7 @@ import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.core.textstructure.action.FindStructureAction;
 import org.elasticsearch.xpack.core.textstructure.structurefinder.TextStructure;
-import org.elasticsearch.xpack.textstructure.structurefinder.FileStructureFinderManager;
+import org.elasticsearch.xpack.textstructure.structurefinder.TextStructureFinderManager;
 
 import java.util.Collections;
 import java.util.List;
@@ -49,13 +49,13 @@ public class RestFindStructureAction extends BaseRestHandler {
         request.setLinesToSample(
             restRequest.paramAsInt(
                 FindStructureAction.Request.LINES_TO_SAMPLE.getPreferredName(),
-                FileStructureFinderManager.DEFAULT_IDEAL_SAMPLE_LINE_COUNT
+                TextStructureFinderManager.DEFAULT_IDEAL_SAMPLE_LINE_COUNT
             )
         );
         request.setLineMergeSizeLimit(
             restRequest.paramAsInt(
                 FindStructureAction.Request.LINE_MERGE_SIZE_LIMIT.getPreferredName(),
-                FileStructureFinderManager.DEFAULT_LINE_MERGE_SIZE_LIMIT
+                TextStructureFinderManager.DEFAULT_LINE_MERGE_SIZE_LIMIT
             )
         );
         request.setTimeout(

--- a/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/DelimitedTextStructureFinderFactory.java
+++ b/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/DelimitedTextStructureFinderFactory.java
@@ -12,7 +12,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
 
-public class DelimitedFileStructureFinderFactory implements FileStructureFinderFactory {
+public class DelimitedTextStructureFinderFactory implements TextStructureFinderFactory {
 
     static final double DELIMITER_OVERRIDDEN_ALLOWED_FRACTION_OF_BAD_LINES = 0.10d;
     static final double FORMAT_OVERRIDDEN_ALLOWED_FRACTION_OF_BAD_LINES = 0.05d;
@@ -20,15 +20,15 @@ public class DelimitedFileStructureFinderFactory implements FileStructureFinderF
     private final int minFieldsPerRow;
     private final boolean trimFields;
 
-    DelimitedFileStructureFinderFactory(char delimiter, char quote, int minFieldsPerRow, boolean trimFields) {
+    DelimitedTextStructureFinderFactory(char delimiter, char quote, int minFieldsPerRow, boolean trimFields) {
         csvPreference = new CsvPreference.Builder(quote, delimiter, "\n").build();
         this.minFieldsPerRow = minFieldsPerRow;
         this.trimFields = trimFields;
     }
 
-    DelimitedFileStructureFinderFactory makeSimilar(Character quote, Boolean trimFields) {
+    DelimitedTextStructureFinderFactory makeSimilar(Character quote, Boolean trimFields) {
 
-        return new DelimitedFileStructureFinderFactory(
+        return new DelimitedTextStructureFinderFactory(
             (char) csvPreference.getDelimiterChar(),
             (quote == null) ? csvPreference.getQuoteChar() : quote,
             minFieldsPerRow,
@@ -44,10 +44,10 @@ public class DelimitedFileStructureFinderFactory implements FileStructureFinderF
     /**
      * Rules are:
      * - It must contain at least two complete records
-     * - There must be a minimum number of fields per record (otherwise files with no commas could be treated as CSV!)
+     * - There must be a minimum number of fields per record (otherwise text with no commas could be treated as CSV!)
      * - Every record except the last must have the same number of fields
      * The reason the last record is allowed to have fewer fields than the others is that
-     * it could have been truncated when the file was sampled.
+     * it could have been truncated when the text was sampled.
      */
     @Override
     public boolean canCreateFromSample(List<String> explanation, String sample, double allowedFractionOfBadLines) {
@@ -63,7 +63,7 @@ public class DelimitedFileStructureFinderFactory implements FileStructureFinderF
                 formatName = Character.getName(csvPreference.getDelimiterChar()).toLowerCase(Locale.ROOT) + " delimited values";
                 break;
         }
-        return DelimitedFileStructureFinder.canCreateFromSample(
+        return DelimitedTextStructureFinder.canCreateFromSample(
             explanation,
             sample,
             minFieldsPerRow,
@@ -74,17 +74,17 @@ public class DelimitedFileStructureFinderFactory implements FileStructureFinderF
     }
 
     @Override
-    public FileStructureFinder createFromSample(
+    public TextStructureFinder createFromSample(
         List<String> explanation,
         String sample,
         String charsetName,
         Boolean hasByteOrderMarker,
         int lineMergeSizeLimit,
-        FileStructureOverrides overrides,
+        TextStructureOverrides overrides,
         TimeoutChecker timeoutChecker
     ) throws IOException {
         CsvPreference adjustedCsvPreference = new CsvPreference.Builder(csvPreference).maxLinesPerRow(lineMergeSizeLimit).build();
-        return DelimitedFileStructureFinder.makeDelimitedFileStructureFinder(
+        return DelimitedTextStructureFinder.makeDelimitedTextStructureFinder(
             explanation,
             sample,
             charsetName,

--- a/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/FieldStatsCalculator.java
+++ b/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/FieldStatsCalculator.java
@@ -55,7 +55,7 @@ public class FieldStatsCalculator {
 
     public FieldStatsCalculator(Map<String, String> mapping) {
 
-        switch (mapping.get(FileStructureUtils.MAPPING_TYPE_SETTING)) {
+        switch (mapping.get(TextStructureUtils.MAPPING_TYPE_SETTING)) {
             case "byte":
             case "short":
             case "integer":
@@ -67,7 +67,7 @@ public class FieldStatsCalculator {
                 break;
             case "date":
             case "date_nanos":
-                String format = mapping.get(FileStructureUtils.MAPPING_FORMAT_SETTING);
+                String format = mapping.get(TextStructureUtils.MAPPING_FORMAT_SETTING);
                 dateFormatter = (format == null) ? DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER : DateFormatter.forPattern(format);
                 // Dates are treated like strings for top hits
                 countsByStringValue = new TreeMap<>();
@@ -94,8 +94,8 @@ public class FieldStatsCalculator {
                 try {
                     countsByNumericValue.compute(Double.valueOf(fieldValue), (k, v) -> (v == null) ? 1 : (1 + v));
                 } catch (NumberFormatException e) {
-                    // This should not happen in the usual context this class is used in within the file structure finder,
-                    // as "double" should be big enough to hold any value that the file structure finder considers numeric
+                    // This should not happen in the usual context this class is used in within the structure finder,
+                    // as "double" should be big enough to hold any value that the structure finder considers numeric
                     throw new IllegalArgumentException(
                         "Field with numeric mapping [" + fieldValue + "] could not be parsed as type double",
                         e

--- a/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/GrokPatternCreator.java
+++ b/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/GrokPatternCreator.java
@@ -504,7 +504,7 @@ public final class GrokPatternCreator {
         ValueOnlyGrokPatternCandidate(String grokPatternName, String mappingType, String fieldName) {
             this(
                 grokPatternName,
-                Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, mappingType),
+                Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, mappingType),
                 fieldName,
                 "\\b",
                 "\\b",
@@ -526,7 +526,7 @@ public final class GrokPatternCreator {
         ) {
             this(
                 grokPatternName,
-                Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, mappingType),
+                Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, mappingType),
                 fieldName,
                 "\\b",
                 "\\b",
@@ -544,7 +544,7 @@ public final class GrokPatternCreator {
         ValueOnlyGrokPatternCandidate(String grokPatternName, String mappingType, String fieldName, String preBreak, String postBreak) {
             this(
                 grokPatternName,
-                Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, mappingType),
+                Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, mappingType),
                 fieldName,
                 preBreak,
                 postBreak,
@@ -627,9 +627,9 @@ public final class GrokPatternCreator {
             String adjustedFieldName = buildFieldName(fieldNameCountStore, fieldName);
             Map<String, String> adjustedMapping = mapping;
             // If the mapping is type "date" with no format, try to adjust it to include the format
-            if (FileStructureUtils.DATE_MAPPING_WITHOUT_FORMAT.equals(adjustedMapping)) {
+            if (TextStructureUtils.DATE_MAPPING_WITHOUT_FORMAT.equals(adjustedMapping)) {
                 try {
-                    adjustedMapping = FileStructureUtils.findTimestampMapping(explanation, values, timeoutChecker);
+                    adjustedMapping = TextStructureUtils.findTimestampMapping(explanation, values, timeoutChecker);
                 } catch (IllegalArgumentException e) {
                     // This feels like it shouldn't happen, but there may be some obscure edge case
                     // where it does, and in production it will cause less frustration to just return
@@ -642,7 +642,7 @@ public final class GrokPatternCreator {
                 mappings.put(adjustedFieldName, adjustedMapping);
             }
             if (fieldStats != null) {
-                fieldStats.put(adjustedFieldName, FileStructureUtils.calculateFieldStats(adjustedMapping, values, timeoutChecker));
+                fieldStats.put(adjustedFieldName, TextStructureUtils.calculateFieldStats(adjustedMapping, values, timeoutChecker));
             }
             return "%{" + grokPatternName + ":" + adjustedFieldName + "}";
         }
@@ -716,13 +716,13 @@ public final class GrokPatternCreator {
                 timeoutChecker.check("full message Grok pattern field extraction");
             }
             String adjustedFieldName = buildFieldName(fieldNameCountStore, fieldName);
-            Map<String, String> mapping = FileStructureUtils.guessScalarMapping(explanation, adjustedFieldName, values, timeoutChecker);
+            Map<String, String> mapping = TextStructureUtils.guessScalarMapping(explanation, adjustedFieldName, values, timeoutChecker);
             timeoutChecker.check("mapping determination");
             if (mappings != null) {
                 mappings.put(adjustedFieldName, mapping);
             }
             if (fieldStats != null) {
-                fieldStats.put(adjustedFieldName, FileStructureUtils.calculateFieldStats(mapping, values, timeoutChecker));
+                fieldStats.put(adjustedFieldName, TextStructureUtils.calculateFieldStats(mapping, values, timeoutChecker));
             }
             return "\\b" + fieldName + "=%{USER:" + adjustedFieldName + "}";
         }
@@ -857,7 +857,7 @@ public final class GrokPatternCreator {
 
                 for (Map.Entry<String, Collection<String>> valuesForField : valuesPerField.entrySet()) {
                     String fieldName = valuesForField.getKey();
-                    Map<String, String> mapping = FileStructureUtils.guessScalarMapping(
+                    Map<String, String> mapping = TextStructureUtils.guessScalarMapping(
                         explanation,
                         fieldName,
                         valuesForField.getValue(),
@@ -871,7 +871,7 @@ public final class GrokPatternCreator {
                     if (fieldStats != null) {
                         fieldStats.put(
                             fieldName,
-                            FileStructureUtils.calculateFieldStats(mapping, valuesForField.getValue(), timeoutChecker)
+                            TextStructureUtils.calculateFieldStats(mapping, valuesForField.getValue(), timeoutChecker)
                         );
                     }
                 }

--- a/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/LogTextStructureFinderFactory.java
+++ b/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/LogTextStructureFinderFactory.java
@@ -10,7 +10,7 @@ import org.elasticsearch.xpack.core.textstructure.structurefinder.TextStructure;
 import java.util.List;
 import java.util.regex.Pattern;
 
-public class TextLogFileStructureFinderFactory implements FileStructureFinderFactory {
+public class LogTextStructureFinderFactory implements TextStructureFinderFactory {
 
     // This works because, by default, dot doesn't match newlines
     private static final Pattern TWO_NON_BLANK_LINES_PATTERN = Pattern.compile(".\n+.");
@@ -40,16 +40,16 @@ public class TextLogFileStructureFinderFactory implements FileStructureFinderFac
     }
 
     @Override
-    public FileStructureFinder createFromSample(
+    public TextStructureFinder createFromSample(
         List<String> explanation,
         String sample,
         String charsetName,
         Boolean hasByteOrderMarker,
         int lineMergeSizeLimit,
-        FileStructureOverrides overrides,
+        TextStructureOverrides overrides,
         TimeoutChecker timeoutChecker
     ) {
-        return TextLogFileStructureFinder.makeTextLogFileStructureFinder(
+        return LogTextStructureFinder.makeLogTextStructureFinder(
             explanation,
             sample,
             charsetName,

--- a/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/NdJsonTextStructureFinder.java
+++ b/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/NdJsonTextStructureFinder.java
@@ -26,17 +26,17 @@ import static org.elasticsearch.common.xcontent.json.JsonXContent.jsonXContent;
 /**
  * Newline-delimited JSON.
  */
-public class NdJsonFileStructureFinder implements FileStructureFinder {
+public class NdJsonTextStructureFinder implements TextStructureFinder {
 
     private final List<String> sampleMessages;
     private final TextStructure structure;
 
-    static NdJsonFileStructureFinder makeNdJsonFileStructureFinder(
+    static NdJsonTextStructureFinder makeNdJsonTextStructureFinder(
         List<String> explanation,
         String sample,
         String charsetName,
         Boolean hasByteOrderMarker,
-        FileStructureOverrides overrides,
+        TextStructureOverrides overrides,
         TimeoutChecker timeoutChecker
     ) throws IOException {
 
@@ -59,7 +59,7 @@ public class NdJsonFileStructureFinder implements FileStructureFinder {
             .setNumLinesAnalyzed(sampleMessages.size())
             .setNumMessagesAnalyzed(sampleRecords.size());
 
-        Tuple<String, TimestampFormatFinder> timeField = FileStructureUtils.guessTimestampField(
+        Tuple<String, TimestampFormatFinder> timeField = TextStructureUtils.guessTimestampField(
             explanation,
             sampleRecords,
             overrides,
@@ -73,7 +73,7 @@ public class NdJsonFileStructureFinder implements FileStructureFinder {
                 .setJavaTimestampFormats(timeField.v2().getJavaTimestampFormats())
                 .setNeedClientTimezone(needClientTimeZone)
                 .setIngestPipeline(
-                    FileStructureUtils.makeIngestPipelineDefinition(
+                    TextStructureUtils.makeIngestPipelineDefinition(
                         null,
                         Collections.emptyMap(),
                         null,
@@ -88,12 +88,12 @@ public class NdJsonFileStructureFinder implements FileStructureFinder {
                 );
         }
 
-        Tuple<SortedMap<String, Object>, SortedMap<String, FieldStats>> mappingsAndFieldStats = FileStructureUtils
+        Tuple<SortedMap<String, Object>, SortedMap<String, FieldStats>> mappingsAndFieldStats = TextStructureUtils
             .guessMappingsAndCalculateFieldStats(explanation, sampleRecords, timeoutChecker);
 
         Map<String, Object> fieldMappings = mappingsAndFieldStats.v1();
         if (timeField != null) {
-            fieldMappings.put(FileStructureUtils.DEFAULT_TIMESTAMP_FIELD, timeField.v2().getEsDateMappingTypeWithoutFormat());
+            fieldMappings.put(TextStructureUtils.DEFAULT_TIMESTAMP_FIELD, timeField.v2().getEsDateMappingTypeWithoutFormat());
         }
 
         if (mappingsAndFieldStats.v2() != null) {
@@ -101,13 +101,13 @@ public class NdJsonFileStructureFinder implements FileStructureFinder {
         }
 
         TextStructure structure = structureBuilder.setMappings(
-            Collections.singletonMap(FileStructureUtils.MAPPING_PROPERTIES_SETTING, fieldMappings)
+            Collections.singletonMap(TextStructureUtils.MAPPING_PROPERTIES_SETTING, fieldMappings)
         ).setExplanation(explanation).build();
 
-        return new NdJsonFileStructureFinder(sampleMessages, structure);
+        return new NdJsonTextStructureFinder(sampleMessages, structure);
     }
 
-    private NdJsonFileStructureFinder(List<String> sampleMessages, TextStructure structure) {
+    private NdJsonTextStructureFinder(List<String> sampleMessages, TextStructure structure) {
         this.sampleMessages = Collections.unmodifiableList(sampleMessages);
         this.structure = structure;
     }

--- a/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/NdJsonTextStructureFinderFactory.java
+++ b/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/NdJsonTextStructureFinderFactory.java
@@ -17,7 +17,7 @@ import java.util.Locale;
 
 import static org.elasticsearch.common.xcontent.json.JsonXContent.jsonXContent;
 
-public class NdJsonFileStructureFinderFactory implements FileStructureFinderFactory {
+public class NdJsonTextStructureFinderFactory implements TextStructureFinderFactory {
 
     @Override
     public boolean canFindFormat(TextStructure.Format format) {
@@ -73,16 +73,16 @@ public class NdJsonFileStructureFinderFactory implements FileStructureFinderFact
     }
 
     @Override
-    public FileStructureFinder createFromSample(
+    public TextStructureFinder createFromSample(
         List<String> explanation,
         String sample,
         String charsetName,
         Boolean hasByteOrderMarker,
         int lineMergeSizeLimit,
-        FileStructureOverrides overrides,
+        TextStructureOverrides overrides,
         TimeoutChecker timeoutChecker
     ) throws IOException {
-        return NdJsonFileStructureFinder.makeNdJsonFileStructureFinder(
+        return NdJsonTextStructureFinder.makeNdJsonTextStructureFinder(
             explanation,
             sample,
             charsetName,

--- a/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/TextStructureFinder.java
+++ b/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/TextStructureFinder.java
@@ -9,7 +9,7 @@ import org.elasticsearch.xpack.core.textstructure.structurefinder.TextStructure;
 
 import java.util.List;
 
-public interface FileStructureFinder {
+public interface TextStructureFinder {
 
     /**
      * The (possibly multi-line) messages that the sampled lines were combined into.
@@ -18,8 +18,8 @@ public interface FileStructureFinder {
     List<String> getSampleMessages();
 
     /**
-     * Retrieve the structure of the file used to instantiate the finder.
-     * @return The file structure.
+     * Retrieve the structure of the text used to instantiate the finder.
+     * @return The text structure.
      */
     TextStructure getStructure();
 }

--- a/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/TextStructureFinderFactory.java
+++ b/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/TextStructureFinderFactory.java
@@ -9,50 +9,50 @@ import org.elasticsearch.xpack.core.textstructure.structurefinder.TextStructure;
 
 import java.util.List;
 
-public interface FileStructureFinderFactory {
+public interface TextStructureFinderFactory {
 
     /**
-     * Can this factory create a {@link FileStructureFinder} that can find the supplied format?
+     * Can this factory create a {@link TextStructureFinder} that can find the supplied format?
      * @param format The format to query, or <code>null</code>.
      * @return <code>true</code> if {@code format} is <code>null</code> or the factory
-     *         can produce a {@link FileStructureFinder} that can find {@code format}.
+     *         can produce a {@link TextStructureFinder} that can find {@code format}.
      */
     boolean canFindFormat(TextStructure.Format format);
 
     /**
-     * Given a sample of a file, decide whether this factory will be able
+     * Given some sample text, decide whether this factory will be able
      * to create an appropriate object to represent its ingestion configs.
      * @param explanation List of reasons for making decisions.  May contain items when passed and new reasons
      *                    can be appended by this method.
-     * @param sample A sample from the file to be ingested.
+     * @param sample A sample from the text to be ingested.
      * @param allowedFractionOfBadLines How many lines of the passed sample are allowed to be considered "bad".
      *                                  Provided as a fraction from interval [0, 1]
      * @return <code>true</code> if this factory can create an appropriate
-     *         file structure given the sample; otherwise <code>false</code>.
+     *         text structure given the sample; otherwise <code>false</code>.
      */
     boolean canCreateFromSample(List<String> explanation, String sample, double allowedFractionOfBadLines);
 
     /**
-     * Create an object representing the structure of a file.
+     * Create an object representing the structure of some text.
      * @param explanation List of reasons for making decisions.  May contain items when passed and new reasons
      *                    can be appended by this method.
-     * @param sample A sample from the file to be ingested.
+     * @param sample A sample from the text to be ingested.
      * @param charsetName The name of the character set in which the sample was provided.
      * @param hasByteOrderMarker Did the sample have a byte order marker?  <code>null</code> means "not relevant".
      * @param lineMergeSizeLimit Maximum number of characters permitted when lines are merged to create messages.
      * @param overrides Stores structure decisions that have been made by the end user, and should
-     *                  take precedence over anything the {@link FileStructureFinder} may decide.
+     *                  take precedence over anything the {@link TextStructureFinder} may decide.
      * @param timeoutChecker Will abort the operation if its timeout is exceeded.
-     * @return A {@link FileStructureFinder} object suitable for determining the structure of the supplied sample.
+     * @return A {@link TextStructureFinder} object suitable for determining the structure of the supplied sample.
      * @throws Exception if something goes wrong during creation.
      */
-    FileStructureFinder createFromSample(
+    TextStructureFinder createFromSample(
         List<String> explanation,
         String sample,
         String charsetName,
         Boolean hasByteOrderMarker,
         int lineMergeSizeLimit,
-        FileStructureOverrides overrides,
+        TextStructureOverrides overrides,
         TimeoutChecker timeoutChecker
     ) throws Exception;
 }

--- a/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/TextStructureOverrides.java
+++ b/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/TextStructureOverrides.java
@@ -12,16 +12,16 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * An immutable holder for the aspects of file structure detection that can be overridden
+ * An immutable holder for the aspects of text structure detection that can be overridden
  * by the end user.  Every field can be <code>null</code>, and this means that that
- * aspect of the file structure detection is not overridden.
+ * aspect of the text structure detection is not overridden.
  *
  * There is no consistency checking in this class.  Consistency checking of the different
  * fields is done in {@link FindStructureAction.Request}.
  */
-public class FileStructureOverrides {
+public class TextStructureOverrides {
 
-    public static final FileStructureOverrides EMPTY_OVERRIDES = new Builder().build();
+    public static final TextStructureOverrides EMPTY_OVERRIDES = new Builder().build();
 
     private final String charset;
     private final TextStructure.Format format;
@@ -34,7 +34,7 @@ public class FileStructureOverrides {
     private final String timestampFormat;
     private final String timestampField;
 
-    public FileStructureOverrides(FindStructureAction.Request request) {
+    public TextStructureOverrides(FindStructureAction.Request request) {
 
         this(
             request.getCharset(),
@@ -50,7 +50,7 @@ public class FileStructureOverrides {
         );
     }
 
-    private FileStructureOverrides(
+    private TextStructureOverrides(
         String charset,
         TextStructure.Format format,
         List<String> columnNames,
@@ -146,7 +146,7 @@ public class FileStructureOverrides {
             return false;
         }
 
-        FileStructureOverrides that = (FileStructureOverrides) other;
+        TextStructureOverrides that = (TextStructureOverrides) other;
         return Objects.equals(this.charset, that.charset)
             && Objects.equals(this.format, that.format)
             && Objects.equals(this.columnNames, that.columnNames)
@@ -222,9 +222,9 @@ public class FileStructureOverrides {
             return this;
         }
 
-        public FileStructureOverrides build() {
+        public TextStructureOverrides build() {
 
-            return new FileStructureOverrides(
+            return new TextStructureOverrides(
                 charset,
                 format,
                 columnNames,

--- a/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/TextStructureUtils.java
+++ b/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/TextStructureUtils.java
@@ -27,9 +27,9 @@ import java.util.TreeMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public final class FileStructureUtils {
+public final class TextStructureUtils {
 
-    private static final Logger logger = LogManager.getLogger(FileStructureUtils.class);
+    private static final Logger logger = LogManager.getLogger(TextStructureUtils.class);
     public static final String DEFAULT_TIMESTAMP_FIELD = "@timestamp";
     public static final String MAPPING_TYPE_SETTING = "type";
     public static final String MAPPING_FORMAT_SETTING = "format";
@@ -83,7 +83,7 @@ public final class FileStructureUtils {
 
     private static final String BEAT_TIMEZONE_FIELD = "event.timezone";
 
-    private FileStructureUtils() {}
+    private TextStructureUtils() {}
 
     /**
      * Given one or more sample records, find a timestamp field that is consistently present in them all.
@@ -92,12 +92,12 @@ public final class FileStructureUtils {
      * - Must have the same timestamp format in every record
      * If multiple fields meet these criteria then the one that occurred first in the first sample record
      * is chosen.
-     * @param explanation List of reasons for choosing the overall file structure.  This list
+     * @param explanation List of reasons for choosing the overall text structure.  This list
      *                    may be non-empty when the method is called, and this method may
      *                    append to it.
      * @param sampleRecords List of records derived from the provided sample.
-     * @param overrides Aspects of the file structure that are known in advance.  These take precedence over
-     *                  values determined by structure analysis.  An exception will be thrown if the file structure
+     * @param overrides Aspects of the text structure that are known in advance.  These take precedence over
+     *                  values determined by structure analysis.  An exception will be thrown if the text structure
      *                  is incompatible with an overridden value.
      * @param timeoutChecker Will abort the operation if its timeout is exceeded.
      * @return A tuple of (field name, timestamp format finder) if one can be found, or <code>null</code> if
@@ -106,7 +106,7 @@ public final class FileStructureUtils {
     static Tuple<String, TimestampFormatFinder> guessTimestampField(
         List<String> explanation,
         List<Map<String, ?>> sampleRecords,
-        FileStructureOverrides overrides,
+        TextStructureOverrides overrides,
         TimeoutChecker timeoutChecker
     ) {
         if (sampleRecords.isEmpty()) {
@@ -190,7 +190,7 @@ public final class FileStructureUtils {
     private static List<Tuple<String, TimestampFormatFinder>> findCandidates(
         List<String> explanation,
         List<Map<String, ?>> sampleRecords,
-        FileStructureOverrides overrides,
+        TextStructureOverrides overrides,
         TimeoutChecker timeoutChecker
     ) {
 
@@ -319,7 +319,7 @@ public final class FileStructureUtils {
             return guessMappingAndCalculateFieldStats(
                 explanation,
                 fieldName,
-                fieldValues.stream().flatMap(FileStructureUtils::flatten).collect(Collectors.toList()),
+                fieldValues.stream().flatMap(TextStructureUtils::flatten).collect(Collectors.toList()),
                 timeoutChecker
             );
         }
@@ -345,7 +345,7 @@ public final class FileStructureUtils {
     /**
      * Finds the appropriate date mapping for a collection of field values.  Throws
      * {@link IllegalArgumentException} if no consistent date mapping can be found.
-     * @param explanation List of reasons for choosing the overall file structure.  This list
+     * @param explanation List of reasons for choosing the overall text structure.  This list
      *                    may be non-empty when the method is called, and this method may
      *                    append to it.
      * @param fieldValues Values of the field for which mappings are to be guessed.  The guessed
@@ -369,7 +369,7 @@ public final class FileStructureUtils {
     /**
      * Given some sample values for a field, guess the most appropriate index mapping for the
      * field.
-     * @param explanation List of reasons for choosing the overall file structure.  This list
+     * @param explanation List of reasons for choosing the overall text structure.  This list
      *                    may be non-empty when the method is called, and this method may
      *                    append to it.
      * @param fieldName Name of the field for which mappings are to be guessed.
@@ -421,7 +421,7 @@ public final class FileStructureUtils {
             return Collections.singletonMap(MAPPING_TYPE_SETTING, "geo_shape");
         }
 
-        if (fieldValues.stream().anyMatch(FileStructureUtils::isMoreLikelyTextThanKeyword)) {
+        if (fieldValues.stream().anyMatch(TextStructureUtils::isMoreLikelyTextThanKeyword)) {
             return Collections.singletonMap(MAPPING_TYPE_SETTING, "text");
         }
 
@@ -453,7 +453,7 @@ public final class FileStructureUtils {
     }
 
     /**
-     * Create an ingest pipeline definition appropriate for the file structure.
+     * Create an ingest pipeline definition appropriate for the text structure.
      * @param grokPattern The Grok pattern used for parsing semi-structured text formats.  <code>null</code> for
      *                    fully structured formats.
      * @param customGrokPatternDefinitions The definitions for any custom patterns that {@code grokPattern} uses.

--- a/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/TimeoutChecker.java
+++ b/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/TimeoutChecker.java
@@ -105,7 +105,7 @@ public class TimeoutChecker implements Closeable {
             return grok.captures(text);
         } finally {
             // If a timeout has occurred then this check will overwrite any timeout exception thrown by Grok.captures() and this
-            // is intentional - the exception from this class makes more sense in the context of the find file structure API
+            // is intentional - the exception from this class makes more sense in the context of the find structure API
             check(where);
         }
     }

--- a/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/TimestampFormatFinder.java
+++ b/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/TimestampFormatFinder.java
@@ -1144,7 +1144,7 @@ public final class TimestampFormatFinder {
      * so we just need to know if it has nanosecond resolution or not.
      */
     public Map<String, String> getEsDateMappingTypeWithoutFormat() {
-        return Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, needNanosecondPrecision() ? "date_nanos" : "date");
+        return Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, needNanosecondPrecision() ? "date_nanos" : "date");
     }
 
     /**
@@ -1156,10 +1156,10 @@ public final class TimestampFormatFinder {
         List<String> javaTimestampFormats = getJavaTimestampFormats();
         if (javaTimestampFormats.contains("TAI64N")) {
             // There's no format for TAI64N in the timestamp formats used in mappings
-            return Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "keyword");
+            return Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "keyword");
         }
         Map<String, String> mapping = new LinkedHashMap<>();
-        mapping.put(FileStructureUtils.MAPPING_TYPE_SETTING, needNanosecondPrecision() ? "date_nanos" : "date");
+        mapping.put(TextStructureUtils.MAPPING_TYPE_SETTING, needNanosecondPrecision() ? "date_nanos" : "date");
         String formats = javaTimestampFormats.stream().map(format -> {
             switch (format) {
                 case "ISO8601":
@@ -1173,7 +1173,7 @@ public final class TimestampFormatFinder {
             }
         }).collect(Collectors.joining("||"));
         if (formats.isEmpty() == false) {
-            mapping.put(FileStructureUtils.MAPPING_FORMAT_SETTING, formats);
+            mapping.put(TextStructureUtils.MAPPING_FORMAT_SETTING, formats);
         }
         return mapping;
     }

--- a/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/XmlTextStructureFinder.java
+++ b/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/XmlTextStructureFinder.java
@@ -32,17 +32,17 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.regex.Pattern;
 
-public class XmlFileStructureFinder implements FileStructureFinder {
+public class XmlTextStructureFinder implements TextStructureFinder {
 
     private final List<String> sampleMessages;
     private final TextStructure structure;
 
-    static XmlFileStructureFinder makeXmlFileStructureFinder(
+    static XmlTextStructureFinder makeXmlTextStructureFinder(
         List<String> explanation,
         String sample,
         String charsetName,
         Boolean hasByteOrderMarker,
-        FileStructureOverrides overrides,
+        TextStructureOverrides overrides,
         TimeoutChecker timeoutChecker
     ) throws IOException, ParserConfigurationException, SAXException {
 
@@ -96,7 +96,7 @@ public class XmlFileStructureFinder implements FileStructureFinder {
             .setNumMessagesAnalyzed(sampleRecords.size())
             .setMultilineStartPattern("^\\s*<" + topLevelTag);
 
-        Tuple<String, TimestampFormatFinder> timeField = FileStructureUtils.guessTimestampField(
+        Tuple<String, TimestampFormatFinder> timeField = TextStructureUtils.guessTimestampField(
             explanation,
             sampleRecords,
             overrides,
@@ -110,7 +110,7 @@ public class XmlFileStructureFinder implements FileStructureFinder {
                 .setJavaTimestampFormats(timeField.v2().getJavaTimestampFormats())
                 .setNeedClientTimezone(needClientTimeZone)
                 .setIngestPipeline(
-                    FileStructureUtils.makeIngestPipelineDefinition(
+                    TextStructureUtils.makeIngestPipelineDefinition(
                         null,
                         Collections.emptyMap(),
                         null,
@@ -123,7 +123,7 @@ public class XmlFileStructureFinder implements FileStructureFinder {
                 );
         }
 
-        Tuple<SortedMap<String, Object>, SortedMap<String, FieldStats>> mappingsAndFieldStats = FileStructureUtils
+        Tuple<SortedMap<String, Object>, SortedMap<String, FieldStats>> mappingsAndFieldStats = TextStructureUtils
             .guessMappingsAndCalculateFieldStats(explanation, sampleRecords, timeoutChecker);
 
         if (mappingsAndFieldStats.v2() != null) {
@@ -132,19 +132,19 @@ public class XmlFileStructureFinder implements FileStructureFinder {
 
         Map<String, Object> innerFieldMappings = mappingsAndFieldStats.v1();
         Map<String, Object> secondLevelProperties = new LinkedHashMap<>();
-        secondLevelProperties.put(FileStructureUtils.MAPPING_TYPE_SETTING, "object");
-        secondLevelProperties.put(FileStructureUtils.MAPPING_PROPERTIES_SETTING, innerFieldMappings);
+        secondLevelProperties.put(TextStructureUtils.MAPPING_TYPE_SETTING, "object");
+        secondLevelProperties.put(TextStructureUtils.MAPPING_PROPERTIES_SETTING, innerFieldMappings);
         SortedMap<String, Object> outerFieldMappings = new TreeMap<>();
         outerFieldMappings.put(topLevelTag, secondLevelProperties);
         if (timeField != null) {
-            outerFieldMappings.put(FileStructureUtils.DEFAULT_TIMESTAMP_FIELD, timeField.v2().getEsDateMappingTypeWithoutFormat());
+            outerFieldMappings.put(TextStructureUtils.DEFAULT_TIMESTAMP_FIELD, timeField.v2().getEsDateMappingTypeWithoutFormat());
         }
 
         TextStructure structure = structureBuilder.setMappings(
-            Collections.singletonMap(FileStructureUtils.MAPPING_PROPERTIES_SETTING, outerFieldMappings)
+            Collections.singletonMap(TextStructureUtils.MAPPING_PROPERTIES_SETTING, outerFieldMappings)
         ).setExplanation(explanation).build();
 
-        return new XmlFileStructureFinder(sampleMessages, structure);
+        return new XmlTextStructureFinder(sampleMessages, structure);
     }
 
     private static DocumentBuilderFactory makeDocBuilderFactory() throws ParserConfigurationException {
@@ -166,7 +166,7 @@ public class XmlFileStructureFinder implements FileStructureFinder {
         return docBuilderFactory;
     }
 
-    private XmlFileStructureFinder(List<String> sampleMessages, TextStructure structure) {
+    private XmlTextStructureFinder(List<String> sampleMessages, TextStructure structure) {
         this.sampleMessages = Collections.unmodifiableList(sampleMessages);
         this.structure = structure;
     }

--- a/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/XmlTextStructureFinderFactory.java
+++ b/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/XmlTextStructureFinderFactory.java
@@ -18,11 +18,11 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.util.List;
 
-public class XmlFileStructureFinderFactory implements FileStructureFinderFactory {
+public class XmlTextStructureFinderFactory implements TextStructureFinderFactory {
 
     private final XMLInputFactory xmlFactory;
 
-    public XmlFileStructureFinderFactory() {
+    public XmlTextStructureFinderFactory() {
         xmlFactory = XMLInputFactory.newInstance();
         xmlFactory.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, Boolean.FALSE);
         xmlFactory.setProperty(XMLInputFactory.IS_VALIDATING, Boolean.FALSE);
@@ -137,16 +137,16 @@ public class XmlFileStructureFinderFactory implements FileStructureFinderFactory
     }
 
     @Override
-    public FileStructureFinder createFromSample(
+    public TextStructureFinder createFromSample(
         List<String> explanation,
         String sample,
         String charsetName,
         Boolean hasByteOrderMarker,
         int lineMergeSizeLimit,
-        FileStructureOverrides overrides,
+        TextStructureOverrides overrides,
         TimeoutChecker timeoutChecker
     ) throws IOException, ParserConfigurationException, SAXException {
-        return XmlFileStructureFinder.makeXmlFileStructureFinder(
+        return XmlTextStructureFinder.makeXmlTextStructureFinder(
             explanation,
             sample,
             charsetName,

--- a/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/transport/TransportFindStructureAction.java
+++ b/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/transport/TransportFindStructureAction.java
@@ -13,9 +13,9 @@ import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.textstructure.action.FindStructureAction;
-import org.elasticsearch.xpack.textstructure.structurefinder.FileStructureFinder;
-import org.elasticsearch.xpack.textstructure.structurefinder.FileStructureFinderManager;
-import org.elasticsearch.xpack.textstructure.structurefinder.FileStructureOverrides;
+import org.elasticsearch.xpack.textstructure.structurefinder.TextStructureFinder;
+import org.elasticsearch.xpack.textstructure.structurefinder.TextStructureFinderManager;
+import org.elasticsearch.xpack.textstructure.structurefinder.TextStructureOverrides;
 
 import java.io.InputStream;
 
@@ -34,31 +34,31 @@ public class TransportFindStructureAction extends HandledTransportAction<FindStr
     @Override
     protected void doExecute(Task task, FindStructureAction.Request request, ActionListener<FindStructureAction.Response> listener) {
 
-        // As determining the file structure might take a while, we run
+        // As determining the text structure might take a while, we run
         // in a different thread to avoid blocking the network thread.
         threadPool.executor(GENERIC).execute(() -> {
             try {
-                listener.onResponse(buildFileStructureResponse(request));
+                listener.onResponse(buildTextStructureResponse(request));
             } catch (Exception e) {
                 listener.onFailure(e);
             }
         });
     }
 
-    private FindStructureAction.Response buildFileStructureResponse(FindStructureAction.Request request) throws Exception {
+    private FindStructureAction.Response buildTextStructureResponse(FindStructureAction.Request request) throws Exception {
 
-        FileStructureFinderManager structureFinderManager = new FileStructureFinderManager(threadPool.scheduler());
+        TextStructureFinderManager structureFinderManager = new TextStructureFinderManager(threadPool.scheduler());
 
         try (InputStream sampleStream = request.getSample().streamInput()) {
-            FileStructureFinder fileStructureFinder = structureFinderManager.findFileStructure(
+            TextStructureFinder textStructureFinder = structureFinderManager.findTextStructure(
                 request.getLinesToSample(),
                 request.getLineMergeSizeLimit(),
                 sampleStream,
-                new FileStructureOverrides(request),
+                new TextStructureOverrides(request),
                 request.getTimeout()
             );
 
-            return new FindStructureAction.Response(fileStructureFinder.getStructure());
+            return new FindStructureAction.Response(textStructureFinder.getStructure());
         }
     }
 }

--- a/x-pack/plugin/text-structure/src/test/java/org/elasticsearch/xpack/textstructure/structurefinder/DelimitedTextStructureFinderFactoryTests.java
+++ b/x-pack/plugin/text-structure/src/test/java/org/elasticsearch/xpack/textstructure/structurefinder/DelimitedTextStructureFinderFactoryTests.java
@@ -7,10 +7,10 @@ package org.elasticsearch.xpack.textstructure.structurefinder;
 
 public class DelimitedTextStructureFinderFactoryTests extends TextStructureTestCase {
 
-    private FileStructureFinderFactory csvFactory = new DelimitedFileStructureFinderFactory(',', '"', 2, false);
-    private FileStructureFinderFactory tsvFactory = new DelimitedFileStructureFinderFactory('\t', '"', 2, false);
-    private FileStructureFinderFactory semiColonDelimitedfactory = new DelimitedFileStructureFinderFactory(';', '"', 4, false);
-    private FileStructureFinderFactory pipeDelimitedFactory = new DelimitedFileStructureFinderFactory('|', '"', 5, true);
+    private final TextStructureFinderFactory csvFactory = new DelimitedTextStructureFinderFactory(',', '"', 2, false);
+    private final TextStructureFinderFactory tsvFactory = new DelimitedTextStructureFinderFactory('\t', '"', 2, false);
+    private final TextStructureFinderFactory semiColonDelimitedfactory = new DelimitedTextStructureFinderFactory(';', '"', 4, false);
+    private final TextStructureFinderFactory pipeDelimitedFactory = new DelimitedTextStructureFinderFactory('|', '"', 5, true);
 
     // CSV - no need to check NDJSON or XML because they come earlier in the order we check formats
 

--- a/x-pack/plugin/text-structure/src/test/java/org/elasticsearch/xpack/textstructure/structurefinder/DelimitedTextStructureFinderTests.java
+++ b/x-pack/plugin/text-structure/src/test/java/org/elasticsearch/xpack/textstructure/structurefinder/DelimitedTextStructureFinderTests.java
@@ -20,7 +20,7 @@ import java.util.TreeMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.elasticsearch.xpack.textstructure.structurefinder.DelimitedFileStructureFinder.levenshteinFieldwiseCompareRows;
+import static org.elasticsearch.xpack.textstructure.structurefinder.DelimitedTextStructureFinder.levenshteinFieldwiseCompareRows;
 import static org.elasticsearch.xpack.textstructure.structurefinder.TimestampFormatFinder.stringToNumberPosBitSet;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.contains;
@@ -30,8 +30,8 @@ import static org.hamcrest.Matchers.not;
 
 public class DelimitedTextStructureFinderTests extends TextStructureTestCase {
 
-    private final FileStructureFinderFactory csvFactory = new DelimitedFileStructureFinderFactory(',', '"', 2, false);
-    private final FileStructureFinderFactory tsvFactory = new DelimitedFileStructureFinderFactory('\t', '"', 3, false);
+    private final TextStructureFinderFactory csvFactory = new DelimitedTextStructureFinderFactory(',', '"', 2, false);
+    private final TextStructureFinderFactory tsvFactory = new DelimitedTextStructureFinderFactory('\t', '"', 3, false);
 
     public void testCreateConfigsGivenCompleteCsv() throws Exception {
         String sample = "time,message\n" + "2018-05-17T13:41:23,hello\n" + "2018-05-17T13:41:32,hello again\n";
@@ -39,13 +39,13 @@ public class DelimitedTextStructureFinderTests extends TextStructureTestCase {
 
         String charset = randomFrom(POSSIBLE_CHARSETS);
         Boolean hasByteOrderMarker = randomHasByteOrderMarker(charset);
-        FileStructureFinder structureFinder = csvFactory.createFromSample(
+        TextStructureFinder structureFinder = csvFactory.createFromSample(
             explanation,
             sample,
             charset,
             hasByteOrderMarker,
-            FileStructureFinderManager.DEFAULT_LINE_MERGE_SIZE_LIMIT,
-            FileStructureOverrides.EMPTY_OVERRIDES,
+            TextStructureFinderManager.DEFAULT_LINE_MERGE_SIZE_LIMIT,
+            TextStructureOverrides.EMPTY_OVERRIDES,
             NOOP_TIMEOUT_CHECKER
         );
 
@@ -89,13 +89,13 @@ public class DelimitedTextStructureFinderTests extends TextStructureTestCase {
 
         String charset = randomFrom(POSSIBLE_CHARSETS);
         Boolean hasByteOrderMarker = randomHasByteOrderMarker(charset);
-        FileStructureFinder structureFinder = csvFactory.createFromSample(
+        TextStructureFinder structureFinder = csvFactory.createFromSample(
             explanation,
             sample,
             charset,
             hasByteOrderMarker,
-            FileStructureFinderManager.DEFAULT_LINE_MERGE_SIZE_LIMIT,
-            FileStructureOverrides.EMPTY_OVERRIDES,
+            TextStructureFinderManager.DEFAULT_LINE_MERGE_SIZE_LIMIT,
+            TextStructureOverrides.EMPTY_OVERRIDES,
             NOOP_TIMEOUT_CHECKER
         );
 
@@ -140,13 +140,13 @@ public class DelimitedTextStructureFinderTests extends TextStructureTestCase {
 
         String charset = randomFrom(POSSIBLE_CHARSETS);
         Boolean hasByteOrderMarker = randomHasByteOrderMarker(charset);
-        FileStructureFinder structureFinder = csvFactory.createFromSample(
+        TextStructureFinder structureFinder = csvFactory.createFromSample(
             explanation,
             sample,
             charset,
             hasByteOrderMarker,
-            FileStructureFinderManager.DEFAULT_LINE_MERGE_SIZE_LIMIT,
-            FileStructureOverrides.builder().setQuote('"').build(),
+            TextStructureFinderManager.DEFAULT_LINE_MERGE_SIZE_LIMIT,
+            TextStructureOverrides.builder().setQuote('"').build(),
             NOOP_TIMEOUT_CHECKER
         );
 
@@ -175,19 +175,19 @@ public class DelimitedTextStructureFinderTests extends TextStructureTestCase {
 
     public void testCreateConfigsGivenCompleteCsvAndColumnNamesOverride() throws Exception {
 
-        FileStructureOverrides overrides = FileStructureOverrides.builder().setColumnNames(Arrays.asList("my_time", "my_message")).build();
+        TextStructureOverrides overrides = TextStructureOverrides.builder().setColumnNames(Arrays.asList("my_time", "my_message")).build();
 
         String sample = "time,message\n" + "2018-05-17T13:41:23,hello\n" + "2018-05-17T13:41:32,hello again\n";
         assertTrue(csvFactory.canCreateFromSample(explanation, sample, 0.0));
 
         String charset = randomFrom(POSSIBLE_CHARSETS);
         Boolean hasByteOrderMarker = randomHasByteOrderMarker(charset);
-        FileStructureFinder structureFinder = csvFactory.createFromSample(
+        TextStructureFinder structureFinder = csvFactory.createFromSample(
             explanation,
             sample,
             charset,
             hasByteOrderMarker,
-            FileStructureFinderManager.DEFAULT_LINE_MERGE_SIZE_LIMIT,
+            TextStructureFinderManager.DEFAULT_LINE_MERGE_SIZE_LIMIT,
             overrides,
             NOOP_TIMEOUT_CHECKER
         );
@@ -218,19 +218,19 @@ public class DelimitedTextStructureFinderTests extends TextStructureTestCase {
 
         // It's obvious the first row really should be a header row, so by overriding
         // detection with the wrong choice the results will be completely changed
-        FileStructureOverrides overrides = FileStructureOverrides.builder().setHasHeaderRow(false).build();
+        TextStructureOverrides overrides = TextStructureOverrides.builder().setHasHeaderRow(false).build();
 
         String sample = "time,message\n" + "2018-05-17T13:41:23,hello\n" + "2018-05-17T13:41:32,hello again\n";
         assertTrue(csvFactory.canCreateFromSample(explanation, sample, 0.0));
 
         String charset = randomFrom(POSSIBLE_CHARSETS);
         Boolean hasByteOrderMarker = randomHasByteOrderMarker(charset);
-        FileStructureFinder structureFinder = csvFactory.createFromSample(
+        TextStructureFinder structureFinder = csvFactory.createFromSample(
             explanation,
             sample,
             charset,
             hasByteOrderMarker,
-            FileStructureFinderManager.DEFAULT_LINE_MERGE_SIZE_LIMIT,
+            TextStructureFinderManager.DEFAULT_LINE_MERGE_SIZE_LIMIT,
             overrides,
             NOOP_TIMEOUT_CHECKER
         );
@@ -264,13 +264,13 @@ public class DelimitedTextStructureFinderTests extends TextStructureTestCase {
 
         String charset = randomFrom(POSSIBLE_CHARSETS);
         Boolean hasByteOrderMarker = randomHasByteOrderMarker(charset);
-        FileStructureFinder structureFinder = csvFactory.createFromSample(
+        TextStructureFinder structureFinder = csvFactory.createFromSample(
             explanation,
             sample,
             charset,
             hasByteOrderMarker,
-            FileStructureFinderManager.DEFAULT_LINE_MERGE_SIZE_LIMIT,
-            FileStructureOverrides.EMPTY_OVERRIDES,
+            TextStructureFinderManager.DEFAULT_LINE_MERGE_SIZE_LIMIT,
+            TextStructureOverrides.EMPTY_OVERRIDES,
             NOOP_TIMEOUT_CHECKER
         );
 
@@ -307,13 +307,13 @@ public class DelimitedTextStructureFinderTests extends TextStructureTestCase {
 
         String charset = randomFrom(POSSIBLE_CHARSETS);
         Boolean hasByteOrderMarker = randomHasByteOrderMarker(charset);
-        FileStructureFinder structureFinder = csvFactory.createFromSample(
+        TextStructureFinder structureFinder = csvFactory.createFromSample(
             explanation,
             sample,
             charset,
             hasByteOrderMarker,
-            FileStructureFinderManager.DEFAULT_LINE_MERGE_SIZE_LIMIT,
-            FileStructureOverrides.EMPTY_OVERRIDES,
+            TextStructureFinderManager.DEFAULT_LINE_MERGE_SIZE_LIMIT,
+            TextStructureOverrides.EMPTY_OVERRIDES,
             NOOP_TIMEOUT_CHECKER
         );
 
@@ -372,7 +372,7 @@ public class DelimitedTextStructureFinderTests extends TextStructureTestCase {
 
         // Default timestamp field is the first field from the start of each row that contains a
         // consistent timestamp format, so if we want the second we need an override
-        FileStructureOverrides overrides = FileStructureOverrides.builder().setTimestampField("tpep_dropoff_datetime").build();
+        TextStructureOverrides overrides = TextStructureOverrides.builder().setTimestampField("tpep_dropoff_datetime").build();
 
         String sample = "VendorID,tpep_pickup_datetime,tpep_dropoff_datetime,passenger_count,trip_distance,RatecodeID,"
             + "store_and_fwd_flag,PULocationID,DOLocationID,payment_type,fare_amount,extra,mta_tax,tip_amount,tolls_amount,"
@@ -384,12 +384,12 @@ public class DelimitedTextStructureFinderTests extends TextStructureTestCase {
 
         String charset = randomFrom(POSSIBLE_CHARSETS);
         Boolean hasByteOrderMarker = randomHasByteOrderMarker(charset);
-        FileStructureFinder structureFinder = csvFactory.createFromSample(
+        TextStructureFinder structureFinder = csvFactory.createFromSample(
             explanation,
             sample,
             charset,
             hasByteOrderMarker,
-            FileStructureFinderManager.DEFAULT_LINE_MERGE_SIZE_LIMIT,
+            TextStructureFinderManager.DEFAULT_LINE_MERGE_SIZE_LIMIT,
             overrides,
             NOOP_TIMEOUT_CHECKER
         );
@@ -456,13 +456,13 @@ public class DelimitedTextStructureFinderTests extends TextStructureTestCase {
 
         String charset = randomFrom(POSSIBLE_CHARSETS);
         Boolean hasByteOrderMarker = randomHasByteOrderMarker(charset);
-        FileStructureFinder structureFinder = csvFactory.createFromSample(
+        TextStructureFinder structureFinder = csvFactory.createFromSample(
             explanation,
             sample,
             charset,
             hasByteOrderMarker,
-            FileStructureFinderManager.DEFAULT_LINE_MERGE_SIZE_LIMIT,
-            FileStructureOverrides.EMPTY_OVERRIDES,
+            TextStructureFinderManager.DEFAULT_LINE_MERGE_SIZE_LIMIT,
+            TextStructureOverrides.EMPTY_OVERRIDES,
             NOOP_TIMEOUT_CHECKER
         );
 
@@ -516,7 +516,7 @@ public class DelimitedTextStructureFinderTests extends TextStructureTestCase {
 
     public void testCreateConfigsGivenCsvWithTrailingNullsExceptHeaderAndColumnNamesOverride() throws Exception {
 
-        FileStructureOverrides overrides = FileStructureOverrides.builder()
+        TextStructureOverrides overrides = TextStructureOverrides.builder()
             .setColumnNames(
                 Arrays.asList(
                     "my_VendorID",
@@ -550,12 +550,12 @@ public class DelimitedTextStructureFinderTests extends TextStructureTestCase {
 
         String charset = randomFrom(POSSIBLE_CHARSETS);
         Boolean hasByteOrderMarker = randomHasByteOrderMarker(charset);
-        FileStructureFinder structureFinder = csvFactory.createFromSample(
+        TextStructureFinder structureFinder = csvFactory.createFromSample(
             explanation,
             sample,
             charset,
             hasByteOrderMarker,
-            FileStructureFinderManager.DEFAULT_LINE_MERGE_SIZE_LIMIT,
+            TextStructureFinderManager.DEFAULT_LINE_MERGE_SIZE_LIMIT,
             overrides,
             NOOP_TIMEOUT_CHECKER
         );
@@ -616,13 +616,13 @@ public class DelimitedTextStructureFinderTests extends TextStructureTestCase {
 
         String charset = randomFrom(POSSIBLE_CHARSETS);
         Boolean hasByteOrderMarker = randomHasByteOrderMarker(charset);
-        FileStructureFinder structureFinder = csvFactory.createFromSample(
+        TextStructureFinder structureFinder = csvFactory.createFromSample(
             explanation,
             sample,
             charset,
             hasByteOrderMarker,
-            FileStructureFinderManager.DEFAULT_LINE_MERGE_SIZE_LIMIT,
-            FileStructureOverrides.EMPTY_OVERRIDES,
+            TextStructureFinderManager.DEFAULT_LINE_MERGE_SIZE_LIMIT,
+            TextStructureOverrides.EMPTY_OVERRIDES,
             NOOP_TIMEOUT_CHECKER
         );
 
@@ -666,13 +666,13 @@ public class DelimitedTextStructureFinderTests extends TextStructureTestCase {
 
         String charset = randomFrom(POSSIBLE_CHARSETS);
         Boolean hasByteOrderMarker = randomHasByteOrderMarker(charset);
-        FileStructureFinder structureFinder = tsvFactory.createFromSample(
+        TextStructureFinder structureFinder = tsvFactory.createFromSample(
             explanation,
             sample,
             charset,
             hasByteOrderMarker,
-            FileStructureFinderManager.DEFAULT_LINE_MERGE_SIZE_LIMIT,
-            FileStructureOverrides.EMPTY_OVERRIDES,
+            TextStructureFinderManager.DEFAULT_LINE_MERGE_SIZE_LIMIT,
+            TextStructureOverrides.EMPTY_OVERRIDES,
             NOOP_TIMEOUT_CHECKER
         );
 
@@ -707,13 +707,13 @@ public class DelimitedTextStructureFinderTests extends TextStructureTestCase {
 
         String charset = randomFrom(POSSIBLE_CHARSETS);
         Boolean hasByteOrderMarker = randomHasByteOrderMarker(charset);
-        FileStructureFinder structureFinder = csvFactory.createFromSample(
+        TextStructureFinder structureFinder = csvFactory.createFromSample(
             explanation,
             sample,
             charset,
             hasByteOrderMarker,
-            FileStructureFinderManager.DEFAULT_LINE_MERGE_SIZE_LIMIT,
-            FileStructureOverrides.EMPTY_OVERRIDES,
+            TextStructureFinderManager.DEFAULT_LINE_MERGE_SIZE_LIMIT,
+            TextStructureOverrides.EMPTY_OVERRIDES,
             NOOP_TIMEOUT_CHECKER
         );
 
@@ -747,10 +747,10 @@ public class DelimitedTextStructureFinderTests extends TextStructureTestCase {
             + "2014-06-23 00:00:01Z,JBU,877.5927,farequote\n"
             + "2014-06-23 00:00:01Z,KLM,1355.4812,farequote\n";
 
-        Tuple<Boolean, String[]> header = DelimitedFileStructureFinder.findHeaderFromSample(
+        Tuple<Boolean, String[]> header = DelimitedTextStructureFinder.findHeaderFromSample(
             explanation,
-            DelimitedFileStructureFinder.readRows(withHeader, CsvPreference.EXCEL_PREFERENCE, NOOP_TIMEOUT_CHECKER).v1(),
-            FileStructureOverrides.EMPTY_OVERRIDES
+            DelimitedTextStructureFinder.readRows(withHeader, CsvPreference.EXCEL_PREFERENCE, NOOP_TIMEOUT_CHECKER).v1(),
+            TextStructureOverrides.EMPTY_OVERRIDES
         );
 
         assertTrue(header.v1());
@@ -763,10 +763,10 @@ public class DelimitedTextStructureFinderTests extends TextStructureTestCase {
             + "2014-06-23 00:00:01Z,JBU,877.5927,farequote\n"
             + "2014-06-23 00:00:01Z,KLM,1355.4812,farequote\n";
 
-        Tuple<Boolean, String[]> header = DelimitedFileStructureFinder.findHeaderFromSample(
+        Tuple<Boolean, String[]> header = DelimitedTextStructureFinder.findHeaderFromSample(
             explanation,
-            DelimitedFileStructureFinder.readRows(noHeader, CsvPreference.EXCEL_PREFERENCE, NOOP_TIMEOUT_CHECKER).v1(),
-            FileStructureOverrides.EMPTY_OVERRIDES
+            DelimitedTextStructureFinder.readRows(noHeader, CsvPreference.EXCEL_PREFERENCE, NOOP_TIMEOUT_CHECKER).v1(),
+            TextStructureOverrides.EMPTY_OVERRIDES
         );
 
         assertFalse(header.v1());
@@ -775,25 +775,25 @@ public class DelimitedTextStructureFinderTests extends TextStructureTestCase {
 
     public void testLevenshteinDistance() {
 
-        assertEquals(0, DelimitedFileStructureFinder.levenshteinDistance("cat", "cat"));
-        assertEquals(3, DelimitedFileStructureFinder.levenshteinDistance("cat", "dog"));
-        assertEquals(5, DelimitedFileStructureFinder.levenshteinDistance("cat", "mouse"));
-        assertEquals(3, DelimitedFileStructureFinder.levenshteinDistance("cat", ""));
+        assertEquals(0, DelimitedTextStructureFinder.levenshteinDistance("cat", "cat"));
+        assertEquals(3, DelimitedTextStructureFinder.levenshteinDistance("cat", "dog"));
+        assertEquals(5, DelimitedTextStructureFinder.levenshteinDistance("cat", "mouse"));
+        assertEquals(3, DelimitedTextStructureFinder.levenshteinDistance("cat", ""));
 
-        assertEquals(3, DelimitedFileStructureFinder.levenshteinDistance("dog", "cat"));
-        assertEquals(0, DelimitedFileStructureFinder.levenshteinDistance("dog", "dog"));
-        assertEquals(4, DelimitedFileStructureFinder.levenshteinDistance("dog", "mouse"));
-        assertEquals(3, DelimitedFileStructureFinder.levenshteinDistance("dog", ""));
+        assertEquals(3, DelimitedTextStructureFinder.levenshteinDistance("dog", "cat"));
+        assertEquals(0, DelimitedTextStructureFinder.levenshteinDistance("dog", "dog"));
+        assertEquals(4, DelimitedTextStructureFinder.levenshteinDistance("dog", "mouse"));
+        assertEquals(3, DelimitedTextStructureFinder.levenshteinDistance("dog", ""));
 
-        assertEquals(5, DelimitedFileStructureFinder.levenshteinDistance("mouse", "cat"));
-        assertEquals(4, DelimitedFileStructureFinder.levenshteinDistance("mouse", "dog"));
-        assertEquals(0, DelimitedFileStructureFinder.levenshteinDistance("mouse", "mouse"));
-        assertEquals(5, DelimitedFileStructureFinder.levenshteinDistance("mouse", ""));
+        assertEquals(5, DelimitedTextStructureFinder.levenshteinDistance("mouse", "cat"));
+        assertEquals(4, DelimitedTextStructureFinder.levenshteinDistance("mouse", "dog"));
+        assertEquals(0, DelimitedTextStructureFinder.levenshteinDistance("mouse", "mouse"));
+        assertEquals(5, DelimitedTextStructureFinder.levenshteinDistance("mouse", ""));
 
-        assertEquals(3, DelimitedFileStructureFinder.levenshteinDistance("", "cat"));
-        assertEquals(3, DelimitedFileStructureFinder.levenshteinDistance("", "dog"));
-        assertEquals(5, DelimitedFileStructureFinder.levenshteinDistance("", "mouse"));
-        assertEquals(0, DelimitedFileStructureFinder.levenshteinDistance("", ""));
+        assertEquals(3, DelimitedTextStructureFinder.levenshteinDistance("", "cat"));
+        assertEquals(3, DelimitedTextStructureFinder.levenshteinDistance("", "dog"));
+        assertEquals(5, DelimitedTextStructureFinder.levenshteinDistance("", "mouse"));
+        assertEquals(0, DelimitedTextStructureFinder.levenshteinDistance("", ""));
     }
 
     public void testMakeShortFieldMask() {
@@ -804,13 +804,13 @@ public class DelimitedTextStructureFinderTests extends TextStructureTestCase {
         rows.add(Arrays.asList(randomAlphaOfLength(5), randomAlphaOfLength(5), randomAlphaOfLength(5)));
         rows.add(Arrays.asList(randomAlphaOfLength(5), randomAlphaOfLength(5), randomAlphaOfLength(80)));
 
-        BitSet shortFieldMask = DelimitedFileStructureFinder.makeShortFieldMask(rows, 110);
+        BitSet shortFieldMask = DelimitedTextStructureFinder.makeShortFieldMask(rows, 110);
         assertThat(shortFieldMask, equalTo(stringToNumberPosBitSet("111")));
-        shortFieldMask = DelimitedFileStructureFinder.makeShortFieldMask(rows, 80);
+        shortFieldMask = DelimitedTextStructureFinder.makeShortFieldMask(rows, 80);
         assertThat(shortFieldMask, equalTo(stringToNumberPosBitSet("11 ")));
-        shortFieldMask = DelimitedFileStructureFinder.makeShortFieldMask(rows, 50);
+        shortFieldMask = DelimitedTextStructureFinder.makeShortFieldMask(rows, 50);
         assertThat(shortFieldMask, equalTo(stringToNumberPosBitSet(" 1 ")));
-        shortFieldMask = DelimitedFileStructureFinder.makeShortFieldMask(rows, 20);
+        shortFieldMask = DelimitedTextStructureFinder.makeShortFieldMask(rows, 20);
         assertThat(shortFieldMask, equalTo(stringToNumberPosBitSet("   ")));
     }
 
@@ -883,44 +883,44 @@ public class DelimitedTextStructureFinderTests extends TextStructureTestCase {
 
     public void testLineHasUnescapedQuote() {
 
-        assertFalse(DelimitedFileStructureFinder.lineHasUnescapedQuote("a,b,c", CsvPreference.EXCEL_PREFERENCE));
-        assertFalse(DelimitedFileStructureFinder.lineHasUnescapedQuote("\"a\",b,c", CsvPreference.EXCEL_PREFERENCE));
-        assertFalse(DelimitedFileStructureFinder.lineHasUnescapedQuote("\"a,b\",c", CsvPreference.EXCEL_PREFERENCE));
-        assertFalse(DelimitedFileStructureFinder.lineHasUnescapedQuote("\"a,b,c\"", CsvPreference.EXCEL_PREFERENCE));
-        assertFalse(DelimitedFileStructureFinder.lineHasUnescapedQuote("a,\"b\",c", CsvPreference.EXCEL_PREFERENCE));
-        assertFalse(DelimitedFileStructureFinder.lineHasUnescapedQuote("a,b,\"c\"", CsvPreference.EXCEL_PREFERENCE));
-        assertFalse(DelimitedFileStructureFinder.lineHasUnescapedQuote("a,\"b\"\"\",c", CsvPreference.EXCEL_PREFERENCE));
-        assertFalse(DelimitedFileStructureFinder.lineHasUnescapedQuote("a,b,\"c\"\"\"", CsvPreference.EXCEL_PREFERENCE));
-        assertFalse(DelimitedFileStructureFinder.lineHasUnescapedQuote("\"\"\"a\",b,c", CsvPreference.EXCEL_PREFERENCE));
-        assertFalse(DelimitedFileStructureFinder.lineHasUnescapedQuote("\"a\"\"\",b,c", CsvPreference.EXCEL_PREFERENCE));
-        assertFalse(DelimitedFileStructureFinder.lineHasUnescapedQuote("\"a,\"\"b\",c", CsvPreference.EXCEL_PREFERENCE));
-        assertTrue(DelimitedFileStructureFinder.lineHasUnescapedQuote("between\"words,b,c", CsvPreference.EXCEL_PREFERENCE));
-        assertTrue(DelimitedFileStructureFinder.lineHasUnescapedQuote("x and \"y\",b,c", CsvPreference.EXCEL_PREFERENCE));
+        assertFalse(DelimitedTextStructureFinder.lineHasUnescapedQuote("a,b,c", CsvPreference.EXCEL_PREFERENCE));
+        assertFalse(DelimitedTextStructureFinder.lineHasUnescapedQuote("\"a\",b,c", CsvPreference.EXCEL_PREFERENCE));
+        assertFalse(DelimitedTextStructureFinder.lineHasUnescapedQuote("\"a,b\",c", CsvPreference.EXCEL_PREFERENCE));
+        assertFalse(DelimitedTextStructureFinder.lineHasUnescapedQuote("\"a,b,c\"", CsvPreference.EXCEL_PREFERENCE));
+        assertFalse(DelimitedTextStructureFinder.lineHasUnescapedQuote("a,\"b\",c", CsvPreference.EXCEL_PREFERENCE));
+        assertFalse(DelimitedTextStructureFinder.lineHasUnescapedQuote("a,b,\"c\"", CsvPreference.EXCEL_PREFERENCE));
+        assertFalse(DelimitedTextStructureFinder.lineHasUnescapedQuote("a,\"b\"\"\",c", CsvPreference.EXCEL_PREFERENCE));
+        assertFalse(DelimitedTextStructureFinder.lineHasUnescapedQuote("a,b,\"c\"\"\"", CsvPreference.EXCEL_PREFERENCE));
+        assertFalse(DelimitedTextStructureFinder.lineHasUnescapedQuote("\"\"\"a\",b,c", CsvPreference.EXCEL_PREFERENCE));
+        assertFalse(DelimitedTextStructureFinder.lineHasUnescapedQuote("\"a\"\"\",b,c", CsvPreference.EXCEL_PREFERENCE));
+        assertFalse(DelimitedTextStructureFinder.lineHasUnescapedQuote("\"a,\"\"b\",c", CsvPreference.EXCEL_PREFERENCE));
+        assertTrue(DelimitedTextStructureFinder.lineHasUnescapedQuote("between\"words,b,c", CsvPreference.EXCEL_PREFERENCE));
+        assertTrue(DelimitedTextStructureFinder.lineHasUnescapedQuote("x and \"y\",b,c", CsvPreference.EXCEL_PREFERENCE));
 
-        assertFalse(DelimitedFileStructureFinder.lineHasUnescapedQuote("a\tb\tc", CsvPreference.TAB_PREFERENCE));
-        assertFalse(DelimitedFileStructureFinder.lineHasUnescapedQuote("\"a\"\tb\tc", CsvPreference.TAB_PREFERENCE));
-        assertFalse(DelimitedFileStructureFinder.lineHasUnescapedQuote("\"a\tb\"\tc", CsvPreference.TAB_PREFERENCE));
-        assertFalse(DelimitedFileStructureFinder.lineHasUnescapedQuote("\"a\tb\tc\"", CsvPreference.TAB_PREFERENCE));
-        assertFalse(DelimitedFileStructureFinder.lineHasUnescapedQuote("a\t\"b\"\tc", CsvPreference.TAB_PREFERENCE));
-        assertFalse(DelimitedFileStructureFinder.lineHasUnescapedQuote("a\tb\t\"c\"", CsvPreference.TAB_PREFERENCE));
-        assertFalse(DelimitedFileStructureFinder.lineHasUnescapedQuote("a\t\"b\"\"\"\tc", CsvPreference.TAB_PREFERENCE));
-        assertFalse(DelimitedFileStructureFinder.lineHasUnescapedQuote("a\tb\t\"c\"\"\"", CsvPreference.TAB_PREFERENCE));
-        assertFalse(DelimitedFileStructureFinder.lineHasUnescapedQuote("\"\"\"a\"\tb\tc", CsvPreference.TAB_PREFERENCE));
-        assertFalse(DelimitedFileStructureFinder.lineHasUnescapedQuote("\"a\"\"\"\tb\tc", CsvPreference.TAB_PREFERENCE));
-        assertFalse(DelimitedFileStructureFinder.lineHasUnescapedQuote("\"a\t\"\"b\"\tc", CsvPreference.TAB_PREFERENCE));
-        assertTrue(DelimitedFileStructureFinder.lineHasUnescapedQuote("between\"words\tb\tc", CsvPreference.TAB_PREFERENCE));
-        assertTrue(DelimitedFileStructureFinder.lineHasUnescapedQuote("x and \"y\"\tb\tc", CsvPreference.TAB_PREFERENCE));
+        assertFalse(DelimitedTextStructureFinder.lineHasUnescapedQuote("a\tb\tc", CsvPreference.TAB_PREFERENCE));
+        assertFalse(DelimitedTextStructureFinder.lineHasUnescapedQuote("\"a\"\tb\tc", CsvPreference.TAB_PREFERENCE));
+        assertFalse(DelimitedTextStructureFinder.lineHasUnescapedQuote("\"a\tb\"\tc", CsvPreference.TAB_PREFERENCE));
+        assertFalse(DelimitedTextStructureFinder.lineHasUnescapedQuote("\"a\tb\tc\"", CsvPreference.TAB_PREFERENCE));
+        assertFalse(DelimitedTextStructureFinder.lineHasUnescapedQuote("a\t\"b\"\tc", CsvPreference.TAB_PREFERENCE));
+        assertFalse(DelimitedTextStructureFinder.lineHasUnescapedQuote("a\tb\t\"c\"", CsvPreference.TAB_PREFERENCE));
+        assertFalse(DelimitedTextStructureFinder.lineHasUnescapedQuote("a\t\"b\"\"\"\tc", CsvPreference.TAB_PREFERENCE));
+        assertFalse(DelimitedTextStructureFinder.lineHasUnescapedQuote("a\tb\t\"c\"\"\"", CsvPreference.TAB_PREFERENCE));
+        assertFalse(DelimitedTextStructureFinder.lineHasUnescapedQuote("\"\"\"a\"\tb\tc", CsvPreference.TAB_PREFERENCE));
+        assertFalse(DelimitedTextStructureFinder.lineHasUnescapedQuote("\"a\"\"\"\tb\tc", CsvPreference.TAB_PREFERENCE));
+        assertFalse(DelimitedTextStructureFinder.lineHasUnescapedQuote("\"a\t\"\"b\"\tc", CsvPreference.TAB_PREFERENCE));
+        assertTrue(DelimitedTextStructureFinder.lineHasUnescapedQuote("between\"words\tb\tc", CsvPreference.TAB_PREFERENCE));
+        assertTrue(DelimitedTextStructureFinder.lineHasUnescapedQuote("x and \"y\"\tb\tc", CsvPreference.TAB_PREFERENCE));
     }
 
     public void testRowContainsDuplicateNonEmptyValues() {
 
-        assertNull(DelimitedFileStructureFinder.findDuplicateNonEmptyValues(Collections.singletonList("a")));
-        assertNull(DelimitedFileStructureFinder.findDuplicateNonEmptyValues(Collections.singletonList("")));
-        assertNull(DelimitedFileStructureFinder.findDuplicateNonEmptyValues(Arrays.asList("a", "b", "c")));
-        assertEquals("a", DelimitedFileStructureFinder.findDuplicateNonEmptyValues(Arrays.asList("a", "b", "a")));
-        assertEquals("b", DelimitedFileStructureFinder.findDuplicateNonEmptyValues(Arrays.asList("a", "b", "b")));
-        assertNull(DelimitedFileStructureFinder.findDuplicateNonEmptyValues(Arrays.asList("a", "", "")));
-        assertNull(DelimitedFileStructureFinder.findDuplicateNonEmptyValues(Arrays.asList("", "a", "")));
+        assertNull(DelimitedTextStructureFinder.findDuplicateNonEmptyValues(Collections.singletonList("a")));
+        assertNull(DelimitedTextStructureFinder.findDuplicateNonEmptyValues(Collections.singletonList("")));
+        assertNull(DelimitedTextStructureFinder.findDuplicateNonEmptyValues(Arrays.asList("a", "b", "c")));
+        assertEquals("a", DelimitedTextStructureFinder.findDuplicateNonEmptyValues(Arrays.asList("a", "b", "a")));
+        assertEquals("b", DelimitedTextStructureFinder.findDuplicateNonEmptyValues(Arrays.asList("a", "b", "b")));
+        assertNull(DelimitedTextStructureFinder.findDuplicateNonEmptyValues(Arrays.asList("a", "", "")));
+        assertNull(DelimitedTextStructureFinder.findDuplicateNonEmptyValues(Arrays.asList("", "a", "")));
     }
 
     public void testMakeCsvProcessorSettings() {
@@ -930,7 +930,7 @@ public class DelimitedTextStructureFinderTests extends TextStructureTestCase {
         char separator = randomFrom(',', ';', '\t', '|');
         char quote = randomFrom('"', '\'');
         boolean trim = randomBoolean();
-        Map<String, Object> settings = DelimitedFileStructureFinder.makeCsvProcessorSettings(field, targetFields, separator, quote, trim);
+        Map<String, Object> settings = DelimitedTextStructureFinder.makeCsvProcessorSettings(field, targetFields, separator, quote, trim);
         assertThat(settings.get("field"), equalTo(field));
         assertThat(settings.get("target_fields"), equalTo(targetFields));
         assertThat(settings.get("ignore_missing"), equalTo(false));
@@ -967,12 +967,12 @@ public class DelimitedTextStructureFinderTests extends TextStructureTestCase {
         Map<String, Object> mappings = new TreeMap<>();
         for (String columnName : columnNames) {
             if (columnName.equals(timeFieldName)) {
-                mappings.put(columnName, Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "date"));
+                mappings.put(columnName, Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "date"));
             } else {
                 mappings.put(
                     columnName,
                     Collections.singletonMap(
-                        FileStructureUtils.MAPPING_TYPE_SETTING,
+                        TextStructureUtils.MAPPING_TYPE_SETTING,
                         randomFrom("boolean", "long", "double", "text", "keyword")
                     )
                 );
@@ -980,7 +980,7 @@ public class DelimitedTextStructureFinderTests extends TextStructureTestCase {
         }
 
         assertNull(
-            DelimitedFileStructureFinder.makeMultilineStartPattern(
+            DelimitedTextStructureFinder.makeMultilineStartPattern(
                 explanation,
                 columnNames,
                 1,
@@ -1004,9 +1004,9 @@ public class DelimitedTextStructureFinderTests extends TextStructureTestCase {
         Map<String, Object> mappings = new TreeMap<>();
         for (String columnName : columnNames) {
             if (columnName.equals(timeFieldName)) {
-                mappings.put(columnName, Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "date"));
+                mappings.put(columnName, Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "date"));
             } else {
-                mappings.put(columnName, Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, randomFrom("text", "keyword")));
+                mappings.put(columnName, Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, randomFrom("text", "keyword")));
             }
         }
 
@@ -1015,7 +1015,7 @@ public class DelimitedTextStructureFinderTests extends TextStructureTestCase {
             + "\"?\\d{4}-\\d{2}-\\d{2}[T ]\\d{2}:\\d{2}";
         assertEquals(
             expected,
-            DelimitedFileStructureFinder.makeMultilineStartPattern(
+            DelimitedTextStructureFinder.makeMultilineStartPattern(
                 explanation,
                 columnNames,
                 2,
@@ -1043,9 +1043,9 @@ public class DelimitedTextStructureFinderTests extends TextStructureTestCase {
         Map<String, Object> mappings = new TreeMap<>();
         for (String columnName : columnNames) {
             if (columnName.equals(chosenField)) {
-                mappings.put(columnName, Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, type));
+                mappings.put(columnName, Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, type));
             } else {
-                mappings.put(columnName, Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, randomFrom("text", "keyword")));
+                mappings.put(columnName, Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, randomFrom("text", "keyword")));
             }
         }
 
@@ -1058,7 +1058,7 @@ public class DelimitedTextStructureFinderTests extends TextStructureTestCase {
             + "\"),";
         assertEquals(
             expected,
-            DelimitedFileStructureFinder.makeMultilineStartPattern(explanation, columnNames, 2, ",", "\"", mappings, null, null)
+            DelimitedTextStructureFinder.makeMultilineStartPattern(explanation, columnNames, 2, ",", "\"", mappings, null, null)
         );
         assertThat(explanation, contains("Created a multi-line start pattern based on [" + type + "] column [" + chosenField + "]"));
     }
@@ -1068,16 +1068,16 @@ public class DelimitedTextStructureFinderTests extends TextStructureTestCase {
         List<String> columnNames = Stream.generate(() -> randomAlphaOfLengthBetween(5, 10)).limit(10).collect(Collectors.toList());
         Map<String, Object> mappings = new TreeMap<>();
         for (String columnName : columnNames) {
-            mappings.put(columnName, Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, randomFrom("text", "keyword")));
+            mappings.put(columnName, Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, randomFrom("text", "keyword")));
         }
 
-        assertNull(DelimitedFileStructureFinder.makeMultilineStartPattern(explanation, columnNames, 2, ",", "\"", mappings, null, null));
+        assertNull(DelimitedTextStructureFinder.makeMultilineStartPattern(explanation, columnNames, 2, ",", "\"", mappings, null, null));
         assertThat(explanation, contains("Failed to create a suitable multi-line start pattern"));
     }
 
     static Map<String, Object> randomCsvProcessorSettings() {
         String field = randomAlphaOfLength(10);
-        return DelimitedFileStructureFinder.makeCsvProcessorSettings(
+        return DelimitedTextStructureFinder.makeCsvProcessorSettings(
             field,
             Arrays.asList(generateRandomStringArray(10, field.length() - 1, false, false)),
             randomFrom(',', ';', '\t', '|'),

--- a/x-pack/plugin/text-structure/src/test/java/org/elasticsearch/xpack/textstructure/structurefinder/FieldStatsCalculatorTests.java
+++ b/x-pack/plugin/text-structure/src/test/java/org/elasticsearch/xpack/textstructure/structurefinder/FieldStatsCalculatorTests.java
@@ -16,9 +16,9 @@ import java.util.Map;
 
 public class FieldStatsCalculatorTests extends TextStructureTestCase {
 
-    private static final Map<String, String> LONG = Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "long");
-    private static final Map<String, String> DOUBLE = Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "double");
-    private static final Map<String, String> KEYWORD = Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "keyword");
+    private static final Map<String, String> LONG = Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "long");
+    private static final Map<String, String> DOUBLE = Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "double");
+    private static final Map<String, String> KEYWORD = Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "keyword");
 
     public void testMean() {
 
@@ -111,7 +111,7 @@ public class FieldStatsCalculatorTests extends TextStructureTestCase {
     public void testCalculateGivenEmpty() {
 
         FieldStatsCalculator calculator = new FieldStatsCalculator(
-            randomFrom(Arrays.asList(LONG, DOUBLE, KEYWORD, FileStructureUtils.DATE_MAPPING_WITHOUT_FORMAT))
+            randomFrom(Arrays.asList(LONG, DOUBLE, KEYWORD, TextStructureUtils.DATE_MAPPING_WITHOUT_FORMAT))
         );
 
         calculator.accept(Collections.emptyList());
@@ -216,7 +216,7 @@ public class FieldStatsCalculatorTests extends TextStructureTestCase {
 
     public void testGivenDateFieldWithoutFormat() {
 
-        FieldStatsCalculator calculator = new FieldStatsCalculator(FileStructureUtils.DATE_MAPPING_WITHOUT_FORMAT);
+        FieldStatsCalculator calculator = new FieldStatsCalculator(TextStructureUtils.DATE_MAPPING_WITHOUT_FORMAT);
 
         calculator.accept(
             Arrays.asList(
@@ -254,8 +254,8 @@ public class FieldStatsCalculatorTests extends TextStructureTestCase {
     public void testGivenDateFieldWithFormat() {
 
         Map<String, String> dateMapping = new HashMap<>();
-        dateMapping.put(FileStructureUtils.MAPPING_TYPE_SETTING, "date");
-        dateMapping.put(FileStructureUtils.MAPPING_FORMAT_SETTING, "M/dd/yyyy h:mma");
+        dateMapping.put(TextStructureUtils.MAPPING_TYPE_SETTING, "date");
+        dateMapping.put(TextStructureUtils.MAPPING_FORMAT_SETTING, "M/dd/yyyy h:mma");
         FieldStatsCalculator calculator = new FieldStatsCalculator(dateMapping);
 
         calculator.accept(

--- a/x-pack/plugin/text-structure/src/test/java/org/elasticsearch/xpack/textstructure/structurefinder/GrokPatternCreatorTests.java
+++ b/x-pack/plugin/text-structure/src/test/java/org/elasticsearch/xpack/textstructure/structurefinder/GrokPatternCreatorTests.java
@@ -260,14 +260,14 @@ public class GrokPatternCreatorTests extends TextStructureTestCase {
         assertEquals(
             "%{SYSLOGTIMESTAMP:timestamp} .*? .*?\\[%{INT:field}\\]: %{LOGLEVEL:loglevel} \\(.*? .*? .*?\\) .*? "
                 + "%{QUOTEDSTRING:field2}: %{IP:ipaddress}#%{INT:field3}",
-            grokPatternCreator.createGrokPatternFromExamples("SYSLOGTIMESTAMP", FileStructureUtils.DATE_MAPPING_WITHOUT_FORMAT, "timestamp")
+            grokPatternCreator.createGrokPatternFromExamples("SYSLOGTIMESTAMP", TextStructureUtils.DATE_MAPPING_WITHOUT_FORMAT, "timestamp")
         );
         assertEquals(5, mappings.size());
-        assertEquals(Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "long"), mappings.get("field"));
-        assertEquals(Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "keyword"), mappings.get("loglevel"));
-        assertEquals(Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "keyword"), mappings.get("field2"));
-        assertEquals(Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "ip"), mappings.get("ipaddress"));
-        assertEquals(Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "long"), mappings.get("field3"));
+        assertEquals(Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "long"), mappings.get("field"));
+        assertEquals(Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "keyword"), mappings.get("loglevel"));
+        assertEquals(Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "keyword"), mappings.get("field2"));
+        assertEquals(Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "ip"), mappings.get("ipaddress"));
+        assertEquals(Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "long"), mappings.get("field3"));
     }
 
     public void testCreateGrokPatternFromExamplesGivenCatalinaLogs() {
@@ -297,12 +297,12 @@ public class GrokPatternCreatorTests extends TextStructureTestCase {
             "%{CATALINA_DATESTAMP:timestamp} .*? .*?\\n%{LOGLEVEL:loglevel}: .*",
             grokPatternCreator.createGrokPatternFromExamples(
                 "CATALINA_DATESTAMP",
-                FileStructureUtils.DATE_MAPPING_WITHOUT_FORMAT,
+                TextStructureUtils.DATE_MAPPING_WITHOUT_FORMAT,
                 "timestamp"
             )
         );
         assertEquals(1, mappings.size());
-        assertEquals(Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "keyword"), mappings.get("loglevel"));
+        assertEquals(Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "keyword"), mappings.get("loglevel"));
     }
 
     public void testCreateGrokPatternFromExamplesGivenMultiTimestampLogs() {
@@ -334,19 +334,19 @@ public class GrokPatternCreatorTests extends TextStructureTestCase {
                 + "%{IP:ipaddress}\\t.*?\\t%{LOGLEVEL:loglevel}\\t.*",
             grokPatternCreator.createGrokPatternFromExamples(
                 "TIMESTAMP_ISO8601",
-                FileStructureUtils.DATE_MAPPING_WITHOUT_FORMAT,
+                TextStructureUtils.DATE_MAPPING_WITHOUT_FORMAT,
                 "timestamp"
             )
         );
         assertEquals(5, mappings.size());
-        assertEquals(Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "long"), mappings.get("field"));
+        assertEquals(Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "long"), mappings.get("field"));
         Map<String, String> expectedDateMapping = new HashMap<>();
-        expectedDateMapping.put(FileStructureUtils.MAPPING_TYPE_SETTING, "date");
-        expectedDateMapping.put(FileStructureUtils.MAPPING_FORMAT_SETTING, "iso8601");
+        expectedDateMapping.put(TextStructureUtils.MAPPING_TYPE_SETTING, "date");
+        expectedDateMapping.put(TextStructureUtils.MAPPING_FORMAT_SETTING, "iso8601");
         assertEquals(expectedDateMapping, mappings.get("extra_timestamp"));
-        assertEquals(Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "long"), mappings.get("field2"));
-        assertEquals(Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "ip"), mappings.get("ipaddress"));
-        assertEquals(Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "keyword"), mappings.get("loglevel"));
+        assertEquals(Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "long"), mappings.get("field2"));
+        assertEquals(Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "ip"), mappings.get("ipaddress"));
+        assertEquals(Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "keyword"), mappings.get("loglevel"));
     }
 
     public void testCreateGrokPatternFromExamplesGivenMultiTimestampLogsAndIndeterminateFormat() {
@@ -378,19 +378,19 @@ public class GrokPatternCreatorTests extends TextStructureTestCase {
                 + "%{IP:ipaddress}\\t.*?\\t%{LOGLEVEL:loglevel}\\t.*",
             grokPatternCreator.createGrokPatternFromExamples(
                 "TIMESTAMP_ISO8601",
-                FileStructureUtils.DATE_MAPPING_WITHOUT_FORMAT,
+                TextStructureUtils.DATE_MAPPING_WITHOUT_FORMAT,
                 "timestamp"
             )
         );
         assertEquals(5, mappings.size());
-        assertEquals(Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "long"), mappings.get("field"));
+        assertEquals(Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "long"), mappings.get("field"));
         Map<String, String> expectedDateMapping = new HashMap<>();
-        expectedDateMapping.put(FileStructureUtils.MAPPING_TYPE_SETTING, "date_nanos");
-        expectedDateMapping.put(FileStructureUtils.MAPPING_FORMAT_SETTING, "dd/MM/yyyy HH:mm:ss,SSSSSS");
+        expectedDateMapping.put(TextStructureUtils.MAPPING_TYPE_SETTING, "date_nanos");
+        expectedDateMapping.put(TextStructureUtils.MAPPING_FORMAT_SETTING, "dd/MM/yyyy HH:mm:ss,SSSSSS");
         assertEquals(expectedDateMapping, mappings.get("extra_timestamp"));
-        assertEquals(Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "long"), mappings.get("field2"));
-        assertEquals(Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "ip"), mappings.get("ipaddress"));
-        assertEquals(Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "keyword"), mappings.get("loglevel"));
+        assertEquals(Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "long"), mappings.get("field2"));
+        assertEquals(Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "ip"), mappings.get("ipaddress"));
+        assertEquals(Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "keyword"), mappings.get("loglevel"));
     }
 
     public void testCreateGrokPatternFromExamplesGivenMultiTimestampLogsAndCustomDefinition() {
@@ -418,22 +418,22 @@ public class GrokPatternCreatorTests extends TextStructureTestCase {
         );
 
         Map<String, String> customMapping = new HashMap<>();
-        customMapping.put(FileStructureUtils.MAPPING_TYPE_SETTING, "date");
-        customMapping.put(FileStructureUtils.MAPPING_FORMAT_SETTING, "M/dd/yyyy h:mma");
+        customMapping.put(TextStructureUtils.MAPPING_TYPE_SETTING, "date");
+        customMapping.put(TextStructureUtils.MAPPING_FORMAT_SETTING, "M/dd/yyyy h:mma");
         assertEquals(
             "%{INT:field}\\t%{CUSTOM_TIMESTAMP:timestamp}\\t%{TIMESTAMP_ISO8601:extra_timestamp}\\t%{INT:field2}\\t.*?\\t"
                 + "%{IP:ipaddress}\\t.*?\\t%{LOGLEVEL:loglevel}\\t.*",
             grokPatternCreator.createGrokPatternFromExamples("CUSTOM_TIMESTAMP", customMapping, "timestamp")
         );
         assertEquals(5, mappings.size());
-        assertEquals(Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "long"), mappings.get("field"));
+        assertEquals(Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "long"), mappings.get("field"));
         Map<String, String> expectedDateMapping = new HashMap<>();
-        expectedDateMapping.put(FileStructureUtils.MAPPING_TYPE_SETTING, "date");
-        expectedDateMapping.put(FileStructureUtils.MAPPING_FORMAT_SETTING, "iso8601");
+        expectedDateMapping.put(TextStructureUtils.MAPPING_TYPE_SETTING, "date");
+        expectedDateMapping.put(TextStructureUtils.MAPPING_FORMAT_SETTING, "iso8601");
         assertEquals(expectedDateMapping, mappings.get("extra_timestamp"));
-        assertEquals(Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "long"), mappings.get("field2"));
-        assertEquals(Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "ip"), mappings.get("ipaddress"));
-        assertEquals(Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "keyword"), mappings.get("loglevel"));
+        assertEquals(Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "long"), mappings.get("field2"));
+        assertEquals(Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "ip"), mappings.get("ipaddress"));
+        assertEquals(Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "keyword"), mappings.get("loglevel"));
     }
 
     public void testCreateGrokPatternFromExamplesGivenTimestampAndTimeWithoutDate() {
@@ -465,16 +465,16 @@ public class GrokPatternCreatorTests extends TextStructureTestCase {
                 + "%{IP:ipaddress}\\t.*?\\t%{LOGLEVEL:loglevel}\\t.*",
             grokPatternCreator.createGrokPatternFromExamples(
                 "TIMESTAMP_ISO8601",
-                FileStructureUtils.DATE_MAPPING_WITHOUT_FORMAT,
+                TextStructureUtils.DATE_MAPPING_WITHOUT_FORMAT,
                 "timestamp"
             )
         );
         assertEquals(5, mappings.size());
-        assertEquals(Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "long"), mappings.get("field"));
-        assertEquals(Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "keyword"), mappings.get("time"));
-        assertEquals(Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "long"), mappings.get("field2"));
-        assertEquals(Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "ip"), mappings.get("ipaddress"));
-        assertEquals(Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "keyword"), mappings.get("loglevel"));
+        assertEquals(Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "long"), mappings.get("field"));
+        assertEquals(Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "keyword"), mappings.get("time"));
+        assertEquals(Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "long"), mappings.get("field2"));
+        assertEquals(Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "ip"), mappings.get("ipaddress"));
+        assertEquals(Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "keyword"), mappings.get("loglevel"));
     }
 
     public void testFindFullLineGrokPatternGivenApacheCombinedLogs() {
@@ -512,16 +512,16 @@ public class GrokPatternCreatorTests extends TextStructureTestCase {
             grokPatternCreator.findFullLineGrokPattern(randomBoolean() ? "timestamp" : null)
         );
         assertEquals(10, mappings.size());
-        assertEquals(Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "text"), mappings.get("agent"));
-        assertEquals(Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "keyword"), mappings.get("auth"));
-        assertEquals(Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "long"), mappings.get("bytes"));
-        assertEquals(Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "ip"), mappings.get("clientip"));
-        assertEquals(Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "double"), mappings.get("httpversion"));
-        assertEquals(Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "keyword"), mappings.get("ident"));
-        assertEquals(Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "keyword"), mappings.get("referrer"));
-        assertEquals(Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "keyword"), mappings.get("request"));
-        assertEquals(Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "long"), mappings.get("response"));
-        assertEquals(Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "keyword"), mappings.get("verb"));
+        assertEquals(Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "text"), mappings.get("agent"));
+        assertEquals(Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "keyword"), mappings.get("auth"));
+        assertEquals(Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "long"), mappings.get("bytes"));
+        assertEquals(Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "ip"), mappings.get("clientip"));
+        assertEquals(Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "double"), mappings.get("httpversion"));
+        assertEquals(Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "keyword"), mappings.get("ident"));
+        assertEquals(Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "keyword"), mappings.get("referrer"));
+        assertEquals(Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "keyword"), mappings.get("request"));
+        assertEquals(Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "long"), mappings.get("response"));
+        assertEquals(Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "keyword"), mappings.get("verb"));
     }
 
     public void testAdjustForPunctuationGivenCommonPrefix() {
@@ -608,18 +608,18 @@ public class GrokPatternCreatorTests extends TextStructureTestCase {
 
         grokPatternCreator.validateFullLineGrokPattern(grokPattern, timestampField);
         assertEquals(9, mappings.size());
-        assertEquals(Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "long"), mappings.get("serial_no"));
+        assertEquals(Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "long"), mappings.get("serial_no"));
         Map<String, String> expectedDateMapping = new HashMap<>();
-        expectedDateMapping.put(FileStructureUtils.MAPPING_TYPE_SETTING, "date");
-        expectedDateMapping.put(FileStructureUtils.MAPPING_FORMAT_SETTING, "iso8601");
+        expectedDateMapping.put(TextStructureUtils.MAPPING_TYPE_SETTING, "date");
+        expectedDateMapping.put(TextStructureUtils.MAPPING_FORMAT_SETTING, "iso8601");
         assertEquals(expectedDateMapping, mappings.get("local_timestamp"));
-        assertEquals(Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "long"), mappings.get("user_id"));
-        assertEquals(Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "keyword"), mappings.get("host"));
-        assertEquals(Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "ip"), mappings.get("client_ip"));
-        assertEquals(Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "keyword"), mappings.get("method"));
-        assertEquals(Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "keyword"), mappings.get("severity"));
-        assertEquals(Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "keyword"), mappings.get("program"));
-        assertEquals(Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "keyword"), mappings.get("message"));
+        assertEquals(Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "long"), mappings.get("user_id"));
+        assertEquals(Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "keyword"), mappings.get("host"));
+        assertEquals(Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "ip"), mappings.get("client_ip"));
+        assertEquals(Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "keyword"), mappings.get("method"));
+        assertEquals(Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "keyword"), mappings.get("severity"));
+        assertEquals(Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "keyword"), mappings.get("program"));
+        assertEquals(Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "keyword"), mappings.get("message"));
     }
 
     public void testValidateFullLineGrokPatternGivenValidAndCustomDefinition() {
@@ -653,18 +653,18 @@ public class GrokPatternCreatorTests extends TextStructureTestCase {
 
         grokPatternCreator.validateFullLineGrokPattern(grokPattern, timestampField);
         assertEquals(9, mappings.size());
-        assertEquals(Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "long"), mappings.get("serial_no"));
+        assertEquals(Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "long"), mappings.get("serial_no"));
         Map<String, String> expectedDateMapping = new HashMap<>();
-        expectedDateMapping.put(FileStructureUtils.MAPPING_TYPE_SETTING, "date");
-        expectedDateMapping.put(FileStructureUtils.MAPPING_FORMAT_SETTING, "iso8601");
+        expectedDateMapping.put(TextStructureUtils.MAPPING_TYPE_SETTING, "date");
+        expectedDateMapping.put(TextStructureUtils.MAPPING_FORMAT_SETTING, "iso8601");
         assertEquals(expectedDateMapping, mappings.get("utc_timestamp"));
-        assertEquals(Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "long"), mappings.get("user_id"));
-        assertEquals(Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "keyword"), mappings.get("host"));
-        assertEquals(Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "ip"), mappings.get("client_ip"));
-        assertEquals(Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "keyword"), mappings.get("method"));
-        assertEquals(Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "keyword"), mappings.get("severity"));
-        assertEquals(Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "keyword"), mappings.get("program"));
-        assertEquals(Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "keyword"), mappings.get("message"));
+        assertEquals(Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "long"), mappings.get("user_id"));
+        assertEquals(Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "keyword"), mappings.get("host"));
+        assertEquals(Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "ip"), mappings.get("client_ip"));
+        assertEquals(Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "keyword"), mappings.get("method"));
+        assertEquals(Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "keyword"), mappings.get("severity"));
+        assertEquals(Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "keyword"), mappings.get("program"));
+        assertEquals(Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "keyword"), mappings.get("message"));
     }
 
     public void testValidateFullLineGrokPatternGivenInvalid() {

--- a/x-pack/plugin/text-structure/src/test/java/org/elasticsearch/xpack/textstructure/structurefinder/LogTextStructureFinderFactoryTests.java
+++ b/x-pack/plugin/text-structure/src/test/java/org/elasticsearch/xpack/textstructure/structurefinder/LogTextStructureFinderFactoryTests.java
@@ -5,9 +5,9 @@
  */
 package org.elasticsearch.xpack.textstructure.structurefinder;
 
-public class TextLogTextStructureFinderFactoryTests extends TextStructureTestCase {
+public class LogTextStructureFinderFactoryTests extends TextStructureTestCase {
 
-    private FileStructureFinderFactory factory = new TextLogFileStructureFinderFactory();
+    private final TextStructureFinderFactory factory = new LogTextStructureFinderFactory();
 
     // No need to check NDJSON, XML, CSV, TSV, semi-colon delimited values or pipe
     // delimited values because they come earlier in the order we check formats

--- a/x-pack/plugin/text-structure/src/test/java/org/elasticsearch/xpack/textstructure/structurefinder/LogTextStructureFinderTests.java
+++ b/x-pack/plugin/text-structure/src/test/java/org/elasticsearch/xpack/textstructure/structurefinder/LogTextStructureFinderTests.java
@@ -16,9 +16,9 @@ import java.util.stream.Collectors;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
 
-public class TextLogTextStructureFinderTests extends TextStructureTestCase {
+public class LogTextStructureFinderTests extends TextStructureTestCase {
 
-    private final FileStructureFinderFactory factory = new TextLogFileStructureFinderFactory();
+    private final TextStructureFinderFactory factory = new LogTextStructureFinderFactory();
 
     public void testCreateConfigsGivenLowLineMergeSizeLimit() {
 
@@ -42,7 +42,7 @@ public class TextLogTextStructureFinderTests extends TextStructureTestCase {
                 charset,
                 hasByteOrderMarker,
                 100,
-                FileStructureOverrides.EMPTY_OVERRIDES,
+                TextStructureOverrides.EMPTY_OVERRIDES,
                 NOOP_TIMEOUT_CHECKER
             )
         );
@@ -60,13 +60,13 @@ public class TextLogTextStructureFinderTests extends TextStructureTestCase {
 
         String charset = randomFrom(POSSIBLE_CHARSETS);
         Boolean hasByteOrderMarker = randomHasByteOrderMarker(charset);
-        FileStructureFinder structureFinder = factory.createFromSample(
+        TextStructureFinder structureFinder = factory.createFromSample(
             explanation,
             TEXT_SAMPLE,
             charset,
             hasByteOrderMarker,
-            FileStructureFinderManager.DEFAULT_LINE_MERGE_SIZE_LIMIT,
-            FileStructureOverrides.EMPTY_OVERRIDES,
+            TextStructureFinderManager.DEFAULT_LINE_MERGE_SIZE_LIMIT,
+            TextStructureOverrides.EMPTY_OVERRIDES,
             NOOP_TIMEOUT_CHECKER
         );
 
@@ -103,18 +103,18 @@ public class TextLogTextStructureFinderTests extends TextStructureTestCase {
             + "2/1/2019 11:00PM INFO foo\n"
             + "2/2/2019 1:23AM DEBUG bar\n";
 
-        FileStructureOverrides overrides = FileStructureOverrides.builder().setTimestampFormat("M/d/yyyy h:mma").build();
+        TextStructureOverrides overrides = TextStructureOverrides.builder().setTimestampFormat("M/d/yyyy h:mma").build();
 
         assertTrue(factory.canCreateFromSample(explanation, sample, 0.0));
 
         String charset = randomFrom(POSSIBLE_CHARSETS);
         Boolean hasByteOrderMarker = randomHasByteOrderMarker(charset);
-        FileStructureFinder structureFinder = factory.createFromSample(
+        TextStructureFinder structureFinder = factory.createFromSample(
             explanation,
             sample,
             charset,
             hasByteOrderMarker,
-            FileStructureFinderManager.DEFAULT_LINE_MERGE_SIZE_LIMIT,
+            TextStructureFinderManager.DEFAULT_LINE_MERGE_SIZE_LIMIT,
             overrides,
             NOOP_TIMEOUT_CHECKER
         );
@@ -147,18 +147,18 @@ public class TextLogTextStructureFinderTests extends TextStructureTestCase {
 
     public void testCreateConfigsGivenElasticsearchLogAndTimestampFieldOverride() throws Exception {
 
-        FileStructureOverrides overrides = FileStructureOverrides.builder().setTimestampField("my_time").build();
+        TextStructureOverrides overrides = TextStructureOverrides.builder().setTimestampField("my_time").build();
 
         assertTrue(factory.canCreateFromSample(explanation, TEXT_SAMPLE, 0.0));
 
         String charset = randomFrom(POSSIBLE_CHARSETS);
         Boolean hasByteOrderMarker = randomHasByteOrderMarker(charset);
-        FileStructureFinder structureFinder = factory.createFromSample(
+        TextStructureFinder structureFinder = factory.createFromSample(
             explanation,
             TEXT_SAMPLE,
             charset,
             hasByteOrderMarker,
-            FileStructureFinderManager.DEFAULT_LINE_MERGE_SIZE_LIMIT,
+            TextStructureFinderManager.DEFAULT_LINE_MERGE_SIZE_LIMIT,
             overrides,
             NOOP_TIMEOUT_CHECKER
         );
@@ -191,7 +191,7 @@ public class TextLogTextStructureFinderTests extends TextStructureTestCase {
 
     public void testCreateConfigsGivenElasticsearchLogAndGrokPatternOverride() throws Exception {
 
-        FileStructureOverrides overrides = FileStructureOverrides.builder()
+        TextStructureOverrides overrides = TextStructureOverrides.builder()
             .setGrokPattern(
                 "\\[%{TIMESTAMP_ISO8601:timestamp}\\]"
                     + "\\[%{LOGLEVEL:loglevel} *\\]\\[%{JAVACLASS:class} *\\] \\[%{HOSTNAME:node}\\] %{JAVALOGMESSAGE:message}"
@@ -202,12 +202,12 @@ public class TextLogTextStructureFinderTests extends TextStructureTestCase {
 
         String charset = randomFrom(POSSIBLE_CHARSETS);
         Boolean hasByteOrderMarker = randomHasByteOrderMarker(charset);
-        FileStructureFinder structureFinder = factory.createFromSample(
+        TextStructureFinder structureFinder = factory.createFromSample(
             explanation,
             TEXT_SAMPLE,
             charset,
             hasByteOrderMarker,
-            FileStructureFinderManager.DEFAULT_LINE_MERGE_SIZE_LIMIT,
+            TextStructureFinderManager.DEFAULT_LINE_MERGE_SIZE_LIMIT,
             overrides,
             NOOP_TIMEOUT_CHECKER
         );
@@ -247,7 +247,7 @@ public class TextLogTextStructureFinderTests extends TextStructureTestCase {
     public void testCreateConfigsGivenElasticsearchLogAndImpossibleGrokPatternOverride() {
 
         // This Grok pattern cannot be matched against the messages in the sample because the fields are in the wrong order
-        FileStructureOverrides overrides = FileStructureOverrides.builder()
+        TextStructureOverrides overrides = TextStructureOverrides.builder()
             .setGrokPattern(
                 "\\[%{LOGLEVEL:loglevel} *\\]"
                     + "\\[%{HOSTNAME:node}\\]\\[%{TIMESTAMP_ISO8601:timestamp}\\] \\[%{JAVACLASS:class} *\\] %{JAVALOGMESSAGE:message}"
@@ -265,7 +265,7 @@ public class TextLogTextStructureFinderTests extends TextStructureTestCase {
                 TEXT_SAMPLE,
                 charset,
                 hasByteOrderMarker,
-                FileStructureFinderManager.DEFAULT_LINE_MERGE_SIZE_LIMIT,
+                TextStructureFinderManager.DEFAULT_LINE_MERGE_SIZE_LIMIT,
                 overrides,
                 NOOP_TIMEOUT_CHECKER
             )
@@ -281,7 +281,7 @@ public class TextLogTextStructureFinderTests extends TextStructureTestCase {
     public void testCreateConfigsGivenElasticsearchLogAndInvalidGrokPatternOverride() {
 
         // This Grok pattern has a low-level syntax error
-        FileStructureOverrides overrides = FileStructureOverrides.builder().setGrokPattern("[").build();
+        TextStructureOverrides overrides = TextStructureOverrides.builder().setGrokPattern("[").build();
 
         assertTrue(factory.canCreateFromSample(explanation, TEXT_SAMPLE, 0.0));
 
@@ -294,7 +294,7 @@ public class TextLogTextStructureFinderTests extends TextStructureTestCase {
                 TEXT_SAMPLE,
                 charset,
                 hasByteOrderMarker,
-                FileStructureFinderManager.DEFAULT_LINE_MERGE_SIZE_LIMIT,
+                TextStructureFinderManager.DEFAULT_LINE_MERGE_SIZE_LIMIT,
                 overrides,
                 NOOP_TIMEOUT_CHECKER
             )
@@ -324,8 +324,8 @@ public class TextLogTextStructureFinderTests extends TextStructureTestCase {
                 sample,
                 charset,
                 hasByteOrderMarker,
-                FileStructureFinderManager.DEFAULT_LINE_MERGE_SIZE_LIMIT,
-                FileStructureOverrides.EMPTY_OVERRIDES,
+                TextStructureFinderManager.DEFAULT_LINE_MERGE_SIZE_LIMIT,
+                TextStructureOverrides.EMPTY_OVERRIDES,
                 NOOP_TIMEOUT_CHECKER
             )
         );
@@ -343,7 +343,7 @@ public class TextLogTextStructureFinderTests extends TextStructureTestCase {
             String simpleDateRegex = candidateTimestampFormat.simplePattern.pattern();
             assertEquals(
                 "^" + simpleDateRegex.replaceFirst("^\\\\b", ""),
-                TextLogFileStructureFinder.createMultiLineMessageStartRegex(Collections.emptySet(), simpleDateRegex)
+                LogTextStructureFinder.createMultiLineMessageStartRegex(Collections.emptySet(), simpleDateRegex)
             );
         }
     }
@@ -353,7 +353,7 @@ public class TextLogTextStructureFinderTests extends TextStructureTestCase {
             String simpleDateRegex = candidateTimestampFormat.simplePattern.pattern();
             assertEquals(
                 "^" + simpleDateRegex.replaceFirst("^\\\\b", ""),
-                TextLogFileStructureFinder.createMultiLineMessageStartRegex(Collections.singleton(""), simpleDateRegex)
+                LogTextStructureFinder.createMultiLineMessageStartRegex(Collections.singleton(""), simpleDateRegex)
             );
         }
     }
@@ -363,7 +363,7 @@ public class TextLogTextStructureFinderTests extends TextStructureTestCase {
             String simpleDateRegex = candidateTimestampFormat.simplePattern.pattern();
             assertEquals(
                 "^\\[.*?\\] \\[" + simpleDateRegex,
-                TextLogFileStructureFinder.createMultiLineMessageStartRegex(Collections.singleton("[ERROR] ["), simpleDateRegex)
+                LogTextStructureFinder.createMultiLineMessageStartRegex(Collections.singleton("[ERROR] ["), simpleDateRegex)
             );
         }
     }
@@ -374,7 +374,7 @@ public class TextLogTextStructureFinderTests extends TextStructureTestCase {
             String simpleDateRegex = candidateTimestampFormat.simplePattern.pattern();
             assertEquals(
                 "^\\[.*?\\] \\[" + simpleDateRegex,
-                TextLogFileStructureFinder.createMultiLineMessageStartRegex(prefaces, simpleDateRegex)
+                LogTextStructureFinder.createMultiLineMessageStartRegex(prefaces, simpleDateRegex)
             );
         }
     }
@@ -383,10 +383,7 @@ public class TextLogTextStructureFinderTests extends TextStructureTestCase {
         for (TimestampFormatFinder.CandidateTimestampFormat candidateTimestampFormat : TimestampFormatFinder.ORDERED_CANDIDATE_FORMATS) {
             Set<String> prefaces = Sets.newHashSet("host-1.acme.com|", "my_host.elastic.co|");
             String simpleDateRegex = candidateTimestampFormat.simplePattern.pattern();
-            assertEquals(
-                "^.*?\\|" + simpleDateRegex,
-                TextLogFileStructureFinder.createMultiLineMessageStartRegex(prefaces, simpleDateRegex)
-            );
+            assertEquals("^.*?\\|" + simpleDateRegex, LogTextStructureFinder.createMultiLineMessageStartRegex(prefaces, simpleDateRegex));
         }
     }
 
@@ -394,7 +391,7 @@ public class TextLogTextStructureFinderTests extends TextStructureTestCase {
         for (TimestampFormatFinder.CandidateTimestampFormat candidateTimestampFormat : TimestampFormatFinder.ORDERED_CANDIDATE_FORMATS) {
             Set<String> prefaces = Sets.newHashSet("", "[non-standard] ");
             String simpleDateRegex = candidateTimestampFormat.simplePattern.pattern();
-            assertEquals("^.*?" + simpleDateRegex, TextLogFileStructureFinder.createMultiLineMessageStartRegex(prefaces, simpleDateRegex));
+            assertEquals("^.*?" + simpleDateRegex, LogTextStructureFinder.createMultiLineMessageStartRegex(prefaces, simpleDateRegex));
         }
     }
 }

--- a/x-pack/plugin/text-structure/src/test/java/org/elasticsearch/xpack/textstructure/structurefinder/NdJsonTextStructureFinderFactoryTests.java
+++ b/x-pack/plugin/text-structure/src/test/java/org/elasticsearch/xpack/textstructure/structurefinder/NdJsonTextStructureFinderFactoryTests.java
@@ -7,7 +7,7 @@ package org.elasticsearch.xpack.textstructure.structurefinder;
 
 public class NdJsonTextStructureFinderFactoryTests extends TextStructureTestCase {
 
-    private FileStructureFinderFactory factory = new NdJsonFileStructureFinderFactory();
+    private final TextStructureFinderFactory factory = new NdJsonTextStructureFinderFactory();
 
     public void testCanCreateFromSampleGivenNdJson() {
 

--- a/x-pack/plugin/text-structure/src/test/java/org/elasticsearch/xpack/textstructure/structurefinder/NdJsonTextStructureFinderTests.java
+++ b/x-pack/plugin/text-structure/src/test/java/org/elasticsearch/xpack/textstructure/structurefinder/NdJsonTextStructureFinderTests.java
@@ -11,20 +11,20 @@ import java.util.Collections;
 
 public class NdJsonTextStructureFinderTests extends TextStructureTestCase {
 
-    private final FileStructureFinderFactory factory = new NdJsonFileStructureFinderFactory();
+    private final TextStructureFinderFactory factory = new NdJsonTextStructureFinderFactory();
 
     public void testCreateConfigsGivenGoodJson() throws Exception {
         assertTrue(factory.canCreateFromSample(explanation, NDJSON_SAMPLE, 0.0));
 
         String charset = randomFrom(POSSIBLE_CHARSETS);
         Boolean hasByteOrderMarker = randomHasByteOrderMarker(charset);
-        FileStructureFinder structureFinder = factory.createFromSample(
+        TextStructureFinder structureFinder = factory.createFromSample(
             explanation,
             NDJSON_SAMPLE,
             charset,
             hasByteOrderMarker,
-            FileStructureFinderManager.DEFAULT_LINE_MERGE_SIZE_LIMIT,
-            FileStructureOverrides.EMPTY_OVERRIDES,
+            TextStructureFinderManager.DEFAULT_LINE_MERGE_SIZE_LIMIT,
+            TextStructureOverrides.EMPTY_OVERRIDES,
             NOOP_TIMEOUT_CHECKER
         );
 

--- a/x-pack/plugin/text-structure/src/test/java/org/elasticsearch/xpack/textstructure/structurefinder/TextStructureTestCase.java
+++ b/x-pack/plugin/text-structure/src/test/java/org/elasticsearch/xpack/textstructure/structurefinder/TextStructureTestCase.java
@@ -23,7 +23,7 @@ public abstract class TextStructureTestCase extends ESTestCase {
         Charset.availableCharsets()
             .keySet()
             .stream()
-            .filter(name -> FileStructureFinderManager.FILEBEAT_SUPPORTED_ENCODINGS.contains(name.toLowerCase(Locale.ROOT)))
+            .filter(name -> TextStructureFinderManager.FILEBEAT_SUPPORTED_ENCODINGS.contains(name.toLowerCase(Locale.ROOT)))
             .collect(Collectors.toList())
     );
 

--- a/x-pack/plugin/text-structure/src/test/java/org/elasticsearch/xpack/textstructure/structurefinder/TextStructureUtilsTests.java
+++ b/x-pack/plugin/text-structure/src/test/java/org/elasticsearch/xpack/textstructure/structurefinder/TextStructureUtilsTests.java
@@ -23,22 +23,22 @@ import static org.hamcrest.Matchers.instanceOf;
 public class TextStructureUtilsTests extends TextStructureTestCase {
 
     public void testMoreLikelyGivenText() {
-        assertTrue(FileStructureUtils.isMoreLikelyTextThanKeyword("the quick brown fox jumped over the lazy dog"));
-        assertTrue(FileStructureUtils.isMoreLikelyTextThanKeyword(randomAlphaOfLengthBetween(257, 10000)));
+        assertTrue(TextStructureUtils.isMoreLikelyTextThanKeyword("the quick brown fox jumped over the lazy dog"));
+        assertTrue(TextStructureUtils.isMoreLikelyTextThanKeyword(randomAlphaOfLengthBetween(257, 10000)));
     }
 
     public void testMoreLikelyGivenKeyword() {
-        assertFalse(FileStructureUtils.isMoreLikelyTextThanKeyword("1"));
-        assertFalse(FileStructureUtils.isMoreLikelyTextThanKeyword("DEBUG"));
-        assertFalse(FileStructureUtils.isMoreLikelyTextThanKeyword(randomAlphaOfLengthBetween(1, 256)));
+        assertFalse(TextStructureUtils.isMoreLikelyTextThanKeyword("1"));
+        assertFalse(TextStructureUtils.isMoreLikelyTextThanKeyword("DEBUG"));
+        assertFalse(TextStructureUtils.isMoreLikelyTextThanKeyword(randomAlphaOfLengthBetween(1, 256)));
     }
 
     public void testGuessTimestampGivenSingleSampleSingleField() {
         Map<String, String> sample = Collections.singletonMap("field1", "2018-05-24T17:28:31,735");
-        Tuple<String, TimestampFormatFinder> match = FileStructureUtils.guessTimestampField(
+        Tuple<String, TimestampFormatFinder> match = TextStructureUtils.guessTimestampField(
             explanation,
             Collections.singletonList(sample),
-            FileStructureOverrides.EMPTY_OVERRIDES,
+            TextStructureOverrides.EMPTY_OVERRIDES,
             NOOP_TIMEOUT_CHECKER
         );
         assertNotNull(match);
@@ -49,10 +49,10 @@ public class TextStructureUtilsTests extends TextStructureTestCase {
 
     public void testGuessTimestampGivenSingleSampleSingleFieldAndConsistentTimeFieldOverride() {
 
-        FileStructureOverrides overrides = FileStructureOverrides.builder().setTimestampField("field1").build();
+        TextStructureOverrides overrides = TextStructureOverrides.builder().setTimestampField("field1").build();
 
         Map<String, String> sample = Collections.singletonMap("field1", "2018-05-24T17:28:31,735");
-        Tuple<String, TimestampFormatFinder> match = FileStructureUtils.guessTimestampField(
+        Tuple<String, TimestampFormatFinder> match = TextStructureUtils.guessTimestampField(
             explanation,
             Collections.singletonList(sample),
             overrides,
@@ -66,12 +66,12 @@ public class TextStructureUtilsTests extends TextStructureTestCase {
 
     public void testGuessTimestampGivenSingleSampleSingleFieldAndImpossibleTimeFieldOverride() {
 
-        FileStructureOverrides overrides = FileStructureOverrides.builder().setTimestampField("field2").build();
+        TextStructureOverrides overrides = TextStructureOverrides.builder().setTimestampField("field2").build();
 
         Map<String, String> sample = Collections.singletonMap("field1", "2018-05-24T17:28:31,735");
         IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
-            () -> FileStructureUtils.guessTimestampField(explanation, Collections.singletonList(sample), overrides, NOOP_TIMEOUT_CHECKER)
+            () -> TextStructureUtils.guessTimestampField(explanation, Collections.singletonList(sample), overrides, NOOP_TIMEOUT_CHECKER)
         );
 
         assertEquals("Specified timestamp field [field2] is not present in record [{field1=2018-05-24T17:28:31,735}]", e.getMessage());
@@ -79,10 +79,10 @@ public class TextStructureUtilsTests extends TextStructureTestCase {
 
     public void testGuessTimestampGivenSingleSampleSingleFieldAndConsistentTimeFormatOverride() {
 
-        FileStructureOverrides overrides = FileStructureOverrides.builder().setTimestampFormat("ISO8601").build();
+        TextStructureOverrides overrides = TextStructureOverrides.builder().setTimestampFormat("ISO8601").build();
 
         Map<String, String> sample = Collections.singletonMap("field1", "2018-05-24T17:28:31,735");
-        Tuple<String, TimestampFormatFinder> match = FileStructureUtils.guessTimestampField(
+        Tuple<String, TimestampFormatFinder> match = TextStructureUtils.guessTimestampField(
             explanation,
             Collections.singletonList(sample),
             overrides,
@@ -96,12 +96,12 @@ public class TextStructureUtilsTests extends TextStructureTestCase {
 
     public void testGuessTimestampGivenSingleSampleSingleFieldAndImpossibleTimeFormatOverride() {
 
-        FileStructureOverrides overrides = FileStructureOverrides.builder().setTimestampFormat("EEE MMM dd HH:mm:ss yyyy").build();
+        TextStructureOverrides overrides = TextStructureOverrides.builder().setTimestampFormat("EEE MMM dd HH:mm:ss yyyy").build();
 
         Map<String, String> sample = Collections.singletonMap("field1", "2018-05-24T17:28:31,735");
         IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
-            () -> FileStructureUtils.guessTimestampField(explanation, Collections.singletonList(sample), overrides, NOOP_TIMEOUT_CHECKER)
+            () -> TextStructureUtils.guessTimestampField(explanation, Collections.singletonList(sample), overrides, NOOP_TIMEOUT_CHECKER)
         );
 
         assertEquals(
@@ -113,10 +113,10 @@ public class TextStructureUtilsTests extends TextStructureTestCase {
     public void testGuessTimestampGivenSamplesWithSameSingleTimeField() {
         Map<String, String> sample1 = Collections.singletonMap("field1", "2018-05-24T17:28:31,735");
         Map<String, String> sample2 = Collections.singletonMap("field1", "2018-05-24T17:33:39,406");
-        Tuple<String, TimestampFormatFinder> match = FileStructureUtils.guessTimestampField(
+        Tuple<String, TimestampFormatFinder> match = TextStructureUtils.guessTimestampField(
             explanation,
             Arrays.asList(sample1, sample2),
-            FileStructureOverrides.EMPTY_OVERRIDES,
+            TextStructureOverrides.EMPTY_OVERRIDES,
             NOOP_TIMEOUT_CHECKER
         );
         assertNotNull(match);
@@ -128,10 +128,10 @@ public class TextStructureUtilsTests extends TextStructureTestCase {
     public void testGuessTimestampGivenSamplesWithOneSingleTimeFieldDifferentFormat() {
         Map<String, String> sample1 = Collections.singletonMap("field1", "2018-05-24T17:28:31,735");
         Map<String, String> sample2 = Collections.singletonMap("field1", "Thu May 24 17:33:39 2018");
-        Tuple<String, TimestampFormatFinder> match = FileStructureUtils.guessTimestampField(
+        Tuple<String, TimestampFormatFinder> match = TextStructureUtils.guessTimestampField(
             explanation,
             Arrays.asList(sample1, sample2),
-            FileStructureOverrides.EMPTY_OVERRIDES,
+            TextStructureOverrides.EMPTY_OVERRIDES,
             NOOP_TIMEOUT_CHECKER
         );
         assertNull(match);
@@ -140,10 +140,10 @@ public class TextStructureUtilsTests extends TextStructureTestCase {
     public void testGuessTimestampGivenSamplesWithDifferentSingleTimeField() {
         Map<String, String> sample1 = Collections.singletonMap("field1", "2018-05-24T17:28:31,735");
         Map<String, String> sample2 = Collections.singletonMap("another_field", "2018-05-24T17:33:39,406");
-        Tuple<String, TimestampFormatFinder> match = FileStructureUtils.guessTimestampField(
+        Tuple<String, TimestampFormatFinder> match = TextStructureUtils.guessTimestampField(
             explanation,
             Arrays.asList(sample1, sample2),
-            FileStructureOverrides.EMPTY_OVERRIDES,
+            TextStructureOverrides.EMPTY_OVERRIDES,
             NOOP_TIMEOUT_CHECKER
         );
         assertNull(match);
@@ -154,10 +154,10 @@ public class TextStructureUtilsTests extends TextStructureTestCase {
         sample.put("foo", "not a time");
         sample.put("time", "2018-05-24 17:28:31,735");
         sample.put("bar", 42);
-        Tuple<String, TimestampFormatFinder> match = FileStructureUtils.guessTimestampField(
+        Tuple<String, TimestampFormatFinder> match = TextStructureUtils.guessTimestampField(
             explanation,
             Collections.singletonList(sample),
-            FileStructureOverrides.EMPTY_OVERRIDES,
+            TextStructureOverrides.EMPTY_OVERRIDES,
             NOOP_TIMEOUT_CHECKER
         );
         assertNotNull(match);
@@ -175,10 +175,10 @@ public class TextStructureUtilsTests extends TextStructureTestCase {
         sample2.put("foo", "whatever");
         sample2.put("time", "2018-05-29 11:53:02,837");
         sample2.put("bar", 17);
-        Tuple<String, TimestampFormatFinder> match = FileStructureUtils.guessTimestampField(
+        Tuple<String, TimestampFormatFinder> match = TextStructureUtils.guessTimestampField(
             explanation,
             Arrays.asList(sample1, sample2),
-            FileStructureOverrides.EMPTY_OVERRIDES,
+            TextStructureOverrides.EMPTY_OVERRIDES,
             NOOP_TIMEOUT_CHECKER
         );
         assertNotNull(match);
@@ -196,10 +196,10 @@ public class TextStructureUtilsTests extends TextStructureTestCase {
         sample2.put("foo", "whatever");
         sample2.put("time", "May 29 2018 11:53:02");
         sample2.put("bar", 17);
-        Tuple<String, TimestampFormatFinder> match = FileStructureUtils.guessTimestampField(
+        Tuple<String, TimestampFormatFinder> match = TextStructureUtils.guessTimestampField(
             explanation,
             Arrays.asList(sample1, sample2),
-            FileStructureOverrides.EMPTY_OVERRIDES,
+            TextStructureOverrides.EMPTY_OVERRIDES,
             NOOP_TIMEOUT_CHECKER
         );
         assertNull(match);
@@ -214,10 +214,10 @@ public class TextStructureUtilsTests extends TextStructureTestCase {
         sample2.put("red_herring", "whatever");
         sample2.put("time", "2018-05-29 11:53:02,837");
         sample2.put("bar", 17);
-        Tuple<String, TimestampFormatFinder> match = FileStructureUtils.guessTimestampField(
+        Tuple<String, TimestampFormatFinder> match = TextStructureUtils.guessTimestampField(
             explanation,
             Arrays.asList(sample1, sample2),
-            FileStructureOverrides.EMPTY_OVERRIDES,
+            TextStructureOverrides.EMPTY_OVERRIDES,
             NOOP_TIMEOUT_CHECKER
         );
         assertNotNull(match);
@@ -235,10 +235,10 @@ public class TextStructureUtilsTests extends TextStructureTestCase {
         sample2.put("foo", "whatever");
         sample2.put("time", "May 29 2018 11:53:02");
         sample2.put("red_herring", "17");
-        Tuple<String, TimestampFormatFinder> match = FileStructureUtils.guessTimestampField(
+        Tuple<String, TimestampFormatFinder> match = TextStructureUtils.guessTimestampField(
             explanation,
             Arrays.asList(sample1, sample2),
-            FileStructureOverrides.EMPTY_OVERRIDES,
+            TextStructureOverrides.EMPTY_OVERRIDES,
             NOOP_TIMEOUT_CHECKER
         );
         assertNotNull(match);
@@ -256,10 +256,10 @@ public class TextStructureUtilsTests extends TextStructureTestCase {
         sample2.put("foo", "whatever");
         sample2.put("time2", "May 29 2018 11:53:02");
         sample2.put("bar", 42);
-        Tuple<String, TimestampFormatFinder> match = FileStructureUtils.guessTimestampField(
+        Tuple<String, TimestampFormatFinder> match = TextStructureUtils.guessTimestampField(
             explanation,
             Arrays.asList(sample1, sample2),
-            FileStructureOverrides.EMPTY_OVERRIDES,
+            TextStructureOverrides.EMPTY_OVERRIDES,
             NOOP_TIMEOUT_CHECKER
         );
         assertNull(match);
@@ -276,10 +276,10 @@ public class TextStructureUtilsTests extends TextStructureTestCase {
         sample2.put("time2", "May 10 2018 11:53:02");
         sample2.put("time3", "Thu, May 10 2018 11:53:02");
         sample2.put("bar", 42);
-        Tuple<String, TimestampFormatFinder> match = FileStructureUtils.guessTimestampField(
+        Tuple<String, TimestampFormatFinder> match = TextStructureUtils.guessTimestampField(
             explanation,
             Arrays.asList(sample1, sample2),
-            FileStructureOverrides.EMPTY_OVERRIDES,
+            TextStructureOverrides.EMPTY_OVERRIDES,
             NOOP_TIMEOUT_CHECKER
         );
         assertNotNull(match);
@@ -293,26 +293,26 @@ public class TextStructureUtilsTests extends TextStructureTestCase {
     }
 
     public void testGuessMappingGivenKeyword() {
-        Map<String, String> expected = Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "keyword");
+        Map<String, String> expected = Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "keyword");
 
         assertEquals(expected, guessMapping(explanation, "foo", Arrays.asList("ERROR", "INFO", "DEBUG")));
         assertEquals(expected, guessMapping(explanation, "foo", Arrays.asList("2018-06-11T13:26:47Z", "not a date")));
     }
 
     public void testGuessMappingGivenText() {
-        Map<String, String> expected = Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "text");
+        Map<String, String> expected = Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "text");
 
         assertEquals(expected, guessMapping(explanation, "foo", Arrays.asList("a", "the quick brown fox jumped over the lazy dog")));
     }
 
     public void testGuessMappingGivenIp() {
-        Map<String, String> expected = Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "ip");
+        Map<String, String> expected = Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "ip");
 
         assertEquals(expected, guessMapping(explanation, "foo", Arrays.asList("10.0.0.1", "172.16.0.1", "192.168.0.1")));
     }
 
     public void testGuessMappingGivenDouble() {
-        Map<String, String> expected = Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "double");
+        Map<String, String> expected = Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "double");
 
         assertEquals(expected, guessMapping(explanation, "foo", Arrays.asList("3.14159265359", "0", "-8")));
         // 12345678901234567890 is too long for long
@@ -322,7 +322,7 @@ public class TextStructureUtilsTests extends TextStructureTestCase {
     }
 
     public void testGuessMappingGivenLong() {
-        Map<String, String> expected = Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "long");
+        Map<String, String> expected = Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "long");
 
         assertEquals(expected, guessMapping(explanation, "foo", Arrays.asList("500", "3", "-3")));
         assertEquals(expected, guessMapping(explanation, "foo", Arrays.asList(500, 6, 0)));
@@ -330,31 +330,31 @@ public class TextStructureUtilsTests extends TextStructureTestCase {
 
     public void testGuessMappingGivenDate() {
         Map<String, String> expected = new HashMap<>();
-        expected.put(FileStructureUtils.MAPPING_TYPE_SETTING, "date");
-        expected.put(FileStructureUtils.MAPPING_FORMAT_SETTING, "iso8601");
+        expected.put(TextStructureUtils.MAPPING_TYPE_SETTING, "date");
+        expected.put(TextStructureUtils.MAPPING_FORMAT_SETTING, "iso8601");
 
         assertEquals(expected, guessMapping(explanation, "foo", Arrays.asList("2018-06-11T13:26:47Z", "2018-06-11T13:27:12Z")));
     }
 
     public void testGuessMappingGivenBoolean() {
-        Map<String, String> expected = Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "boolean");
+        Map<String, String> expected = Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "boolean");
 
         assertEquals(expected, guessMapping(explanation, "foo", Arrays.asList("false", "true")));
         assertEquals(expected, guessMapping(explanation, "foo", Arrays.asList(true, false)));
     }
 
     public void testGuessMappingGivenArray() {
-        Map<String, String> expected = Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "long");
+        Map<String, String> expected = Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "long");
 
         assertEquals(expected, guessMapping(explanation, "foo", Arrays.asList(42, Arrays.asList(1, -99))));
 
-        expected = Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "keyword");
+        expected = Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "keyword");
 
         assertEquals(expected, guessMapping(explanation, "foo", Arrays.asList(new String[] { "x", "y" }, "z")));
     }
 
     public void testGuessMappingGivenObject() {
-        Map<String, String> expected = Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "object");
+        Map<String, String> expected = Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "object");
 
         assertEquals(
             expected,
@@ -387,18 +387,18 @@ public class TextStructureUtilsTests extends TextStructureTestCase {
         sample2.put("bar", 17);
         sample2.put("nothing", null);
 
-        Tuple<SortedMap<String, Object>, SortedMap<String, FieldStats>> mappingsAndFieldStats = FileStructureUtils
+        Tuple<SortedMap<String, Object>, SortedMap<String, FieldStats>> mappingsAndFieldStats = TextStructureUtils
             .guessMappingsAndCalculateFieldStats(explanation, Arrays.asList(sample1, sample2), NOOP_TIMEOUT_CHECKER);
         assertNotNull(mappingsAndFieldStats);
 
         Map<String, Object> mappings = mappingsAndFieldStats.v1();
         assertNotNull(mappings);
-        assertEquals(Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "keyword"), mappings.get("foo"));
+        assertEquals(Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "keyword"), mappings.get("foo"));
         Map<String, String> expectedTimeMapping = new HashMap<>();
-        expectedTimeMapping.put(FileStructureUtils.MAPPING_TYPE_SETTING, "date");
-        expectedTimeMapping.put(FileStructureUtils.MAPPING_FORMAT_SETTING, "yyyy-MM-dd HH:mm:ss,SSS");
+        expectedTimeMapping.put(TextStructureUtils.MAPPING_TYPE_SETTING, "date");
+        expectedTimeMapping.put(TextStructureUtils.MAPPING_FORMAT_SETTING, "yyyy-MM-dd HH:mm:ss,SSS");
         assertEquals(expectedTimeMapping, mappings.get("time"));
-        assertEquals(Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, "long"), mappings.get("bar"));
+        assertEquals(Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "long"), mappings.get("bar"));
         assertNull(mappings.get("nothing"));
 
         Map<String, FieldStats> fieldStats = mappingsAndFieldStats.v2();
@@ -422,7 +422,7 @@ public class TextStructureUtilsTests extends TextStructureTestCase {
     public void testMakeIngestPipelineDefinitionGivenNdJsonWithoutTimestamp() {
 
         assertNull(
-            FileStructureUtils.makeIngestPipelineDefinition(
+            TextStructureUtils.makeIngestPipelineDefinition(
                 null,
                 Collections.emptyMap(),
                 null,
@@ -446,7 +446,7 @@ public class TextStructureUtilsTests extends TextStructureTestCase {
         boolean needClientTimezone = randomBoolean();
         boolean needNanosecondPrecision = randomBoolean();
 
-        Map<String, Object> pipeline = FileStructureUtils.makeIngestPipelineDefinition(
+        Map<String, Object> pipeline = TextStructureUtils.makeIngestPipelineDefinition(
             null,
             Collections.emptyMap(),
             null,
@@ -470,7 +470,7 @@ public class TextStructureUtilsTests extends TextStructureTestCase {
         assertEquals(needClientTimezone, dateProcessor.containsKey("timezone"));
         assertEquals(timestampFormats, dateProcessor.get("formats"));
         if (needNanosecondPrecision) {
-            assertEquals(FileStructureUtils.NANOSECOND_DATE_OUTPUT_FORMAT, dateProcessor.get("output_format"));
+            assertEquals(TextStructureUtils.NANOSECOND_DATE_OUTPUT_FORMAT, dateProcessor.get("output_format"));
         } else {
             assertNull(dateProcessor.get("output_format"));
         }
@@ -484,7 +484,7 @@ public class TextStructureUtilsTests extends TextStructureTestCase {
 
         Map<String, Object> csvProcessorSettings = DelimitedTextStructureFinderTests.randomCsvProcessorSettings();
 
-        Map<String, Object> pipeline = FileStructureUtils.makeIngestPipelineDefinition(
+        Map<String, Object> pipeline = TextStructureUtils.makeIngestPipelineDefinition(
             null,
             Collections.emptyMap(),
             csvProcessorSettings,
@@ -523,7 +523,7 @@ public class TextStructureUtilsTests extends TextStructureTestCase {
         String firstTargetField = ((List<String>) csvProcessorSettings.get("target_fields")).get(0);
         csvProcessorSettings.put("field", firstTargetField);
 
-        Map<String, Object> pipeline = FileStructureUtils.makeIngestPipelineDefinition(
+        Map<String, Object> pipeline = TextStructureUtils.makeIngestPipelineDefinition(
             null,
             Collections.emptyMap(),
             csvProcessorSettings,
@@ -560,10 +560,10 @@ public class TextStructureUtilsTests extends TextStructureTestCase {
         String firstTargetField = ((List<String>) csvProcessorSettings.get("target_fields")).get(0);
         Map<String, Object> mappingsForConversions = Collections.singletonMap(
             firstTargetField,
-            Collections.singletonMap(FileStructureUtils.MAPPING_TYPE_SETTING, mappingType)
+            Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, mappingType)
         );
 
-        Map<String, Object> pipeline = FileStructureUtils.makeIngestPipelineDefinition(
+        Map<String, Object> pipeline = TextStructureUtils.makeIngestPipelineDefinition(
             null,
             Collections.emptyMap(),
             csvProcessorSettings,
@@ -616,7 +616,7 @@ public class TextStructureUtilsTests extends TextStructureTestCase {
         boolean needClientTimezone = randomBoolean();
         boolean needNanosecondPrecision = randomBoolean();
 
-        Map<String, Object> pipeline = FileStructureUtils.makeIngestPipelineDefinition(
+        Map<String, Object> pipeline = TextStructureUtils.makeIngestPipelineDefinition(
             null,
             Collections.emptyMap(),
             csvProcessorSettings,
@@ -646,7 +646,7 @@ public class TextStructureUtilsTests extends TextStructureTestCase {
         assertEquals(needClientTimezone, dateProcessor.containsKey("timezone"));
         assertEquals(timestampFormats, dateProcessor.get("formats"));
         if (needNanosecondPrecision) {
-            assertEquals(FileStructureUtils.NANOSECOND_DATE_OUTPUT_FORMAT, dateProcessor.get("output_format"));
+            assertEquals(TextStructureUtils.NANOSECOND_DATE_OUTPUT_FORMAT, dateProcessor.get("output_format"));
         } else {
             assertNull(dateProcessor.get("output_format"));
         }
@@ -671,7 +671,7 @@ public class TextStructureUtilsTests extends TextStructureTestCase {
         boolean needClientTimezone = randomBoolean();
         boolean needNanosecondPrecision = randomBoolean();
 
-        Map<String, Object> pipeline = FileStructureUtils.makeIngestPipelineDefinition(
+        Map<String, Object> pipeline = TextStructureUtils.makeIngestPipelineDefinition(
             grokPattern,
             Collections.emptyMap(),
             null,
@@ -700,7 +700,7 @@ public class TextStructureUtilsTests extends TextStructureTestCase {
         assertEquals(needClientTimezone, dateProcessor.containsKey("timezone"));
         assertEquals(timestampFormats, dateProcessor.get("formats"));
         if (needNanosecondPrecision) {
-            assertEquals(FileStructureUtils.NANOSECOND_DATE_OUTPUT_FORMAT, dateProcessor.get("output_format"));
+            assertEquals(TextStructureUtils.NANOSECOND_DATE_OUTPUT_FORMAT, dateProcessor.get("output_format"));
         } else {
             assertNull(dateProcessor.get("output_format"));
         }
@@ -714,25 +714,25 @@ public class TextStructureUtilsTests extends TextStructureTestCase {
     }
 
     public void testGuessGeoPoint() {
-        Map<String, String> mapping = FileStructureUtils.guessScalarMapping(
+        Map<String, String> mapping = TextStructureUtils.guessScalarMapping(
             explanation,
             "foo",
             Arrays.asList("POINT (-77.03653 38.897676)", "POINT (-50.03653 28.8973)"),
             NOOP_TIMEOUT_CHECKER
         );
-        assertThat(mapping.get(FileStructureUtils.MAPPING_TYPE_SETTING), equalTo("geo_point"));
+        assertThat(mapping.get(TextStructureUtils.MAPPING_TYPE_SETTING), equalTo("geo_point"));
 
-        mapping = FileStructureUtils.guessScalarMapping(
+        mapping = TextStructureUtils.guessScalarMapping(
             explanation,
             "foo",
             Arrays.asList("POINT (-77.03653 38.897676)", "bar"),
             NOOP_TIMEOUT_CHECKER
         );
-        assertThat(mapping.get(FileStructureUtils.MAPPING_TYPE_SETTING), equalTo("keyword"));
+        assertThat(mapping.get(TextStructureUtils.MAPPING_TYPE_SETTING), equalTo("keyword"));
     }
 
     public void testGuessGeoShape() {
-        Map<String, String> mapping = FileStructureUtils.guessScalarMapping(
+        Map<String, String> mapping = TextStructureUtils.guessScalarMapping(
             explanation,
             "foo",
             Arrays.asList(
@@ -751,19 +751,19 @@ public class TextStructureUtilsTests extends TextStructureTestCase {
             ),
             NOOP_TIMEOUT_CHECKER
         );
-        assertThat(mapping.get(FileStructureUtils.MAPPING_TYPE_SETTING), equalTo("geo_shape"));
+        assertThat(mapping.get(TextStructureUtils.MAPPING_TYPE_SETTING), equalTo("geo_shape"));
 
-        mapping = FileStructureUtils.guessScalarMapping(
+        mapping = TextStructureUtils.guessScalarMapping(
             explanation,
             "foo",
             Arrays.asList("POINT (-77.03653 38.897676)", "LINESTRING (-77.03653 38.897676, -77.009051 38.889939)", "bar"),
             NOOP_TIMEOUT_CHECKER
         );
-        assertThat(mapping.get(FileStructureUtils.MAPPING_TYPE_SETTING), equalTo("keyword"));
+        assertThat(mapping.get(TextStructureUtils.MAPPING_TYPE_SETTING), equalTo("keyword"));
     }
 
     private Map<String, String> guessMapping(List<String> explanation, String fieldName, List<Object> fieldValues) {
-        Tuple<Map<String, String>, FieldStats> mappingAndFieldStats = FileStructureUtils.guessMappingAndCalculateFieldStats(
+        Tuple<Map<String, String>, FieldStats> mappingAndFieldStats = TextStructureUtils.guessMappingAndCalculateFieldStats(
             explanation,
             fieldName,
             fieldValues,

--- a/x-pack/plugin/text-structure/src/test/java/org/elasticsearch/xpack/textstructure/structurefinder/TimestampFormatFinderTests.java
+++ b/x-pack/plugin/text-structure/src/test/java/org/elasticsearch/xpack/textstructure/structurefinder/TimestampFormatFinderTests.java
@@ -1501,10 +1501,10 @@ public class TimestampFormatFinderTests extends TextStructureTestCase {
             + "[2018-06-27T11:59:23,588][INFO ][o.e.p.PluginsService     ] [node-0] loaded module [x-pack-watcher]\n"
             + "[2018-06-27T11:59:23,588][INFO ][o.e.p.PluginsService     ] [node-0] no plugins loaded\n";
 
-        TimestampFormatFinder timestampFormatFinder = TextLogFileStructureFinder.populateTimestampFormatFinder(
+        TimestampFormatFinder timestampFormatFinder = LogTextStructureFinder.populateTimestampFormatFinder(
             explanation,
             sample.split("\n"),
-            FileStructureOverrides.EMPTY_OVERRIDES,
+            TextStructureOverrides.EMPTY_OVERRIDES,
             NOOP_TIMEOUT_CHECKER
         );
         timestampFormatFinder.selectBestMatch();
@@ -1519,10 +1519,10 @@ public class TimestampFormatFinderTests extends TextStructureTestCase {
 
     public void testSelectBestMatchGivenExceptionTrace() {
 
-        TimestampFormatFinder timestampFormatFinder = TextLogFileStructureFinder.populateTimestampFormatFinder(
+        TimestampFormatFinder timestampFormatFinder = LogTextStructureFinder.populateTimestampFormatFinder(
             explanation,
             EXCEPTION_TRACE_SAMPLE.split("\n"),
-            FileStructureOverrides.EMPTY_OVERRIDES,
+            TextStructureOverrides.EMPTY_OVERRIDES,
             NOOP_TIMEOUT_CHECKER
         );
 
@@ -1541,9 +1541,9 @@ public class TimestampFormatFinderTests extends TextStructureTestCase {
 
     public void testSelectBestMatchGivenExceptionTraceAndTimestampFormatOverride() {
 
-        FileStructureOverrides overrides = FileStructureOverrides.builder().setTimestampFormat("yyyy-MM-dd HH:mm:ss").build();
+        TextStructureOverrides overrides = TextStructureOverrides.builder().setTimestampFormat("yyyy-MM-dd HH:mm:ss").build();
 
-        TimestampFormatFinder timestampFormatFinder = TextLogFileStructureFinder.populateTimestampFormatFinder(
+        TimestampFormatFinder timestampFormatFinder = LogTextStructureFinder.populateTimestampFormatFinder(
             explanation,
             EXCEPTION_TRACE_SAMPLE.split("\n"),
             overrides,
@@ -1556,9 +1556,9 @@ public class TimestampFormatFinderTests extends TextStructureTestCase {
 
     public void testSelectBestMatchGivenExceptionTraceAndImpossibleTimestampFormatOverride() {
 
-        FileStructureOverrides overrides = FileStructureOverrides.builder().setTimestampFormat("MMM dd HH:mm:ss").build();
+        TextStructureOverrides overrides = TextStructureOverrides.builder().setTimestampFormat("MMM dd HH:mm:ss").build();
 
-        TimestampFormatFinder timestampFormatFinder = TextLogFileStructureFinder.populateTimestampFormatFinder(
+        TimestampFormatFinder timestampFormatFinder = LogTextStructureFinder.populateTimestampFormatFinder(
             explanation,
             EXCEPTION_TRACE_SAMPLE.split("\n"),
             overrides,

--- a/x-pack/plugin/text-structure/src/test/java/org/elasticsearch/xpack/textstructure/structurefinder/XmlTextStructureFinderFactoryTests.java
+++ b/x-pack/plugin/text-structure/src/test/java/org/elasticsearch/xpack/textstructure/structurefinder/XmlTextStructureFinderFactoryTests.java
@@ -7,7 +7,7 @@ package org.elasticsearch.xpack.textstructure.structurefinder;
 
 public class XmlTextStructureFinderFactoryTests extends TextStructureTestCase {
 
-    private FileStructureFinderFactory factory = new XmlFileStructureFinderFactory();
+    private final TextStructureFinderFactory factory = new XmlTextStructureFinderFactory();
 
     // No need to check NDJSON because it comes earlier in the order we check formats
 

--- a/x-pack/plugin/text-structure/src/test/java/org/elasticsearch/xpack/textstructure/structurefinder/XmlTextStructureFinderTests.java
+++ b/x-pack/plugin/text-structure/src/test/java/org/elasticsearch/xpack/textstructure/structurefinder/XmlTextStructureFinderTests.java
@@ -11,20 +11,20 @@ import java.util.Collections;
 
 public class XmlTextStructureFinderTests extends TextStructureTestCase {
 
-    private final FileStructureFinderFactory factory = new XmlFileStructureFinderFactory();
+    private final TextStructureFinderFactory factory = new XmlTextStructureFinderFactory();
 
     public void testCreateConfigsGivenGoodXml() throws Exception {
         assertTrue(factory.canCreateFromSample(explanation, XML_SAMPLE, 0.0));
 
         String charset = randomFrom(POSSIBLE_CHARSETS);
         Boolean hasByteOrderMarker = randomHasByteOrderMarker(charset);
-        FileStructureFinder structureFinder = factory.createFromSample(
+        TextStructureFinder structureFinder = factory.createFromSample(
             explanation,
             XML_SAMPLE,
             charset,
             hasByteOrderMarker,
-            FileStructureFinderManager.DEFAULT_LINE_MERGE_SIZE_LIMIT,
-            FileStructureOverrides.EMPTY_OVERRIDES,
+            TextStructureFinderManager.DEFAULT_LINE_MERGE_SIZE_LIMIT,
+            TextStructureOverrides.EMPTY_OVERRIDES,
             NOOP_TIMEOUT_CHECKER
         );
 


### PR DESCRIPTION
Completes the process of renaming "file" to "text" in the
text structure plugin.

The unit test classes for some of the classes renamed in
this PR had already been renamed before, so they weren't
easy to navigate to in IntelliJ.