### PR TITLE
Fix eager created gradle tasks

### DIFF
--- a/x-pack/plugin/ilm/build.gradle
+++ b/x-pack/plugin/ilm/build.gradle
@@ -19,6 +19,6 @@ dependencies {
 
 addQaCheckDependencies()
 
-test {
+tasks.named("test").configure {
   systemProperty 'es.rollup_v2_feature_flag_enabled', 'true'
 }

--- a/x-pack/plugin/security/qa/operator-privileges-tests/build.gradle
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/build.gradle
@@ -18,7 +18,7 @@ dependencies {
 
 File repoDir = file("$buildDir/testclusters/repo")
 
-javaRestTest {
+tasks.named("javaRestTest").configure {
   /* To support taking snapshots, we have to set path.repo setting */
   systemProperty 'tests.path.repo', repoDir
 }


### PR DESCRIPTION
Brings us back to zero eagerly created tasks. Gradle does not
provide a way to enforcing task avoidance api. I raised that
with the Gradle team, maybe we get something in future
gradle versions that can help us enforcing using the task avoidance
api