### PR TITLE
[ML] fixing rare `_close` API timeout bug

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManager.java
@@ -521,6 +521,12 @@ public class AutodetectProcessManager implements ClusterStateListener {
                         logger.debug("Aborted opening job [{}] as it has been closed", job.getId());
                         return;
                     }
+                    // We check again after the process state is locked, but doing a which `isClosing` check here
+                    if (processContext.getJobTask().isClosing()) {
+                        logger.debug("Aborted opening job [{}] as it is being closed", job.getId());
+                        jobTask.markAsCompleted();
+                        return;
+                    }
 
                     try {
                         if (createProcessAndSetRunning(processContext, job, params, closeHandler)) {
@@ -575,6 +581,11 @@ public class AutodetectProcessManager implements ClusterStateListener {
             if (processContext.getState() != ProcessContext.ProcessStateName.NOT_RUNNING) {
                 logger.debug("Cannot open job [{}] when its state is [{}]",
                     job.getId(), processContext.getState().getClass().getName());
+                return false;
+            }
+            if (processContext.getJobTask().isClosing()) {
+                logger.debug("Cannot open job [{}] as it is closing", job.getId());
+                processContext.getJobTask().markAsCompleted();
                 return false;
             }
             AutodetectCommunicator communicator = create(processContext.getJobTask(), job, params, handler);
@@ -714,7 +725,7 @@ public class AutodetectProcessManager implements ClusterStateListener {
         // it is reachable to enable killing a job while it is closing
         ProcessContext processContext = processByAllocation.get(allocationId);
         if (processContext == null) {
-            logger.debug("Cannot close job [{}] as it has already been closed", jobId);
+            logger.debug("Cannot close job [{}] as it has already been closed or is closing", jobId);
             return;
         }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManager.java
@@ -521,7 +521,7 @@ public class AutodetectProcessManager implements ClusterStateListener {
                         logger.debug("Aborted opening job [{}] as it has been closed", job.getId());
                         return;
                     }
-                    // We check again after the process state is locked, but doing a which `isClosing` check here
+                    // We check again after the process state is locked to ensure no race conditions are hit.
                     if (processContext.getJobTask().isClosing()) {
                         logger.debug("Aborted opening job [{}] as it is being closed", job.getId());
                         jobTask.markAsCompleted();

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/task/JobTask.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/task/JobTask.java
@@ -23,6 +23,7 @@ public class JobTask extends AllocatedPersistentTask implements OpenJobAction.Jo
 
     private final String jobId;
     private volatile AutodetectProcessManager autodetectProcessManager;
+    private volatile boolean isClosing = false;
 
     JobTask(String jobId, long id, String type, String action, TaskId parentTask, Map<String, String> headers) {
         super(id, type, action, "job-" + jobId, parentTask, headers);
@@ -44,7 +45,12 @@ public class JobTask extends AllocatedPersistentTask implements OpenJobAction.Jo
         autodetectProcessManager.killProcess(this, false, reason);
     }
 
+    public boolean isClosing() {
+        return isClosing;
+    }
+
     public void closeJob(String reason) {
+        isClosing = true;
         autodetectProcessManager.closeJob(this, false, reason);
     }
 

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/set_upgrade_mode.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/set_upgrade_mode.yml
@@ -64,7 +64,11 @@ setup:
       cluster.put_settings:
         body: >
           {
-             "transient": {"logger.org.elasticsearch.xpack.ml.action.TransportSetUpgradeModeAction": "TRACE" }
+            "transient": {
+              "logger.org.elasticsearch.xpack.ml.action.TransportSetUpgradeModeAction": "TRACE",
+              "logger.org.elasticsearch.xpack.ml.action.TransportCloseJobAction": "TRACE",
+              "logger.org.elasticsearch.xpack.ml.job.process.autodetect.AutodetectProcessManager": "TRACE"
+            }
           }
 
 ---
@@ -79,9 +83,6 @@ teardown:
 
 ---
 "Test setting upgrade_mode to false when it is already false":
-  - skip:
-      version: all
-      reason: Bug fix url https://github.com/elastic/elasticsearch/issues/65947
   - do:
       ml.start_datafeed:
         datafeed_id: set-upgrade-mode-job-datafeed
@@ -108,9 +109,6 @@ teardown:
 
 ---
 "Setting upgrade_mode to enabled":
-  - skip:
-      version: all
-      reason: Bug fix url https://github.com/elastic/elasticsearch/issues/65947
   - do:
       ml.start_datafeed:
         datafeed_id: set-upgrade-mode-job-datafeed
@@ -160,9 +158,6 @@ teardown:
 
 ---
 "Setting upgrade mode to disabled from enabled":
-  - skip:
-      version: all
-      reason: Bug fix url https://github.com/elastic/elasticsearch/issues/65947
   - do:
       ml.start_datafeed:
         datafeed_id: set-upgrade-mode-job-datafeed
@@ -235,9 +230,6 @@ teardown:
 
 ---
 "Attempt to open job when upgrade_mode is enabled":
-  - skip:
-      version: all
-      reason: Bug fix url https://github.com/elastic/elasticsearch/issues/65947
   - do:
       ml.put_job:
         job_id: failing-set-upgrade-mode-job


### PR DESCRIPTION
There is a sneaky bug that occurs in testing when we close jobs.

It appears that if a job is just recently assigned to a node (and in the process of reopening). When this occurs a call to `_close` will eventually timeout.

We don’t actually close the job if it is assigned to a node but does not yet have a native process. There is a window where we ignore the `CLOSING` state and the continue to create the process context and even overwrite the `CLOSING` state back to OPENED.

The close API thinks the job is already closed because it doesn’t have a native process. The job continues executing as it never checks again if it is closing. The model snapshot revert that was added to when a job starts executing on a node has only exacerbated an existing bug.

End users could potentially see this bug, but the recovery from it is easy. They can simply call `_close` again and it will work. 

closes #65947