### PR TITLE
Remove support for JAVA_HOME

### DIFF
--- a/distribution/src/bin/elasticsearch-env
+++ b/distribution/src/bin/elasticsearch-env
@@ -63,7 +63,7 @@ fi
 
 # warn that we are not observing the value of JAVA_HOME
 if [ ! -z "$JAVA_HOME" ]; then
-  echo "warning: ignoring JAVA_HOME=$JAVA_HOME; using $JAVA_TYPE"
+  echo "warning: ignoring JAVA_HOME=$JAVA_HOME; using $JAVA_TYPE" >&2
 fi
 
 # JAVA_OPTS is not a built-in JVM mechanism but some people think it is so we

--- a/distribution/src/bin/elasticsearch-env
+++ b/distribution/src/bin/elasticsearch-env
@@ -39,11 +39,6 @@ ES_CLASSPATH="$ES_HOME/lib/*"
 if [ ! -z "$ES_JAVA_HOME" ]; then
   JAVA="$ES_JAVA_HOME/bin/java"
   JAVA_TYPE="ES_JAVA_HOME"
-elif [ ! -z "$JAVA_HOME" ]; then
-  # fallback to JAVA_HOME
-  echo "warning: usage of JAVA_HOME is deprecated, use ES_JAVA_HOME" >&2
-  JAVA="$JAVA_HOME/bin/java"
-  JAVA_TYPE="JAVA_HOME"
 else
   # use the bundled JDK (default)
   if [ "$(uname -s)" = "Darwin" ]; then
@@ -64,6 +59,11 @@ fi
 if [ ! -z "$JAVA_TOOL_OPTIONS" ]; then
   echo "warning: ignoring JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
   unset JAVA_TOOL_OPTIONS
+fi
+
+# warn that we are not observing the value of JAVA_HOME
+if [ ! -z "$JAVA_HOME" ]; then
+  echo "warning: ignoring JAVA_HOME=$JAVA_HOME; using $JAVA_TYPE"
 fi
 
 # JAVA_OPTS is not a built-in JVM mechanism but some people think it is so we

