### PR TITLE
[7.11] [DOCS] Remove a ',' added to the end of the synonym in example docs (#68187)

### DIFF
--- a/docs/src/test/cluster/config/analysis/synonym.txt
+++ b/docs/src/test/cluster/config/analysis/synonym.txt
@@ -4,7 +4,7 @@
 # and replace with all alternatives on the RHS.  These types of mappings
 # ignore the expand parameter in the schema.
 # Examples:
-i-pod, i pod => ipod,
+i-pod, i pod => ipod
 sea biscuit, sea biscit => seabiscuit
 
 # Equivalent synonyms may be separated with commas and give


### PR DESCRIPTION
Backports the following commits to 7.11:
 - [DOCS] Remove a ',' added to the end of the synonym in example docs (#68187)