### PR TITLE
[7.x][ML] Preserve inference progress upon starting data frame analyt…

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/inference/InferenceRunner.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/inference/InferenceRunner.java
@@ -13,11 +13,18 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.OriginSettingClient;
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.aggregations.AggregationBuilders;
+import org.elasticsearch.search.aggregations.metrics.Max;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfig;
@@ -30,6 +37,7 @@ import org.elasticsearch.xpack.ml.extractor.ExtractedField;
 import org.elasticsearch.xpack.ml.extractor.ExtractedFields;
 import org.elasticsearch.xpack.ml.inference.loadingservice.LocalModel;
 import org.elasticsearch.xpack.ml.inference.loadingservice.ModelLoadingService;
+import org.elasticsearch.xpack.ml.utils.MlIndicesUtils;
 import org.elasticsearch.xpack.ml.utils.persistence.LimitAwareBulkIndexer;
 import org.elasticsearch.xpack.ml.utils.persistence.ResultsPersisterService;
 
@@ -83,11 +91,13 @@ public class InferenceRunner {
         try {
             PlainActionFuture<LocalModel> localModelPlainActionFuture = new PlainActionFuture<>();
             modelLoadingService.getModelForPipeline(modelId, localModelPlainActionFuture);
+            InferenceState inferenceState = restoreInferenceState();
+            dataCountsTracker.setTestDocsCount(inferenceState.processedTestDocsCount);
             TestDocsIterator testDocsIterator = new TestDocsIterator(new OriginSettingClient(client, ClientHelper.ML_ORIGIN), config,
-                extractedFields);
+                extractedFields, inferenceState.lastIncrementalId);
             try (LocalModel localModel = localModelPlainActionFuture.actionGet()) {
                 LOGGER.debug("Loaded inference model [{}]", localModel);
-                inferTestDocs(localModel, testDocsIterator);
+                inferTestDocs(localModel, testDocsIterator, inferenceState.processedTestDocsCount);
             }
         } catch (Exception e) {
             LOGGER.error(new ParameterizedMessage("[{}] Error running inference on model [{}]", config.getId(), modelId), e);
@@ -102,10 +112,36 @@ public class InferenceRunner {
         }
     }
 
+    private InferenceState restoreInferenceState() {
+        SearchRequest searchRequest = new SearchRequest(config.getDest().getIndex());
+        searchRequest.indicesOptions(MlIndicesUtils.addIgnoreUnavailable(SearchRequest.DEFAULT_INDICES_OPTIONS));
+        SearchSourceBuilder sourceBuilder = (new SearchSourceBuilder()
+            .size(0)
+            .query(QueryBuilders.boolQuery().filter(
+                QueryBuilders.termQuery(config.getDest().getResultsField() + "." + DestinationIndex.IS_TRAINING, false)))
+            .fetchSource(false)
+            .aggregation(AggregationBuilders.max(DestinationIndex.INCREMENTAL_ID).field(DestinationIndex.INCREMENTAL_ID))
+            .trackTotalHits(true)
+        );
+        searchRequest.source(sourceBuilder);
+
+        SearchResponse searchResponse = ClientHelper.executeWithHeaders(config.getHeaders(), ClientHelper.ML_ORIGIN, client,
+            () -> client.search(searchRequest).actionGet());
+
+        Max maxIncrementalIdAgg = searchResponse.getAggregations().get(DestinationIndex.INCREMENTAL_ID);
+        long processedTestDocCount = searchResponse.getHits().getTotalHits().value;
+        Long lastIncrementalId = processedTestDocCount == 0 ? null : (long) maxIncrementalIdAgg.getValue();
+        if (lastIncrementalId != null) {
+            LOGGER.debug(() -> new ParameterizedMessage("[{}] Resuming inference; last incremental id [{}]; processed test doc count [{}]",
+                config.getId(), lastIncrementalId, processedTestDocCount));
+        }
+        return new InferenceState(lastIncrementalId, processedTestDocCount);
+    }
+
     // Visible for testing
