### PR TITLE
[Transform] Make sure remote clusters are at least 7.12 if transform uses search runtime fields

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
@@ -50,7 +50,7 @@ import static org.elasticsearch.common.settings.Setting.timeSetting;
 /**
  * Basic service for accessing remote clusters via gateway nodes
  */
-public class RemoteClusterService extends RemoteClusterAware implements Closeable {
+public final class RemoteClusterService extends RemoteClusterAware implements Closeable {
 
     private final Logger logger = LogManager.getLogger(RemoteClusterService.class);
 

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
@@ -50,7 +50,7 @@ import static org.elasticsearch.common.settings.Setting.timeSetting;
 /**
  * Basic service for accessing remote clusters via gateway nodes
  */
-public final class RemoteClusterService extends RemoteClusterAware implements Closeable {
+public class RemoteClusterService extends RemoteClusterAware implements Closeable {
 
     private final Logger logger = LogManager.getLogger(RemoteClusterService.class);
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/common/validation/SourceDestValidator.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/common/validation/SourceDestValidator.java
@@ -442,6 +442,14 @@ public final class SourceDestValidator {
             this.reason = reason;
         }
 
+        public Version getMinExpectedVersion() {
+            return minExpectedVersion;
+        }
+
+        public String getReason() {
+            return reason;
+        }
+
         @Override
         public void validate(Context context, ActionListener<Context> listener) {
             List<String> remoteIndices = new ArrayList<>(context.resolveRemoteSource());

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfig.java
@@ -13,7 +13,6 @@ import org.elasticsearch.cluster.AbstractDiffable;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -24,6 +23,8 @@ import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.common.time.TimeUtils;
+import org.elasticsearch.xpack.core.common.validation.SourceDestValidator;
+import org.elasticsearch.xpack.core.common.validation.SourceDestValidator.SourceDestValidation;
 import org.elasticsearch.xpack.core.transform.TransformField;
 import org.elasticsearch.xpack.core.transform.TransformMessages;
 import org.elasticsearch.xpack.core.transform.transforms.latest.LatestConfig;
@@ -33,9 +34,9 @@ import org.elasticsearch.xpack.core.transform.utils.ExceptionsHelper;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
@@ -313,11 +314,14 @@ public class TransformConfig extends AbstractDiffable<TransformConfig> implement
      *
      * @return version
      */
-    public Optional<Tuple<Version, String>> getMinRemoteClusterVersion() {
+    public List<SourceDestValidation> getAdditionalValidations() {
         if ((source.getRuntimeMappings() == null || source.getRuntimeMappings().isEmpty()) == false) {
-            return Optional.of(Tuple.tuple(FIELD_CAPS_RUNTIME_MAPPINGS_INTRODUCED_VERSION, "runtime fields"));
+            SourceDestValidation validation =
+                new SourceDestValidator.RemoteClusterMinimumVersionValidation(
+                    FIELD_CAPS_RUNTIME_MAPPINGS_INTRODUCED_VERSION, "source.runtime_mappings field was set");
+            return Collections.singletonList(validation);
         } else {
-            return Optional.empty();
+            return Collections.emptyList();
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfig.java
@@ -34,6 +34,7 @@ import java.time.Instant;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
@@ -45,6 +46,8 @@ public class TransformConfig extends AbstractDiffable<TransformConfig> implement
 
     public static final String NAME = "data_frame_transform_config";
     public static final ParseField HEADERS = new ParseField("headers");
+    /** Version in which {@code FieldCapabilitiesRequest.runtime_fields} field was introduced. */
+    private static final Version FIELD_CAPS_RUNTIME_MAPPINGS_INTRODUCED_VERSION = Version.V_7_12_0;
 
     // types of transforms
     public static final ParseField PIVOT_TRANSFORM = new ParseField("pivot");
@@ -302,6 +305,19 @@ public class TransformConfig extends AbstractDiffable<TransformConfig> implement
     @Nullable
     public RetentionPolicyConfig getRetentionPolicyConfig() {
         return retentionPolicyConfig;
+    }
+
+    /**
+     * Determines the minimum version of a cluster in multi-cluster setup that is needed to successfully run this transform config.
+     *
+     * @return version
+     */
+    public Optional<Version> getMinRemoteClusterVersion() {
+        if ((source.getRuntimeMappings() == null || source.getRuntimeMappings().isEmpty()) == false) {
+            return Optional.of(FIELD_CAPS_RUNTIME_MAPPINGS_INTRODUCED_VERSION);
+        } else {
+            return Optional.empty();
+        }
     }
 
     public ActionRequestValidationException validate(ActionRequestValidationException validationException) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfig.java
@@ -13,6 +13,7 @@ import org.elasticsearch.cluster.AbstractDiffable;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -312,9 +313,9 @@ public class TransformConfig extends AbstractDiffable<TransformConfig> implement
      *
      * @return version
      */
-    public Optional<Version> getMinRemoteClusterVersion() {
+    public Optional<Tuple<Version, String>> getMinRemoteClusterVersion() {
         if ((source.getRuntimeMappings() == null || source.getRuntimeMappings().isEmpty()) == false) {
-            return Optional.of(FIELD_CAPS_RUNTIME_MAPPINGS_INTRODUCED_VERSION);
+            return Optional.of(Tuple.tuple(FIELD_CAPS_RUNTIME_MAPPINGS_INTRODUCED_VERSION, "runtime fields"));
         } else {
             return Optional.empty();
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/validation/RemoteClusterMinimumVersionValidationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/validation/RemoteClusterMinimumVersionValidationTests.java
@@ -62,7 +62,7 @@ public class RemoteClusterMinimumVersionValidationTests extends ESTestCase {
                 e -> fail(e.getMessage())));
     }
 
-    public void testValidate_RemoteClusterVersionTooLow() {
+    public void testValidate_OneRemoteClusterVersionTooLow() {
         doReturn(new HashSet<>(Arrays.asList("cluster-A", "cluster-B", "cluster-C"))).when(context).getRegisteredRemoteClusterNames();
         SourceDestValidation validation = new RemoteClusterMinimumVersionValidation(MIN_EXPECTED_VERSION, REASON);
         validation.validate(
@@ -70,8 +70,21 @@ public class RemoteClusterMinimumVersionValidationTests extends ESTestCase {
             ActionListener.wrap(
                 ctx -> assertThat(
                     ctx.getValidationException().validationErrors(),
-                    contains("remote clusters are expected to run at least version [7.11.0], but cluster [cluster-A] had version [7.10.2]; "
-                        + "reason: [some reason]")),
+                    contains("remote clusters are expected to run at least version [7.11.0] (reason: [some reason]), "
+                        + "but the following clusters were too old: [cluster-A (7.10.2)]")),
+                e -> fail(e.getMessage())));
+    }
+
+    public void testValidate_TwoRemoteClusterVersionsTooLow() {
+        doReturn(new HashSet<>(Arrays.asList("cluster-A", "cluster-B", "cluster-C"))).when(context).getRegisteredRemoteClusterNames();
+        SourceDestValidation validation = new RemoteClusterMinimumVersionValidation(Version.V_7_11_2, REASON);
+        validation.validate(
+            context,
+            ActionListener.wrap(
+                ctx -> assertThat(
+                    ctx.getValidationException().validationErrors(),
+                    contains("remote clusters are expected to run at least version [7.11.2] (reason: [some reason]), "
+                        + "but the following clusters were too old: [cluster-A (7.10.2), cluster-B (7.11.0)]")),
                 e -> fail(e.getMessage())));
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/validation/RemoteClusterMinimumVersionValidationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/validation/RemoteClusterMinimumVersionValidationTests.java
@@ -23,6 +23,7 @@ import java.util.TreeSet;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.emptySortedSet;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.doReturn;
@@ -42,6 +43,12 @@ public class RemoteClusterMinimumVersionValidationTests extends ESTestCase {
         doReturn(Version.V_7_10_2).when(context).getRemoteClusterVersion("cluster-A");
         doReturn(Version.V_7_11_0).when(context).getRemoteClusterVersion("cluster-B");
         doReturn(Version.V_7_11_2).when(context).getRemoteClusterVersion("cluster-C");
+    }
+
+    public void testGetters() {
+        RemoteClusterMinimumVersionValidation validation = new RemoteClusterMinimumVersionValidation(MIN_EXPECTED_VERSION, REASON);
+        assertThat(validation.getMinExpectedVersion(), is(equalTo(MIN_EXPECTED_VERSION)));
+        assertThat(validation.getReason(), is(equalTo(REASON)));
     }
 
     public void testValidate_NoRemoteClusters() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/validation/RemoteClusterMinimumVersionValidationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/validation/RemoteClusterMinimumVersionValidationTests.java
@@ -11,8 +11,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.transport.NoSuchRemoteClusterException;
-import org.elasticsearch.transport.RemoteClusterService;
-import org.elasticsearch.transport.Transport;
 import org.elasticsearch.xpack.core.common.validation.SourceDestValidator.Context;
 import org.elasticsearch.xpack.core.common.validation.SourceDestValidator.RemoteClusterMinimumVersionValidation;
 import org.elasticsearch.xpack.core.common.validation.SourceDestValidator.SourceDestValidation;
@@ -25,37 +23,28 @@ import java.util.HashSet;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
 
 public class RemoteClusterMinimumVersionValidationTests extends ESTestCase {
 
     private static final Version MIN_EXPECTED_VERSION = Version.V_7_11_0;
+    private static final String REASON = "some reason";
 
     private Context context;
-    private RemoteClusterService remoteClusterService;
-    private Transport.Connection connectionA;  // 7.10.2
-    private Transport.Connection connectionB;  // 7.11.0
-    private Transport.Connection connectionC;  // 7.11.2
 
     @Before
     public void setUpMocks() {
-        connectionA = mock(Transport.Connection.class);
-        when(connectionA.getVersion()).thenReturn(Version.V_7_10_2);
-        connectionB = mock(Transport.Connection.class);
-        when(connectionB.getVersion()).thenReturn(Version.V_7_11_0);
-        connectionC = mock(Transport.Connection.class);
-        when(connectionC.getVersion()).thenReturn(Version.V_7_11_2);
-        remoteClusterService = mock(RemoteClusterService.class);
-        when(remoteClusterService.getConnection("cluster-A")).thenReturn(connectionA);
-        when(remoteClusterService.getConnection("cluster-B")).thenReturn(connectionB);
-        when(remoteClusterService.getConnection("cluster-C")).thenReturn(connectionC);
-        context = new Context(null, null, remoteClusterService, null, null, null, null, null, null, null);
+        context = spy(new Context(null, null, null, null, null, null, null, null, null, null));
+        doReturn(Version.V_7_10_2).when(context).getRemoteClusterVersion("cluster-A");
+        doReturn(Version.V_7_11_0).when(context).getRemoteClusterVersion("cluster-B");
+        doReturn(Version.V_7_11_2).when(context).getRemoteClusterVersion("cluster-C");
     }
 
     public void testValidate_NoRemoteClusters() {
-        when(remoteClusterService.getRegisteredRemoteClusterNames()).thenReturn(Collections.emptySet());
-        SourceDestValidation validation = new RemoteClusterMinimumVersionValidation(MIN_EXPECTED_VERSION);
+        doReturn(Collections.emptySet()).when(context).getRegisteredRemoteClusterNames();
+        SourceDestValidation validation = new RemoteClusterMinimumVersionValidation(MIN_EXPECTED_VERSION, REASON);
         validation.validate(
             context,
             ActionListener.wrap(
@@ -64,8 +53,8 @@ public class RemoteClusterMinimumVersionValidationTests extends ESTestCase {
     }
 
     public void testValidate_RemoteClustersVersionsOk() {
-        when(remoteClusterService.getRegisteredRemoteClusterNames()).thenReturn(new HashSet<>(Arrays.asList("cluster-B", "cluster-C")));
-        SourceDestValidation validation = new RemoteClusterMinimumVersionValidation(MIN_EXPECTED_VERSION);
+        doReturn(new HashSet<>(Arrays.asList("cluster-B", "cluster-C"))).when(context).getRegisteredRemoteClusterNames();
+        SourceDestValidation validation = new RemoteClusterMinimumVersionValidation(MIN_EXPECTED_VERSION, REASON);
         validation.validate(
             context,
             ActionListener.wrap(
@@ -74,24 +63,22 @@ public class RemoteClusterMinimumVersionValidationTests extends ESTestCase {
     }
 
     public void testValidate_RemoteClusterVersionTooLow() {
-        when(remoteClusterService.getRegisteredRemoteClusterNames())
-            .thenReturn(new HashSet<>(Arrays.asList("cluster-A", "cluster-B", "cluster-C")));
-        SourceDestValidation validation = new RemoteClusterMinimumVersionValidation(MIN_EXPECTED_VERSION);
+        doReturn(new HashSet<>(Arrays.asList("cluster-A", "cluster-B", "cluster-C"))).when(context).getRegisteredRemoteClusterNames();
+        SourceDestValidation validation = new RemoteClusterMinimumVersionValidation(MIN_EXPECTED_VERSION, REASON);
         validation.validate(
             context,
             ActionListener.wrap(
                 ctx -> assertThat(
                     ctx.getValidationException().validationErrors(),
-                    contains(
-                        "remote clusters are expected to run at least version [7.11.0], but cluster [cluster-A] had version [7.10.2]")),
+                    contains("remote clusters are expected to run at least version [7.11.0], but cluster [cluster-A] had version [7.10.2]; "
+                        + "reason: [some reason]")),
                 e -> fail(e.getMessage())));
     }
 
     public void testValidate_NoSuchRemoteCluster() {
-        when(remoteClusterService.getRegisteredRemoteClusterNames())
-            .thenReturn(new HashSet<>(Arrays.asList("cluster-B", "cluster-C", "cluster-D")));
-        when(remoteClusterService.getConnection("cluster-D")).thenThrow(new NoSuchRemoteClusterException("cluster-D"));
-        SourceDestValidation validation = new RemoteClusterMinimumVersionValidation(MIN_EXPECTED_VERSION);
+        doReturn(new HashSet<>(Arrays.asList("cluster-B", "cluster-C", "cluster-D"))).when(context).getRegisteredRemoteClusterNames();
+        doThrow(new NoSuchRemoteClusterException("cluster-D")).when(context).getRemoteClusterVersion("cluster-D");
+        SourceDestValidation validation = new RemoteClusterMinimumVersionValidation(MIN_EXPECTED_VERSION, REASON);
         validation.validate(
             context,
             ActionListener.wrap(
@@ -100,9 +87,9 @@ public class RemoteClusterMinimumVersionValidationTests extends ESTestCase {
     }
 
     public void testValidate_OtherProblem() {
-        when(remoteClusterService.getRegisteredRemoteClusterNames()).thenReturn(new HashSet<>(Arrays.asList("cluster-B", "cluster-C")));
-        when(remoteClusterService.getConnection("cluster-C")).thenThrow(new IllegalArgumentException("some-other-problem"));
-        SourceDestValidation validation = new RemoteClusterMinimumVersionValidation(MIN_EXPECTED_VERSION);
+        doReturn(new HashSet<>(Arrays.asList("cluster-B", "cluster-C"))).when(context).getRegisteredRemoteClusterNames();
+        doThrow(new IllegalArgumentException("some-other-problem")).when(context).getRemoteClusterVersion("cluster-C");
+        SourceDestValidation validation = new RemoteClusterMinimumVersionValidation(MIN_EXPECTED_VERSION, REASON);
         validation.validate(
             context,
             ActionListener.wrap(

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/validation/RemoteClusterMinimumVersionValidationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/validation/RemoteClusterMinimumVersionValidationTests.java
@@ -17,9 +17,11 @@ import org.elasticsearch.xpack.core.common.validation.SourceDestValidator.Source
 import org.junit.Before;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
+import java.util.TreeSet;
 
+import static java.util.Collections.emptySet;
+import static java.util.Collections.emptySortedSet;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
@@ -43,7 +45,8 @@ public class RemoteClusterMinimumVersionValidationTests extends ESTestCase {
     }
 
     public void testValidate_NoRemoteClusters() {
-        doReturn(Collections.emptySet()).when(context).getRegisteredRemoteClusterNames();
+        doReturn(emptySet()).when(context).getRegisteredRemoteClusterNames();
+        doReturn(emptySortedSet()).when(context).resolveRemoteSource();
         SourceDestValidation validation = new RemoteClusterMinimumVersionValidation(MIN_EXPECTED_VERSION, REASON);
         validation.validate(
             context,
@@ -54,6 +57,7 @@ public class RemoteClusterMinimumVersionValidationTests extends ESTestCase {
 
     public void testValidate_RemoteClustersVersionsOk() {
         doReturn(new HashSet<>(Arrays.asList("cluster-B", "cluster-C"))).when(context).getRegisteredRemoteClusterNames();
+        doReturn(new TreeSet<>(Arrays.asList("cluster-B:dummy", "cluster-C:dummy"))).when(context).resolveRemoteSource();
         SourceDestValidation validation = new RemoteClusterMinimumVersionValidation(MIN_EXPECTED_VERSION, REASON);
         validation.validate(
             context,
@@ -64,6 +68,7 @@ public class RemoteClusterMinimumVersionValidationTests extends ESTestCase {
 
     public void testValidate_OneRemoteClusterVersionTooLow() {
         doReturn(new HashSet<>(Arrays.asList("cluster-A", "cluster-B", "cluster-C"))).when(context).getRegisteredRemoteClusterNames();
+        doReturn(new TreeSet<>(Arrays.asList("cluster-A:dummy", "cluster-B:dummy", "cluster-C:dummy"))).when(context).resolveRemoteSource();
         SourceDestValidation validation = new RemoteClusterMinimumVersionValidation(MIN_EXPECTED_VERSION, REASON);
         validation.validate(
             context,
@@ -77,6 +82,7 @@ public class RemoteClusterMinimumVersionValidationTests extends ESTestCase {
 
     public void testValidate_TwoRemoteClusterVersionsTooLow() {
         doReturn(new HashSet<>(Arrays.asList("cluster-A", "cluster-B", "cluster-C"))).when(context).getRegisteredRemoteClusterNames();
+        doReturn(new TreeSet<>(Arrays.asList("cluster-A:dummy", "cluster-B:dummy", "cluster-C:dummy"))).when(context).resolveRemoteSource();
         SourceDestValidation validation = new RemoteClusterMinimumVersionValidation(Version.V_7_11_2, REASON);
         validation.validate(
             context,
@@ -90,6 +96,7 @@ public class RemoteClusterMinimumVersionValidationTests extends ESTestCase {
 
     public void testValidate_NoSuchRemoteCluster() {
         doReturn(new HashSet<>(Arrays.asList("cluster-B", "cluster-C", "cluster-D"))).when(context).getRegisteredRemoteClusterNames();
+        doReturn(new TreeSet<>(Arrays.asList("cluster-B:dummy", "cluster-C:dummy", "cluster-D:dummy"))).when(context).resolveRemoteSource();
         doThrow(new NoSuchRemoteClusterException("cluster-D")).when(context).getRemoteClusterVersion("cluster-D");
         SourceDestValidation validation = new RemoteClusterMinimumVersionValidation(MIN_EXPECTED_VERSION, REASON);
         validation.validate(
@@ -101,6 +108,7 @@ public class RemoteClusterMinimumVersionValidationTests extends ESTestCase {
 
     public void testValidate_OtherProblem() {
         doReturn(new HashSet<>(Arrays.asList("cluster-B", "cluster-C"))).when(context).getRegisteredRemoteClusterNames();
+        doReturn(new TreeSet<>(Arrays.asList("cluster-B:dummy", "cluster-C:dummy"))).when(context).resolveRemoteSource();
         doThrow(new IllegalArgumentException("some-other-problem")).when(context).getRemoteClusterVersion("cluster-C");
         SourceDestValidation validation = new RemoteClusterMinimumVersionValidation(MIN_EXPECTED_VERSION, REASON);
         validation.validate(

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/validation/RemoteClusterMinimumVersionValidationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/validation/RemoteClusterMinimumVersionValidationTests.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.common.validation;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.transport.NoSuchRemoteClusterException;
+import org.elasticsearch.transport.RemoteClusterService;
+import org.elasticsearch.transport.Transport;
+import org.elasticsearch.xpack.core.common.validation.SourceDestValidator.Context;
+import org.elasticsearch.xpack.core.common.validation.SourceDestValidator.RemoteClusterMinimumVersionValidation;
+import org.elasticsearch.xpack.core.common.validation.SourceDestValidator.SourceDestValidation;
+import org.junit.Before;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class RemoteClusterMinimumVersionValidationTests extends ESTestCase {
+
+    private static final Version MIN_EXPECTED_VERSION = Version.V_7_11_0;
+
+    private Context context;
+    private RemoteClusterService remoteClusterService;
+    private Transport.Connection connectionA;  // 7.10.2
+    private Transport.Connection connectionB;  // 7.11.0
+    private Transport.Connection connectionC;  // 7.11.2
+
+    @Before
+    public void setUpMocks() {
+        connectionA = mock(Transport.Connection.class);
+        when(connectionA.getVersion()).thenReturn(Version.V_7_10_2);
+        connectionB = mock(Transport.Connection.class);
+        when(connectionB.getVersion()).thenReturn(Version.V_7_11_0);
+        connectionC = mock(Transport.Connection.class);
+        when(connectionC.getVersion()).thenReturn(Version.V_7_11_2);
+        remoteClusterService = mock(RemoteClusterService.class);
+        when(remoteClusterService.getConnection("cluster-A")).thenReturn(connectionA);
+        when(remoteClusterService.getConnection("cluster-B")).thenReturn(connectionB);
+        when(remoteClusterService.getConnection("cluster-C")).thenReturn(connectionC);
+        context = new Context(null, null, remoteClusterService, null, null, null, null, null, null, null);
+    }
+
+    public void testValidate_NoRemoteClusters() {
+        when(remoteClusterService.getRegisteredRemoteClusterNames()).thenReturn(Collections.emptySet());
+        SourceDestValidation validation = new RemoteClusterMinimumVersionValidation(MIN_EXPECTED_VERSION);
+        validation.validate(
+            context,
+            ActionListener.wrap(
+                ctx -> assertThat(ctx.getValidationException(), is(nullValue())),
+                e -> fail(e.getMessage())));
+    }
+
+    public void testValidate_RemoteClustersVersionsOk() {
+        when(remoteClusterService.getRegisteredRemoteClusterNames()).thenReturn(new HashSet<>(Arrays.asList("cluster-B", "cluster-C")));
+        SourceDestValidation validation = new RemoteClusterMinimumVersionValidation(MIN_EXPECTED_VERSION);
+        validation.validate(
+            context,
+            ActionListener.wrap(
+                ctx -> assertThat(ctx.getValidationException(), is(nullValue())),
+                e -> fail(e.getMessage())));
+    }
+
+    public void testValidate_RemoteClusterVersionTooLow() {
+        when(remoteClusterService.getRegisteredRemoteClusterNames())
+            .thenReturn(new HashSet<>(Arrays.asList("cluster-A", "cluster-B", "cluster-C")));
+        SourceDestValidation validation = new RemoteClusterMinimumVersionValidation(MIN_EXPECTED_VERSION);
+        validation.validate(
+            context,
+            ActionListener.wrap(
+                ctx -> assertThat(
+                    ctx.getValidationException().validationErrors(),
+                    contains(
+                        "remote clusters are expected to run at least version [7.11.0], but cluster [cluster-A] had version [7.10.2]")),
+                e -> fail(e.getMessage())));
+    }
+
+    public void testValidate_NoSuchRemoteCluster() {
+        when(remoteClusterService.getRegisteredRemoteClusterNames())
+            .thenReturn(new HashSet<>(Arrays.asList("cluster-B", "cluster-C", "cluster-D")));
+        when(remoteClusterService.getConnection("cluster-D")).thenThrow(new NoSuchRemoteClusterException("cluster-D"));
+        SourceDestValidation validation = new RemoteClusterMinimumVersionValidation(MIN_EXPECTED_VERSION);
+        validation.validate(
+            context,
+            ActionListener.wrap(
+                ctx -> assertThat(ctx.getValidationException().validationErrors(), contains("no such remote cluster: [cluster-D]")),
+                e -> fail(e.getMessage())));
+    }
+
+    public void testValidate_OtherProblem() {
+        when(remoteClusterService.getRegisteredRemoteClusterNames()).thenReturn(new HashSet<>(Arrays.asList("cluster-B", "cluster-C")));
+        when(remoteClusterService.getConnection("cluster-C")).thenThrow(new IllegalArgumentException("some-other-problem"));
+        SourceDestValidation validation = new RemoteClusterMinimumVersionValidation(MIN_EXPECTED_VERSION);
+        validation.validate(
+            context,
+            ActionListener.wrap(
+                ctx -> assertThat(
+                    ctx.getValidationException().validationErrors(),
+                    contains("Error resolving remote source: some-other-problem")),
+                e -> fail(e.getMessage())));
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfigTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.core.transform.transforms;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.DeprecationHandler;
@@ -574,7 +575,7 @@ public class TransformConfigTests extends AbstractSerializingTransformTestCase<T
             + "} } } } }";
 
         TransformConfig transformConfig = createTransformConfigFromString(json, "body_id", true);
-        assertThat(transformConfig.getMinRemoteClusterVersion().get(), is(equalTo(Version.V_7_12_0)));
+        assertThat(transformConfig.getMinRemoteClusterVersion().get(), is(equalTo(Tuple.tuple(Version.V_7_12_0, "runtime fields"))));
     }
 
     private TransformConfig createTransformConfigFromString(String json, String id) throws IOException {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPreviewTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPreviewTransformAction.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.transform.action;
 
 import org.apache.lucene.util.SetOnce;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ingest.SimulatePipelineAction;
 import org.elasticsearch.action.ingest.SimulatePipelineRequest;
@@ -20,6 +21,7 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ToXContent;
@@ -124,7 +126,10 @@ public class TransportPreviewTransformAction extends HandledTransportAction<
         List<SourceDestValidator.SourceDestValidation> validations;
         if (config.getMinRemoteClusterVersion().isPresent()) {
             validations = new ArrayList<>(SourceDestValidations.PREVIEW_VALIDATIONS);
-            validations.add(new SourceDestValidator.RemoteClusterMinimumVersionValidation(config.getMinRemoteClusterVersion().get()));
+            Tuple<Version, String> minRemoteClusterVersionAndReason = config.getMinRemoteClusterVersion().get();
+            validations.add(
+                new SourceDestValidator.RemoteClusterMinimumVersionValidation(
+                    minRemoteClusterVersionAndReason.v1(), minRemoteClusterVersionAndReason.v2()));
         } else {
             validations = SourceDestValidations.PREVIEW_VALIDATIONS;
         }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPreviewTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPreviewTransformAction.java
@@ -121,13 +121,19 @@ public class TransportPreviewTransformAction extends HandledTransportAction<
         ClusterState clusterState = clusterService.state();
 
         final TransformConfig config = request.getConfig();
-
+        List<SourceDestValidator.SourceDestValidation> validations;
+        if (config.getMinRemoteClusterVersion().isPresent()) {
+            validations = new ArrayList<>(SourceDestValidations.PREVIEW_VALIDATIONS);
+            validations.add(new SourceDestValidator.RemoteClusterMinimumVersionValidation(config.getMinRemoteClusterVersion().get()));
+        } else {
+            validations = SourceDestValidations.PREVIEW_VALIDATIONS;
+        }
         sourceDestValidator.validate(
             clusterState,
             config.getSource().getIndex(),
             config.getDestination().getIndex(),
             config.getDestination().getPipeline(),
-            SourceDestValidations.PREVIEW_VALIDATIONS,
+            validations,
             ActionListener.wrap(r -> {
                 // create the function for validation
                 final Function function = FunctionFactory.create(config);

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPutTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPutTransformAction.java
@@ -25,6 +25,7 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.ingest.IngestService;
@@ -211,7 +212,10 @@ public class TransportPutTransformAction extends AcknowledgedTransportMasterNode
             validations = SourceDestValidations.NON_DEFERABLE_VALIDATIONS;
         } else if (config.getMinRemoteClusterVersion().isPresent()) {
             validations = new ArrayList<>(SourceDestValidations.ALL_VALIDATIONS);
-            validations.add(new SourceDestValidator.RemoteClusterMinimumVersionValidation(config.getMinRemoteClusterVersion().get()));
+            Tuple<Version, String> minRemoteClusterVersionAndReason = config.getMinRemoteClusterVersion().get();
+            validations.add(
+                new SourceDestValidator.RemoteClusterMinimumVersionValidation(
+                    minRemoteClusterVersionAndReason.v1(), minRemoteClusterVersionAndReason.v2()));
         } else {
             validations = SourceDestValidations.ALL_VALIDATIONS;
         }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStartTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStartTransformAction.java
@@ -24,6 +24,7 @@ import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
@@ -257,7 +258,10 @@ public class TransportStartTransformAction extends TransportMasterNodeAction<Sta
             List<SourceDestValidator.SourceDestValidation> validations;
             if (config.getMinRemoteClusterVersion().isPresent()) {
                 validations = new ArrayList<>(SourceDestValidations.ALL_VALIDATIONS);
-                validations.add(new SourceDestValidator.RemoteClusterMinimumVersionValidation(config.getMinRemoteClusterVersion().get()));
+                Tuple<Version, String> minRemoteClusterVersionAndReason = config.getMinRemoteClusterVersion().get();
+                validations.add(
+                    new SourceDestValidator.RemoteClusterMinimumVersionValidation(
+                        minRemoteClusterVersionAndReason.v1(), minRemoteClusterVersionAndReason.v2()));
             } else {
                 validations = SourceDestValidations.ALL_VALIDATIONS;
             }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpdateTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpdateTransformAction.java
@@ -24,6 +24,7 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.logging.LoggerMessageFormat;
 import org.elasticsearch.common.settings.Settings;
@@ -238,7 +239,10 @@ public class TransportUpdateTransformAction extends TransportTasksAction<Transfo
                 validations = SourceDestValidations.NON_DEFERABLE_VALIDATIONS;
             } else if (config.getMinRemoteClusterVersion().isPresent()) {
                 validations = new ArrayList<>(SourceDestValidations.ALL_VALIDATIONS);
-                validations.add(new SourceDestValidator.RemoteClusterMinimumVersionValidation(config.getMinRemoteClusterVersion().get()));
+                Tuple<Version, String> minRemoteClusterVersionAndReason = config.getMinRemoteClusterVersion().get();
+                validations.add(
+                    new SourceDestValidator.RemoteClusterMinimumVersionValidation(
+                        minRemoteClusterVersionAndReason.v1(), minRemoteClusterVersionAndReason.v2()));
             } else {
                 validations = SourceDestValidations.ALL_VALIDATIONS;
             }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpdateTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpdateTransformAction.java
@@ -24,7 +24,6 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.logging.LoggerMessageFormat;
 import org.elasticsearch.common.settings.Settings;
@@ -69,7 +68,6 @@ import org.elasticsearch.xpack.transform.transforms.TransformTask;
 import org.elasticsearch.xpack.transform.utils.SourceDestValidations;
 
 import java.time.Clock;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -234,24 +232,12 @@ public class TransportUpdateTransformAction extends TransportTasksAction<Transfo
                 updateListener = listener;
             }
 
-            List<SourceDestValidator.SourceDestValidation> validations;
-            if (request.isDeferValidation()) {
-                validations = SourceDestValidations.NON_DEFERABLE_VALIDATIONS;
-            } else if (config.getMinRemoteClusterVersion().isPresent()) {
-                validations = new ArrayList<>(SourceDestValidations.ALL_VALIDATIONS);
-                Tuple<Version, String> minRemoteClusterVersionAndReason = config.getMinRemoteClusterVersion().get();
-                validations.add(
-                    new SourceDestValidator.RemoteClusterMinimumVersionValidation(
-                        minRemoteClusterVersionAndReason.v1(), minRemoteClusterVersionAndReason.v2()));
-            } else {
-                validations = SourceDestValidations.ALL_VALIDATIONS;
-            }
             sourceDestValidator.validate(
                 clusterState,
                 updatedConfig.getSource().getIndex(),
                 updatedConfig.getDestination().getIndex(),
                 updatedConfig.getDestination().getPipeline(),
-                validations,
+                SourceDestValidations.getValidations(request.isDeferValidation(), config.getAdditionalValidations()),
                 ActionListener.wrap(
                     validationResponse -> {
                         checkPriviledgesAndUpdateTransform(request, clusterState, updatedConfig, configAndVersion.v2(), updateListener);

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/utils/SourceDestValidations.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/utils/SourceDestValidations.java
@@ -7,8 +7,9 @@
 
 package org.elasticsearch.xpack.transform.utils;
 
-import org.elasticsearch.xpack.core.common.validation.SourceDestValidator;
+import org.elasticsearch.xpack.core.common.validation.SourceDestValidator.SourceDestValidation;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -26,10 +27,10 @@ public final class SourceDestValidations {
 
     private SourceDestValidations() {}
 
-    public static final List<SourceDestValidator.SourceDestValidation> PREVIEW_VALIDATIONS = Arrays.asList(
+    private static final List<SourceDestValidation> PREVIEW_VALIDATIONS = Arrays.asList(
         SOURCE_MISSING_VALIDATION, REMOTE_SOURCE_VALIDATION, DESTINATION_PIPELINE_MISSING_VALIDATION);
 
-    public static final List<SourceDestValidator.SourceDestValidation> ALL_VALIDATIONS = Arrays.asList(
+    private static final List<SourceDestValidation> ALL_VALIDATIONS = Arrays.asList(
         SOURCE_MISSING_VALIDATION,
         REMOTE_SOURCE_VALIDATION,
         DESTINATION_IN_SOURCE_VALIDATION,
@@ -37,7 +38,29 @@ public final class SourceDestValidations {
         DESTINATION_PIPELINE_MISSING_VALIDATION
     );
 
-    public static final List<SourceDestValidator.SourceDestValidation> NON_DEFERABLE_VALIDATIONS = Collections.singletonList(
+    private static final List<SourceDestValidation> NON_DEFERABLE_VALIDATIONS = Collections.singletonList(
         DESTINATION_SINGLE_INDEX_VALIDATION
     );
+
+    public static List<SourceDestValidation> getValidations(boolean isDeferValidation, List<SourceDestValidation> additionalValidations) {
+        return getValidations(isDeferValidation, ALL_VALIDATIONS, additionalValidations);
+    }
+
+    public static List<SourceDestValidation> getValidationsForPreview(List<SourceDestValidation> additionalValidations) {
+        return getValidations(false, PREVIEW_VALIDATIONS, additionalValidations);
+    }
+
+    private static List<SourceDestValidation> getValidations(boolean isDeferValidation,
+                                                             List<SourceDestValidation> primaryValidations,
+                                                             List<SourceDestValidation> additionalValidations) {
+        if (isDeferValidation) {
+            return SourceDestValidations.NON_DEFERABLE_VALIDATIONS;
+        }
+        if (additionalValidations.isEmpty()) {
+            return primaryValidations;
+        }
+        List<SourceDestValidation> validations = new ArrayList<>(primaryValidations);
+        validations.addAll(additionalValidations);
+        return validations;
+    }
 }

--- a/x-pack/qa/multi-cluster-tests-with-security/src/test/resources/rest-api-spec/test/multi_cluster/80_transform.yml
+++ b/x-pack/qa/multi-cluster-tests-with-security/src/test/resources/rest-api-spec/test/multi_cluster/80_transform.yml
@@ -144,6 +144,42 @@ teardown:
   - match: { transforms.0.checkpointing.operations_behind: 2 }
 
 ---
+"Batch transform preview from remote cluster":
+  - do:
+      headers: { Authorization: "Basic am9lOnRyYW5zZm9ybS1wYXNzd29yZA==" }
+      transform.preview_transform:
+        body:  >
+          {
+            "source": {
+              "index": "my_remote_cluster:test_index",
+              "runtime_mappings" : {
+                "user-upper": {
+                  "type": "keyword",
+                  "script": "emit(doc['user'].value.toUpperCase())"
+                }
+              }
+            },
+            "pivot": {
+              "group_by": { "user": {"terms": {"field": "user-upper"}}},
+              "aggs": {
+                "avg_stars": {"avg": {"field": "stars"}},
+                "max_stars": {"max": {"field": "stars"}}
+              }
+            }
+          }
+  - length: { $body: 2 }
+  - length: { preview: 3 }
+  - match: { preview.0.user: A }
+  - match: { preview.0.avg_stars: 3.6 }
+  - match: { preview.1.user: B }
+  - match: { preview.1.avg_stars: 2.0 }
+  - match: { preview.2.user: C }
+  - match: { preview.2.avg_stars: 4.0 }
+  - match: { generated_dest_index.mappings.properties.user.type: "keyword" }
+  - match: { generated_dest_index.mappings.properties.avg_stars.type: "double" }
+  - match: { generated_dest_index.mappings.properties.max_stars.type: "integer" }
+
+---
 "Batch transform from local and remote cluster":
   - do:
       indices.create:


### PR DESCRIPTION
When transform uses search runtime fields (via `TransformConfig.runtime_mappings` setting), we need to be careful not to send `FieldCaps` requests to clusters older than `7.12` as `7.12` is the first version in which `FieldCaps` request supports runtime fields (see https://github.com/elastic/elasticsearch/pull/68904).
This PR checks whether `TransformConfig` specifies `runtime_mappings`. If so, it creates a validation that collects remote clusters versions, takes the minimum version, and fails when the minimum version is before `7.12`.