### PR TITLE
[DOCS] Add 6.8.14 ml-cpp PRs to release notes

### DIFF
--- a/docs/reference/release-notes.asciidoc
+++ b/docs/reference/release-notes.asciidoc
@@ -5,6 +5,7 @@
 --
 This section summarizes the changes in each release.
 
+* <<release-notes-6.8.14>>
 * <<release-notes-6.8.13>>
 * <<release-notes-6.8.12>>
 * <<release-notes-6.8.11>>

--- a/docs/reference/release-notes/6.8.asciidoc
+++ b/docs/reference/release-notes/6.8.asciidoc
@@ -1,3 +1,19 @@
+[[release-notes-6.8.14]]
+== {es} version 6.8.14
+
+coming::[6.8.14]
+
+Also see <<breaking-changes-6.8,Breaking changes in 6.8>>.
+
+[[bug-6.8.14]]
+[float]
+=== Bug fixes
+
+Machine learning::
+* Fix missing state in persist and restore for anomaly detection. This caused
+suboptimal modeling after a job was closed and reopened or failed over to a
+different node {ml-pull}1668[#1668]
+
 
 [[release-notes-6.8.13]]
 == {es} version 6.8.13

--- a/docs/reference/release-notes/6.8.asciidoc
+++ b/docs/reference/release-notes/6.8.asciidoc
@@ -10,7 +10,7 @@ Also see <<breaking-changes-6.8,Breaking changes in 6.8>>.
 === Bug fixes
 
 Machine learning::
-* Fix missing state in persist and restore for anomaly detection. This caused
+* Fixes missing state in persist and restore for anomaly detection. This caused
 suboptimal modeling after a job was closed and reopened or failed over to a
 different node {ml-pull}1668[#1668]
 


### PR DESCRIPTION
This PR adds the ml-cpp PRs from https://raw.githubusercontent.com/elastic/ml-cpp/6.8/docs/CHANGELOG.asciidoc to the Elasticsearch release notes.