### PR TITLE
[7.10] [DOCS] Format the Get component template API doc (#68259)

### DIFF
--- a/docs/reference/indices/get-component-template.asciidoc
+++ b/docs/reference/indices/get-component-template.asciidoc
@@ -56,7 +56,7 @@ privilege>> to use this API.
 [[get-component-template-api-path-params]]
 ==== {api-path-parms-title}
 
-`<component-template>`
+`<component-template>`::
 (Optional, string)
 Comma-separated list of component template names used to limit the request.
 Wildcard (`*`) expressions are supported.


### PR DESCRIPTION
Backports the following commits to 7.10:
 - [DOCS] Format the Get component template API doc (#68259)