### PR TITLE
Update versions after backport of `max_analyzed_offset`

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.highlight/30_max_analyzed_offset.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.highlight/30_max_analyzed_offset.yml
@@ -41,8 +41,8 @@ setup:
 "Unified highlighter on a field WITHOUT OFFSETS exceeding index.highlight.max_analyzed_offset with max_analyzed_offset=20 should SUCCEED":
 
   - skip:
-      version: " - 7.99.99"
-      reason: max_analyzed_offset query param added in 8.0
+      version: " - 7.11.99"
+      reason: max_analyzed_offset query param added in 7.12.0
 
   - do:
       search:
@@ -67,8 +67,8 @@ setup:
 "Plain highlighter on a field WITHOUT OFFSETS exceeding index.highlight.max_analyzed_offset with max_analyzed_offset=20 should SUCCEED":
 
   - skip:
-      version: " - 7.99.99"
-      reason: max_analyzed_offset query param added in 8.0
+      version: " - 7.11.99"
+      reason: max_analyzed_offset query param added in 7.12.0
 
   - do:
       search:
@@ -104,8 +104,8 @@ setup:
 "Plain highlighter on a field WITH OFFSETS exceeding index.highlight.max_analyzed_offset with max_analyzed_offset=20 should SUCCEED":
 
   - skip:
-      version: " - 7.99.99"
-      reason: max_analyzed_offset query param added in 8.0
+      version: " - 7.11.99"
+      reason: max_analyzed_offset query param added in 7.12.0
 
   - do:
       search:
@@ -118,8 +118,8 @@ setup:
 "Plain highlighter with max_analyzed_offset < 0 should FAIL":
 
   - skip:
-      version: " - 7.99.99"
-      reason: max_analyzed_offset query param added in 8.0
+      version: " - 7.11.99"
+      reason: max_analyzed_offset query param added in 7.12.0
 
   - do:
       catch: bad_request

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/AbstractHighlighterBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/AbstractHighlighterBuilder.java
@@ -159,7 +159,7 @@ public abstract class AbstractHighlighterBuilder<HB extends AbstractHighlighterB
             options(in.readMap());
         }
         requireFieldMatch(in.readOptionalBoolean());
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_12_0)) {
             maxAnalyzedOffset(in.readOptionalInt());
         }
     }
@@ -203,7 +203,7 @@ public abstract class AbstractHighlighterBuilder<HB extends AbstractHighlighterB
             out.writeMap(options);
         }
         out.writeOptionalBoolean(requireFieldMatch);
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_12_0)) {
             out.writeOptionalInt(maxAnalyzedOffset);
         }
         doWriteTo(out);


### PR DESCRIPTION
Since #69016 is merged, versions for serialisation/deserialisation
and YAML tests are updated.

Follows: #67325
