### PR TITLE
fix naming in `HttpPipelinedResponse`

### DIFF
--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpPipeliningHandler.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpPipeliningHandler.java
@@ -55,7 +55,7 @@ public class Netty4HttpPipeliningHandler extends ChannelDuplexHandler {
         try {
             List<Tuple<HttpPipelinedResponse, ChannelPromise>> readyResponses = aggregator.write(response, promise);
             for (Tuple<HttpPipelinedResponse, ChannelPromise> readyResponse : readyResponses) {
-                ctx.write(readyResponse.v1().getDelegateRequest(), readyResponse.v2());
+                ctx.write(readyResponse.v1().getDelegateResponse(), readyResponse.v2());
             }
             success = true;
         } catch (IllegalStateException e) {

--- a/plugins/transport-nio/src/main/java/org/elasticsearch/http/nio/HttpReadWriteHandler.java
+++ b/plugins/transport-nio/src/main/java/org/elasticsearch/http/nio/HttpReadWriteHandler.java
@@ -164,9 +164,9 @@ public class HttpReadWriteHandler implements NioChannelHandler {
     private static boolean assertMessageTypes(Object message) {
         assert message instanceof HttpPipelinedResponse : "This channel only supports messages that are of type: "
             + HttpPipelinedResponse.class + ". Found type: " + message.getClass() + ".";
-        assert ((HttpPipelinedResponse) message).getDelegateRequest() instanceof NioHttpResponse :
+        assert ((HttpPipelinedResponse) message).getDelegateResponse() instanceof NioHttpResponse :
             "This channel only pipelined responses with a delegate of type: " + NioHttpResponse.class +
-                ". Found type: " + ((HttpPipelinedResponse) message).getDelegateRequest().getClass() + ".";
+                ". Found type: " + ((HttpPipelinedResponse) message).getDelegateResponse().getClass() + ".";
         return true;
     }
 }

--- a/plugins/transport-nio/src/main/java/org/elasticsearch/http/nio/NioHttpPipeliningHandler.java
+++ b/plugins/transport-nio/src/main/java/org/elasticsearch/http/nio/NioHttpPipeliningHandler.java
@@ -58,7 +58,7 @@ public class NioHttpPipeliningHandler extends ChannelDuplexHandler {
             List<Tuple<HttpPipelinedResponse, NettyListener>> readyResponses = aggregator.write(response, listener);
             success = true;
             for (Tuple<HttpPipelinedResponse, NettyListener> responseToWrite : readyResponses) {
-                ctx.write(responseToWrite.v1().getDelegateRequest(), responseToWrite.v2());
+                ctx.write(responseToWrite.v1().getDelegateResponse(), responseToWrite.v2());
             }
         } catch (IllegalStateException e) {
             ctx.channel().close();

--- a/server/src/main/java/org/elasticsearch/http/HttpPipelinedResponse.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpPipelinedResponse.java
@@ -32,7 +32,7 @@ public class HttpPipelinedResponse implements HttpPipelinedMessage, HttpResponse
         return delegate.containsHeader(name);
     }
 
-    public HttpResponse getDelegateRequest() {
+    public HttpResponse getDelegateResponse() {
         return delegate;
     }
 }


### PR DESCRIPTION
fix naming in `HttpPipelinedResponse`