### PR TITLE
Deprecate GeoPolygon query in favour of GeoShape query. (#64227)

### DIFF
--- a/docs/reference/query-dsl/geo-polygon-query.asciidoc
+++ b/docs/reference/query-dsl/geo-polygon-query.asciidoc
@@ -4,6 +4,9 @@
 <titleabbrev>Geo-polygon</titleabbrev>
 ++++
 
+deprecated[7.12.0,"Use <<query-dsl-geo-shape-query>> instead,
+where polygons are defined in geojson or wkt."]
+
 A query returning hits that only fall within a polygon of
 points. Here is an example:
 
@@ -31,6 +34,7 @@ GET /_search
   }
 }
 --------------------------------------------------
+// TEST[warning:Deprecated field [geo_polygon] used, replaced by [[geo_shape] query where polygons are defined in geojson or wkt]]
 
 [discrete]
 ==== Query Options
@@ -80,6 +84,7 @@ GET /_search
   }
 }
 --------------------------------------------------
+// TEST[warning:Deprecated field [geo_polygon] used, replaced by [[geo_shape] query where polygons are defined in geojson or wkt]]
 
 [discrete]
 ===== Lat Lon as String
@@ -110,6 +115,7 @@ GET /_search
   }
 }
 --------------------------------------------------
+// TEST[warning:Deprecated field [geo_polygon] used, replaced by [[geo_shape] query where polygons are defined in geojson or wkt]]
 
 [discrete]
 ===== Geohash
@@ -138,6 +144,7 @@ GET /_search
   }
 }
 --------------------------------------------------
+// TEST[warning:Deprecated field [geo_polygon] used, replaced by [[geo_shape] query where polygons are defined in geojson or wkt]]
 
 [discrete]
 ==== geo_point Type

