### PR TITLE
Adds retention policy to HLRC put transform API

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/transform/transforms/TransformConfigUpdate.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/transform/transforms/TransformConfigUpdate.java
@@ -15,7 +15,6 @@ import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.common.xcontent.XContentParserUtils;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -40,7 +39,8 @@ public class TransformConfigUpdate implements ToXContentObject {
             SyncConfig syncConfig = (SyncConfig) args[3];
             String description = (String) args[4];
             SettingsConfig settings = (SettingsConfig) args[5];
-            return new TransformConfigUpdate(source, dest, frequency, syncConfig, description, settings);
+            RetentionPolicyConfig retentionPolicyConfig = (RetentionPolicyConfig) args[6];
+            return new TransformConfigUpdate(source, dest, frequency, syncConfig, description, settings, retentionPolicyConfig);
         }
     );
 
@@ -48,17 +48,14 @@ public class TransformConfigUpdate implements ToXContentObject {
         PARSER.declareObject(optionalConstructorArg(), (p, c) -> SourceConfig.PARSER.apply(p, null), TransformConfig.SOURCE);
         PARSER.declareObject(optionalConstructorArg(), (p, c) -> DestConfig.PARSER.apply(p, null), TransformConfig.DEST);
         PARSER.declareString(optionalConstructorArg(), TransformConfig.FREQUENCY);
-        PARSER.declareObject(optionalConstructorArg(), (p, c) -> parseSyncConfig(p), TransformConfig.SYNC);
+        PARSER.declareNamedObject(optionalConstructorArg(), (p, c, n) -> p.namedObject(SyncConfig.class, n, c), TransformConfig.SYNC);
         PARSER.declareString(optionalConstructorArg(), TransformConfig.DESCRIPTION);
         PARSER.declareObject(optionalConstructorArg(), (p, c) -> SettingsConfig.fromXContent(p), TransformConfig.SETTINGS);
-    }
-
-    private static SyncConfig parseSyncConfig(XContentParser parser) throws IOException {
-        XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
-        XContentParserUtils.ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.nextToken(), parser);
-        SyncConfig syncConfig = parser.namedObject(SyncConfig.class, parser.currentName(), false);
-        XContentParserUtils.ensureExpectedToken(XContentParser.Token.END_OBJECT, parser.nextToken(), parser);
-        return syncConfig;
+        PARSER.declareNamedObject(
+            optionalConstructorArg(),
+            (p, c, n) -> p.namedObject(RetentionPolicyConfig.class, n, c),
+            TransformConfig.RETENTION_POLICY
+        );
     }
 
     private final SourceConfig source;
