### PR TITLE
[7.12] [DOCS] Remove beta label from searchable_snapshot ILM action docs (#69196)

### DIFF
--- a/docs/reference/ilm/actions/ilm-delete.asciidoc
+++ b/docs/reference/ilm/actions/ilm-delete.asciidoc
@@ -10,7 +10,6 @@ Permanently removes the index.
 ==== Options
 
 `delete_searchable_snapshot`::
-beta:[]
 (Optional, Boolean)
 Deletes the searchable snapshot created in a previous phase.
 Defaults to `true`.

--- a/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
+++ b/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
@@ -2,8 +2,6 @@
 [[ilm-searchable-snapshot]]
 === Searchable snapshot
 
-beta::[]
-
 Phases allowed: hot, cold, frozen.
 
 Takes a snapshot of the managed index in the configured repository

--- a/docs/reference/ilm/ilm-actions.asciidoc
+++ b/docs/reference/ilm/ilm-actions.asciidoc
@@ -35,7 +35,6 @@ index. For example, you can roll up hourly data into daily or weekly summaries.
 endif::[]
 
 <<ilm-searchable-snapshot, Searchable snapshot>>::
-beta:[]
 Take a snapshot of the managed index in the configured repository
 and mount it as a searchable snapshot.
 


### PR DESCRIPTION
Searchable snapshots are GA since 7.11

Co-authored-by: James Rodewig <40268737+jrodewig@users.noreply.github.com>
(cherry picked from commit 4bf09f66d82c736e9051ccd41eff4a08233d0259)
Signed-off-by: Andrei Dan <andrei.dan@elastic.co>

Backport of #69196
