### PR TITLE
Scripting: Parse stdlib files for parameter names

### DIFF
--- a/modules/lang-painless/build.gradle
+++ b/modules/lang-painless/build.gradle
@@ -87,6 +87,7 @@ sourceSets {
 dependencies {
   docImplementation project(':server')
   docImplementation project(':modules:lang-painless')
+  docImplementation 'com.github.javaparser:javaparser-core:3.18.0'
 }
 
 testClusters {
@@ -123,6 +124,7 @@ tasks.register("generateContextApiSpec", DefaultTestClustersTask) {
       main = 'org.elasticsearch.painless.ContextApiSpecGenerator'
       classpath = sourceSets.doc.runtimeClasspath
       systemProperty "cluster.uri", "${-> testClusters.generateContextApiSpecCluster.singleNode().getAllHttpSocketURI().get(0)}"
+      systemProperty "jdksrc", System.getProperty("jdksrc")
     }.assertNormalExitValue()
   }
 }

--- a/modules/lang-painless/src/doc/java/org/elasticsearch/painless/ContextApiSpecGenerator.java
+++ b/modules/lang-painless/src/doc/java/org/elasticsearch/painless/ContextApiSpecGenerator.java
@@ -37,8 +37,15 @@ import java.util.List;
 public class ContextApiSpecGenerator {
     public static void main(String[] args) throws IOException {
         List<PainlessContextInfo> contexts = ContextGeneratorCommon.getContextInfos();
-        ContextGeneratorCommon.PainlessInfos infos = new ContextGeneratorCommon.PainlessInfos(contexts);
         Path rootDir = resetRootDir();
+        ContextGeneratorCommon.PainlessInfos infos;
+        Path jdksrc = getJdkSrc();
+        if (jdksrc != null) {
+            infos = new ContextGeneratorCommon.PainlessInfos(contexts, new StdlibJavadocExtractor(jdksrc));
+        } else {
+            infos = new ContextGeneratorCommon.PainlessInfos(contexts);
+        }
+
         Path json = rootDir.resolve("painless-common.json");
         try (PrintStream jsonStream = new PrintStream(
              Files.newOutputStream(json, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE),
@@ -71,5 +78,14 @@ public class ContextApiSpecGenerator {
         Files.createDirectories(rootDir);
 
         return rootDir;
+    }
+
+    @SuppressForbidden(reason = "resolve jdk src directory with environment")
+    private static Path getJdkSrc() {
+        String jdksrc = System.getProperty("jdksrc");
+        if (jdksrc == null || "".equals(jdksrc)) {
+            return null;
+        }
+        return PathUtils.get(jdksrc);
     }
 }

--- a/modules/lang-painless/src/doc/java/org/elasticsearch/painless/ContextGeneratorCommon.java
+++ b/modules/lang-painless/src/doc/java/org/elasticsearch/painless/ContextGeneratorCommon.java
@@ -203,9 +203,14 @@ public class ContextGeneratorCommon {
         public final List<PainlessInfoJson.Context> contexts;
 
         public final Map<String, String> javaNamesToDisplayNames;
+        public final Map<String, String> javaNamesToJavadoc;
+        public final Map<String, List<String>> javaNamesToArgs;
 
         public PainlessInfos(List<PainlessContextInfo> contextInfos) {
             javaNamesToDisplayNames = getDisplayNames(contextInfos);
+
+            javaNamesToJavadoc = new HashMap<>();
+            javaNamesToArgs = new HashMap<>();
 
             Set<PainlessContextClassInfo> commonClassInfos = getCommon(contextInfos, PainlessContextInfo::getClasses);
             common = PainlessInfoJson.Class.fromInfos(sortClassInfos(commonClassInfos), javaNamesToDisplayNames);
@@ -219,6 +224,27 @@ public class ContextGeneratorCommon {
             contexts = contextInfos.stream()
                 .map(ctx -> new PainlessInfoJson.Context(ctx, commonClassInfos, javaNamesToDisplayNames))
                 .collect(Collectors.toList());
+        }
+
+        public PainlessInfos(List<PainlessContextInfo> contextInfos, StdlibJavadocExtractor extractor) throws IOException {
+            javaNamesToDisplayNames = getDisplayNames(contextInfos);
+
+            javaNamesToJavadoc = new HashMap<>();
+            javaNamesToArgs = new HashMap<>();
+
+            Set<PainlessContextClassInfo> commonClassInfos = getCommon(contextInfos, PainlessContextInfo::getClasses);
+            common = PainlessInfoJson.Class.fromInfos(sortClassInfos(commonClassInfos), javaNamesToDisplayNames, extractor);
+
+            importedMethods = getCommon(contextInfos, PainlessContextInfo::getImportedMethods);
+
+            classBindings = getCommon(contextInfos, PainlessContextInfo::getClassBindings);
+
+            instanceBindings = getCommon(contextInfos, PainlessContextInfo::getInstanceBindings);
+
+            contexts = new ArrayList<>(contextInfos.size());
+            for (PainlessContextInfo contextInfo : contextInfos) {
+                contexts.add(new PainlessInfoJson.Context(contextInfo, commonClassInfos, javaNamesToDisplayNames, extractor));
+            }
         }
 
         private <T> Set<T> getCommon(List<PainlessContextInfo> contexts, Function<PainlessContextInfo,List<T>> getter) {

--- a/modules/lang-painless/src/doc/java/org/elasticsearch/painless/ContextGeneratorCommon.java
+++ b/modules/lang-painless/src/doc/java/org/elasticsearch/painless/ContextGeneratorCommon.java
@@ -71,48 +71,15 @@ public class ContextGeneratorCommon {
     }
 
     public static String getType(Map<String, String> javaNamesToDisplayNames, String javaType) {
-        int arrayDimensions = 0;
-
-        while (javaType.charAt(arrayDimensions) == '[') {
-            ++arrayDimensions;
+        if (javaType.endsWith("[]") == false) {
+            return javaNamesToDisplayNames.getOrDefault(javaType, javaType);
         }
-
-        if (arrayDimensions > 0) {
-            if (javaType.charAt(javaType.length() - 1) == ';') {
-                javaType = javaType.substring(arrayDimensions + 1, javaType.length() - 1);
-            } else {
-                javaType = javaType.substring(arrayDimensions);
-            }
+        int bracePosition = javaType.indexOf('[');
+        String braces = javaType.substring(bracePosition);
+        String type = javaType.substring(0, bracePosition);
+        if (javaNamesToDisplayNames.containsKey(type)) {
+            return javaNamesToDisplayNames.get(type) + braces;
         }
-
-        if ("Z".equals(javaType) || "boolean".equals(javaType)) {
-            javaType = "boolean";
-        } else if ("V".equals(javaType) || "void".equals(javaType)) {
-            javaType = "void";
-        } else if ("B".equals(javaType) || "byte".equals(javaType)) {
-            javaType = "byte";
-        } else if ("S".equals(javaType) || "short".equals(javaType)) {
-            javaType = "short";
-        } else if ("C".equals(javaType) || "char".equals(javaType)) {
-            javaType = "char";
-        } else if ("I".equals(javaType) || "int".equals(javaType)) {
-            javaType = "int";
-        } else if ("J".equals(javaType) || "long".equals(javaType)) {
-            javaType = "long";
-        } else if ("F".equals(javaType) || "float".equals(javaType)) {
-            javaType = "float";
-        } else if ("D".equals(javaType) || "double".equals(javaType)) {
-            javaType = "double";
-        } else if ("org.elasticsearch.painless.lookup.def".equals(javaType)) {
-            javaType = "def";
-        } else {
-            javaType = javaNamesToDisplayNames.get(javaType);
-        }
-
-        while (arrayDimensions-- > 0) {
-            javaType += "[]";
-        }
-
         return javaType;
     }
 

--- a/modules/lang-painless/src/doc/java/org/elasticsearch/painless/PainlessInfoJson.java
+++ b/modules/lang-painless/src/doc/java/org/elasticsearch/painless/PainlessInfoJson.java
@@ -212,11 +212,11 @@ public class PainlessInfoJson {
             builder.field(PainlessContextMethodInfo.DECLARING.getPreferredName(), declaring);
             builder.field(PainlessContextMethodInfo.NAME.getPreferredName(), name);
             builder.field(PainlessContextMethodInfo.RTN.getPreferredName(), rtn);
-            if (javadoc != null) {
+            if (javadoc != null && "".equals(javadoc) == false) {
                 builder.field(JAVADOC.getPreferredName(), javadoc);
             }
             builder.field(PainlessContextMethodInfo.PARAMETERS.getPreferredName(), parameters);
-            if (parameterNames != null) {
+            if (parameterNames != null && parameterNames.size() > 0) {
                 builder.field(PARAMETER_NAMES.getPreferredName(), parameterNames);
             }
             builder.endObject();
@@ -268,10 +268,10 @@ public class PainlessInfoJson {
             builder.startObject();
             builder.field(PainlessContextConstructorInfo.DECLARING.getPreferredName(), declaring);
             builder.field(PainlessContextConstructorInfo.PARAMETERS.getPreferredName(), parameters);
-            if (parameterNames != null) {
+            if (parameterNames != null && parameterNames.size() > 0) {
                 builder.field(PARAMETER_NAMES.getPreferredName(), parameterNames);
             }
-            if (javadoc != null) {
+            if (javadoc != null && "".equals(javadoc) == false) {
                 builder.field(JAVADOC.getPreferredName(), javadoc);
             }
             builder.endObject();
@@ -315,7 +315,7 @@ public class PainlessInfoJson {
             builder.field(PainlessContextFieldInfo.DECLARING.getPreferredName(), declaring);
             builder.field(PainlessContextFieldInfo.NAME.getPreferredName(), name);
             builder.field(PainlessContextFieldInfo.TYPE.getPreferredName(), type);
-            if (javadoc != null) {
+            if (javadoc != null && "".equals(javadoc) == false) {
                 builder.field(JAVADOC.getPreferredName(), javadoc);
             }
             builder.endObject();

--- a/modules/lang-painless/src/doc/java/org/elasticsearch/painless/StdlibJavadocExtractor.java
+++ b/modules/lang-painless/src/doc/java/org/elasticsearch/painless/StdlibJavadocExtractor.java
@@ -1,0 +1,225 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.painless;
+
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Modifier;
+import com.github.javaparser.ast.body.ConstructorDeclaration;
+import com.github.javaparser.ast.body.FieldDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.VariableDeclarator;
+import com.github.javaparser.ast.visitor.VoidVisitorAdapter;
+import com.github.javaparser.javadoc.Javadoc;
+import org.elasticsearch.common.SuppressForbidden;
+import org.elasticsearch.painless.action.PainlessContextMethodInfo;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class StdlibJavadocExtractor {
+    private final Path root;
+
+    public StdlibJavadocExtractor(Path root) {
+        this.root = root;
+    }
+
+    @SuppressForbidden(reason = "resolve class file from java src directory with environment")
+    private File openClassFile(String className) {
+        int dollarPosition = className.indexOf("$");
+        if (dollarPosition >= 0) {
+            className = className.substring(0, dollarPosition);
+        }
+        String[] packages = className.split("\\.");
+        String path = String.join("/", packages);
+        Path classPath = root.resolve(path + ".java");
+        return classPath.toFile();
+    }
+
+    public ParsedJavaClass parseClass(String className) throws IOException {
+        ParsedJavaClass pj = new ParsedJavaClass();
+        if (className.contains(".") && className.startsWith("java")) { // TODO(stu): handle primitives & not stdlib
+            ClassFileVisitor visitor = new ClassFileVisitor();
+            CompilationUnit cu = StaticJavaParser.parse(openClassFile(className));
+            visitor.visit(cu, pj);
+        }
+        return pj;
+    }
+
+    public static class ParsedJavaClass {
+        public final Map<MethodSignature, ParsedMethod> methods;
+        public final Map<String, String> fields;
+        public final Map<List<String>, ParsedMethod> constructors;
+
+        public ParsedJavaClass() {
+            methods = new HashMap<>();
+            fields = new HashMap<>();
+            constructors = new HashMap<>();
+        }
+
+        public ParsedMethod getMethod(PainlessContextMethodInfo info, Map<String, String> javaNamesToDisplayNames) {
+            return methods.get(MethodSignature.fromInfo(info, javaNamesToDisplayNames));
+        }
+
+        @Override
+        public String toString() {
+            return "ParsedJavaClass{" +
+                "methods=" + methods +
+                '}';
+        }
+
+        public void putMethod(MethodDeclaration declaration) {
+            methods.put(
+                MethodSignature.fromDeclaration(declaration),
+                new ParsedMethod(
+                        declaration.getJavadoc().map(Javadoc::toText).orElse(""),
+                        declaration.getParameters()
+                                .stream()
+                                .map(p -> p.getName().asString())
+                                .collect(Collectors.toList())
+                )
+            );
+        }
+
+        public void putConstructor(ConstructorDeclaration declaration) {
+            constructors.put(
+                declaration.getParameters().stream().map(p -> stripTypeParameters(p.getType().asString())).collect(Collectors.toList()),
+                new ParsedMethod(
+                        declaration.getJavadoc().map(Javadoc::toText).orElse(""),
+                        declaration.getParameters()
+                                .stream()
+                                .map(p -> p.getName().asString())
+                                .collect(Collectors.toList())
+                )
+            );
+        }
+
+        private static String stripTypeParameters(String type) {
+            int start = 0;
+            int count = 0;
+            for (int i=0; i<type.length(); i++) {
+                char c = type.charAt(i);
+                if (c == '<') {
+                    if (start == 0) {
+                        start = i;
+                    }
+                    count++;
+                } else if (c == '>') {
+                    count--;
+                    if (count == 0) {
+                        return type.substring(0, start);
+                    }
+                }
+            }
+            return type;
+        }
+
+        public ParsedMethod getConstructor(List<String> parameters) {
+            return constructors.get(parameters);
+        }
+
+        public String getField(String name) {
+            return fields.get(name);
+        }
+
+        public void putField(FieldDeclaration declaration) {
+            for (VariableDeclarator var : declaration.getVariables()) {
+                fields.put(var.getNameAsString(), declaration.getJavadoc().map(Javadoc::toText).orElse(""));
+            }
+        }
+    }
+
+    public static class MethodSignature {
+        public final String name;
+        public final List<String> parameterTypes;
+
+        public MethodSignature(String name, List<String> parameterTypes) {
+            this.name = name;
+            this.parameterTypes = parameterTypes;
+        }
+
+        public static MethodSignature fromInfo(PainlessContextMethodInfo info,Map<String, String> javaNamesToDisplayNames) {
+            return new MethodSignature(
+                info.getName(),
+                info.getParameters().stream().map(javaNamesToDisplayNames::get).collect(Collectors.toList())
+            );
+        }
+
+        public static MethodSignature fromDeclaration(MethodDeclaration declaration) {
+            return new MethodSignature(
+                    declaration.getNameAsString(),
+                    declaration.getParameters()
+                            .stream()
+                            .map(p -> p.getType().asString())
+                            .collect(Collectors.toList())
+            );
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof MethodSignature)) return false;
+            MethodSignature that = (MethodSignature) o;
+            return Objects.equals(name, that.name) &&
+                Objects.equals(parameterTypes, that.parameterTypes);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(name, parameterTypes);
+        }
+    }
+
+    public static class ParsedMethod {
+        public final String javadoc;
+        public final List<String> parameterNames;
+
+        public ParsedMethod(String javadoc, List<String> parameterNames) {
+            this.javadoc = javadoc;
+            this.parameterNames = parameterNames;
+        }
+    }
+
+    private static class ClassFileVisitor extends VoidVisitorAdapter<ParsedJavaClass> {
+        @Override
+        public void visit(MethodDeclaration methodDeclaration, ParsedJavaClass parsed) {
+            parsed.putMethod(methodDeclaration);
+        }
+
+        @Override
+        public void visit(FieldDeclaration fieldDeclaration, ParsedJavaClass parsed) {
+            if (fieldDeclaration.hasModifier(Modifier.Keyword.PUBLIC) == false) {
+                return;
+            }
+            parsed.putField(fieldDeclaration);
+        }
+
+        @Override
+        public void visit(ConstructorDeclaration constructorDeclaration, ParsedJavaClass parsed) {
+            parsed.putConstructor(constructorDeclaration);
+        }
+    }
+}

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessContextConstructorInfo.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessContextConstructorInfo.java
@@ -63,7 +63,9 @@ public class PainlessContextConstructorInfo implements Writeable, ToXContentObje
     public PainlessContextConstructorInfo(PainlessConstructor painlessConstructor) {
         this (
                 painlessConstructor.javaConstructor.getDeclaringClass().getName(),
-                painlessConstructor.typeParameters.stream().map(Class::getName).collect(Collectors.toList())
+                painlessConstructor.typeParameters.stream()
+                        .map(c -> PainlessContextTypeInfo.getType(c.getName()))
+                        .collect(Collectors.toList())
         );
     }
 

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessContextFieldInfo.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessContextFieldInfo.java
@@ -63,7 +63,7 @@ public class PainlessContextFieldInfo implements Writeable, ToXContentObject {
         this(
                 painlessField.javaField.getDeclaringClass().getName(),
                 painlessField.javaField.getName(),
-                painlessField.typeParameter.getName()
+                PainlessContextTypeInfo.getType(painlessField.typeParameter.getName())
         );
     }
 

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessContextMethodInfo.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessContextMethodInfo.java
@@ -72,8 +72,8 @@ public class PainlessContextMethodInfo implements Writeable, ToXContentObject {
         this(
                 painlessMethod.javaMethod.getDeclaringClass().getName(),
                 painlessMethod.javaMethod.getName(),
-                painlessMethod.returnType.getName(),
-                painlessMethod.typeParameters.stream().map(Class::getName).collect(Collectors.toList())
+                PainlessContextTypeInfo.getType(painlessMethod.returnType.getName()),
+                painlessMethod.typeParameters.stream().map(c -> PainlessContextTypeInfo.getType(c.getName())).collect(Collectors.toList())
         );
     }
 

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessContextTypeInfo.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessContextTypeInfo.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.painless.action;
+
+public class PainlessContextTypeInfo {
+    /**
+     * Translates array types from internal java Field Descriptors (JVM Spec 4.3.2) to readable names.  Also translates
+     * the fully qualified name of the def type to "def".
+     */
+    public static String getType(String javaType) {
+        int arrayDimensions = 0;
+
+        while (javaType.charAt(arrayDimensions) == '[') {
+            ++arrayDimensions;
+        }
+
+        if (arrayDimensions > 0) {
+            if (javaType.charAt(javaType.length() - 1) == ';') {
+                // Arrays of object types have the form [L<name>; where <name> is the class path, trimming the L & ;
+                javaType = javaType.substring(arrayDimensions + 1, javaType.length() - 1);
+            } else {
+                javaType = javaType.substring(arrayDimensions);
+            }
+        }
+
+        if ("Z".equals(javaType) || "boolean".equals(javaType)) {
+            javaType = "boolean";
+        } else if ("V".equals(javaType) || "void".equals(javaType)) {
+            javaType = "void";
+        } else if ("B".equals(javaType) || "byte".equals(javaType)) {
+            javaType = "byte";
+        } else if ("S".equals(javaType) || "short".equals(javaType)) {
+            javaType = "short";
+        } else if ("C".equals(javaType) || "char".equals(javaType)) {
+            javaType = "char";
+        } else if ("I".equals(javaType) || "int".equals(javaType)) {
+            javaType = "int";
+        } else if ("J".equals(javaType) || "long".equals(javaType)) {
+            javaType = "long";
+        } else if ("F".equals(javaType) || "float".equals(javaType)) {
+            javaType = "float";
+        } else if ("D".equals(javaType) || "double".equals(javaType)) {
+            javaType = "double";
+        } else if ("org.elasticsearch.painless.lookup.def".equals(javaType)) {
+            javaType = "def";
+        }
+
+        while (arrayDimensions-- > 0) {
+            javaType += "[]";
+        }
+
+        return javaType;
+    }
+}


### PR DESCRIPTION
* Task `generateContextApiSpec` takes optional system parameter
  `jdksrc` with path to extracted java standard library source
  files.
* stdlib source files are the source of `parameter_names` list
  and the `javadoc` value.
* javadoc values may contain newlines and markup such as
  `{@code XX}`, `<p>`, `@throws`

Example method:
```
{
  "declaring": "Appendable",
  "name": "append",
  "return": "Appendable",
  "javadoc": "Appends a subsequence of the specified character sequence to this...",
  "parameters": ["CharSequence", "int", "int" ],
  "parameter_names": ["csq", "start", "end"]
}
```
Scripting: readable array types for context

Instead of fixing up array names post-hoc when generating the api spec
and painless context docs, fix them up in the `_scripts/painless/_context`
API call.