@@ -74,7 +71,8 @@ public class TransformConfigUpdate implements ToXContentObject {
         final TimeValue frequency,
         final SyncConfig syncConfig,
         final String description,
-        final SettingsConfig settings
+        final SettingsConfig settings,
+        final RetentionPolicyConfig retentionPolicyConfig
     ) {
         this.source = source;
         this.dest = dest;
@@ -184,6 +182,7 @@ public class TransformConfigUpdate implements ToXContentObject {
         private SyncConfig syncConfig;
         private String description;
         private SettingsConfig settings;
+        private RetentionPolicyConfig retentionPolicyConfig;
 
         public Builder setSource(SourceConfig source) {
             this.source = source;
@@ -215,8 +214,13 @@ public class TransformConfigUpdate implements ToXContentObject {
             return this;
         }
 
+        public Builder setRetentionPolicyConfig(RetentionPolicyConfig retentionPolicyConfig) {
+            this.retentionPolicyConfig = retentionPolicyConfig;
+            return this;
+        }
+
         public TransformConfigUpdate build() {
-            return new TransformConfigUpdate(source, dest, frequency, syncConfig, description, settings);
+            return new TransformConfigUpdate(source, dest, frequency, syncConfig, description, settings, retentionPolicyConfig);
         }
     }
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/TransformDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/TransformDocumentationIT.java
@@ -268,6 +268,10 @@ public class TransformDocumentationIT extends ESRestHighLevelClientTestCase {
                 .setDelay(TimeValue.timeValueSeconds(120))
                 .build()) // <4>
             .setDescription("This is my updated transform") // <5>
+            .setRetentionPolicyConfig(TimeRetentionPolicyConfig.builder()
+                .setField("time-field")
+                .setMaxAge(TimeValue.timeValueDays(30))
+                .build()) // <6>
             .build();
         // end::update-transform-config
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/transform/transforms/TransformConfigUpdateTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/transform/transforms/TransformConfigUpdateTests.java
@@ -23,6 +23,8 @@ import java.util.List;
 import static org.elasticsearch.client.transform.transforms.DestConfigTests.randomDestConfig;
 import static org.elasticsearch.client.transform.transforms.SettingsConfigTests.randomSettingsConfig;
 import static org.elasticsearch.client.transform.transforms.SourceConfigTests.randomSourceConfig;
+import static org.elasticsearch.client.transform.transforms.TransformConfigTests.randomRetentionPolicyConfig;
+import static org.elasticsearch.client.transform.transforms.TransformConfigTests.randomSyncConfig;
 
 public class TransformConfigUpdateTests extends AbstractXContentTestCase<TransformConfigUpdate> {
 
@@ -33,12 +35,9 @@ public class TransformConfigUpdateTests extends AbstractXContentTestCase<Transfo
             randomBoolean() ? null : TimeValue.timeValueMillis(randomIntBetween(1_000, 3_600_000)),
             randomBoolean() ? null : randomSyncConfig(),
             randomBoolean() ? null : randomAlphaOfLengthBetween(1, 1000),
-            randomBoolean() ? null : randomSettingsConfig()
+            randomBoolean() ? null : randomSettingsConfig(),
+            randomBoolean() ? null : randomRetentionPolicyConfig()
         );
-    }
-
-    public static SyncConfig randomSyncConfig() {
-        return TimeSyncConfigTests.randomTimeSyncConfig();
     }
 
     @Override

--- a/docs/java-rest/high-level/transform/put_transform.asciidoc
+++ b/docs/java-rest/high-level/transform/put_transform.asciidoc
@@ -39,9 +39,12 @@ include-tagged::{doc-tests-file}[{api}-config]
 <1> The {transform} ID
 <2> The source indices and query from which to gather data
 <3> The destination index and optional pipeline
-<4> How often to check for updates to the source indices
+<4> Optional, indicates how often to check for updates to the source indices
 <5> The PivotConfig
 <6> Optional free text description of the {transform}
+<7> Optional {transform} settings
+<8> Optional retention policy for the data in the destination index
+<9> Details required only when the {transform} runs continuously
 
 [id="{upid}-{api}-query-config"]
 
@@ -112,6 +115,18 @@ include-tagged::{doc-tests-file}[{api}-agg-config]
 --------------------------------------------------
 <1> Aggregate the average star rating
 
+===== RetentionPolicyConfig
+
+Defines a retention policy for the {transform}. Data that meets the defined
+criteria is deleted from the destination index.
+
+["source","java",subs="attributes,callouts,macros"]
+--------------------------------------------------
+include-tagged::{doc-tests-file}[{api}-retention-policy-config]
+--------------------------------------------------
+<1> The date field that is used to calculate the age of the document.
+<2> Specifies the maximum age of a document in the destination index.
+
 ===== SettingsConfig
 
 Defines settings.
@@ -123,6 +138,18 @@ include-tagged::{doc-tests-file}[{api}-settings-config]
 <1> The maximum paging size for the {transform} when pulling data
 from the source. The size dynamically adjusts as the {transform}
 is running to recover from and prevent OOM issues.
+
+===== SyncConfig
+
+Defines the properties {transforms} require to run continuously.
+
+["source","java",subs="attributes,callouts,macros"]
+--------------------------------------------------
+include-tagged::{doc-tests-file}[{api}-sync-config]
+--------------------------------------------------
+<1> The date field that is used to identify new documents in the source.
+<2> The time delay between the current time and the latest input data time.
+
 
 include::../execution.asciidoc[]
 

--- a/docs/java-rest/high-level/transform/update_transform.asciidoc
+++ b/docs/java-rest/high-level/transform/update_transform.asciidoc
@@ -42,7 +42,7 @@ include-tagged::{doc-tests-file}[{api}-config]
 <3> How often to check for updates to the source indices.
 <4> How to keep the {transform} in sync with incoming data.
 <5> Optional free text description of the {transform}.
-<5> Optional retention policy for the data in the destination index
+<6> Optional retention policy for the data in the destination index
 
 include::../execution.asciidoc[]
 

--- a/docs/java-rest/high-level/transform/update_transform.asciidoc
+++ b/docs/java-rest/high-level/transform/update_transform.asciidoc
@@ -42,6 +42,7 @@ include-tagged::{doc-tests-file}[{api}-config]
 <3> How often to check for updates to the source indices.
 <4> How to keep the {transform} in sync with incoming data.
 <5> Optional free text description of the {transform}.
+<5> Optional retention policy for the data in the destination index
 
 include::../execution.asciidoc[]
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfigUpdate.java
@@ -16,7 +16,6 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.common.xcontent.XContentParserUtils;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xpack.core.transform.TransformField;
 import org.elasticsearch.xpack.core.transform.TransformMessages;
@@ -56,26 +55,14 @@ public class TransformConfigUpdate implements Writeable {
         PARSER.declareObject(optionalConstructorArg(), (p, c) -> SourceConfig.fromXContent(p, false), TransformField.SOURCE);
         PARSER.declareObject(optionalConstructorArg(), (p, c) -> DestConfig.fromXContent(p, false), TransformField.DESTINATION);
         PARSER.declareString(optionalConstructorArg(), TransformField.FREQUENCY);
-        PARSER.declareObject(optionalConstructorArg(), (p, c) -> parseSyncConfig(p), TransformField.SYNC);
+        PARSER.declareNamedObject(optionalConstructorArg(), (p, c, n) -> p.namedObject(SyncConfig.class, n, c), TransformField.SYNC);
         PARSER.declareString(optionalConstructorArg(), TransformField.DESCRIPTION);
         PARSER.declareObject(optionalConstructorArg(), (p, c) -> SettingsConfig.fromXContent(p, false), TransformField.SETTINGS);
-        PARSER.declareObject(optionalConstructorArg(), (p, c) -> parseRetentionPolicyConfig(p), TransformField.RETENTION_POLICY);
-    }
-
-    private static SyncConfig parseSyncConfig(XContentParser parser) throws IOException {
-        XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
-        XContentParserUtils.ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.nextToken(), parser);
-        SyncConfig syncConfig = parser.namedObject(SyncConfig.class, parser.currentName(), false);
-        XContentParserUtils.ensureExpectedToken(XContentParser.Token.END_OBJECT, parser.nextToken(), parser);
-        return syncConfig;
-    }
-
-    private static RetentionPolicyConfig parseRetentionPolicyConfig(XContentParser parser) throws IOException {
-        XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
-        XContentParserUtils.ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.nextToken(), parser);
-        RetentionPolicyConfig retentionPolicyConfig = parser.namedObject(RetentionPolicyConfig.class, parser.currentName(), true);
-        XContentParserUtils.ensureExpectedToken(XContentParser.Token.END_OBJECT, parser.nextToken(), parser);
-        return retentionPolicyConfig;
+        PARSER.declareNamedObject(
+            optionalConstructorArg(),
+            (p, c, n) -> p.namedObject(RetentionPolicyConfig.class, n, c),
+            TransformField.RETENTION_POLICY
+        );
     }
 
     private final SourceConfig source;


### PR DESCRIPTION
This PR must be merged after https://github.com/elastic/elasticsearch/pull/68728

It adds the configuration examples for syncConfig and retentionPolicyConfig to the put transform API and the update transform API (e.g. https://www.elastic.co/guide/en/elasticsearch/client/java-rest/master/java-rest-high-put-transform.html)


### Preview

https://elasticsearch_68768.docs-preview.app.elstc.co/guide/en/elasticsearch/client/java-rest/master/java-rest-high-put-transform.html
https://elasticsearch_68768.docs-preview.app.elstc.co/guide/en/elasticsearch/client/java-rest/master/java-rest-high-update-transform.html