### PR TITLE
tag::get-mappings-response

### DIFF
--- a/docs/java-rest/high-level/indices/get_mappings.asciidoc
+++ b/docs/java-rest/high-level/indices/get_mappings.asciidoc
@@ -44,7 +44,9 @@ executed operation as follows:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests-file}[{api}-response]
+ImmutableOpenMap<String, ImmutableOpenMap<String, MappingMetaData>> allMappings = getMappingResponse.mappings();
+MappingMetadata indexMapping = allMappings.get("twitter").get("_doc");
+Map<String, Object> mapping = indexMapping.sourceAsMap();
 --------------------------------------------------
 <1> Returning all indices' mappings
 <2> Retrieving the mappings for a particular index


### PR DESCRIPTION
I found that there is a problem with the response content acquisition method in version 7.3.2.
Although the code is used normally in the test class, it cannot be used normally in the actual code development.
The original code is:
Map<String, MappingMetadata> allMappings = getMappingResponse.mappings(); 
MappingMetadata indexMapping = allMappings.get("twitter"); 
Map<String, Object> mapping = indexMapping.sourceAsMap(); 
After testing the API, the correct usage should be as follows：
ImmutableOpenMap<String, ImmutableOpenMap<String, MappingMetaData>> allMappings = getMappingResponse.mappings();
MappingMetadata indexMapping = allMappings.get("twitter").get("_doc");
Map<String, Object> mapping = indexMapping.sourceAsMap();
I can't modify it in the source code.

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
