### PR TITLE
Move mappingSource from DocumentMapper to Mapping

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -10,10 +10,8 @@ package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.ElasticsearchGenerationException;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.compress.CompressedXContent;
-import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.analysis.IndexAnalyzers;
@@ -27,7 +25,6 @@ import java.util.stream.Stream;
 
 public class DocumentMapper {
     private final String type;
-    private final CompressedXContent mappingSource;
     private final DocumentParser documentParser;
     private final MappingLookup mappingLookup;
     private final MetadataFieldMapper[] deleteTombstoneMetadataFieldMappers;
@@ -51,13 +48,6 @@ public class DocumentMapper {
         this.type = mapping.root().name();
         this.documentParser = documentParser;
         this.mappingLookup = MappingLookup.fromMapping(mapping, documentParser, indexSettings, indexAnalyzers);
-
-        try {
-            mappingSource = new CompressedXContent(mapping, XContentType.JSON, ToXContent.EMPTY_PARAMS);
-        } catch (Exception e) {
-            throw new ElasticsearchGenerationException("failed to serialize source for type [" + type + "]", e);
-        }
-
         final Collection<String> deleteTombstoneMetadataFields = Arrays.asList(VersionFieldMapper.NAME, IdFieldMapper.NAME,
             SeqNoFieldMapper.NAME, SeqNoFieldMapper.PRIMARY_TERM_NAME, SeqNoFieldMapper.TOMBSTONE_NAME);
         this.deleteTombstoneMetadataFieldMappers = Stream.of(mapping.metadataMappers)
@@ -81,7 +71,7 @@ public class DocumentMapper {
     }
 
     public CompressedXContent mappingSource() {
-        return this.mappingSource;
+        return this.mapping().mappingSource();
     }
 
     public RootObjectMapper root() {


### PR DESCRIPTION
As we move parsing logic out of DocumentMapper, the reference to the mapping source also does not belong to it and can be moved out to Mapping which is the representation of the parsed mappings.