### PR TITLE
Painless: improve error message on non-constant

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DefaultConstantFoldingOptimizationPhase.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DefaultConstantFoldingOptimizationPhase.java
@@ -841,12 +841,17 @@ public class DefaultConstantFoldingOptimizationPhase extends IRTreeBaseVisitor<C
         Object[] args = new Object[irInvokeCallMemberNode.getArgumentNodes().size()];
         for (int i = 0; i < irInvokeCallMemberNode.getArgumentNodes().size(); i++) {
             ExpressionNode argNode = irInvokeCallMemberNode.getArgumentNodes().get(i);
-            if (argNode instanceof ConstantNode == false) {
+            IRDConstant constantDecoration = argNode.getDecoration(IRDConstant.class);
+            if (constantDecoration == null) {
                 // TODO find a better string to output
                 throw irInvokeCallMemberNode.getLocation()
-                    .createError(new IllegalArgumentException("all arguments must be constant but the [" + (i + 1) + "] argument isn't"));
+                    .createError(
+                        new IllegalArgumentException(
+                            "all arguments to [" + javaMethod.getName() + "] must be constant but the [" + (i + 1) + "] argument isn't"
+                        )
+                    );
             }
-            args[i] = ((ConstantNode) argNode).getDecorationValue(IRDConstant.class);
+            args[i] = constantDecoration.getValue();
         }
         Object result;
         try {

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/BindingsTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/BindingsTests.java
@@ -211,7 +211,7 @@ public class BindingsTests extends ScriptTestCase {
             IllegalArgumentException.class,
             () -> scriptEngine.compile(null, "def a = 2; classMul(2, a)", BindingsTestScript.CONTEXT, Collections.emptyMap())
         );
-        assertThat(e.getMessage(), equalTo("all arguments must be constant but the [2] argument isn't"));
+        assertThat(e.getMessage(), equalTo("all arguments to [classMul] must be constant but the [2] argument isn't"));
     }
 
     public void testClassMethodCompileTimeOnlyThrows() {
@@ -240,7 +240,7 @@ public class BindingsTests extends ScriptTestCase {
             IllegalArgumentException.class,
             () -> scriptEngine.compile(null, "def a = 2; instanceMul(a, 2)", BindingsTestScript.CONTEXT, Collections.emptyMap())
         );
-        assertThat(e.getMessage(), equalTo("all arguments must be constant but the [1] argument isn't"));
+        assertThat(e.getMessage(), equalTo("all arguments to [instanceMul] must be constant but the [1] argument isn't"));
     }
 
     public void testCompileTimeOnlyParameterFoldedToConstant() {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/250_grok.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/250_grok.yml
@@ -80,7 +80,7 @@ fetch:
 ---
 mutable pattern:
   - do:
-      catch: /all arguments must be constant but the \[1\] argument isn't/
+      catch: /all arguments to \[grok\] must be constant but the \[1\] argument isn't/
       search:
         index: http_logs
         body:


### PR DESCRIPTION
As of #68088 painless can have methods where all parameters must be
constant. This improves the error message when the parameter isn't. It's
still not super great, but its better and its what we can easily give
at that point in the compiler.
