### PR TITLE
Skip translog-policy BWC testing on versions prior to 6.3.0

### DIFF
--- a/qa/translog-policy/build.gradle
+++ b/qa/translog-policy/build.gradle
@@ -15,9 +15,8 @@ apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-test'
 apply from : "$rootDir/gradle/bwc-test.gradle"
 
-boolean isDefaultDistro = System.getProperty('tests.distribution', 'oss') == 'default'
 for (Version bwcVersion : BuildParams.bwcVersions.indexCompatible) {
-  if (bwcVersion.before('6.3.0') && isDefaultDistro) {
+  if (bwcVersion.before('6.3.0')) {
     // explicitly running restart on the current node does not work in step 2
     // below when plugins are installed, wihch is the case for x-pack as a plugin
     // prior to 6.3.0


### PR DESCRIPTION
As a result of #69153 the translog-policy BWC tests began failing as the configuration assumed a default distribution type of "OSS". These tests on BWC versions prior to 6.3.0 are incompatible with the default distribution so they need to be skipped.