### PR TITLE
Reorder arguments to StepListener#whenComplete

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/StepListener.java
+++ b/server/src/main/java/org/elasticsearch/action/StepListener.java
@@ -62,10 +62,10 @@ public final class StepListener<Response> extends NotifyOnceListener<Response> {
      * Registers the given actions which are called when this step is completed. If this step is completed successfully,
      * the {@code onResponse} is called with the result; otherwise the {@code onFailure} is called with the failure.
      *
-     * @param onResponse is called when this step is completed successfully
      * @param onFailure  is called when this step is completed with a failure
+     * @param onResponse is called when this step is completed successfully
      */
-    public void whenComplete(CheckedConsumer<Response, Exception> onResponse, Consumer<Exception> onFailure) {
+    public void whenComplete(Consumer<Exception> onFailure, CheckedConsumer<Response, Exception> onResponse) {
         addListener(ActionListener.wrap(onResponse, onFailure));
     }
 
@@ -80,7 +80,7 @@ public final class StepListener<Response> extends NotifyOnceListener<Response> {
             StepListener<OtherResponse> other,
             BiFunction<Response, OtherResponse, OuterResponse> fn) {
         final StepListener<OuterResponse> combined = new StepListener<>();
-        whenComplete(r1 -> other.whenComplete(r2 -> combined.onResponse(fn.apply(r1, r2)), combined::onFailure), combined::onFailure);
+        whenComplete(combined::onFailure, r1 -> other.whenComplete(combined::onFailure, r2 -> combined.onResponse(fn.apply(r1, r2))));
         return combined;
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/cleanup/TransportCleanupRepositoryAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/cleanup/TransportCleanupRepositoryAction.java
@@ -144,7 +144,7 @@ public final class TransportCleanupRepositoryAction extends TransportMasterNodeA
         final BlobStoreRepository blobStoreRepository = (BlobStoreRepository) repository;
         final StepListener<RepositoryData> repositoryDataListener = new StepListener<>();
         repository.getRepositoryData(repositoryDataListener);
-        repositoryDataListener.whenComplete(repositoryData -> {
+        repositoryDataListener.whenComplete(listener::onFailure, repositoryData -> {
             final long repositoryStateId = repositoryData.getGenId();
             logger.info("Running cleanup operations on repository [{}][{}]", repositoryName, repositoryStateId);
             clusterService.submitStateUpdateTask("cleanup repository [" + repositoryName + "][" + repositoryStateId + ']',
@@ -242,6 +242,6 @@ public final class TransportCleanupRepositoryAction extends TransportMasterNodeA
                             });
                     }
                 });
-        }, listener::onFailure);
+        });
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/TransportGetSnapshotsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/TransportGetSnapshotsAction.java
@@ -130,8 +130,8 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
             repositoriesService.getRepositoryData(repo, repositoryDataListener);
         }
 
-        repositoryDataListener.whenComplete(repositoryData -> loadSnapshotInfos(snapshotsInProgress, repo, snapshots,
-                ignoreUnavailable, verbose, allSnapshotIds, currentSnapshots, repositoryData, listener), listener::onFailure);
+        repositoryDataListener.whenComplete(listener::onFailure, repositoryData -> loadSnapshotInfos(snapshotsInProgress, repo, snapshots,
+                ignoreUnavailable, verbose, allSnapshotIds, currentSnapshots, repositoryData, listener));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
@@ -91,18 +91,18 @@ public class TransportClusterStatsAction extends TransportNodesAction<ClusterSta
         final StepListener<AnalysisStats> analysisStatsStep = new StepListener<>();
         mappingStatsCache.get(metadata, cancellableTask::isCancelled, mappingStatsStep);
         analysisStatsCache.get(metadata, cancellableTask::isCancelled, analysisStatsStep);
