### PR TITLE
[7.x] [DOCS] Remove 7.11.1 coming tag (#69070)

### DIFF
--- a/docs/reference/release-notes/7.11.asciidoc
+++ b/docs/reference/release-notes/7.11.asciidoc
@@ -1,9 +1,6 @@
 [[release-notes-7.11.1]]
 == {es} version 7.11.1
 
-coming::[7.11.1]
-
-
 Also see <<breaking-changes-7.11,Breaking changes in 7.11>>.
 
 [[enhancement-7.11.1]]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Remove 7.11.1 coming tag (#69070)