### PR TITLE
Fix testDeleteActionDoesntDeleteSearchableSnapshot

### DIFF
--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/TimeSeriesLifecycleActionsIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/TimeSeriesLifecycleActionsIT.java
@@ -1444,7 +1444,16 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
                 return false;
             }
         }, 30, TimeUnit.SECONDS));
-        assertBusy(() -> assertFalse(indexExists(restoredIndexName)));
+
+        // wait for **both** the restored and the original managed index to not exist anymore
+        // (making sure the ILM policy finished - asserting only on the restored index has the
+        // problem of a fast executing test code that will have the
+        // `assertFalse(indexExists(restoredIndexName))` assertion pass before the restored index
+        // ever existed)
+        assertBusy(() -> {
+            assertFalse(indexExists(index));
+            assertFalse(indexExists(restoredIndexName));
+        }, 90, TimeUnit.SECONDS);
 
         assertTrue("the snapshot we generate in the cold phase should not be deleted by the delete phase", waitUntil(() -> {
             try {


### PR DESCRIPTION
The flakiness was caused by the assertions in the test not capturing
the expected ILM state. Namely, asserting the `restored` index doesn't
exist is also true before it ever exists (not only after it's deleted)

The intention was to assert ILM finished execution for the restored and
the index was deleted. 
This changes the code to assert both the original managed and the restored
index do not exist before moving on to assert the snapshot survives the
`delete` action execution.

Fixes #67712 