### PR TITLE
[DOCS] Reuse ILM rollup action config

### DIFF
--- a/docs/reference/ilm/actions/ilm-rollup.asciidoc
+++ b/docs/reference/ilm/actions/ilm-rollup.asciidoc
@@ -7,30 +7,58 @@ Phases allowed: hot, cold.
 Aggregates an index's time series data and stores the results in a new read-only
 index. For example, you can roll up hourly data into daily or weekly summaries.
 
-For more information about rollup, see the <<rollup-api, rollup action documentation>>.
+This action corresponds to the <<rollup-api,rollup API>>. The name of the
+resulting rollup index is `rollup-<original-index-name>`. If {ilm-init} performs
+the `rollup` action on a backing index for a data stream, the rollup index is a
+backing index for the same stream.
 
-The name of the rolled up index will be the original index name of the managed index prefixed
-with `rollup-`.
+To use the `rollup` action in the hot phase, the <<ilm-rollover,`rollover`>>
+action must be present. If no `rollover` action is configured, {ilm-init} will
+reject the policy.
 
+[role="child_attributes"]
 [[ilm-rollup-options]]
 ==== Options
 
 `config`::
 (Required, object)
-The rollup configuration, a more detailed description of the
-rollup configuration specification can be found <<rollup-api-request-body,here>>.
+Configures the rollup action.
++
+.Properties of `config`
+[%collapsible%open]
+====
+include::{es-repo-dir}/rollup/apis/rollup-api.asciidoc[tag=rollup-config]
+====
 
 `rollup_policy`::
 (Optional, string)
-The name of an <<index-lifecycle-management, {ilm}>> ({ilm-init}) policy to associate
-with the newly created rollup index.
+Lifecycle policy for the resulting rollup index. If you don't specify a policy,
+{ilm-init} will not manage the rollup index.
 
 [[ilm-rollup-ex]]
 ==== Example
 
+////
 [source,console]
 ----
-PUT _ilm/policy/my_policy
+PUT _ilm/policy/my-rollup-ilm-policy
+{
+  "policy": {
+    "phases": {
+      "delete": {
+        "actions": {
+          "delete" : { }
+        }
+      }
+    }
+  }
+}
+----
+////
+
+[source,console]
+----
+PUT _ilm/policy/my-policy
 {
   "policy": {
     "phases": {
@@ -46,13 +74,14 @@ PUT _ilm/policy/my_policy
               },
               "metrics": [
                 {
-                  "field": "temperature",
+                  "field": "my-numeric-field",
                   "metrics": [
                     "avg"
                   ]
                 }
               ]
-            }
+            },
+            "rollup_policy": "my-rollup-ilm-policy"
           }
         }
       }
@@ -60,3 +89,4 @@ PUT _ilm/policy/my_policy
   }
 }
 ----
+// TEST[continued]

--- a/docs/reference/rollup/apis/rollup-api.asciidoc
+++ b/docs/reference/rollup/apis/rollup-api.asciidoc
@@ -82,6 +82,7 @@ for the same stream.
 [[rollup-api-request-body]]
 ==== {api-request-body-title}
 
+// tag::rollup-config[]
 `groups`::
 (Required, object)
 Aggregates and stores fields in the rollup.
@@ -193,6 +194,7 @@ stores both the `sum` and `value_count` values. This lets you accurately average
 rollups over larger time intervals. For example, you can accurately roll up
 hourly averages into daily averages.
 =====
+// end::rollup-config[]
 
 `page_size`::
 (Optional, integer)


### PR DESCRIPTION
Updates the `rollup` ILM action docs to reuse parameters from the rollup API.