### PR TITLE
[ML] Unmute explain_data_frame_analytics/Test field_selection given body

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/explain_data_frame_analytics.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/explain_data_frame_analytics.yml
@@ -179,9 +179,6 @@
 
 ---
 "Test field_selection given body":
-  - skip:
-      version: "all"
-      reason: "Awaits fix: https://github.com/elastic/elasticsearch/issues/68337"
 
   - do:
       indices.create:


### PR DESCRIPTION
The test was failing in the release tests as a new parameter was added
in the c++ side and we had to build a non-snapshot artifact for the ml-cpp
repo. This is now done so we can unmute the test.

Fixes #68337
