### PR TITLE
[DOCS] Updating ILM phase language

### DIFF
--- a/docs/reference/ilm/update-lifecycle-policy.asciidoc
+++ b/docs/reference/ilm/update-lifecycle-policy.asciidoc
@@ -7,11 +7,13 @@
 ++++
 
 You can change how the lifecycle of an index or collection of rolling indices is managed
-by modifying the current policy or switching to a different policy. 
+by modifying the current policy or switching to a different policy.
 
-To ensure that policy updates don't put an index into a state where it can't exit the current phase,
-the phase definition is cached in the index metadata when it enters the phase. 
-This cached definition is used to complete the phase. 
+To ensure that policy updates don't put an index into a state where it can't
+exit the current phase, the phase definition is cached in the index metadata
+when it enters the phase. If changes can be safely applied, {ilm-init} updates
+the cached phase definition. If they cannot, phase execution continues using
+the cached definition.
 
 When the index advances to the next phase, it uses the phase definition from the updated policy.
 
@@ -26,9 +28,9 @@ is using an earlier version that needs to be updated.
 Changes to `min_age` are not propagated to the cached definition.
 Changing a phase's `min_age` does not affect indices that are currently executing that phase.
 
-For example, if you create a policy that has a hot phase that does not specify a `min_age`, 
-indices immediately enter the hot phase when the policy is applied. 
-If you then update the policy to specify a `min_age` of 1 day for the hot phase, 
+For example, if you create a policy that has a hot phase that does not specify a `min_age`,
+indices immediately enter the hot phase when the policy is applied.
+If you then update the policy to specify a `min_age` of 1 day for the hot phase,
 that has no effect on indices that are already in the hot phase.
 Indices created _after_ the policy update won't enter the hot phase until they are a day old.
 
@@ -36,6 +38,6 @@ Indices created _after_ the policy update won't enter the hot phase until they a
 [[ilm-apply-new-policy]]
 === How new policies are applied
 
-When you apply a different policy to a managed index, 
-the index completes the current phase using the cached definition from the previous policy. 
+When you apply a different policy to a managed index,
+the index completes the current phase using the cached definition from the previous policy.
 The index starts using the new policy when it moves to the next phase.


### PR DESCRIPTION
Updates the language regarding ILM phasing to be consistent with the explanation found in the [phase execution](https://www.elastic.co/guide/en/elasticsearch/reference/7.10/ilm-index-lifecycle.html#ilm-phase-execution) page.

Closes [#3846](https://github.com/elastic/sdh-elasticsearch/issues/3846)