### PR TITLE
Correctly handle nulls when fetching multiple values from source

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceValueFetcher.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceValueFetcher.java
@@ -61,8 +61,6 @@ public abstract class SourceValueFetcher implements ValueFetcher {
                     for (Object o : (List<?>) value) {
                         if (o != null) {
                             queue.add(o);
-                        } else if (nullValue != null) {
-                            queue.add(nullValue);
                         }
                     }
                 } else {

--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceValueFetcher.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceValueFetcher.java
@@ -58,7 +58,13 @@ public abstract class SourceValueFetcher implements ValueFetcher {
             while (queue.isEmpty() == false) {
                 Object value = queue.poll();
                 if (value instanceof List) {
-                    queue.addAll((List<?>) value);
+                    for (Object o : (List<?>) value) {
+                        if (o != null) {
+                            queue.add(o);
+                        } else if (nullValue != null) {
+                            queue.add(nullValue);
+                        }
+                    }
                 } else {
                     try {
                         Object parsedValue = parseSourceValue(value);


### PR DESCRIPTION
If a field contains a single `null` value that would have been substituted via
a mapper's configured `null_value`, then we return this configured value in
that mapper's value fetcher.  However, we also need to handle the case where
the field contains an array, one of which is `null`.

Fixes #68979