### PR TITLE
Add force merge disclaimer to tuning guide

### DIFF
--- a/docs/reference/how-to/disk-usage.asciidoc
+++ b/docs/reference/how-to/disk-usage.asciidoc
@@ -149,6 +149,14 @@ Indices in Elasticsearch are stored in one or more shards. Each shard is a Lucen
 
 The <<indices-forcemerge,`_forcemerge` API>> can be used to reduce the number of segments per shard. In many cases, the number of segments can be reduced to one per shard by setting `max_num_segments=1`.
 
+WARNING: **Force merge should only be called against an index after you have
+finished writing to it.** Force merge can cause very large (>5GB) segments to
+be produced, and if you continue to write to such an index then the automatic
+merge policy will never consider these segments for future merges until they
+mostly consist of deleted documents. This can cause very large segments to
+remain in the index which can result in increased disk usage and worse search
+performance.
+
 [discrete]
 === Shrink Index
 

--- a/docs/reference/how-to/disk-usage.asciidoc
+++ b/docs/reference/how-to/disk-usage.asciidoc
@@ -149,13 +149,7 @@ Indices in Elasticsearch are stored in one or more shards. Each shard is a Lucen
 
 The <<indices-forcemerge,`_forcemerge` API>> can be used to reduce the number of segments per shard. In many cases, the number of segments can be reduced to one per shard by setting `max_num_segments=1`.
 
-WARNING: **Force merge should only be called against an index after you have
-finished writing to it.** Force merge can cause very large (>5GB) segments to
-be produced, and if you continue to write to such an index then the automatic
-merge policy will never consider these segments for future merges until they
-mostly consist of deleted documents. This can cause very large segments to
-remain in the index which can result in increased disk usage and worse search
-performance.
+include::{es-repo-dir}/indices/forcemerge.asciidoc[tag=force-merge-read-only-warn]
 
 [discrete]
 === Shrink Index

--- a/docs/reference/indices/forcemerge.asciidoc
+++ b/docs/reference/indices/forcemerge.asciidoc
@@ -38,6 +38,7 @@ shard by merging some of them together, and also frees up the space used by
 deleted documents. Merging normally happens automatically, but sometimes it is
 useful to trigger a merge manually.
 
+// tag::force-merge-read-only-warn[]
 WARNING: **Force merge should only be called against an index after you have
 finished writing to it.** Force merge can cause very large (>5GB) segments to
 be produced, and if you continue to write to such an index then the automatic
@@ -45,6 +46,7 @@ merge policy will never consider these segments for future merges until they
 mostly consist of deleted documents. This can cause very large segments to
 remain in the index which can result in increased disk usage and worse search
 performance.
+// end::force-merge-read-only-warn[]
 
 
 [[forcemerge-blocks]]


### PR DESCRIPTION
Adding same warning from our [force merge documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-forcemerge.html#forcemerge-api-desc) to this tuning guide.  Please backport to all relevant branches :)