### PR TITLE
Ensure ReplicationOperation notify listener once

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationOperation.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationOperation.java
@@ -119,7 +119,7 @@ public class ReplicationOperation<
 
         totalShards.incrementAndGet();
         pendingActions.incrementAndGet(); // increase by 1 until we finish all primary coordination
-        primary.perform(request, ActionListener.wrap(this::handlePrimaryResult, resultListener::onFailure));
+        primary.perform(request, ActionListener.wrap(this::handlePrimaryResult, this::finishAsFailed));
     }
 
     private void handlePrimaryResult(final PrimaryResultT primaryResult) {


### PR DESCRIPTION
ReplicationOperation can notify the listener twice if the primary shard is demoted after it has completed the primary operation.

Closes #68049