### PR TITLE
[7.11] [DOCS] Rephrase `watcher_admin` role desc (#68870)

### DIFF
--- a/x-pack/docs/en/security/authorization/built-in-roles.asciidoc
+++ b/x-pack/docs/en/security/authorization/built-in-roles.asciidoc
@@ -183,8 +183,9 @@ However, this role does not grant permission to view the data in all indices.
 
 [[built-in-roles-watcher-admin]] `watcher_admin`::
 +
-Grants read access to the `.watches` index, read access to the watch history and
-the triggered watches index and allows to execute all watcher actions.
+Allows users to create and execute all {watcher} actions. Grants read access to
+the `.watches` index. Also grants read access to the watch history and the
+triggered watches index.
 
 [[built-in-roles-watcher-user]] `watcher_user`::
 +


### PR DESCRIPTION
Backports the following commits to 7.11:
 - [DOCS] Rephrase `watcher_admin` role desc (#68870)