### PR TITLE
Remove POSIX Allocate JNA Call

### DIFF
--- a/server/src/main/java/org/elasticsearch/bootstrap/JNAFalloc.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/JNAFalloc.java
@@ -16,7 +16,8 @@ import org.apache.lucene.util.Constants;
 import org.elasticsearch.common.Nullable;
 
 /**
- * System specific wrappers of the fallocate system call via JNA for Linux and OSX.
+ * System specific wrappers of the fallocate system call via JNA for Linux.
+ * TODO: look into adding native implementations for falloc equivalents for other platforms (Windows) to improve performance.
  */
 abstract class JNAFalloc {
 
@@ -27,9 +28,7 @@ abstract class JNAFalloc {
     @Nullable
     public static JNAFalloc falloc() {
         try {
-            if (Constants.MAC_OS_X) {
-                return OSX.INSTANCE;
-            } else if (Constants.LINUX) {
+            if (Constants.LINUX) {
                 return Linux.INSTANCE;
             }
         } catch (Throwable t) {
@@ -53,22 +52,6 @@ abstract class JNAFalloc {
         }
 
         private static native int fallocate(int fd, int mode, long offset, long length);
-    }
-
-    private static class OSX extends JNAFalloc {
-
-        static final OSX INSTANCE = new OSX();
-
-        static {
-            Native.register("c");
-        }
-
-        @Override
-        public int fallocate(int fd, long offset, long length) {
-            return posix_fallocate(fd, offset, length);
-        }
-
-        private static native int posix_fallocate(int fd, long offset, long length);
     }
 
 }


### PR DESCRIPTION
This doesn't work on any modern day OSX so it's just
logging noise for users trying out this functionality on their
laptops.

Sorry for the noise here, I thought `posix_fallocate` was available on OSX these days but turns out https://github.com/elastic/elasticsearch/pull/68858 was too optimistic => lets only keep the Linux version around for now and think about Windows/OSX alternatives if/when needed.