### PR TITLE
[Docs] Add nested fields handling in fields API

### DIFF
--- a/docs/reference/search/search-your-data/retrieve-selected-fields.asciidoc
+++ b/docs/reference/search/search-your-data/retrieve-selected-fields.asciidoc
@@ -168,6 +168,105 @@ a specific order. See the mapping documentation on <<array, arrays>> for more
 background.
 
 [discrete]
+[[search-fields-nested]]
+==== Handling of nested fields
+
+The `fields` response for <<nested,`nested` fields>> is slightly different from that
+of regular object fields. While leaf values inside regular `object` fields are
+returned as a flat list, values inside `nested` fields are grouped according
+to maintain the independence of each object inside the original nested array.
+For each entry inside a nested field array, values are again returned as a flat list
+unless there are other `nested` fields inside the parent nested object, in which case
+the same procedure is repeated again for the deeper nested fields.
+
+Given the following mapping where `user` is a nested field, after indexing
+the following document and retrieving all fields under the `user` field:
+
+[source,console]
+--------------------------------------------------
+PUT my-index-000001
+{
+  "mappings": {
+    "properties": {
+      "user": {
+        "type": "nested"
+      }
+    }
+  }
+}
+
+PUT my-index-000001/_doc/1?refresh=true
+{
+  "group" : "fans",
+  "user" : [
+    {
+      "first" : "John",
+      "last" :  "Smith"
+    },
+    {
+      "first" : "Alice",
+      "last" :  "White"
+    }
+  ]
+}
+
+POST my-index-000001/_search
+{
+  "fields": ["*"],
+  "_source": false
+}
+--------------------------------------------------
+
+the response will group `first` and `last` name instead of
+returning them as a flat list.
+
+[source,console-result]
+----
+{
+  "took": 2,
+  "timed_out": false,
+  "_shards": {
+    "total": 1,
+    "successful": 1,
+    "skipped": 0,
+    "failed": 0
+  },
+  "hits": {
+    "total": {
+      "value": 1,
+      "relation": "eq"
+    },
+    "max_score": 1.0,
+    "hits": [{
+      "_index": "my-index-000001",
+      "_id": "1",
+      "_score": 1.0,
+      "fields": {
+        "group" : ["fans"],
+        "group.keyword" : ["fans"],
+        "user": [{
+            "first": ["John"],
+            "first.keyword": ["John"],
+            "last": ["Smith"],
+            "last.keyword": ["Smith"]
+          },
+          {
+            "first": ["Alice"],
+            "first.keyword": ["Alice"],
+            "last": ["White"],
+            "last.keyword": ["White"]
+          }
+        ]
+      }
+    }]
+  }
+}
+----
+// TESTRESPONSE[s/"took": 2/"took": $body.took/]
+// TESTRESPONSE[s/"max_score" : 1.0/"max_score" : $body.hits.max_score/]
+// TESTRESPONSE[s/"_score" : 1.0/"_score" : $body.hits.hits.0._score/]
+
+[discrete]
 [[retrieve-unmapped-fields]]
 ==== Retrieving unmapped fields
 

--- a/docs/reference/search/search-your-data/retrieve-selected-fields.asciidoc
+++ b/docs/reference/search/search-your-data/retrieve-selected-fields.asciidoc
@@ -173,8 +173,8 @@ background.
 
 The `fields` response for <<nested,`nested` fields>> is slightly different from that
 of regular object fields. While leaf values inside regular `object` fields are
-returned as a flat list, values inside `nested` fields are grouped according
-to maintain the independence of each object inside the original nested array.
+returned as a flat list, values inside `nested` fields are grouped to maintain the
+independence of each object inside the original nested array.
 For each entry inside a nested field array, values are again returned as a flat list
 unless there are other `nested` fields inside the parent nested object, in which case
 the same procedure is repeated again for the deeper nested fields.
@@ -188,8 +188,13 @@ PUT my-index-000001
 {
   "mappings": {
     "properties": {
+      "group" : { "type" : "keyword" },
       "user": {
-        "type": "nested"
+        "type": "nested",
+        "properties": {
+          "first" : { "type" : "keyword" },
+          "last" : { "type" : "keyword" }
+        }
       }
     }
   }
@@ -243,18 +248,13 @@ returning them as a flat list.
       "_score": 1.0,
       "fields": {
         "group" : ["fans"],
-        "group.keyword" : ["fans"],
         "user": [{
             "first": ["John"],
-            "first.keyword": ["John"],
             "last": ["Smith"],
-            "last.keyword": ["Smith"]
           },
           {
             "first": ["Alice"],
-            "first.keyword": ["Alice"],
             "last": ["White"],
-            "last.keyword": ["White"]
           }
         ]
       }
@@ -265,6 +265,62 @@ returning them as a flat list.
 // TESTRESPONSE[s/"took": 2/"took": $body.took/]
 // TESTRESPONSE[s/"max_score" : 1.0/"max_score" : $body.hits.max_score/]
 // TESTRESPONSE[s/"_score" : 1.0/"_score" : $body.hits.hits.0._score/]
+
+Nested fields will be grouped by their nested paths, no matter the pattern used to retrieve them.
+For example, querying only for the `user.first` field in the example above:
+
+[source,console]
+--------------------------------------------------
+POST my-index-000001/_search
+{
+  "fields": ["user.first"],
+  "_source": false
+}
+--------------------------------------------------
+// TEST[continued]
+
+will return only the users first name but still maintain the structure of the nested `user` array:
+
+[source,console-result]
+----
+{
+  "took": 2,
+  "timed_out": false,
+  "_shards": {
+    "total": 1,
+    "successful": 1,
+    "skipped": 0,
+    "failed": 0
+  },
+  "hits": {
+    "total": {
+      "value": 1,
+      "relation": "eq"
+    },
+    "max_score": 1.0,
+    "hits": [{
+      "_index": "my-index-000001",
+      "_id": "1",
+      "_score": 1.0,
+      "fields": {
+        "user": [{
+            "first": ["John"],
+          },
+          {
+            "first": ["Alice"],
+          }
+        ]
+      }
+    }]
+  }
+}
+----
+// TESTRESPONSE[s/"took": 2/"took": $body.took/]
+// TESTRESPONSE[s/"max_score" : 1.0/"max_score" : $body.hits.max_score/]
+// TESTRESPONSE[s/"_score" : 1.0/"_score" : $body.hits.hits.0._score/]
+
+However, when the `fields` pattern targets the nested `user` field directly, no
+values will be returned since the pattern doesn't match any leaf fields.
 
 [discrete]
 [[retrieve-unmapped-fields]]


### PR DESCRIPTION
This change adds a paragraph on the different response format for nested fields
in the fields API and adds an example snippet.

Related to #63709 