### PR TITLE
[DOCS] [7.11] Add links to ESS for setting up remote clusters on cloud. (#68…

### DIFF
--- a/docs/reference/ccr/getting-started.asciidoc
+++ b/docs/reference/ccr/getting-started.asciidoc
@@ -64,6 +64,10 @@ that are periodically created in a remote cluster
 You can manually create follower indices to replicate specific indices on a
 remote cluster, or configure auto-follow patterns to replicate rolling time series indices.
 
+TIP: If you want to replicate data across clusters in the cloud, you can
+link:{cloud}/ec-enable-ccs.html[configure remote clusters on {ess}]. Then, you
+can <<modules-cross-cluster-search,search across clusters>> and set up {ccr}.
+
 video::https://static-www.elastic.co/v3/assets/bltefdd0b53724fa2ce/blt994089f5e841ad69/5f6265de6f40ab4648b5cf9b/ccr-setup-video-edited.mp4[width=700, height=500, options="autoplay,loop"]
 
 [[ccr-getting-started-prerequisites]]

--- a/docs/reference/search/search-your-data/search-across-clusters.asciidoc
+++ b/docs/reference/search/search-your-data/search-across-clusters.asciidoc
@@ -28,6 +28,10 @@ The following APIs support {ccs}:
 
 To perform a {ccs}, you must have at least one remote cluster configured.
 
+TIP: If you want to search across clusters in the cloud, you can
+link:{cloud}/ec-enable-ccs.html[configure remote clusters on {ess}]. Then, you
+can search across clusters and <<ccr-getting-started,set up {ccr}>>.
+
 The following <<cluster-update-settings,cluster update settings>> API request
 adds three remote clusters:`cluster_one`, `cluster_two`, and `cluster_three`.
 


### PR DESCRIPTION
7.11 backport for #68401

Should not be merged until 7.11 is live (currently 9 February 2021).