### PR TITLE
[7.x] [DOCS] Add security privileges to search API docs (#68009)

### DIFF
--- a/docs/reference/search/count.asciidoc
+++ b/docs/reference/search/count.asciidoc
@@ -21,6 +21,13 @@ the <<search-search,search API>> works.
 
 `GET /<target>/_count`
 
+[[search-count-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `read`
+<<privileges-list-indices,index privilege>> for the target data stream, index,
+or index alias.
+
 
 [[search-count-api-desc]]
 ==== {api-description-title}

--- a/docs/reference/search/explain.asciidoc
+++ b/docs/reference/search/explain.asciidoc
@@ -26,6 +26,12 @@ GET /my-index-000001/_explain/0
 
 `POST /<index>/_explain/<id>`
 
+[[search-explain-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `read`
+<<privileges-list-indices,index privilege>> for the target index.
+
 [[search-explain-api-desc]]
 ==== {api-description-title}
 

--- a/docs/reference/search/field-caps.asciidoc
+++ b/docs/reference/search/field-caps.asciidoc
@@ -26,6 +26,12 @@ GET /_field_caps?fields=rating
 
 `POST /<target>/_field_caps?fields=<fields>`
 
+[[search-field-caps-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the
+`view_index_metadata`, `read`, or `manage` <<privileges-list-indices,index
+privilege>> for the target data stream, index, or index alias.
 
 [[search-field-caps-api-desc]]
 ==== {api-description-title}

--- a/docs/reference/search/multi-search.asciidoc
+++ b/docs/reference/search/multi-search.asciidoc
@@ -21,6 +21,12 @@ GET my-index-000001/_msearch
 
 `GET /<target>/_msearch`
 
+[[search-multi-search-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `read`
+<<privileges-list-indices,index privilege>> for the target data stream, index,
+or index alias. For cross-cluster search, see <<cross-cluster-configuring>>.
 
 [[search-multi-search-api-desc]]
 ==== {api-description-title}

--- a/docs/reference/search/point-in-time-api.asciidoc
+++ b/docs/reference/search/point-in-time-api.asciidoc
@@ -14,6 +14,16 @@ the same point in time. For example, if <<indices-refresh,refreshes>> happen bet
 search_after requests, then the results of those requests might not be consistent as
 changes happening between searches are only visible to the more recent point in time.
 
+[[point-in-time-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `read`
+<<privileges-list-indices,index privilege>> for the target data stream, index,
+or index alias.
+
+[[point-in-time-api-example]]
+==== {api-examples-title}
+
 A point in time must be opened explicitly before being used in search requests. The
 keep_alive parameter tells Elasticsearch how long it should keep a point in time alive,
 e.g. `?keep_alive=5m`.

--- a/docs/reference/search/rank-eval.asciidoc
+++ b/docs/reference/search/rank-eval.asciidoc
@@ -14,6 +14,12 @@ typical search queries.
 
 `POST /<target>/_rank_eval`
 
+[[search-rank-eval-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `read`
+<<privileges-list-indices,index privilege>> for the target data stream, index,
+or index alias.
 
 [[search-rank-eval-api-desc]]
 ==== {api-description-title}

--- a/docs/reference/search/scroll-api.asciidoc
+++ b/docs/reference/search/scroll-api.asciidoc
@@ -48,6 +48,13 @@ deprecated:[7.0.0]
 
 `POST /_search/scroll`
 
+[[scroll-api-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `read`
+<<privileges-list-indices,index privilege>> for the target data stream, index,
+or index alias.
+
 [[scroll-api-desc]]
 ==== {api-description-title}
 

--- a/docs/reference/search/search-shards.asciidoc
+++ b/docs/reference/search/search-shards.asciidoc
@@ -16,8 +16,14 @@ GET /my-index-000001/_search_shards
 [[search-shards-api-request]]
 ==== {api-request-title}
 
-`GET /<index>/_search_shards`
+`GET /<target>/_search_shards`
 
+[[search-shards-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the
+`view_index_metadata` or `manage` <<privileges-list-indices,index privilege>>
+for the target data stream, index, or index alias.
 
 [[search-shards-api-desc]]
 ==== {api-description-title}
@@ -31,7 +37,13 @@ are used, the filter is returned as part of the `indices` section.
 [[search-shards-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index]
+`<target>`::
+(Optional, string)
+Comma-separated list of data streams, indices, and index aliases to search.
+Wildcard (`*`) expressions are supported.
++
+To search all data streams and indices in a cluster, omit this parameter or use
+`_all` or `*`.
 
 
 [[search-shards-api-query-params]]

--- a/docs/reference/search/search-template.asciidoc
+++ b/docs/reference/search/search-template.asciidoc
@@ -25,6 +25,12 @@ GET _search/template
 
 `GET _search/template`
 
+[[search-template-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `read`
+<<privileges-list-indices,index privilege>> for the target data stream, index,
+or index alias. For cross-cluster search, see <<cross-cluster-configuring>>.
 
 [[search-template-api-desc]]
 ==== {api-description-title}
@@ -653,6 +659,12 @@ Allows to execute several search template requests.
 
 `GET _msearch/template`
 
+[[multi-search-template-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `read`
+<<privileges-list-indices,index privilege>> for the target data stream, index,
+or index alias. For cross-cluster search, see <<cross-cluster-configuring>>.
 
 [[multi-search-template-api-desc]]
 ==== {api-description-title}

--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -23,6 +23,13 @@ GET /my-index-000001/_search
 
 `POST /_search`
 
+[[search-search-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `read`
+<<privileges-list-indices,index privilege>> for the target data stream, index,
+or index alias. For cross-cluster search, see <<cross-cluster-configuring>>.
+
 [[search-search-api-desc]]
 ==== {api-description-title}
 

--- a/docs/reference/search/validate.asciidoc
+++ b/docs/reference/search/validate.asciidoc
@@ -18,6 +18,12 @@ GET my-index-000001/_validate/query?q=user.id:kimchy
 
 `GET /<target>/_validate/<query>`
 
+[[search-validate-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `read`
+<<privileges-list-indices,index privilege>> for the target data stream, index,
+or index alias.
 
 [[search-validate-api-desc]]
 ==== {api-description-title}


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Add security privileges to search API docs (#68009)