### PR TITLE
[DOCS] EQL: Document `like` and `regex` keywords

### DIFF
--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -246,19 +246,19 @@ Returns `true` if the condition to the right is `false`.
 
 [source,eql]
 ----
-my_field in ("Foo", "BAR", "BAZ")             // case-sensitive
-my_field in~ ("foo", "bar", "baz")            // case-insensitive
+my_field in ("Value-1", "VALUE2", "VAL3")                 // case-sensitive
+my_field in~ ("value-1", "value2", "val3")                // case-insensitive
 
-my_field not in ("Foo", "BAR", "BAZ")         // case-sensitive
-my_field not in~ ("foo", "bar", "baz")        // case-insensitive
+my_field not in ("Value-1", "VALUE2", "VAL3")             // case-sensitive
+my_field not in~ ("value-1", "value2", "val3")            // case-insensitive
 
-my_field : ("foo", "bar", "baz")              // case-insensitive
+my_field : ("value-1", "value2", "val3")                  // case-insensitive
 
-my_field like  ("F*O", "BA?", "QUX")          // case-sensitive
-my_field like~ ("f*o", "ba?", "qux")          // case-insensitive
+my_field like  ("Value-*", "VALUE2", "VAL?")              // case-sensitive
+my_field like~ ("value-*", "value2", "val?")              // case-insensitive
 
-my_field regex  ("[fF]*o", "BA[^Z].?", "QUX") // case-sensitive
-my_field regex~ ("f*o?", "ba[^z].?", "qux")   // case-insensitive
+my_field regex  ("[vV]alue-[0-9]", "VALUE[^2].?", "VAL3") // case-sensitive
+my_field regex~  ("value-[0-9]", "value[^2].?", "val3")   // case-sensitive
 ----
 
 `in` (case-sensitive)::

--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -434,7 +434,7 @@ characters:
 
 [source,eql]
 ----
-my_field : "doc*"     // Matches "doc", "docs", or "document" but not "dos"
+my_field : "doc*"     // Matches "doc", "docs", or "document" but not "DOS"
 my_field : "*doc"     // Matches "adoc" or "asciidoc"
 my_field : "d*c"      // Matches "doc" or "disc"
 

--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -460,7 +460,7 @@ The `:` operator and `like` keyword also support wildcards in
 [source,eql]
 ----
 my_field : ("doc*", "f*o", "ba?", "qux")
-my_field like ("F*O", "BA?", "QUX")
+my_field like ("Doc*", "F*O", "BA?", "QUX")
 ----
 
 [discrete]

--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -163,16 +163,16 @@ the operator uses a case-sensitive lexicographic order.
 NOTE: `=` is not supported as an equal operator. Use `==` or `:` instead.
 
 [discrete]
-[[eql-syntax-pattern-comparison-operators]]
-=== Pattern comparison operators
+[[eql-syntax-pattern-comparison-keywords]]
+=== Pattern comparison keywords
 
 [source,eql]
 ----
-my_field like  "FOO*"       // case-sensitive wildcard matching
-my_field like~ "foo*"       // case-insensitive wildcard matching
+my_field like  "VALUE*"         // case-sensitive wildcard matching
+my_field like~ "value*"         // case-insensitive wildcard matching
 
-my_field regex  "BA[^Z].?"  // case-sensitive regex matching
-my_field regex~ "ba[^z].?"  // case-insensitive regex matching
+my_field regex  "VALUE[^Z].?"   // case-sensitive regex matching
+my_field regex~ "value[^z].?"   // case-insensitive regex matching
 ----
 
 `like` (case-sensitive)::

--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -163,6 +163,31 @@ the operator uses a case-sensitive lexicographic order.
 NOTE: `=` is not supported as an equal operator. Use `==` or `:` instead.
 
 [discrete]
