### PR TITLE
Publish plugin-classloader library JAR

### DIFF
--- a/libs/plugin-classloader/build.gradle
+++ b/libs/plugin-classloader/build.gradle
@@ -6,6 +6,8 @@
  * Side Public License, v 1.
  */
 
+// This is only required because :server needs this at runtime.
+// We'll be removing this in 8.0 so for now just publish the JAR to make dependency resolution work.
 apply plugin: 'elasticsearch.publish'
 
 tasks.named("test").configure { enabled = false }

--- a/libs/plugin-classloader/build.gradle
+++ b/libs/plugin-classloader/build.gradle
@@ -6,6 +6,8 @@
  * Side Public License, v 1.
  */
 
+apply plugin: 'elasticsearch.publish'
+
 tasks.named("test").configure { enabled = false }
 
 // test depend on ES core...


### PR DESCRIPTION
The `:server` project depends on `:libs:plugin-classloader` but we aren't actually publishing the latter artifacts to maven central. This causes issues when folks try to resolve the elasticsearch dependency, or anything that depends on it (test framework, HLRC, build-tools, etc).

Eventually this library is going to go away entirely and it's actually not really required at runtime by any of these transitive dependencies, but to ensure we don't incidentally introduce any breaking dependencies in the meantime the safest thing is just to publish the artifact to address the dependency resolution errors.

We'll follow up on this PR by adding a check to the build to ensure that dependencies of published projects are also published.