--- a/server/src/main/java/org/elasticsearch/index/query/GeoPolygonQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/GeoPolygonQueryBuilder.java
@@ -32,8 +32,15 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+/**
+ * @deprecated use {@link GeoShapeQueryBuilder}
+ */
+@Deprecated
 public class GeoPolygonQueryBuilder extends AbstractQueryBuilder<GeoPolygonQueryBuilder> {
     public static final String NAME = "geo_polygon";
+
+    public static final String GEO_POLYGON_DEPRECATION_MSG = "[" + GeoShapeQueryBuilder.NAME + "] query " +
+        "where polygons are defined in geojson or wkt";
 
     /**
      * The default value for ignore_unmapped.
@@ -51,6 +58,7 @@ public class GeoPolygonQueryBuilder extends AbstractQueryBuilder<GeoPolygonQuery
 
     private boolean ignoreUnmapped = DEFAULT_IGNORE_UNMAPPED;
 
+    @Deprecated
     public GeoPolygonQueryBuilder(String fieldName, List<GeoPoint> points) {
         if (Strings.isEmpty(fieldName)) {
             throw new IllegalArgumentException("fieldName must not be null");

--- a/server/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
@@ -647,7 +647,9 @@ public final class QueryBuilders {
      * A filter to filter based on a polygon defined by a set of locations  / points.
      *
      * @param name The location field name.
+     * @deprecated use {@link #geoIntersectionQuery(String, Geometry)} instead
      */
+    @Deprecated
     public static GeoPolygonQueryBuilder geoPolygonQuery(String name, List<GeoPoint> points) {
         return new GeoPolygonQueryBuilder(name, points);
     }

--- a/server/src/main/java/org/elasticsearch/search/SearchModule.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchModule.java
@@ -900,7 +900,9 @@ public class SearchModule {
         registerQuery(new QuerySpec<>(GeoDistanceQueryBuilder.NAME, GeoDistanceQueryBuilder::new, GeoDistanceQueryBuilder::fromXContent));
         registerQuery(new QuerySpec<>(GeoBoundingBoxQueryBuilder.NAME, GeoBoundingBoxQueryBuilder::new,
                 GeoBoundingBoxQueryBuilder::fromXContent));
-        registerQuery(new QuerySpec<>(GeoPolygonQueryBuilder.NAME, GeoPolygonQueryBuilder::new, GeoPolygonQueryBuilder::fromXContent));
+        registerQuery(new QuerySpec<>(
+            (new ParseField(GeoPolygonQueryBuilder.NAME).withAllDeprecated(GeoPolygonQueryBuilder.GEO_POLYGON_DEPRECATION_MSG)),
+            GeoPolygonQueryBuilder::new, GeoPolygonQueryBuilder::fromXContent));
         registerQuery(new QuerySpec<>(ExistsQueryBuilder.NAME, ExistsQueryBuilder::new, ExistsQueryBuilder::fromXContent));
         registerQuery(new QuerySpec<>(MatchNoneQueryBuilder.NAME, MatchNoneQueryBuilder::new, MatchNoneQueryBuilder::fromXContent));
         registerQuery(new QuerySpec<>(TermsSetQueryBuilder.NAME, TermsSetQueryBuilder::new, TermsSetQueryBuilder::fromXContent));

--- a/server/src/test/java/org/elasticsearch/index/query/GeoPolygonQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/GeoPolygonQueryBuilderTests.java
@@ -62,7 +62,7 @@ public class GeoPolygonQueryBuilderTests extends AbstractQueryTestCase<GeoPolygo
             List<GeoPoint> points = queryBuilder.points();
             double[] lats = new double[points.size()];
             double[] lons = new double[points.size()];
-            for (int i =0; i < points.size(); i++) {
+            for (int i = 0; i < points.size(); i++) {
                 lats[i] = points.get(i).getLat();
                 lons[i] = points.get(i).getLon();
             }
@@ -71,6 +71,34 @@ public class GeoPolygonQueryBuilderTests extends AbstractQueryTestCase<GeoPolygo
             Query dvQuery = ((IndexOrDocValuesQuery) query).getRandomAccessQuery();
             assertEquals(LatLonDocValuesField.newSlowPolygonQuery(expectedFieldName, polygon), dvQuery);
         }
+    }
+
+    @Override
+    public void testUnknownField() throws IOException {
+        super.testUnknownField();
+        assertDeprecationWarning();
+    }
+
+    @Override
+    public void testUnknownObjectException() throws IOException {
+        super.testUnknownObjectException();
+        assertDeprecationWarning();
+    }
+
+    @Override
+    public void testFromXContent() throws IOException {
+        super.testFromXContent();
+        assertDeprecationWarning();
+    }
+
+    @Override
+    public void testValidOutput() throws IOException {
+        super.testValidOutput();
+        assertDeprecationWarning();
+    }
+
+    private void assertDeprecationWarning() {
+        assertWarnings("Deprecated field [geo_polygon] used, replaced by [[geo_shape] query where polygons are defined in geojson or wkt]");
     }
 
     private static List<GeoPoint> randomPolygon() {
@@ -97,7 +125,7 @@ public class GeoPolygonQueryBuilderTests extends AbstractQueryTestCase<GeoPolygo
 
     public void testEmptyPolygon() {
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
-                () -> new GeoPolygonQueryBuilder(GEO_POINT_FIELD_NAME, Collections.emptyList()));
+            () -> new GeoPolygonQueryBuilder(GEO_POINT_FIELD_NAME, Collections.emptyList()));
         assertEquals("polygon must not be null or empty", e.getMessage());
 
         e = expectThrows(IllegalArgumentException.class, () -> new GeoPolygonQueryBuilder(GEO_POINT_FIELD_NAME, null));
@@ -110,7 +138,7 @@ public class GeoPolygonQueryBuilderTests extends AbstractQueryTestCase<GeoPolygo
         points.add(new GeoPoint(90, 90));
         points.add(new GeoPoint(0, 90));
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
-                () -> new GeoPolygonQueryBuilder(GEO_POINT_FIELD_NAME, points));
+            () -> new GeoPolygonQueryBuilder(GEO_POINT_FIELD_NAME, points));
         assertEquals("too few points defined for geo_polygon query", e.getMessage());
     }
 
