### PR TITLE
[7.x] Use Java 11 compatibility for buildSrc

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -146,6 +146,10 @@ if (project != rootProject) {
   apply plugin: 'elasticsearch.build'
   apply plugin: 'elasticsearch.publish'
 
+  // We have to set this again down here since the elasticsearch.java plugin defaults to minimumRuntimeVersion
+  targetCompatibility = '11'
+  sourceCompatibility = '11'
+
   // groovydoc succeeds, but has some weird internal exception...
   tasks.named("groovydoc").configure {
     enabled = false

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -56,6 +56,12 @@ if (JavaVersion.current() < JavaVersion.VERSION_11) {
   throw new GradleException('At least Java 11 is required to build elasticsearch gradle tools')
 }
 
+allprojects {
+  apply plugin: 'java'
+  targetCompatibility = '11'
+  sourceCompatibility = '11'
+}
+
 sourceSets {
   integTest {
     compileClasspath += sourceSets["main"].output + configurations["testRuntimeClasspath"]
@@ -139,11 +145,6 @@ if (project == rootProject) {
 if (project != rootProject) {
   apply plugin: 'elasticsearch.build'
   apply plugin: 'elasticsearch.publish'
-
-  allprojects {
-    targetCompatibility = 10
-    sourceCompatibility = 10
-  }
 
   // groovydoc succeeds, but has some weird internal exception...
   tasks.named("groovydoc").configure {
@@ -277,7 +278,7 @@ class VersionPropertiesLoader {
           elasticsearch
       )
     }
-    String qualifier = systemProperties.getProperty("build.version_qualifier", "");
+    String qualifier = systemProperties.getProperty("build.version_qualifier", "")
     if (qualifier.isEmpty() == false) {
       if (qualifier.matches("(alpha|beta|rc)\\d+") == false) {
         throw new IllegalStateException("Invalid qualifier: " + qualifier)


### PR DESCRIPTION
We have some inconsistencies in the target compatibility version for `buildSrc` in the `7.x` branch. We use version 10 for the `build-tools` JAR, but when building the `buildSrc.jar` used by the build itself we don't explicit set it, so it inherits the build Java version. This caused weird issues with IDE integration.

Additionally we are bumping from 10 to 11 now to be in-line with what lives in `master`. The reason we held off on doing this before was because the hadoop project had not yet moved to building with Java 11 but that is now since sorted out so we can safely bump.