### PR TITLE
[7.11] [DOCS] Document the `stack.templates.enabled` setting (#68328)

### DIFF
--- a/docs/reference/indices/index-templates.asciidoc
+++ b/docs/reference/indices/index-templates.asciidoc
@@ -23,16 +23,27 @@ If a new data stream or index matches more than one index template, the index te
 // tag::built-in-index-templates[]
 [IMPORTANT]
 ====
-{es} has built-in index templates for the `metrics-*-*`, `logs-*-*`, and
-`synthetics-*-*` index patterns, each with a priority of `100`. The
-{fleet-guide}/fleet-overview.html[{agent}] uses these templates to create data
-streams. If you use the {agent}, assign your index templates a priority lower
-than `100` to avoid overriding the built-in templates.
+{es} has built-in index templates, each with a priority of `100`, for the
+following index patterns:
 
-Otherwise, to avoid accidentally applying the built-in templates, use a
-non-overlapping index pattern or assign templates with an overlapping pattern a
-`priority` higher than `100`.
+// tag::built-in-index-template-patterns[]
+- `logs-*-*`
+- `metrics-*-*`
+- `synthetics-*-*`
+// end::built-in-index-template-patterns[]
 
+The {fleet-guide}/fleet-overview.html[{agent}] uses these templates to create
+data streams. If you use the {agent}, assign your index templates a priority
+lower than `100` to avoid overriding the built-in templates. Otherwise, to avoid
+accidentally applying the built-in templates, do one or more of the following:
+
+- To disable all built-index index and component templates, set
+<<stack-templates-enabled,`stack.templates.enabled`>> to `false` using the
+<<cluster-update-settings,cluster update settings API>>.
+
+- Use a non-overlapping index pattern.
+
+- Assign templates with an overlapping pattern a `priority` higher than `100`.
 For example, if you don't use the {agent} and want to create a template for the
 `logs-*` index pattern, assign your template a priority of `200`. This ensures
 your template is applied instead of the built-in template for `logs-*-*`.

--- a/docs/reference/indices/put-component-template.asciidoc
+++ b/docs/reference/indices/put-component-template.asciidoc
@@ -85,7 +85,29 @@ except before the opening curly bracket.
 `<component-template>`::
 (Required, string)
 Name of the component template to create.
++
+[IMPORTANT]
+====
+{es} includes the following built-in component templates:
 
+// tag::built-in-component-templates[]
+- `logs-mappings`
+- `logs-settings`
+- `metrics-mappings`
+- `metrics-settings`
+- `synthetics-mapping`
+- `synthetics-settings`
+// end::built-in-component-templates[]
+
+The {fleet-guide}/fleet-overview.html[{agent}] uses these templates to configure
+backing indices for its data streams. If you use the {agent} and want to
+overwrite one of these templates, set the `version` for your replacement
+template higher than the current version.
+
+If you don't use the {agent} and want to disable all built-in component and
+index templates, set <<stack-templates-enabled,`stack.templates.enabled`>> to
+`false` using the <<cluster-update-settings,cluster update settings API>>.
+====
 
 [[put-component-template-api-query-params]]
 ==== {api-query-parms-title}

--- a/docs/reference/modules/indices/index_management.asciidoc
+++ b/docs/reference/modules/indices/index_management.asciidoc
@@ -32,3 +32,22 @@ IMPORTANT: Closed indices are a data loss risk because they are not included whe
 (<<static-cluster-setting,Static>>)
 Specifies the hosts that can be <<reindex-from-remote,reindexed from remotely>>. Expects a YAML array of `host:port` strings. Consists of a comma-delimited list of `host:port` entries. Defaults to `["\*.io:*", "\*.com:*"]`.
 // end::reindex-remote-whitelist[]
+
+[[stack-templates-enabled]]
+`stack.templates.enabled` {ess-icon}::
++
+--
+(<<dynamic-cluster-setting,Dynamic>>)
+If `true`, enables built-in index and component templates. The
+{fleet-guide}/fleet-overview.html[{agent}] uses these templates to create data
+streams. If `false`, {es} disables these index and component templates. Defaults
+to `true`.
+
+This setting affects the following built-in index templates:
+
+include::{es-repo-dir}/indices/index-templates.asciidoc[tag=built-in-index-template-patterns]
+
+This setting also affects the following built-in component templates:
+
+include::{es-repo-dir}/indices/put-component-template.asciidoc[tag=built-in-component-templates]
+--


### PR DESCRIPTION
Backports the following commits to 7.11:
 - [DOCS] Document the `stack.templates.enabled` setting (#68328)