### PR TITLE
Drop rawtypes suppression from test framework (backport of #68247)

### DIFF
--- a/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/RestMultiSearchTemplateActionTests.java
+++ b/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/RestMultiSearchTemplateActionTests.java
@@ -46,7 +46,7 @@ public class RestMultiSearchTemplateActionTests extends RestActionTestCase {
             .withContent(bytesContent, XContentType.JSON)
             .build();
         // We're not actually testing anything to do with the client, but need to set this so it doesn't fail the test for being unset.
-        verifyingClient.setExecuteVerifier((arg1, arg2) -> null);
+        verifyingClient.setExecuteVerifier((arg1, arg2) -> {});
 
         dispatchRequest(request);
         assertWarnings(RestMultiSearchTemplateAction.TYPES_DEPRECATION_MESSAGE);
@@ -62,7 +62,7 @@ public class RestMultiSearchTemplateActionTests extends RestActionTestCase {
             .withContent(bytesContent, XContentType.JSON)
             .build();
         // We're not actually testing anything to do with the client, but need to set this so it doesn't fail the test for being unset.
-        verifyingClient.setExecuteVerifier((arg1, arg2) -> null);
+        verifyingClient.setExecuteVerifier((arg1, arg2) -> {});
 
         dispatchRequest(request);
         assertWarnings(RestMultiSearchTemplateAction.TYPES_DEPRECATION_MESSAGE);

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/forcemerge/RestForceMergeActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/forcemerge/RestForceMergeActionTests.java
@@ -86,7 +86,7 @@ public class RestForceMergeActionTests extends RestActionTestCase {
             .build();
 
         // We're not actually testing anything to do with the client, but need to set this so it doesn't fail the test for being unset.
-        verifyingClient.setExecuteVerifier((arg1, arg2) -> null);
+        verifyingClient.setExecuteVerifier((arg1, arg2) -> {});
 
         dispatchRequest(request);
         assertWarnings("setting only_expunge_deletes and max_num_segments at the same time is deprecated " +

--- a/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestGetFieldMappingActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestGetFieldMappingActionTests.java
@@ -52,7 +52,7 @@ public class RestGetFieldMappingActionTests extends RestActionTestCase {
         }
 
         // We're not actually testing anything to do with the client, but need to set this so it doesn't fail the test for being unset.
-        verifyingClient.setExecuteVerifier((arg1, arg2) -> null);
+        verifyingClient.setExecuteVerifier((arg1, arg2) -> {});
 
         RestRequest deprecatedRequest = new FakeRestRequest.Builder(xContentRegistry())
             .withMethod(RestRequest.Method.GET)
@@ -81,7 +81,7 @@ public class RestGetFieldMappingActionTests extends RestActionTestCase {
             .build();
 
         // We're not actually testing anything to do with the client, but need to set this so it doesn't fail the test for being unset.
-        verifyingClient.setExecuteVerifier((arg1, arg2) -> null);
+        verifyingClient.setExecuteVerifier((arg1, arg2) -> {});
 
         FakeRestChannel channel = new FakeRestChannel(request, false, 1);
         ThreadContext threadContext = new ThreadContext(Settings.EMPTY);

--- a/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestGetMappingActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestGetMappingActionTests.java
@@ -79,7 +79,7 @@ public class RestGetMappingActionTests extends RestActionTestCase {
             .build();
 
         // We're not actually testing anything to do with the client, but need to set this so it doesn't fail the test for being unset.
-        verifyingClient.setExecuteVerifier((arg1, arg2) -> null);
+        verifyingClient.setExecuteVerifier((arg1, arg2) -> {});
 
         FakeRestChannel channel = new FakeRestChannel(request, false, 1);
         ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
@@ -102,7 +102,7 @@ public class RestGetMappingActionTests extends RestActionTestCase {
             .build();
 
         // We're not actually testing anything to do with the client, but need to set this so it doesn't fail the test for being unset.
-        verifyingClient.setExecuteVerifier((arg1, arg2) -> null);
+        verifyingClient.setExecuteVerifier((arg1, arg2) -> {});
 
         FakeRestChannel channel = new FakeRestChannel(request, false, 1);
         ThreadContext threadContext = new ThreadContext(Settings.EMPTY);

--- a/server/src/test/java/org/elasticsearch/rest/action/document/RestDeleteActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/document/RestDeleteActionTests.java
@@ -34,7 +34,7 @@ public class RestDeleteActionTests extends RestActionTestCase {
 
     public void testTypeInPath() {
         // We're not actually testing anything to do with the client, but need to set this so it doesn't fail the test for being unset.
-        verifyingClient.setExecuteVerifier((arg1, arg2) -> null);
+        verifyingClient.setExecuteVerifier((arg1, arg2) -> {});
 
         RestRequest deprecatedRequest = new FakeRestRequest.Builder(xContentRegistry())
             .withMethod(Method.DELETE)

--- a/server/src/test/java/org/elasticsearch/rest/action/document/RestGetActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/document/RestGetActionTests.java
@@ -33,7 +33,7 @@ public class RestGetActionTests extends RestActionTestCase {
 
     public void testTypeInPathWithGet() {
         // We're not actually testing anything to do with the client, but need to set this so it doesn't fail the test for being unset.
-        verifyingClient.setExecuteVerifier((arg1, arg2) -> null);
+        verifyingClient.setExecuteVerifier((arg1, arg2) -> {});
 
         FakeRestRequest.Builder deprecatedRequest = new FakeRestRequest.Builder(xContentRegistry())
             .withPath("/some_index/some_type/some_id");
@@ -47,7 +47,7 @@ public class RestGetActionTests extends RestActionTestCase {
 
     public void testTypeInPathWithHead() {
         // We're not actually testing anything to do with the client, but need to set this so it doesn't fail the test for being unset.
-        verifyingClient.setExecuteVerifier((arg1, arg2) -> null);
+        verifyingClient.setExecuteVerifier((arg1, arg2) -> {});
 
         FakeRestRequest.Builder deprecatedRequest = new FakeRestRequest.Builder(xContentRegistry())
             .withPath("/some_index/some_type/some_id");

--- a/server/src/test/java/org/elasticsearch/rest/action/document/RestGetSourceActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/document/RestGetSourceActionTests.java
@@ -67,7 +67,7 @@ public class RestGetSourceActionTests extends RestActionTestCase {
      */
     public void testTypeInPath() {
         // We're not actually testing anything to do with the client, but need to set this so it doesn't fail the test for being unset.
-        verifyingClient.setExecuteVerifier((arg1, arg2) -> null);
+        verifyingClient.setExecuteVerifier((arg1, arg2) -> {});
         for (Method method : Arrays.asList(Method.GET, Method.HEAD)) {
             // Ensure we have a fresh context for each request so we don't get duplicate headers
             try (ThreadContext.StoredContext ignore = verifyingClient.threadPool().getThreadContext().stashContext()) {
@@ -87,7 +87,7 @@ public class RestGetSourceActionTests extends RestActionTestCase {
      */
     public void testTypeParameter() {
         // We're not actually testing anything to do with the client, but need to set this so it doesn't fail the test for being unset.
-        verifyingClient.setExecuteVerifier((arg1, arg2) -> null);
+        verifyingClient.setExecuteVerifier((arg1, arg2) -> {});
         Map<String, String> params = new HashMap<>();
         params.put("type", "some_type");
         for (Method method : Arrays.asList(Method.GET, Method.HEAD)) {

--- a/server/src/test/java/org/elasticsearch/rest/action/document/RestIndexActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/document/RestIndexActionTests.java
@@ -109,7 +109,6 @@ public class RestIndexActionTests extends RestActionTestCase {
             assertThat(request, instanceOf(IndexRequest.class));
             assertThat(((IndexRequest) request).opType(), equalTo(expectedOpType));
             executeCalled.set(true);
-            return null;
         });
         RestRequest autoIdRequest = new FakeRestRequest.Builder(xContentRegistry())
             .withMethod(RestRequest.Method.POST)

--- a/server/src/test/java/org/elasticsearch/rest/action/document/RestMultiGetActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/document/RestMultiGetActionTests.java
@@ -39,7 +39,7 @@ public class RestMultiGetActionTests extends RestActionTestCase {
 
     public void testTypeInPath() {
         // We're not actually testing anything to do with the client, but need to set this so it doesn't fail the test for being unset.
-        verifyingClient.setExecuteVerifier((arg1, arg2) -> null);
+        verifyingClient.setExecuteVerifier((arg1, arg2) -> {});
 
         RestRequest deprecatedRequest = new FakeRestRequest.Builder(xContentRegistry())
             .withMethod(Method.GET)
@@ -71,7 +71,7 @@ public class RestMultiGetActionTests extends RestActionTestCase {
             .endObject();
 
         // We're not actually testing anything to do with the client, but need to set this so it doesn't fail the test for being unset.
-        verifyingClient.setExecuteVerifier((arg1, arg2) -> null);
+        verifyingClient.setExecuteVerifier((arg1, arg2) -> {});
 
         RestRequest request = new FakeRestRequest.Builder(xContentRegistry())
             .withPath("_mget")

--- a/server/src/test/java/org/elasticsearch/rest/action/document/RestMultiTermVectorsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/document/RestMultiTermVectorsActionTests.java
@@ -47,7 +47,7 @@ public class RestMultiTermVectorsActionTests extends RestActionTestCase {
             .build();
 
         // We're not actually testing anything to do with the client, but need to set this so it doesn't fail the test for being unset.
-        verifyingClient.setExecuteVerifier((arg1, arg2) -> null);
+        verifyingClient.setExecuteVerifier((arg1, arg2) -> {});
 
         dispatchRequest(request);
         assertWarnings(RestMultiTermVectorsAction.TYPES_DEPRECATION_MESSAGE);
@@ -64,7 +64,7 @@ public class RestMultiTermVectorsActionTests extends RestActionTestCase {
             .build();
 
         // We're not actually testing anything to do with the client, but need to set this so it doesn't fail the test for being unset.
-        verifyingClient.setExecuteVerifier((arg1, arg2) -> null);
+        verifyingClient.setExecuteVerifier((arg1, arg2) -> {});
 
         dispatchRequest(request);
         assertWarnings(RestMultiTermVectorsAction.TYPES_DEPRECATION_MESSAGE);
@@ -87,7 +87,7 @@ public class RestMultiTermVectorsActionTests extends RestActionTestCase {
             .build();
 
         // We're not actually testing anything to do with the client, but need to set this so it doesn't fail the test for being unset.
-        verifyingClient.setExecuteVerifier((arg1, arg2) -> null);
+        verifyingClient.setExecuteVerifier((arg1, arg2) -> {});
 
         dispatchRequest(request);
         assertWarnings(RestTermVectorsAction.TYPES_DEPRECATION_MESSAGE);

--- a/server/src/test/java/org/elasticsearch/rest/action/document/RestTermVectorsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/document/RestTermVectorsActionTests.java
@@ -45,7 +45,7 @@ public class RestTermVectorsActionTests extends RestActionTestCase {
             .build();
 
         // We're not actually testing anything to do with the client, but need to set this so it doesn't fail the test for being unset.
-        verifyingClient.setExecuteVerifier((arg1, arg2) -> null);
+        verifyingClient.setExecuteVerifier((arg1, arg2) -> {});
 
         dispatchRequest(request);
         assertWarnings(RestTermVectorsAction.TYPES_DEPRECATION_MESSAGE);
@@ -64,7 +64,7 @@ public class RestTermVectorsActionTests extends RestActionTestCase {
             .build();
 
          // We're not actually testing anything to do with the client, but need to set this so it doesn't fail the test for being unset.
-         verifyingClient.setExecuteVerifier((arg1, arg2) -> null);
+         verifyingClient.setExecuteVerifier((arg1, arg2) -> {});
 
         dispatchRequest(request);
         assertWarnings(RestTermVectorsAction.TYPES_DEPRECATION_MESSAGE);

--- a/server/src/test/java/org/elasticsearch/rest/action/document/RestUpdateActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/document/RestUpdateActionTests.java
@@ -48,7 +48,7 @@ public class RestUpdateActionTests extends RestActionTestCase {
 
     public void testTypeInPath() {
         // We're not actually testing anything to do with the client, but need to set this so it doesn't fail the test for being unset.
-        verifyingClient.setExecuteVerifier((arg1, arg2) -> null);
+        verifyingClient.setExecuteVerifier((arg1, arg2) -> {});
 
         RestRequest deprecatedRequest = new FakeRestRequest.Builder(xContentRegistry())
             .withMethod(Method.POST)

--- a/server/src/test/java/org/elasticsearch/rest/action/search/RestCountActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/search/RestCountActionTests.java
@@ -42,7 +42,7 @@ public class RestCountActionTests extends RestActionTestCase {
             .build();
 
         // We're not actually testing anything to do with the client, but need to set this so it doesn't fail the test for being unset.
-        verifyingClient.setExecuteVerifier((arg1, arg2) -> null);
+        verifyingClient.setExecuteVerifier((arg1, arg2) -> {});
 
         dispatchRequest(request);
         assertWarnings(RestCountAction.TYPES_DEPRECATION_MESSAGE);
@@ -59,7 +59,7 @@ public class RestCountActionTests extends RestActionTestCase {
             .build();
 
         // We're not actually testing anything to do with the client, but need to set this so it doesn't fail the test for being unset.
-        verifyingClient.setExecuteVerifier((arg1, arg2) -> null);
+        verifyingClient.setExecuteVerifier((arg1, arg2) -> {});
 
         dispatchRequest(request);
         assertWarnings(RestCountAction.TYPES_DEPRECATION_MESSAGE);

--- a/server/src/test/java/org/elasticsearch/rest/action/search/RestExplainActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/search/RestExplainActionTests.java
@@ -33,7 +33,7 @@ public class RestExplainActionTests extends RestActionTestCase {
 
     public void testTypeInPath() {
         // We're not actually testing anything to do with the client, but need to set this so it doesn't fail the test for being unset.
-        verifyingClient.setExecuteVerifier((arg1, arg2) -> null);
+        verifyingClient.setExecuteVerifier((arg1, arg2) -> {});
 
         RestRequest deprecatedRequest = new FakeRestRequest.Builder(xContentRegistry())
             .withMethod(RestRequest.Method.GET)

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/adjacency/InternalAdjacencyMatrixTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/adjacency/InternalAdjacencyMatrixTests.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.search.aggregations.bucket.adjacency;
 
 import org.elasticsearch.search.aggregations.InternalAggregations;
-import org.elasticsearch.search.aggregations.ParsedMultiBucketAggregation;
 import org.elasticsearch.test.InternalMultiBucketAggregationTestCase;
 
 import java.util.ArrayList;
@@ -94,7 +93,7 @@ public class InternalAdjacencyMatrixTests extends InternalMultiBucketAggregation
     }
 
     @Override
-    protected Class<? extends ParsedMultiBucketAggregation> implementationClass() {
+    protected Class<ParsedAdjacencyMatrix> implementationClass() {
         return ParsedAdjacencyMatrix.class;
     }
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/filter/InternalFiltersTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/filter/InternalFiltersTests.java
@@ -22,7 +22,6 @@ package org.elasticsearch.search.aggregations.bucket.filter;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregation.ReduceContext;
 import org.elasticsearch.search.aggregations.InternalAggregations;
-import org.elasticsearch.search.aggregations.ParsedMultiBucketAggregation;
 import org.elasticsearch.search.aggregations.bucket.filter.InternalFilters.InternalBucket;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator.PipelineTree;
@@ -90,7 +89,7 @@ public class InternalFiltersTests extends InternalMultiBucketAggregationTestCase
     }
 
     @Override
-    protected Class<? extends ParsedMultiBucketAggregation> implementationClass() {
+    protected Class<ParsedFilters> implementationClass() {
         return ParsedFilters.class;
     }
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoGridTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoGridTestCase.java
@@ -20,7 +20,6 @@ package org.elasticsearch.search.aggregations.bucket.geogrid;
 
 import org.apache.lucene.index.IndexWriter;
 import org.elasticsearch.search.aggregations.InternalAggregations;
-import org.elasticsearch.search.aggregations.ParsedMultiBucketAggregation;
 import org.elasticsearch.test.InternalMultiBucketAggregationTestCase;
 
 import java.util.ArrayList;
@@ -119,7 +118,7 @@ public abstract class GeoGridTestCase<B extends InternalGeoGridBucket, T extends
     }
 
     @Override
-    protected Class<? extends ParsedMultiBucketAggregation> implementationClass() {
+    protected Class<ParsedGeoGrid> implementationClass() {
         return ParsedGeoGrid.class;
     }
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalAutoDateHistogramTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalAutoDateHistogramTests.java
@@ -25,7 +25,6 @@ import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
-import org.elasticsearch.search.aggregations.ParsedMultiBucketAggregation;
 import org.elasticsearch.search.aggregations.bucket.histogram.AutoDateHistogramAggregationBuilder.RoundingInfo;
 import org.elasticsearch.search.aggregations.bucket.histogram.InternalAutoDateHistogram.BucketInfo;
 import org.elasticsearch.test.InternalMultiBucketAggregationTestCase;
@@ -261,7 +260,7 @@ public class InternalAutoDateHistogramTests extends InternalMultiBucketAggregati
     }
 
     @Override
-    protected Class<? extends ParsedMultiBucketAggregation> implementationClass() {
+    protected Class<ParsedAutoDateHistogram> implementationClass() {
         return ParsedAutoDateHistogram.class;
     }
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogramTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogramTests.java
@@ -24,7 +24,6 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.BucketOrder;
 import org.elasticsearch.search.aggregations.InternalAggregations;
-import org.elasticsearch.search.aggregations.ParsedMultiBucketAggregation;
 import org.elasticsearch.test.InternalMultiBucketAggregationTestCase;
 
 import java.time.ZonedDateTime;
@@ -147,7 +146,7 @@ public class InternalDateHistogramTests extends InternalMultiBucketAggregationTe
     }
 
     @Override
-    protected Class<? extends ParsedMultiBucketAggregation> implementationClass() {
+    protected Class<ParsedDateHistogram> implementationClass() {
         return ParsedDateHistogram.class;
     }
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogramTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogramTests.java
@@ -23,7 +23,6 @@ import org.apache.lucene.util.TestUtil;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.BucketOrder;
 import org.elasticsearch.search.aggregations.InternalAggregations;
-import org.elasticsearch.search.aggregations.ParsedMultiBucketAggregation;
 import org.elasticsearch.test.InternalAggregationTestCase;
 import org.elasticsearch.test.InternalMultiBucketAggregationTestCase;
 
@@ -149,7 +148,7 @@ public class InternalHistogramTests extends InternalMultiBucketAggregationTestCa
     }
 
     @Override
-    protected Class<? extends ParsedMultiBucketAggregation> implementationClass() {
+    protected Class<ParsedHistogram> implementationClass() {
         return ParsedHistogram.class;
     }
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalVariableWidthHistogramTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalVariableWidthHistogramTests.java
@@ -30,7 +30,6 @@ import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.MultiBucketConsumerService;
-import org.elasticsearch.search.aggregations.ParsedMultiBucketAggregation;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.test.InternalMultiBucketAggregationTestCase;
 
@@ -92,7 +91,7 @@ public class InternalVariableWidthHistogramTests extends
     }
 
     @Override
-    protected Class<? extends ParsedMultiBucketAggregation> implementationClass() {
+    protected Class<ParsedVariableWidthHistogram> implementationClass() {
         return ParsedVariableWidthHistogram.class;
     }
     @Override

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalBinaryRangeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalBinaryRangeTests.java
@@ -86,7 +86,7 @@ public class InternalBinaryRangeTests extends InternalRangeTestCase<InternalBina
     }
 
     @Override
-    protected Class<? extends ParsedMultiBucketAggregation> implementationClass() {
+    protected Class<ParsedBinaryRange> implementationClass() {
         return ParsedBinaryRange.class;
     }
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalDateRangeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalDateRangeTests.java
@@ -90,7 +90,7 @@ public class InternalDateRangeTests extends InternalRangeTestCase<InternalDateRa
     }
 
     @Override
-    protected Class<? extends ParsedMultiBucketAggregation> implementationClass() {
+    protected Class<ParsedDateRange> implementationClass() {
         return ParsedDateRange.class;
     }
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalGeoDistanceTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalGeoDistanceTests.java
@@ -77,7 +77,7 @@ public class InternalGeoDistanceTests extends InternalRangeTestCase<InternalGeoD
     }
 
     @Override
-    protected Class<? extends ParsedMultiBucketAggregation> implementationClass() {
+    protected Class<ParsedGeoDistance> implementationClass() {
         return ParsedGeoDistance.class;
     }
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalRangeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalRangeTests.java
@@ -90,7 +90,7 @@ public class InternalRangeTests extends InternalRangeTestCase<InternalRange> {
     }
 
     @Override
-    protected Class<? extends ParsedMultiBucketAggregation> implementationClass() {
+    protected Class<ParsedRange> implementationClass() {
         return ParsedRange.class;
     }
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/DoubleTermsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/DoubleTermsTests.java
@@ -22,7 +22,6 @@ package org.elasticsearch.search.aggregations.bucket.terms;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.BucketOrder;
 import org.elasticsearch.search.aggregations.InternalAggregations;
-import org.elasticsearch.search.aggregations.ParsedMultiBucketAggregation;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -61,7 +60,7 @@ public class DoubleTermsTests extends InternalTermsTestCase {
     }
 
     @Override
-    protected Class<? extends ParsedMultiBucketAggregation> implementationClass() {
+    protected Class<ParsedDoubleTerms> implementationClass() {
         return ParsedDoubleTerms.class;
     }
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/LongRareTermsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/LongRareTermsTests.java
@@ -24,7 +24,6 @@ import org.elasticsearch.common.util.SetBackedScalingCuckooFilter;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.BucketOrder;
 import org.elasticsearch.search.aggregations.InternalAggregations;
-import org.elasticsearch.search.aggregations.ParsedMultiBucketAggregation;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -52,7 +51,7 @@ public class LongRareTermsTests extends InternalRareTermsTestCase {
     }
 
     @Override
-    protected Class<? extends ParsedMultiBucketAggregation> implementationClass() {
+    protected Class<ParsedLongRareTerms> implementationClass() {
         return ParsedLongRareTerms.class;
     }
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/LongTermsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/LongTermsTests.java
@@ -22,7 +22,6 @@ package org.elasticsearch.search.aggregations.bucket.terms;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.BucketOrder;
 import org.elasticsearch.search.aggregations.InternalAggregations;
-import org.elasticsearch.search.aggregations.ParsedMultiBucketAggregation;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -61,7 +60,7 @@ public class LongTermsTests extends InternalTermsTestCase {
     }
 
     @Override
-    protected Class<? extends ParsedMultiBucketAggregation> implementationClass() {
+    protected Class<ParsedLongTerms> implementationClass() {
         return ParsedLongTerms.class;
     }
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantLongTermsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantLongTermsTests.java
@@ -21,7 +21,6 @@ package org.elasticsearch.search.aggregations.bucket.terms;
 
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.InternalAggregations;
-import org.elasticsearch.search.aggregations.ParsedMultiBucketAggregation;
 import org.elasticsearch.search.aggregations.bucket.terms.heuristic.SignificanceHeuristic;
 
 import java.util.ArrayList;
@@ -64,7 +63,7 @@ public class SignificantLongTermsTests extends InternalSignificantTermsTestCase 
     }
 
     @Override
-    protected Class<? extends ParsedMultiBucketAggregation> implementationClass() {
+    protected Class<ParsedSignificantLongTerms> implementationClass() {
         return ParsedSignificantLongTerms.class;
     }
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantStringTermsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantStringTermsTests.java
@@ -22,7 +22,6 @@ package org.elasticsearch.search.aggregations.bucket.terms;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.InternalAggregations;
-import org.elasticsearch.search.aggregations.ParsedMultiBucketAggregation;
 import org.elasticsearch.search.aggregations.bucket.terms.heuristic.SignificanceHeuristic;
 
 import java.util.ArrayList;
@@ -57,7 +56,7 @@ public class SignificantStringTermsTests extends InternalSignificantTermsTestCas
     }
 
     @Override
-    protected Class<? extends ParsedMultiBucketAggregation> implementationClass() {
+    protected Class<ParsedSignificantStringTerms> implementationClass() {
         return ParsedSignificantStringTerms.class;
     }
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/StringRareTermsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/StringRareTermsTests.java
@@ -25,7 +25,6 @@ import org.elasticsearch.common.util.SetBackedScalingCuckooFilter;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.BucketOrder;
 import org.elasticsearch.search.aggregations.InternalAggregations;
-import org.elasticsearch.search.aggregations.ParsedMultiBucketAggregation;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -56,7 +55,7 @@ public class StringRareTermsTests extends InternalRareTermsTestCase {
     }
 
     @Override
-    protected Class<? extends ParsedMultiBucketAggregation> implementationClass() {
+    protected Class<ParsedStringRareTerms> implementationClass() {
         return ParsedStringRareTerms.class;
     }
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsTests.java
@@ -23,7 +23,6 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.BucketOrder;
 import org.elasticsearch.search.aggregations.InternalAggregations;
-import org.elasticsearch.search.aggregations.ParsedMultiBucketAggregation;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -55,7 +54,7 @@ public class StringTermsTests extends InternalTermsTestCase {
     }
 
     @Override
-    protected Class<? extends ParsedMultiBucketAggregation> implementationClass() {
+    protected Class<ParsedStringTerms> implementationClass() {
         return ParsedStringTerms.class;
     }
 

--- a/test/framework/build.gradle
+++ b/test/framework/build.gradle
@@ -39,8 +39,7 @@ dependencies {
   api "org.elasticsearch:mocksocket:${versions.mocksocket}"
 }
 
-tasks.named("compileJava").configure { options.compilerArgs << '-Xlint:-cast,-rawtypes,-unchecked' }
-tasks.named("compileTestJava").configure { options.compilerArgs << '-Xlint:-rawtypes' }
+tasks.named("compileJava").configure { options.compilerArgs << '-Xlint:-cast,-unchecked' }
 
 // the main files are actually test files, so use the appropriate forbidden api sigs
 tasks.named('forbiddenApisMain').configure {

--- a/test/framework/src/main/java/org/elasticsearch/index/replication/ESIndexLevelReplicationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/replication/ESIndexLevelReplicationTestCase.java
@@ -800,8 +800,11 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
         }
     }
 
-    private <Request extends ReplicatedWriteRequest & DocWriteRequest> BulkShardRequest executeReplicationRequestOnPrimary(
-            IndexShard primary, Request request) throws Exception {
+    private <
+        Request extends ReplicatedWriteRequest<Request> & DocWriteRequest<Request>> BulkShardRequest executeReplicationRequestOnPrimary(
+            IndexShard primary,
+            Request request
+        ) throws Exception {
         final BulkShardRequest bulkShardRequest = new BulkShardRequest(shardId, request.getRefreshPolicy(),
             new BulkItemRequest[]{new BulkItemRequest(0, request)});
         final PlainActionFuture<BulkShardRequest> res = new PlainActionFuture<>();

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractBuilderTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractBuilderTestCase.java
@@ -284,6 +284,7 @@ public abstract class AbstractBuilderTestCase extends ESTestCase {
         public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
             if (method.equals(Client.class.getMethod("get", GetRequest.class, ActionListener.class))) {
                 GetResponse getResponse = delegate.executeGet((GetRequest) args[0]);
+                @SuppressWarnings("unchecked")  // We matched the method above.
                 ActionListener<GetResponse> listener = (ActionListener<GetResponse>) args[1];
                 if (randomBoolean()) {
                     listener.onResponse(getResponse);
@@ -337,7 +338,7 @@ public abstract class AbstractBuilderTestCase extends ESTestCase {
 
             client = (Client) Proxy.newProxyInstance(
                     Client.class.getClassLoader(),
-                    new Class[]{Client.class},
+                    new Class<?>[]{Client.class},
                     clientInvocationHandler);
             ScriptModule scriptModule = createScriptModule(pluginsService.filterPlugins(ScriptPlugin.class));
             List<Setting<?>> additionalSettings = pluginsService.getPluginSettings();

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalMultiBucketAggregationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalMultiBucketAggregationTestCase.java
@@ -97,7 +97,7 @@ public abstract class InternalMultiBucketAggregationTestCase<T extends InternalA
 
     protected abstract T createTestInstance(String name, Map<String, Object> metadata, InternalAggregations aggregations);
 
-    protected abstract Class<? extends ParsedMultiBucketAggregation> implementationClass();
+    protected abstract Class<? extends ParsedMultiBucketAggregation<?>> implementationClass();
 
     @Override
     protected final void assertFromXContent(T aggregation, ParsedAggregation parsedAggregation) {
@@ -149,7 +149,7 @@ public abstract class InternalMultiBucketAggregationTestCase<T extends InternalA
     }
 
     protected void assertMultiBucketsAggregation(MultiBucketsAggregation expected, MultiBucketsAggregation actual, boolean checkOrder) {
-        Class<? extends ParsedMultiBucketAggregation> parsedClass = implementationClass();
+        Class<? extends ParsedMultiBucketAggregation<?>> parsedClass = implementationClass();
         assertNotNull("Parsed aggregation class must not be null", parsedClass);
         assertTrue("Unexpected parsed class, expected instance of: " + actual + ", but was: " + parsedClass,
                 parsedClass.isInstance(actual));

--- a/test/framework/src/main/java/org/elasticsearch/test/client/NoOpNodeClient.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/client/NoOpNodeClient.java
@@ -69,6 +69,7 @@ public class NoOpNodeClient extends NodeClient {
     }
 
     @Override
+    @SuppressWarnings("rawtypes")
     public void initialize(Map<ActionType, TransportAction> actions, Supplier<String> localNodeId,
                            RemoteClusterService remoteClusterService, NamedWriteableRegistry namedWriteableRegistry) {
         throw new UnsupportedOperationException("cannot initialize " + this.getClass().getSimpleName());

--- a/test/framework/src/main/java/org/elasticsearch/test/hamcrest/CollectionAssertions.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/hamcrest/CollectionAssertions.java
@@ -27,11 +27,11 @@ import org.hamcrest.Matcher;
  */
 public class CollectionAssertions {
 
-    public static Matcher<ImmutableOpenMap> hasKey(final String key) {
+    public static Matcher<ImmutableOpenMap<String, ?>> hasKey(final String key) {
         return new CollectionMatchers.ImmutableOpenMapHasKeyMatcher(key);
     }
 
-    public static Matcher<ImmutableOpenMap> hasAllKeys(final String... keys) {
+    public static Matcher<ImmutableOpenMap<String, ?>> hasAllKeys(final String... keys) {
         return new CollectionMatchers.ImmutableOpenMapHasAllKeysMatcher(keys);
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/hamcrest/CollectionMatchers.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/hamcrest/CollectionMatchers.java
@@ -31,7 +31,7 @@ import java.util.List;
  */
 public class CollectionMatchers {
 
-    public static class ImmutableOpenMapHasKeyMatcher extends TypeSafeMatcher<ImmutableOpenMap> {
+    public static class ImmutableOpenMapHasKeyMatcher extends TypeSafeMatcher<ImmutableOpenMap<String, ?>> {
 
         private final String key;
 
@@ -40,12 +40,12 @@ public class CollectionMatchers {
         }
 
         @Override
-        protected boolean matchesSafely(ImmutableOpenMap item) {
+        protected boolean matchesSafely(ImmutableOpenMap<String, ?> item) {
             return item.containsKey(key);
         }
 
         @Override
-        public void describeMismatchSafely(final ImmutableOpenMap map, final Description mismatchDescription) {
+        public void describeMismatchSafely(final ImmutableOpenMap<String, ?> map, final Description mismatchDescription) {
             if (map.size() == 0) {
                 mismatchDescription.appendText("was empty");
             } else {
@@ -59,7 +59,7 @@ public class CollectionMatchers {
         }
     }
 
-    public static class ImmutableOpenMapHasAllKeysMatcher extends TypeSafeMatcher<ImmutableOpenMap> {
+    public static class ImmutableOpenMapHasAllKeysMatcher extends TypeSafeMatcher<ImmutableOpenMap<String, ?>> {
 
         private final List<String> keys;
         private String missingKey;
@@ -69,7 +69,7 @@ public class CollectionMatchers {
         }
 
         @Override
-        protected boolean matchesSafely(ImmutableOpenMap item) {
+        protected boolean matchesSafely(ImmutableOpenMap<String, ?> item) {
             for (String key: keys) {
                 if (item.containsKey(key) == false) {
                     missingKey = key;
@@ -81,7 +81,7 @@ public class CollectionMatchers {
         }
 
         @Override
-        public void describeMismatchSafely(final ImmutableOpenMap map, final Description mismatchDescription) {
+        public void describeMismatchSafely(final ImmutableOpenMap<String, ?> map, final Description mismatchDescription) {
             if (map.size() == 0) {
                 mismatchDescription.appendText("was empty");
             } else {

--- a/test/framework/src/main/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
@@ -134,7 +134,7 @@ public class ElasticsearchAssertions {
      *
      * @param builder the request builder
      */
-    public static void assertBlocked(ActionRequestBuilder builder) {
+    public static void assertBlocked(ActionRequestBuilder<?, ?> builder) {
         assertBlocked(builder, (ClusterBlock) null);
     }
 
@@ -165,7 +165,7 @@ public class ElasticsearchAssertions {
      * @param builder the request builder
      * @param expectedBlockId the expected block id
      */
-    public static void assertBlocked(final ActionRequestBuilder builder, @Nullable final Integer expectedBlockId) {
+    public static void assertBlocked(final ActionRequestBuilder<?, ?> builder, @Nullable final Integer expectedBlockId) {
         try {
             builder.get();
             fail("Request executed with success but a ClusterBlockException was expected");
@@ -193,7 +193,7 @@ public class ElasticsearchAssertions {
      * @param builder the request builder
      * @param expectedBlock the expected block
      */
-    public static void assertBlocked(final ActionRequestBuilder builder, @Nullable final ClusterBlock expectedBlock) {
+    public static void assertBlocked(final ActionRequestBuilder<?, ?> builder, @Nullable final ClusterBlock expectedBlock) {
         assertBlocked(builder, expectedBlock != null ? expectedBlock.id() : null);
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/hamcrest/TupleMatchers.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/hamcrest/TupleMatchers.java
@@ -57,6 +57,6 @@ public class TupleMatchers {
      * <pre>assertThat(Tuple.tuple("myValue1", "myValue2"), isTuple(startsWith("my"), containsString("Val")))</pre>
      */
     public static <V1, V2> TupleMatcher<? extends V1, ? extends V2> isTuple(Matcher<? super V1> v1Matcher, Matcher<? super V2> v2Matcher) {
-        return new TupleMatcher(v1Matcher, v2Matcher);
+        return new TupleMatcher<>(v1Matcher, v2Matcher);
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransport.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransport.java
@@ -144,7 +144,7 @@ public class MockTransport extends StubbableTransport {
      * @param e         the failure
      */
     public void handleError(final long requestId, final TransportException e) {
-        final TransportResponseHandler transportResponseHandler = getResponseHandlers().onResponseReceived(requestId, listener);
+        final TransportResponseHandler<?> transportResponseHandler = getResponseHandlers().onResponseReceived(requestId, listener);
         if (transportResponseHandler != null) {
             transportResponseHandler.handleException(e);
         }

--- a/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransportService.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransportService.java
@@ -383,7 +383,7 @@ public final class MockTransportService extends TransportService {
                 }
 
                 // poor mans request cloning...
-                RequestHandlerRegistry reg = MockTransportService.this.getRequestHandler(action);
+                RequestHandlerRegistry<?> reg = MockTransportService.this.getRequestHandler(action);
                 BytesStreamOutput bStream = new BytesStreamOutput();
                 request.writeTo(bStream);
                 final TransportRequest clonedRequest = reg.newRequest(bStream.bytes().streamInput());
@@ -520,6 +520,7 @@ public final class MockTransportService extends TransportService {
         return (StubbableConnectionManager) connectionManager;
     }
 
+    @SuppressWarnings("resource") // Close is handled elsewhere
     public Transport getOriginalTransport() {
         Transport transport = transport();
         while (transport instanceof StubbableTransport) {

--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -473,6 +473,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             }
 
             @Override
+            @SuppressWarnings("rawtypes")
             public void onResponseReceived(long requestId, Transport.ResponseContext context) {
                 if (context.action().equals(ACTION)) {
                     responseReceived.incrementAndGet();

--- a/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/ObjectPathTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/ObjectPathTests.java
@@ -119,7 +119,7 @@ public class ObjectPathTests extends ESTestCase {
                 BytesReference.bytes(xContentBuilder));
         Object object = objectPath.evaluate("field1.array1");
         assertThat(object, instanceOf(List.class));
-        List list = (List) object;
+        List<?> list = (List<?>) object;
         assertThat(list.size(), equalTo(2));
         assertThat(list.get(0), instanceOf(String.class));
         assertThat(list.get(0), equalTo("value1"));

--- a/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/ClientYamlTestSectionTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/ClientYamlTestSectionTests.java
@@ -224,7 +224,7 @@ public class ClientYamlTestSectionTests extends AbstractClientYamlTestFragmentPa
         matchAssertion = (MatchAssertion)testSection.getExecutableSections().get(4);
         assertThat(matchAssertion.getField(), equalTo("_source"));
         assertThat(matchAssertion.getExpectedValue(), instanceOf(Map.class));
-        Map map = (Map) matchAssertion.getExpectedValue();
+        Map<?, ?> map = (Map<?, ?>) matchAssertion.getExpectedValue();
         assertThat(map.size(), equalTo(1));
         assertThat(map.get("foo").toString(), equalTo("Hello: 中文"));
 

--- a/x-pack/plugin/graph/src/test/java/org/elasticsearch/xpack/graph/rest/action/RestGraphActionTests.java
+++ b/x-pack/plugin/graph/src/test/java/org/elasticsearch/xpack/graph/rest/action/RestGraphActionTests.java
@@ -27,7 +27,7 @@ public class RestGraphActionTests extends RestActionTestCase {
             .withContent(new BytesArray("{}"), XContentType.JSON)
             .build();
         // We're not actually testing anything to do with the client, but need to set this so it doesn't fail the test for being unset.
-        verifyingClient.setExecuteVerifier((arg1, arg2) -> null);
+        verifyingClient.setExecuteVerifier((arg1, arg2) -> {});
 
         dispatchRequest(request);
         assertWarnings(RestGraphAction.TYPES_DEPRECATION_MESSAGE);


### PR DESCRIPTION
This drops the `-Xlint:-rawtypes` suppression from the test framework
build because it makes it easier to write code with "funny" assumptions.
For the most part I made the assumptions explicit rather than implicit.
Some of them are still "funny", but at least they are a little more
obvious when you read the code.

I also had to touch a pile of agg tests due to a signature that had a raw
type as well.
