### PR TITLE
[ML] Increase memory estimates for categorization

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportEstimateModelMemoryAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportEstimateModelMemoryAction.java
@@ -200,6 +200,12 @@ public class TransportEstimateModelMemoryAction
             return 0;
         }
 
+        // 10MB is a pretty conservative estimate of the memory requirement for categorization,
+        // providing categorization is working well and not creating large numbers of inappropriate
+        // categories.  Often it is considerably less, but it's very hard to predict from simple
+        // statistics.
+        long memoryPerPartitionMb = 10;
+
         long relevantPartitionFieldCardinalityEstimate = 1;
         if (analysisConfig.getPerPartitionCategorizationConfig().isEnabled()) {
             // It is enforced that only one partition field name be configured when per-partition categorization
@@ -212,11 +218,15 @@ public class TransportEstimateModelMemoryAction
                     break;
                 }
             }
+            // If per-partition categorization is in use and stop-on-warn is not being used
+            // then there is a high risk that one or more of the partitions will turn out to
+            // categorize badly, so bump up the estimate.
+            if (analysisConfig.getPerPartitionCategorizationConfig().isStopOnWarn() == false) {
+                memoryPerPartitionMb *= 2;
+            }
         }
 
-        // 5MB is a pretty conservative estimate of the memory requirement for categorization.
-        // Often it is considerably less, but it's very hard to predict from simple statistics.
-        return ByteSizeValue.ofMb(5 * relevantPartitionFieldCardinalityEstimate).getBytes();
+        return ByteSizeValue.ofMb(memoryPerPartitionMb * relevantPartitionFieldCardinalityEstimate).getBytes();
     }
 
     static long cardinalityEstimate(String description, String fieldName, Map<String, Long> suppliedCardinailityEstimates,

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportEstimateModelMemoryActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportEstimateModelMemoryActionTests.java
@@ -95,7 +95,7 @@ public class TransportEstimateModelMemoryActionTests extends ESTestCase {
         AnalysisConfig analysisConfig =
             createCountAnalysisConfig(randomAlphaOfLength(10), randomBoolean() ? "part" : null);
         assertThat(TransportEstimateModelMemoryAction.calculateCategorizationRequirementBytes(analysisConfig, overallCardinality),
-            is(5L * 1024 * 1024));
+            is(10L * 1024 * 1024));
     }
 
     public void testCalculateCategorizationRequirementBytesPerPartitionCategorization() {
@@ -104,10 +104,11 @@ public class TransportEstimateModelMemoryActionTests extends ESTestCase {
         Map<String, Long> overallCardinality = new HashMap<>();
         overallCardinality.put("part", partitionCardinality);
 
+        boolean isStopOnWarn = randomBoolean();
         AnalysisConfig analysisConfig = createCountAnalysisConfigBuilder(randomAlphaOfLength(10), "part")
-            .setPerPartitionCategorizationConfig(new PerPartitionCategorizationConfig(true, randomBoolean())).build();
+            .setPerPartitionCategorizationConfig(new PerPartitionCategorizationConfig(true, isStopOnWarn)).build();
         assertThat(TransportEstimateModelMemoryAction.calculateCategorizationRequirementBytes(analysisConfig, overallCardinality),
-            is(partitionCardinality * 5L * 1024 * 1024));
+            is(partitionCardinality * 10L * (isStopOnWarn ? 1 : 2) * 1024 * 1024));
     }
 
     public void testRoundUpToNextMb() {


### PR DESCRIPTION
Previously we estimated 5MB per categorizer within the overall
job model memory estimate.  5MB is a reasonable estimate in the
case where categorization works well and creates a few hundred
categories, and the examples are not too big.  However, for
messages that do not categorize well and create thousands of
categories it can be much too low.

We introduced the stop_on_warn option to prevent log formats
that do not categorize well from blowing up categorization
memory usage. But even then it is possible that some log
formats may require extra space for large examples.

This change doubles the estimate per categorizer to 10MB, and
in cases where per-partition categorization is enabled but
stop_on_warn is not doubles this again to 20MB, as it is very
likely that there will be some message types that do not
categorize well.

Message types that do not categorize well will still cause the
job to go to the hard_limit memory status if stop_on_warn is
not enabled, but at least they will run a bit longer before
doing this, allowing a fuller picture of how categorization is
working for other partitions to be observed.  The only long
term fix for partitions that do not categorize well for some
reason remains to stop categorizing, as stop_on_warn would.