### PR TITLE
[7.11] [DOCS] Add missing xref to 7.11 breaking changes (#68613)

### DIFF
--- a/docs/reference/migration/migrate_7_11.asciidoc
+++ b/docs/reference/migration/migrate_7_11.asciidoc
@@ -9,6 +9,7 @@ your application to {es} 7.11.
 
 See also <<release-highlights>> and <<es-release-notes>>.
 
+* <<breaking_711_ml_changes>>
 * <<breaking_711_search_changes>>
 * <<breaking_711_transform_changes>>
 


### PR DESCRIPTION
Backports the following commits to 7.11:
 - [DOCS] Add missing xref to 7.11 breaking changes (#68613)