### PR TITLE
lower skip version for token_count yaml test

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/330_fetch_fields.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/330_fetch_fields.yml
@@ -263,8 +263,8 @@ setup:
 ---
 "Test token count":
   - skip:
-      version: " - 7.99.99"
-      reason: "support for token_count isn't yet backported"
+      version: " - 7.9.99"
+      reason: "support for token_count was instroduced in 7.10"
   - do:
       indices.create:
         index:  test


### PR DESCRIPTION
While backporting 63709 I noted that some skip-versions in this yaml test file
were still at 7.99.99, although the feature is probably backported. In this case reading
https://github.com/elastic/elasticsearch/pull/63515 I assume the functionality is in 7.10
and we can run the test on the higher 7.x branches.