### PR TITLE
Make RollupAction a master-node-action (#68420)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackClientPlugin.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackClientPlugin.java
@@ -108,6 +108,7 @@ import org.elasticsearch.xpack.core.ml.action.DeleteTrainedModelAction;
 import org.elasticsearch.xpack.core.ml.action.EvaluateDataFrameAction;
 import org.elasticsearch.xpack.core.ml.action.ExplainDataFrameAnalyticsAction;
 import org.elasticsearch.xpack.core.ml.action.FinalizeJobExecutionAction;
+import org.elasticsearch.xpack.core.rollup.action.RollupIndexerAction;
 import org.elasticsearch.xpack.core.textstructure.action.FindStructureAction;
 import org.elasticsearch.xpack.core.ml.action.FlushJobAction;
 import org.elasticsearch.xpack.core.ml.action.ForecastJobAction;
@@ -515,6 +516,7 @@ public class XPackClientPlugin extends Plugin implements ActionPlugin, NetworkPl
 
         // rollupV2
         if (RollupV2.isEnabled()) {
+            actions.add(RollupIndexerAction.INSTANCE);
             actions.add(RollupAction.INSTANCE);
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/RollupAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/RollupAction.java
@@ -10,17 +10,15 @@ package org.elasticsearch.xpack.core.rollup.action;
 import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
-import org.elasticsearch.action.support.broadcast.BroadcastRequest;
-import org.elasticsearch.action.support.broadcast.BroadcastResponse;
-import org.elasticsearch.action.support.broadcast.BroadcastShardRequest;
-import org.elasticsearch.action.support.broadcast.BroadcastShardResponse;
+import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.action.support.master.MasterNodeRequest;
 import org.elasticsearch.client.ElasticsearchClient;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.xpack.core.rollup.RollupActionConfig;
@@ -29,15 +27,15 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
 
-public class RollupAction extends ActionType<RollupAction.Response> {
+public class RollupAction extends ActionType<AcknowledgedResponse> {
     public static final RollupAction INSTANCE = new RollupAction();
     public static final String NAME = "indices:admin/xpack/rollup";
 
     private RollupAction() {
-        super(NAME, RollupAction.Response::new);
+        super(NAME, AcknowledgedResponse::readFrom);
     }
 
-    public static class Request extends BroadcastRequest<Request> implements ToXContentObject {
+    public static class Request extends MasterNodeRequest<Request> implements IndicesRequest, ToXContentObject {
         private String sourceIndex;
         private String rollupIndex;
         private RollupActionConfig rollupConfig;
@@ -61,6 +59,11 @@ public class RollupAction extends ActionType<RollupAction.Response> {
         @Override
         public String[] indices() {
             return new String[] { sourceIndex };
+        }
+
+        @Override
+        public IndicesOptions indicesOptions() {
+            return IndicesOptions.STRICT_SINGLE_INDEX_NO_EXPAND_FORBID_CLOSED;
         }
 
         @Override
@@ -123,91 +126,10 @@ public class RollupAction extends ActionType<RollupAction.Response> {
         }
     }
 
-    public static class RequestBuilder extends ActionRequestBuilder<Request, Response> {
+    public static class RequestBuilder extends ActionRequestBuilder<Request, AcknowledgedResponse> {
 
         protected RequestBuilder(ElasticsearchClient client, RollupAction action) {
             super(client, action, new Request());
-        }
-    }
-
-    public static class Response extends BroadcastResponse implements Writeable, ToXContentObject {
-        private final boolean created;
-
-        public Response(boolean created) {
-            this.created = created;
-        }
-
-        public Response(StreamInput in) throws IOException {
-            super(in);
-            created = in.readBoolean();
-        }
-
-        @Override
-        public void writeTo(StreamOutput out) throws IOException {
-            out.writeBoolean(created);
-        }
-
-        public boolean isCreated() {
-            return created;
-        }
-
-        @Override
-        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-            builder.startObject();
-            builder.field("created", created);
-            builder.endObject();
-            return builder;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            Response response = (Response) o;
-            return created == response.created;
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(created);
-        }
-    }
-
-    public static class ShardRequest extends BroadcastShardRequest {
-        private final Request request;
-
-        public ShardRequest(StreamInput in) throws IOException {
-            super(in);
-            this.request = new Request(in);
-        }
-
-        public ShardRequest(ShardId shardId, Request request) {
-            super(shardId, request);
-            this.request = request;
-        }
-
-        public String getRollupIndex() {
-            return request.getRollupIndex();
-        }
-
-        public RollupActionConfig getRollupConfig() {
-            return request.getRollupConfig();
-        }
-
-        @Override
-        public void writeTo(StreamOutput out) throws IOException {
-            super.writeTo(out);
-            request.writeTo(out);
-        }
-    }
-
-    public static class ShardResponse extends BroadcastShardResponse {
-        public ShardResponse(StreamInput in) throws IOException {
-            super(in);
-        }
-
-        public ShardResponse(ShardId shardId) {
-            super(shardId);
         }
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/RollupIndexerAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/RollupIndexerAction.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.core.rollup.action;
+
+
+import org.elasticsearch.action.ActionRequestBuilder;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.action.support.broadcast.BroadcastRequest;
+import org.elasticsearch.action.support.broadcast.BroadcastResponse;
+import org.elasticsearch.action.support.broadcast.BroadcastShardRequest;
+import org.elasticsearch.action.support.broadcast.BroadcastShardResponse;
+import org.elasticsearch.client.ElasticsearchClient;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskId;
+import org.elasticsearch.xpack.core.rollup.RollupActionConfig;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+
+public class RollupIndexerAction extends ActionType<RollupIndexerAction.Response> {
+    public static final RollupIndexerAction INSTANCE = new RollupIndexerAction();
+    public static final String NAME = "indices:admin/xpack/rollup_indexer";
+
+    private RollupIndexerAction() {
+        super(NAME, RollupIndexerAction.Response::new);
+    }
+
+    public static class Request extends BroadcastRequest<Request> implements IndicesRequest, ToXContentObject {
+        private RollupAction.Request rollupRequest;
+
+        public Request(RollupAction.Request rollupRequest) {
+            this.rollupRequest = rollupRequest;
+        }
+
+        public Request() {
+        }
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            this.rollupRequest = new RollupAction.Request(in);
+        }
+
+        @Override
+        public String[] indices() {
+            return rollupRequest.indices();
+        }
+
+        @Override
+        public IndicesOptions indicesOptions() {
+            return rollupRequest.indicesOptions();
+        }
+
+        public RollupAction.Request getRollupRequest() {
+            return rollupRequest;
+        }
+
+        @Override
+        public Task createTask(long id, String type, String action, TaskId parentTaskId, Map<String, String> headers) {
+            return new RollupTask(id, type, action, parentTaskId, rollupRequest.getRollupIndex(), rollupRequest.getRollupConfig(), headers);
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            rollupRequest.writeTo(out);
+        }
+
+        @Override
+        public ActionRequestValidationException validate() {
+            return null;
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            builder.field("rollup_request", rollupRequest);
+            builder.endObject();
+            return builder;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(rollupRequest);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            Request other = (Request) obj;
+            return Objects.equals(rollupRequest, other.rollupRequest);
+        }
+    }
+
+    public static class RequestBuilder extends ActionRequestBuilder<Request, Response> {
+
+        protected RequestBuilder(ElasticsearchClient client, RollupIndexerAction action) {
+            super(client, action, new Request());
+        }
+    }
+
+    public static class Response extends BroadcastResponse implements Writeable, ToXContentObject {
+        private final boolean created;
+
+        public Response(boolean created) {
+            this.created = created;
+        }
+
+        public Response(StreamInput in) throws IOException {
+            super(in);
+            created = in.readBoolean();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeBoolean(created);
+        }
+
+        public boolean isCreated() {
+            return created;
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            builder.field("created", created);
+            builder.endObject();
+            return builder;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Response response = (Response) o;
+            return created == response.created;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(created);
+        }
+    }
+
+    public static class ShardRequest extends BroadcastShardRequest {
+        private final Request request;
+
+        public ShardRequest(StreamInput in) throws IOException {
+            super(in);
+            this.request = new Request(in);
+        }
+
+        public ShardRequest(ShardId shardId, Request request) {
+            super(shardId, request);
+            this.request = request;
+        }
+
+        public String getRollupIndex() {
+            return request.getRollupRequest().getRollupIndex();
+        }
+
+        public RollupActionConfig getRollupConfig() {
+            return request.getRollupRequest().getRollupConfig();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            request.writeTo(out);
+        }
+    }
+
+    public static class ShardResponse extends BroadcastShardResponse {
+        public ShardResponse(StreamInput in) throws IOException {
+            super(in);
+        }
+
+        public ShardResponse(ShardId shardId) {
+            super(shardId);
+        }
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/RollupStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/RollupStepTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.core.ilm;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.DataStream;
@@ -141,9 +142,9 @@ public class RollupStepTests extends AbstractStepTestCase<RollupStep> {
         Mockito.doAnswer(invocation -> {
             RollupAction.Request request = (RollupAction.Request) invocation.getArguments()[1];
             @SuppressWarnings("unchecked")
-            ActionListener<RollupAction.Response> listener = (ActionListener<RollupAction.Response>) invocation.getArguments()[2];
+            ActionListener<AcknowledgedResponse> listener = (ActionListener<AcknowledgedResponse>) invocation.getArguments()[2];
             assertRollupActionRequest(request, sourceIndex);
-            listener.onResponse(new RollupAction.Response(true));
+            listener.onResponse(AcknowledgedResponse.of(true));
             return null;
         }).when(client).execute(Mockito.any(), Mockito.any(), Mockito.any());
     }

--- a/x-pack/plugin/rollup/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/rollup/10_basic.yml
+++ b/x-pack/plugin/rollup/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/rollup/10_basic.yml
@@ -73,7 +73,7 @@ setup:
               }
             ]
           }
-  - is_true: created
+  - is_true: acknowledged
 
   - do:
       indices.forcemerge:

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/Rollup.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/Rollup.java
@@ -44,6 +44,7 @@ import org.elasticsearch.xpack.core.rollup.action.GetRollupCapsAction;
 import org.elasticsearch.xpack.core.rollup.action.GetRollupIndexCapsAction;
 import org.elasticsearch.xpack.core.rollup.action.GetRollupJobsAction;
 import org.elasticsearch.xpack.core.rollup.action.PutRollupJobAction;
+import org.elasticsearch.xpack.core.rollup.action.RollupIndexerAction;
 import org.elasticsearch.xpack.core.rollup.action.RollupSearchAction;
 import org.elasticsearch.xpack.core.rollup.action.StartRollupJobAction;
 import org.elasticsearch.xpack.core.rollup.action.StopRollupJobAction;
@@ -68,6 +69,7 @@ import org.elasticsearch.xpack.rollup.rest.RestStartRollupJobAction;
 import org.elasticsearch.xpack.rollup.rest.RestStopRollupJobAction;
 import org.elasticsearch.xpack.rollup.v2.RestRollupAction;
 import org.elasticsearch.xpack.rollup.v2.TransportRollupAction;
+import org.elasticsearch.xpack.rollup.v2.TransportRollupIndexerAction;
 
 import java.time.Clock;
 import java.util.ArrayList;
@@ -160,6 +162,7 @@ public class Rollup extends Plugin implements ActionPlugin, PersistentTaskPlugin
         ));
 
         if (RollupV2.isEnabled()) {
+            actions.add(new ActionHandler<>(RollupIndexerAction.INSTANCE, TransportRollupIndexerAction.class));
             actions.add(new ActionHandler<>(RollupAction.INSTANCE, TransportRollupAction.class));
         }
 

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/v2/TransportRollupAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/v2/TransportRollupAction.java
@@ -9,14 +9,13 @@ package org.elasticsearch.xpack.rollup.v2;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
-import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest;
 import org.elasticsearch.action.admin.indices.shrink.ResizeRequest;
 import org.elasticsearch.action.admin.indices.shrink.ResizeType;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.broadcast.TransportBroadcastAction;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.action.support.master.AcknowledgedTransportMasterNodeAction;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.OriginSettingClient;
 import org.elasticsearch.cluster.ClusterState;
@@ -30,27 +29,21 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.RollupGroup;
 import org.elasticsearch.cluster.metadata.RollupMetadata;
-import org.elasticsearch.cluster.routing.GroupShardsIterator;
-import org.elasticsearch.cluster.routing.ShardIterator;
-import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.time.WriteableZoneId;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.Index;
-import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
-import org.elasticsearch.indices.IndicesService;
-import org.elasticsearch.tasks.Task;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.rollup.RollupActionConfig;
 import org.elasticsearch.xpack.core.rollup.RollupActionGroupConfig;
+import org.elasticsearch.xpack.core.rollup.action.RollupIndexerAction;
 import org.elasticsearch.xpack.core.rollup.job.HistogramGroupConfig;
 import org.elasticsearch.xpack.core.rollup.job.MetricConfig;
 import org.elasticsearch.xpack.core.rollup.RollupActionDateHistogramGroupConfig;
@@ -58,146 +51,93 @@ import org.elasticsearch.xpack.core.rollup.action.RollupAction;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicReferenceArray;
-
-import static org.elasticsearch.xpack.rollup.Rollup.TASK_THREAD_POOL_NAME;
 
 /**
- * A {@link TransportBroadcastAction} that rollups all the shards of a single index into a new one.
- *
- * TODO: Enforce that rollup-indices of indices backing a datastream must be hidden.
- *       Enforce that we don't retry on another replica if we throw an error after sending some buckets.
+ * The master rollup action that coordinates
+ *  -  creating rollup temporary index
+ *  -  calling {@link TransportRollupIndexerAction} to index rolluped up documents
+ *  -  cleaning up state
  */
-public class TransportRollupAction
-    extends TransportBroadcastAction<RollupAction.Request, RollupAction.Response, RollupAction.ShardRequest, RollupAction.ShardResponse> {
-
-    private static final int SORTER_RAM_SIZE_MB = 100;
+public class TransportRollupAction extends AcknowledgedTransportMasterNodeAction<RollupAction.Request> {
 
     private final Client client;
     private final ClusterService clusterService;
-    private final IndicesService indicesService;
 
     @Inject
     public TransportRollupAction(Client client,
                                  ClusterService clusterService,
                                  TransportService transportService,
-                                 IndicesService indicesService,
+                                 ThreadPool threadPool,
                                  ActionFilters actionFilters,
                                  IndexNameExpressionResolver indexNameExpressionResolver) {
-        super(RollupAction.NAME, clusterService, transportService, actionFilters,
-            indexNameExpressionResolver, RollupAction.Request::new, RollupAction.ShardRequest::new, TASK_THREAD_POOL_NAME);
+        super(RollupAction.NAME, transportService, clusterService, threadPool, actionFilters, RollupAction.Request::new,
+            indexNameExpressionResolver, ThreadPool.Names.SAME);
         this.client = new OriginSettingClient(client, ClientHelper.ROLLUP_ORIGIN);
         this.clusterService = clusterService;
-        this.indicesService = indicesService;
     }
 
     @Override
-    protected GroupShardsIterator<ShardIterator> shards(ClusterState clusterState, RollupAction.Request request, String[] concreteIndices) {
-        if (concreteIndices.length > 1) {
-            throw new IllegalArgumentException("multiple indices: " + Arrays.toString(concreteIndices));
-        }
-        // Random routing to limit request to a single shard
-        String routing = Integer.toString(Randomness.get().nextInt(1000));
-        Map<String, Set<String>> routingMap = indexNameExpressionResolver.resolveSearchRouting(clusterState, routing, request.indices());
-        return clusterService.operationRouting().searchShards(clusterState, concreteIndices, routingMap, null);
-    }
+    protected void masterOperation(RollupAction.Request request, ClusterState state, ActionListener<AcknowledgedResponse> listener)
+            throws Exception {
+        String originalIndexName = request.getSourceIndex();
+        String tmpIndexName = ".rolluptmp-" + request.getRollupIndex();
 
-    @Override
-    protected ClusterBlockException checkGlobalBlock(ClusterState state, RollupAction.Request request) {
-        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
-    }
-
-    @Override
-    protected ClusterBlockException checkRequestBlock(ClusterState state, RollupAction.Request request, String[] concreteIndices) {
-        return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_WRITE, concreteIndices);
-    }
-
-    @Override
-    protected void doExecute(Task task, RollupAction.Request request, ActionListener<RollupAction.Response> listener) {
+        final XContentBuilder mapping;
         try {
-            String tmpIndexName =  ".rolluptmp-" + request.getRollupIndex();
-            createTempRollupIndex(request, tmpIndexName,
-                ActionListener.wrap(
-                    resp -> {
-                        new Async(task, request, listener).start();
-                    },
-                    listener::onFailure
-                )
-            );
-        } catch (IOException exc) {
-            // here because the mapping could not be parsed. temp index was not created.
-            listener.onFailure(exc);
-        }
-    }
-
-    @Override
-    protected RollupAction.ShardRequest newShardRequest(int numShards, ShardRouting shard, RollupAction.Request request) {
-        return new RollupAction.ShardRequest(shard.shardId(), request);
-    }
-
-    @Override
-    protected RollupAction.ShardResponse shardOperation(RollupAction.ShardRequest request, Task task) throws IOException {
-        IndexService indexService = indicesService.indexService(request.shardId().getIndex());
-        String tmpIndexName =  ".rolluptmp-" + request.getRollupIndex();
-        RollupShardIndexer indexer = new RollupShardIndexer(client, indexService, request.shardId(),
-            request.getRollupConfig(), tmpIndexName, SORTER_RAM_SIZE_MB);
-        indexer.execute();
-        return new RollupAction.ShardResponse(request.shardId());
-    }
-
-    @Override
-    protected RollupAction.ShardResponse readShardResponse(StreamInput in) throws IOException {
-        return new RollupAction.ShardResponse(in);
-    }
-
-    @Override
-    protected RollupAction.Response newResponse(RollupAction.Request request,
-                                                AtomicReferenceArray<?> shardsResponses,
-                                                ClusterState clusterState) {
-        for (int i = 0; i < shardsResponses.length(); i++) {
-            Object shardResponse = shardsResponses.get(i);
-            if (shardResponse == null) {
-                throw new ElasticsearchException("missing shard");
-            } else if (shardResponse instanceof Exception) {
-                throw new ElasticsearchException((Exception) shardResponse);
-            }
-        }
-        return new RollupAction.Response(true);
-    }
-
-    private class Async extends AsyncBroadcastAction {
-        private final RollupAction.Request request;
-        private final ActionListener<RollupAction.Response> listener;
-
-        protected Async(Task task, RollupAction.Request request, ActionListener<RollupAction.Response> listener) {
-            super(task, request, listener);
-            this.request = request;
-            this.listener = listener;
+            mapping = getMapping(request.getRollupConfig());
+        } catch (IOException e) {
+            listener.onFailure(e);
+            return;
         }
 
-        @Override
-        protected void finishHim() {
-            try {
-                RollupAction.Response resp = newResponse(request, shardsResponses, clusterService.state());
-                shrinkAndPublishIndex(request, ActionListener.wrap(v -> listener.onResponse(resp), listener::onFailure));
-            } catch (Exception e) {
-                deleteTmpIndex(".rolluptmp-" + request.getRollupIndex(), ActionListener.wrap(() -> listener.onFailure(e)));
-            }
-        }
-    }
-
-    private void createTempRollupIndex(RollupAction.Request request,
-                                       String tmpIndex,
-                                       ActionListener<CreateIndexResponse> listener) throws IOException {
-        CreateIndexRequest req = new CreateIndexRequest(tmpIndex, Settings.builder()
+        CreateIndexRequest req = new CreateIndexRequest(tmpIndexName, Settings.builder()
             .put(IndexMetadata.SETTING_INDEX_HIDDEN, true).build())
-            .mapping("_doc", getMapping(request.getRollupConfig()));
-        client.admin().indices().create(req, listener);
+            .mapping("_doc", mapping);
+        RollupIndexerAction.Request rollupIndexerRequest = new RollupIndexerAction.Request(request);
+        ResizeRequest resizeRequest = new ResizeRequest(request.getRollupIndex(), tmpIndexName);
+        resizeRequest.setResizeType(ResizeType.CLONE);
+        resizeRequest.getTargetIndexRequest()
+            .settings(Settings.builder().put(IndexMetadata.SETTING_INDEX_HIDDEN, false).build());
+        UpdateSettingsRequest updateSettingsReq = new UpdateSettingsRequest(
+            Settings.builder().put(IndexMetadata.SETTING_BLOCKS_WRITE, true).build(), tmpIndexName);
+
+        // 1. create hidden temporary index
+        // 2. run rollup indexer
+        // 3. make temp index read-only
+        // 4. shrink index
+        // 5. delete temporary index
+        // at any point if there is an issue, then cleanup temp index
+        client.admin().indices().create(req, ActionListener.wrap(createIndexResponse ->
+            client.execute(RollupIndexerAction.INSTANCE, rollupIndexerRequest, ActionListener.wrap(indexerResp -> {
+                if (indexerResp.isCreated()) {
+                    client.admin().indices().updateSettings(updateSettingsReq, ActionListener.wrap(updateSettingsResponse -> {
+                        if (updateSettingsResponse.isAcknowledged()) {
+                            client.admin().indices().resizeIndex(resizeRequest, ActionListener.wrap(resizeResponse -> {
+                                if (resizeResponse.isAcknowledged()) {
+                                    publishMetadata(request, originalIndexName, tmpIndexName, listener);
+                                } else {
+                                    deleteTmpIndex(originalIndexName, tmpIndexName, listener,
+                                        new ElasticsearchException("Unable to resize temp rollup index [" + tmpIndexName + "]"));
+                                }
+                            }, e -> deleteTmpIndex(originalIndexName, tmpIndexName, listener, e)));
+                        } else {
+                            deleteTmpIndex(originalIndexName, tmpIndexName, listener,
+                                new ElasticsearchException("Unable to update settings of temp rollup index [" + tmpIndexName + "]"));
+                        }
+                    }, e -> deleteTmpIndex(originalIndexName, tmpIndexName, listener, e)));
+                } else {
+                    deleteTmpIndex(originalIndexName, tmpIndexName, listener,
+                        new ElasticsearchException("Unable to index into temp rollup index [" + tmpIndexName + "]"));
+                }
+            }, e -> deleteTmpIndex(originalIndexName, tmpIndexName, listener, e))), listener::onFailure));
+    }
+
+    @Override
+    protected ClusterBlockException checkBlock(RollupAction.Request request, ClusterState state) {
+        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
     }
 
     private XContentBuilder getMapping(RollupActionConfig config) throws IOException {
@@ -256,37 +196,18 @@ public class TransportRollupAction
         return builder.endObject();
     }
 
-    private void shrinkAndPublishIndex(RollupAction.Request request, ActionListener<RollupAction.Response> listener) {
-        String tmpIndexName = ".rolluptmp-" + request.getRollupIndex();
-        ResizeRequest resizeRequest = new ResizeRequest(request.getRollupIndex(), tmpIndexName);
-        resizeRequest.setResizeType(ResizeType.CLONE);
-        resizeRequest.getTargetIndexRequest()
-            .settings(Settings.builder().put(IndexMetadata.SETTING_INDEX_HIDDEN, false).build());
-        UpdateSettingsRequest updateSettingsReq = new UpdateSettingsRequest(
-            Settings.builder().put(IndexMetadata.SETTING_BLOCKS_WRITE, true).build(), tmpIndexName);
-        client.admin().indices().updateSettings(updateSettingsReq,
-            ActionListener.wrap(
-                resp -> {
-                    client.admin().indices().resizeIndex(resizeRequest,
-                        ActionListener.wrap(ack -> publishMetadata(request, listener), listener::onFailure));
-                },
-                listener::onFailure
-            )
-        );
-    }
-
-    private void publishMetadata(RollupAction.Request request, ActionListener<RollupAction.Response> listener) {
+    private void publishMetadata(RollupAction.Request request, String originalIndexName, String tmpIndexName,
+                                 ActionListener<AcknowledgedResponse> listener) {
         // update Rollup metadata to include this index
         clusterService.submitStateUpdateTask("update-rollup-metadata", new ClusterStateUpdateTask() {
             @Override
             public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
                 // Everything went well, time to delete the temporary index
-                deleteTmpIndex(".rolluptmp-" + request.getRollupIndex(),
-                    ActionListener.wrap(r -> listener.onResponse(new RollupAction.Response(true)), listener::onFailure));
+                deleteTmpIndex(originalIndexName, tmpIndexName, listener, null);
             }
 
             @Override
-            public ClusterState execute(ClusterState currentState) throws Exception {
+            public ClusterState execute(ClusterState currentState) {
                 String rollupIndexName = request.getRollupIndex();
                 IndexMetadata rollupIndexMetadata = currentState.getMetadata().index(rollupIndexName);
                 Index rollupIndex = rollupIndexMetadata.getIndex();
@@ -337,15 +258,27 @@ public class TransportRollupAction
 
             @Override
             public void onFailure(String source, Exception e) {
-                // Everything went well, time to delete the temporary index
-                deleteTmpIndex(".rolluptmp-" + request.getRollupIndex(),
-                    ActionListener.wrap(() -> listener.onFailure(
-                        new ElasticsearchException("failed to publish new cluster state with rollup metadata", e))));
+                deleteTmpIndex(originalIndexName, tmpIndexName,
+                    listener, new ElasticsearchException("failed to publish new cluster state with rollup metadata", e));
             }
         });
     }
 
-    private void deleteTmpIndex(String tmpIndex, ActionListener<AcknowledgedResponse> listener) {
-        client.admin().indices().delete(new DeleteIndexRequest(tmpIndex), listener);
+    private void deleteTmpIndex(String originalIndex, String tmpIndex, ActionListener<AcknowledgedResponse> listener, Exception e) {
+        client.admin().indices().delete(new DeleteIndexRequest(tmpIndex), new ActionListener<AcknowledgedResponse>() {
+            @Override
+            public void onResponse(AcknowledgedResponse acknowledgedResponse) {
+                if (e == null && acknowledgedResponse.isAcknowledged()) {
+                    listener.onResponse(acknowledgedResponse);
+                } else {
+                    listener.onFailure(new ElasticsearchException("Unable to rollup index [" + originalIndex + "]", e));
+                }
+            }
+
+            @Override
+            public void onFailure(Exception deleteException) {
+                listener.onFailure(new ElasticsearchException("Unable to delete temp rollup index [" + tmpIndex  + "]", e));
+            }
+        });
     }
 }

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/v2/TransportRollupIndexerAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/v2/TransportRollupIndexerAction.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.rollup.v2;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.broadcast.TransportBroadcastAction;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.client.OriginSettingClient;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.block.ClusterBlockException;
+import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.routing.GroupShardsIterator;
+import org.elasticsearch.cluster.routing.ShardIterator;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Randomness;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.index.IndexService;
+import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.ClientHelper;
+import org.elasticsearch.xpack.core.rollup.action.RollupIndexerAction;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+
+import static org.elasticsearch.xpack.rollup.Rollup.TASK_THREAD_POOL_NAME;
+
+/**
+ * A {@link TransportBroadcastAction} that rollups all the shards of a single index into a new one.
+ *
+ * TODO: Enforce that we don't retry on another replica if we throw an error after sending some buckets.
+ */
+public class TransportRollupIndexerAction
+    extends TransportBroadcastAction<RollupIndexerAction.Request, RollupIndexerAction.Response,
+    RollupIndexerAction.ShardRequest, RollupIndexerAction.ShardResponse> {
+
+    private static final int SORTER_RAM_SIZE_MB = 100;
+
+    private final Client client;
+    private final ClusterService clusterService;
+    private final IndicesService indicesService;
+
+    @Inject
+    public TransportRollupIndexerAction(Client client,
+                                        ClusterService clusterService,
+                                        TransportService transportService,
+                                        IndicesService indicesService,
+                                        ActionFilters actionFilters,
+                                        IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(RollupIndexerAction.NAME, clusterService, transportService, actionFilters,
+            indexNameExpressionResolver, RollupIndexerAction.Request::new, RollupIndexerAction.ShardRequest::new,
+            TASK_THREAD_POOL_NAME);
+        this.client = new OriginSettingClient(client, ClientHelper.ROLLUP_ORIGIN);
+        this.clusterService = clusterService;
+        this.indicesService = indicesService;
+    }
+
+    @Override
+    protected GroupShardsIterator<ShardIterator> shards(ClusterState clusterState,
+                                                        RollupIndexerAction.Request request,
+                                                        String[] concreteIndices) {
+        if (concreteIndices.length > 1) {
+            throw new IllegalArgumentException("multiple indices: " + Arrays.toString(concreteIndices));
+        }
+        // Random routing to limit request to a single shard
+        String routing = Integer.toString(Randomness.get().nextInt(1000));
+        Map<String, Set<String>> routingMap = indexNameExpressionResolver.resolveSearchRouting(clusterState, routing, request.indices());
+        return clusterService.operationRouting().searchShards(clusterState, concreteIndices, routingMap, null);
+    }
+
+    @Override
+    protected ClusterBlockException checkGlobalBlock(ClusterState state, RollupIndexerAction.Request request) {
+        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
+    }
+
+    @Override
+    protected ClusterBlockException checkRequestBlock(ClusterState state, RollupIndexerAction.Request request,
+                                                      String[] concreteIndices) {
+        return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_WRITE, concreteIndices);
+    }
+
+    @Override
+    protected void doExecute(Task task, RollupIndexerAction.Request request, ActionListener<RollupIndexerAction.Response> listener) {
+        new Async(task, request, listener).start();
+    }
+
+    @Override
+    protected RollupIndexerAction.ShardRequest newShardRequest(int numShards, ShardRouting shard,
+                                                               RollupIndexerAction.Request request) {
+        return new RollupIndexerAction.ShardRequest(shard.shardId(), request);
+    }
+
+    @Override
+    protected RollupIndexerAction.ShardResponse shardOperation(RollupIndexerAction.ShardRequest request, Task task) throws IOException {
+        IndexService indexService = indicesService.indexService(request.shardId().getIndex());
+        String tmpIndexName =  ".rolluptmp-" + request.getRollupIndex();
+        RollupShardIndexer indexer = new RollupShardIndexer(client, indexService, request.shardId(),
+            request.getRollupConfig(), tmpIndexName, SORTER_RAM_SIZE_MB);
+        indexer.execute();
+        return new RollupIndexerAction.ShardResponse(request.shardId());
+    }
+
+    @Override
+    protected RollupIndexerAction.ShardResponse readShardResponse(StreamInput in) throws IOException {
+        return new RollupIndexerAction.ShardResponse(in);
+    }
+
+    @Override
+    protected RollupIndexerAction.Response newResponse(RollupIndexerAction.Request request,
+                                                AtomicReferenceArray<?> shardsResponses,
+                                                ClusterState clusterState) {
+        for (int i = 0; i < shardsResponses.length(); i++) {
+            Object shardResponse = shardsResponses.get(i);
+            if (shardResponse == null) {
+                throw new ElasticsearchException("missing shard");
+            } else if (shardResponse instanceof Exception) {
+                throw new ElasticsearchException((Exception) shardResponse);
+            }
+        }
+        return new RollupIndexerAction.Response(true);
+    }
+
+    private class Async extends AsyncBroadcastAction {
+        private final RollupIndexerAction.Request request;
+        private final ActionListener<RollupIndexerAction.Response> listener;
+
+        protected Async(Task task, RollupIndexerAction.Request request, ActionListener<RollupIndexerAction.Response> listener) {
+            super(task, request, listener);
+            this.request = request;
+            this.listener = listener;
+        }
+
+        @Override
+        protected void finishHim() {
+            try {
+                RollupIndexerAction.Response resp = newResponse(request, shardsResponses, clusterService.state());
+                listener.onResponse(resp);
+            } catch (Exception e) {
+                listener.onFailure(e);
+            }
+        }
+    }
+}

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/v2/RollupActionSingleNodeTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/v2/RollupActionSingleNodeTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -102,8 +103,8 @@ public class RollupActionSingleNodeTests extends ESSingleNodeTestCase {
         bulkIndex(sourceSupplier);
         rollup(config);
         assertRollupIndex(config);
-        ResourceAlreadyExistsException exception = expectThrows(ResourceAlreadyExistsException.class, () -> rollup(config));
-        assertThat(exception.getMessage(), containsString(rollupIndex));
+        ElasticsearchException exception = expectThrows(ElasticsearchException.class, () -> rollup(config));
+        assertThat(exception.getMessage(), containsString("Unable to rollup index [" + index + "]"));
     }
 
     public void testTemporaryIndexDeletedOnRollupFailure() throws Exception {
@@ -260,9 +261,9 @@ public class RollupActionSingleNodeTests extends ESSingleNodeTestCase {
     }
 
     private void rollup(RollupActionConfig config) {
-        RollupAction.Response rollupResponse = client().execute(RollupAction.INSTANCE,
+        AcknowledgedResponse rollupResponse = client().execute(RollupAction.INSTANCE,
             new RollupAction.Request(index, rollupIndex, config)).actionGet();
-        assertTrue(rollupResponse.isCreated());
+        assertTrue(rollupResponse.isAcknowledged());
     }
 
     private void assertRollupIndex(RollupActionConfig config) {

--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
@@ -321,6 +321,7 @@ public class Constants {
         "indices:admin/xpack/ccr/put_follow",
         "indices:admin/xpack/ccr/unfollow",
         "indices:admin/xpack/rollup",
+        "indices:admin/xpack/rollup_indexer",
         "indices:data/read/async_search/delete",
         "indices:data/read/async_search/get",
         "indices:data/read/async_search/submit",


### PR DESCRIPTION
this commit moves most of the coordination of setting up a rollup index
to the master node RollupAction. The indexing and broadcast action,
RollupIndexerAction, was created and split out as its own action to handle
indexing into the rollup index.

backport or #68420.