### PR TITLE
ConcurrentBulkProcessor

### DIFF
--- a/libs/core/src/main/java/org/elasticsearch/common/collect/PersistentQueue.java
+++ b/libs/core/src/main/java/org/elasticsearch/common/collect/PersistentQueue.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.common.collect;
+
+import java.util.NoSuchElementException;
+
+public final class PersistentQueue<V> {
+
+    private static final PersistentQueue<?> empty = new PersistentQueue<>(PersistentStack.empty(), PersistentStack.empty());
+
+    @SuppressWarnings("unchecked")
+    public static <V> PersistentQueue<V> empty() {
+        return (PersistentQueue<V>) empty;
+    }
+
+    private final PersistentStack<V> inbound;
+    private final PersistentStack<V> outbound;
+
+    private PersistentQueue(PersistentStack<V> inbound, PersistentStack<V> outbound) {
+        this.inbound = inbound;
+        this.outbound = outbound;
+    }
+
+    public boolean isEmpty() {
+        return inbound.isEmpty() && outbound.isEmpty();
+    }
+
+    public PersistentQueue<V> add(V item) {
+        return new PersistentQueue<>(inbound.push(item), outbound);
+    }
+
+    public Tuple<V, PersistentQueue<V>> remove() {
+        if (outbound.isEmpty() && inbound.isEmpty()) {
+            throw new NoSuchElementException();
+        } else if (outbound.isEmpty()) {
+            PersistentStack<V> s = PersistentStack.empty();
+            for (V item : inbound) {
+                s = s.push(item);
+            }
+            return new Tuple<>(s.head(), new PersistentQueue<>(PersistentStack.empty(), s.tail()));
+        } else {
+            return new Tuple<>(outbound.head(), new PersistentQueue<>(inbound, outbound.tail()));
+        }
+    }
+}

--- a/libs/core/src/main/java/org/elasticsearch/common/collect/PersistentStack.java
+++ b/libs/core/src/main/java/org/elasticsearch/common/collect/PersistentStack.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.common.collect;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+public abstract class PersistentStack<V> implements Iterable<V> {
+
+    private static final PersistentStack<?> EMPTY = new Empty<>();
+
+    @SuppressWarnings("unchecked")
+    public static <V> PersistentStack<V> empty() {
+        return (PersistentStack<V>) EMPTY;
+    }
+
+    private PersistentStack() {
+    }
+
+    public abstract V head();
+
+    public abstract PersistentStack<V> tail();
+
+    public abstract boolean isEmpty();
+
+    public abstract int size();
+
+    public PersistentStack<V> push(V item) {
+        return new Head<>(item, this);
+    }
+
+    private static final class Head<V> extends PersistentStack<V> {
+
+        private final V head;
+        private final int size;
+        private final PersistentStack<V> tail;
+
+        private Head(V head, PersistentStack<V> tail) {
+            this.head = head;
+            this.tail = tail;
+            this.size = tail.size() + 1;
+        }
+
+        @Override
+        public V head() {
+            return head;
+        }
+
+        @Override
+        public PersistentStack<V> tail() {
+            return tail;
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return false;
+        }
+
+        @Override
+        public int size() {
+            return size;
+        }
+
+        @Override
+        public Iterator<V> iterator() {
+            return new PersistentStackIterator<>(this);
+        }
+    }
+
+    private static final class Empty<V> extends PersistentStack<V> {
+
+        @Override
+        public V head() {
+            throw new NoSuchElementException();
+        }
+
+        @Override
+        public PersistentStack<V> tail() {
+            return empty();
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return true;
+        }
+
+        @Override
+        public int size() {
+            return 0;
+        }
+
+        @Override
+        public Iterator<V> iterator() {
+            return Collections.emptyIterator();
+        }
+    }
+
+    private static final class PersistentStackIterator<V> implements Iterator<V> {
+        PersistentStack<V> curr;
+
+        private PersistentStackIterator(PersistentStack<V> curr) {
+            this.curr = curr;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return curr.isEmpty() == false;
+        }
+
+        @Override
+        public V next() {
+            V h = curr.head();
+            curr = curr.tail();
+            return h;
+        }
+    }
+}

