### PR TITLE
SLM: max/after and max/failed fix

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotRetentionConfiguration.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotRetentionConfiguration.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.LongSupplier;
 import java.util.function.Predicate;
@@ -144,7 +145,13 @@ public class SnapshotRetentionConfiguration implements ToXContentObject, Writeab
             // count) snapshots to be eligible for deletion
             if (this.maximumSnapshotCount != null) {
                 if (successfulSnapshotCount > this.maximumSnapshotCount) {
-                    final long snapsToDelete = successfulSnapshotCount - this.maximumSnapshotCount;
+                    final long successfulSnapsToDelete = successfulSnapshotCount - this.maximumSnapshotCount;
+                    final Optional<SnapshotInfo> firstNonEligible = sortedSnapshots.stream()
+                        .filter(snap -> SnapshotState.SUCCESS.equals(snap.state()))
+                        .skip(successfulSnapsToDelete)
+                        .findFirst();
+                    assert firstNonEligible.isPresent();
+                    final int snapsToDelete = sortedSnapshots.indexOf(firstNonEligible.get());
                     final boolean eligible = sortedSnapshots.stream()
                         .limit(snapsToDelete)
                         .anyMatch(s -> s.equals(si));
@@ -152,13 +159,12 @@ public class SnapshotRetentionConfiguration implements ToXContentObject, Writeab
                     if (eligible) {
                         logger.trace("[{}]: ELIGIBLE as it is one of the {} oldest snapshots with " +
                                 "{} non-failed snapshots ({} total), over the limit of {} maximum snapshots",
-                            snapName, snapsToDelete, successfulSnapshotCount, totalSnapshotCount, this.maximumSnapshotCount);
+                            snapName, successfulSnapsToDelete, successfulSnapshotCount, totalSnapshotCount, this.maximumSnapshotCount);
                         return true;
                     } else {
-                        logger.trace("[{}]: INELIGIBLE as it is not one of the {} oldest snapshots with " +
+                        logger.trace("[{}]: SKIPPING as it is not one of the {} oldest snapshots with " +
                                 "{} non-failed snapshots ({} total), over the limit of {} maximum snapshots",
-                            snapName, snapsToDelete, successfulSnapshotCount, totalSnapshotCount, this.maximumSnapshotCount);
-                        return false;
+                            snapName, successfulSnapsToDelete, successfulSnapshotCount, totalSnapshotCount, this.maximumSnapshotCount);
                     }
                 }
             }


### PR DESCRIPTION
Combining both maximum and expire after retention configuration did not
compose well in that, as long as there are any snapshots to delete due
to the maximum criteria, the expire after criteria was not evaluated,
fixed to consider both.

When evaluating the maximum criteria, a number of snapshots to delete
was calculated based on successful snapshots. However, when evaluating
which snapshot is eligible for deletion, the entire list was used,
resulting in deleting too few snapshots.
