### PR TITLE
[DOCS] Fix Kibana timeout settings refs

### DIFF
--- a/x-pack/docs/en/security/authentication/oidc-guide.asciidoc
+++ b/x-pack/docs/en/security/authentication/oidc-guide.asciidoc
@@ -518,9 +518,13 @@ interface, you must configure {kib} to use a `https` URL to connect to {es}, and
 you may need to configure `elasticsearch.ssl.certificateAuthorities` to trust
 the certificates that {es} has been configured to use.
 
-OpenID Connect authentication in {kib} is also subject to the
-`xpack.security.sessionTimeout` setting that is described in the {kib} security
-documentation, and you may wish to adjust this timeout to meet your local needs.
+SAML authentication in {kib} is subject to the following timeout settings in
+`kibana.yml`:
+
+- {kibana-ref}/xpack-security-session-management.html#session-idle-timeout[`xpack.security.session.idleTimeout`]
+- {kibana-ref}/xpack-security-session-management.html#session-lifespan[`xpack.security.session.lifespan`]
+
+You may want to adjust these timeouts based on your security requirements.
 
 The three additional settings that are required for OpenID Connect support are shown below:
 

--- a/x-pack/docs/en/security/authentication/oidc-guide.asciidoc
+++ b/x-pack/docs/en/security/authentication/oidc-guide.asciidoc
@@ -518,7 +518,7 @@ interface, you must configure {kib} to use a `https` URL to connect to {es}, and
 you may need to configure `elasticsearch.ssl.certificateAuthorities` to trust
 the certificates that {es} has been configured to use.
 
-SAML authentication in {kib} is subject to the following timeout settings in
+OpenID Connect authentication in {kib} is subject to the following timeout settings in
 `kibana.yml`:
 
 - {kibana-ref}/xpack-security-session-management.html#session-idle-timeout[`xpack.security.session.idleTimeout`]

--- a/x-pack/docs/en/security/authentication/saml-guide.asciidoc
+++ b/x-pack/docs/en/security/authentication/saml-guide.asciidoc
@@ -752,9 +752,13 @@ interface, you must configure {kib} to use a `https` URL to connect to {es}, and
 you may need to configure `elasticsearch.ssl.certificateAuthorities` to trust
 the certificates that {es} has been configured to use.
 
-SAML authentication in {kib} is also subject to the
-`xpack.security.sessionTimeout` setting that is described in the {kib} security
-documentation, and you may wish to adjust this timeout to meet your local needs.
+SAML authentication in {kib} is subject to the following timeout settings in
+`kibana.yml`:
+
+- {kibana-ref}/xpack-security-session-management.html#session-idle-timeout[`xpack.security.session.idleTimeout`]
+- {kibana-ref}/xpack-security-session-management.html#session-lifespan[`xpack.security.session.lifespan`]
+
+You may want to adjust these timeouts based on your security requirements.
 
 The three additional settings that are required for SAML support are shown below:
 


### PR DESCRIPTION
Removes and replaces an outdated reference to the `xpack.security.sessionTimeout` Kibana setting.

https://github.com/elastic/kibana/pull/49855 replaced this setting in 7.6.


### Previews
- Configuring Kibana for OIDC: https://elasticsearch_68594.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/oidc-kibana.html
- Configuring Kibana for SAML: https://elasticsearch_68594.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/saml-kibana.html