--- a/libs/core/src/test/java/org/elasticsearch/common/collect/PersistentStackTests.java
+++ b/libs/core/src/test/java/org/elasticsearch/common/collect/PersistentStackTests.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.common.collect;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.NoSuchElementException;
+
+public class PersistentStackTests extends ESTestCase {
+
+    public void testEmptyStack() {
+        PersistentStack<String> empty = PersistentStack.empty();
+        assertEquals(0, empty.size());
+        assertEquals(empty, empty.tail());
+        expectThrows(NoSuchElementException.class, empty::head);
+        assertFalse(empty.iterator().hasNext());
+        expectThrows(NoSuchElementException.class, empty.iterator()::next);
+    }
+
+    public void testStack() {
+        PersistentStack<String> stack = PersistentStack.<String>empty().push("a").push("b").push("c");
+        String[] expected = new String[]{"c", "b", "a"};
+        int i = 0;
+        for (String actual : stack) {
+            assertEquals(expected[i++], actual);
+        }
+
+        assertEquals(3, stack.size());
+        assertEquals(2, stack.tail().size());
+        assertEquals(1, stack.tail().tail().size());
+        assertEquals(0, stack.tail().tail().tail().size());
+
+        assertEquals("c", stack.head());
+        assertEquals("b", stack.tail().head());
+        assertEquals("a", stack.tail().tail().head());
+    }
+
+    public void testLongIteration() {
+        PersistentStack<Integer> stack = PersistentStack.empty();
+        for (int i = 0; i < 1000000; i++) {
+            stack = stack.push(i);
+        }
+        int i = 999999;
+        for (Integer integer : stack) {
+            assertEquals(i--, (int) integer);
+        }
+        assertEquals(-1, i);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
@@ -143,7 +143,7 @@ public class BulkRequest extends ActionRequest implements CompositeIndicesReques
 
         requests.add(request);
         // lack of source is validated in validate() method
-        sizeInBytes += (request.source() != null ? request.source().length() : 0) + REQUEST_OVERHEAD;
+        sizeInBytes += getSize(request);
         indices.add(request.index());
         return this;
     }
@@ -160,15 +160,8 @@ public class BulkRequest extends ActionRequest implements CompositeIndicesReques
         applyGlobalMandatoryParameters(request);
 
         requests.add(request);
-        if (request.doc() != null) {
-            sizeInBytes += request.doc().source().length();
-        }
-        if (request.upsertRequest() != null) {
-            sizeInBytes += request.upsertRequest().source().length();
-        }
-        if (request.script() != null) {
-            sizeInBytes += request.script().getIdOrCode().length() * 2;
-        }
+        long size = getSize(request);
+        sizeInBytes +=size;
         indices.add(request.index());
         return this;
     }
@@ -181,7 +174,7 @@ public class BulkRequest extends ActionRequest implements CompositeIndicesReques
         applyGlobalMandatoryParameters(request);
 
         requests.add(request);
-        sizeInBytes += REQUEST_OVERHEAD;
+        sizeInBytes += getSize(request);
         indices.add(request.index());
         return this;
     }
