### PR TITLE
Fix BlobStoreRepositoryTest Leaking a RepoData Write Operation (#68441)

### DIFF
--- a/server/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryTests.java
@@ -185,14 +185,13 @@ public class BlobStoreRepositoryTests extends ESSingleNodeTestCase {
         assertThat(repository.readSnapshotIndexLatestBlob(), equalTo(expectedGeneration + 2L));
     }
 
-    public void testRepositoryDataConcurrentModificationNotAllowed() {
+    public void testRepositoryDataConcurrentModificationNotAllowed() throws Exception {
         final BlobStoreRepository repository = setupRepo();
 
         // write to index generational file
         RepositoryData repositoryData = generateRandomRepoData();
         final long startingGeneration = repositoryData.getGenId();
-        final PlainActionFuture<RepositoryData> future = PlainActionFuture.newFuture();
-        repository.writeIndexGen(repositoryData, startingGeneration, Version.CURRENT, Function.identity(), future);
+        writeIndexGen(repository, repositoryData, startingGeneration);
 
         // write repo data again to index generational file, errors because we already wrote to the
         // N+1 generation from which this repository data instance was created


### PR DESCRIPTION
We were leaking a repo data write operation here by never waiting on the future.
Since we normally don't invoke `writeIndexGen` manually there are no safety measures
around removing the repository from the cluster state and adding it back with a different
path concurrently, leading to a collision between repo generation CS updates since all tests
use the same repository name.
Fix the missing write and added some trace logging that was very helpful in tracking this down.

Closes #68437

backport of #68441 