### PR TITLE
Fix Issues with CS Handling in ILM Async Steps (#68361)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/AsyncActionStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/AsyncActionStep.java
@@ -18,7 +18,7 @@ import java.util.Objects;
  */
 public abstract class AsyncActionStep extends Step {
 
-    private Client client;
+    private final Client client;
 
     public AsyncActionStep(StepKey key, StepKey nextStepKey, Client client) {
         super(key, nextStepKey);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/AsyncRetryDuringSnapshotActionStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/AsyncRetryDuringSnapshotActionStep.java
@@ -11,14 +11,14 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateObserver;
+import org.elasticsearch.cluster.NotMasterException;
 import org.elasticsearch.cluster.SnapshotsInProgress;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.Index;
-import org.elasticsearch.repositories.IndexId;
+import org.elasticsearch.node.NodeClosedException;
 import org.elasticsearch.snapshots.SnapshotInProgressException;
-
-import java.util.function.Consumer;
 
 /**
  * This is an abstract AsyncActionStep that wraps the performed action listener, checking to see
@@ -36,7 +36,8 @@ public abstract class AsyncRetryDuringSnapshotActionStep extends AsyncActionStep
     public final void performAction(IndexMetadata indexMetadata, ClusterState currentClusterState,
                                     ClusterStateObserver observer, Listener listener) {
         // Wrap the original listener to handle exceptions caused by ongoing snapshots
-        SnapshotExceptionListener snapshotExceptionListener = new SnapshotExceptionListener(indexMetadata.getIndex(), listener, observer);
+        SnapshotExceptionListener snapshotExceptionListener = new SnapshotExceptionListener(indexMetadata.getIndex(), listener, observer,
+                currentClusterState.nodes().getLocalNode());
         performDuringNoSnapshot(indexMetadata, currentClusterState, snapshotExceptionListener);
     }
 
@@ -56,11 +57,14 @@ public abstract class AsyncRetryDuringSnapshotActionStep extends AsyncActionStep
         private final Index index;
         private final Listener originalListener;
         private final ClusterStateObserver observer;
+        private final DiscoveryNode localNode;
 
-        SnapshotExceptionListener(Index index, Listener originalListener, ClusterStateObserver observer) {
+        SnapshotExceptionListener(Index index, Listener originalListener, ClusterStateObserver observer,
+                                  DiscoveryNode localNode) {
             this.index = index;
             this.originalListener = originalListener;
             this.observer = observer;
+            this.localNode = localNode;
         }
 
         @Override
@@ -73,87 +77,72 @@ public abstract class AsyncRetryDuringSnapshotActionStep extends AsyncActionStep
             if (e instanceof SnapshotInProgressException) {
                 try {
                     logger.debug("[{}] attempted to run ILM step but a snapshot is in progress, step will retry at a later time",
-                        index.getName());
+                            index.getName());
+                    final String indexName = index.getName();
                     observer.waitForNextChange(
-                        new NoSnapshotRunningListener(observer, index.getName(), state -> {
-                            IndexMetadata idxMeta = state.metadata().index(index);
-                            if (idxMeta == null) {
-                                // The index has since been deleted, mission accomplished!
-                                originalListener.onResponse(true);
-                            }
-                            // Re-invoke the performAction method with the new state
-                            performAction(idxMeta, state, observer, originalListener);
-                        }, originalListener::onFailure),
-                        // TODO: what is a good timeout value for no new state received during this time?
-                        TimeValue.timeValueHours(12));
+                            new ClusterStateObserver.Listener() {
+                                @Override
+                                public void onNewClusterState(ClusterState state) {
+                                    if (state.nodes().isLocalNodeElectedMaster() == false) {
+                                        originalListener.onFailure(new NotMasterException("no longer master"));
+                                        return;
+                                    }
+                                    try {
+                                        logger.debug("[{}] retrying ILM step after snapshot has completed", indexName);
+                                        IndexMetadata idxMeta = state.metadata().index(index);
+                                        if (idxMeta == null) {
+                                            // The index has since been deleted, mission accomplished!
+                                            originalListener.onResponse(true);
+                                        } else {
+                                            // Re-invoke the performAction method with the new state
+                                            performAction(idxMeta, state, observer, originalListener);
+                                        }
+                                    } catch (Exception e) {
+                                        originalListener.onFailure(e);
+                                    }
+                                }
+
+                                @Override
+                                public void onClusterServiceClose() {
+                                    originalListener.onFailure(new NodeClosedException(localNode));
+                                }
+
+                                @Override
+                                public void onTimeout(TimeValue timeout) {
+                                    originalListener.onFailure(
+                                            new IllegalStateException("step timed out while waiting for snapshots to complete"));
+                                }
+                            },
+                            state -> {
+                                if (state.nodes().isLocalNodeElectedMaster() == false) {
+                                    // ILM actions should only run on master, lets bail on failover
+                                    return true;
+                                }
+                                if (state.metadata().index(index) == null) {
+                                    // The index has since been deleted, mission accomplished!
+                                    return true;
+                                }
+                                for (SnapshotsInProgress.Entry snapshot :
+                                        state.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY).entries()) {
+                                    if (snapshot.indices().stream().anyMatch(name -> name.getName().equals(indexName))) {
+                                        // There is a snapshot running with this index name
+                                        return false;
+                                    }
+                                }
+                                // There are no snapshots for this index, so it's okay to proceed with this state
+                                return true;
+                            },
+                            TimeValue.MAX_VALUE);
                 } catch (Exception secondError) {
                     // There was a second error trying to set up an observer,
                     // fail the original listener
                     secondError.addSuppressed(e);
+                    assert false : new AssertionError("This should never fail", secondError);
                     originalListener.onFailure(secondError);
                 }
             } else {
                 originalListener.onFailure(e);
             }
-        }
-    }
-
-    /**
-     * A {@link ClusterStateObserver.Listener} that invokes the given function with the new state,
-     * once no snapshots are running. If a snapshot is still running it registers a new listener
-     * and tries again. Passes any exceptions to the original exception listener if they occur.
-     */
-    class NoSnapshotRunningListener implements ClusterStateObserver.Listener {
-
-        private final Consumer<ClusterState> reRun;
-        private final Consumer<Exception> exceptionConsumer;
-        private final ClusterStateObserver observer;
-        private final String indexName;
-
-        NoSnapshotRunningListener(ClusterStateObserver observer, String indexName,
-                                  Consumer<ClusterState> reRun,
-                                  Consumer<Exception> exceptionConsumer) {
-            this.observer = observer;
-            this.reRun = reRun;
-            this.exceptionConsumer = exceptionConsumer;
-            this.indexName = indexName;
-        }
-
-        @Override
-        public void onNewClusterState(ClusterState state) {
-            try {
-                if (snapshotInProgress(state)) {
-                    observer.waitForNextChange(this);
-                } else {
-                    logger.debug("[{}] retrying ILM step after snapshot has completed", indexName);
-                    reRun.accept(state);
-                }
-            } catch (Exception e) {
-                exceptionConsumer.accept(e);
-            }
-        }
-
-        private boolean snapshotInProgress(ClusterState state) {
-            for (SnapshotsInProgress.Entry snapshot : state.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY).entries()) {
-                if (snapshot.indices().stream()
-                    .map(IndexId::getName)
-                    .anyMatch(name -> name.equals(indexName))) {
-                    // There is a snapshot running with this index name
-                    return true;
-                }
-            }
-            // There are no snapshots for this index, so it's okay to proceed with this state
-            return false;
-        }
-
-        @Override
-        public void onClusterServiceClose() {
-            // This means the cluster is being shut down, so nothing to do here
-        }
-
-        @Override
-        public void onTimeout(TimeValue timeout) {
-            exceptionConsumer.accept(new IllegalStateException("step timed out while waiting for snapshots to complete"));
         }
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CloseFollowerIndexStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CloseFollowerIndexStepTests.java
@@ -136,7 +136,7 @@ public class CloseFollowerIndexStepTests extends AbstractStepMasterTimeoutTestCa
             .numberOfReplicas(0)
             .build();
         CloseFollowerIndexStep step = new CloseFollowerIndexStep(randomStepKey(), randomStepKey(), client);
-        step.performAction(indexMetadata, null, null, new AsyncActionStep.Listener() {
+        step.performAction(indexMetadata, emptyClusterState(), null, new AsyncActionStep.Listener() {
             @Override
             public void onResponse(boolean complete) {
                 assertThat(complete, is(true));

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/MoveToErrorStepUpdateTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/MoveToErrorStepUpdateTask.java
@@ -5,9 +5,15 @@
  */
 package org.elasticsearch.xpack.ilm;
 
-import org.elasticsearch.ElasticsearchException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.apache.logging.log4j.util.MessageSupplier;
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
+import org.elasticsearch.cluster.NotMasterException;
+import org.elasticsearch.cluster.coordination.FailedToCommitClusterStateException;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
@@ -21,13 +27,16 @@ import java.util.function.Consumer;
 import java.util.function.LongSupplier;
 
 public class MoveToErrorStepUpdateTask extends ClusterStateUpdateTask {
+
+    private static final Logger logger = LogManager.getLogger(MoveToErrorStepUpdateTask.class);
+
     private final Index index;
     private final String policy;
     private final Step.StepKey currentStepKey;
     private final BiFunction<IndexMetadata, Step.StepKey, Step> stepLookupFunction;
     private final Consumer<ClusterState> stateChangeConsumer;
-    private LongSupplier nowSupplier;
-    private Exception cause;
+    private final LongSupplier nowSupplier;
+    private final Exception cause;
 
     public MoveToErrorStepUpdateTask(Index index, String policy, Step.StepKey currentStepKey, Exception cause, LongSupplier nowSupplier,
                                      BiFunction<IndexMetadata, Step.StepKey, Step> stepLookupFunction,
@@ -39,22 +48,6 @@ public class MoveToErrorStepUpdateTask extends ClusterStateUpdateTask {
         this.nowSupplier = nowSupplier;
         this.stepLookupFunction = stepLookupFunction;
         this.stateChangeConsumer = stateChangeConsumer;
-    }
-
-    Index getIndex() {
-        return index;
-    }
-
-    String getPolicy() {
-        return policy;
-    }
-
-    Step.StepKey getCurrentStepKey() {
-        return currentStepKey;
-    }
-
-    Exception getCause() {
-        return cause;
     }
 
     @Override
@@ -86,7 +79,14 @@ public class MoveToErrorStepUpdateTask extends ClusterStateUpdateTask {
 
     @Override
     public void onFailure(String source, Exception e) {
-        throw new ElasticsearchException("policy [" + policy + "] for index [" + index.getName()
-                + "] failed trying to move from step [" + currentStepKey + "] to the ERROR step.", e);
+        final MessageSupplier messageSupplier = () -> new ParameterizedMessage(
+                "policy [{}] for index [{}] failed trying to move from step [{}] to the ERROR step.", policy, index.getName(),
+                currentStepKey);
+        if (ExceptionsHelper.unwrap(e, NotMasterException.class, FailedToCommitClusterStateException.class) != null) {
+            logger.debug(messageSupplier, e);
+        } else {
+            logger.error(messageSupplier, e);
+            assert false : new AssertionError("unexpected exception", e);
+        }
     }
 }

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/MoveToErrorStepUpdateTaskTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/MoveToErrorStepUpdateTaskTests.java
@@ -118,23 +118,6 @@ public class MoveToErrorStepUpdateTaskTests extends ESTestCase {
         assertThat(newState, sameInstance(clusterState));
     }
 
-    public void testOnFailure() {
-        StepKey currentStepKey = new StepKey("current-phase", "current-action", "current-name");
-        long now = randomNonNegativeLong();
-        Exception cause = new ElasticsearchException("THIS IS AN EXPECTED CAUSE");
-
-        setStateToKey(currentStepKey);
-
-        MoveToErrorStepUpdateTask task = new MoveToErrorStepUpdateTask(index, policy, currentStepKey, cause, () -> now,
-            (idxMeta, stepKey) -> new MockStep(stepKey, new StepKey("next-phase", "action", "step")), state -> {});
-        Exception expectedException = new RuntimeException();
-        ElasticsearchException exception = expectThrows(ElasticsearchException.class,
-                () -> task.onFailure(randomAlphaOfLength(10), expectedException));
-        assertEquals("policy [" + policy + "] for index [" + index.getName() + "] failed trying to move from step [" + currentStepKey
-                + "] to the ERROR step.", exception.getMessage());
-        assertSame(expectedException, exception.getCause());
-    }
-
     private void setStatePolicy(String policy) {
         clusterState = ClusterState.builder(clusterState)
             .metadata(Metadata.builder(clusterState.metadata())


### PR DESCRIPTION
* No need to spin on all CS changes when waiting for a snapshot to go away,
just use an appropriate predicate
* Stop waiting for a new state if we are not master any longer since we can't
complete the action anyway at this point (worse yet it will potentially run concurrently
on local and master if it uses the `client` to execute its requests)
* Properly fail the CS listener if the node is shutting down to get easier to debug
logging
* Stop throwing exceptions in `clusterStateProcessed` in the error step mover, this is forbidden

backport of #68361 