+[[eql-syntax-pattern-comparison-operators]]
+=== Pattern comparison operators
+
+[source,eql]
+----
+my_field like  "FOO*"       // case-sensitive wildcard matching
+my_field like~ "foo*"       // case-insensitive wildcard matching
+
+my_field regex  "BA[^Z].?"  // case-sensitive regex matching
+my_field regex~ "ba[^z].?"  // case-insensitive regex matching
+----
+
+`like` (case-sensitive)::
+Returns `true` if the string to the left of the operator matches a
+<<eql-syntax-wildcards,wildcard pattern>> to the right. Supports
+<<eql-syntax-lookup-operators,list lookups>>. Can only be used to compare
+strings. For case-insensitive matching, use `like~`.
+
+`regex` (case-sensitive)::
+Returns `true` if the string to the left of the operator matches a regular
+expression to the right. For supported regular expression syntax, see
+<<regexp-syntax>>. Supports <<eql-syntax-lookup-operators,list lookups>>. Can
+only be used to compare strings. For case-insensitive matching, use `regex~`.
+
+[discrete]
 [[limitations-for-comparisons]]
 === Limitations for comparisons
 
@@ -221,13 +246,19 @@ Returns `true` if the condition to the right is `false`.
 
 [source,eql]
 ----
-my_field in ("Foo", "BAR", "BAZ")       // case-sensitive
-my_field in~ ("foo", "bar", "baz")      // case-insensitive
+my_field in ("Foo", "BAR", "BAZ")             // case-sensitive
+my_field in~ ("foo", "bar", "baz")            // case-insensitive
 
-my_field not in ("Foo", "BAR", "BAZ")   // case-sensitive
-my_field not in~ ("foo", "bar", "baz")  // case-insensitive
+my_field not in ("Foo", "BAR", "BAZ")         // case-sensitive
+my_field not in~ ("foo", "bar", "baz")        // case-insensitive
 
-my_field : ("foo", "bar", "baz")        // case-insensitive
+my_field : ("foo", "bar", "baz")              // case-insensitive
+
+my_field like  ("F*O", "BA?", "QUX")          // case-sensitive
+my_field like~ ("f*o", "ba?", "qux")          // case-insensitive
+
+my_field regex  ("[fF]*o", "BA[^Z].?", "QUX") // case-sensitive
+my_field regex~ ("f*o?", "ba[^z].?", "qux")   // case-insensitive
 ----
 
 `in` (case-sensitive)::
@@ -241,6 +272,17 @@ case-insensitive matching, use `not in~`.
 `:` (case-insensitive)::
 Returns `true` if the string is contained in the provided list. Can only be used
 to compare strings.
+
+`like` (case-sensitive)::
+Returns `true` if the string matches a <<eql-syntax-wildcards,wildcard pattern>>
+in the provided list. Can only be used to compare strings. For case-insensitive
+matching, use `like~`.
+
+`regex` (case-sensitive)::
+Returns `true` if the string matches a regular expression pattern in the
+provided list. For supported regular expression syntax, see <<regexp-syntax>>.
+Can only be used to compare strings. For case-insensitive matching, use
+`regex~`.
 
 [discrete]
 [[eql-syntax-math-operators]]
@@ -386,32 +428,39 @@ use a regular string with the `\"` escape sequence.
 [[eql-syntax-wildcards]]
 === Wildcards
 
-For string comparisons using the `:` operator, you can use the `*` and `?`
-wildcards to match specific patterns. The `*` wildcard matches zero or more
+For string comparisons using the `:` or `like` operator, you can use the `*` and
+`?` wildcards to match specific patterns. The `*` wildcard matches zero or more
 characters:
 
 [source,eql]
 ----
-my_field : "doc*"  // Matches "doc", "docs", or "document" but not "dos"
-my_field : "*doc"  // Matches "adoc" or "asciidoc"
-my_field : "d*c"   // Matches "doc" or "disc"
+my_field : "doc*"     // Matches "doc", "docs", or "document" but not "dos"
+my_field : "*doc"     // Matches "adoc" or "asciidoc"
+my_field : "d*c"      // Matches "doc" or "disc"
+
+my_field like "DOC*"  // Matches "DOC", "DOCS", "DOCs", or "DOCUMENT" but not "DOS"
+my_field like "D*C"   // Matches "DOC", "DISC", or "DisC"
 ----
 
 The `?` wildcard matches exactly one character:
 
 [source,eql]
 ----
