### PR TITLE
[master] [DOCS] Fix typo (#68362)

### DIFF
--- a/docs/reference/sql/index.asciidoc
+++ b/docs/reference/sql/index.asciidoc
@@ -16,7 +16,7 @@ X-Pack includes a SQL feature to execute SQL queries against {es}
 indices and return results in tabular format.
 
 The following chapters aim to cover everything from usage, to syntax and drivers.
-Experience users or those in a hurry might want to jump directly to 
+Experienced users or those in a hurry might want to jump directly to
 the list of SQL <<sql-commands, commands>> and <<sql-functions, functions>>.
 
 <<sql-overview, Overview>>::


### PR DESCRIPTION
Backports the following commits to master:
 - [DOCS] Fix typo (#68362)