### PR TITLE
[7.11] ILM: fix searchable snapshot action to wait for the restored index (#68309)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitForIndexColorStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitForIndexColorStep.java
@@ -76,12 +76,12 @@ class WaitForIndexColorStep extends ClusterStateWaitStep {
     @Override
     public Result isConditionMet(Index index, ClusterState clusterState) {
         String indexName = indexNamePrefix != null ? indexNamePrefix + index.getName() : index.getName();
-        IndexMetadata indexMetadata = clusterState.metadata().index(index);
-
+        IndexMetadata indexMetadata = clusterState.metadata().index(indexName);
+        // check if the (potentially) derived index exists
         if (indexMetadata == null) {
-            String errorMessage = String.format(Locale.ROOT, "[%s] lifecycle action for index [%s] executed but index no longer exists",
-                getKey().getAction(), indexName);
-            // Index must have been since deleted
+            String errorMessage = String.format(Locale.ROOT, "[%s] lifecycle action for index [%s] executed but the target index [%s] " +
+                    "does not exist",
+                getKey().getAction(), index.getName(), indexName);
             logger.debug(errorMessage);
             return new Result(false, new Info(errorMessage));
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForIndexColorStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForIndexColorStepTests.java
@@ -210,5 +210,87 @@ public class WaitForIndexColorStepTests extends AbstractStepTestCase<WaitForInde
         assertThat(info, notNullValue());
         assertThat(info.getMessage(), equalTo("index is red; no indexRoutingTable"));
     }
+
+    public void testStepReturnsFalseIfTargetIndexIsMissing() {
+        IndexMetadata originalIndex = IndexMetadata.builder(randomAlphaOfLength(5))
+            .settings(settings(Version.CURRENT))
+            .numberOfShards(1)
+            .numberOfReplicas(2)
+            .build();
+
+        String indexPrefix = randomAlphaOfLengthBetween(5, 10) + "-";
+        ShardRouting shardRouting =
+            TestShardRouting.newShardRouting(originalIndex.getIndex().getName(), 0, "1", true, ShardRoutingState.STARTED);
+        IndexRoutingTable indexRoutingTable = IndexRoutingTable.builder(originalIndex.getIndex())
+            .addShard(shardRouting).build();
+
+        ClusterState clusterState = ClusterState.builder(new ClusterName("_name"))
+            .metadata(Metadata.builder().put(originalIndex, true).build())
+            .routingTable(RoutingTable.builder().add(indexRoutingTable).build())
+            .build();
+
+        WaitForIndexColorStep step = new WaitForIndexColorStep(randomStepKey(), randomStepKey(), ClusterHealthStatus.GREEN, indexPrefix);
+        ClusterStateWaitStep.Result result = step.isConditionMet(originalIndex.getIndex(), clusterState);
+        assertThat(result.isComplete(), is(false));
+        WaitForIndexColorStep.Info info = (WaitForIndexColorStep.Info) result.getInfomationContext();
+        String targetIndex = indexPrefix + originalIndex.getIndex().getName();
+        assertThat(info.getMessage(), is("[" + step.getKey().getAction() + "] lifecycle action for index [" +
+            originalIndex.getIndex().getName() + "] executed but the target index [" + targetIndex + "] does not exist"));
+    }
+
+    public void testStepWaitsForTargetIndexHealthWhenPrefixConfigured() {
+        IndexMetadata originalIndex = IndexMetadata.builder(randomAlphaOfLength(5))
+            .settings(settings(Version.CURRENT))
+            .numberOfShards(1)
+            .numberOfReplicas(2)
+            .build();
+        ShardRouting originalShardRouting =
+            TestShardRouting.newShardRouting(originalIndex.getIndex().getName(), 0, "1", true, ShardRoutingState.STARTED);
+        IndexRoutingTable originalIndexRoutingTable = IndexRoutingTable.builder(originalIndex.getIndex())
+            .addShard(originalShardRouting).build();
+
+        String indexPrefix = randomAlphaOfLengthBetween(5, 10) + "-";
+        String targetIndexName = indexPrefix + originalIndex.getIndex().getName();
+        IndexMetadata targetIndex = IndexMetadata.builder(targetIndexName)
+            .settings(settings(Version.CURRENT))
+            .numberOfShards(1)
+            .numberOfReplicas(2)
+            .build();
+
+        {
+            ShardRouting targetShardRouting =
+                TestShardRouting.newShardRouting(targetIndexName, 0, "1", true, ShardRoutingState.INITIALIZING);
+            IndexRoutingTable targetIndexRoutingTable = IndexRoutingTable.builder(originalIndex.getIndex())
+                .addShard(targetShardRouting).build();
+
+            ClusterState clusterTargetInitializing = ClusterState.builder(new ClusterName("_name"))
+                .metadata(Metadata.builder().put(originalIndex, true).put(targetIndex, true).build())
+                .routingTable(RoutingTable.builder().add(originalIndexRoutingTable).add(targetIndexRoutingTable).build())
+                .build();
+
+            WaitForIndexColorStep step = new WaitForIndexColorStep(randomStepKey(), randomStepKey(), ClusterHealthStatus.GREEN);
+            ClusterStateWaitStep.Result result = step.isConditionMet(originalIndex.getIndex(), clusterTargetInitializing);
+            assertThat(result.isComplete(), is(false));
+            WaitForIndexColorStep.Info info = (WaitForIndexColorStep.Info) result.getInfomationContext();
+            assertThat(info.getMessage(), is("index is not green; not all shards are active"));
+        }
+
+        {
+            ShardRouting targetShardRouting =
+                TestShardRouting.newShardRouting(targetIndexName, 0, "1", true, ShardRoutingState.STARTED);
+            IndexRoutingTable targetIndexRoutingTable = IndexRoutingTable.builder(originalIndex.getIndex())
+                .addShard(targetShardRouting).build();
+
+            ClusterState clusterTargetInitializing = ClusterState.builder(new ClusterName("_name"))
+                .metadata(Metadata.builder().put(originalIndex, true).put(targetIndex, true).build())
+                .routingTable(RoutingTable.builder().add(originalIndexRoutingTable).add(targetIndexRoutingTable).build())
+                .build();
+
+            WaitForIndexColorStep step = new WaitForIndexColorStep(randomStepKey(), randomStepKey(), ClusterHealthStatus.GREEN);
+            ClusterStateWaitStep.Result result = step.isConditionMet(originalIndex.getIndex(), clusterTargetInitializing);
+            assertThat(result.isComplete(), is(true));
+            assertThat(result.getInfomationContext(), nullValue());
+        }
+    }
 }
 


### PR DESCRIPTION
This fixes a bug in `WaitForIndexColorStep` which was not waiting for the
restored index to be `GREEN` but it was checking the original/managed index.

This has the potential of ILM moving forward with the `searchable_snapshot` action
and deleting the original index, whilst the restored index is not fully restored
and allocated, yielding a possible **search** downtime.

(cherry picked from commit 480795c8b54460000d8b74fbbdb7385c7cb608c5)
Signed-off-by: Andrei Dan <andrei.dan@elastic.co>

Backport of #68309 