### PR TITLE
[DOCS] Minor rewording for HTTP settings

### DIFF
--- a/docs/reference/modules/http.asciidoc
+++ b/docs/reference/modules/http.asciidoc
@@ -1,17 +1,9 @@
 [[http-settings]]
-==== HTTP settings
+==== Advanced HTTP settings
 
-The following settings allow you to configure the HTTP interface independently
-of the <<transport-settings,transport interface>>. You can also configure both
-interfaces together using the <<common-network-settings,network settings>>.
-
-`http.port`::
-(<<static-cluster-setting,Static>>)
-The port to bind for HTTP client communication. Accepts a single value or a
-range. If a range is specified, the node will bind to the first available port
-in the range.
-+
-Defaults to `9200-9300`.
+Use the following advanced settings to configure the HTTP interface
+independently of the <<transport-settings,transport interface>>. You can also
+configure both interfaces together using the <<common-network-settings,network settings>>.
 
 `http.host`::
 (<<static-cluster-setting,Static>>)

--- a/docs/reference/modules/http.asciidoc
+++ b/docs/reference/modules/http.asciidoc
@@ -25,29 +25,23 @@ Defaults to the address given by `network.host`.
 
 `http.bind_host`::
 (<<static-cluster-setting,Static>>)
-The network address(es) that the node should bind to for listening to
+The network address(es) to which the node should bind in order to listen for
 incoming HTTP connections. Accepts a list of IP addresses, hostnames, and
 <<network-interface-values,special values>>. Defaults to the address given by
-`http.host` or `network.bind_host`.
-+
-Use this setting only if your needs meet these requirements:
-
-* Binding to multiple addresses, or using different addresses for publishing and
-binding.
-* Using different binding configurations for the transport and HTTP interfaces.
+`http.host` or `network.bind_host`. Use this setting only if you require to
+bind to multiple addresses or to use different addresses for publishing and
+binding, and you also require different binding configurations for the
+transport and HTTP interfaces.
 
 `http.publish_host`::
 (<<static-cluster-setting,Static>>)
 The network address for HTTP clients to contact the node using sniffing.
 Accepts an IP address, a hostname, or a <<network-interface-values,special
 value>>. Defaults to the address given by `http.host` or
-`network.publish_host`.
-+
-Use this setting only if your needs meet these requirements:
-
-* Binding to multiple addresses, or using different addresses for publishing and
-binding.
-* Using different binding configurations for the transport and HTTP interfaces.
+`network.publish_host`. Use this setting only if you require to bind to
+multiple addresses or to use different addresses for publishing and binding,
+and you also require different binding configurations for the transport and
+HTTP interfaces.
 
 `http.publish_port`::
 (<<static-cluster-setting,Static>>)

--- a/docs/reference/modules/http.asciidoc
+++ b/docs/reference/modules/http.asciidoc
@@ -25,23 +25,29 @@ Defaults to the address given by `network.host`.
 
 `http.bind_host`::
 (<<static-cluster-setting,Static>>)
-The network address(es) to which the node should bind in order to listen for
+The network address(es) that the node should bind to for listening to
 incoming HTTP connections. Accepts a list of IP addresses, hostnames, and
 <<network-interface-values,special values>>. Defaults to the address given by
-`http.host` or `network.bind_host`. Use this setting only if you require to
-bind to multiple addresses or to use different addresses for publishing and
-binding, and you also require different binding configurations for the
-transport and HTTP interfaces.
+`http.host` or `network.bind_host`.
++
+Use this setting only if your needs meet these requirements:
+
+* Binding to multiple addresses, or using different addresses for publishing and
+binding.
+* Using different binding configurations for the transport and HTTP interfaces.
 
 `http.publish_host`::
 (<<static-cluster-setting,Static>>)
 The network address for HTTP clients to contact the node using sniffing.
 Accepts an IP address, a hostname, or a <<network-interface-values,special
 value>>. Defaults to the address given by `http.host` or
-`network.publish_host`. Use this setting only if you require to bind to
-multiple addresses or to use different addresses for publishing and binding,
-and you also require different binding configurations for the transport and
-HTTP interfaces.
+`network.publish_host`.
++
+Use this setting only if your needs meet these requirements:
+
+* Binding to multiple addresses, or using different addresses for publishing and
+binding.
+* Using different binding configurations for the transport and HTTP interfaces.
 
 `http.publish_port`::
 (<<static-cluster-setting,Static>>)

--- a/docs/reference/modules/transport.asciidoc
+++ b/docs/reference/modules/transport.asciidoc
@@ -1,19 +1,10 @@
 [[transport-settings]]
-==== Transport settings
+==== Advanced transport settings
 
-Use the following settings to configure the transport interface
+Use the following advanced settings to configure the transport interface
 independently of the <<http-settings,HTTP interface>>. Use the
 <<common-network-settings,network
 settings>> to configure both interfaces together.
-
-`transport.port`::
-(<<static-cluster-setting,Static>>)
-The port to bind for communication between nodes. Accepts a single value or a
-range. If a range is specified, the node will bind to the first available port
-in the range. Set this setting to a single port, not a range, on every
-master-eligible node.
-+
-Defaults to `9300-9400`.
 
 `transport.host`::
 (<<static-cluster-setting,Static>>)


### PR DESCRIPTION
Rewording the conditions for `http.bind_host` and `http.publish_host` for clarity.