### PR TITLE
[DOCS] Expand simple query string query's synonym section

### DIFF
--- a/docs/reference/analysis/token-graphs.asciidoc
+++ b/docs/reference/analysis/token-graphs.asciidoc
@@ -39,6 +39,10 @@ record the `positionLength` for multi-position tokens. This filters include:
 * <<analysis-synonym-graph-tokenfilter,`synonym_graph`>>
 * <<analysis-word-delimiter-graph-tokenfilter,`word_delimiter_graph`>>
 
+Some tokenizers, such as the
+{plugin}/analysis-nori-tokenizer.html[`nori_tokenizer`], also accurately
+decompose compound tokens into multi-position tokens.
+
 In the following graph, `domain name system` and its synonym, `dns`, both have a
 position of `0`. However, `dns` has a `positionLength` of `3`. Other tokens in
 the graph have a default `positionLength` of `1`.

--- a/docs/reference/query-dsl/simple-query-string-query.asciidoc
+++ b/docs/reference/query-dsl/simple-query-string-query.asciidoc
@@ -86,9 +86,10 @@ query string into tokens. Defaults to the
 `default_field`. If no analyzer is mapped, the index's default analyzer is used.
 
 `auto_generate_synonyms_phrase_query`::
-(Optional, Boolean) If `true`, <<query-dsl-match-query-phrase,match phrase>>
-queries are automatically created for multi-term synonyms. Defaults to `true`.
-See <<simple-query-string-synonyms>> for an example.
+(Optional, Boolean) If `true`, the parser creates a
+<<query-dsl-match-query-phrase,`match_phrase`>> query for each
+<<token-graphs-multi-position-tokens,multi-position token>>. Defaults to `true`.
+For examples, see <<simple-query-string-synonyms>>.
 
 `flags`::
 (Optional, string) List of enabled operators for the
@@ -273,33 +274,39 @@ GET /_search
 <1> The `subject` field is three times as important as the `message` field.
 
 [[simple-query-string-synonyms]]
-===== Synonyms
+===== Multi-position tokens
 
-The `simple_query_string` query supports multi-terms synonym expansion with the <<analysis-synonym-graph-tokenfilter,
-synonym_graph>> token filter. When this filter is used, the parser creates a phrase query for each multi-terms synonyms.
-For example, the following synonym: `"ny, new york"` would produce:
+The `simple_query_string` query supports
+<<token-graphs-multi-position-tokens,multi-position tokens>> produced by graph
+token filters, such as <<analysis-synonym-graph-tokenfilter,`synonym_graph`>> or
+<<analysis-word-delimiter-graph-tokenfilter,`word_delimiter_graph`>>.
+
+By default, the parser creates a <<query-dsl-match-query-phrase,`match_phrase`>>
+query for each multi-position token. For example, the parser creates a
+`match_phrase` query for the multi-word synonym `ny, new york`:
 
 `(ny OR ("new york"))`
 
-It is also possible to match multi terms synonyms with conjunctions instead:
+To match multi-position tokens with an `AND` conjunction instead, set
+`auto_generate_synonyms_phrase_query` to `false`:
 
 [source,console]
---------------------------------------------------
+----
 GET /_search
 {
-   "query": {
-       "simple_query_string" : {
-           "query" : "ny city",
-           "auto_generate_synonyms_phrase_query" : false
-       }
-   }
+  "query": {
+    "simple_query_string": {
+      "query": "ny city",
+      "auto_generate_synonyms_phrase_query": false
+    }
+  }
 }
---------------------------------------------------
+----
 
-The example above creates a boolean query:
+For the above example, the parser creates the following
+<<query-dsl-bool-query,`bool`>> query:
 
 `(ny OR (new AND york)) city)`
 
-that matches documents with the term `ny` or the conjunction `new AND york`.
-By default the parameter `auto_generate_synonyms_phrase_query` is set to `true`.
-
+This `bool` query matches documents with the term `ny` or the conjunction
+`new AND york`.

