### PR TITLE
[7.x] [Transform] Take runtime mappings into account when deducing dest index mappings (#68530)

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/transform/preview_transforms.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/transform/preview_transforms.yml
@@ -390,8 +390,8 @@ setup:
   - match: { generated_dest_index.mappings.properties.airline.type: "keyword" }
   - match: { generated_dest_index.mappings.properties.by-hour.type: "date" }
   - match: { generated_dest_index.mappings.properties.avg_response.type: "double" }
-  - is_false: generated_dest_index.mappings.properties.time\.max.type
-  - is_false: generated_dest_index.mappings.properties.time\.min.type
+  - match: { generated_dest_index.mappings.properties.time\.max.type: "date" }
+  - match: { generated_dest_index.mappings.properties.time\.min.type: "date" }
 
 ---
 "Test preview transform latest with search runtime fields":

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformUsingSearchRuntimeFieldsIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformUsingSearchRuntimeFieldsIT.java
@@ -129,7 +129,7 @@ public class TransformUsingSearchRuntimeFieldsIT extends TransformIntegTestCase 
         PreviewTransformResponse previewResponse = previewTransform(config, RequestOptions.DEFAULT);
         // Verify preview mappings
         Map<String, Object> expectedMappingProperties =
-            new HashMap<>() {{
+            new HashMap<String, Object>() {{
                 put("by-user", singletonMap("type", "keyword"));
                 put("review_score", singletonMap("type", "double"));
                 put("review_score_max", singletonMap("type", "long"));

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/Pivot.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/Pivot.java
@@ -87,7 +87,7 @@ public class Pivot extends AbstractCompositeAggFunction {
 
     @Override
     public void deduceMappings(Client client, SourceConfig sourceConfig, final ActionListener<Map<String, String>> listener) {
-        SchemaUtil.deduceMappings(client, config, sourceConfig.getIndex(), listener);
+        SchemaUtil.deduceMappings(client, config, sourceConfig.getIndex(), sourceConfig.getRuntimeMappings(), listener);
     }
 
     /**

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationSchemaAndResultTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationSchemaAndResultTests.java
@@ -40,6 +40,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
+import static java.util.Collections.emptyMap;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -89,7 +90,7 @@ public class AggregationSchemaAndResultTests extends ESTestCase {
                         field,
                         Collections.singletonMap(
                             type,
-                            new FieldCapabilities(field, type, true, true, null, null, null, Collections.emptyMap())
+                            new FieldCapabilities(field, type, true, true, null, null, null, emptyMap())
                         )
                     );
                 }
@@ -125,7 +126,7 @@ public class AggregationSchemaAndResultTests extends ESTestCase {
         // scripted metric produces no output because its dynamic
         aggs.addAggregator(AggregationBuilders.scriptedMetric("collapsed_ratings"));
 
-        AggregationConfig aggregationConfig = new AggregationConfig(Collections.emptyMap(), aggs);
+        AggregationConfig aggregationConfig = new AggregationConfig(emptyMap(), aggs);
         GroupConfig groupConfig = GroupConfigTests.randomGroupConfig();
         PivotConfig pivotConfig = new PivotConfig(groupConfig, aggregationConfig, null);
         long numGroupsWithoutScripts = groupConfig.getGroups()
@@ -135,7 +136,7 @@ public class AggregationSchemaAndResultTests extends ESTestCase {
             .count();
 
         this.<Map<String, String>>assertAsync(
-            listener -> SchemaUtil.deduceMappings(client, pivotConfig, new String[] { "source-index" }, listener),
+            listener -> SchemaUtil.deduceMappings(client, pivotConfig, new String[] { "source-index" }, emptyMap(), listener),
             mappings -> {
                 assertEquals(numGroupsWithoutScripts + 10, mappings.size());
                 assertEquals("long", mappings.get("max_rating"));
@@ -192,7 +193,7 @@ public class AggregationSchemaAndResultTests extends ESTestCase {
                 )
         );
 
-        AggregationConfig aggregationConfig = new AggregationConfig(Collections.emptyMap(), aggs);
+        AggregationConfig aggregationConfig = new AggregationConfig(emptyMap(), aggs);
         GroupConfig groupConfig = GroupConfigTests.randomGroupConfig();
         PivotConfig pivotConfig = new PivotConfig(groupConfig, aggregationConfig, null);
         long numGroupsWithoutScripts = groupConfig.getGroups()
@@ -202,7 +203,7 @@ public class AggregationSchemaAndResultTests extends ESTestCase {
             .count();
 
         this.<Map<String, String>>assertAsync(
-            listener -> SchemaUtil.deduceMappings(client, pivotConfig, new String[] { "source-index" }, listener),
+            listener -> SchemaUtil.deduceMappings(client, pivotConfig, new String[] { "source-index" }, emptyMap(), listener),
             mappings -> {
                 assertEquals(numGroupsWithoutScripts + 12, mappings.size());
                 assertEquals("long", mappings.get("filter_1"));

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/SchemaUtilTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/SchemaUtilTests.java
@@ -152,7 +152,7 @@ public class SchemaUtilTests extends ESTestCase {
     }
 
     public void testGetSourceFieldMappingsWithRuntimeMappings() throws InterruptedException {
-        Map<String, Object> runtimeMappings = new HashMap<>() {{
+        Map<String, Object> runtimeMappings = new HashMap<String, Object>() {{
             put("field-2", singletonMap("type", "keyword"));
             put("field-3", singletonMap("type", "boolean"));
         }};

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/SchemaUtilTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/SchemaUtilTests.java
@@ -29,7 +29,13 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
 import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.is;
 
 public class SchemaUtilTests extends ESTestCase {
 
@@ -90,7 +96,7 @@ public class SchemaUtilTests extends ESTestCase {
         try (Client client = new FieldCapsMockClient(getTestName())) {
             // fields is null
             this.<Map<String, String>>assertAsync(
-                listener -> SchemaUtil.getSourceFieldMappings(client, new String[] { "index-1", "index-2" }, null, listener),
+                listener -> SchemaUtil.getSourceFieldMappings(client, new String[] { "index-1", "index-2" }, null, emptyMap(), listener),
                 mappings -> {
                     assertNotNull(mappings);
                     assertTrue(mappings.isEmpty());
@@ -99,7 +105,8 @@ public class SchemaUtilTests extends ESTestCase {
 
             // fields is empty
             this.<Map<String, String>>assertAsync(
-                listener -> SchemaUtil.getSourceFieldMappings(client, new String[] { "index-1", "index-2" }, new String[] {}, listener),
+                listener ->
+                    SchemaUtil.getSourceFieldMappings(client, new String[] { "index-1", "index-2" }, new String[] {}, emptyMap(), listener),
                 mappings -> {
                     assertNotNull(mappings);
                     assertTrue(mappings.isEmpty());
@@ -108,7 +115,7 @@ public class SchemaUtilTests extends ESTestCase {
 
             // indices is null
             this.<Map<String, String>>assertAsync(
-                listener -> SchemaUtil.getSourceFieldMappings(client, null, new String[] { "field-1", "field-2" }, listener),
+                listener -> SchemaUtil.getSourceFieldMappings(client, null, new String[] { "field-1", "field-2" }, emptyMap(), listener),
                 mappings -> {
                     assertNotNull(mappings);
                     assertTrue(mappings.isEmpty());
@@ -117,7 +124,8 @@ public class SchemaUtilTests extends ESTestCase {
 
             // indices is empty
             this.<Map<String, String>>assertAsync(
-                listener -> SchemaUtil.getSourceFieldMappings(client, new String[] {}, new String[] { "field-1", "field-2" }, listener),
+                listener ->
+                    SchemaUtil.getSourceFieldMappings(client, new String[] {}, new String[] { "field-1", "field-2" }, emptyMap(), listener),
                 mappings -> {
                     assertNotNull(mappings);
                     assertTrue(mappings.isEmpty());
@@ -130,6 +138,7 @@ public class SchemaUtilTests extends ESTestCase {
                     client,
                     new String[] { "index-1", "index-2" },
                     new String[] { "field-1", "field-2" },
+                    emptyMap(),
                     listener
                 ),
                 mappings -> {
@@ -137,6 +146,30 @@ public class SchemaUtilTests extends ESTestCase {
                     assertEquals(2, mappings.size());
                     assertEquals("long", mappings.get("field-1"));
                     assertEquals("long", mappings.get("field-2"));
+                }
+            );
+        }
+    }
+
+    public void testGetSourceFieldMappingsWithRuntimeMappings() throws InterruptedException {
+        Map<String, Object> runtimeMappings = new HashMap<>() {{
+            put("field-2", singletonMap("type", "keyword"));
+            put("field-3", singletonMap("type", "boolean"));
+        }};
+        try (Client client = new FieldCapsMockClient(getTestName())) {
+            this.<Map<String, String>>assertAsync(
+                listener -> SchemaUtil.getSourceFieldMappings(
+                    client,
+                    new String[] { "index-1", "index-2" },
+                    new String[] { "field-1", "field-2" },
+                    runtimeMappings,
+                    listener
+                ),
+                mappings -> {
+                    assertThat(mappings, is(aMapWithSize(3)));
+                    assertThat(
+                        mappings,
+                        allOf(hasEntry("field-1", "long"), hasEntry("field-2", "keyword"), hasEntry("field-3", "boolean")));
                 }
             );
         }
@@ -158,7 +191,7 @@ public class SchemaUtilTests extends ESTestCase {
                 FieldCapabilitiesRequest fieldCapsRequest = (FieldCapabilitiesRequest) request;
                 Map<String, Map<String, FieldCapabilities>> responseMap = new HashMap<>();
                 for (String field : fieldCapsRequest.fields()) {
-                    responseMap.put(field, Collections.singletonMap(field, createFieldCapabilities(field, "long")));
+                    responseMap.put(field, singletonMap(field, createFieldCapabilities(field, "long")));
                 }
 
                 final FieldCapabilitiesResponse response = new FieldCapabilitiesResponse(fieldCapsRequest.indices(), responseMap);


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Transform] Take runtime mappings into account when deducing dest index mappings  (#68530)