### PR TITLE
Workaround for JDK bug with total mem on Debian8

### DIFF
--- a/server/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
+++ b/server/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
@@ -100,11 +100,16 @@ public class OsProbe {
             return 0;
         }
         try {
-            final long totalMem = (long) getTotalPhysicalMemorySize.invoke(osMxBean);
+            long totalMem = (long) getTotalPhysicalMemorySize.invoke(osMxBean);
             if (totalMem < 0) {
                 logger.debug("OS reported a negative total memory value [{}]", totalMem);
                 return 0;
             }
+            if (totalMem == 0 && isDebian8()) {
+                // workaround for JDK bug on debian8: https://github.com/elastic/elasticsearch/issues/67089#issuecomment-756114654
+                totalMem = getTotalMemFromProcMeminfo();
+            }
+
             return totalMem;
         } catch (Exception e) {
             logger.warn("exception retrieving total physical memory", e);
@@ -639,6 +644,56 @@ public class OsProbe {
         } else {
             return Collections.emptyList();
         }
+    }
+
+    /**
+     * Returns the lines from /proc/meminfo as a workaround for JDK bugs that prevent retrieval of total system memory
+     * on some Linux variants such as Debian8.
+     */
+    @SuppressForbidden(reason = "access /proc/meminfo")
+    List<String> readProcMeminfo() throws IOException {
+        final List<String> lines;
+        if (Files.exists(PathUtils.get("/proc/meminfo"))) {
+            lines = Files.readAllLines(PathUtils.get("/proc/meminfo"));
+            assert lines != null && lines.isEmpty() == false;
+            return lines;
+        } else {
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * Retrieves system total memory in bytes from /proc/meminfo
+     */
+    long getTotalMemFromProcMeminfo() throws IOException {
+        List<String> meminfoLines = readProcMeminfo();
+        final List<String> memTotalLines = meminfoLines.stream().filter(line -> line.startsWith("MemTotal")).collect(Collectors.toList());
+        assert memTotalLines.size() <= 1 : memTotalLines;
+        final Optional<String> maybeMemTotalLine = memTotalLines.size() == 1 ? Optional.of(memTotalLines.get(0)) : Optional.empty();
+        if (maybeMemTotalLine.isPresent()) {
+            final String memTotalLine = maybeMemTotalLine.get();
+            int beginIdx = memTotalLine.indexOf("MemTotal:");
+            int endIdx = memTotalLine.lastIndexOf(" kB");
+            if (beginIdx + 9 < endIdx) {
+                final String memTotalString = memTotalLine.substring(beginIdx + 9, endIdx).trim();
+                try {
+                    long memTotalInKb = Long.parseLong(memTotalString);
+                    return memTotalInKb * 1024;
+                } catch (NumberFormatException e) {
+                    logger.warn("Unable to retrieve total memory from meminfo line [" + memTotalLine + "]");
+                    return 0;
+                }
+            } else {
+                logger.warn("Unable to retrieve total memory from meminfo line [" + memTotalLine + "]");
+                return 0;
+            }
+        } else {
+            return 0;
+        }
+    }
+
+    boolean isDebian8() throws IOException {
+        return Constants.LINUX && getPrettyName().equals("Debian GNU/Linux 8 (jessie)");
     }
 
     public OsStats osStats() {

--- a/server/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
+++ b/server/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
@@ -669,9 +669,8 @@ public class OsProbe {
         List<String> meminfoLines = readProcMeminfo();
         final List<String> memTotalLines = meminfoLines.stream().filter(line -> line.startsWith("MemTotal")).collect(Collectors.toList());
         assert memTotalLines.size() <= 1 : memTotalLines;
-        final Optional<String> maybeMemTotalLine = memTotalLines.size() == 1 ? Optional.of(memTotalLines.get(0)) : Optional.empty();
-        if (maybeMemTotalLine.isPresent()) {
-            final String memTotalLine = maybeMemTotalLine.get();
+        if (memTotalLines.size() == 1) {
+            final String memTotalLine = memTotalLines.get(0);
             int beginIdx = memTotalLine.indexOf("MemTotal:");
             int endIdx = memTotalLine.lastIndexOf(" kB");
             if (beginIdx + 9 < endIdx) {


### PR DESCRIPTION
Reads total system memory from `/proc/meminfo` on Debian8 systems if the JDK reports `0` total memory. See https://github.com/elastic/elasticsearch/issues/66885#issuecomment-757888941 for more background.

Fixes #66629.
