### PR TITLE
Extend NamedObjectRegistry with compatible entries

### DIFF
--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -464,7 +464,10 @@ public class Node implements Closeable {
                 pluginsService.filterPlugins(Plugin.class).stream()
                     .flatMap(p -> p.getNamedXContent().stream()),
                 ClusterModule.getNamedXWriteables().stream())
-                .flatMap(Function.identity()).collect(toList()));
+                .flatMap(Function.identity()).collect(toList()),
+                pluginsService.filterPlugins(Plugin.class).stream()
+                    .flatMap(p -> p.getNamedXContentForCompatibility().stream()).collect(toList())
+                );
             final MetaStateService metaStateService = new MetaStateService(nodeEnvironment, xContentRegistry);
             final PersistedClusterStateService lucenePersistedStateFactory
                 = new PersistedClusterStateService(nodeEnvironment, xContentRegistry, bigArrays, clusterService.getClusterSettings(),

--- a/server/src/main/java/org/elasticsearch/plugins/Plugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/Plugin.java
@@ -126,6 +126,15 @@ public abstract class Plugin implements Closeable {
     }
 
     /**
+     * Returns parsers with compatible logic for named objects this plugin will parse from
+     * {@link XContentParser#namedObject(Class, String, Object)}.
+     * @see NamedWriteableRegistry
+     */
+    public List<NamedXContentRegistry.Entry> getNamedXContentForCompatibility() {
+        return Collections.emptyList();
+    }
+
+    /**
      * Called before a new index is created on a node. The given module can be used to register index-level
      * extensions.
      */

--- a/server/src/test/java/org/elasticsearch/common/xcontent/CompatibleNamedXContentRegistryTests.java
+++ b/server/src/test/java/org/elasticsearch/common/xcontent/CompatibleNamedXContentRegistryTests.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.xcontent;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.rest.FakeRestRequest;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.core.IsEqual.equalTo;
+
+/**
+ * A test where a named object parser is overridden by a compatible implementation in order to support the old parser (N-1)
+ * The old parser is only available when a parser is using compatibility (created when a request was compatible)
+ */
+public class CompatibleNamedXContentRegistryTests extends ESTestCase {
+    static class ParentObject {
+        private static final ConstructingObjectParser<ParentObject, String> PARSER =
+            new ConstructingObjectParser<>("parentParser", false,
+                (a, name) -> new ParentObject(name, (SubObject) a[0]));
+
+        String name;
+        SubObject subObject;
+
+        static {
+            PARSER.declareNamedObject(ConstructingObjectParser.constructorArg(),
+                (p, c, n) -> p.namedObject(SubObject.class, n, null),
+                new ParseField("subObject"));
+        }
+
+        ParentObject(String name, SubObject subObject) {
+            this.name = name;
+            this.subObject = subObject;
+        }
+
+
+        public static ParentObject parse(XContentParser parser) {
+            return PARSER.apply(parser, null);
+        }
+    }
+
+    static class SubObject {
+        private static final ConstructingObjectParser<SubObject, String> PARSER = new ConstructingObjectParser<>(
+            "parser1", false,
+            a -> new SubObject((String) a[0]));
+
+        static {
+            PARSER.declareString(ConstructingObjectParser.constructorArg(), new ParseField("new_field"));
+        }
+
+        String field;
+
+        SubObject(String field) {
+            this.field = field;
+        }
+
+        public static SubObject parse(XContentParser parser) {
+            return PARSER.apply(parser, null);
+        }
+    }
+
+    static class OldSubObject extends SubObject {
+        private static final ConstructingObjectParser<SubObject, String> PARSER = new ConstructingObjectParser<>(
+            "parser2", false,
+            a -> new SubObject((String) a[0]));
+
+        static {
+            PARSER.declareString(ConstructingObjectParser.constructorArg(), new ParseField("old_field"));
+        }
+
+        OldSubObject(String field) {
+            super(field);
+        }
+
+        public static SubObject parse(XContentParser parser) {
+            return PARSER.apply(parser, null);
+        }
+    }
+
+    public void testNotCompatibleRequest() throws IOException {
+        NamedXContentRegistry registry = new NamedXContentRegistry(
+            Arrays.asList(new NamedXContentRegistry.Entry(SubObject.class, new ParseField("namedObjectName1"), SubObject::parse)),
+            Arrays.asList(new NamedXContentRegistry.Entry(SubObject.class, new ParseField("namedObjectName1"), OldSubObject::parse)));
+
+        XContentBuilder b = XContentBuilder.builder(XContentType.JSON.xContent());
+        b.startObject();
+        b.startObject("subObject");
+        b.startObject("namedObjectName1");
+        b.field("new_field", "value1");
+        b.endObject();
+        b.endObject();
+        b.endObject();
+
+        String mediaType = XContentType.VND_JSON.toParsedMediaType()
+            .responseContentTypeHeader(Map.of(MediaType.COMPATIBLE_WITH_PARAMETER_NAME,
+                String.valueOf(Version.CURRENT.major)));
+        List<String> mediaTypeList = Collections.singletonList(mediaType);
+
+        RestRequest restRequest = new FakeRestRequest.Builder(registry)
+            .withContent(BytesReference.bytes(b), RestRequest.parseContentType(mediaTypeList))
+            .withPath("/foo")
+            .withHeaders(Map.of("Content-Type", mediaTypeList, "Accept", mediaTypeList))
+            .build();
+
+        try (XContentParser p = restRequest.contentParser()) {
+            ParentObject parse = ParentObject.parse(p);
+            assertThat(parse.subObject.field, equalTo("value1"));
+        }
+
+    }
+
+    public void testCompatibleRequest() throws IOException {
+        NamedXContentRegistry compatibleRegistry = new NamedXContentRegistry(
+            Arrays.asList(new NamedXContentRegistry.Entry(SubObject.class, new ParseField("namedObjectName1"), SubObject::parse)),
+            Arrays.asList(new NamedXContentRegistry.Entry(SubObject.class, new ParseField("namedObjectName1"), OldSubObject::parse)));
+
+        XContentBuilder b = XContentBuilder.builder(XContentType.JSON.xContent());
+        b.startObject();
+        b.startObject("subObject");
+        b.startObject("namedObjectName1");
+        b.field("old_field", "value1");
+        b.endObject();
+        b.endObject();
+        b.endObject();
+        String mediaType = XContentType.VND_JSON.toParsedMediaType()
+            .responseContentTypeHeader(Map.of(MediaType.COMPATIBLE_WITH_PARAMETER_NAME,
+                String.valueOf(Version.CURRENT.minimumRestCompatibilityVersion().major)));
+        List<String> mediaTypeList = Collections.singletonList(mediaType);
+
+        RestRequest restRequest2 = new FakeRestRequest.Builder(compatibleRegistry)
+            .withContent(BytesReference.bytes(b), RestRequest.parseContentType(mediaTypeList))
+            .withPath("/foo")
+            .withHeaders(Map.of("Content-Type", mediaTypeList, "Accept", mediaTypeList))
+            .build();
+
+        try (XContentParser p = restRequest2.contentParser()) {
+            ParentObject parse = ParentObject.parse(p);
+            assertThat(parse.subObject.field, equalTo("value1"));
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/rest/RestControllerTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/RestControllerTests.java
@@ -31,7 +31,6 @@ import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
-import org.elasticsearch.common.xcontent.MediaType;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentType;
@@ -758,12 +757,6 @@ public class RestControllerTests extends ESTestCase {
                     return Version.fromString(version + ".0.0");
                 }
             }));
-    }
-
-    private String randomCompatibleMediaType(byte version) {
-        XContentType type = randomFrom(XContentType.VND_JSON, XContentType.VND_SMILE, XContentType.VND_CBOR, XContentType.VND_YAML);
-        return type.toParsedMediaType()
-            .responseContentTypeHeader(Map.of(MediaType.COMPATIBLE_WITH_PARAMETER_NAME, String.valueOf(version)));
     }
 
     private static final class TestHttpServerTransport extends AbstractLifecycleComponent implements

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -79,6 +79,7 @@ import org.elasticsearch.common.util.MockBigArrays;
 import org.elasticsearch.common.util.MockPageCacheRecycler;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
