### PR TITLE
[DOCS] Add Elastic data stream naming scheme docs

### DIFF
--- a/docs/reference/data-streams/set-up-a-data-stream.asciidoc
+++ b/docs/reference/data-streams/set-up-a-data-stream.asciidoc
@@ -90,6 +90,42 @@ For example, if you don't use {agent} and want to create a template for the
 your template is applied instead of the built-in template for `logs-*-*`.
 ====
 
+[[elastic-data-stream-naming-scheme]]
+.The Elastic data stream naming scheme
+****
+The {agent} uses the Elastic data stream naming scheme to name its data streams.
+If you use the {agent} or the {ecs-ref}[Elastic Common Schema (ECS)], we
+recommend you use the Elastic naming scheme for your other data streams. This
+will help you organize your data consistently and avoid naming collisions.
+
+The naming scheme splits data into different data streams based on the following
+components. Each component corresponds to a
+<<constant-keyword-field-type,constant keyword>> field defined in the ECS.
+
+`type`::
+Generic type describing the data, such as `logs`, `metrics`, or `synthetics`.
+Corresponds to the `data_stream.type` field.
+
+`dataset`::
+Describes the ingested data and its structure. Corresponds to the
+`data_stream.dataset` field. Defaults to `generic`.
+
+`namespace`::
+User-configurable arbitrary grouping. Corresponds to the `data_stream.dataset`
+field. Defaults to `default`.
+
+The naming scheme separates these components with a `-` character:
+
+```
+<type>-<dataset>-<namespace>
+```
+
+For example, the {agent} uses the `logs-nginx.access-production` data
+stream to store data with a type of `logs`, a dataset of `nginx.access`, and a
+namespace of `production`. If you use the {agent} to ingest a log file, it
+stores the data in the `logs-generic-default` data stream.
+****
+
 include::{es-repo-dir}/data-streams/data-streams.asciidoc[tag=timestamp-reqs]
 
 If using {ilm-init}, specify your lifecycle policy in the `index.lifecycle.name`

--- a/docs/reference/data-streams/set-up-a-data-stream.asciidoc
+++ b/docs/reference/data-streams/set-up-a-data-stream.asciidoc
@@ -94,9 +94,8 @@ your template is applied instead of the built-in template for `logs-*-*`.
 .The Elastic data stream naming scheme
 ****
 The {agent} uses the Elastic data stream naming scheme to name its data streams.
-If you use the {agent} or the {ecs-ref}[Elastic Common Schema (ECS)], we
-recommend you use the Elastic naming scheme for your other data streams. This
-will help you organize your data consistently and avoid naming collisions.
+To help you organize your data consistently and avoid naming collisions, we
+recommend you use the Elastic naming scheme for your other data streams.
 
 The naming scheme splits data into different data streams based on the following
 components. Each component corresponds to a

--- a/docs/reference/data-streams/set-up-a-data-stream.asciidoc
+++ b/docs/reference/data-streams/set-up-a-data-stream.asciidoc
@@ -99,7 +99,8 @@ recommend you also use the Elastic naming scheme for your other data streams.
 
 The naming scheme splits data into different data streams based on the following
 components. Each component corresponds to a
-<<constant-keyword-field-type,constant keyword>> field defined in the ECS.
+<<constant-keyword-field-type,constant keyword>> field defined in the
+{ecs-ref}[Elastic Common Schema (ECS)].
 
 `type`::
 Generic type describing the data, such as `logs`, `metrics`, or `synthetics`.

--- a/docs/reference/data-streams/set-up-a-data-stream.asciidoc
+++ b/docs/reference/data-streams/set-up-a-data-stream.asciidoc
@@ -95,7 +95,7 @@ your template is applied instead of the built-in template for `logs-*-*`.
 ****
 The {agent} uses the Elastic data stream naming scheme to name its data streams.
 To help you organize your data consistently and avoid naming collisions, we
-recommend you use the Elastic naming scheme for your other data streams.
+recommend you also use the Elastic naming scheme for your other data streams.
 
 The naming scheme splits data into different data streams based on the following
 components. Each component corresponds to a

--- a/docs/reference/indices/create-data-stream.asciidoc
+++ b/docs/reference/indices/create-data-stream.asciidoc
@@ -56,9 +56,8 @@ See <<set-up-a-data-stream>>.
 (Required, string) Name of the data stream to create.
 
 // tag::data-stream-name[]
-If using {agent} or the {ecs-ref}[Elastic Common Schema (ECS)], we recommend
-using the <<elastic-data-stream-naming-scheme,Elastic data stream naming
-scheme>>. Data stream names must meet the following criteria:
+We recommend using the <<elastic-data-stream-naming-scheme,Elastic data stream
+naming scheme>>. Data stream names must meet the following criteria:
 
 - Lowercase only
 - Cannot include `\`, `/`, `*`, `?`, `"`, `<`, `>`, `|`, `,`, `#`, `:`, or a

--- a/docs/reference/indices/create-data-stream.asciidoc
+++ b/docs/reference/indices/create-data-stream.asciidoc
@@ -56,7 +56,9 @@ See <<set-up-a-data-stream>>.
 (Required, string) Name of the data stream to create.
 
 // tag::data-stream-name[]
-Data stream names must meet the following criteria:
+If using {agent} or the {ecs-ref}[Elastic Common Schema (ECS)], we recommend
+using the <<elastic-data-stream-naming-scheme,Elastic data stream naming
+scheme>>. Data stream names must meet the following criteria:
 
 - Lowercase only
 - Cannot include `\`, `/`, `*`, `?`, `"`, `<`, `>`, `|`, `,`, `#`, `:`, or a


### PR DESCRIPTION
Documents the Elastic data stream naming scheme, based on the [An introduction to the Elastic data stream naming scheme](https://www.elastic.co/blog/an-introduction-to-the-elastic-data-stream-naming-scheme) blog post.

### Previews
- Elastic data stream naming stream sidebar: https://elasticsearch_68310.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/set-up-a-data-stream.html#elastic-data-stream-naming-scheme
- Create a data stream: https://elasticsearch_68310.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/indices-create-data-stream.html#indices-create-data-stream-api-path-params