### PR TITLE
Fix testIdenticalSearchableSnapshotActionIsNoop

### DIFF
--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/SearchableSnapshotActionIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/SearchableSnapshotActionIT.java
@@ -375,11 +375,13 @@ public class SearchableSnapshotActionIT extends ESRestTestCase {
             null
         );
 
-        createIndex(index, Settings.builder()
-            .put(LifecycleSettings.LIFECYCLE_NAME, policy)
-            .build());
+        createIndex(index, Settings.EMPTY);
         ensureGreen(index);
         indexDocument(client(), index, true);
+
+        // enable ILM after we indexed a document as otherwise ILM might sometimes run so fast the indexDocument call will fail with
+        // `index_not_found_exception`
+        updateIndexSettings(index, Settings.builder().put(LifecycleSettings.LIFECYCLE_NAME, policy));
 
         final String searchableSnapMountedIndexName = (storage == MountSearchableSnapshotRequest.Storage.FULL_COPY ?
             SearchableSnapshotAction.FULL_RESTORED_INDEX_PREFIX : SearchableSnapshotAction.PARTIAL_RESTORED_INDEX_PREFIX) + index;
@@ -425,11 +427,13 @@ public class SearchableSnapshotActionIT extends ESRestTestCase {
             null
         );
 
-        createIndex(index, Settings.builder()
-            .put(LifecycleSettings.LIFECYCLE_NAME, policy)
-            .build());
+        createIndex(index, Settings.EMPTY);
         ensureGreen(index);
         indexDocument(client(), index, true);
+
+        // enable ILM after we indexed a document as otherwise ILM might sometimes run so fast the indexDocument call will fail with
+        // `index_not_found_exception`
+        updateIndexSettings(index, Settings.builder().put(LifecycleSettings.LIFECYCLE_NAME, policy));
 
         final String searchableSnapMountedIndexName = SearchableSnapshotAction.PARTIAL_RESTORED_INDEX_PREFIX +
             SearchableSnapshotAction.FULL_RESTORED_INDEX_PREFIX + index;


### PR DESCRIPTION
This fixes the flakiness in testIdenticalSearchableSnapshotActionIsNoop and
testConvertingSearchableSnapshotFromFullToPartial caused by the fact that we
enabled ILM for the index and *after that* indexed a document. If ILM runs
very fast in CI the `indexDocument` call could fail (as ILM deleted the index already), 
or in the case of testIdenticalSearchableSnapshotActionIsNoop all the assertions in 
the test will pass but the final one that checks there is one document indexed fails
because the `indexDocument` call didn't execute.

Fixes #68977