### PR TITLE
[7.x] Reconcile state of pre and post-snapshot data streams

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -878,6 +878,26 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
         return true;
     }
 
+    /**
+     * Reconciles the cluster state metadata taken at the end of a snapshot with the data streams and indices
+     * contained in the snapshot. Certain actions taken during a snapshot such as rolling over a data stream
+     * or deleting a backing index may result in situations where some reconciliation is required.
+     *
+     * @return Reconciled {@link Metadata} instance
+     */
+    public static Metadata snapshot(Metadata metadata, List<String> dataStreams, List<String> indices) {
+        var builder = Metadata.builder(metadata);
+        for (var dsName : dataStreams) {
+            var dataStream = metadata.dataStreams().get(dsName);
+            if (dataStream == null) {
+                // should never occur since data streams cannot be deleted while they have snapshots underway
+                throw new IllegalArgumentException("unable to find data stream [" + dsName + "]");
+            }
+            builder.put(dataStream.snapshot(indices));
+        }
+        return builder.build();
+    }
+
     @Override
     public Diff<Metadata> diff(Metadata previousState) {
         return new MetadataDiff(previousState, this);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -886,9 +886,9 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
      * @return Reconciled {@link Metadata} instance
      */
     public static Metadata snapshot(Metadata metadata, List<String> dataStreams, List<String> indices) {
-        var builder = Metadata.builder(metadata);
-        for (var dsName : dataStreams) {
-            var dataStream = metadata.dataStreams().get(dsName);
+        Metadata.Builder builder = Metadata.builder(metadata);
+        for (String dsName : dataStreams) {
+            DataStream dataStream = metadata.dataStreams().get(dsName);
             if (dataStream == null) {
                 // should never occur since data streams cannot be deleted while they have snapshots underway
                 throw new IllegalArgumentException("unable to find data stream [" + dsName + "]");

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamTests.java
@@ -17,11 +17,19 @@ import org.elasticsearch.test.AbstractSerializingTestCase;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.cluster.DataStreamTestHelper.createTimestampField;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.in;
+import static org.hamcrest.Matchers.not;
 
 public class DataStreamTests extends AbstractSerializingTestCase<DataStream> {
 
@@ -151,5 +159,70 @@ public class DataStreamTests extends AbstractSerializingTestCase<DataStream> {
 
         Index newBackingIndex = new Index("replacement-index", UUIDs.randomBase64UUID(random()));
         expectThrows(IllegalArgumentException.class, () -> original.replaceBackingIndex(indices.get(writeIndexPosition), newBackingIndex));
+    }
+
+    public void testSnapshot() {
+        var preSnapshotDataStream = DataStreamTestHelper.randomInstance();
+        var indicesToRemove = randomSubsetOf(preSnapshotDataStream.getIndices());
+        if (indicesToRemove.size() == preSnapshotDataStream.getIndices().size()) {
+            // never remove them all
+            indicesToRemove.remove(0);
+        }
+        var indicesToAdd = DataStreamTestHelper.randomIndexInstances();
+        var postSnapshotIndices = new ArrayList<>(preSnapshotDataStream.getIndices());
+        postSnapshotIndices.removeAll(indicesToRemove);
+        postSnapshotIndices.addAll(indicesToAdd);
+
+        var postSnapshotDataStream = new DataStream(
+            preSnapshotDataStream.getName(),
+            preSnapshotDataStream.getTimeStampField(),
+            postSnapshotIndices,
+            preSnapshotDataStream.getGeneration() + randomIntBetween(0, 5),
+            preSnapshotDataStream.getMetadata() == null ? null : new HashMap<>(preSnapshotDataStream.getMetadata()),
+            preSnapshotDataStream.isHidden(),
+            preSnapshotDataStream.isReplicated() && randomBoolean());
+
+        var reconciledDataStream =
+            postSnapshotDataStream.snapshot(preSnapshotDataStream.getIndices().stream().map(Index::getName).collect(Collectors.toList()));
+
+        assertThat(reconciledDataStream.getName(), equalTo(postSnapshotDataStream.getName()));
+        assertThat(reconciledDataStream.getTimeStampField(), equalTo(postSnapshotDataStream.getTimeStampField()));
+        assertThat(reconciledDataStream.getGeneration(), equalTo(postSnapshotDataStream.getGeneration()));
+        if (reconciledDataStream.getMetadata() != null) {
+            assertThat(
+                new HashSet<>(reconciledDataStream.getMetadata().entrySet()),
+                hasItems(postSnapshotDataStream.getMetadata().entrySet().toArray())
+            );
+        } else {
+            assertNull(postSnapshotDataStream.getMetadata());
+        }
+        assertThat(reconciledDataStream.isHidden(), equalTo(postSnapshotDataStream.isHidden()));
+        assertThat(reconciledDataStream.isReplicated(), equalTo(postSnapshotDataStream.isReplicated()));
+        assertThat(reconciledDataStream.getIndices(), everyItem(not(in(indicesToRemove))));
+        assertThat(reconciledDataStream.getIndices(), everyItem(not(in(indicesToAdd))));
+        assertThat(reconciledDataStream.getIndices().size(), equalTo(preSnapshotDataStream.getIndices().size() - indicesToRemove.size()));
+    }
+
+    public void testSnapshotWithAllBackingIndicesRemoved() {
+        var preSnapshotDataStream = DataStreamTestHelper.randomInstance();
+        var indicesToAdd = DataStreamTestHelper.randomIndexInstances();
+
+        var postSnapshotDataStream = new DataStream(
+            preSnapshotDataStream.getName(),
+            preSnapshotDataStream.getTimeStampField(),
+            indicesToAdd,
+            preSnapshotDataStream.getGeneration(),
+            preSnapshotDataStream.getMetadata(),
+            preSnapshotDataStream.isHidden(),
+            preSnapshotDataStream.isReplicated()
+        );
+
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> postSnapshotDataStream.snapshot(
+                preSnapshotDataStream.getIndices().stream().map(Index::getName).collect(Collectors.toList())
+            )
+        );
+        assertThat(e.getMessage(), containsString("cannot reconcile data stream without at least one backing index"));
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamTests.java
@@ -162,18 +162,18 @@ public class DataStreamTests extends AbstractSerializingTestCase<DataStream> {
     }
 
     public void testSnapshot() {
-        var preSnapshotDataStream = DataStreamTestHelper.randomInstance();
-        var indicesToRemove = randomSubsetOf(preSnapshotDataStream.getIndices());
+        DataStream preSnapshotDataStream = DataStreamTestHelper.randomInstance();
+        List<Index> indicesToRemove = randomSubsetOf(preSnapshotDataStream.getIndices());
         if (indicesToRemove.size() == preSnapshotDataStream.getIndices().size()) {
             // never remove them all
             indicesToRemove.remove(0);
         }
-        var indicesToAdd = DataStreamTestHelper.randomIndexInstances();
-        var postSnapshotIndices = new ArrayList<>(preSnapshotDataStream.getIndices());
+        List<Index> indicesToAdd = DataStreamTestHelper.randomIndexInstances();
+        List<Index> postSnapshotIndices = new ArrayList<>(preSnapshotDataStream.getIndices());
         postSnapshotIndices.removeAll(indicesToRemove);
         postSnapshotIndices.addAll(indicesToAdd);
 
-        var postSnapshotDataStream = new DataStream(
+        DataStream postSnapshotDataStream = new DataStream(
             preSnapshotDataStream.getName(),
             preSnapshotDataStream.getTimeStampField(),
             postSnapshotIndices,
@@ -182,7 +182,7 @@ public class DataStreamTests extends AbstractSerializingTestCase<DataStream> {
             preSnapshotDataStream.isHidden(),
             preSnapshotDataStream.isReplicated() && randomBoolean());
 
-        var reconciledDataStream =
+        DataStream reconciledDataStream =
             postSnapshotDataStream.snapshot(preSnapshotDataStream.getIndices().stream().map(Index::getName).collect(Collectors.toList()));
 
         assertThat(reconciledDataStream.getName(), equalTo(postSnapshotDataStream.getName()));
@@ -204,10 +204,10 @@ public class DataStreamTests extends AbstractSerializingTestCase<DataStream> {
     }
 
     public void testSnapshotWithAllBackingIndicesRemoved() {
-        var preSnapshotDataStream = DataStreamTestHelper.randomInstance();
-        var indicesToAdd = DataStreamTestHelper.randomIndexInstances();
+        DataStream preSnapshotDataStream = DataStreamTestHelper.randomInstance();
+        List<Index> indicesToAdd = DataStreamTestHelper.randomIndexInstances();
 
-        var postSnapshotDataStream = new DataStream(
+        DataStream postSnapshotDataStream = new DataStream(
             preSnapshotDataStream.getName(),
             preSnapshotDataStream.getTimeStampField(),
             indicesToAdd,

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
@@ -1259,10 +1259,10 @@ public class MetadataTests extends ESTestCase {
      * Tests for the implementation of data stream snapshot reconciliation are located in {@link DataStreamTests#testSnapshot()}
      */
     public void testSnapshot() {
-        var postSnapshotMetadata = randomMetadata(randomIntBetween(1, 5));
-        var dataStreamsToSnapshot = randomSubsetOf(new ArrayList<>(postSnapshotMetadata.dataStreams().keySet()));
+        Metadata postSnapshotMetadata = randomMetadata(randomIntBetween(1, 5));
+        List<String> dataStreamsToSnapshot = randomSubsetOf(new ArrayList<>(postSnapshotMetadata.dataStreams().keySet()));
         List<String> indicesInSnapshot = new ArrayList<>();
-        for (var dsName : dataStreamsToSnapshot) {
+        for (String dsName : dataStreamsToSnapshot) {
             // always include at least one backing index per data stream
             DataStream ds = postSnapshotMetadata.dataStreams().get(dsName);
             indicesInSnapshot.addAll(
@@ -1272,7 +1272,7 @@ public class MetadataTests extends ESTestCase {
                 )
             );
         }
-        var reconciledMetadata = Metadata.snapshot(postSnapshotMetadata, dataStreamsToSnapshot, indicesInSnapshot);
+        Metadata reconciledMetadata = Metadata.snapshot(postSnapshotMetadata, dataStreamsToSnapshot, indicesInSnapshot);
         assertThat(reconciledMetadata.dataStreams().size(), equalTo(postSnapshotMetadata.dataStreams().size()));
         for (DataStream ds : reconciledMetadata.dataStreams().values()) {
             assertThat(ds.getIndices().size(), greaterThanOrEqualTo(1));
@@ -1280,10 +1280,10 @@ public class MetadataTests extends ESTestCase {
     }
 
     public void testSnapshotWithMissingDataStream() {
-        var postSnapshotMetadata = randomMetadata(randomIntBetween(1, 5));
-        var dataStreamsToSnapshot = randomSubsetOf(new ArrayList<>(postSnapshotMetadata.dataStreams().keySet()));
+        Metadata postSnapshotMetadata = randomMetadata(randomIntBetween(1, 5));
+        List<String> dataStreamsToSnapshot = randomSubsetOf(new ArrayList<>(postSnapshotMetadata.dataStreams().keySet()));
         List<String> indicesInSnapshot = new ArrayList<>();
-        for (var dsName : dataStreamsToSnapshot) {
+        for (String dsName : dataStreamsToSnapshot) {
             // always include at least one backing index per data stream
             DataStream ds = postSnapshotMetadata.dataStreams().get(dsName);
             indicesInSnapshot.addAll(

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
@@ -38,6 +38,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
@@ -50,6 +51,7 @@ import static org.elasticsearch.cluster.DataStreamTestHelper.createTimestampFiel
 import static org.elasticsearch.cluster.metadata.Metadata.Builder.validateDataStreams;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.startsWith;
@@ -1238,7 +1240,6 @@ public class MetadataTests extends ESTestCase {
         validateDataStreams(indicesLookup, dataStreamMetadata);
     }
 
-
     public void testValidateDataStreamsForNullDataStreamMetadata() {
         Metadata metadata = Metadata.builder().put(
             IndexMetadata.builder("foo-index")
@@ -1254,7 +1255,58 @@ public class MetadataTests extends ESTestCase {
         }
     }
 
+    /**
+     * Tests for the implementation of data stream snapshot reconciliation are located in {@link DataStreamTests#testSnapshot()}
+     */
+    public void testSnapshot() {
+        var postSnapshotMetadata = randomMetadata(randomIntBetween(1, 5));
+        var dataStreamsToSnapshot = randomSubsetOf(new ArrayList<>(postSnapshotMetadata.dataStreams().keySet()));
+        List<String> indicesInSnapshot = new ArrayList<>();
+        for (var dsName : dataStreamsToSnapshot) {
+            // always include at least one backing index per data stream
+            DataStream ds = postSnapshotMetadata.dataStreams().get(dsName);
+            indicesInSnapshot.addAll(
+                randomSubsetOf(
+                    randomIntBetween(1, ds.getIndices().size()),
+                    ds.getIndices().stream().map(Index::getName).collect(Collectors.toList())
+                )
+            );
+        }
+        var reconciledMetadata = Metadata.snapshot(postSnapshotMetadata, dataStreamsToSnapshot, indicesInSnapshot);
+        assertThat(reconciledMetadata.dataStreams().size(), equalTo(postSnapshotMetadata.dataStreams().size()));
+        for (DataStream ds : reconciledMetadata.dataStreams().values()) {
+            assertThat(ds.getIndices().size(), greaterThanOrEqualTo(1));
+        }
+    }
+
+    public void testSnapshotWithMissingDataStream() {
+        var postSnapshotMetadata = randomMetadata(randomIntBetween(1, 5));
+        var dataStreamsToSnapshot = randomSubsetOf(new ArrayList<>(postSnapshotMetadata.dataStreams().keySet()));
+        List<String> indicesInSnapshot = new ArrayList<>();
+        for (var dsName : dataStreamsToSnapshot) {
+            // always include at least one backing index per data stream
+            DataStream ds = postSnapshotMetadata.dataStreams().get(dsName);
+            indicesInSnapshot.addAll(
+                randomSubsetOf(
+                    randomIntBetween(1, ds.getIndices().size()),
+                    ds.getIndices().stream().map(Index::getName).collect(Collectors.toList())
+                )
+            );
+        }
+        String missingDataStream = randomAlphaOfLength(5).toLowerCase(Locale.ROOT);
+        dataStreamsToSnapshot.add(missingDataStream);
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> Metadata.snapshot(postSnapshotMetadata, dataStreamsToSnapshot, indicesInSnapshot)
+        );
+        assertThat(e.getMessage(), containsString("unable to find data stream [" + missingDataStream + "]"));
+    }
+
     public static Metadata randomMetadata() {
+        return randomMetadata(1);
+    }
+
+    public static Metadata randomMetadata(int numDataStreams) {
         Metadata.Builder md = Metadata.builder()
             .put(buildIndexMetadata("index", "alias", randomBoolean() ? null : randomBoolean()).build(), randomBoolean())
             .put(IndexTemplateMetadata.builder("template" + randomAlphaOfLength(3))
@@ -1276,11 +1328,13 @@ public class MetadataTests extends ESTestCase {
             .put("component_template_" + randomAlphaOfLength(3), ComponentTemplateTests.randomInstance())
             .put("index_template_v2_" + randomAlphaOfLength(3), ComposableIndexTemplateTests.randomInstance());
 
-        DataStream randomDataStream = DataStreamTestHelper.randomInstance();
-        for (Index index : randomDataStream.getIndices()) {
-            md.put(DataStreamTestHelper.getIndexMetadataBuilderForIndex(index));
+        for (int k = 0; k < numDataStreams; k++) {
+            DataStream randomDataStream = DataStreamTestHelper.randomInstance();
+            for (Index index : randomDataStream.getIndices()) {
+                md.put(DataStreamTestHelper.getIndexMetadataBuilderForIndex(index));
+            }
+            md.put(randomDataStream);
         }
-        md.put(randomDataStream);
 
         return md.build();
     }


### PR DESCRIPTION
Reconciles the pre-snapshot and post-snapshot states of a data stream. Any backing indices deleted during a snapshot must be excluded from the post-snapshot state of the data stream because they will not be available after restoring the snapshot. Also, any new backing indices created during a snapshot must also be excluded from the post-snapshot state of the data stream because they will not be included in the snapshot. This works supports some improvements to the handling of data streams in snapshots.

Backport of #68868
