### PR TITLE
EQL: improve EQL request/response serialization tests for bwc versions

### DIFF
--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchRequest.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchRequest.java
@@ -319,7 +319,7 @@ public class EqlSearchRequest extends ActionRequest implements IndicesRequest.Re
             out.writeOptionalTimeValue(keepAlive);
             out.writeBoolean(keepOnCompletion);
         }
-        if (out.getVersion().onOrAfter(Version.V_7_10_0)) {
+        if (out.getVersion().before(Version.V_7_10_0)) {
             out.writeBoolean(true);
         }
     }

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/AbstractBWCSerializationTestCase.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/AbstractBWCSerializationTestCase.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.eql;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.test.AbstractSerializingTestCase;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.elasticsearch.Version.getDeclaredVersions;
+import static org.hamcrest.Matchers.equalTo;
+
+public abstract class AbstractBWCSerializationTestCase<T extends Writeable & ToXContent> extends AbstractSerializingTestCase<T> {
+
+    private static final List<Version> ALL_VERSIONS = Collections.unmodifiableList(getDeclaredVersions(Version.class));
+    private static Version EQL_GA_VERSION = Version.V_7_10_0;
+
+    private static List<Version> getAllBWCVersions(Version version) {
+        return ALL_VERSIONS.stream().filter(v -> v.onOrAfter(EQL_GA_VERSION) && v.before(version) && version.isCompatible(v)).collect(
+            Collectors.toList());
+    }
+
+    private static final List<Version> DEFAULT_BWC_VERSIONS = getAllBWCVersions(Version.CURRENT);
+
+    public final void testBwcSerialization() throws IOException {
+        for (int runs = 0; runs < NUMBER_OF_TEST_RUNS; runs++) {
+            T testInstance = createTestInstance();
+            for (Version bwcVersion : DEFAULT_BWC_VERSIONS) {
+                assertBwcSerialization(testInstance, bwcVersion);
+            }
+        }
+    }
+
+    protected final void assertBwcSerialization(T testInstance, Version version) throws IOException {
+        T deserializedInstance = copyInstance(testInstance, version);
+        assertOnBWCObject(testInstance, deserializedInstance, version);
+    }
+
+    protected void assertOnBWCObject(T testInstance, T bwcDeserializedObject, Version version) {
+        assertNotSame(version.toString(), bwcDeserializedObject, testInstance);
+        assertThat(version.toString(), testInstance, equalTo(bwcDeserializedObject));
+        assertEquals(version.toString(), testInstance.hashCode(), bwcDeserializedObject.hashCode());
+    }
+}

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/action/EqlSearchRequestTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/action/EqlSearchRequestTests.java
@@ -14,8 +14,8 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.SearchModule;
-import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.eql.AbstractBWCSerializationTestCase;
 import org.junit.Before;
 
 import java.io.IOException;
@@ -25,7 +25,7 @@ import java.util.function.Supplier;
 
 import static org.elasticsearch.index.query.AbstractQueryBuilder.parseInnerQueryBuilder;
 
-public class EqlSearchRequestTests extends AbstractSerializingTestCase<EqlSearchRequest> {
+public class EqlSearchRequestTests extends AbstractBWCSerializationTestCase<EqlSearchRequest> {
 
     // TODO: possibly add mutations
     static String defaultTestFilter = "{\n" +

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/action/EqlSearchResponseTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/action/EqlSearchResponseTests.java
@@ -13,7 +13,7 @@ import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.test.AbstractSerializingTestCase;
+import org.elasticsearch.xpack.eql.AbstractBWCSerializationTestCase;
 import org.elasticsearch.xpack.eql.action.EqlSearchResponse.Event;
 
 import java.io.IOException;
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.Supplier;
 
-public class EqlSearchResponseTests extends AbstractSerializingTestCase<EqlSearchResponse> {
+public class EqlSearchResponseTests extends AbstractBWCSerializationTestCase<EqlSearchResponse> {
 
     private static class RandomSource implements ToXContentObject {
 


### PR DESCRIPTION
Improves testing for stream serialization/deserialization of EqlSearchResponse/Request considering bwc versions. (#68339)

(cherry picked from commit 3a1f5dc10131fa81b0537e0890d3d2d0b9c0db98)