### PR TITLE
Allow reading of /proc/meminfo for JDK bug workaround

### DIFF
--- a/server/src/main/resources/org/elasticsearch/bootstrap/security.policy
+++ b/server/src/main/resources/org/elasticsearch/bootstrap/security.policy
@@ -153,4 +153,6 @@ grant {
   permission java.io.FilePermission "/sys/fs/cgroup/memory", "read";
   permission java.io.FilePermission "/sys/fs/cgroup/memory/-", "read";
 
+  // system memory on Linux systems affected by JDK bug (#66629)
+  permission java.io.FilePermission "/proc/meminfo", "read";
 };


### PR DESCRIPTION
Allows `/proc/meminfo` to be read so that https://github.com/elastic/elasticsearch/pull/68542 works on Debian8 systems.
