### PR TITLE
[DOCS] Note rollup metrics cannot be used in histogram

### DIFF
--- a/docs/reference/rollup/apis/rollup-api.asciidoc
+++ b/docs/reference/rollup/apis/rollup-api.asciidoc
@@ -130,9 +130,12 @@ Groups and stores <<number,numeric>> field values based on a provided interval.
 [%collapsible%open]
 ======
 `fields`::
-(Required*, array of strings)
-Array of <<number,numeric>> fields to group. If you specify a `histogram`
-object, this property is required.
+(Required*, string or array of strings)
+<<number,Numeric>> fields to group. If you specify a `histogram` object, this
+property is required.
++
+WARNING: Do not use the same fields in `metrics.fields`. If you specify a field
+in both `histogram.fields` and `metrics.fields`, the roll up attempt will fail.
 
 `interval`::
 (Required*, integer)
@@ -149,9 +152,9 @@ Stores values for <<keyword,keyword family>> and <<number,numeric>> fields.
 [%collapsible%open]
 ======
 `fields`::
-(Required*, array of strings)
-Array of <<keyword,keyword family>> and <<number,numeric>> fields to store. If
-you specify a `terms` object, this property is required.
+(Required*, string or array of strings)
+<<keyword,Keyword family>> and <<number,numeric>> fields to store. If you
+specify a `terms` object, this property is required.
 +
 TIP: Avoid storing high-cardinality fields. High-cardinality fields can greatly
 increase the size of the resulting rollup index.
@@ -159,7 +162,7 @@ increase the size of the resulting rollup index.
 =====
 
 `metrics`::
-(Required, array of objects)
+(Required, object or array of objects)
 Collects and stores metrics for <<number,numeric>> fields. You must specify at
 least one `metrics` object.
 +
@@ -169,10 +172,13 @@ least one `metrics` object.
 `field`::
 (Required, string)
 <<number,Numeric>> field to collect metrics for.
++
+WARNING: Do not use the same field in `histogram.fields`. If you specify a field
+in both `histogram.fields` and `metrics.fields`, the roll up attempt will fail.
 
 `metrics`::
-(Required, array of strings)
-Array of metrics to collect. Each value corresponds to a
+(Required, string or array of strings)
+Metrics to collect. Each value corresponds to a
 <<search-aggregations-metrics,metric aggregation>>. Valid values are
 <<search-aggregations-metrics-min-aggregation,`min`>>,
 <<search-aggregations-metrics-max-aggregation,`max`>>,

--- a/docs/reference/rollup/apis/rollup-api.asciidoc
+++ b/docs/reference/rollup/apis/rollup-api.asciidoc
@@ -134,8 +134,8 @@ Groups and stores <<number,numeric>> field values based on a provided interval.
 <<number,Numeric>> fields to group. If you specify a `histogram` object, this
 property is required.
 +
-WARNING: If you specify the same field in both `histogram` and `metrics`, the
-rollup attempt will fail.
+WARNING: Do not use the same fields in `histogram` and `metrics`. If you specify
+the same field in both `histogram` and `metrics`, the rollup attempt will fail.
 
 `interval`::
 (Required*, integer)
@@ -173,8 +173,8 @@ least one `metrics` object.
 (Required, string)
 <<number,Numeric>> field to collect metrics for.
 +
-WARNING: If you specify the same field in both `histogram` and `metrics`, the
-rollup attempt will fail.
+WARNING: Do not use the same fields in `histogram` and `metrics`. If you specify
+the same field in both `histogram` and `metrics`, the rollup attempt will fail.
 
 `metrics`::
 (Required, string or array of strings)

--- a/docs/reference/rollup/apis/rollup-api.asciidoc
+++ b/docs/reference/rollup/apis/rollup-api.asciidoc
@@ -135,7 +135,7 @@ Groups and stores <<number,numeric>> field values based on a provided interval.
 property is required.
 +
 WARNING: Do not use the same fields in `metrics.fields`. If you specify a field
-in both `histogram.fields` and `metrics.fields`, the roll up attempt will fail.
+in both `histogram.fields` and `metrics.fields`, the rollup attempt will fail.
 
 `interval`::
 (Required*, integer)
@@ -174,7 +174,7 @@ least one `metrics` object.
 <<number,Numeric>> field to collect metrics for.
 +
 WARNING: Do not use the same field in `histogram.fields`. If you specify a field
-in both `histogram.fields` and `metrics.fields`, the roll up attempt will fail.
+in both `histogram.fields` and `metrics.fields`, the rollup attempt will fail.
 
 `metrics`::
 (Required, string or array of strings)

--- a/docs/reference/rollup/apis/rollup-api.asciidoc
+++ b/docs/reference/rollup/apis/rollup-api.asciidoc
@@ -134,8 +134,8 @@ Groups and stores <<number,numeric>> field values based on a provided interval.
 <<number,Numeric>> fields to group. If you specify a `histogram` object, this
 property is required.
 +
-WARNING: Do not use the same fields in `metrics`. If you specify a field in
-both `histogram` and `metrics`, the rollup attempt will fail.
+WARNING: If you specify the same field in both `histogram` and `metrics`, the
+rollup attempt will fail.
 
 `interval`::
 (Required*, integer)
@@ -173,8 +173,8 @@ least one `metrics` object.
 (Required, string)
 <<number,Numeric>> field to collect metrics for.
 +
-WARNING: Do not use the same field in `histogram`. If you specify a field in
-both `histogram` and `metrics`, the rollup attempt will fail.
+WARNING: If you specify the same field in both `histogram` and `metrics`, the
+rollup attempt will fail.
 
 `metrics`::
 (Required, string or array of strings)

--- a/docs/reference/rollup/apis/rollup-api.asciidoc
+++ b/docs/reference/rollup/apis/rollup-api.asciidoc
@@ -134,8 +134,8 @@ Groups and stores <<number,numeric>> field values based on a provided interval.
 <<number,Numeric>> fields to group. If you specify a `histogram` object, this
 property is required.
 +
-WARNING: Do not use the same fields in `metrics.fields`. If you specify a field
-in both `histogram.fields` and `metrics.fields`, the rollup attempt will fail.
+WARNING: Do not use the same fields in `metrics`. If you specify a field in
+both `histogram` and `metrics`, the rollup attempt will fail.
 
 `interval`::
 (Required*, integer)
@@ -173,8 +173,8 @@ least one `metrics` object.
 (Required, string)
 <<number,Numeric>> field to collect metrics for.
 +
-WARNING: Do not use the same field in `histogram.fields`. If you specify a field
-in both `histogram.fields` and `metrics.fields`, the rollup attempt will fail.
+WARNING: Do not use the same field in `histogram`. If you specify a field in
+both `histogram` and `metrics`, the rollup attempt will fail.
 
 `metrics`::
 (Required, string or array of strings)


### PR DESCRIPTION
If you specify a numeric field in both the histogram and metrics configuration of a rollup, the rollup will fail due to duplicate fields in the mapping.

This updates the rollup API docs to note this limitation.