### PR TITLE
Mute "order by sub agg containing nested" test correctly

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/20_terms.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/20_terms.yml
@@ -1111,7 +1111,7 @@ setup:
 ---
 "order by sub agg containing nested":
   - skip:
-        version: "7.99.99 - "
+        version: " - 7.99.99"
         reason: "https://github.com/elastic/elasticsearch/issues/66876"
   - do:
       indices.put_mapping:


### PR DESCRIPTION
Fat-fingered the skip statement in this one.

Relates to #66876
