### PR TITLE
[DOCS] Minor fixes to ILM rollup docs

### DIFF
--- a/docs/reference/ilm/actions/ilm-rollup.asciidoc
+++ b/docs/reference/ilm/actions/ilm-rollup.asciidoc
@@ -7,15 +7,16 @@ Phases allowed: hot, cold.
 Aggregates an index's time series data and stores the results in a new read-only
 index. For example, you can roll up hourly data into daily or weekly summaries.
 
-For more information about rollup, see the <<rollup-api, rollup action documentation>>
+For more information about rollup, see the <<rollup-api, rollup action documentation>>.
 
 The name of the rolled up index will be the original index name of the managed index prefixed
 with `rollup-`.
 
 [[ilm-rollup-options]]
-==== Rollup options
+==== Options
+
 `config`::
-(Required, integer)
+(Required, object)
 The rollup configuration, a more detailed description of the
 rollup configuration specification can be found <<rollup-api-request-body,here>>.
 
@@ -28,14 +29,14 @@ with the newly created rollup index.
 ==== Example
 
 [source,console]
---------------------------------------------------
+----
 PUT _ilm/policy/my_policy
 {
   "policy": {
     "phases": {
       "cold": {
         "actions": {
-          "rollup" : {
+          "rollup": {
             "config": {
               "groups": {
                 "date_histogram": {
@@ -44,7 +45,12 @@ PUT _ilm/policy/my_policy
                 }
               },
               "metrics": [
-                { "field": "temperature", "metrics": [ "avg" ] }
+                {
+                  "field": "temperature",
+                  "metrics": [
+                    "avg"
+                  ]
+                }
               ]
             }
           }
@@ -53,4 +59,4 @@ PUT _ilm/policy/my_policy
     }
   }
 }
---------------------------------------------------
+----

--- a/docs/reference/ilm/ilm-actions.asciidoc
+++ b/docs/reference/ilm/ilm-actions.asciidoc
@@ -28,6 +28,12 @@ Block write operations to the index.
 Remove the index as the write index for the rollover alias and
 start indexing to a new index.
 
+ifdef::permanently-unreleased-branch[]
+<<ilm-rollup,Rollup>>::
+Aggregates an index's time series data and stores the results in a new read-only
+index. For example, you can roll up hourly data into daily or weekly summaries.
+endif::[]
+
 <<ilm-searchable-snapshot, Searchable snapshot>>::
 beta:[]
 Take a snapshot of the managed index in the configured repository
@@ -47,14 +53,6 @@ Performed automatically before a rollover, shrink, or searchable snapshot action
 <<ilm-wait-for-snapshot,Wait for snapshot>>::
 Ensure that a snapshot exists before deleting the index.
 
-ifdef::permanently-unreleased-branch[]
-
-<<ilm-rollup,Rollup>>::
-Aggregates an index's time series data and stores the results in a new read-only
-index. For example, you can roll up hourly data into daily or weekly summaries.
-
-endif::[]
-
 include::actions/ilm-allocate.asciidoc[]
 include::actions/ilm-delete.asciidoc[]
 include::actions/ilm-forcemerge.asciidoc[]
@@ -62,12 +60,11 @@ include::actions/ilm-freeze.asciidoc[]
 include::actions/ilm-migrate.asciidoc[]
 include::actions/ilm-readonly.asciidoc[]
 include::actions/ilm-rollover.asciidoc[]
+ifdef::permanently-unreleased-branch[]
+include::actions/ilm-rollup.asciidoc[]
+endif::[]
 include::actions/ilm-searchable-snapshot.asciidoc[]
 include::actions/ilm-set-priority.asciidoc[]
 include::actions/ilm-shrink.asciidoc[]
 include::actions/ilm-unfollow.asciidoc[]
 include::actions/ilm-wait-for-snapshot.asciidoc[]
-
-ifdef::permanently-unreleased-branch[]
-include::actions/ilm-rollup.asciidoc[]
-endif::[]

--- a/docs/reference/ilm/ilm-index-lifecycle.asciidoc
+++ b/docs/reference/ilm/ilm-index-lifecycle.asciidoc
@@ -86,6 +86,9 @@ the rollover criteria, it could be 20 minutes before the rollover is complete.
   - <<ilm-readonly,Read-Only>>
   - <<ilm-shrink,Shrink>>
   - <<ilm-forcemerge,Force Merge>>
+ifdef::permanently-unreleased-branch[]
+  - <<ilm-rollup,Rollup>>
+endif::[]
 * Warm
   - <<ilm-set-priority,Set Priority>>
   - <<ilm-unfollow,Unfollow>>
@@ -100,6 +103,9 @@ the rollover criteria, it could be 20 minutes before the rollover is complete.
   - <<ilm-allocate,Allocate>>
   - <<ilm-migrate,Migrate>>
   - <<ilm-freeze,Freeze>>
+ifdef::permanently-unreleased-branch[]
+  - <<ilm-rollup,Rollup>>
+endif::[]
   - <<ilm-searchable-snapshot, Searchable Snapshot>>
 * Delete
   - <<ilm-wait-for-snapshot,Wait For Snapshot>>


### PR DESCRIPTION
Changes:

- Change `Rollup options` to `Options` for better consistency with other ILM action docs.
- Reorders the `rollup` action alphabetically under the ILM actions nav and list page.
- Adds `rollup` to the hot and cold phase lists on the Index lifecycle page.