### PR TITLE
[Transform] Set runtime mappings on search request in LatestContinuousIT

### DIFF
--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/LatestContinuousIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/LatestContinuousIT.java
@@ -38,11 +38,17 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
-@AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/68394")
 public class LatestContinuousIT extends ContinuousTestCase {
 
     private static final String NAME = "continuous-latest-test";
 
+    private static final Map<String, Object> RUNTIME_MAPPINGS =
+        new HashMap<>() {{
+            put("event-upper-at-search", new HashMap<>() {{
+                put("type", "keyword");
+                put("script", singletonMap("source", "if (params._source.event != null) {emit(params._source.event.toUpperCase())}"));
+            }});
+        }};
     private static final String MISSING_BUCKET_KEY = "~~NULL~~"; // ensure that this key is last after sorting
 
     private final String eventField;
@@ -55,20 +61,13 @@ public class LatestContinuousIT extends ContinuousTestCase {
 
     @Override
     public TransformConfig createConfig() {
-        Map<String, Object> runtimeMappings =
-            new HashMap<>() {{
-                put("event-upper-at-search", new HashMap<>() {{
-                    put("type", "keyword");
-                    put("script", singletonMap("source", "if (params._source.event != null) {emit(params._source.event.toUpperCase())}"));
-                }});
-            }};
         TransformConfig.Builder transformConfigBuilder =
             new TransformConfig.Builder()
                 .setId(NAME)
                 .setSource(
                     SourceConfig.builder()
                         .setIndex(CONTINUOUS_EVENTS_SOURCE_INDEX)
-                        .setRuntimeMappings(runtimeMappings)
+                        .setRuntimeMappings(RUNTIME_MAPPINGS)
                         .build())
                 .setDest(new DestConfig(NAME, INGEST_PIPELINE))
                 .setLatestConfig(
@@ -93,6 +92,8 @@ public class LatestContinuousIT extends ContinuousTestCase {
                 .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN)
                 .source(
                     new SearchSourceBuilder()
+                        // runtime mappings are needed in case "event-upper-at-search" is selected as the event field in test constructor
+                        .runtimeMappings(RUNTIME_MAPPINGS)
                         .size(0)
                         .aggregation(
                             new TermsAggregationBuilder("by_event")

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/LatestContinuousIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/LatestContinuousIT.java
@@ -43,8 +43,8 @@ public class LatestContinuousIT extends ContinuousTestCase {
     private static final String NAME = "continuous-latest-test";
 
     private static final Map<String, Object> RUNTIME_MAPPINGS =
-        new HashMap<>() {{
-            put("event-upper-at-search", new HashMap<>() {{
+        new HashMap<String, Object>() {{
+            put("event-upper-at-search", new HashMap<String, Object>() {{
                 put("type", "keyword");
                 put("script", singletonMap("source", "if (params._source.event != null) {emit(params._source.event.toUpperCase())}"));
             }});


### PR DESCRIPTION
In `LatestContinuousIT` we sometimes use search runtime field in transform.
We should set the same search runtime field in runtime mappings of the search request against source index.
This PR implements this.

Fixes https://github.com/elastic/elasticsearch/issues/68394