### PR TITLE
Drop rawtypes warnings from identityprovider (backport of #68249)

### DIFF
--- a/x-pack/plugin/identity-provider/build.gradle
+++ b/x-pack/plugin/identity-provider/build.gradle
@@ -53,7 +53,7 @@ dependencies {
 }
 
 tasks.withType(JavaCompile).configureEach {
-  options.compilerArgs << "-Xlint:-rawtypes,-unchecked"
+  options.compilerArgs << "-Xlint:-unchecked"
 }
 
 tasks.named("dependencyLicenses").configure {

--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/idp/SamlIdPMetadataBuilder.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/idp/SamlIdPMetadataBuilder.java
@@ -197,7 +197,7 @@ public class SamlIdPMetadataBuilder {
     }
 
     private List<NameIDFormat> buildNameIDFormats() {
-        List<NameIDFormat> formats = new ArrayList();
+        List<NameIDFormat> formats = new ArrayList<>();
         if (nameIdFormats.isEmpty()) {
             throw new IllegalStateException("NameID format has not been specified");
         }

--- a/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/action/TransportPutSamlServiceProviderActionTests.java
+++ b/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/action/TransportPutSamlServiceProviderActionTests.java
@@ -145,12 +145,13 @@ public class TransportPutSamlServiceProviderActionTests extends ESTestCase {
                 "_doc", doc.docId, randomLong(), randomLong(), randomLong(), created);
             writeResponse.set(docWriteResponse);
 
-            ActionListener listener = (ActionListener) args[args.length - 1];
+            @SuppressWarnings("unchecked")
+            ActionListener<DocWriteResponse> listener = (ActionListener<DocWriteResponse>) args[args.length - 1];
             listener.onResponse(docWriteResponse);
 
             return null;
         }).when(index).writeDocument(any(SamlServiceProviderDocument.class), any(DocWriteRequest.OpType.class),
-            any(WriteRequest.RefreshPolicy.class), any(ActionListener.class));
+            any(WriteRequest.RefreshPolicy.class), any());
 
         return writeResponse;
     }
@@ -168,10 +169,12 @@ public class TransportPutSamlServiceProviderActionTests extends ESTestCase {
             String entityId = (String) args[0];
             assertThat(entityId, equalTo(expectedEntityId));
 
-            ActionListener<Set<SamlServiceProviderIndex.DocumentSupplier>> listener = (ActionListener) args[args.length - 1];
+            @SuppressWarnings("unchecked")
+            ActionListener<Set<SamlServiceProviderIndex.DocumentSupplier>> listener = (ActionListener<
+                Set<SamlServiceProviderIndex.DocumentSupplier>>) args[args.length - 1];
             listener.onResponse(documentSuppliers);
 
             return null;
-        }).when(index).findByEntityId(anyString(), any(ActionListener.class));
+        }).when(index).findByEntityId(anyString(), any());
     }
 }


### PR DESCRIPTION
We barely used it and it makes it easier for us to write code with
"funny" assumptions. This change mostly makes the assumptions more clear
without really changing them.

Co-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>
