### PR TITLE
Add read permissions for `apm_user` role to APM fleet indices

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -192,36 +192,36 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                         },
                     null, MetadataUtils.DEFAULT_RESERVED_METADATA))
                 .put("apm_user", new RoleDescriptor("apm_user",
-                    null, 
+                    null,
                     new RoleDescriptor.IndicesPrivileges[] {
                         // Self managed APM Server
                         // Can be removed in 8.0
                         RoleDescriptor.IndicesPrivileges.builder().indices("apm-*")
                             .privileges("read", "view_index_metadata").build(),
-                        
-                        // APM Server under fleet (data streams)
-                        RoleDescriptor.IndicesPrivileges.builder().indices("logs-apm.*")
+
+                            // APM Server under fleet (data streams)
+                            RoleDescriptor.IndicesPrivileges.builder().indices("logs-apm.*")
                             .privileges("read", "view_index_metadata").build(),
-                        RoleDescriptor.IndicesPrivileges.builder().indices("metrics-apm.*")
-                            .privileges("read", "view_index_metadata").build(),         
-                        RoleDescriptor.IndicesPrivileges.builder().indices("traces-apm.*")
-                            .privileges("read", "view_index_metadata").build(),    
-                        
-                        // Machine Learning indices. Only needed for legacy reasons
-                        // Can be removed in 8.0
-                        RoleDescriptor.IndicesPrivileges.builder().indices(".ml-anomalies*")
+                            RoleDescriptor.IndicesPrivileges.builder().indices("metrics-apm.*")
                             .privileges("read", "view_index_metadata").build(),
-                        
-                        // Annotations
-                        RoleDescriptor.IndicesPrivileges.builder().indices("observability-annotations")
+                            RoleDescriptor.IndicesPrivileges.builder().indices("traces-apm.*")
+                            .privileges("read", "view_index_metadata").build(),
+
+                            // Machine Learning indices. Only needed for legacy reasons
+                            // Can be removed in 8.0
+                            RoleDescriptor.IndicesPrivileges.builder().indices(".ml-anomalies*")
+                            .privileges("read", "view_index_metadata").build(),
+
+                            // Annotations
+                            RoleDescriptor.IndicesPrivileges.builder().indices("observability-annotations")
                             .privileges("read", "view_index_metadata").build()
-                    }, 
+                    },
                     new RoleDescriptor.ApplicationResourcePrivileges[] {
                         RoleDescriptor.ApplicationResourcePrivileges.builder().application("kibana-*").resources("*").privileges("reserved_ml_apm_user").build()
-                    }, 
-                    null, 
-                    null, 
-                    MetadataUtils.getDeprecatedReservedMetadata("This role will be removed in 8.0"), 
+                    },
+                    null,
+                    null,
+                    MetadataUtils.getDeprecatedReservedMetadata("This role will be removed in 8.0"),
                     null
                 ))
                 .put("machine_learning_user", new RoleDescriptor("machine_learning_user", new String[] { "monitor_ml" },

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -152,15 +152,7 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                                 RoleDescriptor.IndicesPrivileges.builder()
                                     .indices("apm-*")
                                     .privileges("read", "read_cross_cluster").build(),
-                                RoleDescriptor.IndicesPrivileges.builder()
-                                    .indices("logs-apm*")
-                                    .privileges("read", "read_cross_cluster").build(),
-                                RoleDescriptor.IndicesPrivileges.builder()
-                                    .indices("metrics-apm*")
-                                    .privileges("read", "read_cross_cluster").build(),
-                                RoleDescriptor.IndicesPrivileges.builder()
-                                    .indices("traces-apm*")
-                                    .privileges("read", "read_cross_cluster").build(),                            
+                                RoleDescriptor.IndicesPrivileges.builder()                 
                                 // Data telemetry reads mappings, metadata and stats of indices
                                 RoleDescriptor.IndicesPrivileges.builder()
                                     .indices("*")

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -152,6 +152,15 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                                 RoleDescriptor.IndicesPrivileges.builder()
                                     .indices("apm-*")
                                     .privileges("read", "read_cross_cluster").build(),
+                                RoleDescriptor.IndicesPrivileges.builder()
+                                    .indices("logs-apm*")
+                                    .privileges("read", "read_cross_cluster").build(),
+                                RoleDescriptor.IndicesPrivileges.builder()
+                                    .indices("metrics-apm*")
+                                    .privileges("read", "read_cross_cluster").build(),
+                                RoleDescriptor.IndicesPrivileges.builder()
+                                    .indices("traces-apm*")
+                                    .privileges("read", "read_cross_cluster").build(),                            
                                 // Data telemetry reads mappings, metadata and stats of indices
                                 RoleDescriptor.IndicesPrivileges.builder()
                                     .indices("*")

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -152,7 +152,6 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                                 RoleDescriptor.IndicesPrivileges.builder()
                                     .indices("apm-*")
                                     .privileges("read", "read_cross_cluster").build(),
-                                RoleDescriptor.IndicesPrivileges.builder()                 
                                 // Data telemetry reads mappings, metadata and stats of indices
                                 RoleDescriptor.IndicesPrivileges.builder()
                                     .indices("*")

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -193,10 +193,25 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                     null, MetadataUtils.DEFAULT_RESERVED_METADATA))
                 .put("apm_user", new RoleDescriptor("apm_user",
                     null, new RoleDescriptor.IndicesPrivileges[] {
+                        // Self managed APM Server
+                        // Can be removed in 8.0
                         RoleDescriptor.IndicesPrivileges.builder().indices("apm-*")
                             .privileges("read", "view_index_metadata").build(),
+                        
+                        // APM Server under fleet (data streams)
+                        RoleDescriptor.IndicesPrivileges.builder().indices("logs-apm*")
+                            .privileges("read", "view_index_metadata").build(),
+                        RoleDescriptor.IndicesPrivileges.builder().indices("metrics-apm*")
+                            .privileges("read", "view_index_metadata").build(),         
+                        RoleDescriptor.IndicesPrivileges.builder().indices("traces-apm*")
+                            .privileges("read", "view_index_metadata").build(),    
+                        
+                        // Machine Learning indices. Only needed for legacy reasons
+                        // Can be removed in 8.0
                         RoleDescriptor.IndicesPrivileges.builder().indices(".ml-anomalies*")
                             .privileges("read", "view_index_metadata").build(),
+                        
+                        // Annotations
                         RoleDescriptor.IndicesPrivileges.builder().indices("observability-annotations")
                             .privileges("read", "view_index_metadata").build()
                     }, new RoleDescriptor.ApplicationResourcePrivileges[] {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -199,11 +199,11 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                             .privileges("read", "view_index_metadata").build(),
                         
                         // APM Server under fleet (data streams)
-                        RoleDescriptor.IndicesPrivileges.builder().indices("logs-apm*")
+                        RoleDescriptor.IndicesPrivileges.builder().indices("logs-apm.*")
                             .privileges("read", "view_index_metadata").build(),
-                        RoleDescriptor.IndicesPrivileges.builder().indices("metrics-apm*")
+                        RoleDescriptor.IndicesPrivileges.builder().indices("metrics-apm.*")
                             .privileges("read", "view_index_metadata").build(),         
-                        RoleDescriptor.IndicesPrivileges.builder().indices("traces-apm*")
+                        RoleDescriptor.IndicesPrivileges.builder().indices("traces-apm.*")
                             .privileges("read", "view_index_metadata").build(),    
                         
                         // Machine Learning indices. Only needed for legacy reasons

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -192,7 +192,8 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                         },
                     null, MetadataUtils.DEFAULT_RESERVED_METADATA))
                 .put("apm_user", new RoleDescriptor("apm_user",
-                    null, new RoleDescriptor.IndicesPrivileges[] {
+                    null, 
+                    new RoleDescriptor.IndicesPrivileges[] {
                         // Self managed APM Server
                         // Can be removed in 8.0
                         RoleDescriptor.IndicesPrivileges.builder().indices("apm-*")
@@ -214,10 +215,15 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                         // Annotations
                         RoleDescriptor.IndicesPrivileges.builder().indices("observability-annotations")
                             .privileges("read", "view_index_metadata").build()
-                    }, new RoleDescriptor.ApplicationResourcePrivileges[] {
-                            RoleDescriptor.ApplicationResourcePrivileges.builder()
-                                .application("kibana-*").resources("*").privileges("reserved_ml_apm_user").build()
-                        }, null, null, MetadataUtils.DEFAULT_RESERVED_METADATA, null))
+                    }, 
+                    new RoleDescriptor.ApplicationResourcePrivileges[] {
+                        RoleDescriptor.ApplicationResourcePrivileges.builder().application("kibana-*").resources("*").privileges("reserved_ml_apm_user").build()
+                    }, 
+                    null, 
+                    null, 
+                    MetadataUtils.getDeprecatedReservedMetadata("This role will be removed in 8.0"), 
+                    null
+                ))
                 .put("machine_learning_user", new RoleDescriptor("machine_learning_user", new String[] { "monitor_ml" },
                         new RoleDescriptor.IndicesPrivileges[] {
                                 RoleDescriptor.IndicesPrivileges.builder().indices(".ml-anomalies*", ".ml-notifications*")

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -217,7 +217,13 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                             .privileges("read", "view_index_metadata").build()
                     },
                     new RoleDescriptor.ApplicationResourcePrivileges[] {
-                        RoleDescriptor.ApplicationResourcePrivileges.builder().application("kibana-*").resources("*").privileges("reserved_ml_apm_user").build()
+                        RoleDescriptor
+                                .ApplicationResourcePrivileges
+                                .builder()
+                                .application("kibana-*")
+                                .resources("*")
+                                .privileges("reserved_ml_apm_user")
+                                .build()
                     },
                     null,
                     null,

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -1256,7 +1256,14 @@ public class ReservedRolesStoreTests extends ESTestCase {
         assertThat(role.runAs().check(randomAlphaOfLengthBetween(1, 12)), is(false));
 
         assertNoAccessAllowed(role, "foo");
+        assertNoAccessAllowed(role, "foo-apm");
+        assertNoAccessAllowed(role, "foo-logs-apm");
+        assertNoAccessAllowed(role, "foo-traces-apm");
+        assertNoAccessAllowed(role, "foo-metrics-apm");
 
+        assertOnlyReadAllowed(role, "logs-apm" + randomIntBetween(0, 5));
+        assertOnlyReadAllowed(role, "traces-apm" + randomIntBetween(0, 5));
+        assertOnlyReadAllowed(role, "metrics-apm" + randomIntBetween(0, 5));
         assertOnlyReadAllowed(role, "apm-" + randomIntBetween(0, 5));
         assertOnlyReadAllowed(role, AnomalyDetectorsIndexFields.RESULTS_INDEX_PREFIX + AnomalyDetectorsIndexFields.RESULTS_INDEX_DEFAULT);
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -1257,13 +1257,13 @@ public class ReservedRolesStoreTests extends ESTestCase {
 
         assertNoAccessAllowed(role, "foo");
         assertNoAccessAllowed(role, "foo-apm");
-        assertNoAccessAllowed(role, "foo-logs-apm");
-        assertNoAccessAllowed(role, "foo-traces-apm");
-        assertNoAccessAllowed(role, "foo-metrics-apm");
+        assertNoAccessAllowed(role, "foo-logs-apm.bar");
+        assertNoAccessAllowed(role, "foo-traces-apm.bar");
+        assertNoAccessAllowed(role, "foo-metrics-apm.bar");
 
-        assertOnlyReadAllowed(role, "logs-apm" + randomIntBetween(0, 5));
-        assertOnlyReadAllowed(role, "traces-apm" + randomIntBetween(0, 5));
-        assertOnlyReadAllowed(role, "metrics-apm" + randomIntBetween(0, 5));
+        assertOnlyReadAllowed(role, "logs-apm." + randomIntBetween(0, 5));
+        assertOnlyReadAllowed(role, "traces-apm." + randomIntBetween(0, 5));
+        assertOnlyReadAllowed(role, "metrics-apm." + randomIntBetween(0, 5));
         assertOnlyReadAllowed(role, "apm-" + randomIntBetween(0, 5));
         assertOnlyReadAllowed(role, AnomalyDetectorsIndexFields.RESULTS_INDEX_PREFIX + AnomalyDetectorsIndexFields.RESULTS_INDEX_DEFAULT);
 


### PR DESCRIPTION
Related: https://github.com/elastic/kibana/issues/87501

**Permissions to `apm_user`**
Starting in 7.12 APM Server will be available under fleet. In this mode data will no longer be ingested to `apm-*` indices but to `logs-apm*, metrics-apm*, traces-apm*`.

This PR ensures that users upgrading to APM Server under fleet can still access APM data.

~**Permissions to `kibana_user`**
In Kibana there is a background task that collects telemetry. We want ensure that this background task can access APM indices and upload telemetry based on this.~

Note to self: 
```sh
# run tests
./gradlew :x-pack:plugin:core:test --tests 'org.elasticsearch.xpack.core.security.authz.store.*'
```

cc @elastic/apm-ui 