-my_field : "doc?"  // Matches "docs" but not "doc", "document", or "dos"
-my_field : "?doc"  // Matches "adoc" but not "asciidoc"
-my_field : "d?c"   // Matches "doc" but not "disc"
+my_field : "doc?"     // Matches "docs" but not "doc", "document", or "DOS"
+my_field : "?doc"     // Matches "adoc" but not "asciidoc"
+my_field : "d?c"      // Matches "doc" but not "disc"
+
+my_field like "DOC?"  // Matches "DOCS" or "DOCs" but not "DOC", "DOCUMENT", or "DOS"
+my_field like "D?c"   // Matches "DOC" but not "DISC"
 ----
 
-The `:` operator also supports wildcards in <<eql-syntax-lookup-operators,list
-lookups>>:
+The `:` and `like` operators also support wildcards in
+<<eql-syntax-lookup-operators,list lookups>>:
 
 [source,eql]
 ----
 my_field : ("doc*", "f*o", "ba?", "qux")
+my_field like ("F*O", "BA?", "QUX")
 ----
 
 [discrete]

--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -176,13 +176,13 @@ my_field regex~ "value[^z].?"   // case-insensitive regex matching
 ----
 
 `like` (case-sensitive)::
-Returns `true` if the string to the left of the operator matches a
+Returns `true` if the string to the left of the keyword matches a
 <<eql-syntax-wildcards,wildcard pattern>> to the right. Supports
 <<eql-syntax-lookup-operators,list lookups>>. Can only be used to compare
 strings. For case-insensitive matching, use `like~`.
 
 `regex` (case-sensitive)::
-Returns `true` if the string to the left of the operator matches a regular
+Returns `true` if the string to the left of the keyword matches a regular
 expression to the right. For supported regular expression syntax, see
 <<regexp-syntax>>. Supports <<eql-syntax-lookup-operators,list lookups>>. Can
 only be used to compare strings. For case-insensitive matching, use `regex~`.
@@ -428,9 +428,9 @@ use a regular string with the `\"` escape sequence.
 [[eql-syntax-wildcards]]
 === Wildcards
 
-For string comparisons using the `:` or `like` operator, you can use the `*` and
-`?` wildcards to match specific patterns. The `*` wildcard matches zero or more
-characters:
+For string comparisons using the `:` operator or `like` keyword, you can use the
+`*` and `?` wildcards to match specific patterns. The `*` wildcard matches zero
+or more characters:
 
 [source,eql]
 ----
@@ -454,7 +454,7 @@ my_field like "DOC?"  // Matches "DOCS" or "DOCs" but not "DOC", "DOCUMENT", or 
 my_field like "D?c"   // Matches "DOC" but not "DISC"
 ----
 
-The `:` and `like` operators also support wildcards in
+The `:` operator and `like` keyword also support wildcards in
 <<eql-syntax-lookup-operators,list lookups>>:
 
 [source,eql]

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -25,19 +25,20 @@ Other versions:
 | {ref-bare}/7.1/release-highlights-7.1.0.html[7.1]
 | {ref-bare}/7.0/release-highlights-7.0.0.html[7.0]
 
-
-
-// Use the notable-highlights tag to mark entries that
-// should be featured in the Stack Installation and Upgrade Guide:
 // tag::notable-highlights[]
-// [discrete]
-// === Heading
-//
-// Description.
-// end::notable-highlights[]
+[discrete]
+[[eql-like-regex-operators]]
+=== EQL: `like` and `regex` operators
 
