### PR TITLE
[7.x] [DOCS] Remove keyword/ip from list of unsupported fields in top_metrics agg (#69036)

### DIFF
--- a/docs/reference/aggregations/metrics/top-metrics-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/top-metrics-aggregation.asciidoc
@@ -54,8 +54,7 @@ faster.
 The `sort` field in the metric request functions exactly the same as the `sort` field in the
 <<sort-search-results, search>> request except:
 
-* It can't be used on <<binary,binary>>, <<flattened,flattened>>, <<ip,ip>>,
-<<keyword,keyword>>, or <<text,text>> fields.
+* It can't be used on <<binary,binary>>, <<flattened,flattened>> or <<text,text>> fields.
 * It only supports a single sort value so which document wins ties is not specified.
 
 The metrics that the aggregation returns is the first hit that would be returned by the search


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Remove keyword/ip from list of unsupported fields in top_metrics agg (#69036)