### PR TITLE
Add support for aliases referring to data streams.

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesRequest.java
@@ -102,4 +102,9 @@ public class GetAliasesRequest extends MasterNodeReadRequest<GetAliasesRequest> 
     public ActionRequestValidationException validate() {
         return null;
     }
+
+    @Override
+    public boolean includeDataStreams() {
+        return true;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesResponse.java
@@ -10,6 +10,8 @@ package org.elasticsearch.action.admin.indices.alias.get;
 
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.cluster.metadata.AliasMetadata;
+import org.elasticsearch.cluster.metadata.DataStreamAlias;
+import org.elasticsearch.cluster.metadata.DataStreamMetadata;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -21,23 +23,34 @@ import java.util.Objects;
 public class GetAliasesResponse extends ActionResponse {
 
     private final ImmutableOpenMap<String, List<AliasMetadata>> aliases;
+    private final List<DataStreamAlias> dataStreamAliases;
 
-    public GetAliasesResponse(ImmutableOpenMap<String, List<AliasMetadata>> aliases) {
+    public GetAliasesResponse(ImmutableOpenMap<String, List<AliasMetadata>> aliases, List<DataStreamAlias> dataStreamAliases) {
         this.aliases = aliases;
+        this.dataStreamAliases = dataStreamAliases;
     }
 
     public GetAliasesResponse(StreamInput in) throws IOException {
         super(in);
         aliases = in.readImmutableMap(StreamInput::readString, i -> i.readList(AliasMetadata::new));
+        dataStreamAliases = in.getVersion().onOrAfter(DataStreamMetadata.DATA_STREAM_ALIAS_VERSION) ?
+            in.readList(DataStreamAlias::new) : List.of();
     }
 
     public ImmutableOpenMap<String, List<AliasMetadata>> getAliases() {
         return aliases;
     }
 
+    public List<DataStreamAlias> getDataStreamAliases() {
+        return dataStreamAliases;
+    }
+
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeMap(aliases, StreamOutput::writeString, StreamOutput::writeList);
+        if (out.getVersion().onOrAfter(DataStreamMetadata.DATA_STREAM_ALIAS_VERSION)) {
+            out.writeList(dataStreamAliases);
+        }
     }
 
     @Override
@@ -49,11 +62,12 @@ public class GetAliasesResponse extends ActionResponse {
             return false;
         }
         GetAliasesResponse that = (GetAliasesResponse) o;
-        return Objects.equals(aliases, that.aliases);
+        return Objects.equals(aliases, that.aliases) &&
+            Objects.equals(dataStreamAliases, that.dataStreamAliases);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(aliases);
+        return Objects.hash(aliases, dataStreamAliases);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesAction.java
@@ -14,6 +14,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.AliasMetadata;
+import org.elasticsearch.cluster.metadata.DataStreamAlias;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -21,6 +22,7 @@ import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.indices.SystemIndices;
 import org.elasticsearch.indices.SystemIndices.SystemIndexAccessLevel;
@@ -68,7 +70,7 @@ public class TransportGetAliasesAction extends TransportMasterNodeReadAction<Get
         final SystemIndexAccessLevel systemIndexAccessLevel = indexNameExpressionResolver.getSystemIndexAccessLevel();
         ImmutableOpenMap<String, List<AliasMetadata>> aliases = state.metadata().findAliases(request, concreteIndices);
         listener.onResponse(new GetAliasesResponse(postProcess(request, concreteIndices, aliases, state,
-            systemIndexAccessLevel, threadPool.getThreadContext(), systemIndices)));
+            systemIndexAccessLevel, threadPool.getThreadContext(), systemIndices), postProcess(request, state)));
     }
 
     /**
@@ -91,6 +93,32 @@ public class TransportGetAliasesAction extends TransportMasterNodeReadAction<Get
             checkSystemIndexAccess(request, systemIndices, state, finalResponse, systemIndexAccessLevel, threadContext);
         }
         return finalResponse;
+    }
+
+    List<DataStreamAlias> postProcess(GetAliasesRequest request, ClusterState state) {
+        List<DataStreamAlias> result = new ArrayList<>();
+        boolean noAliasesSpecified = request.getOriginalAliases() == null || request.getOriginalAliases().length == 0;
+        List<String> requestedDataStreams =
+            indexNameExpressionResolver.dataStreamNames(state, request.indicesOptions(), request.indices());
+        for (var alias : state.metadata().dataStreamAliases().values()) {
+            if (noAliasesSpecified == false && Regex.simpleMatch(request.aliases(), alias.getName()) == false) {
+                continue;
+            }
+
+            boolean dataStreamNameMatch = false;
+            for (String requestedDataStream : requestedDataStreams) {
+                if (Regex.simpleMatch(alias.getDataStreams(), requestedDataStream)) {
+                    dataStreamNameMatch = true;
+                    break;
+                }
+            }
+            if (dataStreamNameMatch == false) {
+                continue;
+            }
+
+            result.add(alias);
+        }
+        return result;
     }
 
     private static void checkSystemIndexAccess(GetAliasesRequest request, SystemIndices systemIndices, ClusterState state,

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/ResolveIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/ResolveIndexAction.java
@@ -558,10 +558,9 @@ public class ResolveIndexAction extends ActionType<ResolveIndexAction.Response> 
                             index.getParentDataStream() == null ? null : index.getParentDataStream().getName()));
                         break;
                     case ALIAS:
-                        IndexAbstraction.Alias alias = (IndexAbstraction.Alias) ia;
-                        String[] indexNames = alias.getIndices().stream().map(i -> i.getIndex().getName()).toArray(String[]::new);
+                        String[] indexNames = ia.getIndices().stream().map(i -> i.getIndex().getName()).toArray(String[]::new);
                         Arrays.sort(indexNames);
-                        aliases.add(new ResolvedAlias(alias.getName(), indexNames));
+                        aliases.add(new ResolvedAlias(ia.getName(), indexNames));
                         break;
                     case DATA_STREAM:
                         IndexAbstraction.DataStream dataStream = (IndexAbstraction.DataStream) ia;

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/AliasAction.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/AliasAction.java
@@ -241,8 +241,7 @@ public abstract class AliasAction {
         @Override
         boolean apply(NewAliasValidator aliasValidator, Metadata.Builder metadata, IndexMetadata index) {
             aliasValidator.validate(aliasName, null, null, isWriteDataStream);
-            metadata.put(aliasName, dataStreamName, isWriteDataStream);
-            return true;
+            return metadata.put(aliasName, dataStreamName, isWriteDataStream);
         }
     }
 
@@ -272,8 +271,7 @@ public abstract class AliasAction {
         @Override
         boolean apply(NewAliasValidator aliasValidator, Metadata.Builder metadata, IndexMetadata index) {
             boolean mustExist = this.mustExist != null ? this.mustExist : false;
-            metadata.removeDataStreamAlias(aliasName, dataStreamName, mustExist);
-            return true;
+            return metadata.removeDataStreamAlias(aliasName, dataStreamName, mustExist);
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/AliasValidator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/AliasValidator.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.cluster.metadata;
 
-import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
@@ -97,9 +96,9 @@ public class AliasValidator {
         }
 
         IndexAbstraction other = indexLookup.apply(alias);
-        if (other != null) {
-            String message = "a resource of type [" + other.getType() + "] already exists using the name [" + alias + "]";
-            throw new ResourceAlreadyExistsException(message);
+        if (other != null && other.getType() != IndexAbstraction.Type.ALIAS) {
+            String message = "a data stream or index [" + other.getName() + "] already exists using the name as the alias";
+            throw new InvalidAliasNameException(alias, message);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamAlias.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamAlias.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+package org.elasticsearch.cluster.metadata;
+
+import org.elasticsearch.cluster.AbstractDiffable;
+import org.elasticsearch.cluster.Diff;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+
+public class DataStreamAlias extends AbstractDiffable<DataStreamAlias> implements ToXContentObject {
+
+    public static final ParseField DATA_STREAMS_FIELD = new ParseField("data_streams");
+    public static final ParseField WRITE_DATA_STREAM_FIELD = new ParseField("write_data_stream");
+
+    @SuppressWarnings("unchecked")
+    private static final ConstructingObjectParser<DataStreamAlias, String> PARSER = new ConstructingObjectParser<>(
+        "data_stream_alias",
+        false,
+        (args, name) -> new DataStreamAlias(name, (List<String>) args[0], (String) args[1])
+    );
+
+    static {
+        PARSER.declareStringArray(ConstructingObjectParser.constructorArg(), DATA_STREAMS_FIELD);
+        PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), WRITE_DATA_STREAM_FIELD);
+    }
+
+    private final String name;
+    private final List<String> dataStreams;
+    private final String writeDataStream;
+
+    public DataStreamAlias(String name, List<String> dataStreams, String writeDataStream) {
+        this.name = name;
+        this.dataStreams = dataStreams;
+        this.writeDataStream = writeDataStream;
+    }
+
+    public DataStreamAlias(StreamInput in) throws IOException {
+        this.name = in.readString();
+        this.dataStreams = in.readStringList();
+        this.writeDataStream = in.readOptionalString();
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public List<String> getDataStreams() {
+        return dataStreams;
+    }
+
+    public String getWriteDataStream() {
+        return writeDataStream;
+    }
+
+    public static Diff<DataStreamAlias> readDiffFrom(StreamInput in) throws IOException {
+        return readDiffFrom(DataStreamAlias::new, in);
+    }
+
+    public static DataStreamAlias fromXContent(XContentParser parser) throws IOException {
+        XContentParser.Token token = parser.currentToken();
+        if (token != XContentParser.Token.FIELD_NAME) {
+            throw new ParsingException(parser.getTokenLocation(), "unexpected token");
+        }
+        String name = parser.currentName();
+        DataStreamAlias alias = PARSER.parse(parser, name);
+        return alias;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(name);
+        builder.field(DATA_STREAMS_FIELD.getPreferredName(), dataStreams);
+        if (writeDataStream != null) {
+            builder.field(WRITE_DATA_STREAM_FIELD.getPreferredName(), writeDataStream);
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(name);
+        out.writeStringCollection(dataStreams);
+        out.writeOptionalString(writeDataStream);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DataStreamAlias that = (DataStreamAlias) o;
+        return Objects.equals(name, that.name) &&
+            Objects.equals(dataStreams, that.dataStreams) &&
+            Objects.equals(writeDataStream, that.writeDataStream);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, dataStreams, writeDataStream);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamMetadata.java
@@ -23,6 +23,7 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import java.io.IOException;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -33,9 +34,17 @@ public class DataStreamMetadata implements Metadata.Custom {
 
     public static final String TYPE = "data_stream";
     private static final ParseField DATA_STREAM = new ParseField("data_stream");
+    private static final ParseField DATA_STREAM_ALIASES = new ParseField("data_stream_aliases");
     @SuppressWarnings("unchecked")
     private static final ConstructingObjectParser<DataStreamMetadata, Void> PARSER = new ConstructingObjectParser<>(TYPE, false,
-        a -> new DataStreamMetadata((Map<String, DataStream>) a[0]));
+        args -> {
+            Map<String, DataStream> dataStreams = (Map<String, DataStream>) args[0];
+            Map<String, DataStreamAlias> dataStreamAliases = (Map<String, DataStreamAlias>) args[1];
+            if (dataStreamAliases == null) {
+                dataStreamAliases = Map.of();
+            }
+            return new DataStreamMetadata(dataStreams, dataStreamAliases);
+    });
 
     static {
         PARSER.declareObject(ConstructingObjectParser.constructorArg(), (p, c) -> {
@@ -46,20 +55,42 @@ public class DataStreamMetadata implements Metadata.Custom {
             }
             return dataStreams;
         }, DATA_STREAM);
+        PARSER.declareObject(ConstructingObjectParser.optionalConstructorArg(), (p, c) -> {
+            Map<String, DataStreamAlias> dataStreams = new HashMap<>();
+            while (p.nextToken() != XContentParser.Token.END_OBJECT) {
+                DataStreamAlias alias = DataStreamAlias.fromXContent(p);
+                dataStreams.put(alias.getName(), alias);
+            }
+            return dataStreams;
+        }, DATA_STREAM_ALIASES);
     }
 
-    private final Map<String, DataStream> dataStreams;
+    public static final Version DATA_STREAM_ALIAS_VERSION = Version.V_8_0_0;
 
-    public DataStreamMetadata(Map<String, DataStream> dataStreams) {
-        this.dataStreams = dataStreams;
+    private final Map<String, DataStream> dataStreams;
+    private final Map<String, DataStreamAlias> dataStreamAliases;
+
+    public DataStreamMetadata(Map<String, DataStream> dataStreams,
+                              Map<String, DataStreamAlias> dataStreamAliases) {
+        this.dataStreams = Objects.requireNonNull(dataStreams);
+        this.dataStreamAliases = Objects.requireNonNull(dataStreamAliases);
     }
 
     public DataStreamMetadata(StreamInput in) throws IOException {
         this.dataStreams = in.readMap(StreamInput::readString, DataStream::new);
+        if (in.getVersion().onOrAfter(DATA_STREAM_ALIAS_VERSION)) {
+            this.dataStreamAliases = in.readMap(StreamInput::readString, DataStreamAlias::new);
+        } else {
+            this.dataStreamAliases = Map.of();
+        }
     }
 
     public Map<String, DataStream> dataStreams() {
         return this.dataStreams;
+    }
+
+    public Map<String, DataStreamAlias> getDataStreamAliases() {
+        return dataStreamAliases;
     }
 
     @Override
@@ -89,6 +120,9 @@ public class DataStreamMetadata implements Metadata.Custom {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeMap(this.dataStreams, StreamOutput::writeString, (stream, val) -> val.writeTo(stream));
+        if (out.getVersion().onOrAfter(DATA_STREAM_ALIAS_VERSION)) {
+            out.writeMap(this.dataStreamAliases, StreamOutput::writeString, (stream, val) -> val.writeTo(stream));
+        }
     }
 
     public static DataStreamMetadata fromXContent(XContentParser parser) throws IOException {
@@ -102,6 +136,11 @@ public class DataStreamMetadata implements Metadata.Custom {
             builder.field(dataStream.getKey(), dataStream.getValue());
         }
         builder.endObject();
+        builder.startObject(DATA_STREAM_ALIASES.getPreferredName());
+        for (Map.Entry<String, DataStreamAlias> dataStream : dataStreamAliases.entrySet()) {
+            dataStream.getValue().toXContent(builder, params);
+        }
+        builder.endObject();
         return builder;
     }
 
@@ -111,7 +150,7 @@ public class DataStreamMetadata implements Metadata.Custom {
 
     @Override
     public int hashCode() {
-        return Objects.hash(this.dataStreams);
+        return Objects.hash(this.dataStreams, dataStreamAliases);
     }
 
     @Override
@@ -123,7 +162,8 @@ public class DataStreamMetadata implements Metadata.Custom {
             return false;
         }
         DataStreamMetadata other = (DataStreamMetadata) obj;
-        return Objects.equals(this.dataStreams, other.dataStreams);
+        return Objects.equals(this.dataStreams, other.dataStreams) &&
+            Objects.equals(this.dataStreamAliases, other.dataStreamAliases);
     }
 
     @Override
@@ -133,40 +173,71 @@ public class DataStreamMetadata implements Metadata.Custom {
 
     public static class Builder {
 
-        private final Map<String, DataStream> dataStreams = new HashMap<>();
+        private final Map<String, DataStream> dataStreams;
+        private final Map<String, DataStreamAlias> dataStreamAliases;
+
+        public Builder(Map<String, DataStream> dataStreams, Map<String, DataStreamAlias> dataStreamAliases) {
+            this.dataStreams = dataStreams;
+            this.dataStreamAliases = dataStreamAliases;
+        }
+
+        public Builder() {
+            this.dataStreams = new HashMap<>();
+            this.dataStreamAliases = new HashMap<>();
+        }
 
         public Builder putDataStream(DataStream dataStream) {
             dataStreams.put(dataStream.getName(), dataStream);
             return this;
         }
 
+        public Builder putDataStreamAlias(String name, List<String> dataStreams, String writeDataStream) {
+            dataStreamAliases.put(name, new DataStreamAlias(name, dataStreams, writeDataStream));
+            return this;
+        }
+
         public DataStreamMetadata build() {
-            return new DataStreamMetadata(dataStreams);
+            return new DataStreamMetadata(dataStreams, dataStreamAliases);
         }
     }
 
     static class DataStreamMetadataDiff implements NamedDiff<Metadata.Custom> {
 
         final Diff<Map<String, DataStream>> dataStreamDiff;
+        final Diff<Map<String, DataStreamAlias>> dataStreamAliasDiff;
 
         DataStreamMetadataDiff(DataStreamMetadata before, DataStreamMetadata after) {
             this.dataStreamDiff = DiffableUtils.diff(before.dataStreams, after.dataStreams,
+                DiffableUtils.getStringKeySerializer());
+            this.dataStreamAliasDiff = DiffableUtils.diff(before.dataStreamAliases, after.dataStreamAliases,
                 DiffableUtils.getStringKeySerializer());
         }
 
         DataStreamMetadataDiff(StreamInput in) throws IOException {
             this.dataStreamDiff = DiffableUtils.readJdkMapDiff(in, DiffableUtils.getStringKeySerializer(),
                 DataStream::new, DataStream::readDiffFrom);
+            if (in.getVersion().onOrAfter(DATA_STREAM_ALIAS_VERSION)) {
+                this.dataStreamAliasDiff = DiffableUtils.readJdkMapDiff(in, DiffableUtils.getStringKeySerializer(),
+                    DataStreamAlias::new, DataStreamAlias::readDiffFrom);
+            } else {
+                this.dataStreamAliasDiff = null;
+            }
         }
 
         @Override
         public Metadata.Custom apply(Metadata.Custom part) {
-            return new DataStreamMetadata(dataStreamDiff.apply(((DataStreamMetadata) part).dataStreams));
+            return new DataStreamMetadata(
+                dataStreamDiff.apply(((DataStreamMetadata) part).dataStreams),
+                dataStreamAliasDiff != null ? dataStreamAliasDiff.apply(((DataStreamMetadata) part).dataStreamAliases) : Map.of()
+            );
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             dataStreamDiff.writeTo(out);
+            if (out.getVersion().onOrAfter(DATA_STREAM_ALIAS_VERSION)) {
+                dataStreamAliasDiff.writeTo(out);
+            }
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexAbstraction.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexAbstraction.java
@@ -324,4 +324,58 @@ public interface IndexAbstraction {
             return dataStream;
         }
     }
+
+    class DataStreamAlias implements IndexAbstraction {
+
+        private final org.elasticsearch.cluster.metadata.DataStreamAlias dataStreamAlias;
+        private final List<IndexMetadata> indicesOfAllDataStreams;
+        private final IndexMetadata writeIndexOfWriteDataStream;
+
+        public DataStreamAlias(org.elasticsearch.cluster.metadata.DataStreamAlias dataStreamAlias,
+                               List<IndexMetadata> indicesOfAllDataStreams,
+                               IndexMetadata writeIndexOfWriteDataStream) {
+            this.dataStreamAlias = dataStreamAlias;
+            this.indicesOfAllDataStreams = indicesOfAllDataStreams;
+            this.writeIndexOfWriteDataStream = writeIndexOfWriteDataStream;
+        }
+
+        @Override
+        public Type getType() {
+            return Type.ALIAS;
+        }
+
+        @Override
+        public String getName() {
+            return dataStreamAlias.getName();
+        }
+
+        @Override
+        public List<IndexMetadata> getIndices() {
+            return indicesOfAllDataStreams;
+        }
+
+        @Override
+        public IndexMetadata getWriteIndex() {
+            return writeIndexOfWriteDataStream;
+        }
+
+        @Override
+        public DataStream getParentDataStream() {
+            return null;
+        }
+
+        @Override
+        public boolean isHidden() {
+            return false;
+        }
+
+        @Override
+        public boolean isSystem() {
+            return false;
+        }
+
+        public org.elasticsearch.cluster.metadata.DataStreamAlias getDataStreamAlias() {
+            return dataStreamAlias;
+        }
+    }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -140,8 +140,11 @@ public class IndexNameExpressionResolver {
             indexExpressions = new String[]{"*"};
         }
 
-        List<String> dataStreams = wildcardExpressionResolver.resolve(context, Arrays.asList(indexExpressions));
-        return ((dataStreams == null) ? List.<String>of() : dataStreams).stream()
+        List<String> expressions = Arrays.asList(indexExpressions);
+        for (ExpressionResolver expressionResolver : expressionResolvers) {
+            expressions = expressionResolver.resolve(context, expressions);
+        }
+        return ((expressions == null) ? List.<String>of() : expressions).stream()
             .map(x -> state.metadata().getIndicesLookup().get(x))
             .filter(Objects::nonNull)
             .filter(ia -> ia.getType() == IndexAbstraction.Type.DATA_STREAM)
@@ -593,7 +596,7 @@ public class IndexNameExpressionResolver {
                     String concreteIndex = index.getIndex().getName();
                     AliasMetadata aliasMetadata = index.getAliases().get(indexAbstraction.getName());
                     if (norouting.contains(concreteIndex) == false) {
-                        if (aliasMetadata.searchRoutingValues().isEmpty() == false) {
+                        if (aliasMetadata != null && aliasMetadata.searchRoutingValues().isEmpty() == false) {
                             // Routing alias
                             if (routings == null) {
                                 routings = new HashMap<>();

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -564,7 +564,12 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
         if (writeIndex == null) {
             throw new IllegalArgumentException("alias [" + aliasOrIndex + "] does not have a write index");
         }
-        return resolveRouting(routing, aliasOrIndex, writeIndex.getAliases().get(result.getName()));
+        AliasMetadata writeIndexAliasMetadata = writeIndex.getAliases().get(result.getName());
+        if (writeIndexAliasMetadata != null) {
+            return resolveRouting(routing, aliasOrIndex, writeIndexAliasMetadata);
+        } else {
+            return routing;
+        }
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamService.java
@@ -221,6 +221,15 @@ public class MetadataCreateDataStreamService {
         logger.info("adding data stream [{}] with write index [{}] and backing indices [{}]", dataStreamName,
             writeIndex.getIndex().getName(),
             Strings.arrayToCommaDelimitedString(backingIndices.stream().map(i -> i.getIndex().getName()).toArray()));
+
+        if (template.getDataStreamTemplate().getAliases() != null) {
+            for (var alias : template.getDataStreamTemplate().getAliases().values()) {
+                // TODO: If the write alias has already been set then
+                // it should point to the current data stream
+                builder.put(alias.getAlias(), dataStreamName, alias.getWriteAlias());
+            }
+        }
+
         return ClusterState.builder(currentState).metadata(builder).build();
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexAliasesService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexAliasesService.java
@@ -33,7 +33,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.SortedMap;
 import java.util.function.Function;
 
 import static java.util.Collections.emptyList;
@@ -113,7 +112,7 @@ public class MetadataIndexAliasesService {
                     continue;
                 }
                 if (action.isDataStreamOperation()) {
-                    SortedMap<String, IndexAbstraction> lookup = currentState.metadata().getIndicesLookup();
+                    Map<String, IndexAbstraction> lookup = currentState.metadata().getIndicesLookup();
                     NewAliasValidator newAliasValidator = (alias, indexRouting, filter, writeIndex) -> {
                         aliasValidator.validateAlias(alias, action.getIndex(), lookup::get);
                     };

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/alias/AliasActionsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/alias/AliasActionsTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParseException;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.alias.RandomAliasActionsGenerator;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
@@ -26,7 +27,6 @@ import java.util.Map;
 import java.util.Objects;
 
 import static org.elasticsearch.index.alias.RandomAliasActionsGenerator.randomAliasAction;
-import static org.elasticsearch.index.alias.RandomAliasActionsGenerator.randomMap;
 import static org.elasticsearch.index.alias.RandomAliasActionsGenerator.randomRouting;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.arrayContaining;
@@ -111,7 +111,7 @@ public class AliasActionsTests extends ESTestCase {
     public void testParseAdd() throws IOException {
         String[] indices = generateRandomStringArray(10, 5, false, false);
         String[] aliases = generateRandomStringArray(10, 5, false, false);
-        Map<String, Object> filter = randomBoolean() ? randomMap(5) : null;
+        Map<String, Object> filter = randomBoolean() ? RandomAliasActionsGenerator.randomMap(5) : null;
         Object searchRouting = randomBoolean() ? randomRouting() : null;
         Object indexRouting = randomBoolean() ? randomBoolean() ? searchRouting : randomRouting() : null;
         boolean writeIndex = randomBoolean();

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesResponseTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.cluster.metadata.DataStreamTestHelper;
 import org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.elasticsearch.cluster.metadata.AliasMetadata.Builder;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 
@@ -35,7 +36,8 @@ public class GetAliasesResponseTests extends AbstractWireSerializingTestCase<Get
 
     @Override
     protected GetAliasesResponse mutateInstance(GetAliasesResponse response) {
-        return new GetAliasesResponse(mutateAliases(response.getAliases()), randomList(5, DataStreamTestHelper::randomAliasInstance));
+        return new GetAliasesResponse(mutateAliases(response.getAliases()),
+            randomMap(5, 5, () -> new Tuple<>(randomAlphaOfLength(4), randomList(5, DataStreamTestHelper::randomAliasInstance))));
     }
 
     private static ImmutableOpenMap<String, List<AliasMetadata>> mutateAliases(ImmutableOpenMap<String, List<AliasMetadata>> aliases) {
@@ -76,7 +78,8 @@ public class GetAliasesResponseTests extends AbstractWireSerializingTestCase<Get
     }
 
     private static GetAliasesResponse createTestItem() {
-        return new GetAliasesResponse(createIndicesAliasesMap(0, 5).build(), randomList(5, DataStreamTestHelper::randomAliasInstance));
+        return new GetAliasesResponse(mutateAliases(createIndicesAliasesMap(0, 5).build()
+        ), randomMap(5, 5, () -> new Tuple<>(randomAlphaOfLength(4), randomList(5, DataStreamTestHelper::randomAliasInstance))));
     }
 
     private static ImmutableOpenMap.Builder<String, List<AliasMetadata>> createIndicesAliasesMap(int min, int max) {

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesResponseTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.action.admin.indices.alias.get;
 
+import org.elasticsearch.cluster.metadata.DataStreamTestHelper;
 import org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.elasticsearch.cluster.metadata.AliasMetadata.Builder;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
@@ -34,7 +35,7 @@ public class GetAliasesResponseTests extends AbstractWireSerializingTestCase<Get
 
     @Override
     protected GetAliasesResponse mutateInstance(GetAliasesResponse response) {
-        return new GetAliasesResponse(mutateAliases(response.getAliases()));
+        return new GetAliasesResponse(mutateAliases(response.getAliases()), randomList(5, DataStreamTestHelper::randomAliasInstance));
     }
 
     private static ImmutableOpenMap<String, List<AliasMetadata>> mutateAliases(ImmutableOpenMap<String, List<AliasMetadata>> aliases) {
@@ -75,7 +76,7 @@ public class GetAliasesResponseTests extends AbstractWireSerializingTestCase<Get
     }
 
     private static GetAliasesResponse createTestItem() {
-        return new GetAliasesResponse(createIndicesAliasesMap(0, 5).build());
+        return new GetAliasesResponse(createIndicesAliasesMap(0, 5).build(), randomList(5, DataStreamTestHelper::randomAliasInstance));
     }
 
     private static ImmutableOpenMap.Builder<String, List<AliasMetadata>> createIndicesAliasesMap(int min, int max) {

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplateTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplateTests.java
@@ -139,7 +139,7 @@ public class ComposableIndexTemplateTests extends AbstractDiffableSerializationT
         if (randomBoolean()) {
             return null;
         } else {
-            return new ComposableIndexTemplate.DataStreamTemplate();
+           return DataStreamTemplateTests.randomInstance();
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamMetadataTests.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.cluster.metadata;
 
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.test.AbstractNamedWriteableTestCase;
 
 import java.io.IOException;
@@ -16,18 +17,34 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.elasticsearch.test.AbstractXContentTestCase.xContentTester;
+
 public class DataStreamMetadataTests extends AbstractNamedWriteableTestCase<DataStreamMetadata> {
+
+    public void testFromXContent() throws IOException {
+        xContentTester(this::createParser, this::createTestInstance, ToXContent.EMPTY_PARAMS, DataStreamMetadata::fromXContent)
+            .assertEqualsConsumer(this::assertEqualInstances)
+            .test();
+    }
 
     @Override
     protected DataStreamMetadata createTestInstance() {
         if (randomBoolean()) {
-            return new DataStreamMetadata(Collections.emptyMap());
+            return new DataStreamMetadata(Map.of(), Map.of());
         }
         Map<String, DataStream> dataStreams = new HashMap<>();
         for (int i = 0; i < randomIntBetween(1, 5); i++) {
             dataStreams.put(randomAlphaOfLength(5), DataStreamTestHelper.randomInstance());
         }
-        return new DataStreamMetadata(dataStreams);
+
+        Map<String, DataStreamAlias> dataStreamsAliases = new HashMap<>();
+        if (randomBoolean()) {
+            for (int i = 0; i < randomIntBetween(1, 5); i++) {
+                DataStreamAlias alias = DataStreamTestHelper.randomAliasInstance();
+                dataStreamsAliases.put(alias.getName(), alias);
+            }
+        }
+        return new DataStreamMetadata(dataStreams, dataStreamsAliases);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamTemplateTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamTemplateTests.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+package org.elasticsearch.cluster.metadata;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.elasticsearch.cluster.metadata.ComposableIndexTemplate.DataStreamAliasTemplate;
+import org.elasticsearch.cluster.metadata.ComposableIndexTemplate.DataStreamTemplate;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.test.AbstractSerializingTestCase;
+
+public class DataStreamTemplateTests extends AbstractSerializingTestCase<DataStreamTemplate> {
+
+    @Override
+    protected DataStreamTemplate doParseInstance(XContentParser parser) throws IOException {
+        return DataStreamTemplate.PARSER.parse(parser, null);
+    }
+
+    @Override
+    protected Writeable.Reader<DataStreamTemplate> instanceReader() {
+        return DataStreamTemplate::new;
+    }
+
+    @Override
+    protected DataStreamTemplate createTestInstance() {
+        return randomInstance();
+    }
+
+    public static DataStreamTemplate randomInstance() {
+        if (randomBoolean()) {
+            return new ComposableIndexTemplate.DataStreamTemplate();
+        }
+
+        boolean hidden = randomBoolean();
+        Map<String, DataStreamAliasTemplate> aliases = null;
+        if (randomBoolean()) {
+            aliases = new HashMap<>();
+            int numAliases = randomIntBetween(1, 5);
+            for (int i = 0; i < numAliases; i++) {
+                ComposableIndexTemplate.DataStreamAliasTemplate instance = randomAliasInstance();
+                aliases.put(instance.getAlias(), instance);
+            }
+        }
+        return new ComposableIndexTemplate.DataStreamTemplate(hidden, aliases);
+    }
+
+    static DataStreamAliasTemplate randomAliasInstance() {
+        String alias = randomAlphaOfLength(4);
+        Boolean writeAlias = null;
+        if (randomBoolean()) {
+            writeAlias = randomBoolean();
+        }
+        return new DataStreamAliasTemplate(alias, writeAlias);
+    }
+}

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexAliasesServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexAliasesServiceTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.index.Index;
@@ -29,9 +30,12 @@ import java.util.List;
 import static java.util.Collections.singletonList;
 import static org.elasticsearch.cluster.metadata.DataStreamTestHelper.createTimestampField;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anySetOf;
@@ -496,6 +500,32 @@ public class MetadataIndexAliasesServiceTests extends ESTestCase {
             singletonList(new AliasAction.Add(backingIndexName, "test", null, null, null, null, null))));
         assertThat(exception.getMessage(), is("The provided index [" + backingIndexName + "] is a backing index belonging to data " +
             "stream [foo-stream]. Data streams and their backing indices don't support alias operations."));
+    }
+
+    public void testDataStreamAliases() {
+        ClusterState state = DataStreamTestHelper.getClusterStateWithDataStreams(List.of(
+            new Tuple<>("logs-foobar", 1), new Tuple<>("metrics-foobar", 1)), List.of());
+
+        ClusterState result = service.applyAliasActions(state, List.of(
+            new AliasAction.AddDataStreamAlias("foobar", "logs-foobar", null),
+            new AliasAction.AddDataStreamAlias("foobar", "metrics-foobar", null)
+        ));
+        assertThat(result.metadata().dataStreamAliases().get("foobar"), notNullValue());
+        assertThat(result.metadata().dataStreamAliases().get("foobar").getDataStreams(),
+            containsInAnyOrder("logs-foobar", "metrics-foobar"));
+        assertThat(result.metadata().dataStreamAliases().get("foobar").getWriteDataStream(), nullValue());
+
+        result = service.applyAliasActions(result, List.of(
+            new AliasAction.RemoveDataStreamAlias("foobar", "logs-foobar", null)
+        ));
+        assertThat(result.metadata().dataStreamAliases().get("foobar"), notNullValue());
+        assertThat(result.metadata().dataStreamAliases().get("foobar").getDataStreams(), containsInAnyOrder("metrics-foobar"));
+        assertThat(result.metadata().dataStreamAliases().get("foobar").getWriteDataStream(), nullValue());
+
+        result = service.applyAliasActions(result, List.of(
+            new AliasAction.RemoveDataStreamAlias("foobar", "metrics-foobar", null)
+        ));
+        assertThat(result.metadata().dataStreamAliases().get("foobar"), nullValue());
     }
 
     private ClusterState applyHiddenAliasMix(ClusterState before, Boolean isHidden1, Boolean isHidden2) {

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
@@ -57,7 +57,6 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
-import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.Matchers.startsWith;
 
 public class MetadataTests extends ESTestCase {
@@ -1236,11 +1235,12 @@ public class MetadataTests extends ESTestCase {
         Metadata.Builder mdBuilder = Metadata.builder();
 
         mdBuilder.put(DataStreamTestHelper.randomInstance("logs-postgres-eu"));
-        mdBuilder.put("logs-postgres", "logs-postgres-eu", null);
+        assertThat(mdBuilder.put("logs-postgres", "logs-postgres-eu", null), is(true));
         mdBuilder.put(DataStreamTestHelper.randomInstance("logs-postgres-us"));
-        mdBuilder.put("logs-postgres", "logs-postgres-us", null);
+        assertThat(mdBuilder.put("logs-postgres", "logs-postgres-us", null), is(true));
         mdBuilder.put(DataStreamTestHelper.randomInstance("logs-postgres-au"));
-        mdBuilder.put("logs-postgres", "logs-postgres-au", null);
+        assertThat(mdBuilder.put("logs-postgres", "logs-postgres-au", null), is(true));
+        assertThat(mdBuilder.put("logs-postgres", "logs-postgres-au", null), is(false));
 
         Metadata metadata = mdBuilder.build();
         assertThat(metadata.dataStreamAliases().get("logs-postgres"), notNullValue());
@@ -1259,7 +1259,7 @@ public class MetadataTests extends ESTestCase {
         assertThat(metadata.dataStreamAliases().get("logs-postgres").getDataStreams(), containsInAnyOrder("logs-postgres-replicated"));
 
         mdBuilder = Metadata.builder(metadata);
-        mdBuilder.put("logs-postgres", "logs-postgres-replicated", true);
+        assertThat(mdBuilder.put("logs-postgres", "logs-postgres-replicated", true), is(true));
 
         metadata = mdBuilder.build();
         assertThat(metadata.dataStreamAliases().get("logs-postgres"), notNullValue());
@@ -1339,20 +1339,20 @@ public class MetadataTests extends ESTestCase {
             containsInAnyOrder("logs-postgres-eu", "logs-postgres-us", "logs-postgres-au"));
 
         mdBuilder = Metadata.builder(metadata);
-        mdBuilder.removeDataStreamAlias("logs-postgres", "logs-postgres-us", true);
+        assertThat(mdBuilder.removeDataStreamAlias("logs-postgres", "logs-postgres-us", true), is(true));
         metadata = mdBuilder.build();
         assertThat(metadata.dataStreamAliases().get("logs-postgres"), notNullValue());
         assertThat(metadata.dataStreamAliases().get("logs-postgres").getDataStreams(),
             containsInAnyOrder("logs-postgres-eu", "logs-postgres-au"));
 
         mdBuilder = Metadata.builder(metadata);
-        mdBuilder.removeDataStreamAlias("logs-postgres", "logs-postgres-au", true);
+        assertThat(mdBuilder.removeDataStreamAlias("logs-postgres", "logs-postgres-au", true), is(true));
         metadata = mdBuilder.build();
         assertThat(metadata.dataStreamAliases().get("logs-postgres"), notNullValue());
         assertThat(metadata.dataStreamAliases().get("logs-postgres").getDataStreams(), containsInAnyOrder("logs-postgres-eu"));
 
         mdBuilder = Metadata.builder(metadata);
-        mdBuilder.removeDataStreamAlias("logs-postgres", "logs-postgres-eu", true);
+        assertThat(mdBuilder.removeDataStreamAlias("logs-postgres", "logs-postgres-eu", true), is(true));
         metadata = mdBuilder.build();
         assertThat(metadata.dataStreamAliases().get("logs-postgres"), nullValue());
     }
@@ -1372,8 +1372,7 @@ public class MetadataTests extends ESTestCase {
 
         Metadata.Builder mdBuilder2 = Metadata.builder(metadata);
         expectThrows(ResourceNotFoundException.class, () -> mdBuilder2.removeDataStreamAlias("logs-mysql", "logs-postgres-us", true));
-        Metadata.Builder r = mdBuilder2.removeDataStreamAlias("logs-mysql", "logs-postgres-us", false);
-        assertThat(r, sameInstance(mdBuilder2));
+        assertThat(mdBuilder2.removeDataStreamAlias("logs-mysql", "logs-postgres-us", false), is(false));
     }
 
     public static Metadata randomMetadata() {

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.cluster.metadata;
 
+import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.indices.alias.get.GetAliasesRequest;
 import org.elasticsearch.cluster.ClusterModule;
@@ -49,11 +50,14 @@ import static org.elasticsearch.cluster.metadata.DataStreamTestHelper.createBack
 import static org.elasticsearch.cluster.metadata.DataStreamTestHelper.createFirstBackingIndex;
 import static org.elasticsearch.cluster.metadata.DataStreamTestHelper.createTimestampField;
 import static org.elasticsearch.cluster.metadata.Metadata.Builder.validateDataStreams;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.Matchers.startsWith;
 
 public class MetadataTests extends ESTestCase {
@@ -1226,6 +1230,149 @@ public class MetadataTests extends ESTestCase {
             () -> Metadata.snapshot(postSnapshotMetadata, dataStreamsToSnapshot, indicesInSnapshot)
         );
         assertThat(e.getMessage(), containsString("unable to find data stream [" + missingDataStream + "]"));
+    }
+
+    public void testDataStreamAliases() {
+        Metadata.Builder mdBuilder = Metadata.builder();
+
+        mdBuilder.put(DataStreamTestHelper.randomInstance("logs-postgres-eu"));
+        mdBuilder.put("logs-postgres", "logs-postgres-eu", null);
+        mdBuilder.put(DataStreamTestHelper.randomInstance("logs-postgres-us"));
+        mdBuilder.put("logs-postgres", "logs-postgres-us", null);
+        mdBuilder.put(DataStreamTestHelper.randomInstance("logs-postgres-au"));
+        mdBuilder.put("logs-postgres", "logs-postgres-au", null);
+
+        Metadata metadata = mdBuilder.build();
+        assertThat(metadata.dataStreamAliases().get("logs-postgres"), notNullValue());
+        assertThat(metadata.dataStreamAliases().get("logs-postgres").getDataStreams(),
+            containsInAnyOrder("logs-postgres-eu", "logs-postgres-us", "logs-postgres-au"));
+    }
+
+    public void testDataStreamWriteAlias() {
+        Metadata.Builder mdBuilder = Metadata.builder();
+        mdBuilder.put(DataStreamTestHelper.randomInstance("logs-postgres-replicated"));
+        mdBuilder.put("logs-postgres", "logs-postgres-replicated", null);
+
+        Metadata metadata = mdBuilder.build();
+        assertThat(metadata.dataStreamAliases().get("logs-postgres"), notNullValue());
+        assertThat(metadata.dataStreamAliases().get("logs-postgres").getWriteDataStream(), nullValue());
+        assertThat(metadata.dataStreamAliases().get("logs-postgres").getDataStreams(), containsInAnyOrder("logs-postgres-replicated"));
+
+        mdBuilder = Metadata.builder(metadata);
+        mdBuilder.put("logs-postgres", "logs-postgres-replicated", true);
+
+        metadata = mdBuilder.build();
+        assertThat(metadata.dataStreamAliases().get("logs-postgres"), notNullValue());
+        assertThat(metadata.dataStreamAliases().get("logs-postgres").getWriteDataStream(), equalTo("logs-postgres-replicated"));
+        assertThat(metadata.dataStreamAliases().get("logs-postgres").getDataStreams(), containsInAnyOrder("logs-postgres-replicated"));
+    }
+
+    public void testDataStreamMultipleWriteAlias() {
+        Metadata.Builder mdBuilder = Metadata.builder();
+        mdBuilder.put(DataStreamTestHelper.randomInstance("logs-foobar"));
+        mdBuilder.put(DataStreamTestHelper.randomInstance("logs-barbaz"));
+        mdBuilder.put("logs", "logs-foobar", true);
+        mdBuilder.put("logs", "logs-barbaz", true);
+
+        Metadata metadata = mdBuilder.build();
+        assertThat(metadata.dataStreamAliases().get("logs"), notNullValue());
+        assertThat(metadata.dataStreamAliases().get("logs").getWriteDataStream(), equalTo("logs-barbaz"));
+        assertThat(metadata.dataStreamAliases().get("logs").getDataStreams(), containsInAnyOrder("logs-foobar", "logs-barbaz"));
+    }
+
+    public void testDataStreamReferToNonExistingDataStream() {
+        Metadata.Builder mdBuilder = Metadata.builder();
+
+        Exception e = expectThrows(IllegalArgumentException.class, () -> mdBuilder.put("logs-postgres", "logs-postgres-eu", null));
+        assertThat(e.getMessage(), equalTo("alias [logs-postgres] refers to a non existing data stream [logs-postgres-eu]"));
+
+        mdBuilder.put(DataStreamTestHelper.randomInstance("logs-postgres-eu"));
+        mdBuilder.put("logs-postgres", "logs-postgres-eu", null);
+        Metadata metadata = mdBuilder.build();
+        assertThat(metadata.dataStreamAliases().get("logs-postgres"), notNullValue());
+        assertThat(metadata.dataStreamAliases().get("logs-postgres").getDataStreams(), containsInAnyOrder("logs-postgres-eu"));
+    }
+
+    public void testDeleteDataStreamShouldUpdateAlias() {
+        Metadata.Builder mdBuilder = Metadata.builder();
+        mdBuilder.put(DataStreamTestHelper.randomInstance("logs-postgres-eu"));
+        mdBuilder.put("logs-postgres", "logs-postgres-eu", null);
+        mdBuilder.put(DataStreamTestHelper.randomInstance("logs-postgres-us"));
+        mdBuilder.put("logs-postgres", "logs-postgres-us", null);
+        mdBuilder.put(DataStreamTestHelper.randomInstance("logs-postgres-au"));
+        mdBuilder.put("logs-postgres", "logs-postgres-au", null);
+        Metadata metadata = mdBuilder.build();
+        assertThat(metadata.dataStreamAliases().get("logs-postgres"), notNullValue());
+        assertThat(metadata.dataStreamAliases().get("logs-postgres").getDataStreams(),
+            containsInAnyOrder("logs-postgres-eu", "logs-postgres-us", "logs-postgres-au"));
+
+        mdBuilder = Metadata.builder(metadata);
+        mdBuilder.removeDataStream("logs-postgres-us");
+        metadata = mdBuilder.build();
+        assertThat(metadata.dataStreamAliases().get("logs-postgres"), notNullValue());
+        assertThat(metadata.dataStreamAliases().get("logs-postgres").getDataStreams(),
+            containsInAnyOrder("logs-postgres-eu", "logs-postgres-au"));
+
+        mdBuilder = Metadata.builder(metadata);
+        mdBuilder.removeDataStream("logs-postgres-au");
+        metadata = mdBuilder.build();
+        assertThat(metadata.dataStreamAliases().get("logs-postgres"), notNullValue());
+        assertThat(metadata.dataStreamAliases().get("logs-postgres").getDataStreams(), containsInAnyOrder("logs-postgres-eu"));
+
+        mdBuilder = Metadata.builder(metadata);
+        mdBuilder.removeDataStream("logs-postgres-eu");
+        metadata = mdBuilder.build();
+        assertThat(metadata.dataStreamAliases().get("logs-postgres"), nullValue());
+    }
+
+    public void testDeleteDataStreamAlias() {
+        Metadata.Builder mdBuilder = Metadata.builder();
+        mdBuilder.put(DataStreamTestHelper.randomInstance("logs-postgres-eu"));
+        mdBuilder.put("logs-postgres", "logs-postgres-eu", null);
+        mdBuilder.put(DataStreamTestHelper.randomInstance("logs-postgres-us"));
+        mdBuilder.put("logs-postgres", "logs-postgres-us", null);
+        mdBuilder.put(DataStreamTestHelper.randomInstance("logs-postgres-au"));
+        mdBuilder.put("logs-postgres", "logs-postgres-au", null);
+        Metadata metadata = mdBuilder.build();
+        assertThat(metadata.dataStreamAliases().get("logs-postgres"), notNullValue());
+        assertThat(metadata.dataStreamAliases().get("logs-postgres").getDataStreams(),
+            containsInAnyOrder("logs-postgres-eu", "logs-postgres-us", "logs-postgres-au"));
+
+        mdBuilder = Metadata.builder(metadata);
+        mdBuilder.removeDataStreamAlias("logs-postgres", "logs-postgres-us", true);
+        metadata = mdBuilder.build();
+        assertThat(metadata.dataStreamAliases().get("logs-postgres"), notNullValue());
+        assertThat(metadata.dataStreamAliases().get("logs-postgres").getDataStreams(),
+            containsInAnyOrder("logs-postgres-eu", "logs-postgres-au"));
+
+        mdBuilder = Metadata.builder(metadata);
+        mdBuilder.removeDataStreamAlias("logs-postgres", "logs-postgres-au", true);
+        metadata = mdBuilder.build();
+        assertThat(metadata.dataStreamAliases().get("logs-postgres"), notNullValue());
+        assertThat(metadata.dataStreamAliases().get("logs-postgres").getDataStreams(), containsInAnyOrder("logs-postgres-eu"));
+
+        mdBuilder = Metadata.builder(metadata);
+        mdBuilder.removeDataStreamAlias("logs-postgres", "logs-postgres-eu", true);
+        metadata = mdBuilder.build();
+        assertThat(metadata.dataStreamAliases().get("logs-postgres"), nullValue());
+    }
+
+    public void testDeleteDataStreamAliasMustExists() {
+        Metadata.Builder mdBuilder = Metadata.builder();
+        mdBuilder.put(DataStreamTestHelper.randomInstance("logs-postgres-eu"));
+        mdBuilder.put("logs-postgres", "logs-postgres-eu", null);
+        mdBuilder.put(DataStreamTestHelper.randomInstance("logs-postgres-us"));
+        mdBuilder.put("logs-postgres", "logs-postgres-us", null);
+        mdBuilder.put(DataStreamTestHelper.randomInstance("logs-postgres-au"));
+        mdBuilder.put("logs-postgres", "logs-postgres-au", null);
+        Metadata metadata = mdBuilder.build();
+        assertThat(metadata.dataStreamAliases().get("logs-postgres"), notNullValue());
+        assertThat(metadata.dataStreamAliases().get("logs-postgres").getDataStreams(),
+            containsInAnyOrder("logs-postgres-eu", "logs-postgres-us", "logs-postgres-au"));
+
+        expectThrows(ResourceNotFoundException.class, () -> mdBuilder.removeDataStreamAlias("logs-postgres", "logs-postgres-nz", true));
+        Metadata.Builder r = mdBuilder.removeDataStreamAlias("logs-postgres", "logs-postgres-nz", false);
+        assertThat(r, sameInstance(mdBuilder));
     }
 
     public static Metadata randomMetadata() {

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
@@ -1159,7 +1159,7 @@ public class MetadataTests extends ESTestCase {
                 indicesLookup.put(indexMeta.getIndex().getName(), new IndexAbstraction.Index(indexMeta, dataStreamAbstraction));
             }
         }
-        DataStreamMetadata dataStreamMetadata = new DataStreamMetadata(Map.of(dataStreamName, dataStream));
+        DataStreamMetadata dataStreamMetadata = new DataStreamMetadata(Map.of(dataStreamName, dataStream), Map.of());
 
         // prefixed indices with a lower generation than the data stream's generation are allowed even if the non-prefixed, matching the
         // data stream backing indices naming pattern, indices are already in the system

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
@@ -1370,9 +1370,10 @@ public class MetadataTests extends ESTestCase {
         assertThat(metadata.dataStreamAliases().get("logs-postgres").getDataStreams(),
             containsInAnyOrder("logs-postgres-eu", "logs-postgres-us", "logs-postgres-au"));
 
-        expectThrows(ResourceNotFoundException.class, () -> mdBuilder.removeDataStreamAlias("logs-postgres", "logs-postgres-nz", true));
-        Metadata.Builder r = mdBuilder.removeDataStreamAlias("logs-postgres", "logs-postgres-nz", false);
-        assertThat(r, sameInstance(mdBuilder));
+        Metadata.Builder mdBuilder2 = Metadata.builder(metadata);
+        expectThrows(ResourceNotFoundException.class, () -> mdBuilder2.removeDataStreamAlias("logs-mysql", "logs-postgres-us", true));
+        Metadata.Builder r = mdBuilder2.removeDataStreamAlias("logs-mysql", "logs-postgres-us", false);
+        assertThat(r, sameInstance(mdBuilder2));
     }
 
     public static Metadata randomMetadata() {

--- a/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestGetAliasesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestGetAliasesActionTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import static org.elasticsearch.rest.RestStatus.OK;
 import static org.elasticsearch.rest.RestStatus.NOT_FOUND;
@@ -41,7 +42,7 @@ public class RestGetAliasesActionTests extends ESTestCase {
         final AliasMetadata fooAliasMetadata = AliasMetadata.builder("foo").build();
         openMapBuilder.put("index", Arrays.asList(fooAliasMetadata, foobarAliasMetadata));
         final RestResponse restResponse = RestGetAliasesAction.buildRestResponse(false, new String[0], openMapBuilder.build(),
-            List.of(), xContentBuilder);
+            Map.of(), xContentBuilder);
         assertThat(restResponse.status(), equalTo(OK));
         assertThat(restResponse.contentType(), equalTo("application/json"));
         assertThat(restResponse.content().utf8ToString(), equalTo("{\"index\":{\"aliases\":{\"foo\":{},\"foobar\":{}}}}"));
@@ -51,7 +52,7 @@ public class RestGetAliasesActionTests extends ESTestCase {
         final XContentBuilder xContentBuilder = XContentFactory.contentBuilder(XContentType.JSON);
         final ImmutableOpenMap.Builder<String, List<AliasMetadata>> openMapBuilder = ImmutableOpenMap.builder();
         final RestResponse restResponse = RestGetAliasesAction.buildRestResponse(true, new String[] { "baz*" }, openMapBuilder.build(),
-            List.of(), xContentBuilder);
+            Map.of(), xContentBuilder);
         assertThat(restResponse.status(), equalTo(OK));
         assertThat(restResponse.contentType(), equalTo("application/json"));
         assertThat(restResponse.content().utf8ToString(), equalTo("{}"));
@@ -63,7 +64,7 @@ public class RestGetAliasesActionTests extends ESTestCase {
         final AliasMetadata aliasMetadata = AliasMetadata.builder("foobar").build();
         openMapBuilder.put("index", Arrays.asList(aliasMetadata));
         final RestResponse restResponse = RestGetAliasesAction.buildRestResponse(true, new String[] { "baz*", "foobar*" },
-                openMapBuilder.build(), List.of(), xContentBuilder);
+                openMapBuilder.build(), Map.of(), xContentBuilder);
         assertThat(restResponse.status(), equalTo(OK));
         assertThat(restResponse.contentType(), equalTo("application/json"));
         assertThat(restResponse.content().utf8ToString(), equalTo("{\"index\":{\"aliases\":{\"foobar\":{}}}}"));
@@ -73,7 +74,7 @@ public class RestGetAliasesActionTests extends ESTestCase {
         final XContentBuilder xContentBuilder = XContentFactory.contentBuilder(XContentType.JSON);
         final ImmutableOpenMap.Builder<String, List<AliasMetadata>> openMapBuilder = ImmutableOpenMap.builder();
         final RestResponse restResponse = RestGetAliasesAction.buildRestResponse(true, new String[] { "foob*", "-foo*" },
-                openMapBuilder.build(), List.of(), xContentBuilder);
+                openMapBuilder.build(), Map.of(), xContentBuilder);
         assertThat(restResponse.status(), equalTo(OK));
         assertThat(restResponse.contentType(), equalTo("application/json"));
         assertThat(restResponse.content().utf8ToString(), equalTo("{}"));
@@ -85,7 +86,7 @@ public class RestGetAliasesActionTests extends ESTestCase {
         final AliasMetadata aliasMetadata = AliasMetadata.builder("foo").build();
         openMapBuilder.put("index", Arrays.asList(aliasMetadata));
         final RestResponse restResponse = RestGetAliasesAction.buildRestResponse(true, new String[] { "foo*", "-foob*" },
-                openMapBuilder.build(), List.of(), xContentBuilder);
+                openMapBuilder.build(), Map.of(), xContentBuilder);
         assertThat(restResponse.status(), equalTo(OK));
         assertThat(restResponse.contentType(), equalTo("application/json"));
         assertThat(restResponse.content().utf8ToString(), equalTo("{\"index\":{\"aliases\":{\"foo\":{}}}}"));
@@ -104,7 +105,7 @@ public class RestGetAliasesActionTests extends ESTestCase {
         }
 
         final RestResponse restResponse = RestGetAliasesAction.buildRestResponse(true, aliasPattern, openMapBuilder.build(),
-            List.of(), xContentBuilder);
+            Map.of(), xContentBuilder);
         assertThat(restResponse.status(), equalTo(NOT_FOUND));
         assertThat(restResponse.contentType(), equalTo("application/json"));
         assertThat(restResponse.content().utf8ToString(),
@@ -115,7 +116,7 @@ public class RestGetAliasesActionTests extends ESTestCase {
         final XContentBuilder xContentBuilder = XContentFactory.contentBuilder(XContentType.JSON);
         final ImmutableOpenMap.Builder<String, List<AliasMetadata>> openMapBuilder = ImmutableOpenMap.builder();
         final RestResponse restResponse = RestGetAliasesAction.buildRestResponse(true, new String[] { "foo", "foofoo", "-foo*" },
-                openMapBuilder.build(), List.of(), xContentBuilder);
+                openMapBuilder.build(), Map.of(), xContentBuilder);
         assertThat(restResponse.status(), equalTo(OK));
         assertThat(restResponse.contentType(), equalTo("application/json"));
         assertThat(restResponse.content().utf8ToString(), equalTo("{}"));

--- a/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestGetAliasesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestGetAliasesActionTests.java
@@ -41,7 +41,7 @@ public class RestGetAliasesActionTests extends ESTestCase {
         final AliasMetadata fooAliasMetadata = AliasMetadata.builder("foo").build();
         openMapBuilder.put("index", Arrays.asList(fooAliasMetadata, foobarAliasMetadata));
         final RestResponse restResponse = RestGetAliasesAction.buildRestResponse(false, new String[0], openMapBuilder.build(),
-                xContentBuilder);
+            List.of(), xContentBuilder);
         assertThat(restResponse.status(), equalTo(OK));
         assertThat(restResponse.contentType(), equalTo("application/json"));
         assertThat(restResponse.content().utf8ToString(), equalTo("{\"index\":{\"aliases\":{\"foo\":{},\"foobar\":{}}}}"));
@@ -51,7 +51,7 @@ public class RestGetAliasesActionTests extends ESTestCase {
         final XContentBuilder xContentBuilder = XContentFactory.contentBuilder(XContentType.JSON);
         final ImmutableOpenMap.Builder<String, List<AliasMetadata>> openMapBuilder = ImmutableOpenMap.builder();
         final RestResponse restResponse = RestGetAliasesAction.buildRestResponse(true, new String[] { "baz*" }, openMapBuilder.build(),
-                xContentBuilder);
+            List.of(), xContentBuilder);
         assertThat(restResponse.status(), equalTo(OK));
         assertThat(restResponse.contentType(), equalTo("application/json"));
         assertThat(restResponse.content().utf8ToString(), equalTo("{}"));
@@ -63,7 +63,7 @@ public class RestGetAliasesActionTests extends ESTestCase {
         final AliasMetadata aliasMetadata = AliasMetadata.builder("foobar").build();
         openMapBuilder.put("index", Arrays.asList(aliasMetadata));
         final RestResponse restResponse = RestGetAliasesAction.buildRestResponse(true, new String[] { "baz*", "foobar*" },
-                openMapBuilder.build(), xContentBuilder);
+                openMapBuilder.build(), List.of(), xContentBuilder);
         assertThat(restResponse.status(), equalTo(OK));
         assertThat(restResponse.contentType(), equalTo("application/json"));
         assertThat(restResponse.content().utf8ToString(), equalTo("{\"index\":{\"aliases\":{\"foobar\":{}}}}"));
@@ -73,7 +73,7 @@ public class RestGetAliasesActionTests extends ESTestCase {
         final XContentBuilder xContentBuilder = XContentFactory.contentBuilder(XContentType.JSON);
         final ImmutableOpenMap.Builder<String, List<AliasMetadata>> openMapBuilder = ImmutableOpenMap.builder();
         final RestResponse restResponse = RestGetAliasesAction.buildRestResponse(true, new String[] { "foob*", "-foo*" },
-                openMapBuilder.build(), xContentBuilder);
+                openMapBuilder.build(), List.of(), xContentBuilder);
         assertThat(restResponse.status(), equalTo(OK));
         assertThat(restResponse.contentType(), equalTo("application/json"));
         assertThat(restResponse.content().utf8ToString(), equalTo("{}"));
@@ -85,7 +85,7 @@ public class RestGetAliasesActionTests extends ESTestCase {
         final AliasMetadata aliasMetadata = AliasMetadata.builder("foo").build();
         openMapBuilder.put("index", Arrays.asList(aliasMetadata));
         final RestResponse restResponse = RestGetAliasesAction.buildRestResponse(true, new String[] { "foo*", "-foob*" },
-                openMapBuilder.build(), xContentBuilder);
+                openMapBuilder.build(), List.of(), xContentBuilder);
         assertThat(restResponse.status(), equalTo(OK));
         assertThat(restResponse.contentType(), equalTo("application/json"));
         assertThat(restResponse.content().utf8ToString(), equalTo("{\"index\":{\"aliases\":{\"foo\":{}}}}"));
@@ -104,7 +104,7 @@ public class RestGetAliasesActionTests extends ESTestCase {
         }
 
         final RestResponse restResponse = RestGetAliasesAction.buildRestResponse(true, aliasPattern, openMapBuilder.build(),
-                xContentBuilder);
+            List.of(), xContentBuilder);
         assertThat(restResponse.status(), equalTo(NOT_FOUND));
         assertThat(restResponse.contentType(), equalTo("application/json"));
         assertThat(restResponse.content().utf8ToString(),
@@ -115,7 +115,7 @@ public class RestGetAliasesActionTests extends ESTestCase {
         final XContentBuilder xContentBuilder = XContentFactory.contentBuilder(XContentType.JSON);
         final ImmutableOpenMap.Builder<String, List<AliasMetadata>> openMapBuilder = ImmutableOpenMap.builder();
         final RestResponse restResponse = RestGetAliasesAction.buildRestResponse(true, new String[] { "foo", "foofoo", "-foo*" },
-                openMapBuilder.build(), xContentBuilder);
+                openMapBuilder.build(), List.of(), xContentBuilder);
         assertThat(restResponse.status(), equalTo(OK));
         assertThat(restResponse.contentType(), equalTo("application/json"));
         assertThat(restResponse.content().utf8ToString(), equalTo("{}"));

--- a/test/framework/src/main/java/org/elasticsearch/cluster/metadata/DataStreamTestHelper.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/metadata/DataStreamTestHelper.java
@@ -125,10 +125,18 @@ public final class DataStreamTestHelper {
         return randomInstance(System::currentTimeMillis);
     }
 
+    public static DataStream randomInstance(String name) {
+        return randomInstance(name, System::currentTimeMillis);
+    }
+
     public static DataStream randomInstance(LongSupplier timeProvider) {
+        String dataStreamName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
+        return randomInstance(dataStreamName, timeProvider);
+    }
+
+    public static DataStream randomInstance(String dataStreamName, LongSupplier timeProvider) {
         List<Index> indices = randomIndexInstances();
         long generation = indices.size() + ESTestCase.randomLongBetween(1, 128);
-        String dataStreamName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
         indices.add(new Index(getDefaultBackingIndexName(dataStreamName, generation), UUIDs.randomBase64UUID(LuceneTestCase.random())));
         Map<String, Object> metadata = null;
         if (randomBoolean()) {

--- a/test/framework/src/main/java/org/elasticsearch/cluster/metadata/DataStreamTestHelper.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/metadata/DataStreamTestHelper.java
@@ -28,6 +28,7 @@ import static org.elasticsearch.cluster.metadata.DataStream.BACKING_INDEX_PREFIX
 import static org.elasticsearch.cluster.metadata.DataStream.DATE_FORMATTER;
 import static org.elasticsearch.cluster.metadata.DataStream.getDefaultBackingIndexName;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_INDEX_UUID;
+import static org.elasticsearch.test.ESTestCase.generateRandomStringArray;
 import static org.elasticsearch.test.ESTestCase.randomAlphaOfLength;
 import static org.elasticsearch.test.ESTestCase.randomBoolean;
 
@@ -135,6 +136,14 @@ public final class DataStreamTestHelper {
         }
         return new DataStream(dataStreamName, createTimestampField("@timestamp"), indices, generation, metadata,
             randomBoolean(), randomBoolean(), false, timeProvider);
+    }
+
+    public static DataStreamAlias randomAliasInstance() {
+        return new DataStreamAlias(
+            randomAlphaOfLength(5),
+            List.of(generateRandomStringArray(5, 5, false)),
+            randomBoolean() ? randomAlphaOfLength(5) : null
+        );
     }
 
     /**

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -45,6 +45,7 @@ import org.elasticsearch.common.CheckedRunnable;
 import org.elasticsearch.common.RestApiVersion;
 import org.elasticsearch.common.SuppressForbidden;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.io.PathUtils;
 import org.elasticsearch.common.io.PathUtilsForTesting;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
@@ -123,6 +124,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -829,6 +831,15 @@ public abstract class ESTestCase extends LuceneTestCase {
         return list;
     }
 
+    public static <K, V> Map<K, V> randomMap(int minListSize, int maxListSize, Supplier<Tuple<K, V>> valueConstructor) {
+        final int size = randomIntBetween(minListSize, maxListSize);
+        Map<K, V> list = new HashMap<>(size);
+        for (int i = 0; i < size; i++) {
+            Tuple<K, V> entry = valueConstructor.get();
+            list.put(entry.v1(), entry.v2());
+        }
+        return list;
+    }
 
     private static final String[] TIME_SUFFIXES = new String[]{"d", "h", "ms", "s", "m", "micros", "nanos"};
 

--- a/x-pack/plugin/data-streams/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/datastreams/DataStreamsRestIT.java
+++ b/x-pack/plugin/data-streams/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/datastreams/DataStreamsRestIT.java
@@ -89,4 +89,143 @@ public class DataStreamsRestIT extends ESRestTestCase {
         Exception e = expectThrows(ResponseException.class, () -> client().performRequest(putComposableIndexTemplateRequest));
         assertThat(e.getMessage(), containsString("template [my-template] has alias and data stream definitions"));
     }
+
+    public void testDataStreamAliases() throws Exception {
+        // Create a template
+        Request putComposableIndexTemplateRequest = new Request("POST", "/_index_template/1");
+        putComposableIndexTemplateRequest.setJsonEntity("{\"index_patterns\": [\"logs-*\"], \"data_stream\": {}}");
+        assertOK(client().performRequest(putComposableIndexTemplateRequest));
+
+        Request createDocRequest = new Request("POST", "/logs-myapp1/_doc?refresh=true");
+        createDocRequest.setJsonEntity("{ \"@timestamp\": \"2022-12-12\"}");
+        assertOK(client().performRequest(createDocRequest));
+
+        createDocRequest = new Request("POST", "/logs-myapp2/_doc?refresh=true");
+        createDocRequest.setJsonEntity("{ \"@timestamp\": \"2022-12-12\"}");
+        assertOK(client().performRequest(createDocRequest));
+
+        // Add logs-myapp1 -> logs & logs-myapp2 -> logs
+        Request updateAliasesRequest = new Request("POST", "/_aliases");
+        updateAliasesRequest.setJsonEntity("{\"actions\":[{\"add\":{\"index\":\"logs-myapp1\",\"alias\":\"logs\"}}," +
+            "{\"add\":{\"index\":\"logs-myapp2\",\"alias\":\"logs\"}}]}");
+        assertOK(client().performRequest(updateAliasesRequest));
+
+        Request getAliasesRequest = new Request("GET", "/_aliases");
+        Map<String, Object> getAliasesResponse = entityAsMap(client().performRequest(getAliasesRequest));
+        assertEquals(Map.of("logs", Map.of()), XContentMapValues.extractValue("logs-myapp1.aliases", getAliasesResponse));
+        assertEquals(Map.of("logs", Map.of()), XContentMapValues.extractValue("logs-myapp2.aliases", getAliasesResponse));
+
+        Request searchRequest = new Request("GET", "/logs/_search");
+        Map<String, Object> searchResponse = entityAsMap(client().performRequest(searchRequest));
+        assertEquals(2, XContentMapValues.extractValue("hits.total.value", searchResponse));
+
+        // Remove logs-myapp1 -> logs & logs-myapp2 -> logs
+        updateAliasesRequest = new Request("POST", "/_aliases");
+        updateAliasesRequest.setJsonEntity("{\"actions\":[{\"remove\":{\"index\":\"logs-myapp1\",\"alias\":\"logs\"}}," +
+            "{\"remove\":{\"index\":\"logs-myapp2\",\"alias\":\"logs\"}}]}");
+        assertOK(client().performRequest(updateAliasesRequest));
+
+        getAliasesRequest = new Request("GET", "/_aliases");
+        getAliasesResponse = entityAsMap(client().performRequest(getAliasesRequest));
+        assertEquals(Map.of(), XContentMapValues.extractValue("logs-myapp1.aliases", getAliasesResponse));
+        assertEquals(Map.of(), XContentMapValues.extractValue("logs-myapp2.aliases", getAliasesResponse));
+        expectThrows(ResponseException.class, () -> client().performRequest(new Request("GET", "/logs/_search")));
+
+        // Add logs-* -> logs
+        updateAliasesRequest = new Request("POST", "/_aliases");
+        updateAliasesRequest.setJsonEntity("{\"actions\":[{\"add\":{\"index\":\"logs-*\",\"alias\":\"logs\"}}]}");
+        assertOK(client().performRequest(updateAliasesRequest));
+
+        getAliasesRequest = new Request("GET", "/_aliases");
+        getAliasesResponse = entityAsMap(client().performRequest(getAliasesRequest));
+        assertEquals(Map.of("logs", Map.of()), XContentMapValues.extractValue("logs-myapp1.aliases", getAliasesResponse));
+        assertEquals(Map.of("logs", Map.of()), XContentMapValues.extractValue("logs-myapp2.aliases", getAliasesResponse));
+
+        searchRequest = new Request("GET", "/logs/_search");
+        searchResponse = entityAsMap(client().performRequest(searchRequest));
+        assertEquals(2, XContentMapValues.extractValue("hits.total.value", searchResponse));
+
+        // Remove logs-* -> logs
+        updateAliasesRequest = new Request("POST", "/_aliases");
+        updateAliasesRequest.setJsonEntity("{\"actions\":[{\"remove\":{\"index\":\"logs-*\",\"alias\":\"logs\"}}]}");
+        assertOK(client().performRequest(updateAliasesRequest));
+
+        getAliasesRequest = new Request("GET", "/_aliases");
+        getAliasesResponse = entityAsMap(client().performRequest(getAliasesRequest));
+        assertEquals(Map.of(), XContentMapValues.extractValue("logs-myapp1.aliases", getAliasesResponse));
+        assertEquals(Map.of(), XContentMapValues.extractValue("logs-myapp2.aliases", getAliasesResponse));
+        expectThrows(ResponseException.class, () -> client().performRequest(new Request("GET", "/logs/_search")));
+    }
+
+    public void testDataStreamWriteAlias() throws IOException {
+        // Create a template
+        Request putComposableIndexTemplateRequest = new Request("POST", "/_index_template/1");
+        putComposableIndexTemplateRequest.setJsonEntity("{\"index_patterns\": [\"logs-*\"], \"data_stream\": {}}");
+        assertOK(client().performRequest(putComposableIndexTemplateRequest));
+
+        Request createDocRequest = new Request("POST", "/logs-emea/_doc?refresh=true");
+        createDocRequest.setJsonEntity("{ \"@timestamp\": \"2022-12-12\"}");
+        assertOK(client().performRequest(createDocRequest));
+
+        createDocRequest = new Request("POST", "/logs-nasa/_doc?refresh=true");
+        createDocRequest.setJsonEntity("{ \"@timestamp\": \"2022-12-12\"}");
+        assertOK(client().performRequest(createDocRequest));
+
+        Request updateAliasesRequest = new Request("POST", "/_aliases");
+        updateAliasesRequest.setJsonEntity(
+            "{\"actions\":[{\"add\":{\"index\":\"logs-emea\",\"alias\":\"logs\",\"is_write_index\":true}}," +
+            "{\"add\":{\"index\":\"logs-nasa\",\"alias\":\"logs\"}}]}");
+        assertOK(client().performRequest(updateAliasesRequest));
+
+        Request getAliasesRequest = new Request("GET", "/_aliases");
+        Map<String, Object> getAliasesResponse = entityAsMap(client().performRequest(getAliasesRequest));
+        assertEquals(
+            Map.of("logs", Map.of("is_write_data_stream", true)),
+            XContentMapValues.extractValue("logs-emea.aliases", getAliasesResponse)
+        );
+        assertEquals(Map.of("logs", Map.of()), XContentMapValues.extractValue("logs-nasa.aliases", getAliasesResponse));
+
+        Request searchRequest = new Request("GET", "/logs/_search");
+        Map<String, Object> searchResponse = entityAsMap(client().performRequest(searchRequest));
+        assertEquals(2, XContentMapValues.extractValue("hits.total.value", searchResponse));
+
+        createDocRequest = new Request("POST", "/logs/_doc?refresh=true");
+        createDocRequest.setJsonEntity("{ \"@timestamp\": \"2022-12-12\"}");
+        assertOK(client().performRequest(createDocRequest));
+
+        updateAliasesRequest = new Request("POST", "/_aliases");
+        updateAliasesRequest.setJsonEntity("{\"actions\":[" +
+            "{\"add\":{\"index\":\"logs-emea\",\"alias\":\"logs\",\"is_write_index\":false}}," +
+            "{\"add\":{\"index\":\"logs-nasa\",\"alias\":\"logs\",\"is_write_index\":true}}" +
+            "]}");
+        assertOK(client().performRequest(updateAliasesRequest));
+
+        createDocRequest = new Request("POST", "/logs/_doc?refresh=true");
+        createDocRequest.setJsonEntity("{ \"@timestamp\": \"2022-12-12\"}");
+        assertOK(client().performRequest(createDocRequest));
+    }
+
+    public void testDataStreamAliasTemplate() throws Exception {
+        // Create a template
+        Request putComposableIndexTemplateRequest = new Request("POST", "/_index_template/1");
+        putComposableIndexTemplateRequest.setJsonEntity("{\"index_patterns\": [\"logs-*\"], \"data_stream\": {\"aliases\":{\"logs\":{}}}}");
+        assertOK(client().performRequest(putComposableIndexTemplateRequest));
+
+        Request createDocRequest = new Request("POST", "/logs-myapp1/_doc?refresh=true");
+        createDocRequest.setJsonEntity("{ \"@timestamp\": \"2022-12-12\"}");
+        assertOK(client().performRequest(createDocRequest));
+
+        createDocRequest = new Request("POST", "/logs-myapp2/_doc?refresh=true");
+        createDocRequest.setJsonEntity("{ \"@timestamp\": \"2022-12-12\"}");
+        assertOK(client().performRequest(createDocRequest));
+
+        Request getAliasesRequest = new Request("GET", "/_aliases");
+        Map<String, Object> getAliasesResponse = entityAsMap(client().performRequest(getAliasesRequest));
+        assertEquals(Map.of("logs", Map.of()), XContentMapValues.extractValue("logs-myapp1.aliases", getAliasesResponse));
+        assertEquals(Map.of("logs", Map.of()), XContentMapValues.extractValue("logs-myapp2.aliases", getAliasesResponse));
+
+        Request searchRequest = new Request("GET", "/logs/_search");
+        Map<String, Object> searchResponse = entityAsMap(client().performRequest(searchRequest));
+        assertEquals(2, XContentMapValues.extractValue("hits.total.value", searchResponse));
+    }
 }

--- a/x-pack/plugin/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
+++ b/x-pack/plugin/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
@@ -92,7 +92,6 @@ import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItemInArray;
-import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -694,7 +693,10 @@ public class DataStreamIT extends ESIntegTestCase {
         aliasesAddRequest.addAliasAction(addAction);
         assertAcked(client().admin().indices().aliases(aliasesAddRequest).actionGet());
         GetAliasesResponse response = client().admin().indices().getAliases(new GetAliasesRequest()).actionGet();
-        assertThat(response.getDataStreamAliases(), hasItems(equalTo(new DataStreamAlias("foo", List.of("metrics-foo"), null))));
+        assertThat(
+            response.getDataStreamAliases(),
+            equalTo(Map.of("metrics-foo", List.of(new DataStreamAlias("foo", List.of("metrics-foo"), null))))
+        );
     }
 
     public void testAliasActionsFailOnDataStreamBackingIndices() throws Exception {

--- a/x-pack/plugin/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
+++ b/x-pack/plugin/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
@@ -14,6 +14,8 @@ import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
+import org.elasticsearch.action.admin.indices.alias.get.GetAliasesRequest;
+import org.elasticsearch.action.admin.indices.alias.get.GetAliasesResponse;
 import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
 import org.elasticsearch.action.admin.indices.get.GetIndexResponse;
 import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse;
@@ -42,6 +44,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.metadata.DataStream;
+import org.elasticsearch.cluster.metadata.DataStreamAlias;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Template;
 import org.elasticsearch.common.Nullable;
@@ -89,6 +92,7 @@ import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItemInArray;
+import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -562,7 +566,7 @@ public class DataStreamIT extends ESIntegTestCase {
         verifyResolvability(dataStreamName, client().admin().indices().prepareForceMerge(dataStreamName), false);
         verifyResolvability(dataStreamName, client().admin().indices().prepareValidateQuery(dataStreamName), false);
         verifyResolvability(dataStreamName, client().admin().indices().prepareRecoveries(dataStreamName), false);
-        verifyResolvability(dataStreamName, client().admin().indices().prepareGetAliases("dummy").addIndices(dataStreamName), true);
+        verifyResolvability(dataStreamName, client().admin().indices().prepareGetAliases("dummy").addIndices(dataStreamName), false);
         verifyResolvability(dataStreamName, client().admin().indices().prepareGetFieldMappings(dataStreamName), false);
         verifyResolvability(
             dataStreamName,
@@ -677,7 +681,7 @@ public class DataStreamIT extends ESIntegTestCase {
         assertTrue(maybeE.isPresent());
     }
 
-    public void testAliasActionsFailOnDataStreams() throws Exception {
+    public void testAliasActionsOnDataStreams() throws Exception {
         putComposableIndexTemplate("id1", List.of("metrics-foo*"));
         String dataStreamName = "metrics-foo";
         CreateDataStreamAction.Request createDataStreamRequest = new CreateDataStreamAction.Request(dataStreamName);
@@ -688,8 +692,9 @@ public class DataStreamIT extends ESIntegTestCase {
             .aliases("foo");
         IndicesAliasesRequest aliasesAddRequest = new IndicesAliasesRequest();
         aliasesAddRequest.addAliasAction(addAction);
-        Exception e = expectThrows(IndexNotFoundException.class, () -> client().admin().indices().aliases(aliasesAddRequest).actionGet());
-        assertThat(e.getMessage(), equalTo("no such index [" + dataStreamName + "]"));
+        assertAcked(client().admin().indices().aliases(aliasesAddRequest).actionGet());
+        GetAliasesResponse response = client().admin().indices().getAliases(new GetAliasesRequest()).actionGet();
+        assertThat(response.getDataStreamAliases(), hasItems(equalTo(new DataStreamAlias("foo", List.of("metrics-foo"), null))));
     }
 
     public void testAliasActionsFailOnDataStreamBackingIndices() throws Exception {

--- a/x-pack/plugin/data-streams/src/test/java/org/elasticsearch/xpack/datastreams/DataStreamsStatsTests.java
+++ b/x-pack/plugin/data-streams/src/test/java/org/elasticsearch/xpack/datastreams/DataStreamsStatsTests.java
@@ -242,7 +242,7 @@ public class DataStreamsStatsTests extends ESSingleNodeTestCase {
             null,
             null,
             null,
-            new ComposableIndexTemplate.DataStreamTemplate(hidden),
+            new ComposableIndexTemplate.DataStreamTemplate(hidden, Map.of()),
             null
         );
         assertTrue(

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolverTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolverTests.java
@@ -1624,18 +1624,18 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         final User user = new User("data-stream-tester2", "data_stream_test2");
         GetAliasesRequest request = new GetAliasesRequest("*");
         assertThat(request, instanceOf(IndicesRequest.Replaceable.class));
-        assertThat(request.includeDataStreams(), is(false));
+        assertThat(request.includeDataStreams(), is(true));
 
         // data streams and their backing indices should _not_ be in the authorized list since the backing indices
         // do not match the requested pattern
         List<String> dataStreams = List.of("logs-foo", "logs-foobar");
         final List<String> authorizedIndices = buildAuthorizedIndices(user, GetAliasesAction.NAME, request);
         for (String dsName : dataStreams) {
-            assertThat(authorizedIndices, not(hasItem(dsName)));
+            assertThat(authorizedIndices, hasItem(dsName));
             DataStream dataStream = metadata.dataStreams().get(dsName);
-            assertThat(authorizedIndices, not(hasItem(dsName)));
+            assertThat(authorizedIndices, hasItem(dsName));
             for (Index i : dataStream.getIndices()) {
-                assertThat(authorizedIndices, not(hasItem(i.getName())));
+                assertThat(authorizedIndices, hasItem(i.getName()));
             }
         }
 
@@ -1643,11 +1643,11 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         // pattern
         ResolvedIndices resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(request, metadata, authorizedIndices);
         for (String dsName : dataStreams) {
-            assertThat(resolvedIndices.getLocal(), not(hasItem(dsName)));
+            assertThat(resolvedIndices.getLocal(), hasItem(dsName));
             DataStream dataStream = metadata.dataStreams().get(dsName);
-            assertThat(resolvedIndices.getLocal(), not(hasItem(dsName)));
+            assertThat(resolvedIndices.getLocal(), hasItem(dsName));
             for (Index i : dataStream.getIndices()) {
-                assertThat(resolvedIndices.getLocal(), not(hasItem(i.getName())));
+                assertThat(resolvedIndices.getLocal(), hasItem(i.getName()));
             }
         }
     }
@@ -1657,24 +1657,24 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         String dataStreamName = "logs-foobar";
         GetAliasesRequest request = new GetAliasesRequest(dataStreamName);
         assertThat(request, instanceOf(IndicesRequest.Replaceable.class));
-        assertThat(request.includeDataStreams(), is(false));
+        assertThat(request.includeDataStreams(), is(true));
 
         // data streams and their backing indices should _not_ be in the authorized list since the backing indices
         // do not match the requested name
         final List<String> authorizedIndices = buildAuthorizedIndices(user, GetAliasesAction.NAME, request);
-        assertThat(authorizedIndices, not(hasItem(dataStreamName)));
+        assertThat(authorizedIndices, hasItem(dataStreamName));
         DataStream dataStream = metadata.dataStreams().get(dataStreamName);
-        assertThat(authorizedIndices, not(hasItem(dataStreamName)));
+        assertThat(authorizedIndices, hasItem(dataStreamName));
         for (Index i : dataStream.getIndices()) {
-            assertThat(authorizedIndices, not(hasItem(i.getName())));
+            assertThat(authorizedIndices, hasItem(i.getName()));
         }
 
         // neither data streams nor their backing indices will be in the resolved list since the backing indices do not match the
         // requested name(s)
         ResolvedIndices resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(request, metadata, authorizedIndices);
-        assertThat(resolvedIndices.getLocal(), not(hasItem(dataStreamName)));
+        assertThat(resolvedIndices.getLocal(), hasItem(dataStreamName));
         for (Index i : dataStream.getIndices()) {
-            assertThat(resolvedIndices.getLocal(), not(hasItem(i.getName())));
+            assertThat(resolvedIndices.getLocal(), hasItem(i.getName()));
         }
     }
 
@@ -1771,24 +1771,24 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         String dataStreamName = "logs-foobar";
         GetAliasesRequest request = new GetAliasesRequest(dataStreamName);
         assertThat(request, instanceOf(IndicesRequest.Replaceable.class));
-        assertThat(request.includeDataStreams(), is(false));
+        assertThat(request.includeDataStreams(), is(true));
 
         // data streams and their backing indices should _not_ be in the authorized list since the backing indices
         // did not match the requested pattern and the request does not support data streams
         final List<String> authorizedIndices = buildAuthorizedIndices(user, GetAliasesAction.NAME, request);
-        assertThat(authorizedIndices, not(hasItem(dataStreamName)));
+        assertThat(authorizedIndices, hasItem(dataStreamName));
         DataStream dataStream = metadata.dataStreams().get(dataStreamName);
-        assertThat(authorizedIndices, not(hasItem(dataStreamName)));
+        assertThat(authorizedIndices, hasItem(dataStreamName));
         for (Index i : dataStream.getIndices()) {
-            assertThat(authorizedIndices, not(hasItem(i.getName())));
+            assertThat(authorizedIndices, hasItem(i.getName()));
         }
 
         // neither data streams nor their backing indices will be in the resolved list since the request does not support data streams
         // and the backing indices do not match the requested name
         ResolvedIndices resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(request, metadata, authorizedIndices);
-        assertThat(resolvedIndices.getLocal(), not(hasItem(dataStreamName)));
+        assertThat(resolvedIndices.getLocal(), hasItem(dataStreamName));
         for (Index i : dataStream.getIndices()) {
-            assertThat(resolvedIndices.getLocal(), not(hasItem(i.getName())));
+            assertThat(resolvedIndices.getLocal(), hasItem(i.getName()));
         }
     }
 
@@ -1843,7 +1843,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         String indexName = ".ds-logs-foobar-*";
         GetAliasesRequest request = new GetAliasesRequest(indexName);
         assertThat(request, instanceOf(IndicesRequest.Replaceable.class));
-        assertThat(request.includeDataStreams(), is(false));
+        assertThat(request.includeDataStreams(), is(true));
 
         // data streams should _not_ be in the authorized list but their backing indices that matched both the requested pattern
         // and the authorized pattern should be in the list
@@ -1869,7 +1869,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         String indexName = ".ds-logs-foobar-*";
         GetAliasesRequest request = new GetAliasesRequest(indexName);
         assertThat(request, instanceOf(IndicesRequest.Replaceable.class));
-        assertThat(request.includeDataStreams(), is(false));
+        assertThat(request.includeDataStreams(), is(true));
 
         // data streams should _not_ be in the authorized list but a single backing index that matched the requested pattern
         // and the authorized name should be in the list

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/data_stream/140_data_stream_aliases.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/data_stream/140_data_stream_aliases.yml
@@ -1,0 +1,172 @@
+---
+"Create data stream alias":
+  - skip:
+      version: " - 7.99.99"
+      reason: "data streams alias not yet backported to the 7.x branch"
+      features: allowed_warnings
+
+  - do:
+      allowed_warnings:
+        - "index template [my-template] has index patterns [events-*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [my-template] will take precedence during new index creation"
+      indices.put_index_template:
+        name: my-template
+        body:
+          index_patterns: [events-*]
+          template:
+            settings:
+              index.number_of_replicas: 0
+          data_stream: {}
+
+  - do:
+      indices.create_data_stream:
+        name: events-app1
+  - is_true: acknowledged
+
+  - do:
+      index:
+        index:  events-app1
+        refresh: true
+        body:
+          '@timestamp': '2022-12-12'
+          foo: bar
+
+  - do:
+      indices.create_data_stream:
+        name: events-app2
+  - is_true: acknowledged
+
+  - do:
+      index:
+        index:  events-app2
+        refresh: true
+        body:
+          '@timestamp': '2022-12-12'
+          foo: bar
+
+  - do:
+      indices.update_aliases:
+        body:
+          actions:
+            - add:
+                index: events-app1
+                alias: events
+            - add:
+                index: events-app2
+                alias: events
+
+  - do:
+      indices.get_data_stream:
+        name: "*"
+  - match: { data_streams.0.name: events-app1 }
+  - match: { data_streams.1.name: events-app2 }
+
+  - do:
+      indices.get_alias: {}
+
+  - match: {events-app1.aliases.events: {}}
+  - match: {events-app2.aliases.events: {}}
+
+  - do:
+      search:
+        index: events
+        body: { query: { match_all: {} } }
+  - length:   { hits.hits: 2  }
+
+  - do:
+      indices.update_aliases:
+        body:
+          actions:
+            - remove:
+                index: events-app2
+                alias: events
+
+  - do:
+      indices.get_alias: {}
+
+  - match: {events-app1.aliases.events: {}}
+  - is_false:  events-app2.aliases.events
+
+  - do:
+      search:
+        index: events
+        body: { query: { match_all: {} } }
+  - length:   { hits.hits: 1  }
+
+  - do:
+      indices.update_aliases:
+        body:
+          actions:
+            - remove:
+                index: events-app1
+                alias: events
+
+  - do:
+      indices.get_alias: {}
+  - is_false:  events-app1.aliases.events
+  - is_false:  events-app2.aliases.events
+
+---
+"Create data stream alias from composable index template":
+  - skip:
+      version: " - 7.99.99"
+      reason: "data streams alias not yet backported to the 7.x branch"
+      features: allowed_warnings
+
+  - do:
+      allowed_warnings:
+        - "index template [my-template] has index patterns [events-*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [my-template] will take precedence during new index creation"
+      indices.put_index_template:
+        name: my-template
+        body:
+          index_patterns: [events-*]
+          template:
+            settings:
+              index.number_of_replicas: 0
+          data_stream:
+            aliases:
+                events: {}
+
+  - do:
+      index:
+        index:  events-app1
+        refresh: true
+        body:
+          '@timestamp': '2022-12-12'
+          foo: bar
+
+  - do:
+      index:
+        index:  events-app2
+        refresh: true
+        body:
+          '@timestamp': '2022-12-12'
+          foo: bar
+
+  - do:
+      indices.get_data_stream:
+        name: "*"
+  - match: { data_streams.0.name: events-app1 }
+  - match: { data_streams.1.name: events-app2 }
+
+  - do:
+      indices.get_alias: {}
+
+  - match: {events-app1.aliases.events: {}}
+  - match: {events-app2.aliases.events: {}}
+
+  - do:
+      search:
+        index: events
+        body: { query: { match_all: {} } }
+  - length:   { hits.hits: 2  }
+
+  - do:
+      indices.update_aliases:
+        body:
+          actions:
+            - remove:
+                index: events-app1
+                alias: events
+            - remove:
+                index: events-app2
+                alias: events

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/data_stream/140_data_stream_aliases.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/data_stream/140_data_stream_aliases.yml
@@ -72,39 +72,6 @@
         body: { query: { match_all: {} } }
   - length:   { hits.hits: 2  }
 
-  - do:
-      indices.update_aliases:
-        body:
-          actions:
-            - remove:
-                index: events-app2
-                alias: events
-
-  - do:
-      indices.get_alias: {}
-
-  - match: {events-app1.aliases.events: {}}
-  - is_false:  events-app2.aliases.events
-
-  - do:
-      search:
-        index: events
-        body: { query: { match_all: {} } }
-  - length:   { hits.hits: 1  }
-
-  - do:
-      indices.update_aliases:
-        body:
-          actions:
-            - remove:
-                index: events-app1
-                alias: events
-
-  - do:
-      indices.get_alias: {}
-  - is_false:  events-app1.aliases.events
-  - is_false:  events-app2.aliases.events
-
 ---
 "Create data stream alias from composable index template":
   - skip:
@@ -159,14 +126,3 @@
         index: events
         body: { query: { match_all: {} } }
   - length:   { hits.hits: 2  }
-
-  - do:
-      indices.update_aliases:
-        body:
-          actions:
-            - remove:
-                index: events-app1
-                alias: events
-            - remove:
-                index: events-app2
-                alias: events

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/security/authz/50_data_streams.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/security/authz/50_data_streams.yml
@@ -192,8 +192,8 @@ teardown:
 
   - do:
       headers: { Authorization: "Basic dGVzdF91c2VyOngtcGFjay10ZXN0LXBhc3N3b3Jk" } # test_user
-      indices.get_alias:
-        name: easy*
+      indices.get:
+        index: easy*
 
   - match: {easy-index.aliases.easy-alias: {}}
   - is_false: easy-data-stream1

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/security/authz/51_data_stream_aliases.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/security/authz/51_data_stream_aliases.yml
@@ -1,0 +1,279 @@
+---
+setup:
+  - skip:
+      features: ["headers", "allowed_warnings"]
+      version: " - 7.99.99"
+      reason: "data stream aliases not yet backported to 7.x branch"
+
+  - do:
+      cluster.health:
+        wait_for_status: yellow
+
+  - do:
+      security.put_role:
+        name: "ingest_events_role"
+        body:  >
+          {
+            "indices": [
+              { "names": ["events*"], "privileges": ["create_doc", "create_index"] }
+            ]
+          }
+
+  - do:
+      security.put_role:
+        name: "query_events_role"
+        body:  >
+          {
+            "indices": [
+              { "names": ["app1", "events*"], "privileges": ["read", "view_index_metadata", "monitor"] }
+            ]
+          }
+
+  - do:
+      security.put_role:
+        name: "admin_events_role"
+        body:  >
+          {
+            "indices": [
+              { "names": ["events*"], "privileges": ["read", "write", "manage"] }
+            ]
+          }
+
+  - do:
+      security.put_role:
+        name: "ingest_logs_role"
+        body:  >
+          {
+            "indices": [
+              { "names": ["logs*"], "privileges": ["create_doc", "create_index"] }
+            ]
+          }
+
+  - do:
+      security.put_role:
+        name: "query_logs_role"
+        body:  >
+          {
+            "indices": [
+              { "names": ["app1", "logs*"], "privileges": ["read", "view_index_metadata", "monitor"] }
+            ]
+          }
+
+  - do:
+      security.put_role:
+        name: "admin_logs_role"
+        body:  >
+          {
+            "indices": [
+              { "names": ["logs*"], "privileges": ["read", "write", "manage"] }
+            ]
+          }
+
+  - do:
+      security.put_user:
+        username: "test_user"
+        body:  >
+          {
+            "password" : "x-pack-test-password",
+            "roles" : [ "ingest_events_role", "query_events_role" ],
+            "full_name" : "user with privileges on event data streams"
+          }
+
+  - do:
+      security.put_user:
+        username: "no_authz_user"
+        body:  >
+          {
+            "password" : "x-pack-test-password",
+            "roles" : [ "ingest_logs_role", "query_logs_role" ],
+            "full_name" : "user with privileges on logs data streams"
+          }
+
+  - do:
+      allowed_warnings:
+        - "index template [my-template1] has index patterns [events-*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [my-template1] will take precedence during new index creation"
+      indices.put_index_template:
+        name: my-template1
+        body:
+          index_patterns: [events-*]
+          template:
+            mappings:
+              properties:
+                '@timestamp':
+                  type: date
+                'foo':
+                  type: keyword
+          data_stream:
+            aliases:
+              app1: {}
+
+  - do:
+      allowed_warnings:
+        - "index template [my-template2] has index patterns [logs-*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [my-template2] will take precedence during new index creation"
+      indices.put_index_template:
+        name: my-template2
+        body:
+          index_patterns: [logs-*]
+          template:
+            mappings:
+              properties:
+                '@timestamp':
+                  type: date
+                'foo':
+                  type: keyword
+          data_stream:
+            aliases:
+              app1: {}
+
+---
+teardown:
+  - do:
+      security.delete_user:
+        username: "test_user"
+        ignore: 404
+
+  - do:
+      security.delete_user:
+        username: "test_user2"
+        ignore: 404
+
+  - do:
+      security.delete_role:
+        name: "ingest_events_role"
+        ignore: 404
+
+  - do:
+      security.delete_role:
+        name: "query_events_role"
+        ignore: 404
+
+  - do:
+      security.delete_role:
+        name: "admin_events_role"
+        ignore: 404
+
+  - do:
+      security.delete_role:
+        name: "ingest_logs_role"
+        ignore: 404
+
+  - do:
+      security.delete_role:
+        name: "query_logs_role"
+        ignore: 404
+
+  - do:
+      security.delete_role:
+        name: "admin_logs_role"
+        ignore: 404
+
+---
+"Basic read authorization test":
+  - skip:
+      features: ["headers", "allowed_warnings"]
+      version: " - 7.99.99"
+      reason: "data stream aliases not yet backported to 7.x branch"
+
+  - do:
+      index:
+        index:  events-app1
+        refresh: true
+        body:
+          '@timestamp': '2022-12-12'
+          foo: bar
+
+  - do:
+      index:
+        index:  logs-app1
+        refresh: true
+        body:
+          '@timestamp': '2022-12-12'
+          bar: baz
+
+  # app1 allows access to both data streams for this user irregardless whether privileges have been granted on data streams
+  - do:
+      headers: { Authorization: "Basic dGVzdF91c2VyOngtcGFjay10ZXN0LXBhc3N3b3Jk" } # test_user
+      search:
+        rest_total_hits_as_int: true
+        index: app1
+  - match: { hits.total: 2 }
+  - match: { hits.hits.0._source.foo: bar }
+  - match: { hits.hits.1._source.bar: baz }
+
+  # this user is authorized to use events-app1 data stream directly
+  - do:
+      headers: { Authorization: "Basic dGVzdF91c2VyOngtcGFjay10ZXN0LXBhc3N3b3Jk" } # test_user
+      search:
+        rest_total_hits_as_int: true
+        index: events-app1
+  - match: { hits.total: 1 }
+  - match: { hits.hits.0._source.foo: bar }
+
+  # this user is authorized to use a backing index of events-app1 data stream directly
+  - do:
+      headers: { Authorization: "Basic dGVzdF91c2VyOngtcGFjay10ZXN0LXBhc3N3b3Jk" } # test_user
+      search:
+        rest_total_hits_as_int: true
+        index: .ds-events-app1*
+  - match: { hits.total: 1 }
+  - match: { hits.hits.0._source.foo: bar }
+
+  # this user isn't authorized to use logs-app1 data stream directly
+  - do:
+      headers: { Authorization: "Basic dGVzdF91c2VyOngtcGFjay10ZXN0LXBhc3N3b3Jk" } # test_user
+      catch: forbidden
+      search:
+        rest_total_hits_as_int: true
+        index: logs-app1
+
+  # this user isn't authorized to use a backing index of logs-app1 data stream directly
+  - do:
+      headers: { Authorization: "Basic dGVzdF91c2VyOngtcGFjay10ZXN0LXBhc3N3b3Jk" } # test_user
+      search:
+        rest_total_hits_as_int: true
+        index: .ds-logs-app1*
+  - match: { hits.total: 0 }
+
+  # app1 allows access to both data streams for this user irregardless whether privileges have been granted on data streams
+  - do:
+      headers: { Authorization: "Basic bm9fYXV0aHpfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" } # no_authz_user
+      search:
+        rest_total_hits_as_int: true
+        index: app1
+  - match: { hits.total: 2 }
+  - match: { hits.hits.0._source.foo: bar }
+  - match: { hits.hits.1._source.bar: baz }
+
+  # this user isn't authorized to use events-app1 data stream directly
+  - do:
+      headers: { Authorization: "Basic bm9fYXV0aHpfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" } # no_authz_user
+      catch: forbidden
+      search:
+        rest_total_hits_as_int: true
+        index: events-app1
+
+  # this user isn't authorized to use a backing index of events-app1 data stream directly
+  - do:
+      headers: { Authorization: "Basic bm9fYXV0aHpfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" } # no_authz_user
+      search:
+        rest_total_hits_as_int: true
+        index: .ds-events-app1*
+  - match: { hits.total: 0 }
+
+  # this user is authorized to use logs-app1 data stream directly
+  - do:
+      headers: { Authorization: "Basic bm9fYXV0aHpfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" } # no_authz_user
+      search:
+        rest_total_hits_as_int: true
+        index: logs-app1
+  - match: { hits.total: 1 }
+  - match: { hits.hits.0._source.bar: baz }
+
+  # this user is authorized to use a backing index of logs-app1 data stream directly
+  - do:
+      headers: { Authorization: "Basic bm9fYXV0aHpfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" } # no_authz_user
+      search:
+        rest_total_hits_as_int: true
+        index: .ds-logs-app1*
+  - match: { hits.total: 1 }
+  - match: { hits.hits.0._source.bar: baz }


### PR DESCRIPTION
Aliases to data streams can be defined on composable index templates
and via the existing update aliases api. Aliases can either only refer to
data streams or to indices. Also the existing get aliases api has been
modified to support returning data stream aliases.

Aliases for data streams are stored independently from data streams and
are stored in `DataStreamMetadata`. This has the benefit when backing
indices are removed from data streams then data stream aliases don't
need to be updated.

With this PR, the authorization model is different than for regular aliases:
* Authorization is determined on the data stream level.
* No authorization is defined on the data stream alias level.
* A data stream alias always resolves to all data streams, 
  but whether the alias can be accessed is depends on whether
  the user is allowed to access all the data streams the alias refers to.

Closes #66163

Demo snippet:

```
PUT /_data_stream/logs-foo-bar

POST /logs-foo-bar/_doc
{
    "@timestamp": "2222-12-12"
}

PUT /_data_stream/logs-bar-baz

POST /logs-bar-baz/_doc
{
    "@timestamp": "3333-12-12"
}

POST /_aliases
{
  "actions" : [
    { "add" : { "index" : "logs-foo-bar", "alias" : "logs" } },
    { "add" : { "index" : "logs-bar-baz", "alias" : "logs" } }
  ]
}
```

`GET /_aliases` yields:

```json
{
    ".ds-ilm-history-5-2021.02.18-000001": {
        "aliases": {}
    },
    ".ds-logs-foo-bar-2021.02.18-000001": {
        "aliases": {}
    },
    ".ds-logs-bar-baz-2021.02.18-000001": {
        "aliases": {}
    },
    "logs-bar-baz": {
        "aliases": {
            "logs": {}
        }
    },
    "logs-foo-bar": {
        "aliases": {
            "logs": {}
        }
    }
}
```

`GET /logs/_search` yields:

```json
{
    "took": 7,
    "timed_out": false,
    "_shards": {
        "total": 2,
        "successful": 2,
        "skipped": 0,
        "failed": 0
    },
    "hits": {
        "total": {
            "value": 2,
            "relation": "eq"
        },
        "max_score": 1,
        "hits": [
            {
                "_index": ".ds-logs-bar-baz-2021.02.18-000001",
                "_id": "BOK2tXcBqlZpXLd0WcFv",
                "_score": 1,
                "_source": {
                    "@timestamp": "3333-12-12"
                }
            },
            {
                "_index": ".ds-logs-foo-bar-2021.02.18-000001",
                "_id": "_eK2tXcBqlZpXLd0TcD5",
                "_score": 1,
                "_source": {
                    "@timestamp": "2222-12-12"
                }
            }
        ]
    }
}
```