-// Omit the notable highlights tag for entries that only need to appear in the ES ref:
-// [discrete]
-// === Heading
-//
-// Description.
+In 7.12, we added the `like` and `regex` operators to EQL. You can use the
+`like` operator to match strings to
+{ref}/eql-syntax.html#eql-syntax-wildcards[wildcard patterns], such as `foo*` or
+`ba?`. You can use the `regex` operator to match strings to regular expressions.
+You can use both `like` and `regex` as lookup operators to match a string
+against a list of patterns.
+
+By default, both operators are case-sensitive. For case-insensitive matching,
+use `like~` or `regex~`. For more information, see the
+{ref}/eql-syntax.html#eql-syntax-pattern-comparison-operators[Pattern comparison
+operators] section of the {ref}/eql-syntax.html[EQL syntax documentation].
+// end::notable-highlights[]

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -30,15 +30,14 @@ Other versions:
 [[eql-like-regex-keywords]]
 === EQL: `like` and `regex` keywords
 
-In 7.12, we added the `like` and `regex` keywords to EQL. You can use the
-`like` keyword to match strings to
-{ref}/eql-syntax.html#eql-syntax-wildcards[wildcard patterns], such as `foo*` or
-`ba?`. You can use the `regex` keyword to match strings to regular expressions.
-You can use both `like` and `regex` to match a string
-against a list of patterns.
+In 7.12, we added the `like` and `regex` keywords to EQL. You can use the `like`
+keyword to match strings to {ref}/eql-syntax.html#eql-syntax-wildcards[wildcard
+patterns], such as `foo*` or `ba?`. You can use the `regex` keyword to match
+strings to regular expressions. You can use both `like` and `regex` to match a
+string against a list of patterns.
 
-By default, both keywords are case-sensitive. For case-insensitive matching,
-use `like~` or `regex~`. For more information, see the
+By default, both keywords are case-sensitive. For case-insensitive matching, use
+`like~` or `regex~`. For more information, see the
 {ref}/eql-syntax.html#eql-syntax-pattern-comparison-keywords[Pattern comparison
 keywords] section of the {ref}/eql-syntax.html[EQL syntax documentation].
 // end::notable-highlights[]

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -27,18 +27,18 @@ Other versions:
 
 // tag::notable-highlights[]
 [discrete]
-[[eql-like-regex-operators]]
-=== EQL: `like` and `regex` operators
+[[eql-like-regex-keywords]]
+=== EQL: `like` and `regex` keywords
 
-In 7.12, we added the `like` and `regex` operators to EQL. You can use the
-`like` operator to match strings to
+In 7.12, we added the `like` and `regex` keywords to EQL. You can use the
+`like` keyword to match strings to
 {ref}/eql-syntax.html#eql-syntax-wildcards[wildcard patterns], such as `foo*` or
-`ba?`. You can use the `regex` operator to match strings to regular expressions.
-You can use both `like` and `regex` as lookup operators to match a string
+`ba?`. You can use the `regex` keyword to match strings to regular expressions.
+You can use both `like` and `regex` to match a string
 against a list of patterns.
 
-By default, both operators are case-sensitive. For case-insensitive matching,
+By default, both keywords are case-sensitive. For case-insensitive matching,
 use `like~` or `regex~`. For more information, see the
-{ref}/eql-syntax.html#eql-syntax-pattern-comparison-operators[Pattern comparison
-operators] section of the {ref}/eql-syntax.html[EQL syntax documentation].
+{ref}/eql-syntax.html#eql-syntax-pattern-comparison-keywords[Pattern comparison
+keywords] section of the {ref}/eql-syntax.html[EQL syntax documentation].
 // end::notable-highlights[]


### PR DESCRIPTION
Documents the `like` and `regex` operators.

Relates to #68791.

### Previews

- Pattern comparison operators: https://elasticsearch_68932.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.x/eql-syntax.html#eql-syntax-pattern-comparison-operators
- Lookup operators: https://elasticsearch_68932.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.x/eql-syntax.html#eql-syntax-lookup-operators
- Wildcards: https://elasticsearch_68932.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.x/eql-syntax.html#eql-syntax-wildcards
- Release highlight: https://elasticsearch_68932.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.x/release-highlights.html#eql-like-regex-operators