### PR TITLE
[DOCS] Remove keyword/ip from unsupported fields in top_metrics

### DIFF
--- a/docs/reference/aggregations/metrics/top-metrics-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/top-metrics-aggregation.asciidoc
@@ -54,8 +54,7 @@ faster.
 The `sort` field in the metric request functions exactly the same as the `sort` field in the
 <<sort-search-results, search>> request except:
 
-* It can't be used on <<binary,binary>>, <<flattened,flattened>>, <<ip,ip>>,
-<<keyword,keyword>>, or <<text,text>> fields.
+* It can't be used on <<binary,binary>>, <<flattened,flattened>> or <<text,text>> fields.
 * It only supports a single sort value so which document wins ties is not specified.
 
 The metrics that the aggregation returns is the first hit that would be returned by the search


### PR DESCRIPTION
In https://github.com/elastic/elasticsearch/pull/64967, Nik added support for keyword and ip fields for top_metrics. However, the docs for top_metrics still mention keyword and ip fields as not supported. This PR removes those mentions.

I figure it might be good to have some keyword examples as well but I'll leave that up to others and open this PR to at least start the conversation.