### PR TITLE
Remove integration testing using OSS distribution

### DIFF
--- a/plugins/examples/painless-whitelist/build.gradle
+++ b/plugins/examples/painless-whitelist/build.gradle
@@ -22,7 +22,7 @@ dependencies {
 }
 
 testClusters.all {
-  testDistribution = 'OSS'
+  testDistribution = 'DEFAULT'
 }
 
 tasks.named("test").configure { enabled = false }

--- a/qa/build.gradle
+++ b/qa/build.gradle
@@ -1,17 +1,9 @@
-import org.elasticsearch.gradle.test.RestIntegTestTask
 import org.elasticsearch.gradle.testclusters.TestClustersPlugin
 
 subprojects { Project subproj ->
-  subproj.tasks.withType(RestIntegTestTask).configureEach {
-    if (subproj.extensions.findByName("${it.name}Cluster")) {
-      subproj.extensions.configure("${it.name}Cluster") { cluster ->
-        cluster.distribution = System.getProperty('tests.distribution', 'oss')
-      }
-    }
-  }
   plugins.withType(TestClustersPlugin).whenPluginAdded {
     testClusters.all {
-      testDistribution = System.getProperty('tests.distribution', 'oss').toUpperCase()
+      testDistribution = 'DEFAULT'
     }
   }
 }


### PR DESCRIPTION
This is simply the first part of addressing #68797. For now we are simply removing the usages of the oss distribution in internal testing and replacing it with the default distribution. This is necessary now that we no longer publish oss artifacts we get build failures [like this](https://gradle-enterprise.elastic.co/s/mw7bxlgc2hvpi) when the build attempts to download oss distributions for versions 7.11 and later for released versions. We'll follow up this work to actually remove the ability to _build_ an oss artifact but for now we just want to address the BWC build failures.