### PR TITLE
Add grok and dissect methods to runtime fields (backport of #68088)

### DIFF
--- a/libs/dissect/src/main/java/org/elasticsearch/dissect/DissectKey.java
+++ b/libs/dissect/src/main/java/org/elasticsearch/dissect/DissectKey.java
@@ -102,7 +102,7 @@ public final class DissectKey {
         }
 
         if (name == null || (name.isEmpty() && !skip)) {
-            throw new DissectException.KeyParse(key, "The key name could be determined");
+            throw new DissectException.KeyParse(key, "The key name could not be determined");
         }
     }
 

--- a/libs/dissect/src/main/java/org/elasticsearch/dissect/DissectParser.java
+++ b/libs/dissect/src/main/java/org/elasticsearch/dissect/DissectParser.java
@@ -34,7 +34,8 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
- * <p>Splits (dissects) a string into its parts based on a pattern.</p><p>A dissect pattern is composed of a set of keys and delimiters.
+ * Splits (dissects) a string into its parts based on a pattern.
+ * <p>A dissect pattern is composed of a set of keys and delimiters.
  * For example the dissect pattern: <pre>%{a} %{b},%{c}</pre> has 3 keys (a,b,c) and two delimiters (space and comma). This pattern will
  * match a string of the form: <pre>foo bar,baz</pre> and will result a key/value pairing of <pre>a=foo, b=bar, and c=baz.</pre>
  * <p>Matches are all or nothing. For example, the same pattern will NOT match <pre>foo bar baz</pre> since all of the delimiters did not
@@ -276,7 +277,19 @@ public final class DissectParser {
         }
         Map<String, String> results = dissectMatch.getResults();
 
-        if (dissectMatch.isValid(results) == false) {
+        return dissectMatch.isValid(results) ? results : null;
+    }
+
+    /**
+     * <p>Entry point to dissect a string into it's parts.</p>
+     *
+     * @param inputString The string to dissect
+     * @return the key/value Map of the results
+     * @throws DissectException if unable to dissect a pair into it's parts.
+     */
+    public Map<String, String> forceParse(String inputString) {
+        Map<String, String> results = parse(inputString);
+        if (results == null) {
             throw new DissectException.FindMatch(pattern, inputString);
         }
         return results;

--- a/libs/dissect/src/test/java/org/elasticsearch/dissect/DissectParserTests.java
+++ b/libs/dissect/src/test/java/org/elasticsearch/dissect/DissectParserTests.java
@@ -344,11 +344,12 @@ public class DissectParserTests extends ESTestCase {
         }
     }
 
-    private DissectException assertFail(String pattern, String input){
-        return expectThrows(DissectException.class, () -> new DissectParser(pattern, null).parse(input));
+    private DissectException assertFail(String pattern, String input) {
+        return expectThrows(DissectException.class, () -> new DissectParser(pattern, null).forceParse(input));
     }
 
     private void assertMiss(String pattern, String input) {
+        assertNull(new DissectParser(pattern, null).parse(input)); 
         DissectException e = assertFail(pattern, input);
         assertThat(e.getMessage(), CoreMatchers.containsString("Unable to find match for dissect pattern"));
         assertThat(e.getMessage(), CoreMatchers.containsString(pattern));

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DissectProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DissectProcessor.java
@@ -54,7 +54,7 @@ public final class DissectProcessor extends AbstractProcessor {
         } else if (input == null) {
             throw new IllegalArgumentException("field [" + field + "] is null, cannot process it.");
         }
-        dissectParser.parse(input).forEach(ingestDocument::setFieldValue);
+        dissectParser.forceParse(input).forEach(ingestDocument::setFieldValue);
         return ingestDocument;
     }
 

--- a/modules/lang-painless/spi/src/main/java/org/elasticsearch/painless/spi/annotation/CompileTimeOnlyAnnotation.java
+++ b/modules/lang-painless/spi/src/main/java/org/elasticsearch/painless/spi/annotation/CompileTimeOnlyAnnotation.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.painless.spi.annotation;
+
+/**
+ * Methods annotated with this must be run at compile time so their arguments
+ * must all be constant and they produce a constant.
+ */
+public class CompileTimeOnlyAnnotation {
+    public static final String NAME = "compile_time_only";
+
+    public static final CompileTimeOnlyAnnotation INSTANCE = new CompileTimeOnlyAnnotation();
+
+    private CompileTimeOnlyAnnotation() {}
+}

--- a/modules/lang-painless/spi/src/main/java/org/elasticsearch/painless/spi/annotation/CompileTimeOnlyAnnotationParser.java
+++ b/modules/lang-painless/spi/src/main/java/org/elasticsearch/painless/spi/annotation/CompileTimeOnlyAnnotationParser.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.painless.spi.annotation;
+
+import java.util.Map;
+
+/**
+ * Methods annotated with {@link CompileTimeOnlyAnnotation} must be run at
+ * compile time so their arguments must all be constant and they produce a
+ * constant.
+ */
+public class CompileTimeOnlyAnnotationParser implements WhitelistAnnotationParser {
+
+    public static final CompileTimeOnlyAnnotationParser INSTANCE = new CompileTimeOnlyAnnotationParser();
+
+    private CompileTimeOnlyAnnotationParser() {}
+
+    @Override
+    public Object parse(Map<String, String> arguments) {
+        if (arguments.isEmpty() == false) {
+            throw new IllegalArgumentException(
+                "unexpected parameters for [@" + CompileTimeOnlyAnnotation.NAME + "] annotation, found " + arguments
+            );
+        }
+
+        return CompileTimeOnlyAnnotation.INSTANCE;
+    }
+}

--- a/modules/lang-painless/spi/src/main/java/org/elasticsearch/painless/spi/annotation/WhitelistAnnotationParser.java
+++ b/modules/lang-painless/spi/src/main/java/org/elasticsearch/painless/spi/annotation/WhitelistAnnotationParser.java
@@ -36,7 +36,8 @@ public interface WhitelistAnnotationParser {
                     new AbstractMap.SimpleEntry<>(NoImportAnnotation.NAME, NoImportAnnotationParser.INSTANCE),
                     new AbstractMap.SimpleEntry<>(DeprecatedAnnotation.NAME, DeprecatedAnnotationParser.INSTANCE),
                     new AbstractMap.SimpleEntry<>(NonDeterministicAnnotation.NAME, NonDeterministicAnnotationParser.INSTANCE),
-                    new AbstractMap.SimpleEntry<>(InjectConstantAnnotation.NAME, InjectConstantAnnotationParser.INSTANCE)
+                    new AbstractMap.SimpleEntry<>(InjectConstantAnnotation.NAME, InjectConstantAnnotationParser.INSTANCE),
+                    new AbstractMap.SimpleEntry<>(CompileTimeOnlyAnnotation.NAME, CompileTimeOnlyAnnotationParser.INSTANCE)
             ).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))
     );
 

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Compiler.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Compiler.java
@@ -26,6 +26,7 @@ import org.elasticsearch.painless.lookup.PainlessLookup;
 import org.elasticsearch.painless.node.SClass;
 import org.elasticsearch.painless.phase.DefaultConstantFoldingOptimizationPhase;
 import org.elasticsearch.painless.phase.DefaultIRTreeToASMBytesPhase;
+import org.elasticsearch.painless.phase.DefaultStaticConstantExtractionPhase;
 import org.elasticsearch.painless.phase.DefaultStringConcatenationOptimizationPhase;
 import org.elasticsearch.painless.phase.DocFieldsPhase;
 import org.elasticsearch.painless.phase.PainlessSemanticAnalysisPhase;
