### PR TITLE
Make GET _cluster/stats cancellable

### DIFF
--- a/qa/smoke-test-http/src/test/java/org/elasticsearch/http/ClusterStatsRestCancellationIT.java
+++ b/qa/smoke-test-http/src/test/java/org/elasticsearch/http/ClusterStatsRestCancellationIT.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.http;
+
+import org.apache.http.client.methods.HttpGet;
+import org.elasticsearch.action.admin.cluster.stats.ClusterStatsAction;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.client.Cancellable;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.ResponseListener;
+import org.elasticsearch.cluster.routing.allocation.DiskThresholdSettings;
+import org.elasticsearch.common.lease.Releasable;
+import org.elasticsearch.common.lease.Releasables;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.index.IndexService;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.engine.Engine;
+import org.elasticsearch.index.engine.EngineConfig;
+import org.elasticsearch.index.engine.EngineFactory;
+import org.elasticsearch.index.engine.ReadOnlyEngine;
+import org.elasticsearch.index.seqno.SeqNoStats;
+import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.shard.IndexShardTestCase;
+import org.elasticsearch.index.translog.TranslogStats;
+import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.plugins.EnginePlugin;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.tasks.CancellableTask;
+import org.elasticsearch.tasks.TaskInfo;
+import org.elasticsearch.transport.TransportService;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.Semaphore;
+import java.util.function.Function;
+
+import static java.util.Collections.singletonList;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.not;
+
+public class ClusterStatsRestCancellationIT extends HttpSmokeTestCase {
+
+    public static final Setting<Boolean> BLOCK_STATS_SETTING = Setting.boolSetting("index.block_stats", false, Setting.Property.IndexScope);
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return CollectionUtils.appendToCopy(super.nodePlugins(), ClusterStatsRestCancellationIT.StatsBlockingPlugin.class);
+    }
+
+    @Override
+    protected boolean addMockInternalEngine() {
+        return false;
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+                .put(super.nodeSettings(nodeOrdinal))
+                // disable internal cluster info service to avoid internal cluster stats calls
+                .put(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING.getKey(), false)
+                .build();
+    }
+
+    public void testClusterStateRestCancellation() throws Exception {
+
+        createIndex("test", Settings.builder().put(BLOCK_STATS_SETTING.getKey(), true).build());
+        ensureGreen("test");
+
+        final List<Semaphore> statsBlocks = new ArrayList<>();
+        for (final IndicesService indicesService : internalCluster().getInstances(IndicesService.class)) {
+            for (final IndexService indexService : indicesService) {
+                for (final IndexShard indexShard : indexService) {
+                    final Engine engine = IndexShardTestCase.getEngine(indexShard);
+                    if (engine instanceof StatsBlockingEngine) {
+                        statsBlocks.add(((StatsBlockingEngine) engine).statsBlock);
+                    }
+                }
+            }
+        }
+        assertThat(statsBlocks, not(empty()));
+
+        final List<Releasable> releasables = new ArrayList<>();
+        try {
+            for (final Semaphore statsBlock : statsBlocks) {
+                statsBlock.acquire();
+                releasables.add(statsBlock::release);
+            }
+
+            final Request clusterStatsRequest = new Request(HttpGet.METHOD_NAME, "/_cluster/stats");
+
+            final PlainActionFuture<Void> future = new PlainActionFuture<>();
+            logger.info("--> sending cluster state request");
+            final Cancellable cancellable = getRestClient().performRequestAsync(clusterStatsRequest, new ResponseListener() {
+                @Override
+                public void onSuccess(Response response) {
+                    future.onResponse(null);
+                }
+
+                @Override
+                public void onFailure(Exception exception) {
+                    future.onFailure(exception);
+                }
+            });
+
+            logger.info("--> waiting for task to start");
+            assertBusy(() -> {
+                final List<TaskInfo> tasks = client().admin().cluster().prepareListTasks().get().getTasks();
+                assertTrue(tasks.toString(), tasks.stream().anyMatch(t -> t.getAction().startsWith(ClusterStatsAction.NAME)));
+            });
+
+            logger.info("--> waiting for at least one task to hit a block");
+            assertBusy(() -> assertTrue(statsBlocks.stream().anyMatch(Semaphore::hasQueuedThreads)));
+
+            logger.info("--> cancelling cluster stats request");
+            cancellable.cancel();
+            expectThrows(CancellationException.class, future::actionGet);
+
+            logger.info("--> checking that all cluster stats tasks are marked as cancelled");
+            assertBusy(() -> {
+                boolean foundTask = false;
+                for (TransportService transportService : internalCluster().getInstances(TransportService.class)) {
+                    for (CancellableTask cancellableTask : transportService.getTaskManager().getCancellableTasks().values()) {
+                        if (cancellableTask.getAction().startsWith(ClusterStatsAction.NAME)) {
+                            foundTask = true;
+                            assertTrue(cancellableTask.isCancelled());
+                        }
+                    }
+                }
+                assertTrue(foundTask);
+            });
+        } finally {
+            Releasables.close(releasables);
+        }
+
+        logger.info("--> checking that all cluster stats tasks have finished");
+        assertBusy(() -> {
+            final List<TaskInfo> tasks = client().admin().cluster().prepareListTasks().get().getTasks();
+            assertTrue(tasks.toString(), tasks.stream().noneMatch(t -> t.getAction().startsWith(ClusterStatsAction.NAME)));
+        });
+    }
+
+    public static class StatsBlockingPlugin extends Plugin implements EnginePlugin {
+
+        @Override
+        public Optional<EngineFactory> getEngineFactory(IndexSettings indexSettings) {
+            if (BLOCK_STATS_SETTING.get(indexSettings.getSettings())) {
+                return Optional.of(StatsBlockingEngine::new);
+            }
+            return Optional.empty();
+        }
+
+        @Override
+        public List<Setting<?>> getSettings() {
+            return singletonList(BLOCK_STATS_SETTING);
+        }
+    }
+
+    private static class StatsBlockingEngine extends ReadOnlyEngine {
+
+        final Semaphore statsBlock = new Semaphore(1);
+
+        StatsBlockingEngine(EngineConfig config) {
+            super(config, null, new TranslogStats(), true, Function.identity(), true);
+        }
+
+        @Override
+        public SeqNoStats getSeqNoStats(long globalCheckpoint) {
+            try {
+                statsBlock.acquire();
+            } catch (InterruptedException e) {
+                throw new AssertionError(e);
+            }
+            statsBlock.release();
+            return super.getSeqNoStats(globalCheckpoint);
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/AnalysisStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/AnalysisStats.java
@@ -41,7 +41,7 @@ public final class AnalysisStats implements ToXContentFragment, Writeable {
     /**
      * Create {@link AnalysisStats} from the given cluster state.
      */
-    public static AnalysisStats of(Metadata metadata) {
+    public static AnalysisStats of(Metadata metadata, Runnable ensureNotCancelled) {
         final Map<String, IndexFeatureStats> usedCharFilterTypes = new HashMap<>();
         final Map<String, IndexFeatureStats> usedTokenizerTypes = new HashMap<>();
         final Map<String, IndexFeatureStats> usedTokenFilterTypes = new HashMap<>();
@@ -52,6 +52,7 @@ public final class AnalysisStats implements ToXContentFragment, Writeable {
         final Map<String, IndexFeatureStats> usedBuiltInAnalyzers = new HashMap<>();
 
         for (IndexMetadata indexMetadata : metadata) {
+            ensureNotCancelled.run();
             if (indexMetadata.isSystem()) {
                 // Don't include system indices in statistics about analysis,
                 // we care about the user's indices.

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsRequest.java
@@ -11,8 +11,12 @@ package org.elasticsearch.action.admin.cluster.stats;
 import org.elasticsearch.action.support.nodes.BaseNodesRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.tasks.CancellableTask;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskId;
 
 import java.io.IOException;
+import java.util.Map;
 
 /**
  * A request to get cluster level stats.
@@ -29,6 +33,11 @@ public class ClusterStatsRequest extends BaseNodesRequest<ClusterStatsRequest> {
      */
     public ClusterStatsRequest(String... nodesIds) {
         super(nodesIds);
+    }
+
+    @Override
+    public Task createTask(long id, String type, String action, TaskId parentTaskId, Map<String, String> headers) {
+        return new CancellableTask(id, type, action, "", parentTaskId, headers);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/MappingStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/MappingStats.java
@@ -38,9 +38,10 @@ public final class MappingStats implements ToXContentFragment, Writeable {
     /**
      * Create {@link MappingStats} from the given cluster state.
      */
-    public static MappingStats of(Metadata metadata) {
+    public static MappingStats of(Metadata metadata, Runnable ensureNotCancelled) {
         Map<String, IndexFeatureStats> fieldTypes = new HashMap<>();
         for (IndexMetadata indexMetadata : metadata) {
+            ensureNotCancelled.run();
             if (indexMetadata.isSystem()) {
                 // Don't include system indices in statistics about mappings,
                 // we care about the user's indices.

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
@@ -8,10 +8,10 @@
 
 package org.elasticsearch.action.admin.cluster.stats;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.lucene.store.AlreadyClosedException;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.FailedNodeException;
+import org.elasticsearch.action.StepListener;
 import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
 import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
 import org.elasticsearch.action.admin.indices.stats.CommonStats;
@@ -28,6 +28,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.util.CancellableSingleObjectCache;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.engine.CommitStats;
 import org.elasticsearch.index.seqno.RetentionLeaseStats;
@@ -35,6 +36,10 @@ import org.elasticsearch.index.seqno.SeqNoStats;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.node.NodeService;
+import org.elasticsearch.tasks.CancellableTask;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskCancelledException;
+import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.transport.Transports;
@@ -42,11 +47,11 @@ import org.elasticsearch.transport.Transports;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
 
 public class TransportClusterStatsAction extends TransportNodesAction<ClusterStatsRequest, ClusterStatsResponse,
         TransportClusterStatsAction.ClusterStatsNodeRequest, ClusterStatsNodeResponse> {
-
-    private static final Logger logger = LogManager.getLogger(TransportClusterStatsAction.class);
 
     private static final CommonStatsFlags SHARD_STATS_FLAGS = new CommonStatsFlags(CommonStatsFlags.Flag.Docs, CommonStatsFlags.Flag.Store,
         CommonStatsFlags.Flag.FieldData, CommonStatsFlags.Flag.QueryCache,
@@ -55,12 +60,8 @@ public class TransportClusterStatsAction extends TransportNodesAction<ClusterSta
     private final NodeService nodeService;
     private final IndicesService indicesService;
 
-    // guards #mappingStats, #analysisStats and #metaVersion
-    private final Object statsMutex = new Object();
-
-    private MappingStats mappingStats;
-    private AnalysisStats analysisStats;
-    private long metaVersion = -1L;
+    private final MetadataStatsCache<MappingStats> mappingStatsCache = new MetadataStatsCache<>(MappingStats::of);
+    private final MetadataStatsCache<AnalysisStats> analysisStatsCache = new MetadataStatsCache<>(AnalysisStats::of);
 
     @Inject
     public TransportClusterStatsAction(ThreadPool threadPool, ClusterService clusterService, TransportService transportService,
@@ -72,49 +73,45 @@ public class TransportClusterStatsAction extends TransportNodesAction<ClusterSta
     }
 
     @Override
-    protected ClusterStatsResponse newResponse(ClusterStatsRequest request,
-                                               List<ClusterStatsNodeResponse> responses, List<FailedNodeException> failures) {
-        assert Transports.assertNotTransportThread("Constructor of ClusterStatsResponse runs expensive computations on mappings found in" +
-                " the cluster state that are too slow for a transport thread");
+    protected void newResponseAsync(
+            final Task task,
+            final ClusterStatsRequest request,
+            final List<ClusterStatsNodeResponse> responses,
+            final List<FailedNodeException> failures,
+            final ActionListener<ClusterStatsResponse> listener) {
+        assert Transports.assertNotTransportThread("Computation of mapping/analysis stats runs expensive computations on mappings found in "
+                + "the cluster state that are too slow for a transport thread");
+        assert Thread.currentThread().getName().contains("[" + ThreadPool.Names.MANAGEMENT + "]") : Thread.currentThread().getName();
+        assert task instanceof CancellableTask;
+        final CancellableTask cancellableTask = (CancellableTask) task;
         final ClusterState state = clusterService.state();
         final Metadata metadata = state.metadata();
-        MappingStats currentMappingStats = null;
-        AnalysisStats currentAnalysisStats = null;
-        // check if we already served a stats request for the current metadata version and have the stats cached
-        synchronized (statsMutex) {
-            if (metadata.version() == metaVersion) {
-                logger.trace("Found cached mapping and analysis stats for metadata version [{}]", metadata.version());
-                currentMappingStats = this.mappingStats;
-                currentAnalysisStats = this.analysisStats;
-            }
-        }
-        if (currentMappingStats == null) {
-            // we didn't find any cached stats so we recompute them outside the mutex since the computation might be expensive for larger
-            // cluster states
-            logger.trace("Computing mapping and analysis stats for metadata version [{}]", metadata.version());
-            currentMappingStats = MappingStats.of(metadata);
-            currentAnalysisStats = AnalysisStats.of(metadata);
-            synchronized (statsMutex) {
-                // cache the computed stats unless they became outdated because of a concurrent cluster state update and a concurrent
-                // stats request has already cached a newer version
-                if (metadata.version() > metaVersion) {
-                    logger.trace("Caching mapping and analysis stats for metadata version [{}]", metadata.version());
-                    metaVersion = metadata.version();
-                    this.mappingStats = currentMappingStats;
-                    this.analysisStats = currentAnalysisStats;
-                }
-            }
-        }
-        VersionStats versionStats = VersionStats.of(metadata, responses);
-        return new ClusterStatsResponse(
-            System.currentTimeMillis(),
-            state.metadata().clusterUUID(),
-            clusterService.getClusterName(),
-            responses,
-            failures,
-            currentMappingStats,
-            currentAnalysisStats,
-            versionStats);
+
+        final StepListener<MappingStats> mappingStatsStep = new StepListener<>();
+        final StepListener<AnalysisStats> analysisStatsStep = new StepListener<>();
+        mappingStatsCache.get(metadata, cancellableTask::isCancelled, mappingStatsStep);
+        analysisStatsCache.get(metadata, cancellableTask::isCancelled, analysisStatsStep);
+        mappingStatsStep.whenComplete(mappingStats -> analysisStatsStep.whenComplete(analysisStats -> ActionListener.completeWith(
+                listener,
+                () -> new ClusterStatsResponse(
+                        System.currentTimeMillis(),
+                        metadata.clusterUUID(),
+                        clusterService.getClusterName(),
+                        responses,
+                        failures,
+                        mappingStats,
+                        analysisStats,
+                        VersionStats.of(metadata, responses))
+        ), listener::onFailure), listener::onFailure);
+    }
+
+    @Override
+    protected ClusterStatsResponse newResponse(
+            ClusterStatsRequest request,
+            List<ClusterStatsNodeResponse> responses,
+            List<FailedNodeException> failures) {
+        assert false;
+        throw new UnsupportedOperationException("use newResponseAsync instead");
     }
 
     @Override
@@ -129,12 +126,23 @@ public class TransportClusterStatsAction extends TransportNodesAction<ClusterSta
 
     @Override
     protected ClusterStatsNodeResponse nodeOperation(ClusterStatsNodeRequest nodeRequest) {
+        assert false;
+        throw new UnsupportedOperationException("task is required");
+    }
+
+    @Override
+    protected ClusterStatsNodeResponse nodeOperation(ClusterStatsNodeRequest nodeRequest, Task task) {
+        assert task instanceof CancellableTask;
+        final CancellableTask cancellableTask = (CancellableTask) task;
         NodeInfo nodeInfo = nodeService.info(true, true, false, true, false, true, false, true, false, false, false);
         NodeStats nodeStats = nodeService.stats(CommonStatsFlags.NONE,
                 true, true, true, false, true, false, false, false, false, false, true, false, false, false);
         List<ShardStats> shardsStats = new ArrayList<>();
         for (IndexService indexService : indicesService) {
             for (IndexShard indexShard : indexService) {
+                if (cancellableTask.isCancelled()) {
+                    throw new TaskCancelledException("task cancelled");
+                }
                 if (indexShard.routingEntry() != null && indexShard.routingEntry().active()) {
                     // only report on fully started shards
                     CommitStats commitStats;
@@ -186,9 +194,37 @@ public class TransportClusterStatsAction extends TransportNodesAction<ClusterSta
         }
 
         @Override
+        public Task createTask(long id, String type, String action, TaskId parentTaskId, Map<String, String> headers) {
+            return new CancellableTask(id, type, action, "", parentTaskId, headers);
+        }
+
+        @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
             request.writeTo(out);
+        }
+    }
+
+    private static class MetadataStatsCache<T> extends CancellableSingleObjectCache<Metadata, Long, T> {
+        private final BiFunction<Metadata, Runnable, T> function;
+
+        MetadataStatsCache(BiFunction<Metadata, Runnable, T> function) {
+            this.function = function;
+        }
+
+        @Override
+        protected void refresh(Metadata metadata, Runnable ensureNotCancelled, ActionListener<T> listener) {
+            ActionListener.completeWith(listener, () -> function.apply(metadata, ensureNotCancelled));
+        }
+
+        @Override
+        protected Long getKey(Metadata indexMetadata) {
+            return indexMetadata.version();
+        }
+
+        @Override
+        protected boolean isFresh(Long currentKey, Long newKey) {
+            return newKey <= currentKey;
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesAction.java
@@ -10,7 +10,6 @@ package org.elasticsearch.action.support.nodes;
 
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
@@ -101,15 +100,22 @@ public abstract class TransportNodesAction<NodesRequest extends BaseNodesRequest
     }
 
     /**
-     * Map the responses into {@code nodeResponseClass} responses and {@link FailedNodeException}s.
+     * Map the responses into {@code nodeResponseClass} responses and {@link FailedNodeException}s, convert to a {@link NodesResponse} and
+     * pass it to the listener. Fails the listener with a {@link NullPointerException} if {@code nodesResponses} is null.
      *
      * @param request The associated request.
      * @param nodesResponses All node-level responses
-     * @return Never {@code null}.
      * @throws NullPointerException if {@code nodesResponses} is {@code null}
-     * @see #newResponse(BaseNodesRequest, List, List)
+     * @see #newResponseAsync(Task, BaseNodesRequest, List, List, ActionListener)
      */
-    protected NodesResponse newResponse(NodesRequest request, AtomicReferenceArray<?> nodesResponses) {
+    // exposed for tests
+    void newResponse(Task task, NodesRequest request, AtomicReferenceArray<?> nodesResponses, ActionListener<NodesResponse> listener) {
+
+        if (nodesResponses == null) {
+            listener.onFailure(new NullPointerException("nodesResponses"));
+            return;
+        }
+
         final List<NodeResponse> responses = new ArrayList<>();
         final List<FailedNodeException> failures = new ArrayList<>();
 
@@ -123,7 +129,7 @@ public abstract class TransportNodesAction<NodesRequest extends BaseNodesRequest
             }
         }
 
-        return newResponse(request, responses, failures);
+        newResponseAsync(task, request, responses, failures, listener);
     }
 
     /**
@@ -136,6 +142,19 @@ public abstract class TransportNodesAction<NodesRequest extends BaseNodesRequest
      * @throws NullPointerException if any parameter is {@code null}.
      */
     protected abstract NodesResponse newResponse(NodesRequest request, List<NodeResponse> responses, List<FailedNodeException> failures);
+
+    /**
+     * Create a new {@link NodesResponse}, possibly asynchronously. The default implementation is synchronous and calls
+     * {@link #newResponse(BaseNodesRequest, List, List)}
+     */
+    protected void newResponseAsync(
+            Task task,
+            NodesRequest request,
+            List<NodeResponse> responses,
+            List<FailedNodeException> failures,
+            ActionListener<NodesResponse> listener) {
+        ActionListener.completeWith(listener, () -> newResponse(request, responses, failures));
+    }
 
     protected abstract NodeRequest newNodeRequest(NodesRequest request);
 
@@ -185,8 +204,9 @@ public abstract class TransportNodesAction<NodesRequest extends BaseNodesRequest
         void start() {
             final DiscoveryNode[] nodes = request.concreteNodes();
             if (nodes.length == 0) {
-                // nothing to notify
-                threadPool.generic().execute(() -> listener.onResponse(newResponse(request, responses)));
+                // nothing to notify, so respond immediately, but always fork even if finalExecutor == SAME
+                final String executor = finalExecutor.equals(ThreadPool.Names.SAME) ? ThreadPool.Names.GENERIC : finalExecutor;
+                threadPool.executor(executor).execute(() -> newResponse(task, request, responses, listener));
                 return;
             }
             final TransportRequestOptions transportRequestOptions = TransportRequestOptions.timeout(request.timeout());
@@ -241,7 +261,7 @@ public abstract class TransportNodesAction<NodesRequest extends BaseNodesRequest
         }
 
         private void finishHim() {
-            threadPool.executor(finalExecutor).execute(ActionRunnable.supply(listener, () -> newResponse(request, responses)));
+            threadPool.executor(finalExecutor).execute(() -> newResponse(task, request, responses, listener));
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/common/util/CancellableSingleObjectCache.java
+++ b/server/src/main/java/org/elasticsearch/common/util/CancellableSingleObjectCache.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.common.util;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ListenableActionFuture;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.util.concurrent.AbstractRefCounted;
+import org.elasticsearch.tasks.TaskCancelledException;
+
+import java.util.ArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BooleanSupplier;
+
+/**
+ * A cache of a single object whose refresh process can be cancelled. The cached value is computed lazily on the first retrieval, and
+ * associated with a key which is used to determine its freshness for subsequent retrievals.
+ * <p>
+ * This is useful for things like computing stats over cluster metadata: the first time stats are requested they are computed, but
+ * subsequent calls re-use the computed value as long as they pertain to the same metadata version. If stats are requested for a different
+ * metadata version then the cached value is dropped and a new one is computed.
+ * <p>
+ * Retrievals happen via the async {@link #get} method. If a retrieval is cancelled (e.g. the channel on which to return the stats is
+ * closed) then the computation carries on running in case another retrieval for the same key arrives in future. However if all of the
+ * retrievals for a key are cancelled <i>and</i> a retrieval occurs for a fresher key then the computation itself is cancelled.
+ * <p>
+ * Cancellation is based on polling: the {@link #refresh} method checks whether it should abort whenever it is convenient to do so, which in
+ * turn checks all the pending retrievals to see whether they have been cancelled.
+ *
+ * @param <Input> The type of the input to the computation of the cached value.
+ * @param <Key>   The key type. The cached value is associated with a key, and subsequent {@link #get} calls compare keys of the given input
+ *                value to determine whether the cached value is fresh or not. See {@link #isFresh}.
+ * @param <Value> The type of the cached value.
+ */
+public abstract class CancellableSingleObjectCache<Input, Key, Value> {
+
+    private final AtomicReference<CachedItem> currentCachedItemRef = new AtomicReference<>();
+
+    /**
+     * Compute a new value for the cache.
+     * <p>
+     * If an exception is thrown, or passed to the {@code listener}, then it is passed on to all waiting listeners but it is not cached so
+     * that subsequent retrievals will trigger subsequent calls to this method.
+     * <p>
+     * Implementations of this method should poll for cancellation by running {@code ensureNotCancelled} whenever appropriate. The
+     * computation is cancelled if all of the corresponding retrievals have been cancelled <i>and</i> a retrieval has since happened for a
+     * fresher key.
+     *
+     * @param input              The input to this computation, which will be converted to a key and used to determine whether it is
+     *                           suitably fresh for future requests too.
+     * @param ensureNotCancelled A {@link Runnable} which throws a {@link TaskCancelledException} if the result of the computation is no
+     *                           longer needed. On cancellation, notifying the {@code listener} is optional.
+     * @param listener           A {@link ActionListener} which should be notified when the computation completes. If the computation fails
+     *                           by calling {@link ActionListener#onFailure} then the result is returned to the pending listeners but is not
+     *                           cached.
+     */
+    protected abstract void refresh(Input input, Runnable ensureNotCancelled, ActionListener<Value> listener);
+
+    /**
+     * Compute the key for the given input value.
+     */
+    protected abstract Key getKey(Input input);
+
+    /**
+     * Compute whether the {@code currentKey} is fresh enough for a retrieval associated with {@code newKey}.
+     *
+     * @param currentKey The key of the current (cached or pending) value.
+     * @param newKey     The key associated with a new retrival.
+     * @return {@code true} if a value computed for {@code currentKey} is fresh enough to satisfy a retrieval for {@code newKey}.
+     */
+    protected boolean isFresh(Key currentKey, Key newKey) {
+        return currentKey.equals(newKey);
+    }
+
+    /**
+     * Start a retrieval for the value associated with the given {@code input}, and pass it to the given {@code listener}.
+     * <p>
+     * If a fresh-enough result is available when this method is called then the {@code listener} is notified immediately, on this thread.
+     * If a fresh-enough result is already being computed then the {@code listener} is captured and will be notified when the result becomes
+     * available, on the thread on which the refresh completes. If no fresh-enough result is either pending or available then this method
+     * starts to compute one by calling {@link #refresh} on this thread.
+     *
+     * @param input       The input to compute the desired value, converted to a {@link Key} to determine if the value that's currently
+     *                    cached or pending is fresh enough.
+     * @param isCancelled Returns {@code true} if the listener no longer requires the value being computed.
+     * @param listener    The listener to notify when the desired value becomes available.
+     */
+    public final void get(Input input, BooleanSupplier isCancelled, ActionListener<Value> listener) {
+
+        final Key key = getKey(input);
+
+        CachedItem newCachedItem = null;
+
+        do {
+            if (isCancelled.getAsBoolean()) {
+                listener.onFailure(new TaskCancelledException("task cancelled"));
+                return;
+            }
+
+            final CachedItem currentCachedItem = currentCachedItemRef.get();
+            if (currentCachedItem != null && isFresh(currentCachedItem.getKey(), key)) {
+                final boolean listenerAdded = currentCachedItem.addListener(listener, isCancelled);
+                if (listenerAdded) {
+                    return;
+                }
+
+                assert currentCachedItem.refCount() == 0 : currentCachedItem.refCount();
+                assert currentCachedItemRef.get() != currentCachedItem;
+
+                // Our item was only just released, possibly cancelled, by another get() with a fresher key. We don't simply retry
+                // since that would evict the new item. Instead let's see if it was cancelled or whether it completed properly.
+                if (currentCachedItem.getFuture().isDone()) {
+                    try {
+                        listener.onResponse(currentCachedItem.getFuture().actionGet(0L));
+                        return;
+                    } catch (TaskCancelledException e) {
+                        // previous task was cancelled before completion, therefore we must perform our own one-shot refresh
+                    } catch (Exception e) {
+                        // either the refresh completed exceptionally or the listener threw an exception; call onFailure() either way
+                        listener.onFailure(e);
+                        return;
+                    }
+                } // else it's just about to be cancelled, so we can just retry knowing that it will be removed very soon
+
+                continue;
+            }
+
+            if (newCachedItem == null) {
+                newCachedItem = new CachedItem(key);
+            }
+
+            if (currentCachedItemRef.compareAndSet(currentCachedItem, newCachedItem)) {
+                if (currentCachedItem != null) {
+                    currentCachedItem.decRef();
+                }
+                startRefresh(input, newCachedItem);
+                final boolean listenerAdded = newCachedItem.addListener(listener, isCancelled);
+                assert listenerAdded;
+                newCachedItem.decRef();
+                return;
+            }
+            // else the CAS failed because we lost a race to a concurrent retrieval; try again from the top since we expect the race winner
+            // to be fresh enough for us and therefore we can just wait for its result.
+        } while (true);
+    }
+
+    private void startRefresh(Input input, CachedItem cachedItem) {
+        try {
+            refresh(input, cachedItem::ensureNotCancelled, cachedItem.getFuture());
+        } catch (Exception e) {
+            cachedItem.getFuture().onFailure(e);
+        }
+    }
+
+    /**
+     * An item in the cache, representing a single invocation of {@link #refresh}.
+     * <p>
+     * This item is ref-counted so that it can be cancelled if it becomes irrelevant. References are held by:
+     * <ul>
+     *     <li>Every listener that is waiting for the result, released on cancellation. There's no need to release on completion because
+     *     there's nothing to cancel once the refresh has completed.</li>
+     *     <li>The cache itself, released once this item is no longer the current one in the cache, either because it failed or because a
+     *     fresher computation was started.</li>
+     *     <li>The process that adds the first listener, released once the first listener is added.</li>
+     * </ul>
+     */
+    private final class CachedItem extends AbstractRefCounted {
+
+        private final Key key;
+        private final ListenableActionFuture<Value> future = new ListenableActionFuture<>();
+        private final CancellationChecks cancellationChecks = new CancellationChecks();
+
+        CachedItem(Key key) {
+            super("cached item");
+            this.key = key;
+            incRef(); // start with a refcount of 2 so we're not closed while adding the first listener
+            this.future.addListener(new ActionListener<Value>() {
+                @Override
+                public void onResponse(Value value) {
+                    cancellationChecks.clear();
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    cancellationChecks.clear();
+                    // Do not cache this failure
+                    if (currentCachedItemRef.compareAndSet(CachedItem.this, null)) {
+                        // Release reference held by the cache, so that concurrent calls to addListener() fail and retry. Not totally
+                        // necessary, we could also fail those listeners as if they'd been added slightly sooner, but it makes the ref
+                        // counting easier to document.
+                        decRef();
+                    }
+                }
+            });
+        }
+
+        Key getKey() {
+            return key;
+        }
+
+        ListenableActionFuture<Value> getFuture() {
+            return future;
+        }
+
+        boolean addListener(ActionListener<Value> listener, BooleanSupplier isCancelled) {
+            if (tryIncRef()) {
+                if (future.isDone()) {
+                    // No need to bother with ref counting & cancellation any more, just complete the listener.
+                    // We know it wasn't cancelled because there are still references.
+                    ActionListener.completeWith(listener, () -> future.actionGet(0L));
+                } else {
+                    // Refresh is still pending; it's not cancelled because there are still references.
+                    future.addListener(listener);
+                    final AtomicBoolean released = new AtomicBoolean();
+                    cancellationChecks.add(() -> {
+                        if (released.get() == false && isCancelled.getAsBoolean() && released.compareAndSet(false, true)) {
+                            decRef();
+                        }
+                    });
+                }
+                return true;
+            } else {
+                return false;
+            }
+        }
+
+        void ensureNotCancelled() {
+            cancellationChecks.runAll();
+            if (refCount() == 0) {
+                throw new TaskCancelledException("task cancelled");
+            }
+        }
+
+        @Override
+        protected void closeInternal() {
+            // Complete the future (and hence all its listeners) with an exception if it hasn't already been completed.
+            future.onFailure(new TaskCancelledException("task cancelled"));
+        }
+    }
+
+    private static final class CancellationChecks {
+        @Nullable // if cleared
+        private ArrayList<Runnable> checks = new ArrayList<>();
+
+        synchronized void clear() {
+            checks = null;
+        }
+
+        synchronized void add(Runnable check) {
+            if (checks != null) {
+                checks.add(check);
+            }
+        }
+
+        void runAll() {
+            // It's ok not to run all the checks so there's no need for a completely synchronized iteration.
+            final int count;
+            synchronized (this) {
+                if (checks == null) {
+                    return;
+                }
+                count = checks.size();
+            }
+            for (int i = 0; i < count; i++) {
+                final Runnable cancellationCheck;
+                synchronized (this) {
+                    if (checks == null) {
+                        return;
+                    }
+                    cancellationCheck = checks.get(i);
+                }
+                cancellationCheck.run();
+            }
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterStatsAction.java
@@ -13,6 +13,7 @@ import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestActions.NodesResponseRestListener;
+import org.elasticsearch.rest.action.RestCancellableNodeClient;
 
 import java.io.IOException;
 import java.util.List;
@@ -39,7 +40,8 @@ public class RestClusterStatsAction extends BaseRestHandler {
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
         ClusterStatsRequest clusterStatsRequest = new ClusterStatsRequest().nodesIds(request.paramAsStringArray("nodeId", null));
         clusterStatsRequest.timeout(request.param("timeout"));
-        return channel -> client.admin().cluster().clusterStats(clusterStatsRequest, new NodesResponseRestListener<>(channel));
+        return channel -> new RestCancellableNodeClient(client, request.getHttpChannel())
+                .admin().cluster().clusterStats(clusterStatsRequest, new NodesResponseRestListener<>(channel));
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/AnalysisStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/AnalysisStatsTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 
 import java.io.IOException;
@@ -176,7 +177,7 @@ public class AnalysisStatsTests extends AbstractWireSerializingTestCase<Analysis
         Metadata metadata = new Metadata.Builder()
                 .put(indexMetadata)
                 .build();
-        AnalysisStats analysisStats = AnalysisStats.of(metadata);
+        AnalysisStats analysisStats = AnalysisStats.of(metadata, () -> {});
         IndexFeatureStats expectedStats = new IndexFeatureStats("german");
         expectedStats.count = 1;
         expectedStats.indexCount = 1;
@@ -199,7 +200,23 @@ public class AnalysisStatsTests extends AbstractWireSerializingTestCase<Analysis
         Metadata metadata = new Metadata.Builder()
                 .put(indexMetadata)
                 .build();
-        AnalysisStats analysisStats = AnalysisStats.of(metadata);
+        AnalysisStats analysisStats = AnalysisStats.of(metadata, () -> {});
         assertEquals(Collections.emptySet(), analysisStats.getUsedBuiltInAnalyzers());
+    }
+
+    public void testChecksForCancellation() {
+        Settings settings = Settings.builder()
+                .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 4)
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
+                .build();
+        IndexMetadata.Builder indexMetadata = new IndexMetadata.Builder("foo")
+                .settings(settings);
+        Metadata metadata = new Metadata.Builder()
+                .put(indexMetadata)
+                .build();
+        expectThrows(TaskCancelledException.class, () -> AnalysisStats.of(metadata, () -> {
+            throw new TaskCancelledException("task cancelled");
+        }));
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/MappingStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/MappingStatsTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 
 import java.io.IOException;
@@ -76,7 +77,7 @@ public class MappingStatsTests extends AbstractWireSerializingTestCase<MappingSt
         Metadata metadata = new Metadata.Builder()
                 .put(indexMetadata)
                 .build();
-        MappingStats mappingStats = MappingStats.of(metadata);
+        MappingStats mappingStats = MappingStats.of(metadata, () -> {});
         IndexFeatureStats expectedStats = new IndexFeatureStats("long");
         expectedStats.count = 1;
         expectedStats.indexCount = 1;
@@ -99,7 +100,23 @@ public class MappingStatsTests extends AbstractWireSerializingTestCase<MappingSt
         Metadata metadata = new Metadata.Builder()
                 .put(indexMetadata)
                 .build();
-        MappingStats mappingStats = MappingStats.of(metadata);
+        MappingStats mappingStats = MappingStats.of(metadata, () -> {});
         assertEquals(Collections.emptySet(), mappingStats.getFieldTypeStats());
+    }
+
+    public void testChecksForCancellation() {
+        Settings settings = Settings.builder()
+                .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 4)
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
+                .build();
+        IndexMetadata.Builder indexMetadata = new IndexMetadata.Builder("foo")
+                .settings(settings);
+        Metadata metadata = new Metadata.Builder()
+                .put(indexMetadata)
+                .build();
+        expectThrows(TaskCancelledException.class, () -> MappingStats.of(metadata, () -> {
+            throw new TaskCancelledException("task cancelled");
+        }));
     }
 }

--- a/server/src/test/java/org/elasticsearch/common/util/CancellableSingleObjectCacheTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/CancellableSingleObjectCacheTests.java
@@ -1,0 +1,293 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.common.util;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.StepListener;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
+import org.elasticsearch.tasks.TaskCancelledException;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import java.util.LinkedList;
+import java.util.Objects;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.sameInstance;
+
+public class CancellableSingleObjectCacheTests extends ESTestCase {
+
+    public void testNoPendingRefreshIfAlreadyCancelled() {
+        final TestCache testCache = new TestCache();
+        final TestFuture future = new TestFuture();
+        testCache.get("foo", () -> true, future);
+        testCache.assertPendingRefreshes(0);
+        assertTrue(future.isDone());
+        expectThrows(ExecutionException.class, TaskCancelledException.class, future::get);
+    }
+
+    public void testListenersCompletedByRefresh() {
+        final TestCache testCache = new TestCache();
+
+        // The first get() calls the refresh function
+        final TestFuture future0 = new TestFuture();
+        testCache.get("foo", () -> false, future0);
+        testCache.assertPendingRefreshes(1);
+
+        // The second get() with a matching key does not refresh again
+        final TestFuture future1 = new TestFuture();
+        testCache.get("foo", () -> false, future1);
+        assertFalse(future0.isDone());
+        assertFalse(future1.isDone());
+        testCache.assertPendingRefreshes(1);
+        testCache.completeNextRefresh("foo", 1);
+        assertThat(future0.actionGet(0L), equalTo(1));
+        assertThat(future0.actionGet(0L), sameInstance(future1.actionGet(0L)));
+
+        // A further get() call with a matching key re-uses the cached value
+        final TestFuture future2 = new TestFuture();
+        testCache.get("foo", () -> false, future2);
+        testCache.assertNoPendingRefreshes();
+        assertThat(future2.actionGet(0L), sameInstance(future1.actionGet(0L)));
+
+        // A call with a different key triggers another refresh
+        final TestFuture future3 = new TestFuture();
+        testCache.get("bar", () -> false, future3);
+        assertFalse(future3.isDone());
+        testCache.assertPendingRefreshes(1);
+        testCache.completeNextRefresh("bar", 2);
+        assertThat(future3.actionGet(0L), equalTo(2));
+    }
+
+    public void testListenerCompletedByRefreshEvenIfDiscarded() {
+        final TestCache testCache = new TestCache();
+
+        // This computation is discarded before it completes.
+        final TestFuture future1 = new TestFuture();
+        final AtomicBoolean future1Cancelled = new AtomicBoolean();
+        testCache.get("foo", future1Cancelled::get, future1);
+        future1Cancelled.set(true);
+        testCache.assertPendingRefreshes(1);
+        assertFalse(future1.isDone());
+
+        // However the refresh continues and makes its result available to a later get() call for the same value.
+        final TestFuture future2 = new TestFuture();
+        testCache.get("foo", () -> false, future2);
+        testCache.assertPendingRefreshes(1);
+        testCache.completeNextRefresh("foo", 1);
+        assertThat(future2.actionGet(0L), equalTo(1));
+
+        // ... and the original listener is also completed successfully
+        assertThat(future1.actionGet(0L), sameInstance(future2.actionGet(0L)));
+    }
+
+    public void testListenerCompletedWithCancellationExceptionIfRefreshCancelled() {
+        final TestCache testCache = new TestCache();
+
+        // This computation is discarded before it completes.
+        final TestFuture future1 = new TestFuture();
+        final AtomicBoolean future1Cancelled = new AtomicBoolean();
+        testCache.get("foo", future1Cancelled::get, future1);
+        future1Cancelled.set(true);
+        testCache.assertPendingRefreshes(1);
+
+        assertFalse(future1.isDone());
+
+        // A second get() call with a non-matching key cancels the original refresh and starts another one
+        final TestFuture future2 = new TestFuture();
+        testCache.get("bar", () -> false, future2);
+        testCache.assertPendingRefreshes(2);
+        testCache.assertNextRefreshCancelled();
+        expectThrows(TaskCancelledException.class, () -> future1.actionGet(0L));
+        testCache.completeNextRefresh("bar", 2);
+        assertThat(future2.actionGet(0L), equalTo(2));
+    }
+
+    public void testExceptionCompletesListenersButIsNotCached() {
+        final TestCache testCache = new TestCache();
+
+        // If a refresh results in an exception then all the pending get() calls complete exceptionally
+        final TestFuture future0 = new TestFuture();
+        final TestFuture future1 = new TestFuture();
+        testCache.get("foo", () -> false, future0);
+        testCache.get("foo", () -> false, future1);
+        testCache.assertPendingRefreshes(1);
+        final ElasticsearchException exception = new ElasticsearchException("simulated");
+        testCache.completeNextRefresh(exception);
+        assertSame(exception, expectThrows(ElasticsearchException.class, () -> future0.actionGet(0L)));
+        assertSame(exception, expectThrows(ElasticsearchException.class, () -> future1.actionGet(0L)));
+
+        testCache.assertNoPendingRefreshes();
+        // The exception is not cached, however, so a subsequent get() call with a matching key performs another refresh
+        final TestFuture future2 = new TestFuture();
+        testCache.get("foo", () -> false, future2);
+        testCache.assertPendingRefreshes(1);
+        testCache.completeNextRefresh("foo", 1);
+        assertThat(future2.actionGet(0L), equalTo(1));
+    }
+
+    public void testConcurrentRefreshesAndCancellation() throws InterruptedException {
+        final ThreadPool threadPool = new TestThreadPool("test");
+        try {
+            final CancellableSingleObjectCache<String, String, Integer> testCache
+                    = new CancellableSingleObjectCache<String, String, Integer>() {
+                @Override
+                protected void refresh(String s, Runnable ensureNotCancelled, ActionListener<Integer> listener) {
+                    threadPool.generic().execute(() -> ActionListener.completeWith(listener, () -> {
+                        ensureNotCancelled.run();
+                        if (s.equals("FAIL")) {
+                            throw new ElasticsearchException("simulated");
+                        }
+                        return s.length();
+                    }));
+                }
+
+                @Override
+                protected String getKey(String s) {
+                    return s;
+                }
+            };
+            final int count = 1000;
+            final CountDownLatch startLatch = new CountDownLatch(1);
+            final CountDownLatch finishLatch = new CountDownLatch(count);
+            final BlockingQueue<Runnable> queue = ConcurrentCollections.newBlockingQueue();
+
+            for (int i = 0; i < count; i++) {
+                final boolean cancel = randomBoolean();
+                final String input = randomFrom("FAIL", "foo", "barbaz", "quux", "gruly");
+                queue.offer(() -> {
+                    try {
+                        assertTrue(startLatch.await(10, TimeUnit.SECONDS));
+                    } catch (InterruptedException e) {
+                        throw new AssertionError(e);
+                    }
+
+                    final StepListener<Integer> stepListener = new StepListener<>();
+                    final AtomicBoolean isComplete = new AtomicBoolean();
+                    final AtomicBoolean isCancelled = new AtomicBoolean();
+                    testCache.get(input, isCancelled::get, ActionListener.runBefore(stepListener,
+                            () -> assertTrue(isComplete.compareAndSet(false, true))));
+
+                    final Runnable next = queue.poll();
+                    if (next != null) {
+                        threadPool.generic().execute(next);
+                    }
+
+                    if (cancel) {
+                        isCancelled.set(true);
+                    }
+
+                    stepListener.whenComplete(len -> {
+                        finishLatch.countDown();
+                        assertThat(len, equalTo(input.length()));
+                        assertNotEquals("FAIL", input);
+                    }, e -> {
+                        finishLatch.countDown();
+                        if (e instanceof TaskCancelledException) {
+                            assertTrue(cancel);
+                        } else {
+                            assertEquals("FAIL", input);
+                        }
+                    });
+                });
+            }
+
+            for (int i = 0; i < 10; i++) {
+                threadPool.generic().execute(Objects.requireNonNull(queue.poll()));
+            }
+
+            startLatch.countDown();
+            assertTrue(finishLatch.await(10, TimeUnit.SECONDS));
+        } finally {
+            ThreadPool.terminate(threadPool, 10, TimeUnit.SECONDS);
+        }
+    }
+
+    private static class TestCache extends CancellableSingleObjectCache<String, String, Integer> {
+
+        private final LinkedList<StepListener<Function<String, Integer>>> pendingRefreshes = new LinkedList<>();
+
+        @Override
+        protected void refresh(String input, Runnable ensureNotCancelled, ActionListener<Integer> listener) {
+            final StepListener<Function<String, Integer>> stepListener = new StepListener<>();
+            pendingRefreshes.offer(stepListener);
+            stepListener.whenComplete(f -> ActionListener.completeWith(listener, () -> {
+                ensureNotCancelled.run();
+                return f.apply(input);
+            }), listener::onFailure);
+        }
+
+        @Override
+        protected String getKey(String s) {
+            return s;
+        }
+
+        void assertPendingRefreshes(int expected) {
+            assertThat(pendingRefreshes.size(), equalTo(expected));
+        }
+
+        void assertNoPendingRefreshes() {
+            assertThat(pendingRefreshes, empty());
+        }
+
+        void completeNextRefresh(String key, int value) {
+            nextRefresh().onResponse(k -> {
+                assertThat(k, equalTo(key));
+                return value;
+            });
+        }
+
+        void completeNextRefresh(Exception e) {
+            nextRefresh().onFailure(e);
+        }
+
+        void assertNextRefreshCancelled() {
+            nextRefresh().onResponse(k -> {
+                throw new AssertionError("should not be called");
+            });
+        }
+
+        private StepListener<Function<String, Integer>> nextRefresh() {
+            assertThat(pendingRefreshes, not(empty()));
+            final StepListener<Function<String, Integer>> nextRefresh = pendingRefreshes.poll();
+            assertNotNull(nextRefresh);
+            return nextRefresh;
+        }
+
+    }
+
+    private static class TestFuture extends PlainActionFuture<Integer> {
+
+        private final AtomicBoolean isCompleted = new AtomicBoolean();
+
+        @Override
+        public void onResponse(Integer result) {
+            assertTrue(isCompleted.compareAndSet(false, true));
+            super.onResponse(result);
+        }
+
+        @Override
+        public void onFailure(Exception e) {
+            assertTrue(isCompleted.compareAndSet(false, true));
+            super.onFailure(e);
+        }
+    }
+
+}

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/cluster/ClusterStatsMonitoringDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/cluster/ClusterStatsMonitoringDocTests.java
@@ -334,8 +334,8 @@ public class ClusterStatsMonitoringDocTests extends BaseMonitoringDocTestCase<Cl
                                                                             clusterName,
                                                                             singletonList(mockNodeResponse),
                                                                             emptyList(),
-                                                                            MappingStats.of(metadata),
-                                                                            AnalysisStats.of(metadata),
+                                                                            MappingStats.of(metadata, () -> {}),
+                                                                            AnalysisStats.of(metadata, () -> {}),
                                                                             VersionStats.of(metadata, singletonList(mockNodeResponse)));
 
         final MonitoringDoc.Node node = new MonitoringDoc.Node("_uuid", "_host", "_addr", "_ip", "_name", 1504169190855L);


### PR DESCRIPTION
Today `GET _cluster/stats` can be quite expensive, and is typically
retrieved periodically by monitoring systems (e.g. Metricbeat) that
implement a client-side timeout. When the client times out it closes the
HTTP connection in use. With this commit we react to the close of the
HTTP connection by cancelling the ongoing stats request, avoiding
unnecessary duplicated work.

Relates #55550
Backport of #68676 