### PR TITLE
Update unit tests to handle platforms with larger default stack sizes

### DIFF
--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/parser/SqlParserTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/parser/SqlParserTests.java
@@ -255,9 +255,9 @@ public class SqlParserTests extends ESTestCase {
         // 1000 elements is ok
         new SqlParser().createExpression(join(" OR ", nCopies(1000, "a = b")));
 
-        // 5000 elements cause stack overflow
+        // 10000 elements cause stack overflow
         ParsingException e = expectThrows(ParsingException.class, () ->
-            new SqlParser().createExpression(join(" OR ", nCopies(5000, "a = b"))));
+            new SqlParser().createExpression(join(" OR ", nCopies(10000, "a = b"))));
         assertThat(e.getMessage(),
             startsWith("line -1:0: SQL statement is too large, causing stack overflow when generating the parsing tree: ["));
     }
@@ -271,7 +271,7 @@ public class SqlParserTests extends ESTestCase {
 
         // 5000 elements cause stack overflow
         ParsingException e = expectThrows(ParsingException.class, () -> new SqlParser().createExpression(
-            join("", nCopies(1000, "abs(")).concat("i").concat(join("", nCopies(1000, ")")))));
+            join("", nCopies(5000, "abs(")).concat("i").concat(join("", nCopies(5000, ")")))));
         assertThat(e.getMessage(),
             startsWith("line -1:0: SQL statement is too large, causing stack overflow when generating the parsing tree: ["));
     }
@@ -282,9 +282,9 @@ public class SqlParserTests extends ESTestCase {
         // 1000 elements is ok
         new SqlParser().createExpression(join(" + ", nCopies(1000, "a")));
 
-        // 5000 elements cause stack overflow
+        // 10000 elements cause stack overflow
         ParsingException e = expectThrows(ParsingException.class, () ->
-            new SqlParser().createExpression(join(" + ", nCopies(5000, "a"))));
+            new SqlParser().createExpression(join(" + ", nCopies(10000, "a"))));
         assertThat(e.getMessage(),
             startsWith("line -1:0: SQL statement is too large, causing stack overflow when generating the parsing tree: ["));
     }
@@ -298,11 +298,11 @@ public class SqlParserTests extends ESTestCase {
                 .concat("t")
                 .concat(join("", nCopies(199, ")"))));
 
-        // 500 elements cause stack overflow
+        // 1000 elements cause stack overflow
         ParsingException e = expectThrows(ParsingException.class, () -> new SqlParser().createStatement(
-            join(" (", nCopies(500, "SELECT * FROM"))
+            join(" (", nCopies(1000, "SELECT * FROM"))
                 .concat("t")
-                .concat(join("", nCopies(499, ")")))));
+                .concat(join("", nCopies(999, ")")))));
         assertThat(e.getMessage(),
             startsWith("line -1:0: SQL statement is too large, causing stack overflow when generating the parsing tree: ["));
     }


### PR DESCRIPTION
It seems on ARM, the default thread stack size is 2MB instead of 1MB as on x86. This causes unit tests that purposefully throw `StackOverflowException` to fail, since no exception is thrown with the larger stack. You can replicate this locally even on an x86 machine pretty easily by adding `test.jvmArgs "-Xss2m"` to the build file.

https://gradle-enterprise.elastic.co/s/mibnrb6isuki6/tests/:x-pack:plugin:sql:test/org.elasticsearch.xpack.sql.parser.SqlParserTests/testLimitToPreventStackOverflowFromLargeSubselectTree#1

This simply doubles the size of inputs here to trigger an exception even on platforms with larger stacks.