@@ -428,5 +421,27 @@ public class BulkRequest extends ActionRequest implements CompositeIndicesReques
 
     public Set<String> getIndices() {
         return Collections.unmodifiableSet(indices);
+    }
+
+    public static long getSize(UpdateRequest request) {
+        long size = REQUEST_OVERHEAD;
+        if (request.doc() != null) {
+            size += request.doc().source().length();
+        }
+        if (request.upsertRequest() != null) {
+            size += request.upsertRequest().source().length();
+        }
+        if (request.script() != null) {
+            size += ((long) request.script().getIdOrCode().length()) * 2;
+        }
+        return size;
+    }
+
+    public static long getSize(DeleteRequest request) {
+        return REQUEST_OVERHEAD;
+    }
+
+    public static long getSize(IndexRequest request) {
+        return (request.source() != null ? request.source().length() : 0) + REQUEST_OVERHEAD;
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/bulk/ConcurrentBulkProcessor.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/ConcurrentBulkProcessor.java
@@ -28,7 +28,6 @@ import java.util.function.Supplier;
 
 public class ConcurrentBulkProcessor implements AutoCloseable {
 
-    private static final long REQUEST_OVERHEAD = 50;
     private static final State EMPTY_STATE = new State(PersistentStack.empty(), 0);
 
     private final ConcurrentBulkRequestHandler bulkRequestHandler;
@@ -116,7 +115,7 @@ public class ConcurrentBulkProcessor implements AutoCloseable {
         return scheduler.scheduleWithFixedDelay(this::flush, flushInterval, ThreadPool.Names.GENERIC);
     }
 
-    private final static class State {
+    private static final class State {
         private final PersistentStack<DocWriteRequest<?>> actions;
         private final long size;
 

--- a/server/src/main/java/org/elasticsearch/action/bulk/ConcurrentBulkProcessor.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/ConcurrentBulkProcessor.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.bulk;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.DocWriteRequest;
+import org.elasticsearch.action.delete.DeleteRequest;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.update.UpdateRequest;
+import org.elasticsearch.common.collect.PersistentStack;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.threadpool.Scheduler;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
+
+public class ConcurrentBulkProcessor implements AutoCloseable {
+
+    private static final long REQUEST_OVERHEAD = 50;
+    private static final State EMPTY_STATE = new State(PersistentStack.empty(), 0);
+
+    private final ConcurrentBulkRequestHandler bulkRequestHandler;
+    private final ByteSizeValue bulkSize;
+    private final long bulkActions;
+    private final Runnable onClose;
+    private final Supplier<BulkRequest> bulkRequestSupplier;
+    private final AtomicInteger executionIdGen = new AtomicInteger();
+    private final AtomicReference<State> state = new AtomicReference<>(EMPTY_STATE);
+    private final AtomicBoolean closed = new AtomicBoolean();
+    private final Scheduler.Cancellable cancellableFlushTask;
+
+    public ConcurrentBulkProcessor(BiConsumer<BulkRequest, ActionListener<BulkResponse>> consumer, BackoffPolicy backoffPolicy,
+                                   BulkProcessor.Listener listener, int concurrentRequests, long bulkActions, ByteSizeValue bulkSize,
+                                   TimeValue flushInterval, Scheduler flushScheduler, Scheduler retryScheduler, Runnable onClose,
+                                   Supplier<BulkRequest> bulkRequestSupplier) {
+        this.bulkSize = bulkSize;
+        this.bulkActions = bulkActions;
+        this.onClose = onClose;
+        this.bulkRequestSupplier = bulkRequestSupplier;
+        this.bulkRequestHandler = new ConcurrentBulkRequestHandler(concurrentRequests, consumer, backoffPolicy, retryScheduler, listener);
+        this.cancellableFlushTask = startFlushTask(flushInterval, flushScheduler);
+    }
+
+    public void add(IndexRequest request) {
+        updateState(request, BulkRequest.getSize(request));
+    }
+
+    public void add(DeleteRequest request) {
+        updateState(request, BulkRequest.getSize(request));
+    }
+
+    public void add(UpdateRequest request) {
+        updateState(request, BulkRequest.getSize(request));
+    }
+
+    private void updateState(DocWriteRequest<?> request, long finalSizeInBytes) {
+        if (closed.get()) {
+            throw new IllegalStateException("bulk process already closed");
+        }
+        State newState = state.updateAndGet(s -> new State(s.actions.push(request), s.size + finalSizeInBytes));
+        if (closed.get() || newState.actions.size() >= bulkActions || new ByteSizeValue(newState.size).compareTo(bulkSize) >= 0) {
+            flush();
+        }
+    }
+
+    public void flush() {
+        BulkRequest bulkRequest = bulkRequestSupplier.get();
+        for (DocWriteRequest<?> action : state.getAndSet(EMPTY_STATE).actions) {
+            bulkRequest.add(action);
+        }
+        if (bulkRequest.numberOfActions() > 0) {
+            bulkRequestHandler.execute(bulkRequest, executionIdGen.getAndIncrement());
+        }
+    }
+
+    @Override
+    public void close() {
+        closed.set(true);
+        cancellableFlushTask.cancel();
+        flush();
+        onClose.run();
+    }
+
+    public boolean awaitClose(long value, TimeUnit units) throws InterruptedException {
+        close();
+        bulkRequestHandler.awaitClose(value, units);
+        return false;
+    }
+
+    private Scheduler.Cancellable startFlushTask(TimeValue flushInterval, Scheduler scheduler) {
+        if (flushInterval == null) {
+            return new Scheduler.Cancellable() {
+                @Override
+                public boolean cancel() {
+                    return false;
+                }
+
+                @Override
+                public boolean isCancelled() {
+                    return true;
+                }
+            };
+        }
+        return scheduler.scheduleWithFixedDelay(this::flush, flushInterval, ThreadPool.Names.GENERIC);
+    }
+
+    private final static class State {
+        private final PersistentStack<DocWriteRequest<?>> actions;
+        private final long size;
+
+        private State(PersistentStack<DocWriteRequest<?>> actions, long size) {
+            this.actions = actions;
+            this.size = size;
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/bulk/ConcurrentBulkRequestHandler.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/ConcurrentBulkRequestHandler.java
@@ -111,33 +111,33 @@ public class ConcurrentBulkRequestHandler {
         }
     }
 
-    private final static class Execution {
+    private static final class Execution {
         private final BulkRequest request;
         private final long executionId;
 
-        public Execution(BulkRequest request, long executionId) {
+        private Execution(BulkRequest request, long executionId) {
             this.request = request;
             this.executionId = executionId;
         }
     }
 
     private class BulkActionListener implements ActionListener<BulkResponse> {
-        private final long finalExecutionId;
-        private final BulkRequest finalRequest;
+        private final long executionId;
+        private final BulkRequest request;
 
-        public BulkActionListener(long finalExecutionId, BulkRequest finalRequest) {
-            this.finalExecutionId = finalExecutionId;
-            this.finalRequest = finalRequest;
+        private BulkActionListener(long executionId, BulkRequest request) {
+            this.executionId = executionId;
+            this.request = request;
         }
 
         @Override
         public void onResponse(BulkResponse bulkItemResponses) {
-            listener.afterBulk(finalExecutionId, finalRequest, bulkItemResponses);
+            listener.afterBulk(executionId, request, bulkItemResponses);
         }
 
         @Override
         public void onFailure(Exception e) {
-            listener.afterBulk(finalExecutionId, finalRequest, e);
+            listener.afterBulk(executionId, request, e);
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/bulk/ConcurrentBulkRequestHandler.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/ConcurrentBulkRequestHandler.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.bulk;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.collect.PersistentQueue;
+import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.threadpool.Scheduler;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
+
+public class ConcurrentBulkRequestHandler {
+
+    private final int maxConcurrentRequests;
+    private final BiConsumer<BulkRequest, ActionListener<BulkResponse>> consumer;
+    private final BulkProcessor.Listener listener;
+    private final Retry retry;
+    private final AtomicReference<State> state = new AtomicReference<>(new State(PersistentQueue.empty(), 0));
+
+    public ConcurrentBulkRequestHandler(int maxConcurrentRequests, BiConsumer<BulkRequest, ActionListener<BulkResponse>> consumer,
+                                        BackoffPolicy backoffPolicy, Scheduler retryScheduler, BulkProcessor.Listener listener) {
+        this.maxConcurrentRequests = Math.max(maxConcurrentRequests, 1);
+        this.consumer = consumer;
+        this.listener = listener;
+        this.retry = new Retry(backoffPolicy, retryScheduler);
+    }
+
+    public void execute(BulkRequest request, long executionId) {
+        Execution execution = new Execution(request, executionId);
+        State newState = state.updateAndGet(s -> s.concurrentRequests == maxConcurrentRequests ?
+            new State(s.pendingTask.add(execution), s.concurrentRequests) :
+            new State(s.pendingTask, s.concurrentRequests + 1));
+        if (newState.pendingTask.isEmpty()) {
+            innerExecute(request, executionId);
+        }
+    }
+
+    private void innerExecute(BulkRequest request, long executionId) {
+        while (true) {
+            listener.beforeBulk(executionId, request);
+            AtomicBoolean shouldContinueHere = new AtomicBoolean();
+            try {
+                retry.withBackoff(consumer, request, ActionListener.runAfter(new BulkActionListener(executionId, request), () -> {
+                    if (shouldContinueHere.getAndSet(true)) {
+                        Optional<Execution> nextExecution = updateStateAfterBulk();
+                        nextExecution.ifPresent(execution -> innerExecute(execution.request, execution.executionId));
+                    }
+                }));
+            } catch (Exception e) {
+                listener.afterBulk(executionId, request, e);
+                shouldContinueHere.set(true);
+            }
+            if (shouldContinueHere.getAndSet(true) == false) {
+                return;
+            }
+            Optional<Execution> nextExecution = updateStateAfterBulk();
+            if (nextExecution.isEmpty()) {
+                return;
+            }
+            request = nextExecution.get().request;
+            executionId = nextExecution.get().executionId;
+        }
+    }
+
+    private Optional<Execution> updateStateAfterBulk() {
+        State newState = state.updateAndGet(s -> {
+            if (s.pendingTask.isEmpty()) {
+                return new State(s.pendingTask, s.concurrentRequests - 1);
+            } else {
+                Tuple<Execution, PersistentQueue<Execution>> remove = s.pendingTask.remove();
+                return new State(remove.v2(), s.concurrentRequests, remove.v1());
+            }
+        });
+        return Optional.ofNullable(newState.toExecute);
+    }
+
+    public boolean awaitClose(long value, TimeUnit units) throws InterruptedException {
+        long millis = units.toMillis(value);
+        for (int i = 0; i < 100; i++) {
+            if (state.get().concurrentRequests == 0) {
+                return true;
+            }
+            Thread.sleep(millis / 100);
+        }
+        return false;
+    }
+
+    private static final class State {
+        private final PersistentQueue<Execution> pendingTask;
+        private final int concurrentRequests;
+        private final Execution toExecute;
+
+        private State(PersistentQueue<Execution> pendingTask, int concurrentRequests, Execution toExecute) {
+            this.pendingTask = pendingTask;
+            this.concurrentRequests = concurrentRequests;
+            this.toExecute = toExecute;
+        }
+
+        private State(PersistentQueue<Execution> pendingTask, int concurrentRequests) {
+            this(pendingTask, concurrentRequests, null);
+        }
+    }
+
+    private final static class Execution {
+        private final BulkRequest request;
+        private final long executionId;
+
+        public Execution(BulkRequest request, long executionId) {
+            this.request = request;
+            this.executionId = executionId;
+        }
+    }
+
+    private class BulkActionListener implements ActionListener<BulkResponse> {
+        private final long finalExecutionId;
+        private final BulkRequest finalRequest;
+
+        public BulkActionListener(long finalExecutionId, BulkRequest finalRequest) {
+            this.finalExecutionId = finalExecutionId;
+            this.finalRequest = finalRequest;
+        }
+
+        @Override
+        public void onResponse(BulkResponse bulkItemResponses) {
+            listener.afterBulk(finalExecutionId, finalRequest, bulkItemResponses);
+        }
+
+        @Override
+        public void onFailure(Exception e) {
+            listener.afterBulk(finalExecutionId, finalRequest, e);
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/action/bulk/ConcurrentBulkProcessorTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/ConcurrentBulkProcessorTests.java
@@ -1,0 +1,404 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.bulk;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.Scheduler;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.junit.After;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
+
+import static org.elasticsearch.common.unit.ByteSizeUnit.GB;
+
+public class ConcurrentBulkProcessorTests extends ESTestCase {
+
+    private ThreadPool threadPool;
+    private final Logger logger = LogManager.getLogger(ConcurrentBulkProcessorTests.class);
+
+    @Before
+    public void startThreadPool() {
+        threadPool = new TestThreadPool("ConcurrentBulkProcessorTests");
+    }
+
+    @After
+    public void stopThreadPool() throws InterruptedException {
+        terminate(threadPool);
+    }
+
+    public void testSimpleCase() {
+        BulkResponse response = new BulkResponse(new BulkItemResponse[0], 1);
+        AtomicInteger reqCount = new AtomicInteger();
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failureCount = new AtomicInteger();
+        AtomicInteger docCount = new AtomicInteger();
+        AtomicReference<Throwable> exception = new AtomicReference<>();
+        ConcurrentBulkProcessor bulkProcessor = new ConcurrentBulkProcessor((r, l) -> l.onResponse(response),
+            BackoffPolicy.noBackoff(),
+            countingListener(reqCount, successCount, failureCount, docCount, exception),
+            1,
+            1,
+            new ByteSizeValue(1, GB),
+            null,
+            threadPool,
+            threadPool,
+            () -> {
+            }, BulkRequest::new);
+        bulkProcessor.add(new IndexRequest());
+        assertEquals(1, successCount.get());
+        assertEquals(1, reqCount.get());
+        assertEquals(1, docCount.get());
+        assertEquals(0, failureCount.get());
+        assertNull(exception.get());
+        bulkProcessor.add(new IndexRequest());
+        assertEquals(2, successCount.get());
+        assertEquals(2, reqCount.get());
+        assertEquals(2, docCount.get());
+        assertEquals(0, failureCount.get());
+        assertNull(exception.get());
+    }
+
+    public void testSimpleCase2() {
+        BulkResponse response = new BulkResponse(new BulkItemResponse[0], 1);
+        AtomicInteger reqCount = new AtomicInteger();
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failureCount = new AtomicInteger();
+        AtomicInteger docCount = new AtomicInteger();
+        AtomicReference<Throwable> exception = new AtomicReference<>();
+        ConcurrentBulkProcessor bulkProcessor = new ConcurrentBulkProcessor((r, l) -> l.onResponse(response),
+            BackoffPolicy.noBackoff(),
+            countingListener(reqCount, successCount, failureCount, docCount, exception),
+            3,
+            1,
+            new ByteSizeValue(1, GB),
+            null,
+            threadPool,
+            threadPool,
+            () -> {
+            }, BulkRequest::new);
+        bulkProcessor.add(new IndexRequest());
+        bulkProcessor.add(new IndexRequest());
+        assertEquals(0, successCount.get());
+        assertEquals(0, reqCount.get());
+        assertEquals(0, docCount.get());
+        assertEquals(0, failureCount.get());
+        assertNull(exception.get());
+        bulkProcessor.add(new IndexRequest());
+        assertEquals(1, successCount.get());
+        assertEquals(1, reqCount.get());
+        assertEquals(3, docCount.get());
+        assertEquals(0, failureCount.get());
+        assertNull(exception.get());
+    }
+
+    public void testConcurrentBulkProcessorFlushPreservesContext() throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(1);
+        final String headerKey = randomAlphaOfLengthBetween(1, 8);
+        final String transientKey = randomAlphaOfLengthBetween(1, 8);
+        final String headerValue = randomAlphaOfLengthBetween(1, 32);
+        final Object transientValue = new Object();
+
+        BiConsumer<BulkRequest, ActionListener<BulkResponse>> consumer = (request, listener) -> {
+            ThreadContext threadContext = threadPool.getThreadContext();
+            assertEquals(headerValue, threadContext.getHeader(headerKey));
+            assertSame(transientValue, threadContext.getTransient(transientKey));
+            latch.countDown();
+        };
+
+        final int bulkSize = randomIntBetween(2, 32);
+        final TimeValue flushInterval = TimeValue.timeValueSeconds(1L);
+        final ConcurrentBulkProcessor bulkProcessor;
+        assertNull(threadPool.getThreadContext().getHeader(headerKey));
+        assertNull(threadPool.getThreadContext().getTransient(transientKey));
+        try (ThreadContext.StoredContext ignore = threadPool.getThreadContext().stashContext()) {
+            threadPool.getThreadContext().putHeader(headerKey, headerValue);
+            threadPool.getThreadContext().putTransient(transientKey, transientValue);
+            bulkProcessor = new ConcurrentBulkProcessor(consumer, BackoffPolicy.noBackoff(), emptyListener(),
+                1, bulkSize, new ByteSizeValue(5, ByteSizeUnit.MB), flushInterval,
+                threadPool, threadPool, () -> {
+            }, BulkRequest::new);
+        }
+        assertNull(threadPool.getThreadContext().getHeader(headerKey));
+        assertNull(threadPool.getThreadContext().getTransient(transientKey));
+
+        // add a single item which won't be over the size or number of items
+        bulkProcessor.add(new IndexRequest());
+
+        // wait for flush to execute
+        latch.await();
+
+        assertNull(threadPool.getThreadContext().getHeader(headerKey));
+        assertNull(threadPool.getThreadContext().getTransient(transientKey));
+        bulkProcessor.close();
+    }
+
+    public void testConcurrentExecutions() throws Exception {
+        final AtomicBoolean called = new AtomicBoolean(false);
+        final AtomicReference<Throwable> exceptionRef = new AtomicReference<>();
+        int estimatedTimeForTest = Integer.MAX_VALUE;
+        final int simulateWorkTimeInMillis = 5;
+        int concurrentClients = 0;
+        int concurrentBulkRequests = 0;
+        int expectedExecutions = 0;
+        int maxBatchSize = 0;
+        int maxDocuments = 0;
+        int iterations = 0;
+        boolean runTest = true;
+        //find some randoms that allow this test to take under ~ 10 seconds
+        while (estimatedTimeForTest > 10_000) {
+            if (iterations++ > 1_000) { //extremely unlikely
+                runTest = false;
+                break;
+            }
+            maxBatchSize = randomIntBetween(1, 100);
+            maxDocuments = randomIntBetween(maxBatchSize, 1_000_000);
+            concurrentClients = randomIntBetween(1, 20);
+            concurrentBulkRequests = randomIntBetween(0, 20);
+            expectedExecutions = maxDocuments / maxBatchSize;
+            estimatedTimeForTest = (expectedExecutions * simulateWorkTimeInMillis) /
+                Math.min(concurrentBulkRequests + 1, concurrentClients);
+        }
+        assumeTrue("failed to find random values that allows test to run quickly", runTest);
+        BulkResponse bulkResponse = new BulkResponse(new BulkItemResponse[]{new BulkItemResponse()}, 0);
+        AtomicInteger failureCount = new AtomicInteger(0);
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger requestCount = new AtomicInteger(0);
+        AtomicInteger docCount = new AtomicInteger(0);
+        BiConsumer<BulkRequest, ActionListener<BulkResponse>> consumer = (request, listener) ->
+        {
+            try {
+                Thread.sleep(simulateWorkTimeInMillis); //simulate work
+                listener.onResponse(bulkResponse);
+            } catch (InterruptedException e) {
+                //should never happen
+                Thread.currentThread().interrupt();
+                failureCount.getAndIncrement();
+                exceptionRef.set(ExceptionsHelper.useOrSuppress(exceptionRef.get(), e));
+            }
+        };
+        try (ConcurrentBulkProcessor bulkProcessor = new ConcurrentBulkProcessor(consumer, BackoffPolicy.noBackoff(),
+            countingListener(requestCount, successCount, failureCount, docCount, exceptionRef),
+            concurrentBulkRequests, maxBatchSize, new ByteSizeValue(Integer.MAX_VALUE), null,
+            (command, delay, executor) -> null, (command, delay, executor) -> null, () -> called.set(true), BulkRequest::new)) {
+
+            ExecutorService executorService = Executors.newFixedThreadPool(concurrentClients);
+            CountDownLatch startGate = new CountDownLatch(1 + concurrentClients);
+
+            List<Future<?>> futures = new ArrayList<>();
+            for (final AtomicInteger i = new AtomicInteger(0); i.get() < maxDocuments; i.incrementAndGet()) {
+                IndexRequest indexRequest = new IndexRequest().id("" + i);
+                futures.add(executorService.submit(() -> {
+                    try {
+                        //don't start any work until all tasks are submitted
+                        startGate.countDown();
+                        startGate.await();
+                        bulkProcessor.add(indexRequest);
+
+                    } catch (Exception e) {
+                        throw ExceptionsHelper.convertToRuntime(e);
+                    }
+                }));
+            }
+            startGate.countDown();
+            startGate.await();
+
+            for (Future<?> f : futures) {
+                try {
+                    f.get();
+                } catch (Exception e) {
+                    failureCount.incrementAndGet();
+                    exceptionRef.set(ExceptionsHelper.useOrSuppress(exceptionRef.get(), e));
+                }
+            }
+            executorService.shutdown();
+            executorService.awaitTermination(10, TimeUnit.SECONDS);
+
+            if (exceptionRef.get() != null) {
+                logger.error("exception(s) caught during test", exceptionRef.get());
+            }
+            assertEquals(0, failureCount.get());
+            assertEquals(successCount.get(), requestCount.get());
+        }
+        //count total docs after processor is closed since there may have been partial batches that are flushed on close.
+        assertEquals(docCount.get(), maxDocuments);
+    }
+
+    public void testConcurrentExecutionsWithFlush() throws Exception {
+        final AtomicReference<Throwable> exceptionRef = new AtomicReference<>();
+        final int maxDocuments = 100_000;
+        final int concurrentClients = 2;
+        final int maxBatchSize = Integer.MAX_VALUE; //don't flush based on size
+        final int concurrentBulkRequests = randomIntBetween(0, 20);
+        final int simulateWorkTimeInMillis = 5;
+        BulkResponse bulkResponse = new BulkResponse(new BulkItemResponse[]{new BulkItemResponse()}, 0);
+        AtomicInteger failureCount = new AtomicInteger(0);
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger requestCount = new AtomicInteger(0);
+        AtomicInteger docCount = new AtomicInteger(0);
+        BiConsumer<BulkRequest, ActionListener<BulkResponse>> consumer = (request, listener) ->
+        {
+            try {
+                Thread.sleep(simulateWorkTimeInMillis); //simulate work
+                listener.onResponse(bulkResponse);
+            } catch (InterruptedException e) {
+                //should never happen
+                Thread.currentThread().interrupt();
+                failureCount.getAndIncrement();
+                exceptionRef.set(ExceptionsHelper.useOrSuppress(exceptionRef.get(), e));
+            }
+        };
+        ScheduledExecutorService flushExecutor = Executors.newScheduledThreadPool(1);
+        try (ConcurrentBulkProcessor bulkProcessor = new ConcurrentBulkProcessor(consumer, BackoffPolicy.noBackoff(),
+            countingListener(requestCount, successCount, failureCount, docCount, exceptionRef),
+            concurrentBulkRequests, maxBatchSize, new ByteSizeValue(Integer.MAX_VALUE),
+            TimeValue.timeValueMillis(simulateWorkTimeInMillis * 2),
+            (command, delay, executor) ->
+                Scheduler.wrapAsScheduledCancellable(flushExecutor.schedule(command, delay.millis(), TimeUnit.MILLISECONDS)),
+            (command, delay, executor) ->
+                Scheduler.wrapAsScheduledCancellable(flushExecutor.schedule(command, delay.millis(), TimeUnit.MILLISECONDS)),
+            () ->
+            {
+                flushExecutor.shutdown();
+                try {
+                    flushExecutor.awaitTermination(10L, TimeUnit.SECONDS);
+                    if (flushExecutor.isTerminated() == false) {
+                        flushExecutor.shutdownNow();
+                    }
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                }
+            },
+            BulkRequest::new)) {
+
+            ExecutorService executorService = Executors.newFixedThreadPool(concurrentClients);
+            IndexRequest indexRequest = new IndexRequest();
+            List<Future> futures = new ArrayList<>();
+            CountDownLatch startGate = new CountDownLatch(1 + concurrentClients);
+            for (final AtomicInteger i = new AtomicInteger(0); i.getAndIncrement() < maxDocuments; ) {
+                futures.add(executorService.submit(() -> {
+                    try {
+                        //don't start any work until all tasks are submitted
+                        startGate.countDown();
+                        startGate.await();
+
+                        bulkProcessor.add(indexRequest);
+                    } catch (Exception e) {
+                        throw ExceptionsHelper.convertToRuntime(e);
+                    }
+                }));
+            }
+            startGate.countDown();
+            startGate.await();
+
+            for (Future f : futures) {
+                try {
+                    f.get();
+                } catch (Exception e) {
+                    failureCount.incrementAndGet();
+                    exceptionRef.set(ExceptionsHelper.useOrSuppress(exceptionRef.get(), e));
+                }
+            }
+            executorService.shutdown();
+            executorService.awaitTermination(10, TimeUnit.SECONDS);
+        }
+
+        if (failureCount.get() > 0 || requestCount.get() != successCount.get() || maxDocuments != docCount.get()) {
+            if (exceptionRef.get() != null) {
+                logger.error("exception(s) caught during test", exceptionRef.get());
+            }
+            fail("\nRequested Bulks: " + requestCount.get() + "\n" +
+                "Successful Bulks: " + successCount.get() + "\n" +
+                "Failed Bulks: " + failureCount.get() + "\n" +
+                "Total Documents: " + docCount.get() + "\n" +
+                "Max Documents: " + maxDocuments + "\n" +
+                "Max Batch Size: " + maxBatchSize + "\n" +
+                "Concurrent Clients: " + concurrentClients + "\n" +
+                "Concurrent Bulk Requests: " + concurrentBulkRequests + "\n"
+            );
+        }
+    }
+
+    public void testAwaitOnCloseCallsOnClose() throws Exception {
+        final AtomicBoolean called = new AtomicBoolean(false);
+        BiConsumer<BulkRequest, ActionListener<BulkResponse>> consumer = (request, listener) -> {
+        };
+        ConcurrentBulkProcessor bulkProcessor = new ConcurrentBulkProcessor(consumer, BackoffPolicy.noBackoff(), emptyListener(),
+            0, 10, new ByteSizeValue(1000), null,
+            (command, delay, executor) -> null, (command, delay, executor) -> null, () -> called.set(true), BulkRequest::new);
+
+        assertFalse(called.get());
+        bulkProcessor.awaitClose(100, TimeUnit.MILLISECONDS);
+        assertTrue(called.get());
+    }
+
+    private BulkProcessor.Listener emptyListener() {
+        return new BulkProcessor.Listener() {
+            @Override
+            public void beforeBulk(long executionId, BulkRequest request) {
+            }
+
+            @Override
+            public void afterBulk(long executionId, BulkRequest request, BulkResponse response) {
+            }
+
+            @Override
+            public void afterBulk(long executionId, BulkRequest request, Throwable failure) {
+            }
+        };
+    }
+
+    private BulkProcessor.Listener countingListener(AtomicInteger requestCount, AtomicInteger successCount, AtomicInteger failureCount,
+                                                    AtomicInteger docCount, AtomicReference<Throwable> exceptionRef) {
+
+        return new BulkProcessor.Listener() {
+            @Override
+            public void beforeBulk(long executionId, BulkRequest request) {
+                requestCount.incrementAndGet();
+            }
+
+            @Override
+            public void afterBulk(long executionId, BulkRequest request, BulkResponse response) {
+                successCount.incrementAndGet();
+                docCount.addAndGet(request.requests().size());
+            }
+
+            @Override
+            public void afterBulk(long executionId, BulkRequest request, Throwable failure) {
+                if (failure != null) {
+                    failureCount.incrementAndGet();
+                    exceptionRef.set(ExceptionsHelper.useOrSuppress(exceptionRef.get(), failure));
+
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
This change adds `ConcurrentBulkProcessor`, alternative for `BulkProcessor` that never blocks. It preserves most characteristics of `BulkProcessor` but doesn't handle `concurrentRequests=0` (fallbacks to `1`). Pending requests are stored in queues and then handled by listeners after previous bulk finishes 