### PR TITLE
[7.x] [DOCS] Expands feature processors property description and adds a link of conceptual docs (#68213)

### DIFF
--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -574,12 +574,17 @@ By default, this value is calculated during hyperparameter optimization.
 end::dfas-eta-growth[]
 
 tag::dfas-feature-processors[]
+Advanced configuration option.
 A collection of feature preprocessors that modify one or more included fields.
 The analysis uses the resulting one or more features instead of the
 original document field. Multiple `feature_processors` entries can refer to the
-same document fields.
-Note, automatic categorical {ml-docs}/ml-feature-encoding.html[feature encoding] 
-still occurs.
+same document fields. Automatic categorical 
+{ml-docs}/ml-feature-encoding.html[feature encoding] still occurs for the fields 
+that are unprocessed by a custom processor or that have categorical values.
+Only use this if you want to override the automatic feature encoding of the 
+specified fields. Refer to 
+{ml-docs}/ml-feature-processors.html[{dfanalytics} feature processors] to learn 
+more.
 end::dfas-feature-processors[]
 
 tag::dfas-feature-processors-feat-name[]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Expands feature processors property description and adds a link of conceptual docs (#68213)