### PR TITLE
Further BWC changes for system indices

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -169,8 +169,8 @@ tasks.register("verifyVersions") {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = false
-String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/68811" /* place a PR link here when committing bwc changes */
+boolean bwc_tests_enabled = true
+String bwc_tests_disabled_issue = "" /* place a PR link here when committing bwc changes */
 /*
  * FIPS 140-2 behavior was fixed in 7.11.0. Before that there is no way to run elasticsearch in a
  * JVM that is properly configured to be in fips mode with BCFIPS. For now we need to disable

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/TransportAutoPutMappingAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/TransportAutoPutMappingAction.java
@@ -20,6 +20,8 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.MetadataMappingService;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.logging.DeprecationCategory;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.indices.SystemIndices;
 import org.elasticsearch.tasks.Task;
@@ -31,6 +33,7 @@ import static org.elasticsearch.action.admin.indices.mapping.put.TransportPutMap
 public class TransportAutoPutMappingAction extends AcknowledgedTransportMasterNodeAction<PutMappingRequest> {
 
     private static final Logger logger = LogManager.getLogger(TransportAutoPutMappingAction.class);
+    private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(TransportAutoPutMappingAction.class);
 
     private final MetadataMappingService metadataMappingService;
     private final SystemIndices systemIndices;
@@ -72,9 +75,7 @@ public class TransportAutoPutMappingAction extends AcknowledgedTransportMasterNo
 
         final String message = TransportPutMappingAction.checkForSystemIndexViolations(systemIndices, concreteIndices, request);
         if (message != null) {
-            logger.warn(message);
-            listener.onFailure(new IllegalStateException(message));
-            return;
+            deprecationLogger.deprecate(DeprecationCategory.API, "open_system_index_access", message);
         }
 
         performMappingUpdate(concreteIndices, request, listener, metadataMappingService);

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/TransportPutMappingAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/TransportPutMappingAction.java
@@ -170,10 +170,14 @@ public class TransportPutMappingAction extends AcknowledgedTransportMasterNodeAc
         }
 
         if (violations.isEmpty() == false) {
+            logger.debug(() -> new ParameterizedMessage("Updating mappings in {}"
+                + ": system indices can only use mappings from their descriptors,"
+                + " but the mappings in the request [{}] did not match those in the descriptor(s)."
+                + " This will not work in the next major version", violations, requestMappings));
             return "Updating mappings in "
                 + violations
                 + ": system indices can only use mappings from their descriptors,"
-                + " but the mappings in the request [" + requestMappings + "] did not match those in the descriptor(s)."
+                + " but the mappings in the request did not match those in the descriptor(s)."
                 + " This will not work in the next major version";
         }
 

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/TransformInternalIndex.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/TransformInternalIndex.java
@@ -394,7 +394,7 @@ public final class TransformInternalIndex {
         try {
             CreateIndexRequest request = new CreateIndexRequest(TransformInternalIndexConstants.LATEST_INDEX_VERSIONED_NAME)
                 .settings(settings())
-                .mapping(Strings.toString(mappings()))
+                .mapping(MapperService.SINGLE_MAPPING_NAME, mappings())
                 // BWC: for mixed clusters with nodes < 7.5, we need the alias to make new docs visible for them
                 .alias(new Alias(".data-frame-internal-3"))
                 .origin(TRANSFORM_ORIGIN);

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/30_ml_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/30_ml_jobs_crud.yml
@@ -111,6 +111,8 @@ setup:
 
 ---
 "Test get old cluster job's timing stats":
+  - skip:
+      features: allowed_warnings
   - do:
       ml.get_job_stats:
         job_id: old-cluster-job-with-ts
@@ -120,6 +122,8 @@ setup:
   - gte:   { jobs.0.timing_stats.bucket_count: 0 }
 
   - do:
+      allowed_warnings:
+         - 'Updating mappings in [.ml-config]: system indices can only use mappings from their descriptors, but the mappings in the request did not match those in the descriptor(s). This will not work in the next major version'
       ml.delete_job:
         job_id: old-cluster-job-with-ts
   - match: { acknowledged: true }


### PR DESCRIPTION
This is an extenstion of #68760.

1. Makes system index mappings updates deprecated but not banned
   for automatic mappings updates as well as explicit mappings
   updates
2. Moves the actual mapping update out of the deprecation warning
   into a debug message to make it easier to allow these warnings
   in YAML tests
3. Allows the warning in the affected YAML tests