@@ -119,91 +147,96 @@ public class GeoPolygonQueryBuilderTests extends AbstractQueryTestCase<GeoPolygo
         points.add(new GeoPoint(0, 90));
         points.add(new GeoPoint(90, 90));
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
-                () -> new GeoPolygonQueryBuilder(GEO_POINT_FIELD_NAME, points));
+            () -> new GeoPolygonQueryBuilder(GEO_POINT_FIELD_NAME, points));
         assertEquals("too few points defined for geo_polygon query", e.getMessage());
     }
 
     public void testParsingAndToQueryParsingExceptions() throws IOException {
         String[] brokenFiles = new String[]{
-                "/org/elasticsearch/index/query/geo_polygon_exception_1.json",
-                "/org/elasticsearch/index/query/geo_polygon_exception_2.json",
-                "/org/elasticsearch/index/query/geo_polygon_exception_3.json",
-                "/org/elasticsearch/index/query/geo_polygon_exception_4.json",
-                "/org/elasticsearch/index/query/geo_polygon_exception_5.json"
+            "/org/elasticsearch/index/query/geo_polygon_exception_1.json",
+            "/org/elasticsearch/index/query/geo_polygon_exception_2.json",
+            "/org/elasticsearch/index/query/geo_polygon_exception_3.json",
+            "/org/elasticsearch/index/query/geo_polygon_exception_4.json",
+            "/org/elasticsearch/index/query/geo_polygon_exception_5.json"
         };
         for (String brokenFile : brokenFiles) {
             String query = copyToStringFromClasspath(brokenFile);
             expectThrows(ParsingException.class, () -> parseQuery(query));
         }
+        assertDeprecationWarning();
     }
 
     public void testParsingAndToQuery1() throws IOException {
         String query = "{\n" +
-                "    \"geo_polygon\":{\n" +
-                "        \"" + GEO_POINT_FIELD_NAME + "\":{\n" +
-                "            \"points\":[\n" +
-                "                [-70, 40],\n" +
-                "                [-80, 30],\n" +
-                "                [-90, 20]\n" +
-                "            ]\n" +
-                "        }\n" +
-                "    }\n" +
-                "}\n";
+            "    \"geo_polygon\":{\n" +
+            "        \"" + GEO_POINT_FIELD_NAME + "\":{\n" +
+            "            \"points\":[\n" +
+            "                [-70, 40],\n" +
+            "                [-80, 30],\n" +
+            "                [-90, 20]\n" +
+            "            ]\n" +
+            "        }\n" +
+            "    }\n" +
+            "}\n";
         assertGeoPolygonQuery(query);
+        assertDeprecationWarning();
     }
 
     public void testParsingAndToQuery2() throws IOException {
         String query = "{\n" +
-                "    \"geo_polygon\":{\n" +
-                "        \"" + GEO_POINT_FIELD_NAME + "\":{\n" +
-                "            \"points\":[\n" +
-                "                {\n" +
-                "                    \"lat\":40,\n" +
-                "                    \"lon\":-70\n" +
-                "                },\n" +
-                "                {\n" +
-                "                    \"lat\":30,\n" +
-                "                    \"lon\":-80\n" +
-                "                },\n" +
-                "                {\n" +
-                "                    \"lat\":20,\n" +
-                "                    \"lon\":-90\n" +
-                "                }\n" +
-                "            ]\n" +
-                "        }\n" +
-                "    }\n" +
-                "}\n";
+            "    \"geo_polygon\":{\n" +
+            "        \"" + GEO_POINT_FIELD_NAME + "\":{\n" +
+            "            \"points\":[\n" +
+            "                {\n" +
+            "                    \"lat\":40,\n" +
+            "                    \"lon\":-70\n" +
+            "                },\n" +
+            "                {\n" +
+            "                    \"lat\":30,\n" +
+            "                    \"lon\":-80\n" +
+            "                },\n" +
+            "                {\n" +
+            "                    \"lat\":20,\n" +
+            "                    \"lon\":-90\n" +
+            "                }\n" +
+            "            ]\n" +
+            "        }\n" +
+            "    }\n" +
+            "}\n";
         assertGeoPolygonQuery(query);
+        assertDeprecationWarning();
     }
 
     public void testParsingAndToQuery3() throws IOException {
         String query = "{\n" +
-                "    \"geo_polygon\":{\n" +
-                "        \"" + GEO_POINT_FIELD_NAME + "\":{\n" +
-                "            \"points\":[\n" +
-                "                \"40, -70\",\n" +
-                "                \"30, -80\",\n" +
-                "                \"20, -90\"\n" +
-                "            ]\n" +
-                "        }\n" +
-                "    }\n" +
-                "}\n";
+            "    \"geo_polygon\":{\n" +
+            "        \"" + GEO_POINT_FIELD_NAME + "\":{\n" +
+            "            \"points\":[\n" +
+            "                \"40, -70\",\n" +
+            "                \"30, -80\",\n" +
+            "                \"20, -90\"\n" +
+            "            ]\n" +
+            "        }\n" +
+            "    }\n" +
+            "}\n";
         assertGeoPolygonQuery(query);
+        assertDeprecationWarning();
     }
 
     public void testParsingAndToQuery4() throws IOException {
         String query = "{\n" +
-                "    \"geo_polygon\":{\n" +
-                "        \"" + GEO_POINT_FIELD_NAME + "\":{\n" +
-                "            \"points\":[\n" +
-                "                \"drn5x1g8cu2y\",\n" +
-                "                \"30, -80\",\n" +
-                "                \"20, -90\"\n" +
-                "            ]\n" +
-                "        }\n" +
-                "    }\n" +
-                "}\n";
+            "    \"geo_polygon\":{\n" +
+            "        \"" + GEO_POINT_FIELD_NAME + "\":{\n" +
+            "            \"points\":[\n" +
+            "                \"drn5x1g8cu2y\",\n" +
+            "                \"30, -80\",\n" +
+            "                \"20, -90\"\n" +
+            "            ]\n" +
+            "        }\n" +
+            "    }\n" +
+            "}\n";
         assertGeoPolygonQuery(query);
+        assertDeprecationWarning();
     }
 
     private void assertGeoPolygonQuery(String query) throws IOException {
@@ -214,7 +247,7 @@ public class GeoPolygonQueryBuilderTests extends AbstractQueryTestCase<GeoPolygo
 
     public void testFromJson() throws IOException {
         String json =
-                "{\n" +
+            "{\n" +
                 "  \"geo_polygon\" : {\n" +
                 "    \"person.location\" : {\n" +
                 "      \"points\" : [ [ -70.0, 40.0 ], [ -80.0, 30.0 ], [ -90.0, 20.0 ], [ -70.0, 40.0 ] ]\n" +
@@ -227,6 +260,7 @@ public class GeoPolygonQueryBuilderTests extends AbstractQueryTestCase<GeoPolygo
         GeoPolygonQueryBuilder parsed = (GeoPolygonQueryBuilder) parseQuery(json);
         checkGeneratedJson(json, parsed);
         assertEquals(json, 4, parsed.points().size());
+        assertDeprecationWarning();
     }
 
     public void testIgnoreUnmapped() throws IOException {
@@ -274,5 +308,6 @@ public class GeoPolygonQueryBuilderTests extends AbstractQueryTestCase<GeoPolygo
 
         QueryShardException e2 = expectThrows(QueryShardException.class, () -> parseQuery(queryInvalidLon).toQuery(context));
         assertThat(e2.getMessage(), containsString("illegal longitude value [-190.0] for [geo_polygon]"));
+        assertDeprecationWarning();
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/SearchModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchModuleTests.java
@@ -105,7 +105,7 @@ public class SearchModuleTests extends ESTestCase {
             @Override
             public List<ScoreFunctionSpec<?>> getScoreFunctions() {
                 return singletonList(new ScoreFunctionSpec<>(GaussDecayFunctionBuilder.NAME, GaussDecayFunctionBuilder::new,
-                        GaussDecayFunctionBuilder.PARSER));
+                    GaussDecayFunctionBuilder.PARSER));
             }
         };
         expectThrows(IllegalArgumentException.class, registryForPlugin(registersDupeScoreFunction));
