### PR TITLE
Clarify what query components cross_fields supports

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/search/MatchQueryParser.java
+++ b/server/src/main/java/org/elasticsearch/index/search/MatchQueryParser.java
@@ -241,6 +241,8 @@ public class MatchQueryParser {
         assert analyzer != null;
 
         MatchQueryBuilder builder = new MatchQueryBuilder(analyzer, fieldType, enablePositionIncrements, autoGenerateSynonymsPhraseQuery);
+        String resolvedFieldName = fieldType.name();
+        String stringValue = value.toString();
 
         /*
          * If a keyword analyzer is used, we know that further analysis isn't
@@ -249,7 +251,7 @@ public class MatchQueryParser {
          * a prefix query instead
          */
         if (analyzer == Lucene.KEYWORD_ANALYZER && type != Type.PHRASE_PREFIX) {
-            final Term term = new Term(fieldType.name(), value.toString());
+            final Term term = new Term(resolvedFieldName, stringValue);
             if (type == Type.BOOLEAN_PREFIX
                     && (fieldType instanceof TextFieldMapper.TextFieldType || fieldType instanceof KeywordFieldMapper.KeywordFieldType)) {
                 return builder.newPrefixQuery(term);
@@ -261,16 +263,16 @@ public class MatchQueryParser {
         Query query;
         switch (type) {
             case BOOLEAN:
-                query = builder.createBooleanQuery(fieldName, value.toString(), occur);
+                query = builder.createBooleanQuery(resolvedFieldName, stringValue, occur);
                 break;
             case BOOLEAN_PREFIX:
-                query = builder.createBooleanPrefixQuery(fieldName, value.toString(), occur);
+                query = builder.createBooleanPrefixQuery(resolvedFieldName, stringValue, occur);
                 break;
             case PHRASE:
-                query = builder.createPhraseQuery(fieldName, value.toString(), phraseSlop);
+                query = builder.createPhraseQuery(resolvedFieldName, stringValue, phraseSlop);
                 break;
             case PHRASE_PREFIX:
-                query = builder.createPhrasePrefixQuery(fieldName, value.toString(), phraseSlop);
+                query = builder.createPhrasePrefixQuery(resolvedFieldName, stringValue, phraseSlop);
                 break;
             default:
                 throw new IllegalStateException("No type found for [" + type + "]");

--- a/server/src/main/java/org/elasticsearch/index/search/MatchQueryParser.java
+++ b/server/src/main/java/org/elasticsearch/index/search/MatchQueryParser.java
@@ -258,32 +258,23 @@ public class MatchQueryParser {
             }
         }
 
-        return parseInternal(type, fieldType.name(), builder, value);
-    }
-
-    protected final Query parseInternal(Type type, String fieldName, MatchQueryBuilder builder, Object value) throws IOException {
-        final Query query;
+        Query query;
         switch (type) {
             case BOOLEAN:
                 query = builder.createBooleanQuery(fieldName, value.toString(), occur);
                 break;
-
             case BOOLEAN_PREFIX:
                 query = builder.createBooleanPrefixQuery(fieldName, value.toString(), occur);
                 break;
-
             case PHRASE:
                 query = builder.createPhraseQuery(fieldName, value.toString(), phraseSlop);
                 break;
-
             case PHRASE_PREFIX:
                 query = builder.createPhrasePrefixQuery(fieldName, value.toString(), phraseSlop);
                 break;
-
             default:
                 throw new IllegalStateException("No type found for [" + type + "]");
         }
-
         return query == null ? zeroTermsQuery() : query;
     }
 

--- a/server/src/main/java/org/elasticsearch/index/search/MultiMatchQueryParser.java
+++ b/server/src/main/java/org/elasticsearch/index/search/MultiMatchQueryParser.java
@@ -132,7 +132,7 @@ public class MultiMatchQueryParser extends MatchQueryParser {
                 builder = new MatchQueryBuilder(group.getKey(), group.getValue().get(0).fieldType,
                     enablePositionIncrements, autoGenerateSynonymsPhraseQuery);
             } else {
-                builder = new BlendedQueryBuilder(group.getKey(), group.getValue(), tieBreaker,
+                builder = new CrossFieldsQueryBuilder(group.getKey(), group.getValue(), tieBreaker,
                     enablePositionIncrements, autoGenerateSynonymsPhraseQuery);
             }
 
@@ -163,11 +163,11 @@ public class MultiMatchQueryParser extends MatchQueryParser {
         return queries;
     }
 
-    private class BlendedQueryBuilder extends MatchQueryBuilder {
+    private class CrossFieldsQueryBuilder extends MatchQueryBuilder {
         private final List<FieldAndBoost> blendedFields;
         private final float tieBreaker;
 
-        BlendedQueryBuilder(Analyzer analyzer, List<FieldAndBoost> blendedFields, float tieBreaker,
+        CrossFieldsQueryBuilder(Analyzer analyzer, List<FieldAndBoost> blendedFields, float tieBreaker,
                                 boolean enablePositionIncrements, boolean autoGenerateSynonymsPhraseQuery) {
             super(analyzer, blendedFields.get(0).fieldType, enablePositionIncrements, autoGenerateSynonymsPhraseQuery);
             this.blendedFields = blendedFields;


### PR DESCRIPTION
The parsing logic for the `cross_fields` mode was very general, making it hard
to tell what query components it actually supports. This PR clarifies that only
'bag of words' queries are supported, it does not accept phrase or prefix
queries. It also renames `BlendedQueryBuilder` -> `CrossFieldsQueryBuilder` for
clarity.
