### PR TITLE
Relax checks on mappings or settings updates

### DIFF
--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/TokenBackwardsCompatibilityIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/TokenBackwardsCompatibilityIT.java
@@ -36,7 +36,7 @@ public class TokenBackwardsCompatibilityIT extends AbstractUpgradeTestCase {
     private Collection<RestClient> twoClients = null;
 
     @Before
-    private void collectClientsByVersion() throws IOException {
+    public void collectClientsByVersion() throws IOException {
         Map<Version, RestClient> clientsByVersion = getRestClientByVersion();
         if (clientsByVersion.size() == 2) {
             // usual case, clients have different versions
@@ -52,7 +52,7 @@ public class TokenBackwardsCompatibilityIT extends AbstractUpgradeTestCase {
     }
 
     @After
-    private void closeClientsByVersion() throws IOException {
+    public void closeClientsByVersion() throws IOException {
         for (RestClient client : twoClients) {
             client.close();
         }
@@ -394,6 +394,9 @@ public class TokenBackwardsCompatibilityIT extends AbstractUpgradeTestCase {
                 "    \"password\": \"" + password + "\",\n" +
                 "    \"grant_type\": \"password\"\n" +
                 "}");
+        createTokenRequest.setOptions(RequestOptions.DEFAULT.toBuilder()
+            .setWarningsHandler(warnings ->
+                warnings.size() > 1 || warnings.get(0).contains("system indices can only use mappings from their descriptors") == false));
         Response response = client().performRequest(createTokenRequest);
         assertOK(response);
         return entityAsMap(response);
@@ -426,6 +429,9 @@ public class TokenBackwardsCompatibilityIT extends AbstractUpgradeTestCase {
                 "    \"refresh_token\": \"" + refreshToken + "\",\n" +
                 "    \"grant_type\": \"refresh_token\"\n" +
                 "}");
+        refreshTokenRequest.setOptions(RequestOptions.DEFAULT.toBuilder()
+            .setWarningsHandler(warnings ->
+                warnings.size() > 1 || warnings.get(0).contains("system indices can only use mappings from their descriptors") == false));
         Response refreshResponse = client.performRequest(refreshTokenRequest);
         assertOK(refreshResponse);
         return entityAsMap(refreshResponse);

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/TokenBackwardsCompatibilityIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/TokenBackwardsCompatibilityIT.java
@@ -394,9 +394,14 @@ public class TokenBackwardsCompatibilityIT extends AbstractUpgradeTestCase {
                 "    \"password\": \"" + password + "\",\n" +
                 "    \"grant_type\": \"password\"\n" +
                 "}");
-        createTokenRequest.setOptions(RequestOptions.DEFAULT.toBuilder()
-            .setWarningsHandler(warnings ->
-                warnings.size() > 1 || warnings.get(0).contains("system indices can only use mappings from their descriptors") == false));
+        createTokenRequest.setOptions(
+            RequestOptions.DEFAULT.toBuilder()
+                .setWarningsHandler(
+                    warnings -> warnings.isEmpty() == false
+                        && (warnings.size() > 1
+                            || warnings.get(0).contains("system indices can only use mappings from their descriptors") == false)
+                )
+        );
         Response response = client().performRequest(createTokenRequest);
         assertOK(response);
         return entityAsMap(response);
@@ -429,9 +434,14 @@ public class TokenBackwardsCompatibilityIT extends AbstractUpgradeTestCase {
                 "    \"refresh_token\": \"" + refreshToken + "\",\n" +
                 "    \"grant_type\": \"refresh_token\"\n" +
                 "}");
-        refreshTokenRequest.setOptions(RequestOptions.DEFAULT.toBuilder()
-            .setWarningsHandler(warnings ->
-                warnings.size() > 1 || warnings.get(0).contains("system indices can only use mappings from their descriptors") == false));
+        refreshTokenRequest.setOptions(
+            RequestOptions.DEFAULT.toBuilder()
+                .setWarningsHandler(
+                    warnings -> warnings.isEmpty() == false
+                        && (warnings.size() > 1
+                            || warnings.get(0).contains("system indices can only use mappings from their descriptors") == false)
+                )
+        );
         Response refreshResponse = client.performRequest(refreshTokenRequest);
         assertOK(refreshResponse);
         return entityAsMap(refreshResponse);


### PR DESCRIPTION
Closes #68757.

The strict checks of overriding mappings or settings updates is causing
various BWC problems, so relax them to deprecation messages in 7.x