### PR TITLE
Adding note to IP filter docs to warn about some filters being inherited

### DIFF
--- a/x-pack/docs/en/security/using-ip-filtering.asciidoc
+++ b/x-pack/docs/en/security/using-ip-filtering.asciidoc
@@ -23,7 +23,8 @@ You configure IP filtering by specifying the `xpack.security.transport.filter.al
 `xpack.security.transport.filter.deny` settings in in `elasticsearch.yml`. Allow rules
 take precedence over the deny rules.
 
-NOTE: When applying `xpack.security.transport.filter.\*` settings they will be inherited to `xpack.security.http.filter.*` unless you explicitly set a http filter rule. 
+IMPORTANT: Unless explicitly specified, `xpack.security.http.filter.*` settings default to
+the corresponding `xpack.security.transport.filter.*` setting's value.
 
 [source,yaml]
 --------------------------------------------------

--- a/x-pack/docs/en/security/using-ip-filtering.asciidoc
+++ b/x-pack/docs/en/security/using-ip-filtering.asciidoc
@@ -23,6 +23,8 @@ You configure IP filtering by specifying the `xpack.security.transport.filter.al
 `xpack.security.transport.filter.deny` settings in in `elasticsearch.yml`. Allow rules
 take precedence over the deny rules.
 
+NOTE: When applying `xpack.security.transport.filter.\*` settings they will be inherited to `xpack.security.http.filter.*` unless you explicitly set a http filter rule. 
+
 [source,yaml]
 --------------------------------------------------
 xpack.security.transport.filter.allow: "192.168.0.1"


### PR DESCRIPTION
Adding a note to IP filter docs to warn that transport filters are inherited to http filters.
Might be worth to also note that this behavior is not the same for http -> transport

fixes #41790
