### PR TITLE
Add processor architectures to cluster stats

### DIFF
--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -766,6 +766,23 @@ Human-readable name of an operating system used by one or more selected nodes.
 Number of selected nodes using the operating system.
 ======
 
+`architectures`::
+(array of objects)
+Contains statistics about processor architectures (for example, x86_64 or
+aarch64) used by selected nodes.
++
+.Properties of `architectures`
+[%collapsible%open]
+======
+`arch`:::
+(string)
+Name of an architecture used by one or more selected nodes.
+
+`count`:::
+(string)
+Number of selected nodes using the architecture.
+======
+
 `mem`::
 (object)
 Contains statistics about memory used by selected nodes.
@@ -1249,6 +1266,12 @@ The API returns the following response:
          "pretty_names": [
             {
                "pretty_name": "Mac OS X",
+               "count": 1
+            }
+         ],
+         "architectures": [
+            {
+               "arch": "x86_64",
                "count": 1
             }
          ],

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodes.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodes.java
@@ -248,6 +248,7 @@ public class ClusterStatsNodes implements ToXContentFragment {
         final int allocatedProcessors;
         final ObjectIntHashMap<String> names;
         final ObjectIntHashMap<String> prettyNames;
+        final ObjectIntHashMap<String> architectures;
         final org.elasticsearch.monitor.os.OsStats.Mem mem;
 
         /**
@@ -256,6 +257,7 @@ public class ClusterStatsNodes implements ToXContentFragment {
         private OsStats(List<NodeInfo> nodeInfos, List<NodeStats> nodeStatsList) {
             this.names = new ObjectIntHashMap<>();
             this.prettyNames = new ObjectIntHashMap<>();
+            this.architectures = new ObjectIntHashMap<>();
             int availableProcessors = 0;
             int allocatedProcessors = 0;
             for (NodeInfo nodeInfo : nodeInfos) {
@@ -267,6 +269,9 @@ public class ClusterStatsNodes implements ToXContentFragment {
                 }
                 if (nodeInfo.getInfo(OsInfo.class).getPrettyName() != null) {
                     prettyNames.addTo(nodeInfo.getInfo(OsInfo.class).getPrettyName(), 1);
+                }
+                if (nodeInfo.getInfo(OsInfo.class).getArch() != null) {
+                    architectures.addTo(nodeInfo.getInfo(OsInfo.class).getArch(), 1);
                 }
             }
             this.availableProcessors = availableProcessors;
@@ -308,6 +313,8 @@ public class ClusterStatsNodes implements ToXContentFragment {
             static final String NAMES = "names";
             static final String PRETTY_NAME = "pretty_name";
             static final String PRETTY_NAMES = "pretty_names";
+            static final String ARCH = "arch";
+            static final String ARCHITECTURES = "architectures";
             static final String COUNT = "count";
         }
 
@@ -335,6 +342,18 @@ public class ClusterStatsNodes implements ToXContentFragment {
                     {
                         builder.field(Fields.PRETTY_NAME, prettyName.key);
                         builder.field(Fields.COUNT, prettyName.value);
+                    }
+                    builder.endObject();
+                }
+            }
+            builder.endArray();
+            builder.startArray(Fields.ARCHITECTURES);
+            {
+                for (final ObjectIntCursor<String> arch : architectures) {
+                    builder.startObject();
+                    {
+                        builder.field(Fields.ARCH, arch.key);
+                        builder.field(Fields.COUNT, arch.value);
                     }
                     builder.endObject();
                 }

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/cluster/ClusterStatsMonitoringDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/cluster/ClusterStatsMonitoringDocTests.java
@@ -267,6 +267,7 @@ public class ClusterStatsMonitoringDocTests extends BaseMonitoringDocTestCase<Cl
         when(mockOsInfo.getAllocatedProcessors()).thenReturn(16);
         when(mockOsInfo.getName()).thenReturn("_os_name");
         when(mockOsInfo.getPrettyName()).thenReturn("_pretty_os_name");
+        when(mockOsInfo.getArch()).thenReturn("_architecture");
 
         final JvmInfo mockJvmInfo = mock(JvmInfo.class);
         when(mockNodeInfo.getInfo(JvmInfo.class)).thenReturn(mockJvmInfo);
@@ -489,6 +490,12 @@ public class ClusterStatsMonitoringDocTests extends BaseMonitoringDocTestCase<Cl
                         + "\"pretty_names\":["
                           + "{"
                             + "\"pretty_name\":\"_pretty_os_name\","
+                            + "\"count\":1"
+                          + "}"
+                        + "],"
+                        + "\"architectures\":["
+                          + "{"
+                            + "\"arch\":\"_architecture\","
                             + "\"count\":1"
                           + "}"
                         + "],"


### PR DESCRIPTION
This change adds a new "architectures" section to the
cluster stats, containing a summary of how many nodes
in the cluster are on each processor architecture.

The intention is to make it easier to see whether
clusters are running on aarch64, or mixed x86_64/aarch64,
which may aid support as aarch64 becomes more commonly
used.

Backport of #68264