### PR TITLE
Replace NOT operator with explicit `false` check - part 10

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/admin/indices/settings/put/UpdateSettingsRequestSerializationTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/settings/put/UpdateSettingsRequestSerializationTests.java
@@ -39,7 +39,7 @@ public class UpdateSettingsRequestSerializationTests extends AbstractWireSeriali
         mutators.add(() -> mutation.indices(mutateIndices(request.indices())));
         mutators.add(() -> mutation.indicesOptions(randomValueOtherThan(request.indicesOptions(),
                 () -> IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean()))));
-        mutators.add(() -> mutation.setPreserveExisting(!request.isPreserveExisting()));
+        mutators.add(() -> mutation.setPreserveExisting(request.isPreserveExisting() == false));
         randomFrom(mutators).run();
         return mutation;
     }

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/settings/put/UpdateSettingsRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/settings/put/UpdateSettingsRequestTests.java
@@ -70,7 +70,7 @@ public class UpdateSettingsRequestTests extends AbstractXContentTestCase<UpdateS
     protected boolean assertToXContentEquivalence() {
         // if enclosedSettings are used, disable the XContentEquivalence check as the
         // parsed.toXContent is not equivalent to the test instance
-        return !enclosedSettings;
+        return enclosedSettings == false;
     }
 
 }