@@ -227,6 +228,7 @@ final class Compiler {
         ClassNode classNode = (ClassNode)scriptScope.getDecoration(root, IRNodeDecoration.class).getIRNode();
         new DefaultStringConcatenationOptimizationPhase().visitClass(classNode, null);
         new DefaultConstantFoldingOptimizationPhase().visitClass(classNode, null);
+        new DefaultStaticConstantExtractionPhase().visitClass(classNode, scriptScope);
         new DefaultIRTreeToASMBytesPhase().visitScript(classNode);
         byte[] bytes = classNode.getBytes();
 
@@ -263,6 +265,7 @@ final class Compiler {
         ClassNode classNode = (ClassNode)scriptScope.getDecoration(root, IRNodeDecoration.class).getIRNode();
         new DefaultStringConcatenationOptimizationPhase().visitClass(classNode, null);
         new DefaultConstantFoldingOptimizationPhase().visitClass(classNode, null);
+        new DefaultStaticConstantExtractionPhase().visitClass(classNode, scriptScope);
         classNode.setDebugStream(debugStream);
         new DefaultIRTreeToASMBytesPhase().visitScript(classNode);
 

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/lookup/PainlessInstanceBinding.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/lookup/PainlessInstanceBinding.java
@@ -21,6 +21,7 @@ package org.elasticsearch.painless.lookup;
 
 import java.lang.reflect.Method;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 public class PainlessInstanceBinding {
@@ -30,13 +31,21 @@ public class PainlessInstanceBinding {
 
     public final Class<?> returnType;
     public final List<Class<?>> typeParameters;
+    public final Map<Class<?>, Object> annotations;
 
-    PainlessInstanceBinding(Object targetInstance, Method javaMethod, Class<?> returnType, List<Class<?>> typeParameters) {
+    PainlessInstanceBinding(
+        Object targetInstance,
+        Method javaMethod,
+        Class<?> returnType,
+        List<Class<?>> typeParameters,
+        Map<Class<?>, Object> annotations
+    ) {
         this.targetInstance = targetInstance;
         this.javaMethod = javaMethod;
 
         this.returnType = returnType;
         this.typeParameters = typeParameters;
+        this.annotations = annotations;
     }
 
     @Override
@@ -54,7 +63,8 @@ public class PainlessInstanceBinding {
         return targetInstance == that.targetInstance &&
                 Objects.equals(javaMethod, that.javaMethod) &&
                 Objects.equals(returnType, that.returnType) &&
-                Objects.equals(typeParameters, that.typeParameters);
+                Objects.equals(typeParameters, that.typeParameters) &&
+                Objects.equals(annotations, that.annotations);
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/lookup/PainlessLookupBuilder.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/lookup/PainlessLookupBuilder.java
@@ -30,6 +30,7 @@ import org.elasticsearch.painless.spi.WhitelistConstructor;
 import org.elasticsearch.painless.spi.WhitelistField;
 import org.elasticsearch.painless.spi.WhitelistInstanceBinding;
 import org.elasticsearch.painless.spi.WhitelistMethod;
+import org.elasticsearch.painless.spi.annotation.CompileTimeOnlyAnnotation;
 import org.elasticsearch.painless.spi.annotation.InjectConstantAnnotation;
 import org.elasticsearch.painless.spi.annotation.NoImportAnnotation;
 import org.objectweb.asm.ClassWriter;
@@ -174,7 +175,8 @@ public final class PainlessLookupBuilder {
                     origin = whitelistInstanceBinding.origin;
                     painlessLookupBuilder.addPainlessInstanceBinding(
                             whitelistInstanceBinding.targetInstance, whitelistInstanceBinding.methodName,
-                            whitelistInstanceBinding.returnCanonicalTypeName, whitelistInstanceBinding.canonicalTypeNameParameters);
+                            whitelistInstanceBinding.returnCanonicalTypeName, whitelistInstanceBinding.canonicalTypeNameParameters,
+                            whitelistInstanceBinding.painlessAnnotations);
                 }
             }
         } catch (Exception exception) {
@@ -393,6 +395,10 @@ public final class PainlessLookupBuilder {
                     "[[" + targetCanonicalClassName + "], " + typesToCanonicalTypeNames(typeParameters) + "]", iae);
         }
 
+        if (annotations.containsKey(CompileTimeOnlyAnnotation.class)) {
+            throw new IllegalArgumentException("constructors can't have @" + CompileTimeOnlyAnnotation.NAME);
+        }
+
         MethodType methodType = methodHandle.type();
 
         String painlessConstructorKey = buildPainlessConstructorKey(typeParametersSize);
@@ -572,6 +578,10 @@ public final class PainlessLookupBuilder {
                         typesToCanonicalTypeNames(typeParameters) + "]" +
                         "with augmented class [" + typeToCanonicalTypeName(augmentedClass) + "]", iae);
             }
+        }
+
+        if (annotations.containsKey(CompileTimeOnlyAnnotation.class)) {
+            throw new IllegalArgumentException("regular methods can't have @" + CompileTimeOnlyAnnotation.NAME);
         }
 
         MethodType methodType = methodHandle.type();
@@ -989,6 +999,10 @@ public final class PainlessLookupBuilder {
                     "invalid method name [" + methodName + "] for class binding [" + targetCanonicalClassName + "].");
         }
 
+        if (annotations.containsKey(CompileTimeOnlyAnnotation.class)) {
+            throw new IllegalArgumentException("class bindings can't have @" + CompileTimeOnlyAnnotation.NAME);
+        }
+
         Method[] javaMethods = targetClass.getMethods();
         Method javaMethod = null;
 
@@ -1079,7 +1093,8 @@ public final class PainlessLookupBuilder {
     }
 
     public void addPainlessInstanceBinding(Object targetInstance,
-            String methodName, String returnCanonicalTypeName, List<String> canonicalTypeNameParameters) {
+            String methodName, String returnCanonicalTypeName, List<String> canonicalTypeNameParameters,
+            Map<Class<?>, Object> painlessAnnotations) {
 
         Objects.requireNonNull(targetInstance);
         Objects.requireNonNull(methodName);
@@ -1108,10 +1123,16 @@ public final class PainlessLookupBuilder {
                     "[[" + targetCanonicalClassName + "], [" + methodName + "], " + canonicalTypeNameParameters + "]");
         }
 
-        addPainlessInstanceBinding(targetInstance, methodName, returnType, typeParameters);
+        addPainlessInstanceBinding(targetInstance, methodName, returnType, typeParameters, painlessAnnotations);
     }
 
