### PR TITLE
[7.10] [DOCS] Reuse timestamp reqs (#68299)

### DIFF
--- a/docs/reference/data-streams/data-streams.asciidoc
+++ b/docs/reference/data-streams/data-streams.asciidoc
@@ -31,10 +31,12 @@ Each data stream requires a matching <<index-templates,index template>>. The
 template contains the mappings and settings used to configure the stream's
 backing indices.
 
+// tag::timestamp-reqs[]
 Every document indexed to a data stream must contain a `@timestamp` field,
 mapped as a <<date,`date`>> or <<date_nanos,`date_nanos`>> field type. If the
 index template doesn't specify a mapping for the `@timestamp` field, {es} maps
 `@timestamp` as a `date` field  with default options.
+// end::timestamp-reqs[]
 
 The same index template can be used for multiple data streams. You cannot
 delete an index template in use by a data stream.

--- a/docs/reference/data-streams/set-up-a-data-stream.asciidoc
+++ b/docs/reference/data-streams/set-up-a-data-stream.asciidoc
@@ -86,8 +86,7 @@ For example, if you don't use {agent} and want to create a template for the
 your template is applied instead of the built-in template for `logs-*-*`.
 ====
 
-If the index template doesn't specify a mapping for the `@timestamp` field, {es}
-maps `@timestamp` as a `date` field  with default options.
+include::{es-repo-dir}/data-streams/data-streams.asciidoc[tag=timestamp-reqs]
 
 If using {ilm-init}, specify your lifecycle policy in the `index.lifecycle.name`
 setting.


### PR DESCRIPTION
Backports the following commits to 7.10:
 - [DOCS] Reuse timestamp reqs (#68299)