### PR TITLE
SQL: Fix the MINUTE_OF_DAY() function that throws exception when used in comparisons (#68783)

### DIFF
--- a/x-pack/plugin/sql/qa/server/src/main/resources/datetime.csv-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/datetime.csv-spec
@@ -153,6 +153,16 @@ SELECT WEEK(birth_date) week, birth_date FROM test_emp WHERE WEEK(birth_date) > 
 2              |1953-01-07T00:00:00.000Z
 ;
 
+minuteOfDayFilterEquality
+SELECT MINUTE_OF_DAY(CONCAT(CONCAT('2021-01-22T14:26:06.', (salary % 2)::text), 'Z')::datetime) AS min_of_day 
+FROM test_emp WHERE min_of_day = 866 LIMIT 2;
+
+  min_of_day:i 
+---------------
+866            
+866            
+;
+
 selectAddWithDateTime
 schema::dt_year:s|dt_quarter:s|dt_month:s|dt_week:s|dt_day:s|dt_hours:s|dt_min:s|dt_sec:s|dt_millis:s|dt_mcsec:s|dt_nsec:s
 SELECT DATE_ADD('year', 10, '2019-09-04T11:22:33.123Z'::datetime)::string as dt_year, DATE_ADD('quarter', -10, '2019-09-04T11:22:33.123Z'::datetime)::string as dt_quarter, DATE_ADD('month', 20, '2019-09-04T11:22:33.123Z'::datetime)::string as dt_month,

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/MinuteOfDay.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/MinuteOfDay.java
@@ -34,6 +34,6 @@ public class MinuteOfDay extends TimeFunction {
 
     @Override
     public String dateTimeFormat() {
-        throw new UnsupportedOperationException("is there a format for it?");
+        return null;
     }
 }


### PR DESCRIPTION
The `MINUTE_OF_DAY()` extraction function does not have an equivalent
expressible using a datetime format pattern.

The `MinuteOfDay.dateTimeFormat()` is called during the query
translation and throws an exception, but the return value actually
does not impact the translated query (binary comparisons with
`DateTimeFunction` on one side always turn into a script query).

This change fixes the immediate issue raised as part of #67872,
add integration tests covering the problem, but leaves the removal
of the unnecessary `dateTimeFormat()` function a separate PR.