### PR TITLE
Add runtime field section to Field Capabilities API

### DIFF
--- a/docs/reference/search/field-caps.asciidoc
+++ b/docs/reference/search/field-caps.asciidoc
@@ -88,6 +88,13 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailab
 (Optional,  <<query-dsl,query object>> Allows to filter indices if the provided
 query rewrites to `match_none` on every shard.
 
+`runtime_mappings`::
+(Optional, object)
+Defines ad-hoc <<runtime-search-request,runtime fields>> in the request similar
+to the way it is done in <<search-api-body-runtime, search requests>>. This fields
+exist only as part of the query and take precedence over fields defined with the
+same name in the index mappings.
+
 [[search-field-caps-api-response-body]]
 ==== {api-response-body-title}
 

--- a/docs/reference/search/field-caps.asciidoc
+++ b/docs/reference/search/field-caps.asciidoc
@@ -91,7 +91,7 @@ query rewrites to `match_none` on every shard.
 `runtime_mappings`::
 (Optional, object)
 Defines ad-hoc <<runtime-search-request,runtime fields>> in the request similar
-to the way it is done in <<search-api-body-runtime, search requests>>. This fields
+to the way it is done in <<search-api-body-runtime, search requests>>. These fields
 exist only as part of the query and take precedence over fields defined with the
 same name in the index mappings.
 

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
@@ -101,7 +101,7 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
             };
             for (String index : concreteIndices) {
                 client.executeLocally(TransportFieldCapabilitiesIndexAction.TYPE, new FieldCapabilitiesIndexRequest(request.fields(),
-                    index, localIndices, request.indexFilter(), nowInMillis), innerListener);
+                    index, localIndices, request.indexFilter(), nowInMillis, request.runtimeFields()), innerListener);
             }
 
             // this is the cross cluster part of this API - we force the other cluster to not merge the results but instead

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesIndexAction.java
@@ -107,7 +107,7 @@ public class TransportFieldCapabilitiesIndexAction
         try (Engine.Searcher searcher = indexShard.acquireSearcher(Engine.CAN_MATCH_SEARCH_SOURCE)) {
 
             final SearchExecutionContext searchExecutionContext = indexService.newSearchExecutionContext(shardId.id(), 0,
-                searcher, request::nowInMillis, null, Collections.emptyMap());
+                searcher, request::nowInMillis, null, request.runtimeFields());
 
             if (canMatchShard(request, searchExecutionContext) == false) {
                 return new FieldCapabilitiesIndexResponse(request.index(), Collections.emptyMap(), false);

--- a/server/src/main/java/org/elasticsearch/rest/action/RestFieldCapabilitiesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/RestFieldCapabilitiesAction.java
@@ -11,13 +11,16 @@ package org.elasticsearch.rest.action;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 
 import java.io.IOException;
 import java.util.List;
 
+import static org.elasticsearch.index.query.AbstractQueryBuilder.parseInnerQueryBuilder;
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 
@@ -50,9 +53,19 @@ public class RestFieldCapabilitiesAction extends BaseRestHandler {
         fieldRequest.includeUnmapped(request.paramAsBoolean("include_unmapped", false));
         request.withContentOrSourceParamParserOrNull(parser -> {
             if (parser != null) {
-                fieldRequest.indexFilter(RestActions.getQueryContent("index_filter", parser));
+                PARSER.parse(parser, fieldRequest, null);
             }
         });
         return channel -> client.fieldCaps(fieldRequest, new RestToXContentListener<>(channel));
+    }
+
+    private static ParseField INDEX_FILTER_FIELD = new ParseField("index_filter");
+    private static ParseField RUNTIME_MAPPINGS_FIELD = new ParseField("runtime_mappings");
+
+    private static final ObjectParser<FieldCapabilitiesRequest, Void> PARSER = new ObjectParser<>("field_caps_request");
+
+    static {
+        PARSER.declareObject(FieldCapabilitiesRequest::indexFilter, (p, c) -> parseInnerQueryBuilder(p), INDEX_FILTER_FIELD);
+        PARSER.declareObject(FieldCapabilitiesRequest::runtimeFields, (p, c) -> p.map(), RUNTIME_MAPPINGS_FIELD);
     }
 }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/40_runtime_mappings.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/runtime_fields/40_runtime_mappings.yml
@@ -1,0 +1,87 @@
+---
+setup:
+  - do:
+        indices.create:
+          index: test-1
+          body:
+            mappings:
+              properties:
+                timestamp:
+                  type: date
+
+  - do:
+      index:
+        index:  test-1
+        body:   { timestamp: "2015-01-02" }
+
+  - do:
+      indices.refresh:
+        index: [test-1]
+
+---
+"Field caps with runtime mappings section":
+
+  - skip:
+      version: " - 7.99.99"
+      reason: Runtime mappings support was added in 8.0
+
+  - do:
+      field_caps:
+        index: test-*
+        fields: "*"
+        body:
+          runtime_mappings:
+            day_of_week:
+              type: keyword
+              script:
+                source: "emit(doc['timestamp'].value.dayOfWeekEnum.getDisplayName(TextStyle.FULL, Locale.ROOT))"
+
+  - match: {indices:                             ["test-1"]}
+  - length: {fields.timestamp:                            1}
+  - match: {fields.timestamp.date.type:                date}
+  - match: {fields.timestamp.date.searchable:          true}
+  - match: {fields.timestamp.date.aggregatable:        true}
+  - length: {fields.day_of_week:                          1}
+  - match: {fields.day_of_week.keyword.type:           keyword}
+  - match: {fields.day_of_week.keyword.searchable:        true}
+  - match: {fields.day_of_week.keyword.aggregatable:      true}
+
+---
+"Field caps with runtime mappings section overwriting existing mapping":
+
+  - skip:
+      version: " - 7.99.99"
+      reason: Runtime mappings support was added in 8.0
+
+  - do:
+      index:
+        index:  test-2
+        body:   { day_of_week: 123 }
+
+  - do:
+      field_caps:
+        index: test-*
+        fields: "day*"
+
+  - match: {indices:                    ["test-1", "test-2"]}
+  - length: {fields.day_of_week:                          1}
+  - match: {fields.day_of_week.long.type:          long}
+  - match: {fields.day_of_week.long.searchable:        true}
+  - match: {fields.day_of_week.long.aggregatable:      true}
+
+  - do:
+      field_caps:
+        index: test-*
+        fields: "day*"
+        body:
+          runtime_mappings:
+            day_of_week:
+              type: keyword
+              script:
+                source: "emit(doc['timestamp'].value.dayOfWeekEnum.getDisplayName(TextStyle.FULL, Locale.ROOT))"
+
+  - match: {indices:                    ["test-1", "test-2"]}
+  - length: {fields.day_of_week:                          1}
+  - match: {fields.day_of_week.keyword.type:          keyword}
+  - match: {fields.day_of_week.keyword.searchable:        true}
+  - match: {fields.day_of_week.keyword.aggregatable:      true}


### PR DESCRIPTION
Currently runtime fields from search requests don't appear in the output of the
field capabilities API, but some consumer of runtime fields would like to see
runtime section just like they are defined in search requests reflected and
merged into the field capabilities output.
This change adds parsing of a "runtime_mappings" section equivallent to the one
on search requests to the `_field_caps` endpoint, passes this section down to
the shard level where any runtime fields defined here overwrite the mapping of
the targetet indices.

Closes #68117