### PR TITLE
Update intervals-query.asciidoc

### DIFF
--- a/docs/reference/query-dsl/intervals-query.asciidoc
+++ b/docs/reference/query-dsl/intervals-query.asciidoc
@@ -18,7 +18,7 @@ parent sources.
 ==== Example request
 
 The following `intervals` search returns documents containing `my
-favorite food` immediately followed by `hot water` or `cold porridge` in the
+favorite food` without any gap, followed by `hot water` or `cold porridge` in the
 `my_text` field.
 
 This search would match a `my_text` value of `my favorite food is cold


### PR DESCRIPTION
The doc is misleading here : 
The following intervals search returns documents containing `my favorite food` **immediately** followed by `hot water` or `cold porridge`

max_gaps apply only to the match query and is not used for checking proximity with the other match. the example given actually : 
`This search would match a my_text value of my favorite food is cold`