### PR TITLE
[Test] Fix testKerberosGrantTypeWillFailOnBase64DecodeError (#68358)

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/token/TransportCreateTokenActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/token/TransportCreateTokenActionTests.java
@@ -285,7 +285,7 @@ public class TransportCreateTokenActionTests extends ESTestCase {
             authenticationService, securityContext);
         final CreateTokenRequest createTokenRequest = new CreateTokenRequest();
         createTokenRequest.setGrantType("_kerberos");
-        final char[] invalidBase64Chars = "!\"#$%&\\'()*,./:;<>?@[]^_`{|}~\t\n\r".toCharArray();
+        final char[] invalidBase64Chars = "!\"#$%&\\'()*,.:;<>?@[]^_`{|}~\t\n\r".toCharArray();
         final String kerberosTicketValue = Strings.arrayToDelimitedString(
             randomArray(1, 10, Character[]::new,
                 () -> invalidBase64Chars[randomIntBetween(0, invalidBase64Chars.length - 1)]), "");


### PR DESCRIPTION
The slash character ("/") is a valid base64 char according to Table 1 of rfc4684.
Hence it should be removed the test since the test is for testing invalid base64 chars.
