### PR TITLE
Make DocumentMapper final

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -25,7 +25,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.stream.Stream;
 
-public class DocumentMapper {
+public final class DocumentMapper {
     private final String type;
     private final CompressedXContent mappingSource;
     private final DocumentParser documentParser;


### PR DESCRIPTION
DocumentMapper used to have only private constructors and created through its corresponding builder. The builder was recently removed and its constructors are no longer private, hence it makes sense to make the class final as it is not supposed to be subclassed.