### PR TITLE
[7.10] [DOCS] Add collapsible sections to multi search API docs (#68695)

### DIFF
--- a/docs/reference/search/multi-search.asciidoc
+++ b/docs/reference/search/multi-search.asciidoc
@@ -161,6 +161,7 @@ shards. This is usually slower but more accurate.
 Specifies whether aggregation and suggester names should be prefixed by their
 respective types in the response.
 
+[role="child_attributes"]
 [[search-multi-search-api-request-body]]
 ==== {api-request-body-title}
 
@@ -168,16 +169,16 @@ The request body contains a newline-delimited list of search `<header>` and
 search `<body>` objects.
 
 `<header>`::
-+
---
 (Required, object)
 Contains parameters used to limit or change the subsequent search body request.
-
++
 This object is required for each search body but can be empty (`{}`) or a blank
 line.
---
-
-`allow_no_indices`:::
++
+.Properties of `<header>` objects
+[%collapsible%open]
+====
+`allow_no_indices`::
 (Optional, Boolean)
 If `true`, the request does *not* return an error if a wildcard expression or
 `_all` value retrieves only missing or closed indices.
@@ -185,40 +186,15 @@ If `true`, the request does *not* return an error if a wildcard expression or
 This parameter also applies to <<indices-aliases,index aliases>> that point to a
 missing or closed index.
 
-`expand_wildcards`:::
-+
---
-(Optional, string)
-Type of index that wildcard expressions can match. If the request can target
-data streams, this argument determines whether wildcard expressions match
-hidden data streams. Supports comma-separated values, such as `open,hidden`.
-Valid values are:
-
-`all`::
-Match any data stream or index, including <<hidden-indices,hidden>> ones.
-
-`open`::
-Match open, non-hidden indices. Also matches any non-hidden data stream.
-
-`closed`::
-Match closed, non-hidden indices. Also matches any non-hidden data stream. Data
-streams cannot be closed.
-
-`hidden`::
-Match hidden data streams and hidden indices. Must be combined with `open`,
-`closed`, or both.
-
-`none`::
-Wildcard expressions are not accepted.
---
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 +
 Defaults to `open`.
 
-`ignore_unavailable`:::
+`ignore_unavailable`::
 (Optional, Boolean) If `true`, documents from missing or closed indices are not
 included in the response. Defaults to `false`.
 
-`index`:::
+`index`::
 (Optional, string or array of strings)
 Data streams, indices, and index aliases to search. Wildcard (`*`) expressions
 are supported. You can specify multiple targets as an array.
@@ -226,21 +202,21 @@ are supported. You can specify multiple targets as an array.
 If this parameter is not specified, the `<target>` request path parameter
 is used as a fallback.
 
-`preference`:::
+`preference`::
 (Optional, string)
 Node or shard used to perform the search. Random by default.
 
-`request_cache`:::
+`request_cache`::
 (Optional, Boolean)
 If `true`, the request cache can be used for this search. Defaults to
 index-level settings. See <<shard-request-cache>>.
 
-`routing`:::
+`routing`::
 (Optional, string)
 Custom <<mapping-routing-field,routing value>> used to route search operations
 to a specific shard.
 
-`search_type`:::
+`search_type`::
 +
 --
 (Optional, string)
@@ -249,35 +225,40 @@ scoring returned documents.
 
 Options are:
 
-`query_then_fetch`::
+`query_then_fetch`:::
 (default)
 Documents are scored using local term and document frequencies for the shard.
 This is usually faster but less accurate.
 
-`dfs_query_then_fetch`::
+`dfs_query_then_fetch`:::
 Documents are scored using global term and document frequencies across all
 shards. This is usually slower but more accurate.
 --
+====
 
 `<body>`::
 (Optional, object)
 Contains parameters for a search request:
-
-`aggregations`:::
++
+.Properties of `<body>` objects
+[%collapsible%open]
+====
+`aggregations`::
 (Optional, <<search-aggregations,aggregation object>>)
 Aggregations you wish to run during the search. See <<search-aggregations>>.
 
-`query`:::
+`query`::
 (Optional, <<query-dsl,query DSL object>>) Query you wish to run during the
 search. Hits matching this query are returned in the response.
 
-`from`:::
+`from`::
 (Optional, integer)
 Starting offset for returned hits. Defaults to `0`.
 
-`size`:::
+`size`::
 (Optional, integer)
 Number of hits to return. Defaults to `10`.
+====
 
 [[search-multi-search-api-response-body]]
 ==== {api-response-body-title}


### PR DESCRIPTION
Backports the following commits to 7.10:
 - [DOCS] Add collapsible sections to multi search API docs (#68695)