@@ -146,7 +146,7 @@ public class SearchModuleTests extends ESTestCase {
             @Override
             public List<AggregationSpec> getAggregations() {
                 return singletonList(new AggregationSpec(TermsAggregationBuilder.NAME, TermsAggregationBuilder::new,
-                        TermsAggregationBuilder.PARSER));
+                    TermsAggregationBuilder.PARSER));
             }
         };
         expectThrows(IllegalArgumentException.class, registryForPlugin(registersDupeAggregation));
@@ -155,11 +155,11 @@ public class SearchModuleTests extends ESTestCase {
             @Override
             public List<PipelineAggregationSpec> getPipelineAggregations() {
                 return singletonList(new PipelineAggregationSpec(
-                        DerivativePipelineAggregationBuilder.NAME,
-                        DerivativePipelineAggregationBuilder::new,
-                        DerivativePipelineAggregator::new,
-                        DerivativePipelineAggregationBuilder::parse)
-                            .addResultReader(InternalDerivative::new));
+                    DerivativePipelineAggregationBuilder.NAME,
+                    DerivativePipelineAggregationBuilder::new,
+                    DerivativePipelineAggregator::new,
+                    DerivativePipelineAggregationBuilder::parse)
+                    .addResultReader(InternalDerivative::new));
             }
         };
         expectThrows(IllegalArgumentException.class, registryForPlugin(registersDupePipelineAggregation));
