### PR TITLE
Fix Failure in testQueryPhaseIsExecutedInAnAvailableNodeWhenAllShardsCanBeSkipped

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/TimestampFieldMapperService.java
+++ b/server/src/main/java/org/elasticsearch/indices/TimestampFieldMapperService.java
@@ -112,6 +112,7 @@ public class TimestampFieldMapperService extends AbstractLifecycleComponent impl
                         protected void doRun() throws Exception {
                             try (MapperService mapperService = indicesService.createIndexMapperService(indexMetadata)) {
                                 mapperService.merge(indexMetadata, MapperService.MergeReason.MAPPING_RECOVERY);
+                                logger.trace("computed timestamp field mapping for {}", index);
                                 future.onResponse(fromMapperService(mapperService));
                             }
                         }

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsCanMatchOnCoordinatorIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsCanMatchOnCoordinatorIntegTests.java
@@ -14,8 +14,6 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
-import org.elasticsearch.cluster.routing.IndexRoutingTable;
-import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
@@ -321,16 +319,20 @@ public class SearchableSnapshotsCanMatchOnCoordinatorIntegTests extends BaseSear
         internalCluster().stopNode(dataNodeHoldingSearchableSnapshot);
         waitUntilAllShardsAreUnassigned(updatedIndexMetadata.getIndex());
 
-        SearchResponse newSearchResponse = client().search(request).actionGet();
+        // busy assert since computing the time stamp field from the cluster state happens off of the CS applier thread and thus can be
+        // slightly delayed
+        assertBusy(() -> {
+            SearchResponse newSearchResponse = client().search(request).actionGet();
 
-        // All the regular index searches succeeded
-        assertThat(newSearchResponse.getSuccessfulShards(), equalTo(totalShards));
-        assertThat(newSearchResponse.getFailedShards(), equalTo(0));
-        // We have to query at least one node to construct a valid response, and we pick
-        // a shard that's available in order to construct the search response
-        assertThat(newSearchResponse.getSkippedShards(), equalTo(totalShards - 1));
-        assertThat(newSearchResponse.getTotalShards(), equalTo(totalShards));
-        assertThat(newSearchResponse.getHits().getTotalHits().value, equalTo(0L));
+            // All the regular index searches succeeded
+            assertThat(newSearchResponse.getSuccessfulShards(), equalTo(totalShards));
+            assertThat(newSearchResponse.getFailedShards(), equalTo(0));
+            // We have to query at least one node to construct a valid response, and we pick
+            // a shard that's available in order to construct the search response
+            assertThat(newSearchResponse.getSkippedShards(), equalTo(totalShards - 1));
+            assertThat(newSearchResponse.getTotalShards(), equalTo(totalShards));
+            assertThat(newSearchResponse.getHits().getTotalHits().value, equalTo(0L));
+        });
     }
 
     public void testSearchableSnapshotShardsThatHaveMatchingDataAreNotSkippedOnTheCoordinatingNode() throws Exception {
@@ -502,10 +504,6 @@ public class SearchableSnapshotsCanMatchOnCoordinatorIntegTests extends BaseSear
     }
 
     private void waitUntilAllShardsAreUnassigned(Index index) throws Exception {
-        assertBusy(() -> {
-            ClusterService clusterService = internalCluster().getCurrentMasterNodeInstance(ClusterService.class);
-            IndexRoutingTable indexRoutingTable = clusterService.state().getRoutingTable().index(index);
-            assertThat(indexRoutingTable.allPrimaryShardsUnassigned(), equalTo(true));
-        });
+        awaitClusterState(state -> state.getRoutingTable().index(index).allPrimaryShardsUnassigned());
     }
 }


### PR DESCRIPTION
We have to busy assert here due to the async nature of the CS application in this test.
Also, made the busy assertion that waits for unassigned primaries use the more deterministic
listener-based CS utility and added trace logging that would have made this much easier to
track down.

Closes #68591
