### PR TITLE
[7.x] [DOCS] Fix typo (#68364)

### DIFF
--- a/docs/reference/search/point-in-time-api.asciidoc
+++ b/docs/reference/search/point-in-time-api.asciidoc
@@ -49,7 +49,7 @@ POST /_search <1>
 and {ref}/search-request-body.html#request-body-search-preference[`preference`]
 as these parameters are copied from the point in time.
 <2> The `id` parameter tells Elasticsearch to execute the request using contexts
-from this point int time.
+from this point in time.
 <3> The `keep_alive` parameter tells Elasticsearch how long it should extend
 the time to live of the point in time.
 

--- a/server/src/main/java/org/elasticsearch/search/builder/PointInTimeBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/builder/PointInTimeBuilder.java
@@ -90,7 +90,7 @@ public final class PointInTimeBuilder implements Writeable, ToXContentObject {
     public static PointInTimeBuilder fromXContent(XContentParser parser) throws IOException {
         final XContentParams params = PARSER.parse(parser, null);
         if (params.encodedId == null) {
-            throw new IllegalArgumentException("point int time id is not provided");
+            throw new IllegalArgumentException("point in time id is not provided");
         }
         return new PointInTimeBuilder(params.encodedId).setKeepAlive(params.keepAlive);
     }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Fix typo (#68364)