### PR TITLE
[master] [DOCS] Add missing newline for bulleted list in top_metrics docs (#68481)

### DIFF
--- a/docs/reference/aggregations/metrics/top-metrics-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/top-metrics-aggregation.asciidoc
@@ -53,6 +53,7 @@ faster.
 
 The `sort` field in the metric request functions exactly the same as the `sort` field in the
 <<sort-search-results, search>> request except:
+
 * It can't be used on <<binary,binary>>, <<flattened,flattened>>, <<ip,ip>>,
 <<keyword,keyword>>, or <<text,text>> fields.
 * It only supports a single sort value so which document wins ties is not specified.


### PR DESCRIPTION
Backports the following commits to master:
 - [DOCS] Add missing newline for bulleted list in top_metrics docs (#68481)