### PR TITLE
[7.x] [DOCS] Add security privileges to snapshot/restore API docs (#67955)

### DIFF
--- a/docs/reference/snapshot-restore/apis/clean-up-repo-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/clean-up-repo-api.asciidoc
@@ -31,6 +31,12 @@ POST /_snapshot/my_repository/_cleanup
 
 `POST /_snapshot/<repository>/_cleanup`
 
+[[clean-up-snapshot-repo-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `manage`
+<<privileges-list-cluster,cluster privilege>> to use this API.
+
 [[clean-up-snapshot-repo-api-desc]]
 ==== {api-description-title}
 

--- a/docs/reference/snapshot-restore/apis/clone-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/clone-snapshot-api.asciidoc
@@ -20,6 +20,12 @@ PUT /_snapshot/my_repository/source_snapshot/_clone/target_snapshot
 
 `PUT /_snapshot/<repository>/<source_snapshot>/_clone/<target_snapshot>`
 
+[[clone-snapshot-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `manage`
+<<privileges-list-cluster,cluster privilege>> to use this API.
+
 [[clone-snapshot-api-desc]]
 ==== {api-description-title}
 

--- a/docs/reference/snapshot-restore/apis/create-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/create-snapshot-api.asciidoc
@@ -34,6 +34,13 @@ PUT /_snapshot/my_repository/my_snapshot
 
 `POST /_snapshot/<repository>/<snapshot>`
 
+[[create-snapshot-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the
+`create_snapshot` or `manage` <<privileges-list-cluster,cluster privilege>> to
+use this API.
+
 [[create-snapshot-api-desc]]
 ==== {api-description-title}
 

--- a/docs/reference/snapshot-restore/apis/delete-repo-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/delete-repo-api.asciidoc
@@ -34,6 +34,12 @@ DELETE /_snapshot/my_repository
 
 `DELETE /_snapshot/<repository>`
 
+[[delete-snapshot-repo-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `manage`
+<<privileges-list-cluster,cluster privilege>> to use this API.
+
 [[delete-snapshot-repo-api-path-params]]
 ==== {api-path-parms-title}
 

--- a/docs/reference/snapshot-restore/apis/delete-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/delete-snapshot-api.asciidoc
@@ -36,6 +36,12 @@ DELETE /_snapshot/my_repository/my_snapshot
 
 `DELETE /_snapshot/<repository>/<snapshot>`
 
+[[delete-snapshot-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `manage`
+<<privileges-list-cluster,cluster privilege>> to use this API.
+
 [[delete-snapshot-api-desc]]
 ==== {api-description-title}
 

--- a/docs/reference/snapshot-restore/apis/get-repo-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/get-repo-api.asciidoc
@@ -33,6 +33,13 @@ GET /_snapshot/my_repository
 
 `GET /_snapshot`
 
+[[get-snapshot-repo-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the
+`monitor_snapshot`, `create_snapshot`, or `manage`
+<<privileges-list-cluster,cluster privilege>> to use this API.
+
 [[get-snapshot-repo-api-path-params]]
 ==== {api-path-parms-title}
 

--- a/docs/reference/snapshot-restore/apis/get-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/get-snapshot-api.asciidoc
@@ -34,6 +34,13 @@ GET /_snapshot/my_repository/my_snapshot
 
 `GET /_snapshot/<repository>/<snapshot>`
 
+[[get-snapshot-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the
+`monitor_snapshot`, `create_snapshot`, or `manage`
+<<privileges-list-cluster,cluster privilege>> to use this API.
+
 [[get-snapshot-api-desc]]
 ==== {api-description-title}
 

--- a/docs/reference/snapshot-restore/apis/get-snapshot-status-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/get-snapshot-status-api.asciidoc
@@ -81,6 +81,13 @@ GET /_snapshot/my_repository/my_snapshot/_status
 
 `GET /_snapshot/<repository>/<snapshot>/_status`
 
+[[get-snapshot-status-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the
+`monitor_snapshot`, `create_snapshot`, or `manage`
+<<privileges-list-cluster,cluster privilege>> to use this API.
+
 [[get-snapshot-status-api-desc]]
 ==== {api-description-title}
 

--- a/docs/reference/snapshot-restore/apis/put-repo-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/put-repo-api.asciidoc
@@ -24,6 +24,12 @@ PUT /_snapshot/my_repository
 
 `POST /_snapshot/<repository>`
 
+[[put-snapshot-repo-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `manage`
+<<privileges-list-cluster,cluster privilege>> to use this API.
+
 [[put-snapshot-repo-api-desc]]
 ==== {api-description-title}
 

--- a/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
@@ -61,6 +61,12 @@ POST /_snapshot/my_repository/my_snapshot/_restore
 
 `POST /_snapshot/<repository>/<snapshot>/_restore`
 
+[[restore-snapshot-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `manage`
+<<privileges-list-cluster,cluster privilege>> to use this API.
+
 [[restore-snapshot-api-desc]]
 ==== {api-description-title}
 

--- a/docs/reference/snapshot-restore/apis/verify-repo-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/verify-repo-api.asciidoc
@@ -30,6 +30,12 @@ POST /_snapshot/my_repository/_verify
 
 `POST /_snapshot/<repository>/_verify`
 
+[[verify-snapshot-repo-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `manage`
+<<privileges-list-cluster,cluster privilege>> to use this API.
+
 [[verify-snapshot-repo-api-desc]]
 ==== {api-description-title}
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Add security privileges to snapshot/restore API docs (#67955)