### PR TITLE
Enable `BooleanNegation` checkstyle rule always

### DIFF
--- a/buildSrc/src/main/resources/checkstyle.xml
+++ b/buildSrc/src/main/resources/checkstyle.xml
@@ -124,17 +124,17 @@
     </module>
 
     <!-- Forbid using '!' for logical negations in favour of checking against 'false' explicitly. -->
-    <!-- This is disabled for now because there are many violations, hence the rule is reporting at the "warning" severity. -->
-    <!--
+    <!-- This is only reported in the IDE for now because there are many violations -->
     <module name="DescendantToken">
-      <property name="id" value="BooleanNegation" />
-      <property name="tokens" value="EXPR"/>
-      <property name="limitedTokens" value="LNOT"/>
-      <property name="maximumNumber" value="0"/>
-      <property name="maximumDepth" value="1"/>
-      <message key="descendant.token.max" value="Do not negate boolean expressions with '!', but check explicitly with '== false' as it is more explicit"/>
+        <property name="id" value="BooleanNegation" />
+        <property name="tokens" value="EXPR"/>
+        <property name="limitedTokens" value="LNOT"/>
+        <property name="maximumNumber" value="0"/>
+        <property name="maximumDepth" value="2"/>
+        <message
+            key="descendant.token.max"
+            value="Do not negate boolean expressions with '!', but check explicitly with '== false' as it is more explicit"/>
     </module>
-    -->
 
   </module>
 </module>

--- a/buildSrc/src/main/resources/checkstyle_ide_fragment.xml
+++ b/buildSrc/src/main/resources/checkstyle_ide_fragment.xml
@@ -8,18 +8,6 @@
 <!-- Checkstyle config by the `:configureIdeCheckstyle` task.           -->
 
 <module name="IdeFragment">
-    <!-- Forbid using '!' for logical negations in favour of checking against 'false' explicitly. -->
-    <!-- This is only reported in the IDE for now because there are many violations -->
-    <module name="DescendantToken">
-        <property name="id" value="BooleanNegation" />
-        <property name="tokens" value="EXPR"/>
-        <property name="limitedTokens" value="LNOT"/>
-        <property name="maximumNumber" value="0"/>
-        <property name="maximumDepth" value="2"/>
-        <message
-            key="descendant.token.max"
-            value="Do not negate boolean expressions with '!', but check explicitly with '== false' as it is more explicit"/>
-    </module>
 
     <!-- See CONTRIBUTING.md for our guidelines on Javadoc -->
 


### PR DESCRIPTION
Having fixed all the uses of `!` for boolean negation, now enforce the `== false` style via Checkstyle all the time.