### PR TITLE
[7.x] [Transform] Set runtime mappings on search request in LatestContinuousIT (#68429)

### DIFF
--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/LatestContinuousIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/LatestContinuousIT.java
@@ -41,6 +41,13 @@ public class LatestContinuousIT extends ContinuousTestCase {
 
     private static final String NAME = "continuous-latest-test";
 
+    private static final Map<String, Object> RUNTIME_MAPPINGS =
+        new HashMap<String, Object>() {{
+            put("event-upper-at-search", new HashMap<String, Object>() {{
+                put("type", "keyword");
+                put("script", singletonMap("source", "if (params._source.event != null) {emit(params._source.event.toUpperCase())}"));
+            }});
+        }};
     private static final String MISSING_BUCKET_KEY = "~~NULL~~"; // ensure that this key is last after sorting
 
     private final String eventField;
@@ -53,20 +60,13 @@ public class LatestContinuousIT extends ContinuousTestCase {
 
     @Override
     public TransformConfig createConfig() {
-        Map<String, Object> runtimeMappings =
-            new HashMap<String, Object>() {{
-                put("event-upper-at-search", new HashMap<String, Object>() {{
-                    put("type", "keyword");
-                    put("script", singletonMap("source", "if (params._source.event != null) {emit(params._source.event.toUpperCase())}"));
-                }});
-            }};
         TransformConfig.Builder transformConfigBuilder =
             new TransformConfig.Builder()
                 .setId(NAME)
                 .setSource(
                     SourceConfig.builder()
                         .setIndex(CONTINUOUS_EVENTS_SOURCE_INDEX)
-                        .setRuntimeMappings(runtimeMappings)
+                        .setRuntimeMappings(RUNTIME_MAPPINGS)
                         .build())
                 .setDest(new DestConfig(NAME, INGEST_PIPELINE))
                 .setLatestConfig(
@@ -91,6 +91,8 @@ public class LatestContinuousIT extends ContinuousTestCase {
                 .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN)
                 .source(
                     new SearchSourceBuilder()
+                        // runtime mappings are needed in case "event-upper-at-search" is selected as the event field in test constructor
+                        .runtimeMappings(RUNTIME_MAPPINGS)
                         .size(0)
                         .aggregation(
                             new TermsAggregationBuilder("by_event")


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Transform] Set runtime mappings on search request in LatestContinuousIT  (#68429)