### PR TITLE
Adjust serialization version and re-enable BWC

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -175,8 +175,8 @@ tasks.register("verifyVersions") {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = false
-String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/68321" /* place a PR link here when committing bwc changes */
+boolean bwc_tests_enabled = true
+String bwc_tests_disabled_issue = "" /* place a PR link here when committing bwc changes */
 /*
  * FIPS 140-2 behavior was fixed in 7.11.0. Before that there is no way to run elasticsearch in a
  * JVM that is properly configured to be in fips mode with BCFIPS. For now we need to disable

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/shrink/ResizeRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/shrink/ResizeRequest.java
@@ -70,7 +70,7 @@ public class ResizeRequest extends AcknowledgedRequest<ResizeRequest> implements
         sourceIndex = in.readString();
         type = in.readEnum(ResizeType.class);
         copySettings = in.readOptionalBoolean();
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_12_0)) {
             if (in.readBoolean()) {
                 maxSinglePrimarySize = new ByteSizeValue(in);
             }
@@ -117,7 +117,7 @@ public class ResizeRequest extends AcknowledgedRequest<ResizeRequest> implements
         out.writeString(sourceIndex);
         out.writeEnum(type);
         out.writeOptionalBoolean(copySettings);
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_12_0)) {
             out.writeOptionalWriteable(maxSinglePrimarySize);
         }
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ShrinkAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ShrinkAction.java
@@ -80,7 +80,7 @@ public class ShrinkAction implements LifecycleAction {
     }
 
     public ShrinkAction(StreamInput in) throws IOException {
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_12_0)) {
             if (in.readBoolean()) {
                 this.numberOfShards = in.readVInt();
                 this.maxSinglePrimarySize = null;
@@ -104,7 +104,7 @@ public class ShrinkAction implements LifecycleAction {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_12_0)) {
             boolean hasNumberOfShards = numberOfShards != null;
             out.writeBoolean(hasNumberOfShards);
             if (hasNumberOfShards) {


### PR DESCRIPTION
Adjust ResizeRequest and ShrinkAction serialization now that #68321
has been merged, and re-enable BWC testing.

Related to #67705, #68321, and #68329