### PR TITLE
[DOCS] EQL: Add `filter_path` param to EQL search API docs

### DIFF
--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -84,7 +84,7 @@ Defaults to `open`.
 
 `filter_path`::
 (Optional, string)
-Comma-separated list of properties used to filter the API response. See
+Comma-separated list of filters for the API response. See
 <<common-options-response-filtering>>.
 
 `ignore_unavailable`::

--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -82,6 +82,11 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 +
 Defaults to `open`.
 
+`filter_path`::
+(Optional, string)
+Comma-separated list of properties used to filter the API response. See
+<<common-options-response-filtering>>.
+
 `ignore_unavailable`::
 (Optional, Boolean) If `true`, missing or closed indices are not included in the
 response. Defaults to `true`.

--- a/docs/reference/eql/eql.asciidoc
+++ b/docs/reference/eql/eql.asciidoc
@@ -136,6 +136,49 @@ GET /my-index-000001/_eql/search
 ----
 // TEST[setup:sec_logs]
 
+Use the <<common-options-response-filtering,`filter_path`>> query parameter to
+filter the properties returned in the API response. For example, the following
+search returns only the timestamp and PID for each matching event.
+
+[source,console]
+----
+GET /my-index-000001/_eql/search?filter_path=hits.events._source.@timestamp,hits.events._source.process.pid
+{
+  "query": """
+    process where process.name == "regsvr32.exe"
+  """
+}
+----
+// TEST[setup:sec_logs]
+
+The API returns the following response.
+
+[source,console-result]
+----
+{
+  "hits" : {
+    "events" : [
+      {
+        "_source" : {
+          "@timestamp" : "2099-12-07T11:07:09.000Z",
+          "process" : {
+            "pid" : 2012
+          }
+        }
+      },
+      {
+        "_source" : {
+          "@timestamp" : "2099-12-07T11:07:10.000Z",
+          "process" : {
+            "pid" : 2012
+          }
+        }
+      }
+    ]
+  }
+}
+----
+
 [discrete]
 [[eql-search-sequence]]
 === Search for a sequence of events

--- a/docs/reference/eql/eql.asciidoc
+++ b/docs/reference/eql/eql.asciidoc
@@ -137,8 +137,8 @@ GET /my-index-000001/_eql/search
 // TEST[setup:sec_logs]
 
 Use the <<common-options-response-filtering,`filter_path`>> query parameter to
-filter the properties returned in the API response. For example, the following
-search returns only the timestamp and PID for each matching event.
+filter the API response. For example, the following search returns only the
+timestamp and PID for each matching event.
 
 [source,console]
 ----


### PR DESCRIPTION
Adds docs for the `filter_path` parameter to the EQL docs.

While the `filter_path` parameter is already covered in our API conventions docs, [response filtering](https://www.elastic.co/guide/en/elasticsearch/reference/master/common-options.html#common-options-response-filtering) is particularly useful for EQL users. Those users may not be aware of the parameter otherwise.

### Previews
- Run an EQL search: https://elasticsearch_68537.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/eql.html#run-an-eql-search
- EQL search API: https://elasticsearch_68537.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/eql-search-api.html#eql-search-api-query-params