### PR TITLE
[master] [DOCS] EQL: Document `like` and `regex` keywords (#68932)

### DIFF
--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -163,6 +163,31 @@ the operator uses a case-sensitive lexicographic order.
 NOTE: `=` is not supported as an equal operator. Use `==` or `:` instead.
 
 [discrete]
+[[eql-syntax-pattern-comparison-keywords]]
+=== Pattern comparison keywords
+
+[source,eql]
+----
+my_field like  "VALUE*"         // case-sensitive wildcard matching
+my_field like~ "value*"         // case-insensitive wildcard matching
+
+my_field regex  "VALUE[^Z].?"   // case-sensitive regex matching
+my_field regex~ "value[^z].?"   // case-insensitive regex matching
+----
+
+`like` (case-sensitive)::
+Returns `true` if the string to the left of the keyword matches a
+<<eql-syntax-wildcards,wildcard pattern>> to the right. Supports
+<<eql-syntax-lookup-operators,list lookups>>. Can only be used to compare
+strings. For case-insensitive matching, use `like~`.
+
+`regex` (case-sensitive)::
+Returns `true` if the string to the left of the keyword matches a regular
+expression to the right. For supported regular expression syntax, see
+<<regexp-syntax>>. Supports <<eql-syntax-lookup-operators,list lookups>>. Can
+only be used to compare strings. For case-insensitive matching, use `regex~`.
+
+[discrete]
 [[limitations-for-comparisons]]
 === Limitations for comparisons
 
@@ -221,13 +246,19 @@ Returns `true` if the condition to the right is `false`.
 
 [source,eql]
 ----
-my_field in ("Foo", "BAR", "BAZ")       // case-sensitive
-my_field in~ ("foo", "bar", "baz")      // case-insensitive
+my_field in ("Value-1", "VALUE2", "VAL3")                 // case-sensitive
+my_field in~ ("value-1", "value2", "val3")                // case-insensitive
 
-my_field not in ("Foo", "BAR", "BAZ")   // case-sensitive
-my_field not in~ ("foo", "bar", "baz")  // case-insensitive
+my_field not in ("Value-1", "VALUE2", "VAL3")             // case-sensitive
+my_field not in~ ("value-1", "value2", "val3")            // case-insensitive
 
-my_field : ("foo", "bar", "baz")        // case-insensitive
+my_field : ("value-1", "value2", "val3")                  // case-insensitive
+
+my_field like  ("Value-*", "VALUE2", "VAL?")              // case-sensitive
+my_field like~ ("value-*", "value2", "val?")              // case-insensitive
+
+my_field regex  ("[vV]alue-[0-9]", "VALUE[^2].?", "VAL3") // case-sensitive
+my_field regex~  ("value-[0-9]", "value[^2].?", "val3")   // case-sensitive
 ----
 
 `in` (case-sensitive)::
@@ -241,6 +272,17 @@ case-insensitive matching, use `not in~`.
 `:` (case-insensitive)::
 Returns `true` if the string is contained in the provided list. Can only be used
 to compare strings.
+
+`like` (case-sensitive)::
+Returns `true` if the string matches a <<eql-syntax-wildcards,wildcard pattern>>
+in the provided list. Can only be used to compare strings. For case-insensitive
+matching, use `like~`.
+
+`regex` (case-sensitive)::
+Returns `true` if the string matches a regular expression pattern in the
+provided list. For supported regular expression syntax, see <<regexp-syntax>>.
+Can only be used to compare strings. For case-insensitive matching, use
+`regex~`.
 
 [discrete]
 [[eql-syntax-math-operators]]
@@ -386,32 +428,39 @@ use a regular string with the `\"` escape sequence.
 [[eql-syntax-wildcards]]
 === Wildcards
 
-For string comparisons using the `:` operator, you can use the `*` and `?`
-wildcards to match specific patterns. The `*` wildcard matches zero or more
-characters:
+For string comparisons using the `:` operator or `like` keyword, you can use the
+`*` and `?` wildcards to match specific patterns. The `*` wildcard matches zero
+or more characters:
 
 [source,eql]
 ----
-my_field : "doc*"  // Matches "doc", "docs", or "document" but not "dos"
-my_field : "*doc"  // Matches "adoc" or "asciidoc"
-my_field : "d*c"   // Matches "doc" or "disc"
+my_field : "doc*"     // Matches "doc", "docs", or "document" but not "DOS"
+my_field : "*doc"     // Matches "adoc" or "asciidoc"
+my_field : "d*c"      // Matches "doc" or "disc"
+
+my_field like "DOC*"  // Matches "DOC", "DOCS", "DOCs", or "DOCUMENT" but not "DOS"
+my_field like "D*C"   // Matches "DOC", "DISC", or "DisC"
 ----
 
 The `?` wildcard matches exactly one character:
 
 [source,eql]
 ----
-my_field : "doc?"  // Matches "docs" but not "doc", "document", or "dos"
-my_field : "?doc"  // Matches "adoc" but not "asciidoc"
-my_field : "d?c"   // Matches "doc" but not "disc"
+my_field : "doc?"     // Matches "docs" but not "doc", "document", or "DOS"
+my_field : "?doc"     // Matches "adoc" but not "asciidoc"
+my_field : "d?c"      // Matches "doc" but not "disc"
+
+my_field like "DOC?"  // Matches "DOCS" or "DOCs" but not "DOC", "DOCUMENT", or "DOS"
+my_field like "D?c"   // Matches "DOC" but not "DISC"
 ----
 
-The `:` operator also supports wildcards in <<eql-syntax-lookup-operators,list
-lookups>>:
+The `:` operator and `like` keyword also support wildcards in
+<<eql-syntax-lookup-operators,list lookups>>:
 
 [source,eql]
 ----
 my_field : ("doc*", "f*o", "ba?", "qux")
+my_field like ("Doc*", "F*O", "BA?", "QUX")
 ----
 
 [discrete]


### PR DESCRIPTION
Backports the following commits to master:
 - [DOCS] EQL: Document `like` and `regex` keywords (#68932)