### PR TITLE
Replace NOT operator with explicit `false` check - part 4

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsIT.java
@@ -117,7 +117,7 @@ public class ClusterStatsIT extends ESIntegTestCase {
             if (isRemoteClusterClientNode) {
                 incrementCountForRole(DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE.roleName(), expectedCounts);
             }
-            if (!isDataNode && !isMasterNode && !isIngestNode && !isRemoteClusterClientNode) {
+            if (isDataNode == false && isMasterNode == false && isIngestNode == false && isRemoteClusterClientNode == false) {
                 incrementCountForRole(ClusterStatsNodes.Counts.COORDINATING_ONLY, expectedCounts);
             }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/health/TransportClusterHealthAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/health/TransportClusterHealthAction.java
@@ -283,7 +283,7 @@ public class TransportClusterHealthAction extends TransportMasterNodeReadAction<
                 // missing indices, wait a bit more...
             }
         }
-        if (!request.waitForNodes().isEmpty()) {
+        if (request.waitForNodes().isEmpty() == false) {
             if (request.waitForNodes().startsWith(">=")) {
                 int expected = Integer.parseInt(request.waitForNodes().substring(2));
                 if (response.getNumberOfNodes() >= expected) {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoResponse.java
@@ -88,7 +88,7 @@ public class NodesInfoResponse extends BaseNodesResponse<NodeInfo> implements To
             }
             builder.endArray();
 
-            if (!nodeInfo.getNode().getAttributes().isEmpty()) {
+            if (nodeInfo.getNode().getAttributes().isEmpty() == false) {
                 builder.startObject("attributes");
                 for (Map.Entry<String, String> entry : nodeInfo.getNode().getAttributes().entrySet()) {
                     builder.field(entry.getKey(), entry.getValue());

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
@@ -278,7 +278,7 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
         }
         builder.endArray();
 
-        if (!getNode().getAttributes().isEmpty()) {
+        if (getNode().getAttributes().isEmpty() == false) {
             builder.startObject("attributes");
             for (Map.Entry<String, String> attrEntry : getNode().getAttributes().entrySet()) {
                 builder.field(attrEntry.getKey(), attrEntry.getValue());

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/list/ListTasksResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/list/ListTasksResponse.java
@@ -181,7 +181,7 @@ public class ListTasksResponse extends BaseTasksResponse implements ToXContentOb
                 }
                 builder.endArray();
 
-                if (!node.getAttributes().isEmpty()) {
+                if (node.getAttributes().isEmpty() == false) {
                     builder.startObject("attributes");
                     for (Map.Entry<String, String> attrEntry : node.getAttributes().entrySet()) {
                         builder.field(attrEntry.getKey(), attrEntry.getValue());

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/put/PutRepositoryRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/put/PutRepositoryRequest.java
@@ -204,7 +204,7 @@ public class PutRepositoryRequest extends AcknowledgedRequest<PutRepositoryReque
             if (name.equals("type")) {
                 type(entry.getValue().toString());
             } else if (name.equals("settings")) {
-                if (!(entry.getValue() instanceof Map)) {
+                if ((entry.getValue() instanceof Map) == false) {
                     throw new IllegalArgumentException("Malformed settings section, should include an inner object");
                 }
                 @SuppressWarnings("unchecked")

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/settings/TransportClusterUpdateSettingsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/settings/TransportClusterUpdateSettingsAction.java
@@ -160,7 +160,7 @@ public class TransportClusterUpdateSettingsAction extends
                 // We're about to send a second update task, so we need to check if we're still the elected master
                 // For example the minimum_master_node could have been breached and we're no longer elected master,
                 // so we should *not* execute the reroute.
-                if (!clusterService.state().nodes().isLocalNodeElectedMaster()) {
+                if (clusterService.state().nodes().isLocalNodeElectedMaster() == false) {
                     logger.debug("Skipping reroute after cluster update settings, because node is no longer master");
                     listener.onResponse(new ClusterUpdateSettingsResponse(updateSettingsAcked, updater.getTransientUpdates(),
                         updater.getPersistentUpdate()));

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
@@ -485,7 +485,7 @@ public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotReq
                     throw new IllegalArgumentException("malformed rename_replacement");
                 }
             } else if (name.equals("index_settings")) {
-                if (!(entry.getValue() instanceof Map)) {
+                if ((entry.getValue() instanceof Map) == false) {
                     throw new IllegalArgumentException("malformed index_settings section");
                 }
                 indexSettings((Map<String, Object>) entry.getValue());

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportSnapshotsStatusAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportSnapshotsStatusAction.java
@@ -116,7 +116,7 @@ public class TransportSnapshotsStatusAction extends TransportMasterNodeAction<Sn
             }
         }
 
-        if (!nodesIds.isEmpty()) {
+        if (nodesIds.isEmpty() == false) {
             // There are still some snapshots running - check their progress
             Snapshot[] snapshots = new Snapshot[currentSnapshots.size()];
             for (int i = 0; i < currentSnapshots.size(); i++) {
@@ -143,7 +143,7 @@ public class TransportSnapshotsStatusAction extends TransportMasterNodeAction<Sn
         // First process snapshot that are currently processed
         List<SnapshotStatus> builder = new ArrayList<>();
         Set<String> currentSnapshotNames = new HashSet<>();
-        if (!currentSnapshotEntries.isEmpty()) {
+        if (currentSnapshotEntries.isEmpty() == false) {
             Map<String, TransportNodesSnapshotsStatus.NodeSnapshotStatus> nodeSnapshotStatusMap;
             if (nodeSnapshotStatuses != null) {
                 nodeSnapshotStatusMap = nodeSnapshotStatuses.getNodesMap();
@@ -310,7 +310,7 @@ public class TransportSnapshotsStatusAction extends TransportMasterNodeAction<Sn
     private SnapshotInfo snapshot(SnapshotsInProgress snapshotsInProgress, String repositoryName, SnapshotId snapshotId) {
         List<SnapshotsInProgress.Entry> entries =
             SnapshotsService.currentSnapshots(snapshotsInProgress, repositoryName, Collections.singletonList(snapshotId.getName()));
-        if (!entries.isEmpty()) {
+        if (entries.isEmpty() == false) {
             return new SnapshotInfo(entries.iterator().next());
         }
         return repositoriesService.repository(repositoryName).getSnapshotInfo(snapshotId);

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodes.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodes.java
@@ -89,7 +89,7 @@ public class ClusterStatsNodes implements ToXContentFragment {
             TransportAddress publishAddress =
                     nodeResponse.nodeInfo().getInfo(TransportInfo.class).address().publishAddress();
             final InetAddress inetAddress = publishAddress.address().getAddress();
-            if (!seenAddresses.add(inetAddress)) {
+            if (seenAddresses.add(inetAddress) == false) {
                 continue;
             }
             if (nodeResponse.nodeStats().getFs() != null) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/get/TransportGetIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/get/TransportGetIndexAction.java
@@ -80,19 +80,19 @@ public class TransportGetIndexAction extends TransportClusterInfoAction<GetIndex
         for (Feature feature : features) {
             switch (feature) {
             case MAPPINGS:
-                    if (!doneMappings) {
+                    if (doneMappings == false) {
                         mappingsResult = state.metadata().findMappings(concreteIndices, indicesService.getFieldFilter());
                         doneMappings = true;
                     }
                     break;
             case ALIASES:
-                    if (!doneAliases) {
+                    if (doneAliases == false) {
                         aliasesResult = state.metadata().findAllAliases(concreteIndices);
                         doneAliases = true;
                     }
                     break;
             case SETTINGS:
-                    if (!doneSettings) {
+                    if (doneSettings == false) {
                         ImmutableOpenMap.Builder<String, Settings> settingsMapBuilder = ImmutableOpenMap.builder();
                         ImmutableOpenMap.Builder<String, Settings> defaultSettingsMapBuilder = ImmutableOpenMap.builder();
                         for (String index : concreteIndices) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetFieldMappingsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetFieldMappingsResponse.java
@@ -174,7 +174,7 @@ public class GetFieldMappingsResponse extends ActionResponse implements ToXConte
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (!(o instanceof FieldMappingMetadata)) return false;
+            if ((o instanceof FieldMappingMetadata) == false) return false;
             FieldMappingMetadata that = (FieldMappingMetadata) o;
             return Objects.equals(fullName, that.fullName) &&
                 Objects.equals(source, that.source);
@@ -210,7 +210,7 @@ public class GetFieldMappingsResponse extends ActionResponse implements ToXConte
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof GetFieldMappingsResponse)) return false;
+        if ((o instanceof GetFieldMappingsResponse) == false) return false;
         GetFieldMappingsResponse that = (GetFieldMappingsResponse) o;
         return Objects.equals(mappings, that.mappings);
     }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/recovery/TransportRecoveryAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/recovery/TransportRecoveryAction.java
@@ -77,7 +77,7 @@ public class TransportRecoveryAction extends TransportBroadcastByNodeAction<Reco
                 continue;
             }
             String indexName = recoveryState.getShardId().getIndexName();
-            if (!shardResponses.containsKey(indexName)) {
+            if (shardResponses.containsKey(indexName) == false) {
                 shardResponses.put(indexName, new ArrayList<>());
             }
             if (request.activeOnly()) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsResponse.java
@@ -132,7 +132,7 @@ public class GetSettingsResponse extends ActionResponse implements ToXContentObj
     Map<String, Settings> indexToDefaultSettings) throws IOException {
         String indexName = parser.currentName();
         parser.nextToken();
-        while (!parser.isClosed() && parser.currentToken() != XContentParser.Token.END_OBJECT) {
+        while (parser.isClosed() == false && parser.currentToken() != XContentParser.Token.END_OBJECT) {
             parseSettingsField(parser, indexName, indexToSettings, indexToDefaultSettings);
         }
     }
@@ -146,7 +146,7 @@ public class GetSettingsResponse extends ActionResponse implements ToXContentObj
         XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         parser.nextToken();
 
-        while (!parser.isClosed()) {
+        while (parser.isClosed() == false) {
             if (parser.currentToken() == XContentParser.Token.START_OBJECT) {
                 //we must assume this is an index entry
                 parseIndexEntry(parser, indexToSettings, indexToDefaultSettings);

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsResponse.java
@@ -138,7 +138,7 @@ public class IndicesStatsResponse extends BroadcastResponse {
         final String level = params.param("level", "indices");
         final boolean isLevelValid =
             "cluster".equalsIgnoreCase(level) || "indices".equalsIgnoreCase(level) || "shards".equalsIgnoreCase(level);
-        if (!isLevelValid) {
+        if (isLevelValid == false) {
             throw new IllegalArgumentException("level parameter must be one of [cluster] or [indices] or [shards] but was [" + level + "]");
         }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/TransportSimulateIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/TransportSimulateIndexTemplateAction.java
@@ -195,7 +195,7 @@ public class TransportSimulateIndexTemplateAction
             tempIndexService -> {
                 MapperService mapperService = tempIndexService.mapperService();
                 for (Map<String, Object> mapping : mappings) {
-                    if (!mapping.isEmpty()) {
+                    if (mapping.isEmpty() == false) {
                         mapperService.merge(MapperService.SINGLE_MAPPING_NAME, mapping, MapperService.MergeReason.INDEX_TEMPLATE);
                     }
                 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequest.java
@@ -337,7 +337,7 @@ public class PutIndexTemplateRequest extends MasterNodeRequest<PutIndexTemplateR
             } else if (name.equals("mappings")) {
                 Map<String, Object> mappings = (Map<String, Object>) entry.getValue();
                 for (Map.Entry<String, Object> entry1 : mappings.entrySet()) {
-                    if (!(entry1.getValue() instanceof Map)) {
+                    if ((entry1.getValue() instanceof Map) == false) {
                         throw new IllegalArgumentException(
                             "Malformed [mappings] section for type [" + entry1.getKey() +
                                 "], should include an inner object describing the mapping");

--- a/server/src/main/java/org/elasticsearch/action/support/broadcast/TransportBroadcastAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/broadcast/TransportBroadcastAction.java
@@ -217,7 +217,7 @@ public abstract class TransportBroadcastAction<
             if (nextShard != null) {
                 if (e != null) {
                     if (logger.isTraceEnabled()) {
-                        if (!TransportActions.isShardNotAvailableException(e)) {
+                        if (TransportActions.isShardNotAvailableException(e) == false) {
                             logger.trace(new ParameterizedMessage(
                                 "{}: failed to execute [{}]", shard != null ? shard.shortSummary() : shardIt.shardId(), request), e);
                         }
@@ -227,7 +227,7 @@ public abstract class TransportBroadcastAction<
             } else {
                 if (logger.isDebugEnabled()) {
                     if (e != null) {
-                        if (!TransportActions.isShardNotAvailableException(e)) {
+                        if (TransportActions.isShardNotAvailableException(e) == false) {
                             logger.debug(new ParameterizedMessage(
                                 "{}: failed to execute [{}]", shard != null ? shard.shortSummary() : shardIt.shardId(), request), e);
                         }
@@ -257,7 +257,7 @@ public abstract class TransportBroadcastAction<
                 return;
             }
 
-            if (!(e instanceof BroadcastShardOperationFailedException)) {
+            if ((e instanceof BroadcastShardOperationFailedException) == false) {
                 e = new BroadcastShardOperationFailedException(shardIt.shardId(), e);
             }
 
@@ -267,7 +267,7 @@ public abstract class TransportBroadcastAction<
                 shardsResponses.set(shardIndex, e);
             }
 
-            if (!(response instanceof Throwable)) {
+            if ((response instanceof Throwable) == false) {
                 // we should never really get here...
                 return;
             }

--- a/server/src/main/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeAction.java
@@ -138,7 +138,7 @@ public abstract class TransportBroadcastByNodeAction<Request extends BroadcastRe
                 totalShards += response.getTotalShards();
                 successfulShards += response.getSuccessfulShards();
                 for (BroadcastShardOperationFailedException throwable : response.getExceptions()) {
-                    if (!TransportActions.isShardNotAvailableException(throwable)) {
+                    if (TransportActions.isShardNotAvailableException(throwable) == false) {
                         exceptions.add(new DefaultShardOperationFailedException(throwable.getShardId().getIndexName(),
                             throwable.getShardId().getId(), throwable));
                     }
@@ -281,7 +281,7 @@ public abstract class TransportBroadcastByNodeAction<Request extends BroadcastRe
                 // routing table as such
                 if (shard.assignedToNode() && nodes.get(shard.currentNodeId()) != null) {
                     String nodeId = shard.currentNodeId();
-                    if (!nodeIds.containsKey(nodeId)) {
+                    if (nodeIds.containsKey(nodeId) == false) {
                         nodeIds.put(nodeId, new ArrayList<>());
                     }
                     nodeIds.get(nodeId).add(shard);

--- a/server/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeAction.java
@@ -131,7 +131,7 @@ public abstract class TransportMasterNodeAction<Request extends MasterNodeReques
                     // check for block, if blocked, retry, else, execute locally
                     final ClusterBlockException blockException = checkBlock(request, clusterState);
                     if (blockException != null) {
-                        if (!blockException.retryable()) {
+                        if (blockException.retryable() == false) {
                             logger.trace("can't execute due to a non-retryable cluster block", blockException);
                             listener.onFailure(blockException);
                         } else {

--- a/server/src/main/java/org/elasticsearch/action/support/single/instance/TransportInstanceSingleOperationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/single/instance/TransportInstanceSingleOperationAction.java
@@ -184,7 +184,7 @@ public abstract class TransportInstanceSingleOperationAction<
             ShardRouting shard = shardIt.nextOrNull();
             assert shard != null;
 
-            if (!shard.active()) {
+            if (shard.active() == false) {
                 retry(null);
                 return;
             }

--- a/server/src/main/java/org/elasticsearch/action/support/single/shard/TransportSingleShardAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/single/shard/TransportSingleShardAction.java
@@ -83,7 +83,7 @@ public abstract class TransportSingleShardAction<Request extends SingleShardRequ
         this.transportShardAction = actionName + "[s]";
         this.executor = executor;
 
-        if (!isSubAction()) {
+        if (isSubAction() == false) {
             transportService.registerRequestHandler(actionName, ThreadPool.Names.SAME, request, new TransportHandler());
         }
         transportService.registerRequestHandler(transportShardAction, ThreadPool.Names.SAME, request, new ShardTransportHandler());

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
@@ -813,7 +813,7 @@ public class BalancedShardsAllocator implements ShardsAllocator {
                             allocation.clusterInfo(), allocation.snapshotShardSizeInfo(), allocation.metadata(), allocation.routingTable());
                         shard = routingNodes.initializeShard(shard, minNode.getNodeId(), null, shardSize, allocation.changes());
                         minNode.addShard(shard);
-                        if (!shard.primary()) {
+                        if (shard.primary() == false) {
                             // copy over the same replica shards to the secondary array so they will get allocated
                             // in a subsequent iteration, allowing replicas of other shards to be allocated first
                             while(i < primaryLength-1 && comparator.compare(primary[i], primary[i+1]) == 0) {
@@ -842,7 +842,8 @@ public class BalancedShardsAllocator implements ShardsAllocator {
                         }
 
                         unassigned.ignoreShard(shard, allocationDecision.getAllocationStatus(), allocation.changes());
-                        if (!shard.primary()) { // we could not allocate it and we are a replica - check if we can ignore the other replicas
+                        if (shard.primary() == false) {
+                            // we could not allocate it and we are a replica - check if we can ignore the other replicas
                             while(i < primaryLength-1 && comparator.compare(primary[i], primary[i+1]) == 0) {
                                 unassigned.ignoreShard(primary[++i], allocationDecision.getAllocationStatus(), allocation.changes());
                             }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/command/AbstractAllocateAllocationCommand.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/command/AbstractAllocateAllocationCommand.java
@@ -151,7 +151,7 @@ public abstract class AbstractAllocateAllocationCommand implements AllocationCom
      * Handle case where a disco node cannot be found in the routing table. Usually means that it's not a data node.
      */
     protected RerouteExplanation explainOrThrowMissingRoutingNode(RoutingAllocation allocation, boolean explain, DiscoveryNode discoNode) {
-        if (!discoNode.isDataNode()) {
+        if (discoNode.isDataNode() == false) {
             return explainOrThrowRejectedCommand(explain, allocation, "allocation can only be done on data nodes, not [" + node + "]");
         } else {
             return explainOrThrowRejectedCommand(explain, allocation, "could not find [" + node + "] among the routing nodes");
@@ -206,7 +206,7 @@ public abstract class AbstractAllocateAllocationCommand implements AllocationCom
                                              @Nullable RecoverySource recoverySource) {
         for (RoutingNodes.UnassignedShards.UnassignedIterator it = routingNodes.unassigned().iterator(); it.hasNext(); ) {
             ShardRouting unassigned = it.next();
-            if (!unassigned.equalsIgnoringMetadata(shardRouting)) {
+            if (unassigned.equalsIgnoringMetadata(shardRouting) == false) {
                 continue;
             }
             if (unassignedInfo != null || recoverySource != null) {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/command/AllocationCommands.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/command/AllocationCommands.java
@@ -137,7 +137,7 @@ public class AllocationCommands implements ToXContentFragment {
             throw new ElasticsearchParseException("No commands");
         }
         if (token == XContentParser.Token.FIELD_NAME) {
-            if (!parser.currentName().equals("commands")) {
+            if (parser.currentName().equals("commands") == false) {
                 throw new ElasticsearchParseException("expected field name to be named [commands], got [{}] instead", parser.currentName());
             }
             token = parser.nextToken();

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/command/MoveAllocationCommand.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/command/MoveAllocationCommand.java
@@ -116,7 +116,7 @@ public class MoveAllocationCommand implements AllocationCommand {
         }
 
         for (ShardRouting shardRouting : fromRoutingNode) {
-            if (!shardRouting.shardId().getIndexName().equals(index)) {
+            if (shardRouting.shardId().getIndexName().equals(index) == false) {
                 continue;
             }
             if (shardRouting.shardId().id() != shardId) {
@@ -125,7 +125,7 @@ public class MoveAllocationCommand implements AllocationCommand {
             found = true;
 
             // TODO we can possibly support also relocating cases, where we cancel relocation and move...
-            if (!shardRouting.started()) {
+            if (shardRouting.started() == false) {
                 if (explain) {
                     return new RerouteExplanation(this, allocation.decision(Decision.NO, "move_allocation_command",
                             "shard " + shardId + " has not been started"));
@@ -149,7 +149,7 @@ public class MoveAllocationCommand implements AllocationCommand {
                 allocation.clusterInfo().getShardSize(shardRouting, ShardRouting.UNAVAILABLE_EXPECTED_SHARD_SIZE), allocation.changes());
         }
 
-        if (!found) {
+        if (found == false) {
             if (explain) {
                 return new RerouteExplanation(this, allocation.decision(Decision.NO,
                         "move_allocation_command", "shard " + shardId + " not found"));

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDeciders.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDeciders.java
@@ -51,7 +51,7 @@ public class AllocationDeciders extends AllocationDecider {
             Decision decision = allocationDecider.canRebalance(shardRouting, allocation);
             // short track if a NO is returned.
             if (decision.type() == Decision.Type.NO) {
-                if (!allocation.debugDecision()) {
+                if (allocation.debugDecision() == false) {
                     return Decision.NO;
                 } else {
                     ret.add(decision);
@@ -78,7 +78,7 @@ public class AllocationDeciders extends AllocationDecider {
                         shardRouting, node.node(), allocationDecider.getClass().getSimpleName());
                 }
                 // short circuit only if debugging is not enabled
-                if (!allocation.debugDecision()) {
+                if (allocation.debugDecision() == false) {
                     return Decision.NO;
                 } else {
                     ret.add(decision);
@@ -107,7 +107,7 @@ public class AllocationDeciders extends AllocationDecider {
                     logger.trace("Shard [{}] can not remain on node [{}] due to [{}]",
                         shardRouting, node.nodeId(), allocationDecider.getClass().getSimpleName());
                 }
-                if (!allocation.debugDecision()) {
+                if (allocation.debugDecision() == false) {
                     return Decision.NO;
                 } else {
                     ret.add(decision);
@@ -126,7 +126,7 @@ public class AllocationDeciders extends AllocationDecider {
             Decision decision = allocationDecider.canAllocate(indexMetadata, node, allocation);
             // short track if a NO is returned.
             if (decision.type() == Decision.Type.NO) {
-                if (!allocation.debugDecision()) {
+                if (allocation.debugDecision() == false) {
                     return Decision.NO;
                 } else {
                     ret.add(decision);
@@ -145,7 +145,7 @@ public class AllocationDeciders extends AllocationDecider {
             Decision decision = allocationDecider.shouldAutoExpandToNode(indexMetadata, node, allocation);
             // short track if a NO is returned.
             if (decision.type() == Decision.Type.NO) {
-                if (!allocation.debugDecision()) {
+                if (allocation.debugDecision() == false) {
                     return Decision.NO;
                 } else {
                     ret.add(decision);
@@ -164,7 +164,7 @@ public class AllocationDeciders extends AllocationDecider {
             Decision decision = allocationDecider.canAllocate(shardRouting, allocation);
             // short track if a NO is returned.
             if (decision.type() == Decision.Type.NO) {
-                if (!allocation.debugDecision()) {
+                if (allocation.debugDecision() == false) {
                     return Decision.NO;
                 } else {
                     ret.add(decision);
@@ -183,7 +183,7 @@ public class AllocationDeciders extends AllocationDecider {
             Decision decision = allocationDecider.canRebalance(allocation);
             // short track if a NO is returned.
             if (decision.type() == Decision.Type.NO) {
-                if (!allocation.debugDecision()) {
+                if (allocation.debugDecision() == false) {
                     return Decision.NO;
                 } else {
                     ret.add(decision);
@@ -211,7 +211,7 @@ public class AllocationDeciders extends AllocationDecider {
                     logger.trace("Shard [{}] can not be forcefully allocated to node [{}] due to [{}].",
                         shardRouting.shardId(), node.nodeId(), decider.getClass().getSimpleName());
                 }
-                if (!allocation.debugDecision()) {
+                if (allocation.debugDecision() == false) {
                     return Decision.NO;
                 } else {
                     ret.add(decision);

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/RebalanceOnlyWhenActiveAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/RebalanceOnlyWhenActiveAllocationDecider.java
@@ -31,7 +31,7 @@ public class RebalanceOnlyWhenActiveAllocationDecider extends AllocationDecider 
 
     @Override
     public Decision canRebalance(ShardRouting shardRouting, RoutingAllocation allocation) {
-        if (!allocation.routingNodes().allReplicasActive(shardRouting.shardId(), allocation.metadata())) {
+        if (allocation.routingNodes().allReplicasActive(shardRouting.shardId(), allocation.metadata()) == false) {
             return allocation.decision(Decision.NO, NAME, "rebalancing is not allowed until all replicas in the cluster are active");
         }
         return allocation.decision(Decision.YES, NAME, "rebalancing is allowed as all replicas are active in the cluster");

--- a/server/src/main/java/org/elasticsearch/common/geo/builders/PolygonBuilder.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/builders/PolygonBuilder.java
@@ -171,7 +171,7 @@ public class PolygonBuilder extends ShapeBuilder<JtsGeometry, org.elasticsearch.
                     "invalid number of points in LinearRing (found [" + points.size() + "] - must be >= 4)");
         }
 
-        if (!points.get(0).equals(points.get(points.size() - 1))) {
+        if (points.get(0).equals(points.get(points.size() - 1)) == false) {
                 throw new IllegalArgumentException("invalid LinearRing found (coordinates are not closed)");
         }
     }
@@ -438,7 +438,7 @@ public class PolygonBuilder extends ShapeBuilder<JtsGeometry, org.elasticsearch.
                         prev.component = visitID;
                         prev = visitedEdge.get(prev.coordinate).v1();
                         ++splitIndex;
-                    } while (!current.coordinate.equals(prev.coordinate));
+                    } while (current.coordinate.equals(prev.coordinate) == false);
                     ++connectedComponents;
                 } else {
                     visitedEdge.put(current.coordinate, new Tuple<Edge, Edge>(prev, current));

--- a/server/src/main/java/org/elasticsearch/common/geo/builders/ShapeBuilder.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/builders/ShapeBuilder.java
@@ -281,7 +281,7 @@ public abstract class ShapeBuilder<T extends Shape, G extends org.elasticsearch.
             edges[i].intersect = Edge.MAX_COORDINATE;
 
             double position = intersection(p1, p2, dateline);
-            if (!Double.isNaN(position)) {
+            if (Double.isNaN(position) == false) {
                 edges[i].intersection(position);
                 numIntersections++;
                 maxComponent = Math.max(maxComponent, edges[i].component);
@@ -517,7 +517,7 @@ public abstract class ShapeBuilder<T extends Shape, G extends org.elasticsearch.
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof ShapeBuilder)) return false;
+        if ((o instanceof ShapeBuilder) == false) return false;
 
         ShapeBuilder<?,?,?> that = (ShapeBuilder<?,?,?>) o;
 

--- a/server/src/main/java/org/elasticsearch/common/geo/parsers/GeoWKTParser.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/parsers/GeoWKTParser.java
@@ -221,7 +221,7 @@ public class GeoWKTParser {
         List<Coordinate> coordinates = parseCoordinateList(stream, ignoreZValue, coerce);
         int coordinatesNeeded = coerce ? 3 : 4;
         if (coordinates.size() >= coordinatesNeeded) {
-            if (!coordinates.get(0).equals(coordinates.get(coordinates.size() - 1))) {
+            if (coordinates.get(0).equals(coordinates.get(coordinates.size() - 1)) == false) {
                 if (coerce) {
                     coordinates.add(coordinates.get(0));
                 } else {

--- a/server/src/main/java/org/elasticsearch/common/inject/assistedinject/FactoryProvider.java
+++ b/server/src/main/java/org/elasticsearch/common/inject/assistedinject/FactoryProvider.java
@@ -144,8 +144,8 @@ public class FactoryProvider<F> implements Provider<F>, HasDependencies {
     private void checkDeclaredExceptionsMatch() {
         for (Map.Entry<Method, AssistedConstructor<?>> entry : factoryMethodToConstructor.entrySet()) {
             for (Class<?> constructorException : entry.getValue().getDeclaredExceptions()) {
-                if (!isConstructorExceptionCompatibleWithFactoryExeception(
-                        constructorException, entry.getKey().getExceptionTypes())) {
+                if (isConstructorExceptionCompatibleWithFactoryExeception(
+                        constructorException, entry.getKey().getExceptionTypes()) == false) {
                     throw newConfigurationException("Constructor %s declares an exception, but no compatible "
                             + "exception is thrown by the factory method %s", entry.getValue(), entry.getKey());
                 }
@@ -168,7 +168,7 @@ public class FactoryProvider<F> implements Provider<F>, HasDependencies {
         Set<Dependency<?>> dependencies = new HashSet<>();
         for (AssistedConstructor<?> constructor : factoryMethodToConstructor.values()) {
             for (Parameter parameter : constructor.getAllParameters()) {
-                if (!parameter.isProvidedByFactory()) {
+                if (parameter.isProvidedByFactory() == false) {
                     dependencies.add(Dependency.get(parameter.getPrimaryBindingKey()));
                 }
             }

--- a/server/src/main/java/org/elasticsearch/common/inject/assistedinject/ParameterListKey.java
+++ b/server/src/main/java/org/elasticsearch/common/inject/assistedinject/ParameterListKey.java
@@ -47,7 +47,7 @@ class ParameterListKey {
         if (o == this) {
             return true;
         }
-        if (!(o instanceof ParameterListKey)) {
+        if ((o instanceof ParameterListKey) == false) {
             return false;
         }
         ParameterListKey other = (ParameterListKey) o;

--- a/server/src/main/java/org/elasticsearch/common/inject/internal/AbstractBindingBuilder.java
+++ b/server/src/main/java/org/elasticsearch/common/inject/internal/AbstractBindingBuilder.java
@@ -110,7 +110,7 @@ public abstract class AbstractBindingBuilder<T> {
     }
 
     protected void checkNotTargetted() {
-        if (!(binding instanceof UntargettedBindingImpl)) {
+        if ((binding instanceof UntargettedBindingImpl) == false) {
             binder.addError(IMPLEMENTATION_ALREADY_SET);
         }
     }

--- a/server/src/main/java/org/elasticsearch/common/inject/internal/ConstructionContext.java
+++ b/server/src/main/java/org/elasticsearch/common/inject/internal/ConstructionContext.java
@@ -65,7 +65,7 @@ public class ConstructionContext<T> {
         // the implementation type, I'll be able to get away with one proxy
         // instance (as opposed to one per caller).
 
-        if (!expectedType.isInterface()) {
+        if (expectedType.isInterface() == false) {
             throw errors.cannotSatisfyCircularDependency(expectedType).toException();
         }
 

--- a/server/src/main/java/org/elasticsearch/common/inject/internal/Errors.java
+++ b/server/src/main/java/org/elasticsearch/common/inject/internal/Errors.java
@@ -324,7 +324,7 @@ public final class Errors {
     public Errors errorInUserCode(Throwable cause, String messageFormat, Object... arguments) {
         Collection<Message> messages = getMessagesFromThrowable(cause);
 
-        if (!messages.isEmpty()) {
+        if (messages.isEmpty() == false) {
             return merge(messages);
         } else {
             return addMessage(cause, messageFormat, arguments);
@@ -354,7 +354,7 @@ public final class Errors {
     }
 
     public void throwCreationExceptionIfErrorsExist() {
-        if (!hasErrors()) {
+        if (hasErrors() == false) {
             return;
         }
 
@@ -362,7 +362,7 @@ public final class Errors {
     }
 
     public void throwConfigurationExceptionIfErrorsExist() {
-        if (!hasErrors()) {
+        if (hasErrors() == false) {
             return;
         }
 
@@ -370,7 +370,7 @@ public final class Errors {
     }
 
     public void throwProvisionExceptionIfErrorsExist() {
-        if (!hasErrors()) {
+        if (hasErrors() == false) {
             return;
         }
 

--- a/server/src/main/java/org/elasticsearch/common/inject/internal/MoreTypes.java
+++ b/server/src/main/java/org/elasticsearch/common/inject/internal/MoreTypes.java
@@ -69,7 +69,7 @@ public class MoreTypes {
      * @throws ConfigurationException if {@code type} contains a type variable
      */
     public static <T> TypeLiteral<T> makeKeySafe(TypeLiteral<T> type) {
-        if (!isFullySpecified(type.getType())) {
+        if (isFullySpecified(type.getType()) == false) {
             String message = type + " cannot be used as a key; It is not fully specified.";
             throw new ConfigurationException(singleton(new Message(message)));
         }
@@ -144,7 +144,7 @@ public class MoreTypes {
             // Neal isn't either but suspects some pathological case related
             // to nested classes exists.
             Type rawType = parameterizedType.getRawType();
-            if (!(rawType instanceof Class)) {
+            if ((rawType instanceof Class) == false) {
                 throw new IllegalArgumentException(
                         "Expected a Class, but <" + type +"> is of type " + type.getClass().getName()
                 );
@@ -179,7 +179,7 @@ public class MoreTypes {
             return a.equals(b);
 
         } else if (a instanceof ParameterizedType) {
-            if (!(b instanceof ParameterizedType)) {
+            if ((b instanceof ParameterizedType) == false) {
                 return false;
             }
 
@@ -191,7 +191,7 @@ public class MoreTypes {
                     && Arrays.equals(pa.getActualTypeArguments(), pb.getActualTypeArguments());
 
         } else if (a instanceof GenericArrayType) {
-            if (!(b instanceof GenericArrayType)) {
+            if ((b instanceof GenericArrayType) == false) {
                 return false;
             }
 
@@ -200,7 +200,7 @@ public class MoreTypes {
             return equals(ga.getGenericComponentType(), gb.getGenericComponentType());
 
         } else if (a instanceof WildcardType) {
-            if (!(b instanceof WildcardType)) {
+            if ((b instanceof WildcardType) == false) {
                 return false;
             }
 
@@ -210,7 +210,7 @@ public class MoreTypes {
                     && Arrays.equals(wa.getLowerBounds(), wb.getLowerBounds());
 
         } else if (a instanceof TypeVariable) {
-            if (!(b instanceof TypeVariable)) {
+            if ((b instanceof TypeVariable) == false) {
                 return false;
             }
             TypeVariable<?> va = (TypeVariable) a;
@@ -377,7 +377,7 @@ public class MoreTypes {
         }
 
         // check our supertypes
-        if (!rawType.isInterface()) {
+        if (rawType.isInterface() == false) {
             while (rawType != Object.class) {
                 Class<?> rawSupertype = rawType.getSuperclass();
                 if (rawSupertype == toResolve) {
@@ -480,12 +480,12 @@ public class MoreTypes {
                 return false;
             }
 
-            if (!MoreTypes.isFullySpecified(rawType)) {
+            if (MoreTypes.isFullySpecified(rawType) == false) {
                 return false;
             }
 
             for (Type type : typeArguments) {
-                if (!MoreTypes.isFullySpecified(type)) {
+                if (MoreTypes.isFullySpecified(type) == false) {
                     return false;
                 }
             }

--- a/server/src/main/java/org/elasticsearch/common/inject/internal/SourceProvider.java
+++ b/server/src/main/java/org/elasticsearch/common/inject/internal/SourceProvider.java
@@ -66,7 +66,7 @@ public class SourceProvider {
     public StackTraceElement get() {
         for (final StackTraceElement element : new Throwable().getStackTrace()) {
             String className = element.getClassName();
-            if (!classNamesToSkip.contains(className)) {
+            if (classNamesToSkip.contains(className) == false) {
                 return element;
             }
         }

--- a/server/src/main/java/org/elasticsearch/common/inject/name/NamedImpl.java
+++ b/server/src/main/java/org/elasticsearch/common/inject/name/NamedImpl.java
@@ -40,7 +40,7 @@ class NamedImpl implements Named {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof Named)) {
+        if ((o instanceof Named) == false) {
             return false;
         }
 

--- a/server/src/main/java/org/elasticsearch/common/inject/spi/Elements.java
+++ b/server/src/main/java/org/elasticsearch/common/inject/spi/Elements.java
@@ -129,7 +129,7 @@ public final class Elements {
          */
         private RecordingBinder(
                 RecordingBinder prototype, Object source, SourceProvider sourceProvider) {
-            if (!(source == null ^ sourceProvider == null)) {
+            if ((source == null ^ sourceProvider == null) == false) {
                 throw new IllegalArgumentException();
             }
 
@@ -211,7 +211,7 @@ public final class Elements {
                     throw e;
                 } catch (RuntimeException e) {
                     Collection<Message> messages = Errors.getMessagesFromThrowable(e);
-                    if (!messages.isEmpty()) {
+                    if (messages.isEmpty() == false) {
                         elements.addAll(messages);
                     } else {
                         addError(e);

--- a/server/src/main/java/org/elasticsearch/common/inject/spi/InjectionPoint.java
+++ b/server/src/main/java/org/elasticsearch/common/inject/spi/InjectionPoint.java
@@ -376,7 +376,7 @@ public final class InjectionPoint {
             try {
                 injectionPoints.add(factory.create(typeLiteral, member, errors));
             } catch (ConfigurationException ignorable) {
-                if (!inject.optional()) {
+                if (inject.optional() == false) {
                     errors.merge(ignorable.getErrorMessages());
                 }
             }

--- a/server/src/main/java/org/elasticsearch/common/inject/spi/Message.java
+++ b/server/src/main/java/org/elasticsearch/common/inject/spi/Message.java
@@ -114,7 +114,7 @@ public final class Message implements Element {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof Message)) {
+        if ((o instanceof Message) == false) {
             return false;
         }
         Message e = (Message) o;

--- a/server/src/main/java/org/elasticsearch/common/inject/util/Modules.java
+++ b/server/src/main/java/org/elasticsearch/common/inject/util/Modules.java
@@ -184,7 +184,7 @@ public final class Modules {
                     new ModuleWriter(binder()) {
                         @Override
                         public <T> Void visit(Binding<T> binding) {
-                            if (!overriddenKeys.remove(binding.getKey())) {
+                            if (overriddenKeys.remove(binding.getKey()) == false) {
                                 super.visit(binding);
 
                                 // Record when a scope instance is used in a binding
@@ -237,7 +237,7 @@ public final class Modules {
                     new ModuleWriter(binder()) {
                         @Override
                         public Void visit(ScopeBinding scopeBinding) {
-                            if (!overridesScopeAnnotations.remove(scopeBinding.getAnnotationType())) {
+                            if (overridesScopeAnnotations.remove(scopeBinding.getAnnotationType()) == false) {
                                 super.visit(scopeBinding);
                             } else {
                                 Object source = scopeInstancesInUse.get(scopeBinding.getScope());

--- a/server/src/main/java/org/elasticsearch/common/io/stream/ByteBufferStreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/ByteBufferStreamInput.java
@@ -33,7 +33,7 @@ public class ByteBufferStreamInput extends StreamInput {
 
     @Override
     public int read() throws IOException {
-        if (!buffer.hasRemaining()) {
+        if (buffer.hasRemaining() == false) {
             return -1;
         }
         return buffer.get() & 0xFF;
@@ -41,7 +41,7 @@ public class ByteBufferStreamInput extends StreamInput {
 
     @Override
     public byte readByte() throws IOException {
-        if (!buffer.hasRemaining()) {
+        if (buffer.hasRemaining() == false) {
             throw new EOFException();
         }
         return buffer.get();
@@ -49,7 +49,7 @@ public class ByteBufferStreamInput extends StreamInput {
 
     @Override
     public int read(byte[] b, int off, int len) throws IOException {
-        if (!buffer.hasRemaining()) {
+        if (buffer.hasRemaining() == false) {
             return -1;
         }
 

--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -389,7 +389,7 @@ public abstract class StreamOutput extends OutputStream {
     private final BytesRefBuilder spare = new BytesRefBuilder();
 
     public void writeText(Text text) throws IOException {
-        if (!text.hasBytes()) {
+        if (text.hasBytes() == false) {
             final String string = text.string();
             spare.copyChars(string);
             writeInt(spare.length());

--- a/server/src/main/java/org/elasticsearch/common/lucene/search/MoreLikeThisQuery.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/search/MoreLikeThisQuery.java
@@ -101,7 +101,7 @@ public class MoreLikeThisQuery extends Query {
             return false;
         if (boostTermsFactor != other.boostTermsFactor)
             return false;
-        if (!(Arrays.equals(likeText, other.likeText)))
+        if ((Arrays.equals(likeText, other.likeText)) == false)
             return false;
         if (maxDocFreq != other.maxDocFreq)
             return false;
@@ -115,19 +115,19 @@ public class MoreLikeThisQuery extends Query {
             return false;
         if (minWordLen != other.minWordLen)
             return false;
-        if (!Arrays.equals(moreLikeFields, other.moreLikeFields))
+        if (Arrays.equals(moreLikeFields, other.moreLikeFields) == false)
             return false;
-        if (!minimumShouldMatch.equals(other.minimumShouldMatch))
+        if (minimumShouldMatch.equals(other.minimumShouldMatch) == false)
             return false;
         if (similarity == null) {
             if (other.similarity != null)
                 return false;
-        } else if (!similarity.equals(other.similarity))
+        } else if (similarity.equals(other.similarity) == false)
             return false;
         if (stopWords == null) {
             if (other.stopWords != null)
                 return false;
-        } else if (!stopWords.equals(other.stopWords))
+        } else if (stopWords.equals(other.stopWords) == false)
             return false;
         return true;
     }
@@ -209,7 +209,7 @@ public class MoreLikeThisQuery extends Query {
                 }
             }
         }
-        if (!skipTerms.isEmpty()) {
+        if (skipTerms.isEmpty() == false) {
             mlt.setSkipTerms(skipTerms);
         }
     }

--- a/server/src/main/java/org/elasticsearch/common/lucene/search/MultiPhrasePrefixQuery.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/search/MultiPhrasePrefixQuery.java
@@ -199,7 +199,7 @@ public class MultiPhrasePrefixQuery extends Query {
             }
 
             for (BytesRef term = termsEnum.term(); term != null; term = termsEnum.next()) {
-                if (!StringHelper.startsWith(term, prefix.bytes())) {
+                if (StringHelper.startsWith(term, prefix.bytes()) == false) {
                     break;
                 }
 
@@ -304,8 +304,7 @@ public class MultiPhrasePrefixQuery extends Query {
         while (iterator1.hasNext()) {
             Term[] termArray1 = iterator1.next();
             Term[] termArray2 = iterator2.next();
-            if (!(termArray1 == null ? termArray2 == null : Arrays.equals(termArray1,
-                    termArray2))) {
+            if ((termArray1 == null ? termArray2 == null : Arrays.equals(termArray1, termArray2)) == false) {
                 return false;
             }
         }

--- a/server/src/main/java/org/elasticsearch/common/lucene/search/Queries.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/search/Queries.java
@@ -91,7 +91,7 @@ public class Queries {
     }
 
     static boolean isNegativeQuery(Query q) {
-        if (!(q instanceof BooleanQuery)) {
+        if ((q instanceof BooleanQuery) == false) {
             return false;
         }
         List<BooleanClause> clauses = ((BooleanQuery) q).clauses();

--- a/server/src/main/java/org/elasticsearch/common/lucene/search/function/FunctionScoreQuery.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/search/function/FunctionScoreQuery.java
@@ -299,7 +299,7 @@ public class FunctionScoreQuery extends Query {
         public Explanation explain(LeafReaderContext context, int doc) throws IOException {
 
             Explanation expl = subQueryWeight.explain(context, doc);
-            if (!expl.isMatch()) {
+            if (expl.isMatch() == false) {
                 return expl;
             }
             boolean singleFunction = functions.length == 1 && functions[0] instanceof FilterScoreFunction == false;

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/BaseFuture.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/BaseFuture.java
@@ -107,7 +107,7 @@ public abstract class BaseFuture<V> implements Future<V> {
 
     @Override
     public boolean cancel(boolean mayInterruptIfRunning) {
-        if (!sync.cancel()) {
+        if (sync.cancel() == false) {
             return false;
         }
         done(false);
@@ -239,7 +239,7 @@ public abstract class BaseFuture<V> implements Future<V> {
                 ExecutionException, InterruptedException {
 
             // Attempt to acquire the shared lock with a timeout.
-            if (!tryAcquireSharedNanos(-1, nanos)) {
+            if (tryAcquireSharedNanos(-1, nanos) == false) {
                 throw new TimeoutException("Timeout waiting for task.");
             }
 

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/EsAbortPolicy.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/EsAbortPolicy.java
@@ -32,7 +32,7 @@ public class EsAbortPolicy implements XRejectedExecutionHandler {
         if (r instanceof AbstractRunnable) {
             if (((AbstractRunnable) r).isForceExecution()) {
                 BlockingQueue<Runnable> queue = executor.getQueue();
-                if (!(queue instanceof SizeBlockingQueue)) {
+                if ((queue instanceof SizeBlockingQueue) == false) {
                     throw new IllegalStateException("forced execution, but expected a size queue");
                 }
                 try {

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
@@ -257,7 +257,7 @@ public class EsExecutors {
         @Override
         public boolean offer(E e) {
             // first try to transfer to a waiting worker thread
-            if (!tryTransfer(e)) {
+            if (tryTransfer(e) == false) {
                 // check if there might be spare capacity in the thread
                 // pool executor
                 int left = executor.getMaximumPoolSize() - executor.getCorePoolSize();

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/PrioritizedEsThreadPoolExecutor.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/PrioritizedEsThreadPoolExecutor.java
@@ -160,7 +160,7 @@ public class PrioritizedEsThreadPoolExecutor extends EsThreadPoolExecutor {
 
     @Override
     protected <T> RunnableFuture<T> newTaskFor(Runnable runnable, T value) {
-        if (!(runnable instanceof PrioritizedRunnable)) {
+        if ((runnable instanceof PrioritizedRunnable) == false) {
             runnable = PrioritizedRunnable.wrap(runnable, Priority.NORMAL);
         }
         Priority priority = ((PrioritizedRunnable) runnable).priority();
@@ -169,7 +169,7 @@ public class PrioritizedEsThreadPoolExecutor extends EsThreadPoolExecutor {
 
     @Override
     protected <T> RunnableFuture<T> newTaskFor(Callable<T> callable) {
-        if (!(callable instanceof PrioritizedCallable)) {
+        if ((callable instanceof PrioritizedCallable) == false) {
             callable = PrioritizedCallable.wrap(callable, Priority.NORMAL);
         }
         return new PrioritizedFutureTask<>((PrioritizedCallable)callable, insertionOrder.incrementAndGet());

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/SizeBlockingQueue.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/SizeBlockingQueue.java
@@ -140,7 +140,7 @@ public class SizeBlockingQueue<E> extends AbstractQueue<E> implements BlockingQu
             }
         }
         boolean offered = queue.offer(e);
-        if (!offered) {
+        if (offered == false) {
             size.decrementAndGet();
         }
         return offered;

--- a/server/src/main/java/org/elasticsearch/common/util/iterable/Iterables.java
+++ b/server/src/main/java/org/elasticsearch/common/util/iterable/Iterables.java
@@ -92,12 +92,12 @@ public class Iterables {
         } else {
             Iterator<T> it = iterable.iterator();
             for (int index = 0; index < position; index++) {
-                if (!it.hasNext()) {
+                if (it.hasNext() == false) {
                     throw new IndexOutOfBoundsException(Integer.toString(position));
                 }
                 it.next();
             }
-            if (!it.hasNext()) {
+            if (it.hasNext() == false) {
                 throw new IndexOutOfBoundsException(Integer.toString(position));
             }
             return it.next();

--- a/server/src/main/java/org/elasticsearch/index/cache/bitset/BitsetFilterCache.java
+++ b/server/src/main/java/org/elasticsearch/index/cache/bitset/BitsetFilterCache.java
@@ -205,7 +205,7 @@ public final class BitsetFilterCache extends AbstractIndexComponent
 
         @Override
         public boolean equals(Object o) {
-            if (!(o instanceof QueryWrapperBitSetProducer)) return false;
+            if ((o instanceof QueryWrapperBitSetProducer) == false) return false;
             return this.query.equals(((QueryWrapperBitSetProducer) o).query);
         }
 
@@ -230,7 +230,7 @@ public final class BitsetFilterCache extends AbstractIndexComponent
                 return TerminationHandle.NO_WAIT;
             }
 
-            if (!loadRandomAccessFiltersEagerly) {
+            if (loadRandomAccessFiltersEagerly == false) {
                 return TerminationHandle.NO_WAIT;
             }
 

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/PagedBytesIndexFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/PagedBytesIndexFieldData.java
@@ -154,7 +154,7 @@ public class PagedBytesIndexFieldData extends AbstractIndexOrdinalsFieldData {
             success = true;
             return data;
         } finally {
-            if (!success) {
+            if (success == false) {
                 // If something went wrong, unwind any current estimations we've made
                 estimator.afterLoad(termsEnum, 0);
             } else {

--- a/server/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionBuilder.java
@@ -250,7 +250,7 @@ public abstract class DecayFunctionBuilder<DFB extends DecayFunctionBuilder<DFB>
                 throw new ElasticsearchParseException("parameter [{}] not supported!", parameterName);
             }
         }
-        if (!scaleFound || !refFound) {
+        if (scaleFound == false || refFound == false) {
             throw new ElasticsearchParseException("both [{}] and [{}] must be set for numeric fields.", DecayFunctionBuilder.SCALE,
                     DecayFunctionBuilder.ORIGIN);
         }

--- a/server/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshot.java
+++ b/server/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshot.java
@@ -216,11 +216,11 @@ public class BlobStoreIndexShardSnapshot implements ToXContentFragment {
             if (partBytes != fileInfo.partBytes) {
                 return false;
             }
-            if (!name.equals(fileInfo.name)) {
+            if (name.equals(fileInfo.name) == false) {
                 return false;
             }
             if (partSize != null) {
-                if (!partSize.equals(fileInfo.partSize)) {
+                if (partSize.equals(fileInfo.partSize) == false) {
                     return false;
                 }
             } else {

--- a/server/src/main/java/org/elasticsearch/indices/fielddata/cache/IndicesFieldDataCache.java
+++ b/server/src/main/java/org/elasticsearch/indices/fielddata/cache/IndicesFieldDataCache.java
@@ -232,8 +232,8 @@ public class IndicesFieldDataCache implements RemovalListener<IndicesFieldDataCa
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             Key key = (Key) o;
-            if (!indexCache.equals(key.indexCache)) return false;
-            if (!readerKey.equals(key.readerKey)) return false;
+            if (indexCache.equals(key.indexCache) == false) return false;
+            if (readerKey.equals(key.readerKey) == false) return false;
             return true;
         }
 

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterStateAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterStateAction.java
@@ -97,7 +97,7 @@ public class RestClusterStateAction extends BaseRestHandler {
 
         final String[] indices = Strings.splitStringByCommaToArray(request.param("indices", "_all"));
         boolean isAllIndicesOnly = indices.length == 1 && "_all".equals(indices[0]);
-        if (!isAllIndicesOnly) {
+        if (isAllIndicesOnly == false) {
             clusterStateRequest.indices(indices);
         }
 

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestNodesStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestNodesStatsAction.java
@@ -118,7 +118,7 @@ public class RestNodesStatsAction extends BaseRestHandler {
                 }
             }
 
-            if (!invalidMetrics.isEmpty()) {
+            if (invalidMetrics.isEmpty() == false) {
                 throw new IllegalArgumentException(unrecognized(request, invalidMetrics, METRICS.keySet(), "metric"));
             }
 
@@ -141,7 +141,7 @@ public class RestNodesStatsAction extends BaseRestHandler {
                         }
                     }
 
-                    if (!invalidIndexMetrics.isEmpty()) {
+                    if (invalidIndexMetrics.isEmpty() == false) {
                         throw new IllegalArgumentException(unrecognized(request, invalidIndexMetrics, FLAGS.keySet(), "index metric"));
                     }
 

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestIndicesStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestIndicesStatsAction.java
@@ -106,7 +106,7 @@ public class RestIndicesStatsAction extends BaseRestHandler {
                 }
             }
 
-            if (!invalidMetrics.isEmpty()) {
+            if (invalidMetrics.isEmpty() == false) {
                 throw new IllegalArgumentException(unrecognized(request, invalidMetrics, METRICS.keySet(), "metric"));
             }
         }

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestTable.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestTable.java
@@ -101,7 +101,7 @@ public class RestTable {
                 DisplayHeader header = headers.get(col);
                 boolean isLastColumn = col == lastHeader;
                 pad(new Table.Cell(header.display, table.findHeaderByName(header.name)), width[col], request, out, isLastColumn);
-                if (!isLastColumn) {
+                if (isLastColumn == false) {
                     out.append(" ");
                 }
             }
@@ -115,7 +115,7 @@ public class RestTable {
                 DisplayHeader header = headers.get(col);
                 boolean isLastColumn = col == lastHeader;
                 pad(table.getAsMap().get(header.name).get(row), width[col], request, out, isLastColumn);
-                if (!isLastColumn) {
+                if (isLastColumn == false) {
                     out.append(" ");
                 }
             }
@@ -334,7 +334,7 @@ public class RestTable {
                 out.append(sValue);
             }
             // Ignores the leftover spaces if the cell is the last of the column.
-            if (!isLast) {
+            if (isLast == false) {
                 for (byte i = 0; i < leftOver; i++) {
                     out.append(" ");
                 }

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestThreadPoolAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestThreadPoolAction.java
@@ -193,7 +193,9 @@ public class RestThreadPoolAction extends AbstractCatAction {
             }
             for (Map.Entry<String, ThreadPoolStats.Stats> entry : poolThreadStats.entrySet()) {
 
-                if (!included.contains(entry.getKey())) continue;
+                if (included.contains(entry.getKey()) == false) {
+                    continue;
+                }
 
                 table.startRow();
 

--- a/server/src/main/java/org/elasticsearch/rest/action/document/RestTermVectorsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/document/RestTermVectorsAction.java
@@ -97,7 +97,7 @@ public class RestTermVectorsAction extends BaseRestHandler {
                 if (selectedFields == null) {
                     selectedFields = new HashSet<>();
                 }
-                if (!selectedFields.contains(field)) {
+                if (selectedFields.contains(field) == false) {
                     field = field.replaceAll("\\s", "");
                     selectedFields.add(field);
                 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/AutoDateHistogramAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/AutoDateHistogramAggregationBuilder.java
@@ -265,7 +265,7 @@ public class AutoDateHistogramAggregationBuilder extends ValuesSourceAggregation
             this.unitAbbreviation = unitAbbreviation;
             this.innerIntervals = innerIntervals;
             Objects.requireNonNull(dateTimeUnit, "dateTimeUnit cannot be null");
-            if (!ALLOWED_INTERVALS.containsKey(dateTimeUnit)) {
+            if (ALLOWED_INTERVALS.containsKey(dateTimeUnit) == false) {
                 throw new IllegalArgumentException("dateTimeUnit must be one of " + ALLOWED_INTERVALS.keySet().toString());
             }
             this.dateTimeUnit = ALLOWED_INTERVALS.get(dateTimeUnit);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalRange.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalRange.java
@@ -128,13 +128,13 @@ public class InternalRange<B extends InternalRange.Bucket, R extends InternalRan
                 builder.startObject();
                 builder.field(CommonFields.KEY.getPreferredName(), key);
             }
-            if (!Double.isInfinite(from)) {
+            if (Double.isInfinite(from) == false) {
                 builder.field(CommonFields.FROM.getPreferredName(), from);
                 if (format != DocValueFormat.RAW) {
                     builder.field(CommonFields.FROM_AS_STRING.getPreferredName(), format.format(from));
                 }
             }
-            if (!Double.isInfinite(to)) {
+            if (Double.isInfinite(to) == false) {
                 builder.field(CommonFields.TO.getPreferredName(), to);
                 if (format != DocValueFormat.RAW) {
                     builder.field(CommonFields.TO_AS_STRING.getPreferredName(), format.format(to));

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/IncludeExclude.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/IncludeExclude.java
@@ -561,7 +561,7 @@ public class IncludeExclude implements Writeable, ToXContentFragment {
             throw new ElasticsearchParseException("Missing start of array in include/exclude clause");
         }
         while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
-            if (!parser.currentToken().isValue()) {
+            if (parser.currentToken().isValue() == false) {
                 throw new ElasticsearchParseException("Array elements in include/exclude clauses should be string values");
             }
             set.add(new BytesRef(parser.text()));

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalTerms.java
@@ -102,7 +102,7 @@ public abstract class InternalTerms<A extends InternalTerms<A, B>, B extends Int
 
         @Override
         public long getDocCountError() {
-            if (!showDocCountError) {
+            if (showDocCountError == false) {
                 throw new IllegalStateException("show_terms_doc_count_error is false");
             }
             return docCountError;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/heuristic/ChiSquare.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/heuristic/ChiSquare.java
@@ -48,7 +48,7 @@ public class ChiSquare extends NXYSignificanceHeuristic {
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof ChiSquare)) {
+        if ((other instanceof ChiSquare) == false) {
             return false;
         }
         return super.equals(other);
@@ -70,7 +70,7 @@ public class ChiSquare extends NXYSignificanceHeuristic {
         Frequencies frequencies = computeNxys(subsetFreq, subsetSize, supersetFreq, supersetSize, "ChiSquare");
 
         // here we check if the term appears more often in subset than in background without subset.
-        if (!includeNegatives && frequencies.N11 / frequencies.N_1 < frequencies.N10 / frequencies.N_0) {
+        if (includeNegatives == false && frequencies.N11 / frequencies.N_1 < frequencies.N10 / frequencies.N_0) {
             return Double.NEGATIVE_INFINITY;
         }
         return (frequencies.N * Math.pow((frequencies.N11 * frequencies.N00 - frequencies.N01 * frequencies.N10), 2.0) /

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/heuristic/GND.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/heuristic/GND.java
@@ -58,7 +58,7 @@ public class GND extends NXYSignificanceHeuristic {
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof GND)) {
+        if ((other instanceof GND) == false) {
             return false;
         }
         return super.equals(other);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/heuristic/MutualInformation.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/heuristic/MutualInformation.java
@@ -51,7 +51,7 @@ public class MutualInformation extends NXYSignificanceHeuristic {
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof MutualInformation)) {
+        if ((other instanceof MutualInformation) == false) {
             return false;
         }
         return super.equals(other);
@@ -82,7 +82,7 @@ public class MutualInformation extends NXYSignificanceHeuristic {
             score = Double.NEGATIVE_INFINITY;
         }
         // here we check if the term appears more often in subset than in background without subset.
-        if (!includeNegatives && frequencies.N11 / frequencies.N_1 < frequencies.N10 / frequencies.N_0) {
+        if (includeNegatives == false && frequencies.N11 / frequencies.N_1 < frequencies.N10 / frequencies.N_0) {
             score = Double.NEGATIVE_INFINITY;
         }
         return score;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/heuristic/PercentageScore.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/heuristic/PercentageScore.java
@@ -60,7 +60,7 @@ public class PercentageScore extends SignificanceHeuristic {
     public static SignificanceHeuristic parse(XContentParser parser)
             throws IOException, QueryShardException {
         // move to the closing bracket
-        if (!parser.nextToken().equals(XContentParser.Token.END_OBJECT)) {
+        if (parser.nextToken().equals(XContentParser.Token.END_OBJECT) == false) {
             throw new ElasticsearchParseException("failed to parse [percentage] significance heuristic. expected an empty object, " +
                     "but got [{}] instead", parser.currentToken());
         }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregationBuilder.java
@@ -819,7 +819,7 @@ public class TopHitsAggregationBuilder extends AbstractAggregationBuilder<TopHit
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        if (!super.equals(o)) return false;
+        if (super.equals(o) == false) return false;
         TopHitsAggregationBuilder that = (TopHitsAggregationBuilder) o;
         return from == that.from &&
             size == that.size &&

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/AbstractPipelineAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/AbstractPipelineAggregationBuilder.java
@@ -102,7 +102,7 @@ public abstract class AbstractPipelineAggregationBuilder<PAB extends AbstractPip
         }
         builder.startObject(type);
 
-        if (!overrideBucketsPath() && bucketsPaths != null) {
+        if (overrideBucketsPath() == false && bucketsPaths != null) {
             builder.startArray(PipelineAggregator.Parser.BUCKETS_PATH.getPreferredName());
             for (String path : bucketsPaths) {
                 builder.value(path);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/SerialDiffPipelineAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/SerialDiffPipelineAggregator.java
@@ -83,7 +83,7 @@ public class SerialDiffPipelineAggregator extends PipelineAggregator {
             }
 
             // Both have values, calculate diff and replace the "empty" bucket
-            if (!Double.isNaN(thisBucketValue) && !Double.isNaN(lagValue)) {
+            if (Double.isNaN(thisBucketValue) == false && Double.isNaN(lagValue) == false) {
                 double diff = thisBucketValue - lagValue;
 
                 List<InternalAggregation> aggs = StreamSupport.stream(bucket.getAggregations().spliterator(), false).map(

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/AggregationPath.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/AggregationPath.java
@@ -133,7 +133,7 @@ public class AggregationPath {
             PathElement token = (PathElement) o;
 
             if (key != null ? !key.equals(token.key) : token.key != null) return false;
-            if (!name.equals(token.name)) return false;
+            if (name.equals(token.name) == false) return false;
 
             return true;
         }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/CoreValuesSourceType.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/CoreValuesSourceType.java
@@ -161,7 +161,7 @@ public enum CoreValuesSourceType implements ValuesSourceType {
 
         @Override
         public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script, AggregationContext context) {
-            if (!(fieldContext.indexFieldData() instanceof IndexGeoPointFieldData)) {
+            if ((fieldContext.indexFieldData() instanceof IndexGeoPointFieldData) == false) {
                 throw new IllegalArgumentException("Expected geo_point type on field [" + fieldContext.field() +
                     "], but got [" + fieldContext.fieldType().typeName() + "]");
             }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceConfig.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceConfig.java
@@ -228,7 +228,7 @@ public class ValuesSourceConfig {
      */
     public static ValuesSourceConfig resolveFieldOnly(MappedFieldType fieldType, AggregationContext context) {
         FieldContext fieldContext = context.buildFieldContext(fieldType);
-        ValuesSourceType vstype = fieldContext.indexFieldData().getValuesSourceType(); 
+        ValuesSourceType vstype = fieldContext.indexFieldData().getValuesSourceType();
         return new ValuesSourceConfig(vstype, fieldContext, false, null, null, null, null, null, context);
     }
 
@@ -276,7 +276,7 @@ public class ValuesSourceConfig {
         this.timeZone = timeZone;
         this.format = format == null ? DocValueFormat.RAW : format;
 
-        if (!valid()) {
+        if (valid() == false) {
             // TODO: resolve no longer generates invalid configs.  Once VSConfig is immutable, we can drop this check
             throw new IllegalStateException(
                 "value source config is invalid; must have either a field context or a script or marked as unwrapped");

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchSourceContext.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchSourceContext.java
@@ -210,8 +210,8 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
         FetchSourceContext that = (FetchSourceContext) o;
 
         if (fetchSource != that.fetchSource) return false;
-        if (!Arrays.equals(excludes, that.excludes)) return false;
-        if (!Arrays.equals(includes, that.includes)) return false;
+        if (Arrays.equals(excludes, that.excludes) == false) return false;
+        if (Arrays.equals(includes, that.includes) == false) return false;
 
         return true;
     }

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/FastVectorHighlighter.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/FastVectorHighlighter.java
@@ -84,7 +84,7 @@ public class FastVectorHighlighter implements Highlighter {
         Encoder encoder = field.fieldOptions().encoder().equals("html") ?
             HighlightUtils.Encoders.HTML : HighlightUtils.Encoders.DEFAULT;
 
-        if (!fieldContext.cache.containsKey(CACHE_KEY)) {
+        if (fieldContext.cache.containsKey(CACHE_KEY) == false) {
             fieldContext.cache.put(CACHE_KEY, new HighlighterEntry());
         }
         HighlighterEntry cache = (HighlighterEntry) fieldContext.cache.get(CACHE_KEY);
@@ -185,7 +185,7 @@ public class FastVectorHighlighter implements Highlighter {
         BoundaryScanner boundaryScanner = getBoundaryScanner(field);
         FieldOptions options = field.fieldOptions();
         Function<SourceLookup, BaseFragmentsBuilder> supplier;
-        if (!forceSource && fieldType.isStored()) {
+        if (forceSource == false && fieldType.isStored()) {
             if (options.numberOfFragments() != 0 && options.scoreOrdered()) {
                 supplier = ignored -> new ScoreOrderFragmentsBuilder(options.preTags(), options.postTags(), boundaryScanner);
             } else {

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/FragmentBuilderHelper.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/FragmentBuilderHelper.java
@@ -46,7 +46,7 @@ public final class FragmentBuilderHelper {
      */
     public static WeightedFragInfo fixWeightedFragInfo(WeightedFragInfo fragInfo) {
         assert fragInfo != null : "FragInfo must not be null";
-        if (!fragInfo.getSubInfos().isEmpty()) {
+        if (fragInfo.getSubInfos().isEmpty() == false) {
             /* This is a special case where broken analysis like WDF is used for term-vector creation at index-time
              * which can potentially mess up the offsets. To prevent a SAIIOBException we need to resort
              * the fragments based on their offsets rather than using solely the positions as it is done in

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/PlainHighlighter.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/PlainHighlighter.java
@@ -61,7 +61,7 @@ public class PlainHighlighter implements Highlighter {
 
         Encoder encoder = field.fieldOptions().encoder().equals("html") ? HighlightUtils.Encoders.HTML : HighlightUtils.Encoders.DEFAULT;
 
-        if (!fieldContext.cache.containsKey(CACHE_KEY)) {
+        if (fieldContext.cache.containsKey(CACHE_KEY) == false) {
             fieldContext.cache.put(CACHE_KEY, new HashMap<>());
         }
         @SuppressWarnings("unchecked")
@@ -120,7 +120,8 @@ public class PlainHighlighter implements Highlighter {
             }
 
             try (TokenStream tokenStream = analyzer.tokenStream(fieldType.name(), text)) {
-                if (!tokenStream.hasAttribute(CharTermAttribute.class) || !tokenStream.hasAttribute(OffsetAttribute.class)) {
+                if (tokenStream.hasAttribute(CharTermAttribute.class) == false
+                        || tokenStream.hasAttribute(OffsetAttribute.class) == false) {
                     // can't perform highlighting if the stream has no terms (binary token stream) or no offsets
                     continue;
                 }
@@ -183,7 +184,7 @@ public class PlainHighlighter implements Highlighter {
     private static int findGoodEndForNoHighlightExcerpt(int noMatchSize, Analyzer analyzer, String fieldName, String contents)
             throws IOException {
         try (TokenStream tokenStream = analyzer.tokenStream(fieldName, contents)) {
-            if (!tokenStream.hasAttribute(OffsetAttribute.class)) {
+            if (tokenStream.hasAttribute(OffsetAttribute.class) == false) {
                 // Can't split on term boundaries without offsets
                 return -1;
             }

--- a/server/src/main/java/org/elasticsearch/search/profile/query/CollectorResult.java
+++ b/server/src/main/java/org/elasticsearch/search/profile/query/CollectorResult.java
@@ -149,7 +149,7 @@ public class CollectorResult implements ToXContentObject, Writeable {
         }
         builder.field(TIME_NANOS.getPreferredName(), getTime());
 
-        if (!children.isEmpty()) {
+        if (children.isEmpty() == false) {
             builder = builder.startArray(CHILDREN.getPreferredName());
             for (CollectorResult child : children) {
                 builder = child.toXContent(builder, params);

--- a/server/src/main/java/org/elasticsearch/search/suggest/completion/context/CategoryContextMapping.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/completion/context/CategoryContextMapping.java
@@ -192,7 +192,7 @@ public class CategoryContextMapping extends ContextMapping<CategoryQueryContext>
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        if (!super.equals(o)) return false;
+        if (super.equals(o) == false) return false;
         CategoryContextMapping mapping = (CategoryContextMapping) o;
         return !(fieldName != null ? !fieldName.equals(mapping.fieldName) : mapping.fieldName != null);
     }

--- a/server/src/main/java/org/elasticsearch/search/suggest/completion/context/GeoContextMapping.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/completion/context/GeoContextMapping.java
@@ -314,7 +314,7 @@ public class GeoContextMapping extends ContextMapping<GeoQueryContext> {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        if (!super.equals(o)) return false;
+        if (super.equals(o) == false) return false;
         GeoContextMapping that = (GeoContextMapping) o;
         if (precision != that.precision) return false;
         return !(fieldName != null ? !fieldName.equals(that.fieldName) : that.fieldName != null);

--- a/server/src/main/java/org/elasticsearch/search/suggest/phrase/DirectCandidateGenerator.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/phrase/DirectCandidateGenerator.java
@@ -317,7 +317,7 @@ public final class DirectCandidateGenerator extends CandidateGenerator {
             if (term == null) {
                 if (other.term != null) return false;
             } else {
-                if (!term.equals(other.term)) return false;
+                if (term.equals(other.term) == false) return false;
             }
             return true;
         }

--- a/server/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggester.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggester.java
@@ -126,7 +126,7 @@ public final class PhraseSuggester extends Suggester<PhraseSuggestionContext> {
                         collateMatch = Lucene.exists(searcher, parsedQuery.query());
                     }
                 }
-                if (!collateMatch && !collatePrune) {
+                if (collateMatch == false && collatePrune == false) {
                     continue;
                 }
                 Text phrase = new Text(spare.toString());

--- a/server/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestion.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestion.java
@@ -98,7 +98,7 @@ public class PhraseSuggestion extends Suggest.Suggestion<PhraseSuggestion.Entry>
             // objects being merged with PhraseSuggestion.Entry objects.  We merge Suggestion.Entry objects
             // by assuming they had a low cutoff score rather than a high one as that is the more common scenario
             // and the simplest one for us to implement.
-            if (!(other instanceof PhraseSuggestion.Entry)) {
+            if ((other instanceof PhraseSuggestion.Entry) == false) {
                 return;
             }
             PhraseSuggestion.Entry otherSuggestionEntry = (PhraseSuggestion.Entry) other;

--- a/server/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilder.java
@@ -458,7 +458,7 @@ public class PhraseSuggestionBuilder extends SuggestionBuilder<PhraseSuggestionB
         }
         builder.field(FORCE_UNIGRAM_FIELD.getPreferredName(), forceUnigrams);
         builder.field(TOKEN_LIMIT_FIELD.getPreferredName(), tokenLimit);
-        if (!generators.isEmpty()) {
+        if (generators.isEmpty() == false) {
             Set<Entry<String, List<CandidateGenerator>>> entrySet = generators.entrySet();
             for (Entry<String, List<CandidateGenerator>> entry : entrySet) {
                 builder.startArray(entry.getKey());

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/validate/query/QueryExplanationTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/validate/query/QueryExplanationTests.java
@@ -32,7 +32,7 @@ public class QueryExplanationTests extends AbstractSerializingTestCase<QueryExpl
         int shard = randomInt(100);
         Boolean valid = isValid;
         String errorField = null;
-        if (!valid) {
+        if (valid == false) {
             errorField = randomAlphaOfLength(randomIntBetween(10, 100));
         }
         String explanation = randomAlphaOfLength(randomIntBetween(10, 100));

--- a/server/src/test/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeActionTests.java
@@ -343,7 +343,7 @@ public class TransportBroadcastByNodeActionTests extends ESTestCase {
         ShardsIterator shardIt = clusterService.state().routingTable().allShards(new String[]{TEST_INDEX});
         Set<String> set = new HashSet<>();
         for (ShardRouting shard : shardIt) {
-            if (!shard.currentNodeId().equals(masterNode.getId())) {
+            if (shard.currentNodeId().equals(masterNode.getId()) == false) {
                 set.add(shard.currentNodeId());
             }
         }
@@ -389,7 +389,7 @@ public class TransportBroadcastByNodeActionTests extends ESTestCase {
         int successfulShards = 0;
         int failedShards = 0;
         for (Object result : action.getResults().values()) {
-            if (!(result instanceof ElasticsearchException)) {
+            if ((result instanceof ElasticsearchException) == false) {
                 successfulShards++;
             } else {
                 failedShards++;
@@ -429,7 +429,7 @@ public class TransportBroadcastByNodeActionTests extends ESTestCase {
         ShardsIterator shardIt = clusterService.state().getRoutingTable().allShards(new String[]{TEST_INDEX});
         Map<String, List<ShardRouting>> map = new HashMap<>();
         for (ShardRouting shard : shardIt) {
-            if (!map.containsKey(shard.currentNodeId())) {
+            if (map.containsKey(shard.currentNodeId()) == false) {
                 map.put(shard.currentNodeId(), new ArrayList<>());
             }
             map.get(shard.currentNodeId()).add(shard);


### PR DESCRIPTION
Part 4.

We have an in-house rule to compare explicitly against `false` instead
of using the logical not operator (`!`). However, this hasn't
historically been enforced, meaning that there are many violations in
the source at present.

We now have a Checkstyle rule that can detect these cases, but before we
can turn it on, we need to fix the existing violations. This is being
done over a series of PRs, since there are a lot to fix.