### PR TITLE
[7.10] [DOCS] Document what makes a geo-point malformed (#59045)

### DIFF
--- a/docs/reference/mapping/types/geo-point.asciidoc
+++ b/docs/reference/mapping/types/geo-point.asciidoc
@@ -123,6 +123,8 @@ The following parameters are accepted by `geo_point` fields:
 
     If `true`, malformed geo-points are ignored. If `false` (default),
     malformed geo-points throw an exception and reject the whole document.
+    A geo-point is considered malformed if its latitude is outside the range 
+    -90 <= latitude <= 90, or if its longitude is outside the range -180 <= longitude <= 180.
 
 `ignore_z_value`::
 


### PR DESCRIPTION
Backports the following commits to 7.10:
 - [DOCS] Document what makes a geo-point malformed (#59045)