### PR TITLE
Remove Dead Test Code Branch in SparseFileTrackerTests (#68801)

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/SparseFileTrackerTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/SparseFileTrackerTests.java
@@ -91,17 +91,6 @@ public class SparseFileTrackerTests extends ESTestCase {
                     containsString("unable to listen to range")
                 );
                 assertThat(invoked.get(), is(false));
-            } else {
-                e = expectThrows(
-                    IllegalArgumentException.class,
-                    () -> sparseFileTracker.waitForRange(ByteRange.of(start, end), ByteRange.of(start - 1L, end), listener)
-                );
-                assertThat(
-                    "listener range start must not be smaller than zero",
-                    e.getMessage(),
-                    containsString("invalid range to listen to")
-                );
-                assertThat(invoked.get(), is(false));
             }
 
             if (end < length) {


### PR DESCRIPTION
This branch makes no sense and was failing for the `start == 0` case
now that we assert that byte ranges are well formed.

backport of #68801 