### PR TITLE
[Transform] Add alias for old transform index to internal index

### DIFF
--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/TransformInternalIndex.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/TransformInternalIndex.java
@@ -96,6 +96,8 @@ public final class TransformInternalIndex {
             .setDescription("Contains Transform configuration data")
             .setMappings(mappings())
             .setSettings(settings())
+            // BWC: for mixed clusters with nodes < 7.5, we need the alias to make new docs visible for them
+            .setAliasName(".data-frame-internal-3")
             .setVersionMetaKey("version")
             .setOrigin(TRANSFORM_ORIGIN)
             .build();


### PR DESCRIPTION
This change should have been included in #68747. In 7.x we need
to account for the scenario where a 7.12 master node is running in
a mixed version cluster with 7.4 nodes that expect the transform
internal index to match the pattern ".data-frame-internal*".

Fixes #68893