### PR TITLE
[DOCS] Remove beta label from searchable_snapshot ILM action docs

### DIFF
--- a/docs/reference/ilm/actions/ilm-delete.asciidoc
+++ b/docs/reference/ilm/actions/ilm-delete.asciidoc
@@ -10,7 +10,6 @@ Permanently removes the index.
 ==== Options
 
 `delete_searchable_snapshot`::
-beta:[]
 (Optional, Boolean)
 Deletes the searchable snapshot created in a previous phase.
 Defaults to `true`.

--- a/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
+++ b/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
@@ -2,8 +2,6 @@
 [[ilm-searchable-snapshot]]
 === Searchable snapshot
 
-beta::[]
-
 Phases allowed: hot, cold, frozen.
 
 Takes a snapshot of the managed index in the configured repository

--- a/docs/reference/ilm/ilm-actions.asciidoc
+++ b/docs/reference/ilm/ilm-actions.asciidoc
@@ -35,7 +35,6 @@ index. For example, you can roll up hourly data into daily or weekly summaries.
 endif::[]
 
 <<ilm-searchable-snapshot, Searchable snapshot>>::
-beta:[]
 Take a snapshot of the managed index in the configured repository
 and mount it as a searchable snapshot.
 


### PR DESCRIPTION
Searchable snapshots are GA since 7.11
