### PR TITLE
[DOCS] Update package description.

### DIFF
--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -10,12 +10,7 @@ https://www.docker.elastic.co[www.docker.elastic.co]. The source files
 are in
 https://github.com/elastic/elasticsearch/blob/{branch}/distribution/docker[Github].
 
-These images are free to use under the Elastic license. They contain open source
-and free commercial features and access to paid commercial features.
-{kibana-ref}/managing-licenses.html[Start a 30-day trial] to try out all of the
-paid commercial features. See the
-https://www.elastic.co/subscriptions[Subscriptions] page for information about
-Elastic license levels.
+include::license.asciidoc[]
 
 ==== Pulling the image
 

--- a/docs/reference/setup/install/license.asciidoc
+++ b/docs/reference/setup/install/license.asciidoc
@@ -1,6 +1,2 @@
-This package is free to use under the Elastic license. It contains open source 
-and free commercial features and access to paid commercial features.  
-{kibana-ref}/managing-licenses.html[Start a 30-day trial] to try out all of the 
-paid commercial features. See the 
-https://www.elastic.co/subscriptions[Subscriptions] page for information about 
-Elastic license levels.
+This package contains both free and subscription features.
+<<managing-licenses,Start a 30-day trial>> to try out all of the features.

--- a/docs/reference/setup/install/license.asciidoc
+++ b/docs/reference/setup/install/license.asciidoc
@@ -1,2 +1,2 @@
 This package contains both free and subscription features.
-<<managing-licenses,Start a 30-day trial>> to try out all of the features.
+<<license-settings,Start a 30-day trial>> to try out all of the features.

--- a/docs/reference/setup/install/windows.asciidoc
+++ b/docs/reference/setup/install/windows.asciidoc
@@ -91,12 +91,6 @@ security configuration and built-in user configuration:
 [[msi-installer-xpack]]
 image::images/msi_installer/msi_installer_xpack.png[]
 
-NOTE: {xpack} includes a choice of a Trial or Basic license. A Trial license is
-valid for 30 days, after which you can obtain one of the available subscriptions.
-The Basic license is free and perpetual. Consult the
-https://www.elastic.co/subscriptions[available subscriptions] for further
-details on which features are available under which license.
-
 After clicking the install button, the installation will begin:
 
 [[msi-installer-installing]]
@@ -335,7 +329,7 @@ different installation directory to the default one:
 
 ["source","sh",subs="attributes,callouts"]
 --------------------------------------------
-start /wait msiexec.exe /i elasticsearch-{version}.msi /qn INSTALLDIR="C:\Custom Install Directory\{version}" 
+start /wait msiexec.exe /i elasticsearch-{version}.msi /qn INSTALLDIR="C:\Custom Install Directory\{version}"
 --------------------------------------------
 
 Consult the https://msdn.microsoft.com/en-us/library/windows/desktop/aa367988(v=vs.85).aspx[Windows Installer SDK Command-Line Options]


### PR DESCRIPTION
Updates the package description on the installation pages to align with https://github.com/elastic/kibana/pull/90354.