### PR TITLE
Centralize common code for footer checksum read in BaseSearchableSnapshotIndexInput class

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -668,6 +668,11 @@ public abstract class ESTestCase extends LuceneTestCase {
         return (byte) random().nextInt();
     }
 
+    public static byte randomNonNegativeByte() {
+        byte randomByte =  randomByte();
+        return (byte) (randomByte == Byte.MIN_VALUE ? 0 : Math.abs(randomByte));
+    }
+
     /**
      * Helper method to create a byte array of a given length populated with random byte values
      *

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/BaseSearchableSnapshotIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/BaseSearchableSnapshotIndexInput.java
@@ -6,6 +6,8 @@
  */
 package org.elasticsearch.index.store;
 
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.store.BufferedIndexInput;
 import org.apache.lucene.store.IOContext;
 import org.elasticsearch.common.blobstore.BlobContainer;
@@ -16,11 +18,16 @@ import org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsConstants;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Predicate;
+
+import static org.elasticsearch.index.store.checksum.ChecksumBlobContainerIndexInput.checksumToBytesArray;
 
 public abstract class BaseSearchableSnapshotIndexInput extends BufferedIndexInput {
 
+    protected final Logger logger;
     protected final BlobContainer blobContainer;
     protected final FileInfo fileInfo;
     protected final IOContext context;
@@ -33,6 +40,7 @@ public abstract class BaseSearchableSnapshotIndexInput extends BufferedIndexInpu
     private AtomicBoolean closed;
 
     public BaseSearchableSnapshotIndexInput(
+        Logger logger,
         String resourceDesc,
         BlobContainer blobContainer,
         FileInfo fileInfo,
@@ -42,6 +50,7 @@ public abstract class BaseSearchableSnapshotIndexInput extends BufferedIndexInpu
         long length
     ) {
         super(resourceDesc, context);
+        this.logger = Objects.requireNonNull(logger);
         this.blobContainer = Objects.requireNonNull(blobContainer);
         this.fileInfo = Objects.requireNonNull(fileInfo);
         this.context = Objects.requireNonNull(context);
@@ -54,23 +63,58 @@ public abstract class BaseSearchableSnapshotIndexInput extends BufferedIndexInpu
         this.isClone = false;
     }
 
-    public BaseSearchableSnapshotIndexInput(
-        String resourceDesc,
-        BlobContainer blobContainer,
-        FileInfo fileInfo,
-        IOContext context,
-        IndexInputStats stats,
-        long offset,
-        long length,
-        int bufferSize
-    ) {
-        this(resourceDesc, blobContainer, fileInfo, context, stats, offset, length);
-        setBufferSize(bufferSize);
-    }
-
     @Override
     public final long length() {
         return length;
+    }
+
+    @Override
+    protected final void readInternal(ByteBuffer b) throws IOException {
+        assert assertCurrentThreadIsNotCacheFetchAsync();
+
+        // We can detect that we're going to read the last 16 bytes (that contains the footer checksum) of the file. Such reads are often
+        // executed when opening a Directory and since we have the checksum in the snapshot metadata we can use it to fill the ByteBuffer.
+        if (maybeReadChecksumFromFileInfo(b)) {
+            logger.trace("read footer of file [{}], bypassing all caches", fileInfo.physicalName());
+            assert b.remaining() == 0L : b.remaining();
+            return;
+        }
+
+        doReadInternal(b);
+    }
+
+    protected abstract void doReadInternal(ByteBuffer b) throws IOException;
+
+    /**
+     * Detects read operations that are executed on the last 16 bytes of the index input which is where Lucene stores the footer checksum
+     * of Lucene files. If such a read is detected this method tries to complete the read operation by reading the checksum from the
+     * {@link FileInfo} in memory rather than reading the bytes from the {@link BufferedIndexInput} because that could trigger more cache
+     * operations.
+     *
+     * @return true if the footer checksum has been read from the {@link FileInfo}
+     */
+    private boolean maybeReadChecksumFromFileInfo(ByteBuffer b) throws IOException {
+        final int remaining = b.remaining();
+        if (remaining != CodecUtil.footerLength()) {
+            return false;
+        }
+        final long position = getFilePointer() + this.offset;
+        if (position != fileInfo.length() - CodecUtil.footerLength()) {
+            return false;
+        }
+        if (isClone) {
+            return false;
+        }
+        boolean success = false;
+        try {
+            b.put(checksumToBytesArray(fileInfo.checksum()));
+            success = true;
+        } catch (NumberFormatException e) {
+            // tests disable this optimisation by passing an invalid checksum
+        } finally {
+            assert b.remaining() == (success ? 0L : remaining) : b.remaining() + " remaining bytes but success is " + success;
+        }
+        return success;
     }
 
     /**
@@ -173,11 +217,18 @@ public abstract class BaseSearchableSnapshotIndexInput extends BufferedIndexInpu
             if (isClone == false) {
                 stats.incrementCloseCount();
             }
-            innerClose();
+            doClose();
         }
     }
 
-    public abstract void innerClose() throws IOException;
+    public abstract void doClose() throws IOException;
+
+    protected void ensureContext(Predicate<IOContext> predicate) throws IOException {
+        if (predicate.test(context) == false) {
+            assert false : "this method should not be used with this context " + context;
+            throw new IOException("Cannot read the index input using context [context=" + context + ", input=" + this + ']');
+        }
+    }
 
     protected final boolean assertCurrentThreadMayAccessBlobStore() {
         final String threadName = Thread.currentThread().getName();
@@ -199,4 +250,15 @@ public abstract class BaseSearchableSnapshotIndexInput extends BufferedIndexInpu
         return true;
     }
 
+    protected static boolean isCacheFetchAsyncThread(final String threadName) {
+        return threadName.contains('[' + SearchableSnapshotsConstants.CACHE_FETCH_ASYNC_THREAD_POOL_NAME + ']');
+    }
+
+    protected static boolean assertCurrentThreadIsNotCacheFetchAsync() {
+        final String threadName = Thread.currentThread().getName();
+        assert false == isCacheFetchAsyncThread(threadName) : "expected the current thread ["
+            + threadName
+            + "] to belong to the cache fetch async thread pool";
+        return true;
+    }
 }

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/direct/DirectBlobContainerIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/direct/DirectBlobContainerIndexInput.java
@@ -6,6 +6,8 @@
  */
 package org.elasticsearch.index.store.direct;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.elasticsearch.common.CheckedRunnable;
@@ -54,6 +56,8 @@ import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsUti
  */
 public class DirectBlobContainerIndexInput extends BaseSearchableSnapshotIndexInput {
 
+    private static final Logger logger = LogManager.getLogger(DirectBlobContainerIndexInput.class);
+
     private long position;
 
     @Nullable // if not currently reading sequentially
@@ -97,14 +101,15 @@ public class DirectBlobContainerIndexInput extends BaseSearchableSnapshotIndexIn
         long sequentialReadSize,
         int bufferSize
     ) {
-        super(resourceDesc, blobContainer, fileInfo, context, stats, offset, length, bufferSize);
+        super(logger, resourceDesc, blobContainer, fileInfo, context, stats, offset, length);
         this.position = position;
         assert sequentialReadSize >= 0;
         this.sequentialReadSize = sequentialReadSize;
+        setBufferSize(bufferSize);
     }
 
     @Override
-    protected void readInternal(ByteBuffer b) throws IOException {
+    protected void doReadInternal(ByteBuffer b) throws IOException {
         ensureOpen();
         if (fileInfo.numberOfParts() == 1) {
             readInternalBytes(0, position, b, b.remaining());
@@ -319,7 +324,7 @@ public class DirectBlobContainerIndexInput extends BaseSearchableSnapshotIndexIn
     }
 
     @Override
-    public void innerClose() throws IOException {
+    public void doClose() throws IOException {
         closeStreamForSequentialReads();
     }
 

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/SearchableSnapshotDirectoryStatsTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/SearchableSnapshotDirectoryStatsTests.java
@@ -616,9 +616,14 @@ public class SearchableSnapshotDirectoryStatsTests extends AbstractSearchableSna
 
         final Long seekingThreshold = randomBoolean() ? randomLongBetween(1L, fileContent.length) : null;
 
+        // Passing a wrong checksum here disables the BaseSearchableSnapshotIndexInput#maybeReadChecksumFromFileInfo(ByteBuffer)
+        // optimisation which, if it was enabled, would makes the stats tests much more complicated in order to accommodate for
+        // potential footer checksum reads.
+        final String fileChecksum = "_checksum";
+
         final String blobName = randomUnicodeOfLength(10);
         final BlobContainer blobContainer = singleBlobContainer(blobName, fileContent);
-        final StoreFileMetadata metadata = new StoreFileMetadata(fileName, fileContent.length, "_checksum", Version.CURRENT.luceneVersion);
+        final StoreFileMetadata metadata = new StoreFileMetadata(fileName, fileContent.length, fileChecksum, Version.CURRENT.luceneVersion);
         final List<FileInfo> files = Collections.singletonList(new FileInfo(blobName, metadata, new ByteSizeValue(fileContent.length)));
         final BlobStoreIndexShardSnapshot snapshot = new BlobStoreIndexShardSnapshot(snapshotId.getName(), 0L, files, 0L, 0L, 0, 0L);
         final Path shardDir = randomShardPath(shardId);

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/SearchableSnapshotDirectoryTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/SearchableSnapshotDirectoryTests.java
@@ -49,6 +49,7 @@ import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.common.blobstore.BlobPath;
 import org.elasticsearch.common.blobstore.fs.FsBlobContainer;
 import org.elasticsearch.common.blobstore.fs.FsBlobStore;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.io.PathUtils;
 import org.elasticsearch.common.io.PathUtilsForTesting;
 import org.elasticsearch.common.lease.Releasable;
@@ -96,7 +97,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.SeekableByteChannel;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.DirectoryStream;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
@@ -661,14 +661,17 @@ public class SearchableSnapshotDirectoryTests extends AbstractSearchableSnapshot
             final Path shardSnapshotDir = createTempDir();
             for (int i = 0; i < nbRandomFiles; i++) {
                 final String fileName = "file_" + randomAlphaOfLength(10);
-                final byte[] fileContent = randomUnicodeOfLength(randomIntBetween(1, 100_000)).getBytes(StandardCharsets.UTF_8);
+
+                final Tuple<String, byte[]> bytes = randomChecksumBytes(randomIntBetween(1, 100_000));
+                final byte[] input = bytes.v2();
+                final String checksum = bytes.v1();
                 final String blobName = randomAlphaOfLength(15);
-                Files.write(shardSnapshotDir.resolve(blobName), fileContent, StandardOpenOption.CREATE_NEW);
+                Files.write(shardSnapshotDir.resolve(blobName), input, StandardOpenOption.CREATE_NEW);
                 randomFiles.add(
                     new BlobStoreIndexShardSnapshot.FileInfo(
                         blobName,
-                        new StoreFileMetadata(fileName, fileContent.length, "_check", Version.CURRENT.luceneVersion),
-                        new ByteSizeValue(fileContent.length)
+                        new StoreFileMetadata(fileName, input.length, checksum, Version.CURRENT.luceneVersion),
+                        new ByteSizeValue(input.length)
                     )
                 );
             }

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/FrozenIndexInputTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/FrozenIndexInputTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.index.store.cache;
 import org.apache.lucene.store.IndexInput;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.env.Environment;
@@ -30,7 +31,6 @@ import org.elasticsearch.xpack.searchablesnapshots.cache.CacheService;
 import org.elasticsearch.xpack.searchablesnapshots.cache.FrozenCacheService;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
@@ -45,12 +45,15 @@ public class FrozenIndexInputTests extends AbstractSearchableSnapshotsTestCase {
 
     public void testRandomReads() throws IOException {
         final String fileName = randomAlphaOfLengthBetween(5, 10).toLowerCase(Locale.ROOT);
-        final byte[] fileData = randomUnicodeOfLength(randomIntBetween(1, 100_000)).getBytes(StandardCharsets.UTF_8);
+        final Tuple<String, byte[]> bytes = randomChecksumBytes(randomIntBetween(1, 100_000));
+
+        final byte[] fileData = bytes.v2();
+        final String checksum = bytes.v1();
 
         final Path tempDir = createTempDir().resolve(SHARD_ID.getIndex().getUUID()).resolve(String.valueOf(SHARD_ID.getId()));
         final FileInfo fileInfo = new FileInfo(
             randomAlphaOfLength(10),
-            new StoreFileMetadata(fileName, fileData.length, "_na", Version.CURRENT.luceneVersion),
+            new StoreFileMetadata(fileName, fileData.length, checksum, Version.CURRENT.luceneVersion),
             new ByteSizeValue(fileData.length)
         );
 
@@ -100,7 +103,7 @@ public class FrozenIndexInputTests extends AbstractSearchableSnapshotsTestCase {
         ) {
             directory.loadSnapshot(createRecoveryState(true), ActionListener.wrap(() -> {}));
 
-            // TODO does not test the checksum shortcut, does not test using the recovery range size
+            // TODO does not test using the recovery range size
             final IndexInput indexInput = directory.openInput(fileName, newIOContext(random()));
             assertThat(indexInput, instanceOf(FrozenIndexInput.class));
             assertEquals(fileData.length, indexInput.length());

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsTestCase.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsTestCase.java
@@ -7,6 +7,12 @@
 
 package org.elasticsearch.xpack.searchablesnapshots;
 
+import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.store.ByteBuffersDataOutput;
+import org.apache.lucene.store.ByteBuffersIndexInput;
+import org.apache.lucene.store.ByteBuffersIndexOutput;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
@@ -16,6 +22,7 @@ import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.TestShardRouting;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.collect.Set;
 import org.elasticsearch.common.lucene.store.ESIndexInputTestCase;
 import org.elasticsearch.common.settings.ClusterSettings;
@@ -27,6 +34,7 @@ import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.store.Store;
 import org.elasticsearch.index.store.cache.CacheFile;
 import org.elasticsearch.index.store.cache.CacheKey;
 import org.elasticsearch.indices.recovery.RecoveryState;
@@ -49,6 +57,7 @@ import org.junit.Before;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -59,6 +68,7 @@ import java.util.Locale;
 import java.util.SortedSet;
 import java.util.concurrent.TimeUnit;
 
+import static com.carrotsearch.randomizedtesting.RandomizedTest.randomAsciiLettersOfLengthBetween;
 import static org.elasticsearch.index.store.cache.TestUtils.randomPopulateAndReads;
 
 public abstract class AbstractSearchableSnapshotsTestCase extends ESIndexInputTestCase {
@@ -304,5 +314,23 @@ public abstract class AbstractSearchableSnapshotsTestCase extends ESIndexInputTe
             }
         }
         return cacheFiles;
+    }
+
+    public static Tuple<String, byte[]> randomChecksumBytes(int length) throws IOException {
+        return randomChecksumBytes(randomUnicodeOfLength(length).getBytes(StandardCharsets.UTF_8));
+    }
+
+    public static Tuple<String, byte[]> randomChecksumBytes(byte[] bytes) throws IOException {
+        final ByteBuffersDataOutput out = new ByteBuffersDataOutput();
+        try (IndexOutput output = new ByteBuffersIndexOutput(out, "randomChecksumBytes()", "randomChecksumBytes()")) {
+            CodecUtil.writeHeader(output, randomAsciiLettersOfLengthBetween(0, 127), randomNonNegativeByte());
+            output.writeBytes(bytes, bytes.length);
+            CodecUtil.writeFooter(output);
+        }
+        final String checksum;
+        try (IndexInput input = new ByteBuffersIndexInput(out.toDataInput(), "checksumEntireFile()")) {
+            checksum = Store.digestToString(CodecUtil.checksumEntireFile(input));
+        }
+        return Tuple.tuple(checksum, out.toArrayCopy());
     }
 }


### PR DESCRIPTION
This commit factorizes in the BaseSearchableSnapshotIndexInput
class some common code used to read the footer checksum of
searchable snapshots IndexInput implementations.

This change helps to maintain the code to read the footer checksum
in one place and helps to enable this optimisation for
DirectBlobContainerIndexInput. It also helps to assert the non-usage
of the cache fetch async thread pool when reading from a index input
in a single place.

Finally, the index input unit tests have been adapted to account for
the footer checksum read optimisation: they now generate a binary
content that contains a valid footer checksum.

Backport of #68902