--- a/server/src/test/java/org/elasticsearch/action/ingest/SimulateDocumentVerboseResultTests.java
+++ b/server/src/test/java/org/elasticsearch/action/ingest/SimulateDocumentVerboseResultTests.java
@@ -23,7 +23,7 @@ public class SimulateDocumentVerboseResultTests extends AbstractXContentTestCase
         int numDocs = randomIntBetween(0, 5);
         List<SimulateProcessorResult> results = new ArrayList<>();
         for (int i = 0; i<numDocs; i++) {
-            boolean isSuccessful = !(withFailures && randomBoolean());
+            boolean isSuccessful = (withFailures && randomBoolean()) == false;
             boolean isIgnoredError = withFailures && randomBoolean();
             boolean hasCondition = withFailures && randomBoolean();
             results.add(

--- a/server/src/test/java/org/elasticsearch/action/main/MainResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/main/MainResponseTests.java
@@ -95,7 +95,7 @@ public class MainResponseTests extends AbstractSerializingTestCase<MainResponse>
             case 2:
                 // toggle the snapshot flag of the original Build parameter
                 build = new Build(
-                    Build.Flavor.UNKNOWN, Build.Type.UNKNOWN, build.hash(), build.date(), !build.isSnapshot(),
+                    Build.Flavor.UNKNOWN, Build.Type.UNKNOWN, build.hash(), build.date(), build.isSnapshot() == false,
                     build.getQualifiedVersion()
                 );
                 break;

--- a/server/src/test/java/org/elasticsearch/cluster/health/ClusterIndexHealthTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/health/ClusterIndexHealthTests.java
@@ -154,7 +154,7 @@ public class ClusterIndexHealthTests extends AbstractSerializingTestCase<Cluster
             case "status":
                 ClusterHealthStatus status = randomFrom(
                     Arrays.stream(ClusterHealthStatus.values()).filter(
-                        value -> !value.equals(instance.getStatus())
+                        value -> value.equals(instance.getStatus()) == false
                     ).collect(Collectors.toList())
                 );
                 return new ClusterIndexHealth(instance.getIndex(), instance.getNumberOfShards(),

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
@@ -492,7 +492,7 @@ public class MetadataTests extends ESTestCase {
     public void testMetadataGlobalStateChangesOnClusterUUIDChanges() {
         final Metadata metadata1 = Metadata.builder().clusterUUID(UUIDs.randomBase64UUID()).clusterUUIDCommitted(randomBoolean()).build();
         final Metadata metadata2 = Metadata.builder(metadata1).clusterUUID(UUIDs.randomBase64UUID()).build();
-        final Metadata metadata3 = Metadata.builder(metadata1).clusterUUIDCommitted(!metadata1.clusterUUIDCommitted()).build();
+        final Metadata metadata3 = Metadata.builder(metadata1).clusterUUIDCommitted(metadata1.clusterUUIDCommitted() == false).build();
         assertFalse(Metadata.isGlobalStateEquals(metadata1, metadata2));
         assertFalse(Metadata.isGlobalStateEquals(metadata1, metadata3));
         final Metadata metadata4 = Metadata.builder(metadata2).clusterUUID(metadata1.clusterUUID()).build();

--- a/server/src/test/java/org/elasticsearch/cluster/routing/OperationRoutingTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/OperationRoutingTests.java
@@ -364,7 +364,7 @@ public class OperationRoutingTests extends ESTestCase{
             final List<String> nodes = new ArrayList<>();
             final List<ShardRouting> expected = new ArrayList<>();
             for (int i = 0; i < count; i++) {
-                if (randomBoolean() && !shards.get(position).initializing()) {
+                if (randomBoolean() && shards.get(position).initializing() == false) {
                     nodes.add(shards.get(position).currentNodeId());
                     expected.add(shards.get(position));
                     position++;
@@ -466,7 +466,7 @@ public class OperationRoutingTests extends ESTestCase{
             final List<String> nodes = new ArrayList<>();
             final List<ShardRouting> expected = new ArrayList<>();
             for (int i = 0; i < count; i++) {
-                if (randomBoolean() && !shards.get(position).initializing()) {
+                if (randomBoolean() && shards.get(position).initializing() == false) {
                     nodes.add(shards.get(position).currentNodeId());
                     expected.add(shards.get(position));
                     position++;

--- a/server/src/test/java/org/elasticsearch/common/util/set/SetsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/set/SetsTests.java
@@ -83,7 +83,7 @@ public class SetsTests extends ESTestCase {
     private void assertDifference(
             final int endExclusive, final Tuple<Set<Integer>, Set<Integer>> sets, final Set<Integer> difference) {
         for (int i = 0; i < endExclusive; i++) {
-            assertThat(difference.contains(i), equalTo(sets.v1().contains(i) && !sets.v2().contains(i)));
+            assertThat(difference.contains(i), equalTo(sets.v1().contains(i) && sets.v2().contains(i) == false));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/gateway/PrimaryShardAllocatorTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/PrimaryShardAllocatorTests.java
@@ -284,7 +284,7 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
             randomFrom(CLUSTER_RECOVERED, INDEX_REOPENED), primaryAllocId, replicaAllocId);
         boolean node1HasPrimaryShard = randomBoolean();
         testAllocator.addData(node1, node1HasPrimaryShard ? primaryAllocId : replicaAllocId, node1HasPrimaryShard);
-        testAllocator.addData(node2, node1HasPrimaryShard ? replicaAllocId : primaryAllocId, !node1HasPrimaryShard);
+        testAllocator.addData(node2, node1HasPrimaryShard ? replicaAllocId : primaryAllocId, node1HasPrimaryShard == false);
         allocateAllUnassigned(allocation);
         assertThat(allocation.routingNodesChanged(), equalTo(true));
         assertThat(allocation.routingNodes().unassigned().ignored().isEmpty(), equalTo(true));

--- a/server/src/test/java/org/elasticsearch/index/mapper/MultiFieldTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/MultiFieldTests.java
@@ -143,7 +143,7 @@ public class MultiFieldTests extends MapperServiceTestCase {
         String[] multiFieldNames = new String[randomIntBetween(2, 10)];
         Set<String> seenFields = new HashSet<>();
         for (int i = 0; i < multiFieldNames.length; i++) {
-            multiFieldNames[i] = randomValueOtherThanMany(s -> !seenFields.add(s), () -> randomAlphaOfLength(4));
+            multiFieldNames[i] = randomValueOtherThanMany(s -> seenFields.add(s) == false, () -> randomAlphaOfLength(4));
         }
 
         DocumentMapper docMapper = createDocumentMapper(fieldMapping(b -> {

--- a/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldTypeTests.java
@@ -266,7 +266,7 @@ public class RangeFieldTypeTests extends FieldTypeTestCase {
 
         // get exact lower and upper bounds similar to what we would parse for `date` fields for same input strings
         DateFieldType dateFieldType = new DateFieldType("field");
-        long lowerBoundLong = dateFieldType.parseToLong(lowerAsString, !includeLower, null, formatter.toDateMathParser(), () -> 0);
+        long lowerBoundLong = dateFieldType.parseToLong(lowerAsString, includeLower == false, null, formatter.toDateMathParser(), () -> 0);
         if (includeLower == false) {
             ++lowerBoundLong;
         }

--- a/server/src/test/java/org/elasticsearch/index/query/MatchIntervalsSourceProviderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/MatchIntervalsSourceProviderTests.java
@@ -41,7 +41,7 @@ public class MatchIntervalsSourceProviderTests extends AbstractSerializingTestCa
                 maxGaps++;
                 break;
             case 2:
-                isOrdered = !isOrdered;
+                isOrdered = isOrdered == false;
                 break;
             case 3:
                 analyzer = analyzer == null ? randomAlphaOfLength(5) : null;

--- a/server/src/test/java/org/elasticsearch/index/search/SimpleQueryStringQueryParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/search/SimpleQueryStringQueryParserTests.java
@@ -21,11 +21,11 @@ public class SimpleQueryStringQueryParserTests extends ESTestCase {
         assertNotEquals(settings1, null);
         assertNotEquals(settings1, s);
 
-        settings2.lenient(!settings1.lenient());
+        settings2.lenient(settings1.lenient() == false);
         assertNotEquals(settings1, settings2);
 
         settings2 = new SimpleQueryStringQueryParser.Settings();
-        settings2.analyzeWildcard(!settings1.analyzeWildcard());
+        settings2.analyzeWildcard(settings1.analyzeWildcard() == false);
         assertNotEquals(settings1, settings2);
 
         settings2 = new SimpleQueryStringQueryParser.Settings();
@@ -33,7 +33,7 @@ public class SimpleQueryStringQueryParserTests extends ESTestCase {
         assertNotEquals(settings1, settings2);
 
         settings2 = new SimpleQueryStringQueryParser.Settings();
-        settings2.autoGenerateSynonymsPhraseQuery(!settings1.autoGenerateSynonymsPhraseQuery());
+        settings2.autoGenerateSynonymsPhraseQuery(settings1.autoGenerateSynonymsPhraseQuery() == false);
         assertNotEquals(settings1, settings2);
 
         settings2 = new SimpleQueryStringQueryParser.Settings();
@@ -45,7 +45,7 @@ public class SimpleQueryStringQueryParserTests extends ESTestCase {
         assertNotEquals(settings1, settings2);
 
         settings2 = new SimpleQueryStringQueryParser.Settings();
-        settings2.fuzzyTranspositions(!settings1.fuzzyTranspositions());
+        settings2.fuzzyTranspositions(settings1.fuzzyTranspositions() == false);
         assertNotEquals(settings1, settings2);
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/seqno/ReplicationTrackerTestCase.java
+++ b/server/src/test/java/org/elasticsearch/index/seqno/ReplicationTrackerTestCase.java
@@ -58,7 +58,7 @@ public abstract class ReplicationTrackerTestCase extends ESTestCase  {
     }
 
     static IndexShardRoutingTable routingTable(final Set<AllocationId> initializingIds, final ShardRouting primaryShard) {
-        assert !initializingIds.contains(primaryShard.allocationId());
+        assert initializingIds.contains(primaryShard.allocationId()) == false;
         final ShardId shardId = new ShardId("test", "_na_", 0);
         final IndexShardRoutingTable.Builder builder = new IndexShardRoutingTable.Builder(shardId);
         for (final AllocationId initializingId : initializingIds) {

--- a/server/src/test/java/org/elasticsearch/index/seqno/ReplicationTrackerTests.java
+++ b/server/src/test/java/org/elasticsearch/index/seqno/ReplicationTrackerTests.java
@@ -232,7 +232,7 @@ public class ReplicationTrackerTests extends ReplicationTrackerTestCase {
         assigned
                 .entrySet()
                 .stream()
-                .filter(e -> !e.getKey().equals(missingActiveID))
+                .filter(e -> e.getKey().equals(missingActiveID) == false)
                 .forEach(e -> updateLocalCheckpoint(tracker, e.getKey().getId(), e.getValue()));
 
         if (missingActiveID.equals(primaryId) == false) {
@@ -491,10 +491,10 @@ public class ReplicationTrackerTests extends ReplicationTrackerTestCase {
         final Set<AllocationId> removingActiveAllocationIds = new HashSet<>(randomSubsetOf(activeAllocationIds));
         removingActiveAllocationIds.remove(primaryId);
         final Set<AllocationId> newActiveAllocationIds =
-                activeAllocationIds.stream().filter(a -> !removingActiveAllocationIds.contains(a)).collect(Collectors.toSet());
+                activeAllocationIds.stream().filter(a -> removingActiveAllocationIds.contains(a) == false).collect(Collectors.toSet());
         final List<AllocationId> removingInitializingAllocationIds = randomSubsetOf(initializingIds);
         final Set<AllocationId> newInitializingAllocationIds =
-                initializingIds.stream().filter(a -> !removingInitializingAllocationIds.contains(a)).collect(Collectors.toSet());
+                initializingIds.stream().filter(a -> removingInitializingAllocationIds.contains(a) == false).collect(Collectors.toSet());
         routingTable = routingTable(newInitializingAllocationIds, primaryId);
         tracker.updateFromMaster(initialClusterStateVersion + 1, ids(newActiveAllocationIds), routingTable);
         assertTrue(newActiveAllocationIds.stream().allMatch(a -> tracker.getTrackedLocalCheckpointForShard(a.getId()).inSync));
@@ -922,7 +922,7 @@ public class ReplicationTrackerTests extends ReplicationTrackerTestCase {
     }
 
     private static Set<AllocationId> exclude(Collection<AllocationId> allocationIds, Set<String> excludeIds) {
-        return allocationIds.stream().filter(aId -> !excludeIds.contains(aId.getId())).collect(Collectors.toSet());
+        return allocationIds.stream().filter(aId -> excludeIds.contains(aId.getId()) == false).collect(Collectors.toSet());
     }
 
     private static Tuple<Set<AllocationId>, Set<AllocationId>> randomActiveAndInitializingAllocationIds(

--- a/server/src/test/java/org/elasticsearch/monitor/os/OsProbeTests.java
+++ b/server/src/test/java/org/elasticsearch/monitor/os/OsProbeTests.java
@@ -244,7 +244,7 @@ public class OsProbeTests extends ESTestCase {
         // This cgroup data is missing a line about memory
         List<String> procSelfCgroupLines = getProcSelfGroupLines(hierarchy)
             .stream()
-            .filter(line -> !line.contains(":memory:"))
+            .filter(line -> line.contains(":memory:") == false)
             .collect(Collectors.toList());
 
         final OsProbe probe = buildStubOsProbe(true, hierarchy, procSelfCgroupLines);

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/VariableWidthHistogramAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/VariableWidthHistogramAggregatorTests.java
@@ -586,7 +586,7 @@ public class VariableWidthHistogramAggregatorTests extends AggregatorTestCase {
     }
 
     private void indexSampleData(List<Number> dataset, RandomIndexWriter indexWriter, boolean multipleSegments) throws IOException {
-        if(!multipleSegments) {
+        if (multipleSegments == false) {
             // Put all of the documents into one segment
             List<Document> documents = new ArrayList<>();
             for (final Number doc : dataset) {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregationBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregationBuilderTests.java
@@ -79,7 +79,7 @@ public class RangeAggregationBuilderTests extends AbstractSerializingTestCase<Ra
                 name += randomAlphaOfLength(1);
                 break;
             case 1:
-                keyed = !keyed;
+                keyed = keyed == false;
                 break;
             case 2:
                 field += randomAlphaOfLength(1);

--- a/server/src/test/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilderTests.java
@@ -109,7 +109,7 @@ public class PhraseSuggestionBuilderTests extends AbstractSuggestionBuilderTestC
             }
             break;
         case 7:
-            builder.collatePrune(builder.collatePrune() == null ? randomBoolean() : !builder.collatePrune() );
+            builder.collatePrune(builder.collatePrune() == null ? randomBoolean() : builder.collatePrune() == false );
             break;
         case 8:
             // preTag, postTag
@@ -122,7 +122,7 @@ public class PhraseSuggestionBuilderTests extends AbstractSuggestionBuilderTestC
             }
             break;
         case 9:
-            builder.forceUnigrams(builder.forceUnigrams() == null ? randomBoolean() : ! builder.forceUnigrams());
+            builder.forceUnigrams(builder.forceUnigrams() == null ? randomBoolean() : builder.forceUnigrams() == false);
             break;
         case 10:
             Map<String, Object> collateParams = builder.collateParams() == null ? new HashMap<>(1) : builder.collateParams();

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotsInProgressSerializationTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotsInProgressSerializationTests.java
@@ -143,11 +143,11 @@ public class SnapshotsInProgressSerializationTests extends AbstractDiffableWireS
     private Entry mutateEntry(Entry entry) {
         switch (randomInt(7)) {
             case 0:
-                boolean includeGlobalState = !entry.includeGlobalState();
+                boolean includeGlobalState = entry.includeGlobalState() == false;
                 return new Entry(entry.snapshot(), includeGlobalState, entry.partial(), entry.state(), entry.indices(), entry.dataStreams(),
                     entry.startTime(), entry.repositoryStateId(), entry.shards(), entry.failure(), entry.userMetadata(), entry.version());
             case 1:
-                boolean partial = !entry.partial();
+                boolean partial = entry.partial() == false;
                 return new Entry(entry.snapshot(), entry.includeGlobalState(), partial, entry.state(), entry.indices(), entry.dataStreams(),
                     entry.startTime(), entry.repositoryStateId(), entry.shards(), entry.failure(), entry.userMetadata(), entry.version());
             case 2:

--- a/test/framework/src/test/java/org/elasticsearch/test/VersionUtilsTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/VersionUtilsTests.java
@@ -295,7 +295,7 @@ public class VersionUtilsTests extends ESTestCase {
                 .collect(toList());
 
         List<String> releasedIndexCompatible = released.stream()
-                .filter(v -> !Version.CURRENT.equals(v))
+                .filter(v -> Version.CURRENT.equals(v) == false)
                 .map(Object::toString)
                 .collect(toList());
         assertEquals(releasedIndexCompatible, indexCompatible.released);
@@ -313,7 +313,7 @@ public class VersionUtilsTests extends ESTestCase {
 
         Version minimumCompatibleVersion = Version.CURRENT.minimumCompatibilityVersion();
         List<String> releasedWireCompatible = released.stream()
-                .filter(v -> !Version.CURRENT.equals(v))
+                .filter(v -> Version.CURRENT.equals(v) == false)
                 .filter(v -> v.onOrAfter(minimumCompatibleVersion))
                 .map(Object::toString)
                 .collect(toList());

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/stringstats/StringStatsAggregationBuilderTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/stringstats/StringStatsAggregationBuilderTests.java
@@ -64,7 +64,7 @@ public class StringStatsAggregationBuilderTests extends AbstractSerializingTestC
     protected StringStatsAggregationBuilder mutateInstance(StringStatsAggregationBuilder instance) throws IOException {
         if (randomBoolean()) {
             StringStatsAggregationBuilder mutant = new StringStatsAggregationBuilder(instance.getName());
-            mutant.showDistribution(!instance.showDistribution());
+            mutant.showDistribution(instance.showDistribution() == false);
             return mutant;
         }
         StringStatsAggregationBuilder mutant = new StringStatsAggregationBuilder(randomAlphaOfLength(4));

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/LicensesMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/LicensesMetadata.java
@@ -20,6 +20,7 @@ import org.elasticsearch.license.License.OperationMode;
 
 import java.io.IOException;
 import java.util.EnumSet;
+import java.util.Objects;
 
 /**
  * Contains metadata about registered licenses
@@ -92,8 +93,8 @@ public class LicensesMetadata extends AbstractNamedDiffable<Metadata.Custom> imp
 
         LicensesMetadata that = (LicensesMetadata) o;
 
-        if (license != null ? !license.equals(that.license) : that.license != null) return false;
-        return trialVersion != null ? trialVersion.equals(that.trialVersion) : that.trialVersion == null;
+        return Objects.equals(license, that.license)
+            && Objects.equals(trialVersion, that.trialVersion);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/graph/Vertex.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/graph/Vertex.java
@@ -225,19 +225,14 @@ public class Vertex implements ToXContentFragment {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o)
+            if (this == o) {
                 return true;
-            if (o == null || getClass() != o.getClass())
+            }
+            if (o == null || getClass() != o.getClass()) {
                 return false;
-
+            }
             VertexId vertexId = (VertexId) o;
-
-            if (field != null ? !field.equals(vertexId.field) : vertexId.field != null)
-                return false;
-            if (term != null ? !term.equals(vertexId.term) : vertexId.term != null)
-                return false;
-
-            return true;
+            return Objects.equals(field, vertexId.field) && Objects.equals(term, vertexId.term);
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PersistJobAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PersistJobAction.java
@@ -48,7 +48,7 @@ public class PersistJobAction extends ActionType<PersistJobAction.Response> {
         }
 
         public boolean isForeground() {
-            return !isBackGround();
+            return isBackGround() == false;
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/RuleScope.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/RuleScope.java
@@ -83,7 +83,7 @@ public class RuleScope implements ToXContentObject, Writeable {
     }
 
     public void validate(Set<String> validKeys) {
-        Optional<String> invalidKey = scope.keySet().stream().filter(k -> !validKeys.contains(k)).findFirst();
+        Optional<String> invalidKey = scope.keySet().stream().filter(k -> validKeys.contains(k) == false).findFirst();
         if (invalidKey.isPresent()) {
             if (validKeys.isEmpty()) {
                 throw ExceptionsHelper.badRequestException(Messages.getMessage(Messages.JOB_CONFIG_DETECTION_RULE_SCOPE_NO_AVAILABLE_FIELDS,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/MlStrings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/MlStrings.java
@@ -66,7 +66,7 @@ public final class MlStrings {
     }
 
     public static boolean isValidId(String id) {
-        return id != null && VALID_ID_CHAR_PATTERN.matcher(id).matches() && !Metadata.ALL.equals(id);
+        return id != null && VALID_ID_CHAR_PATTERN.matcher(id).matches() && Metadata.ALL.equals(id) == false;
     }
 
     /**

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/Privilege.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/Privilege.java
@@ -14,6 +14,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -59,9 +60,7 @@ public class Privilege {
 
         Privilege privilege = (Privilege) o;
 
-        if (name != null ? !name.equals(privilege.name) : privilege.name != null) return false;
-
-        return true;
+        return Objects.equals(name, privilege.name);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/PEMKeyConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/PEMKeyConfig.java
@@ -143,15 +143,16 @@ class PEMKeyConfig extends KeyConfig {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         PEMKeyConfig that = (PEMKeyConfig) o;
-
-        if (keyPath != null ? !keyPath.equals(that.keyPath) : that.keyPath != null) return false;
-        if (keyPassword != null ? !keyPassword.equals(that.keyPassword) : that.keyPassword != null) return false;
-        return certPath != null ? certPath.equals(that.certPath) : that.certPath == null;
-
+        return Objects.equals(keyPath, that.keyPath)
+            && Objects.equals(keyPassword, that.keyPassword)
+            && Objects.equals(certPath, that.certPath);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/SSLClientAuth.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/SSLClientAuth.java
@@ -22,8 +22,8 @@ public enum SSLClientAuth {
 
         public void configure(SSLParameters sslParameters) {
             // nothing to do here
-            assert !sslParameters.getWantClientAuth();
-            assert !sslParameters.getNeedClientAuth();
+            assert sslParameters.getWantClientAuth() == false;
+            assert sslParameters.getNeedClientAuth() == false;
         }
     },
     OPTIONAL() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/SSLConfiguration.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/SSLConfiguration.java
@@ -19,6 +19,7 @@ import java.nio.file.Path;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import static org.elasticsearch.xpack.core.ssl.SSLConfigurationSettings.getKeyStoreType;
 
@@ -134,26 +135,12 @@ public final class SSLConfiguration {
 
         SSLConfiguration that = (SSLConfiguration) o;
 
-        if (this.keyConfig() != null ? !this.keyConfig().equals(that.keyConfig()) : that.keyConfig() != null) {
-            return false;
-        }
-        if (this.trustConfig() != null ? !this.trustConfig().equals(that.trustConfig()) : that.trustConfig() != null) {
-            return false;
-        }
-        if (this.cipherSuites() != null ? !this.cipherSuites().equals(that.cipherSuites()) : that.cipherSuites() != null) {
-            return false;
-        }
-        if (this.supportedProtocols().equals(that.supportedProtocols()) == false) {
-            return false;
-        }
-        if (this.verificationMode() != that.verificationMode()) {
-            return false;
-        }
-        if (this.sslClientAuth() != that.sslClientAuth()) {
-            return false;
-        }
-        return this.supportedProtocols() != null ?
-                this.supportedProtocols().equals(that.supportedProtocols()) : that.supportedProtocols() == null;
+        return Objects.equals(this.keyConfig(), that.keyConfig())
+            && Objects.equals(this.trustConfig(), that.trustConfig())
+            && Objects.equals(this.cipherSuites(), that.cipherSuites())
+            && Objects.equals(this.supportedProtocols(), that.supportedProtocols())
+            && Objects.equals(this.verificationMode(), that.verificationMode())
+            && Objects.equals(this.sslClientAuth(), that.sslClientAuth());
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/SSLService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/SSLService.java
@@ -421,7 +421,7 @@ public class SSLService {
                     + " are supported by this JVM");
         }
 
-        if (log && !unsupportedCiphers.isEmpty()) {
+        if (log && unsupportedCiphers.isEmpty() == false) {
             logger.error("unsupported ciphers [{}] were requested but cannot be used in this JVM, however there are supported ciphers " +
                     "that will be used [{}]. If you are trying to use ciphers with a key length greater than 128 bits on an Oracle JVM, " +
                     "you will need to install the unlimited strength JCE policy files.", unsupportedCiphers, supportedCiphersList);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/StoreKeyConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/StoreKeyConfig.java
@@ -178,21 +178,16 @@ class StoreKeyConfig extends KeyConfig {
         }
         StoreKeyConfig that = (StoreKeyConfig) o;
         return Objects.equals(keyStorePath, that.keyStorePath)
+            && Objects.equals(keyStoreType, that.keyStoreType)
             && Objects.equals(keyStorePassword, that.keyStorePassword)
             && Objects.equals(keyStoreAlgorithm, that.keyStoreAlgorithm)
             && Objects.equals(keyPassword, that.keyPassword)
-            && Objects.equals(keyStoreType, that.keyStoreType)
             && Objects.equals(trustStoreAlgorithm, that.trustStoreAlgorithm);
     }
 
     @Override
     public int hashCode() {
-        int result = keyStorePath != null ? keyStorePath.hashCode() : 0;
-        result = 31 * result + (keyStorePassword != null ? keyStorePassword.hashCode() : 0);
-        result = 31 * result + (keyStoreAlgorithm != null ? keyStoreAlgorithm.hashCode() : 0);
-        result = 31 * result + (keyPassword != null ? keyPassword.hashCode() : 0);
-        result = 31 * result + (trustStoreAlgorithm != null ? trustStoreAlgorithm.hashCode() : 0);
-        return result;
+        return Objects.hash(keyStorePath, keyStoreType, keyStorePassword, keyStoreAlgorithm, keyPassword, trustStoreAlgorithm);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/StoreKeyConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/StoreKeyConfig.java
@@ -167,20 +167,22 @@ class StoreKeyConfig extends KeyConfig {
             "the configured PKCS#11 token does not contain a private key entry";
         throw new IllegalArgumentException(message);
     }
+
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         StoreKeyConfig that = (StoreKeyConfig) o;
-
-        if (keyStorePath != null ? !keyStorePath.equals(that.keyStorePath) : that.keyStorePath != null) return false;
-        if (keyStorePassword != null ? !keyStorePassword.equals(that.keyStorePassword) : that.keyStorePassword != null)
-            return false;
-        if (keyStoreAlgorithm != null ? !keyStoreAlgorithm.equals(that.keyStoreAlgorithm) : that.keyStoreAlgorithm != null)
-            return false;
-        if (keyPassword != null ? !keyPassword.equals(that.keyPassword) : that.keyPassword != null) return false;
-        return trustStoreAlgorithm != null ? trustStoreAlgorithm.equals(that.trustStoreAlgorithm) : that.trustStoreAlgorithm == null;
+        return Objects.equals(keyStorePath, that.keyStorePath)
+            && Objects.equals(keyStorePassword, that.keyStorePassword)
+            && Objects.equals(keyStoreAlgorithm, that.keyStoreAlgorithm)
+            && Objects.equals(keyPassword, that.keyPassword)
+            && Objects.equals(keyStoreType, that.keyStoreType)
+            && Objects.equals(trustStoreAlgorithm, that.trustStoreAlgorithm);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/StoreTrustConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/StoreTrustConfig.java
@@ -102,23 +102,22 @@ class StoreTrustConfig extends TrustConfig {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        StoreTrustConfig that = (StoreTrustConfig) o;
-
-        if (trustStorePath != null ? !trustStorePath.equals(that.trustStorePath) : that.trustStorePath != null) return false;
-        if (trustStorePassword != null ? !trustStorePassword.equals(that.trustStorePassword) : that.trustStorePassword != null)
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
             return false;
-        return trustStoreAlgorithm != null ? trustStoreAlgorithm.equals(that.trustStoreAlgorithm) : that.trustStoreAlgorithm == null;
+        }
+        StoreTrustConfig that = (StoreTrustConfig) o;
+        return Objects.equals(trustStorePath, that.trustStorePath)
+            && Objects.equals(trustStoreType, that.trustStoreType)
+            && Objects.equals(trustStorePassword, that.trustStorePassword)
+            && Objects.equals(trustStoreAlgorithm, that.trustStoreAlgorithm);
     }
 
     @Override
     public int hashCode() {
-        int result = trustStorePath != null ? trustStorePath.hashCode() : 0;
-        result = 31 * result + (trustStorePassword != null ? trustStorePassword.hashCode() : 0);
-        result = 31 * result + (trustStoreAlgorithm != null ? trustStoreAlgorithm.hashCode() : 0);
-        return result;
+        return Objects.hash(trustStorePath, trustStoreType, trustStorePassword, trustStoreAlgorithm);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/utils/TransformStrings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/utils/TransformStrings.java
@@ -29,7 +29,7 @@ public final class TransformStrings {
     }
 
     public static boolean isValidId(String id) {
-        return id != null && VALID_ID_CHAR_PATTERN.matcher(id).matches() && !Metadata.ALL.equals(id);
+        return id != null && VALID_ID_CHAR_PATTERN.matcher(id).matches() && Metadata.ALL.equals(id) == false;
     }
 
     /**

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/execution/WatchExecutionContext.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/execution/WatchExecutionContext.java
@@ -163,7 +163,7 @@ public abstract class WatchExecutionContext {
     }
 
     public void onInputResult(Input.Result inputResult) {
-        assert !phase.sealed();
+        assert phase.sealed() == false;
         this.inputResult = inputResult;
         if (inputResult.status() == Input.Result.Status.SUCCESS) {
             this.payload = inputResult.payload();
@@ -180,7 +180,7 @@ public abstract class WatchExecutionContext {
     }
 
     public void onConditionResult(Condition.Result conditionResult) {
-        assert !phase.sealed();
+        assert phase.sealed() == false;
         this.conditionResult = conditionResult;
         watch().status().onCheck(conditionResult.met(), executionTime);
     }
@@ -195,7 +195,7 @@ public abstract class WatchExecutionContext {
     }
 
     public void onWatchTransformResult(Transform.Result result) {
-        assert !phase.sealed();
+        assert phase.sealed() == false;
         this.transformResult = result;
         if (result.status() == Transform.Result.Status.SUCCESS) {
             this.payload = result.payload();
@@ -212,7 +212,7 @@ public abstract class WatchExecutionContext {
     }
 
     public void onActionResult(ActionWrapperResult result) {
-        assert !phase.sealed();
+        assert phase.sealed() == false;
         actionsResults.put(result.id(), result);
         watch().status().onActionResult(result.id(), executionTime, result.action());
     }
@@ -222,13 +222,13 @@ public abstract class WatchExecutionContext {
     }
 
     public WatchRecord abortBeforeExecution(ExecutionState state, String message) {
-        assert !phase.sealed();
+        assert phase.sealed() == false;
         phase = ExecutionPhase.ABORTED;
         return new WatchRecord.MessageWatchRecord(id, triggerEvent, state, message, getNodeId());
     }
 
     public WatchRecord abortFailedExecution(String message) {
-        assert !phase.sealed();
+        assert phase.sealed() == false;
         phase = ExecutionPhase.ABORTED;
         long executionTime = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - relativeStartTime);
         WatchExecutionResult result = new WatchExecutionResult(this, executionTime);
@@ -237,7 +237,7 @@ public abstract class WatchExecutionContext {
     }
 
     public WatchRecord abortFailedExecution(Exception e) {
-        assert !phase.sealed();
+        assert phase.sealed() == false;
         phase = ExecutionPhase.ABORTED;
         long executionTime = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - relativeStartTime);
         WatchExecutionResult result = new WatchExecutionResult(this, executionTime);
@@ -246,7 +246,7 @@ public abstract class WatchExecutionContext {
     }
 
     public WatchRecord finish() {
-        assert !phase.sealed();
+        assert phase.sealed() == false;
         phase = ExecutionPhase.FINISHED;
         long executionTime = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - relativeStartTime);
         WatchExecutionResult result = new WatchExecutionResult(this, executionTime);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/MulticlassConfusionMatrixResultTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/MulticlassConfusionMatrixResultTests.java
@@ -63,7 +63,7 @@ public class MulticlassConfusionMatrixResultTests extends AbstractSerializingTes
     @Override
     protected Predicate<String> getRandomFieldsExcludeFilter() {
         // allow unknown fields in the root of the object only
-        return field -> !field.isEmpty();
+        return field -> field.isEmpty() == false;
     }
 
     public void testConstructor_ValidationFailures() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfigTests.java
@@ -91,7 +91,7 @@ public class TrainedModelConfigTests extends AbstractBWCSerializationTestCase<Tr
 
     @Override
     protected Predicate<String> getRandomFieldsExcludeFilter() {
-        return field -> !field.isEmpty();
+        return field -> field.isEmpty() == false;
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelDefinitionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelDefinitionTests.java
@@ -51,7 +51,7 @@ public class TrainedModelDefinitionTests extends AbstractSerializingTestCase<Tra
 
     @Override
     protected Predicate<String> getRandomFieldsExcludeFilter() {
-        return field -> !field.isEmpty();
+        return field -> field.isEmpty() == false;
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelInputTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelInputTests.java
@@ -38,7 +38,7 @@ public class TrainedModelInputTests extends AbstractSerializingTestCase<TrainedM
 
     @Override
     protected Predicate<String> getRandomFieldsExcludeFilter() {
-        return field -> !field.isEmpty();
+        return field -> field.isEmpty() == false;
     }
 
     public static TrainedModelInput createRandomInput() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/MultiTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/MultiTests.java
@@ -6,10 +6,9 @@
  */
 package org.elasticsearch.xpack.core.ml.inference.preprocessing;
 
-import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasEntry;
+import org.elasticsearch.common.collect.MapBuilder;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -19,9 +18,10 @@ import java.util.Map;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
-import org.elasticsearch.common.collect.MapBuilder;
-import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.xcontent.XContentParser;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
 
 public class MultiTests extends PreProcessingTests<Multi> {
 
@@ -34,7 +34,7 @@ public class MultiTests extends PreProcessingTests<Multi> {
 
     @Override
     protected Predicate<String> getRandomFieldsExcludeFilter() {
-        return field -> !field.isEmpty();
+        return field -> field.isEmpty() == false;
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/PreProcessingTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/PreProcessingTests.java
@@ -51,7 +51,7 @@ public abstract class PreProcessingTests<T extends PreProcessor> extends Abstrac
 
     @Override
     protected Predicate<String> getRandomFieldsExcludeFilter() {
-        return field -> !field.isEmpty();
+        return field -> field.isEmpty() == false;
     }
 
     void testProcess(PreProcessor preProcessor, Map<String, Object> fieldValues, Map<String, Matcher<? super Object>> assertions) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/SourceConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/SourceConfigTests.java
@@ -71,7 +71,7 @@ public class SourceConfigTests extends AbstractSerializingTransformTestCase<Sour
     @Override
     protected Predicate<String> getRandomFieldsExcludeFilter() {
         // allow unknown fields in the root of the object only as QueryConfig stores a Map<String, Object>
-        return field -> !field.isEmpty();
+        return field -> field.isEmpty() == false;
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformIndexerPositionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformIndexerPositionTests.java
@@ -39,7 +39,7 @@ public class TransformIndexerPositionTests extends AbstractSerializingTestCase<T
 
     @Override
     protected Predicate<String> getRandomFieldsExcludeFilter() {
-        return field -> !field.isEmpty();
+        return field -> field.isEmpty() == false;
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformStateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformStateTests.java
@@ -58,7 +58,7 @@ public class TransformStateTests extends AbstractSerializingTestCase<TransformSt
 
     @Override
     protected Predicate<String> getRandomFieldsExcludeFilter() {
-        return field -> !field.isEmpty();
+        return field -> field.isEmpty() == false;
     }
 
     public void testBackwardsSerialization() throws IOException {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformStatsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformStatsTests.java
@@ -60,7 +60,7 @@ public class TransformStatsTests extends AbstractSerializingTestCase<TransformSt
 
     @Override
     protected Predicate<String> getRandomFieldsExcludeFilter() {
-        return field -> !field.isEmpty();
+        return field -> field.isEmpty() == false;
     }
 
     public void testBwcWith73() throws IOException {

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/planner/Verifier.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/planner/Verifier.java
@@ -26,7 +26,7 @@ abstract class Verifier {
                 failures.add(fail(p, "Unplanned item {}", ((UnplannedExec) p).plan().nodeName()));
             }
             p.forEachExpressionUp(e -> {
-                if (e.childrenResolved() && !e.resolved()) {
+                if (e.childrenResolved() && e.resolved() == false) {
                     failures.add(fail(e, "Unresolved expression"));
                 }
             });
@@ -42,7 +42,7 @@ abstract class Verifier {
                 failures.add(fail(p, "Unexecutable item {}", p.nodeName()));
             }
             p.forEachExpressionUp(e -> {
-                if (e.childrenResolved() && !e.resolved()) {
+                if (e.childrenResolved() && e.resolved() == false) {
                     failures.add(fail(e, "Unresolved expression"));
                 }
             });

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetJobsStatsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetJobsStatsAction.java
@@ -213,6 +213,6 @@ public class TransportGetJobsStatsAction extends TransportTasksAction<JobTask, G
     static List<String> determineJobIdsWithoutLiveStats(List<String> requestedJobIds,
                                                         List<GetJobsStatsAction.Response.JobStats> stats) {
         Set<String> excludeJobIds = stats.stream().map(GetJobsStatsAction.Response.JobStats::getJobId).collect(Collectors.toSet());
-        return requestedJobIds.stream().filter(jobId -> !excludeJobIds.contains(jobId)).collect(Collectors.toList());
+        return requestedJobIds.stream().filter(jobId -> excludeJobIds.contains(jobId) == false).collect(Collectors.toList());
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetOverallBucketsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetOverallBucketsAction.java
@@ -127,7 +127,7 @@ public class TransportGetOverallBucketsAction extends HandledTransportAction<Get
     }
 
     private static boolean requiresAggregation(GetOverallBucketsAction.Request request, TimeValue maxBucketSpan) {
-        return request.getBucketSpan() != null && !request.getBucketSpan().equals(maxBucketSpan);
+        return request.getBucketSpan() != null && request.getBucketSpan().equals(maxBucketSpan) == false;
     }
 
     private static void checkValidBucketSpan(TimeValue bucketSpan, TimeValue maxBucketSpan) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/TimeBasedExtractedFields.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/TimeBasedExtractedFields.java
@@ -65,7 +65,7 @@ public class TimeBasedExtractedFields extends ExtractedFields {
             throw new IllegalArgumentException("cannot retrieve time field [" + timeField + "] because it is not aggregatable");
         }
         ExtractedField timeExtractedField = extractedTimeField(timeField, scriptFields);
-        List<String> remainingFields = job.allInputFields().stream().filter(f -> !f.equals(timeField)).collect(Collectors.toList());
+        List<String> remainingFields = job.allInputFields().stream().filter(f -> f.equals(timeField) == false).collect(Collectors.toList());
         List<ExtractedField> allExtractedFields = new ArrayList<>(remainingFields.size() + 1);
         allExtractedFields.add(timeExtractedField);
         remainingFields.forEach(field -> allExtractedFields.add(extractionMethodDetector.detect(field)));

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/JobSnapshotUpgraderResultProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/JobSnapshotUpgraderResultProcessor.java
@@ -163,11 +163,11 @@ public class JobSnapshotUpgraderResultProcessor {
             logUnexpectedResult(Bucket.RESULT_TYPE_VALUE);
         }
         List<AnomalyRecord> records = result.getRecords();
-        if (records != null && !records.isEmpty()) {
+        if (records != null && records.isEmpty() == false) {
             logUnexpectedResult(AnomalyRecord.RESULT_TYPE_VALUE);
         }
         List<Influencer> influencers = result.getInfluencers();
-        if (influencers != null && !influencers.isEmpty()) {
+        if (influencers != null && influencers.isEmpty() == false) {
             logUnexpectedResult(Influencer.RESULT_TYPE_VALUE);
         }
         CategoryDefinition categoryDefinition = result.getCategoryDefinition();

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/writer/AbstractDataToProcessWriter.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/writer/AbstractDataToProcessWriter.java
@@ -76,7 +76,7 @@ public abstract class AbstractDataToProcessWriter implements DataToProcessWriter
             latestEpochMs = date.getTime();
         }
 
-        boolean isDateFormatString = dataDescription.isTransformTime() && !dataDescription.isEpochMs();
+        boolean isDateFormatString = dataDescription.isTransformTime() && dataDescription.isEpochMs() == false;
         if (isDateFormatString) {
             dateTransformer = new DateFormatDateTransformer(dataDescription.getTimeFormat());
         } else {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/NamedPipeHelper.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/NamedPipeHelper.java
@@ -110,7 +110,7 @@ public class NamedPipeHelper {
 
         // Can't use Files.isRegularFile() on on named pipes on Windows, as it renders them unusable,
         // but luckily there's an even simpler check (that's not possible on *nix)
-        if (Constants.WINDOWS && !file.toString().startsWith(WIN_PIPE_PREFIX)) {
+        if (Constants.WINDOWS && file.toString().startsWith(WIN_PIPE_PREFIX) == false) {
             throw new IOException(file + " is not a named pipe");
         }
 
@@ -231,7 +231,7 @@ public class NamedPipeHelper {
 
         // Periodically check whether the file exists until the timeout expires, then, if
         // it's still not available throw a FileNotFoundException
-        while (timeoutMillisRemaining > 0 && !Files.exists(file)) {
+        while (timeoutMillisRemaining > 0 && Files.exists(file) == false) {
             long thisSleep = Math.min(timeoutMillisRemaining, PAUSE_TIME_MS);
             timeoutMillisRemaining -= thisSleep;
             try {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingDeciderServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingDeciderServiceTests.java
@@ -341,7 +341,7 @@ public class MlAutoscalingDeciderServiceTests extends ESTestCase {
         service.onMaster();
         service.setUseAuto(true);
         boolean waitingAnalytics = randomBoolean();
-        boolean waitingAnomalyJobs = !waitingAnalytics || randomBoolean();
+        boolean waitingAnomalyJobs = waitingAnalytics == false || randomBoolean();
         int maxWaitingAnalytics = randomIntBetween(1, 2);
         int maxWaitingAnomaly = randomIntBetween(1, 2);
         List<String> assignedAnomalyJobs = randomList(0, 2, () -> randomAlphaOfLength(10));
@@ -377,7 +377,7 @@ public class MlAutoscalingDeciderServiceTests extends ESTestCase {
         service.onMaster();
         service.setUseAuto(true);
         boolean waitingAnalytics = randomBoolean();
-        boolean waitingAnomalyJobs = !waitingAnalytics || randomBoolean();
+        boolean waitingAnomalyJobs = waitingAnalytics == false || randomBoolean();
         int maxWaitingAnalytics = randomIntBetween(1, 2);
         int maxWaitingAnomaly = randomIntBetween(1, 2);
         ClusterState clusterState = clusterState(

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/MockBatchedDocumentsIterator.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/MockBatchedDocumentsIterator.java
@@ -52,7 +52,7 @@ public class MockBatchedDocumentsIterator<T> extends BatchedResultsIterator<T> {
             throw new IllegalStateException("Required include interim value [" + requireIncludeInterim + "]; actual was ["
                     + includeInterim + "]");
         }
-        if ((!wasTimeRangeCalled) || !hasNext()) {
+        if (wasTimeRangeCalled == false || hasNext() == false) {
             throw new NoSuchElementException();
         }
         return batches.get(index++);

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/local/LocalExporter.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/local/LocalExporter.java
@@ -531,7 +531,7 @@ public class LocalExporter extends Exporter implements ClusterStateListener, Cle
         logger.debug("installing template [{}]", template);
 
         PutIndexTemplateRequest request = new PutIndexTemplateRequest(template).source(source, XContentType.JSON);
-        assert !Thread.currentThread().isInterrupted() : "current thread has been interrupted before putting index template!!!";
+        assert Thread.currentThread().isInterrupted() == false : "current thread has been interrupted before putting index template!!!";
 
         executeAsyncWithOrigin(client.threadPool().getThreadContext(), MONITORING_ORIGIN, request, listener,
                 client.admin().indices()::putTemplate);

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/optimizer/OptimizerRules.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/optimizer/OptimizerRules.java
@@ -615,7 +615,7 @@ public final class OptimizerRules {
                     } else {
                         ranges.add(r);
                     }
-                } else if (ex instanceof BinaryComparison && !(ex instanceof Equals || ex instanceof NotEquals)) {
+                } else if (ex instanceof BinaryComparison && (ex instanceof Equals || ex instanceof NotEquals) == false) {
                     BinaryComparison bc = (BinaryComparison) ex;
 
                     if (bc.right().foldable() && (findConjunctiveComparisonInRange(bc, ranges) || findExistingComparison(bc, bcs, true))) {
@@ -818,7 +818,7 @@ public final class OptimizerRules {
                         }
 
                         // if the range in included, no need to add it
-                        return compared && (!((lower && !lowerEq) || (upper && !upperEq)));
+                        return compared && (((lower && lowerEq == false) || (upper && upperEq == false)) == false);
                     }
                 }
             }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/plan/logical/Project.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/plan/logical/Project.java
@@ -45,7 +45,7 @@ public class Project extends UnaryPlan {
 
     @Override
     public boolean resolved() {
-        return super.resolved() && !Expressions.anyMatch(projections, Functions::isAggregate);
+        return super.resolved() && Expressions.anyMatch(projections, Functions::isAggregate) == false;
     }
 
     @Override

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/rule/RuleExecutor.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/rule/RuleExecutor.java
@@ -85,7 +85,7 @@ public abstract class RuleExecutor<TreeType extends Node<TreeType>> {
 
         public boolean hasChanged() {
             if (lazyHasChanged == null) {
-                lazyHasChanged = !before.equals(after);
+                lazyHasChanged = before.equals(after) == false;
             }
             return lazyHasChanged;
         }
@@ -173,7 +173,7 @@ public abstract class RuleExecutor<TreeType extends Node<TreeType>> {
                     }
                 }
                 batchDuration = System.currentTimeMillis() - batchStart;
-            } while (hasChanged && !batch.limit.reached(batchRuns));
+            } while (hasChanged && batch.limit.reached(batchRuns) == false);
 
             totalDuration += batchDuration;
 

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/type/Types.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/type/Types.java
@@ -28,7 +28,7 @@ public abstract class Types {
     @SuppressWarnings("unchecked")
     public static Map<String, EsField> fromEs(DataTypeRegistry typeRegistry, Map<String, Object> asMap) {
         Map<String, Object> props = null;
-        if (asMap != null && !asMap.isEmpty()) {
+        if (asMap != null && asMap.isEmpty() == false) {
             props = (Map<String, Object>) asMap.get("properties");
         }
         return props == null || props.isEmpty() ? emptyMap() : startWalking(typeRegistry, props);

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/util/StringUtils.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/util/StringUtils.java
@@ -48,7 +48,7 @@ public final class StringUtils {
             char ch = s.charAt(i);
             if (Character.isAlphabetic(ch)) {
                 if (Character.isUpperCase(ch)) {
-                    if (i > 0 && !previousCharWasUp) {
+                    if (i > 0 && previousCharWasUp == false) {
                         sb.append("_");
                     }
                     previousCharWasUp = true;

--- a/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/expression/function/UnresolvedFunctionTests.java
+++ b/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/expression/function/UnresolvedFunctionTests.java
@@ -77,7 +77,7 @@ public class UnresolvedFunctionTests extends AbstractNodeTestCase<UnresolvedFunc
                 randomValueOtherThan(uf.children(), UnresolvedFunctionTests::randomFunctionArgs),
                 uf.analyzed(), uf.unresolvedMessage()),
             () -> new UnresolvedFunction(uf.source(), uf.name(), uf.resolutionStrategy(), uf.children(),
-                !uf.analyzed(), uf.unresolvedMessage()),
+                uf.analyzed() == false, uf.unresolvedMessage()),
             () -> new UnresolvedFunction(uf.source(), uf.name(), uf.resolutionStrategy(), uf.children(),
                 uf.analyzed(), randomValueOtherThan(uf.unresolvedMessage(), () -> randomAlphaOfLength(5)))
         ));
@@ -109,8 +109,8 @@ public class UnresolvedFunctionTests extends AbstractNodeTestCase<UnresolvedFunc
             uf.transformPropertiesOnly(Object.class, p -> Objects.equals(p, uf.unresolvedMessage()) ? newUnresolvedMessage : p));
 
         assertEquals(new UnresolvedFunction(uf.source(), uf.name(), uf.resolutionStrategy(), uf.children(),
-                !uf.analyzed(), uf.unresolvedMessage()),
-            uf.transformPropertiesOnly(Object.class, p -> Objects.equals(p, uf.analyzed()) ? !uf.analyzed() : p));
+                uf.analyzed() == false, uf.unresolvedMessage()),
+            uf.transformPropertiesOnly(Object.class, p -> Objects.equals(p, uf.analyzed()) ? uf.analyzed() == false : p));
 
     }
 

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/RollupResponseTranslator.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/RollupResponseTranslator.java
@@ -345,7 +345,7 @@ public class RollupResponseTranslator {
     private static List<InternalAggregation> unrollAgg(InternalAggregations rolled, InternalAggregations original,
                                                        InternalAggregations currentTree) {
         return rolled.asList().stream()
-                .filter(subAgg -> !subAgg.getName().endsWith("." + RollupField.COUNT_FIELD))
+                .filter(subAgg -> subAgg.getName().endsWith("." + RollupField.COUNT_FIELD) == false)
                 .map(agg -> {
                     // During the translation process, some aggregations' doc_counts are stored in accessory
                     // `sum` metric aggs, so we may need to extract that.  Unfortunately, structure of multibucket vs
@@ -505,7 +505,7 @@ public class RollupResponseTranslator {
                 .asList().stream()
                 // Avoid any rollup count metrics, as that's not a true "sub-agg" but rather agg
                 // added by the rollup for accounting purposes (e.g. doc_count)
-                .filter(subAgg -> !subAgg.getName().endsWith("." + RollupField.COUNT_FIELD))
+                .filter(subAgg -> subAgg.getName().endsWith("." + RollupField.COUNT_FIELD) == false)
                 .map(subAgg -> {
 
                     long count = getAggCount(subAgg, bucket.getAggregations().asMap());

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldFuzzyQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldFuzzyQueryTests.java
@@ -69,7 +69,7 @@ public class StringScriptFieldFuzzyQueryTests extends AbstractStringScriptFieldQ
                 prefixLength += 1;
                 break;
             case 5:
-                transpositions = !transpositions;
+                transpositions = transpositions == false;
                 break;
             default:
                 fail();

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldPrefixQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldPrefixQueryTests.java
@@ -50,7 +50,7 @@ public class StringScriptFieldPrefixQueryTests extends AbstractStringScriptField
                 prefix += "modified";
                 break;
             case 3:
-                caseInsensitive = !caseInsensitive;
+                caseInsensitive = caseInsensitive == false;
                 break;
             default:
                 fail();

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldRangeQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldRangeQueryTests.java
@@ -103,13 +103,13 @@ public class StringScriptFieldRangeQueryTests extends AbstractStringScriptFieldQ
                 if (lower == null) {
                     lower = mutate(lower);
                 }
-                includeLower = !includeLower;
+                includeLower = includeLower == false;
                 break;
             case 5:
                 if (upper == null) {
                     upper = mutate(upper);
                 }
-                includeUpper = !includeUpper;
+                includeUpper = includeUpper == false;
                 break;
             default:
                 fail();

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldTermQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldTermQueryTests.java
@@ -49,7 +49,7 @@ public class StringScriptFieldTermQueryTests extends AbstractStringScriptFieldQu
                 term += "modified";
                 break;
             case 3:
-                caseInsensitive = !caseInsensitive;
+                caseInsensitive = caseInsensitive == false;
                 break;
             default:
                 fail();

--- a/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldWildcardQueryTests.java
+++ b/x-pack/plugin/runtime-fields/src/test/java/org/elasticsearch/xpack/runtimefields/query/StringScriptFieldWildcardQueryTests.java
@@ -49,7 +49,7 @@ public class StringScriptFieldWildcardQueryTests extends AbstractStringScriptFie
                 pattern += "modified";
                 break;
             case 3:
-                caseInsensitive = !caseInsensitive;
+                caseInsensitive = caseInsensitive == false;
                 break;
             default:
                 fail();

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/RBACEngine.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/RBACEngine.java
@@ -309,7 +309,7 @@ public class RBACEngine implements AuthorizationEngine {
             IndicesAndAliasesResolver.allowsRemoteIndices((IndicesRequest) request)) {
             // remote indices are allowed
             indicesAsyncSupplier.getAsync(ActionListener.wrap(resolvedIndices -> {
-                assert !resolvedIndices.isEmpty()
+                assert resolvedIndices.isEmpty() == false
                     : "every indices request needs to have its indices set thus the resolved indices must not be empty";
                 //all wildcard expressions have been resolved and only the security plugin could have set '-*' here.
                 //'-*' matches no indices so we allow the request to go through, which will yield an empty response
@@ -326,7 +326,7 @@ public class RBACEngine implements AuthorizationEngine {
                 ActionListener.wrap(indexAuthorizationResult -> {
                     if (indexAuthorizationResult.isGranted()) {
                         indicesAsyncSupplier.getAsync(ActionListener.wrap(resolvedIndices -> {
-                            assert !resolvedIndices.isEmpty()
+                            assert resolvedIndices.isEmpty() == false
                                 : "every indices request needs to have its indices set thus the resolved indices must not be empty";
                             //all wildcard expressions have been resolved and only the security plugin could have set '-*' here.
                             //'-*' matches no indices so we allow the request to go through, which will yield an empty response

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlSpMetadataBuilderTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlSpMetadataBuilderTests.java
@@ -57,7 +57,7 @@ public class SamlSpMetadataBuilderTests extends SamlTestCase {
             fail("Expected exactly 3 certificate in " + certPath);
         }
         List<Class> notX509Certificates = Arrays.stream(threeCerts).filter((cert) -> {
-            return !(cert instanceof X509Certificate);
+            return (cert instanceof X509Certificate) == false;
         }).map(cert -> cert.getClass()).collect(Collectors.toList());
         if (notX509Certificates.isEmpty() == false) {
             fail("Expected exactly X509Certificates, but found " + notX509Certificates);

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/TriangleTreeReader.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/TriangleTreeReader.java
@@ -88,7 +88,7 @@ class TriangleTreeReader {
         int nextMaxY = Math.toIntExact(thisMaxY - input.readVLong());
         int size = input.readVInt();
         if (visitor.push(nextMaxX, nextMaxY)) {
-            return visit(input, visitor, !splitX, nextMaxX, nextMaxY, false);
+            return visit(input, visitor, splitX == false, nextMaxX, nextMaxY, false);
         } else {
             input.skipBytes(size);
             return visitor.push();
@@ -102,7 +102,7 @@ class TriangleTreeReader {
             int nextMaxY = Math.toIntExact(thisMaxY - input.readVLong());
             int size = input.readVInt();
             if (visitor.push(nextMaxX, nextMaxY)) {
-                return visit(input, visitor, !splitX, nextMaxX, nextMaxY, false);
+                return visit(input, visitor, splitX == false, nextMaxX, nextMaxY, false);
             } else {
                 input.skipBytes(size);
             }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/TriangleTreeWriter.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/TriangleTreeWriter.java
@@ -75,8 +75,8 @@ class TriangleTreeWriter {
         }
         TriangleTreeNode newNode = components[mid];
         // find children
-        newNode.left = createTree(components, low, mid - 1, !splitX);
-        newNode.right = createTree(components, mid + 1, high, !splitX);
+        newNode.left = createTree(components, low, mid - 1, splitX == false);
+        newNode.right = createTree(components, mid + 1, high, splitX == false);
 
         // pull up max values to this node
         if (newNode.left != null) {

--- a/x-pack/plugin/sql/qa/jdbc/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/ResultSetTestCase.java
+++ b/x-pack/plugin/sql/qa/jdbc/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/ResultSetTestCase.java
@@ -6,6 +6,20 @@
  */
 package org.elasticsearch.xpack.sql.qa.jdbc;
 
+import org.elasticsearch.client.Request;
+import org.elasticsearch.common.CheckedBiConsumer;
+import org.elasticsearch.common.CheckedBiFunction;
+import org.elasticsearch.common.CheckedConsumer;
+import org.elasticsearch.common.CheckedFunction;
+import org.elasticsearch.common.CheckedSupplier;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.sql.jdbc.EsType;
+import org.junit.Before;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
@@ -46,20 +60,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.elasticsearch.client.Request;
-import org.elasticsearch.common.CheckedBiConsumer;
-import org.elasticsearch.common.CheckedBiFunction;
-import org.elasticsearch.common.CheckedConsumer;
-import org.elasticsearch.common.CheckedFunction;
-import org.elasticsearch.common.CheckedSupplier;
-import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.collect.Tuple;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.json.JsonXContent;
-import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xpack.sql.jdbc.EsType;
-import org.junit.Before;
-
 import static java.lang.String.format;
 import static java.util.Calendar.DAY_OF_MONTH;
 import static java.util.Calendar.ERA;
@@ -71,7 +71,6 @@ import static java.util.Calendar.SECOND;
 import static java.util.Calendar.YEAR;
 import static java.util.regex.Pattern.compile;
 import static java.util.regex.Pattern.quote;
-import static org.hamcrest.Matchers.matchesPattern;
 import static org.elasticsearch.common.time.DateUtils.toMilliSeconds;
 import static org.elasticsearch.xpack.sql.qa.jdbc.JdbcTestUtils.JDBC_DRIVER_VERSION;
 import static org.elasticsearch.xpack.sql.qa.jdbc.JdbcTestUtils.JDBC_TIMEZONE;
@@ -81,6 +80,7 @@ import static org.elasticsearch.xpack.sql.qa.jdbc.JdbcTestUtils.extractNanosOnly
 import static org.elasticsearch.xpack.sql.qa.jdbc.JdbcTestUtils.of;
 import static org.elasticsearch.xpack.sql.qa.jdbc.JdbcTestUtils.randomTimeInNanos;
 import static org.elasticsearch.xpack.sql.qa.jdbc.JdbcTestUtils.versionSupportsDateNanos;
+import static org.hamcrest.Matchers.matchesPattern;
 
 public abstract class ResultSetTestCase extends JdbcIntegrationTestCase {
 
@@ -1125,7 +1125,7 @@ public abstract class ResultSetTestCase extends JdbcIntegrationTestCase {
             assertErrorMessageForDateTimeValues(sqle, Boolean.class, toMilliSeconds(randomDateNanos2), extractNanosOnly(randomDateNanos2));
 
             results.next();
-            for (String fld : fieldsNames.stream().filter(f -> !f.equals("test_keyword")).collect(Collectors.toCollection(HashSet::new))) {
+            for (String fld : fieldsNames.stream().filter(f -> f.equals("test_keyword") == false).collect(Collectors.toSet())) {
                 assertTrue("Expected: <true> but was: <false> for field " + fld, results.getBoolean(fld));
                 assertEquals("Expected: <true> but was: <false> for field " + fld, true, results.getObject(fld, Boolean.class));
             }

--- a/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/JdbcAssert.java
+++ b/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/JdbcAssert.java
@@ -250,7 +250,7 @@ public class JdbcAssert {
                         String columnClassName = metaData.getColumnClassName(column);
 
                         // fix for CSV which returns the shortName not fully-qualified name
-                        if (columnClassName != null && !columnClassName.contains(".")) {
+                        if (columnClassName != null && columnClassName.contains(".") == false) {
                             switch (columnClassName) {
                                 case "Date":
                                     columnClassName = "java.sql.Date";

--- a/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/SqlSpecTestCase.java
+++ b/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/SqlSpecTestCase.java
@@ -81,8 +81,8 @@ public abstract class SqlSpecTestCase extends SpecBaseIntegrationTestCase {
         // we skip the tests in case of these locales because ES-SQL is Locale-insensitive for now
         // while H2 does take the Locale into consideration
         String[] h2IncompatibleLocales = new String[] { "tr", "az", "tr-TR", "tr-CY", "az-Latn", "az-Cyrl", "az-Latn-AZ", "az-Cyrl-AZ" };
-        boolean goodLocale = !Arrays.stream(h2IncompatibleLocales)
-            .anyMatch((l) -> Locale.getDefault().equals(new Locale.Builder().setLanguageTag(l).build()));
+        boolean goodLocale = Arrays.stream(h2IncompatibleLocales)
+            .anyMatch((l) -> Locale.getDefault().equals(new Locale.Builder().setLanguageTag(l).build())) == false;
         if (fileName.startsWith("case-functions")) {
             Assume.assumeTrue(goodLocale);
         }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/math/MathProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/math/MathProcessor.java
@@ -147,7 +147,7 @@ public class MathProcessor implements Processor {
 
     @Override
     public Object process(Object input) {
-        if (input != null && !(input instanceof Number)) {
+        if (input != null && (input instanceof Number) == false) {
             throw new SqlIllegalArgumentException("A number is required; received [{}]", input);
         }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/ReplaceFunctionProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/ReplaceFunctionProcessor.java
@@ -51,7 +51,7 @@ public class ReplaceFunctionProcessor implements Processor {
         if ((input instanceof String || input instanceof Character) == false) {
             throw new SqlIllegalArgumentException("A string/char is required; received [{}]", input);
         }
-        if (!(pattern instanceof String || pattern instanceof Character)) {
+        if ((pattern instanceof String || pattern instanceof Character) == false) {
             throw new SqlIllegalArgumentException("A string/char is required; received [{}]", pattern);
         }
         if ((replacement instanceof String || replacement instanceof Character) == false) {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/optimizer/Optimizer.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/optimizer/Optimizer.java
@@ -1198,8 +1198,8 @@ public class Optimizer extends RuleExecutor<LogicalPlan> {
          * that its filter (WHERE clause) is folded to FALSE.
          */
         private static boolean isNotQueryWithFromClauseAndFilterFoldedToFalse(UnaryPlan plan) {
-            return (!(plan.child() instanceof LocalRelation) || (plan.child() instanceof LocalRelation &&
-                !(((LocalRelation) plan.child()).executable() instanceof EmptyExecutable)));
+            return ((plan.child() instanceof LocalRelation) == false || (plan.child() instanceof LocalRelation &&
+                (((LocalRelation) plan.child()).executable() instanceof EmptyExecutable) == false));
         }
     }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTables.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTables.java
@@ -118,7 +118,7 @@ public class SysTables extends Command {
         String cRegex = clusterPattern != null ? clusterPattern.asJavaRegex() : null;
 
         // if the catalog doesn't match, don't return any results
-        if (cRegex != null && !Pattern.matches(cRegex, cluster)) {
+        if (cRegex != null && Pattern.matches(cRegex, cluster) == false) {
             listener.onResponse(Page.last(Rows.empty(output())));
             return;
         }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/planner/Verifier.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/planner/Verifier.java
@@ -26,7 +26,7 @@ abstract class Verifier {
                 failures.add(fail(p, "Unplanned item"));
             }
             p.forEachExpressionUp(e -> {
-                if (e.childrenResolved() && !e.resolved()) {
+                if (e.childrenResolved() && e.resolved() == false) {
                     failures.add(fail(e, "Unresolved expression"));
                 }
             });
@@ -43,7 +43,7 @@ abstract class Verifier {
                 failures.add(fail(p, "Unexecutable item"));
             }
             p.forEachExpressionUp(e -> {
-                if (e.childrenResolved() && !e.resolved()) {
+                if (e.childrenResolved() && e.resolved() == false) {
                     failures.add(fail(e, "Unresolved expression"));
                 }
             });

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TextFormat.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TextFormat.java
@@ -225,7 +225,7 @@ enum TextFormat implements MediaType {
                 }
                 return true;
             } else {
-                return !header.toLowerCase(Locale.ROOT).equals(PARAM_HEADER_ABSENT);
+                return header.toLowerCase(Locale.ROOT).equals(PARAM_HEADER_ABSENT) == false;
             }
         }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/session/SqlSession.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/session/SqlSession.java
@@ -136,7 +136,7 @@ public class SqlSession implements Session {
 
             String cluster = table.cluster();
 
-            if (Strings.hasText(cluster) && !indexResolver.clusterName().equals(cluster)) {
+            if (Strings.hasText(cluster) && indexResolver.clusterName().equals(cluster) == false) {
                 listener.onFailure(new MappingException("Cannot inspect indices in cluster/catalog [{}]", cluster));
             }
 

--- a/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/TimestampFormatFinder.java
+++ b/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/TimestampFormatFinder.java
@@ -384,7 +384,7 @@ public final class TimestampFormatFinder {
             char curChar = overrideFormat.charAt(pos);
 
             if (curChar == '\'') {
-                notQuoted = !notQuoted;
+                notQuoted = notQuoted == false;
             } else if (notQuoted && Character.isLetter(curChar)) {
                 int startPos = pos;
                 int endPos = startPos + 1;
@@ -1508,7 +1508,7 @@ public final class TimestampFormatFinder {
                     for (int pos = 0; pos < format.length(); ++pos) {
                         char curChar = format.charAt(pos);
                         if (curChar == '\'') {
-                            notQuoted = !notQuoted;
+                            notQuoted = notQuoted == false;
                         } else if (notQuoted && (curChar == 'X' || curChar == 'z')) {
                             return false;
                         }
@@ -1538,7 +1538,7 @@ public final class TimestampFormatFinder {
                             // from off to on or on to off and then back. However, since by definition there
                             // is nothing in between the consecutive single quotes in this case, the net
                             // effect is correct and good enough for what this method is doing.
-                            notQuoted = !notQuoted;
+                            notQuoted = notQuoted == false;
                             consecutiveSs = 0;
                         } else if (notQuoted) {
                             if (curChar == 'S') {

--- a/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/XmlTextStructureFinderFactory.java
+++ b/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/XmlTextStructureFinderFactory.java
@@ -49,7 +49,7 @@ public class XmlTextStructureFinderFactory implements TextStructureFinderFactory
         int completeDocCount = 0;
         String commonRootElementName = null;
         String remainder = sample.trim();
-        boolean mightBeAnotherDocument = !remainder.isEmpty();
+        boolean mightBeAnotherDocument = remainder.isEmpty() == false;
 
         // This processing is extremely complicated because it's necessary
         // to create a new XML stream reader per document, but each one
@@ -115,7 +115,7 @@ public class XmlTextStructureFinderFactory implements TextStructureFinderFactory
                             }
                             endPos += location.getColumnNumber() - 1;
                             remainder = remainder.substring(endPos).trim();
-                            mightBeAnotherDocument = !remainder.isEmpty();
+                            mightBeAnotherDocument = remainder.isEmpty() == false;
                             break;
                         }
                     }

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/input/search/SearchInput.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/input/search/SearchInput.java
@@ -23,6 +23,7 @@ import java.time.ZoneId;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 import static java.util.Collections.unmodifiableSet;
@@ -52,15 +53,17 @@ public class SearchInput implements Input {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         SearchInput that = (SearchInput) o;
-
-        if (request != null ? !request.equals(that.request) : that.request != null) return false;
-        if (extractKeys != null ? !extractKeys.equals(that.extractKeys) : that.extractKeys != null) return false;
-        if (timeout != null ? !timeout.equals(that.timeout) : that.timeout != null) return false;
-        return !(dynamicNameTimeZone != null ? !dynamicNameTimeZone.equals(that.dynamicNameTimeZone) : that.dynamicNameTimeZone != null);
+        return Objects.equals(request, that.request)
+            && Objects.equals(extractKeys, that.extractKeys)
+            && Objects.equals(timeout, that.timeout)
+            && Objects.equals(dynamicNameTimeZone, that.dynamicNameTimeZone);
     }
 
     @Override

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transform/search/SearchTransform.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transform/search/SearchTransform.java
@@ -20,6 +20,7 @@ import org.elasticsearch.xpack.watcher.support.search.WatcherSearchTemplateReque
 
 import java.io.IOException;
 import java.time.ZoneId;
+import java.util.Objects;
 
 import static org.elasticsearch.common.unit.TimeValue.timeValueMillis;
 
@@ -56,14 +57,16 @@ public class SearchTransform implements Transform {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         SearchTransform that = (SearchTransform) o;
-
-        if (request != null ? !request.equals(that.request) : that.request != null) return false;
-        if (timeout != null ? !timeout.equals(that.timeout) : that.timeout != null) return false;
-        return !(dynamicNameTimeZone != null ? !dynamicNameTimeZone.equals(that.dynamicNameTimeZone) : that.dynamicNameTimeZone != null);
+        return Objects.equals(request, that.request)
+            && Objects.equals(timeout, that.timeout)
+            && Objects.equals(dynamicNameTimeZone, that.dynamicNameTimeZone);
     }
 
     @Override

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/TransportExecuteWatchAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/TransportExecuteWatchAction.java
@@ -99,7 +99,7 @@ public class TransportExecuteWatchAction extends WatcherTransportAction<ExecuteW
                     }, listener::onFailure), client::get);
         } else if (request.getWatchSource() != null) {
             try {
-                assert !request.isRecordExecution();
+                assert request.isRecordExecution() == false;
                 Watch watch = watchParser.parse(ExecuteWatchRequest.INLINE_WATCH_ID, true, request.getWatchSource(),
                     request.getXContentType(), SequenceNumbers.UNASSIGNED_SEQ_NO, SequenceNumbers.UNASSIGNED_PRIMARY_TERM);
                 executeWatch(request, listener, watch, false);

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/actions/slack/SlackActionTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/actions/slack/SlackActionTests.java
@@ -133,8 +133,8 @@ public class SlackActionTests extends ESTestCase {
         SentMessages sentMessages = new SentMessages(accountName, messages);
         when(account.send(message, eq(any()))).thenReturn(sentMessages);
 
-        Action.Result.Status expectedStatus = !hasError ? Action.Result.Status.SUCCESS :
-                !hasSuccess ? Action.Result.Status.FAILURE :
+        Action.Result.Status expectedStatus = hasError == false ? Action.Result.Status.SUCCESS :
+                hasSuccess == false ? Action.Result.Status.FAILURE :
                         Action.Result.Status.PARTIAL_FAILURE;
 
 


### PR DESCRIPTION
Part 10 (and hopefully the last one).

We have an in-house rule to compare explicitly against `false` instead
of using the logical not operator (`!`). However, this hasn't
historically been enforced, meaning that there are many violations in
the source at present.

We now have a Checkstyle rule that can detect these cases, but before we
can turn it on, we need to fix the existing violations. This is being
done over a series of PRs, since there are a lot to fix.