### PR TITLE
It's flame graph time! (backport of #68312)

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -24,12 +24,24 @@ If you want to run a specific benchmark class like, say,
 `MemoryStatsBenchmark`, you can use `--args`:
 
 ```
-gradlew -p benchmarks run --args ' MemoryStatsBenchmark'
+gradlew -p benchmarks run --args 'MemoryStatsBenchmark'
 ```
 
-Everything in the `'` gets sent on the command line to JMH. The leading ` `
-inside the `'`s is important. Without it parameters are sometimes sent to
-gradle.
+Everything in the `'` gets sent on the command line to JMH.
+
+You can set benchmark parameters with `-p`:
+```
+gradlew -p benchmarks/ run --args 'RoundingBenchmark.round -prounder=es -prange="2000-10-01 to 2000-11-01" -pzone=America/New_York -pinterval=10d -pcount=1000000'
+```
+
+The benchmark code defines default values for the parameters so if
+you leave out any out JMH will run with each default value, one after
+the other. This will run with `interval` set to `calendar year` then
+`calendar hour` then `10d` then `5d` then `1h`:
+```
+gradlew -p benchmarks/ run --args 'RoundingBenchmark.round -prounder=es -prange="2000-10-01 to 2000-11-01" -pzone=America/New_York -pcount=1000000'
+```
+
 
 ## Adding Microbenchmarks
 
@@ -55,7 +67,8 @@ To get realistic results, you should exercise care when running benchmarks. Here
 * Use the integrated profilers in JMH to dig deeper if benchmark results to not match your hypotheses:
     * Add `-prof gc` to the options to check whether the garbage collector runs during a microbenchmarks and skews
    your results. If so, try to force a GC between runs (`-gc true`) but watch out for the caveats.
-    * Add `-prof perf` or `-prof perfasm` (both only available on Linux) to see hotspots.
+    * Add `-prof perf` or `-prof perfasm` (both only available on Linux, see Disassembling below) to see hotspots.
+    * Add `-prof async` to see hotspots.
 * Have your benchmarks peer-reviewed.
 
 ### Don't
@@ -65,6 +78,8 @@ To get realistic results, you should exercise care when running benchmarks. Here
 * Look only at the `Score` column and ignore `Error`. Instead take countermeasures to keep `Error` low / variance explainable.
 
 ## Disassembling
+
+NOTE: Linux only. Sorry Mac and Windows.
 
 Disassembling is fun! Maybe not always useful, but always fun! Generally, you'll want to install `perf` and FCML's `hsdis`.
 `perf` is generally available via `apg-get install perf` or `pacman -S perf`. FCML is a little more involved. This worked
@@ -88,3 +103,30 @@ gradlew -p benchmarks run --args ' MemoryStatsBenchmark -jvmArgs "-XX:+UnlockDia
 ```
 
 If you want `perf` to find the hot methods for you then do add `-prof:perfasm`.
+
+## Async Profiler
+
+Note: Linux and Mac only. Sorry Windows.
+
+The async profiler is neat because it does not suffer from the safepoint
+bias problem. And because it makes pretty flame graphs!
+
+Let user processes read performance stuff:
+```
+sudo bash
+echo 0 > /proc/sys/kernel/kptr_restrict
+echo 1 > /proc/sys/kernel/perf_event_paranoid
+exit
+```
+
+Grab the async profiler from https://github.com/jvm-profiling-tools/async-profiler
+and run `prof async` like so:
+```
+gradlew -p benchmarks/ run --args 'LongKeyedBucketOrdsBenchmark.multiBucket -prof "async:libPath=/home/nik9000/Downloads/tmp/async-profiler-1.8.3-linux-x64/build/libasyncProfiler.so;dir=/tmp/prof;output=flamegraph"'
+```
+
+If you are on mac this'll warn you that you downloaded the shared library from
+the internet. You'll need to go to settings and allow it to run.
+
+The profiler tells you it'll be more accurate if you install debug symbols
+with the JVM. I didn't and the results looked pretty good to me. (2021-02-01)

--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -29,7 +29,7 @@ archivesBaseName = 'elasticsearch-benchmarks'
 tasks.named("test").configure { enabled = false }
 
 dependencies {
-  api( project(":server")) {
+  api(project(":server")) {
     // JMH ships with the conflicting version 4.6. This prevents us from using jopt-simple in benchmarks (which should be ok) but allows
     // us to invoke the JMH uberjar as usual.
     exclude group: 'net.sf.jopt-simple', module: 'jopt-simple'
@@ -59,12 +59,6 @@ tasks.named("dependenciesInfo").configure {  enabled = false }
 tasks.named("thirdPartyAudit").configure {
   ignoreViolations(
           // these classes intentionally use JDK internal API (and this is ok since the project is maintained by Oracle employees)
-          'org.openjdk.jmh.profile.AbstractHotspotProfiler',
-          'org.openjdk.jmh.profile.HotspotThreadProfiler',
-          'org.openjdk.jmh.profile.HotspotClassloadingProfiler',
-          'org.openjdk.jmh.profile.HotspotCompilationProfiler',
-          'org.openjdk.jmh.profile.HotspotMemoryProfiler',
-          'org.openjdk.jmh.profile.HotspotRuntimeProfiler',
           'org.openjdk.jmh.util.Utils'
   )
 }

--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -41,7 +41,7 @@ securemock        = 1.2
 mocksocket        = 1.2
 
 # benchmark dependencies
-jmh               = 1.19
+jmh               = 1.26
 
 # test dependencies
 # when updating this version, also update :qa:evil-tests


### PR DESCRIPTION
Upgrade JMH to latest (1.26) to pick up its async profiler integration
and update the documentation to include instructions to running the
async profiler and making pretty pretty flame graphs.
