### PR TITLE
[7.11] Fix testDeleteActionDoesntDeleteSearchableSnapshot (#68376)

### DIFF
--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/TimeSeriesLifecycleActionsIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/TimeSeriesLifecycleActionsIT.java
@@ -1447,7 +1447,16 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
                 return false;
             }
         }, 30, TimeUnit.SECONDS));
-        assertBusy(() -> assertFalse(indexExists(restoredIndexName)));
+
+        // wait for **both** the restored and the original managed index to not exist anymore
+        // (making sure the ILM policy finished - asserting only on the restored index has the
+        // problem of a fast executing test code that will have the
+        // `assertFalse(indexExists(restoredIndexName))` assertion pass before the restored index
+        // ever existed)
+        assertBusy(() -> {
+            assertFalse(indexExists(index));
+            assertFalse(indexExists(restoredIndexName));
+        }, 90, TimeUnit.SECONDS);
 
         assertTrue("the snapshot we generate in the cold phase should not be deleted by the delete phase", waitUntil(() -> {
             try {


### PR DESCRIPTION
(cherry picked from commit 4ce4a128a712534822aec3ad9845a5dd63608039)
Signed-off-by: Andrei Dan <andrei.dan@elastic.co>

Backport of #68376 