### PR TITLE
Frozen Prototype File Chunk Writing/Reading Infrastructure

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/io/Channels.java
+++ b/server/src/main/java/org/elasticsearch/common/io/Channels.java
@@ -40,7 +40,7 @@ public final class Channels {
     /**
      * The maximum chunk size for writes in bytes
      */
-    private static final int WRITE_CHUNK_SIZE = 8192;
+    public static final int WRITE_CHUNK_SIZE = 8192;
 
     /**
      * read <i>length</i> bytes from <i>position</i> of a file channel

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
@@ -258,7 +258,7 @@ public class SearchableSnapshots extends Plugin implements IndexStorePlugin, Eng
             this.cacheService.set(cacheService);
             final FrozenCacheService frozenCacheService;
             try {
-                frozenCacheService = new FrozenCacheService(environment, settings, threadPool);
+                frozenCacheService = new FrozenCacheService(environment, threadPool);
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
@@ -20,6 +20,7 @@ import org.elasticsearch.cluster.routing.allocation.decider.AllocationDecider;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Setting;
@@ -257,7 +258,7 @@ public class SearchableSnapshots extends Plugin implements IndexStorePlugin, Eng
             this.cacheService.set(cacheService);
             final FrozenCacheService frozenCacheService;
             try {
-                frozenCacheService = new FrozenCacheService(settings, threadPool);
+                frozenCacheService = new FrozenCacheService(environment, settings, threadPool);
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }
@@ -533,6 +534,11 @@ public class SearchableSnapshots extends Plugin implements IndexStorePlugin, Eng
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to build " + SNAPSHOT_BLOB_CACHE_INDEX + " index mappings", e);
         }
+    }
+
+    @Override
+    public void close() throws IOException {
+        Releasables.close(frozenCacheService.get());
     }
 
     public static final class CacheServiceSupplier implements Supplier<CacheService> {

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/FrozenCacheService.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/FrozenCacheService.java
@@ -121,7 +121,7 @@ public class FrozenCacheService implements Releasable {
 
     private final AtomicReference<CacheFileRegion>[] regionOwners; // to assert exclusive access of regions
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     public FrozenCacheService(Environment environment, Settings settings, ThreadPool threadPool) throws IOException {
         this.currentTimeSupplier = threadPool::relativeTimeInMillis;
         final long cacheSize = SNAPSHOT_CACHE_SIZE_SETTING.get(settings).getBytes();

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/FrozenCacheService.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/FrozenCacheService.java
@@ -146,7 +146,7 @@ public class FrozenCacheService implements Releasable {
         this.maxFreq = SNAPSHOT_CACHE_MAX_FREQ_SETTING.get(settings);
         this.minTimeDelta = SNAPSHOT_CACHE_MIN_TIME_DELTA_SETTING.get(settings).millis();
         freqs = new Entry[maxFreq];
-        sharedBytes = new SharedBytes(numRegions, regionSize, environment.dataFiles()[0].resolve("snap_cache"));
+        sharedBytes = new SharedBytes(numRegions, regionSize, environment);
         new CacheDecayTask(threadPool, SNAPSHOT_CACHE_DECAY_INTERVAL_SETTING.get(settings)).rescheduleIfNecessary();
         this.rangeSize = FROZEN_CACHE_RANGE_SIZE_SETTING.get(settings);
         this.recoveryRangeSize = FROZEN_CACHE_RECOVERY_RANGE_SIZE_SETTING.get(settings);

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/SharedBytes.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/SharedBytes.java
@@ -46,6 +46,7 @@ public class SharedBytes extends AbstractRefCounted {
         final long fileSize = numRegions * regionSize;
         if (fileSize > 0) {
             final ByteBuffer fillBytes = ByteBuffer.allocate(Channels.WRITE_CHUNK_SIZE);
+            Files.createDirectories(file.getParent());
             this.fileChannel = FileChannel.open(file, OPEN_OPTIONS);
             long written = fileChannel.size();
             while (written < fileSize) {
@@ -80,13 +81,13 @@ public class SharedBytes extends AbstractRefCounted {
             if (io == null || io.tryIncRef() == false) {
                 final IO newIO;
                 boolean success = false;
-                SharedBytes.this.incRef();
+                incRef();
                 try {
                     newIO = new IO(p);
                     success = true;
                 } finally {
                     if (success == false) {
-                        SharedBytes.this.decRef();
+                        decRef();
                     }
                 }
                 return newIO;

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/SharedBytes.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/SharedBytes.java
@@ -7,14 +7,11 @@
 package org.elasticsearch.xpack.searchablesnapshots.cache;
 
 import org.elasticsearch.common.SuppressForbidden;
+import org.elasticsearch.common.io.Channels;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
-import java.nio.channels.FileLock;
-import java.nio.channels.ReadableByteChannel;
-import java.nio.channels.WritableByteChannel;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 
@@ -30,134 +27,63 @@ public class SharedBytes {
 
     private final FileChannel fileChannel;
 
-    @SuppressForbidden(reason = "Use positional writes on purpose")
     SharedBytes(int numRegions, long regionSize, Path file) throws IOException {
         this.numRegions = numRegions;
         this.regionSize = regionSize;
         final long fileSize = numRegions * regionSize;
         if (fileSize > 0) {
+            final ByteBuffer fillBytes = ByteBuffer.allocate(Channels.WRITE_CHUNK_SIZE);
             this.fileChannel = FileChannel.open(file, OPEN_OPTIONS);
-            // write one byte at the end of the file to make sure all bytes are allocated
-            fileChannel.write(ByteBuffer.allocate(1), fileSize - 1);
+            long written = 0;
+            while (written < fileSize) {
+                final int toWrite = Math.toIntExact(Math.min(fileSize - written, Channels.WRITE_CHUNK_SIZE));
+                fillBytes.position(0).limit(toWrite);
+                // write one byte at the end of the file to make sure all bytes are allocated
+                Channels.writeToChannel(fillBytes, fileChannel);
+                written += toWrite;
+            }
         } else {
             this.fileChannel = null;
         }
     }
 
-    FileChannel getFileChannel(int sharedBytesPos) {
+    public final class IO {
+
+        private final long pageStart;
+
+        private IO(final long sharedBytesPos) {
+            pageStart = getPhysicalOffset(sharedBytesPos);
+        }
+
+        @SuppressForbidden(reason = "Use positional reads on purpose")
+        public int read(ByteBuffer dst, long position) throws IOException {
+            checkOffsets(position, dst.remaining());
+            return fileChannel.read(dst, position);
+        }
+
+        @SuppressForbidden(reason = "Use positional writes on purpose")
+        public int write(ByteBuffer src, long position) throws IOException {
+            checkOffsets(position, src.remaining());
+            return fileChannel.write(src, position);
+        }
+
+        private void checkOffsets(long position, long length) {
+            long pageEnd = pageStart + regionSize;
+            if (position < pageStart || position > pageEnd || position + length > pageEnd) {
+                assert false;
+                throw new IllegalArgumentException("bad access");
+            }
+        }
+    }
+
+    IO getFileChannel(int sharedBytesPos) {
         assert fileChannel != null;
-        // return fileChannel;
-        return new FileChannel() {
-            @Override
-            public int read(ByteBuffer dst) throws IOException {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public long read(ByteBuffer[] dsts, int offset, int length) throws IOException {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public int write(ByteBuffer src) throws IOException {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            @SuppressForbidden(reason = "Use positional writes on purpose")
-            public long write(ByteBuffer[] srcs, int offset, int length) throws IOException {
-                checkOffsets(offset, length);
-                return fileChannel.write(srcs, offset, length);
-            }
-
-            @Override
-            public long position() throws IOException {
-                return fileChannel.position();
-            }
-
-            @Override
-            public FileChannel position(long newPosition) throws IOException {
-                checkOffsets(newPosition, 0);
-                return fileChannel.position(newPosition);
-            }
-
-            @Override
-            public long size() throws IOException {
-                return fileChannel.size();
-            }
-
-            @Override
-            public FileChannel truncate(long size) throws IOException {
-                assert false;
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public void force(boolean metaData) throws IOException {
-                fileChannel.force(metaData);
-            }
-
-            @Override
-            public long transferTo(long position, long count, WritableByteChannel target) throws IOException {
-                checkOffsets(position, count);
-                return fileChannel.transferTo(position, count, target);
-            }
-
-            @Override
-            public long transferFrom(ReadableByteChannel src, long position, long count) throws IOException {
-                checkOffsets(position, count);
-                return fileChannel.transferFrom(src, position, count);
-            }
-
-            @Override
-            @SuppressForbidden(reason = "Use positional reads on purpose")
-            public int read(ByteBuffer dst, long position) throws IOException {
-                checkOffsets(position, dst.remaining());
-                return fileChannel.read(dst, position);
-            }
-
-            @Override
-            @SuppressForbidden(reason = "Use positional writes on purpose")
-            public int write(ByteBuffer src, long position) throws IOException {
-                checkOffsets(position, src.remaining());
-                return fileChannel.write(src, position);
-            }
-
-            private void checkOffsets(long position, long length) {
-                long pageStart = getPhysicalOffset(sharedBytesPos);
-                long pageEnd = pageStart + regionSize;
-                if (position < getPhysicalOffset(sharedBytesPos) || position > pageEnd || position + length > pageEnd) {
-                    assert false;
-                    throw new IllegalArgumentException("bad access");
-                }
-            }
-
-            @Override
-            public MappedByteBuffer map(MapMode mode, long position, long size) throws IOException {
-                assert false;
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public FileLock lock(long position, long size, boolean shared) throws IOException {
-                assert false;
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public FileLock tryLock(long position, long size, boolean shared) throws IOException {
-                assert false;
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            protected void implCloseChannel() throws IOException {
-                fileChannel.close();
-            }
-        };
+        return new IO(sharedBytesPos);
     }
 
     long getPhysicalOffset(long chunkPosition) {
-        return chunkPosition * regionSize;
+        long physicalOffset = chunkPosition * regionSize;
+        assert physicalOffset <= numRegions * regionSize;
+        return physicalOffset;
     }
 }

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/SharedBytes.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/SharedBytes.java
@@ -6,16 +6,25 @@
 
 package org.elasticsearch.xpack.searchablesnapshots.cache;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.SuppressForbidden;
 import org.elasticsearch.common.io.Channels;
+import org.elasticsearch.common.util.concurrent.AbstractRefCounted;
+import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
+import org.elasticsearch.core.internal.io.IOUtils;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.util.Map;
 
-public class SharedBytes {
+public class SharedBytes extends AbstractRefCounted {
+
+    private static final Logger logger = LogManager.getLogger(SharedBytes.class);
 
     private static final StandardOpenOption[] OPEN_OPTIONS = new StandardOpenOption[] {
         StandardOpenOption.READ,
@@ -27,14 +36,18 @@ public class SharedBytes {
 
     private final FileChannel fileChannel;
 
+    private final Path path;
+
     SharedBytes(int numRegions, long regionSize, Path file) throws IOException {
+        super("shared-bytes");
         this.numRegions = numRegions;
         this.regionSize = regionSize;
+        this.path = file;
         final long fileSize = numRegions * regionSize;
         if (fileSize > 0) {
             final ByteBuffer fillBytes = ByteBuffer.allocate(Channels.WRITE_CHUNK_SIZE);
             this.fileChannel = FileChannel.open(file, OPEN_OPTIONS);
-            long written = 0;
+            long written = fileChannel.size();
             while (written < fileSize) {
                 final int toWrite = Math.toIntExact(Math.min(fileSize - written, Channels.WRITE_CHUNK_SIZE));
                 fillBytes.position(0).limit(toWrite);
@@ -42,16 +55,60 @@ public class SharedBytes {
                 Channels.writeToChannel(fillBytes, fileChannel);
                 written += toWrite;
             }
+            if (written > fileChannel.size()) {
+                fileChannel.truncate(fileSize);
+            }
         } else {
             this.fileChannel = null;
         }
     }
 
-    public final class IO {
+    @Override
+    protected void closeInternal() {
+        try {
+            IOUtils.close(fileChannel, () -> Files.deleteIfExists(path));
+        } catch (IOException e) {
+            logger.warn("Failed to clean up shared bytes file", e);
+        }
+    }
 
+    private final Map<Integer, IO> ios = ConcurrentCollections.newConcurrentMap();
+
+    IO getFileChannel(int sharedBytesPos) {
+        assert fileChannel != null;
+        return ios.compute(sharedBytesPos, (p, io) -> {
+            if (io == null || io.tryIncRef() == false) {
+                final IO newIO;
+                boolean success = false;
+                SharedBytes.this.incRef();
+                try {
+                    newIO = new IO(p);
+                    success = true;
+                } finally {
+                    if (success == false) {
+                        SharedBytes.this.decRef();
+                    }
+                }
+                return newIO;
+            }
+            return io;
+        });
+    }
+
+    long getPhysicalOffset(long chunkPosition) {
+        long physicalOffset = chunkPosition * regionSize;
+        assert physicalOffset <= numRegions * regionSize;
+        return physicalOffset;
+    }
+
+    public final class IO extends AbstractRefCounted {
+
+        private final int sharedBytesPos;
         private final long pageStart;
 
-        private IO(final long sharedBytesPos) {
+        private IO(final int sharedBytesPos) {
+            super("shared-bytes-io");
+            this.sharedBytesPos = sharedBytesPos;
             pageStart = getPhysicalOffset(sharedBytesPos);
         }
 
@@ -74,16 +131,11 @@ public class SharedBytes {
                 throw new IllegalArgumentException("bad access");
             }
         }
-    }
 
-    IO getFileChannel(int sharedBytesPos) {
-        assert fileChannel != null;
-        return new IO(sharedBytesPos);
-    }
-
-    long getPhysicalOffset(long chunkPosition) {
-        long physicalOffset = chunkPosition * regionSize;
-        assert physicalOffset <= numRegions * regionSize;
-        return physicalOffset;
+        @Override
+        protected void closeInternal() {
+            ios.remove(sharedBytesPos, this);
+            SharedBytes.this.decRef();
+        }
     }
 }

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/SharedBytes.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/SharedBytes.java
@@ -32,6 +32,8 @@ public class SharedBytes extends AbstractRefCounted {
         StandardOpenOption.WRITE,
         StandardOpenOption.CREATE };
 
+    private static final String CACHE_FILE_NAME = "snap_cache";
+
     final int numRegions;
     final long regionSize;
 
@@ -51,7 +53,7 @@ public class SharedBytes extends AbstractRefCounted {
             for (Path path : environment.dataFiles()) {
                 // TODO: be resilient to this check failing and try next path?
                 long usableSpace = getUsableSpace(path);
-                Path p = path.resolve("snap_cache");
+                Path p = path.resolve(CACHE_FILE_NAME);
                 if (Files.exists(p)) {
                     usableSpace += Files.size(p);
                 }
@@ -82,6 +84,9 @@ public class SharedBytes extends AbstractRefCounted {
             }
         } else {
             this.fileChannel = null;
+            for (Path path : environment.dataFiles()) {
+                Files.deleteIfExists(path.resolve(CACHE_FILE_NAME));
+            }
         }
         this.path = cacheFile;
     }

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/FrozenIndexInputTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/FrozenIndexInputTests.java
@@ -84,11 +84,14 @@ public class FrozenIndexInputTests extends AbstractSearchableSnapshotsTestCase {
             .put(FrozenCacheService.SNAPSHOT_CACHE_REGION_SIZE_SETTING.getKey(), regionSize)
             .put(FrozenCacheService.FROZEN_CACHE_RANGE_SIZE_SETTING.getKey(), rangeSize)
             .put(FrozenCacheService.SNAPSHOT_CACHE_SIZE_SETTING.getKey(), cacheSize)
+            .put("path.home", createTempDir())
             .build();
         final Environment environment = TestEnvironment.newEnvironment(settings);
-        final FrozenCacheService cacheService = new FrozenCacheService(environment, settings, threadPool);
 
-        try (TestSearchableSnapshotDirectory directory = new TestSearchableSnapshotDirectory(cacheService, tempDir, fileInfo, fileData)) {
+        try (
+            FrozenCacheService cacheService = new FrozenCacheService(environment, threadPool);
+            TestSearchableSnapshotDirectory directory = new TestSearchableSnapshotDirectory(cacheService, tempDir, fileInfo, fileData)
+        ) {
             directory.loadSnapshot(createRecoveryState(true), ActionListener.wrap(() -> {}));
 
             // TODO does not test the checksum shortcut, does not test using the recovery range size

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/FrozenIndexInputTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/FrozenIndexInputTests.java
@@ -11,6 +11,9 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.ShardPath;
@@ -78,13 +81,14 @@ public class FrozenIndexInputTests extends AbstractSearchableSnapshotsTestCase {
             cacheSize = new ByteSizeValue(randomLongBetween(1L, 10L) * regionSize.getBytes() + randomIntBetween(0, 100));
         }
 
-        final FrozenCacheService cacheService = new FrozenCacheService(
-            Settings.builder()
+        final Settings settings = Settings.builder()
                 .put(FrozenCacheService.SNAPSHOT_CACHE_REGION_SIZE_SETTING.getKey(), regionSize)
                 .put(FrozenCacheService.FROZEN_CACHE_RANGE_SIZE_SETTING.getKey(), rangeSize)
                 .put(FrozenCacheService.SNAPSHOT_CACHE_SIZE_SETTING.getKey(), cacheSize)
-                .build(),
-            threadPool
+                .build();
+        final Environment environment = TestEnvironment.newEnvironment(settings);
+        final FrozenCacheService cacheService = new FrozenCacheService(
+                environment, settings, threadPool
         );
 
         try (TestSearchableSnapshotDirectory directory = new TestSearchableSnapshotDirectory(cacheService, tempDir, fileInfo, fileData)) {

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/FrozenIndexInputTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/FrozenIndexInputTests.java
@@ -29,6 +29,7 @@ import org.elasticsearch.xpack.searchablesnapshots.cache.FrozenCacheService;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Locale;
@@ -87,6 +88,9 @@ public class FrozenIndexInputTests extends AbstractSearchableSnapshotsTestCase {
             .put("path.home", createTempDir())
             .build();
         final Environment environment = TestEnvironment.newEnvironment(settings);
+        for (Path path : environment.dataFiles()) {
+            Files.createDirectories(path);
+        }
 
         try (
             FrozenCacheService cacheService = new FrozenCacheService(environment, threadPool);

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/FrozenIndexInputTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/FrozenIndexInputTests.java
@@ -12,7 +12,6 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.env.Environment;
-import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
@@ -82,14 +81,12 @@ public class FrozenIndexInputTests extends AbstractSearchableSnapshotsTestCase {
         }
 
         final Settings settings = Settings.builder()
-                .put(FrozenCacheService.SNAPSHOT_CACHE_REGION_SIZE_SETTING.getKey(), regionSize)
-                .put(FrozenCacheService.FROZEN_CACHE_RANGE_SIZE_SETTING.getKey(), rangeSize)
-                .put(FrozenCacheService.SNAPSHOT_CACHE_SIZE_SETTING.getKey(), cacheSize)
-                .build();
+            .put(FrozenCacheService.SNAPSHOT_CACHE_REGION_SIZE_SETTING.getKey(), regionSize)
+            .put(FrozenCacheService.FROZEN_CACHE_RANGE_SIZE_SETTING.getKey(), rangeSize)
+            .put(FrozenCacheService.SNAPSHOT_CACHE_SIZE_SETTING.getKey(), cacheSize)
+            .build();
         final Environment environment = TestEnvironment.newEnvironment(settings);
-        final FrozenCacheService cacheService = new FrozenCacheService(
-                environment, settings, threadPool
-        );
+        final FrozenCacheService cacheService = new FrozenCacheService(environment, settings, threadPool);
 
         try (TestSearchableSnapshotDirectory directory = new TestSearchableSnapshotDirectory(cacheService, tempDir, fileInfo, fileData)) {
             directory.loadSnapshot(createRecoveryState(true), ActionListener.wrap(() -> {}));

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/FrozenCacheServiceTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/FrozenCacheServiceTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.searchablesnapshots.cache;
 import org.elasticsearch.cluster.coordination.DeterministicTaskQueue;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.store.cache.CacheKey;
@@ -17,6 +18,8 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.searchablesnapshots.cache.FrozenCacheService.CacheFileRegion;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import static org.elasticsearch.node.Node.NODE_NAME_SETTING;
 
@@ -30,9 +33,11 @@ public class FrozenCacheServiceTests extends ESTestCase {
             .put("path.home", createTempDir())
             .build();
         final DeterministicTaskQueue taskQueue = new DeterministicTaskQueue(settings, random());
-        try (
-            FrozenCacheService cacheService = new FrozenCacheService(TestEnvironment.newEnvironment(settings), taskQueue.getThreadPool())
-        ) {
+        final Environment environment = TestEnvironment.newEnvironment(settings);
+        for (Path path : environment.dataFiles()) {
+            Files.createDirectories(path);
+        }
+        try (FrozenCacheService cacheService = new FrozenCacheService(environment, taskQueue.getThreadPool())) {
             final CacheKey cacheKey = generateCacheKey();
             assertEquals(5, cacheService.freeRegionCount());
             final CacheFileRegion region0 = cacheService.get(cacheKey, 250, 0);
@@ -74,9 +79,11 @@ public class FrozenCacheServiceTests extends ESTestCase {
             .put("path.home", createTempDir())
             .build();
         final DeterministicTaskQueue taskQueue = new DeterministicTaskQueue(settings, random());
-        try (
-            FrozenCacheService cacheService = new FrozenCacheService(TestEnvironment.newEnvironment(settings), taskQueue.getThreadPool())
-        ) {
+        final Environment environment = TestEnvironment.newEnvironment(settings);
+        for (Path path : environment.dataFiles()) {
+            Files.createDirectories(path);
+        }
+        try (FrozenCacheService cacheService = new FrozenCacheService(environment, taskQueue.getThreadPool())) {
             final CacheKey cacheKey = generateCacheKey();
             assertEquals(2, cacheService.freeRegionCount());
             final CacheFileRegion region0 = cacheService.get(cacheKey, 250, 0);

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/FrozenCacheServiceTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/FrozenCacheServiceTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.searchablesnapshots.cache;
 import org.elasticsearch.cluster.coordination.DeterministicTaskQueue;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.store.cache.CacheKey;
 import org.elasticsearch.test.ESTestCase;
@@ -28,7 +29,11 @@ public class FrozenCacheServiceTests extends ESTestCase {
             .put(FrozenCacheService.SNAPSHOT_CACHE_REGION_SIZE_SETTING.getKey(), "100b")
             .build();
         final DeterministicTaskQueue taskQueue = new DeterministicTaskQueue(settings, random());
-        final FrozenCacheService cacheService = new FrozenCacheService(settings, taskQueue.getThreadPool());
+        final FrozenCacheService cacheService = new FrozenCacheService(
+            TestEnvironment.newEnvironment(settings),
+            settings,
+            taskQueue.getThreadPool()
+        );
         final CacheKey cacheKey = generateCacheKey();
         assertEquals(5, cacheService.freeRegionCount());
         final CacheFileRegion region0 = cacheService.get(cacheKey, 250, 0);
@@ -68,7 +73,11 @@ public class FrozenCacheServiceTests extends ESTestCase {
             .put(FrozenCacheService.SNAPSHOT_CACHE_REGION_SIZE_SETTING.getKey(), "100b")
             .build();
         final DeterministicTaskQueue taskQueue = new DeterministicTaskQueue(settings, random());
-        final FrozenCacheService cacheService = new FrozenCacheService(settings, taskQueue.getThreadPool());
+        final FrozenCacheService cacheService = new FrozenCacheService(
+            TestEnvironment.newEnvironment(settings),
+            settings,
+            taskQueue.getThreadPool()
+        );
         final CacheKey cacheKey = generateCacheKey();
         assertEquals(2, cacheService.freeRegionCount());
         final CacheFileRegion region0 = cacheService.get(cacheKey, 250, 0);

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/FrozenCacheServiceTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/FrozenCacheServiceTests.java
@@ -27,43 +27,43 @@ public class FrozenCacheServiceTests extends ESTestCase {
             .put(NODE_NAME_SETTING.getKey(), "node")
             .put(FrozenCacheService.SNAPSHOT_CACHE_SIZE_SETTING.getKey(), "500b")
             .put(FrozenCacheService.SNAPSHOT_CACHE_REGION_SIZE_SETTING.getKey(), "100b")
+            .put("path.home", createTempDir())
             .build();
         final DeterministicTaskQueue taskQueue = new DeterministicTaskQueue(settings, random());
-        final FrozenCacheService cacheService = new FrozenCacheService(
-            TestEnvironment.newEnvironment(settings),
-            settings,
-            taskQueue.getThreadPool()
-        );
-        final CacheKey cacheKey = generateCacheKey();
-        assertEquals(5, cacheService.freeRegionCount());
-        final CacheFileRegion region0 = cacheService.get(cacheKey, 250, 0);
-        assertEquals(100L, region0.tracker.getLength());
-        assertEquals(4, cacheService.freeRegionCount());
-        final CacheFileRegion region1 = cacheService.get(cacheKey, 250, 1);
-        assertEquals(100L, region1.tracker.getLength());
-        assertEquals(3, cacheService.freeRegionCount());
-        final CacheFileRegion region2 = cacheService.get(cacheKey, 250, 2);
-        assertEquals(50L, region2.tracker.getLength());
-        assertEquals(2, cacheService.freeRegionCount());
+        try (
+            FrozenCacheService cacheService = new FrozenCacheService(TestEnvironment.newEnvironment(settings), taskQueue.getThreadPool())
+        ) {
+            final CacheKey cacheKey = generateCacheKey();
+            assertEquals(5, cacheService.freeRegionCount());
+            final CacheFileRegion region0 = cacheService.get(cacheKey, 250, 0);
+            assertEquals(100L, region0.tracker.getLength());
+            assertEquals(4, cacheService.freeRegionCount());
+            final CacheFileRegion region1 = cacheService.get(cacheKey, 250, 1);
+            assertEquals(100L, region1.tracker.getLength());
+            assertEquals(3, cacheService.freeRegionCount());
+            final CacheFileRegion region2 = cacheService.get(cacheKey, 250, 2);
+            assertEquals(50L, region2.tracker.getLength());
+            assertEquals(2, cacheService.freeRegionCount());
 
-        assertTrue(region1.tryEvict());
-        assertEquals(3, cacheService.freeRegionCount());
-        assertFalse(region1.tryEvict());
-        assertEquals(3, cacheService.freeRegionCount());
-        region0.populateAndRead(
-            Tuple.tuple(0L, 1L),
-            Tuple.tuple(0L, 1L),
-            (channel, channelPos, relativePos, length) -> 1,
-            (channel, channelPos, relativePos, length, progressUpdater) -> progressUpdater.accept(length),
-            taskQueue.getThreadPool().executor(ThreadPool.Names.GENERIC)
-        );
-        assertFalse(region0.tryEvict());
-        assertEquals(3, cacheService.freeRegionCount());
-        taskQueue.runAllRunnableTasks();
-        assertTrue(region0.tryEvict());
-        assertEquals(4, cacheService.freeRegionCount());
-        assertTrue(region2.tryEvict());
-        assertEquals(5, cacheService.freeRegionCount());
+            assertTrue(region1.tryEvict());
+            assertEquals(3, cacheService.freeRegionCount());
+            assertFalse(region1.tryEvict());
+            assertEquals(3, cacheService.freeRegionCount());
+            region0.populateAndRead(
+                Tuple.tuple(0L, 1L),
+                Tuple.tuple(0L, 1L),
+                (channel, channelPos, relativePos, length) -> 1,
+                (channel, channelPos, relativePos, length, progressUpdater) -> progressUpdater.accept(length),
+                taskQueue.getThreadPool().executor(ThreadPool.Names.GENERIC)
+            );
+            assertFalse(region0.tryEvict());
+            assertEquals(3, cacheService.freeRegionCount());
+            taskQueue.runAllRunnableTasks();
+            assertTrue(region0.tryEvict());
+            assertEquals(4, cacheService.freeRegionCount());
+            assertTrue(region2.tryEvict());
+            assertEquals(5, cacheService.freeRegionCount());
+        }
     }
 
     public void testAutoEviction() throws IOException {
@@ -71,34 +71,34 @@ public class FrozenCacheServiceTests extends ESTestCase {
             .put(NODE_NAME_SETTING.getKey(), "node")
             .put(FrozenCacheService.SNAPSHOT_CACHE_SIZE_SETTING.getKey(), "200b")
             .put(FrozenCacheService.SNAPSHOT_CACHE_REGION_SIZE_SETTING.getKey(), "100b")
+            .put("path.home", createTempDir())
             .build();
         final DeterministicTaskQueue taskQueue = new DeterministicTaskQueue(settings, random());
-        final FrozenCacheService cacheService = new FrozenCacheService(
-            TestEnvironment.newEnvironment(settings),
-            settings,
-            taskQueue.getThreadPool()
-        );
-        final CacheKey cacheKey = generateCacheKey();
-        assertEquals(2, cacheService.freeRegionCount());
-        final CacheFileRegion region0 = cacheService.get(cacheKey, 250, 0);
-        assertEquals(100L, region0.tracker.getLength());
-        assertEquals(1, cacheService.freeRegionCount());
-        final CacheFileRegion region1 = cacheService.get(cacheKey, 250, 1);
-        assertEquals(100L, region1.tracker.getLength());
-        assertEquals(0, cacheService.freeRegionCount());
-        assertFalse(region0.isEvicted());
-        assertFalse(region1.isEvicted());
+        try (
+            FrozenCacheService cacheService = new FrozenCacheService(TestEnvironment.newEnvironment(settings), taskQueue.getThreadPool())
+        ) {
+            final CacheKey cacheKey = generateCacheKey();
+            assertEquals(2, cacheService.freeRegionCount());
+            final CacheFileRegion region0 = cacheService.get(cacheKey, 250, 0);
+            assertEquals(100L, region0.tracker.getLength());
+            assertEquals(1, cacheService.freeRegionCount());
+            final CacheFileRegion region1 = cacheService.get(cacheKey, 250, 1);
+            assertEquals(100L, region1.tracker.getLength());
+            assertEquals(0, cacheService.freeRegionCount());
+            assertFalse(region0.isEvicted());
+            assertFalse(region1.isEvicted());
 
-        // acquire region 2, which should evict region 0 (oldest)
-        final CacheFileRegion region2 = cacheService.get(cacheKey, 250, 2);
-        assertEquals(50L, region2.tracker.getLength());
-        assertEquals(0, cacheService.freeRegionCount());
-        assertTrue(region0.isEvicted());
-        assertFalse(region1.isEvicted());
+            // acquire region 2, which should evict region 0 (oldest)
+            final CacheFileRegion region2 = cacheService.get(cacheKey, 250, 2);
+            assertEquals(50L, region2.tracker.getLength());
+            assertEquals(0, cacheService.freeRegionCount());
+            assertTrue(region0.isEvicted());
+            assertFalse(region1.isEvicted());
 
-        // explicitly evict region 1
-        assertTrue(region1.tryEvict());
-        assertEquals(1, cacheService.freeRegionCount());
+            // explicitly evict region 1
+            assertTrue(region1.tryEvict());
+            assertEquals(1, cacheService.freeRegionCount());
+        }
     }
 
     private static CacheKey generateCacheKey() {


### PR DESCRIPTION
This adds all the necessary infrastructure to use the reusable, single-file cache in practice:

* Create cache file in a data directory instead of a temp directory
* Fully pre-allocate it (the existing solution would at least on Linux still do a sparse allocation)
* Manage file channel resource by ref counting
* Add minimal abstraction in place of exposing `FileChannel` to allow for adjusting the concrete paging approach under the hood in a follow-up

I'd open a follow-up for the more complicated logical changes introducing two page sizes based on this (almost done with those, but I hope/think this gives us what we need for initial experiments meanwhile and is easier to review in isolation).

