### PR TITLE
[DOCS] Update priority recommendation for index templates

### DIFF
--- a/docs/reference/cat/templates.asciidoc
+++ b/docs/reference/cat/templates.asciidoc
@@ -64,9 +64,9 @@ The API returns the following response:
 [source,txt]
 ----
 name          index_patterns order version composed_of
-my-template-0 [te*]          200           []
-my-template-1 [tea*]         201           []
-my-template-2 [teak*]        202   7       []
+my-template-0 [te*]          500           []
+my-template-1 [tea*]         501           []
+my-template-2 [teak*]        502   7       []
 ----
 // TESTRESPONSE[s/\*/\\*/ s/\[/\\[/ s/\]/\\]/ non_json]
 

--- a/docs/reference/cat/templates.asciidoc
+++ b/docs/reference/cat/templates.asciidoc
@@ -55,9 +55,9 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-v]
 ----
 GET _cat/templates/my-template-*?v=true&s=name
 ----
-// TEST[s/^/PUT _index_template\/my-template-0\n{"index_patterns": "te*", "priority": 200}\n/]
-// TEST[s/^/PUT _index_template\/my-template-1\n{"index_patterns": "tea*", "priority": 201}\n/]
-// TEST[s/^/PUT _index_template\/my-template-2\n{"index_patterns": "teak*", "priority": 202, "version": 7}\n/]
+// TEST[s/^/PUT _index_template\/my-template-0\n{"index_patterns": "te*", "priority": 500}\n/]
+// TEST[s/^/PUT _index_template\/my-template-1\n{"index_patterns": "tea*", "priority": 501}\n/]
+// TEST[s/^/PUT _index_template\/my-template-2\n{"index_patterns": "teak*", "priority": 502, "version": 7}\n/]
 
 The API returns the following response:
 

--- a/docs/reference/data-streams/change-mappings-and-settings.asciidoc
+++ b/docs/reference/data-streams/change-mappings-and-settings.asciidoc
@@ -102,7 +102,7 @@ PUT /_index_template/my-data-stream-template
 {
   "index_patterns": [ "my-data-stream*" ],
   "data_stream": { },
-  "priority": 200,
+  "priority": 500,
   "template": {
     "mappings": {
       "properties": {
@@ -185,7 +185,7 @@ PUT /_index_template/my-data-stream-template
 {
   "index_patterns": [ "my-data-stream*" ],
   "data_stream": { },
-  "priority": 200,
+  "priority": 500,
   "template": {
     "mappings": {
       "properties": {
@@ -290,7 +290,7 @@ PUT /_index_template/my-data-stream-template
 {
   "index_patterns": [ "my-data-stream*" ],
   "data_stream": { },
-  "priority": 200,
+  "priority": 500,
   "template": {
     "settings": {
       "index.refresh_interval": "30s"             <1>
@@ -344,7 +344,7 @@ PUT /_index_template/my-data-stream-template
 {
   "index_patterns": [ "my-data-stream*" ],
   "data_stream": { },
-  "priority": 200,
+  "priority": 500,
   "template": {
     "settings": {
       "sort.field": [ "@timestamp"],             <1>
@@ -446,7 +446,7 @@ PUT /_index_template/new-data-stream-template
 {
   "index_patterns": [ "new-data-stream*" ],
   "data_stream": { },
-  "priority": 200,
+  "priority": 500,
   "template": {
     "mappings": {
       "properties": {

--- a/docs/reference/data-streams/set-up-a-data-stream.asciidoc
+++ b/docs/reference/data-streams/set-up-a-data-stream.asciidoc
@@ -139,7 +139,7 @@ PUT /_index_template/my-data-stream-template
 {
   "index_patterns": [ "my-data-stream*" ],
   "data_stream": { },
-  "priority": 200,
+  "priority": 500,
   "template": {
     "settings": {
       "index.lifecycle.name": "my-data-stream-policy"

--- a/docs/reference/indices/index-templates.asciidoc
+++ b/docs/reference/indices/index-templates.asciidoc
@@ -33,9 +33,12 @@ following index patterns:
 // end::built-in-index-template-patterns[]
 
 The {fleet-guide}/fleet-overview.html[{agent}] uses these templates to create
-data streams. If you use the {agent}, assign your index templates a priority
-lower than `100` to avoid overriding the built-in templates. Otherwise, to avoid
-accidentally applying the built-in templates, do one or more of the following:
+data streams. Index templates created by {fleet} integrations use similar
+overlapping index patterns and have a priority up to `200`.
+
+If you use {fleet} or the {agent}, assign your index templates a priority
+lower than `100` to avoid overriding these templates. Otherwise, to avoid
+accidentally applying the templates, do one or more of the following:
 
 - To disable all built-index index and component templates, set
 <<stack-templates-enabled,`stack.templates.enabled`>> to `false` using the
@@ -43,10 +46,11 @@ accidentally applying the built-in templates, do one or more of the following:
 
 - Use a non-overlapping index pattern.
 
-- Assign templates with an overlapping pattern a `priority` higher than `100`.
-For example, if you don't use the {agent} and want to create a template for the
-`logs-*` index pattern, assign your template a priority of `200`. This ensures
-your template is applied instead of the built-in template for `logs-*-*`.
+- Assign templates with an overlapping pattern a `priority` higher than `200`.
+For example, if you don't use {fleet} or the {agent} and want to create a
+template for the `logs-*` index pattern, assign your template a priority of
+`500`. This ensures your template is applied instead of the built-in template
+for `logs-*-*`.
 ====
 // end::built-in-index-templates[]
 
@@ -110,7 +114,7 @@ PUT _index_template/template_1
       "mydata": { }
     }
   },
-  "priority": 200,
+  "priority": 500,
   "composed_of": ["component_template1", "other_component_template"],
   "version": 3,
   "_meta": {


### PR DESCRIPTION
Updates the recommended priority for index templates to `>200`.
This prevents conflicts with templates created for Fleet integrations.

Fixes #68982