### PR TITLE
[Transform] Simplify code for destination index mappings deduction

### DIFF
--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/SchemaUtilTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/SchemaUtilTests.java
@@ -195,6 +195,11 @@ public class SchemaUtilTests extends ESTestCase {
                 for (String field : fieldCapsRequest.fields()) {
                     responseMap.put(field, singletonMap(field, createFieldCapabilities(field, "long")));
                 }
+                for (Map.Entry<String, Object> runtimeField : fieldCapsRequest.runtimeFields().entrySet()) {
+                    String field = runtimeField.getKey();
+                    String type = (String)((Map) runtimeField.getValue()).get("type");
+                    responseMap.put(field, singletonMap(field, createFieldCapabilities(field, type)));
+                }
 
                 final FieldCapabilitiesResponse response = new FieldCapabilitiesResponse(fieldCapsRequest.indices(), responseMap);
                 listener.onResponse((Response) response);


### PR DESCRIPTION
This PR takes advantage of https://github.com/elastic/elasticsearch/pull/68904 by simplifying how the destination index mappings are being deduced.
Instead of merging the `FieldCapabilitiesResponse` with runtime mappings in Transform code, the new field of `FieldCapabilitiesRequest` is used.

Labeling this as `>non-issue` as this PR alters an unreleased feature (i.e. search runtime fields).

Closes #68516
