### PR TITLE
Refactor gradle test transform unit tests 

### DIFF
--- a/buildSrc/src/test/java/org/elasticsearch/gradle/test/rest/transform/TransformTests.java
+++ b/buildSrc/src/test/java/org/elasticsearch/gradle/test/rest/transform/TransformTests.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.gradle.test.rest.transform;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.SequenceWriter;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLParser;
+import org.elasticsearch.gradle.test.GradleUnitTestCase;
+import org.elasticsearch.gradle.test.rest.transform.headers.InjectHeaders;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.core.IsCollectionContaining;
+import org.junit.Before;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.stream.Collectors;
+
+abstract public class TransformTests extends GradleUnitTestCase {
+
+    private static final YAMLFactory YAML_FACTORY = new YAMLFactory();
+    private static final ObjectMapper MAPPER = new ObjectMapper(YAML_FACTORY);
+    private static final ObjectReader READER = MAPPER.readerFor(ObjectNode.class);
+
+    private static final Map<String, String> headers1 = Map.of("foo", "bar");
+    private static final Map<String, String> headers2 = Map.of("abc", "xyz");
+
+    RestTestTransformer transformer;
+
+    @Before
+    public void setup() {
+        transformer = new RestTestTransformer();
+    }
+
+    protected void validateSetupAndTearDown(List<ObjectNode> transformedTests) {
+        assertThat(transformedTests.stream().filter(node -> node.get("setup") != null).count(), CoreMatchers.equalTo(1L));
+        transformedTests.stream().filter(node -> node.get("setup") != null).forEach(this::assertSetup);
+        transformedTests.stream().filter(node -> node.get("teardown") != null).forEach(this::assertTeardown);
+    }
+
+    protected ObjectNode validateSkipNodesExist(List<ObjectNode> tests) {
+        List<ObjectNode> skipNodes = tests.stream()
+            .filter(node -> node.get("setup") != null)
+            .filter(node -> getSkipNode((ArrayNode) node.get("setup")) != null)
+            .map(node -> getSkipNode((ArrayNode) node.get("setup")))
+            .collect(Collectors.toList());
+        assertThat(skipNodes.size(), CoreMatchers.equalTo(1));
+        return skipNodes.get(0);
+    }
+
+    protected void validateSkipNodesDoesNotExist(List<ObjectNode> tests) {
+        List<ObjectNode> skipNodes = tests.stream()
+            .filter(node -> node.get("setup") != null)
+            .filter(node -> getSkipNode((ArrayNode) node.get("setup")) != null)
+            .map(node -> getSkipNode((ArrayNode) node.get("setup")))
+            .collect(Collectors.toList());
+        assertThat(skipNodes.size(), CoreMatchers.equalTo(0));
+    }
+
+    protected void validatePreExistingFeatureExist(List<ObjectNode> tests) {
+        assertThat(validateSkipNodesExist(tests).get("features"), CoreMatchers.notNullValue());
+    }
+
+    protected void validateSetupDoesNotExist(List<ObjectNode> tests) {
+        assertThat(tests.stream().filter(node -> node.get("setup") != null).count(), CoreMatchers.equalTo(0L));
+    }
+
+    protected void validateFeatureNameExists(List<ObjectNode> tests, String featureName) {
+        ObjectNode skipNode = validateSkipNodesExist(tests);
+        JsonNode featureValues = skipNode.get("features");
+        assertNotNull(featureValues);
+
+        List<String> features = new ArrayList<>(1);
+        if (featureValues.isArray()) {
+            Iterator<JsonNode> featuresIt = featureValues.elements();
+            while (featuresIt.hasNext()) {
+                JsonNode feature = featuresIt.next();
+                features.add(feature.asText());
+            }
+        } else if (featureValues.isTextual()) {
+            features.add(featureValues.asText());
+        }
+
+        assertThat(features, IsCollectionContaining.hasItem(featureName));
+    }
+
+    protected void validateSetupExist(List<ObjectNode> tests) {
+        assertThat(tests.stream().filter(node -> node.get("setup") != null).count(), CoreMatchers.equalTo(1L));
+    }
+
+    protected List<ObjectNode> transformTests(List<ObjectNode> tests) {
+        return transformTests(tests, getTransformations());
+    }
+
+    protected List<ObjectNode> transformTests(List<ObjectNode> tests, List<RestTestTransform<?>> transforms) {
+        List<ObjectNode> t = transformer.transformRestTests(new LinkedList<>(tests), transforms);
+        if (getKnownFeatures() != null) {
+            getKnownFeatures().forEach(name -> { validateFeatureNameExists(t, name); });
+        }
+        return t;
+    }
+
+    protected List<String> getKnownFeatures() {
+        return null;
+    }
+
+    protected List<RestTestTransform<?>> getTransformations() {
+        List<RestTestTransform<?>> transformations = new ArrayList<>();
+        transformations.add(new InjectHeaders(headers1));
+        transformations.add(new InjectHeaders(headers2));
+        return transformations;
+    }
+
+    protected List<ObjectNode> getTests(String relativePath) throws Exception {
+        String testName = relativePath;
+        File testFile = new File(getClass().getResource(testName).toURI());
+        YAMLParser yamlParser = YAML_FACTORY.createParser(testFile);
+        return READER.<ObjectNode>readValues(yamlParser).readAll();
+    }
+
+    protected void assertTeardown(ObjectNode teardownNode) {
+        assertThat(teardownNode.get("teardown"), CoreMatchers.instanceOf(ArrayNode.class));
+        ObjectNode skipNode = getSkipNode((ArrayNode) teardownNode.get("teardown"));
+        assertSkipNode(skipNode);
+    }
+
+    protected void assertSetup(ObjectNode setupNode) {
+        assertThat(setupNode.get("setup"), CoreMatchers.instanceOf(ArrayNode.class));
+        ObjectNode skipNode = getSkipNode((ArrayNode) setupNode.get("setup"));
+        assertSkipNode(skipNode);
+    }
+
+    protected void assertSkipNode(ObjectNode skipNode) {
+        assertThat(skipNode, CoreMatchers.notNullValue());
+        List<String> featureValues = new ArrayList<>();
+        if (skipNode.get("features").isArray()) {
+            assertThat(skipNode.get("features"), CoreMatchers.instanceOf(ArrayNode.class));
+            ArrayNode features = (ArrayNode) skipNode.get("features");
+            features.forEach(x -> {
+                if (x.isTextual()) {
+                    featureValues.add(x.asText());
+                }
+            });
+        } else {
+            featureValues.add(skipNode.get("features").asText());
+        }
+        assertEquals(featureValues.stream().distinct().count(), featureValues.size());
+    }
+
+    protected ObjectNode getSkipNode(ArrayNode setupNodeValue) {
+        Iterator<JsonNode> setupIt = setupNodeValue.elements();
+        while (setupIt.hasNext()) {
+            JsonNode arrayEntry = setupIt.next();
+            if (arrayEntry.isObject()) {
+                ObjectNode skipCandidate = (ObjectNode) arrayEntry;
+                if (skipCandidate.get("skip") != null) {
+                    ObjectNode skipNode = (ObjectNode) skipCandidate.get("skip");
+                    return skipNode;
+                }
+            }
+        }
+        return null;
+    }
+
+    protected void validateBodyHasHeaders(List<ObjectNode> tests, Map<String, String> expectedHeaders) {
+        tests.forEach(test -> {
+            Iterator<Map.Entry<String, JsonNode>> testsIterator = test.fields();
+            while (testsIterator.hasNext()) {
+                Map.Entry<String, JsonNode> testObject = testsIterator.next();
+                assertThat(testObject.getValue(), CoreMatchers.instanceOf(ArrayNode.class));
+                ArrayNode testBody = (ArrayNode) testObject.getValue();
+                testBody.forEach(arrayObject -> {
+                    assertThat(arrayObject, CoreMatchers.instanceOf(ObjectNode.class));
+                    ObjectNode testSection = (ObjectNode) arrayObject;
+                    if (testSection.get("do") != null) {
+                        ObjectNode doSection = (ObjectNode) testSection.get("do");
+                        assertThat(doSection.get("headers"), CoreMatchers.notNullValue());
+                        ObjectNode headersNode = (ObjectNode) doSection.get("headers");
+                        LongAdder assertions = new LongAdder();
+                        expectedHeaders.forEach((k, v) -> {
+                            assertThat(headersNode.get(k), CoreMatchers.notNullValue());
+                            TextNode textNode = (TextNode) headersNode.get(k);
+                            assertThat(textNode.asText(), CoreMatchers.equalTo(v));
+                            assertions.increment();
+                        });
+                        assertThat(assertions.intValue(), CoreMatchers.equalTo(expectedHeaders.size()));
+                    }
+                });
+            }
+        });
+    }
+
+    protected void validateSetupAndTearDownForMatchTests(List<ObjectNode> tests) {
+        ObjectNode setUp = tests.get(0);
+        assertThat(setUp.get("setup"), CoreMatchers.notNullValue());
+        ObjectNode tearDown = tests.get(1);
+        assertThat(tearDown.get("teardown"), CoreMatchers.notNullValue());
+        ObjectNode firstTest = tests.get(2);
+        assertThat(firstTest.get("First test"), CoreMatchers.notNullValue());
+        ObjectNode lastTest = tests.get(tests.size() - 1);
+        assertThat(lastTest.get("Last test"), CoreMatchers.notNullValue());
+
+        // setup
+        JsonNode setup = setUp.get("setup");
+        assertThat(setup, CoreMatchers.instanceOf(ArrayNode.class));
+        ArrayNode setupParentArray = (ArrayNode) setup;
+
+        AtomicBoolean setUpHasMatchObject = new AtomicBoolean(false);
+        setupParentArray.elements().forEachRemaining(node -> {
+            assertThat(node, CoreMatchers.instanceOf(ObjectNode.class));
+            ObjectNode childObject = (ObjectNode) node;
+            JsonNode matchObject = childObject.get("match");
+            if (matchObject != null) {
+                setUpHasMatchObject.set(true);
+            }
+        });
+        assertFalse(setUpHasMatchObject.get());
+
+        // teardown
+        JsonNode teardown = tearDown.get("teardown");
+        assertThat(teardown, CoreMatchers.instanceOf(ArrayNode.class));
+        ArrayNode teardownParentArray = (ArrayNode) teardown;
+
+        AtomicBoolean teardownHasMatchObject = new AtomicBoolean(false);
+        teardownParentArray.elements().forEachRemaining(node -> {
+            assertThat(node, CoreMatchers.instanceOf(ObjectNode.class));
+            ObjectNode childObject = (ObjectNode) node;
+            JsonNode matchObject = childObject.get("match");
+            if (matchObject != null) {
+                teardownHasMatchObject.set(true);
+            }
+        });
+        assertFalse(teardownHasMatchObject.get());
+    }
+
+    protected boolean getHumanDebug() {
+        return false;
+    }
+
+    // only to help manually debug
+    protected void printTest(String testName, List<ObjectNode> tests) {
+        if (getHumanDebug()) {
+            System.out.println("\n************* " + testName + " *************");
+            try (SequenceWriter sequenceWriter = MAPPER.writer().writeValues(System.out)) {
+                for (ObjectNode transformedTest : tests) {
+                    sequenceWriter.write(transformedTest);
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/buildSrc/src/test/java/org/elasticsearch/gradle/test/rest/transform/TransformTests.java
+++ b/buildSrc/src/test/java/org/elasticsearch/gradle/test/rest/transform/TransformTests.java
@@ -26,6 +26,7 @@ import org.junit.Before;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -112,14 +113,13 @@ public abstract class TransformTests extends GradleUnitTestCase {
 
     protected List<ObjectNode> transformTests(List<ObjectNode> tests, List<RestTestTransform<?>> transforms) {
         List<ObjectNode> t = transformer.transformRestTests(new LinkedList<>(tests), transforms);
-        if (getKnownFeatures() != null) {
-            getKnownFeatures().forEach(name -> { validateFeatureNameExists(t, name); });
-        }
+        getKnownFeatures().forEach(name -> { validateFeatureNameExists(t, name); });
+
         return t;
     }
 
     protected List<String> getKnownFeatures() {
-        return null;
+        return Collections.emptyList();
     }
 
     protected List<RestTestTransform<?>> getTransformations() {
@@ -130,8 +130,7 @@ public abstract class TransformTests extends GradleUnitTestCase {
     }
 
     protected List<ObjectNode> getTests(String relativePath) throws Exception {
-        String testName = relativePath;
-        File testFile = new File(getClass().getResource(testName).toURI());
+        File testFile = new File(getClass().getResource(relativePath).toURI());
         YAMLParser yamlParser = YAML_FACTORY.createParser(testFile);
         return READER.<ObjectNode>readValues(yamlParser).readAll();
     }

--- a/buildSrc/src/test/java/org/elasticsearch/gradle/test/rest/transform/TransformTests.java
+++ b/buildSrc/src/test/java/org/elasticsearch/gradle/test/rest/transform/TransformTests.java
@@ -34,7 +34,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.stream.Collectors;
 
-abstract public class TransformTests extends GradleUnitTestCase {
+public abstract class TransformTests extends GradleUnitTestCase {
 
     private static final YAMLFactory YAML_FACTORY = new YAMLFactory();
     private static final ObjectMapper MAPPER = new ObjectMapper(YAML_FACTORY);

--- a/buildSrc/src/test/java/org/elasticsearch/gradle/test/rest/transform/feature/InjectFeatureTests.java
+++ b/buildSrc/src/test/java/org/elasticsearch/gradle/test/rest/transform/feature/InjectFeatureTests.java
@@ -8,47 +8,13 @@
 
 package org.elasticsearch.gradle.test.rest.transform.feature;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectReader;
-import com.fasterxml.jackson.databind.SequenceWriter;
-import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.fasterxml.jackson.dataformat.yaml.YAMLParser;
-import org.elasticsearch.gradle.test.GradleUnitTestCase;
-import org.elasticsearch.gradle.test.rest.transform.RestTestTransform;
-import org.elasticsearch.gradle.test.rest.transform.RestTestTransformer;
-import org.elasticsearch.gradle.test.rest.transform.headers.InjectHeaders;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.core.IsCollectionContaining;
-import org.junit.Before;
+import org.elasticsearch.gradle.test.rest.transform.TransformTests;
 import org.junit.Test;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
-public class InjectFeatureTests extends GradleUnitTestCase {
-
-    private static final YAMLFactory YAML_FACTORY = new YAMLFactory();
-    private static final ObjectMapper MAPPER = new ObjectMapper(YAML_FACTORY);
-    private static final ObjectReader READER = MAPPER.readerFor(ObjectNode.class);
-
-    private static final Map<String, String> headers1 = Map.of("foo", "bar");
-    private static final Map<String, String> headers2 = Map.of("abc", "xyz");
-    RestTestTransformer transformer;
-
-    @Before
-    public void setup() {
-        transformer = new RestTestTransformer();
-    }
+public class InjectFeatureTests extends TransformTests {
 
     /**
      * test file does not have a setup
@@ -132,147 +98,5 @@ public class InjectFeatureTests extends GradleUnitTestCase {
         List<ObjectNode> transformedTests = transformTests(tests);
         printTest(testName, transformedTests);
         validateSetupAndTearDown(transformedTests);
-    }
-
-    protected void validateSetupAndTearDown(List<ObjectNode> transformedTests) {
-        assertThat(transformedTests.stream().filter(node -> node.get("setup") != null).count(), CoreMatchers.equalTo(1L));
-        transformedTests.stream().filter(node -> node.get("setup") != null).forEach(this::assertSetup);
-        transformedTests.stream().filter(node -> node.get("teardown") != null).forEach(this::assertTeardown);
-    }
-
-    protected ObjectNode validateSkipNodesExist(List<ObjectNode> tests) {
-        List<ObjectNode> skipNodes = tests.stream()
-            .filter(node -> node.get("setup") != null)
-            .filter(node -> getSkipNode((ArrayNode) node.get("setup")) != null)
-            .map(node -> getSkipNode((ArrayNode) node.get("setup")))
-            .collect(Collectors.toList());
-        assertThat(skipNodes.size(), CoreMatchers.equalTo(1));
-        return skipNodes.get(0);
-    }
-
-    protected void validateSkipNodesDoesNotExist(List<ObjectNode> tests) {
-        List<ObjectNode> skipNodes = tests.stream()
-            .filter(node -> node.get("setup") != null)
-            .filter(node -> getSkipNode((ArrayNode) node.get("setup")) != null)
-            .map(node -> getSkipNode((ArrayNode) node.get("setup")))
-            .collect(Collectors.toList());
-        assertThat(skipNodes.size(), CoreMatchers.equalTo(0));
-    }
-
-    protected void validatePreExistingFeatureExist(List<ObjectNode> tests) {
-        assertThat(validateSkipNodesExist(tests).get("features"), CoreMatchers.notNullValue());
-    }
-
-    protected void validateSetupDoesNotExist(List<ObjectNode> tests) {
-        assertThat(tests.stream().filter(node -> node.get("setup") != null).count(), CoreMatchers.equalTo(0L));
-    }
-
-    protected void validateFeatureNameExists(List<ObjectNode> tests, String featureName) {
-        ObjectNode skipNode = validateSkipNodesExist(tests);
-        JsonNode featureValues = skipNode.get("features");
-        assertNotNull(featureValues);
-
-        List<String> features = new ArrayList<>(1);
-        if (featureValues.isArray()) {
-            Iterator<JsonNode> featuresIt = featureValues.elements();
-            while (featuresIt.hasNext()) {
-                JsonNode feature = featuresIt.next();
-                features.add(feature.asText());
-            }
-        } else if (featureValues.isTextual()) {
-            features.add(featureValues.asText());
-        }
-
-        assertThat(features, IsCollectionContaining.hasItem(featureName));
-    }
-
-    protected void validateSetupExist(List<ObjectNode> tests) {
-        assertThat(tests.stream().filter(node -> node.get("setup") != null).count(), CoreMatchers.equalTo(1L));
-    }
-
-    protected List<ObjectNode> transformTests(List<ObjectNode> tests) {
-        List<ObjectNode> t = transformer.transformRestTests(new LinkedList<>(tests), getTransformations());
-        getKnownFeatures().forEach(name -> { validateFeatureNameExists(t, name); });
-        return t;
-    }
-
-    protected List<String> getKnownFeatures() {
-        return Collections.singletonList("headers");
-    }
-
-    protected List<RestTestTransform<?>> getTransformations() {
-        List<RestTestTransform<?>> transformations = new ArrayList<>();
-        transformations.add(new InjectHeaders(headers1));
-        transformations.add(new InjectHeaders(headers2));
-        return transformations;
-    }
-
-    protected List<ObjectNode> getTests(String relativePath) throws Exception {
-        String testName = relativePath;
-        File testFile = new File(getClass().getResource(testName).toURI());
-        YAMLParser yamlParser = YAML_FACTORY.createParser(testFile);
-        return READER.<ObjectNode>readValues(yamlParser).readAll();
-    }
-
-    protected void assertTeardown(ObjectNode teardownNode) {
-        assertThat(teardownNode.get("teardown"), CoreMatchers.instanceOf(ArrayNode.class));
-        ObjectNode skipNode = getSkipNode((ArrayNode) teardownNode.get("teardown"));
-        assertSkipNode(skipNode);
-    }
-
-    protected void assertSetup(ObjectNode setupNode) {
-        assertThat(setupNode.get("setup"), CoreMatchers.instanceOf(ArrayNode.class));
-        ObjectNode skipNode = getSkipNode((ArrayNode) setupNode.get("setup"));
-        assertSkipNode(skipNode);
-    }
-
-    protected void assertSkipNode(ObjectNode skipNode) {
-        assertThat(skipNode, CoreMatchers.notNullValue());
-        List<String> featureValues = new ArrayList<>();
-        if (skipNode.get("features").isArray()) {
-            assertThat(skipNode.get("features"), CoreMatchers.instanceOf(ArrayNode.class));
-            ArrayNode features = (ArrayNode) skipNode.get("features");
-            features.forEach(x -> {
-                if (x.isTextual()) {
-                    featureValues.add(x.asText());
-                }
-            });
-        } else {
-            featureValues.add(skipNode.get("features").asText());
-        }
-        assertEquals(featureValues.stream().distinct().count(), featureValues.size());
-    }
-
-    protected ObjectNode getSkipNode(ArrayNode setupNodeValue) {
-        Iterator<JsonNode> setupIt = setupNodeValue.elements();
-        while (setupIt.hasNext()) {
-            JsonNode arrayEntry = setupIt.next();
-            if (arrayEntry.isObject()) {
-                ObjectNode skipCandidate = (ObjectNode) arrayEntry;
-                if (skipCandidate.get("skip") != null) {
-                    ObjectNode skipNode = (ObjectNode) skipCandidate.get("skip");
-                    return skipNode;
-                }
-            }
-        }
-        return null;
-    }
-
-    protected boolean getHumanDebug() {
-        return false;
-    }
-
-    // only to help manually debug
-    protected void printTest(String testName, List<ObjectNode> tests) {
-        if (getHumanDebug()) {
-            System.out.println("\n************* " + testName + " *************");
-            try (SequenceWriter sequenceWriter = MAPPER.writer().writeValues(System.out)) {
-                for (ObjectNode transformedTest : tests) {
-                    sequenceWriter.write(transformedTest);
-                }
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
-        }
     }
 }

--- a/buildSrc/src/test/java/org/elasticsearch/gradle/test/rest/transform/header/InjectHeaderTests.java
+++ b/buildSrc/src/test/java/org/elasticsearch/gradle/test/rest/transform/header/InjectHeaderTests.java
@@ -8,21 +8,15 @@
 
 package org.elasticsearch.gradle.test.rest.transform.header;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.node.TextNode;
 import org.elasticsearch.gradle.test.rest.transform.RestTestTransform;
 import org.elasticsearch.gradle.test.rest.transform.feature.InjectFeatureTests;
 import org.elasticsearch.gradle.test.rest.transform.headers.InjectHeaders;
-import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.LongAdder;
 
 public class InjectHeaderTests extends InjectFeatureTests {
 
@@ -76,33 +70,5 @@ public class InjectHeaderTests extends InjectFeatureTests {
     @Override
     protected boolean getHumanDebug() {
         return false;
-    }
-
-    private void validateBodyHasHeaders(List<ObjectNode> tests, Map<String, String> headers) {
-        tests.forEach(test -> {
-            Iterator<Map.Entry<String, JsonNode>> testsIterator = test.fields();
-            while (testsIterator.hasNext()) {
-                Map.Entry<String, JsonNode> testObject = testsIterator.next();
-                assertThat(testObject.getValue(), CoreMatchers.instanceOf(ArrayNode.class));
-                ArrayNode testBody = (ArrayNode) testObject.getValue();
-                testBody.forEach(arrayObject -> {
-                    assertThat(arrayObject, CoreMatchers.instanceOf(ObjectNode.class));
-                    ObjectNode testSection = (ObjectNode) arrayObject;
-                    if (testSection.get("do") != null) {
-                        ObjectNode doSection = (ObjectNode) testSection.get("do");
-                        assertThat(doSection.get("headers"), CoreMatchers.notNullValue());
-                        ObjectNode headersNode = (ObjectNode) doSection.get("headers");
-                        LongAdder assertions = new LongAdder();
-                        headers.forEach((k, v) -> {
-                            assertThat(headersNode.get(k), CoreMatchers.notNullValue());
-                            TextNode textNode = (TextNode) headersNode.get(k);
-                            assertThat(textNode.asText(), CoreMatchers.equalTo(v));
-                            assertions.increment();
-                        });
-                        assertThat(assertions.intValue(), CoreMatchers.equalTo(headers.size()));
-                    }
-                });
-            }
-        });
     }
 }

--- a/buildSrc/src/test/java/org/elasticsearch/gradle/test/rest/transform/match/AddMatchTests.java
+++ b/buildSrc/src/test/java/org/elasticsearch/gradle/test/rest/transform/match/AddMatchTests.java
@@ -10,114 +10,55 @@ package org.elasticsearch.gradle.test.rest.transform.match;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectReader;
-import com.fasterxml.jackson.databind.SequenceWriter;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.fasterxml.jackson.dataformat.yaml.YAMLParser;
-import org.elasticsearch.gradle.test.GradleUnitTestCase;
-import org.elasticsearch.gradle.test.rest.transform.RestTestTransformer;
+import org.elasticsearch.gradle.test.rest.transform.TransformTests;
 import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 
-import java.io.File;
-import java.io.IOException;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-public class AddMatchTests extends GradleUnitTestCase {
+public class AddMatchTests extends TransformTests {
 
     private static final YAMLFactory YAML_FACTORY = new YAMLFactory();
     private static final ObjectMapper MAPPER = new ObjectMapper(YAML_FACTORY);
-    private static final ObjectReader READER = MAPPER.readerFor(ObjectNode.class);
-
-    private static final boolean humanDebug = false; // useful for humans trying to debug these tests
 
     @Test
     public void testAddAllNotSupported() throws Exception {
         String testName = "/rest/transform/match/match.yml";
-        File testFile = new File(getClass().getResource(testName).toURI());
-        YAMLParser yamlParser = YAML_FACTORY.createParser(testFile);
-        List<ObjectNode> tests = READER.<ObjectNode>readValues(yamlParser).readAll();
-        RestTestTransformer transformer = new RestTestTransformer();
+        List<ObjectNode> tests = getTests(testName);
         JsonNode addNode = MAPPER.convertValue("_doc", JsonNode.class);
         assertEquals(
             "adding matches is only supported for named tests",
             expectThrows(
                 NullPointerException.class,
-                () -> transformer.transformRestTests(
-                    new LinkedList<>(tests),
-                    Collections.singletonList(new AddMatch("_type", addNode, null))
-                )
+                () -> transformTests(new LinkedList<>(tests), Collections.singletonList(new AddMatch("_type", addNode, null)))
             ).getMessage()
         );
-
     }
 
     @Test
     public void testAddByTest() throws Exception {
         String testName = "/rest/transform/match/match.yml";
-        File testFile = new File(getClass().getResource(testName).toURI());
-        YAMLParser yamlParser = YAML_FACTORY.createParser(testFile);
-        List<ObjectNode> tests = READER.<ObjectNode>readValues(yamlParser).readAll();
-        RestTestTransformer transformer = new RestTestTransformer();
+        List<ObjectNode> tests = getTests(testName);
         JsonNode addNode = MAPPER.convertValue(123456789, JsonNode.class);
         validateTest(tests, true);
-        List<ObjectNode> transformedTests = transformer.transformRestTests(
+        List<ObjectNode> transformedTests = transformTests(
             new LinkedList<>(tests),
-            Collections.singletonList(new AddMatch("my_number", addNode, "Basic"))
+            Collections.singletonList(new AddMatch("my_number", addNode, "Last test"))
         );
         printTest(testName, transformedTests);
         validateTest(tests, false);
     }
 
     private void validateTest(List<ObjectNode> tests, boolean beforeTransformation) {
-        ObjectNode setUp = tests.get(0);
-        assertThat(setUp.get("setup"), CoreMatchers.notNullValue());
-        ObjectNode tearDown = tests.get(1);
-        assertThat(tearDown.get("teardown"), CoreMatchers.notNullValue());
-        ObjectNode firstTest = tests.get(2);
-        assertThat(firstTest.get("Test that queries on _index match against the correct indices."), CoreMatchers.notNullValue());
-        ObjectNode lastTest = tests.get(tests.size() - 1);
-        assertThat(lastTest.get("Basic"), CoreMatchers.notNullValue());
-
-        // setup
-        JsonNode setup = setUp.get("setup");
-        assertThat(setup, CoreMatchers.instanceOf(ArrayNode.class));
-        ArrayNode setupParentArray = (ArrayNode) setup;
-
-        AtomicBoolean setUpHasMatchObject = new AtomicBoolean(false);
-        setupParentArray.elements().forEachRemaining(node -> {
-            assertThat(node, CoreMatchers.instanceOf(ObjectNode.class));
-            ObjectNode childObject = (ObjectNode) node;
-            JsonNode matchObject = childObject.get("match");
-            if (matchObject != null) {
-                setUpHasMatchObject.set(true);
-            }
-        });
-        assertFalse(setUpHasMatchObject.get());
-
-        // teardown
-        JsonNode teardown = tearDown.get("teardown");
-        assertThat(teardown, CoreMatchers.instanceOf(ArrayNode.class));
-        ArrayNode teardownParentArray = (ArrayNode) teardown;
-
-        AtomicBoolean teardownHasMatchObject = new AtomicBoolean(false);
-        teardownParentArray.elements().forEachRemaining(node -> {
-            assertThat(node, CoreMatchers.instanceOf(ObjectNode.class));
-            ObjectNode childObject = (ObjectNode) node;
-            JsonNode matchObject = childObject.get("match");
-            if (matchObject != null) {
-                teardownHasMatchObject.set(true);
-            }
-        });
-        assertFalse(teardownHasMatchObject.get());
-
+        validateSetupAndTearDownForMatchTests(tests);
         // first test
-        JsonNode firstTestChild = firstTest.get("Test that queries on _index match against the correct indices.");
+        JsonNode firstTestChild = tests.get(2).get("First test");
         assertThat(firstTestChild, CoreMatchers.instanceOf(ArrayNode.class));
         ArrayNode firstTestParentArray = (ArrayNode) firstTestChild;
 
@@ -133,7 +74,7 @@ public class AddMatchTests extends GradleUnitTestCase {
         assertTrue(firstTestHasMatchObject.get());
 
         // last test
-        JsonNode lastTestChild = lastTest.get("Basic");
+        JsonNode lastTestChild = tests.get(tests.size() - 1).get("Last test");
         assertThat(lastTestChild, CoreMatchers.instanceOf(ArrayNode.class));
         ArrayNode lastTestParentArray = (ArrayNode) lastTestChild;
 
@@ -159,17 +100,8 @@ public class AddMatchTests extends GradleUnitTestCase {
         }
     }
 
-    // only to help manually debug
-    private void printTest(String testName, List<ObjectNode> tests) {
-        if (humanDebug) {
-            System.out.println("\n************* " + testName + " *************");
-            try (SequenceWriter sequenceWriter = MAPPER.writer().writeValues(System.out)) {
-                for (ObjectNode transformedTest : tests) {
-                    sequenceWriter.write(transformedTest);
-                }
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
-        }
+    @Override
+    protected boolean getHumanDebug() {
+        return false;
     }
 }

--- a/buildSrc/src/test/java/org/elasticsearch/gradle/test/rest/transform/match/ReplaceMatchTests.java
+++ b/buildSrc/src/test/java/org/elasticsearch/gradle/test/rest/transform/match/ReplaceMatchTests.java
@@ -10,42 +10,30 @@ package org.elasticsearch.gradle.test.rest.transform.match;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectReader;
-import com.fasterxml.jackson.databind.SequenceWriter;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.fasterxml.jackson.dataformat.yaml.YAMLParser;
-import org.elasticsearch.gradle.test.GradleUnitTestCase;
-import org.elasticsearch.gradle.test.rest.transform.RestTestTransformer;
+import org.elasticsearch.gradle.test.rest.transform.TransformTests;
 import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 
-import java.io.File;
-import java.io.IOException;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-public class ReplaceMatchTests extends GradleUnitTestCase {
+public class ReplaceMatchTests extends TransformTests {
 
     private static final YAMLFactory YAML_FACTORY = new YAMLFactory();
     private static final ObjectMapper MAPPER = new ObjectMapper(YAML_FACTORY);
-    private static final ObjectReader READER = MAPPER.readerFor(ObjectNode.class);
-
-    private static final boolean humanDebug = false; // useful for humans trying to debug these tests
 
     @Test
     public void testReplaceAll() throws Exception {
         String testName = "/rest/transform/match/match.yml";
-        File testFile = new File(getClass().getResource(testName).toURI());
-        YAMLParser yamlParser = YAML_FACTORY.createParser(testFile);
-        List<ObjectNode> tests = READER.<ObjectNode>readValues(yamlParser).readAll();
-        RestTestTransformer transformer = new RestTestTransformer();
+        List<ObjectNode> tests = getTests(testName);
         JsonNode replacementNode = MAPPER.convertValue("_replaced_type", JsonNode.class);
         validateTest(tests, true, true);
-        List<ObjectNode> transformedTests = transformer.transformRestTests(
+        List<ObjectNode> transformedTests = transformTests(
             new LinkedList<>(tests),
             Collections.singletonList(new ReplaceMatch("_type", replacementNode, null))
         );
@@ -57,64 +45,21 @@ public class ReplaceMatchTests extends GradleUnitTestCase {
     @Test
     public void testReplaceByTest() throws Exception {
         String testName = "/rest/transform/match/match.yml";
-        File testFile = new File(getClass().getResource(testName).toURI());
-        YAMLParser yamlParser = YAML_FACTORY.createParser(testFile);
-        List<ObjectNode> tests = READER.<ObjectNode>readValues(yamlParser).readAll();
-        RestTestTransformer transformer = new RestTestTransformer();
+        List<ObjectNode> tests = getTests(testName);
         JsonNode replacementNode = MAPPER.convertValue("_replaced_type", JsonNode.class);
         validateTest(tests, true, false);
-        List<ObjectNode> transformedTests = transformer.transformRestTests(
+        List<ObjectNode> transformedTests = transformTests(
             new LinkedList<>(tests),
-            Collections.singletonList(new ReplaceMatch("_type", replacementNode, "Basic"))
+            Collections.singletonList(new ReplaceMatch("_type", replacementNode, "Last test"))
         );
         printTest(testName, transformedTests);
         validateTest(tests, false, false);
     }
 
     private void validateTest(List<ObjectNode> tests, boolean beforeTransformation, boolean allTests) {
-        ObjectNode setUp = tests.get(0);
-        assertThat(setUp.get("setup"), CoreMatchers.notNullValue());
-        ObjectNode tearDown = tests.get(1);
-        assertThat(tearDown.get("teardown"), CoreMatchers.notNullValue());
-        ObjectNode firstTest = tests.get(2);
-        assertThat(firstTest.get("Test that queries on _index match against the correct indices."), CoreMatchers.notNullValue());
-        ObjectNode lastTest = tests.get(tests.size() - 1);
-        assertThat(lastTest.get("Basic"), CoreMatchers.notNullValue());
-
-        // setup
-        JsonNode setup = setUp.get("setup");
-        assertThat(setup, CoreMatchers.instanceOf(ArrayNode.class));
-        ArrayNode setupParentArray = (ArrayNode) setup;
-
-        AtomicBoolean setUpHasMatchObject = new AtomicBoolean(false);
-        setupParentArray.elements().forEachRemaining(node -> {
-            assertThat(node, CoreMatchers.instanceOf(ObjectNode.class));
-            ObjectNode childObject = (ObjectNode) node;
-            JsonNode matchObject = childObject.get("match");
-            if (matchObject != null) {
-                setUpHasMatchObject.set(true);
-            }
-        });
-        assertFalse(setUpHasMatchObject.get());
-
-        // teardown
-        JsonNode teardown = tearDown.get("teardown");
-        assertThat(teardown, CoreMatchers.instanceOf(ArrayNode.class));
-        ArrayNode teardownParentArray = (ArrayNode) teardown;
-
-        AtomicBoolean teardownHasMatchObject = new AtomicBoolean(false);
-        teardownParentArray.elements().forEachRemaining(node -> {
-            assertThat(node, CoreMatchers.instanceOf(ObjectNode.class));
-            ObjectNode childObject = (ObjectNode) node;
-            JsonNode matchObject = childObject.get("match");
-            if (matchObject != null) {
-                teardownHasMatchObject.set(true);
-            }
-        });
-        assertFalse(teardownHasMatchObject.get());
-
+        validateSetupAndTearDownForMatchTests(tests);
         // first test
-        JsonNode firstTestChild = firstTest.get("Test that queries on _index match against the correct indices.");
+        JsonNode firstTestChild = tests.get(2).get("First test");
         assertThat(firstTestChild, CoreMatchers.instanceOf(ArrayNode.class));
         ArrayNode firstTestParentArray = (ArrayNode) firstTestChild;
 
@@ -139,7 +84,7 @@ public class ReplaceMatchTests extends GradleUnitTestCase {
         assertTrue(firstTestHasTypeMatch.get());
 
         // last test
-        JsonNode lastTestChild = lastTest.get("Basic");
+        JsonNode lastTestChild = tests.get(tests.size() - 1).get("Last test");
         assertThat(lastTestChild, CoreMatchers.instanceOf(ArrayNode.class));
         ArrayNode lastTestParentArray = (ArrayNode) lastTestChild;
 
@@ -168,7 +113,6 @@ public class ReplaceMatchTests extends GradleUnitTestCase {
             JsonNode otherTestChild = otherTest.get(otherTest.fields().next().getKey());
             assertThat(otherTestChild, CoreMatchers.instanceOf(ArrayNode.class));
             ArrayNode otherTestParentArray = (ArrayNode) otherTestChild;
-            AtomicBoolean otherTestHasTypeMatch = new AtomicBoolean(false);
             otherTestParentArray.elements().forEachRemaining(node -> {
                 assertThat(node, CoreMatchers.instanceOf(ObjectNode.class));
                 ObjectNode childObject = (ObjectNode) node;
@@ -184,17 +128,8 @@ public class ReplaceMatchTests extends GradleUnitTestCase {
         }
     }
 
-    // only to help manually debug
-    private void printTest(String testName, List<ObjectNode> tests) {
-        if (humanDebug) {
-            System.out.println("\n************* " + testName + " *************");
-            try (SequenceWriter sequenceWriter = MAPPER.writer().writeValues(System.out)) {
-                for (ObjectNode transformedTest : tests) {
-                    sequenceWriter.write(transformedTest);
-                }
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
-        }
+    @Override
+    protected boolean getHumanDebug() {
+        return false;
     }
 }

--- a/buildSrc/src/test/resources/rest/transform/match/match.yml
+++ b/buildSrc/src/test/resources/rest/transform/match/match.yml
@@ -1,40 +1,24 @@
 ---
 setup:
   - do:
-      indices.create:
-        index: single_doc_index
-        body:
-          settings:
-            index:
-              number_of_shards: 1
-              number_of_replicas: 0
+      something:
+        here: ok
 ---
 teardown:
   - do:
-      indices.delete:
-        index: single_doc_index
-        ignore_unavailable: true
-
+      something_else:
+        here: true
 ---
-"Test that queries on _index match against the correct indices.":
+"First test":
 
   - do:
-      bulk:
-        refresh: true
-        body:
-          - '{"index": {"_index": "single_doc_index"}}'
-          - '{"f1": "local_cluster", "sort_field": 0}'
+      something:
+        that_is: true
 
   - do:
-      search:
-        rest_total_hits_as_int: true
-        index: "single_doc_index,my_remote_cluster:single_doc_index"
-        body:
-          query:
-            term:
-              "_index": "single_doc_index"
+      and: again
 
-  - match: { hits.total: 1 }
+  - match: { copied.from.real.test.total: 1 }
   - match: { hits.hits.0._index: "single_doc_index"}
   - match: { _shards.total: 2 }
   - match: { _shards.successful: 2 }
@@ -42,60 +26,37 @@ teardown:
   - match: { _shards.failed: 0 }
 
   - do:
-      search:
-        rest_total_hits_as_int: true
-        index: "single_doc_index,my_remote_cluster:single_doc_index"
-        body:
-          query:
-            term:
-              "_index": "my_remote_cluster:single_doc_index"
+      and: again
 
   - match: { hits.total: 1 }
   - match: { hits.hits.0._index: "my_remote_cluster:single_doc_index"}
   - match: { _shards.total: 2 }
   - match: { _shards.successful: 2 }
   - match: { _shards.skipped : 0}
-  - match: { _shards.failed: 0 }
+  - match: { _below_is_target_for_tests: 0 }
   - match: { _type:    foo   }
 
 ---
-"Test that queries on _index that don't match are skipped":
+"Also has _type match":
 
   - do:
-      bulk:
-        refresh: true
-        body:
-          - '{"index": {"_index": "single_doc_index"}}'
-          - '{"f1": "local_cluster", "sort_field": 0}'
+      something:
+        that_is: true
 
   - do:
-      search:
-        ccs_minimize_roundtrips: false
-        track_total_hits: true
-        index: "single_doc_index,my_remote_cluster:single_doc_index"
-        pre_filter_shard_size: 1
-        body:
-          query:
-            term:
-              "_index": "does_not_match"
+      and: again
 
   - match: { hits.total.value: 0 }
   - match: { _type:    test   }
+  - match: { _below_is_target_for_tests: 0 }
+  - match: { _type: foo }
   - match: { _shards.total: 2 }
   - match: { _shards.successful: 2 }
   - match: { _shards.skipped : 1}
   - match: { _shards.failed: 0 }
 
   - do:
-      search:
-        ccs_minimize_roundtrips: false
-        track_total_hits: true
-        index: "single_doc_index,my_remote_cluster:single_doc_index"
-        pre_filter_shard_size: 1
-        body:
-          query:
-            term:
-              "_index": "my_remote_cluster:does_not_match"
+      not_random_but_representive: "of actual test"
 
   - match: { hits.total.value: 0 }
   - match: { _shards.total: 2 }
@@ -104,25 +65,14 @@ teardown:
   - match: { _shards.failed: 0 }
 
 ---
-"no _type":
+"Does not have _type match ":
 
   - do:
-      bulk:
-        refresh: true
-        body:
-          - '{"index": {"_index": "single_doc_index"}}'
-          - '{"f1": "local_cluster", "sort_field": 0}'
+      something:
+        that_is: true
 
   - do:
-      search:
-        ccs_minimize_roundtrips: false
-        track_total_hits: true
-        index: "single_doc_index,my_remote_cluster:single_doc_index"
-        pre_filter_shard_size: 1
-        body:
-          query:
-            term:
-              "_index": "does_not_match"
+      and: again
 
   - match: { hits.total.value: 0 }
   - match: { _shards.total: 2 }
@@ -131,15 +81,7 @@ teardown:
   - match: { _shards.failed: 0 }
 
   - do:
-      search:
-        ccs_minimize_roundtrips: false
-        track_total_hits: true
-        index: "single_doc_index,my_remote_cluster:single_doc_index"
-        pre_filter_shard_size: 1
-        body:
-          query:
-            term:
-              "_index": "my_remote_cluster:does_not_match"
+      it: again
 
   - match: { hits.total.value: 0 }
   - match: { _shards.total: 2 }
@@ -147,20 +89,10 @@ teardown:
   - match: { _shards.skipped : 1}
   - match: { _shards.failed: 0 }
 ---
-"Basic":
+"Last test":
 
   - do:
-      index:
-        index: test_1
-        type:  test
-        id:    中文
-        body:  { "foo": "Hello: 中文" }
-
-  - do:
-      get:
-        index: test_1
-        type:  test
-        id:    中文
+      something:  中文
 
   - match: { _index:   test_1 }
   - match: { _type:    test   }
@@ -168,13 +100,10 @@ teardown:
   - match: { _source:  { foo: "Hello: 中文" } }
 
   - do:
-      get:
-        index: test_1
-        type: _all
-        id:    中文
+      something_else:  中文
 
   - match: { _index:   test_1 }
-  - match: { _type:    test   }
+  - match: { _type:    "the value does not matter" }
   - match: { _id:      中文      }
   - match: { _source:  { foo: "Hello: 中文" } }
 


### PR DESCRIPTION
This commit refactors some of the rest test transformations unit tests. 
Similar to #68944, but this change focuses on the "match" tests. 
Specifically, this refactor introduces a common parent that the "match"
tests (and other future tests) can consume. Also, the example tests
have been simplified to better illustrate the change. 

There should no functional changes, just refactoring. This will help with 
future commits to allow focus only for the relevant changes. 