### PR TITLE
[REST Compatible API] Reindex size field

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/transform/feature/FeatureInjector.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/transform/feature/FeatureInjector.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import org.elasticsearch.gradle.test.rest.transform.RestTestTransformGlobalSetup;
 import org.elasticsearch.gradle.test.rest.transform.RestTestTransformGlobalTeardown;
+import org.gradle.api.tasks.Internal;
 
 import javax.annotation.Nullable;
 import java.util.Iterator;
@@ -73,6 +74,7 @@ public abstract class FeatureInjector implements RestTestTransformGlobalSetup, R
      *       features: allowed_warnings
      * </pre>
      */
+    @Internal
     public abstract String getSkipFeatureName();
 
     private boolean hasFeature(ArrayNode skipParent) {

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/transform/headers/InjectHeaders.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/transform/headers/InjectHeaders.java
@@ -15,6 +15,7 @@ import org.elasticsearch.gradle.test.rest.transform.RestTestTransform;
 import org.elasticsearch.gradle.test.rest.transform.RestTestTransformByParentObject;
 import org.elasticsearch.gradle.test.rest.transform.feature.FeatureInjector;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Internal;
 
 import java.util.Map;
 
@@ -49,6 +50,7 @@ public class InjectHeaders extends FeatureInjector implements RestTestTransformB
     }
 
     @Override
+    @Internal
     public String getKeyToFind() {
         return "do";
     }

--- a/modules/reindex/build.gradle
+++ b/modules/reindex/build.gradle
@@ -16,6 +16,7 @@ apply plugin: 'elasticsearch.test-with-dependencies'
 apply plugin: 'elasticsearch.jdk-download'
 apply plugin: 'elasticsearch.yaml-rest-test'
 apply plugin: 'elasticsearch.java-rest-test'
+apply plugin: 'elasticsearch.yaml-rest-compat-test'
 apply plugin: 'elasticsearch.internal-cluster-test'
 
 esplugin {
@@ -157,4 +158,20 @@ if (Os.isFamily(Os.FAMILY_WINDOWS)) {
         nonInputProperties.systemProperty "es${version}.port", "${-> fixture.get().addressAndPort}"
     }
   }
+}
+
+tasks.named("yamlRestCompatTest").configure {
+  systemProperty 'tests.rest.blacklist', [
+    'reindex/20_validation/reindex without source gives useful error message', /* type in exception message */
+    'reindex/85_scripting/Reindex all docs with one doc deletion', /*type in a request*/
+    'delete_by_query/10_basic/Limit by size',
+    'delete_by_query/10_basic/Response for version conflict \\(seq no powered\\)',
+    'delete_by_query/20_validation/both max_docs and size fails',
+    'delete_by_query/20_validation/invalid size fails',
+    'update_by_query/10_basic/Limit by size',
+    'update_by_query/10_basic/Response for version conflict \\(seq no powered\\)',
+    'update_by_query/20_validation/inconsistent max_docs and size fails',
+    'update_by_query/20_validation/invalid size fails',
+    'update_by_query/20_validation/update_by_query without source gives useful error message'
+  ].join(',')
 }

--- a/server/src/main/java/org/elasticsearch/index/reindex/ReindexRequest.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/ReindexRequest.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.compatibility.RestApiCompatibleVersion;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.uid.Versions;
@@ -346,9 +347,16 @@ public class ReindexRequest extends AbstractBulkIndexByScrollRequest<ReindexRequ
 
         PARSER.declareField(sourceParser::parse, new ParseField("source"), ObjectParser.ValueType.OBJECT);
         PARSER.declareField((p, v, c) -> destParser.parse(p, v.getDestination(), c), new ParseField("dest"), ObjectParser.ValueType.OBJECT);
-        PARSER.declareInt(ReindexRequest::setMaxDocsValidateIdentical, new ParseField("max_docs"));
+
+        PARSER.declareInt(ReindexRequest::setMaxDocsValidateIdentical,
+            new ParseField("max_docs", "size").withRestApiCompatibilityVersions(RestApiCompatibleVersion.V_7));
+
+        PARSER.declareInt(ReindexRequest::setMaxDocsValidateIdentical,
+            new ParseField("max_docs").withRestApiCompatibilityVersions(RestApiCompatibleVersion.V_8));
         // avoid silently accepting an ignored size.
-        PARSER.declareInt((r,s) -> failOnSizeSpecified(), new ParseField("size"));
+        PARSER.declareInt((r,s) -> failOnSizeSpecified(),
+            new ParseField("size").withRestApiCompatibilityVersions(RestApiCompatibleVersion.V_8));
+
         PARSER.declareField((p, v, c) -> v.setScript(Script.parse(p)), new ParseField("script"),
             ObjectParser.ValueType.OBJECT);
         PARSER.declareString(ReindexRequest::setConflicts, new ParseField("conflicts"));


### PR DESCRIPTION
The commit #43373 has removed outer level size field in version 7.
This commit allows for the use of the size field in server ES8 using
compatible REST API.

relates #51816


This is a surgical approach with just adding a new field declaration to existing parser. A different - copying - approach is presented here https://github.com/elastic/elasticsearch/pull/68355
