### PR TITLE
[DOCS] Fix rollup V2 security docs

### DIFF
--- a/docs/reference/rollup/apis/rollup-api.asciidoc
+++ b/docs/reference/rollup/apis/rollup-api.asciidoc
@@ -51,13 +51,13 @@ POST /my-index-000001/_rollup/rollup-my-index-000001
 [[rollup-api-prereqs]]
 ==== {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have the `manage_rollup`
-or `manage` <<privileges-list-cluster,cluster privilege>> to use this API.
-
 * You can only roll up an index that contains:
 
 ** A <<date,`date`>> or <<date_nanos,`date_nanos`>> timestamp field
 ** One or more <<number,numeric>> fields
+
+* If the {es} {security-features} are enabled, you must have the `manage`
+<<privileges-list-indices,index privilege>> for the index you roll up.
 
 [[rollup-api-path-params]]
 ==== {api-path-parms-title}

--- a/x-pack/docs/en/security/authorization/privileges.asciidoc
+++ b/x-pack/docs/en/security/authorization/privileges.asciidoc
@@ -94,8 +94,9 @@ All operations on ingest pipelines.
 ifdef::permanently-unreleased-branch[]
 
 `manage_rollup`::
-All rollup operations. Includes legacy rollup operations, such as creating,
-starting, stopping and deleting rollup jobs.
+All <<legacy-rollup-apis,legacy rollup>> operations, such as creating, starting,
+stopping and deleting rollup jobs. This privilege is not required to use the
+{ilm-init} <<ilm-rollup,`rollup`>> action or <<rollup-api,rollup API>>.
 
 endif::[]
 ifndef::permanently-unreleased-branch[]

--- a/x-pack/docs/en/security/authorization/privileges.asciidoc
+++ b/x-pack/docs/en/security/authorization/privileges.asciidoc
@@ -95,7 +95,7 @@ ifdef::permanently-unreleased-branch[]
 
 `manage_rollup`::
 All <<legacy-rollup-apis,legacy rollup>> operations, such as creating, starting,
-stopping and deleting rollup jobs. This privilege is not required to use the
+stopping, and deleting rollup jobs. This privilege is not required to use the
 {ilm-init} <<ilm-rollup,`rollup`>> action or <<rollup-api,rollup API>>.
 
 endif::[]


### PR DESCRIPTION
The ILM `rollup` action and rollup API no longer require the `manage_rollup` cluster privilege.