+import org.elasticsearch.common.xcontent.MediaType;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContent;
@@ -1133,6 +1134,12 @@ public abstract class ESTestCase extends LuceneTestCase {
     }
 
     private static final GeohashGenerator geohashGenerator = new GeohashGenerator();
+
+    public String randomCompatibleMediaType(byte version) {
+        XContentType type = randomFrom(XContentType.VND_JSON, XContentType.VND_SMILE, XContentType.VND_CBOR, XContentType.VND_YAML);
+        return type.toParsedMediaType()
+            .responseContentTypeHeader(Map.of(MediaType.COMPATIBLE_WITH_PARAMETER_NAME, String.valueOf(version)));
+    }
 
     public static class GeohashGenerator extends CodepointSetGenerator {
         private static final char[] ASCII_SET = "0123456789bcdefghjkmnpqrstuvwxyz".toCharArray();


### PR DESCRIPTION
when parsing xContent objects `named object` can be registered and need to be parsed as per N-1 rules. 
`named objects` are declared on a parser (`PARSER.declareNamedObject`) and the corresponding parsing logic is registered in `NamedObjectRegistry`. 
There is a need to use an old `N-1` "configuration" of the registry in order to support the compatible parsing logic. 

This commit extends the NamedObjectRegistry with additional set of `compatible entries`, which provide the compatible parsing logic. Those entries are then in turn used in `parseNamedObject` when  `xContentParser` is using compatibility.

relates #51816