### PR TITLE
[DOCS] Fixes n_gram_encoding in data frame analytics APIs

### DIFF
--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -172,11 +172,11 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=dfas-feature-processors-multi]
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=dfas-feature-processors-multi-proc]
 =======
 
-`ngram_encoding`::::
+`n_gram_encoding`::::
 (object)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=dfas-feature-processors-ngram]
 +
-.Properties of `ngram_encoding`
+.Properties of `n_gram_encoding`
 [%collapsible%open]
 =======
 `feature_prefix`::::

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -619,7 +619,7 @@ The ordered array of custom processors to execute. Must be more than 1.
 end::dfas-feature-processors-multi-proc[]
 
 tag::dfas-feature-processors-ngram[]
-The configuration information necessary to perform ngram encoding. Features 
+The configuration information necessary to perform n-gram encoding. Features 
 written out by this encoder have the following name format: 
 `<feature_prefix>.<ngram><string position>`. For example, if the 
 `feature_prefix` is `f`, the feature name for the second unigram in a string is 
@@ -635,18 +635,18 @@ The name of the text field to encode.
 end::dfas-feature-processors-ngram-field[]
 
 tag::dfas-feature-processors-ngram-length[]
-Specifies the length of the ngram substring. Defaults to `50`. Must be greater 
+Specifies the length of the n-gram substring. Defaults to `50`. Must be greater 
 than `0`.
 end::dfas-feature-processors-ngram-length[]
 
 tag::dfas-feature-processors-ngram-ngrams[]
-Specifies which ngrams to gather. It’s an array of integer values where the 
+Specifies which n-grams to gather. It’s an array of integer values where the 
 minimum value is 1, and a maximum value is 5.
 end::dfas-feature-processors-ngram-ngrams[]
 
 tag::dfas-feature-processors-ngram-start[]
-Specifies the zero-indexed start of the ngram substring. Negative values are 
-allowed for encoding ngram of string suffixes. Defaults to `0`.
+Specifies the zero-indexed start of the n-gram substring. Negative values are 
+allowed for encoding n-grams of string suffixes. Defaults to `0`.
 end::dfas-feature-processors-ngram-start[]
 
 tag::dfas-feature-processors-one-hot[]


### PR DESCRIPTION
This PR fixes incorrect occurrences of `ngram_encoding` in the create data frame analytics jobs API.

It also fixes occurrences of `ngram` in the parameter descriptions, so that they align with the `n-gram` terminology in the [Elastic writing style guide](https://brand.elastic.co/302f66895/p/194a3b-writing-style-guide).