### PR TITLE
[6.8] Backport fixes for memory reporting issues

### DIFF
--- a/server/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
+++ b/server/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
@@ -46,8 +46,9 @@ import java.util.stream.Collectors;
  * The {@link OsProbe} class retrieves information about the physical and swap size of the machine
  * memory, as well as the system load average and cpu load.
  *
- * In some exceptional cases, it's possible the underlying native method used by
- * {@link #getFreePhysicalMemorySize()} and {@link #getTotalPhysicalMemorySize()} can return a
+ * In some exceptional cases, it's possible the underlying native methods used by
+ * {@link #getFreePhysicalMemorySize()}, {@link #getTotalPhysicalMemorySize()},
+ * {@link #getFreeSwapSpaceSize()}, and {@link #getTotalSwapSpaceSize()} can return a
  * negative value. Because of this, we prevent those methods from returning negative values,
  * returning 0 instead.
  *
@@ -127,12 +128,19 @@ public class OsProbe {
      */
     public long getFreeSwapSpaceSize() {
         if (getFreeSwapSpaceSize == null) {
-            return -1;
+            logger.warn("getFreeSwapSpaceSize is not available");
+            return 0;
         }
         try {
-            return (long) getFreeSwapSpaceSize.invoke(osMxBean);
+            final long mem = (long) getFreeSwapSpaceSize.invoke(osMxBean);
+            if (mem < 0) {
+                logger.warn("OS reported a negative free swap space size [{}]", mem);
+                return 0;
+            }
+            return mem;
         } catch (Exception e) {
-            return -1;
+            logger.warn("exception retrieving free swap space size", e);
+            return 0;
         }
     }
 
@@ -141,12 +149,19 @@ public class OsProbe {
      */
     public long getTotalSwapSpaceSize() {
         if (getTotalSwapSpaceSize == null) {
-            return -1;
+            logger.warn("getTotalSwapSpaceSize is not available");
+            return 0;
         }
         try {
-            return (long) getTotalSwapSpaceSize.invoke(osMxBean);
+            final long mem = (long) getTotalSwapSpaceSize.invoke(osMxBean);
+            if (mem < 0) {
+                logger.warn("OS reported a negative total swap space size [{}]", mem);
+                return 0;
+            }
+            return mem;
         } catch (Exception e) {
-            return -1;
+            logger.warn("exception retrieving total swap space size", e);
+            return 0;
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/monitor/os/OsStats.java
+++ b/server/src/main/java/org/elasticsearch/monitor/os/OsStats.java
@@ -189,17 +189,23 @@ public class OsStats implements Writeable, ToXContentFragment {
 
     public static class Swap implements Writeable, ToXContentFragment {
 
+        private static final Logger logger = LogManager.getLogger(Swap.class);
+
         private final long total;
         private final long free;
 
         public Swap(long total, long free) {
+            assert total >= 0 : "expected total swap to be positive, got: " + total;
+            assert free >= 0 : "expected free swap to be positive, got: " + total;
             this.total = total;
             this.free = free;
         }
 
         public Swap(StreamInput in) throws IOException {
             this.total = in.readLong();
+            assert total >= 0 : "expected total swap to be positive, got: " + total;
             this.free = in.readLong();
+            assert free >= 0 : "expected free swap to be positive, got: " + total;
         }
 
         @Override
@@ -213,6 +219,17 @@ public class OsStats implements Writeable, ToXContentFragment {
         }
 
         public ByteSizeValue getUsed() {
+            if (total == 0) {
+                // The work in https://github.com/elastic/elasticsearch/pull/42725 established that total memory
+                // can be reported as negative in some cases. Swap can similarly be reported as negative and in
+                // those cases, we force it to zero in which case we can no longer correctly report the used swap
+                // as (total-free) and should report it as zero.
+                //
+                // We intentionally check for (total == 0) rather than (total - free < 0) so as not to hide
+                // cases where (free > total) which would be a different bug.
+                logger.warn("cannot compute used swap when total swap is 0 and free swap is " + free);
+                return new ByteSizeValue(0);
+            }
             return new ByteSizeValue(total - free);
         }
 

--- a/server/src/main/java/org/elasticsearch/monitor/os/OsStats.java
+++ b/server/src/main/java/org/elasticsearch/monitor/os/OsStats.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.monitor.os;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -231,6 +233,8 @@ public class OsStats implements Writeable, ToXContentFragment {
 
     public static class Mem implements Writeable, ToXContentFragment {
 
+        private static final Logger logger = LogManager.getLogger(Mem.class);
+
         private final long total;
         private final long free;
 
@@ -259,6 +263,16 @@ public class OsStats implements Writeable, ToXContentFragment {
         }
 
         public ByteSizeValue getUsed() {
+            if (total == 0) {
+                // The work in https://github.com/elastic/elasticsearch/pull/42725 established that total memory
+                // can be reported as negative in some cases. In those cases, we force it to zero in which case
+                // we can no longer correctly report the used memory as (total-free) and should report it as zero.
+                //
+                // We intentionally check for (total == 0) rather than (total - free < 0) so as not to hide
+                // cases where (free > total) which would be a different bug.
+                logger.warn("cannot compute used memory when total memory is 0 and free memory is " + free);
+                return new ByteSizeValue(0);
+            }
             return new ByteSizeValue(total - free);
         }
 

--- a/server/src/test/java/org/elasticsearch/monitor/os/OsStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/monitor/os/OsStatsTests.java
@@ -25,6 +25,8 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
 
+import static org.hamcrest.Matchers.equalTo;
+
 public class OsStatsTests extends ESTestCase {
 
     public void testSerialization() throws IOException {
@@ -79,6 +81,11 @@ public class OsStatsTests extends ESTestCase {
                 assertEquals(osStats.getCgroup().getMemoryUsageInBytes(), deserializedOsStats.getCgroup().getMemoryUsageInBytes());
             }
         }
+    }
+
+    public void testGetUsedMemoryWithZeroTotal() {
+        OsStats.Mem mem = new OsStats.Mem(0, 1);
+        assertThat(mem.getUsed().getBytes(), equalTo(0L));
     }
 
 }

--- a/server/src/test/java/org/elasticsearch/monitor/os/OsStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/monitor/os/OsStatsTests.java
@@ -84,8 +84,12 @@ public class OsStatsTests extends ESTestCase {
     }
 
     public void testGetUsedMemoryWithZeroTotal() {
-        OsStats.Mem mem = new OsStats.Mem(0, 1);
+        OsStats.Mem mem = new OsStats.Mem(0, randomNonNegativeLong());
         assertThat(mem.getUsed().getBytes(), equalTo(0L));
     }
 
+    public void testGetUsedSwapWithZeroTotal() {
+        OsStats.Swap swap = new OsStats.Swap(0, randomNonNegativeLong());
+        assertThat(swap.getUsed().getBytes(), equalTo(0L));
+    }
 }

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/node/NodeStatsMonitoringDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/node/NodeStatsMonitoringDocTests.java
@@ -335,7 +335,7 @@ public class NodeStatsMonitoringDocTests extends BaseFilteredMonitoringDocTestCa
                 "_memory_ctrl_group", "2000000000", "1000000000");
 
         final OsStats.Mem osMem = new OsStats.Mem(0, 0);
-        final OsStats.Swap osSwap = new OsStats.Swap(no, no);
+        final OsStats.Swap osSwap = new OsStats.Swap(0, 0);
         final OsStats os = new OsStats(no, osCpu, osMem, osSwap, osCgroup);
 
         // Process


### PR DESCRIPTION
There are circumstances in which we can't retrieve correct value for total memory or total swap space, which can lead to subtraction errors and invalid arguments to `ByteSizeValue`. Related test failures have recently appeared in mixed cluster tests with 7.x and 6.8 nodes.

Although this issue shows up in tests, it could also appear as warnings from node stats endpoints.

This PR backports #56435 and #57317 to the 6.8 branch.

Fixes #68447