### PR TITLE
Fix recording sample for run iterations in BulkBenchmarkTask

### DIFF
--- a/client/benchmark/src/main/java/org/elasticsearch/client/benchmark/ops/bulk/BulkBenchmarkTask.java
+++ b/client/benchmark/src/main/java/org/elasticsearch/client/benchmark/ops/bulk/BulkBenchmarkTask.java
@@ -171,7 +171,7 @@ public class BulkBenchmarkTask implements BenchmarkTask {
                     logger.warn("Error while executing bulk request", ex);
                 }
                 long stop = System.nanoTime();
-                if (iteration < warmupIterations) {
+                if (iteration >= warmupIterations) {
                     sampleRecorder.addSample(new Sample("bulk", start, start, stop, success));
                 }
             }


### PR DESCRIPTION
Backport of #64514 