### PR TITLE
[7.x] Enable `BooleanNegation` checkstyle rule always

### DIFF
--- a/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/TestClustersPluginFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/TestClustersPluginFuncTest.groovy
@@ -125,7 +125,7 @@ class TestClustersPluginFuncTest extends AbstractGradleFuncTest {
     }
 
     boolean assertNoCustomDistro(String clusterName) {
-        assert !customDistroFolder(clusterName).exists()
+        assert customDistroFolder(clusterName).exists() == false
         true
     }
 

--- a/buildSrc/src/main/resources/checkstyle.xml
+++ b/buildSrc/src/main/resources/checkstyle.xml
@@ -124,17 +124,17 @@
     </module>
 
     <!-- Forbid using '!' for logical negations in favour of checking against 'false' explicitly. -->
-    <!-- This is disabled for now because there are many violations, hence the rule is reporting at the "warning" severity. -->
-    <!--
+    <!-- This is only reported in the IDE for now because there are many violations -->
     <module name="DescendantToken">
-      <property name="id" value="BooleanNegation" />
-      <property name="tokens" value="EXPR"/>
-      <property name="limitedTokens" value="LNOT"/>
-      <property name="maximumNumber" value="0"/>
-      <property name="maximumDepth" value="1"/>
-      <message key="descendant.token.max" value="Do not negate boolean expressions with '!', but check explicitly with '== false' as it is more explicit"/>
+        <property name="id" value="BooleanNegation" />
+        <property name="tokens" value="EXPR"/>
+        <property name="limitedTokens" value="LNOT"/>
+        <property name="maximumNumber" value="0"/>
+        <property name="maximumDepth" value="2"/>
+        <message
+            key="descendant.token.max"
+            value="Do not negate boolean expressions with '!', but check explicitly with '== false' as it is more explicit"/>
     </module>
-    -->
 
   </module>
 </module>

--- a/buildSrc/src/main/resources/checkstyle_ide_fragment.xml
+++ b/buildSrc/src/main/resources/checkstyle_ide_fragment.xml
@@ -8,18 +8,6 @@
 <!-- Checkstyle config by the `:configureIdeCheckstyle` task.           -->
 
 <module name="IdeFragment">
-    <!-- Forbid using '!' for logical negations in favour of checking against 'false' explicitly. -->
-    <!-- This is only reported in the IDE for now because there are many violations -->
-    <module name="DescendantToken">
-        <property name="id" value="BooleanNegation" />
-        <property name="tokens" value="EXPR"/>
-        <property name="limitedTokens" value="LNOT"/>
-        <property name="maximumNumber" value="0"/>
-        <property name="maximumDepth" value="2"/>
-        <message
-            key="descendant.token.max"
-            value="Do not negate boolean expressions with '!', but check explicitly with '== false' as it is more explicit"/>
-    </module>
 
     <!-- See CONTRIBUTING.md for our guidelines on Javadoc -->
 

--- a/client/benchmark/src/main/java/org/elasticsearch/client/benchmark/transport/TransportClientBenchmark.java
+++ b/client/benchmark/src/main/java/org/elasticsearch/client/benchmark/transport/TransportClientBenchmark.java
@@ -82,7 +82,7 @@ public final class TransportClientBenchmark extends AbstractBenchmark<TransportC
             } catch (ExecutionException e) {
                 throw new ElasticsearchException(e);
             }
