### PR TITLE
Scripting: augmented javadoc to api spec (#69082)

### DIFF
--- a/modules/lang-painless/build.gradle
+++ b/modules/lang-painless/build.gradle
@@ -124,6 +124,7 @@ tasks.register("generateContextApiSpec", DefaultTestClustersTask) {
       classpath = sourceSets.doc.runtimeClasspath
       systemProperty "cluster.uri", "${-> testClusters.generateContextApiSpecCluster.singleNode().getAllHttpSocketURI().get(0)}"
       systemProperty "jdksrc", System.getProperty("jdksrc")
+      systemProperty "packageSources", System.getProperty("packageSources")
     }.assertNormalExitValue()
   }
 }

--- a/modules/lang-painless/src/doc/java/org/elasticsearch/painless/ContextApiSpecGenerator.java
+++ b/modules/lang-painless/src/doc/java/org/elasticsearch/painless/ContextApiSpecGenerator.java
@@ -23,7 +23,10 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class ContextApiSpecGenerator {
     public static void main(String[] args) throws IOException {
@@ -77,28 +80,58 @@ public class ContextApiSpecGenerator {
         if (jdksrc == null || "".equals(jdksrc)) {
             return null;
         }
-        return new JavaClassFilesystemResolver(PathUtils.get(jdksrc));
+        String packageSourcesString = System.getProperty("packageSources");
+        if (packageSourcesString == null || "".equals(packageSourcesString)) {
+            return new JavaClassFilesystemResolver(PathUtils.get(jdksrc));
+        }
+        HashMap<String, Path> packageSources = new HashMap<>();
+        for (String packageSourceString: packageSourcesString.split(";")) {
+            String[] packageSource = packageSourceString.split(":", 2);
+            if (packageSource.length != 2) {
+                throw new IllegalArgumentException(
+                    "Bad format for packageSources. Format <package0>:<path0>;<package1>:<path1> ..."
+                );
+            }
+            packageSources.put(packageSource[0], PathUtils.get(packageSource[1]));
+        }
+        return new JavaClassFilesystemResolver(PathUtils.get(jdksrc), packageSources);
     }
 
     public static class JavaClassFilesystemResolver implements JavaClassResolver {
         private final Path root;
+        private final Map<String, Path> pkgRoots;
 
         public JavaClassFilesystemResolver(Path root) {
             this.root = root;
+            this.pkgRoots = Collections.emptyMap();
+        }
+
+        public JavaClassFilesystemResolver(Path root, Map<String, Path> pkgRoots) {
+            this.root = root;
+            this.pkgRoots = pkgRoots;
         }
 
         @SuppressForbidden(reason = "resolve class file from java src directory with environment")
         public InputStream openClassFile(String className) throws IOException {
             // TODO(stu): handle primitives & not stdlib
-            if (className.contains(".") && className.startsWith("java")) {
+            if (className.contains(".")) {
                 int dollarPosition = className.indexOf("$");
                 if (dollarPosition >= 0) {
                     className = className.substring(0, dollarPosition);
                 }
-                String[] packages = className.split("\\.");
-                String path = String.join("/", packages);
-                Path classPath = root.resolve(path + ".java");
-                return new FileInputStream(classPath.toFile());
+                if (className.startsWith("java")) {
+                    String[] packages = className.split("\\.");
+                    String path = String.join("/", packages);
+                    Path classPath = root.resolve(path + ".java");
+                    return new FileInputStream(classPath.toFile());
+                } else {
+                    String packageName = className.substring(0, className.lastIndexOf("."));
+                    Path root = pkgRoots.get(packageName);
+                    if (root != null) {
+                        Path classPath = root.resolve(className.substring(className.lastIndexOf(".") + 1) + ".java");
+                        return new FileInputStream(classPath.toFile());
+                    }
+                }
             }
             return new InputStream() {
                 @Override

--- a/modules/lang-painless/src/doc/java/org/elasticsearch/painless/PainlessInfoJson.java
+++ b/modules/lang-painless/src/doc/java/org/elasticsearch/painless/PainlessInfoJson.java
@@ -223,7 +223,11 @@ public class PainlessInfoJson {
 
                 JavadocExtractor.ParsedMethod parsedMethod = parsed.getMethod(name, parameterTypes);
                 if ((parsedMethod == null || parsedMethod.isEmpty()) && className.equals(info.getDeclaring()) == false) {
-                    parsedMethod = extractor.parseClass(info.getDeclaring()).getMethod(name, parameterTypes);
+                    JavadocExtractor.ParsedJavaClass parsedDeclared = extractor.parseClass(info.getDeclaring());
+                    parsedMethod = parsedDeclared.getMethod(name, parameterTypes);
+                    if (parsedMethod == null) {
+                        parsedMethod = parsedDeclared.getAugmentedMethod(name, javaNamesToDisplayNames.get(className), parameterTypes);
+                    }
                 }
                 if (parsedMethod != null) {
                     javadoc = parsedMethod.javadoc;


### PR DESCRIPTION
Accept system property `packageSources` with mapping of
package names to source roots.

Format `<package0>:<path0>;<package1>:<path1>`.

Checks ESv2 License in addition to GPLv2.

