### PR TITLE
Revert "Use SequentialStoredFieldsLeafReader to read Lucene changes"

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/engine/LuceneChangesSnapshot.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/LuceneChangesSnapshot.java
@@ -23,7 +23,6 @@ import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.util.ArrayUtil;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.lucene.Lucene;
-import org.elasticsearch.common.lucene.index.SequentialStoredFieldsLeafReader;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.index.fieldvisitor.FieldsVisitor;
@@ -219,12 +218,8 @@ final class LuceneChangesSnapshot implements Translog.Snapshot {
         final String sourceField = parallelArray.hasRecoverySource[docIndex] ? SourceFieldMapper.RECOVERY_SOURCE_NAME :
             SourceFieldMapper.NAME;
         final FieldsVisitor fields = new FieldsVisitor(true, sourceField);
-        if (leaf.reader() instanceof SequentialStoredFieldsLeafReader) {
-            ((SequentialStoredFieldsLeafReader) leaf.reader()).getSequentialStoredFieldsReader().visitDocument(segmentDocID, fields);
-        } else {
-            assert false : "The changes reader isn't wrapped with Lucene#wrapAllDocsLive";
-            throw new IllegalStateException("The changes reader isn't wrapped with Lucene#wrapAllDocsLive");
-        }
+        leaf.reader().document(segmentDocID, fields);
+
         final Translog.Operation op;
         final boolean isTombstone = parallelArray.isTombStone[docIndex];
         if (isTombstone && fields.id() == null) {

--- a/test/framework/src/main/java/org/elasticsearch/test/engine/ThrowingLeafReaderWrapper.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/engine/ThrowingLeafReaderWrapper.java
@@ -8,9 +8,9 @@
 
 package org.elasticsearch.test.engine;
 
-import org.apache.lucene.codecs.StoredFieldsReader;
 import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.Fields;
+import org.apache.lucene.index.FilterLeafReader;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.PostingsEnum;
@@ -20,7 +20,6 @@ import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.automaton.CompiledAutomaton;
-import org.elasticsearch.common.lucene.index.SequentialStoredFieldsLeafReader;
 
 import java.io.IOException;
 
@@ -29,7 +28,7 @@ import java.io.IOException;
  * are called on is. This allows to test parts of the system under certain
  * error conditions that would otherwise not be possible.
  */
-public class ThrowingLeafReaderWrapper extends SequentialStoredFieldsLeafReader {
+public class ThrowingLeafReaderWrapper extends FilterLeafReader {
 
     private final Thrower thrower;
 
@@ -197,10 +196,5 @@ public class ThrowingLeafReaderWrapper extends SequentialStoredFieldsLeafReader 
     @Override
     public CacheHelper getReaderCacheHelper() {
         return in.getReaderCacheHelper();
-    }
-
-    @Override
-    protected StoredFieldsReader doGetSequentialStoredFieldsReader(StoredFieldsReader reader) {
-        return reader;
     }
 }


### PR DESCRIPTION
I benchmarked an improvement in CCR and found that changes introduced in #67190 made CCR 10 times slower (1816 seconds to 26515 seconds).

> "total_read_remote_exec_time_millis" : 26515182
> "total_read_remote_exec_time_millis" :    1816094

With concurrent indexing and Lucene merges, documents in segments are no longer sorted by sequence numbers. And if the index sorting is specified, documents are never sorted by sequence numbers. Using a `mergeInstance` stored field reader will decompress the whole block, which we will not use.

I labelled this non-issue for an unreleased bug. I am also checking the other usages of `mergeInstance` in Elasticsearch.