### PR TITLE
Permit overwritten blobs to be missing

### DIFF
--- a/x-pack/plugin/snapshot-repo-test-kit/qa/rest/build.gradle
+++ b/x-pack/plugin/snapshot-repo-test-kit/qa/rest/build.gradle
@@ -17,7 +17,6 @@ tasks.named("integTest").configure {
 testClusters.matching { it.name == "integTest" }.configureEach {
   testDistribution = 'DEFAULT'
   setting 'path.repo', repoDir.absolutePath
-  setting 'logger.org.elasticsearch.repositories', 'TRACE'
 }
 
 restResources {

--- a/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/RepositoryAnalysisFailureIT.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/RepositoryAnalysisFailureIT.java
@@ -118,7 +118,7 @@ public class RepositoryAnalysisFailureIT extends AbstractSnapshotIntegTestCase {
     public void testFailsOnNotFoundAfterWrite() {
         final RepositoryAnalyzeAction.Request request = new RepositoryAnalyzeAction.Request("test-repo");
         request.maxBlobSize(new ByteSizeValue(10L));
-        request.earlyReadNodeCount(0); // not found on early read is ok
+        request.rareActionProbability(0.0); // not found on an early read or an overwrite is ok
 
         final CountDown countDown = new CountDown(between(1, request.getBlobCount()));
 

--- a/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/BlobAnalyzeAction.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/BlobAnalyzeAction.java
@@ -368,20 +368,7 @@ public class BlobAnalyzeAction extends ActionType<BlobAnalyzeAction.Response> {
                         new ActionListenerResponseHandler<>(new ActionListener<>() {
                             @Override
                             public void onResponse(GetBlobChecksumAction.Response response) {
-                                if (beforeWriteComplete == false && response.isNotFound()) {
-                                    readNodesListener.onFailure(
-                                        new RepositoryVerificationException(
-                                            request.getRepositoryName(),
-                                            "["
-                                                + blobChecksumRequest
-                                                + "] (after write complete) failed on node ["
-                                                + node
-                                                + "]: blob not found"
-                                        )
-                                    );
-                                } else {
-                                    readNodesListener.onResponse(makeNodeResponse(node, beforeWriteComplete, response));
-                                }
+                                readNodesListener.onResponse(makeNodeResponse(node, beforeWriteComplete, response));
                             }
 
                             @Override

--- a/x-pack/plugin/snapshot-repo-test-kit/src/test/java/org/elasticsearch/repositories/blobstore/testkit/AbstractSnapshotRepoTestKitRestTestCase.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/test/java/org/elasticsearch/repositories/blobstore/testkit/AbstractSnapshotRepoTestKitRestTestCase.java
@@ -18,7 +18,6 @@ public abstract class AbstractSnapshotRepoTestKitRestTestCase extends ESRestTest
 
     protected abstract Settings repositorySettings();
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/69087")
     public void testRepositoryAnalysis() throws Exception {
         final String repositoryType = repositoryType();
         final Settings repositorySettings = repositorySettings();


### PR DESCRIPTION
Today blob overwrites are not completely atomic, there is an
intermediate state in which the blob is missing, but the repository
analyser does not fully account for that intermediate state.

This commit relaxes the check for missing blobs if they were
overwritten.

Closes #69087