@@ -168,7 +168,7 @@ public class SearchModuleTests extends ESTestCase {
             @Override
             public List<RescorerSpec<?>> getRescorers() {
                 return singletonList(
-                        new RescorerSpec<>(QueryRescorerBuilder.NAME, QueryRescorerBuilder::new, QueryRescorerBuilder::fromXContent));
+                    new RescorerSpec<>(QueryRescorerBuilder.NAME, QueryRescorerBuilder::new, QueryRescorerBuilder::fromXContent));
             }
         };
         expectThrows(IllegalArgumentException.class, registryForPlugin(registersDupeRescorer));
@@ -192,26 +192,26 @@ public class SearchModuleTests extends ESTestCase {
         }));
 
         assertEquals(1, module.getNamedXContents().stream()
-                .filter(e -> e.categoryClass.equals(SuggestionBuilder.class) &&
-                    e.name.match("term", LoggingDeprecationHandler.INSTANCE)).count());
+            .filter(e -> e.categoryClass.equals(SuggestionBuilder.class) &&
+                e.name.match("term", LoggingDeprecationHandler.INSTANCE)).count());
         assertEquals(1, module.getNamedXContents().stream()
-                .filter(e -> e.categoryClass.equals(SuggestionBuilder.class) &&
-                    e.name.match("phrase", LoggingDeprecationHandler.INSTANCE)).count());
+            .filter(e -> e.categoryClass.equals(SuggestionBuilder.class) &&
+                e.name.match("phrase", LoggingDeprecationHandler.INSTANCE)).count());
         assertEquals(1, module.getNamedXContents().stream()
-                .filter(e -> e.categoryClass.equals(SuggestionBuilder.class) &&
-                    e.name.match("completion", LoggingDeprecationHandler.INSTANCE)).count());
+            .filter(e -> e.categoryClass.equals(SuggestionBuilder.class) &&
+                e.name.match("completion", LoggingDeprecationHandler.INSTANCE)).count());
         assertEquals(1, module.getNamedXContents().stream()
-                .filter(e -> e.categoryClass.equals(SuggestionBuilder.class) &&
-                    e.name.match("test", LoggingDeprecationHandler.INSTANCE)).count());
+            .filter(e -> e.categoryClass.equals(SuggestionBuilder.class) &&
+                e.name.match("test", LoggingDeprecationHandler.INSTANCE)).count());
 
         assertEquals(1, module.getNamedWriteables().stream()
-                .filter(e -> e.categoryClass.equals(SuggestionBuilder.class) && e.name.equals("term")).count());
+            .filter(e -> e.categoryClass.equals(SuggestionBuilder.class) && e.name.equals("term")).count());
         assertEquals(1, module.getNamedWriteables().stream()
-                .filter(e -> e.categoryClass.equals(SuggestionBuilder.class) && e.name.equals("phrase")).count());
+            .filter(e -> e.categoryClass.equals(SuggestionBuilder.class) && e.name.equals("phrase")).count());
         assertEquals(1, module.getNamedWriteables().stream()
-                .filter(e -> e.categoryClass.equals(SuggestionBuilder.class) && e.name.equals("completion")).count());
+            .filter(e -> e.categoryClass.equals(SuggestionBuilder.class) && e.name.equals("completion")).count());
         assertEquals(1, module.getNamedWriteables().stream()
-                .filter(e -> e.categoryClass.equals(SuggestionBuilder.class) && e.name.equals("test")).count());
+            .filter(e -> e.categoryClass.equals(SuggestionBuilder.class) && e.name.equals("test")).count());
 
         assertEquals(1, module.getNamedWriteables().stream()
             .filter(e -> e.categoryClass.equals(Suggestion.class) && e.name.equals("term")).count());
