### PR TITLE
Reduce precision of floating point assertions for arm compatibility

### DIFF
--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/normalize/NormalizePipelineMethodsTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/normalize/NormalizePipelineMethodsTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.util.function.DoubleUnaryOperator;
 
+import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.equalTo;
 
 public class NormalizePipelineMethodsTests extends ESTestCase {
@@ -80,7 +81,7 @@ public class NormalizePipelineMethodsTests extends ESTestCase {
             if (Double.isNaN(DATA[i])) {
                 assertTrue(Double.isNaN(normalizedData[i]));
             } else {
-                assertThat(op.applyAsDouble(DATA[i]), equalTo(normalizedData[i]));
+                assertThat(op.applyAsDouble(DATA[i]), closeTo(normalizedData[i], 0.00000000001));
             }
         }
     }


### PR DESCRIPTION
This is meant to address [this test failure](https://gradle-enterprise.elastic.co/s/rcagiikbzpdqi/tests/:x-pack:plugin:analytics:test/org.elasticsearch.xpack.analytics.normalize.NormalizePipelineMethodsTests/testSoftmax#1) on ARM. This is similar to the issue in https://github.com/elastic/elasticsearch/pull/68976 which is that there are subtle differences in FP precision between x86 and ARM which can cause test failures. It's not clear how pervasive this is as we are doing this a bit whack-a-mole style and I'm not aware of a better generic solution for this. Hopefully there's not too many more instances of this.

cc @breskeby 