### PR TITLE
[7.11] [DOCS] Fix typos for duplicate words (#69125)

### DIFF
--- a/docs/java-rest/high-level/security/get-user-privileges.asciidoc
+++ b/docs/java-rest/high-level/security/get-user-privileges.asciidoc
@@ -22,7 +22,7 @@ This will be the union of all the _cluster_ privileges from the user's roles.
 A `Set` of all _global_ privileges that are held by the user.
 This will be the union of all the _global_ privileges from the user's roles.
 Because this a union of multiple roles, it may contain multiple privileges for
-the same `category` and `operation` (which is why is is represented as a `Set`
+the same `category` and `operation` (which is why it is represented as a `Set`
 rather than a single object).
 
 `indicesPrivileges`::

--- a/docs/java-rest/high-level/security/put-user.asciidoc
+++ b/docs/java-rest/high-level/security/put-user.asciidoc
@@ -8,7 +8,7 @@
 === Put User API
 
 [id="{upid}-{api}-request"]
-==== Put User Request Request
+==== Put User Request
 
 The +{request}+ class is used to create or update a user in the Native Realm.
 There are 3 different factory methods for creating a request.

--- a/docs/plugins/ingest-attachment.asciidoc
+++ b/docs/plugins/ingest-attachment.asciidoc
@@ -140,7 +140,7 @@ PUT _ingest/pipeline/cbor-attachment
 
 The following Python script passes CBOR data to an HTTP indexing request that
 includes the `cbor-attachment` pipeline. The HTTP request headers use a
-a `content-type` of `application/cbor`.
+`content-type` of `application/cbor`.
 
 NOTE: Not all {es} clients support custom HTTP request headers.
 

--- a/docs/reference/aggregations/bucket/datehistogram-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/datehistogram-aggregation.asciidoc
@@ -86,7 +86,7 @@ is the same at the start and end.
 All days begin at the earliest possible time, which is usually 00:00:00
 (midnight).
 One day (1d) is the interval between the start of the day and the start of
-of the following day in the specified time zone, compensating for any intervening
+the following day in the specified time zone, compensating for any intervening
 time changes.
 
 `week`, `1w` ::

--- a/docs/reference/aggregations/metrics/rate-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/rate-aggregation.asciidoc
@@ -195,7 +195,7 @@ GET sales/_search
 --------------------------------------------------
 // TEST[setup:sales]
 <1> Histogram is grouped by month.
-<2> Calculate number of of all sale prices
+<2> Calculate number of all sale prices
 <3> Convert to annual counts
 <4> Changing the mode to value count
 

--- a/docs/reference/analysis/tokenfilters/hunspell-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/hunspell-tokenfilter.asciidoc
@@ -140,7 +140,7 @@ One or more `.dic` files (e.g, `en_US.dic, my_custom.dic`) to use for the
 Hunspell dictionary.
 +
 By default, the `hunspell` filter uses all `.dic` files in the
-`<path.config>/hunspell/<locale>` directory specified specified using the
+`<path.config>/hunspell/<locale>` directory specified using the
 `lang`, `language`, or `locale` parameter. To use another directory, the
 directory's path must be registered using the
 <<indices-analysis-hunspell-dictionary-location,

--- a/docs/reference/docs/data-replication.asciidoc
+++ b/docs/reference/docs/data-replication.asciidoc
@@ -165,7 +165,7 @@ Dirty reads:: An isolated primary can expose writes that will not be acknowledge
 [discrete]
 ==== The Tip of the Iceberg
 
-This document provides a high level overview of how Elasticsearch deals with data. Of course, there is much much more
+This document provides a high level overview of how Elasticsearch deals with data. Of course, there is much more
 going on under the hood. Things like primary terms, cluster state publishing, and master election all play a role in
 keeping this system behaving correctly. This document also doesn't cover known and important
 bugs (both closed and open). We recognize that https://github.com/elastic/elasticsearch/issues?q=label%3Aresiliency[GitHub is hard to keep up with].

--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -71,7 +71,7 @@ POST _reindex
 [[docs-reindex-api-prereqs]]
 ==== {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have the the following
+* If the {es} {security-features} are enabled, you must have the following
 security privileges:
 
 ** The `read` <<privileges-list-indices,index privilege>> for the source data

--- a/docs/reference/glossary.asciidoc
+++ b/docs/reference/glossary.asciidoc
@@ -191,7 +191,7 @@ See the {ref}/indices-forcemerge.html[force merge API].
 // tag::freeze-def-short[]
 Make an index read-only and minimize its memory footprint.
 // end::freeze-def-short[]
-Frozen indices can be searched without incurring the overhead of of re-opening a closed index,
+Frozen indices can be searched without incurring the overhead of re-opening a closed index,
 but searches are throttled and might be slower.
 You can freeze indices to reduce the overhead of keeping older indices searchable
 before you are ready to archive or delete them.

--- a/docs/reference/ilm/actions/ilm-unfollow.asciidoc
+++ b/docs/reference/ilm/actions/ilm-unfollow.asciidoc
@@ -6,7 +6,7 @@ Phases allowed: hot, warm, cold.
 
 Converts a {ref}/ccr-apis.html[{ccr-init}] follower index into a regular index. 
 This enables the shrink, rollover, and searchable snapshot actions
-to be be performed safely on follower indices.
+to be performed safely on follower indices.
 You can also use unfollow directly when moving follower indices through the lifecycle.
 Has no effect on indices that are not followers, phase execution just moves to the next action.
 

--- a/docs/reference/ilm/ilm-tutorial.asciidoc
+++ b/docs/reference/ilm/ilm-tutorial.asciidoc
@@ -314,7 +314,7 @@ when the rollover action is triggered for an index.
 
 You can use the {kib} Create template wizard to add the template. To access the
 wizard, open the menu and go to *Stack Management > Index Management*. In the
-the *Index Templates* tab, click *Create template*.
+*Index Templates* tab, click *Create template*.
 
 [role="screenshot"]
 image:images/ilm/create-template-wizard.png[Create template page]

--- a/docs/reference/ilm/set-up-lifecycle-policy.asciidoc
+++ b/docs/reference/ilm/set-up-lifecycle-policy.asciidoc
@@ -78,7 +78,7 @@ You specify the name of the policy and the alias used to reference the rolling i
 
 You can use the {kib} Create template wizard to create a template. To access the
 wizard, open the menu and go to *Stack Management > Index Management*. In the
-the *Index Templates* tab, click *Create template*.
+*Index Templates* tab, click *Create template*.
 
 [role="screenshot"]
 image:images/ilm/create-template-wizard-my_template.png[Create template page]

--- a/docs/reference/indices/index-templates.asciidoc
+++ b/docs/reference/indices/index-templates.asciidoc
@@ -37,7 +37,7 @@ data streams. If you use the {agent}, assign your index templates a priority
 lower than `100` to avoid overriding the built-in templates. Otherwise, to avoid
 accidentally applying the built-in templates, do one or more of the following:
 
-- To disable all built-index index and component templates, set
+- To disable all built-in index and component templates, set
 <<stack-templates-enabled,`stack.templates.enabled`>> to `false` using the
 <<cluster-update-settings,cluster update settings API>>.
 

--- a/docs/reference/mapping/params/eager-global-ordinals.asciidoc
+++ b/docs/reference/mapping/params/eager-global-ordinals.asciidoc
@@ -43,7 +43,7 @@ circuit breaker>>.
 
 The global ordinal mapping must be built before ordinals can be used during a
 search. By default, the mapping is loaded during search on the first time that
-global ordinals are needed. This is is the right approach if you are optimizing
+global ordinals are needed. This is the right approach if you are optimizing
 for indexing speed, but if search performance is a priority, it's recommended
 to eagerly load global ordinals eagerly on fields that will be used in
 aggregations:

--- a/docs/reference/mapping/types/search-as-you-type.asciidoc
+++ b/docs/reference/mapping/types/search-as-you-type.asciidoc
@@ -207,7 +207,7 @@ the same way.
     Whether field-length should be taken into account when scoring queries.
     Accepts `true` or `false`. This option configures the root field
     and shingle subfields, where its default is `true`. It does not configure
-    the prefix subfield, where it it `false`.
+    the prefix subfield, where it is `false`.
 
 <<mapping-store,`store`>>::
 

--- a/docs/reference/ml/anomaly-detection/apis/update-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/update-datafeed.asciidoc
@@ -126,7 +126,7 @@ POST _ml/datafeeds/datafeed-total-requests/_update
 
 
 When the {dfeed} is updated, you receive the full {dfeed} configuration with
-with the updated values:
+the updated values:
 
 [source,console-result]
 ----

--- a/docs/reference/modules/threadpool.asciidoc
+++ b/docs/reference/modules/threadpool.asciidoc
@@ -214,7 +214,7 @@ node.processors: 2
 There are a few use-cases for explicitly overriding the `node.processors`
 setting:
 
-. If you are running multiple instances of {es} on the same host but want want
+. If you are running multiple instances of {es} on the same host but want
 {es} to size its thread pools as if it only has a fraction of the CPU, you
 should override the `node.processors` setting to the desired fraction, for
 example, if you're running two instances of {es} on a 16-core machine, set

--- a/docs/reference/monitoring/collecting-monitoring-data.asciidoc
+++ b/docs/reference/monitoring/collecting-monitoring-data.asciidoc
@@ -42,7 +42,7 @@ For more information, see <<monitoring-settings>> and <<cluster-update-settings>
 --
 
 .. Set the `xpack.monitoring.collection.enabled` setting to `true` on each
-node in the cluster. By default, it is is disabled (`false`).
+node in the cluster. By default, it is disabled (`false`).
 +
 --
 NOTE: You can specify this setting in either the `elasticsearch.yml` on each

--- a/docs/reference/monitoring/configuring-metricbeat.asciidoc
+++ b/docs/reference/monitoring/configuring-metricbeat.asciidoc
@@ -19,7 +19,7 @@ image::monitoring/images/metricbeat.png[Example monitoring architecture]
 --
 // tag::enable-collection[]
 Set `xpack.monitoring.collection.enabled` to `true` on the
-production cluster. By default, it is is disabled (`false`). 
+production cluster. By default, it is disabled (`false`). 
 
 You can use the following APIs to review and change this setting:
 

--- a/docs/reference/rollup/rollup-getting-started.asciidoc
+++ b/docs/reference/rollup/rollup-getting-started.asciidoc
@@ -165,7 +165,7 @@ GET /sensor_rollup/_rollup_search
 --------------------------------------------------
 // TEST[setup:sensor_prefab_data]
 
-It's a simple aggregation that calculates the maximum of the `temperature` field.  But you'll notice that is is being sent to the `sensor_rollup`
+It's a simple aggregation that calculates the maximum of the `temperature` field.  But you'll notice that it is being sent to the `sensor_rollup`
 index instead of the raw `sensor-*` indices.  And you'll also notice that it is using the `_rollup_search` endpoint.  Otherwise the syntax
 is exactly as you'd expect.
 

--- a/docs/reference/search/search-your-data/long-running-searches.asciidoc
+++ b/docs/reference/search/search-your-data/long-running-searches.asciidoc
@@ -4,7 +4,7 @@
 == Long-running searches
 
 {es} generally allows you to quickly search across big amounts of data. There are
-situations where a search executes on many many shards, possibly against
+situations where a search executes on many shards, possibly against
 <<frozen-indices,frozen indices>> and spanning multiple
 <<modules-remote-clusters,remote clusters>>, for which
 results are not expected to be returned in milliseconds. When you need to

--- a/docs/reference/sql/functions/grouping.asciidoc
+++ b/docs/reference/sql/functions/grouping.asciidoc
@@ -96,5 +96,5 @@ have returned the year 2018 for a date that's actually in 2019. With calendar in
 February 5th, 2019 actually belonging to the 2019 year bucket. 
 
 [IMPORTANT]
-Histogram in SQL cannot be applied applied on **TIME** type.
+Histogram in SQL cannot be applied on **TIME** type.
 E.g.: `HISTOGRAM(CAST(birth_date AS TIME), INTERVAL '10' MINUTES)` is currently not supported.

--- a/x-pack/docs/en/rest-api/security/create-role-mappings.asciidoc
+++ b/x-pack/docs/en/rest-api/security/create-role-mappings.asciidoc
@@ -271,7 +271,7 @@ following mapping matches any user where *all* of these conditions are met:
 
 - the _Distinguished Name_ matches the pattern `*,ou=admin,dc=example,dc=com`,
   or the username is `es-admin`, or the username is `es-system`
-- the user in in the `cn=people,dc=example,dc=com` group
+- the user in the `cn=people,dc=example,dc=com` group
 - the user does not have a `terminated_date`
 
 

--- a/x-pack/docs/en/rest-api/watcher/execute-watch.asciidoc
+++ b/x-pack/docs/en/rest-api/watcher/execute-watch.asciidoc
@@ -129,7 +129,7 @@ user is allowed to read index `a`, but not index `b`, then the exact same set of
 rules will apply during execution of a watch.
 
 When using the execute watch API, the authorization data of the user that
-called the API will be used as a base, instead of of the information who stored
+called the API will be used as a base, instead of the information who stored
 the watch.
 
 //[[watcher-api-execute-watch-response-body]]

--- a/x-pack/docs/en/security/auditing/enable-audit-logging.asciidoc
+++ b/x-pack/docs/en/security/auditing/enable-audit-logging.asciidoc
@@ -17,7 +17,7 @@ TIP: Audit logs are only available on certain subscription levels.
 For more information, see {subscriptions}.
 --
 
-To enable enable audit logging:
+To enable audit logging:
 
 . Set `xpack.security.audit.enabled` to `true` in `elasticsearch.yml`.
 . Restart {es}.

--- a/x-pack/docs/en/security/authentication/kerberos-realm.asciidoc
+++ b/x-pack/docs/en/security/authentication/kerberos-realm.asciidoc
@@ -33,7 +33,7 @@ Kerberos V5 principal names are of format `primary/instance@REALM`, where
 by a slash(`/`) from the primary. For a user, usually it is not used; for
 service hosts, it is the fully qualified domain name of the host.
 
-`REALM` is the Kerberos realm. Usually it is is the domain name in upper case.
+`REALM` is the Kerberos realm. Usually it is the domain name in upper case.
 An example of a typical user principal is `user@ES.DOMAIN.LOCAL`. An example of 
 a typical service principal is `HTTP/es.domain.local@ES.DOMAIN.LOCAL`.
 --

--- a/x-pack/docs/en/security/authentication/oidc-guide.asciidoc
+++ b/x-pack/docs/en/security/authentication/oidc-guide.asciidoc
@@ -601,7 +601,7 @@ APIs require authentication and the necessary authorization level for the authen
 user. For this reason, a Service Account user needs to be created and assigned a role
 that gives them the `manage_oidc` cluster privilege. The use of the `manage_token`
 cluster privilege will be necessary after the authentication takes place, so that the
-the user can maintain access or be subsequently logged out.
+user can maintain access or be subsequently logged out.
 
 [source,console]
 --------------------------------------------------

--- a/x-pack/docs/en/security/ccs-clients-integrations/monitoring.asciidoc
+++ b/x-pack/docs/en/security/ccs-clients-integrations/monitoring.asciidoc
@@ -2,7 +2,7 @@
 === Monitoring and security
 
 The {stack} {monitor-features} consist of two components:
-an agent that you install on on each {es} and Logstash node, and a Monitoring UI
+an agent that you install on each {es} and Logstash node, and a Monitoring UI
 in {kib}. The monitoring agent collects and indexes metrics from the nodes
 and you visualize the data through the Monitoring dashboards in {kib}. The agent
 can index data on the same {es} cluster, or send it to an external

--- a/x-pack/docs/en/security/reference/files.asciidoc
+++ b/x-pack/docs/en/security/reference/files.asciidoc
@@ -12,7 +12,7 @@ The {es} {security-features} use the following files:
   the `file` realm. See <<file-realm>>.
 
 * `ES_PATH_CONF/elasticsearch-users_roles` defines the user roles assignment for the
-  the `file` realm. See <<file-realm>>.
+  `file` realm. See <<file-realm>>.
 
 * `ES_PATH_CONF/role_mapping.yml` defines the role assignments for a
   Distinguished Name (DN) to a role. This allows for LDAP and Active Directory

--- a/x-pack/docs/en/security/securing-communications/tutorial-tls-internode.asciidoc
+++ b/x-pack/docs/en/security/securing-communications/tutorial-tls-internode.asciidoc
@@ -8,7 +8,7 @@ the cluster to use these files.
 
 IMPORTANT: When you enable {es} {security-features}, unless you have a trial
 license, you must use Transport Layer Security (TLS) to encrypt internode
-communication. By following the steps in this tutorial tutorial, you learn how
+communication. By following the steps in this tutorial, you learn how
 to meet the minimum requirements to pass the
 <<bootstrap-checks-tls,TLS bootstrap check>>.
 

--- a/x-pack/docs/en/security/using-ip-filtering.asciidoc
+++ b/x-pack/docs/en/security/using-ip-filtering.asciidoc
@@ -20,7 +20,7 @@ The {es} {security-features} contain an access control feature that allows or
 rejects hosts, domains, or subnets.
 
 You configure IP filtering by specifying the `xpack.security.transport.filter.allow` and
-`xpack.security.transport.filter.deny` settings in in `elasticsearch.yml`. Allow rules
+`xpack.security.transport.filter.deny` settings in `elasticsearch.yml`. Allow rules
 take precedence over the deny rules.
 
 IMPORTANT: Unless explicitly specified, `xpack.security.http.filter.*` settings default to

--- a/x-pack/docs/en/watcher/example-watches/example-watch-meetupdata.asciidoc
+++ b/x-pack/docs/en/watcher/example-watches/example-watch-meetupdata.asciidoc
@@ -55,7 +55,7 @@ curl http://stream.meetup.com/2/rsvps | bin/logstash -f livestream.conf
 // NOTCONSOLE
 -- 
 
-Now that you're indexing the meetup RSVPs, you can set up a watch that lets you know about events you might be interested in. For example, let's create a watch that runs every hour, looks for events that talk about about _Open Source_, and sends an email with information about the events.
+Now that you're indexing the meetup RSVPs, you can set up a watch that lets you know about events you might be interested in. For example, let's create a watch that runs every hour, looks for events that talk about _Open Source_, and sends an email with information about the events.
 
 
 To set up the watch:


### PR DESCRIPTION
Backports the following commits to 7.11:
 - [DOCS] Fix typos for duplicate words (#69125)