-    public void addPainlessInstanceBinding(Object targetInstance, String methodName, Class<?> returnType, List<Class<?>> typeParameters) {
+    public void addPainlessInstanceBinding(
+        Object targetInstance,
+        String methodName,
+        Class<?> returnType,
+        List<Class<?>> typeParameters,
+        Map<Class<?>, Object> painlessAnnotations
+    ) {
         Objects.requireNonNull(targetInstance);
         Objects.requireNonNull(methodName);
         Objects.requireNonNull(returnType);
@@ -1189,7 +1210,7 @@ public final class PainlessLookupBuilder {
 
         PainlessInstanceBinding existingPainlessInstanceBinding = painlessMethodKeysToPainlessInstanceBindings.get(painlessMethodKey);
         PainlessInstanceBinding newPainlessInstanceBinding =
-                new PainlessInstanceBinding(targetInstance, javaMethod, returnType, typeParameters);
+                new PainlessInstanceBinding(targetInstance, javaMethod, returnType, typeParameters, painlessAnnotations);
 
         if (existingPainlessInstanceBinding == null) {
             newPainlessInstanceBinding = painlessInstanceBindingCache.computeIfAbsent(newPainlessInstanceBinding, key -> key);
@@ -1200,11 +1221,13 @@ public final class PainlessLookupBuilder {
                     "[[" + targetCanonicalClassName + "], " +
                     "[" + methodName + "], " +
                     "[" + typeToCanonicalTypeName(returnType) + "], " +
-                    typesToCanonicalTypeNames(typeParameters) + "] and " +
+                    typesToCanonicalTypeNames(typeParameters) + "], " +
+                    painlessAnnotations + " and " +
                     "[[" + targetCanonicalClassName + "], " +
                     "[" + methodName + "], " +
                     "[" + typeToCanonicalTypeName(existingPainlessInstanceBinding.returnType) + "], " +
-                    typesToCanonicalTypeNames(existingPainlessInstanceBinding.typeParameters) + "]");
+                    typesToCanonicalTypeNames(existingPainlessInstanceBinding.typeParameters) + "], " +
+                    existingPainlessInstanceBinding.annotations);
         }
     }
 

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DefaultIRTreeToASMBytesPhase.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DefaultIRTreeToASMBytesPhase.java
@@ -121,10 +121,11 @@ import org.elasticsearch.painless.symbol.IRDecorations.IRDCast;
 import org.elasticsearch.painless.symbol.IRDecorations.IRDClassBinding;
 import org.elasticsearch.painless.symbol.IRDecorations.IRDComparisonType;
 import org.elasticsearch.painless.symbol.IRDecorations.IRDConstant;
+import org.elasticsearch.painless.symbol.IRDecorations.IRDConstantFieldName;
 import org.elasticsearch.painless.symbol.IRDecorations.IRDConstructor;
 import org.elasticsearch.painless.symbol.IRDecorations.IRDDeclarationType;
-import org.elasticsearch.painless.symbol.IRDecorations.IRDDepth;
 import org.elasticsearch.painless.symbol.IRDecorations.IRDDefReferenceEncoding;
+import org.elasticsearch.painless.symbol.IRDecorations.IRDDepth;
 import org.elasticsearch.painless.symbol.IRDecorations.IRDExceptionType;
 import org.elasticsearch.painless.symbol.IRDecorations.IRDExpressionType;
 import org.elasticsearch.painless.symbol.IRDecorations.IRDField;
@@ -1220,7 +1221,13 @@ public class DefaultIRTreeToASMBytesPhase implements IRTreeVisitor<WriteScope> {
         else if (constant instanceof Byte)      methodWriter.push((byte)constant);
         else if (constant instanceof Boolean)   methodWriter.push((boolean)constant);
         else {
-            throw new IllegalStateException("unexpected constant [" + constant + "]");
+            /*
+             * The constant doesn't properly fit into the constant pool so
+             * we should have made a static field for it.
+             */
+            String fieldName = irConstantNode.getDecorationValue(IRDConstantFieldName.class);
+            Type asmFieldType = MethodWriter.getType(irConstantNode.getDecorationValue(IRDExpressionType.class));
+            methodWriter.getStatic(CLASS_TYPE, fieldName, asmFieldType);
         }
     }
 

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DefaultStaticConstantExtractionPhase.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DefaultStaticConstantExtractionPhase.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.painless.phase;
+
+import org.elasticsearch.painless.ir.ClassNode;
+import org.elasticsearch.painless.ir.ConstantNode;
+import org.elasticsearch.painless.ir.FieldNode;
+import org.elasticsearch.painless.symbol.IRDecorations.IRDConstant;
+import org.elasticsearch.painless.symbol.IRDecorations.IRDConstantFieldName;
+import org.elasticsearch.painless.symbol.IRDecorations.IRDExpressionType;
+import org.elasticsearch.painless.symbol.IRDecorations.IRDFieldType;
+import org.elasticsearch.painless.symbol.IRDecorations.IRDModifiers;
+import org.elasticsearch.painless.symbol.IRDecorations.IRDName;
+import org.elasticsearch.painless.symbol.ScriptScope;
+
+import java.lang.reflect.Modifier;
+
+/**
+ * Looks for {@link ConstantNode}s that can't be pushed into the constant pool
+ * and creates a {@code static} constant member that is injected using reflection
+ * on construction.
+ */
+public class DefaultStaticConstantExtractionPhase extends IRTreeBaseVisitor<ScriptScope> {
+    private ClassNode classNode;
+
+    @Override
+    public void visitClass(ClassNode irClassNode, ScriptScope scope) {
+        this.classNode = irClassNode;
+        super.visitClass(irClassNode, scope);
+    }
+
+    @Override
+    public void visitConstant(ConstantNode irConstantNode, ScriptScope scope) {
+        super.visitConstant(irConstantNode, scope);
+        Object constant = irConstantNode.getDecorationValue(IRDConstant.class);
+        if (constant instanceof String
+            || constant instanceof Double
+            || constant instanceof Float
+            || constant instanceof Long
+            || constant instanceof Integer
+            || constant instanceof Character
+            || constant instanceof Short
+            || constant instanceof Byte
+            || constant instanceof Boolean) {
+            /*
+             * Constant can be loaded into the constant pool so we let the byte
+             * code generation phase do that.
+             */
+            return;
+        }
+        /*
+         * The constant *can't* be loaded into the constant pool so we make it
+         * a static constant and register the value with ScriptScope. The byte
+         * code generation will load the static constant.
+         */
+        String fieldName = scope.getNextSyntheticName("constant");
+        scope.addStaticConstant(fieldName, constant);
+        
+        FieldNode constantField = new FieldNode(irConstantNode.getLocation());
+        constantField.attachDecoration(new IRDModifiers(Modifier.PUBLIC | Modifier.STATIC));
+        constantField.attachDecoration(irConstantNode.getDecoration(IRDConstant.class));
+        Class<?> type = irConstantNode.getDecorationValue(IRDExpressionType.class);
+        constantField.attachDecoration(new IRDFieldType(type));
+        constantField.attachDecoration(new IRDName(fieldName));
+        classNode.addFieldNode(constantField);
+
+        irConstantNode.attachDecoration(new IRDConstantFieldName(fieldName));
+    }
+}

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/symbol/IRDecorations.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/symbol/IRDecorations.java
@@ -149,6 +149,15 @@ public class IRDecorations {
     }
 
     /**
+     * describes the field name holding a constant value.
+     */
+    public static class IRDConstantFieldName extends IRDecoration<String> {
+        public IRDConstantFieldName(String value) {
+            super(value);
+        }
+    }
+
+    /**
      * describes the type for a declaration
      */
     public static class IRDDeclarationType extends IRDType {

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/BaseClassTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/BaseClassTests.java
@@ -131,7 +131,7 @@ public class BaseClassTests extends ScriptTestCase {
                 scriptEngine.compile("testNoArgs3", "_score", NoArgs.CONTEXT, emptyMap()));
         assertEquals("cannot resolve symbol [_score]", e.getMessage());
 
-        String debug = Debugger.toString(NoArgs.class, "int i = 0", new CompilerSettings());
+        String debug = Debugger.toString(NoArgs.class, "int i = 0", new CompilerSettings(), Whitelist.BASE_WHITELISTS);
         assertThat(debug, containsString("ACONST_NULL"));
         assertThat(debug, containsString("ARETURN"));
     }
@@ -317,7 +317,7 @@ public class BaseClassTests extends ScriptTestCase {
         scriptEngine.compile("testReturnsVoid1", "map.remove('a')", ReturnsVoid.CONTEXT, emptyMap()).newInstance().execute(map);
         assertEquals(emptyMap(), map);
 
-        String debug = Debugger.toString(ReturnsVoid.class, "int i = 0", new CompilerSettings());
+        String debug = Debugger.toString(ReturnsVoid.class, "int i = 0", new CompilerSettings(), Whitelist.BASE_WHITELISTS);
         // The important thing is that this contains the opcode for returning void
         assertThat(debug, containsString(" RETURN"));
         // We shouldn't contain any weird "default to null" logic
@@ -358,7 +358,7 @@ public class BaseClassTests extends ScriptTestCase {
                 scriptEngine.compile("testReturnsPrimitiveBoolean6", "true || false", ReturnsPrimitiveBoolean.CONTEXT, emptyMap())
                         .newInstance().execute());
 
-        String debug = Debugger.toString(ReturnsPrimitiveBoolean.class, "false", new CompilerSettings());
+        String debug = Debugger.toString(ReturnsPrimitiveBoolean.class, "false", new CompilerSettings(), Whitelist.BASE_WHITELISTS);
         assertThat(debug, containsString("ICONST_0"));
         // The important thing here is that we have the bytecode for returning an integer instead of an object. booleans are integers.
         assertThat(debug, containsString("IRETURN"));
@@ -426,7 +426,7 @@ public class BaseClassTests extends ScriptTestCase {
         assertEquals(2,
                 scriptEngine.compile("testReturnsPrimitiveInt7", "1 + 1", ReturnsPrimitiveInt.CONTEXT, emptyMap()).newInstance().execute());
 
-        String debug = Debugger.toString(ReturnsPrimitiveInt.class, "1", new CompilerSettings());
+        String debug = Debugger.toString(ReturnsPrimitiveInt.class, "1", new CompilerSettings(), Whitelist.BASE_WHITELISTS);
         assertThat(debug, containsString("ICONST_1"));
         // The important thing here is that we have the bytecode for returning an integer instead of an object
         assertThat(debug, containsString("IRETURN"));
@@ -493,7 +493,7 @@ public class BaseClassTests extends ScriptTestCase {
                 "testReturnsPrimitiveFloat7", "def d = Double.valueOf(1.1); d", ReturnsPrimitiveFloat.CONTEXT, emptyMap())
                 .newInstance().execute());
 
-        String debug = Debugger.toString(ReturnsPrimitiveFloat.class, "1f", new CompilerSettings());
+        String debug = Debugger.toString(ReturnsPrimitiveFloat.class, "1f", new CompilerSettings(), Whitelist.BASE_WHITELISTS);
         assertThat(debug, containsString("FCONST_1"));
         // The important thing here is that we have the bytecode for returning a float instead of an object
         assertThat(debug, containsString("FRETURN"));
@@ -556,7 +556,7 @@ public class BaseClassTests extends ScriptTestCase {
                 scriptEngine.compile("testReturnsPrimitiveDouble12", "1.1 + 6.7", ReturnsPrimitiveDouble.CONTEXT, emptyMap())
                         .newInstance().execute(), 0);
 
-        String debug = Debugger.toString(ReturnsPrimitiveDouble.class, "1", new CompilerSettings());
+        String debug = Debugger.toString(ReturnsPrimitiveDouble.class, "1", new CompilerSettings(), Whitelist.BASE_WHITELISTS);
         // The important thing here is that we have the bytecode for returning a double instead of an object
         assertThat(debug, containsString("DRETURN"));
 

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/BindingsTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/BindingsTests.java
@@ -22,6 +22,7 @@ package org.elasticsearch.painless;
 import org.elasticsearch.painless.spi.Whitelist;
 import org.elasticsearch.painless.spi.WhitelistInstanceBinding;
 import org.elasticsearch.painless.spi.WhitelistLoader;
+import org.elasticsearch.painless.spi.annotation.CompileTimeOnlyAnnotation;
 import org.elasticsearch.script.ScriptContext;
 
 import java.util.ArrayList;
@@ -29,7 +30,23 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.startsWith;
+
 public class BindingsTests extends ScriptTestCase {
+
+    public static int classMul(int i, int j) {
+        return i * j;
+    }
+
+    public static int compileTimeBlowUp(int i, int j) {
+        throw new RuntimeException("Boom");
+    }
+
+    public static List<Object> fancyConstant(String thing1, String thing2) {
+        return org.elasticsearch.common.collect.List.of(thing1, thing2);
+    }
 
     public static class BindingTestClass {
         public int state;
@@ -83,6 +100,10 @@ public class BindingsTests extends ScriptTestCase {
         public int getInstanceBindingValue() {
             return value;
         }
+
+        public int instanceMul(int i, int j) {
+            return i * j;
+        }
     }
 
     public abstract static class BindingsTestScript {
@@ -106,9 +127,18 @@ public class BindingsTests extends ScriptTestCase {
                 "setInstanceBindingValue", "void", Collections.singletonList("int"), Collections.emptyList());
         WhitelistInstanceBinding setter = new WhitelistInstanceBinding("test", instanceBindingTestClass,
                 "getInstanceBindingValue", "int", Collections.emptyList(), Collections.emptyList());
+        WhitelistInstanceBinding mul = new WhitelistInstanceBinding(
+            "test",
+            instanceBindingTestClass,
+            "instanceMul",
+            "int",
+            org.elasticsearch.common.collect.List.of("int", "int"),
+            org.elasticsearch.common.collect.List.of(CompileTimeOnlyAnnotation.INSTANCE)
+        );
         List<WhitelistInstanceBinding> instanceBindingsList = new ArrayList<>();
         instanceBindingsList.add(getter);
         instanceBindingsList.add(setter);
+        instanceBindingsList.add(mul);
         Whitelist instanceBindingsWhitelist = new Whitelist(instanceBindingTestClass.getClass().getClassLoader(),
                 Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), instanceBindingsList);
         whitelists.add(instanceBindingsWhitelist);
@@ -179,5 +209,101 @@ public class BindingsTests extends ScriptTestCase {
         factory = scriptEngine.compile(null, script, BindingsTestScript.CONTEXT, Collections.emptyMap());
         executableScript = factory.newInstance();
         assertEquals(8, executableScript.execute(-2, 6));
+    }
+
+    public void testClassMethodCompileTimeOnly() {
+        String script = "classMul(2, 2)";
+        BindingsTestScript.Factory factory = scriptEngine.compile(null, script, BindingsTestScript.CONTEXT, Collections.emptyMap());
+        BindingsTestScript executableScript = factory.newInstance();
+        assertEquals(4, executableScript.execute(1, 1));
+
+        assertThat(
+            Debugger.toString(BindingsTestScript.class, script, new CompilerSettings(), scriptContexts().get(BindingsTestScript.CONTEXT)),
+            containsString("ICONST_4")
+        );
+    }
+
+    public void testClassMethodCompileTimeOnlyVariableParams() {
+        Exception e = expectScriptThrows(
+            IllegalArgumentException.class,
+            () -> scriptEngine.compile(null, "def a = 2; classMul(2, a)", BindingsTestScript.CONTEXT, Collections.emptyMap())
+        );
+        assertThat(e.getMessage(), equalTo("all arguments must be constant but the [2] argument isn't"));
+    }
+
+    public void testClassMethodCompileTimeOnlyThrows() {
+        Exception e = expectScriptThrows(
+            IllegalArgumentException.class,
+            () -> scriptEngine.compile(null, "compileTimeBlowUp(2, 2)", BindingsTestScript.CONTEXT, Collections.emptyMap())
+        );
+        assertThat(e.getMessage(), startsWith("error invoking"));
+        assertThat(e.getCause().getMessage(), equalTo("Boom"));
+    }
+
+    public void testInstanceBindingCompileTimeOnly() {
+        String script = "instanceMul(2, 2)";
+        BindingsTestScript.Factory factory = scriptEngine.compile(null, script, BindingsTestScript.CONTEXT, Collections.emptyMap());
+        BindingsTestScript executableScript = factory.newInstance();
+        assertEquals(4, executableScript.execute(1, 1));
+
+        assertThat(
+            Debugger.toString(BindingsTestScript.class, script, new CompilerSettings(), scriptContexts().get(BindingsTestScript.CONTEXT)),
+            containsString("ICONST_4")
+        );
+    }
+
+    public void testInstanceMethodCompileTimeOnlyVariableParams() {
+        Exception e = expectScriptThrows(
+            IllegalArgumentException.class,
+            () -> scriptEngine.compile(null, "def a = 2; instanceMul(a, 2)", BindingsTestScript.CONTEXT, Collections.emptyMap())
+        );
+        assertThat(e.getMessage(), equalTo("all arguments must be constant but the [1] argument isn't"));
+    }
+
+    public void testCompileTimeOnlyParameterFoldedToConstant() {
+        String script = "classMul(1, 1 + 1)";
+        BindingsTestScript.Factory factory = scriptEngine.compile(null, script, BindingsTestScript.CONTEXT, Collections.emptyMap());
+        BindingsTestScript executableScript = factory.newInstance();
+        assertEquals(2, executableScript.execute(1, 1));
+
+        assertThat(
+            Debugger.toString(BindingsTestScript.class, script, new CompilerSettings(), scriptContexts().get(BindingsTestScript.CONTEXT)),
+            containsString("ICONST_2")
+        );
+    }
+
+    /**
+     * Tests that {@code @compile_time_only} can return values that don't
+     * fit into the constant pool and we'll create them as static members.
+     */
+    public void testCompileTimeOnlyResultOutsideConstantPool() {
+        String script = "fancyConstant('foo', 'bar').stream().mapToInt(String::length).sum()";
+        BindingsTestScript.Factory factory = scriptEngine.compile(null, script, BindingsTestScript.CONTEXT, Collections.emptyMap());
+        BindingsTestScript executableScript = factory.newInstance();
+        assertEquals(6, executableScript.execute(1, 1));
+
+        String code = Debugger.toString(
+            BindingsTestScript.class,
+            script,
+            new CompilerSettings(),
+            scriptContexts().get(BindingsTestScript.CONTEXT)
+        );
+        assertThat(
+            "We make a static field to hold the constant",
+            code,
+            containsString("public static synthetic Ljava/util/List; constant$synthetic$0")
+        );
+        assertThat(
+            "We load the constant from the static field",
+            code,
+            containsString("GETSTATIC org/elasticsearch/painless/PainlessScript$Script.constant$synthetic$0 : Ljava/util/List;")
+        );
+        /*
+         * It's kind of important that we use java.util.List above and *not*
+         * the specific subtype returned by java.util.List.of(). Doing that
+         * means that we don't have to whitelist the actual returned type, just
+         * the interface. The JVM ought to be able to optimize the invocation
+         * because the constant is effectively final.
+         */
     }
 }

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/Debugger.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/Debugger.java
@@ -26,22 +26,23 @@ import org.objectweb.asm.util.Textifier;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.List;
 
 /** quick and dirty tools for debugging */
 final class Debugger {
 
     /** compiles source to bytecode, and returns debugging output */
     static String toString(final String source) {
-        return toString(PainlessTestScript.class, source, new CompilerSettings());
+        return toString(PainlessTestScript.class, source, new CompilerSettings(), Whitelist.BASE_WHITELISTS);
     }
 
     /** compiles to bytecode, and returns debugging output */
-    static String toString(Class<?> iface, String source, CompilerSettings settings) {
+    static String toString(Class<?> iface, String source, CompilerSettings settings, List<Whitelist> whitelists) {
         StringWriter output = new StringWriter();
         PrintWriter outputWriter = new PrintWriter(output);
         Textifier textifier = new Textifier();
         try {
-            new Compiler(iface, null, null, PainlessLookupBuilder.buildFromWhitelists(Whitelist.BASE_WHITELISTS))
+            new Compiler(iface, null, null, PainlessLookupBuilder.buildFromWhitelists(whitelists))
                     .compile("<debugging>", source, settings, textifier);
         } catch (RuntimeException e) {
             textifier.print(outputWriter);

--- a/modules/lang-painless/src/test/resources/org/elasticsearch/painless/spi/org.elasticsearch.painless.test
+++ b/modules/lang-painless/src/test/resources/org/elasticsearch/painless/spi/org.elasticsearch.painless.test
@@ -52,4 +52,7 @@ static_import {
   int addWithState(int, int, int, double) bound_to org.elasticsearch.painless.BindingsTests$BindingTestClass
   int addThisWithState(BindingsTests.BindingsTestScript, int, int, int, double) bound_to org.elasticsearch.painless.BindingsTests$ThisBindingTestClass
   int addEmptyThisWithState(BindingsTests.BindingsTestScript, int) bound_to org.elasticsearch.painless.BindingsTests$EmptyThisBindingTestClass
+  int classMul(int, int) from_class org.elasticsearch.painless.BindingsTests @compile_time_only
+  int compileTimeBlowUp(int, int) from_class org.elasticsearch.painless.BindingsTests @compile_time_only
+  List fancyConstant(String, String) from_class org.elasticsearch.painless.BindingsTests @compile_time_only
 }

--- a/x-pack/plugin/runtime-fields/build.gradle
+++ b/x-pack/plugin/runtime-fields/build.gradle
@@ -11,6 +11,8 @@ archivesBaseName = 'x-pack-runtime-fields'
 dependencies {
   compileOnly project(":server")
   compileOnly project(':modules:lang-painless:spi')
+  api project(':libs:elasticsearch-grok')
+  api project(':libs:elasticsearch-dissect')
   compileOnly project(path: xpackModule('core'), configuration: 'default')
 }
 

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/RuntimeFields.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/RuntimeFields.java
@@ -6,7 +6,17 @@
 
 package org.elasticsearch.xpack.runtimefields;
 
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Module;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.index.mapper.BooleanFieldMapper;
 import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.DynamicRuntimeFieldsBuilder;
@@ -18,7 +28,11 @@ import org.elasticsearch.index.mapper.RuntimeFieldType;
 import org.elasticsearch.plugins.MapperPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.ScriptPlugin;
+import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.script.ScriptContext;
+import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.watcher.ResourceWatcherService;
 import org.elasticsearch.xpack.core.XPackPlugin;
 import org.elasticsearch.xpack.runtimefields.mapper.BooleanFieldScript;
 import org.elasticsearch.xpack.runtimefields.mapper.BooleanScriptFieldType;
@@ -33,14 +47,42 @@ import org.elasticsearch.xpack.runtimefields.mapper.IpScriptFieldType;
 import org.elasticsearch.xpack.runtimefields.mapper.KeywordScriptFieldType;
 import org.elasticsearch.xpack.runtimefields.mapper.LongFieldScript;
 import org.elasticsearch.xpack.runtimefields.mapper.LongScriptFieldType;
+import org.elasticsearch.xpack.runtimefields.mapper.NamedGroupExtractor;
+import org.elasticsearch.xpack.runtimefields.mapper.NamedGroupExtractor.GrokHelper;
 import org.elasticsearch.xpack.runtimefields.mapper.StringFieldScript;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 public final class RuntimeFields extends Plugin implements MapperPlugin, ScriptPlugin {
+
+    static final Setting<TimeValue> GROK_WATCHDOG_INTERVAL = Setting.timeSetting(
+        "runtime_fields.grok.watchdog.interval",
+        TimeValue.timeValueSeconds(1),
+        Setting.Property.NodeScope
+    );
+    static final Setting<TimeValue> GROK_WATCHDOG_MAX_EXECUTION_TIME = Setting.timeSetting(
+        "runtime_fields.grok.watchdog.max_execution_time",
+        TimeValue.timeValueSeconds(1),
+        Setting.Property.NodeScope
+    );
+
+    private final NamedGroupExtractor.GrokHelper grokHelper;
+
+    public RuntimeFields(Settings settings) {
+        grokHelper = new NamedGroupExtractor.GrokHelper(
+            GROK_WATCHDOG_INTERVAL.get(settings),
+            GROK_WATCHDOG_MAX_EXECUTION_TIME.get(settings)
+        );
+    }
+
+    @Override
+    public List<Setting<?>> getSettings() {
+        return org.elasticsearch.common.collect.List.of(GROK_WATCHDOG_INTERVAL, GROK_WATCHDOG_MAX_EXECUTION_TIME);
+    }
 
     @Override
     public Map<String, RuntimeFieldType.Parser> getRuntimeFieldTypes() {
@@ -75,5 +117,27 @@ public final class RuntimeFields extends Plugin implements MapperPlugin, ScriptP
 
     public Collection<Module> createGuiceModules() {
         return Collections.singletonList(b -> XPackPlugin.bindFeatureSet(b, RuntimeFieldsFeatureSet.class));
+    }
+
+    @Override
+    public Collection<Object> createComponents(
+        Client client,
+        ClusterService clusterService,
+        ThreadPool threadPool,
+        ResourceWatcherService resourceWatcherService,
+        ScriptService scriptService,
+        NamedXContentRegistry xContentRegistry,
+        Environment environment,
+        NodeEnvironment nodeEnvironment,
+        NamedWriteableRegistry namedWriteableRegistry,
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        Supplier<RepositoriesService> repositoriesServiceSupplier
+    ) {
+        grokHelper.finishInitializing(threadPool);
+        return org.elasticsearch.common.collect.List.of();
+    }
+
+    public GrokHelper grokHelper() {
+        return grokHelper;
     }
 }

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/AbstractFieldScript.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/AbstractFieldScript.java
@@ -35,7 +35,7 @@ public abstract class AbstractFieldScript {
      */
     static final int MAX_VALUES = 100;
 
-    public static <F> ScriptContext<F> newContext(String name, Class<F> factoryClass) {
+    static <F> ScriptContext<F> newContext(String name, Class<F> factoryClass) {
         return new ScriptContext<>(
             name + "_script_field",
             factoryClass,

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/BooleanFieldScript.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/BooleanFieldScript.java
@@ -8,25 +8,15 @@ package org.elasticsearch.xpack.runtimefields.mapper;
 
 import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.common.Booleans;
-import org.elasticsearch.painless.spi.Whitelist;
-import org.elasticsearch.painless.spi.WhitelistLoader;
 import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptFactory;
 import org.elasticsearch.search.lookup.SearchLookup;
 
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 public abstract class BooleanFieldScript extends AbstractFieldScript {
 
     public static final ScriptContext<Factory> CONTEXT = newContext("boolean_script_field", Factory.class);
-
-    static List<Whitelist> whitelist() {
-        return Collections.singletonList(
-            WhitelistLoader.loadFromResourceFiles(RuntimeFieldsPainlessExtension.class, "boolean_whitelist.txt")
-        );
-    }
 
     @SuppressWarnings("unused")
     public static final String[] PARAMETERS = {};

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/DateFieldScript.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/DateFieldScript.java
@@ -8,23 +8,15 @@ package org.elasticsearch.xpack.runtimefields.mapper;
 
 import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.common.time.DateFormatter;
-import org.elasticsearch.painless.spi.Whitelist;
-import org.elasticsearch.painless.spi.WhitelistLoader;
 import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptFactory;
 import org.elasticsearch.search.lookup.SearchLookup;
 
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
 public abstract class DateFieldScript extends AbstractLongFieldScript {
     public static final ScriptContext<Factory> CONTEXT = newContext("date", Factory.class);
-
-    static List<Whitelist> whitelist() {
-        return Collections.singletonList(WhitelistLoader.loadFromResourceFiles(RuntimeFieldsPainlessExtension.class, "date_whitelist.txt"));
-    }
 
     @SuppressWarnings("unused")
     public static final String[] PARAMETERS = {};

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/DoubleFieldScript.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/DoubleFieldScript.java
@@ -8,24 +8,14 @@ package org.elasticsearch.xpack.runtimefields.mapper;
 
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.util.ArrayUtil;
-import org.elasticsearch.painless.spi.Whitelist;
-import org.elasticsearch.painless.spi.WhitelistLoader;
 import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptFactory;
 import org.elasticsearch.search.lookup.SearchLookup;
 
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 public abstract class DoubleFieldScript extends AbstractFieldScript {
     public static final ScriptContext<Factory> CONTEXT = newContext("double_script_field", Factory.class);
-
-    static List<Whitelist> whitelist() {
-        return Collections.singletonList(
-            WhitelistLoader.loadFromResourceFiles(RuntimeFieldsPainlessExtension.class, "double_whitelist.txt")
-        );
-    }
 
     @SuppressWarnings("unused")
     public static final String[] PARAMETERS = {};

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/GeoPointFieldScript.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/GeoPointFieldScript.java
@@ -6,18 +6,15 @@
 
 package org.elasticsearch.xpack.runtimefields.mapper;
 
+import org.apache.lucene.document.LatLonDocValuesField;
 import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.GeoUtils;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
-import org.elasticsearch.painless.spi.Whitelist;
-import org.elasticsearch.painless.spi.WhitelistLoader;
 import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptFactory;
 import org.elasticsearch.search.lookup.SearchLookup;
-import org.apache.lucene.document.LatLonDocValuesField;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -30,12 +27,6 @@ import static org.apache.lucene.geo.GeoEncodingUtils.encodeLongitude;
  */
 public abstract class GeoPointFieldScript extends AbstractLongFieldScript {
     public static final ScriptContext<Factory> CONTEXT = newContext("geo_point_script_field", Factory.class);
-
-    static List<Whitelist> whitelist() {
-        return Collections.singletonList(
-            WhitelistLoader.loadFromResourceFiles(RuntimeFieldsPainlessExtension.class, "geo_point_whitelist.txt")
-        );
-    }
 
     @SuppressWarnings("unused")
     public static final String[] PARAMETERS = {};

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/IpFieldScript.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/IpFieldScript.java
@@ -12,8 +12,6 @@ import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.index.mapper.IpFieldMapper;
-import org.elasticsearch.painless.spi.Whitelist;
-import org.elasticsearch.painless.spi.WhitelistLoader;
 import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptFactory;
 import org.elasticsearch.search.lookup.SearchLookup;
@@ -21,8 +19,6 @@ import org.elasticsearch.search.lookup.SearchLookup;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.InetAddress;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -41,10 +37,6 @@ import java.util.Map;
  */
 public abstract class IpFieldScript extends AbstractFieldScript {
     public static final ScriptContext<Factory> CONTEXT = newContext("ip_script_field", Factory.class);
-
-    static List<Whitelist> whitelist() {
-        return Collections.singletonList(WhitelistLoader.loadFromResourceFiles(RuntimeFieldsPainlessExtension.class, "ip_whitelist.txt"));
-    }
 
     @SuppressWarnings("unused")
     public static final String[] PARAMETERS = {};

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/LongFieldScript.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/LongFieldScript.java
@@ -8,22 +8,14 @@ package org.elasticsearch.xpack.runtimefields.mapper;
 
 import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
-import org.elasticsearch.painless.spi.Whitelist;
-import org.elasticsearch.painless.spi.WhitelistLoader;
 import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptFactory;
 import org.elasticsearch.search.lookup.SearchLookup;
 
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 public abstract class LongFieldScript extends AbstractLongFieldScript {
     public static final ScriptContext<Factory> CONTEXT = newContext("long_script_field", Factory.class);
-
-    static List<Whitelist> whitelist() {
-        return Collections.singletonList(WhitelistLoader.loadFromResourceFiles(RuntimeFieldsPainlessExtension.class, "long_whitelist.txt"));
-    }
 
     @SuppressWarnings("unused")
     public static final String[] PARAMETERS = {};

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/NamedGroupExtractor.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/NamedGroupExtractor.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.runtimefields.mapper;
+
+import org.apache.lucene.util.SetOnce;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.util.LazyInitializable;
+import org.elasticsearch.dissect.DissectParser;
+import org.elasticsearch.grok.Grok;
+import org.elasticsearch.grok.MatcherWatchdog;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.regex.Pattern;
+
+/**
+ * Extracts named groups from grok and dissect. Think of it kind of like
+ * {@link Pattern} but for grok and dissect.
+ */
+public interface NamedGroupExtractor {
+    /**
+     * Returns a {@link Map} containing all named capture groups if the
+     * string matches or {@code null} if it doesn't.
+     */
+    Map<String, ?> extract(String in);
+
+    /**
+     * Create a {@link NamedGroupExtractor} that runs {@link DissectParser}
+     * with the default {@code appendSeparator}.
+     */
+    static NamedGroupExtractor dissect(String pattern) {
+        return dissect(pattern, null);
+    }
+
+    /**
+     * Create a {@link NamedGroupExtractor} that runs {@link DissectParser}.
+     */
+    static NamedGroupExtractor dissect(String pattern, String appendSeparator) {
+        DissectParser dissect = new DissectParser(pattern, appendSeparator);
+        return new NamedGroupExtractor() {
+            @Override
+            public Map<String, ?> extract(String in) {
+                return dissect.parse(in);
+            }
+        };
+    }
+
+    /**
+     * Builds {@link NamedGroupExtractor}s from grok patterns.
+     */
+    class GrokHelper {
+        private final SetOnce<ThreadPool> threadPoolContainer = new SetOnce<>();
+        private final Supplier<MatcherWatchdog> watchdogSupplier;
+
+        public GrokHelper(TimeValue interval, TimeValue maxExecutionTime) {
+            this.watchdogSupplier = new LazyInitializable<MatcherWatchdog, RuntimeException>(() -> {
+                ThreadPool threadPool = threadPoolContainer.get();
+                if (threadPool == null) {
+                    throw new IllegalStateException("missing call to finishInitializing");
+                }
+                return MatcherWatchdog.newInstance(
+                    interval.millis(),
+                    maxExecutionTime.millis(),
+                    threadPool::relativeTimeInMillis,
+                    (delay, command) -> threadPool.schedule(command, TimeValue.timeValueMillis(delay), ThreadPool.Names.GENERIC)
+                );
+            })::getOrCompute;
+        }
+
+        /**
+         * Finish initializing. This is split from the ctor because we need an
+         * instance of this class to feed into painless before the
+         * {@link ThreadPool} is ready.
+         */
+        public void finishInitializing(ThreadPool threadPool) {
+            threadPoolContainer.set(threadPool);
+        }
+
+        public NamedGroupExtractor grok(String pattern) {
+            MatcherWatchdog watchdog = watchdogSupplier.get();
+            /*
+             * Build the grok pattern in a PrivilegedAction so it can load
+             * things from the classpath.
+             */
+            Grok grok = AccessController.doPrivileged(new PrivilegedAction<Grok>() {
+                @Override
+                public Grok run() {
+                    try {
+                        // Try to collect warnings up front and refuse to compile the expression if there are any
+                        List<String> warnings = new ArrayList<>();
+                        new Grok(Grok.BUILTIN_PATTERNS, pattern, watchdog, warnings::add).match("__nomatch__");
+                        if (false == warnings.isEmpty()) {
+                            throw new IllegalArgumentException("emitted warnings: " + warnings);
+                        }
+
+                        return new Grok(
+                            Grok.BUILTIN_PATTERNS,
+                            pattern,
+                            watchdog,
+                            w -> { throw new IllegalArgumentException("grok [" + pattern + "] emitted a warning: " + w); }
+                        );
+                    } catch (RuntimeException e) {
+                        throw new IllegalArgumentException("error compiling grok pattern [" + pattern + "]: " + e.getMessage(), e);
+                    }
+                }
+            });
+            return new NamedGroupExtractor() {
+                @Override
+                public Map<String, ?> extract(String in) {
+                    return grok.captures(in);
+                }
+            };
+        }
+    }
+}

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/RuntimeFieldsPainlessExtension.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/RuntimeFieldsPainlessExtension.java
@@ -8,29 +8,57 @@ package org.elasticsearch.xpack.runtimefields.mapper;
 
 import org.elasticsearch.painless.spi.PainlessExtension;
 import org.elasticsearch.painless.spi.Whitelist;
+import org.elasticsearch.painless.spi.WhitelistInstanceBinding;
+import org.elasticsearch.painless.spi.WhitelistLoader;
+import org.elasticsearch.painless.spi.annotation.CompileTimeOnlyAnnotation;
 import org.elasticsearch.script.ScriptContext;
+import org.elasticsearch.xpack.runtimefields.RuntimeFields;
 
 import java.util.List;
 import java.util.Map;
 
 public class RuntimeFieldsPainlessExtension implements PainlessExtension {
+    private final Whitelist commonWhitelist = WhitelistLoader.loadFromResourceFiles(AbstractFieldScript.class, "common_whitelist.txt");
+
+    private final Whitelist grokWhitelist;
+
+    public RuntimeFieldsPainlessExtension(RuntimeFields plugin) {
+        grokWhitelist = new Whitelist(
+            commonWhitelist.classLoader,
+            org.elasticsearch.common.collect.List.of(),
+            org.elasticsearch.common.collect.List.of(),
+            org.elasticsearch.common.collect.List.of(),
+            org.elasticsearch.common.collect.List.of(
+                new WhitelistInstanceBinding(
+                    AbstractFieldScript.class.getCanonicalName(),
+                    plugin.grokHelper(),
+                    "grok",
+                    NamedGroupExtractor.class.getName(),
+                    org.elasticsearch.common.collect.List.of(String.class.getName()),
+                    org.elasticsearch.common.collect.List.of(CompileTimeOnlyAnnotation.INSTANCE)
+                )
+            )
+        );
+    }
+
+    private List<Whitelist> load(String path) {
+        return org.elasticsearch.common.collect.List.of(
+            commonWhitelist,
+            grokWhitelist,
+            WhitelistLoader.loadFromResourceFiles(AbstractFieldScript.class, path)
+        );
+    }
+
     @Override
     public Map<ScriptContext<?>, List<Whitelist>> getContextWhitelists() {
-        return org.elasticsearch.common.collect.Map.of(
-            BooleanFieldScript.CONTEXT,
-            BooleanFieldScript.whitelist(),
-            DateFieldScript.CONTEXT,
-            DateFieldScript.whitelist(),
-            DoubleFieldScript.CONTEXT,
-            DoubleFieldScript.whitelist(),
-            GeoPointFieldScript.CONTEXT,
-            GeoPointFieldScript.whitelist(),
-            IpFieldScript.CONTEXT,
-            IpFieldScript.whitelist(),
-            LongFieldScript.CONTEXT,
-            LongFieldScript.whitelist(),
-            StringFieldScript.CONTEXT,
-            StringFieldScript.whitelist()
+        return org.elasticsearch.common.collect.Map.ofEntries(
+            org.elasticsearch.common.collect.Map.entry(BooleanFieldScript.CONTEXT, load("boolean_whitelist.txt")),
+            org.elasticsearch.common.collect.Map.entry(DateFieldScript.CONTEXT, load("date_whitelist.txt")),
+            org.elasticsearch.common.collect.Map.entry(DoubleFieldScript.CONTEXT, load("double_whitelist.txt")),
+            org.elasticsearch.common.collect.Map.entry(GeoPointFieldScript.CONTEXT, load("geo_point_whitelist.txt")),
+            org.elasticsearch.common.collect.Map.entry(IpFieldScript.CONTEXT, load("ip_whitelist.txt")),
+            org.elasticsearch.common.collect.Map.entry(LongFieldScript.CONTEXT, load("long_whitelist.txt")),
+            org.elasticsearch.common.collect.Map.entry(StringFieldScript.CONTEXT, load("string_whitelist.txt"))
         );
     }
 }

--- a/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/StringFieldScript.java
+++ b/x-pack/plugin/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/mapper/StringFieldScript.java
@@ -7,14 +7,11 @@
 package org.elasticsearch.xpack.runtimefields.mapper;
 
 import org.apache.lucene.index.LeafReaderContext;
-import org.elasticsearch.painless.spi.Whitelist;
-import org.elasticsearch.painless.spi.WhitelistLoader;
 import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptFactory;
 import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -26,12 +23,6 @@ public abstract class StringFieldScript extends AbstractFieldScript {
     public static final long MAX_CHARS = 1024 * 1024;
 
     public static final ScriptContext<Factory> CONTEXT = newContext("string_script_field", Factory.class);
-
-    static List<Whitelist> whitelist() {
-        return Collections.singletonList(
-            WhitelistLoader.loadFromResourceFiles(RuntimeFieldsPainlessExtension.class, "string_whitelist.txt")
-        );
-    }
 
     @SuppressWarnings("unused")
     public static final String[] PARAMETERS = {};

--- a/x-pack/plugin/runtime-fields/src/main/resources/org/elasticsearch/xpack/runtimefields/mapper/common_whitelist.txt
+++ b/x-pack/plugin/runtime-fields/src/main/resources/org/elasticsearch/xpack/runtimefields/mapper/common_whitelist.txt
@@ -1,0 +1,14 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+#
+
+class org.elasticsearch.xpack.runtimefields.mapper.NamedGroupExtractor @no_import {
+    Map extract(String);
+}
+
+static_import {
+    org.elasticsearch.xpack.runtimefields.mapper.NamedGroupExtractor dissect(String) from_class org.elasticsearch.xpack.runtimefields.mapper.NamedGroupExtractor @compile_time_only
+    org.elasticsearch.xpack.runtimefields.mapper.NamedGroupExtractor dissect(String, String) from_class org.elasticsearch.xpack.runtimefields.mapper.NamedGroupExtractor @compile_time_only
+}

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/AbstractScriptFieldTypeTestCase.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/AbstractScriptFieldTypeTestCase.java
@@ -313,7 +313,7 @@ public abstract class AbstractScriptFieldTypeTestCase extends MapperServiceTestC
 
     @Override
     protected Collection<? extends Plugin> getPlugins() {
-        return org.elasticsearch.common.collect.List.of(new RuntimeFields(), new TestScriptPlugin());
+        return org.elasticsearch.common.collect.List.of(new RuntimeFields(Settings.EMPTY), new TestScriptPlugin());
     }
 
     private static class TestScriptPlugin extends Plugin implements ScriptPlugin {
@@ -347,7 +347,7 @@ public abstract class AbstractScriptFieldTypeTestCase extends MapperServiceTestC
                 }
 
                 public Set<ScriptContext<?>> getSupportedContexts() {
-                    return org.elasticsearch.common.collect.Set.copyOf(new RuntimeFields().getContexts());
+                    return org.elasticsearch.common.collect.Set.copyOf(new RuntimeFields(Settings.EMPTY).getContexts());
                 }
             };
         }

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/BooleanScriptFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/BooleanScriptFieldTypeTests.java
@@ -515,7 +515,7 @@ public class BooleanScriptFieldTypeTests extends AbstractNonTextScriptFieldTypeT
         };
         ScriptModule scriptModule = new ScriptModule(
             Settings.EMPTY,
-            org.elasticsearch.common.collect.List.of(scriptPlugin, new RuntimeFields())
+            org.elasticsearch.common.collect.List.of(scriptPlugin, new RuntimeFields(Settings.EMPTY))
         );
         try (ScriptService scriptService = new ScriptService(Settings.EMPTY, scriptModule.engines, scriptModule.contexts)) {
             BooleanFieldScript.Factory factory = scriptService.compile(script, BooleanFieldScript.CONTEXT);

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/DateScriptFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/DateScriptFieldTypeTests.java
@@ -615,7 +615,7 @@ public class DateScriptFieldTypeTests extends AbstractNonTextScriptFieldTypeTest
         };
         ScriptModule scriptModule = new ScriptModule(
             Settings.EMPTY,
-            org.elasticsearch.common.collect.List.of(scriptPlugin, new RuntimeFields())
+            org.elasticsearch.common.collect.List.of(scriptPlugin, new RuntimeFields(Settings.EMPTY))
         );
         try (ScriptService scriptService = new ScriptService(Settings.EMPTY, scriptModule.engines, scriptModule.contexts)) {
             DateFieldScript.Factory factory = scriptService.compile(script, DateFieldScript.CONTEXT);

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/DoubleScriptFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/DoubleScriptFieldTypeTests.java
@@ -326,7 +326,7 @@ public class DoubleScriptFieldTypeTests extends AbstractNonTextScriptFieldTypeTe
         };
         ScriptModule scriptModule = new ScriptModule(
             Settings.EMPTY,
-            org.elasticsearch.common.collect.List.of(scriptPlugin, new RuntimeFields())
+            org.elasticsearch.common.collect.List.of(scriptPlugin, new RuntimeFields(Settings.EMPTY))
         );
         try (ScriptService scriptService = new ScriptService(Settings.EMPTY, scriptModule.engines, scriptModule.contexts)) {
             DoubleFieldScript.Factory factory = scriptService.compile(script, DoubleFieldScript.CONTEXT);

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/DynamicRuntimeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/DynamicRuntimeTests.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.runtimefields.mapper;
 
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.MapperServiceTestCase;
 import org.elasticsearch.index.mapper.ObjectMapper;
@@ -21,7 +22,7 @@ import java.util.Collections;
 public class DynamicRuntimeTests extends MapperServiceTestCase {
     @Override
     protected Collection<? extends Plugin> getPlugins() {
-        return Collections.singletonList(new RuntimeFields());
+        return Collections.singletonList(new RuntimeFields(Settings.EMPTY));
     }
 
     public void testDynamicLeafFields() throws IOException {

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/GeoPointScriptFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/GeoPointScriptFieldTypeTests.java
@@ -292,7 +292,7 @@ public class GeoPointScriptFieldTypeTests extends AbstractNonTextScriptFieldType
         };
         ScriptModule scriptModule = new ScriptModule(
             Settings.EMPTY,
-            org.elasticsearch.common.collect.List.of(scriptPlugin, new RuntimeFields())
+            org.elasticsearch.common.collect.List.of(scriptPlugin, new RuntimeFields(Settings.EMPTY))
         );
         try (ScriptService scriptService = new ScriptService(Settings.EMPTY, scriptModule.engines, scriptModule.contexts)) {
             GeoPointFieldScript.Factory factory = scriptService.compile(script, GeoPointFieldScript.CONTEXT);

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/IpScriptFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/IpScriptFieldTypeTests.java
@@ -369,7 +369,7 @@ public class IpScriptFieldTypeTests extends AbstractScriptFieldTypeTestCase {
         };
         ScriptModule scriptModule = new ScriptModule(
             Settings.EMPTY,
-            org.elasticsearch.common.collect.List.of(scriptPlugin, new RuntimeFields())
+            org.elasticsearch.common.collect.List.of(scriptPlugin, new RuntimeFields(Settings.EMPTY))
         );
         try (ScriptService scriptService = new ScriptService(Settings.EMPTY, scriptModule.engines, scriptModule.contexts)) {
             IpFieldScript.Factory factory = scriptService.compile(script, IpFieldScript.CONTEXT);

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/KeywordScriptFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/KeywordScriptFieldTypeTests.java
@@ -448,7 +448,7 @@ public class KeywordScriptFieldTypeTests extends AbstractScriptFieldTypeTestCase
         };
         ScriptModule scriptModule = new ScriptModule(
             Settings.EMPTY,
-            org.elasticsearch.common.collect.List.of(scriptPlugin, new RuntimeFields())
+            org.elasticsearch.common.collect.List.of(scriptPlugin, new RuntimeFields(Settings.EMPTY))
         );
         try (ScriptService scriptService = new ScriptService(Settings.EMPTY, scriptModule.engines, scriptModule.contexts)) {
             StringFieldScript.Factory factory = scriptService.compile(script, StringFieldScript.CONTEXT);

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/LongScriptFieldTypeTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/mapper/LongScriptFieldTypeTests.java
@@ -379,7 +379,7 @@ public class LongScriptFieldTypeTests extends AbstractNonTextScriptFieldTypeTest
         };
         ScriptModule scriptModule = new ScriptModule(
             Settings.EMPTY,
-            org.elasticsearch.common.collect.List.of(scriptPlugin, new RuntimeFields())
+            org.elasticsearch.common.collect.List.of(scriptPlugin, new RuntimeFields(Settings.EMPTY))
         );
         try (ScriptService scriptService = new ScriptService(Settings.EMPTY, scriptModule.engines, scriptModule.contexts)) {
             LongFieldScript.Factory factory = scriptService.compile(script, LongFieldScript.CONTEXT);

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/250_grok.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/250_grok.yml
@@ -1,0 +1,126 @@
+---
+setup:
+  - do:
+      indices.create:
+        index: http_logs
+        body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
+          mappings:
+            runtime:
+              http.clientip:
+                type: ip
+                script:
+                  source: |
+                    String clientip = grok('%{COMMONAPACHELOG}').extract(doc["message"].value)?.clientip;
+                    if (clientip != null) {
+                      emit(clientip);
+                    }
+              http.verb:
+                type: keyword
+                script:
+                  source: |
+                    String verb = grok('%{COMMONAPACHELOG}').extract(doc["message"].value)?.verb;
+                    if (verb != null) {
+                      emit(verb);
+                    }
+              http.response:
+                type: long
+                script:
+                  source: |
+                    String response = grok('%{COMMONAPACHELOG}').extract(doc["message"].value)?.response;
+                    if (response != null) {
+                      emit(Integer.parseInt(response));
+                    }
+            properties:
+              timestamp:
+                type: date
+              message:
+                type: wildcard
+  - do:
+      bulk:
+        index: http_logs
+        refresh: true
+        body: |
+          {"index":{}}
+          {"timestamp": "1998-04-30T14:30:17-05:00", "message" : "40.135.0.0 - - [30/Apr/1998:14:30:17 -0500] \"GET /images/hm_bg.jpg HTTP/1.0\" 200 24736"}
+          {"index":{}}
+          {"timestamp": "1998-04-30T14:30:53-05:00", "message" : "232.0.0.0 - - [30/Apr/1998:14:30:53 -0500] \"GET /images/hm_bg.jpg HTTP/1.0\" 200 24736"}
+          {"index":{}}
+          {"timestamp": "1998-04-30T14:31:12-05:00", "message" : "26.1.0.0 - - [30/Apr/1998:14:31:12 -0500] \"GET /images/hm_bg.jpg HTTP/1.0\" 200 24736"}
+          {"index":{}}
+          {"timestamp": "1998-04-30T14:31:19-05:00", "message" : "247.37.0.0 - - [30/Apr/1998:14:31:19 -0500] \"GET /french/splash_inet.html HTTP/1.0\" 200 3781"}
+          {"index":{}}
+          {"timestamp": "1998-04-30T14:31:22-05:00", "message" : "247.37.0.0 - - [30/Apr/1998:14:31:22 -0500] \"GET /images/hm_nbg.jpg HTTP/1.0\" 304 0"}
+          {"index":{}}
+          {"timestamp": "1998-04-30T14:31:27-05:00", "message" : "252.0.0.0 - - [30/Apr/1998:14:31:27 -0500] \"GET /images/hm_bg.jpg HTTP/1.0\" 200 24736"}
+          {"index":{}}
+          {"timestamp": "1998-04-30T14:31:28-05:00", "message" : "not a valid apache log"}
+
+---
+fetch:
+  - do:
+      search:
+        index: http_logs
+        body:
+          sort: timestamp
+          fields:
+            - http.clientip
+            - http.verb
+            - http.response
+  - match: {hits.total.value: 7}
+  - match: {hits.hits.0.fields.http\.clientip: [40.135.0.0] }
+  - match: {hits.hits.0.fields.http\.verb: [GET] }
+  - match: {hits.hits.0.fields.http\.response: [200] }
+  - is_false: hits.hits.6.fields.http\.clientip
+  - is_false: hits.hits.6.fields.http\.verb
+  - is_false: hits.hits.6.fields.http\.response
+
+---
+mutable pattern:
+  - do:
+      catch: /all arguments must be constant but the \[1\] argument isn't/
+      search:
+        index: http_logs
+        body:
+          runtime_mappings:
+            broken:
+              type: keyword
+              script: |
+                def clientip = grok(doc["type"].value).extract(doc["message"].value)?.clientip;
+                if (clientip != null) {
+                  emit(clientip);
+                }
+
+---
+syntax error in pattern:
+  - do:
+      catch: '/error compiling grok pattern \[.+\]: invalid group name <2134>/'
+      search:
+        index: http_logs
+        body:
+          runtime_mappings:
+            broken:
+              type: keyword
+              script: |
+                def clientip = grok('(?<2134>').extract(doc["message"].value)?.clientip;
+                if (clientip != null) {
+                  emit(clientip);
+                }
+
+---
+warning in pattern:
+  - do:
+      catch: '/error compiling grok pattern \[.+\]: emitted warnings: \[.+]/'
+      search:
+        index: http_logs
+        body:
+          runtime_mappings:
+            broken:
+              type: keyword
+              script: |
+                def clientip = grok('\\o').extract(doc["message"].value)?.clientip;
+                if (clientip != null) {
+                  emit(clientip);
+                }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/260_dissect.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/260_dissect.yml
@@ -1,0 +1,76 @@
+setup:
+  - do:
+      indices.create:
+        index: http_logs
+        body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
+          mappings:
+            runtime:
+              http.clientip:
+                type: ip
+                script:
+                  source: |
+                    String clientip = dissect('%{clientip} %{ident} %{auth} [%{@timestamp}] "%{verb} %{request} HTTP/%{httpversion}" %{status} %{size}').extract(doc["message"].value)?.clientip;
+                    if (clientip != null) {
+                      emit(clientip);
+                    }
+              http.verb:
+                type: keyword
+                script:
+                  source: |
+                    String verb = dissect('%{clientip} %{ident} %{auth} [%{@timestamp}] "%{verb} %{request} HTTP/%{httpversion}" %{status} %{size}').extract(doc["message"].value)?.verb;
+                    if (verb != null) {
+                      emit(verb);
+                    }
+              http.response:
+                type: long
+                script:
+                  source: |
+                    String response = dissect('%{clientip} %{ident} %{auth} [%{@timestamp}] "%{verb} %{request} HTTP/%{httpversion}" %{response} %{size}').extract(doc["message"].value)?.response;
+                    if (response != null) {
+                      emit(Integer.parseInt(response));
+                    }
+            properties:
+              timestamp:
+                type: date
+              message:
+                type: wildcard
+  - do:
+      bulk:
+        index: http_logs
+        refresh: true
+        body: |
+          {"index":{}}
+          {"timestamp": "1998-04-30T14:30:17-05:00", "message" : "40.135.0.0 - - [30/Apr/1998:14:30:17 -0500] \"GET /images/hm_bg.jpg HTTP/1.0\" 200 24736"}
+          {"index":{}}
+          {"timestamp": "1998-04-30T14:30:53-05:00", "message" : "232.0.0.0 - - [30/Apr/1998:14:30:53 -0500] \"GET /images/hm_bg.jpg HTTP/1.0\" 200 24736"}
+          {"index":{}}
+          {"timestamp": "1998-04-30T14:31:12-05:00", "message" : "26.1.0.0 - - [30/Apr/1998:14:31:12 -0500] \"GET /images/hm_bg.jpg HTTP/1.0\" 200 24736"}
+          {"index":{}}
+          {"timestamp": "1998-04-30T14:31:19-05:00", "message" : "247.37.0.0 - - [30/Apr/1998:14:31:19 -0500] \"GET /french/splash_inet.html HTTP/1.0\" 200 3781"}
+          {"index":{}}
+          {"timestamp": "1998-04-30T14:31:22-05:00", "message" : "247.37.0.0 - - [30/Apr/1998:14:31:22 -0500] \"GET /images/hm_nbg.jpg HTTP/1.0\" 304 0"}
+          {"index":{}}
+          {"timestamp": "1998-04-30T14:31:27-05:00", "message" : "252.0.0.0 - - [30/Apr/1998:14:31:27 -0500] \"GET /images/hm_bg.jpg HTTP/1.0\" 200 24736"}
+          {"index":{}}
+          {"timestamp": "1998-04-30T14:31:28-05:00", "message" : "not a valid apache log"}
+---
+fetch:
+  - do:
+      search:
+        index: http_logs
+        body:
+          sort: timestamp
+          fields:
+            - http.clientip
+            - http.verb
+            - http.response
+  - match: {hits.total.value: 7}
+  - match: {hits.hits.0.fields.http\.clientip: [40.135.0.0] }
+  - match: {hits.hits.0.fields.http\.verb: [GET] }
+  - match: {hits.hits.0.fields.http\.response: [200] }
+  - is_false: hits.hits.6.fields.http\.clientip
+  - is_false: hits.hits.6.fields.http\.verb
+  - is_false: hits.hits.6.fields.http\.response


### PR DESCRIPTION
This adds a `grok` and a `dissect` method to runtime fields which
returns a `Matcher` style object you can use to get the matched
patterns. A fairly simple script to extract the "verb" from an apache
log line with `grok` would look like this:
```
String verb = grok('%{COMMONAPACHELOG}').extract(doc["message"].value)?.verb;
if (verb != null) {
  emit(verb);
}
```

And `dissect` would look like:
```
String verb = dissect('%{clientip} %{ident} %{auth} [%{@timestamp}] "%{verb} %{request} HTTP/%{httpversion}" %{status} %{size}').extract(doc["message"].value)?.verb;
if (verb != null) {
  emit(verb);
}
```

We'll work later to get it down to a clean looking one liner, but for
now, this'll do.

The `grok` and `dissect` methods are special in that they only run at
script compile time. You can't pass non-constants to them. They'll
produce compile errors if you send in a bad pattern. This is nice
because they can be expensive to "compile" and there are many other
optimizations we can make when the patterns are available up front.

Closes #67825
