### PR TITLE
Fix off by one Mistake in SparseFileTrackerTests (#68739)

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/SparseFileTrackerTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/SparseFileTrackerTests.java
@@ -71,7 +71,7 @@ public class SparseFileTrackerTests extends ESTestCase {
         if (length > 1L) {
             e = expectThrows(IllegalArgumentException.class, () -> {
                 long start = randomLongBetween(1L, Math.max(1L, length - 1L));
-                long end = randomLongBetween(length, length + 1000L);
+                long end = randomLongBetween(length + 1, length + 1000L);
                 sparseFileTracker.waitForRange(ByteRange.of(start, end), null, listener);
             });
             assertThat("end must not be greater than length", e.getMessage(), containsString("invalid range"));


### PR DESCRIPTION
This was caused by #68709 which turned the edge case of a
range with start > end into a tripped assertion.

backport of #68739