### PR TITLE
Properly Retain Buffer in RecoverySourceHandler (#68283)

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -955,9 +955,10 @@ public class RecoverySourceHandler {
                 @Override
                 protected void executeChunkRequest(FileChunk request, ActionListener<Void> listener) {
                     cancellableThreads.checkForCancel();
+                    final ReleasableBytesReference content = new ReleasableBytesReference(request.content, request);
                     recoveryTarget.writeFileChunk(
-                        request.md, request.position, ReleasableBytesReference.wrap(request.content), request.lastChunk,
-                            translogOps.getAsInt(), ActionListener.runBefore(listener, request::close));
+                        request.md, request.position, content, request.lastChunk,
+                            translogOps.getAsInt(), ActionListener.runBefore(listener, content::close));
                 }
 
                 @Override


### PR DESCRIPTION
This only really applies to tests using the `AsyncRecoveryTarget` as far as I can see but
be that as it may, we should properly handle the ref count on the content here and only
release the buffer once it's released and not tie the bytes to the listener lifecycle.
Otherwise the bytes can't be retained by the multi file writer when dealing with out of order
writes and get released to early.

Closes #68280

backport of #68283 