### PR TITLE
Remove DocumentMapper#merge method (#69005)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -17,7 +17,6 @@ import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.analysis.IndexAnalyzers;
-import org.elasticsearch.index.mapper.MapperService.MergeReason;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -136,11 +135,6 @@ public class DocumentMapper {
         final BytesRef byteRef = new BytesRef(reason);
         parsedDoc.rootDoc().add(new StoredField(SourceFieldMapper.NAME, byteRef.bytes, byteRef.offset, byteRef.length));
         return parsedDoc;
-    }
-
-    public DocumentMapper merge(Mapping mapping, MergeReason reason) {
-        Mapping merged = this.mapping().merge(mapping, reason);
-        return new DocumentMapper(mappingLookup.getIndexSettings(), mappingLookup.getIndexAnalyzers(), documentParser, merged);
     }
 
     public void validate(IndexSettings settings, boolean checkLimits) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/Mapping.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/Mapping.java
@@ -65,7 +65,13 @@ public final class Mapping implements ToXContentFragment {
         this.meta = meta;
     }
 
-    /** Return the root object mapper. */
+    public String type() {
+        return root.name();
+    }
+
+    /**
+     * Return the root object mapper.
+     */
     RootObjectMapper root() {
         return root;
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentMapperTests.java
@@ -12,7 +12,9 @@ import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.core.KeywordAnalyzer;
 import org.apache.lucene.analysis.core.WhitespaceAnalyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.analysis.AnalyzerScope;
 import org.elasticsearch.index.analysis.IndexAnalyzers;
@@ -51,15 +53,18 @@ public class DocumentMapperTests extends MapperServiceTestCase {
         }));
 
         MergeReason reason = randomFrom(MergeReason.MAPPING_UPDATE, MergeReason.INDEX_TEMPLATE);
-        DocumentMapper merged = stage1.merge(stage2.mapping(), reason);
+        Mapping merged = MapperService.mergeMappings(stage1, stage2.mapping(), reason);
 
         // stage1 mapping should not have been modified
         assertThat(stage1.mappers().getMapper("age"), nullValue());
         assertThat(stage1.mappers().getMapper("obj1.prop1"), nullValue());
         // but merged should
-        assertThat(merged.mappers().getMapper("age"), notNullValue());
-        assertThat(merged.mappers().getMapper("obj1.prop1"), notNullValue());
-}
+        IndexSettings indexSettings = createIndexSettings(Version.CURRENT, Settings.EMPTY);
+        IndexAnalyzers indexAnalyzers = createIndexAnalyzers(indexSettings);
+        DocumentMapper mergedMapper = new DocumentMapper(indexSettings, indexAnalyzers, null, merged);
+        assertThat(mergedMapper.mappers().getMapper("age"), notNullValue());
+        assertThat(mergedMapper.mappers().getMapper("obj1.prop1"), notNullValue());
+    }
 
     public void testMergeObjectDynamic() throws Exception {
         DocumentMapper mapper = createDocumentMapper(mapping(b -> { }));
@@ -68,7 +73,7 @@ public class DocumentMapperTests extends MapperServiceTestCase {
         DocumentMapper withDynamicMapper = createDocumentMapper(topMapping(b -> b.field("dynamic", "false")));
         assertThat(withDynamicMapper.root().dynamic(), equalTo(ObjectMapper.Dynamic.FALSE));
 
-        DocumentMapper merged = mapper.merge(withDynamicMapper.mapping(), MergeReason.MAPPING_UPDATE);
+        Mapping merged = MapperService.mergeMappings(mapper, withDynamicMapper.mapping(), MergeReason.MAPPING_UPDATE);
         assertThat(merged.root().dynamic(), equalTo(ObjectMapper.Dynamic.FALSE));
     }
 
@@ -79,12 +84,12 @@ public class DocumentMapperTests extends MapperServiceTestCase {
 
         {
             IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
-                () -> objectMapper.merge(nestedMapper.mapping(), reason));
+                () -> MapperService.mergeMappings(objectMapper, nestedMapper.mapping(), reason));
             assertThat(e.getMessage(), containsString("cannot change object mapping from non-nested to nested"));
         }
         {
             IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
-                () -> nestedMapper.merge(objectMapper.mapping(), reason));
+                () -> MapperService.mergeMappings(nestedMapper, objectMapper.mapping(), reason));
             assertThat(e.getMessage(), containsString("cannot change object mapping from nested to non-nested"));
         }
     }
@@ -220,13 +225,13 @@ public class DocumentMapperTests extends MapperServiceTestCase {
 
         DocumentMapper updatedMapper = createDocumentMapper(fieldMapping(b -> b.field("type", "text")));
 
-        DocumentMapper mergedMapper = initMapper.merge(updatedMapper.mapping(), MergeReason.MAPPING_UPDATE);
-        assertThat(mergedMapper.meta().get("foo"), equalTo("bar"));
+        Mapping merged = MapperService.mergeMappings(initMapper, updatedMapper.mapping(), MergeReason.MAPPING_UPDATE);
+        assertThat(merged.meta.get("foo"), equalTo("bar"));
 
         updatedMapper
             = createDocumentMapper(topMapping(b -> b.startObject("_meta").field("foo", "new_bar").endObject()));
-        mergedMapper = initMapper.merge(updatedMapper.mapping(), MergeReason.MAPPING_UPDATE);
-        assertThat(mergedMapper.meta().get("foo"), equalTo("new_bar"));
+        merged = MapperService.mergeMappings(initMapper, updatedMapper.mapping(), MergeReason.MAPPING_UPDATE);
+        assertThat(merged.meta.get("foo"), equalTo("new_bar"));
     }
 
     public void testMergeMetaForIndexTemplate() throws IOException {
@@ -250,8 +255,8 @@ public class DocumentMapperTests extends MapperServiceTestCase {
         assertThat(initMapper.meta(), equalTo(expected));
 
         DocumentMapper updatedMapper = createDocumentMapper(fieldMapping(b -> b.field("type", "text")));
-        DocumentMapper mergedMapper = initMapper.merge(updatedMapper.mapping(), MergeReason.INDEX_TEMPLATE);
-        assertThat(mergedMapper.meta(), equalTo(expected));
+        Mapping merged = MapperService.mergeMappings(initMapper, updatedMapper.mapping(), MergeReason.INDEX_TEMPLATE);
+        assertThat(merged.meta, equalTo(expected));
 
         updatedMapper = createDocumentMapper(topMapping(b -> {
             b.startObject("_meta");
@@ -266,11 +271,11 @@ public class DocumentMapperTests extends MapperServiceTestCase {
             }
             b.endObject();
         }));
-        mergedMapper = mergedMapper.merge(updatedMapper.mapping(), MergeReason.INDEX_TEMPLATE);
+        merged = merged.merge(updatedMapper.mapping(), MergeReason.INDEX_TEMPLATE);
 
         expected = org.elasticsearch.common.collect.Map.of(
             "field", "value",
             "object", org.elasticsearch.common.collect.Map.of("field1", "value1", "field2", "new_value", "field3", "value3"));
-        assertThat(mergedMapper.meta(), equalTo(expected));
+        assertThat(merged.meta, equalTo(expected));
     }
 }


### PR DESCRIPTION
DocumentMapper exposes a merge method that simply calls merge on the inner Mapping object. We have started to migrate away from building the entire document mapper only for merging, as the inner Mapping object is enough to do so. This will allow us to further simplify and isolate our merging code so that it may not even require a MapperService instance.

With this commit, we remove the DocumentMapper#merge method in favour of calling Mapping#merge instead.
