### PR TITLE
[7.11] [DOCS] Add redirect for scroll in Java API (#68825)

### DIFF
--- a/docs/java-api/index.asciidoc
+++ b/docs/java-api/index.asciidoc
@@ -147,3 +147,5 @@ include::aggs.asciidoc[]
 include::query-dsl.asciidoc[]
 
 include::admin/index.asciidoc[]
+
+include::redirects.asciidoc[]

--- a/docs/java-api/redirects.asciidoc
+++ b/docs/java-api/redirects.asciidoc
@@ -1,0 +1,9 @@
+["appendix",role="exclude",id="redirects"]
+= Deleted pages
+
+The following pages have moved or been deleted.
+
+[role="exclude",id="scrolling"]
+=== Using scrolls in Java
+
+See <<java-search-scrolling>>.


### PR DESCRIPTION
Backports the following commits to 7.11:
 - [DOCS] Add redirect for scroll in Java API (#68825)