### PR TITLE
Scripting: enforce GPLv2 for parsed stdlib docs (#68601)

### DIFF
--- a/modules/lang-painless/src/doc/java/org/elasticsearch/painless/ContextGeneratorCommon.java
+++ b/modules/lang-painless/src/doc/java/org/elasticsearch/painless/ContextGeneratorCommon.java
@@ -182,7 +182,7 @@ public class ContextGeneratorCommon {
                 .collect(Collectors.toList());
         }
 
-        public PainlessInfos(List<PainlessContextInfo> contextInfos, StdlibJavadocExtractor extractor) throws IOException {
+        public PainlessInfos(List<PainlessContextInfo> contextInfos, JavadocExtractor extractor) throws IOException {
             javaNamesToDisplayNames = getDisplayNames(contextInfos);
 
             javaNamesToJavadoc = new HashMap<>();

--- a/modules/lang-painless/src/doc/java/org/elasticsearch/painless/JavaClassResolver.java
+++ b/modules/lang-painless/src/doc/java/org/elasticsearch/painless/JavaClassResolver.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.painless;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public interface JavaClassResolver {
+    InputStream openClassFile(String className) throws IOException;
+}

--- a/modules/lang-painless/src/doc/java/org/elasticsearch/painless/PainlessInfoJson.java
+++ b/modules/lang-painless/src/doc/java/org/elasticsearch/painless/PainlessInfoJson.java
@@ -37,7 +37,7 @@ public class PainlessInfoJson {
                 PainlessContextInfo info,
                 Set<PainlessContextClassInfo> commonClassInfos,
                 Map<String, String> javaNamesToDisplayNames,
-                StdlibJavadocExtractor extractor
+                JavadocExtractor extractor
         ) throws IOException {
             this.name = info.getName();
             List<PainlessContextClassInfo> classInfos = ContextGeneratorCommon.excludeCommonClassInfos(commonClassInfos, info.getClasses());
@@ -111,11 +111,11 @@ public class PainlessInfoJson {
         public static List<Class> fromInfos(
             List<PainlessContextClassInfo> infos,
             Map<String, String> javaNamesToDisplayNames,
-            StdlibJavadocExtractor extractor
+            JavadocExtractor extractor
         ) throws IOException {
             List<Class> classes = new ArrayList<>(infos.size());
             for (PainlessContextClassInfo info : infos) {
-                StdlibJavadocExtractor.ParsedJavaClass parsedClass = extractor.parseClass(info.getName());
+                JavadocExtractor.ParsedJavaClass parsedClass = extractor.parseClass(info.getName());
                 classes.add(new Class(
                         javaNamesToDisplayNames.get(info.getName()),
                         info.isImported(),
@@ -206,7 +206,7 @@ public class PainlessInfoJson {
         public static List<Method> fromInfos(
                 List<PainlessContextMethodInfo> infos,
                 Map<String, String> javaNamesToDisplayNames,
-                StdlibJavadocExtractor.ParsedJavaClass parsed
+                JavadocExtractor.ParsedJavaClass parsed
         ) {
             List<Method> methods = new ArrayList<>(infos.size());
             for (PainlessContextMethodInfo info: infos) {
@@ -216,7 +216,7 @@ public class PainlessInfoJson {
                 String name = info.getName();
                 List<String> parameterTypes = info.getParameters();
 
-                StdlibJavadocExtractor.ParsedMethod parsedMethod = parsed.getMethod(name, parameterTypes);
+                JavadocExtractor.ParsedMethod parsedMethod = parsed.getMethod(name, parameterTypes);
                 if (parsedMethod != null) {
                     javadoc = parsedMethod.javadoc;
                     parameterNames = parsedMethod.parameterNames;
@@ -285,7 +285,7 @@ public class PainlessInfoJson {
         private static List<Constructor> fromInfos(
                 List<PainlessContextConstructorInfo> infos,
                 Map<String, String> javaNamesToDisplayNames,
-                StdlibJavadocExtractor.ParsedJavaClass pj
+                JavadocExtractor.ParsedJavaClass pj
         ) {
             List<Constructor> constructors = new ArrayList<>(infos.size());
             for (PainlessContextConstructorInfo info: infos) {
@@ -293,7 +293,7 @@ public class PainlessInfoJson {
                 List<String> parameterNames = null;
                 String javadoc = null;
 
-                StdlibJavadocExtractor.ParsedMethod parsed = pj.getConstructor(parameterTypes);
+                JavadocExtractor.ParsedMethod parsed = pj.getConstructor(parameterTypes);
                 if (parsed != null) {
                     parameterNames = parsed.parameterNames;
                     javadoc = parsed.javadoc;
@@ -357,7 +357,7 @@ public class PainlessInfoJson {
         public static List<Field> fromInfos(
                 List<PainlessContextFieldInfo> infos,
                 Map<String, String> javaNamesToDisplayNames,
-                StdlibJavadocExtractor.ParsedJavaClass pj
+                JavadocExtractor.ParsedJavaClass pj
         ) {
             List<Field> fields = new ArrayList<>(infos.size());
             for (PainlessContextFieldInfo info: infos) {


### PR DESCRIPTION
When parsing Java standard library javadocs, we need to ensure
that our use will comply with the license.  Our use complies
with GPLv2 licenses but may not comply with proprietary licenses.

Reject .java files that have non-GPL licenses when parsing them
for parameter names and javadoc comments.

Backport: 1152475