### PR TITLE
Add release notes for v7.11.1

### DIFF
--- a/docs/reference/release-notes.asciidoc
+++ b/docs/reference/release-notes.asciidoc
@@ -6,6 +6,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-7.11.1>>
 * <<release-notes-7.11.0>>
 * <<release-notes-7.10.2>>
 * <<release-notes-7.10.1>>

--- a/docs/reference/release-notes/7.11.asciidoc
+++ b/docs/reference/release-notes/7.11.asciidoc
@@ -1,6 +1,9 @@
 [[release-notes-7.11.1]]
 == {es} version 7.11.1
 
+coming::[7.11.1]
+
+
 Also see <<breaking-changes-7.11,Breaking changes in 7.11>>.
 
 [[enhancement-7.11.1]]
@@ -14,7 +17,7 @@ Features/Stats::
 * Add index creation version stats to cluster stats {es-pull}68141[#68141]
 
 Snapshot/Restore::
-* Improve shards evictions in searchable snapshot cache service {es-pull}67160[#67160] (issues: {es-issue}66730[#66730], {es-issue}66958[#66958])
+* Improve shard evictions in searchable snapshot cache service {es-pull}67160[#67160] (issues: {es-issue}66730[#66730], {es-issue}66958[#66958])
 * Make blob cache have async durability {es-pull}66687[#66687]
 
 
@@ -41,7 +44,7 @@ Features/Indices APIs::
 * Fix exception when validating composable template with no template {es-pull}67310[#67310] (issue: {es-issue}66949[#66949])
 
 Features/Ingest::
-* Fix parsing empty value with brackets failed in Dissect ingest processor {es-pull}65524[#65524] (issue: {es-issue}65080[#65080])
+* Fix parsing empty value with brackets failed in dissect ingest processor {es-pull}65524[#65524] (issue: {es-issue}65080[#65080])
 
 Features/Stats::
 * Allow reading of `/proc/meminfo` for JDK bug workaround {es-pull}68742[#68742]
@@ -76,6 +79,8 @@ Snapshot/Restore::
 
 [[release-notes-7.11.0]]
 == {es} version 7.11.0
+
+Also see <<breaking-changes-7.11,Breaking changes in 7.11>>.
 
 [[known-issues-7.11.0]]
 [discrete]

--- a/docs/reference/release-notes/7.11.asciidoc
+++ b/docs/reference/release-notes/7.11.asciidoc
@@ -65,6 +65,9 @@ Machine Learning::
 Network::
 * Fix `AbstractClient#execute` Listener Leak {es-pull}65415[#65415] (issue: {es-issue}65405[#65405])
 
+Packaging::
+* Fix installation using Windows MSI (issue: {es-issue}68914[#68914])
+
 Recovery::
 * Check graveyard on dangling index import {es-pull}67687[#67687]
 

--- a/docs/reference/release-notes/7.11.asciidoc
+++ b/docs/reference/release-notes/7.11.asciidoc
@@ -34,7 +34,7 @@ Cluster Coordination::
 
 Features/ILM+SLM::
 * Check if delete phase has actions {es-pull}66664[#66664] (issue: {es-issue}65847[#65847])
-* Fix handling of configurtions with a combination of both maximum and expire-after retention {es-pull}68352[#68352]
+* Fix handling of configurations with a combination of both maximum and expire-after retention {es-pull}68352[#68352]
 * Fix searchable snapshot action to wait for the restored index {es-pull}68309[#68309] (issue: {es-issue}67879[#67879])
 * Ignore `clusterChanged` events if state not recovered {es-pull}67507[#67507] (issue: {es-issue}67506[#67506])
 * `ShrinkStep` ignores the `isAcknowledged` flag on the response {es-pull}67591[#67591] (issue: {es-issue}53111[#53111])
@@ -53,9 +53,6 @@ Features/Stats::
 Geo::
 * Add support for `distance_feature` query for runtime `geo_point` field {es-pull}68094[#68094] (issue: {es-issue}67910[#67910])
 
-Infra/Core::
-* Fix an error that occurs while starting the service in Windows OS under a path with a space in it {es-pull}61895[#61895] (issue: {es-issue}61891[#61891])
-
 Infra/Scripting::
 * Remove leniency for casting from a `def` type to a `void` type in Painless {es-pull}66957[#66957] (issue: {es-issue}66175[#66175])
 
@@ -66,7 +63,8 @@ Network::
 * Fix `AbstractClient#execute` Listener Leak {es-pull}65415[#65415] (issue: {es-issue}65405[#65405])
 
 Packaging::
-* Fix installation using Windows MSI (issue: {es-issue}68914[#68914])
+* Fix an error that occurs while starting the service in Windows OS under a path with a space in it {es-pull}61895[#61895] (issue: {es-issue}61891[#61891])
+* Fix an issue with MSI installation on Windows that prevents {es} starting https://github.com/elastic/windows-installers/issues/402[#402] (issue: {es-issue}68914[#68914])
 
 Recovery::
 * Check graveyard on dangling index import {es-pull}67687[#67687]
@@ -77,6 +75,7 @@ SQL::
 
 Snapshot/Restore::
 * Reduce number of cache/prewarm threads {es-pull}67021[#67021]
+* Adjust encoding of Azure block IDs {es-pull}68957[#68957] (issue: {es-issue}66489[#66489])
 
 
 

--- a/docs/reference/release-notes/7.11.asciidoc
+++ b/docs/reference/release-notes/7.11.asciidoc
@@ -1,7 +1,81 @@
-[[release-notes-7.11.0]]
-== {es} version 7.11.0
+[[release-notes-7.11.1]]
+== {es} version 7.11.1
 
 Also see <<breaking-changes-7.11,Breaking changes in 7.11>>.
+
+[[enhancement-7.11.1]]
+[float]
+=== Enhancements
+
+Features/Indices APIs::
+* Prevent concurrent rollover race conditions {es-pull}67953[#67953] (issues: {es-issue}64921[#64921], {es-issue}67836[#67836])
+
+Features/Stats::
+* Add index creation version stats to cluster stats {es-pull}68141[#68141]
+
+Snapshot/Restore::
+* Improve shards evictions in searchable snapshot cache service {es-pull}67160[#67160] (issues: {es-issue}66730[#66730], {es-issue}66958[#66958])
+* Make blob cache have async durability {es-pull}66687[#66687]
+
+
+
+[[bug-7.11.1]]
+[float]
+=== Bug fixes
+
+Authentication::
+* Fix permissions for UnboundID LDAP SDK {es-pull}68872[#68872] (issues: {es-issue}64743[#64743], {es-issue}68838[#68838])
+
+Cluster Coordination::
+* Determine data role based on convention {es-pull}66933[#66933] (issue: {es-issue}66000[#66000])
+
+Features/ILM+SLM::
+* Check if delete phase has actions {es-pull}66664[#66664] (issue: {es-issue}65847[#65847])
+* Fix handling of configurtions with a combination of both maximum and expire-after retention {es-pull}68352[#68352]
+* Fix searchable snapshot action to wait for the restored index {es-pull}68309[#68309] (issue: {es-issue}67879[#67879])
+* Ignore `clusterChanged` events if state not recovered {es-pull}67507[#67507] (issue: {es-issue}67506[#67506])
+* `ShrinkStep` ignores the `isAcknowledged` flag on the response {es-pull}67591[#67591] (issue: {es-issue}53111[#53111])
+* Skip rollover if the data stream is rolled over already {es-pull}67778[#67778] (issue: {es-issue}67777[#67777])
+
+Features/Indices APIs::
+* Fix exception when validating composable template with no template {es-pull}67310[#67310] (issue: {es-issue}66949[#66949])
+
+Features/Ingest::
+* Fix parsing empty value with brackets failed in Dissect ingest processor {es-pull}65524[#65524] (issue: {es-issue}65080[#65080])
+
+Features/Stats::
+* Allow reading of `/proc/meminfo` for JDK bug workaround {es-pull}68742[#68742]
+* Workaround for JDK bug with total memory on Debian 8 {es-pull}68542[#68542] (issues: {es-issue}66629[#66629], {es-issue}66885[#66885])
+
+Geo::
+* Add support for `distance_feature` query for runtime `geo_point` field {es-pull}68094[#68094] (issue: {es-issue}67910[#67910])
+
+Infra/Core::
+* Fix an error that occurs while starting the service in Windows OS under a path with a space in it {es-pull}61895[#61895] (issue: {es-issue}61891[#61891])
+
+Infra/Scripting::
+* Remove leniency for casting from a `def` type to a `void` type in Painless {es-pull}66957[#66957] (issue: {es-issue}66175[#66175])
+
+Machine Learning::
+* Ensure mappings are up to date before reverting state {es-pull}68746[#68746]
+
+Network::
+* Fix `AbstractClient#execute` Listener Leak {es-pull}65415[#65415] (issue: {es-issue}65405[#65405])
+
+Recovery::
+* Check graveyard on dangling index import {es-pull}67687[#67687]
+
+SQL::
+* Fix `elasticsearch-sql-cli` under Docker {es-pull}67737[#67737] (issue: {es-issue}57744[#57744])
+* Fix the `MINUTE_OF_DAY()` function that throws exception when used in comparisons {es-pull}68783[#68783] (issues: {es-issue}67872[#67872], {es-issue}68788[#68788])
+
+Snapshot/Restore::
+* Reduce number of cache/prewarm threads {es-pull}67021[#67021]
+
+
+
+[[release-notes-7.11.0]]
+== {es} version 7.11.0
 
 [[known-issues-7.11.0]]
 [discrete]


### PR DESCRIPTION
Add release notes for 7.11.1. I omitted PRs for Autoscaling and the fix to the LLRC license headers.

I didn't explicitly call out the LDAP fix, but I could move it to the top if we prefer?