### PR TITLE
Read CCR changes from translog when possible

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -2507,6 +2507,12 @@ public class InternalEngine extends Engine {
     public Translog.Snapshot newChangesSnapshot(String source,
                                                 long fromSeqNo, long toSeqNo, boolean requiredFullRange) throws IOException {
         ensureOpen();
+        if (requiredFullRange) {
+            final Translog.Snapshot snapshot = translog.newChangesSnapshot(fromSeqNo, toSeqNo);
+            if (snapshot != null) {
+                return snapshot;
+            }
+        }
         refreshIfNeeded(source, toSeqNo);
         Searcher searcher = acquireSearcher(source, SearcherScope.INTERNAL);
         try {

--- a/server/src/main/java/org/elasticsearch/index/translog/BaseTranslogReader.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/BaseTranslogReader.java
@@ -78,9 +78,7 @@ public abstract class BaseTranslogReader implements Comparable<BaseTranslogReade
         return size;
     }
 
-    public TranslogSnapshot newSnapshot() {
-        return new TranslogSnapshot(this, sizeInBytes());
-    }
+    protected abstract TranslogSnapshot newSnapshot();
 
     /**
      * reads an operation at the given position and returns it. The buffer length is equal to the number

--- a/server/src/main/java/org/elasticsearch/index/translog/Translog.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/Translog.java
@@ -641,6 +641,9 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
         if (fromSeqNo < 0 || toSeqNo < 0 || fromSeqNo > toSeqNo) {
             throw new IllegalArgumentException("Invalid range; from_seqno [" + fromSeqNo + "], to_seqno [" + toSeqNo + "]");
         }
+        if (toSeqNo - fromSeqNo >= Integer.MAX_VALUE - 128) {
+            return null;
+        }
         try (ReleasableLock ignored = readLock.acquire()) {
             ensureOpen();
             final int size = Math.toIntExact(toSeqNo - fromSeqNo + 1);

--- a/server/src/test/java/org/elasticsearch/index/translog/TranslogDeletionPolicyTests.java
+++ b/server/src/test/java/org/elasticsearch/index/translog/TranslogDeletionPolicyTests.java
@@ -79,7 +79,8 @@ public class TranslogDeletionPolicyTests extends ESTestCase {
             }
             writer = TranslogWriter.create(new ShardId("index", "uuid", 0), translogUUID, gen,
                 tempDir.resolve(Translog.getFilename(gen)), FileChannel::open, TranslogConfig.DEFAULT_BUFFER_SIZE, 1L, 1L, () -> 1L,
-                () -> 1L, randomNonNegativeLong(), new TragicExceptionHolder(), seqNo -> {}, BigArrays.NON_RECYCLING_INSTANCE);
+                () -> 1L, randomNonNegativeLong(), new TragicExceptionHolder(), seqNo -> {}, BigArrays.NON_RECYCLING_INSTANCE,
+                ESTestCase::randomBoolean);
             writer = Mockito.spy(writer);
             byte[] bytes = new byte[4];
             ByteArrayDataOutput out = new ByteArrayDataOutput(bytes);


### PR DESCRIPTION
Superseded by #69315

I looked into several support cases where CCR on the leader cluster was taking a lot of CPUs. I ran several benchmarks of an append-only challenge with and without CCR. I found that CCR on the leader degraded the indexing throughput by more than 60%.

```        
                                                       Metric |    Baseline |   Contender |     Diff |   Unit
|-------------------------------------------------------------:|------------:|------------:|---------:|-------
|                   Cumulative indexing time of primary shards |     37.0305 |     105.252 |  68.2211 |    min
|            Min cumulative indexing time across primary shard |     7.19343 |     20.5952 |  13.4017 |    min
|         Median cumulative indexing time across primary shard |     7.40897 |     21.0276 |  13.6186 |    min
|            Max cumulative indexing time across primary shard |     7.69098 |     21.3481 |  13.6571 |    min
|          Cumulative indexing throttle time of primary shards |           0 |           0 |        0 |    min
|   Min cumulative indexing throttle time across primary shard |           0 |           0 |        0 |    min
|Median cumulative indexing throttle time across primary shard |           0 |           0 |        0 |    min
|   Max cumulative indexing throttle time across primary shard |           0 |           0 |        0 |    min
|                      Cumulative merge time of primary shards |     0.47225 |     7.17612 |  6.70387 |    min
|                     Cumulative merge count of primary shards |           7 |           8 |        1 |       
|               Min cumulative merge time across primary shard |   0.0289833 |   0.0409833 |    0.012 |    min
|            Median cumulative merge time across primary shard |   0.0471167 |     2.19387 |  2.14675 |    min
|               Max cumulative merge time across primary shard |    0.190817 |     2.60822 |   2.4174 |    min
|             Cumulative merge throttle time of primary shards |   0.0981833 |     1.16685 |  1.06867 |    min
|      Min cumulative merge throttle time across primary shard |           0 |           0 |        0 |    min
|   Median cumulative merge throttle time across primary shard |           0 |     0.35825 |  0.35825 |    min
|      Max cumulative merge throttle time across primary shard |   0.0529167 |    0.415783 |  0.36287 |    min
|                    Cumulative refresh time of primary shards |     0.59265 |     2.22127 |  1.62862 |    min
|                   Cumulative refresh count of primary shards |          72 |          81 |        9 |       
|             Min cumulative refresh time across primary shard |       0.107 |    0.318417 |  0.21142 |    min
|          Median cumulative refresh time across primary shard |    0.116933 |    0.437233 |   0.3203 |    min
|             Max cumulative refresh time across primary shard |    0.141017 |    0.553483 |  0.41247 |    min
|                      Cumulative flush time of primary shards |     5.36292 |     11.5855 |   6.2226 |    min
|                     Cumulative flush count of primary shards |          30 |          31 |        1 |       
|               Min cumulative flush time across primary shard |    0.982083 |      1.9158 |  0.93372 |    min
|            Median cumulative flush time across primary shard |     1.05153 |     2.27915 |  1.22762 |    min
|               Max cumulative flush time across primary shard |     1.25457 |      2.9223 |  1.66773 |    min
|                                      Total Young Gen GC time |       5.042 |      38.794 |   33.752 |      s
|                                     Total Young Gen GC count |         113 |        1534 |     1421 |       
|                                        Total Old Gen GC time |           0 |           0 |        0 |      s
|                                       Total Old Gen GC count |           0 |           0 |        0 |       
|                                                   Store size |     4.66407 |     5.80673 |  1.14266 |     GB
|                                                Translog size | 2.56114e-07 | 2.56114e-07 |        0 |     GB
|                                       Heap used for segments |    0.528534 |    0.613789 |  0.08525 |     MB
|                                     Heap used for doc values |   0.0420074 |   0.0842857 |  0.04228 |     MB
|                                          Heap used for terms |    0.414368 |    0.451263 |   0.0369 |     MB
|                                          Heap used for norms |           0 |           0 |        0 |     MB
|                                         Heap used for points |           0 |           0 |        0 |     MB
|                                  Heap used for stored fields |   0.0721588 |   0.0782394 |  0.00608 |     MB
|                                                Segment count |         146 |         159 |       13 |       
|                                               Min Throughput |     26675.8 |     10617.9 | -16057.9 | docs/s
|                                              Mean Throughput |       29539 |     11439.8 | -18099.2 | docs/s
|                                            Median Throughput |     29786.7 |     11465.1 | -18321.7 | docs/s
|                                               Max Throughput |     30484.4 |     11703.4 | -18780.9 | docs/s
|                                      50th percentile latency |     1097.85 |      3163.5 |  2065.66 |     ms
|                                      90th percentile latency |     1662.71 |     3954.71 |     2292 |     ms
|                                      99th percentile latency |     2882.04 |     6229.13 |  3347.09 |     ms
|                                    99.9th percentile latency |     10588.8 |     27692.5 |  17103.8 |     ms
|                                     100th percentile latency |     17046.4 |     36693.7 |  19647.3 |     ms
|                                 50th percentile service time |     1097.85 |      3163.5 |  2065.66 |     ms
|                                 90th percentile service time |     1662.71 |     3954.71 |     2292 |     ms
|                                 99th percentile service time |     2882.04 |     6229.13 |  3347.09 |     ms
|                               99.9th percentile service time |     10588.8 |     27692.5 |  17103.8 |     ms
|                                100th percentile service time |     17046.4 |     36693.7 |  19647.3 |     ms
|                                                   error rate |           0 |           0 |        0 |      %
```

Two reasons behind this degradation:

1. Reading [_source](https://github.com/elastic/elasticsearch/blob/b914994b40ec26bf8b593080f43bfc17d13b4068/server/src/main/java/org/elasticsearch/index/engine/LuceneChangesSnapshot.java#L221) is quite slow as it's stored in a compressed format (either Deflate or LZ4).
2. CCR requests can lead to a [refresh](https://github.com/elastic/elasticsearch/blob/b914994b40ec26bf8b593080f43bfc17d13b4068/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java#L2510) storm, and Lucene has to work hard to merge many small segments.


I revisited the idea that reads CCR changes from translog and falls back to Lucene if the requesting changes are not available in translog. Unlike the previous approach, we do not retain translog.

It's twice faster than the current code.

```
                                                       Metric |    Baseline |   Contender |     Diff |   Unit
-------------------------------------------------------------:|------------:|------------:|---------:|-------
                   Cumulative indexing time of primary shards |     105.252 |     39.0061 | -66.2455 |    min
            Min cumulative indexing time across primary shard |     20.5952 |     7.59745 | -12.9977 |    min
         Median cumulative indexing time across primary shard |     21.0276 |     7.75367 | -13.2739 |    min
            Max cumulative indexing time across primary shard |     21.3481 |     8.18155 | -13.1666 |    min
          Cumulative indexing throttle time of primary shards |           0 |           0 |        0 |    min
   Min cumulative indexing throttle time across primary shard |           0 |           0 |        0 |    min
Median cumulative indexing throttle time across primary shard |           0 |           0 |        0 |    min
   Max cumulative indexing throttle time across primary shard |           0 |           0 |        0 |    min
                      Cumulative merge time of primary shards |     7.17612 |     2.09103 | -5.08508 |    min
                     Cumulative merge count of primary shards |           8 |           9 |        1 |       
               Min cumulative merge time across primary shard |   0.0409833 |       0.028 | -0.01298 |    min
            Median cumulative merge time across primary shard |     2.19387 |   0.0780333 | -2.11583 |    min
               Max cumulative merge time across primary shard |     2.60822 |       1.014 | -1.59422 |    min
             Cumulative merge throttle time of primary shards |     1.16685 |    0.713933 | -0.45292 |    min
      Min cumulative merge throttle time across primary shard |           0 |           0 |        0 |    min
   Median cumulative merge throttle time across primary shard |     0.35825 |           0 | -0.35825 |    min
      Max cumulative merge throttle time across primary shard |    0.415783 |    0.371267 | -0.04452 |    min
                    Cumulative refresh time of primary shards |     2.22127 |    0.592383 | -1.62888 |    min
                   Cumulative refresh count of primary shards |          81 |          82 |        1 |       
             Min cumulative refresh time across primary shard |    0.318417 |   0.0986167 |  -0.2198 |    min
          Median cumulative refresh time across primary shard |    0.437233 |    0.122733 |  -0.3145 |    min
             Max cumulative refresh time across primary shard |    0.553483 |    0.133317 | -0.42017 |    min
                      Cumulative flush time of primary shards |     11.5855 |     5.13253 | -6.45298 |    min
                     Cumulative flush count of primary shards |          31 |          30 |       -1 |       
               Min cumulative flush time across primary shard |      1.9158 |    0.838017 | -1.07778 |    min
            Median cumulative flush time across primary shard |     2.27915 |     1.06353 | -1.21562 |    min
               Max cumulative flush time across primary shard |      2.9223 |     1.16002 | -1.76228 |    min
                                      Total Young Gen GC time |      38.794 |      12.941 |  -25.853 |      s
                                     Total Young Gen GC count |        1534 |         137 |    -1397 |       
                                        Total Old Gen GC time |           0 |           0 |        0 |      s
                                       Total Old Gen GC count |           0 |           0 |        0 |       
                                                   Store size |     5.80673 |     5.62528 | -0.18145 |     GB
                                                Translog size | 2.56114e-07 | 2.56114e-07 |        0 |     GB
                                       Heap used for segments |    0.613789 |    0.586887 |  -0.0269 |     MB
                                     Heap used for doc values |   0.0842857 |   0.0505028 | -0.03378 |     MB
                                          Heap used for terms |    0.451263 |     0.45694 |  0.00568 |     MB
                                          Heap used for norms |           0 |           0 |        0 |     MB
                                         Heap used for points |           0 |           0 |        0 |     MB
                                  Heap used for stored fields |   0.0782394 |   0.0794449 |  0.00121 |     MB
                                                Segment count |         159 |         161 |        2 |       
                                               Min Throughput |     10617.9 |     24676.2 |  14058.2 | docs/s
                                              Mean Throughput |     11439.8 |     27661.6 |  16221.8 | docs/s
                                            Median Throughput |     11465.1 |     27998.9 |  16533.8 | docs/s
                                               Max Throughput |     11703.4 |     28815.6 |  17112.2 | docs/s
                                      50th percentile latency |      3163.5 |     1178.58 | -1984.93 |     ms
                                      90th percentile latency |     3954.71 |     1812.31 | -2142.39 |     ms
                                      99th percentile latency |     6229.13 |     3219.79 | -3009.34 |     ms
                                    99.9th percentile latency |     27692.5 |     10835.6 |   -16857 |     ms
                                     100th percentile latency |     36693.7 |     11460.5 | -25233.2 |     ms
                                 50th percentile service time |      3163.5 |     1178.58 | -1984.93 |     ms
                                 90th percentile service time |     3954.71 |     1812.31 | -2142.39 |     ms
                                 99th percentile service time |     6229.13 |     3219.79 | -3009.34 |     ms
                               99.9th percentile service time |     27692.5 |     10835.6 |   -16857 |     ms
                                100th percentile service time |     36693.7 |     11460.5 | -25233.2 |     ms
                                                   error rate |           0 |           0 |        0 |      %
```

And it's only 5% slower than the test without CCR.

```
                                                       Metric |    Baseline |   Contender |     Diff |   Unit
-------------------------------------------------------------:|------------:|------------:|---------:|-------
                   Cumulative indexing time of primary shards |     37.0305 |     39.0061 |   1.9756 |    min
            Min cumulative indexing time across primary shard |     7.19343 |     7.59745 |  0.40402 |    min
         Median cumulative indexing time across primary shard |     7.40897 |     7.75367 |   0.3447 |    min
            Max cumulative indexing time across primary shard |     7.69098 |     8.18155 |  0.49057 |    min
          Cumulative indexing throttle time of primary shards |           0 |           0 |        0 |    min
   Min cumulative indexing throttle time across primary shard |           0 |           0 |        0 |    min
Median cumulative indexing throttle time across primary shard |           0 |           0 |        0 |    min
   Max cumulative indexing throttle time across primary shard |           0 |           0 |        0 |    min
                      Cumulative merge time of primary shards |     0.47225 |     2.09103 |  1.61878 |    min
                     Cumulative merge count of primary shards |           7 |           9 |        2 |       
               Min cumulative merge time across primary shard |   0.0289833 |       0.028 | -0.00098 |    min
            Median cumulative merge time across primary shard |   0.0471167 |   0.0780333 |  0.03092 |    min
               Max cumulative merge time across primary shard |    0.190817 |       1.014 |  0.82318 |    min
             Cumulative merge throttle time of primary shards |   0.0981833 |    0.713933 |  0.61575 |    min
      Min cumulative merge throttle time across primary shard |           0 |           0 |        0 |    min
   Median cumulative merge throttle time across primary shard |           0 |           0 |        0 |    min
      Max cumulative merge throttle time across primary shard |   0.0529167 |    0.371267 |  0.31835 |    min
                    Cumulative refresh time of primary shards |     0.59265 |    0.592383 | -0.00027 |    min
                   Cumulative refresh count of primary shards |          72 |          82 |       10 |       
             Min cumulative refresh time across primary shard |       0.107 |   0.0986167 | -0.00838 |    min
          Median cumulative refresh time across primary shard |    0.116933 |    0.122733 |   0.0058 |    min
             Max cumulative refresh time across primary shard |    0.141017 |    0.133317 |  -0.0077 |    min
                      Cumulative flush time of primary shards |     5.36292 |     5.13253 | -0.23038 |    min
                     Cumulative flush count of primary shards |          30 |          30 |        0 |       
               Min cumulative flush time across primary shard |    0.982083 |    0.838017 | -0.14407 |    min
            Median cumulative flush time across primary shard |     1.05153 |     1.06353 |    0.012 |    min
               Max cumulative flush time across primary shard |     1.25457 |     1.16002 | -0.09455 |    min
                                      Total Young Gen GC time |       5.042 |      12.941 |    7.899 |      s
                                     Total Young Gen GC count |         113 |         137 |       24 |       
                                        Total Old Gen GC time |           0 |           0 |        0 |      s
                                       Total Old Gen GC count |           0 |           0 |        0 |       
                                                   Store size |     4.66407 |     5.62528 |  0.96121 |     GB
                                                Translog size | 2.56114e-07 | 2.56114e-07 |        0 |     GB
                                       Heap used for segments |    0.528534 |    0.586887 |  0.05835 |     MB
                                     Heap used for doc values |   0.0420074 |   0.0505028 |   0.0085 |     MB
                                          Heap used for terms |    0.414368 |     0.45694 |  0.04257 |     MB
                                          Heap used for norms |           0 |           0 |        0 |     MB
                                         Heap used for points |           0 |           0 |        0 |     MB
                                  Heap used for stored fields |   0.0721588 |   0.0794449 |  0.00729 |     MB
                                                Segment count |         146 |         161 |       15 |       
                                               Min Throughput |     26675.8 |     24676.2 | -1999.69 | docs/s
                                              Mean Throughput |       29539 |     27661.6 | -1877.39 | docs/s
                                            Median Throughput |     29786.7 |     27998.9 | -1787.87 | docs/s
                                               Max Throughput |     30484.4 |     28815.6 | -1668.79 | docs/s
                                      50th percentile latency |     1097.85 |     1178.58 |    80.73 |     ms
                                      90th percentile latency |     1662.71 |     1812.31 |  149.604 |     ms
                                      99th percentile latency |     2882.04 |     3219.79 |  337.752 |     ms
                                    99.9th percentile latency |     10588.8 |     10835.6 |  246.817 |     ms
                                     100th percentile latency |     17046.4 |     11460.5 | -5585.87 |     ms
                                 50th percentile service time |     1097.85 |     1178.58 |    80.73 |     ms
                                 90th percentile service time |     1662.71 |     1812.31 |  149.604 |     ms
                                 99th percentile service time |     2882.04 |     3219.79 |  337.752 |     ms
                               99.9th percentile service time |     10588.8 |     10835.6 |  246.817 |     ms
                                100th percentile service time |     17046.4 |     11460.5 | -5585.87 |     ms
                                                   error rate |           0 |           0 |        0 |      %
```

I haven't made this PR production ready because I believe we are trying not to leverage translog for other purposes except for local recoveries. However, a counterargument is that we are using translog for realtime gets and updates because of performance reasons.

Once we agreed, I will make it production-ready.