### PR TITLE
[7.x] [DOCS] Correct the path of BwcVersions in the Testing doc (#68798)

### DIFF
--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -546,7 +546,7 @@ For example to run a specific tests from the x-pack rolling upgrade from 7.7.0:
 
 Tests are ran for versions that are not yet released but with which the current version will be compatible with.
 These are automatically checked out and built from source.
-See link:./buildSrc/src/main/java/org/elasticsearch/gradle/VersionCollection.java[VersionCollection]
+See link:./buildSrc/src/main/java/org/elasticsearch/gradle/BwcVersions.java[BwcVersions]
 and link:./distribution/bwc/build.gradle[distribution/bwc/build.gradle]
 for more information.
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Correct the path of BwcVersions in the Testing doc (#68798)