### PR TITLE
[7.x] gradle rest resources plugin clean up (#68174)

### DIFF
--- a/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/RestResourcesPluginFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/RestResourcesPluginFuncTest.groovy
@@ -28,8 +28,8 @@ class RestResourcesPluginFuncTest extends AbstractRestResourcesFuncTest {
         given:
         internalBuild()
         buildFile << """
-            apply plugin: 'elasticsearch.rest-resources'
             apply plugin: 'elasticsearch.java'
+            apply plugin: 'elasticsearch.rest-resources'
         """
 
         String api = "foo.json"
@@ -47,8 +47,8 @@ class RestResourcesPluginFuncTest extends AbstractRestResourcesFuncTest {
         given:
         internalBuild()
         buildFile << """
-           apply plugin: 'elasticsearch.rest-resources'
            apply plugin: 'elasticsearch.java'
+           apply plugin: 'elasticsearch.rest-resources'
         """
         String api = "foo.json"
         setupRestResources([api])
@@ -67,8 +67,8 @@ class RestResourcesPluginFuncTest extends AbstractRestResourcesFuncTest {
         given:
         internalBuild()
         buildFile << """
-            apply plugin: 'elasticsearch.rest-resources'
             apply plugin: 'elasticsearch.java'
+            apply plugin: 'elasticsearch.rest-resources'
 
             restResources {
                 restTests {
@@ -103,8 +103,8 @@ class RestResourcesPluginFuncTest extends AbstractRestResourcesFuncTest {
         given:
         internalBuild()
         buildFile << """
-            apply plugin: 'elasticsearch.rest-resources'
             apply plugin: 'elasticsearch.java'
+            apply plugin: 'elasticsearch.rest-resources'
 
             restResources {
                 restApi {
@@ -136,8 +136,8 @@ class RestResourcesPluginFuncTest extends AbstractRestResourcesFuncTest {
         given:
         internalBuild()
         buildFile << """
-            apply plugin: 'elasticsearch.rest-resources'
             apply plugin: 'elasticsearch.java'
+            apply plugin: 'elasticsearch.rest-resources'
 
             restResources {
                 restApi {

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/CopyRestApiTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/CopyRestApiTask.java
@@ -20,21 +20,18 @@ package org.elasticsearch.gradle.test.rest;
 
 import org.elasticsearch.gradle.VersionProperties;
 import org.elasticsearch.gradle.info.BuildParams;
-import org.elasticsearch.gradle.util.GradleUtils;
 import org.gradle.api.DefaultTask;
-import org.gradle.api.Project;
 import org.gradle.api.file.ArchiveOperations;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileSystemOperations;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.file.ProjectLayout;
-import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.SkipWhenEmpty;
-import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.util.PatternFilterable;
 import org.gradle.api.tasks.util.PatternSet;
@@ -45,8 +42,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -56,45 +51,43 @@ import static org.elasticsearch.gradle.util.GradleUtils.getProjectPathFromTask;
  * Copies the files needed for the Rest YAML specs to the current projects test resources output directory.
  * This is intended to be be used from {@link RestResourcesPlugin} since the plugin wires up the needed
  * configurations and custom extensions.
+ *
  * @see RestResourcesPlugin
  */
 public class CopyRestApiTask extends DefaultTask {
     private static final String REST_API_PREFIX = "rest-api-spec/api";
-    final ListProperty<String> includeCore = getProject().getObjects().listProperty(String.class);
-    final ListProperty<String> includeXpack = getProject().getObjects().listProperty(String.class);
-    String sourceSetName;
-    boolean skipHasRestTestCheck;
-    FileCollection coreConfig;
-    FileCollection xpackConfig;
-    FileCollection additionalConfig;
-    Function<FileCollection, FileTree> coreConfigToFileTree = FileCollection::getAsFileTree;
-    Function<FileCollection, FileTree> xpackConfigToFileTree = FileCollection::getAsFileTree;
-    Function<FileCollection, FileTree> additionalConfigToFileTree = FileCollection::getAsFileTree;
+    private static final String REST_TEST_PREFIX = "rest-api-spec/test";
+    private final ListProperty<String> includeCore = getProject().getObjects().listProperty(String.class);
+    private final ListProperty<String> includeXpack = getProject().getObjects().listProperty(String.class);
+
+    private File outputResourceDir;
+    private File sourceResourceDir;
+    private boolean skipHasRestTestCheck;
+    private FileCollection coreConfig;
+    private FileCollection xpackConfig;
+    private FileCollection additionalConfig;
+    private Function<FileCollection, FileTree> coreConfigToFileTree = FileCollection::getAsFileTree;
+    private Function<FileCollection, FileTree> xpackConfigToFileTree = FileCollection::getAsFileTree;
+    private Function<FileCollection, FileTree> additionalConfigToFileTree = FileCollection::getAsFileTree;
 
     private final PatternFilterable corePatternSet;
     private final PatternFilterable xpackPatternSet;
     private final ProjectLayout projectLayout;
+    private final FileSystemOperations fileSystemOperations;
+    private final ArchiveOperations archiveOperations;
 
     @Inject
-    public CopyRestApiTask(ProjectLayout projectLayout) {
-        corePatternSet = getPatternSetFactory().create();
-        xpackPatternSet = getPatternSetFactory().create();
+    public CopyRestApiTask(
+        ProjectLayout projectLayout,
+        Factory<PatternSet> patternSetFactory,
+        FileSystemOperations fileSystemOperations,
+        ArchiveOperations archiveOperations
+    ) {
+        corePatternSet = patternSetFactory.create();
+        xpackPatternSet = patternSetFactory.create();
         this.projectLayout = projectLayout;
-    }
-
-    @Inject
-    protected Factory<PatternSet> getPatternSetFactory() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Inject
-    protected FileSystemOperations getFileSystemOperations() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Inject
-    protected ArchiveOperations getArchiveOperations() {
-        throw new UnsupportedOperationException();
+        this.fileSystemOperations = fileSystemOperations;
+        this.archiveOperations = archiveOperations;
     }
 
     @Input
@@ -105,11 +98,6 @@ public class CopyRestApiTask extends DefaultTask {
     @Input
     public ListProperty<String> getIncludeXpack() {
         return includeXpack;
-    }
-
-    @Input
-    String getSourceSetName() {
-        return sourceSetName;
     }
 
     @Input
@@ -148,12 +136,7 @@ public class CopyRestApiTask extends DefaultTask {
 
     @OutputDirectory
     public File getOutputDir() {
-        return new File(
-            getSourceSet().orElseThrow(() -> new IllegalArgumentException("could not find source set [" + sourceSetName + "]"))
-                .getOutput()
-                .getResourcesDir(),
-            REST_API_PREFIX
-        );
+        return new File(outputResourceDir, REST_API_PREFIX);
     }
 
     @TaskAction
@@ -162,7 +145,7 @@ public class CopyRestApiTask extends DefaultTask {
         String projectPath = getProjectPathFromTask(getPath());
         if (BuildParams.isInternal()) {
             getLogger().debug("Rest specs for project [{}] will be copied to the test resources.", projectPath);
-            getFileSystemOperations().copy(c -> {
+            fileSystemOperations.copy(c -> {
                 c.from(coreConfigToFileTree.apply(coreConfig));
                 c.into(getOutputDir());
                 c.include(corePatternSet.getIncludes());
@@ -173,10 +156,9 @@ public class CopyRestApiTask extends DefaultTask {
                 projectPath,
                 VersionProperties.getElasticsearch()
             );
-            getFileSystemOperations().copy(c -> {
-                c.from(getArchiveOperations().zipTree(coreConfig.getSingleFile())); // jar file
-                // this ends up as the same dir as outputDir
-                c.into(Objects.requireNonNull(getSourceSet().orElseThrow().getOutput().getResourcesDir()));
+            fileSystemOperations.copy(c -> {
+                c.from(archiveOperations.zipTree(coreConfig.getSingleFile())); // jar file
+                c.into(Objects.requireNonNull(outputResourceDir));
                 if (includeCore.get().isEmpty()) {
                     c.include(REST_API_PREFIX + "/**");
                 } else {
@@ -189,16 +171,16 @@ public class CopyRestApiTask extends DefaultTask {
         // only copy x-pack specs if explicitly instructed
         if (includeXpack.get().isEmpty() == false) {
             getLogger().debug("X-pack rest specs for project [{}] will be copied to the test resources.", projectPath);
-            getFileSystemOperations().copy(c -> {
+            fileSystemOperations.copy(c -> {
                 c.from(xpackConfigToFileTree.apply(xpackConfig));
                 c.into(getOutputDir());
                 c.include(xpackPatternSet.getIncludes());
             });
         }
-        // TODO: once https://github.com/elastic/elasticsearch/pull/62968 lands ensure that this uses `getFileSystemOperations()`
+
         // copy any additional config
         if (additionalConfig != null) {
-            getFileSystemOperations().copy(c -> {
+            fileSystemOperations.copy(c -> {
                 c.from(additionalConfigToFileTree.apply(additionalConfig));
                 c.into(getOutputDir());
             });
@@ -209,19 +191,18 @@ public class CopyRestApiTask extends DefaultTask {
      * Returns true if any files with a .yml extension exist the test resources rest-api-spec/test directory (from source or output dir)
      */
     private boolean projectHasYamlRestTests() {
-        File testSourceResourceDir = getTestSourceResourceDir();
-        File testOutputResourceDir = getTestOutputResourceDir(); // check output for cases where tests are copied programmatically
-
-        if (testSourceResourceDir == null && testOutputResourceDir == null) {
+        if (sourceResourceDir == null && outputResourceDir == null) {
             return false;
         }
         try {
-            if (testSourceResourceDir != null && new File(testSourceResourceDir, "rest-api-spec/test").exists()) {
-                return Files.walk(testSourceResourceDir.toPath().resolve("rest-api-spec/test"))
+            // check source folder for tests
+            if (sourceResourceDir != null && new File(sourceResourceDir, REST_TEST_PREFIX).exists()) {
+                return Files.walk(sourceResourceDir.toPath().resolve(REST_TEST_PREFIX))
                     .anyMatch(p -> p.getFileName().toString().endsWith("yml"));
             }
-            if (testOutputResourceDir != null && new File(testOutputResourceDir, "rest-api-spec/test").exists()) {
-                return Files.walk(testOutputResourceDir.toPath().resolve("rest-api-spec/test"))
+            // check output for cases where tests are copied programmatically
+            if (outputResourceDir != null && new File(outputResourceDir, REST_TEST_PREFIX).exists()) {
+                return Files.walk(new File(outputResourceDir, REST_TEST_PREFIX).toPath())
                     .anyMatch(p -> p.getFileName().toString().endsWith("yml"));
             }
         } catch (IOException e) {
@@ -230,34 +211,50 @@ public class CopyRestApiTask extends DefaultTask {
         return false;
     }
 
-    private File getTestSourceResourceDir() {
-        Optional<SourceSet> testSourceSet = getSourceSet();
-        if (testSourceSet.isPresent()) {
-            SourceSet testSources = testSourceSet.get();
-            Set<File> resourceDir = testSources.getResources()
-                .getSrcDirs()
-                .stream()
-                .filter(f -> f.isDirectory() && f.getParentFile().getName().equals(getSourceSetName()) && f.getName().equals("resources"))
-                .collect(Collectors.toSet());
-            assert resourceDir.size() <= 1;
-            if (resourceDir.size() == 0) {
-                return null;
-            }
-            return resourceDir.iterator().next();
-        } else {
-            return null;
-        }
+    public void setSourceResourceDir(File sourceResourceDir) {
+        this.sourceResourceDir = sourceResourceDir;
     }
 
-    private File getTestOutputResourceDir() {
-        Optional<SourceSet> testSourceSet = getSourceSet();
-        return testSourceSet.map(sourceSet -> sourceSet.getOutput().getResourcesDir()).orElse(null);
+    public void setOutputResourceDir(File outputResourceDir) {
+        this.outputResourceDir = outputResourceDir;
     }
 
-    private Optional<SourceSet> getSourceSet() {
-        Project project = getProject();
-        return project.getConvention().findPlugin(JavaPluginConvention.class) == null
-            ? Optional.empty()
-            : Optional.ofNullable(GradleUtils.getJavaSourceSets(project).findByName(getSourceSetName()));
+    public void setSkipHasRestTestCheck(boolean skipHasRestTestCheck) {
+        this.skipHasRestTestCheck = skipHasRestTestCheck;
     }
+
+    public void setCoreConfig(FileCollection coreConfig) {
+        this.coreConfig = coreConfig;
+    }
+
+    public void setXpackConfig(FileCollection xpackConfig) {
+        this.xpackConfig = xpackConfig;
+    }
+
+    public void setAdditionalConfig(FileCollection additionalConfig) {
+        this.additionalConfig = additionalConfig;
+    }
+
+    public void setCoreConfigToFileTree(Function<FileCollection, FileTree> coreConfigToFileTree) {
+        this.coreConfigToFileTree = coreConfigToFileTree;
+    }
+
+    public void setXpackConfigToFileTree(Function<FileCollection, FileTree> xpackConfigToFileTree) {
+        this.xpackConfigToFileTree = xpackConfigToFileTree;
+    }
+
+    public void setAdditionalConfigToFileTree(Function<FileCollection, FileTree> additionalConfigToFileTree) {
+        this.additionalConfigToFileTree = additionalConfigToFileTree;
+    }
+
+    @Internal
+    public FileCollection getCoreConfig() {
+        return coreConfig;
+    }
+
+    @Internal
+    public FileCollection getXpackConfig() {
+        return xpackConfig;
+    }
+
 }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/CopyRestTestsTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/CopyRestTestsTask.java
@@ -20,21 +20,18 @@ package org.elasticsearch.gradle.test.rest;
 
 import org.elasticsearch.gradle.VersionProperties;
 import org.elasticsearch.gradle.info.BuildParams;
-import org.elasticsearch.gradle.util.GradleUtils;
 import org.gradle.api.DefaultTask;
-import org.gradle.api.Project;
 import org.gradle.api.file.ArchiveOperations;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileSystemOperations;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.file.ProjectLayout;
-import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.SkipWhenEmpty;
-import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.util.PatternFilterable;
 import org.gradle.api.tasks.util.PatternSet;
@@ -43,7 +40,6 @@ import org.gradle.internal.Factory;
 import javax.inject.Inject;
 import java.io.File;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -53,45 +49,40 @@ import static org.elasticsearch.gradle.util.GradleUtils.getProjectPathFromTask;
  * Copies the Rest YAML test to the current projects test resources output directory.
  * This is intended to be be used from {@link RestResourcesPlugin} since the plugin wires up the needed
  * configurations and custom extensions.
+ *
  * @see RestResourcesPlugin
  */
 public class CopyRestTestsTask extends DefaultTask {
     private static final String REST_TEST_PREFIX = "rest-api-spec/test";
-    final ListProperty<String> includeCore = getProject().getObjects().listProperty(String.class);
-    final ListProperty<String> includeXpack = getProject().getObjects().listProperty(String.class);
+    private final ListProperty<String> includeCore = getProject().getObjects().listProperty(String.class);
+    private final ListProperty<String> includeXpack = getProject().getObjects().listProperty(String.class);
 
-    String sourceSetName;
-    FileCollection coreConfig;
-    FileCollection xpackConfig;
-    FileCollection additionalConfig;
-    Function<FileCollection, FileTree> coreConfigToFileTree = FileCollection::getAsFileTree;
-    Function<FileCollection, FileTree> xpackConfigToFileTree = FileCollection::getAsFileTree;
-    Function<FileCollection, FileTree> additionalConfigToFileTree = FileCollection::getAsFileTree;
+    private File outputResourceDir;
+    private FileCollection coreConfig;
+    private FileCollection xpackConfig;
+    private FileCollection additionalConfig;
+    private Function<FileCollection, FileTree> coreConfigToFileTree = FileCollection::getAsFileTree;
+    private Function<FileCollection, FileTree> xpackConfigToFileTree = FileCollection::getAsFileTree;
+    private Function<FileCollection, FileTree> additionalConfigToFileTree = FileCollection::getAsFileTree;
 
     private final PatternFilterable corePatternSet;
     private final PatternFilterable xpackPatternSet;
     private final ProjectLayout projectLayout;
+    private final FileSystemOperations fileSystemOperations;
+    private final ArchiveOperations archiveOperations;
 
     @Inject
-    public CopyRestTestsTask(ProjectLayout projectLayout) {
-        corePatternSet = getPatternSetFactory().create();
-        xpackPatternSet = getPatternSetFactory().create();
+    public CopyRestTestsTask(
+        ProjectLayout projectLayout,
+        Factory<PatternSet> patternSetFactory,
+        FileSystemOperations fileSystemOperations,
+        ArchiveOperations archiveOperations
+    ) {
+        corePatternSet = patternSetFactory.create();
+        xpackPatternSet = patternSetFactory.create();
         this.projectLayout = projectLayout;
-    }
-
-    @Inject
-    protected Factory<PatternSet> getPatternSetFactory() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Inject
-    protected FileSystemOperations getFileSystemOperations() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Inject
-    protected ArchiveOperations getArchiveOperations() {
-        throw new UnsupportedOperationException();
+        this.fileSystemOperations = fileSystemOperations;
+        this.archiveOperations = archiveOperations;
     }
 
     @Input
@@ -102,11 +93,6 @@ public class CopyRestTestsTask extends DefaultTask {
     @Input
     public ListProperty<String> getIncludeXpack() {
         return includeXpack;
-    }
-
-    @Input
-    String getSourceSetName() {
-        return sourceSetName;
     }
 
     @SkipWhenEmpty
@@ -138,12 +124,7 @@ public class CopyRestTestsTask extends DefaultTask {
 
     @OutputDirectory
     public File getOutputDir() {
-        return new File(
-            getSourceSet().orElseThrow(() -> new IllegalArgumentException("could not find source set [" + sourceSetName + "]"))
-                .getOutput()
-                .getResourcesDir(),
-            REST_TEST_PREFIX
-        );
+        return new File(outputResourceDir, REST_TEST_PREFIX);
     }
 
     @TaskAction
@@ -153,7 +134,7 @@ public class CopyRestTestsTask extends DefaultTask {
         if (includeCore.get().isEmpty() == false) {
             if (BuildParams.isInternal()) {
                 getLogger().debug("Rest tests for project [{}] will be copied to the test resources.", projectPath);
-                getFileSystemOperations().copy(c -> {
+                fileSystemOperations.copy(c -> {
                     c.from(coreConfigToFileTree.apply(coreConfig));
                     c.into(getOutputDir());
                     c.include(corePatternSet.getIncludes());
@@ -164,10 +145,9 @@ public class CopyRestTestsTask extends DefaultTask {
                     projectPath,
                     VersionProperties.getElasticsearch()
                 );
-                getFileSystemOperations().copy(c -> {
-                    c.from(getArchiveOperations().zipTree(coreConfig.getSingleFile())); // jar file
-                    // this ends up as the same dir as outputDir
-                    c.into(Objects.requireNonNull(getSourceSet().orElseThrow().getOutput().getResourcesDir()));
+                fileSystemOperations.copy(c -> {
+                    c.from(archiveOperations.zipTree(coreConfig.getSingleFile())); // jar file
+                    c.into(Objects.requireNonNull(outputResourceDir));
                     c.include(
                         includeCore.get().stream().map(prefix -> REST_TEST_PREFIX + "/" + prefix + "*/**").collect(Collectors.toList())
                     );
@@ -177,7 +157,7 @@ public class CopyRestTestsTask extends DefaultTask {
         // only copy x-pack tests if explicitly instructed
         if (includeXpack.get().isEmpty() == false) {
             getLogger().debug("X-pack rest tests for project [{}] will be copied to the test resources.", projectPath);
-            getFileSystemOperations().copy(c -> {
+            fileSystemOperations.copy(c -> {
                 c.from(xpackConfigToFileTree.apply(xpackConfig));
                 c.into(getOutputDir());
                 c.include(xpackPatternSet.getIncludes());
@@ -185,17 +165,48 @@ public class CopyRestTestsTask extends DefaultTask {
         }
         // copy any additional config
         if (additionalConfig != null) {
-            getFileSystemOperations().copy(c -> {
+            fileSystemOperations.copy(c -> {
                 c.from(additionalConfigToFileTree.apply(additionalConfig));
                 c.into(getOutputDir());
             });
         }
     }
 
-    private Optional<SourceSet> getSourceSet() {
-        Project project = getProject();
-        return project.getConvention().findPlugin(JavaPluginConvention.class) == null
-            ? Optional.empty()
-            : Optional.ofNullable(GradleUtils.getJavaSourceSets(project).findByName(getSourceSetName()));
+    public void setOutputResourceDir(File outputResourceDir) {
+        this.outputResourceDir = outputResourceDir;
+    }
+
+    public void setCoreConfig(FileCollection coreConfig) {
+        this.coreConfig = coreConfig;
+    }
+
+    public void setXpackConfig(FileCollection xpackConfig) {
+        this.xpackConfig = xpackConfig;
+    }
+
+    public void setAdditionalConfig(FileCollection additionalConfig) {
+        this.additionalConfig = additionalConfig;
+    }
+
+    public void setCoreConfigToFileTree(Function<FileCollection, FileTree> coreConfigToFileTree) {
+        this.coreConfigToFileTree = coreConfigToFileTree;
+    }
+
+    public void setXpackConfigToFileTree(Function<FileCollection, FileTree> xpackConfigToFileTree) {
+        this.xpackConfigToFileTree = xpackConfigToFileTree;
+    }
+
+    public void setAdditionalConfigToFileTree(Function<FileCollection, FileTree> additionalConfigToFileTree) {
+        this.additionalConfigToFileTree = additionalConfigToFileTree;
+    }
+
+    @Internal
+    public FileCollection getCoreConfig() {
+        return coreConfig;
+    }
+
+    @Internal
+    public FileCollection getXpackConfig() {
+        return xpackConfig;
     }
 }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/RestResourcesPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/RestResourcesPlugin.java
@@ -90,6 +90,9 @@ public class RestResourcesPlugin implements Plugin<Project> {
     public void apply(Project project) {
         RestResourcesExtension extension = project.getExtensions().create(EXTENSION_NAME, RestResourcesExtension.class);
 
+        SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
+        SourceSet defaultSourceSet = sourceSets.getByName(TEST_SOURCE_SET_NAME);
+
         // tests
         Configuration testConfig = project.getConfigurations().create("restTestConfig");
         Configuration xpackTestConfig = project.getConfigurations().create("restXpackTestConfig");
@@ -97,10 +100,10 @@ public class RestResourcesPlugin implements Plugin<Project> {
         project.getConfigurations().create("restXpackTests");
         Provider<CopyRestTestsTask> copyRestYamlTestTask = project.getTasks()
             .register("copyYamlTestsTask", CopyRestTestsTask.class, task -> {
-                task.includeCore.set(extension.restTests.getIncludeCore());
-                task.includeXpack.set(extension.restTests.getIncludeXpack());
-                task.coreConfig = testConfig;
-                task.sourceSetName = SourceSet.TEST_SOURCE_SET_NAME;
+                task.getIncludeCore().set(extension.restTests.getIncludeCore());
+                task.getIncludeXpack().set(extension.restTests.getIncludeXpack());
+                task.setCoreConfig(testConfig);
+                task.setOutputResourceDir(defaultSourceSet.getOutput().getResourcesDir());
                 if (BuildParams.isInternal()) {
                     // core
                     Dependency restTestdependency = project.getDependencies()
@@ -125,36 +128,37 @@ public class RestResourcesPlugin implements Plugin<Project> {
         Configuration xpackSpecConfig = project.getConfigurations().create("restXpackSpec");
         project.getConfigurations().create("restSpecs");
         project.getConfigurations().create("restXpackSpecs");
-        Provider<CopyRestApiTask> copyRestYamlSpecTask = project.getTasks()
-            .register("copyRestApiSpecsTask", CopyRestApiTask.class, task -> {
-                task.includeCore.set(extension.restApi.getIncludeCore());
-                task.includeXpack.set(extension.restApi.getIncludeXpack());
-                task.dependsOn(copyRestYamlTestTask);
-                task.coreConfig = specConfig;
-                task.sourceSetName = SourceSet.TEST_SOURCE_SET_NAME;
-                if (BuildParams.isInternal()) {
-                    Dependency restSpecDependency = project.getDependencies()
-                        .project(Map.of("path", ":rest-api-spec", "configuration", "restSpecs"));
-                    project.getDependencies().add(specConfig.getName(), restSpecDependency);
-                    task.xpackConfig = xpackSpecConfig;
-                    Dependency restXpackSpecDependency = project.getDependencies()
-                        .project(Map.of("path", ":x-pack:plugin", "configuration", "restXpackSpecs"));
-                    project.getDependencies().add(xpackSpecConfig.getName(), restXpackSpecDependency);
-                    task.dependsOn(task.xpackConfig);
-                } else {
-                    Dependency dependency = project.getDependencies()
-                        .create("org.elasticsearch:rest-api-spec:" + VersionProperties.getElasticsearch());
-                    project.getDependencies().add(specConfig.getName(), dependency);
-                }
-                task.dependsOn(xpackSpecConfig);
-            });
-
-        project.afterEvaluate(p -> {
-            SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
-            SourceSet testSourceSet = sourceSets.findByName(SourceSet.TEST_SOURCE_SET_NAME);
-            if (testSourceSet != null) {
-                project.getTasks().named(testSourceSet.getProcessResourcesTaskName()).configure(t -> t.dependsOn(copyRestYamlSpecTask));
+        Provider<CopyRestApiTask> copyRestYamlApiTask = project.getTasks().register("copyRestApiSpecsTask", CopyRestApiTask.class, task -> {
+            task.getIncludeCore().set(extension.restApi.getIncludeCore());
+            task.getIncludeXpack().set(extension.restApi.getIncludeXpack());
+            task.dependsOn(copyRestYamlTestTask);
+            task.setCoreConfig(specConfig);
+            task.setOutputResourceDir(defaultSourceSet.getOutput().getResourcesDir());
+            task.setSourceResourceDir(
+                defaultSourceSet.getResources()
+                    .getSrcDirs()
+                    .stream()
+                    .filter(f -> f.isDirectory() && f.getName().equals("resources"))
+                    .findFirst()
+                    .orElse(null)
+            );
+            if (BuildParams.isInternal()) {
+                Dependency restSpecDependency = project.getDependencies()
+                    .project(Map.of("path", ":rest-api-spec", "configuration", "restSpecs"));
+                project.getDependencies().add(specConfig.getName(), restSpecDependency);
+                task.setXpackConfig(xpackSpecConfig);
+                Dependency restXpackSpecDependency = project.getDependencies()
+                    .project(Map.of("path", ":x-pack:plugin", "configuration", "restXpackSpecs"));
+                project.getDependencies().add(xpackSpecConfig.getName(), restXpackSpecDependency);
+                task.dependsOn(task.getXpackConfig());
+            } else {
+                Dependency dependency = project.getDependencies()
+                    .create("org.elasticsearch:rest-api-spec:" + VersionProperties.getElasticsearch());
+                project.getDependencies().add(specConfig.getName(), dependency);
             }
+            task.dependsOn(xpackSpecConfig);
         });
+
+        project.getTasks().named(defaultSourceSet.getProcessResourcesTaskName()).configure(t -> t.dependsOn(copyRestYamlApiTask));
     }
 }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/RestResourcesPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/RestResourcesPlugin.java
@@ -30,6 +30,8 @@ import org.gradle.api.tasks.SourceSetContainer;
 
 import java.util.Map;
 
+import static org.gradle.api.tasks.SourceSet.TEST_SOURCE_SET_NAME;
+
 /**
  * <p>
  * Gradle plugin to help configure {@link CopyRestApiTask}'s and {@link CopyRestTestsTask} that copies the artifacts needed for the Rest API
@@ -110,11 +112,11 @@ public class RestResourcesPlugin implements Plugin<Project> {
                         .project(Map.of("path", ":rest-api-spec", "configuration", "restTests"));
                     project.getDependencies().add(testConfig.getName(), restTestdependency);
                     // x-pack
-                    task.xpackConfig = xpackTestConfig;
+                    task.setXpackConfig(xpackTestConfig);
                     Dependency restXPackTestdependency = project.getDependencies()
                         .project(Map.of("path", ":x-pack:plugin", "configuration", "restXpackTests"));
                     project.getDependencies().add(xpackTestConfig.getName(), restXPackTestdependency);
-                    task.dependsOn(task.xpackConfig);
+                    task.dependsOn(task.getXpackConfig());
                 } else {
                     Dependency dependency = project.getDependencies()
                         .create("org.elasticsearch:rest-api-spec:" + VersionProperties.getElasticsearch());


### PR DESCRIPTION
This commit cleans up some of the rest resources to honor best practices.

These changes include:
* remove SourceSet from copy api/test tasks and move the logic to the plugin.
  * this allows the tasks talk in simpler terms in File and FileCollections.
* prefer constructor injection over method injection for gradle components
* rename tasks to better match usage:
   * copyRestApiCompatSpecsTask -> copyRestCompatApiTask
   * copyRestApiCompatTestTask -> copyRestCompatTestTask
* remove no longer valid TODO's