### PR TITLE
Slightly speed up scripts

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/lookup/LeafStoredFieldsLookup.java
+++ b/server/src/main/java/org/elasticsearch/search/lookup/LeafStoredFieldsLookup.java
@@ -137,6 +137,14 @@ public class LeafStoredFieldsLookup implements Map<Object, Object> {
     }
 
     private void clearCache() {
+        if (cachedFieldData.isEmpty()) {
+            /*
+             * This code is in the hot path for things like ScoreScript and
+             * runtime fields but the map is almost always empty. So we
+             * bail early then instead of building the entrySet.
+             */
+            return;
+        }
         for (Entry<String, FieldLookup> entry : cachedFieldData.entrySet()) {
             entry.getValue().clear();
         }


### PR DESCRIPTION
This saves a couple of nanoseconds on ever invocation of a painless
script that uses `SearchLookup`. Which is most of the scripts in the hot
path. This amounts to a 3.5% performance savings for things like script
scoring and runtime fields. We got this by speeding up a method that the
async profiler reported as taking 20% of the time running a script score
with painless. This drops it to 1%. You'd think that'd result in a 19%
speed up. But no such luck.
