### PR TITLE
Fix maven publishing after nebula publish update

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -109,6 +109,7 @@ dependencies {
   integTestImplementation('org.spockframework:spock-core:1.3-groovy-2.5') {
     exclude module: "groovy"
   }
+  integTestImplementation "org.xmlunit:xmlunit-core:2.8.2"
 }
 
 /*****************************************************************************

--- a/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/PublishPluginFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/PublishPluginFuncTest.groovy
@@ -33,10 +33,8 @@ class PublishPluginFuncTest extends AbstractGradleFuncTest {
 
         then:
         result.task(":generatePom").outcome == TaskOutcome.SUCCESS
-
-        def generatedPomFile = file("build/distributions/hello-world-1.0.pom")
-        generatedPomFile.exists()
-        assertXmlEquals(generatedPomFile.text, """
+        file("build/distributions/hello-world-1.0.pom").exists()
+        assertXmlEquals(file("build/distributions/hello-world-1.0.pom").text, """
             <project xmlns="http://maven.apache.org/POM/4.0.0" 
                      xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" 
                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
@@ -81,7 +79,6 @@ class PublishPluginFuncTest extends AbstractGradleFuncTest {
         then:
         result.task(":generatePom").outcome == TaskOutcome.SUCCESS
         file("build/distributions/hello-world-plugin-1.0.pom").exists()
-        generatedPomFile.exists()
         assertXmlEquals(file("build/distributions/hello-world-plugin-1.0.pom").text, """
             <project xmlns="http://maven.apache.org/POM/4.0.0" 
                      xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" 

--- a/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/PublishPluginFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/PublishPluginFuncTest.groovy
@@ -1,20 +1,9 @@
 /*
- * Licensed to Elasticsearch under one or more contributor
- * license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright
- * ownership. Elasticsearch licenses this file to you under
- * the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
  */
 
 package org.elasticsearch.gradle
