### PR TITLE
Disable BWC tests for backport of rollover-max-single-shard-size

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -169,8 +169,8 @@ tasks.register("verifyVersions") {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = false
-String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/68490" /* place a PR link here when committing bwc changes */
+boolean bwc_tests_enabled = true
+String bwc_tests_disabled_issue = "" /* place a PR link here when committing bwc changes */
 /*
  * FIPS 140-2 behavior was fixed in 7.11.0. Before that there is no way to run elasticsearch in a
  * JVM that is properly configured to be in fips mode with BCFIPS. For now we need to disable
@@ -178,8 +178,8 @@ String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull
  */
 
 if ( BuildParams.inFipsJvm ) {
-  bwc_tests_enabled = true
-  bwc_tests_disabled_issue = ""
+  bwc_tests_enabled = false
+  bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/issues/66772"
 }
 if (bwc_tests_enabled == false) {
   if (bwc_tests_disabled_issue.isEmpty()) {

--- a/build.gradle
+++ b/build.gradle
@@ -169,8 +169,8 @@ tasks.register("verifyVersions") {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = true
-String bwc_tests_disabled_issue = "" /* place a PR link here when committing bwc changes */
+boolean bwc_tests_enabled = false
+String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/68489" /* place a PR link here when committing bwc changes */
 /*
  * FIPS 140-2 behavior was fixed in 7.11.0. Before that there is no way to run elasticsearch in a
  * JVM that is properly configured to be in fips mode with BCFIPS. For now we need to disable


### PR DESCRIPTION
Need to disable BWC so I can merge #68489. Related to #63026, #67842.

Also related to #68528 and #68534 because there was a little bit of mistaken juggling there that (I think) I'm leaving correctly cleaned up.