### PR TITLE
[DOCS] Clarify put data frame analytics API feature processors option

### DIFF
--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -578,15 +578,15 @@ candidate split.
 end::dfas-feature-bag-fraction[]
 
 tag::dfas-feature-processors[]
-Advanced configuration option.
-A collection of feature preprocessors that modify one or more included fields.
-The analysis uses the resulting one or more features instead of the
-original document field. Multiple `feature_processors` entries can refer to the
-same document fields. Automatic categorical 
-{ml-docs}/ml-feature-encoding.html[feature encoding] still occurs for the fields 
-that are unprocessed by a custom processor or that have categorical values.
-Only use this if you want to override the automatic feature encoding of the 
-specified fields. Refer to 
+Advanced configuration option. A collection of feature preprocessors that modify 
+one or more included fields. The analysis uses the resulting one or more 
+features instead of the original document field. However, these features are 
+ephemeral; they are not stored in the destination index. Multiple 
+`feature_processors` entries can refer to the same document fields. Automatic 
+categorical {ml-docs}/ml-feature-encoding.html[feature encoding] still occurs 
+for the fields that are unprocessed by a custom processor or that have
+categorical values. Use this property only if you want to override the automatic 
+feature encoding of the specified fields. Refer to 
 {ml-docs}/ml-feature-processors.html[{dfanalytics} feature processors] to learn 
 more.
 end::dfas-feature-processors[]
@@ -620,7 +620,7 @@ end::dfas-feature-processors-multi-proc[]
 
 tag::dfas-feature-processors-ngram[]
 The configuration information necessary to perform n-gram encoding. Features 
-written out by this encoder have the following name format: 
+created by this encoder have the following name format: 
 `<feature_prefix>.<ngram><string position>`. For example, if the 
 `feature_prefix` is `f`, the feature name for the second unigram in a string is 
 `f.11`.


### PR DESCRIPTION
This PR updates the [create data frame analytics jobs API](https://www.elastic.co/guide/en/elasticsearch/reference/master/put-dfanalytics.html) documentation, so it's clearer that the resulting features are not stored in the destination index ( as in already mentioned in https://www.elastic.co/guide/en/machine-learning/master/ml-feature-processors.html).

### Preview

https://elasticsearch_69158.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/put-dfanalytics.html