### PR TITLE
[Painless] Augmentation.join can't handle empty strings at the start (backport of #68251)

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/api/Augmentation.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/api/Augmentation.java
@@ -170,8 +170,11 @@ public class Augmentation {
      */
     public static <T> String join(Iterable<T> receiver, String separator) {
         StringBuilder sb = new StringBuilder();
+        boolean firstToken = true;
         for (T t : receiver) {
-            if (sb.length() > 0) {
+            if (firstToken) {
+                firstToken=false;
+            } else {
                 sb.append(separator);
             }
             sb.append(t);

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/AugmentationTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/AugmentationTests.java
@@ -114,6 +114,8 @@ public class AugmentationTests extends ScriptTestCase {
     public void testIterable_Join() {
         assertEquals("test,ing",
                 exec("List l = new ArrayList(); l.add('test'); l.add('ing'); l.join(',')"));
+        assertEquals(";empty;start;;test",
+                exec("List l = new ArrayList(); l.add(''); l.add('empty'); l.add('start'); l.add(''); l.add('test'); l.join(';')"));
     }
 
     public void testIterable_Sum() {


### PR DESCRIPTION
Fixes #33434

