### PR TITLE
Reject remounting snapshot of a searchable snapshot

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/server/src/main/java/org/elasticsearch/index/store/Store.java
@@ -1360,7 +1360,7 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
                 BytesRef ref = bytes.toBytesRef();
                 output.writeBytes(ref.bytes, ref.offset, ref.length);
                 CodecUtil.writeFooter(output);
-            } catch (IOException ex) {
+            } catch (IOException | ImmutableDirectoryException ex) {
                 logger.warn("Can't mark store as corrupted", ex);
             }
             directory().sync(Collections.singleton(corruptionMarkerName));

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
@@ -1306,7 +1306,7 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
             }
         });
         assertThat(remountException.getMessage(), allOf(
-                containsString("is a searchable snapshot backed by index"),
+                containsString("is a snapshot of a searchable snapshot index backed by index"),
                 containsString(repositoryName),
                 containsString(snapshotOne.getName()),
                 containsString(indexName),

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.searchablesnapshots;
 import com.carrotsearch.hppc.cursors.ObjectCursor;
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.search.TotalHits;
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResponse;
 import org.elasticsearch.action.admin.cluster.snapshots.status.SnapshotIndexShardStatus;
@@ -96,7 +97,9 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitC
 import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshots.getDataTiersPreference;
 import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsConstants.SNAPSHOT_DIRECTORY_FACTORY_KEY;
 import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsConstants.SNAPSHOT_RECOVERY_STATE_FACTORY_KEY;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -1288,6 +1291,30 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
         logger.info("--> finished restoring snapshot-2");
 
         assertTotalHits(restoredIndexName, originalAllHits, originalBarHits);
+
+        final IllegalArgumentException remountException = expectThrows(IllegalArgumentException.class, () -> {
+            try {
+                mountSnapshot(
+                        restoreRepositoryName,
+                        snapshotTwo.getName(),
+                        restoredIndexName,
+                        randomAlphaOfLength(10).toLowerCase(Locale.ROOT),
+                        Settings.EMPTY);
+            } catch (Exception e) {
+                final Throwable cause = ExceptionsHelper.unwrap(e, IllegalArgumentException.class);
+                throw cause == null ? e : cause;
+            }
+        });
+        assertThat(remountException.getMessage(), allOf(
+                containsString("is a searchable snapshot backed by index"),
+                containsString(repositoryName),
+                containsString(snapshotOne.getName()),
+                containsString(indexName),
+                containsString(restoreRepositoryName),
+                containsString(snapshotTwo.getName()),
+                containsString(restoredIndexName),
+                containsString("cannot be mounted; did you mean to restore it instead?")
+        ));
     }
 
     private void assertTotalHits(String indexName, TotalHits originalAllHits, TotalHits originalBarHits) throws Exception {

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
@@ -1295,17 +1295,20 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
         final IllegalArgumentException remountException = expectThrows(IllegalArgumentException.class, () -> {
             try {
                 mountSnapshot(
-                        restoreRepositoryName,
-                        snapshotTwo.getName(),
-                        restoredIndexName,
-                        randomAlphaOfLength(10).toLowerCase(Locale.ROOT),
-                        Settings.EMPTY);
+                    restoreRepositoryName,
+                    snapshotTwo.getName(),
+                    restoredIndexName,
+                    randomAlphaOfLength(10).toLowerCase(Locale.ROOT),
+                    Settings.EMPTY
+                );
             } catch (Exception e) {
                 final Throwable cause = ExceptionsHelper.unwrap(e, IllegalArgumentException.class);
                 throw cause == null ? e : cause;
             }
         });
-        assertThat(remountException.getMessage(), allOf(
+        assertThat(
+            remountException.getMessage(),
+            allOf(
                 containsString("is a snapshot of a searchable snapshot index backed by index"),
                 containsString(repositoryName),
                 containsString(snapshotOne.getName()),
@@ -1314,7 +1317,8 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
                 containsString(snapshotTwo.getName()),
                 containsString(restoredIndexName),
                 containsString("cannot be mounted; did you mean to restore it instead?")
-        ));
+            )
+        );
     }
 
     private void assertTotalHits(String indexName, TotalHits originalAllHits, TotalHits originalBarHits) throws Exception {

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/TransportMountSearchableSnapshotAction.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/TransportMountSearchableSnapshotAction.java
@@ -51,6 +51,7 @@ import java.util.Optional;
 import static org.elasticsearch.index.IndexModule.INDEX_RECOVERY_TYPE_SETTING;
 import static org.elasticsearch.index.IndexModule.INDEX_STORE_TYPE_SETTING;
 import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshots.getDataTiersPreference;
+import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsConstants.isSearchableSnapshotStore;
 
 /**
  * Action that mounts a snapshot as a searchable snapshot, by converting the mount request into a restore request with specific settings
@@ -181,7 +182,7 @@ public class TransportMountSearchableSnapshotAction extends TransportMasterNodeA
             ignoreIndexSettings[ignoreIndexSettings.length - 1] = IndexMetadata.SETTING_DATA_PATH;
 
             final IndexMetadata indexMetadata = repository.getSnapshotIndexMetaData(repoData, snapshotId, indexId);
-            if (INDEX_STORE_TYPE_SETTING.get(indexMetadata.getSettings()).equals(SearchableSnapshotsConstants.SNAPSHOT_DIRECTORY_FACTORY_KEY)) {
+            if (isSearchableSnapshotStore(indexMetadata.getSettings())) {
                 throw new IllegalArgumentException(String.format(Locale.ROOT,
                         "index [%s] in snapshot [%s/%s:%s] is a searchable snapshot backed by index [%s] in snapshot [%s/%s:%s] " +
                                 "and cannot be mounted; did you mean to restore it instead?",

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/TransportMountSearchableSnapshotAction.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/TransportMountSearchableSnapshotAction.java
@@ -183,9 +183,11 @@ public class TransportMountSearchableSnapshotAction extends TransportMasterNodeA
 
             final IndexMetadata indexMetadata = repository.getSnapshotIndexMetaData(repoData, snapshotId, indexId);
             if (isSearchableSnapshotStore(indexMetadata.getSettings())) {
-                throw new IllegalArgumentException(String.format(Locale.ROOT,
-                        "index [%s] in snapshot [%s/%s:%s] is a snapshot of a searchable snapshot index " +
-                                "backed by index [%s] in snapshot [%s/%s:%s] and cannot be mounted; did you mean to restore it instead?",
+                throw new IllegalArgumentException(
+                    String.format(
+                        Locale.ROOT,
+                        "index [%s] in snapshot [%s/%s:%s] is a snapshot of a searchable snapshot index "
+                            + "backed by index [%s] in snapshot [%s/%s:%s] and cannot be mounted; did you mean to restore it instead?",
                         indexName,
                         repoName,
                         repository.getMetadata().uuid(),
@@ -193,7 +195,9 @@ public class TransportMountSearchableSnapshotAction extends TransportMasterNodeA
                         SearchableSnapshots.SNAPSHOT_INDEX_NAME_SETTING.get(indexMetadata.getSettings()),
                         SearchableSnapshots.SNAPSHOT_REPOSITORY_NAME_SETTING.get(indexMetadata.getSettings()),
                         SearchableSnapshots.SNAPSHOT_REPOSITORY_UUID_SETTING.get(indexMetadata.getSettings()),
-                        SearchableSnapshots.SNAPSHOT_SNAPSHOT_NAME_SETTING.get(indexMetadata.getSettings())));
+                        SearchableSnapshots.SNAPSHOT_SNAPSHOT_NAME_SETTING.get(indexMetadata.getSettings())
+                    )
+                );
             }
 
             client.admin()

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/TransportMountSearchableSnapshotAction.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/TransportMountSearchableSnapshotAction.java
@@ -184,8 +184,8 @@ public class TransportMountSearchableSnapshotAction extends TransportMasterNodeA
             final IndexMetadata indexMetadata = repository.getSnapshotIndexMetaData(repoData, snapshotId, indexId);
             if (isSearchableSnapshotStore(indexMetadata.getSettings())) {
                 throw new IllegalArgumentException(String.format(Locale.ROOT,
-                        "index [%s] in snapshot [%s/%s:%s] is a searchable snapshot backed by index [%s] in snapshot [%s/%s:%s] " +
-                                "and cannot be mounted; did you mean to restore it instead?",
+                        "index [%s] in snapshot [%s/%s:%s] is a snapshot of a searchable snapshot index " +
+                                "backed by index [%s] in snapshot [%s/%s:%s] and cannot be mounted; did you mean to restore it instead?",
                         indexName,
                         repoName,
                         repository.getMetadata().uuid(),


### PR DESCRIPTION
Today you can mount a snapshot of a searchable snapshot index, but the
shard fails to allocate since the underlying snapshot is devoid of
content. Doing this is a mistake, you probably meant to restore the
index instead, so this commit rejects it earlier with a more helpful
message.

Closes #68792