### PR TITLE
QL: Remove the unnecessary `DateTimeFunction.dateTimeFormat()` (#68788)

### DIFF
--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/planner/ExpressionTranslators.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/planner/ExpressionTranslators.java
@@ -54,7 +54,6 @@ import org.elasticsearch.xpack.ql.type.DataType;
 import org.elasticsearch.xpack.ql.type.DataTypes;
 import org.elasticsearch.xpack.ql.util.Check;
 import org.elasticsearch.xpack.ql.util.CollectionUtils;
-import org.elasticsearch.xpack.ql.util.Holder;
 
 import java.time.OffsetTime;
 import java.time.ZoneId;
@@ -274,12 +273,12 @@ public final class ExpressionTranslators {
             Source source = bc.source();
             String name = handler.nameOf(bc.left());
             Object value = valueOf(bc.right());
-            String format = handler.dateFormat(bc.left());
+            String format = null;
             boolean isDateLiteralComparison = false;
 
             // for a date constant comparison, we need to use a format for the date, to make sure that the format is the same
             // no matter the timezone provided by the user
-            if ((value instanceof ZonedDateTime || value instanceof OffsetTime) && format == null) {
+            if (value instanceof ZonedDateTime || value instanceof OffsetTime) {
                 DateFormatter formatter;
                 if (value instanceof ZonedDateTime) {
                     formatter = DateFormatter.forPattern(DATE_FORMAT);
@@ -346,36 +345,33 @@ public final class ExpressionTranslators {
             Expression val = r.value();
 
             Query query = null;
-            Holder<Object> lower = new Holder<>(valueOf(r.lower()));
-            Holder<Object> upper = new Holder<>(valueOf(r.upper()));
-            Holder<String> format = new Holder<>(handler.dateFormat(val));
+            Object lower = valueOf(r.lower());
+            Object upper = valueOf(r.upper());
+            String format = null;
 
             // for a date constant comparison, we need to use a format for the date, to make sure that the format is the same
             // no matter the timezone provided by the user
-            if (format.get() == null) {
-                DateFormatter formatter = null;
-                if (lower.get() instanceof ZonedDateTime || upper.get() instanceof ZonedDateTime) {
-                    formatter = DateFormatter.forPattern(DATE_FORMAT);
-                } else if (lower.get() instanceof OffsetTime || upper.get() instanceof OffsetTime) {
-                    formatter = DateFormatter.forPattern(TIME_FORMAT);
-                }
-                if (formatter != null) {
-                    // RangeQueryBuilder accepts an Object as its parameter, but it will call .toString() on the ZonedDateTime
-                    // instance which can have a slightly different format depending on the ZoneId used to create the ZonedDateTime
-                    // Since RangeQueryBuilder can handle date as String as well, we'll format it as String and provide the format.
-                    if (lower.get() instanceof ZonedDateTime || lower.get() instanceof OffsetTime) {
-                        lower.set(formatter.format((TemporalAccessor) lower.get()));
-                    }
-                    if (upper.get() instanceof ZonedDateTime || upper.get() instanceof OffsetTime) {
-                        upper.set(formatter.format((TemporalAccessor) upper.get()));
-                    }
-                    format.set(formatter.pattern());
-                }
+            DateFormatter formatter = null;
+            if (lower instanceof ZonedDateTime || upper instanceof ZonedDateTime) {
+                formatter = DateFormatter.forPattern(DATE_FORMAT);
+            } else if (lower instanceof OffsetTime || upper instanceof OffsetTime) {
+                formatter = DateFormatter.forPattern(TIME_FORMAT);
             }
-
-            query = handler.wrapFunctionQuery(r, val, new RangeQuery(r.source(), handler.nameOf(val), lower.get(), r.includeLower(),
-                                                                     upper.get(), r.includeUpper(), format.get(), r.zoneId()));
-
+            if (formatter != null) {
+                // RangeQueryBuilder accepts an Object as its parameter, but it will call .toString() on the ZonedDateTime
+                // instance which can have a slightly different format depending on the ZoneId used to create the ZonedDateTime
+                // Since RangeQueryBuilder can handle date as String as well, we'll format it as String and provide the format.
+                if (lower instanceof ZonedDateTime || lower instanceof OffsetTime) {
+                    lower = formatter.format((TemporalAccessor) lower);
+                }
+                if (upper instanceof ZonedDateTime || upper instanceof OffsetTime) {
+                    upper = formatter.format((TemporalAccessor) upper);
+                }
+                format = formatter.pattern();
+            }
+            query = handler.wrapFunctionQuery(r, val,
+                    new RangeQuery(r.source(), handler.nameOf(val), lower, r.includeLower(), upper, r.includeUpper(), format, r.zoneId()));
+            
             return query;
         }
     }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/planner/QlTranslatorHandler.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/planner/QlTranslatorHandler.java
@@ -41,11 +41,6 @@ public class QlTranslatorHandler implements TranslatorHandler {
     }
 
     @Override
-    public String dateFormat(Expression e) {
-        return null;
-    }
-
-    @Override
     public Object convert(Object value, DataType dataType) {
         return DataTypeConverter.convert(value, dataType);
     }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/planner/TranslatorHandler.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/planner/TranslatorHandler.java
@@ -25,7 +25,5 @@ public interface TranslatorHandler {
 
     String nameOf(Expression e);
 
-    String dateFormat(Expression e);
-
     Object convert(Object value, DataType dataType);
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTimeFunction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTimeFunction.java
@@ -51,9 +51,6 @@ public abstract class DateTimeFunction extends BaseDateTimeFunction {
         return DataTypes.INTEGER;
     }
 
-    // used for applying ranges
-    public abstract String dateTimeFormat();
-
     protected DateTimeExtractor extractor() {
         return extractor;
     }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DayOfMonth.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DayOfMonth.java
@@ -31,8 +31,4 @@ public class DayOfMonth extends DateTimeFunction {
         return new DayOfMonth(source(), newChild, zoneId());
     }
 
-    @Override
-    public String dateTimeFormat() {
-        return "d";
-    }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DayOfYear.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DayOfYear.java
@@ -32,8 +32,4 @@ public class DayOfYear extends DateTimeFunction {
         return new DayOfYear(source(), newChild, zoneId());
     }
 
-    @Override
-    public String dateTimeFormat() {
-        return "D";
-    }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/HourOfDay.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/HourOfDay.java
@@ -31,8 +31,4 @@ public class HourOfDay extends TimeFunction {
         return new HourOfDay(source(), newChild, zoneId());
     }
 
-    @Override
-    public String dateTimeFormat() {
-        return "hour";
-    }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/IsoDayOfWeek.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/IsoDayOfWeek.java
@@ -31,8 +31,4 @@ public class IsoDayOfWeek extends DateTimeFunction {
         return new IsoDayOfWeek(source(), newChild, zoneId());
     }
 
-    @Override
-    public String dateTimeFormat() {
-        return "e";
-    }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/IsoWeekOfYear.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/IsoWeekOfYear.java
@@ -31,8 +31,4 @@ public class IsoWeekOfYear extends DateTimeFunction {
         return new IsoWeekOfYear(source(), newChild, zoneId());
     }
 
-    @Override
-    public String dateTimeFormat() {
-        return "w";
-    }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/MinuteOfDay.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/MinuteOfDay.java
@@ -32,8 +32,4 @@ public class MinuteOfDay extends TimeFunction {
         return new MinuteOfDay(source(), newChild, zoneId());
     }
 
-    @Override
-    public String dateTimeFormat() {
-        return null;
-    }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/MinuteOfHour.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/MinuteOfHour.java
@@ -31,8 +31,4 @@ public class MinuteOfHour extends TimeFunction {
         return new MinuteOfHour(source(), newChild, zoneId());
     }
 
-    @Override
-    public String dateTimeFormat() {
-        return "m";
-    }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/MonthOfYear.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/MonthOfYear.java
@@ -31,8 +31,4 @@ public class MonthOfYear extends DateTimeFunction {
         return new MonthOfYear(source(), newChild, zoneId());
     }
 
-    @Override
-    public String dateTimeFormat() {
-        return "M";
-    }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/SecondOfMinute.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/SecondOfMinute.java
@@ -31,8 +31,4 @@ public class SecondOfMinute extends TimeFunction {
         return new SecondOfMinute(source(), newChild, zoneId());
     }
 
-    @Override
-    public String dateTimeFormat() {
-        return "s";
-    }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/Year.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/Year.java
@@ -34,11 +34,6 @@ public class Year extends DateTimeHistogramFunction {
     }
 
     @Override
-    public String dateTimeFormat() {
-        return "year";
-    }
-
-    @Override
     public String calendarInterval() {
         return Histogram.YEAR_INTERVAL;
     }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/planner/SqlTranslatorHandler.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/planner/SqlTranslatorHandler.java
@@ -16,7 +16,6 @@ import org.elasticsearch.xpack.ql.querydsl.query.GeoDistanceQuery;
 import org.elasticsearch.xpack.ql.querydsl.query.Query;
 import org.elasticsearch.xpack.ql.querydsl.query.ScriptQuery;
 import org.elasticsearch.xpack.ql.type.DataType;
-import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeFunction;
 import org.elasticsearch.xpack.sql.expression.function.scalar.geo.StDistance;
 import org.elasticsearch.xpack.sql.type.SqlDataTypeConverter;
 
@@ -47,14 +46,6 @@ public class SqlTranslatorHandler implements TranslatorHandler {
     @Override
     public String nameOf(Expression e) {
         return QueryTranslator.nameOf(e);
-    }
-
-    @Override
-    public String dateFormat(Expression e) {
-        if (e instanceof DateTimeFunction) {
-            return ((DateTimeFunction) e).dateTimeFormat();
-        }
-        return null;
     }
 
     @Override


### PR DESCRIPTION
Removes the `DateTimeFunction.dateTimeFormat()` and the 
`TranslatorHandler.dateTimeFormat()` methods that were
called, but had no effect on the translated queries.

One of the examples, when this happens, is when one side of the
`BinaryComparison` is a function. The `BinaryComparison` at the
end turns into a `ScriptQuery`, but in the intermediate steps the
`ExpressionTranslators` try to translate it to a `RangeQuery`.

Follows #68783

(cherry-picked from 9ae5753a8e)