### PR TITLE
[DOCS] Fix capitalization for Query DSL

### DIFF
--- a/docs/community-clients/index.asciidoc
+++ b/docs/community-clients/index.asciidoc
@@ -103,7 +103,7 @@ Also see the {client}/go-api/current/index.html[official Elasticsearch Go client
 Also see the {client}/java-api/current/index.html[official Elasticsearch Java client].
 
 * https://github.com/otto-de/flummi[Flummi]:
-  Java Rest client with comprehensive query DSL API
+  Java Rest client with comprehensive Query DSL API
 * https://github.com/searchbox-io/Jest[Jest]:
   Java Rest client.
 

--- a/docs/java-rest/high-level/rollup/search.asciidoc
+++ b/docs/java-rest/high-level/rollup/search.asciidoc
@@ -10,9 +10,9 @@
 experimental::[]
 
 The Rollup Search endpoint allows searching rolled-up data using the standard
-query DSL. The Rollup Search endpoint is needed because, internally,
+Query DSL. The Rollup Search endpoint is needed because, internally,
 rolled-up documents utilize a different document structure than the original
-data. The Rollup Search endpoint rewrites standard query DSL into a format that
+data. The Rollup Search endpoint rewrites standard Query DSL into a format that
 matches the rollup documents, then takes the response and rewrites it back to
 what a client would expect given the original query.
 

--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -186,8 +186,8 @@ returned.
 A greater `fetch_size` value often increases search speed but uses more memory.
 
 `filter`::
-(Optional, <<query-dsl,query DSL object>>)
-Query, written in query DSL, used to filter the events on which the EQL query
+(Optional, <<query-dsl,Query DSL object>>)
+Query, written in Query DSL, used to filter the events on which the EQL query
 runs.
 
 `keep_alive`::

--- a/docs/reference/eql/eql.asciidoc
+++ b/docs/reference/eql/eql.asciidoc
@@ -458,9 +458,9 @@ GET /my-index-000001/_eql/search
 
 [discrete]
 [[eql-search-filter-query-dsl]]
-=== Filter using query DSL
+=== Filter using Query DSL
 
-The `filter` parameter uses <<query-dsl,query DSL>> to limit the documents on
+The `filter` parameter uses <<query-dsl,Query DSL>> to limit the documents on
 which an EQL query runs.
 
 [source,console]

--- a/docs/reference/query-dsl/_query-template.asciidoc
+++ b/docs/reference/query-dsl/_query-template.asciidoc
@@ -1,5 +1,5 @@
 ////
-This is a template for query DSL reference documentation.
+This is a template for Query DSL reference documentation.
 
 To document a new query type, copy this file, remove comments like this, and
 replace "sample" with the appropriate query name.

--- a/docs/reference/rollup/apis/rollup-search.asciidoc
+++ b/docs/reference/rollup/apis/rollup-search.asciidoc
@@ -10,7 +10,7 @@ ifdef::permanently-unreleased-branch[]
 
 include::put-job.asciidoc[tag=legacy-rollup-admon]
 
-Searches legacy rollup data using <<query-dsl,query DSL>>.
+Searches legacy rollup data using <<query-dsl,Query DSL>>.
 
 endif::[]
 ifndef::permanently-unreleased-branch[]
@@ -23,7 +23,7 @@ ifndef::permanently-unreleased-branch[]
 <titleabbrev>Rollup search</titleabbrev>
 ++++
 
-Enables searching rolled-up data using the standard query DSL.
+Enables searching rolled-up data using the standard Query DSL.
 
 experimental[]
 
@@ -39,7 +39,7 @@ endif::[]
 
 The rollup search endpoint is needed because, internally, rolled-up documents
 utilize a different document structure than the original data. The rollup search
-endpoint rewrites standard query DSL into a format that matches the rollup
+endpoint rewrites standard Query DSL into a format that matches the rollup
 documents, then takes the response and rewrites it back to what a client would
 expect given the original query.
 
@@ -128,7 +128,7 @@ PUT _rollup/job/sensor
 
 This rolls up the `sensor-*` pattern and stores the results in `sensor_rollup`.
 To search this rolled up data, we need to use the `_rollup_search` endpoint.
-However, you'll notice that we can use regular query DSL to search the rolled-up
+However, you'll notice that we can use regular Query DSL to search the rolled-up
 data:
 
 [source,console]

--- a/docs/reference/rollup/overview.asciidoc
+++ b/docs/reference/rollup/overview.asciidoc
@@ -42,7 +42,7 @@ automates this process of summarizing historical data.
 Details about setting up and configuring Rollup are covered in <<rollup-put-job,Create Job API>>.
 
 [discrete]
-==== Rollup uses standard query DSL
+==== Rollup uses standard Query DSL
 
 The Rollup feature exposes a new search endpoint (`/_rollup_search` vs the standard `/_search`) which knows how to search
 over rolled-up data.  Importantly, this endpoint accepts 100% normal {es} Query DSL.  Your application does not need to learn

--- a/docs/reference/search/multi-search.asciidoc
+++ b/docs/reference/search/multi-search.asciidoc
@@ -248,7 +248,7 @@ Contains parameters for a search request:
 Aggregations you wish to run during the search. See <<search-aggregations>>.
 
 `query`::
-(Optional, <<query-dsl,query DSL object>>) Query you wish to run during the
+(Optional, <<query-dsl,Query DSL object>>) Query you wish to run during the
 search. Hits matching this query are returned in the response.
 
 `from`::

--- a/docs/reference/sql/endpoints/rest.asciidoc
+++ b/docs/reference/sql/endpoints/rest.asciidoc
@@ -365,10 +365,10 @@ Which will like return the
 
 
 [[sql-rest-filtering]]
-=== Filtering using {es} query DSL
+=== Filtering using {es} Query DSL
 
 One can filter the results that SQL will run on using a standard
-{es} query DSL by specifying the query in the filter
+{es} Query DSL by specifying the query in the filter
 parameter.
 
 [source,console]
@@ -402,7 +402,7 @@ Douglas Adams  |The Hitchhiker's Guide to the Galaxy|180            |1979-10-12T
 
 [TIP]
 =================
-A useful and less obvious usage for standard query DSL filtering is to search documents by a specific <<search-routing, routing key>>.
+A useful and less obvious usage for standard Query DSL filtering is to search documents by a specific <<search-routing, routing key>>.
 Because {es-sql} does not support a `routing` parameter, one can specify a <<mapping-routing-field, `terms` filter for the `_routing` field>> instead:
 
 [source,console]
@@ -548,7 +548,7 @@ s|Description
 
 |filter
 |none
-|Optional {es} query DSL for additional <<sql-rest-filtering, filtering>>.
+|Optional {es} Query DSL for additional <<sql-rest-filtering, filtering>>.
 
 |request_timeout
 |90s

--- a/x-pack/docs/en/watcher/input/http.asciidoc
+++ b/x-pack/docs/en/watcher/input/http.asciidoc
@@ -45,7 +45,7 @@ index:
 --------------------------------------------------
 // NOTCONSOLE
 
-You can use the full Elasticsearch <<query-dsl,query DSL>> to perform
+You can use the full Elasticsearch <<query-dsl,Query DSL>> to perform
 more sophisticated searches. For example, the following `http` input retrieves 
 all documents that contain `event` in the `category` field:
 


### PR DESCRIPTION
Consistently capitalizes `Query DSL`.