### PR TITLE
Drop rawtypes error suppression in runtime-fields

### DIFF
--- a/x-pack/plugin/runtime-fields/build.gradle
+++ b/x-pack/plugin/runtime-fields/build.gradle
@@ -8,10 +8,6 @@ esplugin {
 }
 archivesBaseName = 'x-pack-runtime-fields'
 
-tasks.withType(JavaCompile).configureEach {
-  options.compilerArgs << "-Xlint:-rawtypes"
-}
-
 dependencies {
   compileOnly project(":server")
   compileOnly project(':modules:lang-painless:spi')
@@ -21,4 +17,3 @@ dependencies {
 tasks.named("dependencyLicenses").configure {
   ignoreSha 'x-pack-core'
 }
-

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/AbstractScriptFieldQueryTestCase.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/AbstractScriptFieldQueryTestCase.java
@@ -21,7 +21,7 @@ import java.util.function.Supplier;
 
 import static org.hamcrest.Matchers.equalTo;
 
-public abstract class AbstractScriptFieldQueryTestCase<T extends AbstractScriptFieldQuery> extends ESTestCase {
+public abstract class AbstractScriptFieldQueryTestCase<T extends AbstractScriptFieldQuery<?>> extends ESTestCase {
     protected abstract T createTestInstance();
 
     protected abstract T copy(T orig);


### PR DESCRIPTION
We don't need it and it stops the compiler from warning us if we make
code that is harder to read.
