### PR TITLE
Add StepListener#addListener

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
@@ -142,7 +142,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
         final PlainActionFuture<Collection<AcknowledgedResponse>> allDeletesDone = new PlainActionFuture<>();
         final ActionListener<AcknowledgedResponse> deletesListener = new GroupedActionListener<>(allDeletesDone, deleteFutures.size());
         for (StepListener<AcknowledgedResponse> deleteFuture : deleteFutures) {
-            deleteFuture.whenComplete(deletesListener::onResponse, deletesListener::onFailure);
+            deleteFuture.addListener(deletesListener);
         }
         allDeletesDone.get();
 

--- a/server/src/main/java/org/elasticsearch/action/StepListener.java
+++ b/server/src/main/java/org/elasticsearch/action/StepListener.java
@@ -66,7 +66,7 @@ public final class StepListener<Response> extends NotifyOnceListener<Response> {
      * @param onFailure  is called when this step is completed with a failure
      */
     public void whenComplete(CheckedConsumer<Response, Exception> onResponse, Consumer<Exception> onFailure) {
-        delegate.addListener(ActionListener.wrap(onResponse, onFailure), EsExecutors.newDirectExecutorService(), null);
+        addListener(ActionListener.wrap(onResponse, onFailure));
     }
 
     /**
@@ -100,4 +100,12 @@ public final class StepListener<Response> extends NotifyOnceListener<Response> {
         }
         return FutureUtils.get(delegate, 0L, TimeUnit.NANOSECONDS); // this future is done already - use a non-blocking method.
     }
+
+    /**
+     * Registers the given listener to be notified with the result of this step.
+     */
+    public void addListener(ActionListener<Response> listener) {
+        delegate.addListener(listener, EsExecutors.newDirectExecutorService());
+    }
+
 }

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -583,7 +583,7 @@ public class RecoverySourceHandler {
                         new ThreadedActionListener<>(logger, shard.getThreadPool(),
                             ThreadPool.Names.GENERIC, cloneRetentionLeaseStep, false));
                     logger.trace("cloned primary's retention lease as [{}]", clonedLease);
-                    cloneRetentionLeaseStep.whenComplete(rr -> listener.onResponse(clonedLease), listener::onFailure);
+                    cloneRetentionLeaseStep.addListener(listener.map(rr -> clonedLease));
                 } catch (RetentionLeaseNotFoundException e) {
                     // it's possible that the primary has no retention lease yet if we are doing a rolling upgrade from a version before
                     // 7.4, and in that case we just create a lease using the local checkpoint of the safe commit which we're using for
@@ -595,7 +595,7 @@ public class RecoverySourceHandler {
                     final RetentionLease newLease = shard.addPeerRecoveryRetentionLease(request.targetNode().getId(),
                         estimatedGlobalCheckpoint, new ThreadedActionListener<>(logger, shard.getThreadPool(),
                             ThreadPool.Names.GENERIC, addRetentionLeaseStep, false));
-                    addRetentionLeaseStep.whenComplete(rr -> listener.onResponse(newLease), listener::onFailure);
+                    addRetentionLeaseStep.addListener(listener.map(rr -> newLease));
                     logger.trace("created retention lease with estimated checkpoint of [{}]", estimatedGlobalCheckpoint);
                 }
             }, shardId + " establishing retention lease for [" + request.targetAllocationId() + "]",

--- a/server/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
@@ -158,11 +158,11 @@ public class RepositoriesService extends AbstractLifecycleComponent implements C
 
             // Finally respond to the outer listener with the response from the original cluster state update
             updateRepoUuidStep.whenComplete(
-                    ignored -> acknowledgementStep.whenComplete(listener::onResponse, listener::onFailure),
+                    ignored -> acknowledgementStep.addListener(listener),
                     listener::onFailure);
 
         } else {
-            acknowledgementStep.whenComplete(listener::onResponse, listener::onFailure);
+            acknowledgementStep.addListener(listener);
         }
 
         clusterService.submitStateUpdateTask("put_repository [" + request.name() + "]",

--- a/server/src/main/java/org/elasticsearch/tasks/TaskCancellationService.java
+++ b/server/src/main/java/org/elasticsearch/tasks/TaskCancellationService.java
@@ -98,7 +98,7 @@ public class TaskCancellationService {
             });
             StepListener<Void> setBanListener = new StepListener<>();
             setBanOnChildConnections(reason, waitForCompletion, task, childConnections, setBanListener);
-            setBanListener.whenComplete(groupedListener::onResponse, groupedListener::onFailure);
+            setBanListener.addListener(groupedListener);
             // If we start unbanning when the last child task completed and that child task executed with a specific user, then unban
             // requests are denied because internal requests can't run with a user. We need to remove bans with the current thread context.
             final Runnable removeBansRunnable = transportService.getThreadPool().getThreadContext()
@@ -108,9 +108,9 @@ public class TaskCancellationService {
             // if wait_for_completion is true, then only return when (1) bans are placed on child connections, (2) child tasks are
             // completed or failed, (3) the main task is cancelled. Otherwise, return after bans are placed on child connections.
             if (waitForCompletion) {
-                completedListener.whenComplete(r -> listener.onResponse(null), listener::onFailure);
+                completedListener.addListener(listener);
             } else {
-                setBanListener.whenComplete(r -> listener.onResponse(null), listener::onFailure);
+                setBanListener.addListener(listener);
             }
         } else {
             logger.trace("task [{}] doesn't have any children that should be cancelled", taskId);

--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -2744,7 +2744,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         }
         responseListener.whenComplete(handler::handleResponse, e -> handler.handleException((TransportException) e));
         final PlainActionFuture<T> future = PlainActionFuture.newFuture();
-        responseListener.whenComplete(future::onResponse, future::onFailure);
+        responseListener.addListener(future);
         return future;
     }
 }

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/SearchableSnapshotDirectory.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/SearchableSnapshotDirectory.java
@@ -495,7 +495,7 @@ public class SearchableSnapshotDirectory extends BaseDirectory {
                 final int numberOfParts = file.numberOfParts();
                 final StepListener<Collection<Void>> fileCompletionListener = new StepListener<>();
                 fileCompletionListener.whenComplete(voids -> input.close(), e -> IOUtils.closeWhileHandlingException(input));
-                fileCompletionListener.whenComplete(voids -> completionListener.onResponse(null), completionListener::onFailure);
+                fileCompletionListener.addListener(completionListener.map(voids -> null));
 
                 final GroupedActionListener<Void> partsListener = new GroupedActionListener<>(fileCompletionListener, numberOfParts);
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationService.java
@@ -380,7 +380,7 @@ public class AuthorizationService {
                 prevListener = current;
             }
 
-            prevListener.whenComplete(v -> listener.onResponse(null), listener::onFailure);
+            prevListener.addListener(listener);
             first.intercept(requestInfo, authorizationEngine, authorizationInfo, firstStepListener);
         }
     }


### PR DESCRIPTION
A common pattern today is to set up a sequence of `StepListener` objects
which ultimately notify an outer `ActionListener`. Today we do this as
follows:

    step.whenComplete(listener::onResponse, listener::onFailure);

Since this is such a common pattern, this commit exposes a method that
that adds the listener directly.