@@ -246,14 +246,14 @@ public class SearchModuleTests extends ESTestCase {
         SearchModule module = new SearchModule(Settings.EMPTY, false, emptyList());
 
         Set<String> registeredNonDeprecated = module.getNamedXContents().stream()
-                .filter(e -> e.categoryClass.equals(QueryBuilder.class))
-                .filter(e -> e.name.getDeprecatedNames().length == 0)
-                .map(e -> e.name.getPreferredName())
-                .collect(toSet());
+            .filter(e -> e.categoryClass.equals(QueryBuilder.class))
+            .filter(e -> e.name.getDeprecatedNames().length == 0)
+            .map(e -> e.name.getPreferredName())
+            .collect(toSet());
         Set<String> registeredAll = module.getNamedXContents().stream()
-                .filter(e -> e.categoryClass.equals(QueryBuilder.class))
-                .flatMap(e -> Arrays.stream(e.name.getAllNamesIncludedDeprecated()))
-                .collect(toSet());
+            .filter(e -> e.categoryClass.equals(QueryBuilder.class))
+            .flatMap(e -> Arrays.stream(e.name.getAllNamesIncludedDeprecated()))
+            .collect(toSet());
 
         assertThat(registeredNonDeprecated, containsInAnyOrder(NON_DEPRECATED_QUERIES));
         assertThat(registeredAll, containsInAnyOrder(allSupportedQueries.toArray(new String[0])));
@@ -268,11 +268,11 @@ public class SearchModuleTests extends ESTestCase {
         }));
 
         assertThat(
-                module.getNamedXContents().stream()
-                    .filter(entry -> entry.categoryClass.equals(BaseAggregationBuilder.class) &&
-                        entry.name.match("test", LoggingDeprecationHandler.INSTANCE))
-                    .collect(toList()),
-                hasSize(1));
+            module.getNamedXContents().stream()
+                .filter(entry -> entry.categoryClass.equals(BaseAggregationBuilder.class) &&
+                    entry.name.match("test", LoggingDeprecationHandler.INSTANCE))
+                .collect(toList()),
+            hasSize(1));
     }
 
     public void testRegisterPipelineAggregation() {
@@ -280,16 +280,16 @@ public class SearchModuleTests extends ESTestCase {
             @Override
             public List<PipelineAggregationSpec> getPipelineAggregations() {
                 return singletonList(new PipelineAggregationSpec("test",
-                        TestPipelineAggregationBuilder::new, TestPipelineAggregator::new, TestPipelineAggregationBuilder::fromXContent));
+                    TestPipelineAggregationBuilder::new, TestPipelineAggregator::new, TestPipelineAggregationBuilder::fromXContent));
             }
         }));
 
         assertThat(
-                module.getNamedXContents().stream()
-                    .filter(entry -> entry.categoryClass.equals(BaseAggregationBuilder.class) &&
-                        entry.name.match("test", LoggingDeprecationHandler.INSTANCE))
-                    .collect(toList()),
-                hasSize(1));
+            module.getNamedXContents().stream()
+                .filter(entry -> entry.categoryClass.equals(BaseAggregationBuilder.class) &&
+                    entry.name.match("test", LoggingDeprecationHandler.INSTANCE))
+                .collect(toList()),
+            hasSize(1));
     }
 
     public void testRegisterRescorer() {
@@ -300,64 +300,63 @@ public class SearchModuleTests extends ESTestCase {
             }
         }));
         assertThat(
-                module.getNamedXContents().stream()
-                    .filter(entry -> entry.categoryClass.equals(RescorerBuilder.class) &&
-                        entry.name.match("test", LoggingDeprecationHandler.INSTANCE))
-                    .collect(toList()),
-                hasSize(1));
+            module.getNamedXContents().stream()
+                .filter(entry -> entry.categoryClass.equals(RescorerBuilder.class) &&
+                    entry.name.match("test", LoggingDeprecationHandler.INSTANCE))
+                .collect(toList()),
+            hasSize(1));
     }
 
     private static final String[] NON_DEPRECATED_QUERIES = new String[] {
-            "bool",
-            "boosting",
-            "constant_score",
-            "dis_max",
-            "exists",
-            "field_masking_span",
-            "function_score",
-            "fuzzy",
-            "geo_bounding_box",
-            "geo_distance",
-            "geo_polygon",
-            "geo_shape",
-            "ids",
-            "intervals",
-            "match",
-            "match_all",
-            "match_bool_prefix",
-            "match_none",
-            "match_phrase",
-            "match_phrase_prefix",
-            "more_like_this",
-            "multi_match",
-            "nested",
-            "prefix",
-            "query_string",
-            "range",
-            "regexp",
-            "script",
-            "script_score",
-            "simple_query_string",
-            "span_containing",
-            "span_first",
-            "span_gap",
-            "span_multi",
-            "span_near",
-            "span_not",
-            "span_or",
-            "span_term",
-            "span_within",
-            "term",
-            "terms",
-            "terms_set",
-            "type",
-            "wildcard",
-            "wrapper",
-            "distance_feature"
+        "bool",
+        "boosting",
+        "constant_score",
+        "dis_max",
+        "exists",
+        "field_masking_span",
+        "function_score",
+        "fuzzy",
+        "geo_bounding_box",
+        "geo_distance",
+        "geo_shape",
+        "ids",
+        "intervals",
+        "match",
+        "match_all",
+        "match_bool_prefix",
+        "match_none",
+        "match_phrase",
+        "match_phrase_prefix",
+        "more_like_this",
+        "multi_match",
+        "nested",
+        "prefix",
+        "query_string",
+        "range",
+        "regexp",
+        "script",
+        "script_score",
+        "simple_query_string",
+        "span_containing",
+        "span_first",
+        "span_gap",
+        "span_multi",
+        "span_near",
+        "span_not",
+        "span_or",
+        "span_term",
+        "span_within",
+        "term",
+        "terms",
+        "terms_set",
+        "type",
+        "wildcard",
+        "wrapper",
+        "distance_feature"
     };
 
     //add here deprecated queries to make sure we log a deprecation warnings when they are used
