### PR TITLE
Use Custom Class instead of Tuple for Cached Byte Positions

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/FrozenIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/FrozenIndexInput.java
@@ -21,7 +21,6 @@ import org.elasticsearch.action.StepListener;
 import org.elasticsearch.blobstore.cache.BlobStoreCacheService;
 import org.elasticsearch.blobstore.cache.CachedBlob;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot.FileInfo;
@@ -29,6 +28,7 @@ import org.elasticsearch.index.store.BaseSearchableSnapshotIndexInput;
 import org.elasticsearch.index.store.IndexInputStats;
 import org.elasticsearch.index.store.SearchableSnapshotDirectory;
 import org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsConstants;
+import org.elasticsearch.xpack.searchablesnapshots.cache.ByteRange;
 import org.elasticsearch.xpack.searchablesnapshots.cache.FrozenCacheService.FrozenCacheFile;
 import org.elasticsearch.xpack.searchablesnapshots.cache.SharedBytes;
 
@@ -125,11 +125,11 @@ public class FrozenIndexInput extends BaseSearchableSnapshotIndexInput {
             : fileInfo.partSize().getBytes();
     }
 
-    private Tuple<Long, Long> computeRange(long position) {
+    private ByteRange computeRange(long position) {
         final long rangeSize = getDefaultRangeSize();
         long start = (position / rangeSize) * rangeSize;
         long end = Math.min(start + rangeSize, fileInfo.length());
-        return Tuple.tuple(start, end);
+        return ByteRange.of(start, end);
     }
 
     @Override
@@ -169,7 +169,7 @@ public class FrozenIndexInput extends BaseSearchableSnapshotIndexInput {
             // Can we serve the read directly from disk? If so, do so and don't worry about anything else.
 
             final StepListener<Integer> waitingForRead = frozenCacheFile.readIfAvailableOrPending(
-                Tuple.tuple(position, position + length),
+                ByteRange.of(position, position + length),
                 (channel, pos, relativePos, len) -> {
                     final int read = readCacheFile(channel, pos, relativePos, len, b, position, true, luceneByteBufLock, stopAsyncReads);
                     assert read <= length : read + " vs " + length;
@@ -189,7 +189,7 @@ public class FrozenIndexInput extends BaseSearchableSnapshotIndexInput {
 
             // Requested data is not on disk, so try the cache index next.
 
-            final Tuple<Long, Long> indexCacheMiss; // null if not a miss
+            final ByteRange indexCacheMiss; // null if not a miss
 
             // We try to use the cache index if:
             // - the file is small enough to be fully cached
@@ -207,10 +207,10 @@ public class FrozenIndexInput extends BaseSearchableSnapshotIndexInput {
 
                     if (canBeFullyCached) {
                         // if the index input is smaller than twice the size of the blob cache, it will be fully indexed
-                        indexCacheMiss = Tuple.tuple(0L, fileInfo.length());
+                        indexCacheMiss = ByteRange.of(0L, fileInfo.length());
                     } else {
                         // the index input is too large to fully cache, so just cache the initial range
-                        indexCacheMiss = Tuple.tuple(0L, (long) BlobStoreCacheService.DEFAULT_CACHED_BLOB_SIZE);
+                        indexCacheMiss = ByteRange.of(0L, (long) BlobStoreCacheService.DEFAULT_CACHED_BLOB_SIZE);
                     }
 
                     // We must fill in a cache miss even if CACHE_NOT_READY since the cache index is only created on the first put.
@@ -236,7 +236,7 @@ public class FrozenIndexInput extends BaseSearchableSnapshotIndexInput {
                     assert copiedBytes == length : "copied " + copiedBytes + " but expected " + length;
 
                     try {
-                        final Tuple<Long, Long> cachedRange = Tuple.tuple(cachedBlob.from(), cachedBlob.to());
+                        final ByteRange cachedRange = ByteRange.of(cachedBlob.from(), cachedBlob.to());
                         frozenCacheFile.populateAndRead(
                             cachedRange,
                             cachedRange,
@@ -297,21 +297,18 @@ public class FrozenIndexInput extends BaseSearchableSnapshotIndexInput {
             // Requested data is also not in the cache index, so we must visit the blob store to satisfy both the target range and any
             // miss in the cache index.
 
-            final Tuple<Long, Long> startRangeToWrite = computeRange(position);
-            final Tuple<Long, Long> endRangeToWrite = computeRange(position + length - 1);
-            assert startRangeToWrite.v2() <= endRangeToWrite.v2() : startRangeToWrite + " vs " + endRangeToWrite;
-            final Tuple<Long, Long> rangeToWrite = Tuple.tuple(
-                Math.min(startRangeToWrite.v1(), indexCacheMiss == null ? Long.MAX_VALUE : indexCacheMiss.v1()),
-                Math.max(endRangeToWrite.v2(), indexCacheMiss == null ? Long.MIN_VALUE : indexCacheMiss.v2())
-            );
+            final ByteRange startRangeToWrite = computeRange(position);
+            final ByteRange endRangeToWrite = computeRange(position + length - 1);
+            assert startRangeToWrite.end() <= endRangeToWrite.end() : startRangeToWrite + " vs " + endRangeToWrite;
+            final ByteRange rangeToWrite = startRangeToWrite.minEnvelope(endRangeToWrite).minEnvelope(indexCacheMiss);
 
-            assert rangeToWrite.v1() <= position && position + length <= rangeToWrite.v2() : "["
+            assert rangeToWrite.start() <= position && position + length <= rangeToWrite.end() : "["
                 + position
                 + "-"
                 + (position + length)
                 + "] vs "
                 + rangeToWrite;
-            final Tuple<Long, Long> rangeToRead = Tuple.tuple(position, position + length);
+            final ByteRange rangeToRead = ByteRange.of(position, position + length);
 
             final StepListener<Integer> populateCacheFuture = frozenCacheFile.populateAndRead(
                 rangeToWrite,
@@ -322,7 +319,7 @@ public class FrozenIndexInput extends BaseSearchableSnapshotIndexInput {
                     relativePos,
                     len,
                     b,
-                    rangeToRead.v1(),
+                    rangeToRead.start(),
                     false,
                     luceneByteBufLock,
                     stopAsyncReads
@@ -332,7 +329,7 @@ public class FrozenIndexInput extends BaseSearchableSnapshotIndexInput {
                     channelPos,
                     relativePos,
                     len,
-                    rangeToWrite.v1(),
+                    rangeToWrite.start(),
                     progressUpdater
                 ),
                 directory.cacheFetchAsyncExecutor()
@@ -340,7 +337,7 @@ public class FrozenIndexInput extends BaseSearchableSnapshotIndexInput {
 
             if (indexCacheMiss != null) {
                 final Releasable onCacheFillComplete = stats.addIndexCacheFill();
-                final int indexCacheMissLength = toIntBytes(indexCacheMiss.v2() - indexCacheMiss.v1());
+                final int indexCacheMissLength = toIntBytes(indexCacheMiss.length());
                 // We assume that we only cache small portions of blobs so that we do not need to:
                 // - use a BigArrays for allocation
                 // - use an intermediate copy buffer to read the file in sensibly-sized chunks
@@ -387,7 +384,7 @@ public class FrozenIndexInput extends BaseSearchableSnapshotIndexInput {
                         byteBuffer.position(read); // mark all bytes as accounted for
                         byteBuffer.flip();
                         final BytesReference content = BytesReference.fromByteBuffer(byteBuffer);
-                        directory.putCachedBlob(fileInfo.physicalName(), indexCacheMiss.v1(), content, new ActionListener<>() {
+                        directory.putCachedBlob(fileInfo.physicalName(), indexCacheMiss.start(), content, new ActionListener<>() {
                             @Override
                             public void onResponse(Void response) {
                                 onCacheFillComplete.close();

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/SparseFileTracker.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/SparseFileTracker.java
@@ -10,7 +10,7 @@ import org.elasticsearch.Assertions;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.GroupedActionListener;
 import org.elasticsearch.common.Nullable;
-import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.xpack.searchablesnapshots.cache.ByteRange;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -61,7 +61,7 @@ public class SparseFileTracker {
      * @param length      the length of the file tracked by the sparse file tracker
      * @param ranges      the set of ranges to be considered present
      */
-    public SparseFileTracker(String description, long length, SortedSet<Tuple<Long, Long>> ranges) {
+    public SparseFileTracker(String description, long length, SortedSet<ByteRange> ranges) {
         this.description = description;
         this.length = length;
         if (length < 0) {
@@ -71,14 +71,14 @@ public class SparseFileTracker {
         if (ranges.isEmpty() == false) {
             synchronized (mutex) {
                 Range previous = null;
-                for (Tuple<Long, Long> next : ranges) {
-                    final Range range = new Range(next.v1(), next.v2(), null);
-                    if (range.end <= range.start) {
-                        throw new IllegalArgumentException("Range " + range + " cannot be empty");
+                for (ByteRange next : ranges) {
+                    if (next.length() == 0L) {
+                        throw new IllegalArgumentException("Range " + next + " cannot be empty");
                     }
-                    if (length < range.end) {
-                        throw new IllegalArgumentException("Range " + range + " is exceeding maximum length [" + length + ']');
+                    if (length < next.end()) {
+                        throw new IllegalArgumentException("Range " + next + " is exceeding maximum length [" + length + ']');
                     }
+                    final Range range = new Range(next);
                     if (previous != null && range.start <= previous.end) {
                         throw new IllegalArgumentException("Range " + range + " is overlapping a previous range " + previous);
                     }
@@ -97,8 +97,8 @@ public class SparseFileTracker {
         return length;
     }
 
-    public SortedSet<Tuple<Long, Long>> getCompletedRanges() {
-        SortedSet<Tuple<Long, Long>> completedRanges = null;
+    public SortedSet<ByteRange> getCompletedRanges() {
+        SortedSet<ByteRange> completedRanges = null;
         synchronized (mutex) {
             assert invariant();
             for (Range range : ranges) {
@@ -106,9 +106,9 @@ public class SparseFileTracker {
                     continue;
                 }
                 if (completedRanges == null) {
-                    completedRanges = new TreeSet<>(Comparator.comparingLong(Tuple::v1));
+                    completedRanges = new TreeSet<>();
                 }
-                completedRanges.add(Tuple.tuple(range.start, range.end));
+                completedRanges.add(ByteRange.of(range.start, range.end));
             }
         }
         return completedRanges == null ? Collections.emptySortedSet() : completedRanges;
@@ -136,34 +136,30 @@ public class SparseFileTracker {
      * range from the file is defined by {@code range} but the listener is executed as soon as a (potentially smaller) sub range
      * {@code subRange} becomes available.
      *
-     * @param range    A tuple that contains the (inclusive) start and (exclusive) end of the desired range
-     * @param subRange A tuple that contains the (inclusive) start and (exclusive) end of the listener's range
+     * @param range    A ByteRange that contains the (inclusive) start and (exclusive) end of the desired range
+     * @param subRange A ByteRange that contains the (inclusive) start and (exclusive) end of the listener's range
      * @param listener Listener for when the listening range is fully available
      * @return A collection of gaps that the client should fill in to satisfy this range
      * @throws IllegalArgumentException if invalid range is requested
      */
-    public List<Gap> waitForRange(final Tuple<Long, Long> range, final Tuple<Long, Long> subRange, final ActionListener<Void> listener) {
-        final long start = range.v1();
-        final long end = range.v2();
-        if (end < start || start < 0L || length < end) {
-            throw new IllegalArgumentException("invalid range [start=" + start + ", end=" + end + ", length=" + length + "]");
+    public List<Gap> waitForRange(final ByteRange range, final ByteRange subRange, final ActionListener<Void> listener) {
+        if (length < range.end()) {
+            throw new IllegalArgumentException("invalid range [" + range + ", length=" + length + "]");
         }
 
-        if (subRange.v2() < subRange.v1() || subRange.v1() < 0L || length < subRange.v2()) {
-            throw new IllegalArgumentException(
-                "invalid range to listen to [start=" + subRange.v1() + ", end=" + subRange.v2() + ", length=" + length + "]"
-            );
+        if (length < subRange.end()) {
+            throw new IllegalArgumentException("invalid range to listen to [" + subRange + ", length=" + length + "]");
         }
-        if (subRange.v1() < start || end < subRange.v2()) {
+        if (subRange.isSubRangeOf(range) == false) {
             throw new IllegalArgumentException(
                 "unable to listen to range [start="
-                    + subRange.v1()
+                    + subRange.start()
                     + ", end="
-                    + subRange.v2()
+                    + subRange.end()
                     + "] when range is [start="
-                    + start
+                    + range.start()
                     + ", end="
-                    + end
+                    + range.end()
                     + ", length="
                     + length
                     + "]"
@@ -179,19 +175,19 @@ public class SparseFileTracker {
 
             final List<Range> pendingRanges = new ArrayList<>();
 
-            final Range targetRange = new Range(start, end, null);
+            final Range targetRange = new Range(range);
             final SortedSet<Range> earlierRanges = ranges.headSet(targetRange, false); // ranges with strictly earlier starts
             if (earlierRanges.isEmpty() == false) {
                 final Range lastEarlierRange = earlierRanges.last();
-                if (start < lastEarlierRange.end) {
+                if (range.start() < lastEarlierRange.end) {
                     if (lastEarlierRange.isPending()) {
                         pendingRanges.add(lastEarlierRange);
                     }
-                    targetRange.start = Math.min(end, lastEarlierRange.end);
+                    targetRange.start = Math.min(range.end(), lastEarlierRange.end);
                 }
             }
 
-            while (targetRange.start < end) {
+            while (targetRange.start < range.end()) {
                 assert 0 <= targetRange.start : targetRange;
                 assert invariant();
 
@@ -199,13 +195,13 @@ public class SparseFileTracker {
                 if (existingRanges.isEmpty()) {
                     final Range newPendingRange = new Range(
                         targetRange.start,
-                        end,
-                        new ProgressListenableActionFuture(targetRange.start, end)
+                        range.end(),
+                        new ProgressListenableActionFuture(targetRange.start, range.end())
                     );
                     ranges.add(newPendingRange);
                     pendingRanges.add(newPendingRange);
                     gaps.add(new Gap(newPendingRange));
-                    targetRange.start = end;
+                    targetRange.start = range.end();
                 } else {
                     final Range firstExistingRange = existingRanges.first();
                     assert targetRange.start <= firstExistingRange.start : targetRange + " vs " + firstExistingRange;
@@ -214,9 +210,9 @@ public class SparseFileTracker {
                         if (firstExistingRange.isPending()) {
                             pendingRanges.add(firstExistingRange);
                         }
-                        targetRange.start = Math.min(end, firstExistingRange.end);
+                        targetRange.start = Math.min(range.end(), firstExistingRange.end);
                     } else {
-                        final long newPendingRangeEnd = Math.min(end, firstExistingRange.start);
+                        final long newPendingRangeEnd = Math.min(range.end(), firstExistingRange.start);
                         final Range newPendingRange = new Range(
                             targetRange.start,
                             newPendingRangeEnd,
@@ -230,7 +226,7 @@ public class SparseFileTracker {
                 }
             }
             assert targetRange.start == targetRange.end : targetRange;
-            assert targetRange.start == end : targetRange;
+            assert targetRange.start == range.end() : targetRange;
             assert invariant();
 
             assert ranges.containsAll(pendingRanges) : ranges + " vs " + pendingRanges;
@@ -238,11 +234,11 @@ public class SparseFileTracker {
             assert pendingRanges.size() != 1 || gaps.size() <= 1 : gaps;
 
             // Pending ranges that needs to be filled before executing the listener
-            requiredRanges = (start == subRange.v1() && end == subRange.v2())
+            requiredRanges = range.equals(subRange)
                 ? pendingRanges
                 : pendingRanges.stream()
-                    .filter(pendingRange -> pendingRange.start < subRange.v2())
-                    .filter(pendingRange -> subRange.v1() < pendingRange.end)
+                    .filter(pendingRange -> pendingRange.start < subRange.end())
+                    .filter(pendingRange -> subRange.start() < pendingRange.end)
                     .sorted(Comparator.comparingLong(r -> r.start))
                     .collect(Collectors.toList());
         }
@@ -259,7 +255,7 @@ public class SparseFileTracker {
                 final Range requiredRange = requiredRanges.get(0);
                 requiredRange.completionListener.addListener(
                     wrappedListener.map(progress -> null),
-                    Math.min(requiredRange.completionListener.end, subRange.v2())
+                    Math.min(requiredRange.completionListener.end, subRange.end())
                 );
                 break;
             default:
@@ -268,7 +264,7 @@ public class SparseFileTracker {
                     requiredRanges.size()
                 );
                 requiredRanges.forEach(
-                    r -> r.completionListener.addListener(groupedActionListener, Math.min(r.completionListener.end, subRange.v2()))
+                    r -> r.completionListener.addListener(groupedActionListener, Math.min(r.completionListener.end, subRange.end()))
                 );
         }
 
@@ -277,7 +273,8 @@ public class SparseFileTracker {
 
     /**
      * Called before reading a range from the file to ensure that this range is present. Unlike
-     * {@link SparseFileTracker#waitForRange(Tuple, Tuple, ActionListener)} this method does not expect the caller to fill in any gaps.
+     * {@link SparseFileTracker#waitForRange(ByteRange, ByteRange, ActionListener)} this method does not expect the caller to fill in any
+     * gaps.
      *
      * @param range    A tuple that contains the (inclusive) start and (exclusive) end of the desired range
      * @param listener Listener for when the listening range is fully available
@@ -286,11 +283,9 @@ public class SparseFileTracker {
      *                      filled.
      * @throws IllegalArgumentException if invalid range is requested
      */
-    public boolean waitForRangeIfPending(final Tuple<Long, Long> range, final ActionListener<Void> listener) {
-        final long start = range.v1();
-        final long end = range.v2();
-        if (end < start || start < 0L || length < end) {
-            throw new IllegalArgumentException("invalid range [start=" + start + ", end=" + end + ", length=" + length + "]");
+    public boolean waitForRangeIfPending(final ByteRange range, final ActionListener<Void> listener) {
+        if (length < range.end()) {
+            throw new IllegalArgumentException("invalid range [" + range + ", length=" + length + "]");
         }
 
         final ActionListener<Void> wrappedListener = wrapWithAssertions(listener);
@@ -299,19 +294,19 @@ public class SparseFileTracker {
         synchronized (mutex) {
             assert invariant();
 
-            final Range targetRange = new Range(start, end, null);
+            final Range targetRange = new Range(range);
             final SortedSet<Range> earlierRanges = ranges.headSet(targetRange, false); // ranges with strictly earlier starts
             if (earlierRanges.isEmpty() == false) {
                 final Range lastEarlierRange = earlierRanges.last();
-                if (start < lastEarlierRange.end) {
+                if (range.start() < lastEarlierRange.end) {
                     if (lastEarlierRange.isPending()) {
                         pendingRanges.add(lastEarlierRange);
                     }
-                    targetRange.start = Math.min(end, lastEarlierRange.end);
+                    targetRange.start = Math.min(range.end(), lastEarlierRange.end);
                 }
             }
 
-            while (targetRange.start < end) {
+            while (targetRange.start < range.end()) {
                 assert 0 <= targetRange.start : targetRange;
                 assert invariant();
 
@@ -326,14 +321,14 @@ public class SparseFileTracker {
                         if (firstExistingRange.isPending()) {
                             pendingRanges.add(firstExistingRange);
                         }
-                        targetRange.start = Math.min(end, firstExistingRange.end);
+                        targetRange.start = Math.min(range.end(), firstExistingRange.end);
                     } else {
                         return false;
                     }
                 }
             }
             assert targetRange.start == targetRange.end : targetRange;
-            assert targetRange.start == end : targetRange;
+            assert targetRange.start == range.end() : targetRange;
             assert invariant();
         }
 
@@ -348,7 +343,7 @@ public class SparseFileTracker {
                 final Range pendingRange = pendingRanges.get(0);
                 pendingRange.completionListener.addListener(
                     wrappedListener.map(progress -> null),
-                    Math.min(pendingRange.completionListener.end, end)
+                    Math.min(pendingRange.completionListener.end, range.end())
                 );
                 return true;
             default:
@@ -357,7 +352,7 @@ public class SparseFileTracker {
                     pendingRanges.size()
                 );
                 pendingRanges.forEach(
-                    r -> r.completionListener.addListener(groupedActionListener, Math.min(r.completionListener.end, end))
+                    r -> r.completionListener.addListener(groupedActionListener, Math.min(r.completionListener.end, range.end()))
                 );
                 return true;
         }
@@ -380,13 +375,14 @@ public class SparseFileTracker {
      * some ranges of present bytes. It tries to return the smallest possible range, but does so on a best-effort basis. This method does
      * not acquire anything, which means that another thread may concurrently fill in some of the returned range.
      *
-     * @param start The (inclusive) start of the target range
-     * @param end The (exclusive) end of the target range
+     * @param range The target range
      * @return a range that contains all bytes of the target range which are absent, or {@code null} if there are no such bytes.
      */
-    public Tuple<Long, Long> getAbsentRangeWithin(final long start, final long end) {
+    @Nullable
+    public ByteRange getAbsentRangeWithin(ByteRange range) {
         synchronized (mutex) {
 
+            final long start = range.start();
             // Find the first absent byte in the range
             final SortedSet<Range> startRanges = ranges.headSet(new Range(start, start, null), true); // ranges which start <= 'start'
             long resultStart;
@@ -405,6 +401,7 @@ public class SparseFileTracker {
             }
             assert resultStart >= start;
 
+            final long end = range.end();
             // Find the last absent byte in the range
             final SortedSet<Range> endRanges = ranges.headSet(new Range(end, end, null), false); // ranges which start < 'end'
             final long resultEnd;
@@ -423,7 +420,7 @@ public class SparseFileTracker {
             }
             assert resultEnd <= end;
 
-            return resultStart < resultEnd ? Tuple.tuple(resultStart, resultEnd) : null;
+            return resultStart < resultEnd ? ByteRange.of(resultStart, resultEnd) : null;
         }
     }
 
@@ -600,6 +597,10 @@ public class SparseFileTracker {
 
         @Nullable // if not pending
         final ProgressListenableActionFuture completionListener;
+
+        Range(ByteRange range) {
+            this(range.start(), range.end(), null);
+        }
 
         Range(long start, long end, @Nullable ProgressListenableActionFuture completionListener) {
             assert start <= end : start + "-" + end;

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/ByteRange.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/ByteRange.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.searchablesnapshots.cache;
+
+import org.elasticsearch.common.Nullable;
+
+public final class ByteRange implements Comparable<ByteRange> {
+
+    public static final ByteRange EMPTY = new ByteRange(0L, 0L);
+
+    private final long start;
+
+    private final long end;
+
+    public static ByteRange of(long start, long end) {
+        return new ByteRange(start, end);
+    }
+
+    private ByteRange(long start, long end) {
+        this.start = start;
+        this.end = end;
+        assert start >= 0L : "Start must be >= 0 but saw [" + start + "]";
+        assert end >= start : "End must be greater or equal to start but saw [" + start + "][" + start + "]";
+    }
+
+    /**
+     * Computes the smallest range that contains both this instance as well as the given {@code other} range.
+     *
+     * @param other other range or {@code null} in which case this instance is returned
+     */
+    public ByteRange minEnvelope(@Nullable ByteRange other) {
+        if (other == null) {
+            return this;
+        }
+        if (other.isSubRangeOf(this)) {
+            return this;
+        }
+        if (this.isSubRangeOf(other)) {
+            return other;
+        }
+        return of(Math.min(start, other.start), Math.max(end, other.end));
+    }
+
+    public long start() {
+        return start;
+    }
+
+    public long end() {
+        return end;
+    }
+
+    public long length() {
+        return end - start;
+    }
+
+    /**
+     * Checks if this instance is fully contained in the given {@code range}.
+     */
+    public boolean isSubRangeOf(ByteRange range) {
+        return start >= range.start() && end <= range.end();
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 * Long.hashCode(start) + Long.hashCode(end);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj instanceof ByteRange == false) {
+            return false;
+        }
+        final ByteRange that = (ByteRange) obj;
+        return start == that.start && end == that.end;
+    }
+
+    @Override
+    public String toString() {
+        return "ByteRange{" + start + "}{" + end + "}";
+    }
+
+    @Override
+    public int compareTo(ByteRange o) {
+        return Long.compare(start, o.start);
+    }
+}

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheService.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheService.java
@@ -14,7 +14,6 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.cache.Cache;
 import org.elasticsearch.common.cache.CacheBuilder;
-import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.component.Lifecycle;
 import org.elasticsearch.common.settings.ClusterSettings;
@@ -325,7 +324,7 @@ public class CacheService extends AbstractLifecycleComponent {
         final long fileLength,
         final Path cacheDir,
         final String cacheFileUuid,
-        final SortedSet<Tuple<Long, Long>> cacheFileRanges
+        final SortedSet<ByteRange> cacheFileRanges
     ) throws Exception {
 
         ensureLifecycleInitializing();
@@ -575,7 +574,7 @@ public class CacheService extends AbstractLifecycleComponent {
                             break;
 
                         case NEEDS_FSYNC:
-                            final SortedSet<Tuple<Long, Long>> ranges = cacheFile.fsync();
+                            final SortedSet<ByteRange> ranges = cacheFile.fsync();
                             logger.trace(
                                 "cache file [{}] synchronized with [{}] completed range(s)",
                                 cacheFile.getFile().getFileName(),

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/FrozenCacheService.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/FrozenCacheService.java
@@ -14,7 +14,6 @@ import org.elasticsearch.Assertions;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.StepListener;
 import org.elasticsearch.common.Nullable;
-import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.settings.Setting;
@@ -194,18 +193,21 @@ public class FrozenCacheService implements Releasable {
         return getRegion(position);
     }
 
-    private Tuple<Long, Long> mapSubRangeToRegion(Tuple<Long, Long> range, int region) {
+    private ByteRange mapSubRangeToRegion(ByteRange range, int region) {
         final long regionStart = getRegionStart(region);
         final long regionEnd = getRegionEnd(region);
-        if (range.v1() >= regionEnd || range.v2() <= regionStart) {
-            return Tuple.tuple(0L, 0L);
+        if (range.start() >= regionEnd || range.end() <= regionStart) {
+            return ByteRange.EMPTY;
         }
-        final long rangeStart = Math.max(regionStart, range.v1());
-        final long rangeEnd = Math.min(regionEnd, range.v2());
+        final long rangeStart = Math.max(regionStart, range.start());
+        final long rangeEnd = Math.min(regionEnd, range.end());
         if (rangeStart >= rangeEnd) {
-            return Tuple.tuple(0L, 0L);
+            return ByteRange.EMPTY;
         }
-        return Tuple.tuple(getRegionRelativePosition(rangeStart), rangeEnd == regionEnd ? regionSize : getRegionRelativePosition(rangeEnd));
+        return ByteRange.of(
+            getRegionRelativePosition(rangeStart),
+            rangeEnd == regionEnd ? regionSize : getRegionRelativePosition(rangeEnd)
+        );
     }
 
     private long getRegionSize(long fileLength, int region) {
@@ -578,8 +580,8 @@ public class FrozenCacheService implements Releasable {
         }
 
         public StepListener<Integer> populateAndRead(
-            final Tuple<Long, Long> rangeToWrite,
-            final Tuple<Long, Long> rangeToRead,
+            final ByteRange rangeToWrite,
+            final ByteRange rangeToRead,
             final RangeAvailableHandler reader,
             final RangeMissingHandler writer,
             final Executor executor
@@ -596,7 +598,7 @@ public class FrozenCacheService implements Releasable {
                 final SharedBytes.IO fileChannel = sharedBytes.getFileChannel(sharedBytesPos);
                 listener.whenComplete(integer -> fileChannel.decRef(), e -> fileChannel.decRef());
                 final ActionListener<Void> rangeListener = rangeListener(rangeToRead, reader, listener, fileChannel);
-                if (rangeToRead.v1().equals(rangeToRead.v2())) {
+                if (rangeToRead.length() == 0L) {
                     // nothing to read, skip
                     rangeListener.onResponse(null);
                     return listener;
@@ -642,7 +644,7 @@ public class FrozenCacheService implements Releasable {
         }
 
         @Nullable
-        public StepListener<Integer> readIfAvailableOrPending(final Tuple<Long, Long> rangeToRead, final RangeAvailableHandler reader) {
+        public StepListener<Integer> readIfAvailableOrPending(final ByteRange rangeToRead, final RangeAvailableHandler reader) {
             final StepListener<Integer> listener = new StepListener<>();
             Releasable decrementRef = null;
             try {
@@ -667,7 +669,7 @@ public class FrozenCacheService implements Releasable {
         }
 
         private ActionListener<Void> rangeListener(
-            Tuple<Long, Long> rangeToRead,
+            ByteRange rangeToRead,
             RangeAvailableHandler reader,
             ActionListener<Integer> listener,
             SharedBytes.IO fileChannel
@@ -677,16 +679,16 @@ public class FrozenCacheService implements Releasable {
                 assert regionOwners[sharedBytesPos].get() == CacheFileRegion.this;
                 final int read = reader.onRangeAvailable(
                     fileChannel,
-                    physicalStartOffset + rangeToRead.v1(),
-                    rangeToRead.v1(),
-                    rangeToRead.v2() - rangeToRead.v1()
+                    physicalStartOffset + rangeToRead.start(),
+                    rangeToRead.start(),
+                    rangeToRead.length()
                 );
-                assert read == rangeToRead.v2() - rangeToRead.v1() : "partial read ["
+                assert read == rangeToRead.length() : "partial read ["
                     + read
                     + "] does not match the range to read ["
-                    + rangeToRead.v2()
+                    + rangeToRead.end()
                     + '-'
-                    + rangeToRead.v1()
+                    + rangeToRead.start()
                     + ']';
                 listener.onResponse(read);
             }, listener::onFailure);
@@ -718,19 +720,19 @@ public class FrozenCacheService implements Releasable {
         }
 
         public StepListener<Integer> populateAndRead(
-            final Tuple<Long, Long> rangeToWrite,
-            final Tuple<Long, Long> rangeToRead,
+            final ByteRange rangeToWrite,
+            final ByteRange rangeToRead,
             final RangeAvailableHandler reader,
             final RangeMissingHandler writer,
             final Executor executor
         ) {
             StepListener<Integer> stepListener = null;
-            final long writeStart = rangeToWrite.v1();
-            final long readStart = rangeToRead.v1();
-            for (int i = getRegion(rangeToWrite.v1()); i <= getEndingRegion(rangeToWrite.v2()); i++) {
+            final long writeStart = rangeToWrite.start();
+            final long readStart = rangeToRead.start();
+            for (int i = getRegion(rangeToWrite.start()); i <= getEndingRegion(rangeToWrite.end()); i++) {
                 final int region = i;
-                final Tuple<Long, Long> subRangeToWrite = mapSubRangeToRegion(rangeToWrite, region);
-                final Tuple<Long, Long> subRangeToRead = mapSubRangeToRegion(rangeToRead, region);
+                final ByteRange subRangeToWrite = mapSubRangeToRegion(rangeToWrite, region);
+                final ByteRange subRangeToRead = mapSubRangeToRegion(rangeToRead, region);
                 final CacheFileRegion fileRegion = get(cacheKey, length, region);
                 final StepListener<Integer> lis = fileRegion.populateAndRead(
                     subRangeToWrite,
@@ -765,12 +767,12 @@ public class FrozenCacheService implements Releasable {
         }
 
         @Nullable
-        public StepListener<Integer> readIfAvailableOrPending(final Tuple<Long, Long> rangeToRead, final RangeAvailableHandler reader) {
+        public StepListener<Integer> readIfAvailableOrPending(final ByteRange rangeToRead, final RangeAvailableHandler reader) {
             StepListener<Integer> stepListener = null;
-            final long start = rangeToRead.v1();
-            for (int i = getRegion(rangeToRead.v1()); i <= getEndingRegion(rangeToRead.v2()); i++) {
+            final long start = rangeToRead.start();
+            for (int i = getRegion(rangeToRead.start()); i <= getEndingRegion(rangeToRead.end()); i++) {
                 final int region = i;
-                final Tuple<Long, Long> subRangeToRead = mapSubRangeToRegion(rangeToRead, region);
+                final ByteRange subRangeToRead = mapSubRangeToRegion(rangeToRead, region);
                 final CacheFileRegion fileRegion = get(cacheKey, length, region);
                 final StepListener<Integer> lis = fileRegion.readIfAvailableOrPending(
                     subRangeToRead,

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/PersistentCache.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/PersistentCache.java
@@ -40,7 +40,6 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.io.stream.ByteBufferStreamInput;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -67,7 +66,6 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -132,7 +130,7 @@ public class PersistentCache implements Closeable {
         }
     }
 
-    public void addCacheFile(CacheFile cacheFile, SortedSet<Tuple<Long, Long>> ranges) throws IOException {
+    public void addCacheFile(CacheFile cacheFile, SortedSet<ByteRange> ranges) throws IOException {
         ensureStarted();
         getWriter(cacheFile).updateCacheFile(cacheFile, ranges);
     }
@@ -179,7 +177,7 @@ public class PersistentCache implements Closeable {
                                 final Document document = leafReaderContext.reader().document(docIdSetIterator.docID());
                                 final String cacheFileId = getValue(document, CACHE_ID_FIELD);
                                 if (predicate.test(snapshotCacheDir.resolve(cacheFileId))) {
-                                    long size = buildCacheFileRanges(document).stream().mapToLong(range -> range.v2() - range.v1()).sum();
+                                    long size = buildCacheFileRanges(document).stream().mapToLong(ByteRange::length).sum();
                                     logger.trace("cache file [{}] has size [{}]", getValue(document, CACHE_ID_FIELD), size);
                                     aggregateSize += size;
                                 }
@@ -240,7 +238,7 @@ public class PersistentCache implements Closeable {
 
                                                 final CacheKey cacheKey = buildCacheKey(cacheDocument);
                                                 final long fileLength = getFileLength(cacheDocument);
-                                                final SortedSet<Tuple<Long, Long>> ranges = buildCacheFileRanges(cacheDocument);
+                                                final SortedSet<ByteRange> ranges = buildCacheFileRanges(cacheDocument);
 
                                                 logger.trace("adding cache file with [id={}, key={}, ranges={}]", id, cacheKey, ranges);
                                                 cacheService.put(cacheKey, fileLength, file.getParent(), id, ranges);
@@ -494,7 +492,7 @@ public class PersistentCache implements Closeable {
             return nodePath;
         }
 
-        void updateCacheFile(CacheFile cacheFile, SortedSet<Tuple<Long, Long>> cacheRanges) throws IOException {
+        void updateCacheFile(CacheFile cacheFile, SortedSet<ByteRange> cacheRanges) throws IOException {
             updateCacheFile(buildId(cacheFile), buildDocument(nodePath, cacheFile, cacheRanges));
         }
 
@@ -560,7 +558,7 @@ public class PersistentCache implements Closeable {
         return new Term(CACHE_ID_FIELD, cacheFileUuid);
     }
 
-    private static Document buildDocument(NodeEnvironment.NodePath nodePath, CacheFile cacheFile, SortedSet<Tuple<Long, Long>> cacheRanges)
+    private static Document buildDocument(NodeEnvironment.NodePath nodePath, CacheFile cacheFile, SortedSet<ByteRange> cacheRanges)
         throws IOException {
         final Document document = new Document();
         document.add(new StringField(CACHE_ID_FIELD, buildId(cacheFile), Field.Store.YES));
@@ -568,9 +566,9 @@ public class PersistentCache implements Closeable {
 
         try (BytesStreamOutput output = new BytesStreamOutput()) {
             output.writeVInt(cacheRanges.size());
-            for (Tuple<Long, Long> cacheRange : cacheRanges) {
-                output.writeVLong(cacheRange.v1());
-                output.writeVLong(cacheRange.v2());
+            for (ByteRange cacheRange : cacheRanges) {
+                output.writeVLong(cacheRange.start());
+                output.writeVLong(cacheRange.end());
             }
             output.flush();
             document.add(new StoredField(CACHE_RANGES_FIELD, output.bytes().toBytesRef()));
@@ -614,20 +612,20 @@ public class PersistentCache implements Closeable {
         return Long.parseLong(fileLength);
     }
 
-    private static SortedSet<Tuple<Long, Long>> buildCacheFileRanges(Document document) throws IOException {
+    private static SortedSet<ByteRange> buildCacheFileRanges(Document document) throws IOException {
         final BytesRef cacheRangesBytesRef = document.getBinaryValue(CACHE_RANGES_FIELD);
         assert cacheRangesBytesRef != null;
 
-        final SortedSet<Tuple<Long, Long>> cacheRanges = new TreeSet<>(Comparator.comparingLong(Tuple::v1));
+        final SortedSet<ByteRange> cacheRanges = new TreeSet<>();
         try (StreamInput input = new ByteBufferStreamInput(ByteBuffer.wrap(cacheRangesBytesRef.bytes))) {
             final int length = input.readVInt();
             assert length > 0 : "empty cache ranges";
-            Tuple<Long, Long> previous = null;
+            ByteRange previous = null;
             for (int i = 0; i < length; i++) {
-                final Tuple<Long, Long> range = Tuple.tuple(input.readVLong(), input.readVLong());
-                assert range.v1() < range.v2() : range;
-                assert range.v2() <= getFileLength(document);
-                assert previous == null || previous.v2() < range.v1();
+                final ByteRange range = ByteRange.of(input.readVLong(), input.readVLong());
+                assert range.length() > 0 : range;
+                assert range.start() <= getFileLength(document);
+                assert previous == null || previous.end() < range.start();
 
                 final boolean added = cacheRanges.add(range);
                 assert added : range + " already exist in " + cacheRanges;

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/PersistentCache.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/PersistentCache.java
@@ -624,7 +624,7 @@ public class PersistentCache implements Closeable {
             for (int i = 0; i < length; i++) {
                 final ByteRange range = ByteRange.of(input.readVLong(), input.readVLong());
                 assert range.length() > 0 : range;
-                assert range.start() <= getFileLength(document);
+                assert range.end() <= getFileLength(document);
                 assert previous == null || previous.end() < range.start();
 
                 final boolean added = cacheRanges.add(range);

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsTestCase.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsTestCase.java
@@ -16,7 +16,6 @@ import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.TestShardRouting;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.UUIDs;
-import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.lucene.store.ESIndexInputTestCase;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
@@ -39,6 +38,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.threadpool.ThreadPoolStats;
+import org.elasticsearch.xpack.searchablesnapshots.cache.ByteRange;
 import org.elasticsearch.xpack.searchablesnapshots.cache.CacheService;
 import org.elasticsearch.xpack.searchablesnapshots.cache.FrozenCacheService;
 import org.elasticsearch.xpack.searchablesnapshots.cache.PersistentCache;
@@ -284,7 +284,7 @@ public abstract class AbstractSearchableSnapshotsTestCase extends ESIndexInputTe
                         final CacheFile.EvictionListener listener = evictedCacheFile -> {};
                         cacheFile.acquire(listener);
                         try {
-                            SortedSet<Tuple<Long, Long>> ranges = Collections.emptySortedSet();
+                            SortedSet<ByteRange> ranges = Collections.emptySortedSet();
                             while (ranges.isEmpty()) {
                                 ranges = randomPopulateAndReads(cacheFile, (channel, from, to) -> {
                                     try {

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheServiceTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheServiceTests.java
@@ -104,7 +104,7 @@ public class CacheServiceTests extends AbstractSearchableSnapshotsTestCase {
                     final CacheFile.EvictionListener listener = evictedCacheFile -> {};
                     cacheFile.acquire(listener);
 
-                    final SortedSet<Tuple<Long, Long>> newCacheRanges = randomPopulateAndReads(cacheFile);
+                    final SortedSet<ByteRange> newCacheRanges = randomPopulateAndReads(cacheFile);
                     assertThat(cacheService.isCacheFileToSync(cacheFile), is(newCacheRanges.isEmpty() == false));
                     if (newCacheRanges.isEmpty() == false) {
                         final int numberOfWrites = cacheEntry.getValue().v2() + 1;
@@ -123,7 +123,7 @@ public class CacheServiceTests extends AbstractSearchableSnapshotsTestCase {
                     final CacheFile.EvictionListener listener = evictedCacheFile -> {};
                     cacheFile.acquire(listener);
 
-                    final SortedSet<Tuple<Long, Long>> newRanges = randomPopulateAndReads(cacheFile);
+                    final SortedSet<ByteRange> newRanges = randomPopulateAndReads(cacheFile);
                     assertThat(cacheService.isCacheFileToSync(cacheFile), is(newRanges.isEmpty() == false));
                     updates.put(cacheKey, Tuple.tuple(cacheFile, newRanges.isEmpty() ? 0 : 1));
                     cacheFile.release(listener);
@@ -198,7 +198,7 @@ public class CacheServiceTests extends AbstractSearchableSnapshotsTestCase {
                 resolveSnapshotCache(randomShardPath(cacheKey.getShardId())).resolve(cacheKey.getSnapshotUUID())
             );
             final String cacheFileUuid = UUIDs.randomBase64UUID(random());
-            final SortedSet<Tuple<Long, Long>> cacheFileRanges = randomBoolean() ? randomRanges(fileLength) : emptySortedSet();
+            final SortedSet<ByteRange> cacheFileRanges = randomBoolean() ? randomRanges(fileLength) : emptySortedSet();
 
             if (randomBoolean()) {
                 final Path cacheFilePath = cacheDir.resolve(cacheFileUuid);
@@ -213,8 +213,8 @@ public class CacheServiceTests extends AbstractSearchableSnapshotsTestCase {
                 assertThat(cacheFile.getCacheKey(), equalTo(cacheKey));
                 assertThat(cacheFile.getLength(), equalTo(fileLength));
 
-                for (Tuple<Long, Long> cacheFileRange : cacheFileRanges) {
-                    assertThat(cacheFile.getAbsentRangeWithin(cacheFileRange.v1(), cacheFileRange.v2()), nullValue());
+                for (ByteRange cacheFileRange : cacheFileRanges) {
+                    assertThat(cacheFile.getAbsentRangeWithin(cacheFileRange), nullValue());
                 }
             } else {
                 final FileNotFoundException exception = expectThrows(

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/FrozenCacheServiceTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/FrozenCacheServiceTests.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.searchablesnapshots.cache;
 
 import org.elasticsearch.cluster.coordination.DeterministicTaskQueue;
-import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
@@ -56,8 +55,8 @@ public class FrozenCacheServiceTests extends ESTestCase {
             assertFalse(region1.tryEvict());
             assertEquals(3, cacheService.freeRegionCount());
             region0.populateAndRead(
-                Tuple.tuple(0L, 1L),
-                Tuple.tuple(0L, 1L),
+                ByteRange.of(0L, 1L),
+                ByteRange.of(0L, 1L),
                 (channel, channelPos, relativePos, length) -> 1,
                 (channel, channelPos, relativePos, length, progressUpdater) -> progressUpdater.accept(length),
                 taskQueue.getThreadPool().executor(ThreadPool.Names.GENERIC)

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/PersistentCacheTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/PersistentCacheTests.java
@@ -13,7 +13,6 @@ import org.apache.lucene.document.StringField;
 import org.apache.lucene.mockfile.FilterFileChannel;
 import org.apache.lucene.mockfile.FilterFileSystemProvider;
 import org.apache.lucene.mockfile.FilterPath;
-import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.io.PathUtils;
 import org.elasticsearch.common.io.PathUtilsForTesting;
 import org.elasticsearch.common.settings.Settings;
@@ -225,7 +224,7 @@ public class PersistentCacheTests extends AbstractSearchableSnapshotsTestCase {
 
                 final SnapshotId snapshotId = new SnapshotId("_ignored_", cacheKey.getSnapshotUUID());
                 if (randomBoolean()) {
-                    final Tuple<Long, Long> absent = randomCacheFile.getAbsentRangeWithin(0L, randomCacheFile.getLength());
+                    final ByteRange absent = randomCacheFile.getAbsentRangeWithin(ByteRange.of(0L, randomCacheFile.getLength()));
                     if (absent != null) {
                         assertThat(
                             "Persistent cache should not contain any cached data",
@@ -249,7 +248,7 @@ public class PersistentCacheTests extends AbstractSearchableSnapshotsTestCase {
                         final CacheFile.EvictionListener listener = evictedCacheFile -> {};
                         randomCacheFile.acquire(listener);
                         try {
-                            SortedSet<Tuple<Long, Long>> ranges = null;
+                            SortedSet<ByteRange> ranges = null;
                             while (ranges == null || ranges.isEmpty()) {
                                 ranges = randomPopulateAndReads(randomCacheFile);
                             }


### PR DESCRIPTION
Just a suggestion, but IMO this is much simpler and makes enables some drier solutions for the cache file math down the line:

Using `Tuple` all over is somewhat read to read and forces us to duplicate
a lot of assertions. Using a custom class dries up the assertions and makes
the code easier to follow by adding utilities for some common region math spots.
