### PR TITLE
[7.11] [DOCS] Remove outdated deprecated notes (#68246)

### DIFF
--- a/docs/reference/query-dsl/mlt-query.asciidoc
+++ b/docs/reference/query-dsl/mlt-query.asciidoc
@@ -202,12 +202,11 @@ such as stop words. Defaults to unbounded (`Integer.MAX_VALUE`, which is `2^31-1
 or 2147483647).
 
 `min_word_length`::
-The minimum word length below which the terms will be ignored. The old name
-`min_word_len` is deprecated. Defaults to `0`.
+The minimum word length below which the terms will be ignored. Defaults to `0`.
 
 `max_word_length`::
-The maximum word length above which the terms will be ignored. The old name
-`max_word_len` is deprecated. Defaults to unbounded (`0`).
+The maximum word length above which the terms will be ignored. Defaults to
+unbounded (`0`).
 
 `stop_words`::
 An array of stop words. Any word in this set is considered "uninteresting" and


### PR DESCRIPTION
Backports the following commits to 7.11:
 - [DOCS] Remove outdated deprecated notes (#68246)