### PR TITLE
[7.x] [DOCS] Add `data_frozen` role to node docs (#68713)

### DIFF
--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -26,6 +26,7 @@ configure this setting, the node has the following roles by default:
 * `data_hot`
 * `data_warm`
 * `data_cold`
+* `data_frozen`
 * `ingest`
 * `ml`
 * `remote_cluster_client`
@@ -204,9 +205,10 @@ To create a dedicated data node, set:
 node.roles: [ data ]
 ----
 
-In a multi-tier deployment architecture, you use specialised data roles to assign data nodes to specific tiers: `data_content`,`data_hot`,
-`data_warm`, or `data_cold`. A node can belong to multiple tiers, but a node that has one of the specialised data roles cannot have the
-generic `data` role.
+In a multi-tier deployment architecture, you use specialized data roles to
+assign data nodes to specific tiers: `data_content`,`data_hot`, `data_warm`,
+`data_cold`, or `data_frozen`. A node can belong to multiple tiers, but a node
+that has one of the specialized data roles cannot have the generic `data` role.
 
 [[data-content-node]]
 ==== [x-pack]#Content data node#
@@ -254,6 +256,20 @@ To create a dedicated cold node, set:
 [source,yaml]
 ----
 node.roles: [ data_cold ]
+----
+
+[[data-frozen-node]]
+==== [x-pack]#Frozen data node#
+
+Frozen data nodes store read-only indices that are accessed rarely. Nodes in the
+frozen tier use less performant hardware than the cold tier. To minimize
+resources, indices in the frozen tier may rely on searchable snapshots for
+resiliency.
+
+To create a dedicated frozen node, set:
+[source,yaml]
+----
+node.roles: [ data_frozen ]
 ----
 
 [[node-ingest-node]]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Add `data_frozen` role to node docs (#68713)