### PR TITLE
Rename DocValueFetcher.Leaf to FormattedDocValues

### DIFF
--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
@@ -22,6 +22,7 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentParser.Token;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.index.fielddata.FieldData;
+import org.elasticsearch.index.fielddata.FormattedDocValues;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData;
 import org.elasticsearch.index.fielddata.LeafNumericFieldData;
@@ -517,9 +518,9 @@ public class ScaledFloatFieldMapper extends FieldMapper {
         }
 
         @Override
-        public DocValueFetcher.Leaf getLeafValueFetcher(DocValueFormat format) {
+        public FormattedDocValues getFormattedValues(DocValueFormat format) {
             SortedNumericDoubleValues values = getDoubleValues();
-            return new DocValueFetcher.Leaf() {
+            return new FormattedDocValues() {
                 @Override
                 public boolean advanceExact(int docId) throws IOException {
                     return values.advanceExact(docId);

--- a/server/src/main/java/org/elasticsearch/index/fielddata/FormattedDocValues.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/FormattedDocValues.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index.fielddata;
+
+import java.io.IOException;
+
+public interface FormattedDocValues {
+    /**
+     * Advance the doc values reader to the provided doc.
+     *
+     * @return false if there are no values for this document, true otherwise
+     */
+    boolean advanceExact(int docId) throws IOException;
+
+    /**
+     * A count of the number of values at this document.
+     */
+    int docValueCount() throws IOException;
+
+    /**
+     * Load and format the next value.
+     */
+    Object nextValue() throws IOException;
+}

--- a/server/src/main/java/org/elasticsearch/index/fielddata/LeafFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/LeafFieldData.java
@@ -10,7 +10,6 @@ package org.elasticsearch.index.fielddata;
 
 import org.apache.lucene.util.Accountable;
 import org.elasticsearch.common.lease.Releasable;
-import org.elasticsearch.index.mapper.DocValueFetcher;
 import org.elasticsearch.search.DocValueFormat;
 
 import java.io.IOException;
@@ -31,18 +30,18 @@ public interface LeafFieldData extends Accountable, Releasable {
     SortedBinaryDocValues getBytesValues();
 
     /**
-     * Return a value fetcher for this leaf implementation.
+     * Return a formatted representation of the values
      */
-    default DocValueFetcher.Leaf getLeafValueFetcher(DocValueFormat format) {
+    default FormattedDocValues getFormattedValues(DocValueFormat format) {
         SortedBinaryDocValues values = getBytesValues();
-        return new DocValueFetcher.Leaf() {
+        return new FormattedDocValues() {
             @Override
             public boolean advanceExact(int docId) throws IOException {
                 return values.advanceExact(docId);
             }
 
             @Override
-            public int docValueCount() throws IOException {
+            public int docValueCount() {
                 return values.docValueCount();
             }
 

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/LeafDoubleFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/LeafDoubleFieldData.java
@@ -11,11 +11,11 @@ package org.elasticsearch.index.fielddata.plain;
 import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.util.Accountable;
 import org.elasticsearch.index.fielddata.FieldData;
+import org.elasticsearch.index.fielddata.FormattedDocValues;
 import org.elasticsearch.index.fielddata.LeafNumericFieldData;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
-import org.elasticsearch.index.mapper.DocValueFetcher;
 import org.elasticsearch.search.DocValueFormat;
 
 import java.io.IOException;
@@ -71,9 +71,9 @@ public abstract class LeafDoubleFieldData implements LeafNumericFieldData {
     }
 
     @Override
-    public DocValueFetcher.Leaf getLeafValueFetcher(DocValueFormat format) {
+    public FormattedDocValues getFormattedValues(DocValueFormat format) {
         SortedNumericDoubleValues values = getDoubleValues();
-        return new DocValueFetcher.Leaf() {
+        return new FormattedDocValues() {
             @Override
             public boolean advanceExact(int docId) throws IOException {
                 return values.advanceExact(docId);

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/LeafLongFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/LeafLongFieldData.java
@@ -10,12 +10,12 @@ package org.elasticsearch.index.fielddata.plain;
 
 import org.apache.lucene.index.SortedNumericDocValues;
 import org.elasticsearch.index.fielddata.FieldData;
+import org.elasticsearch.index.fielddata.FormattedDocValues;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData.NumericType;
 import org.elasticsearch.index.fielddata.LeafNumericFieldData;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
-import org.elasticsearch.index.mapper.DocValueFetcher;
 import org.elasticsearch.search.DocValueFormat;
 
 import java.io.IOException;
@@ -68,9 +68,9 @@ public abstract class LeafLongFieldData implements LeafNumericFieldData {
     }
 
     @Override
-    public DocValueFetcher.Leaf getLeafValueFetcher(DocValueFormat format) {
+    public FormattedDocValues getFormattedValues(DocValueFormat format) {
         SortedNumericDocValues values = getLongValues();
-        return new DocValueFetcher.Leaf() {
+        return new FormattedDocValues() {
             @Override
             public boolean advanceExact(int docId) throws IOException {
                 return values.advanceExact(docId);

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/SortedNumericIndexFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/SortedNumericIndexFieldData.java
@@ -19,6 +19,7 @@ import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.NumericUtils;
 import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.index.fielddata.FieldData;
+import org.elasticsearch.index.fielddata.FormattedDocValues;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource.Nested;
 import org.elasticsearch.index.fielddata.IndexFieldDataCache;
@@ -27,7 +28,6 @@ import org.elasticsearch.index.fielddata.LeafNumericFieldData;
 import org.elasticsearch.index.fielddata.NumericDoubleValues;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 import org.elasticsearch.index.fielddata.fieldcomparator.LongValuesComparatorSource;
-import org.elasticsearch.index.mapper.DocValueFetcher;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.MultiValueMode;
@@ -164,10 +164,10 @@ public class SortedNumericIndexFieldData extends IndexNumericFieldData {
         }
 
         @Override
-        public DocValueFetcher.Leaf getLeafValueFetcher(DocValueFormat format) {
+        public FormattedDocValues getFormattedValues(DocValueFormat format) {
             DocValueFormat nanosFormat = DocValueFormat.withNanosecondResolution(format);
             SortedNumericDocValues values = getLongValuesAsNanos();
-            return new DocValueFetcher.Leaf() {
+            return new FormattedDocValues() {
                 @Override
                 public boolean advanceExact(int docId) throws IOException {
                     return values.advanceExact(docId);

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocValueFetcher.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocValueFetcher.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.index.LeafReaderContext;
+import org.elasticsearch.index.fielddata.FormattedDocValues;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.lookup.SourceLookup;
@@ -26,7 +27,7 @@ import static java.util.Collections.emptyList;
 public final class DocValueFetcher implements ValueFetcher {
     private final DocValueFormat format;
     private final IndexFieldData<?> ifd;
-    private Leaf leaf;
+    private FormattedDocValues formattedDocValues;
 
     public DocValueFetcher(DocValueFormat format, IndexFieldData<?> ifd) {
         this.format = format;
@@ -35,36 +36,19 @@ public final class DocValueFetcher implements ValueFetcher {
 
     @Override
     public void setNextReader(LeafReaderContext context) {
-        leaf = ifd.load(context).getLeafValueFetcher(format);
+        formattedDocValues = ifd.load(context).getFormattedValues(format);
     }
 
     @Override
     public List<Object> fetchValues(SourceLookup lookup, Set<String> ignoredFields) throws IOException {
-        if (false == leaf.advanceExact(lookup.docId())) {
+        if (false == formattedDocValues.advanceExact(lookup.docId())) {
             return emptyList();
         }
-        List<Object> result = new ArrayList<Object>(leaf.docValueCount());
-        for (int i = 0, count = leaf.docValueCount(); i < count; ++i) {
-            result.add(leaf.nextValue());
+        List<Object> result = new ArrayList<>(formattedDocValues.docValueCount());
+        for (int i = 0, count = formattedDocValues.docValueCount(); i < count; ++i) {
+            result.add(formattedDocValues.nextValue());
         }
         return result;
     }
 
-    public interface Leaf {
-        /**
-         * Advance the doc values reader to the provided doc.
-         * @return false if there are no values for this document, true otherwise
-         */
-        boolean advanceExact(int docId) throws IOException;
-
-        /**
-         * A count of the number of values at this document.
-         */
-        int docValueCount() throws IOException;
-
-        /**
-         * Load and format the next value.
-         */
-        Object nextValue() throws IOException;
-    }
 }

--- a/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongLeafFieldData.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongLeafFieldData.java
@@ -11,12 +11,12 @@ import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.SortedNumericDocValues;
 import org.elasticsearch.index.fielddata.FieldData;
+import org.elasticsearch.index.fielddata.FormattedDocValues;
 import org.elasticsearch.index.fielddata.LeafNumericFieldData;
 import org.elasticsearch.index.fielddata.NumericDoubleValues;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
-import org.elasticsearch.index.mapper.DocValueFetcher;
 import org.elasticsearch.search.DocValueFormat;
 
 import java.io.IOException;
@@ -94,9 +94,9 @@ public class UnsignedLongLeafFieldData implements LeafNumericFieldData {
     }
 
     @Override
-    public DocValueFetcher.Leaf getLeafValueFetcher(DocValueFormat format) {
+    public FormattedDocValues getFormattedValues(DocValueFormat format) {
         SortedNumericDocValues values = getLongValues();
-        return new DocValueFetcher.Leaf() {
+        return new FormattedDocValues() {
             @Override
             public boolean advanceExact(int docId) throws IOException {
                 return values.advanceExact(docId);

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/v2/FieldValueFetcher.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/v2/FieldValueFetcher.java
@@ -9,8 +9,8 @@ package org.elasticsearch.xpack.rollup.v2;
 
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.index.fielddata.FormattedDocValues;
 import org.elasticsearch.index.fielddata.IndexFieldData;
-import org.elasticsearch.index.mapper.DocValueFetcher;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.DocValueFormat;
@@ -46,9 +46,9 @@ class FieldValueFetcher {
         this.valueFunc = valueFunc;
     }
 
-    DocValueFetcher.Leaf getLeaf(LeafReaderContext context) {
-        final DocValueFetcher.Leaf delegate = fieldData.load(context).getLeafValueFetcher(DocValueFormat.RAW);
-        return new DocValueFetcher.Leaf() {
+    FormattedDocValues getLeaf(LeafReaderContext context) {
+        final FormattedDocValues delegate = fieldData.load(context).getFormattedValues(DocValueFormat.RAW);
+        return new FormattedDocValues() {
             @Override
             public boolean advanceExact(int docId) throws IOException {
                 return delegate.advanceExact(docId);

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/v2/RollupShardIndexer.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/v2/RollupShardIndexer.java
@@ -42,9 +42,9 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.engine.Engine;
+import org.elasticsearch.index.fielddata.FormattedDocValues;
 import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.DocCountFieldMapper;
-import org.elasticsearch.index.mapper.DocValueFetcher;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.shard.IndexShard;
@@ -434,8 +434,8 @@ class RollupShardIndexer {
 
         @Override
         public LeafCollector getLeafCollector(LeafReaderContext context) {
-            final List<DocValueFetcher.Leaf> groupFieldLeaves = leafFetchers(context, groupFieldFetchers);
-            final List<DocValueFetcher.Leaf> metricsFieldLeaves = leafFetchers(context, metricsFieldFetchers);
+            final List<FormattedDocValues> groupFieldLeaves = leafFetchers(context, groupFieldFetchers);
+            final List<FormattedDocValues> metricsFieldLeaves = leafFetchers(context, metricsFieldFetchers);
             return new LeafCollector() {
                 @Override
                 public void setScorer(Scorable scorer) {
@@ -444,7 +444,7 @@ class RollupShardIndexer {
                 @Override
                 public void collect(int docID) throws IOException {
                     List<List<Object>> combinationKeys = new ArrayList<>();
-                    for (DocValueFetcher.Leaf leafField : groupFieldLeaves) {
+                    for (FormattedDocValues leafField : groupFieldLeaves) {
                         if (leafField.advanceExact(docID)) {
                             List<Object> lst = new ArrayList<>();
                             for (int i = 0; i < leafField.docValueCount(); i++) {
@@ -458,11 +458,11 @@ class RollupShardIndexer {
 
                     final BytesRef valueBytes;
                     try (BytesStreamOutput out = new BytesStreamOutput()) {
-                        for (DocValueFetcher.Leaf leaf : metricsFieldLeaves) {
-                            if (leaf.advanceExact(docID)) {
-                                out.writeVInt(leaf.docValueCount());
-                                for (int i = 0; i < leaf.docValueCount(); i++) {
-                                    Object obj = leaf.nextValue();
+                        for (FormattedDocValues formattedDocValues : metricsFieldLeaves) {
+                            if (formattedDocValues.advanceExact(docID)) {
+                                out.writeVInt(formattedDocValues.docValueCount());
+                                for (int i = 0; i < formattedDocValues.docValueCount(); i++) {
+                                    Object obj = formattedDocValues.nextValue();
                                     if (obj instanceof Number == false) {
                                         throw new IllegalArgumentException("Expected [Number], got [" + obj.getClass() + "]");
                                     }
@@ -487,8 +487,8 @@ class RollupShardIndexer {
             };
         }
 
-        private List<DocValueFetcher.Leaf> leafFetchers(LeafReaderContext context, List<FieldValueFetcher> fetchers) {
-            List<DocValueFetcher.Leaf> leaves = new ArrayList<>();
+        private List<FormattedDocValues> leafFetchers(LeafReaderContext context, List<FieldValueFetcher> fetchers) {
+            List<FormattedDocValues> leaves = new ArrayList<>();
             for (FieldValueFetcher fetcher : fetchers) {
                 leaves.add(fetcher.getLeaf(context));
             }


### PR DESCRIPTION
Also moves it to a top-level interface in `fielddata`.  It is not only used by
`DocValueFetcher` any more, and `Leaf` does not really describe what
it does or what it provides.