### PR TITLE
[7.x] [ML] enable upgrade_mode tests and up the logging level (#68937)

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/set_upgrade_mode.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/set_upgrade_mode.yml
@@ -60,6 +60,12 @@ setup:
       cluster.health:
         index: airline-data
         wait_for_status: green
+  - do:
+      cluster.put_settings:
+        body: >
+          {
+             "transient": {"logger.org.elasticsearch.xpack.ml.action.TransportSetUpgradeModeAction": "TRACE" }
+          }
 
 ---
 teardown:
@@ -99,10 +105,6 @@ teardown:
 
 ---
 "Setting upgrade_mode to enabled":
-  - skip:
-      version: all
-      reason: Bug fix url https://github.com/elastic/elasticsearch/issues/65947
-
   - do:
       ml.start_datafeed:
         datafeed_id: set-upgrade-mode-job-datafeed


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ML] enable upgrade_mode tests and up the logging level (#68937)