### PR TITLE
increase log level for test

### DIFF
--- a/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/YamlRestCompatTestPluginFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/YamlRestCompatTestPluginFuncTest.groovy
@@ -296,7 +296,8 @@ class YamlRestCompatTestPluginFuncTest extends AbstractRestResourcesFuncTest {
         }
 
         when:
-        result = gradleRunner(transformTask).build()
+        //TODO: remove "-i" once https://github.com/elastic/elasticsearch/issues/68973 is resolved
+        result = gradleRunner(transformTask, "-i").build()
 
         then:
         result.task(transformTask).outcome == TaskOutcome.UP_TO_DATE


### PR DESCRIPTION
This commit increases the log level for a Gradle test to 
help troubleshoot why it is not UP_TO_DATE when it should be 
(only seen in CI and not locally reproducible). 

related: #68973