-    private static final String[] DEPRECATED_QUERIES = new String[] {"common"};
+    private static final String[] DEPRECATED_QUERIES = new String[] {"common", "geo_polygon"};
 
     /**
      * Dummy test {@link AggregationBuilder} used to test registering aggregation builders.
@@ -521,16 +520,16 @@ public class SearchModuleTests extends ESTestCase {
 
         @Override
         protected Suggestion<? extends Suggestion.Entry<? extends Suggestion.Entry.Option>> innerExecute(
-                String name,
-                SuggestionSearchContext.SuggestionContext suggestion,
-                IndexSearcher searcher,
-                CharsRefBuilder spare) throws IOException {
+            String name,
+            SuggestionSearchContext.SuggestionContext suggestion,
+            IndexSearcher searcher,
+            CharsRefBuilder spare) throws IOException {
             return null;
         }
 
         @Override
         protected Suggestion<? extends Entry<? extends Option>> emptySuggestion(String name, SuggestionContext suggestion,
-                CharsRefBuilder spare) throws IOException {
+                                                                                CharsRefBuilder spare) throws IOException {
             return null;
         }
     }


### PR DESCRIPTION
Following the development in #48928, GeoShape queries in more powerful that GeoPolygon queries and it makes little sense having both. This commit deprecates GeoPolygon queries.

backport #64227