### PR TITLE
[7.11] [DOCS] Reuse built-in index templates admon (#68314)

### DIFF
--- a/docs/reference/data-streams/set-up-a-data-stream.asciidoc
+++ b/docs/reference/data-streams/set-up-a-data-stream.asciidoc
@@ -73,22 +73,7 @@ include::{es-repo-dir}/indices/create-data-stream.asciidoc[tag=data-stream-name]
 
 * A priority for the index template
 +
-[IMPORTANT]
-====
-{es} has built-in index templates for the `metrics-*-*`, `logs-*-*`, and
-`synthetics-*-*` index patterns, each with a priority of `100`.
-{fleet-guide}/fleet-overview.html[{agent}] uses these templates to
-create data streams.
-
-If you use {agent}, assign your index templates a priority lower than `100` to
-avoid overriding the built-in templates. Otherwise, use a non-overlapping index
-pattern or assign templates with an overlapping pattern a `priority` higher than
-`100`.
-
-For example, if you don't use {agent} and want to create a template for the
-`logs-*` index pattern, assign your template a priority of `200`. This ensures
-your template is applied instead of the built-in template for `logs-*-*`.
-====
+include::{es-repo-dir}/indices/index-templates.asciidoc[tag=built-in-index-templates]
 
 include::{es-repo-dir}/data-streams/data-streams.asciidoc[tag=timestamp-reqs]
 

--- a/docs/reference/docs/index_.asciidoc
+++ b/docs/reference/docs/index_.asciidoc
@@ -203,22 +203,7 @@ If the target doesn't exist and doesn't match a data stream template,
 the operation automatically creates the index and applies any matching
 <<index-templates,index templates>>.
 
-[IMPORTANT]
-====
-{es} has built-in index templates for the `metrics-*-*`, `logs-*-*`, and `synthetics-*-*` index
-patterns, each with a priority of `100`.
-{fleet-guide}/fleet-overview.html[{agent}] uses these templates to
-create data streams. If you use {agent}, assign your index templates a priority
-lower than `100` to avoid overriding the built-in templates.
-
-Otherwise, to avoid accidentally applying the built-in templates, use a
-non-overlapping index pattern or assign templates with an overlapping pattern a
-`priority` higher than `100`.
-
-For example, if you don't use {agent} and want to create a template for the
-`logs-*` index pattern, assign your template a priority of `200`. This ensures
-your template is applied instead of the built-in template for `logs-*-*`.
-====
+include::{es-repo-dir}/indices/index-templates.asciidoc[tag=built-in-index-templates]
 
 If no mapping exists, the index operation
 creates a dynamic mapping. By default, new fields and objects are

--- a/docs/reference/indices/index-templates.asciidoc
+++ b/docs/reference/indices/index-templates.asciidoc
@@ -20,22 +20,24 @@ specify settings, mappings, and aliases.
 
 If a new data stream or index matches more than one index template, the index template with the highest priority is used.
 
+// tag::built-in-index-templates[]
 [IMPORTANT]
 ====
-{es} has built-in index templates for the `metrics-*-*`, `logs-*-*`, and `synthetics-*-*` index
-patterns, each with a priority of `100`.
-{fleet-guide}/fleet-overview.html[{agent}] uses these templates to
-create data streams. If you use {agent}, assign your index templates a priority
-lower than `100` to avoid an overriding the built-in templates.
+{es} has built-in index templates for the `metrics-*-*`, `logs-*-*`, and
+`synthetics-*-*` index patterns, each with a priority of `100`. The
+{fleet-guide}/fleet-overview.html[{agent}] uses these templates to create data
+streams. If you use the {agent}, assign your index templates a priority lower
+than `100` to avoid overriding the built-in templates.
 
 Otherwise, to avoid accidentally applying the built-in templates, use a
 non-overlapping index pattern or assign templates with an overlapping pattern a
 `priority` higher than `100`.
 
-For example, if you don't use {agent} and want to create a template for the
+For example, if you don't use the {agent} and want to create a template for the
 `logs-*` index pattern, assign your template a priority of `200`. This ensures
 your template is applied instead of the built-in template for `logs-*-*`.
 ====
+// end::built-in-index-templates[]
 
 When a composable template matches a given index
 it always takes precedence over a legacy template. If no composable template matches, a legacy

--- a/docs/reference/indices/put-index-template.asciidoc
+++ b/docs/reference/indices/put-index-template.asciidoc
@@ -90,22 +90,7 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 Array of wildcard (`*`) expressions
 used to match the names of data streams and indices during creation.
 +
-[IMPORTANT]
-====
-{es} has built-in index templates for the `metrics-*-*`, `logs-*-*`, and `synthetics-*-*` index
-patterns, each with a priority of `100`.
-{fleet-guide}/fleet-overview.html[{agent}] uses these templates to
-create data streams. If you use {agent}, assign your index templates a priority
-lower than `100` to avoid an overriding the built-in templates.
-
-Otherwise, to avoid accidentally applying the built-in templates, use a
-non-overlapping index pattern or assign templates with an overlapping pattern a
-`priority` higher than `100`.
-
-For example, if you don't use {agent} and want to create a template for the
-`logs-*` index pattern, assign your template a priority of `200`. This ensures
-your template is applied instead of the built-in template for `logs-*-*`.
-====
+include::{es-repo-dir}/indices/index-templates.asciidoc[tag=built-in-index-templates]
 
 [xpack]#`data_stream`#::
 (Optional, object)


### PR DESCRIPTION
Backports the following commits to 7.11:
 - [DOCS] Reuse built-in index templates admon (#68314)