### PR TITLE
[7.x] Adding note to IP filter docs to warn about some filters being inherited (#68955)

### DIFF
--- a/x-pack/docs/en/security/using-ip-filtering.asciidoc
+++ b/x-pack/docs/en/security/using-ip-filtering.asciidoc
@@ -23,6 +23,9 @@ You configure IP filtering by specifying the `xpack.security.transport.filter.al
 `xpack.security.transport.filter.deny` settings in in `elasticsearch.yml`. Allow rules
 take precedence over the deny rules.
 
+IMPORTANT: Unless explicitly specified, `xpack.security.http.filter.*` settings default to
+the corresponding `xpack.security.transport.filter.*` setting's value.
+
 [source,yaml]
 --------------------------------------------------
 xpack.security.transport.filter.allow: "192.168.0.1"


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Adding note to IP filter docs to warn about some filters being inherited (#68955)