### PR TITLE
Docs: Add example fetching keyword in top_metrics

### DIFF
--- a/docs/reference/aggregations/metrics/top-metrics-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/top-metrics-aggregation.asciidoc
@@ -54,7 +54,8 @@ faster.
 The `sort` field in the metric request functions exactly the same as the `sort` field in the
 <<sort-search-results, search>> request except:
 
-* It can't be used on <<binary,binary>>, <<flattened,flattened>> or <<text,text>> fields.
+* It can't be used on <<binary,binary>>, <<flattened,flattened>>, <<ip,ip>>,
+  <<keyword,keyword>>, or <<text,text>> fields.
 * It only supports a single sort value so which document wins ties is not specified.
 
 The metrics that the aggregation returns is the first hit that would be returned by the search
@@ -71,6 +72,7 @@ request. So,
 `metrics` selects the fields of the "top" document to return. You can request
 a single metric with something like `"metric": {"field": "m"}` or multiple
 metrics by requesting a list of metrics like `"metric": [{"field": "m"}, {"field": "i"}`.
+The fields can be <<numbers,number>>, <<keywords,keyword>>, or <<ips,ip>>.
 Here is a more complete example:
 
 [source,console,id=search-aggregations-metrics-top-metrics-list-of-metrics]
@@ -85,11 +87,11 @@ PUT /test
 }
 POST /test/_bulk?refresh
 {"index": {}}
-{"s": 1, "m": 3.1415, "i": 1, "d": "2020-01-01T00:12:12Z"}
+{"s": 1, "m": 3.1415, "i": 1, "d": "2020-01-01T00:12:12Z", "t": "cat"}
 {"index": {}}
-{"s": 2, "m": 1.0, "i": 6, "d": "2020-01-02T00:12:12Z"}
+{"s": 2, "m": 1.0, "i": 6, "d": "2020-01-02T00:12:12Z", "t": "dog"}
 {"index": {}}
-{"s": 3, "m": 2.71828, "i": -12, "d": "2019-12-31T00:12:12Z"}
+{"s": 3, "m": 2.71828, "i": -12, "d": "2019-12-31T00:12:12Z", "t": "chicken"}
 POST /test/_search?filter_path=aggregations
 {
   "aggs": {
@@ -98,7 +100,8 @@ POST /test/_search?filter_path=aggregations
         "metrics": [
           {"field": "m"},
           {"field": "i"},
-          {"field": "d"}
+          {"field": "d"},
+          {"field": "t.keyword"}
         ],
         "sort": {"s": "desc"}
       }
@@ -119,7 +122,8 @@ Which returns:
         "metrics": {
           "m": 2.718280076980591,
           "i": -12,
-          "d": "2019-12-31T00:12:12.000Z"
+          "d": "2019-12-31T00:12:12.000Z",
+          "t.keyword": "chicken"
         }
       } ]
     }

--- a/docs/reference/aggregations/metrics/top-metrics-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/top-metrics-aggregation.asciidoc
@@ -72,7 +72,7 @@ request. So,
 `metrics` selects the fields of the "top" document to return. You can request
 a single metric with something like `"metric": {"field": "m"}` or multiple
 metrics by requesting a list of metrics like `"metric": [{"field": "m"}, {"field": "i"}`.
-The fields can be <<numbers,number>>, <<keywords,keyword>>, or <<ips,ip>>.
+The fields can be <<number,numbers>>, <<keyword,keywords>>, or <<ip,ips>>.
 Here is a more complete example:
 
 [source,console,id=search-aggregations-metrics-top-metrics-list-of-metrics]


### PR DESCRIPTION
Adds an example of fetching a keyword field.
