### PR TITLE
Drop rawtypes warning from async search

### DIFF
--- a/x-pack/plugin/async-search/build.gradle
+++ b/x-pack/plugin/async-search/build.gradle
@@ -8,10 +8,6 @@ esplugin {
 }
 archivesBaseName = 'x-pack-async-search'
 
-tasks.withType(JavaCompile).configureEach {
-    options.compilerArgs << "-Xlint:-rawtypes"
-}
-
 addQaCheckDependencies()
 
 dependencies {


### PR DESCRIPTION
It looks like we don't need it and it helps us write code with "funny"
assumptions without realizing it.
