### PR TITLE
Add known issue for AD and LDAP permissions issue

### DIFF
--- a/docs/reference/release-notes/7.11.asciidoc
+++ b/docs/reference/release-notes/7.11.asciidoc
@@ -3,6 +3,20 @@
 
 Also see <<breaking-changes-7.11,Breaking changes in 7.11>>.
 
+[[known-issues-7.11.0]]
+[discrete]
+=== Known issues
+
+* Integration with <<active-directory-realm, Active Directory realms>> and
+  <<ldap-realm, LDAP realms>> is impacted by an issue that prevents
+  Elasticsearch from starting. If you have configured an Active Directory or
+  LDAP realm, then Elasticseach will fail to start with an error message
+  indicating that `Could not initialize class com.unboundid.util.Debug`. This
+  exception is fatal. If you encounter this during an upgrade, because
+  Elasticsearch failed during node construction, you can safely downgrade to
+  your previous version of Elasticsearch. We are actively working on a fix for
+  this issue. For more details, see {es-issue}68838[#68838].
+
 [discrete]
 [[fips-140-2-compliance-7.11.0]]
 === FIPS 140-2 compliance


### PR DESCRIPTION
This commit adds a known issue to the docs for the AD and LDAP permissions issue that arises from incorrect security manager permissions being applied to the x-pack-core module.

Relates #68838 
Relates #68872 