--- a/distribution/src/bin/elasticsearch-env.bat
+++ b/distribution/src/bin/elasticsearch-env.bat
@@ -66,7 +66,7 @@ if defined JAVA_TOOL_OPTIONS (
 
 rem warn that we are not observing the value of $JAVA_HOME
 if defined JAVA_HOME (
-  echo warning: ignoring JAVA_HOME=%JAVA_HOME%; using %JAVA_TYPE%
+  echo warning: ignoring JAVA_HOME=%JAVA_HOME%; using %JAVA_TYPE% >&2
 )
 
 rem JAVA_OPTS is not a built-in JVM mechanism but some people think it is so we

--- a/distribution/src/bin/elasticsearch-env.bat
+++ b/distribution/src/bin/elasticsearch-env.bat
@@ -35,23 +35,17 @@ if "%ES_BUNDLED_JDK%" == "false" (
 
 cd /d "%ES_HOME%"
 
-rem now set the path to java, pass "nojava" arg to skip setting JAVA_HOME and JAVA
+rem now set the path to java, pass "nojava" arg to skip setting ES_JAVA_HOME and JAVA
 if "%1" == "nojava" (
    exit /b
 )
 
 rem comparing to empty string makes this equivalent to bash -v check on env var
 rem and allows to effectively force use of the bundled jdk when launching ES
-rem by setting JAVA_HOME=
+rem by setting ES_JAVA_HOME=
 if defined ES_JAVA_HOME (
   set JAVA="%ES_JAVA_HOME%\bin\java.exe"
   set JAVA_TYPE=ES_JAVA_HOME
-) else if defined JAVA_HOME (
-  rem fallback to JAVA_HOME
-  echo "warning: usage of JAVA_HOME is deprecated, use ES_JAVA_HOME" >&2
-  set JAVA="%JAVA_HOME%\bin\java.exe"
-  set "ES_JAVA_HOME=%JAVA_HOME%"
-  set JAVA_TYPE=JAVA_HOME
 ) else (
   rem use the bundled JDK (default)
   set JAVA="%ES_HOME%\jdk\bin\java.exe"
@@ -68,6 +62,11 @@ rem do not let JAVA_TOOL_OPTIONS slip in (as the JVM does by default)
 if defined JAVA_TOOL_OPTIONS (
   echo warning: ignoring JAVA_TOOL_OPTIONS=%JAVA_TOOL_OPTIONS%
   set JAVA_TOOL_OPTIONS=
+)
+
+rem warn that we are not observing the value of $JAVA_HOME
+if defined JAVA_HOME (
+  echo warning: ignoring JAVA_HOME=%JAVA_HOME%; using %JAVA_TYPE%
 )
 
 rem JAVA_OPTS is not a built-in JVM mechanism but some people think it is so we

--- a/docs/reference/migration/migrate_8_0/packaging.asciidoc
+++ b/docs/reference/migration/migrate_8_0/packaging.asciidoc
@@ -25,7 +25,7 @@ fail.
 the bundled JDK (preferable), or set `ES_JAVA_HOME`.
 
 *Impact* +
-Use the bundled JDK (preferable), or set `ES_JAVA_HOME`. `JAVA_HOME` will
-silently be ignored.
+Use the bundled JDK (preferable), or set `ES_JAVA_HOME`. `JAVA_HOME` will be
+ignored.
 ====
 //end::notable-breaking-changes[]

--- a/docs/reference/migration/migrate_8_0/packaging.asciidoc
+++ b/docs/reference/migration/migrate_8_0/packaging.asciidoc
@@ -15,3 +15,17 @@ Use Java 11 or higher. Attempts to run {es} 8.0 using earlier Java versions will
 fail.
 ====
 //end::notable-breaking-changes[]
+
+//tag::notable-breaking-changes[]
+.JAVA_HOME is no longer supported.
+[%collapsible]
+====
+*Details* +
+`JAVA_HOME` is no longer supported to set the path for the JDK. Instead, use
+the bundled JDK (preferable), or set `ES_JAVA_HOME`.
+
+*Impact* +
+Use the bundled JDK (preferable), or set `ES_JAVA_HOME`. `JAVA_HOME` will
+silently be ignored.
+====
+//end::notable-breaking-changes[]

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/ArchiveTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/ArchiveTests.java
@@ -37,7 +37,6 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.emptyString;
-import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assume.assumeThat;
 import static org.junit.Assume.assumeTrue;

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/ArchiveTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/ArchiveTests.java
@@ -37,6 +37,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assume.assumeThat;
 import static org.junit.Assume.assumeTrue;
@@ -147,7 +148,8 @@ public class ArchiveTests extends PackagingTestCase {
         assertThat(FileUtils.slurpAllLogs(installation.logs, "elasticsearch.log", "*.log.gz"), containsString(systemJavaHome1));
     }
 
-    public void test51JavaHomeOverride() throws Exception {
+    public void test51JavaHomeIgnored() throws Exception {
+        assumeTrue(distribution().hasJdk);
         Platforms.onLinux(() -> {
             String systemJavaHome1 = sh.run("echo $SYSTEM_JAVA_HOME").stdout.trim();
             sh.getEnv().put("JAVA_HOME", systemJavaHome1);
@@ -163,40 +165,15 @@ public class ArchiveTests extends PackagingTestCase {
 
         final Installation.Executables bin = installation.executables();
         final Result runResult = sh.run(bin.elasticsearch.toString() + " -V");
-        assertThat(runResult.stderr, containsString("warning: usage of JAVA_HOME is deprecated, use ES_JAVA_HOME"));
+        assertThat(runResult.stderr, containsString("warning: ignoring JAVA_HOME=" + systemJavaHome + "; using bundled JDK"));
 
         startElasticsearch();
         ServerUtils.runElasticsearchTests();
         stopElasticsearch();
 
-        String systemJavaHome1 = sh.getEnv().get("JAVA_HOME");
-        assertThat(FileUtils.slurpAllLogs(installation.logs, "elasticsearch.log", "*.log.gz"), containsString(systemJavaHome1));
-    }
-
-    public void test51EsJavaHomeOverrideOverridesJavaHome() throws Exception {
-        Platforms.onLinux(() -> {
-            String systemJavaHome1 = sh.run("echo $SYSTEM_JAVA_HOME").stdout.trim();
-            sh.getEnv().put("ES_JAVA_HOME", systemJavaHome1);
-            // deliberately set to a location that does not exist, if ES_JAVA_HOME takes precedence this is ignored
-            sh.getEnv().put("JAVA_HOME", "doesnotexist");
-        });
-        Platforms.onWindows(() -> {
-            final String systemJavaHome1 = sh.run("$Env:SYSTEM_JAVA_HOME").stdout.trim();
-            sh.getEnv().put("ES_JAVA_HOME", systemJavaHome1);
-            // deliberately set to a location that does not exist, if ES_JAVA_HOME takes precedence this is ignored
-            sh.getEnv().put("JAVA_HOME", "doesnotexist");
-        });
-
-        final Installation.Executables bin = installation.executables();
-        final Result runResult = sh.run(bin.elasticsearch.toString() + " -V");
-        assertThat(runResult.stderr, not(containsString("warning: usage of JAVA_HOME is deprecated, use ES_JAVA_HOME")));
-
-        startElasticsearch();
-        ServerUtils.runElasticsearchTests();
-        stopElasticsearch();
-
-        String systemJavaHome1 = sh.getEnv().get("ES_JAVA_HOME");
-        assertThat(FileUtils.slurpAllLogs(installation.logs, "elasticsearch.log", "*.log.gz"), containsString(systemJavaHome1));
+        // if the JDK started with the bundled JDK then we know that JAVA_HOME was ignored
+        String bundledJdk = installation.bundledJdk.toString();
+        assertThat(FileUtils.slurpAllLogs(installation.logs, "elasticsearch.log", "*.log.gz"), containsString(bundledJdk));
     }
 
     public void test52BundledJdkRemoved() throws Exception {

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Shell.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Shell.java
@@ -156,7 +156,6 @@ public class Shell {
             setWorkingDirectory(builder, workingDirectory);
         }
         builder.environment().keySet().remove("ES_JAVA_HOME"); // start with a fresh environment
-        builder.environment().keySet().remove("JAVA_HOME");
         for (Map.Entry<String, String> entry : env.entrySet()) {
             builder.environment().put(entry.getKey(), entry.getValue());
         }


### PR DESCRIPTION
This commit removes support for JAVA_HOME. As we previously deprecated usage of JAVA_HOME to override the path for the JDK, this commit follows up by removing support for JAVA_HOME. Note that we do not treat JAVA_HOME being set as a failure, as it is perfectly reasonable for a user to have JAVA_HOME configured at the system level.

Closes #55820
