### PR TITLE
[7.11] [DOCS] EQL: Update differences from Endgame EQL syntax (#69124)

### DIFF
--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -745,8 +745,7 @@ follows:
 `process_name == "cmd.exe"` is not equivalent to 
 `process_name == "Cmd.exe"`.
 
-* In {es} EQL, functions are case-sensitive. To make a function
-case-insensitive, use `~`, such as `endsWith~(process_name, ".exe")`.
+* In {es} EQL, functions are case-sensitive by default.
 
 * For case-insensitive equality comparisons, use the `:` operator. Both `*` and
 `?` are recognized wildcard characters.

--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -77,7 +77,7 @@ escape event categories that:
 [[eql-syntax-escape-a-field-name]]
 === Escape a field name
 
-Use enclosing enclosing backticks (+++`+++) to escape field names that:
+Use enclosing backticks (+++`+++) to escape field names that:
 
 * Contain a hyphen (`-`)
 * Contain a space
@@ -741,13 +741,19 @@ sub-fields of a `nested` field. However, data streams and indices containing
 {es} EQL differs from the {eql-ref}/index.html[Elastic Endgame EQL syntax] as
 follows:
 
-* Most operators and functions in {es} EQL are case-sensitive. For
-case-insensitive equality comparisons, use the `:` operator.
+* In {es} EQL, most operators are case-sensitive. For example,
+`process_name == "cmd.exe"` is not equivalent to 
+`process_name == "Cmd.exe"`.
 
-* Comparisons using the `==` and `!=` operators do not expand wildcard
-characters. For example, `process_name == "cmd*.exe"` interprets `*` as a
-literal asterisk, not a wildcard. For case-sensitive wildcard matching, use the
-<<eql-fn-wildcard,`wildcard`>> function.
+* In {es} EQL, functions are case-sensitive. To make a function
+case-insensitive, use `~`, such as `endsWith~(process_name, ".exe")`.
+
+* For case-insensitive equality comparisons, use the `:` operator. Both `*` and
+`?` are recognized wildcard characters.
+
+* The `==` and `!=` operators do not expand wildcard characters. For example,
+`process_name == "cmd*.exe"` interprets `*` as a literal asterisk, not a
+wildcard.
 
 * `=` cannot be substituted for the `==` operator.
 


### PR DESCRIPTION
Backports the following commits to 7.11:
 - [DOCS] EQL: Update differences from Endgame EQL syntax (#69124)