### PR TITLE
Ignore .swp files in forbiddenPatterns task

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/internal/precommit/ForbiddenPatternsTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/internal/precommit/ForbiddenPatternsTask.java
@@ -65,7 +65,9 @@ public abstract class ForbiddenPatternsTask extends DefaultTask {
         .exclude("**/*.jks")
         .exclude("**/*.crt")
         .exclude("**/*.keystore")
-        .exclude("**/*.png");
+        .exclude("**/*.png")
+        // vim swap file - included here to stop the build falling over if you happen to have a file open :-|
+        .exclude("**/.*.swp");
 
     /*
      * The rules: a map from the rule name, to a rule regex pattern.


### PR DESCRIPTION
Vim will write swap files in `$PWD/.$FILE.swp`, which causes the
`forbiddenPatterns` task to fail the build. Ignore these files so that
having a file open in vim doesn't fail the build.