### PR TITLE
manage_own_api_key not keys

### DIFF
--- a/x-pack/docs/en/security/authorization/privileges.asciidoc
+++ b/x-pack/docs/en/security/authorization/privileges.asciidoc
@@ -78,7 +78,7 @@ roles of the user who created or updated them.
 --
 
 `manage_own_api_key`::
-All security-related operations on {es} API keys that are owned by the current
+All security-related operations on the {es} API key that is owned by the current
 authenticated user. The operations include
 <<security-api-create-api-key,creating new API keys>>,
 <<security-api-get-api-key,retrieving information about API keys>>, and


### PR DESCRIPTION
The docs indicate that one could manage multiple keys which are owned by this user. As each key is independent, it is only possible for a user with `manage_own_api_key` to manipulate their own key (singular). This change makes that subtle difference more explicit.