-    void inferTestDocs(LocalModel model, TestDocsIterator testDocsIterator) {
+    void inferTestDocs(LocalModel model, TestDocsIterator testDocsIterator, long processedTestDocsCount) {
         long totalDocCount = 0;
-        long processedDocCount = 0;
+        long processedDocCount = processedTestDocsCount;
 
         try (LimitAwareBulkIndexer bulkIndexer = new LimitAwareBulkIndexer(settings, this::executeBulkRequest)) {
             while (testDocsIterator.hasNext()) {
@@ -168,5 +204,16 @@ public class InferenceRunner {
             config.getId(),
             () -> isCancelled == false,
             retryMessage -> {});
+    }
+
+    private static class InferenceState {
+
+        private final Long lastIncrementalId;
+        private final long processedTestDocsCount;
+
+        InferenceState(@Nullable Long lastIncrementalId, long processedTestDocsCount) {
+            this.lastIncrementalId = lastIncrementalId;
+            this.processedTestDocsCount = processedTestDocsCount;
+        }
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/inference/TestDocsIterator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/inference/TestDocsIterator.java
@@ -32,10 +32,11 @@ public class TestDocsIterator extends SearchAfterDocumentsIterator<SearchHit> {
     private Long lastDocId;
     private final Map<String, String> docValueFieldAndFormatPairs;
 
-    TestDocsIterator(OriginSettingClient client, DataFrameAnalyticsConfig config, ExtractedFields extractedFields) {
+    TestDocsIterator(OriginSettingClient client, DataFrameAnalyticsConfig config, ExtractedFields extractedFields, Long lastIncrementalId) {
         super(client, config.getDest().getIndex(), true);
         this.config = Objects.requireNonNull(config);
         this.docValueFieldAndFormatPairs = buildDocValueFieldAndFormatPairs(extractedFields);
+        this.lastDocId = lastIncrementalId;
     }
 
     private static Map<String, String> buildDocValueFieldAndFormatPairs(ExtractedFields extractedFields) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/stats/DataCountsTracker.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/stats/DataCountsTracker.java
@@ -51,7 +51,7 @@ public class DataCountsTracker {
         skippedDocsCount = 0;
     }
 
-    public void resetTestDocsCount() {
-        testDocsCount = 0;
+    public void setTestDocsCount(long testDocsCount) {
+        this.testDocsCount = testDocsCount;
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/steps/InferenceStep.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/steps/InferenceStep.java
@@ -62,8 +62,6 @@ public class InferenceStep extends AbstractDataFrameAnalyticsStep {
             return;
         }
 
-        task.getStatsHolder().getDataCountsTracker().resetTestDocsCount();
-
         ActionListener<String> modelIdListener = ActionListener.wrap(
             modelId -> runInference(modelId, listener),
             listener::onFailure

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/inference/InferenceRunnerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/inference/InferenceRunnerTests.java
@@ -111,7 +111,7 @@ public class InferenceRunnerTests extends ESTestCase {
 
         InferenceRunner inferenceRunner = createInferenceRunner(extractedFields);
 
-        inferenceRunner.inferTestDocs(localModel, testDocsIterator);
+        inferenceRunner.inferTestDocs(localModel, testDocsIterator, 0L);
 
         ArgumentCaptor<BulkRequest> argumentCaptor = ArgumentCaptor.forClass(BulkRequest.class);
 
@@ -150,7 +150,7 @@ public class InferenceRunnerTests extends ESTestCase {
         InferenceRunner inferenceRunner = createInferenceRunner(extractedFields);
         inferenceRunner.cancel();
 
-        inferenceRunner.inferTestDocs(localModel, infiniteDocsIterator);
+        inferenceRunner.inferTestDocs(localModel, infiniteDocsIterator, 0L);
 
         Mockito.verifyNoMoreInteractions(localModel, resultsPersisterService);
         assertThat(progressTracker.getInferenceProgressPercent(), equalTo(0));

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/stats/DataCountsTrackerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/stats/DataCountsTrackerTests.java
@@ -22,10 +22,10 @@ public class DataCountsTrackerTests extends ESTestCase {
         assertThat(resetDataCounts, equalTo(new DataCounts(JOB_ID)));
     }
 
-    public void testResetTestDocsCount() {
+    public void testSetTestDocsCount() {
         DataCountsTracker dataCountsTracker = new DataCountsTracker(new DataCounts(JOB_ID, 10, 20, 30));
-        dataCountsTracker.resetTestDocsCount();
+        dataCountsTracker.setTestDocsCount(15);
         DataCounts resetDataCounts = dataCountsTracker.report();
-        assertThat(resetDataCounts, equalTo(new DataCounts(JOB_ID, 10, 0, 30)));
+        assertThat(resetDataCounts, equalTo(new DataCounts(JOB_ID, 10, 15, 30)));
     }
 }


### PR DESCRIPTION
…ics (#68222)

When starting a data frame analytics job was stopped during inference,
inference starts from scratch. This means any progress made previously
is lost. This commit improves this behaviour by preserving existing
progress.

Instead of starting inference from scratch, we now search the destination
index in order to obtain the prior state of inference. This can be
described by 1. the max incremental id that has `is_training: false`,
and 2. the number of docs with `is_training: false`. Max incremental id
is then used as the `search_after` key when we iterate the test docs.
The number of docs with `is_training: false` enables us to calculate
progress correctly after we continue iterating the test docs.

Backport of #68222
