### PR TITLE
Replace NOT operator with explicit `false` check - part 7

### DIFF
--- a/libs/dissect/src/main/java/org/elasticsearch/dissect/DissectKey.java
+++ b/libs/dissect/src/main/java/org/elasticsearch/dissect/DissectKey.java
@@ -90,7 +90,7 @@ public final class DissectKey {
                 break;
         }
 
-        if (name == null || (name.isEmpty() && !skip)) {
+        if (name == null || (name.isEmpty() && skip == false)) {
             throw new DissectException.KeyParse(key, "The key name could not be determined");
         }
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
@@ -1658,7 +1658,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
             boolean atLeastOne = false;
             List<String> indices = new ArrayList<>();
             for (int j = 0; j < numIndices; j++) {
-                if (all || randomBoolean() || !atLeastOne) {
+                if (all || randomBoolean() || atLeastOne == false) {
                     indices.add("test-idx-" + j);
                     atLeastOne = true;
                 }

--- a/server/src/main/java/org/elasticsearch/bootstrap/BootstrapChecks.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/BootstrapChecks.java
@@ -306,7 +306,7 @@ final class BootstrapChecks {
 
         @Override
         public BootstrapCheckResult check(BootstrapContext context) {
-            if (BootstrapSettings.MEMORY_LOCK_SETTING.get(context.settings()) && !isMemoryLocked()) {
+            if (BootstrapSettings.MEMORY_LOCK_SETTING.get(context.settings()) && isMemoryLocked()) == false {
                 return BootstrapCheckResult.failure("memory locking requested for elasticsearch process but memory is not locked");
             } else {
                 return BootstrapCheckResult.success();
@@ -529,7 +529,7 @@ final class BootstrapChecks {
 
         @Override
         public BootstrapCheckResult check(BootstrapContext context) {
-            if (BootstrapSettings.SYSTEM_CALL_FILTER_SETTING.get(context.settings()) && !isSystemCallFilterInstalled()) {
+            if (BootstrapSettings.SYSTEM_CALL_FILTER_SETTING.get(context.settings()) && isSystemCallFilterInstalled()) == false {
                 final String message =  "system call filters failed to install; " +
                         "check the logs and fix your configuration or disable system call filters at your own risk";
                 return BootstrapCheckResult.failure(message);

--- a/server/src/main/java/org/elasticsearch/bootstrap/BootstrapChecks.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/BootstrapChecks.java
@@ -306,7 +306,7 @@ final class BootstrapChecks {
 
         @Override
         public BootstrapCheckResult check(BootstrapContext context) {
-            if (BootstrapSettings.MEMORY_LOCK_SETTING.get(context.settings()) && isMemoryLocked()) == false {
+            if (BootstrapSettings.MEMORY_LOCK_SETTING.get(context.settings()) && isMemoryLocked() == false) {
                 return BootstrapCheckResult.failure("memory locking requested for elasticsearch process but memory is not locked");
             } else {
                 return BootstrapCheckResult.success();
@@ -529,7 +529,7 @@ final class BootstrapChecks {
 
         @Override
         public BootstrapCheckResult check(BootstrapContext context) {
-            if (BootstrapSettings.SYSTEM_CALL_FILTER_SETTING.get(context.settings()) && isSystemCallFilterInstalled()) == false {
+            if (BootstrapSettings.SYSTEM_CALL_FILTER_SETTING.get(context.settings()) && isSystemCallFilterInstalled() == false) {
                 final String message =  "system call filters failed to install; " +
                         "check the logs and fix your configuration or disable system call filters at your own risk";
                 return BootstrapCheckResult.failure(message);

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterName.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterName.java
@@ -57,9 +57,7 @@ public class ClusterName implements Writeable {
 
         ClusterName that = (ClusterName) o;
 
-        if (value != null ? !value.equals(that.value) : that.value != null) return false;
-
-        return true;
+        return Objects.equals(value, that.value);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -270,7 +270,7 @@ public class IndexNameExpressionResolver {
                     concreteIndices.add(writeIndex.getIndex());
                 }
             } else {
-                if (indexAbstraction.getIndices().size() > 1 && !options.allowAliasesToMultipleIndices()) {
+                if (indexAbstraction.getIndices().size() > 1 && options.allowAliasesToMultipleIndices() == false) {
                     String[] indexNames = new String[indexAbstraction.getIndices().size()];
                     int i = 0;
                     for (IndexMetadata indexMetadata : indexAbstraction.getIndices()) {
@@ -828,7 +828,7 @@ public class IndexNameExpressionResolver {
             if (result == null) {
                 return expressions;
             }
-            if (result.isEmpty() && !options.allowNoIndices()) {
+            if (result.isEmpty() && options.allowNoIndices() == false) {
                 IndexNotFoundException infe = new IndexNotFoundException((String)null);
                 infe.setResources("index_or_alias", expressions.toArray(new String[0]));
                 throw infe;

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -1480,7 +1480,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
             metadata.coordinationMetadata().toXContent(builder, params);
             builder.endObject();
 
-            if (context != XContentContext.API && !metadata.persistentSettings().isEmpty()) {
+            if (context != XContentContext.API && metadata.persistentSettings().isEmpty() == false) {
                 builder.startObject("settings");
                 metadata.persistentSettings().toXContent(builder, new MapParams(Collections.singletonMap("flat_settings", "true")));
                 builder.endObject();

--- a/server/src/main/java/org/elasticsearch/cluster/routing/ShardRouting.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/ShardRouting.java
@@ -23,6 +23,7 @@ import org.elasticsearch.index.shard.ShardId;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * {@link ShardRouting} immutably encapsulates information about shard
@@ -519,28 +520,13 @@ public final class ShardRouting implements Writeable, ToXContentObject {
 
     /** returns true if the current routing is identical to the other routing in all but meta fields, i.e., unassigned info */
     public boolean equalsIgnoringMetadata(ShardRouting other) {
-        if (primary != other.primary) {
-            return false;
-        }
-        if (shardId != null ? !shardId.equals(other.shardId) : other.shardId != null) {
-            return false;
-        }
-        if (currentNodeId != null ? !currentNodeId.equals(other.currentNodeId) : other.currentNodeId != null) {
-            return false;
-        }
-        if (relocatingNodeId != null ? !relocatingNodeId.equals(other.relocatingNodeId) : other.relocatingNodeId != null) {
-            return false;
-        }
-        if (allocationId != null ? !allocationId.equals(other.allocationId) : other.allocationId != null) {
-            return false;
-        }
-        if (state != other.state) {
-            return false;
-        }
-        if (recoverySource != null ? !recoverySource.equals(other.recoverySource) : other.recoverySource != null) {
-            return false;
-        }
-        return true;
+        return primary == other.primary
+            && Objects.equals(shardId, other.shardId)
+            && Objects.equals(currentNodeId, other.currentNodeId)
+            && Objects.equals(relocatingNodeId, other.relocatingNodeId)
+            && Objects.equals(allocationId, other.allocationId)
+            && state == other.state
+            && Objects.equals(recoverySource, other.recoverySource);
     }
 
     @Override
@@ -548,14 +534,11 @@ public final class ShardRouting implements Writeable, ToXContentObject {
         if (this == o) {
             return true;
         }
-        if (o == null || !(o instanceof ShardRouting)) {
+        if (o == null || getClass() != o.getClass()) {
             return false;
         }
         ShardRouting that = (ShardRouting) o;
-        if (unassignedInfo != null ? !unassignedInfo.equals(that.unassignedInfo) : that.unassignedInfo != null) {
-            return false;
-        }
-        return equalsIgnoringMetadata(that);
+        return Objects.equals(unassignedInfo, that.unassignedInfo) && equalsIgnoringMetadata(that);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/gateway/PrimaryShardAllocator.java
+++ b/server/src/main/java/org/elasticsearch/gateway/PrimaryShardAllocator.java
@@ -136,7 +136,7 @@ public abstract class PrimaryShardAllocator extends BaseGatewayShardAllocator {
                          unassignedShard.index(), unassignedShard.id(), unassignedShard, decidedNode.nodeShardState.getNode());
             node = decidedNode.nodeShardState.getNode();
             allocationId = decidedNode.nodeShardState.allocationId();
-        } else if (nodesToAllocate.throttleNodeShards.isEmpty() && !nodesToAllocate.noNodeShards.isEmpty()) {
+        } else if (nodesToAllocate.throttleNodeShards.isEmpty() && nodesToAllocate.noNodeShards.isEmpty() == false) {
             // The deciders returned a NO decision for all nodes with shard copies, so we check if primary shard
             // can be force-allocated to one of the nodes.
             nodesToAllocate = buildNodesToAllocate(allocation, nodeShardsResult.orderedAllocationCandidates, unassignedShard, true);

--- a/server/src/main/java/org/elasticsearch/http/DefaultRestChannel.java
+++ b/server/src/main/java/org/elasticsearch/http/DefaultRestChannel.java
@@ -145,7 +145,7 @@ public class DefaultRestChannel extends AbstractRestChannel implements RestChann
     }
 
     private void setHeaderField(HttpResponse response, String headerField, String value, boolean override) {
-        if (override || !response.containsHeader(headerField)) {
+        if (override || response.containsHeader(headerField) == false) {
             response.addHeader(headerField, value);
         }
     }

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -604,7 +604,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
             sb.append(pipelineName);
         }
         String tag = processor.getTag();
-        if(tag != null && !tag.isEmpty()){
+        if (tag != null && tag.isEmpty() == false) {
             sb.append(":");
             sb.append(tag);
         }

--- a/server/src/main/java/org/elasticsearch/monitor/jvm/DeadlockAnalyzer.java
+++ b/server/src/main/java/org/elasticsearch/monitor/jvm/DeadlockAnalyzer.java
@@ -16,6 +16,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import static java.util.Collections.unmodifiableMap;
@@ -84,7 +85,7 @@ public class DeadlockAnalyzer {
         Set<Long> knownDeadlockedThreads = threadInfoMap.keySet();
         for (ThreadInfo threadInfo : allThreads) {
             Thread.State state = threadInfo.getThreadState();
-            if (state == Thread.State.BLOCKED && !knownDeadlockedThreads.contains(threadInfo.getThreadId())) {
+            if (state == Thread.State.BLOCKED && knownDeadlockedThreads.contains(threadInfo.getThreadId()) == false) {
                 for (LinkedHashSet<ThreadInfo> cycle : cycles) {
                     if (cycle.contains(threadInfoMap.get(Long.valueOf(threadInfo.getLockOwnerId())))) {
                         LinkedHashSet<ThreadInfo> chain = new LinkedHashSet<>();
@@ -147,9 +148,7 @@ public class DeadlockAnalyzer {
 
             Deadlock deadlock = (Deadlock) o;
 
-            if (memberIds != null ? !memberIds.equals(deadlock.memberIds) : deadlock.memberIds != null) return false;
-
-            return true;
+            return Objects.equals(memberIds, deadlock.memberIds);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/plugins/PluginInfo.java
+++ b/server/src/main/java/org/elasticsearch/plugins/PluginInfo.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -386,9 +387,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
 
         if (name.equals(that.name) == false) return false;
         // TODO: since the plugins are unique by their directory name, this should only be a name check, version should not matter?
-        if (version != null ? !version.equals(that.version) : that.version != null) return false;
-
-        return true;
+        return Objects.equals(version, that.version);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/rest/BytesRestResponse.java
+++ b/server/src/main/java/org/elasticsearch/rest/BytesRestResponse.java
@@ -122,7 +122,7 @@ public class BytesRestResponse extends RestResponse {
 
     private ToXContent.Params paramsFromRequest(RestRequest restRequest) {
         ToXContent.Params params = restRequest;
-        if (params.paramAsBoolean("error_trace", !REST_EXCEPTION_SKIP_STACK_TRACE_DEFAULT) && false == skipStackTrace()) {
+        if (params.paramAsBoolean("error_trace", REST_EXCEPTION_SKIP_STACK_TRACE_DEFAULT == false) && skipStackTrace() == false) {
             params =  new ToXContent.DelegatingMapParams(singletonMap(REST_EXCEPTION_SKIP_STACK_TRACE, "false"), params);
         }
         return params;

--- a/server/src/main/java/org/elasticsearch/script/Script.java
+++ b/server/src/main/java/org/elasticsearch/script/Script.java
@@ -637,7 +637,7 @@ public final class Script implements ToXContentObject, Writeable {
             builder.field(LANG_PARSE_FIELD.getPreferredName(), lang);
         }
 
-        if (options != null && !options.isEmpty()) {
+        if (options != null && options.isEmpty() == false) {
             builder.field(OPTIONS_PARSE_FIELD.getPreferredName(), options);
         }
 
@@ -691,17 +691,18 @@ public final class Script implements ToXContentObject, Writeable {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        Script script = (Script)o;
-
-        if (type != script.type) return false;
-        if (lang != null ? !lang.equals(script.lang) : script.lang != null) return false;
-        if (idOrCode.equals(script.idOrCode) == false) return false;
-        if (options != null ? !options.equals(script.options) : script.options != null) return false;
-        return params.equals(script.params);
-
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Script script = (Script) o;
+        return type == script.type
+            && Objects.equals(lang, script.lang)
+            && Objects.equals(idOrCode, script.idOrCode)
+            && Objects.equals(options, script.options)
+            && Objects.equals(params, script.params);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/script/ScriptCache.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptCache.java
@@ -158,7 +158,7 @@ public class ScriptCache {
             }
         });
 
-        if(!tokenBucketState.tokenSuccessfullyTaken) {
+        if (tokenBucketState.tokenSuccessfullyTaken == false) {
             scriptMetrics.onCompilationLimit();
             // Otherwise reject the request
             throw new CircuitBreakingException("[script] Too many dynamic script compilations within, max: [" +

--- a/server/src/main/java/org/elasticsearch/script/StoredScriptSource.java
+++ b/server/src/main/java/org/elasticsearch/script/StoredScriptSource.java
@@ -418,10 +418,9 @@ public class StoredScriptSource extends AbstractDiffable<StoredScriptSource> imp
 
         StoredScriptSource that = (StoredScriptSource)o;
 
-        if (lang != null ? !lang.equals(that.lang) : that.lang != null) return false;
-        if (source != null ? !source.equals(that.source) : that.source != null) return false;
-        return options != null ? options.equals(that.options) : that.options == null;
-
+        return Objects.equals(lang, that.lang)
+            && Objects.equals(source, that.source)
+            && Objects.equals(options, that.options);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/SearchHit.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchHit.java
@@ -653,7 +653,7 @@ public final class SearchHit implements Writeable, ToXContentObject, Iterable<Do
             }
             builder.endObject();
         }
-        if (highlightFields != null && !highlightFields.isEmpty()) {
+        if (highlightFields != null && highlightFields.isEmpty() == false) {
             builder.startObject(Fields.HIGHLIGHT);
             for (HighlightField field : highlightFields.values()) {
                 field.toXContent(builder, params);

--- a/server/src/main/java/org/elasticsearch/search/collapse/CollapseBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/collapse/CollapseBuilder.java
@@ -198,7 +198,7 @@ public class CollapseBuilder implements Writeable, ToXContentObject {
         if (fieldType.hasDocValues() == false) {
             throw new IllegalArgumentException("cannot collapse on field `" + field + "` without `doc_values`");
         }
-        if (fieldType.isSearchable() == false && (innerHits != null && !innerHits.isEmpty())) {
+        if (fieldType.isSearchable() == false && (innerHits != null && innerHits.isEmpty() == false)) {
             throw new IllegalArgumentException("cannot expand `inner_hits` for collapse field `"
                 + field + "`, " + "only indexed field can retrieve `inner_hits`");
         }

--- a/server/src/main/java/org/elasticsearch/search/sort/SortBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/sort/SortBuilder.java
@@ -155,7 +155,7 @@ public abstract class SortBuilder<T extends SortBuilder<T>> implements NamedWrit
                 sort = true;
             } else {
                 SortField sortField = sortFields.get(0);
-                if (sortField.getType() == SortField.Type.SCORE && !sortField.getReverse()) {
+                if (sortField.getType() == SortField.Type.SCORE && sortField.getReverse() == false) {
                     sort = false;
                 } else {
                     sort = true;

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
@@ -526,7 +526,7 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
             builder.field(END_TIME_IN_MILLIS, endTime);
             builder.humanReadableField(DURATION_IN_MILLIS, DURATION, new TimeValue(Math.max(0L, endTime - startTime)));
         }
-        if (verbose || !shardFailures.isEmpty()) {
+        if (verbose || shardFailures.isEmpty() == false) {
             builder.startArray(FAILURES);
             for (SnapshotShardFailure shardFailure : shardFailures) {
                 shardFailure.toXContent(builder, params);

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotUtils.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotUtils.java
@@ -62,7 +62,7 @@ public class SnapshotUtils {
                     indexOrPattern = indexOrPattern.substring(1);
                 }
             }
-            if (indexOrPattern.isEmpty() || !Regex.isSimpleMatchPattern(indexOrPattern)) {
+            if (indexOrPattern.isEmpty() || Regex.isSimpleMatchPattern(indexOrPattern) == false) {
                 if (availableIndices.contains(indexOrPattern) == false) {
                     if (indicesOptions.ignoreUnavailable() == false) {
                         throw new IndexNotFoundException(indexOrPattern);

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -2205,7 +2205,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                     ShardRouting primary = indexRoutingTable.shard(i).primaryShard();
                     if (readyToExecute == false || inFlightShardStates.isActive(shardId.getIndexName(), shardId.id())) {
                         shardSnapshotStatus = ShardSnapshotStatus.UNASSIGNED_QUEUED;
-                    } else if (primary == null || !primary.assignedToNode()) {
+                    } else if (primary == null || primary.assignedToNode() == false) {
                         shardSnapshotStatus =
                             new ShardSnapshotStatus(null, ShardState.MISSING, "primary shard is not allocated", shardRepoGeneration);
                     } else if (primary.relocating() || primary.initializing()) {
@@ -2542,7 +2542,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
     private static ShardSnapshotStatus startShardSnapshotAfterClone(ClusterState currentState, String shardGeneration, ShardId shardId) {
         final ShardRouting primary = currentState.routingTable().index(shardId.getIndex()).shard(shardId.id()).primaryShard();
         final ShardSnapshotStatus shardSnapshotStatus;
-        if (primary == null || !primary.assignedToNode()) {
+        if (primary == null || primary.assignedToNode() == false) {
             shardSnapshotStatus = new ShardSnapshotStatus(
                     null, ShardState.MISSING, "primary shard is not allocated", shardGeneration);
         } else if (primary.relocating() || primary.initializing()) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/AnomalyRecord.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/AnomalyRecord.java
@@ -330,7 +330,7 @@ public class AnomalyRecord implements ToXContentObject, Writeable {
     }
 
     private void addInputFieldsToMap(Map<String, LinkedHashSet<String>> inputFields, String fieldName, String fieldValue) {
-        if (!Strings.isNullOrEmpty(fieldName) && fieldValue != null) {
+        if (Strings.isNullOrEmpty(fieldName) == false && fieldValue != null) {
             if (ReservedFieldNames.isValidFieldName(fieldName)) {
                 inputFields.computeIfAbsent(fieldName, k -> new LinkedHashSet<>()).add(fieldValue);
             }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/math/ToNumber.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/math/ToNumber.java
@@ -47,7 +47,7 @@ public class ToNumber extends ScalarFunction implements OptionalArgument {
 
     @Override
     protected TypeResolution resolveType() {
-        if (!childrenResolved()) {
+        if (childrenResolved() == false) {
             return new TypeResolution("Unresolved children");
         }
 

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/math/ToNumberFunctionProcessor.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/math/ToNumberFunctionProcessor.java
@@ -54,7 +54,7 @@ public class ToNumberFunctionProcessor implements Processor {
             return null;
         }
 
-        if (!(value instanceof String || value instanceof Character)) {
+        if ((value instanceof String || value instanceof Character) == false) {
             throw new EqlIllegalArgumentException("A string/char is required; received [{}]", value);
         }
 

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/Between.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/Between.java
@@ -54,7 +54,7 @@ public class Between extends CaseInsensitiveScalarFunction implements OptionalAr
 
     @Override
     protected TypeResolution resolveType() {
-        if (!childrenResolved()) {
+        if (childrenResolved() == false) {
             return new TypeResolution("Unresolved children");
         }
 

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/CIDRMatch.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/CIDRMatch.java
@@ -60,7 +60,7 @@ public class CIDRMatch extends ScalarFunction {
 
     @Override
     protected TypeResolution resolveType() {
-        if (!childrenResolved()) {
+        if (childrenResolved() == false) {
             return new TypeResolution("Unresolved children");
         }
 

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/Concat.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/Concat.java
@@ -40,7 +40,7 @@ public class Concat extends ScalarFunction {
 
     @Override
     protected TypeResolution resolveType() {
-        if (!childrenResolved()) {
+        if (childrenResolved() == false) {
             return new TypeResolution("Unresolved children");
         }
 

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/IndexOf.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/IndexOf.java
@@ -47,7 +47,7 @@ public class IndexOf extends CaseInsensitiveScalarFunction implements OptionalAr
 
     @Override
     protected TypeResolution resolveType() {
-        if (!childrenResolved()) {
+        if (childrenResolved() == false) {
             return new TypeResolution("Unresolved children");
         }
 

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/Length.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/Length.java
@@ -44,7 +44,7 @@ public class Length extends ScalarFunction {
 
     @Override
     protected TypeResolution resolveType() {
-        if (!childrenResolved()) {
+        if (childrenResolved() == false) {
             return new TypeResolution("Unresolved children");
         }
 

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/Match.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/Match.java
@@ -63,7 +63,7 @@ public class Match extends BaseSurrogateFunction {
 
     @Override
     protected TypeResolution resolveType() {
-        if (!childrenResolved()) {
+        if (childrenResolved() == false) {
             return new TypeResolution("Unresolved children");
         }
 

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/StringContainsFunctionProcessor.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/StringContainsFunctionProcessor.java
@@ -61,7 +61,7 @@ public class StringContainsFunctionProcessor implements Processor {
     }
 
     private static void throwIfNotString(Object obj) {
-        if (!(obj instanceof String || obj instanceof Character)) {
+        if ((obj instanceof String || obj instanceof Character) == false) {
             throw new EqlIllegalArgumentException("A string/char is required; received [{}]", obj);
         }
     }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/Substring.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/Substring.java
@@ -49,7 +49,7 @@ public class Substring extends ScalarFunction implements OptionalArgument {
 
     @Override
     protected TypeResolution resolveType() {
-        if (!childrenResolved()) {
+        if (childrenResolved() == false) {
             return new TypeResolution("Unresolved children");
         }
 

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/SubstringFunctionProcessor.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/SubstringFunctionProcessor.java
@@ -48,7 +48,7 @@ public class SubstringFunctionProcessor implements Processor {
         if (input == null) {
             return null;
         }
-        if (!(input instanceof String || input instanceof Character)) {
+        if ((input instanceof String || input instanceof Character) == false) {
             throw new EqlIllegalArgumentException("A string/char is required; received [{}]", input);
         }
         if (start == null) {

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/ToString.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/ToString.java
@@ -43,7 +43,7 @@ public class ToString extends ScalarFunction {
 
     @Override
     protected TypeResolution resolveType() {
-        if (!childrenResolved()) {
+        if (childrenResolved() == false) {
             return new TypeResolution("Unresolved children");
         }
 

--- a/x-pack/plugin/ml/qa/no-bootstrap-tests/src/test/java/org/elasticsearch/xpack/ml/utils/NamedPipeHelperNoBootstrapTests.java
+++ b/x-pack/plugin/ml/qa/no-bootstrap-tests/src/test/java/org/elasticsearch/xpack/ml/utils/NamedPipeHelperNoBootstrapTests.java
@@ -134,7 +134,7 @@ public class NamedPipeHelperNoBootstrapTests extends LuceneTestCase {
     }
 
     private static String readLineFromPipeWindows(String pipeName, Pointer handle) throws IOException {
-        if (!ConnectNamedPipe(handle, Pointer.NULL)) {
+        if (ConnectNamedPipe(handle, Pointer.NULL) == false) {
             // ERROR_PIPE_CONNECTED means the pipe was already connected so
             // there was no need to connect it again - not a problem
             if (Native.getLastError() != ERROR_PIPE_CONNECTED) {
@@ -143,7 +143,7 @@ public class NamedPipeHelperNoBootstrapTests extends LuceneTestCase {
         }
         IntByReference numberOfBytesRead = new IntByReference();
         ByteBuffer buf = ByteBuffer.allocateDirect(BUFFER_SIZE);
-        if (!ReadFile(handle, Native.getDirectBufferPointer(buf), new DWord(BUFFER_SIZE), numberOfBytesRead, Pointer.NULL)) {
+        if (ReadFile(handle, Native.getDirectBufferPointer(buf), new DWord(BUFFER_SIZE), numberOfBytesRead, Pointer.NULL) == false) {
             throw new IOException("ReadFile failed for pipe " + pipeName + " with error " + Native.getLastError());
         }
         byte[] content = new byte[numberOfBytesRead.getValue()];
@@ -169,7 +169,7 @@ public class NamedPipeHelperNoBootstrapTests extends LuceneTestCase {
     }
 
     private static void writeLineToPipeWindows(String pipeName, Pointer handle, String line) throws IOException {
-        if (!ConnectNamedPipe(handle, Pointer.NULL)) {
+        if (ConnectNamedPipe(handle, Pointer.NULL) == false) {
             // ERROR_PIPE_CONNECTED means the pipe was already connected so
             // there was no need to connect it again - not a problem
             if (Native.getLastError() != ERROR_PIPE_CONNECTED) {
@@ -179,7 +179,7 @@ public class NamedPipeHelperNoBootstrapTests extends LuceneTestCase {
         IntByReference numberOfBytesWritten = new IntByReference();
         ByteBuffer buf = ByteBuffer.allocateDirect(BUFFER_SIZE);
         buf.put((line + '\n').getBytes(StandardCharsets.UTF_8));
-        if (!WriteFile(handle, Native.getDirectBufferPointer(buf), new DWord(buf.position()), numberOfBytesWritten, Pointer.NULL)) {
+        if (WriteFile(handle, Native.getDirectBufferPointer(buf), new DWord(buf.position()), numberOfBytesWritten, Pointer.NULL) == false) {
             throw new IOException("WriteFile failed for pipe " + pipeName + " with error " + Native.getLastError());
         }
     }
@@ -197,7 +197,7 @@ public class NamedPipeHelperNoBootstrapTests extends LuceneTestCase {
     }
 
     private static void deletePipeWindows(String pipeName, Pointer handle) throws IOException {
-        if (!CloseHandle(handle)) {
+        if (CloseHandle(handle) == false) {
             throw new IOException("CloseHandle failed for pipe " + pipeName + " with error " + Native.getLastError());
         }
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AbstractAggregationDataExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AbstractAggregationDataExtractor.java
@@ -92,7 +92,7 @@ abstract class AbstractAggregationDataExtractor<T extends ActionRequestBuilder<S
 
     @Override
     public Optional<InputStream> next() throws IOException {
-        if (!hasNext()) {
+        if (hasNext() == false) {
             throw new NoSuchElementException();
         }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/chunked/ChunkedDataExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/chunked/ChunkedDataExtractor.java
@@ -103,7 +103,7 @@ public class ChunkedDataExtractor implements DataExtractor {
 
     @Override
     public Optional<InputStream> next() throws IOException {
-        if (!hasNext()) {
+        if (hasNext() == false) {
             throw new NoSuchElementException();
         }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractor.java
@@ -89,11 +89,11 @@ class ScrollDataExtractor implements DataExtractor {
 
     @Override
     public Optional<InputStream> next() throws IOException {
-        if (!hasNext()) {
+        if (hasNext() == false) {
             throw new NoSuchElementException();
         }
         Optional<InputStream> stream = tryNextStream();
-        if (!stream.isPresent()) {
+        if (stream.isPresent() == false) {
             hasNext = false;
         }
         return stream;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/TimeBasedExtractedFields.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/TimeBasedExtractedFields.java
@@ -32,7 +32,7 @@ public class TimeBasedExtractedFields extends ExtractedFields {
         super(allFields,
             Collections.emptyList(),
             Collections.emptyMap());
-        if (!allFields.contains(timeField)) {
+        if (allFields.contains(timeField) == false) {
             throw new IllegalArgumentException("timeField should also be contained in allFields");
         }
         this.timeField = Objects.requireNonNull(timeField);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectCommunicator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectCommunicator.java
@@ -318,7 +318,7 @@ public class AutodetectCommunicator implements Closeable {
      * Throws an exception if the process has exited
      */
     private void checkProcessIsAlive() {
-        if (!autodetectProcess.isProcessAlive()) {
+        if (autodetectProcess.isProcessAlive() == false) {
             // Don't log here - it just causes double logging when the exception gets logged
             throw new ElasticsearchException("[{}] Unexpected death of autodetect: {}", job.getId(), autodetectProcess.readError());
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/params/FlushJobParams.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/params/FlushJobParams.java
@@ -74,14 +74,14 @@ public class FlushJobParams {
     }
 
     public long getAdvanceTime() {
-        if (!shouldAdvanceTime()) {
+        if (shouldAdvanceTime() == false) {
             throw new IllegalStateException();
         }
         return advanceTimeSeconds;
     }
 
     public long getSkipTime() {
-        if (!shouldSkipTime()) {
+        if (shouldSkipTime() == false) {
             throw new IllegalStateException();
         }
         return skipTimeSeconds;
@@ -155,10 +155,10 @@ public class FlushJobParams {
         }
 
         private void checkValidFlushArgumentsCombination() {
-            if (!calcInterim) {
+            if (calcInterim == false) {
                 checkFlushParamIsEmpty(TimeRange.START_PARAM, timeRange.getStart());
                 checkFlushParamIsEmpty(TimeRange.END_PARAM, timeRange.getEnd());
-            } else if (!isValidTimeRange(timeRange)) {
+            } else if (isValidTimeRange(timeRange) == false) {
                 String msg = Messages.getMessage(Messages.REST_INVALID_FLUSH_PARAMS_MISSING, "start");
                 throw new IllegalArgumentException(msg);
             }
@@ -187,7 +187,7 @@ public class FlushJobParams {
         }
 
         private void checkFlushParamIsEmpty(String paramName, String paramValue) {
-            if (!paramValue.isEmpty()) {
+            if (paramValue.isEmpty() == false) {
                 String msg = Messages.getMessage(Messages.REST_INVALID_FLUSH_PARAMS_UNEXPECTED, paramName);
                 throw new IllegalArgumentException(msg);
             }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/params/TimeRange.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/params/TimeRange.java
@@ -85,7 +85,7 @@ public class TimeRange {
         private TimeRange createTimeRange(String start, String end) {
             Long epochStart = null;
             Long epochEnd = null;
-            if (!start.isEmpty()) {
+            if (start.isEmpty() == false) {
                 epochStart = paramToEpochIfValidOrThrow(START_PARAM, start) / MILLISECONDS_IN_SECOND;
                 epochEnd = paramToEpochIfValidOrThrow(END_PARAM, end) / MILLISECONDS_IN_SECOND;
                 if (end.isEmpty() || epochEnd.equals(epochStart)) {
@@ -96,7 +96,7 @@ public class TimeRange {
                     throw new IllegalArgumentException(msg);
                 }
             } else {
-                if (!end.isEmpty()) {
+                if (end.isEmpty() == false) {
                     epochEnd = paramToEpochIfValidOrThrow(END_PARAM, end) / MILLISECONDS_IN_SECOND;
                 }
             }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/writer/XContentRecordReader.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/writer/XContentRecordReader.java
@@ -71,7 +71,7 @@ class XContentRecordReader {
         clearNestedLevel();
 
         XContentParser.Token token = tryNextTokenOrReadToEndOnError();
-        while (!(token == XContentParser.Token.END_OBJECT && nestedLevel == 0)) {
+        while ((token == XContentParser.Token.END_OBJECT && nestedLevel == 0) == false) {
             if (token == null) {
                 break;
             }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/normalizer/Normalizer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/normalizer/Normalizer.java
@@ -149,7 +149,7 @@ public class Normalizer {
                                     boolean parentHadBigChange, Normalizable result) {
         boolean hasBigChange = false;
         if (result.isContainerOnly() == false) {
-            if (!scoresIter.hasNext()) {
+            if (scoresIter.hasNext() == false) {
                 String msg = "Error iterating normalized results";
                 LOGGER.error("[{}] {}", jobId, msg);
                 throw new ElasticsearchException(msg);
@@ -174,7 +174,7 @@ public class Normalizer {
 
         for (Normalizable.ChildType childrenType : result.getChildrenTypes()) {
             List<Normalizable> children = result.getChildren(childrenType);
-            if (!children.isEmpty()) {
+            if (children.isEmpty() == false) {
                 double maxChildrenScore = 0.0;
                 for (Normalizable child : children) {
                     maxChildrenScore = Math.max(

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/normalizer/NormalizerResult.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/normalizer/NormalizerResult.java
@@ -189,7 +189,7 @@ public class NormalizerResult implements ToXContentObject, Writeable {
             return true;
         }
 
-        if (!(other instanceof NormalizerResult)) {
+        if ((other instanceof NormalizerResult) == false) {
             return false;
         }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/normalizer/ScoresUpdater.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/normalizer/ScoresUpdater.java
@@ -110,7 +110,7 @@ public class ScoresUpdater {
                 break;
             }
 
-            while (!buckets.isEmpty() && shutdown == false) {
+            while (buckets.isEmpty() == false && shutdown == false) {
                 Result<Bucket> current = buckets.removeFirst();
                 if (current.result.isNormalizable()) {
                     bucketsToRenormalize.add(new BucketNormalizable(current.result, current.index));
@@ -121,7 +121,7 @@ public class ScoresUpdater {
                 }
             }
         }
-        if (!bucketsToRenormalize.isEmpty()) {
+        if (bucketsToRenormalize.isEmpty() == false) {
             normalizeBuckets(normalizer, bucketsToRenormalize, quantilesState, counts);
         }
     }
@@ -199,7 +199,7 @@ public class ScoresUpdater {
 
         counts[0] += toUpdate.size();
         counts[1] += asNormalizables.size() - toUpdate.size();
-        if (!toUpdate.isEmpty()) {
+        if (toUpdate.isEmpty() == false) {
             updatesPersister.updateResults(toUpdate);
         }
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/normalizer/ShortCircuitingRenormalizer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/normalizer/ShortCircuitingRenormalizer.java
@@ -47,7 +47,7 @@ public class ShortCircuitingRenormalizer implements Renormalizer {
 
     @Override
     public void renormalize(Quantiles quantiles) {
-        if (!isEnabled()) {
+        if (isEnabled() == false) {
             return;
         }
 
@@ -114,7 +114,7 @@ public class ShortCircuitingRenormalizer implements Renormalizer {
     private boolean tryFinishWork() {
         // We cannot tolerate new work being added in between the isEmpty() check and releasing the semaphore
         synchronized (quantilesDeque) {
-            if (!quantilesDeque.isEmpty()) {
+            if (quantilesDeque.isEmpty() == false) {
                 return false;
             }
             semaphore.release();

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationTestUtils.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationTestUtils.java
@@ -105,7 +105,7 @@ public final class AggregationTestUtils {
                 for (Map.Entry<String, Double> keyValue : term.values.entrySet()) {
                     numericAggs.add(createSingleValue(keyValue.getKey(), keyValue.getValue()));
                 }
-                if (!numericAggs.isEmpty()) {
+                if (numericAggs.isEmpty() == false) {
                     Aggregations aggs = createAggs(numericAggs);
                     when(bucket.getAggregations()).thenReturn(aggs);
                 }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/execution/search/extractor/AbstractFieldHitExtractor.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/execution/search/extractor/AbstractFieldHitExtractor.java
@@ -77,7 +77,7 @@ public abstract class AbstractFieldHitExtractor implements HitExtractor {
         this.hitName = hitName;
 
         if (hitName != null) {
-            if (!name.contains(hitName)) {
+            if (name.contains(hitName) == false) {
                 throw new QlIllegalArgumentException("Hitname [{}] specified but not part of the name [{}]", hitName, name);
             }
         }
@@ -234,7 +234,7 @@ public abstract class AbstractFieldHitExtractor implements HitExtractor {
         Deque<Tuple<Integer, Map<String, Object>>> queue = new ArrayDeque<>();
         queue.add(new Tuple<>(-1, map));
 
-        while (!queue.isEmpty()) {
+        while (queue.isEmpty() == false) {
             Tuple<Integer, Map<String, Object>> tuple = queue.removeLast();
             int idx = tuple.v1();
             Map<String, Object> subMap = tuple.v2();

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/function/scalar/string/StartsWith.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/function/scalar/string/StartsWith.java
@@ -42,7 +42,7 @@ public abstract class StartsWith extends CaseInsensitiveScalarFunction {
 
     @Override
     protected TypeResolution resolveType() {
-        if (!childrenResolved()) {
+        if (childrenResolved() == false) {
             return new TypeResolution("Unresolved children");
         }
 

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/function/scalar/whitelist/InternalQlScriptUtils.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/function/scalar/whitelist/InternalQlScriptUtils.java
@@ -32,7 +32,7 @@ public class InternalQlScriptUtils {
     public static <T> Object docValue(Map<String, ScriptDocValues<T>> doc, String fieldName) {
         if (doc.containsKey(fieldName)) {
             ScriptDocValues<T> docValues = doc.get(fieldName);
-            if (!docValues.isEmpty()) {
+            if (docValues.isEmpty() == false) {
                 return docValues.get(0);
             }
         }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/gen/processor/BucketExtractorProcessor.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/gen/processor/BucketExtractorProcessor.java
@@ -45,7 +45,7 @@ public class BucketExtractorProcessor implements Processor {
 
     @Override
     public Object process(Object input) {
-        if (!(input instanceof Bucket)) {
+        if ((input instanceof Bucket) == false) {
             throw new QlIllegalArgumentException("Expected an agg bucket but received {}", input);
         }
         return extractor.extract((Bucket) input);

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/gen/processor/HitExtractorProcessor.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/gen/processor/HitExtractorProcessor.java
@@ -45,7 +45,7 @@ public class HitExtractorProcessor implements Processor {
 
     @Override
     public Object process(Object input) {
-        if (!(input instanceof SearchHit)) {
+        if ((input instanceof SearchHit) == false) {
             throw new QlIllegalArgumentException("Expected a SearchHit but received {}", input);
         }
         return extractor.extract((SearchHit) input);

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/gen/script/Params.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/gen/script/Params.java
@@ -98,7 +98,7 @@ public class Params {
     private static List<Param<?>> flatten(List<Param<?>> params) {
         List<Param<?>> flatten = emptyList();
 
-        if (!params.isEmpty()) {
+        if (params.isEmpty() == false) {
             flatten = new ArrayList<>();
             for (Param<?> p : params) {
                 if (p instanceof Script) {

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/fulltext/FullTextUtils.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/fulltext/FullTextUtils.java
@@ -23,7 +23,7 @@ abstract class FullTextUtils {
     private static final String DELIMITER = ";";
 
     static Map<String, String> parseSettings(String options, Source source) {
-        if (!Strings.hasText(options)) {
+        if (Strings.hasText(options) == false) {
             return emptyMap();
         }
         String[] list = Strings.delimitedListToStringArray(options, DELIMITER);
@@ -49,7 +49,7 @@ abstract class FullTextUtils {
     }
 
     static Map<String, Float> parseFields(String fieldString, Source source) {
-        if (!Strings.hasText(fieldString)) {
+        if (Strings.hasText(fieldString) == false) {
             return emptyMap();
         }
         Set<String> fieldNames = Strings.commaDelimitedListToSet(fieldString);

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/logical/NotProcessor.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/logical/NotProcessor.java
@@ -41,7 +41,7 @@ public class NotProcessor implements Processor {
             return null;
         }
 
-        if (!(input instanceof Boolean)) {
+        if ((input instanceof Boolean) == false) {
             throw new QlIllegalArgumentException("A boolean is required; received {}", input);
         }
 

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/arithmetic/Arithmetics.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/arithmetic/Arithmetics.java
@@ -20,11 +20,11 @@ public final class Arithmetics {
 
     public interface NumericArithmetic extends BiFunction<Number, Number, Number> {
         default Object wrap(Object l, Object r) {
-            if (!(l instanceof Number)) {
+            if ((l instanceof Number) == false) {
                 throw new QlIllegalArgumentException("A number is required; received {}", l);
             }
 
-            if (!(r instanceof Number)) {
+            if ((r instanceof Number) == false) {
                 throw new QlIllegalArgumentException("A number is required; received {}", r);
             }
 

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/arithmetic/DateTimeArithmeticOperation.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/arithmetic/DateTimeArithmeticOperation.java
@@ -19,7 +19,7 @@ abstract class DateTimeArithmeticOperation extends ArithmeticOperation {
 
     @Override
     protected TypeResolution resolveType() {
-        if (!childrenResolved()) {
+        if (childrenResolved() == false) {
             return new TypeResolution("Unresolved children");
         }
 

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/arithmetic/Mul.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/arithmetic/Mul.java
@@ -25,7 +25,7 @@ public class Mul extends ArithmeticOperation implements BinaryComparisonInversib
 
     @Override
     protected TypeResolution resolveType() {
-        if (!childrenResolved()) {
+        if (childrenResolved() == false) {
             return new TypeResolution("Unresolved children");
         }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/file/tool/UsersTool.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/file/tool/UsersTool.java
@@ -282,7 +282,7 @@ public class UsersTool extends LoggingAwareMultiCommand {
             FileAttributesChecker attributesChecker = new FileAttributesChecker(usersFile, rolesFile);
 
             Map<String, char[]> usersMap = FileUserPasswdStore.parseFile(usersFile, null, env.settings());
-            if (!usersMap.containsKey(username)) {
+            if (usersMap.containsKey(username) == false) {
                 throw new UserException(ExitCodes.NO_USER, "User [" + username + "] doesn't exist");
             }
 
@@ -354,7 +354,7 @@ public class UsersTool extends LoggingAwareMultiCommand {
         }
 
         if (username != null) {
-            if (!users.containsKey(username)) {
+            if (users.containsKey(username) == false) {
                 throw new UserException(ExitCodes.NO_USER, "User [" + username + "] doesn't exist");
             }
 
@@ -364,7 +364,7 @@ public class UsersTool extends LoggingAwareMultiCommand {
                 String[] markedRoles = markUnknownRoles(roles, unknownRoles);
                 terminal.println(String.format(Locale.ROOT, "%-15s: %s", username, Arrays.stream(markedRoles).map(s -> s == null ?
                     "-" : s).collect(Collectors.joining(","))));
-                if (!unknownRoles.isEmpty()) {
+                if (unknownRoles.isEmpty() == false) {
                     // at least one role is marked... so printing the legend
                     Path rolesFile = FileRolesStore.resolveFile(env).toAbsolutePath();
                     terminal.println("");
@@ -393,7 +393,7 @@ public class UsersTool extends LoggingAwareMultiCommand {
                 usersExist = true;
             }
 
-            if (!usersExist) {
+            if (usersExist == false) {
                 terminal.println("No users found");
                 return;
             }
@@ -483,7 +483,7 @@ public class UsersTool extends LoggingAwareMultiCommand {
         assert Files.exists(rolesFile);
         Set<String> knownRoles = Sets.union(FileRolesStore.parseFileForRoleNames(rolesFile, null), ReservedRolesStore.names());
         Set<String> unknownRoles = Sets.difference(Sets.newHashSet(roles), knownRoles);
-        if (!unknownRoles.isEmpty()) {
+        if (unknownRoles.isEmpty() == false) {
             terminal.errorPrintln(String.format(Locale.ROOT, "Warning: The following roles [%s] are not in the [%s] file. " +
                     "Make sure the names are correct. If the names are correct and the roles were created using the API please " +
                     "disregard this message. Nonetheless the user will still be associated with all specified roles",

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/support/SessionFactory.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/support/SessionFactory.java
@@ -260,7 +260,7 @@ public abstract class SessionFactory {
             final boolean allClear = Arrays.stream(ldapUrls)
                     .allMatch(s -> STARTS_WITH_LDAP.matcher(s).find());
 
-            if (!allSecure && !allClear) {
+            if (allSecure == false && allClear == false) {
                 //No mixing is allowed because we use the same socketfactory
                 throw new IllegalArgumentException(
                         "configured LDAP protocols are not all equal (ldaps://.. and ldap://..): ["

--- a/x-pack/plugin/sql/qa/jdbc/security/src/test/java/org/elasticsearch/xpack/sql/qa/jdbc/security/JdbcConnectionIT.java
+++ b/x-pack/plugin/sql/qa/jdbc/security/src/test/java/org/elasticsearch/xpack/sql/qa/jdbc/security/JdbcConnectionIT.java
@@ -35,7 +35,7 @@ public class JdbcConnectionIT extends ConnectionTestCase {
             } catch (URISyntaxException e) {
                 throw new RuntimeException("exception while reading the store", e);
             }
-            if (!Files.exists(keyStore)) {
+            if (Files.exists(keyStore) == false) {
                 throw new IllegalStateException("Keystore file [" + keyStore + "] does not exist.");
             }
             builder.put(ESRestTestCase.TRUSTSTORE_PATH, keyStore).put(ESRestTestCase.TRUSTSTORE_PASSWORD, "keypass");

--- a/x-pack/plugin/sql/qa/jdbc/security/src/test/java/org/elasticsearch/xpack/sql/qa/jdbc/security/JdbcSecurityUtils.java
+++ b/x-pack/plugin/sql/qa/jdbc/security/src/test/java/org/elasticsearch/xpack/sql/qa/jdbc/security/JdbcSecurityUtils.java
@@ -39,7 +39,7 @@ final class JdbcSecurityUtils {
         } catch (URISyntaxException e) {
             throw new RuntimeException("exception while reading the store", e);
         }
-        if (!Files.exists(keyStore)) {
+        if (Files.exists(keyStore) == false) {
             throw new IllegalStateException("Keystore file [" + keyStore + "] does not exist.");
         }
         String keyStoreStr = keyStore.toAbsolutePath().toString();

--- a/x-pack/plugin/sql/qa/server/security/src/test/java/org/elasticsearch/xpack/sql/qa/security/CliSecurityIT.java
+++ b/x-pack/plugin/sql/qa/server/security/src/test/java/org/elasticsearch/xpack/sql/qa/security/CliSecurityIT.java
@@ -36,7 +36,7 @@ public class CliSecurityIT extends SqlSecurityTestCase {
             } catch (URISyntaxException e) {
                 throw new RuntimeException("exception while reading the store", e);
             }
-            if (!Files.exists(keyStore)) {
+            if (Files.exists(keyStore) == false) {
                 throw new IllegalStateException("Keystore file [" + keyStore + "] does not exist.");
             }
             keystoreLocation = keyStore.toAbsolutePath().toString();

--- a/x-pack/plugin/sql/qa/server/security/src/test/java/org/elasticsearch/xpack/sql/qa/security/JdbcSecurityIT.java
+++ b/x-pack/plugin/sql/qa/server/security/src/test/java/org/elasticsearch/xpack/sql/qa/security/JdbcSecurityIT.java
@@ -71,7 +71,7 @@ public class JdbcSecurityIT extends SqlSecurityTestCase {
         } catch (URISyntaxException e) {
             throw new RuntimeException("exception while reading the store", e);
         }
-        if (!Files.exists(keyStore)) {
+        if (Files.exists(keyStore) == false) {
             throw new IllegalStateException("Keystore file [" + keyStore + "] does not exist.");
         }
         String keyStoreStr = keyStore.toAbsolutePath().toString();
@@ -200,7 +200,7 @@ public class JdbcSecurityIT extends SqlSecurityTestCase {
 
                 while (actual.next()) {
                     String name = actual.getString("name");
-                    if (!name.startsWith(".security")) {
+                    if (name.startsWith(".security") == false) {
                         actualList.add(name);
                     }
                 }

--- a/x-pack/plugin/sql/qa/server/security/src/test/java/org/elasticsearch/xpack/sql/qa/security/RestSqlIT.java
+++ b/x-pack/plugin/sql/qa/server/security/src/test/java/org/elasticsearch/xpack/sql/qa/security/RestSqlIT.java
@@ -37,7 +37,7 @@ public class RestSqlIT extends RestSqlTestCase {
             } catch (URISyntaxException e) {
                 throw new RuntimeException("exception while reading the store", e);
             }
-            if (!Files.exists(keyStore)) {
+            if (Files.exists(keyStore) == false) {
                 throw new IllegalStateException("Keystore file [" + keyStore + "] does not exist.");
             }
             builder.put(ESRestTestCase.TRUSTSTORE_PATH, keyStore).put(ESRestTestCase.TRUSTSTORE_PASSWORD, "keypass");

--- a/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/SqlProtocolTestCase.java
+++ b/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/SqlProtocolTestCase.java
@@ -304,7 +304,7 @@ public abstract class SqlProtocolTestCase extends ESRestTestCase {
         if (randomBoolean()) {
             request.addParameter("pretty", "true");
         }
-        if (!"json".equals(format) || randomBoolean()) {
+        if ("json".equals(format) == false || randomBoolean()) {
             // since we default to JSON if a format is not specified, randomize setting it or not, explicitly;
             // for any other format, just set the format explicitly
             request.addParameter("format", format);

--- a/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/cli/EmbeddedCli.java
+++ b/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/cli/EmbeddedCli.java
@@ -160,7 +160,7 @@ public class EmbeddedCli implements Closeable {
 
             // Read until the first "good" line (skip the logo or read until an exception)
             boolean isLogoOrException = false;
-            while (!isLogoOrException) {
+            while (isLogoOrException == false) {
                 String line = readLine();
                 if ("SQL".equals(line.trim())) {
                     // it's almost the bottom of the logo, so read the next line (the version) and break out of the loop

--- a/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/DataLoader.java
+++ b/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/DataLoader.java
@@ -218,7 +218,7 @@ public class DataLoader {
 
             // append department
             List<List<String>> list = dep_emp.get(emp_no);
-            if (!list.isEmpty()) {
+            if (list.isEmpty() == false) {
                 bulk.append(", \"dep\" : [");
                 for (List<String> dp : list) {
                     bulk.append("{");

--- a/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/JdbcAssert.java
+++ b/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/JdbcAssert.java
@@ -149,7 +149,7 @@ public class JdbcAssert {
             String expectedName = expectedMeta.getColumnName(column);
             String actualName = actualMeta.getColumnName(column);
 
-            if (!expectedName.equals(actualName)) {
+            if (expectedName.equals(actualName) == false) {
                 // to help debugging, indicate the previous column (which also happened to match and thus was correct)
                 String expectedSet = expectedName;
                 String actualSet = actualName;

--- a/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/SpecBaseIntegrationTestCase.java
+++ b/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/SpecBaseIntegrationTestCase.java
@@ -185,7 +185,7 @@ public abstract class SpecBaseIntegrationTestCase extends JdbcIntegrationTestCas
             while ((line = reader.readLine()) != null) {
                 line = line.trim();
                 // ignore comments
-                if (!line.isEmpty() && !line.startsWith("//")) {
+                if (line.isEmpty() == false && line.startsWith("//") == false) {
                     // parse test name
                     if (testName == null) {
                         if (testNames.keySet().contains(line)) {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/extractor/CompositeKeyExtractor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/extractor/CompositeKeyExtractor.java
@@ -86,7 +86,7 @@ public class CompositeKeyExtractor implements BucketExtractor {
         // get the composite value
         Object m = bucket.getKey();
 
-        if (!(m instanceof Map)) {
+        if ((m instanceof Map) == false) {
             throw new SqlIllegalArgumentException("Unexpected bucket returned: {}", m);
         }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/extractor/MetricAggExtractor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/extractor/MetricAggExtractor.java
@@ -97,7 +97,7 @@ public class MetricAggExtractor implements BucketExtractor {
             throw new SqlIllegalArgumentException("Cannot find an aggregation named {}", name);
         }
 
-        if (!containsValues(agg)) {
+        if (containsValues(agg) == false) {
             return null;
         }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/PercentileAggregate.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/PercentileAggregate.java
@@ -191,7 +191,7 @@ abstract class PercentileAggregate extends NumericAggregate implements EnclosedA
             return true;
         }
 
-        if (!super.equals(o)) {
+        if (super.equals(o) == false) {
             return false;
         }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/PercentileCompoundAggregate.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/PercentileCompoundAggregate.java
@@ -37,7 +37,7 @@ public abstract class PercentileCompoundAggregate extends CompoundNumericAggrega
         if (this == o) {
             return true;
         }
-        if (!super.equals(o)) {
+        if (super.equals(o) == false) {
             return false;
         }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/BaseDateTimeProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/BaseDateTimeProcessor.java
@@ -38,7 +38,7 @@ public abstract class BaseDateTimeProcessor implements Processor {
             return null;
         }
 
-        if (!(input instanceof ZonedDateTime)) {
+        if ((input instanceof ZonedDateTime) == false) {
             throw new SqlIllegalArgumentException("A [date], a [time] or a [datetime] is required; received {}", input);
         }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/BinaryDateTimeDatePartFunction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/BinaryDateTimeDatePartFunction.java
@@ -84,7 +84,7 @@ public abstract class BinaryDateTimeDatePartFunction extends BinaryDateTimeFunct
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        if (!super.equals(o)) {
+        if (super.equals(o) == false) {
             return false;
         }
         BinaryDateTimeDatePartFunction that = (BinaryDateTimeDatePartFunction) o;

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/BinaryDateTimeFunction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/BinaryDateTimeFunction.java
@@ -67,7 +67,7 @@ public abstract class BinaryDateTimeFunction extends BinaryScalarFunction {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        if (!super.equals(o)) {
+        if (super.equals(o) == false) {
             return false;
         }
         BinaryDateTimeFunction that = (BinaryDateTimeFunction) o;

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/BinaryDateTimePipe.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/BinaryDateTimePipe.java
@@ -48,7 +48,7 @@ public abstract class BinaryDateTimePipe extends BinaryPipe {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        if (!super.equals(o)) {
+        if (super.equals(o) == false) {
             return false;
         }
         BinaryDateTimePipe that = (BinaryDateTimePipe) o;

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTimeFormatPipe.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTimeFormatPipe.java
@@ -54,7 +54,7 @@ public class DateTimeFormatPipe extends BinaryDateTimePipe {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        if (!super.equals(o)) {
+        if (super.equals(o) == false) {
             return false;
         }
         DateTimeFormatPipe other = (DateTimeFormatPipe) o;

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTimeParsePipe.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTimeParsePipe.java
@@ -53,7 +53,7 @@ public class DateTimeParsePipe extends BinaryDateTimePipe {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        if (!super.equals(o)) {
+        if (super.equals(o) == false) {
             return false;
         }
         DateTimeParsePipe that = (DateTimeParsePipe) o;

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/ThreeArgsDateTimeFunction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/ThreeArgsDateTimeFunction.java
@@ -110,7 +110,7 @@ public abstract class ThreeArgsDateTimeFunction extends ScalarFunction {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        if (!super.equals(o)) {
+        if (super.equals(o) == false) {
             return false;
         }
         ThreeArgsDateTimeFunction that = (ThreeArgsDateTimeFunction) o;

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/ThreeArgsDateTimePipe.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/ThreeArgsDateTimePipe.java
@@ -72,7 +72,7 @@ public abstract class ThreeArgsDateTimePipe extends Pipe {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        if (!super.equals(o)) {
+        if (super.equals(o) == false) {
             return false;
         }
         ThreeArgsDateTimePipe that = (ThreeArgsDateTimePipe) o;

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/geo/UnaryGeoFunction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/geo/UnaryGeoFunction.java
@@ -39,7 +39,7 @@ public abstract class UnaryGeoFunction extends UnaryScalarFunction {
 
     @Override
     protected TypeResolution resolveType() {
-        if (!childrenResolved()) {
+        if (childrenResolved() == false) {
             return new TypeResolution("Unresolved children");
         }
         return isGeo(field(), operation().toString(), Expressions.ParamOrdinal.DEFAULT);

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/math/BinaryMathProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/math/BinaryMathProcessor.java
@@ -60,7 +60,7 @@ public class BinaryMathProcessor extends FunctionalEnumBinaryProcessor<Number, N
 
     @Override
     protected void checkParameter(Object param) {
-        if (!(param instanceof Number)) {
+        if ((param instanceof Number) == false) {
             throw new SqlIllegalArgumentException("A number is required; received [{}]", param);
         }
     }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/math/BinaryNumericFunction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/math/BinaryNumericFunction.java
@@ -36,7 +36,7 @@ public abstract class BinaryNumericFunction extends BinaryScalarFunction {
 
     @Override
     protected TypeResolution resolveType() {
-        if (!childrenResolved()) {
+        if (childrenResolved() == false) {
             return new TypeResolution("Unresolved children");
         }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/math/BinaryOptionalMathProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/math/BinaryOptionalMathProcessor.java
@@ -46,12 +46,12 @@ public class BinaryOptionalMathProcessor implements Processor {
             if (left == null) {
                 return null;
             }
-            if (!(left instanceof Number)) {
+            if ((left instanceof Number) == false) {
                 throw new SqlIllegalArgumentException("A number is required; received [{}]", left);
             }
 
             if (right != null) {
-                if (!(right instanceof Number)) {
+                if ((right instanceof Number) == false) {
                     throw new SqlIllegalArgumentException("A number is required; received [{}]", right);
                 }
                 if (right instanceof Float || right instanceof Double) {
@@ -97,12 +97,12 @@ public class BinaryOptionalMathProcessor implements Processor {
         if (left == null) {
             return null;
         }
-        if (!(left instanceof Number)) {
+        if ((left instanceof Number) == false) {
             throw new SqlIllegalArgumentException("A number is required; received [{}]", left);
         }
 
         if (right != null) {
-            if (!(right instanceof Number)) {
+            if ((right instanceof Number) == false) {
                 throw new SqlIllegalArgumentException("A number is required; received [{}]", right);
             }
             if (right instanceof Float || right instanceof Double) {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/math/BinaryOptionalNumericFunction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/math/BinaryOptionalNumericFunction.java
@@ -40,7 +40,7 @@ public abstract class BinaryOptionalNumericFunction extends ScalarFunction {
 
     @Override
     protected TypeResolution resolveType() {
-        if (!childrenResolved()) {
+        if (childrenResolved() == false) {
             return new TypeResolution("Unresolved children");
         }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/math/MathFunction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/math/MathFunction.java
@@ -54,7 +54,7 @@ public abstract class MathFunction extends UnaryScalarFunction {
 
     @Override
     protected TypeResolution resolveType() {
-        if (!childrenResolved()) {
+        if (childrenResolved() == false) {
             return new TypeResolution("Unresolved children");
         }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/BinaryStringFunction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/BinaryStringFunction.java
@@ -40,7 +40,7 @@ public abstract class BinaryStringFunction<T,R> extends BinaryScalarFunction {
 
     @Override
     protected TypeResolution resolveType() {
-        if (!childrenResolved()) {
+        if (childrenResolved() == false) {
             return new TypeResolution("Unresolved children");
         }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/BinaryStringNumericProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/BinaryStringNumericProcessor.java
@@ -82,7 +82,7 @@ public class BinaryStringNumericProcessor extends FunctionalEnumBinaryProcessor<
 
     @Override
     protected Object doProcess(Object left, Object right) {
-        if (!(left instanceof String || left instanceof Character)) {
+        if ((left instanceof String || left instanceof Character) == false) {
             throw new SqlIllegalArgumentException("A string/char is required; received [{}]", left);
         }
         // count can be negative, the case is handled by the code, but it must still be int-convertible

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/BinaryStringStringProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/BinaryStringStringProcessor.java
@@ -58,10 +58,10 @@ public class BinaryStringStringProcessor extends FunctionalEnumBinaryProcessor<S
 
     @Override
     protected Object doProcess(Object left, Object right) {
-        if (!(left instanceof String || left instanceof Character)) {
+        if ((left instanceof String || left instanceof Character) == false) {
             throw new SqlIllegalArgumentException("A string/char is required; received [{}]", left);
         }
-        if (!(right instanceof String || right instanceof Character)) {
+        if ((right instanceof String || right instanceof Character) == false) {
             throw new SqlIllegalArgumentException("A string/char is required; received [{}]", right);
         }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/Concat.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/Concat.java
@@ -37,7 +37,7 @@ public class Concat extends BinaryScalarFunction {
 
     @Override
     protected TypeResolution resolveType() {
-        if (!childrenResolved()) {
+        if (childrenResolved() == false) {
             return new TypeResolution("Unresolved children");
         }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/ConcatFunctionProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/ConcatFunctionProcessor.java
@@ -55,10 +55,10 @@ public class ConcatFunctionProcessor extends BinaryProcessor {
         if (source2 == null) {
             return source1;
         }
-        if (!(source1 instanceof String || source1 instanceof Character)) {
+        if ((source1 instanceof String || source1 instanceof Character) == false) {
             throw new SqlIllegalArgumentException("A string/char is required; received [{}]", source1);
         }
-        if (!(source2 instanceof String || source2 instanceof Character)) {
+        if ((source2 instanceof String || source2 instanceof Character) == false) {
             throw new SqlIllegalArgumentException("A string/char is required; received [{}]", source2);
         }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/Insert.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/Insert.java
@@ -47,7 +47,7 @@ public class Insert extends ScalarFunction {
 
     @Override
     protected TypeResolution resolveType() {
-        if (!childrenResolved()) {
+        if (childrenResolved() == false) {
             return new TypeResolution("Unresolved children");
         }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/InsertFunctionProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/InsertFunctionProcessor.java
@@ -51,13 +51,13 @@ public class InsertFunctionProcessor implements Processor {
         if (input == null) {
             return null;
         }
-        if (!(input instanceof String || input instanceof Character)) {
+        if ((input instanceof String || input instanceof Character) == false) {
             throw new SqlIllegalArgumentException("A string/char is required; received [{}]", input);
         }
         if (replacement == null) {
             return input;
         }
-        if (!(replacement instanceof String || replacement instanceof Character)) {
+        if ((replacement instanceof String || replacement instanceof Character) == false) {
             throw new SqlIllegalArgumentException("A string/char is required; received [{}]", replacement);
         }
         if (start == null || length == null) {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/Locate.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/Locate.java
@@ -50,7 +50,7 @@ public class Locate extends ScalarFunction implements OptionalArgument {
 
     @Override
     protected TypeResolution resolveType() {
-        if (!childrenResolved()) {
+        if (childrenResolved() == false) {
             return new TypeResolution("Unresolved children");
         }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/LocateFunctionProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/LocateFunctionProcessor.java
@@ -48,14 +48,14 @@ public class LocateFunctionProcessor implements Processor {
         if (input == null) {
             return null;
         }
-        if (!(input instanceof String || input instanceof Character)) {
+        if ((input instanceof String || input instanceof Character) == false) {
             throw new SqlIllegalArgumentException("A string/char is required; received [{}]", input);
         }
         if (pattern == null) {
             return 0;
         }
 
-        if (!(pattern instanceof String || pattern instanceof Character)) {
+        if ((pattern instanceof String || pattern instanceof Character) == false) {
             throw new SqlIllegalArgumentException("A string/char is required; received [{}]", pattern);
         }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/Replace.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/Replace.java
@@ -44,7 +44,7 @@ public class Replace extends ScalarFunction {
 
     @Override
     protected TypeResolution resolveType() {
-        if (!childrenResolved()) {
+        if (childrenResolved() == false) {
             return new TypeResolution("Unresolved children");
         }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/ReplaceFunctionProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/ReplaceFunctionProcessor.java
@@ -48,16 +48,16 @@ public class ReplaceFunctionProcessor implements Processor {
         if (input == null) {
             return null;
         }
-        if (!(input instanceof String || input instanceof Character)) {
+        if ((input instanceof String || input instanceof Character) == false) {
             throw new SqlIllegalArgumentException("A string/char is required; received [{}]", input);
         }
         if (pattern == null || replacement == null) {
             return input;
         }
-        if (!(pattern instanceof String || pattern instanceof Character)) {
+        if ((pattern instanceof String || pattern instanceof Character) == false) {
             throw new SqlIllegalArgumentException("A string/char is required; received [{}]", pattern);
         }
-        if (!(replacement instanceof String || replacement instanceof Character)) {
+        if ((replacement instanceof String || replacement instanceof Character) == false) {
             throw new SqlIllegalArgumentException("A string/char is required; received [{}]", replacement);
         }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/StringFunctionUtils.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/StringFunctionUtils.java
@@ -21,7 +21,7 @@ final class StringFunctionUtils {
      * @return the resulting String
      */
     static String substring(String s, int start, int length) {
-        if (!hasLength(s)) {
+        if (hasLength(s) == false) {
             return s;
         }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/StringProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/StringProcessor.java
@@ -21,7 +21,7 @@ public class StringProcessor implements Processor {
 
     private interface StringFunction<R> {
         default R apply(Object o) {
-            if (!(o instanceof String || o instanceof Character)) {
+            if ((o instanceof String || o instanceof Character) == false) {
                 throw new SqlIllegalArgumentException("A string/char is required; received [{}]", o);
             }
 
@@ -33,7 +33,7 @@ public class StringProcessor implements Processor {
 
     private interface NumericFunction<R> {
         default R apply(Object o) {
-            if (!(o instanceof Number)) {
+            if ((o instanceof Number) == false) {
                 throw new SqlIllegalArgumentException("A number is required; received [{}]", o);
             }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/Substring.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/Substring.java
@@ -45,7 +45,7 @@ public class Substring extends ScalarFunction {
 
     @Override
     protected TypeResolution resolveType() {
-        if (!childrenResolved()) {
+        if (childrenResolved() == false) {
             return new TypeResolution("Unresolved children");
         }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/SubstringFunctionProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/SubstringFunctionProcessor.java
@@ -49,7 +49,7 @@ public class SubstringFunctionProcessor implements Processor {
         if (input == null) {
             return null;
         }
-        if (!(input instanceof String || input instanceof Character)) {
+        if ((input instanceof String || input instanceof Character) == false) {
             throw new SqlIllegalArgumentException("A string/char is required; received [{}]", input);
         }
         if (start == null || length == null) {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/UnaryStringFunction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/UnaryStringFunction.java
@@ -42,7 +42,7 @@ public abstract class UnaryStringFunction extends UnaryScalarFunction {
 
     @Override
     protected TypeResolution resolveType() {
-        if (!childrenResolved()) {
+        if (childrenResolved() == false) {
             return new TypeResolution("Unresolved children");
         }
         return isStringAndExact(field(), sourceText(), ParamOrdinal.DEFAULT);

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/UnaryStringIntFunction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/UnaryStringIntFunction.java
@@ -44,7 +44,7 @@ public abstract class UnaryStringIntFunction extends UnaryScalarFunction {
 
     @Override
     protected TypeResolution resolveType() {
-        if (!childrenResolved()) {
+        if (childrenResolved() == false) {
             return new TypeResolution("Unresolved children");
         }
         return isInteger(field(), sourceText(), ParamOrdinal.DEFAULT);

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/operator/arithmetic/DateTimeArithmeticOperation.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/operator/arithmetic/DateTimeArithmeticOperation.java
@@ -25,7 +25,7 @@ abstract class DateTimeArithmeticOperation extends SqlArithmeticOperation {
 
     @Override
     protected TypeResolution resolveType() {
-        if (!childrenResolved()) {
+        if (childrenResolved() == false) {
             return new TypeResolution("Unresolved children");
         }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/operator/arithmetic/Mul.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/operator/arithmetic/Mul.java
@@ -29,7 +29,7 @@ public class Mul extends SqlArithmeticOperation implements BinaryComparisonInver
 
     @Override
     protected TypeResolution resolveType() {
-        if (!childrenResolved()) {
+        if (childrenResolved() == false) {
             return new TypeResolution("Unresolved children");
         }
 

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/slack/message/DynamicAttachments.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/slack/message/DynamicAttachments.java
@@ -30,13 +30,13 @@ public class DynamicAttachments implements MessageElement {
 
     public List<Attachment> render(TextTemplateEngine engine, Map<String, Object> model, SlackMessageDefaults.AttachmentDefaults defaults) {
         Object value = ObjectPath.eval(listPath, model);
-        if (!(value instanceof Iterable)) {
+        if ((value instanceof Iterable) == false) {
             throw new IllegalArgumentException("dynamic attachment could not be resolved. expected context [" + listPath + "] to be a " +
                     "list, but found [" + value + "] instead");
         }
         List<Attachment> attachments = new ArrayList<>();
         for (Object obj : (Iterable) value) {
-            if (!(obj instanceof Map)) {
+            if ((obj instanceof Map) == false) {
                 throw new IllegalArgumentException("dynamic attachment could not be resolved. expected [" + listPath + "] list to contain" +
                         " key/value pairs, but found [" + obj + "] instead");
             }

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/slack/message/Field.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/slack/message/Field.java
@@ -38,7 +38,7 @@ class Field implements MessageElement {
         Field field = (Field) o;
 
         if (isShort != field.isShort) return false;
-        if (!title.equals(field.title)) return false;
+        if (title.equals(field.title) == false) return false;
         return value.equals(field.value);
     }
 
@@ -84,7 +84,7 @@ class Field implements MessageElement {
             Template template = (Template) o;
 
             if (isShort != template.isShort) return false;
-            if (!title.equals(template.title)) return false;
+            if (title.equals(template.title) == false) return false;
             return value.equals(template.value);
         }
 

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/slack/message/SlackMessage.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/slack/message/SlackMessage.java
@@ -70,11 +70,11 @@ public class SlackMessage implements MessageElement {
 
         SlackMessage that = (SlackMessage) o;
 
-        if (from != null ? !from.equals(that.from) : that.from != null) return false;
-        if (!Arrays.equals(to, that.to)) return false;
-        if (icon != null ? !icon.equals(that.icon) : that.icon != null) return false;
-        if (text != null ? !text.equals(that.text) : that.text != null) return false;
-        return Arrays.equals(attachments, that.attachments);
+        return Objects.equals(from, that.from)
+            && Arrays.equals(to, that.to)
+            && Objects.equals(icon, that.icon)
+            && Objects.equals(text, that.text)
+            && Arrays.equals(attachments, that.attachments);
     }
 
     @Override

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/slack/message/SlackMessageDefaults.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/slack/message/SlackMessageDefaults.java
@@ -44,7 +44,7 @@ public class SlackMessageDefaults {
         SlackMessageDefaults defaults = (SlackMessageDefaults) o;
 
         return Objects.equals(from, defaults.from)
-            & Arrays.equals(to, defaults.to)
+            && Arrays.equals(to, defaults.to)
             && Objects.equals(icon, defaults.icon)
             && Objects.equals(text, defaults.text)
             && Objects.equals(attachment, defaults.attachment);

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/slack/message/SlackMessageDefaults.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/slack/message/SlackMessageDefaults.java
@@ -43,11 +43,11 @@ public class SlackMessageDefaults {
 
         SlackMessageDefaults defaults = (SlackMessageDefaults) o;
 
-        if (from != null ? !from.equals(defaults.from) : defaults.from != null) return false;
-        if (!Arrays.equals(to, defaults.to)) return false;
-        if (icon != null ? !icon.equals(defaults.icon) : defaults.icon != null) return false;
-        if (text != null ? !text.equals(defaults.text) : defaults.text != null) return false;
-        return !(attachment != null ? !attachment.equals(defaults.attachment) : defaults.attachment != null);
+        return Objects.equals(from, defaults.from)
+            & Arrays.equals(to, defaults.to)
+            && Objects.equals(icon, defaults.icon)
+            && Objects.equals(text, defaults.text)
+            && Objects.equals(attachment, defaults.attachment);
     }
 
     @Override

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/trigger/schedule/support/DayTimes.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/trigger/schedule/support/DayTimes.java
@@ -102,13 +102,13 @@ public class DayTimes implements Times {
 
     public void validate() {
         for (int i = 0; i < hour.length; i++) {
-            if (!validHour(hour[i])) {
+            if (validHour(hour[i]) == false) {
                 throw illegalArgument("invalid time [{}]. invalid time hour value [{}]. time hours must be between 0 and 23 incl.",
                         this, hour[i]);
             }
         }
         for (int i = 0; i < minute.length; i++) {
-            if (!validMinute(minute[i])) {
+            if (validMinute(minute[i]) == false) {
                 throw illegalArgument("invalid time [{}]. invalid time minute value [{}]. time minutes must be between 0 and 59 incl.",
                         this, minute[i]);
             }
@@ -171,8 +171,8 @@ public class DayTimes implements Times {
 
         DayTimes time = (DayTimes) o;
 
-        if (!Arrays.equals(hour, time.hour)) return false;
-        if (!Arrays.equals(minute, time.minute)) return false;
+        if (Arrays.equals(hour, time.hour) == false) return false;
+        if (Arrays.equals(minute, time.minute) == false) return false;
 
         return true;
     }
@@ -234,7 +234,7 @@ public class DayTimes implements Times {
         switch (token) {
             case VALUE_NUMBER:
                 int hour = parser.intValue();
-                if (!DayTimes.validHour(hour)) {
+                if (DayTimes.validHour(hour) == false) {
                     throw new ElasticsearchParseException("invalid time hour value [{}] (possible values may be between 0 and 23 incl.)",
                             hour);
                 }
@@ -244,7 +244,7 @@ public class DayTimes implements Times {
                 String value = parser.text();
                 try {
                     hour = Integer.valueOf(value);
-                    if (!DayTimes.validHour(hour)) {
+                    if (DayTimes.validHour(hour) == false) {
                         String msg = "invalid time hour value [{}] (possible values may be between 0 and 23 incl.)";
                         throw new ElasticsearchParseException(msg, hour);
                     }
@@ -262,7 +262,7 @@ public class DayTimes implements Times {
         switch (token) {
             case VALUE_NUMBER:
                 int minute = parser.intValue();
-                if (!DayTimes.validMinute(minute)) {
+                if (DayTimes.validMinute(minute) == false) {
                     throw new ElasticsearchParseException("invalid time minute value [{}] (possible values may be between 0 and 59 incl.)",
                             minute);
                 }
@@ -272,7 +272,7 @@ public class DayTimes implements Times {
                 String value = parser.text();
                 try {
                     minute = Integer.valueOf(value);
-                    if (!DayTimes.validMinute(minute)) {
+                    if (DayTimes.validMinute(minute) == false) {
                         throw new ElasticsearchParseException("invalid time minute value [{}] (possible values may be between 0 and 59 " +
                                 "incl.)", minute);
                     }

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/trigger/schedule/support/MonthTimes.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/trigger/schedule/support/MonthTimes.java
@@ -82,11 +82,9 @@ public class MonthTimes implements Times {
 
         MonthTimes that = (MonthTimes) o;
 
-        if (Arrays.equals(days, that.days) == false) return false;
-        // order doesn't matter
-        if (newHashSet(times).equals(newHashSet(that.times)) == false) return false;
-
-        return true;
+        return Arrays.equals(days, that.days)
+            // order doesn't matter
+            && newHashSet(times).equals(newHashSet(that.times));
     }
 
     @Override

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/trigger/schedule/support/MonthTimes.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/trigger/schedule/support/MonthTimes.java
@@ -82,9 +82,9 @@ public class MonthTimes implements Times {
 
         MonthTimes that = (MonthTimes) o;
 
-        if (!Arrays.equals(days, that.days)) return false;
+        if (Arrays.equals(days, that.days) == false) return false;
         // order doesn't matter
-        if (!newHashSet(times).equals(newHashSet(that.times))) return false;
+        if (newHashSet(times).equals(newHashSet(that.times)) == false) return false;
 
         return true;
     }

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/trigger/schedule/support/WeekTimes.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/trigger/schedule/support/WeekTimes.java
@@ -71,12 +71,9 @@ public class WeekTimes implements Times {
 
         WeekTimes that = (WeekTimes) o;
 
-        if (days.equals(that.days) == false) return false;
-
-        // we don't care about order
-        if (newHashSet(times).equals(newHashSet(that.times)) == false) return false;
-
-        return true;
+        return days.equals(that.days)
+            // we don't care about order
+            && newHashSet(times).equals(newHashSet(that.times));
     }
 
     @Override

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/trigger/schedule/support/WeekTimes.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/trigger/schedule/support/WeekTimes.java
@@ -71,10 +71,10 @@ public class WeekTimes implements Times {
 
         WeekTimes that = (WeekTimes) o;
 
-        if (!days.equals(that.days)) return false;
+        if (days.equals(that.days) == false) return false;
 
         // we don't care about order
-        if (!newHashSet(times).equals(newHashSet(that.times))) return false;
+        if (newHashSet(times).equals(newHashSet(that.times)) == false) return false;
 
         return true;
     }

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/trigger/schedule/support/YearTimes.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/trigger/schedule/support/YearTimes.java
@@ -90,12 +90,10 @@ public class YearTimes implements Times {
 
         YearTimes that = (YearTimes) o;
 
-        if (Arrays.equals(days, that.days) == false) return false;
-        if (months.equals(that.months) == false) return false;
-        // order doesn't matter
-        if (newHashSet(times).equals(newHashSet(that.times)) == false) return false;
-
-        return true;
+        return Arrays.equals(days, that.days)
+            && months.equals(that.months)
+            // order doesn't matter
+            && newHashSet(times).equals(newHashSet(that.times));
     }
 
     @Override

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/trigger/schedule/support/YearTimes.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/trigger/schedule/support/YearTimes.java
@@ -90,10 +90,10 @@ public class YearTimes implements Times {
 
         YearTimes that = (YearTimes) o;
 
-        if (!Arrays.equals(days, that.days)) return false;
-        if (!months.equals(that.months)) return false;
+        if (Arrays.equals(days, that.days) == false) return false;
+        if (months.equals(that.months) == false) return false;
         // order doesn't matter
-        if (!newHashSet(times).equals(newHashSet(that.times))) return false;
+        if (newHashSet(times).equals(newHashSet(that.times)) == false) return false;
 
         return true;
     }

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/notification/slack/message/SlackMessageTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/notification/slack/message/SlackMessageTests.java
@@ -272,7 +272,7 @@ public class SlackMessageTests extends ESTestCase {
             }
         }
 
-        if (!includeTarget) {
+        if (includeTarget == false) {
             assertThat(to, nullValue());
             to = expected.to;
         }

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/trigger/schedule/engine/TickerScheduleEngineTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/trigger/schedule/engine/TickerScheduleEngineTests.java
@@ -84,7 +84,7 @@ public class TickerScheduleEngineTests extends ESTestCase {
             public void accept(Iterable<TriggerEvent> events) {
                 for (TriggerEvent event : events) {
                     int index = Integer.parseInt(event.jobName());
-                    if (!bits.get(index)) {
+                    if (bits.get(index) == false) {
                         logger.info("job [{}] first fire", index);
                         bits.set(index);
                         firstLatch.countDown();
@@ -98,12 +98,12 @@ public class TickerScheduleEngineTests extends ESTestCase {
 
         engine.start(watches);
         advanceClockIfNeeded(clock.instant().plusMillis(1100).atZone(ZoneOffset.UTC));
-        if (!firstLatch.await(3 * count, TimeUnit.SECONDS)) {
+        if (firstLatch.await(3 * count, TimeUnit.SECONDS) == false) {
             fail("waiting too long for all watches to be triggered");
         }
 
         advanceClockIfNeeded(clock.instant().plusMillis(1100).atZone(ZoneOffset.UTC));
-        if (!secondLatch.await(3 * count, TimeUnit.SECONDS)) {
+        if (secondLatch.await(3 * count, TimeUnit.SECONDS) == false) {
             fail("waiting too long for all watches to be triggered");
         }
         engine.stop();
@@ -139,7 +139,7 @@ public class TickerScheduleEngineTests extends ESTestCase {
                 scheduledTime.getMinute()).build()));
         advanceClockIfNeeded(scheduledTime);
 
-        if (!latch.await(5, TimeUnit.SECONDS)) {
+        if (latch.await(5, TimeUnit.SECONDS) == false) {
             fail("waiting too long for all watches to be triggered");
         }
     }
@@ -176,7 +176,7 @@ public class TickerScheduleEngineTests extends ESTestCase {
                 scheduledTime.getMinute()).build()));
         advanceClockIfNeeded(scheduledTime);
 
-        if (!latch.await(5, TimeUnit.SECONDS)) {
+        if (latch.await(5, TimeUnit.SECONDS) == false) {
             fail("waiting too long for all watches to be triggered");
         }
     }
@@ -221,7 +221,7 @@ public class TickerScheduleEngineTests extends ESTestCase {
                 .build()));
         advanceClockIfNeeded(scheduledTime);
 
-        if (!latch.await(5, TimeUnit.SECONDS)) {
+        if (latch.await(5, TimeUnit.SECONDS) == false) {
             fail("waiting too long for all watches to be triggered");
         }
     }
@@ -251,12 +251,12 @@ public class TickerScheduleEngineTests extends ESTestCase {
         }
 
         advanceClockIfNeeded(clock.instant().plusMillis(1100).atZone(ZoneOffset.UTC));
-        if (!firstLatch.await(3, TimeUnit.SECONDS)) {
+        if (firstLatch.await(3, TimeUnit.SECONDS) == false) {
             fail("waiting too long for all watches to be triggered");
         }
 
         advanceClockIfNeeded(clock.instant().plusMillis(1100).atZone(ZoneOffset.UTC));
-        if (!secondLatch.await(3, TimeUnit.SECONDS)) {
+        if (secondLatch.await(3, TimeUnit.SECONDS) == false) {
             fail("waiting too long for all watches to be triggered");
         }
 


### PR DESCRIPTION
Part 7.

We have an in-house rule to compare explicitly against `false` instead
of using the logical not operator (`!`). However, this hasn't
historically been enforced, meaning that there are many violations in
the source at present.

We now have a Checkstyle rule that can detect these cases, but before we
can turn it on, we need to fix the existing violations. This is being
done over a series of PRs, since there are a lot to fix.