-        mappingStatsStep.whenComplete(mappingStats -> analysisStatsStep.whenComplete(analysisStats -> ActionListener.completeWith(
-                listener,
-                () -> new ClusterStatsResponse(
-                        System.currentTimeMillis(),
-                        metadata.clusterUUID(),
-                        clusterService.getClusterName(),
-                        responses,
-                        failures,
-                        mappingStats,
-                        analysisStats,
-                        VersionStats.of(metadata, responses))
-        ), listener::onFailure), listener::onFailure);
+        mappingStatsStep.whenComplete(listener::onFailure, mappingStats -> analysisStatsStep.whenComplete(listener::onFailure,
+                analysisStats -> ActionListener.completeWith(
+                        listener,
+                        () -> new ClusterStatsResponse(
+                                System.currentTimeMillis(),
+                                metadata.clusterUUID(),
+                                clusterService.getClusterName(),
+                                responses,
+                                failures,
+                                mappingStats,
+                                analysisStats,
+                                VersionStats.of(metadata, responses)))));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/search/ClearScrollController.java
+++ b/server/src/main/java/org/elasticsearch/action/search/ClearScrollController.java
@@ -158,7 +158,7 @@ public final class ClearScrollController implements Runnable {
         } else {
             lookupListener.onResponse((cluster, nodeId) -> nodes.get(nodeId));
         }
-        lookupListener.whenComplete(nodeLookup -> {
+        lookupListener.whenComplete(listener::onFailure, nodeLookup -> {
             final GroupedActionListener<Boolean> groupedListener = new GroupedActionListener<>(
                 listener.map(rs -> Math.toIntExact(rs.stream().filter(r -> r).count())),
                 contextIds.size()
@@ -177,6 +177,6 @@ public final class ClearScrollController implements Runnable {
                     }
                 }
             }
-        }, listener::onFailure);
+        });
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/shard/StoreRecovery.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/StoreRecovery.java
@@ -483,8 +483,13 @@ final class StoreRecovery {
                 indexIdListener.onResponse(indexId);
             }
             assert indexShard.getEngineOrNull() == null;
