### PR TITLE
[Transform] Take runtime mappings into account when deducing dest index mappings

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/transform/preview_transforms.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/transform/preview_transforms.yml
@@ -390,8 +390,8 @@ setup:
   - match: { generated_dest_index.mappings.properties.airline.type: "keyword" }
   - match: { generated_dest_index.mappings.properties.by-hour.type: "date" }
   - match: { generated_dest_index.mappings.properties.avg_response.type: "double" }
-  - is_false: generated_dest_index.mappings.properties.time\.max.type
-  - is_false: generated_dest_index.mappings.properties.time\.min.type
+  - match: { generated_dest_index.mappings.properties.time\.max.type: "date" }
+  - match: { generated_dest_index.mappings.properties.time\.min.type: "date" }
 
 ---
 "Test preview transform latest with search runtime fields":

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/Pivot.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/Pivot.java
@@ -87,7 +87,7 @@ public class Pivot extends AbstractCompositeAggFunction {
 
     @Override
     public void deduceMappings(Client client, SourceConfig sourceConfig, final ActionListener<Map<String, String>> listener) {
-        SchemaUtil.deduceMappings(client, config, sourceConfig.getIndex(), listener);
+        SchemaUtil.deduceMappings(client, config, sourceConfig.getIndex(), sourceConfig.getRuntimeMappings(), listener);
     }
 
     /**

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationSchemaAndResultTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationSchemaAndResultTests.java
@@ -40,6 +40,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
+import static java.util.Collections.emptyMap;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -89,7 +90,7 @@ public class AggregationSchemaAndResultTests extends ESTestCase {
                         field,
                         Collections.singletonMap(
                             type,
-                            new FieldCapabilities(field, type, true, true, null, null, null, Collections.emptyMap())
+                            new FieldCapabilities(field, type, true, true, null, null, null, emptyMap())
                         )
                     );
                 }
@@ -125,7 +126,7 @@ public class AggregationSchemaAndResultTests extends ESTestCase {
         // scripted metric produces no output because its dynamic
         aggs.addAggregator(AggregationBuilders.scriptedMetric("collapsed_ratings"));
 
-        AggregationConfig aggregationConfig = new AggregationConfig(Collections.emptyMap(), aggs);
+        AggregationConfig aggregationConfig = new AggregationConfig(emptyMap(), aggs);
         GroupConfig groupConfig = GroupConfigTests.randomGroupConfig();
         PivotConfig pivotConfig = new PivotConfig(groupConfig, aggregationConfig, null);
         long numGroupsWithoutScripts = groupConfig.getGroups()
@@ -135,7 +136,7 @@ public class AggregationSchemaAndResultTests extends ESTestCase {
             .count();
 
         this.<Map<String, String>>assertAsync(
-            listener -> SchemaUtil.deduceMappings(client, pivotConfig, new String[] { "source-index" }, listener),
+            listener -> SchemaUtil.deduceMappings(client, pivotConfig, new String[] { "source-index" }, emptyMap(), listener),
             mappings -> {
                 assertEquals(numGroupsWithoutScripts + 10, mappings.size());
                 assertEquals("long", mappings.get("max_rating"));
@@ -192,7 +193,7 @@ public class AggregationSchemaAndResultTests extends ESTestCase {
                 )
         );
 
-        AggregationConfig aggregationConfig = new AggregationConfig(Collections.emptyMap(), aggs);
+        AggregationConfig aggregationConfig = new AggregationConfig(emptyMap(), aggs);
         GroupConfig groupConfig = GroupConfigTests.randomGroupConfig();
         PivotConfig pivotConfig = new PivotConfig(groupConfig, aggregationConfig, null);
         long numGroupsWithoutScripts = groupConfig.getGroups()
@@ -202,7 +203,7 @@ public class AggregationSchemaAndResultTests extends ESTestCase {
             .count();
 
         this.<Map<String, String>>assertAsync(
-            listener -> SchemaUtil.deduceMappings(client, pivotConfig, new String[] { "source-index" }, listener),
+            listener -> SchemaUtil.deduceMappings(client, pivotConfig, new String[] { "source-index" }, emptyMap(), listener),
             mappings -> {
                 assertEquals(numGroupsWithoutScripts + 12, mappings.size());
                 assertEquals("long", mappings.get("filter_1"));

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/SchemaUtilTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/SchemaUtilTests.java
@@ -29,7 +29,13 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
 import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.is;
 
 public class SchemaUtilTests extends ESTestCase {
 
@@ -92,7 +98,7 @@ public class SchemaUtilTests extends ESTestCase {
         try (Client client = new FieldCapsMockClient(getTestName())) {
             // fields is null
             this.<Map<String, String>>assertAsync(
-                listener -> SchemaUtil.getSourceFieldMappings(client, new String[] { "index-1", "index-2" }, null, listener),
+                listener -> SchemaUtil.getSourceFieldMappings(client, new String[] { "index-1", "index-2" }, null, emptyMap(), listener),
                 mappings -> {
                     assertNotNull(mappings);
                     assertTrue(mappings.isEmpty());
@@ -101,7 +107,8 @@ public class SchemaUtilTests extends ESTestCase {
 
             // fields is empty
             this.<Map<String, String>>assertAsync(
-                listener -> SchemaUtil.getSourceFieldMappings(client, new String[] { "index-1", "index-2" }, new String[] {}, listener),
+                listener ->
+                    SchemaUtil.getSourceFieldMappings(client, new String[] { "index-1", "index-2" }, new String[] {}, emptyMap(), listener),
                 mappings -> {
                     assertNotNull(mappings);
                     assertTrue(mappings.isEmpty());
@@ -110,7 +117,7 @@ public class SchemaUtilTests extends ESTestCase {
 
             // indices is null
             this.<Map<String, String>>assertAsync(
-                listener -> SchemaUtil.getSourceFieldMappings(client, null, new String[] { "field-1", "field-2" }, listener),
+                listener -> SchemaUtil.getSourceFieldMappings(client, null, new String[] { "field-1", "field-2" }, emptyMap(), listener),
                 mappings -> {
                     assertNotNull(mappings);
                     assertTrue(mappings.isEmpty());
@@ -119,7 +126,8 @@ public class SchemaUtilTests extends ESTestCase {
 
             // indices is empty
             this.<Map<String, String>>assertAsync(
-                listener -> SchemaUtil.getSourceFieldMappings(client, new String[] {}, new String[] { "field-1", "field-2" }, listener),
+                listener ->
+                    SchemaUtil.getSourceFieldMappings(client, new String[] {}, new String[] { "field-1", "field-2" }, emptyMap(), listener),
                 mappings -> {
                     assertNotNull(mappings);
                     assertTrue(mappings.isEmpty());
@@ -132,6 +140,7 @@ public class SchemaUtilTests extends ESTestCase {
                     client,
                     new String[] { "index-1", "index-2" },
                     new String[] { "field-1", "field-2" },
+                    emptyMap(),
                     listener
                 ),
                 mappings -> {
@@ -139,6 +148,30 @@ public class SchemaUtilTests extends ESTestCase {
                     assertEquals(2, mappings.size());
                     assertEquals("long", mappings.get("field-1"));
                     assertEquals("long", mappings.get("field-2"));
+                }
+            );
+        }
+    }
+
+    public void testGetSourceFieldMappingsWithRuntimeMappings() throws InterruptedException {
+        Map<String, Object> runtimeMappings = new HashMap<>() {{
+            put("field-2", singletonMap("type", "keyword"));
+            put("field-3", singletonMap("type", "boolean"));
+        }};
+        try (Client client = new FieldCapsMockClient(getTestName())) {
+            this.<Map<String, String>>assertAsync(
+                listener -> SchemaUtil.getSourceFieldMappings(
+                    client,
+                    new String[] { "index-1", "index-2" },
+                    new String[] { "field-1", "field-2" },
+                    runtimeMappings,
+                    listener
+                ),
+                mappings -> {
+                    assertThat(mappings, is(aMapWithSize(3)));
+                    assertThat(
+                        mappings,
+                        allOf(hasEntry("field-1", "long"), hasEntry("field-2", "keyword"), hasEntry("field-3", "boolean")));
                 }
             );
         }
@@ -160,7 +193,7 @@ public class SchemaUtilTests extends ESTestCase {
                 FieldCapabilitiesRequest fieldCapsRequest = (FieldCapabilitiesRequest) request;
                 Map<String, Map<String, FieldCapabilities>> responseMap = new HashMap<>();
                 for (String field : fieldCapsRequest.fields()) {
-                    responseMap.put(field, Collections.singletonMap(field, createFieldCapabilities(field, "long")));
+                    responseMap.put(field, singletonMap(field, createFieldCapabilities(field, "long")));
                 }
 
                 final FieldCapabilitiesResponse response = new FieldCapabilitiesResponse(fieldCapsRequest.indices(), responseMap);


### PR DESCRIPTION
This PR makes the runtime mappings (provided via Transform config) effective when determining destination index mappings.

Labeling this as `>non-issue` as this PR fixes an unreleased feature (i.e. search runtime fields).

Relates https://github.com/elastic/elasticsearch/issues/68516