### PR TITLE
build-tools check are fixed on aarch64 

### DIFF
--- a/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/DistributionDownloadPluginFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/DistributionDownloadPluginFuncTest.groovy
@@ -54,7 +54,7 @@ class DistributionDownloadPluginFuncTest extends AbstractGradleFuncTest {
         def result = withMockedDistributionDownload(version, platform, runner) {
             // initial run
             def firstRun = build()
-            assertOutputContains(firstRun.output, "Unpacking elasticsearch-${version}-linux-x86_64.tar.gz " +
+            assertOutputContains(firstRun.output, "Unpacking elasticsearch-${version}-linux-${Architecture.current().classifier}.tar.gz " +
                     "using SymbolicLinkPreservingUntarTransform")
             // 2nd invocation
             build()
@@ -62,7 +62,7 @@ class DistributionDownloadPluginFuncTest extends AbstractGradleFuncTest {
 
         then:
         result.task(":setupDistro").outcome == TaskOutcome.SUCCESS
-        assertOutputMissing(result.output, "Unpacking elasticsearch-${version}-linux-x86_64.tar.gz " +
+        assertOutputMissing(result.output, "Unpacking elasticsearch-${version}-linux-${expectedArch}.tar.gz " +
                 "using SymbolicLinkPreservingUntarTransform")
     }
 

--- a/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/DistributionDownloadPluginFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/DistributionDownloadPluginFuncTest.groovy
@@ -51,19 +51,19 @@ class DistributionDownloadPluginFuncTest extends AbstractGradleFuncTest {
         when:
         def guh = new File(testProjectDir.getRoot(), "gradle-user-home").absolutePath;
         def runner = gradleRunner('clean', 'setupDistro', '-i', '-g', guh)
+        def unpackingMessage = "Unpacking elasticsearch-${version}-linux-${Architecture.current().classifier}.tar.gz " +
+                "using SymbolicLinkPreservingUntarTransform"
         def result = withMockedDistributionDownload(version, platform, runner) {
             // initial run
             def firstRun = build()
-            assertOutputContains(firstRun.output, "Unpacking elasticsearch-${version}-linux-${Architecture.current().classifier}.tar.gz " +
-                    "using SymbolicLinkPreservingUntarTransform")
+            assertOutputContains(firstRun.output, unpackingMessage)
             // 2nd invocation
             build()
         }
 
         then:
         result.task(":setupDistro").outcome == TaskOutcome.SUCCESS
-        assertOutputMissing(result.output, "Unpacking elasticsearch-${version}-linux-${expectedArch}.tar.gz " +
-                "using SymbolicLinkPreservingUntarTransform")
+        assertOutputMissing(result.output, unpackingMessage)
     }
 
     def "transforms are reused across projects"() {
@@ -100,7 +100,7 @@ class DistributionDownloadPluginFuncTest extends AbstractGradleFuncTest {
 
         then:
         result.tasks.size() == 3
-        result.output.count("Unpacking elasticsearch-${version}-linux-x86_64.tar.gz " +
+        result.output.count("Unpacking elasticsearch-${version}-linux-${Architecture.current().classifier}.tar.gz " +
                 "using SymbolicLinkPreservingUntarTransform") == 1
     }
 

--- a/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/fixtures/DistributionDownloadFixture.groovy
+++ b/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/fixtures/DistributionDownloadFixture.groovy
@@ -44,8 +44,7 @@ class DistributionDownloadFixture {
     private static String urlPath(String version,ElasticsearchDistribution.Platform platform) {
         String fileType = ((platform == ElasticsearchDistribution.Platform.LINUX ||
                 platform == ElasticsearchDistribution.Platform.DARWIN)) ? "tar.gz" : "zip"
-        String arch = Architecture.current() == Architecture.AARCH64 ? "aarch64" : "x86_64"
-        "/downloads/elasticsearch/elasticsearch-${version}-${platform}-${arch}.$fileType"
+        "/downloads/elasticsearch/elasticsearch-${version}-${platform}-${Architecture.current().classifier}.$fileType"
     }
 
     private static byte[] filebytes(String urlPath) throws IOException {

--- a/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionDownloadPluginFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionDownloadPluginFuncTest.groovy
@@ -130,7 +130,7 @@ class InternalDistributionDownloadPluginFuncTest extends AbstractGradleFuncTest 
             apply plugin:'base'
 
             // packed distro
-            configurations.create("linux-tar")
+            configurations.create("${testArchiveProjectName}")
             tasks.register("buildBwcTask", Tar) {
                 from('bwc-marker.txt')
                 archiveExtension = "tar.gz"
@@ -147,7 +147,7 @@ class InternalDistributionDownloadPluginFuncTest extends AbstractGradleFuncTest 
                 into('build/install/elastic-distro')
             }
             artifacts {
-                it.add("expanded-linux-tar", file('build/install')) {
+                it.add("expanded-${testArchiveProjectName}", file('build/install')) {
                     builtBy expandedTask
                     type = 'directory'
                 }

--- a/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionDownloadPluginFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionDownloadPluginFuncTest.groovy
@@ -8,14 +8,11 @@
 
 package org.elasticsearch.gradle.internal
 
+import org.elasticsearch.gradle.Architecture
 import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.fixtures.AbstractGradleFuncTest
-import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 
-import java.lang.management.ManagementFactory
 
 class InternalDistributionDownloadPluginFuncTest extends AbstractGradleFuncTest {
 
@@ -159,10 +156,12 @@ class InternalDistributionDownloadPluginFuncTest extends AbstractGradleFuncTest 
     }
 
     private void localDistroSetup() {
+        def archSuffix = Architecture.current() == Architecture.AARCH64 ? '-aarch64' : ''
+        def archiveProjectName = "linux${archSuffix}-tar"
         settingsFile << """
-        include ":distribution:archives:linux-tar"
+        include ":distribution:archives:${archiveProjectName}"
         """
-        def bwcSubProjectFolder = testProjectDir.newFolder("distribution", "archives", "linux-tar")
+        def bwcSubProjectFolder = testProjectDir.newFolder("distribution", "archives", archiveProjectName)
         new File(bwcSubProjectFolder, 'current-marker.txt') << "current"
         new File(bwcSubProjectFolder, 'build.gradle') << """
             import org.gradle.api.internal.artifacts.ArtifactAttributes;

--- a/buildSrc/src/integTest/resources/org/elasticsearch/gradle/internal/fake_git/remote/.ci/java-versions.properties
+++ b/buildSrc/src/integTest/resources/org/elasticsearch/gradle/internal/fake_git/remote/.ci/java-versions.properties
@@ -5,6 +5,6 @@
 # in compliance with, at your election, the Elastic License 2.0 or the Server
 # Side Public License, v 1.
 #
-ES_BUILD_JAVA=openjdk12
-ES_RUNTIME_JAVA=openjdk12
+ES_BUILD_JAVA=openjdk11
+ES_RUNTIME_JAVA=openjdk11
 GRADLE_TASK=build

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/Architecture.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/Architecture.java
@@ -10,8 +10,14 @@ package org.elasticsearch.gradle;
 
 public enum Architecture {
 
-    X64,
-    AARCH64;
+    X64("x86_64"),
+    AARCH64("aarch64");
+
+    public final String classifier;
+
+    Architecture(String classifier) {
+        this.classifier = classifier;
+    }
 
     public static Architecture current() {
         final String architecture = System.getProperty("os.arch", "");

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/DistributionDownloadPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/DistributionDownloadPlugin.java
@@ -166,14 +166,11 @@ public class DistributionDownloadPlugin implements Plugin<Project> {
 
         Version distroVersion = Version.fromString(distribution.getVersion());
         String extension = distribution.getType().toString();
-        String classifier = ":" + (Architecture.current() == Architecture.AARCH64 ? "aarch64" : "x86_64");
+        String classifier = ":" + Architecture.current().classifier;
         if (distribution.getType() == Type.ARCHIVE) {
             extension = distribution.getPlatform() == Platform.WINDOWS ? "zip" : "tar.gz";
             if (distroVersion.onOrAfter("7.0.0")) {
-                classifier = ":"
-                    + distribution.getPlatform()
-                    + "-"
-                    + (Architecture.current() == Architecture.AARCH64 ? "aarch64" : "x86_64");
+                classifier = ":" + distribution.getPlatform() + "-" + Architecture.current().classifier;
             } else {
                 classifier = "";
             }

--- a/buildSrc/src/test/java/org/elasticsearch/gradle/BwcVersionsTests.java
+++ b/buildSrc/src/test/java/org/elasticsearch/gradle/BwcVersionsTests.java
@@ -285,6 +285,7 @@ public class BwcVersionsTests extends GradleUnitTestCase {
     public static void setupAll() {
         Assume.assumeFalse(Architecture.current() == Architecture.AARCH64);
     }
+
     @Test(expected = IllegalArgumentException.class)
     public void testExceptionOnEmpty() {
         new BwcVersions(asList("foo", "bar"), Version.fromString("7.0.0"));

--- a/buildSrc/src/test/java/org/elasticsearch/gradle/BwcVersionsTests.java
+++ b/buildSrc/src/test/java/org/elasticsearch/gradle/BwcVersionsTests.java
@@ -1,6 +1,8 @@
 package org.elasticsearch.gradle;
 
 import org.elasticsearch.gradle.test.GradleUnitTestCase;
+import org.junit.Assume;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -279,6 +281,10 @@ public class BwcVersionsTests extends GradleUnitTestCase {
         sampleVersions.put("7.1.0", asList("7_1_0", "7_0_0", "6_7_0", "6_6_1", "6_6_0"));
     }
 
+    @BeforeClass
+    public static void setupAll() {
+        Assume.assumeFalse(Architecture.current() == Architecture.AARCH64);
+    }
     @Test(expected = IllegalArgumentException.class)
     public void testExceptionOnEmpty() {
         new BwcVersions(asList("foo", "bar"), Version.fromString("7.0.0"));


### PR DESCRIPTION
This adds some coverage for our build tools dealing with `aarch64`. 