@@ -91,10 +80,9 @@ class PublishPluginFuncTest extends AbstractGradleFuncTest {
 
         then:
         result.task(":generatePom").outcome == TaskOutcome.SUCCESS
-
-        def generatedPomFile = file("build/distributions/hello-world-plugin-1.0.pom")
+        file("build/distributions/hello-world-plugin-1.0.pom").exists()
         generatedPomFile.exists()
-        assertXmlEquals(generatedPomFile.text, """
+        assertXmlEquals(file("build/distributions/hello-world-plugin-1.0.pom").text, """
             <project xmlns="http://maven.apache.org/POM/4.0.0" 
                      xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" 
                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
@@ -138,9 +126,8 @@ class PublishPluginFuncTest extends AbstractGradleFuncTest {
 
         then:
         result.task(":generatePom").outcome == TaskOutcome.SUCCESS
-        def generatedPomFile = file("build/distributions/hello-world-plugin-1.0.pom")
-        generatedPomFile.exists()
-        assertXmlEquals(generatedPomFile.text, """
+        file("build/distributions/hello-world-plugin-1.0.pom").exists()
+        assertXmlEquals(file("build/distributions/hello-world-plugin-1.0.pom").text, """
             <project xmlns="http://maven.apache.org/POM/4.0.0" 
                      xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" 
                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
@@ -167,6 +154,7 @@ class PublishPluginFuncTest extends AbstractGradleFuncTest {
             version = "1.0"
             group = 'org.acme'        
             description = "just a test project"
+            
             // this is currently required to have validation passed
             // In our elasticsearch build this is currently setup in the 
             // root build.gradle file.
@@ -199,10 +187,8 @@ class PublishPluginFuncTest extends AbstractGradleFuncTest {
 
         then:
         result.task(":generatePom").outcome == TaskOutcome.SUCCESS
-        def generatedPomFile = file("build/distributions/hello-world-1.0.pom")
-        println generatedPomFile.text
-        generatedPomFile.exists()
-        assertXmlEquals(generatedPomFile.text, """
+        file("build/distributions/hello-world-1.0.pom").exists()
+        assertXmlEquals(file("build/distributions/hello-world-1.0.pom").text, """
             <project xmlns="http://maven.apache.org/POM/4.0.0" 
                      xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" 
                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">

--- a/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/PublishPluginFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/PublishPluginFuncTest.groovy
@@ -1,0 +1,273 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.gradle
+
+import org.elasticsearch.gradle.fixtures.AbstractGradleFuncTest
+import org.gradle.testkit.runner.TaskOutcome
+import org.xmlunit.builder.DiffBuilder
+import org.xmlunit.builder.Input
+
+class PublishPluginFuncTest extends AbstractGradleFuncTest {
+
+    def "published pom takes es project description into account"() {
+        given:
+        buildFile << """
+            plugins {
+                id 'elasticsearch.java'
+                id 'elasticsearch.publish'
+            }
+            
+            version = "1.0"
+            group = 'org.acme'
+            description = "custom project description"
+        """
+
+        when:
+        def result = gradleRunner('assemble').build()
+
+        then:
+        result.task(":generatePom").outcome == TaskOutcome.SUCCESS
+
+        def generatedPomFile = file("build/distributions/hello-world-1.0.pom")
+        generatedPomFile.exists()
+        assertXmlEquals(generatedPomFile.text, """
+            <project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+              <modelVersion>4.0.0</modelVersion>
+              <groupId>org.acme</groupId>
+              <artifactId>hello-world</artifactId>
+              <version>1.0</version>
+              <name>hello-world</name>
+              <description>custom project description</description>
+            </project>"""
+        )
+    }
+
+    def "generates pom for shadowed elasticsearch plugin"() {
+        given:
+        file('license.txt') << "License file"
+        file('notice.txt') << "Notice file"
+        buildFile << """
+            plugins {
+                id 'elasticsearch.esplugin'
+                id 'elasticsearch.publish'
+                id 'com.github.johnrengelman.shadow'
+            }
+            
+            esplugin {
+                name = 'hello-world-plugin'
+                classname 'org.acme.HelloWorldPlugin'
+                description = "custom project description"
+            }
+                    
+            // requires elasticsearch artifact available
+            tasks.named('bundlePlugin').configure { enabled = false }
+            licenseFile = file('license.txt')
+            noticeFile = file('notice.txt')
+            version = "1.0"
+            group = 'org.acme'        
+        """
+
+        when:
+        def result = gradleRunner('generatePom').build()
+
+        then:
+        result.task(":generatePom").outcome == TaskOutcome.SUCCESS
+
+        def generatedPomFile = file("build/distributions/hello-world-plugin-1.0.pom")
+        generatedPomFile.exists()
+        assertXmlEquals(generatedPomFile.text, """
+            <project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+              <modelVersion>4.0.0</modelVersion>
+              <groupId>org.acme</groupId>
+              <artifactId>hello-world-plugin</artifactId>
+              <version>1.0</version>
+              <name>hello-world</name>
+              <description>custom project description</description>
+              <dependencies/>
+            </project>"""
+        )
+    }
+
+    def "generates pom for elasticsearch plugin"() {
+        given:
+        file('license.txt') << "License file"
+        file('notice.txt') << "Notice file"
+        buildFile << """
+            plugins {
+                id 'elasticsearch.esplugin'
+                id 'elasticsearch.publish'
+            }
+            
+            esplugin {
+                name = 'hello-world-plugin'
+                classname 'org.acme.HelloWorldPlugin'
+                description = "custom project description"
+            }
+//            
+//              // this is currently required to have validation passed
+//              // In our elasticsearch build this is currently setup in the 
+//              // root build.gradle file.
+//              plugins.withType(MavenPublishPlugin) {
+//                publishing {
+//                  publications {
+//                    // add license information to generated poms
+//                    all {
+//                      pom.withXml { XmlProvider xml ->
+//                        Node node = xml.asNode()
+//                        node.appendNode('inceptionYear', '2009')
+//            
+//                        Node license = node.appendNode('licenses').appendNode('license')
+//                        license.appendNode('name', "The Apache Software License, Version 2.0")
+//                        license.appendNode('url', "http://www.apache.org/licenses/LICENSE-2.0.txt")
+//                        license.appendNode('distribution', 'repo')
+//            
+//                        Node developer = node.appendNode('developers').appendNode('developer')
+//                        developer.appendNode('name', 'Elastic')
+//                        developer.appendNode('url', 'https://www.elastic.co')
+//                      }
+//                    }
+//                  }
+//                }
+//              }
+            
+            // requires elasticsearch artifact available
+            tasks.named('bundlePlugin').configure { enabled = false }
+            licenseFile = file('license.txt')
+            noticeFile = file('notice.txt')
+            version = "1.0"
+            group = 'org.acme'        
+        """
+
+        when:
+        def result = gradleRunner('generatePom').build()
+
+        then:
+        result.task(":generatePom").outcome == TaskOutcome.SUCCESS
+        def generatedPomFile = file("build/distributions/hello-world-plugin-1.0.pom")
+        generatedPomFile.exists()
+        assertXmlEquals(generatedPomFile.text, """
+            <project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+              <!-- This module was also published with a richer model, Gradle metadata,  -->
+              <!-- which should be used instead. Do not delete the following line which  -->
+              <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
+              <!-- that they should prefer consuming it instead. -->
+              <!-- do_not_remove: published-with-gradle-metadata -->
+              <modelVersion>4.0.0</modelVersion>
+              <groupId>org.acme</groupId>
+              <artifactId>hello-world-plugin</artifactId>
+              <version>1.0</version>
+              <name>hello-world</name>
+              <description>custom project description</description>
+            </project>"""
+        )
+    }
+
+    def "generated pom can be tweaked and validated"() {
+        given:
+        // scm info only added for internal builds
+        internalBuild()
+        buildFile << """
+            BuildParams.init { it.setGitOrigin("https://some-repo.com/repo.git") }
+
+            apply plugin:'elasticsearch.java'
+            apply plugin:'elasticsearch.publish'
+
+            version = "1.0"
+            group = 'org.acme'        
+            description = "just a test project"
+            // this is currently required to have validation passed
+            // In our elasticsearch build this is currently setup in the 
+            // root build.gradle file.
+            plugins.withType(MavenPublishPlugin) {
+                publishing {
+                    publications {
+                        // add license information to generated poms
+                        all {
+                            pom.withXml { XmlProvider xml ->
+                                Node node = xml.asNode()
+                                node.appendNode('inceptionYear', '2009')
+                
+                                Node license = node.appendNode('licenses').appendNode('license')
+                                license.appendNode('name', "The Apache Software License, Version 2.0")
+                                license.appendNode('url', "http://www.apache.org/licenses/LICENSE-2.0.txt")
+                                license.appendNode('distribution', 'repo')
+              
+                                Node developer = node.appendNode('developers').appendNode('developer')
+                                developer.appendNode('name', 'Elastic')
+                                developer.appendNode('url', 'https://www.elastic.co')
+                            }
+                        }
+                    }
+                }
+            }
+        """
+
+        when:
+        def result = gradleRunner('generatePom', 'validateNebulaPom').build()
+
+        then:
+        result.task(":generatePom").outcome == TaskOutcome.SUCCESS
+        def generatedPomFile = file("build/distributions/hello-world-1.0.pom")
+        println generatedPomFile.text
+        generatedPomFile.exists()
+        assertXmlEquals(generatedPomFile.text, """
+            <project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+              <modelVersion>4.0.0</modelVersion>
+              <groupId>org.acme</groupId>
+              <artifactId>hello-world</artifactId>
+              <version>1.0</version>
+              <name>hello-world</name>
+              <description>just a test project</description>
+              <url>https://some-repo.com/repo.git</url>
+              <scm>
+                <url>https://some-repo.com/repo.git</url>
+              </scm>
+              <inceptionYear>2009</inceptionYear>
+              <licenses>
+                <license>
+                  <name>The Apache Software License, Version 2.0</name>
+                  <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+                  <distribution>repo</distribution>
+                </license>
+              </licenses>
+              <developers>
+                <developer>
+                  <name>Elastic</name>
+                  <url>https://www.elastic.co</url>
+                </developer>
+              </developers>
+            </project>"""
+        )
+    }
+
+    private boolean assertXmlEquals(String toTest, String expected) {
+        def diff = DiffBuilder.compare(Input.fromString(expected))
+                .ignoreWhitespace()
+                .ignoreComments()
+                .normalizeWhitespace()
+                .withTest(Input.fromString(toTest))
+                .build()
+        diff.differences.each { difference ->
+            println difference
+        }
+        assert diff.hasDifferences() == false
+        true
+    }
+}

--- a/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/PublishPluginFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/PublishPluginFuncTest.groovy
@@ -48,7 +48,9 @@ class PublishPluginFuncTest extends AbstractGradleFuncTest {
         def generatedPomFile = file("build/distributions/hello-world-1.0.pom")
         generatedPomFile.exists()
         assertXmlEquals(generatedPomFile.text, """
-            <project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <project xmlns="http://maven.apache.org/POM/4.0.0" 
+                     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" 
+                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
               <modelVersion>4.0.0</modelVersion>
               <groupId>org.acme</groupId>
               <artifactId>hello-world</artifactId>
@@ -93,7 +95,9 @@ class PublishPluginFuncTest extends AbstractGradleFuncTest {
         def generatedPomFile = file("build/distributions/hello-world-plugin-1.0.pom")
         generatedPomFile.exists()
         assertXmlEquals(generatedPomFile.text, """
-            <project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <project xmlns="http://maven.apache.org/POM/4.0.0" 
+                     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" 
+                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
               <modelVersion>4.0.0</modelVersion>
               <groupId>org.acme</groupId>
               <artifactId>hello-world-plugin</artifactId>
@@ -120,33 +124,7 @@ class PublishPluginFuncTest extends AbstractGradleFuncTest {
                 classname 'org.acme.HelloWorldPlugin'
                 description = "custom project description"
             }
-//            
-//              // this is currently required to have validation passed
-//              // In our elasticsearch build this is currently setup in the 
-//              // root build.gradle file.
-//              plugins.withType(MavenPublishPlugin) {
-//                publishing {
-//                  publications {
-//                    // add license information to generated poms
-//                    all {
-//                      pom.withXml { XmlProvider xml ->
-//                        Node node = xml.asNode()
-//                        node.appendNode('inceptionYear', '2009')
-//            
-//                        Node license = node.appendNode('licenses').appendNode('license')
-//                        license.appendNode('name', "The Apache Software License, Version 2.0")
-//                        license.appendNode('url', "http://www.apache.org/licenses/LICENSE-2.0.txt")
-//                        license.appendNode('distribution', 'repo')
-//            
-//                        Node developer = node.appendNode('developers').appendNode('developer')
-//                        developer.appendNode('name', 'Elastic')
-//                        developer.appendNode('url', 'https://www.elastic.co')
-//                      }
-//                    }
-//                  }
-//                }
-//              }
-            
+           
             // requires elasticsearch artifact available
             tasks.named('bundlePlugin').configure { enabled = false }
             licenseFile = file('license.txt')
@@ -163,12 +141,9 @@ class PublishPluginFuncTest extends AbstractGradleFuncTest {
         def generatedPomFile = file("build/distributions/hello-world-plugin-1.0.pom")
         generatedPomFile.exists()
         assertXmlEquals(generatedPomFile.text, """
-            <project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-              <!-- This module was also published with a richer model, Gradle metadata,  -->
-              <!-- which should be used instead. Do not delete the following line which  -->
-              <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
-              <!-- that they should prefer consuming it instead. -->
-              <!-- do_not_remove: published-with-gradle-metadata -->
+            <project xmlns="http://maven.apache.org/POM/4.0.0" 
+                     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" 
+                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
               <modelVersion>4.0.0</modelVersion>
               <groupId>org.acme</groupId>
               <artifactId>hello-world-plugin</artifactId>
@@ -228,7 +203,9 @@ class PublishPluginFuncTest extends AbstractGradleFuncTest {
         println generatedPomFile.text
         generatedPomFile.exists()
         assertXmlEquals(generatedPomFile.text, """
-            <project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <project xmlns="http://maven.apache.org/POM/4.0.0" 
+                     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" 
+                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
               <modelVersion>4.0.0</modelVersion>
               <groupId>org.acme</groupId>
               <artifactId>hello-world</artifactId>

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/PublishPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/PublishPlugin.java
@@ -59,17 +59,17 @@ public class PublishPlugin implements Plugin<Project> {
         TaskProvider<Task> generatePomTask = project.getTasks().register("generatePom");
         project.getTasks().named(LifecycleBasePlugin.ASSEMBLE_TASK_NAME).configure(assemble -> assemble.dependsOn(generatePomTask));
         project.getTasks()
-                .withType(GenerateMavenPom.class)
-                .configureEach(
-                        pomTask -> pomTask.setDestination(
-                                (Callable<String>) () -> String.format(
-                                        "%s/distributions/%s-%s.pom",
-                                        project.getBuildDir(),
-                                        getArchivesBaseName(project),
-                                        project.getVersion()
-                                )
-                        )
-                );
+            .withType(GenerateMavenPom.class)
+            .configureEach(
+                pomTask -> pomTask.setDestination(
+                    (Callable<String>) () -> String.format(
+                        "%s/distributions/%s-%s.pom",
+                        project.getBuildDir(),
+                        getArchivesBaseName(project),
+                        project.getVersion()
+                    )
+                )
+            );
         PublishingExtension publishing = project.getExtensions().getByType(PublishingExtension.class);
         final var mavenPublications = publishing.getPublications().withType(MavenPublication.class);
         addNameAndDescriptiontoPom(project, mavenPublications);
@@ -80,9 +80,7 @@ public class PublishPlugin implements Plugin<Project> {
             BuildParams.withInternalBuild(() -> publication.getPom().withXml(PublishPlugin::addScmInfo));
             // have to defer this until archivesBaseName is set
             project.afterEvaluate(p -> publication.setArtifactId(getArchivesBaseName(project)));
-            generatePomTask.configure(
-                    t -> t.dependsOn(String.format("generatePomFileFor%sPublication", Util.capitalize(publication.getName())))
-            );
+            generatePomTask.configure(t -> t.dependsOn(project.getTasks().withType(GenerateMavenPom.class)));
         });
     }
 


### PR DESCRIPTION
This PR fixes a couple of issues we have seen after updating the nebula publish plugin:
- Remove nebula related properties added to pom file
- Fix description field generation
- Remove dependency on a few nebula publish plugins and inline logic to our own
plugin
- Fixes also eagerly created tasks by the nebula-shadow-publish plugin we have removed
- Also introduces functional tests to verify generated pom files