-            indexIdListener.whenComplete(idx -> repository.restoreShard(indexShard.store(), restoreSource.snapshot().getSnapshotId(),
-                idx, snapshotShardId, indexShard.recoveryState(), restoreListener), restoreListener::onFailure);
+            indexIdListener.whenComplete(restoreListener::onFailure, idx -> repository.restoreShard(
+                    indexShard.store(),
+                    restoreSource.snapshot().getSnapshotId(),
+                    idx,
+                    snapshotShardId,
+                    indexShard.recoveryState(),
+                    restoreListener));
         } catch (Exception e) {
             restoreListener.onFailure(e);
         }

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -639,10 +639,10 @@ public class RestoreService implements ClusterStateApplier {
 
             // fork handling the above consumer to the generic pool since it loads various pieces of metadata from the repository over a
             // longer period of time
-            repositoryDataListener.whenComplete(repositoryData -> repositoryUuidRefreshListener.whenComplete(ignored ->
+            repositoryDataListener.whenComplete(listener::onFailure, repositoryData ->
+                repositoryUuidRefreshListener.whenComplete(listener::onFailure, ignored ->
                     clusterService.getClusterApplierService().threadPool().generic().execute(
-                            ActionRunnable.wrap(listener, l -> onRepositoryDataReceived.accept(repositoryData))
-                    ), listener::onFailure), listener::onFailure);
+                            ActionRunnable.wrap(listener, l -> onRepositoryDataReceived.accept(repositoryData)))));
 
         } catch (Exception e) {
             logger.warn(() -> new ParameterizedMessage("[{}] failed to restore snapshot",

--- a/server/src/main/java/org/elasticsearch/tasks/TaskCancellationService.java
+++ b/server/src/main/java/org/elasticsearch/tasks/TaskCancellationService.java
@@ -104,7 +104,7 @@ public class TaskCancellationService {
             final Runnable removeBansRunnable = transportService.getThreadPool().getThreadContext()
                 .preserveContext(() -> removeBanOnChildConnections(task, childConnections));
             // We remove bans after all child tasks are completed although in theory we can do it on a per-connection basis.
-            completedListener.whenComplete(r -> removeBansRunnable.run(), e -> removeBansRunnable.run());
+            completedListener.whenComplete(e -> removeBansRunnable.run(), r -> removeBansRunnable.run());
             // if wait_for_completion is true, then only return when (1) bans are placed on child connections, (2) child tasks are
             // completed or failed, (3) the main task is cancelled. Otherwise, return after bans are placed on child connections.
             if (waitForCompletion) {

--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -2742,7 +2742,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         } catch (NodeNotConnectedException ex) {
             futureHandler.handleException(ex);
         }
-        responseListener.whenComplete(handler::handleResponse, e -> handler.handleException((TransportException) e));
+        responseListener.whenComplete(e -> handler.handleException((TransportException) e), handler::handleResponse);
         final PlainActionFuture<T> future = PlainActionFuture.newFuture();
         responseListener.addListener(future);
         return future;

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/SearchableSnapshotDirectory.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/SearchableSnapshotDirectory.java
@@ -494,7 +494,7 @@ public class SearchableSnapshotDirectory extends BaseDirectory {
 
                 final int numberOfParts = file.numberOfParts();
                 final StepListener<Collection<Void>> fileCompletionListener = new StepListener<>();
-                fileCompletionListener.whenComplete(voids -> input.close(), e -> IOUtils.closeWhileHandlingException(input));
+                fileCompletionListener.whenComplete(e -> IOUtils.closeWhileHandlingException(input), voids -> input.close());
                 fileCompletionListener.addListener(completionListener.map(voids -> null));
 
                 final GroupedActionListener<Void> partsListener = new GroupedActionListener<>(fileCompletionListener, numberOfParts);

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/FrozenIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/FrozenIndexInput.java
@@ -379,7 +379,7 @@ public class FrozenIndexInput extends BaseSearchableSnapshotIndexInput {
                     // case, simply move on.
                     onCacheFillComplete.close();
                 } else {
-                    readListener.whenComplete(read -> {
+                    readListener.whenComplete(e -> onCacheFillComplete.close(), read -> {
                         assert read == indexCacheMissLength;
                         byteBuffer.position(read); // mark all bytes as accounted for
                         byteBuffer.flip();
@@ -395,7 +395,7 @@ public class FrozenIndexInput extends BaseSearchableSnapshotIndexInput {
                                 onCacheFillComplete.close();
                             }
                         });
-                    }, e -> onCacheFillComplete.close());
+                    });
                 }
             }
 

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotIndexEventListener.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotIndexEventListener.java
@@ -76,7 +76,7 @@ public class SearchableSnapshotIndexEventListener implements IndexEventListener 
         final ShardRouting shardRouting = indexShard.routingEntry();
         if (success && shardRouting.isRelocationTarget()) {
             final Runnable preWarmCondition = indexShard.addCleanFilesDependency();
-            preWarmListener.whenComplete(v -> preWarmCondition.run(), e -> {
+            preWarmListener.whenComplete(e -> {
                 logger.warn(
                     new ParameterizedMessage(
                         "pre-warm operation failed for [{}] while it was the target of primary relocation [{}]",
@@ -86,7 +86,7 @@ public class SearchableSnapshotIndexEventListener implements IndexEventListener 
                     e
                 );
                 preWarmCondition.run();
-            });
+            }, v -> preWarmCondition.run());
         }
         assert directory.listAll().length > 0 : "expecting directory listing to be non-empty";
         assert success || indexShard.routingEntry().recoverySource().getType() == RecoverySource.Type.PEER

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/TransportMountSearchableSnapshotAction.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/TransportMountSearchableSnapshotAction.java
@@ -160,7 +160,7 @@ public class TransportMountSearchableSnapshotAction extends TransportMasterNodeA
         final Repository repository = repositoriesService.repository(repoName);
         final StepListener<RepositoryData> repositoryDataListener = new StepListener<>();
         repository.getRepositoryData(repositoryDataListener);
-        repositoryDataListener.whenComplete(repoData -> {
+        repositoryDataListener.whenComplete(listener::onFailure, repoData -> {
             final Map<String, IndexId> indexIds = repoData.getIndices();
             if (indexIds.containsKey(indexName) == false) {
                 throw new IndexNotFoundException("index [" + indexName + "] not found in repository [" + repoName + "]");
@@ -214,6 +214,6 @@ public class TransportMountSearchableSnapshotAction extends TransportMasterNodeA
                         .snapshotUuid(snapshotId.getUUID()),
                     listener
                 );
-        }, listener::onFailure);
+        });
     }
 }

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/FrozenCacheService.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/FrozenCacheService.java
@@ -578,9 +578,9 @@ public class FrozenCacheService implements Releasable {
                 decrementRef = Releasables.releaseOnce(this::decRef);
                 ensureOpen();
                 Releasable finalDecrementRef = decrementRef;
-                listener.whenComplete(integer -> finalDecrementRef.close(), throwable -> finalDecrementRef.close());
+                listener.whenComplete(throwable -> finalDecrementRef.close(), integer -> finalDecrementRef.close());
                 final SharedBytes.IO fileChannel = sharedBytes.getFileChannel(sharedBytesPos);
-                listener.whenComplete(integer -> fileChannel.decRef(), e -> fileChannel.decRef());
+                listener.whenComplete(e -> fileChannel.decRef(), integer -> fileChannel.decRef());
                 final ActionListener<Void> rangeListener = rangeListener(rangeToRead, reader, listener, fileChannel);
                 if (rangeToRead.length() == 0L) {
                     // nothing to read, skip
@@ -637,9 +637,9 @@ public class FrozenCacheService implements Releasable {
                 decrementRef = Releasables.releaseOnce(this::decRef);
                 ensureOpen();
                 final Releasable finalDecrementRef = decrementRef;
-                listener.whenComplete(integer -> finalDecrementRef.close(), throwable -> finalDecrementRef.close());
+                listener.whenComplete(throwable -> finalDecrementRef.close(), integer -> finalDecrementRef.close());
                 final SharedBytes.IO fileChannel = sharedBytes.getFileChannel(sharedBytesPos);
-                listener.whenComplete(integer -> fileChannel.decRef(), e -> fileChannel.decRef());
+                listener.whenComplete(e -> fileChannel.decRef(), integer -> fileChannel.decRef());
                 if (tracker.waitForRangeIfPending(rangeToRead, rangeListener(rangeToRead, reader, listener, fileChannel))) {
                     return listener;
                 } else {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationService.java
@@ -375,8 +375,8 @@ public class AuthorizationService {
             while (requestInterceptorIterator.hasNext()) {
                 final RequestInterceptor nextInterceptor = requestInterceptorIterator.next();
                 final StepListener<Void> current = new StepListener<>();
-                prevListener.whenComplete(v -> nextInterceptor.intercept(requestInfo, authorizationEngine, authorizationInfo, current),
-                    listener::onFailure);
+                prevListener.whenComplete(listener::onFailure,
+                        v -> nextInterceptor.intercept(requestInfo, authorizationEngine, authorizationInfo, current));
                 prevListener = current;
             }
 


### PR DESCRIPTION
The `onResponse` argument is typically a large multi-line lambda which
triggers subsequent steps, whereas the `onError` argument is frequently
something short like `listener::onFailure`. I find the separation
between the call to `whenComplete` and the short `onError` argument to
be an obstruction to reading, particularly when calls are nested. I feel
like I am code that was in German written reading.

This commit reverses the order of these arguments to better suit my
taste.