### PR TITLE
Remove deprecated usage of default configuration

### DIFF
--- a/x-pack/docs/build.gradle
+++ b/x-pack/docs/build.gradle
@@ -17,7 +17,7 @@ tasks.named("buildRestTests").configure {
 }
 
 dependencies {
-  testImplementation project(path: xpackModule('core'), configuration: 'default')
+  testImplementation project(path: xpackModule('core'))
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
   testImplementation project(path: xpackProject('plugin').path, configuration: 'testArtifacts')
 }

--- a/x-pack/plugin/analytics/build.gradle
+++ b/x-pack/plugin/analytics/build.gradle
@@ -10,7 +10,7 @@ archivesBaseName = 'x-pack-analytics'
 dependencies {
   compileOnly project(":server")
 
-  compileOnly project(path: xpackModule('core'), configuration: 'default')
+  compileOnly project(path: xpackModule('core'))
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 
   api 'org.apache.commons:commons-math3:3.2'

--- a/x-pack/plugin/async-search/build.gradle
+++ b/x-pack/plugin/async-search/build.gradle
@@ -13,7 +13,7 @@ addQaCheckDependencies()
 dependencies {
   compileOnly project(":server")
 
-  compileOnly project(path: xpackModule('core'), configuration: 'default')
+  compileOnly project(path: xpackModule('core'))
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
   testImplementation project(path: xpackModule('ilm'))
   testImplementation project(path: xpackModule('async'))

--- a/x-pack/plugin/async/build.gradle
+++ b/x-pack/plugin/async/build.gradle
@@ -10,7 +10,7 @@ archivesBaseName = 'x-pack-async'
 
 dependencies {
   compileOnly project(":server")
-  compileOnly project(path: xpackModule('core'), configuration: 'default')
+  compileOnly project(path: xpackModule('core'))
 }
 
 tasks.named("dependencyLicenses").configure {

--- a/x-pack/plugin/autoscaling/build.gradle
+++ b/x-pack/plugin/autoscaling/build.gradle
@@ -13,9 +13,9 @@ esplugin {
 archivesBaseName = 'x-pack-autoscaling'
 
 dependencies {
-  compileOnly project(path: xpackModule('core'), configuration: 'default')
+  compileOnly project(path: xpackModule('core'))
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
-  testImplementation project(path: xpackModule('data-streams'), configuration: 'default')
+  testImplementation project(path: xpackModule('data-streams'))
 }
 
 addQaCheckDependencies()

--- a/x-pack/plugin/ccr/build.gradle
+++ b/x-pack/plugin/ccr/build.gradle
@@ -30,7 +30,7 @@ addQaCheckDependencies()
 dependencies {
   compileOnly project(":server")
 
-  compileOnly project(path: xpackModule('core'), configuration: 'default')
+  compileOnly project(path: xpackModule('core'))
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
   testImplementation project(path: xpackModule('monitoring'), configuration: 'testArtifacts')
 }

--- a/x-pack/plugin/data-streams/build.gradle
+++ b/x-pack/plugin/data-streams/build.gradle
@@ -9,7 +9,7 @@ esplugin {
 archivesBaseName = 'x-pack-data-streams'
 
 dependencies {
-  compileOnly project(path: xpackModule('core'), configuration: 'default')
+  compileOnly project(path: xpackModule('core'))
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }
 

--- a/x-pack/plugin/enrich/build.gradle
+++ b/x-pack/plugin/enrich/build.gradle
@@ -9,7 +9,7 @@ esplugin {
 archivesBaseName = 'x-pack-enrich'
 
 dependencies {
-  compileOnly project(path: xpackModule('core'), configuration: 'default')
+  compileOnly project(path: xpackModule('core'))
   api project(path: ':modules:reindex')
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
   testImplementation project(path: ':modules:ingest-common')

--- a/x-pack/plugin/eql/build.gradle
+++ b/x-pack/plugin/eql/build.gradle
@@ -16,12 +16,12 @@ ext {
 archivesBaseName = 'x-pack-eql'
 
 dependencies {
-  compileOnly project(path: xpackModule('core'), configuration: 'default')
+  compileOnly project(path: xpackModule('core'))
   compileOnly(project(':modules:lang-painless')) {
     exclude group: "org.ow2.asm"
   }
   api "org.antlr:antlr4-runtime:${antlrVersion}"
-  compileOnly project(path: xpackModule('ql'), configuration: 'default')
+  compileOnly project(path: xpackModule('ql'))
 
   testImplementation project(':test:framework')
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')

--- a/x-pack/plugin/eql/qa/common/build.gradle
+++ b/x-pack/plugin/eql/qa/common/build.gradle
@@ -3,7 +3,7 @@ tasks.named("test").configure { enabled = false }
 
 dependencies {
   api project(':test:framework')
-  api project(path: xpackModule('core'), configuration: 'default')
+  api project(path: xpackModule('core'))
   api project(path: xpackModule('core'), configuration: 'testArtifacts')
   api project(xpackModule('ql:test'))
 

--- a/x-pack/plugin/eql/qa/correctness/build.gradle
+++ b/x-pack/plugin/eql/qa/correctness/build.gradle
@@ -15,7 +15,7 @@ restResources {
 
 dependencies {
   javaRestTestImplementation project(':test:framework')
-  javaRestTestImplementation project(path: xpackModule('core'), configuration: 'default')
+  javaRestTestImplementation project(path: xpackModule('core'))
   javaRestTestImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
   javaRestTestImplementation project(xpackModule('ql:test'))
   javaRestTestImplementation 'io.ous:jtoml:2.0.0'

--- a/x-pack/plugin/frozen-indices/build.gradle
+++ b/x-pack/plugin/frozen-indices/build.gradle
@@ -9,6 +9,6 @@ esplugin {
 archivesBaseName = 'x-pack-frozen-indices'
 
 dependencies {
-  compileOnly project(path: xpackModule('core'), configuration: 'default')
+  compileOnly project(path: xpackModule('core'))
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }

--- a/x-pack/plugin/graph/build.gradle
+++ b/x-pack/plugin/graph/build.gradle
@@ -9,7 +9,7 @@ esplugin {
 archivesBaseName = 'x-pack-graph'
 
 dependencies {
-  compileOnly project(path: xpackModule('core'), configuration: 'default')
+  compileOnly project(path: xpackModule('core'))
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }
 

--- a/x-pack/plugin/identity-provider/build.gradle
+++ b/x-pack/plugin/identity-provider/build.gradle
@@ -12,7 +12,7 @@ esplugin {
 archivesBaseName = 'x-pack-identity-provider'
 
 dependencies {
-  compileOnly project(path: xpackModule('core'), configuration: 'default')
+  compileOnly project(path: xpackModule('core'))
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
   // So that we can extend LocalStateCompositeXPackPlugin
   testImplementation project(path: xpackModule('security'), configuration: 'testArtifacts')

--- a/x-pack/plugin/identity-provider/qa/idp-rest-tests/build.gradle
+++ b/x-pack/plugin/identity-provider/qa/idp-rest-tests/build.gradle
@@ -4,8 +4,8 @@ apply plugin: 'elasticsearch.java-rest-test'
 dependencies {
   javaRestTestImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
   //TODO: update javaRestTests to not rely on any code that it is testing
-  javaRestTestImplementation project(path: xpackModule('identity-provider'), configuration: 'default')
-  javaRestTestImplementation project(path: xpackModule('core'), configuration: 'default')
+  javaRestTestImplementation project(path: xpackModule('identity-provider'))
+  javaRestTestImplementation project(path: xpackModule('core'))
 }
 
 testClusters.all {

--- a/x-pack/plugin/ilm/build.gradle
+++ b/x-pack/plugin/ilm/build.gradle
@@ -12,9 +12,9 @@ esplugin {
 archivesBaseName = 'x-pack-ilm'
 
 dependencies {
-  compileOnly project(path: xpackModule('core'), configuration: 'default')
+  compileOnly project(path: xpackModule('core'))
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
-  testImplementation project(path: xpackModule('data-streams'), configuration: 'default')
+  testImplementation project(path: xpackModule('data-streams'))
 }
 
 addQaCheckDependencies()

--- a/x-pack/plugin/ingest/build.gradle
+++ b/x-pack/plugin/ingest/build.gradle
@@ -17,7 +17,7 @@ esplugin {
 archivesBaseName = 'x-pack-ingest'
 
 dependencies {
-  compileOnly project(path: xpackModule('core'), configuration: 'default')
+  compileOnly project(path: xpackModule('core'))
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
   testImplementation project(path: ':modules:ingest-common')
   testImplementation project(path: ':modules:lang-mustache')

--- a/x-pack/plugin/logstash/build.gradle
+++ b/x-pack/plugin/logstash/build.gradle
@@ -8,7 +8,7 @@ esplugin {
 archivesBaseName = 'x-pack-logstash'
 
 dependencies {
-  compileOnly project(path: xpackModule('core'), configuration: 'default')
+  compileOnly project(path: xpackModule('core'))
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }
 

--- a/x-pack/plugin/mapper-aggregate-metric/build.gradle
+++ b/x-pack/plugin/mapper-aggregate-metric/build.gradle
@@ -20,6 +20,6 @@ archivesBaseName = 'x-pack-aggregate-metric'
 dependencies {
   compileOnly project(":server")
 
-  compileOnly project(path: xpackModule('core'), configuration: 'default')
+  compileOnly project(path: xpackModule('core'))
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }

--- a/x-pack/plugin/mapper-constant-keyword/build.gradle
+++ b/x-pack/plugin/mapper-constant-keyword/build.gradle
@@ -10,7 +10,7 @@ esplugin {
 archivesBaseName = 'x-pack-constant-keyword'
 
 dependencies {
-  compileOnly project(path: xpackModule('core'), configuration: 'default')
+  compileOnly project(path: xpackModule('core'))
   internalClusterTestImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }
 

--- a/x-pack/plugin/mapper-flattened/build.gradle
+++ b/x-pack/plugin/mapper-flattened/build.gradle
@@ -10,7 +10,7 @@ esplugin {
 archivesBaseName = 'x-pack-flattened'
 
 dependencies {
-  compileOnly project(path: xpackModule('core'), configuration: 'default')
+  compileOnly project(path: xpackModule('core'))
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }
 

--- a/x-pack/plugin/mapper-unsigned-long/build.gradle
+++ b/x-pack/plugin/mapper-unsigned-long/build.gradle
@@ -19,6 +19,6 @@ archivesBaseName = 'x-pack-unsigned-long'
 
 dependencies {
   compileOnly project(':modules:lang-painless:spi')
-  compileOnly project(path: xpackModule('core'), configuration: 'default')
+  compileOnly project(path: xpackModule('core'))
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }

--- a/x-pack/plugin/mapper-version/build.gradle
+++ b/x-pack/plugin/mapper-version/build.gradle
@@ -12,8 +12,8 @@ esplugin {
 archivesBaseName = 'x-pack-mapper-version'
 
 dependencies {
-  compileOnly project(path: xpackModule('core'), configuration: 'default')
+  compileOnly project(path: xpackModule('core'))
   compileOnly project(':modules:lang-painless:spi')
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
-  testImplementation project(path: xpackModule('analytics'), configuration: 'default')
+  testImplementation project(path: xpackModule('analytics'))
 }

--- a/x-pack/plugin/ml/build.gradle
+++ b/x-pack/plugin/ml/build.gradle
@@ -47,11 +47,11 @@ tasks.named("bundlePlugin").configure {
 
 dependencies {
   compileOnly project(':modules:lang-painless:spi')
-  compileOnly project(path: xpackModule('core'), configuration: 'default')
+  compileOnly project(path: xpackModule('core'))
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
-  testImplementation project(path: xpackModule('ilm'), configuration: 'default')
-  compileOnly project(path: xpackModule('autoscaling'), configuration: 'default')
-  testImplementation project(path: xpackModule('data-streams'), configuration: 'default')
+  testImplementation project(path: xpackModule('ilm'))
+  compileOnly project(path: xpackModule('autoscaling'))
+  testImplementation project(path: xpackModule('data-streams'))
   testImplementation project(':modules:ingest-common')
   // This should not be here
   testImplementation project(path: xpackModule('security'), configuration: 'testArtifacts')

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/build.gradle
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/build.gradle
@@ -2,7 +2,7 @@ import org.elasticsearch.gradle.info.BuildParams
 apply plugin: 'elasticsearch.java-rest-test'
 
 dependencies {
-  javaRestTestImplementation project(path: xpackModule('core'), configuration: 'default')
+  javaRestTestImplementation project(path: xpackModule('core'))
   javaRestTestImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
   javaRestTestImplementation project(path: xpackModule('ml'))
   javaRestTestImplementation project(path: xpackModule('ml'), configuration: 'testArtifacts')

--- a/x-pack/plugin/monitoring/build.gradle
+++ b/x-pack/plugin/monitoring/build.gradle
@@ -9,7 +9,7 @@ esplugin {
 archivesBaseName = 'x-pack-monitoring'
 
 dependencies {
-  compileOnly project(path: xpackModule('core'), configuration: 'default')
+  compileOnly project(path: xpackModule('core'))
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 
   // monitoring deps

--- a/x-pack/plugin/ql/build.gradle
+++ b/x-pack/plugin/ql/build.gradle
@@ -9,7 +9,7 @@ esplugin {
 archivesBaseName = 'x-pack-ql'
 
 dependencies {
-  compileOnly project(path: xpackModule('core'), configuration: 'default')
+  compileOnly project(path: xpackModule('core'))
   testImplementation project(':test:framework')
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
   testImplementation(project(xpackModule('ql:test'))) {

--- a/x-pack/plugin/repositories-metering-api/build.gradle
+++ b/x-pack/plugin/repositories-metering-api/build.gradle
@@ -8,7 +8,7 @@ esplugin {
 archivesBaseName = 'x-pack-repositories-metering-api'
 
 dependencies {
-  compileOnly project(path: xpackModule('core'), configuration: 'default')
+  compileOnly project(path: xpackModule('core'))
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }
 

--- a/x-pack/plugin/repository-encrypted/build.gradle
+++ b/x-pack/plugin/repository-encrypted/build.gradle
@@ -12,7 +12,7 @@ archivesBaseName = 'x-pack-repository-encrypted'
 
 dependencies {
     // necessary for the license check
-    compileOnly project(path: xpackModule('core'), configuration: 'default')
+    compileOnly project(path: xpackModule('core'))
     testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
     // required for integ tests of encrypted FS repository
     internalClusterTestImplementation project(":test:framework")

--- a/x-pack/plugin/rollup/build.gradle
+++ b/x-pack/plugin/rollup/build.gradle
@@ -12,9 +12,9 @@ archivesBaseName = 'x-pack-rollup'
 
 dependencies {
   compileOnly project(":server")
-  compileOnly project(path: xpackModule('core'), configuration: 'default')
-  compileOnly project(path: xpackModule('analytics'), configuration: 'default')
-  compileOnly project(path: xpackModule('mapper-aggregate-metric'), configuration: 'default')
+  compileOnly project(path: xpackModule('core'))
+  compileOnly project(path: xpackModule('analytics'))
+  compileOnly project(path: xpackModule('mapper-aggregate-metric'))
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }
 

--- a/x-pack/plugin/runtime-fields/build.gradle
+++ b/x-pack/plugin/runtime-fields/build.gradle
@@ -13,7 +13,7 @@ dependencies {
   compileOnly project(':modules:lang-painless:spi')
   api project(':libs:elasticsearch-grok')
   api project(':libs:elasticsearch-dissect')
-  compileOnly project(path: xpackModule('core'), configuration: 'default')
+  compileOnly project(path: xpackModule('core'))
 }
 
 tasks.named("dependencyLicenses").configure {

--- a/x-pack/plugin/search-business-rules/build.gradle
+++ b/x-pack/plugin/search-business-rules/build.gradle
@@ -10,7 +10,7 @@ esplugin {
 archivesBaseName = 'x-pack-searchbusinessrules'
 
 dependencies {
-  compileOnly project(path: xpackModule('core'), configuration: 'default')
+  compileOnly project(path: xpackModule('core'))
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
   testImplementation project(":test:framework")
 }

--- a/x-pack/plugin/searchable-snapshots/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/build.gradle
@@ -9,7 +9,7 @@ esplugin {
 archivesBaseName = 'x-pack-searchable-snapshots'
 
 dependencies {
-  compileOnly project(path: xpackModule('core'), configuration: 'default')
+  compileOnly project(path: xpackModule('core'))
   internalClusterTestImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }
 

--- a/x-pack/plugin/security/build.gradle
+++ b/x-pack/plugin/security/build.gradle
@@ -12,7 +12,7 @@ esplugin {
 archivesBaseName = 'x-pack-security'
 
 dependencies {
-  compileOnly project(path: xpackModule('core'), configuration: 'default')
+  compileOnly project(path: xpackModule('core'))
   compileOnly project(path: ':modules:transport-netty4')
   compileOnly project(path: ':plugins:transport-nio')
 

--- a/x-pack/plugin/security/cli/build.gradle
+++ b/x-pack/plugin/security/cli/build.gradle
@@ -7,7 +7,7 @@ archivesBaseName = 'elasticsearch-security-cli'
 
 dependencies {
   compileOnly project(":server")
-  compileOnly project(path: xpackModule('core'), configuration: 'default')
+  compileOnly project(path: xpackModule('core'))
   api "org.bouncycastle:bcpkix-jdk15on:${versions.bouncycastle}"
   api "org.bouncycastle:bcprov-jdk15on:${versions.bouncycastle}"
   testImplementation("com.google.jimfs:jimfs:${versions.jimfs}") {

--- a/x-pack/plugin/security/qa/basic-enable-security/build.gradle
+++ b/x-pack/plugin/security/qa/basic-enable-security/build.gradle
@@ -5,7 +5,7 @@ import org.elasticsearch.gradle.info.BuildParams
 apply plugin: 'elasticsearch.java-rest-test'
 
 dependencies {
-  javaRestTestImplementation project(path: xpackModule('core'), configuration: 'default')
+  javaRestTestImplementation project(path: xpackModule('core'))
   javaRestTestImplementation project(path: xpackModule('security'), configuration: 'testArtifacts')
   javaRestTestImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }

--- a/x-pack/plugin/security/qa/security-basic/build.gradle
+++ b/x-pack/plugin/security/qa/security-basic/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'elasticsearch.java-rest-test'
 import org.elasticsearch.gradle.info.BuildParams
 
 dependencies {
-  javaRestTestImplementation project(path: xpackModule('core'), configuration: 'default')
+  javaRestTestImplementation project(path: xpackModule('core'))
   javaRestTestImplementation project(path: xpackModule('security'), configuration: 'testArtifacts')
   javaRestTestImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }

--- a/x-pack/plugin/security/qa/security-disabled/build.gradle
+++ b/x-pack/plugin/security/qa/security-disabled/build.gradle
@@ -10,7 +10,7 @@ import org.elasticsearch.gradle.info.BuildParams
 apply plugin: 'elasticsearch.java-rest-test'
 
 dependencies {
-  javaRestTestImplementation project(path: xpackModule('core'), configuration: 'default')
+  javaRestTestImplementation project(path: xpackModule('core'))
   javaRestTestImplementation project(path: xpackModule('security'), configuration: 'testArtifacts')
   javaRestTestImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }

--- a/x-pack/plugin/security/qa/security-not-enabled/build.gradle
+++ b/x-pack/plugin/security/qa/security-not-enabled/build.gradle
@@ -9,7 +9,7 @@
 apply plugin: 'elasticsearch.java-rest-test'
 
 dependencies {
-  javaRestTestImplementation project(path: xpackModule('core'), configuration: 'default')
+  javaRestTestImplementation project(path: xpackModule('core'))
   javaRestTestImplementation project(path: xpackModule('security'), configuration: 'testArtifacts')
   javaRestTestImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }

--- a/x-pack/plugin/security/qa/security-trial/build.gradle
+++ b/x-pack/plugin/security/qa/security-trial/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'elasticsearch.java-rest-test'
 
 dependencies {
-  javaRestTestImplementation project(path: xpackModule('core'), configuration: 'default')
+  javaRestTestImplementation project(path: xpackModule('core'))
   javaRestTestImplementation project(path: xpackModule('security'), configuration: 'testArtifacts')
   javaRestTestImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }

--- a/x-pack/plugin/security/qa/tls-basic/build.gradle
+++ b/x-pack/plugin/security/qa/tls-basic/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'elasticsearch.java-rest-test'
 import org.elasticsearch.gradle.info.BuildParams
 
 dependencies {
-  testImplementation project(path: xpackModule('core'), configuration: 'default')
+  testImplementation project(path: xpackModule('core'))
   testImplementation project(path: xpackModule('security'), configuration: 'testArtifacts')
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }

--- a/x-pack/plugin/spatial/build.gradle
+++ b/x-pack/plugin/spatial/build.gradle
@@ -10,10 +10,10 @@ esplugin {
 }
 
 dependencies {
-  compileOnly project(path: xpackModule('core'), configuration: 'default')
+  compileOnly project(path: xpackModule('core'))
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
   yamlRestTestImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
-  api project(path: ':modules:geo', configuration: 'default')
+  api project(path: ':modules:geo')
   restTestConfig project(path: ':modules:geo', configuration: 'restTests')
 }
 

--- a/x-pack/plugin/sql/build.gradle
+++ b/x-pack/plugin/sql/build.gradle
@@ -29,14 +29,14 @@ configurations {
 archivesBaseName = 'x-pack-sql'
 
 dependencies {
-  compileOnly project(path: xpackModule('core'), configuration: 'default')
+  compileOnly project(path: xpackModule('core'))
   compileOnly(project(':modules:lang-painless')) {
     exclude group: "org.ow2.asm"
   }
   api project('sql-action')
   api project(':modules:aggs-matrix-stats')
   api "org.antlr:antlr4-runtime:${antlrVersion}"
-  compileOnly project(path: xpackModule('ql'), configuration: 'default')
+  compileOnly project(path: xpackModule('ql'))
   testImplementation project(':test:framework')
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
   testImplementation project(path: xpackModule('security'), configuration: 'testArtifacts')

--- a/x-pack/plugin/stack/build.gradle
+++ b/x-pack/plugin/stack/build.gradle
@@ -11,7 +11,7 @@ esplugin {
 archivesBaseName = 'x-pack-stack'
 
 dependencies {
-  compileOnly project(path: xpackModule('core'), configuration: 'default')
+  compileOnly project(path: xpackModule('core'))
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }
 

--- a/x-pack/plugin/text-structure/build.gradle
+++ b/x-pack/plugin/text-structure/build.gradle
@@ -8,7 +8,7 @@ esplugin {
 archivesBaseName = 'x-pack-text-structure'
 
 dependencies {
-  compileOnly project(path: xpackModule('core'), configuration: 'default')
+  compileOnly project(path: xpackModule('core'))
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
   api project(':libs:elasticsearch-grok')
   api "com.ibm.icu:icu4j:${versions.icu4j}"

--- a/x-pack/plugin/transform/build.gradle
+++ b/x-pack/plugin/transform/build.gradle
@@ -10,7 +10,7 @@ esplugin {
 dependencies {
   compileOnly project(":server")
 
-  compileOnly project(path: xpackModule('core'), configuration: 'default')
+  compileOnly project(path: xpackModule('core'))
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
   testImplementation project(path: xpackModule('analytics'))
   testImplementation project(path: ':modules:aggs-matrix-stats')

--- a/x-pack/plugin/transform/qa/multi-node-tests/build.gradle
+++ b/x-pack/plugin/transform/qa/multi-node-tests/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'elasticsearch.java-rest-test'
 
 dependencies {
-  javaRestTestImplementation project(path: xpackModule('core'), configuration: 'default')
+  javaRestTestImplementation project(path: xpackModule('core'))
   javaRestTestImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
   javaRestTestImplementation project(path: xpackModule('transform'))
 }

--- a/x-pack/plugin/transform/qa/single-node-tests/build.gradle
+++ b/x-pack/plugin/transform/qa/single-node-tests/build.gradle
@@ -2,7 +2,7 @@
 apply plugin: 'elasticsearch.java-rest-test'
 
 dependencies {
-  javaRestTestImplementation project(path: xpackModule('core'), configuration: 'default')
+  javaRestTestImplementation project(path: xpackModule('core'))
   javaRestTestImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
   javaRestTestImplementation project(path: xpackModule('transform'))
 }

--- a/x-pack/plugin/vectors/build.gradle
+++ b/x-pack/plugin/vectors/build.gradle
@@ -11,7 +11,7 @@ archivesBaseName = 'x-pack-vectors'
 
 dependencies {
   compileOnly project(':modules:lang-painless:spi')
-  compileOnly project(path: xpackModule('core'), configuration: 'default')
+  compileOnly project(path: xpackModule('core'))
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }
 

--- a/x-pack/plugin/voting-only-node/build.gradle
+++ b/x-pack/plugin/voting-only-node/build.gradle
@@ -8,6 +8,6 @@ esplugin {
 }
 
 dependencies {
-  compileOnly project(path: xpackModule('core'), configuration: 'default')
+  compileOnly project(path: xpackModule('core'))
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }

--- a/x-pack/plugin/watcher/build.gradle
+++ b/x-pack/plugin/watcher/build.gradle
@@ -24,7 +24,7 @@ tasks.named("dependencyLicenses").configure {
 dependencies {
   compileOnly project(':server')
   compileOnly project(':modules:lang-painless:spi')
-  compileOnly project(path: xpackModule('core'), configuration: 'default')
+  compileOnly project(path: xpackModule('core'))
   compileOnly project(path: ':modules:transport-netty4')
   compileOnly project(path: ':plugins:transport-nio')
 

--- a/x-pack/plugin/wildcard/build.gradle
+++ b/x-pack/plugin/wildcard/build.gradle
@@ -9,7 +9,7 @@ esplugin {
 archivesBaseName = 'x-pack-wildcard'
 
 dependencies {
-  compileOnly project(path: xpackModule('core'), configuration: 'default')
+  compileOnly project(path: xpackModule('core'))
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }
 

--- a/x-pack/qa/oidc-op-tests/build.gradle
+++ b/x-pack/qa/oidc-op-tests/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'elasticsearch.rest-test'
 apply plugin: 'elasticsearch.test.fixtures'
 
 dependencies {
-  testImplementation project(path: xpackModule('core'), configuration: 'default')
+  testImplementation project(path: xpackModule('core'))
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
   testImplementation project(path: xpackModule('security'), configuration: 'testArtifacts')
 }

--- a/x-pack/qa/openldap-tests/build.gradle
+++ b/x-pack/qa/openldap-tests/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'elasticsearch.standalone-test'
 apply plugin: 'elasticsearch.test.fixtures'
 
 dependencies {
-  testImplementation project(path: xpackModule('core'), configuration: 'default')
+  testImplementation project(path: xpackModule('core'))
   testImplementation project(path: xpackModule('security'), configuration: 'testArtifacts')
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }

--- a/x-pack/qa/password-protected-keystore/build.gradle
+++ b/x-pack/qa/password-protected-keystore/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 dependencies {
-  testImplementation project(path: xpackModule('core'), configuration: 'default')
+  testImplementation project(path: xpackModule('core'))
 }
 
 testClusters.matching { it.name == "integTest" }.configureEach {

--- a/x-pack/qa/reindex-tests-with-security/build.gradle
+++ b/x-pack/qa/reindex-tests-with-security/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'elasticsearch.rest-test'
 apply plugin: 'elasticsearch.rest-resources'
 
 dependencies {
-  testImplementation project(path: xpackModule('core'), configuration: 'default')
+  testImplementation project(path: xpackModule('core'))
   testImplementation project(path: xpackModule('security'), configuration: 'testArtifacts')
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
   testImplementation project(path: ':modules:reindex')

--- a/x-pack/qa/security-setup-password-tests/build.gradle
+++ b/x-pack/qa/security-setup-password-tests/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
 dependencies {
-  testImplementation project(path: xpackModule('core'), configuration: 'default')
+  testImplementation project(path: xpackModule('core'))
   testImplementation project(path: xpackModule('security'))
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }


### PR DESCRIPTION
This has been deprecated in gradle before but we havnt been warned.

Gradle 7.0 will likely introduce a change in behaviour here that we should fix the usage of 
this configuration upfront.

By just using `project(':projectpath')` we will rely on the now default variant aware dependency resolution
meaning that either `apiElements` or `runtimeElements` will be resolved depending on the variant required. 

See https://github.com/gradle/gradle/issues/16027 for further information about the change in Gradle 7.0