-            return !bulkResponse.hasFailures();
+            return bulkResponse.hasFailures() == false;
         }
     }
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/indices/GetMappingsResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/indices/GetMappingsResponseTests.java
@@ -55,7 +55,7 @@ public class GetMappingsResponseTests extends ESTestCase {
     }
 
     private Predicate<String> randomFieldsExcludeFilter() {
-        return field -> !field.equals(MAPPINGS.getPreferredName());
+        return field -> field.equals(MAPPINGS.getPreferredName()) == false;
     }
 
     public static MappingMetadata randomMappingMetadata() {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/EvaluateDataFrameRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/EvaluateDataFrameRequestTests.java
@@ -60,7 +60,7 @@ public class EvaluateDataFrameRequestTests extends AbstractXContentTestCase<Eval
     @Override
     protected Predicate<String> getRandomFieldsExcludeFilter() {
         // allow unknown fields in root only
-        return field -> !field.isEmpty();
+        return field -> field.isEmpty() == false;
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/StandardHtmlStripAnalyzer.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/StandardHtmlStripAnalyzer.java
@@ -38,7 +38,7 @@ public class StandardHtmlStripAnalyzer extends StopwordAnalyzerBase {
     protected TokenStreamComponents createComponents(final String fieldName) {
         final Tokenizer src = new StandardTokenizer();
         TokenStream tok = new LowerCaseFilter(src);
-        if (!stopwords.isEmpty()) {
+        if (stopwords.isEmpty() == false) {
             tok = new StopFilter(tok, stopwords);
         }
         return new TokenStreamComponents(src, tok);

--- a/modules/lang-painless/src/doc/java/org/elasticsearch/painless/JavadocExtractor.java
+++ b/modules/lang-painless/src/doc/java/org/elasticsearch/painless/JavadocExtractor.java
@@ -179,7 +179,7 @@ public class JavadocExtractor {
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (!(o instanceof MethodSignature)) return false;
+            if ((o instanceof MethodSignature) == false) return false;
             MethodSignature that = (MethodSignature) o;
             return Objects.equals(name, that.name) &&
                 Objects.equals(parameterTypes, that.parameterTypes);

--- a/plugins/analysis-phonetic/src/main/java/org/elasticsearch/index/analysis/phonetic/Nysiis.java
+++ b/plugins/analysis-phonetic/src/main/java/org/elasticsearch/index/analysis/phonetic/Nysiis.java
@@ -141,7 +141,7 @@ public class Nysiis implements StringEncoder {
         }
 
         // 5. H -> If previous or next is a non vowel, previous.
-        if (curr == 'H' && (!isVowel(prev) || !isVowel(next))) {
+        if (curr == 'H' && (isVowel(prev) == false || isVowel(next) == false)) {
             return new char[]{prev};
         }
 
@@ -192,7 +192,7 @@ public class Nysiis implements StringEncoder {
      */
     @Override
     public Object encode(Object obj) throws EncoderException {
-        if (!(obj instanceof String)) {
+        if ((obj instanceof String) == false) {
             throw new EncoderException("Parameter supplied to Nysiis encode is not of type java.lang.String");
         }
         return this.nysiis((String) obj);

--- a/qa/smoke-test-http/src/test/java/org/elasticsearch/http/ContextAndHeaderTransportIT.java
+++ b/qa/smoke-test-http/src/test/java/org/elasticsearch/http/ContextAndHeaderTransportIT.java
@@ -257,7 +257,7 @@ public class ContextAndHeaderTransportIT extends HttpSmokeTestCase {
         assertThat(getRequests, hasSize(greaterThan(0)));
 
         for (RequestAndHeaders request : getRequests) {
-            if (!((GetRequest)request.request).index().equals(index)) {
+            if (((GetRequest)request.request).index().equals(index) == false) {
                 continue;
             }
             assertRequestContainsHeader(request.request, request.headers);

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/pipeline/MovAvgIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/pipeline/MovAvgIT.java
@@ -1249,13 +1249,13 @@ public class MovAvgIT extends ESIntegTestCase {
     }
 
     private void assertValidIterators(Iterator expectedBucketIter, Iterator expectedCountsIter, Iterator expectedValuesIter) {
-        if (!expectedBucketIter.hasNext()) {
+        if (expectedBucketIter.hasNext() == false) {
             fail("`expectedBucketIter` iterator ended before `actual` iterator, size mismatch");
         }
-        if (!expectedCountsIter.hasNext()) {
+        if (expectedCountsIter.hasNext() == false) {
             fail("`expectedCountsIter` iterator ended before `actual` iterator, size mismatch");
         }
-        if (!expectedValuesIter.hasNext()) {
+        if (expectedValuesIter.hasNext() == false) {
             fail("`expectedValuesIter` iterator ended before `actual` iterator, size mismatch");
         }
     }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequest.java
@@ -430,7 +430,7 @@ public class CreateSnapshotRequest extends MasterNodeRequest<CreateSnapshotReque
             } else if (name.equals("partial")) {
                 partial(nodeBooleanValue(entry.getValue(), "partial"));
             } else if (name.equals("settings")) {
-                if (!(entry.getValue() instanceof Map)) {
+                if ((entry.getValue() instanceof Map) == false) {
                     throw new IllegalArgumentException("malformed settings section, should indices an inner object");
                 }
                 settings((Map<String, Object>) entry.getValue());

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
@@ -487,7 +487,7 @@ public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotReq
             } else if (name.equals("partial")) {
                 partial(nodeBooleanValue(entry.getValue(), "partial"));
             } else if (name.equals("settings")) {
-                if (!(entry.getValue() instanceof Map)) {
+                if ((entry.getValue() instanceof Map) == false) {
                     throw new IllegalArgumentException("malformed settings section");
                 }
                 DEPRECATION_LOGGER.deprecate(DeprecationCategory.API, "RestoreSnapshotRequest#settings",

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequest.java
@@ -265,7 +265,7 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
             throw new IllegalStateException("mappings for type \"" + type + "\" were already defined");
         }
         // wrap it in a type map if its not
-        if (source.size() != 1 || !source.containsKey(type)) {
+        if (source.size() != 1 || source.containsKey(type) == false) {
             source = MapBuilder.<String, Object>newMapBuilder().put(type, source).map();
         }
         try {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/exists/types/TransportTypesExistsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/exists/types/TransportTypesExistsAction.java
@@ -49,7 +49,7 @@ public class TransportTypesExistsAction extends TransportMasterNodeReadAction<Ty
         }
 
         for (String concreteIndex : concreteIndices) {
-            if (!state.metadata().hasConcreteIndex(concreteIndex)) {
+            if (state.metadata().hasConcreteIndex(concreteIndex) == false) {
                 listener.onResponse(new TypesExistsResponse(false));
                 return;
             }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexResponse.java
@@ -412,7 +412,7 @@ public class GetIndexResponse extends ActionResponse implements ToXContentObject
         ensureExpectedToken(Token.START_OBJECT, parser.currentToken(), parser);
         parser.nextToken();
 
-        while (!parser.isClosed()) {
+        while (parser.isClosed() == false) {
             if (parser.currentToken() == Token.START_OBJECT) {
                 // we assume this is an index entry
                 String indexName = parser.currentName();

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsIndexAction.java
@@ -103,7 +103,7 @@ public class TransportGetFieldMappingsIndexAction
         for (String type : typeIntersection) {
             DocumentMapper documentMapper = indexService.mapperService().documentMapper(type);
             Map<String, FieldMappingMetadata> fieldMapping = findFieldMappingsByType(fieldPredicate, documentMapper, request);
-            if (!fieldMapping.isEmpty()) {
+            if (fieldMapping.isEmpty() == false) {
                 typeMappings.put(type, fieldMapping);
             }
         }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequest.java
@@ -278,7 +278,7 @@ public class PutIndexTemplateRequest extends MasterNodeRequest<PutIndexTemplateR
      */
     public PutIndexTemplateRequest mapping(String type, Map<String, Object> source) {
         // wrap it in a type map if its not
-        if (source.size() != 1 || !source.containsKey(type)) {
+        if (source.size() != 1 || source.containsKey(type) == false) {
             source = MapBuilder.<String, Object>newMapBuilder().put(type, source).map();
         }
         try {

--- a/server/src/main/java/org/elasticsearch/action/support/AutoCreateIndex.java
+++ b/server/src/main/java/org/elasticsearch/action/support/AutoCreateIndex.java
@@ -46,7 +46,7 @@ public final class AutoCreateIndex {
                            IndexNameExpressionResolver resolver,
                            SystemIndices systemIndices) {
         this.resolver = resolver;
-        dynamicMappingDisabled = !MapperService.INDEX_MAPPER_DYNAMIC_SETTING.get(settings);
+        dynamicMappingDisabled = MapperService.INDEX_MAPPER_DYNAMIC_SETTING.get(settings) == false;
         this.systemIndices = systemIndices;
         this.autoCreate = AUTO_CREATE_INDEX_SETTING.get(settings);
         clusterSettings.addSettingsUpdateConsumer(AUTO_CREATE_INDEX_SETTING, this::setAutoCreate);

--- a/server/src/main/java/org/elasticsearch/client/transport/TransportClientNodesService.java
+++ b/server/src/main/java/org/elasticsearch/client/transport/TransportClientNodesService.java
@@ -172,7 +172,7 @@ final class TransportClientNodesService implements Closeable {
                         break;
                     }
                 }
-                if (!found) {
+                if (found == false) {
                     filtered.add(transportAddress);
                 }
             }
@@ -199,7 +199,7 @@ final class TransportClientNodesService implements Closeable {
             }
             List<DiscoveryNode> listNodesBuilder = new ArrayList<>();
             for (DiscoveryNode otherNode : listedNodes) {
-                if (!otherNode.getAddress().equals(transportAddress)) {
+                if (otherNode.getAddress().equals(transportAddress) == false) {
                     listNodesBuilder.add(otherNode);
                 } else {
                     logger.debug("removing address [{}] from listed nodes", otherNode);
@@ -208,7 +208,7 @@ final class TransportClientNodesService implements Closeable {
             listedNodes = Collections.unmodifiableList(listNodesBuilder);
             List<DiscoveryNode> nodesBuilder = new ArrayList<>();
             for (DiscoveryNode otherNode : nodes) {
-                if (!otherNode.getAddress().equals(transportAddress)) {
+                if (otherNode.getAddress().equals(transportAddress) == false) {
                     nodesBuilder.add(otherNode);
                 } else {
                     logger.debug("disconnecting from node with address [{}]", otherNode);
@@ -359,7 +359,7 @@ final class TransportClientNodesService implements Closeable {
         List<DiscoveryNode> establishNodeConnections(Set<DiscoveryNode> nodes) {
             for (Iterator<DiscoveryNode> it = nodes.iterator(); it.hasNext(); ) {
                 DiscoveryNode node = it.next();
-                if (!transportService.nodeConnected(node)) {
+                if (transportService.nodeConnected(node) == false) {
                     try {
                         logger.trace("connecting to node [{}]", node);
                         transportService.connectToNode(node);
@@ -379,7 +379,7 @@ final class TransportClientNodesService implements Closeable {
         public void run() {
             try {
                 nodesSampler.sample();
-                if (!closed) {
+                if (closed == false) {
                     nodesSamplerCancellable = threadPool.schedule(this, nodesSamplerInterval, ThreadPool.Names.GENERIC);
                 }
             } catch (Exception e) {
@@ -407,7 +407,7 @@ final class TransportClientNodesService implements Closeable {
                         TransportRequestOptions.of(pingTimeout, TransportRequestOptions.Type.STATE),
                         handler);
                     final LivenessResponse livenessResponse = handler.txGet();
-                    if (!ignoreClusterName && !clusterName.equals(livenessResponse.getClusterName())) {
+                    if (ignoreClusterName == false && clusterName.equals(livenessResponse.getClusterName()) == false) {
                         logger.warn("node {} not part of the cluster {}, ignoring...", listedNode, clusterName);
                         newFilteredNodes.add(listedNode);
                     } else {
@@ -536,7 +536,7 @@ final class TransportClientNodesService implements Closeable {
             HashSet<DiscoveryNode> newNodes = new HashSet<>();
             HashSet<DiscoveryNode> newFilteredNodes = new HashSet<>();
             for (Map.Entry<DiscoveryNode, ClusterStateResponse> entry : clusterStateResponses.entrySet()) {
-                if (!ignoreClusterName && !clusterName.equals(entry.getValue().getClusterName())) {
+                if (ignoreClusterName == false && clusterName.equals(entry.getValue().getClusterName()) == false) {
                     logger.warn("node {} not part of the cluster {}, ignoring...",
                             entry.getValue().getState().nodes().getLocalNode(), clusterName);
                     newFilteredNodes.add(entry.getKey());

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetadata.java
@@ -413,7 +413,7 @@ public class IndexTemplateMetadata extends AbstractDiffable<IndexTemplateMetadat
                 if (includeTypeName == false) {
                     Map<String, Object> documentMapping = null;
                     for (ObjectObjectCursor<String, CompressedXContent> cursor : indexTemplateMetadata.mappings()) {
-                        if (!cursor.key.equals(MapperService.DEFAULT_MAPPING)) {
+                        if (cursor.key.equals(MapperService.DEFAULT_MAPPING) == false) {
                             assert documentMapping == null;
                             Map<String, Object> mapping = XContentHelper.convertToMap(cursor.value.uncompressed(), true).v2();
                             documentMapping = reduceMapping(cursor.key, mapping);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -394,7 +394,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
                     filteredValues.add(value);
                 }
             }
-            if (!filteredValues.isEmpty()) {
+            if (filteredValues.isEmpty() == false) {
                 return true;
             }
         }
@@ -435,7 +435,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
                         filteredMappings.put(cursor.key, filterFields(cursor.value, fieldPredicate));
                     }
                 }
-                if (!filteredMappings.isEmpty()) {
+                if (filteredMappings.isEmpty() == false) {
                     indexMapBuilder.put(index, filteredMappings.build());
                 }
             }
@@ -616,7 +616,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
                     + aliasMd.getIndexRouting() + "] that resolved to several routing values, rejecting operation");
             }
             if (routing != null) {
-                if (!routing.equals(aliasMd.indexRouting())) {
+                if (routing.equals(aliasMd.indexRouting()) == false) {
                     throw new IllegalArgumentException("Alias [" + aliasOrIndex + "] has index routing associated with it ["
                         + aliasMd.indexRouting() + "], and was provided with routing value [" + routing + "], rejecting operation");
                 }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataMappingService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataMappingService.java
@@ -171,7 +171,7 @@ public class MetadataMappingService {
                                                        mapperService.documentMapper(MapperService.DEFAULT_MAPPING))) {
                 if (mapper != null) {
                     final String type = mapper.type();
-                    if (!mapper.mappingSource().equals(builder.mapping(type).source())) {
+                    if (mapper.mappingSource().equals(builder.mapping(type).source()) == false) {
                         updatedTypes.add(type);
                     }
                 }

--- a/server/src/main/java/org/elasticsearch/common/path/PathTrie.java
+++ b/server/src/main/java/org/elasticsearch/common/path/PathTrie.java
@@ -245,7 +245,7 @@ public class PathTrie<T> {
             }
 
             T nodeValue = node.retrieve(path, index + 1, params, trieMatchingMode);
-            if (nodeValue == null && !usedWildcard && trieMatchingMode != TrieMatchingMode.EXPLICIT_NODES_ONLY) {
+            if (nodeValue == null && usedWildcard == false && trieMatchingMode != TrieMatchingMode.EXPLICIT_NODES_ONLY) {
                 node = children.get(wildcard);
                 if (node != null) {
                     put(params, node, token);

--- a/server/src/main/java/org/elasticsearch/common/util/set/Sets.java
+++ b/server/src/main/java/org/elasticsearch/common/util/set/Sets.java
@@ -88,7 +88,7 @@ public final class Sets {
     public static <T> SortedSet<T> sortedDifference(Set<T> left, Set<T> right) {
         Objects.requireNonNull(left);
         Objects.requireNonNull(right);
-        return left.stream().filter(k -> !right.contains(k)).collect(new SortedSetCollector<>());
+        return left.stream().filter(k -> right.contains(k) == false).collect(new SortedSetCollector<>());
     }
 
     private static class SortedSetCollector<T> implements Collector<T, SortedSet<T>, SortedSet<T>> {

--- a/server/src/main/java/org/elasticsearch/discovery/zen/ElectMasterService.java
+++ b/server/src/main/java/org/elasticsearch/discovery/zen/ElectMasterService.java
@@ -194,7 +194,7 @@ public class ElectMasterService {
             return null;
         }
         // clean non master nodes
-        possibleNodes.removeIf(node -> !node.isMasterNode());
+        possibleNodes.removeIf(node -> node.isMasterNode() == false);
         CollectionUtil.introSort(possibleNodes, ElectMasterService::compareNodes);
         return possibleNodes;
     }

--- a/server/src/main/java/org/elasticsearch/discovery/zen/ElectMasterService.java
+++ b/server/src/main/java/org/elasticsearch/discovery/zen/ElectMasterService.java
@@ -201,10 +201,10 @@ public class ElectMasterService {
 
     /** master nodes go before other nodes, with a secondary sort by id **/
      private static int compareNodes(DiscoveryNode o1, DiscoveryNode o2) {
-        if (o1.isMasterNode() && !o2.isMasterNode()) {
+        if (o1.isMasterNode() && o2.isMasterNode() == false) {
             return -1;
         }
-        if (!o1.isMasterNode() && o2.isMasterNode()) {
+        if (o1.isMasterNode() == false && o2.isMasterNode()) {
             return 1;
         }
         return o1.getId().compareTo(o2.getId());

--- a/server/src/main/java/org/elasticsearch/discovery/zen/MasterFaultDetection.java
+++ b/server/src/main/java/org/elasticsearch/discovery/zen/MasterFaultDetection.java
@@ -151,7 +151,7 @@ public class MasterFaultDetection extends FaultDetection {
     @Override
     protected void handleTransportDisconnect(DiscoveryNode node) {
         synchronized (masterNodeMutex) {
-            if (!node.equals(this.masterNode)) {
+            if (node.equals(this.masterNode) == false) {
                 return;
             }
             if (connectOnNetworkDisconnect) {
@@ -200,7 +200,7 @@ public class MasterFaultDetection extends FaultDetection {
 
         @Override
         public void run() {
-            if (!running) {
+            if (running == false) {
                 // return and don't spawn...
                 return;
             }
@@ -223,7 +223,7 @@ public class MasterFaultDetection extends FaultDetection {
 
                         @Override
                         public void handleResponse(MasterPingResponseResponse response) {
-                            if (!running) {
+                            if (running == false) {
                                 return;
                             }
                             // reset the counter, we got a good result
@@ -237,7 +237,7 @@ public class MasterFaultDetection extends FaultDetection {
 
                         @Override
                         public void handleException(TransportException exp) {
-                            if (!running) {
+                            if (running == false) {
                                 return;
                             }
                             synchronized (masterNodeMutex) {
@@ -318,12 +318,12 @@ public class MasterFaultDetection extends FaultDetection {
             final DiscoveryNodes nodes = clusterStateSupplier.get().nodes();
             // check if we are really the same master as the one we seemed to be think we are
             // this can happen if the master got "kill -9" and then another node started using the same port
-            if (!request.masterNode.equals(nodes.getLocalNode())) {
+            if (request.masterNode.equals(nodes.getLocalNode()) == false) {
                 throw new ThisIsNotTheMasterYouAreLookingForException();
             }
 
             // ping from nodes of version < 1.4.0 will have the clustername set to null
-            if (request.clusterName != null && !request.clusterName.equals(clusterName)) {
+            if (request.clusterName != null && request.clusterName.equals(clusterName) == false) {
                 logger.trace("master fault detection ping request is targeted for a different [{}] cluster then us [{}]",
                     request.clusterName, clusterName);
                 throw new ThisIsNotTheMasterYouAreLookingForException("master fault detection ping request is targeted for a different ["
@@ -338,7 +338,7 @@ public class MasterFaultDetection extends FaultDetection {
             // all processing is finished.
             //
 
-            if (!nodes.isLocalNodeElectedMaster() || !nodes.nodeExists(request.sourceNode)) {
+            if (nodes.isLocalNodeElectedMaster() == false || nodes.nodeExists(request.sourceNode) == false) {
                 logger.trace("checking ping from {} under a cluster state thread", request.sourceNode);
                 masterService.submitStateUpdateTask("master ping (from: " + request.sourceNode + ")", new ClusterStateUpdateTask() {
 
@@ -346,7 +346,7 @@ public class MasterFaultDetection extends FaultDetection {
                     public ClusterState execute(ClusterState currentState) throws Exception {
                         // if we are no longer master, fail...
                         DiscoveryNodes nodes = currentState.nodes();
-                        if (!nodes.nodeExists(request.sourceNode)) {
+                        if (nodes.nodeExists(request.sourceNode) == false) {
                             throw new NodeDoesNotExistOnMasterException();
                         }
                         return currentState;

--- a/server/src/main/java/org/elasticsearch/discovery/zen/NodesFaultDetection.java
+++ b/server/src/main/java/org/elasticsearch/discovery/zen/NodesFaultDetection.java
@@ -105,7 +105,7 @@ public class NodesFaultDetection extends FaultDetection {
     public void updateNodesAndPing(ClusterState clusterState) {
         // remove any nodes we don't need, this will cause their FD to stop
         for (DiscoveryNode monitoredNode : nodesFD.keySet()) {
-            if (!clusterState.nodes().nodeExists(monitoredNode)) {
+            if (clusterState.nodes().nodeExists(monitoredNode) == false) {
                 nodesFD.remove(monitoredNode);
             }
         }
@@ -116,7 +116,7 @@ public class NodesFaultDetection extends FaultDetection {
                 // no need to monitor the local node
                 continue;
             }
-            if (!nodesFD.containsKey(node)) {
+            if (nodesFD.containsKey(node) == false) {
                 NodeFD fd = new NodeFD(node);
                 // it's OK to overwrite an existing nodeFD - it will just stop and the new one will pick things up.
                 nodesFD.put(node, fd);
@@ -212,7 +212,7 @@ public class NodesFaultDetection extends FaultDetection {
 
         @Override
         public void run() {
-            if (!running()) {
+            if (running() == false) {
                 return;
             }
             final TransportRequestOptions options = TransportRequestOptions.of(pingRetryTimeout, TransportRequestOptions.Type.PING);
@@ -224,7 +224,7 @@ public class NodesFaultDetection extends FaultDetection {
 
                         @Override
                         public void handleResponse(PingResponse response) {
-                            if (!running()) {
+                            if (running() == false) {
                                 return;
                             }
                             retryCount = 0;
@@ -233,7 +233,7 @@ public class NodesFaultDetection extends FaultDetection {
 
                         @Override
                         public void handleException(TransportException exp) {
-                            if (!running()) {
+                            if (running() == false) {
                                 return;
                             }
                             if (exp instanceof ConnectTransportException || exp.getCause() instanceof ConnectTransportException) {
@@ -272,12 +272,12 @@ public class NodesFaultDetection extends FaultDetection {
         public void messageReceived(PingRequest request, TransportChannel channel, Task task) throws Exception {
             // if we are not the node we are supposed to be pinged, send an exception
             // this can happen when a kill -9 is sent, and another node is started using the same port
-            if (!localNode.equals(request.targetNode())) {
+            if (localNode.equals(request.targetNode()) == false) {
                 throw new IllegalStateException("Got pinged as node " + request.targetNode() + "], but I am node " + localNode );
             }
 
             // PingRequest will have clusterName set to null if it came from a node of version <1.4.0
-            if (request.clusterName != null && !request.clusterName.equals(clusterName)) {
+            if (request.clusterName != null && request.clusterName.equals(clusterName) == false) {
                 // Don't introduce new exception for bwc reasons
                 throw new IllegalStateException("Got pinged with cluster name [" + request.clusterName + "], but I'm part of cluster ["
                     + clusterName + "]");

--- a/server/src/main/java/org/elasticsearch/discovery/zen/PublishClusterStateAction.java
+++ b/server/src/main/java/org/elasticsearch/discovery/zen/PublishClusterStateAction.java
@@ -186,7 +186,7 @@ public class PublishClusterStateAction {
             // try and serialize the cluster state once (or per version), so we don't serialize it
             // per node when we send it over the wire, compress it while we are at it...
             // we don't send full version if node didn't exist in the previous version of cluster state
-            if (sendFullVersion || !previousState.nodes().nodeExists(node)) {
+            if (sendFullVersion || previousState.nodes().nodeExists(node) == false) {
                 sendFullClusterState(clusterState, serializedStates, node, publishTimeout, sendingController);
             } else {
                 sendClusterStateDiff(clusterState, serializedDiffs, serializedStates, node, publishTimeout, sendingController);
@@ -229,7 +229,7 @@ public class PublishClusterStateAction {
         Diff<ClusterState> diff = null;
         for (final DiscoveryNode node : nodesToPublishTo) {
             try {
-                if (sendFullVersion || !previousState.nodes().nodeExists(node)) {
+                if (sendFullVersion || previousState.nodes().nodeExists(node) == false) {
                     // will send a full reference
                     if (serializedStates.containsKey(node.getVersion()) == false) {
                         serializedStates.put(node.getVersion(), serializeFullClusterState(clusterState, node.getVersion()));

--- a/server/src/main/java/org/elasticsearch/discovery/zen/PublishClusterStateAction.java
+++ b/server/src/main/java/org/elasticsearch/discovery/zen/PublishClusterStateAction.java
@@ -202,7 +202,8 @@ public class PublishClusterStateAction {
         try {
             long timeLeftInNanos = Math.max(0, publishTimeout.nanos() - commitTime);
             final BlockingClusterStatePublishResponseHandler publishResponseHandler = sendingController.getPublishResponseHandler();
-            sendingController.setPublishingTimedOut(!publishResponseHandler.awaitAllNodes(TimeValue.timeValueNanos(timeLeftInNanos)));
+            sendingController.setPublishingTimedOut(
+                    publishResponseHandler.awaitAllNodes(TimeValue.timeValueNanos(timeLeftInNanos)) == false);
             if (sendingController.getPublishingTimedOut()) {
                 DiscoveryNode[] pendingNodes = publishResponseHandler.pendingNodes();
                 // everyone may have just responded

--- a/server/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/server/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -270,7 +270,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent implements Discover
         if (sendLeaveRequest) {
             if (nodes.getMasterNode() == null) {
                 // if we don't know who the master is, nothing to do here
-            } else if (!nodes.isLocalNodeElectedMaster()) {
+            } else if (nodes.isLocalNodeElectedMaster() == false) {
                 try {
                     membership.sendLeaveRequestBlocking(nodes.getMasterNode(), nodes.getLocalNode(), TimeValue.timeValueSeconds(1));
                 } catch (Exception e) {
@@ -424,7 +424,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent implements Discover
             masterNode = findMaster();
         }
 
-        if (!joinThreadControl.joinThreadActive(currentThread)) {
+        if (joinThreadControl.joinThreadActive(currentThread) == false) {
             logger.trace("thread is no longer in currentJoinThread. Stopping.");
             return;
         }
@@ -568,7 +568,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent implements Discover
             // not started, ignore a node failure
             return;
         }
-        if (!localNodeMaster()) {
+        if (localNodeMaster() == false) {
             // nothing to do here...
             return;
         }
@@ -582,13 +582,13 @@ public class ZenDiscovery extends AbstractLifecycleComponent implements Discover
         }
         final int prevMinimumMasterNode = ZenDiscovery.this.electMaster.minimumMasterNodes();
         ZenDiscovery.this.electMaster.minimumMasterNodes(minimumMasterNodes);
-        if (!localNodeMaster()) {
+        if (localNodeMaster() == false) {
             // We only set the new value. If the master doesn't see enough nodes it will revoke it's mastership.
             return;
         }
         synchronized (stateMutex) {
             // check if we have enough master nodes, if not, we need to move into joining the cluster again
-            if (!electMaster.hasEnoughMasterNodes(committedState.get().nodes())) {
+            if (electMaster.hasEnoughMasterNodes(committedState.get().nodes()) == false) {
                 rejoin("not enough master nodes on change of minimum_master_nodes from [" + prevMinimumMasterNode + "] to [" +
                     minimumMasterNodes + "]");
             }
@@ -628,7 +628,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent implements Discover
         }
 
         assert newClusterState.nodes().getMasterNode() != null : "received a cluster state without a master";
-        assert !newClusterState.blocks().hasGlobalBlock(noMasterBlockService.getNoMasterBlock()) :
+        assert newClusterState.blocks().hasGlobalBlock(noMasterBlockService.getNoMasterBlock()) == false :
             "received a cluster state with a master block";
 
         if (currentState.nodes().isLocalNodeElectedMaster() && newClusterState.nodes().isLocalNodeElectedMaster() == false) {
@@ -676,7 +676,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent implements Discover
             nodesFD.updateNodesAndPing(newClusterState);
         } else {
             // check to see that we monitor the correct master of the cluster
-            if (masterFD.masterNode() == null || !masterFD.masterNode().equals(newClusterState.nodes().getMasterNode())) {
+            if (masterFD.masterNode() == null || masterFD.masterNode().equals(newClusterState.nodes().getMasterNode()) == false) {
                 masterFD.restart(newClusterState.nodes().getMasterNode(),
                     "new cluster state received and we are monitoring the wrong master [" + masterFD.masterNode() + "]");
             }
@@ -748,7 +748,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent implements Discover
         if (currentNodes.getMasterNodeId() == null) {
             return;
         }
-        if (!currentNodes.getMasterNodeId().equals(newClusterState.nodes().getMasterNodeId())) {
+        if (currentNodes.getMasterNodeId().equals(newClusterState.nodes().getMasterNodeId()) == false) {
             logger.warn("received a cluster state from a different master than the current one, rejecting (received {}, current {})",
                 newClusterState.nodes().getMasterNode(), currentNodes.getMasterNode());
             throw new IllegalStateException("cluster state from a different master than the current one, rejecting (received " +
@@ -817,7 +817,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent implements Discover
         for (ZenPing.PingResponse pingResponse : pingResponses) {
             // We can't include the local node in pingMasters list, otherwise we may up electing ourselves without
             // any check / verifications from other nodes in ZenDiscover#innerJoinCluster()
-            if (pingResponse.master() != null && !localNode.equals(pingResponse.master())) {
+            if (pingResponse.master() != null && localNode.equals(pingResponse.master()) == false) {
                 activeMasters.add(pingResponse.master());
             }
         }
@@ -842,7 +842,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent implements Discover
                 return null;
             }
         } else {
-            assert !activeMasters.contains(localNode) :
+            assert activeMasters.contains(localNode) == false :
                 "local node should never be elected as master when other nodes indicate an active master";
             // lets tie break between discovered nodes
             return electMaster.tieBreakActiveMasters(activeMasters);
@@ -991,7 +991,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent implements Discover
      */
     static void validateIncomingState(Logger logger, ClusterState incomingState, ClusterState lastState) {
         final ClusterName incomingClusterName = incomingState.getClusterName();
-        if (!incomingClusterName.equals(lastState.getClusterName())) {
+        if (incomingClusterName.equals(lastState.getClusterName()) == false) {
             logger.warn("received cluster state from [{}] which is also master but with a different cluster name [{}]",
                 incomingState.nodes().getMasterNode(), incomingClusterName);
             throw new IllegalStateException("received state from a node that is not part of the cluster");
@@ -1041,7 +1041,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent implements Discover
         public void onPingReceived(final NodesFaultDetection.PingRequest pingRequest) {
             // if we are master, we don't expect any fault detection from another node. If we get it
             // means we potentially have two masters in the cluster.
-            if (!localNodeMaster()) {
+            if (localNodeMaster() == false) {
                 pingsWhileMaster.set(0);
                 return;
             }
@@ -1144,7 +1144,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent implements Discover
                 @Override
                 public void run() {
                     Thread currentThread = Thread.currentThread();
-                    if (!currentJoinThread.compareAndSet(null, currentThread)) {
+                    if (currentJoinThread.compareAndSet(null, currentThread) == false) {
                         return;
                     }
                     while (running.get() && joinThreadActive(currentThread)) {
@@ -1170,7 +1170,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent implements Discover
          */
         public void markThreadAsDoneAndStartNew(Thread joinThread) {
             assert Thread.holdsLock(stateMutex);
-            if (!markThreadAsDone(joinThread)) {
+            if (markThreadAsDone(joinThread) == false) {
                 return;
             }
             startNewThreadIfNotRunning();

--- a/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -240,7 +240,7 @@ public final class NodeEnvironment  implements Closeable {
      * @param settings settings from elasticsearch.yml
      */
     public NodeEnvironment(Settings settings, Environment environment) throws IOException {
-        if (!DiscoveryNode.nodeRequiresLocalStorage(settings)) {
+        if (DiscoveryNode.nodeRequiresLocalStorage(settings) == false) {
             nodePaths = null;
             sharedDataPath = null;
             locks = null;

--- a/server/src/main/java/org/elasticsearch/index/get/ShardGetService.java
+++ b/server/src/main/java/org/elasticsearch/index/get/ShardGetService.java
@@ -304,7 +304,7 @@ public final class ShardGetService extends AbstractIndexShardComponent {
             }
         }
 
-        if (!fetchSourceContext.fetchSource()) {
+        if (fetchSourceContext.fetchSource() == false) {
             source = null;
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -454,7 +454,7 @@ final class DocumentParser {
 
     private static void addFields(ParseContext.Document nestedDoc, ParseContext.Document rootDoc) {
         for (IndexableField field : nestedDoc.getFields()) {
-            if (!field.name().equals(TypeFieldMapper.NAME)) {
+            if (field.name().equals(TypeFieldMapper.NAME) == false) {
                 rootDoc.add(field);
             }
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/Uid.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/Uid.java
@@ -13,6 +13,7 @@ import org.apache.lucene.util.UnicodeUtil;
 
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.Objects;
 
 public final class Uid {
 
@@ -40,13 +41,8 @@ public final class Uid {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-
         Uid uid = (Uid) o;
-
-        if (id != null ? !id.equals(uid.id) : uid.id != null) return false;
-        if (type != null ? !type.equals(uid.type) : uid.type != null) return false;
-
-        return true;
+        return Objects.equals(type, uid.type) && Objects.equals(id, uid.id);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/seqno/ReplicationTracker.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/ReplicationTracker.java
@@ -790,7 +790,7 @@ public class ReplicationTracker extends AbstractIndexShardComponent implements L
             "entries blocking global checkpoint advancement during relocation handoff: " + pendingInSync;
 
         // entries blocking global checkpoint advancement can only exist in primary mode and when not having a relocation handoff
-        assert pendingInSync.isEmpty() || (primaryMode && !handoffInProgress);
+        assert pendingInSync.isEmpty() || (primaryMode && handoffInProgress == false);
 
         // the computed global checkpoint is always up-to-date
         assert primaryMode == false

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexingStats.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexingStats.java
@@ -201,7 +201,7 @@ public class IndexingStats implements Writeable, ToXContentFragment {
             return;
         }
         addTotals(indexingStats);
-        if (includeTypes && indexingStats.typeStats != null && !indexingStats.typeStats.isEmpty()) {
+        if (includeTypes && indexingStats.typeStats != null && indexingStats.typeStats.isEmpty() == false) {
             if (typeStats == null) {
                 typeStats = new HashMap<>(indexingStats.typeStats.size());
             }
@@ -236,7 +236,7 @@ public class IndexingStats implements Writeable, ToXContentFragment {
     public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
         builder.startObject(Fields.INDEXING);
         totalStats.toXContent(builder, params);
-        if (typeStats != null && !typeStats.isEmpty()) {
+        if (typeStats != null && typeStats.isEmpty() == false) {
             builder.startObject(Fields.TYPES);
             for (Map.Entry<String, Stats> entry : typeStats.entrySet()) {
                 builder.startObject(entry.getKey());

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/MovAvgPipelineAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/MovAvgPipelineAggregationBuilder.java
@@ -243,7 +243,7 @@ public class MovAvgPipelineAggregationBuilder extends AbstractPipelineAggregatio
 
     @Override
     protected void validate(ValidationContext context) {
-        if (minimize != null && minimize && !model.canBeMinimized()) {
+        if (minimize != null && minimize && model.canBeMinimized() == false) {
             // If the user asks to minimize, but this model doesn't support
             // it, throw exception
             context.addValidationError("The [" + model + "] model cannot be minimized for aggregation [" + name + "]");

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/MovAvgPipelineAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/MovAvgPipelineAggregator.java
@@ -183,7 +183,7 @@ public class MovAvgPipelineAggregator extends PipelineAggregator {
 
             Double thisBucketValue = resolveBucketValue(histo, iter.previous(), bucketsPaths()[0], gapPolicy);
 
-            if (!(thisBucketValue == null || thisBucketValue.equals(Double.NaN))) {
+            if ((thisBucketValue == null || thisBucketValue.equals(Double.NaN)) == false) {
                 test[window - counter - 1] = thisBucketValue;
                 counter += 1;
             }
@@ -205,7 +205,7 @@ public class MovAvgPipelineAggregator extends PipelineAggregator {
 
             Double thisBucketValue = resolveBucketValue(histo, iter.previous(), bucketsPaths()[0], gapPolicy);
 
-            if (!(thisBucketValue == null || thisBucketValue.equals(Double.NaN))) {
+            if ((thisBucketValue == null || thisBucketValue.equals(Double.NaN)) == false) {
                 train[window - counter - 1] = thisBucketValue;
                 counter += 1;
             }

--- a/server/src/main/java/org/elasticsearch/search/sort/SortBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/sort/SortBuilder.java
@@ -215,7 +215,7 @@ public abstract class SortBuilder<T extends SortBuilder<T>> implements NamedWrit
         if (nestedObjectMapper == null) {
             throw new QueryShardException(context, "[nested] failed to find nested object under path [" + nestedPath + "]");
         }
-        if (!nestedObjectMapper.nested().isNested()) {
+        if (nestedObjectMapper.nested().isNested() == false) {
             throw new QueryShardException(context, "[nested] nested object under path [" + nestedPath + "] is not of nested type");
         }
         ObjectMapper objectMapper = context.nestedScope().getObjectMapper();

--- a/server/src/test/java/org/elasticsearch/client/transport/TransportClientHeadersTests.java
+++ b/server/src/test/java/org/elasticsearch/client/transport/TransportClientHeadersTests.java
@@ -105,7 +105,7 @@ public class TransportClientHeadersTests extends AbstractClientHeadersTestCase {
             plugin.instance.address = transportService.boundAddress().publishAddress();
             client.addTransportAddress(transportService.boundAddress().publishAddress());
 
-            if (!plugin.instance.clusterStateLatch.await(5, TimeUnit.SECONDS)) {
+            if (plugin.instance.clusterStateLatch.await(5, TimeUnit.SECONDS) == false) {
                 fail("takes way too long to get the cluster state");
             }
 

--- a/server/src/test/java/org/elasticsearch/discovery/ZenFaultDetectionTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/ZenFaultDetectionTests.java
@@ -210,7 +210,7 @@ public class ZenFaultDetectionTests extends ESTestCase {
 
         assertEquals(nodeB, failureNode[0]);
         Matcher<String> matcher = Matchers.containsString("verified");
-        if (!shouldRetry) {
+        if (shouldRetry == false) {
             matcher = Matchers.not(matcher);
         }
 
@@ -255,7 +255,7 @@ public class ZenFaultDetectionTests extends ESTestCase {
 
         assertEquals(nodeB, failureNode[0]);
         Matcher<String> matcher = Matchers.containsString("verified");
-        if (!shouldRetry) {
+        if (shouldRetry == false) {
             matcher = Matchers.not(matcher);
         }
 

--- a/server/src/test/java/org/elasticsearch/discovery/zen/ElectMasterServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/zen/ElectMasterServiceTests.java
@@ -72,7 +72,7 @@ public class ElectMasterServiceTests extends ESTestCase {
         DiscoveryNode prevNode = sortedNodes.get(0);
         for (int i = 1; i < sortedNodes.size(); i++) {
             DiscoveryNode node = sortedNodes.get(i);
-            if (!prevNode.isMasterNode()) {
+            if (prevNode.isMasterNode() == false) {
                 assertFalse(node.isMasterNode());
             } else if (node.isMasterNode()) {
                 assertTrue(prevNode.getId().compareTo(node.getId()) < 0);

--- a/server/src/test/java/org/elasticsearch/index/query/CommonTermsQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/CommonTermsQueryBuilderTests.java
@@ -90,7 +90,7 @@ public class CommonTermsQueryBuilderTests extends AbstractQueryTestCase<CommonTe
         ExtendedCommonTermsQuery extendedCommonTermsQuery = (ExtendedCommonTermsQuery) query;
 
         List<Term> terms = extendedCommonTermsQuery.getTerms();
-        if (!terms.isEmpty()) {
+        if (terms.isEmpty() == false) {
             String expectedFieldName = expectedFieldName(queryBuilder.fieldName());
             String actualFieldName = terms.iterator().next().field();
             assertThat(actualFieldName, equalTo(expectedFieldName));

--- a/server/src/test/java/org/elasticsearch/index/query/MatchQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/MatchQueryBuilderTests.java
@@ -174,7 +174,7 @@ public class MatchQueryBuilderTests extends AbstractQueryTestCase<MatchQueryBuil
             assertTrue(queryBuilder.cutoffFrequency() != null);
             ExtendedCommonTermsQuery ectq = (ExtendedCommonTermsQuery) query;
             List<Term> terms = ectq.getTerms();
-            if (!terms.isEmpty()) {
+            if (terms.isEmpty() == false) {
                 Term term = terms.iterator().next();
                 String expectedFieldName = expectedFieldName(queryBuilder.fieldName());
                 assertThat(term.field(), equalTo(expectedFieldName));

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/AbstractSecurityModule.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/AbstractSecurityModule.java
@@ -39,7 +39,7 @@ public abstract class AbstractSecurityModule extends AbstractModule {
 
         @Override
         protected final void configure(boolean clientMode) {
-            assert !clientMode : "[" + getClass().getSimpleName() + "] is a node only module";
+            assert clientMode == false : "[" + getClass().getSimpleName() + "] is a node only module";
             configureNode();
         }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/NativePrivilegeStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/NativePrivilegeStoreTests.java
@@ -583,7 +583,7 @@ public class NativePrivilegeStoreTests extends ESTestCase {
                 CollectionUtils.appendToCopy(Arrays.asList(ClusterHealthStatus.values()), null);
         store.onSecurityIndexStateChange(
             dummyState(securityIndexName, isIndexUpToDate, randomFrom(allPossibleHealthStatus)),
-            dummyState(securityIndexName, !isIndexUpToDate, randomFrom(allPossibleHealthStatus)));
+            dummyState(securityIndexName, isIndexUpToDate == false, randomFrom(allPossibleHealthStatus)));
         assertEquals(++count, store.getNumInvalidation().get());
     }
 


### PR DESCRIPTION
Backport of https://github.com/elastic/elasticsearch/pull/68677

Enforce the `== false` style of boolean negation via Checkstyle all the time in `7.x`, while also fixing the last usages of `!`.