### PR TITLE
Filter out older versions when running bwc tests on aarch64

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/BwcVersions.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/BwcVersions.java
@@ -7,8 +7,6 @@
  */
 package org.elasticsearch.gradle;
 
-import org.jetbrains.annotations.NotNull;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -334,6 +332,7 @@ public class BwcVersions {
             groupByMajor.get(currentVersion.getMajor() - 1).stream(),
             groupByMajor.get(currentVersion.getMajor()).stream()
         ).collect(Collectors.toList());
+
         return Architecture.current() == Architecture.AARCH64
             ? unmodifiableList(filterAarch64SupportedVersions(collect))
             : unmodifiableList(collect);
@@ -354,7 +353,6 @@ public class BwcVersions {
             : unmodifiableList(wireCompat);
     }
 
-    @NotNull
     private List<Version> filterAarch64SupportedVersions(List<Version> wireCompat) {
         return wireCompat.stream().filter(version -> version.onOrAfter("7.12.0")).collect(Collectors.toList());
     }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/BwcVersions.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/BwcVersions.java
@@ -28,15 +28,15 @@ import static java.util.Collections.unmodifiableList;
 
 /**
  * A container for elasticsearch supported version information used in BWC testing.
- *
+ * <p>
  * Parse the Java source file containing the versions declarations and use the known rules to figure out which are all
  * the version the current one is wire and index compatible with.
  * On top of this, figure out which of these are unreleased and provide the branch they can be built from.
- *
+ * <p>
  * Note that in this context, currentVersion is the unreleased version this build operates on.
  * At any point in time there will surely be four such unreleased versions being worked on,
  * thus currentVersion will be one of these.
- *
+ * <p>
  * Considering:
  * <dl>
  *     <dt>M, M &gt; 0</dt>
@@ -56,11 +56,11 @@ import static java.util.Collections.unmodifiableList;
  * <ul>
  * <li>the unreleased <b>staged</b>, M.N-2.0 (N &gt; 2) on the `M.(N-2)` branch</li>
  * </ul>
- *
+ * <p>
  * Each build is only concerned with versions before it, as those are the ones that need to be tested
  * for backwards compatibility. We never look forward, and don't add forward facing version number to branches of previous
  * version.
- *
+ * <p>
  * Each branch has a current version, and expected compatible versions are parsed from the server code's Version` class.
  * We can reliably figure out which the unreleased versions are due to the convention of always adding the next unreleased
  * version number to server in all branches when a version is released.
@@ -162,8 +162,8 @@ public class BwcVersions {
     }
 
     /**
-      * Returns info about the unreleased version, or {@code null} if the version is released.
-      */
+     * Returns info about the unreleased version, or {@code null} if the version is released.
+     */
     public UnreleasedVersionInfo unreleasedInfo(Version version) {
         return unreleased.get(version);
     }
@@ -328,14 +328,11 @@ public class BwcVersions {
     }
 
     public List<Version> getIndexCompatible() {
-        var collect = Stream.concat(
+        var indexCompatibles = Stream.concat(
             groupByMajor.get(currentVersion.getMajor() - 1).stream(),
             groupByMajor.get(currentVersion.getMajor()).stream()
         ).collect(Collectors.toList());
-
-        return Architecture.current() == Architecture.AARCH64
-            ? unmodifiableList(filterAarch64SupportedVersions(collect))
-            : unmodifiableList(collect);
+        return unmodifiableList(filterSupportedVersions(indexCompatibles));
     }
 
     public List<Version> getWireCompatible() {
@@ -348,13 +345,13 @@ public class BwcVersions {
         wireCompat.addAll(groupByMajor.get(currentVersion.getMajor()));
         wireCompat.sort(Version::compareTo);
 
-        return Architecture.current() == Architecture.AARCH64
-            ? unmodifiableList(filterAarch64SupportedVersions(wireCompat))
-            : unmodifiableList(wireCompat);
+        return unmodifiableList(filterSupportedVersions(wireCompat));
     }
 
-    private List<Version> filterAarch64SupportedVersions(List<Version> wireCompat) {
-        return wireCompat.stream().filter(version -> version.onOrAfter("7.12.0")).collect(Collectors.toList());
+    private List<Version> filterSupportedVersions(List<Version> wireCompat) {
+        return Architecture.current() == Architecture.AARCH64
+            ? wireCompat.stream().filter(version -> version.onOrAfter("7.12.0")).collect(Collectors.toList())
+            : wireCompat;
     }
 
     public List<Version> getUnreleasedIndexCompatible() {


### PR DESCRIPTION
Do not run BWC tests for versions < 7.12 on aarch64 as earlier versions are not supported for this architecture.