### PR TITLE
[7.11] [DOCS] Fix typo (#68193)

### DIFF
--- a/docs/reference/setup/install/rpm.asciidoc
+++ b/docs/reference/setup/install/rpm.asciidoc
@@ -20,7 +20,7 @@ from the JDK maintainers (GPLv2+CE). To use your own version of Java,
 see the <<jvm-version, JVM version requirements>>
 
 [[rpm-key]]
-==== Import the Elasticsearch PGP Key
+==== Import the Elasticsearch GPG Key
 
 include::key.asciidoc[]
 


### PR DESCRIPTION
Backports the following commits to 7.11:
 - [DOCS] Fix typo (#68193)