--- a/docs/reference/query-dsl/simple-query-string-query.asciidoc
+++ b/docs/reference/query-dsl/simple-query-string-query.asciidoc
@@ -277,9 +277,10 @@ GET /_search
 ===== Multi-position tokens
 
 By default, the `simple_query_string` query parser creates a
-<<query-dsl-match-query-phrase,`match_phrase`>> query for
-<<token-graphs-multi-position-tokens,multi-position tokens>>. For example, the
-parser creates a `match_phrase` query for the multi-word synonym `ny, new york`:
+<<query-dsl-match-query-phrase,`match_phrase`>> query for each
+<<token-graphs-multi-position-tokens,multi-position token>> in the query string.
+For example, the parser creates a `match_phrase` query for the multi-word
+synonym `ny, new york`:
 
 `(ny OR ("new york"))`
 

--- a/docs/reference/query-dsl/simple-query-string-query.asciidoc
+++ b/docs/reference/query-dsl/simple-query-string-query.asciidoc
@@ -277,9 +277,7 @@ GET /_search
 ===== Multi-position tokens
 
 The `simple_query_string` query supports
-<<token-graphs-multi-position-tokens,multi-position tokens>> produced by graph
-token filters, such as <<analysis-synonym-graph-tokenfilter,`synonym_graph`>> or
-<<analysis-word-delimiter-graph-tokenfilter,`word_delimiter_graph`>>.
+<<token-graphs-multi-position-tokens,multi-position tokens>>.
 
 By default, the parser creates a <<query-dsl-match-query-phrase,`match_phrase`>>
 query for each multi-position token. For example, the parser creates a

--- a/docs/reference/query-dsl/simple-query-string-query.asciidoc
+++ b/docs/reference/query-dsl/simple-query-string-query.asciidoc
@@ -277,11 +277,10 @@ GET /_search
 ===== Multi-position tokens
 
 The `simple_query_string` query supports
-<<token-graphs-multi-position-tokens,multi-position tokens>>.
-
-By default, the parser creates a <<query-dsl-match-query-phrase,`match_phrase`>>
-query for each multi-position token. For example, the parser creates a
-`match_phrase` query for the multi-word synonym `ny, new york`:
+<<token-graphs-multi-position-tokens,multi-position tokens>>. By default, the
+parser creates a <<query-dsl-match-query-phrase,`match_phrase`>> query for each
+multi-position token. For example, the parser creates a `match_phrase` query for
+the multi-word synonym `ny, new york`:
 
 `(ny OR ("new york"))`
 

--- a/docs/reference/query-dsl/simple-query-string-query.asciidoc
+++ b/docs/reference/query-dsl/simple-query-string-query.asciidoc
@@ -276,11 +276,10 @@ GET /_search
 [[simple-query-string-synonyms]]
 ===== Multi-position tokens
 
-The `simple_query_string` query supports
-<<token-graphs-multi-position-tokens,multi-position tokens>>. By default, the
-parser creates a <<query-dsl-match-query-phrase,`match_phrase`>> query for each
-multi-position token. For example, the parser creates a `match_phrase` query for
-the multi-word synonym `ny, new york`:
+By default, the `simple_query_string` query parser creates a
+<<query-dsl-match-query-phrase,`match_phrase`>> query for
+<<token-graphs-multi-position-tokens,multi-position tokens>>. For example, the
+parser creates a `match_phrase` query for the multi-word synonym `ny, new york`:
 
 `(ny OR ("new york"))`
 


### PR DESCRIPTION
As noted in #68720, the simply query string query's `simple_query_string` works for all multi-position tokens, not just multi-word synonyms.

### Previews
- Multi-position tokens: https://elasticsearch_68753.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/token-graphs.html#token-graphs-multi-position-tokens
- Simple query string query: https://elasticsearch_68753.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/query-dsl-simple-query-string-query.html#simple-query-string-synonyms