### PR TITLE
Rename max_single_primary_size to max_primary_shard_size

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -189,8 +189,8 @@ tasks.register("verifyVersions") {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = true
-String bwc_tests_disabled_issue = "" /* place a PR link here when committing bwc changes */
+boolean bwc_tests_enabled = false
+String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/69239" /* place a PR link here when committing bwc changes */
 /*
  * FIPS 140-2 behavior was fixed in 7.11.0. Before that there is no way to run elasticsearch in a
  * JVM that is properly configured to be in fips mode with BCFIPS. For now we need to disable

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ilm/RolloverAction.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ilm/RolloverAction.java
@@ -23,7 +23,7 @@ import java.util.Objects;
 public class RolloverAction implements LifecycleAction, ToXContentObject {
     public static final String NAME = "rollover";
     private static final ParseField MAX_SIZE_FIELD = new ParseField("max_size");
-    private static final ParseField MAX_SINGLE_PRIMARY_SIZE_FIELD = new ParseField("max_single_primary_size");
+    private static final ParseField MAX_PRIMARY_SHARD_SIZE_FIELD = new ParseField("max_primary_shard_size");
     private static final ParseField MAX_AGE_FIELD = new ParseField("max_age");
     private static final ParseField MAX_DOCS_FIELD = new ParseField("max_docs");
 
@@ -35,8 +35,8 @@ public class RolloverAction implements LifecycleAction, ToXContentObject {
             (p, c) -> ByteSizeValue.parseBytesSizeValue(p.text(), MAX_SIZE_FIELD.getPreferredName()),
             MAX_SIZE_FIELD, ValueType.VALUE);
         PARSER.declareField(ConstructingObjectParser.optionalConstructorArg(),
-            (p, c) -> ByteSizeValue.parseBytesSizeValue(p.text(), MAX_SINGLE_PRIMARY_SIZE_FIELD.getPreferredName()),
-            MAX_SINGLE_PRIMARY_SIZE_FIELD, ValueType.VALUE);
+            (p, c) -> ByteSizeValue.parseBytesSizeValue(p.text(), MAX_PRIMARY_SHARD_SIZE_FIELD.getPreferredName()),
+            MAX_PRIMARY_SHARD_SIZE_FIELD, ValueType.VALUE);
         PARSER.declareField(ConstructingObjectParser.optionalConstructorArg(),
             (p, c) -> TimeValue.parseTimeValue(p.text(), MAX_AGE_FIELD.getPreferredName()),
             MAX_AGE_FIELD, ValueType.VALUE);
@@ -44,7 +44,7 @@ public class RolloverAction implements LifecycleAction, ToXContentObject {
     }
 
     private final ByteSizeValue maxSize;
-    private final ByteSizeValue maxSinglePrimarySize;
+    private final ByteSizeValue maxPrimaryShardSize;
     private final TimeValue maxAge;
     private final Long maxDocs;
 
@@ -52,12 +52,12 @@ public class RolloverAction implements LifecycleAction, ToXContentObject {
         return PARSER.apply(parser, null);
     }
 
-    public RolloverAction(ByteSizeValue maxSize, ByteSizeValue maxSinglePrimarySize, TimeValue maxAge, Long maxDocs) {
-        if (maxSize == null && maxSinglePrimarySize == null && maxAge == null && maxDocs == null) {
+    public RolloverAction(ByteSizeValue maxSize, ByteSizeValue maxPrimaryShardSize, TimeValue maxAge, Long maxDocs) {
+        if (maxSize == null && maxPrimaryShardSize == null && maxAge == null && maxDocs == null) {
             throw new IllegalArgumentException("At least one rollover condition must be set.");
         }
         this.maxSize = maxSize;
-        this.maxSinglePrimarySize = maxSinglePrimarySize;
+        this.maxPrimaryShardSize = maxPrimaryShardSize;
         this.maxAge = maxAge;
         this.maxDocs = maxDocs;
     }
@@ -66,8 +66,8 @@ public class RolloverAction implements LifecycleAction, ToXContentObject {
         return maxSize;
     }
 
-    public ByteSizeValue getMaxSinglePrimarySize() {
-        return maxSinglePrimarySize;
+    public ByteSizeValue getMaxPrimaryShardSize() {
+        return maxPrimaryShardSize;
     }
 
     public TimeValue getMaxAge() {
@@ -89,8 +89,8 @@ public class RolloverAction implements LifecycleAction, ToXContentObject {
         if (maxSize != null) {
             builder.field(MAX_SIZE_FIELD.getPreferredName(), maxSize.getStringRep());
         }
-        if (maxSinglePrimarySize != null) {
-            builder.field(MAX_SINGLE_PRIMARY_SIZE_FIELD.getPreferredName(), maxSinglePrimarySize.getStringRep());
+        if (maxPrimaryShardSize != null) {
+            builder.field(MAX_PRIMARY_SHARD_SIZE_FIELD.getPreferredName(), maxPrimaryShardSize.getStringRep());
         }
         if (maxAge != null) {
             builder.field(MAX_AGE_FIELD.getPreferredName(), maxAge.getStringRep());
@@ -104,7 +104,7 @@ public class RolloverAction implements LifecycleAction, ToXContentObject {
 
     @Override
     public int hashCode() {
-        return Objects.hash(maxSize, maxSinglePrimarySize, maxAge, maxDocs);
+        return Objects.hash(maxSize, maxPrimaryShardSize, maxAge, maxDocs);
     }
 
     @Override
@@ -117,7 +117,7 @@ public class RolloverAction implements LifecycleAction, ToXContentObject {
         }
         RolloverAction other = (RolloverAction) obj;
         return Objects.equals(maxSize, other.maxSize) &&
-            Objects.equals(maxSinglePrimarySize, other.maxSinglePrimarySize) &&
+            Objects.equals(maxPrimaryShardSize, other.maxPrimaryShardSize) &&
             Objects.equals(maxAge, other.maxAge) &&
             Objects.equals(maxDocs, other.maxDocs);
     }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ilm/ShrinkAction.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ilm/ShrinkAction.java
@@ -23,7 +23,7 @@ import java.util.Objects;
 public class ShrinkAction implements LifecycleAction, ToXContentObject {
     public static final String NAME = "shrink";
     private static final ParseField NUMBER_OF_SHARDS_FIELD = new ParseField("number_of_shards");
-    private static final ParseField MAX_SINGLE_PRIMARY_SIZE = new ParseField("max_single_primary_size");
+    private static final ParseField MAX_RIMARY_SHARD_SIZE = new ParseField("max_primary_shard_size");
 
     private static final ConstructingObjectParser<ShrinkAction, Void> PARSER =
         new ConstructingObjectParser<>(NAME, true, a -> new ShrinkAction((Integer) a[0], (ByteSizeValue) a[1]));
@@ -31,29 +31,29 @@ public class ShrinkAction implements LifecycleAction, ToXContentObject {
     static {
         PARSER.declareInt(ConstructingObjectParser.optionalConstructorArg(), NUMBER_OF_SHARDS_FIELD);
         PARSER.declareField(ConstructingObjectParser.optionalConstructorArg(),
-            (p, c) -> ByteSizeValue.parseBytesSizeValue(p.text(), MAX_SINGLE_PRIMARY_SIZE.getPreferredName()),
-            MAX_SINGLE_PRIMARY_SIZE, ObjectParser.ValueType.STRING);
+            (p, c) -> ByteSizeValue.parseBytesSizeValue(p.text(), MAX_RIMARY_SHARD_SIZE.getPreferredName()),
+            MAX_RIMARY_SHARD_SIZE, ObjectParser.ValueType.STRING);
     }
 
     private Integer numberOfShards;
-    private ByteSizeValue maxSinglePrimarySize;
+    private ByteSizeValue maxPrimaryShardSize;
 
     public static ShrinkAction parse(XContentParser parser) throws IOException {
         return PARSER.parse(parser, null);
     }
 
-    public ShrinkAction(@Nullable Integer numberOfShards, ByteSizeValue maxSinglePrimarySize) {
-        if (numberOfShards != null && maxSinglePrimarySize != null) {
-            throw new IllegalArgumentException("Cannot set both [number_of_shards] and [max_single_primary_size]");
+    public ShrinkAction(@Nullable Integer numberOfShards, ByteSizeValue maxPrimaryShardSize) {
+        if (numberOfShards != null && maxPrimaryShardSize != null) {
+            throw new IllegalArgumentException("Cannot set both [number_of_shards] and [max_primary_shard_size]");
         }
-        if (numberOfShards == null && maxSinglePrimarySize == null) {
-            throw new IllegalArgumentException("Either [number_of_shards] or [max_single_primary_size] must be set");
+        if (numberOfShards == null && maxPrimaryShardSize == null) {
+            throw new IllegalArgumentException("Either [number_of_shards] or [max_primary_shard_size] must be set");
         }
-        if (maxSinglePrimarySize != null) {
-            if (maxSinglePrimarySize.getBytes() <= 0) {
-                throw new IllegalArgumentException("[max_single_primary_size] must be greater than 0");
+        if (maxPrimaryShardSize != null) {
+            if (maxPrimaryShardSize.getBytes() <= 0) {
+                throw new IllegalArgumentException("[max_primary_shard_size] must be greater than 0");
             }
-            this.maxSinglePrimarySize = maxSinglePrimarySize;
+            this.maxPrimaryShardSize = maxPrimaryShardSize;
         } else {
             if (numberOfShards <= 0) {
                 throw new IllegalArgumentException("[" + NUMBER_OF_SHARDS_FIELD.getPreferredName() + "] must be greater than 0");
@@ -66,8 +66,8 @@ public class ShrinkAction implements LifecycleAction, ToXContentObject {
         return numberOfShards;
     }
 
-    ByteSizeValue getMaxSinglePrimarySize() {
-        return maxSinglePrimarySize;
+    ByteSizeValue getMaxPrimaryShardSize() {
+        return maxPrimaryShardSize;
     }
 
     @Override
@@ -81,8 +81,8 @@ public class ShrinkAction implements LifecycleAction, ToXContentObject {
         if (numberOfShards != null) {
             builder.field(NUMBER_OF_SHARDS_FIELD.getPreferredName(), numberOfShards);
         }
-        if (maxSinglePrimarySize != null) {
-            builder.field(MAX_SINGLE_PRIMARY_SIZE.getPreferredName(), maxSinglePrimarySize);
+        if (maxPrimaryShardSize != null) {
+            builder.field(MAX_RIMARY_SHARD_SIZE.getPreferredName(), maxPrimaryShardSize);
         }
         builder.endObject();
         return builder;
@@ -95,12 +95,12 @@ public class ShrinkAction implements LifecycleAction, ToXContentObject {
         ShrinkAction that = (ShrinkAction) o;
 
         return Objects.equals(numberOfShards, that.numberOfShards) &&
-            Objects.equals(maxSinglePrimarySize, that.maxSinglePrimarySize);
+            Objects.equals(maxPrimaryShardSize, that.maxPrimaryShardSize);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(numberOfShards, maxSinglePrimarySize);
+        return Objects.hash(numberOfShards, maxPrimaryShardSize);
     }
 
     @Override

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ilm/ShrinkAction.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ilm/ShrinkAction.java
@@ -23,7 +23,7 @@ import java.util.Objects;
 public class ShrinkAction implements LifecycleAction, ToXContentObject {
     public static final String NAME = "shrink";
     private static final ParseField NUMBER_OF_SHARDS_FIELD = new ParseField("number_of_shards");
-    private static final ParseField MAX_RIMARY_SHARD_SIZE = new ParseField("max_primary_shard_size");
+    private static final ParseField MAX_PRIMARY_SHARD_SIZE = new ParseField("max_primary_shard_size");
 
     private static final ConstructingObjectParser<ShrinkAction, Void> PARSER =
         new ConstructingObjectParser<>(NAME, true, a -> new ShrinkAction((Integer) a[0], (ByteSizeValue) a[1]));
@@ -31,8 +31,8 @@ public class ShrinkAction implements LifecycleAction, ToXContentObject {
     static {
         PARSER.declareInt(ConstructingObjectParser.optionalConstructorArg(), NUMBER_OF_SHARDS_FIELD);
         PARSER.declareField(ConstructingObjectParser.optionalConstructorArg(),
-            (p, c) -> ByteSizeValue.parseBytesSizeValue(p.text(), MAX_RIMARY_SHARD_SIZE.getPreferredName()),
-            MAX_RIMARY_SHARD_SIZE, ObjectParser.ValueType.STRING);
+            (p, c) -> ByteSizeValue.parseBytesSizeValue(p.text(), MAX_PRIMARY_SHARD_SIZE.getPreferredName()),
+            MAX_PRIMARY_SHARD_SIZE, ObjectParser.ValueType.STRING);
     }
 
     private Integer numberOfShards;
@@ -82,7 +82,7 @@ public class ShrinkAction implements LifecycleAction, ToXContentObject {
             builder.field(NUMBER_OF_SHARDS_FIELD.getPreferredName(), numberOfShards);
         }
         if (maxPrimaryShardSize != null) {
-            builder.field(MAX_RIMARY_SHARD_SIZE.getPreferredName(), maxPrimaryShardSize);
+            builder.field(MAX_PRIMARY_SHARD_SIZE.getPreferredName(), maxPrimaryShardSize);
         }
         builder.endObject();
         return builder;

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/ResizeRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/ResizeRequest.java
@@ -35,7 +35,7 @@ public class ResizeRequest extends TimedRequest implements Validatable, ToXConte
     private final String targetIndex;
     private Settings settings = Settings.EMPTY;
     private Set<Alias> aliases = new HashSet<>();
-    private ByteSizeValue maxSinglePrimarySize;
+    private ByteSizeValue maxPrimaryShardSize;
 
     /**
      * Creates a new resize request
@@ -79,17 +79,17 @@ public class ResizeRequest extends TimedRequest implements Validatable, ToXConte
     }
 
     /**
-     * Sets the max single primary shard size of the target index
+     * Sets the max primary shard size of the target index
      */
-    public void setMaxSinglePrimarySize(ByteSizeValue maxSinglePrimarySize) {
-        this.maxSinglePrimarySize = maxSinglePrimarySize;
+    public void setMaxPrimaryShardSize(ByteSizeValue maxPrimaryShardSize) {
+        this.maxPrimaryShardSize = maxPrimaryShardSize;
     }
 
     /**
-     * Return the max single primary shard size of the target index
+     * Return the max primary shard size of the target index
      */
-    public ByteSizeValue getMaxSinglePrimarySize() {
-        return maxSinglePrimarySize;
+    public ByteSizeValue getMaxPrimaryShardSize() {
+        return maxPrimaryShardSize;
     }
 
     @Override

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/rollover/RolloverRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/rollover/RolloverRequest.java
@@ -10,7 +10,7 @@ package org.elasticsearch.client.indices.rollover;
 import org.elasticsearch.action.admin.indices.rollover.Condition;
 import org.elasticsearch.action.admin.indices.rollover.MaxAgeCondition;
 import org.elasticsearch.action.admin.indices.rollover.MaxDocsCondition;
-import org.elasticsearch.action.admin.indices.rollover.MaxSinglePrimarySizeCondition;
+import org.elasticsearch.action.admin.indices.rollover.MaxPrimaryShardSizeCondition;
 import org.elasticsearch.action.admin.indices.rollover.MaxSizeCondition;
 import org.elasticsearch.client.TimedRequest;
 import org.elasticsearch.client.indices.CreateIndexRequest;
@@ -111,12 +111,12 @@ public class RolloverRequest extends TimedRequest implements ToXContentObject {
     /**
      * Adds a size-based condition to check if the size of the largest primary shard is at least <code>size</code>.
      */
-    public RolloverRequest addMaxSinglePrimarySizeCondition(ByteSizeValue size) {
-        MaxSinglePrimarySizeCondition maxSinglePrimarySizeCondition = new MaxSinglePrimarySizeCondition(size);
-        if (this.conditions.containsKey(maxSinglePrimarySizeCondition.name())) {
-            throw new IllegalArgumentException(maxSinglePrimarySizeCondition + " condition is already set");
+    public RolloverRequest addMaxPrimaryShardSizeCondition(ByteSizeValue size) {
+        MaxPrimaryShardSizeCondition maxPrimaryShardSizeCondition = new MaxPrimaryShardSizeCondition(size);
+        if (this.conditions.containsKey(maxPrimaryShardSizeCondition.name())) {
+            throw new IllegalArgumentException(maxPrimaryShardSizeCondition + " condition is already set");
         }
-        this.conditions.put(maxSinglePrimarySizeCondition.name(), maxSinglePrimarySizeCondition);
+        this.conditions.put(maxPrimaryShardSizeCondition.name(), maxPrimaryShardSizeCondition);
         return this;
     }
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesClientIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesClientIT.java
@@ -958,7 +958,7 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
             rolloverRequest.getCreateIndexRequest().mapping(mappings, XContentType.JSON);
             rolloverRequest.dryRun(false);
             rolloverRequest.addMaxIndexSizeCondition(new ByteSizeValue(1, ByteSizeUnit.MB));
-            rolloverRequest.addMaxSinglePrimarySizeCondition(new ByteSizeValue(1, ByteSizeUnit.MB));
+            rolloverRequest.addMaxPrimaryShardSizeCondition(new ByteSizeValue(1, ByteSizeUnit.MB));
             RolloverResponse rolloverResponse = execute(rolloverRequest, highLevelClient().indices()::rollover,
                     highLevelClient().indices()::rolloverAsync);
             assertTrue(rolloverResponse.isRolledOver());
@@ -968,7 +968,7 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
             assertTrue(conditionStatus.get("[max_docs: 1]"));
             assertTrue(conditionStatus.get("[max_age: 1ms]"));
             assertFalse(conditionStatus.get("[max_size: 1mb]"));
-            assertFalse(conditionStatus.get("[max_single_primary_size: 1mb]"));
+            assertFalse(conditionStatus.get("[max_primary_shard_size: 1mb]"));
             assertEquals("test", rolloverResponse.getOldIndex());
             assertEquals("test_new", rolloverResponse.getNewIndex());
         }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesRequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesRequestConvertersTests.java
@@ -646,7 +646,7 @@ public class IndicesRequestConvertersTests extends ESTestCase {
             resizeRequest.setSettings(Settings.builder().put("index.number_of_shards", 2).build());
         }
         if (resizeType == ResizeType.SHRINK) {
-            resizeRequest.setMaxSinglePrimarySize(new ByteSizeValue(randomIntBetween(1, 100)));
+            resizeRequest.setMaxPrimaryShardSize(new ByteSizeValue(randomIntBetween(1, 100)));
         }
 
         Request request = function.apply(resizeRequest);

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/IndicesClientDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/IndicesClientDocumentationIT.java
@@ -1607,9 +1607,9 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
         } else {
             request.getTargetIndexRequest().settings(Settings.builder()
                 .putNull("index.routing.allocation.require._name"));
-            // tag::shrink-index-request-maxSinglePrimarySize
-            request.setMaxSinglePrimarySize(new ByteSizeValue(50, ByteSizeUnit.GB)); // <1>
-            // end::shrink-index-request-maxSinglePrimarySize
+            // tag::shrink-index-request-maxPrimaryShardSize
+            request.setMaxPrimaryShardSize(new ByteSizeValue(50, ByteSizeUnit.GB)); // <1>
+            // end::shrink-index-request-maxPrimaryShardSize
         }
         // tag::shrink-index-request-aliases
         request.getTargetIndexRequest().alias(new Alias("target_alias")); // <1>
@@ -1802,7 +1802,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
         request.addMaxIndexAgeCondition(new TimeValue(7, TimeUnit.DAYS)); // <2>
         request.addMaxIndexDocsCondition(1000); // <3>
         request.addMaxIndexSizeCondition(new ByteSizeValue(5, ByteSizeUnit.GB)); // <4>
-        request.addMaxSinglePrimarySizeCondition(new ByteSizeValue(2, ByteSizeUnit.GB)); // <5>
+        request.addMaxPrimaryShardSizeCondition(new ByteSizeValue(2, ByteSizeUnit.GB)); // <5>
         // end::rollover-index-request
 
         // tag::rollover-index-request-timeout

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ilm/RolloverActionTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ilm/RolloverActionTests.java
@@ -34,14 +34,14 @@ public class RolloverActionTests extends AbstractXContentTestCase<RolloverAction
         ByteSizeUnit maxSizeUnit = randomFrom(ByteSizeUnit.values());
         ByteSizeValue maxSize = randomBoolean()
             ? null : new ByteSizeValue(randomNonNegativeLong() / maxSizeUnit.toBytes(1), maxSizeUnit);
-        ByteSizeUnit maxSinglePrimarySizeUnit = randomFrom(ByteSizeUnit.values());
-        ByteSizeValue maxSinglePrimarySize = randomBoolean()
-            ? null : new ByteSizeValue(randomNonNegativeLong() / maxSinglePrimarySizeUnit.toBytes(1), maxSinglePrimarySizeUnit);
+        ByteSizeUnit maxPrimaryShardSizeUnit = randomFrom(ByteSizeUnit.values());
+        ByteSizeValue maxPrimaryShardSize = randomBoolean()
+            ? null : new ByteSizeValue(randomNonNegativeLong() / maxPrimaryShardSizeUnit.toBytes(1), maxPrimaryShardSizeUnit);
         TimeValue maxAge = randomBoolean()
             ? null : TimeValue.parseTimeValue(randomPositiveTimeValue(), "rollover_action_test");
-        Long maxDocs = (maxSize == null && maxSinglePrimarySize == null && maxAge == null || randomBoolean())
+        Long maxDocs = (maxSize == null && maxPrimaryShardSize == null && maxAge == null || randomBoolean())
             ? randomNonNegativeLong() : null;
-        return new RolloverAction(maxSize, maxSinglePrimarySize, maxAge, maxDocs);
+        return new RolloverAction(maxSize, maxPrimaryShardSize, maxAge, maxDocs);
     }
 
     public void testNoConditions() {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ilm/ShrinkActionTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ilm/ShrinkActionTests.java
@@ -45,13 +45,13 @@ public class ShrinkActionTests extends AbstractXContentTestCase<ShrinkAction> {
         assertThat(e.getMessage(), equalTo("[number_of_shards] must be greater than 0"));
     }
 
-    public void testMaxSinglePrimarySize() {
-        ByteSizeValue maxSinglePrimarySize1 = new ByteSizeValue(10);
-        Exception e1 = expectThrows(Exception.class, () -> new ShrinkAction(randomIntBetween(1, 100), maxSinglePrimarySize1));
-        assertThat(e1.getMessage(), equalTo("Cannot set both [number_of_shards] and [max_single_primary_size]"));
+    public void testMaxPrimaryShardSize() {
+        ByteSizeValue maxPrimaryShardSize1 = new ByteSizeValue(10);
+        Exception e1 = expectThrows(Exception.class, () -> new ShrinkAction(randomIntBetween(1, 100), maxPrimaryShardSize1));
+        assertThat(e1.getMessage(), equalTo("Cannot set both [number_of_shards] and [max_primary_shard_size]"));
 
-        ByteSizeValue maxSinglePrimarySize2 = new ByteSizeValue(0);
-        Exception e2 = expectThrows(Exception.class, () -> new org.elasticsearch.client.ilm.ShrinkAction(null, maxSinglePrimarySize2));
-        assertThat(e2.getMessage(), equalTo("[max_single_primary_size] must be greater than 0"));
+        ByteSizeValue maxPrimaryShardSize2 = new ByteSizeValue(0);
+        Exception e2 = expectThrows(Exception.class, () -> new org.elasticsearch.client.ilm.ShrinkAction(null, maxPrimaryShardSize2));
+        assertThat(e2.getMessage(), equalTo("[max_primary_shard_size] must be greater than 0"));
     }
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/indices/rollover/RolloverRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/indices/rollover/RolloverRequestTests.java
@@ -11,7 +11,7 @@ package org.elasticsearch.client.indices.rollover;
 import org.elasticsearch.action.admin.indices.rollover.Condition;
 import org.elasticsearch.action.admin.indices.rollover.MaxAgeCondition;
 import org.elasticsearch.action.admin.indices.rollover.MaxDocsCondition;
-import org.elasticsearch.action.admin.indices.rollover.MaxSinglePrimarySizeCondition;
+import org.elasticsearch.action.admin.indices.rollover.MaxPrimaryShardSizeCondition;
 import org.elasticsearch.action.admin.indices.rollover.MaxSizeCondition;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
@@ -39,14 +39,14 @@ public class RolloverRequestTests extends ESTestCase {
         MaxAgeCondition maxAgeCondition = new MaxAgeCondition(new TimeValue(10));
         MaxDocsCondition maxDocsCondition = new MaxDocsCondition(10000L);
         MaxSizeCondition maxSizeCondition = new MaxSizeCondition(new ByteSizeValue(2000));
-        MaxSinglePrimarySizeCondition maxSinglePrimarySizeCondition = new MaxSinglePrimarySizeCondition(new ByteSizeValue(3000));
+        MaxPrimaryShardSizeCondition maxPrimaryShardSizeCondition = new MaxPrimaryShardSizeCondition(new ByteSizeValue(3000));
         Condition<?>[] expectedConditions = new Condition<?>[]{
-            maxAgeCondition, maxDocsCondition, maxSizeCondition, maxSinglePrimarySizeCondition
+            maxAgeCondition, maxDocsCondition, maxSizeCondition, maxPrimaryShardSizeCondition
         };
         rolloverRequest.addMaxIndexAgeCondition(maxAgeCondition.value());
         rolloverRequest.addMaxIndexDocsCondition(maxDocsCondition.value());
         rolloverRequest.addMaxIndexSizeCondition(maxSizeCondition.value());
-        rolloverRequest.addMaxSinglePrimarySizeCondition(maxSinglePrimarySizeCondition.value());
+        rolloverRequest.addMaxPrimaryShardSizeCondition(maxPrimaryShardSizeCondition.value());
         List<Condition<?>> requestConditions = new ArrayList<>(rolloverRequest.getConditions().values());
         assertThat(requestConditions, containsInAnyOrder(expectedConditions));
     }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/indices/rollover/RolloverResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/indices/rollover/RolloverResponseTests.java
@@ -11,7 +11,7 @@ package org.elasticsearch.client.indices.rollover;
 import org.elasticsearch.action.admin.indices.rollover.Condition;
 import org.elasticsearch.action.admin.indices.rollover.MaxAgeCondition;
 import org.elasticsearch.action.admin.indices.rollover.MaxDocsCondition;
-import org.elasticsearch.action.admin.indices.rollover.MaxSinglePrimarySizeCondition;
+import org.elasticsearch.action.admin.indices.rollover.MaxPrimaryShardSizeCondition;
 import org.elasticsearch.action.admin.indices.rollover.MaxSizeCondition;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
@@ -35,7 +35,7 @@ public class RolloverResponseTests extends ESTestCase {
         conditionSuppliers.add(() -> new MaxAgeCondition(new TimeValue(randomNonNegativeLong())));
         conditionSuppliers.add(() -> new MaxDocsCondition(randomNonNegativeLong()));
         conditionSuppliers.add(() -> new MaxSizeCondition(new ByteSizeValue(randomNonNegativeLong())));
-        conditionSuppliers.add(() -> new MaxSinglePrimarySizeCondition(new ByteSizeValue(randomNonNegativeLong())));
+        conditionSuppliers.add(() -> new MaxPrimaryShardSizeCondition(new ByteSizeValue(randomNonNegativeLong())));
     }
 
     public void testFromXContent() throws IOException {

--- a/docs/java-rest/high-level/indices/shrink_index.asciidoc
+++ b/docs/java-rest/high-level/indices/shrink_index.asciidoc
@@ -56,9 +56,9 @@ include-tagged::{doc-tests-file}[{api}-request-settings]
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests-file}[{api}-request-maxSinglePrimarySize]
+include-tagged::{doc-tests-file}[{api}-request-maxPrimaryShardSize]
 --------------------------------------------------
-<1> The max single primary shard size of the target index
+<1> The max primary shard size of the target index
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------

--- a/docs/reference/ilm/actions/ilm-rollover.asciidoc
+++ b/docs/reference/ilm/actions/ilm-rollover.asciidoc
@@ -20,11 +20,11 @@ To roll over an <<indices-aliases, index alias>>, the alias and its write index
 must meet the following conditions:
 
 * The index name must match the pattern '^.*-\\d+$', for example (`my-index-000001`).
-* The `index.lifecycle.rollover_alias` must be configured as the alias to roll over. 
+* The `index.lifecycle.rollover_alias` must be configured as the alias to roll over.
 * The index must be the <<indices-rollover-is-write-index, write index>> for the alias.
 
-For example, if `my-index-000001` has the alias `my_data`, 
-the following settings must be configured. 
+For example, if `my-index-000001` has the alias `my_data`,
+the following settings must be configured.
 
 [source,console]
 --------------------------------------------------
@@ -45,7 +45,7 @@ PUT my-index-000001
 [[ilm-rollover-options]]
 ==== Options
 
-You must specify at least one rollover condition. 
+You must specify at least one rollover condition.
 An empty rollover action is invalid.
 
 `max_age`::
@@ -65,13 +65,13 @@ The document count does *not* include documents in replica shards.
 `max_size`::
 (Optional, <<byte-units, byte units>>)
 Triggers roll over when the index reaches a certain size.
-This is the total size of all primary shards in the index. 
+This is the total size of all primary shards in the index.
 Replicas are not counted toward the maximum index size.
 +
-TIP: To see the current index size, use the <<cat-indices, _cat indices>> API. 
+TIP: To see the current index size, use the <<cat-indices, _cat indices>> API.
 The `pri.store.size` value shows the combined size of all primary shards.
 
-`max_single_primary_size`::
+`max_primary_shard_size`::
 (Optional, <<byte-units, byte units>>)
 Triggers roll over when the largest primary shard in the index reaches a certain size.
 This is the maximum size of the primary shards in the index. As with `max_size`,
@@ -129,7 +129,7 @@ PUT _ilm/policy/my_policy
   }
 }
 --------------------------------------------------
- 
+
 [ilm-rollover-age-ex]]
 ===== Roll over based on index age
 
@@ -156,9 +156,9 @@ PUT _ilm/policy/my_policy
 [ilm-rollover-conditions-ex]]
 ===== Roll over using multiple conditions
 
-When you specify multiple rollover conditions, 
+When you specify multiple rollover conditions,
 the index is rolled over when _any_ of the conditions are met.
-This example rolls the index over if it is at least 7 days old or at least 100 gigabytes. 
+This example rolls the index over if it is at least 7 days old or at least 100 gigabytes.
 
 [source,console]
 --------------------------------------------------
@@ -182,10 +182,10 @@ PUT _ilm/policy/my_policy
 [ilm-rollover-block-ex]]
 ===== Rollover condition blocks phase transition
 
-The rollover action only completes if one of its conditions is met. 
+The rollover action only completes if one of its conditions is met.
 This means that any subsequent phases are blocked until rollover succeeds.
 
-For example, the following policy deletes the index one day after it rolls over. 
+For example, the following policy deletes the index one day after it rolls over.
 It does not delete the index one day after it was created.
 
 [source,console]

--- a/docs/reference/ilm/actions/ilm-shrink.asciidoc
+++ b/docs/reference/ilm/actions/ilm-shrink.asciidoc
@@ -43,11 +43,11 @@ managed indices.
 (Optional, integer)
 Number of shards to shrink to.
 Must be a factor of the number of shards in the source index. This parameter conflicts with
-`max_single_primary_size`, only one of them may be set.
+`max_primary_shard_size`, only one of them may be set.
 
-`max_single_primary_size`::
+`max_primary_shard_size`::
 (Optional, <<byte-units, byte units>>)
-The max single primary shard size for the target index. Used to find the optimum number of shards for the target index.
+The max primary shard size for the target index. Used to find the optimum number of shards for the target index.
 When this parameter is set, each shard's storage in the target index will not be greater than the parameter.
 The shards count of the target index will still be a factor of the source index's shards count, but if the parameter
 is less than the single shard size in the source index, the shards count for the target index will be equal to the source index's shards count.
@@ -84,7 +84,7 @@ PUT _ilm/policy/my_policy
 
 [[ilm-shrink-size-ex]]
 ===== Calculate the number of shards of the new shrunken index based on the storage of the
-source index and the `max_single_primary_size` parameter
+source index and the `max_primary_shard_size` parameter
 
 [source,console]
 --------------------------------------------------
@@ -95,7 +95,7 @@ PUT _ilm/policy/my_policy
       "warm": {
         "actions": {
           "shrink" : {
-            "max_single_primary_size": "50gb"
+            "max_primary_shard_size": "50gb"
           }
         }
       }

--- a/docs/reference/indices/rollover-index.asciidoc
+++ b/docs/reference/indices/rollover-index.asciidoc
@@ -19,7 +19,7 @@ POST /alias1/_rollover/my-index-000002
     "max_age":   "7d",
     "max_docs":  1000,
     "max_size": "5gb",
-    "max_single_primary_size": "2gb"
+    "max_primary_shard_size": "2gb"
   }
 }
 ----
@@ -165,7 +165,7 @@ Replicas are not counted toward the maximum index size.
 TIP: To see the current index size, use the <<cat-indices, _cat indices>> API.
 The `pri.store.size` value shows the combined size of all primary shards.
 
-`max_single_primary_size`::
+`max_primary_shard_size`::
 (Optional, <<byte-units, byte units>>)
 Maximum primary shard size.
 This is the maximum size of the primary shards in the index. As with `max_size`,
@@ -204,7 +204,7 @@ POST /logs_write/_rollover <2>
     "max_age":   "7d",
     "max_docs":  1000,
     "max_size":  "5gb",
-    "max_single_primary_size": "2gb"
+    "max_primary_shard_size": "2gb"
   }
 }
 --------------------------------------------------
@@ -230,7 +230,7 @@ The API returns the following response:
     "[max_age: 7d]": false,
     "[max_docs: 1000]": true,
     "[max_size: 5gb]": false,
-    "[max_single_primary_size: 2gb]": false
+    "[max_primary_shard_size: 2gb]": false
   }
 }
 --------------------------------------------------
@@ -264,7 +264,7 @@ POST /my-data-stream/_rollover <2>
     "max_age": "7d",
     "max_docs": 1000,
     "max_size": "5gb",
-    "max_single_primary_size": "2gb"
+    "max_primary_shard_size": "2gb"
   }
 }
 --------------------------------------------------
@@ -298,7 +298,7 @@ The API returns the following response:
     "[max_age: 7d]": false,
     "[max_docs: 1000]": true,
     "[max_size: 5gb]": false,
-    "[max_single_primary_size: 2gb]": false
+    "[max_primary_shard_size: 2gb]": false
   }
 }
 --------------------------------------------------
@@ -345,7 +345,7 @@ POST /logs_write/_rollover
     "max_age": "7d",
     "max_docs": 1000,
     "max_size": "5gb",
-    "max_single_primary_size": "2gb"
+    "max_primary_shard_size": "2gb"
   },
   "settings": {
     "index.number_of_shards": 2
@@ -376,7 +376,7 @@ POST /my_alias/_rollover/my_new_index_name
     "max_age":   "7d",
     "max_docs":  1000,
     "max_size": "5gb",
-    "max_single_primary_size": "2gb"
+    "max_primary_shard_size": "2gb"
   }
 }
 --------------------------------------------------
@@ -474,7 +474,7 @@ POST /logs_write/_rollover?dry_run
     "max_age": "7d",
     "max_docs": 1000,
     "max_size": "5gb",
-    "max_single_primary_size": "2gb"
+    "max_primary_shard_size": "2gb"
   }
 }
 --------------------------------------------------

--- a/docs/reference/indices/shrink-index.asciidoc
+++ b/docs/reference/indices/shrink-index.asciidoc
@@ -231,9 +231,9 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=target-index-aliases]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=target-index-settings]
 
-`max_single_primary_size`::
+`max_primary_shard_size`::
 (Optional, <<byte-units, byte units>>)
-The max single primary shard size for the target index. Used to find the optimum number of shards for the target index.
+The max primary shard size for the target index. Used to find the optimum number of shards for the target index.
 When this parameter is set, each shard's storage in the target index will not be greater than the parameter.
 The shards count of the target index will still be a factor of the source index's shards count, but if the parameter
 is less than the single shard size in the source index, the shards count for the target index will be equal to the source index's shards count.

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.rollover/35_max_primary_shard_size_condition.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.rollover/35_max_primary_shard_size_condition.yml
@@ -1,8 +1,8 @@
 ---
-"Rollover with max_single_primary_size condition":
+"Rollover with max_primary_shard_size condition":
   - skip:
       version: " - 7.11.99"
-      reason: max_single_primary_size condition was introduced in 7.12.0
+      reason: max_primary_shard_size condition was introduced in 7.12.0
 
   # create index with alias and replica
   - do:
@@ -21,28 +21,28 @@
         body:  { "foo": "hello world" }
         refresh: true
 
-  # perform alias rollover with a large max_single_primary_size, no action.
+  # perform alias rollover with a large max_primary_shard_size, no action.
   - do:
       indices.rollover:
         alias: "logs_search"
         wait_for_active_shards: 1
         body:
           conditions:
-            max_single_primary_size: 100mb
+            max_primary_shard_size: 100mb
 
-  - match: { conditions: { "[max_single_primary_size: 100mb]": false } }
+  - match: { conditions: { "[max_primary_shard_size: 100mb]": false } }
   - match: { rolled_over: false }
 
-  # perform alias rollover with a small max_single_primary_size, got action.
+  # perform alias rollover with a small max_primary_shard_size, got action.
   - do:
       indices.rollover:
         alias: "logs_search"
         wait_for_active_shards: 1
         body:
           conditions:
-            max_single_primary_size: 10b
+            max_primary_shard_size: 10b
 
-  - match: { conditions: { "[max_single_primary_size: 10b]": true } }
+  - match: { conditions: { "[max_primary_shard_size: 10b]": true } }
   - match: { rolled_over: true }
 
   # perform alias rollover on an empty index, no action.
@@ -52,7 +52,7 @@
         wait_for_active_shards: 1
         body:
           conditions:
-            max_single_primary_size: 1b
+            max_primary_shard_size: 1b
 
-  - match: { conditions: { "[max_single_primary_size: 1b]": false } }
+  - match: { conditions: { "[max_primary_shard_size: 1b]": false } }
   - match: { rolled_over: false }

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/rollover/RolloverIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/rollover/RolloverIT.java
@@ -434,7 +434,7 @@ public class RolloverIT extends ESIntegTestCase {
         }
     }
 
-    public void testRolloverMaxSinglePrimarySize() throws Exception {
+    public void testRolloverMaxPrimaryShardSize() throws Exception {
         assertAcked(prepareCreate("test-1").addAlias(new Alias("test_alias")).get());
         int numDocs = randomIntBetween(10, 20);
         for (int i = 0; i < numDocs; i++) {
@@ -443,35 +443,35 @@ public class RolloverIT extends ESIntegTestCase {
         flush("test-1");
         refresh("test_alias");
 
-        // A large max_single_primary_size
+        // A large max_primary_shard_size
         {
             final RolloverResponse response = client().admin().indices()
                 .prepareRolloverIndex("test_alias")
-                .addMaxSinglePrimarySizeCondition(new ByteSizeValue(randomIntBetween(100, 50 * 1024), ByteSizeUnit.MB))
+                .addMaxPrimaryShardSizeCondition(new ByteSizeValue(randomIntBetween(100, 50 * 1024), ByteSizeUnit.MB))
                 .get();
             assertThat(response.getOldIndex(), equalTo("test-1"));
             assertThat(response.getNewIndex(), equalTo("test-000002"));
-            assertThat("No rollover with a large max_single_primary_size condition", response.isRolledOver(), equalTo(false));
+            assertThat("No rollover with a large max_primary_shard_size condition", response.isRolledOver(), equalTo(false));
             final IndexMetadata oldIndex = client().admin().cluster().prepareState().get().getState().metadata().index("test-1");
             assertThat(oldIndex.getRolloverInfos().size(), equalTo(0));
         }
 
-        // A small max_single_primary_size
+        // A small max_primary_shard_size
         {
-            ByteSizeValue maxSinglePrimarySizeCondition = new ByteSizeValue(randomIntBetween(1, 20), ByteSizeUnit.BYTES);
+            ByteSizeValue maxPrimaryShardSizeCondition = new ByteSizeValue(randomIntBetween(1, 20), ByteSizeUnit.BYTES);
             long beforeTime = client().threadPool().absoluteTimeInMillis() - 1000L;
             final RolloverResponse response = client().admin().indices()
                 .prepareRolloverIndex("test_alias")
-                .addMaxSinglePrimarySizeCondition(maxSinglePrimarySizeCondition)
+                .addMaxPrimaryShardSizeCondition(maxPrimaryShardSizeCondition)
                 .get();
             assertThat(response.getOldIndex(), equalTo("test-1"));
             assertThat(response.getNewIndex(), equalTo("test-000002"));
-            assertThat("Should rollover with a small max_single_primary_size condition", response.isRolledOver(), equalTo(true));
+            assertThat("Should rollover with a small max_primary_shard_size condition", response.isRolledOver(), equalTo(true));
             final IndexMetadata oldIndex = client().admin().cluster().prepareState().get().getState().metadata().index("test-1");
             List<Condition<?>> metConditions = oldIndex.getRolloverInfos().get("test_alias").getMetConditions();
             assertThat(metConditions.size(), equalTo(1));
             assertThat(metConditions.get(0).toString(),
-                equalTo(new MaxSinglePrimarySizeCondition(maxSinglePrimarySizeCondition).toString()));
+                equalTo(new MaxPrimaryShardSizeCondition(maxPrimaryShardSizeCondition).toString()));
             assertThat(oldIndex.getRolloverInfos().get("test_alias").getTime(),
                 is(both(greaterThanOrEqualTo(beforeTime)).and(lessThanOrEqualTo(client().threadPool().absoluteTimeInMillis() + 1000L))));
         }
@@ -480,7 +480,7 @@ public class RolloverIT extends ESIntegTestCase {
         {
             final RolloverResponse response = client().admin().indices()
                 .prepareRolloverIndex("test_alias")
-                .addMaxSinglePrimarySizeCondition(new ByteSizeValue(randomNonNegativeLong(), ByteSizeUnit.BYTES))
+                .addMaxPrimaryShardSizeCondition(new ByteSizeValue(randomNonNegativeLong(), ByteSizeUnit.BYTES))
                 .get();
             assertThat(response.getOldIndex(), equalTo("test-000002"));
             assertThat(response.getNewIndex(), equalTo("test-000003"));

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/Condition.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/Condition.java
@@ -75,13 +75,13 @@ public abstract class Condition<T> implements NamedWriteable, ToXContentFragment
         public final long numDocs;
         public final long indexCreated;
         public final ByteSizeValue indexSize;
-        public final ByteSizeValue maxSinglePrimarySize;
+        public final ByteSizeValue maxPrimaryShardSize;
 
-        public Stats(long numDocs, long indexCreated, ByteSizeValue indexSize, ByteSizeValue maxSinglePrimarySize) {
+        public Stats(long numDocs, long indexCreated, ByteSizeValue indexSize, ByteSizeValue maxPrimaryShardSize) {
             this.numDocs = numDocs;
             this.indexCreated = indexCreated;
             this.indexSize = indexSize;
-            this.maxSinglePrimarySize = maxSinglePrimarySize;
+            this.maxPrimaryShardSize = maxPrimaryShardSize;
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MaxPrimaryShardSizeCondition.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MaxPrimaryShardSizeCondition.java
@@ -22,22 +22,22 @@ import java.io.IOException;
  * A size-based condition for the primary shards within an index.
  * Evaluates to <code>true</code> if the size of the largest primary shard is at least {@link #value}.
  */
-public class MaxSinglePrimarySizeCondition extends Condition<ByteSizeValue> {
-    public static final String NAME = "max_single_primary_size";
+public class MaxPrimaryShardSizeCondition extends Condition<ByteSizeValue> {
+    public static final String NAME = "max_primary_shard_size";
 
-    public MaxSinglePrimarySizeCondition(ByteSizeValue value) {
+    public MaxPrimaryShardSizeCondition(ByteSizeValue value) {
         super(NAME);
         this.value = value;
     }
 
-    public MaxSinglePrimarySizeCondition(StreamInput in) throws IOException {
+    public MaxPrimaryShardSizeCondition(StreamInput in) throws IOException {
         super(NAME);
         this.value = new ByteSizeValue(in.readVLong(), ByteSizeUnit.BYTES);
     }
 
     @Override
     public Result evaluate(Stats stats) {
-        return new Result(this, stats.maxSinglePrimarySize.getBytes() >= value.getBytes());
+        return new Result(this, stats.maxPrimaryShardSize.getBytes() >= value.getBytes());
     }
 
     @Override
@@ -57,9 +57,9 @@ public class MaxSinglePrimarySizeCondition extends Condition<ByteSizeValue> {
         return builder.field(NAME, value.getStringRep());
     }
 
-    public static MaxSinglePrimarySizeCondition fromXContent(XContentParser parser) throws IOException {
+    public static MaxPrimaryShardSizeCondition fromXContent(XContentParser parser) throws IOException {
         if (parser.nextToken() == XContentParser.Token.VALUE_STRING) {
-            return new MaxSinglePrimarySizeCondition(ByteSizeValue.parseBytesSizeValue(parser.text(), NAME));
+            return new MaxPrimaryShardSizeCondition(ByteSizeValue.parseBytesSizeValue(parser.text(), NAME));
         } else {
             throw new IllegalArgumentException("invalid token: " + parser.currentToken());
         }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverRequest.java
@@ -44,7 +44,7 @@ public class RolloverRequest extends AcknowledgedRequest<RolloverRequest> implem
     private static final ParseField MAX_AGE_CONDITION = new ParseField(MaxAgeCondition.NAME);
     private static final ParseField MAX_DOCS_CONDITION = new ParseField(MaxDocsCondition.NAME);
     private static final ParseField MAX_SIZE_CONDITION = new ParseField(MaxSizeCondition.NAME);
-    private static final ParseField MAX_SINGLE_PRIMARY_SIZE_CONDITION = new ParseField(MaxSinglePrimarySizeCondition.NAME);
+    private static final ParseField MAX_PRIMARY_SHARD_SIZE_CONDITION = new ParseField(MaxPrimaryShardSizeCondition.NAME);
 
     static {
         CONDITION_PARSER.declareString((conditions, s) ->
@@ -59,9 +59,9 @@ public class RolloverRequest extends AcknowledgedRequest<RolloverRequest> implem
                     new MaxSizeCondition(ByteSizeValue.parseBytesSizeValue(s, MaxSizeCondition.NAME))),
             MAX_SIZE_CONDITION);
         CONDITION_PARSER.declareString((conditions, s) ->
-                conditions.put(MaxSinglePrimarySizeCondition.NAME,
-                    new MaxSinglePrimarySizeCondition(ByteSizeValue.parseBytesSizeValue(s, MaxSinglePrimarySizeCondition.NAME))),
-            MAX_SINGLE_PRIMARY_SIZE_CONDITION);
+                conditions.put(MaxPrimaryShardSizeCondition.NAME,
+                    new MaxPrimaryShardSizeCondition(ByteSizeValue.parseBytesSizeValue(s, MaxPrimaryShardSizeCondition.NAME))),
+            MAX_PRIMARY_SHARD_SIZE_CONDITION);
 
         PARSER.declareField((parser, request, context) -> CONDITION_PARSER.parse(parser, request.conditions, null),
             CONDITIONS, ObjectParser.ValueType.OBJECT);
@@ -206,12 +206,12 @@ public class RolloverRequest extends AcknowledgedRequest<RolloverRequest> implem
     /**
      * Adds a size-based condition to check if the size of the largest primary shard is at least <code>size</code>.
      */
-    public void addMaxSinglePrimarySizeCondition(ByteSizeValue size) {
-        MaxSinglePrimarySizeCondition maxSinglePrimarySizeCondition = new MaxSinglePrimarySizeCondition(size);
-        if (this.conditions.containsKey(maxSinglePrimarySizeCondition.name)) {
-            throw new IllegalArgumentException(maxSinglePrimarySizeCondition + " condition is already set");
+    public void addMaxPrimaryShardSizeCondition(ByteSizeValue size) {
+        MaxPrimaryShardSizeCondition maxPrimaryShardSizeCondition = new MaxPrimaryShardSizeCondition(size);
+        if (this.conditions.containsKey(maxPrimaryShardSizeCondition.name)) {
+            throw new IllegalArgumentException(maxPrimaryShardSizeCondition + " condition is already set");
         }
-        this.conditions.put(maxSinglePrimarySizeCondition.name, maxSinglePrimarySizeCondition);
+        this.conditions.put(maxPrimaryShardSizeCondition.name, maxPrimaryShardSizeCondition);
     }
 
     public boolean isDryRun() {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverRequestBuilder.java
@@ -47,8 +47,8 @@ public class RolloverRequestBuilder extends MasterNodeOperationRequestBuilder<Ro
         return this;
     }
 
-    public RolloverRequestBuilder addMaxSinglePrimarySizeCondition(ByteSizeValue size) {
-        this.request.addMaxSinglePrimarySizeCondition(size);
+    public RolloverRequestBuilder addMaxPrimaryShardSizeCondition(ByteSizeValue size) {
+        this.request.addMaxPrimaryShardSizeCondition(size);
         return this;
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverAction.java
@@ -239,7 +239,7 @@ public class TransportRolloverAction extends TransportMasterNodeAction<RolloverR
                 .map(stats -> stats.getPrimaries().getDocs())
                 .orElse(null);
 
-            final long maxSinglePrimarySize = indexStats.stream()
+            final long maxPrimaryShardSize = indexStats.stream()
                 .map(IndexStats::getShards)
                 .filter(Objects::nonNull)
                 .flatMap(Arrays::stream)
@@ -252,7 +252,7 @@ public class TransportRolloverAction extends TransportMasterNodeAction<RolloverR
                 docsStats == null ? 0 : docsStats.getCount(),
                 metadata.getCreationDate(),
                 new ByteSizeValue(docsStats == null ? 0 : docsStats.getTotalSizeInBytes()),
-                new ByteSizeValue(maxSinglePrimarySize)
+                new ByteSizeValue(maxPrimaryShardSize)
             );
         }
     }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/shrink/ResizeRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/shrink/ResizeRequestBuilder.java
@@ -71,10 +71,10 @@ public class ResizeRequestBuilder extends AcknowledgedRequestBuilder<ResizeReque
     }
 
     /**
-     * Sets the max single primary shard size of the target index.
+     * Sets the max primary shard size of the target index.
      */
-    public ResizeRequestBuilder setMaxSinglePrimarySize(ByteSizeValue maxSinglePrimarySize) {
-        this.request.setMaxSinglePrimarySize(maxSinglePrimarySize);
+    public ResizeRequestBuilder setMaxPrimaryShardSize(ByteSizeValue maxPrimaryShardSize) {
+        this.request.setMaxPrimaryShardSize(maxPrimaryShardSize);
         return this;
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/shrink/TransportResizeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/shrink/TransportResizeAction.java
@@ -127,29 +127,29 @@ public class TransportResizeAction extends TransportMasterNodeAction<ResizeReque
         targetIndexSettingsBuilder.remove(IndexMetadata.SETTING_HISTORY_UUID);
         final Settings targetIndexSettings = targetIndexSettingsBuilder.build();
         final int numShards;
-        ByteSizeValue maxSinglePrimarySize = resizeRequest.getMaxSinglePrimarySize();
+        ByteSizeValue maxPrimaryShardSize = resizeRequest.getMaxPrimaryShardSize();
         if (IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.exists(targetIndexSettings)) {
-            if (resizeRequest.getResizeType() == ResizeType.SHRINK && maxSinglePrimarySize != null) {
-                throw new IllegalArgumentException("Cannot set both index.number_of_shards and max_single_primary_size" +
+            if (resizeRequest.getResizeType() == ResizeType.SHRINK && maxPrimaryShardSize != null) {
+                throw new IllegalArgumentException("Cannot set both index.number_of_shards and max_primary_shard_size" +
                     " for the target index");
             }
             numShards = IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.get(targetIndexSettings);
         } else {
             assert resizeRequest.getResizeType() != ResizeType.SPLIT : "split must specify the number of shards explicitly";
             if (resizeRequest.getResizeType() == ResizeType.SHRINK) {
-                if (maxSinglePrimarySize != null) {
+                if (maxPrimaryShardSize != null) {
                     int sourceIndexShardsNum = sourceMetadata.getNumberOfShards();
                     long sourceIndexStorageBytes = indexStoreStats.getSizeInBytes();
-                    long maxSinglePrimarySizeBytes = maxSinglePrimarySize.getBytes();
-                    long minShardsNum = sourceIndexStorageBytes / maxSinglePrimarySizeBytes;
-                    if (minShardsNum * maxSinglePrimarySizeBytes < sourceIndexStorageBytes) {
+                    long maxPrimaryShardSizeBytes = maxPrimaryShardSize.getBytes();
+                    long minShardsNum = sourceIndexStorageBytes / maxPrimaryShardSizeBytes;
+                    if (minShardsNum * maxPrimaryShardSizeBytes < sourceIndexStorageBytes) {
                         minShardsNum = minShardsNum + 1;
                     }
                     if (minShardsNum > sourceIndexShardsNum) {
-                        logger.info("By setting max_single_primary_size to [{}], the target index [{}] will contain [{}] shards," +
+                        logger.info("By setting max_primary_shard_size to [{}], the target index [{}] will contain [{}] shards," +
                                 " which will be greater than [{}] shards in the source index [{}]," +
                                 " using [{}] for the shard count of the target index [{}]",
-                            maxSinglePrimarySize.toString(), targetIndexName, minShardsNum, sourceIndexShardsNum,
+                            maxPrimaryShardSize.toString(), targetIndexName, minShardsNum, sourceIndexShardsNum,
                             sourceMetadata.getIndex().getName(), sourceIndexShardsNum, targetIndexName);
                         numShards = sourceIndexShardsNum;
                     } else {

--- a/server/src/main/java/org/elasticsearch/indices/IndicesModule.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesModule.java
@@ -11,7 +11,7 @@ package org.elasticsearch.indices;
 import org.elasticsearch.action.admin.indices.rollover.Condition;
 import org.elasticsearch.action.admin.indices.rollover.MaxAgeCondition;
 import org.elasticsearch.action.admin.indices.rollover.MaxDocsCondition;
-import org.elasticsearch.action.admin.indices.rollover.MaxSinglePrimarySizeCondition;
+import org.elasticsearch.action.admin.indices.rollover.MaxPrimaryShardSizeCondition;
 import org.elasticsearch.action.admin.indices.rollover.MaxSizeCondition;
 import org.elasticsearch.action.resync.TransportResyncReplicationAction;
 import org.elasticsearch.common.ParseField;
@@ -78,7 +78,7 @@ public class IndicesModule extends AbstractModule {
             new NamedWriteableRegistry.Entry(Condition.class, MaxAgeCondition.NAME, MaxAgeCondition::new),
             new NamedWriteableRegistry.Entry(Condition.class, MaxDocsCondition.NAME, MaxDocsCondition::new),
             new NamedWriteableRegistry.Entry(Condition.class, MaxSizeCondition.NAME, MaxSizeCondition::new),
-            new NamedWriteableRegistry.Entry(Condition.class, MaxSinglePrimarySizeCondition.NAME, MaxSinglePrimarySizeCondition::new)
+            new NamedWriteableRegistry.Entry(Condition.class, MaxPrimaryShardSizeCondition.NAME, MaxPrimaryShardSizeCondition::new)
         );
     }
 
@@ -90,8 +90,8 @@ public class IndicesModule extends AbstractModule {
                 MaxDocsCondition.fromXContent(p)),
             new NamedXContentRegistry.Entry(Condition.class, new ParseField(MaxSizeCondition.NAME), (p, c) ->
                 MaxSizeCondition.fromXContent(p)),
-            new NamedXContentRegistry.Entry(Condition.class, new ParseField(MaxSinglePrimarySizeCondition.NAME), (p, c) ->
-                MaxSinglePrimarySizeCondition.fromXContent(p))
+            new NamedXContentRegistry.Entry(Condition.class, new ParseField(MaxPrimaryShardSizeCondition.NAME), (p, c) ->
+                MaxPrimaryShardSizeCondition.fromXContent(p))
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/ConditionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/ConditionTests.java
@@ -61,19 +61,19 @@ public class ConditionTests extends ESTestCase {
         assertThat(result.matched, equalTo(true));
     }
 
-    public void testMaxSinglePrimarySize() {
-        MaxSinglePrimarySizeCondition maxSinglePrimarySizeCondition =
-            new MaxSinglePrimarySizeCondition(ByteSizeValue.ofMb(randomIntBetween(10, 20)));
+    public void testMaxPrimaryShardSize() {
+        MaxPrimaryShardSizeCondition maxPrimaryShardSizeCondition =
+            new MaxPrimaryShardSizeCondition(ByteSizeValue.ofMb(randomIntBetween(10, 20)));
 
-        Condition.Result result = maxSinglePrimarySizeCondition.evaluate(new Condition.Stats(randomNonNegativeLong(),
+        Condition.Result result = maxPrimaryShardSizeCondition.evaluate(new Condition.Stats(randomNonNegativeLong(),
             randomNonNegativeLong(), randomByteSize(), ByteSizeValue.ofMb(0)));
         assertThat(result.matched, equalTo(false));
 
-        result = maxSinglePrimarySizeCondition.evaluate(new Condition.Stats(randomNonNegativeLong(), randomNonNegativeLong(),
+        result = maxPrimaryShardSizeCondition.evaluate(new Condition.Stats(randomNonNegativeLong(), randomNonNegativeLong(),
             randomByteSize(), ByteSizeValue.ofMb(randomIntBetween(0, 9))));
         assertThat(result.matched, equalTo(false));
 
-        result = maxSinglePrimarySizeCondition.evaluate(new Condition.Stats(randomNonNegativeLong(), randomNonNegativeLong(),
+        result = maxPrimaryShardSizeCondition.evaluate(new Condition.Stats(randomNonNegativeLong(), randomNonNegativeLong(),
             randomByteSize(), ByteSizeValue.ofMb(randomIntBetween(20, 1000))));
         assertThat(result.matched, equalTo(true));
     }
@@ -91,10 +91,10 @@ public class ConditionTests extends ESTestCase {
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(maxSizeCondition, condition -> new MaxSizeCondition(condition.value),
             condition -> new MaxSizeCondition(randomByteSize()));
 
-        MaxSinglePrimarySizeCondition maxSinglePrimarySizeCondition = new MaxSinglePrimarySizeCondition(randomByteSize());
-        EqualsHashCodeTestUtils.checkEqualsAndHashCode(maxSinglePrimarySizeCondition,
-            condition -> new MaxSinglePrimarySizeCondition(condition.value),
-            condition -> new MaxSinglePrimarySizeCondition(randomByteSize()));
+        MaxPrimaryShardSizeCondition maxPrimaryShardSizeCondition = new MaxPrimaryShardSizeCondition(randomByteSize());
+        EqualsHashCodeTestUtils.checkEqualsAndHashCode(maxPrimaryShardSizeCondition,
+            condition -> new MaxPrimaryShardSizeCondition(condition.value),
+            condition -> new MaxPrimaryShardSizeCondition(randomByteSize()));
     }
 
     private static ByteSizeValue randomByteSize() {

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/RolloverRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/RolloverRequestTests.java
@@ -57,7 +57,7 @@ public class RolloverRequestTests extends ESTestCase {
                     .field("max_age", "10d")
                     .field("max_docs", 100)
                     .field("max_size", "45gb")
-                    .field("max_single_primary_size", "55gb")
+                    .field("max_primary_shard_size", "55gb")
                 .endObject()
             .endObject();
         request.fromXContent(createParser(builder));
@@ -69,9 +69,9 @@ public class RolloverRequestTests extends ESTestCase {
         assertThat(maxDocsCondition.value, equalTo(100L));
         MaxSizeCondition maxSizeCondition = (MaxSizeCondition)conditions.get(MaxSizeCondition.NAME);
         assertThat(maxSizeCondition.value.getBytes(), equalTo(ByteSizeUnit.GB.toBytes(45)));
-        MaxSinglePrimarySizeCondition maxSinglePrimarySizeCondition =
-            (MaxSinglePrimarySizeCondition)conditions.get(MaxSinglePrimarySizeCondition.NAME);
-        assertThat(maxSinglePrimarySizeCondition.value.getBytes(), equalTo(ByteSizeUnit.GB.toBytes(55)));
+        MaxPrimaryShardSizeCondition maxPrimaryShardSizeCondition =
+            (MaxPrimaryShardSizeCondition)conditions.get(MaxPrimaryShardSizeCondition.NAME);
+        assertThat(maxPrimaryShardSizeCondition.value.getBytes(), equalTo(ByteSizeUnit.GB.toBytes(55)));
     }
 
     public void testParsingWithIndexSettings() throws Exception {

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/RolloverResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/RolloverResponseTests.java
@@ -45,7 +45,7 @@ public class RolloverResponseTests extends AbstractWireSerializingTestCase<Rollo
         conditionSuppliers.add(() -> new MaxAgeCondition(new TimeValue(randomNonNegativeLong())));
         conditionSuppliers.add(() -> new MaxDocsCondition(randomNonNegativeLong()));
         conditionSuppliers.add(() -> new MaxSizeCondition(new ByteSizeValue(randomNonNegativeLong())));
-        conditionSuppliers.add(() -> new MaxSinglePrimarySizeCondition(new ByteSizeValue(randomNonNegativeLong())));
+        conditionSuppliers.add(() -> new MaxPrimaryShardSizeCondition(new ByteSizeValue(randomNonNegativeLong())));
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverActionTests.java
@@ -100,9 +100,9 @@ public class TransportRolloverActionTests extends ESTestCase {
         MaxAgeCondition maxAgeCondition = new MaxAgeCondition(TimeValue.timeValueHours(2));
         MaxDocsCondition maxDocsCondition = new MaxDocsCondition(100L);
         MaxSizeCondition maxSizeCondition = new MaxSizeCondition(ByteSizeValue.ofMb(randomIntBetween(10, 100)));
-        MaxSinglePrimarySizeCondition maxSinglePrimarySizeCondition =
-            new MaxSinglePrimarySizeCondition(ByteSizeValue.ofMb(randomIntBetween(10, 100)));
-        final Set<Condition<?>> conditions = Set.of(maxAgeCondition, maxDocsCondition, maxSizeCondition, maxSinglePrimarySizeCondition);
+        MaxPrimaryShardSizeCondition maxPrimaryShardSizeCondition =
+            new MaxPrimaryShardSizeCondition(ByteSizeValue.ofMb(randomIntBetween(10, 100)));
+        final Set<Condition<?>> conditions = Set.of(maxAgeCondition, maxDocsCondition, maxSizeCondition, maxPrimaryShardSizeCondition);
 
         long matchMaxDocs = randomIntBetween(100, 1000);
         long notMatchMaxDocs = randomIntBetween(0, 99);
@@ -135,7 +135,7 @@ public class TransportRolloverActionTests extends ESTestCase {
                 assertThat(entry.getValue(), equalTo(false));
             } else if (entry.getKey().equals(maxSizeCondition.toString())) {
                 assertThat(entry.getValue(), equalTo(false));
-            } else if (entry.getKey().equals(maxSinglePrimarySizeCondition.toString())) {
+            } else if (entry.getKey().equals(maxPrimaryShardSizeCondition.toString())) {
                 assertThat(entry.getValue(), equalTo(false));
             } else {
                 fail("unknown condition result found " + entry.getKey());
@@ -147,9 +147,9 @@ public class TransportRolloverActionTests extends ESTestCase {
         MaxAgeCondition maxAgeCondition = new MaxAgeCondition(TimeValue.timeValueHours(randomIntBetween(1, 3)));
         MaxDocsCondition maxDocsCondition = new MaxDocsCondition(randomNonNegativeLong());
         MaxSizeCondition maxSizeCondition = new MaxSizeCondition(new ByteSizeValue(randomNonNegativeLong()));
-        MaxSinglePrimarySizeCondition maxSinglePrimarySizeCondition =
-            new MaxSinglePrimarySizeCondition(new ByteSizeValue(randomNonNegativeLong()));
-        final Set<Condition<?>> conditions = Set.of(maxAgeCondition, maxDocsCondition, maxSizeCondition, maxSinglePrimarySizeCondition);
+        MaxPrimaryShardSizeCondition maxPrimaryShardSizeCondition =
+            new MaxPrimaryShardSizeCondition(new ByteSizeValue(randomNonNegativeLong()));
+        final Set<Condition<?>> conditions = Set.of(maxAgeCondition, maxDocsCondition, maxSizeCondition, maxPrimaryShardSizeCondition);
 
         final Settings settings = Settings.builder()
             .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
@@ -172,7 +172,7 @@ public class TransportRolloverActionTests extends ESTestCase {
                 assertThat(entry.getValue(), equalTo(false));
             } else if (entry.getKey().equals(maxSizeCondition.toString())) {
                 assertThat(entry.getValue(), equalTo(false));
-            } else if (entry.getKey().equals(maxSinglePrimarySizeCondition.toString())) {
+            } else if (entry.getKey().equals(maxPrimaryShardSizeCondition.toString())) {
                 assertThat(entry.getValue(), equalTo(false));
             } else {
                 fail("unknown condition result found " + entry.getKey());
@@ -184,9 +184,9 @@ public class TransportRolloverActionTests extends ESTestCase {
         MaxAgeCondition maxAgeCondition = new MaxAgeCondition(TimeValue.timeValueHours(2));
         MaxDocsCondition maxDocsCondition = new MaxDocsCondition(100L);
         MaxSizeCondition maxSizeCondition = new MaxSizeCondition(ByteSizeValue.ofMb(randomIntBetween(10, 100)));
-        MaxSinglePrimarySizeCondition maxSinglePrimarySizeCondition =
-            new MaxSinglePrimarySizeCondition(ByteSizeValue.ofMb(randomIntBetween(10, 100)));
-        final Set<Condition<?>> conditions = Set.of(maxAgeCondition, maxDocsCondition, maxSizeCondition, maxSinglePrimarySizeCondition);
+        MaxPrimaryShardSizeCondition maxPrimaryShardSizeCondition =
+            new MaxPrimaryShardSizeCondition(ByteSizeValue.ofMb(randomIntBetween(10, 100)));
+        final Set<Condition<?>> conditions = Set.of(maxAgeCondition, maxDocsCondition, maxSizeCondition, maxPrimaryShardSizeCondition);
 
         final Settings settings = Settings.builder()
             .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/shrink/ResizeRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/shrink/ResizeRequestTests.java
@@ -59,9 +59,9 @@ public class ResizeRequestTests extends ESTestCase {
         }
         {
             ResizeRequest request = new ResizeRequest("target", "source");
-            request.setMaxSinglePrimarySize(new ByteSizeValue(100, ByteSizeUnit.MB));
+            request.setMaxPrimaryShardSize(new ByteSizeValue(100, ByteSizeUnit.MB));
             String actualRequestBody = Strings.toString(request);
-            assertEquals("{\"settings\":{},\"aliases\":{},\"max_single_primary_size\":\"100mb\"}", actualRequestBody);
+            assertEquals("{\"settings\":{},\"aliases\":{},\"max_primary_shard_size\":\"100mb\"}", actualRequestBody);
         }
         {
             ResizeRequest request = new ResizeRequest();

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/shrink/TransportResizeActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/shrink/TransportResizeActionTests.java
@@ -230,19 +230,19 @@ public class TransportResizeActionTests extends ESTestCase {
         assertEquals(TransportResizeAction.calTargetShardsNum(60, 31), 60);
     }
 
-    public void testShrinkWithMaxSinglePrimarySize() {
+    public void testShrinkWithMaxPrimaryShardSize() {
         int sourceIndexShardsNum = randomIntBetween(2, 42);
         IndexMetadata state = createClusterState("source", sourceIndexShardsNum, randomIntBetween(0, 10),
             Settings.builder().put("index.blocks.write", true).build()).metadata().index("source");
         ResizeRequest resizeRequest = new ResizeRequest("target", "source");
-        resizeRequest.setMaxSinglePrimarySize(new ByteSizeValue(10));
+        resizeRequest.setMaxPrimaryShardSize(new ByteSizeValue(10));
         resizeRequest.getTargetIndexRequest()
             .settings(Settings.builder().put("index.number_of_shards", 2).build());
         assertTrue(
             expectThrows(IllegalArgumentException.class, () ->
                 TransportResizeAction.prepareCreateIndexRequest(resizeRequest, state, new StoreStats(between(1, 100), between(1, 100)),
                     (i) -> new DocsStats(Integer.MAX_VALUE, between(1, 1000), between(1, 100)), "target")
-            ).getMessage().startsWith("Cannot set both index.number_of_shards and max_single_primary_size for the target index"));
+            ).getMessage().startsWith("Cannot set both index.number_of_shards and max_primary_shard_size for the target index"));
 
         // create one that won't fail
         ClusterState clusterState = ClusterState.builder(createClusterState("source", 10, 0,
@@ -263,9 +263,9 @@ public class TransportResizeActionTests extends ESTestCase {
         int numSourceShards = clusterState.metadata().index("source").getNumberOfShards();
         DocsStats stats = new DocsStats(between(0, (IndexWriter.MAX_DOCS) / numSourceShards), between(1, 1000), between(1, 10000));
 
-        // each shard's storage will not be greater than the `max_single_primary_size`
+        // each shard's storage will not be greater than the `max_primary_shard_size`
         ResizeRequest target1 = new ResizeRequest("target", "source");
-        target1.setMaxSinglePrimarySize(new ByteSizeValue(2));
+        target1.setMaxPrimaryShardSize(new ByteSizeValue(2));
         StoreStats storeStats = new StoreStats(10, between(1, 100));
         final int targetIndexShardsNum1 = 5;
         final ActiveShardCount activeShardCount1 = ActiveShardCount.from(targetIndexShardsNum1);
@@ -279,10 +279,10 @@ public class TransportResizeActionTests extends ESTestCase {
         assertEquals("shrink_index", request1.cause());
         assertEquals(request1.waitForActiveShards(), activeShardCount1);
 
-        // if `max_single_primary_size` is less than the single shard size of the source index,
+        // if `max_primary_shard_size` is less than the single shard size of the source index,
         // the shards number of the target index will be equal to the source index's shards number
         ResizeRequest target2 = new ResizeRequest("target2", "source");
-        target2.setMaxSinglePrimarySize(new ByteSizeValue(1));
+        target2.setMaxPrimaryShardSize(new ByteSizeValue(1));
         StoreStats storeStats2 = new StoreStats(100, between(1, 100));
         final int targetIndexShardsNum2 = 10;
         final ActiveShardCount activeShardCount2 = ActiveShardCount.from(targetIndexShardsNum2);

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexMetadataTests.java
@@ -10,7 +10,7 @@ package org.elasticsearch.cluster.metadata;
 
 import org.elasticsearch.action.admin.indices.rollover.MaxAgeCondition;
 import org.elasticsearch.action.admin.indices.rollover.MaxDocsCondition;
-import org.elasticsearch.action.admin.indices.rollover.MaxSinglePrimarySizeCondition;
+import org.elasticsearch.action.admin.indices.rollover.MaxPrimaryShardSizeCondition;
 import org.elasticsearch.action.admin.indices.rollover.MaxSizeCondition;
 import org.elasticsearch.action.admin.indices.rollover.RolloverInfo;
 import org.elasticsearch.common.Strings;
@@ -86,7 +86,7 @@ public class IndexMetadataTests extends ESTestCase {
                         new MaxAgeCondition(TimeValue.timeValueMillis(randomNonNegativeLong())),
                         new MaxDocsCondition(randomNonNegativeLong()),
                         new MaxSizeCondition(new ByteSizeValue(randomNonNegativeLong())),
-                        new MaxSinglePrimarySizeCondition(new ByteSizeValue(randomNonNegativeLong()))
+                        new MaxPrimaryShardSizeCondition(new ByteSizeValue(randomNonNegativeLong()))
                     ),
                     randomNonNegativeLong())).build();
         assertEquals(system, metadata.isSystem());

--- a/server/src/test/java/org/elasticsearch/index/shard/RemoveCorruptedShardDataCommandTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/RemoveCorruptedShardDataCommandTests.java
@@ -15,7 +15,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.indices.rollover.Condition;
 import org.elasticsearch.action.admin.indices.rollover.MaxAgeCondition;
 import org.elasticsearch.action.admin.indices.rollover.MaxDocsCondition;
-import org.elasticsearch.action.admin.indices.rollover.MaxSinglePrimarySizeCondition;
+import org.elasticsearch.action.admin.indices.rollover.MaxPrimaryShardSizeCondition;
 import org.elasticsearch.action.admin.indices.rollover.MaxSizeCondition;
 import org.elasticsearch.action.admin.indices.rollover.RolloverInfo;
 import org.elasticsearch.cli.MockTerminal;
@@ -119,7 +119,7 @@ public class RemoveCorruptedShardDataCommandTests extends IndexShardTestCase {
         Condition rolloverCondition = randomFrom(
             new MaxAgeCondition(new TimeValue(randomNonNegativeLong())),
             new MaxDocsCondition(randomNonNegativeLong()),
-            new MaxSinglePrimarySizeCondition(new ByteSizeValue(randomNonNegativeLong())),
+            new MaxPrimaryShardSizeCondition(new ByteSizeValue(randomNonNegativeLong())),
             new MaxSizeCondition(new ByteSizeValue(randomNonNegativeLong()))
         );
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ShrinkStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ShrinkStep.java
@@ -24,14 +24,14 @@ public class ShrinkStep extends AsyncActionStep {
     public static final String NAME = "shrink";
 
     private Integer numberOfShards;
-    private ByteSizeValue maxSinglePrimarySize;
+    private ByteSizeValue maxPrimaryShardSize;
     private String shrunkIndexPrefix;
 
     public ShrinkStep(StepKey key, StepKey nextStepKey, Client client, Integer numberOfShards,
-                      ByteSizeValue maxSinglePrimarySize, String shrunkIndexPrefix) {
+                      ByteSizeValue maxPrimaryShardSize, String shrunkIndexPrefix) {
         super(key, nextStepKey, client);
         this.numberOfShards = numberOfShards;
-        this.maxSinglePrimarySize = maxSinglePrimarySize;
+        this.maxPrimaryShardSize = maxPrimaryShardSize;
         this.shrunkIndexPrefix = shrunkIndexPrefix;
     }
 
@@ -39,8 +39,8 @@ public class ShrinkStep extends AsyncActionStep {
         return numberOfShards;
     }
 
-    public ByteSizeValue getMaxSinglePrimarySize() {
-        return maxSinglePrimarySize;
+    public ByteSizeValue getMaxPrimaryShardSize() {
+        return maxPrimaryShardSize;
     }
 
     String getShrunkIndexPrefix() {
@@ -70,7 +70,7 @@ public class ShrinkStep extends AsyncActionStep {
         String shrunkenIndexName = shrunkIndexPrefix + indexMetadata.getIndex().getName();
         ResizeRequest resizeRequest = new ResizeRequest(shrunkenIndexName, indexMetadata.getIndex().getName())
             .masterNodeTimeout(getMasterTimeout(currentState));
-        resizeRequest.setMaxSinglePrimarySize(maxSinglePrimarySize);
+        resizeRequest.setMaxPrimaryShardSize(maxPrimaryShardSize);
         resizeRequest.getTargetIndexRequest().settings(relevantTargetSettings);
 
         getClient().admin().indices().resizeIndex(resizeRequest, ActionListener.wrap(response -> {
@@ -84,7 +84,7 @@ public class ShrinkStep extends AsyncActionStep {
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), numberOfShards, maxSinglePrimarySize, shrunkIndexPrefix);
+        return Objects.hash(super.hashCode(), numberOfShards, maxPrimaryShardSize, shrunkIndexPrefix);
     }
 
     @Override
@@ -98,7 +98,7 @@ public class ShrinkStep extends AsyncActionStep {
         ShrinkStep other = (ShrinkStep) obj;
         return super.equals(obj) &&
                 Objects.equals(numberOfShards, other.numberOfShards) &&
-                Objects.equals(maxSinglePrimarySize, other.maxSinglePrimarySize) &&
+                Objects.equals(maxPrimaryShardSize, other.maxPrimaryShardSize) &&
                 Objects.equals(shrunkIndexPrefix, other.shrunkIndexPrefix);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitForRolloverReadyStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitForRolloverReadyStep.java
@@ -35,15 +35,15 @@ public class WaitForRolloverReadyStep extends AsyncWaitStep {
     public static final String NAME = "check-rollover-ready";
 
     private final ByteSizeValue maxSize;
-    private final ByteSizeValue maxSinglePrimarySize;
+    private final ByteSizeValue maxPrimaryShardSize;
     private final TimeValue maxAge;
     private final Long maxDocs;
 
     public WaitForRolloverReadyStep(StepKey key, StepKey nextStepKey, Client client,
-                                    ByteSizeValue maxSize, ByteSizeValue maxSinglePrimarySize, TimeValue maxAge, Long maxDocs) {
+                                    ByteSizeValue maxSize, ByteSizeValue maxPrimaryShardSize, TimeValue maxAge, Long maxDocs) {
         super(key, nextStepKey, client);
         this.maxSize = maxSize;
-        this.maxSinglePrimarySize = maxSinglePrimarySize;
+        this.maxPrimaryShardSize = maxPrimaryShardSize;
         this.maxAge = maxAge;
         this.maxDocs = maxDocs;
     }
@@ -144,8 +144,8 @@ public class WaitForRolloverReadyStep extends AsyncWaitStep {
         if (maxSize != null) {
             rolloverRequest.addMaxIndexSizeCondition(maxSize);
         }
-        if (maxSinglePrimarySize != null) {
-            rolloverRequest.addMaxSinglePrimarySizeCondition(maxSinglePrimarySize);
+        if (maxPrimaryShardSize != null) {
+            rolloverRequest.addMaxPrimaryShardSizeCondition(maxPrimaryShardSize);
         }
         if (maxAge != null) {
             rolloverRequest.addMaxIndexAgeCondition(maxAge);
@@ -162,8 +162,8 @@ public class WaitForRolloverReadyStep extends AsyncWaitStep {
         return maxSize;
     }
 
-    ByteSizeValue getMaxSinglePrimarySize() {
-        return maxSinglePrimarySize;
+    ByteSizeValue getMaxPrimaryShardSize() {
+        return maxPrimaryShardSize;
     }
 
     TimeValue getMaxAge() {
@@ -176,7 +176,7 @@ public class WaitForRolloverReadyStep extends AsyncWaitStep {
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), maxSize, maxSinglePrimarySize, maxAge, maxDocs);
+        return Objects.hash(super.hashCode(), maxSize, maxPrimaryShardSize, maxAge, maxDocs);
     }
 
     @Override
@@ -190,7 +190,7 @@ public class WaitForRolloverReadyStep extends AsyncWaitStep {
         WaitForRolloverReadyStep other = (WaitForRolloverReadyStep) obj;
         return super.equals(obj) &&
             Objects.equals(maxSize, other.maxSize) &&
-            Objects.equals(maxSinglePrimarySize, other.maxSinglePrimarySize) &&
+            Objects.equals(maxPrimaryShardSize, other.maxPrimaryShardSize) &&
             Objects.equals(maxAge, other.maxAge) &&
             Objects.equals(maxDocs, other.maxDocs);
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/RolloverActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/RolloverActionTests.java
@@ -32,14 +32,14 @@ public class RolloverActionTests extends AbstractActionTestCase<RolloverAction> 
         ByteSizeUnit maxSizeUnit = randomFrom(ByteSizeUnit.values());
         ByteSizeValue maxSize = randomBoolean() ? null :
             new ByteSizeValue(randomNonNegativeLong() / maxSizeUnit.toBytes(1), maxSizeUnit);
-        ByteSizeUnit maxSinglePrimarySizeUnit = randomFrom(ByteSizeUnit.values());
-        ByteSizeValue maxSinglePrimarySize = randomBoolean() ? null :
-            new ByteSizeValue(randomNonNegativeLong() / maxSinglePrimarySizeUnit.toBytes(1), maxSinglePrimarySizeUnit);
+        ByteSizeUnit maxPrimaryShardSizeUnit = randomFrom(ByteSizeUnit.values());
+        ByteSizeValue maxPrimaryShardSize = randomBoolean() ? null :
+            new ByteSizeValue(randomNonNegativeLong() / maxPrimaryShardSizeUnit.toBytes(1), maxPrimaryShardSizeUnit);
         Long maxDocs = randomBoolean() ? null : randomNonNegativeLong();
         TimeValue maxAge = (maxDocs == null && maxSize == null || randomBoolean())
             ? TimeValue.parseTimeValue(randomPositiveTimeValue(), "rollover_action_test")
             : null;
-        return new RolloverAction(maxSize, maxSinglePrimarySize, maxAge, maxDocs);
+        return new RolloverAction(maxSize, maxPrimaryShardSize, maxAge, maxDocs);
     }
 
     @Override
@@ -50,7 +50,7 @@ public class RolloverActionTests extends AbstractActionTestCase<RolloverAction> 
     @Override
     protected RolloverAction mutateInstance(RolloverAction instance) throws IOException {
         ByteSizeValue maxSize = instance.getMaxSize();
-        ByteSizeValue maxSinglePrimarySize = instance.getMaxSinglePrimarySize();
+        ByteSizeValue maxPrimaryShardSize = instance.getMaxPrimaryShardSize();
         TimeValue maxAge = instance.getMaxAge();
         Long maxDocs = instance.getMaxDocs();
         switch (between(0, 3)) {
@@ -61,9 +61,9 @@ public class RolloverActionTests extends AbstractActionTestCase<RolloverAction> 
                 });
                 break;
             case 1:
-                maxSinglePrimarySize = randomValueOtherThan(maxSinglePrimarySize, () -> {
-                    ByteSizeUnit maxSinglePrimarySizeUnit = randomFrom(ByteSizeUnit.values());
-                    return new ByteSizeValue(randomNonNegativeLong() / maxSinglePrimarySizeUnit.toBytes(1), maxSinglePrimarySizeUnit);
+                maxPrimaryShardSize = randomValueOtherThan(maxPrimaryShardSize, () -> {
+                    ByteSizeUnit maxPrimaryShardSizeUnit = randomFrom(ByteSizeUnit.values());
+                    return new ByteSizeValue(randomNonNegativeLong() / maxPrimaryShardSizeUnit.toBytes(1), maxPrimaryShardSizeUnit);
                 });
                 break;
             case 2:
@@ -76,7 +76,7 @@ public class RolloverActionTests extends AbstractActionTestCase<RolloverAction> 
             default:
                 throw new AssertionError("Illegal randomisation branch");
         }
-        return new RolloverAction(maxSize, maxSinglePrimarySize, maxAge, maxDocs);
+        return new RolloverAction(maxSize, maxPrimaryShardSize, maxAge, maxDocs);
     }
 
     public void testNoConditions() {
@@ -113,7 +113,7 @@ public class RolloverActionTests extends AbstractActionTestCase<RolloverAction> 
         assertEquals(fourthStep.getKey(), thirdStep.getNextStepKey());
         assertEquals(fifthStep.getKey(), fourthStep.getNextStepKey());
         assertEquals(action.getMaxSize(), firstStep.getMaxSize());
-        assertEquals(action.getMaxSinglePrimarySize(), firstStep.getMaxSinglePrimarySize());
+        assertEquals(action.getMaxPrimaryShardSize(), firstStep.getMaxPrimaryShardSize());
         assertEquals(action.getMaxAge(), firstStep.getMaxAge());
         assertEquals(action.getMaxDocs(), firstStep.getMaxDocs());
         assertEquals(nextStepKey, fifthStep.getNextStepKey());

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ShrinkActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ShrinkActionTests.java
@@ -48,7 +48,7 @@ public class ShrinkActionTests extends AbstractActionTestCase<ShrinkAction> {
         if (action.getNumberOfShards() != null) {
             return new ShrinkAction(action.getNumberOfShards() + randomIntBetween(1, 2), null);
         } else {
-            return new ShrinkAction(null, new ByteSizeValue(action.getMaxSinglePrimarySize().getBytes() + 1));
+            return new ShrinkAction(null, new ByteSizeValue(action.getMaxPrimaryShardSize().getBytes() + 1));
         }
     }
 
@@ -62,14 +62,14 @@ public class ShrinkActionTests extends AbstractActionTestCase<ShrinkAction> {
         assertThat(e.getMessage(), equalTo("[number_of_shards] must be greater than 0"));
     }
 
-    public void testMaxSinglePrimarySize() {
-        ByteSizeValue maxSinglePrimarySize1 = new ByteSizeValue(10);
-        Exception e1 = expectThrows(Exception.class, () -> new ShrinkAction(randomIntBetween(1, 100), maxSinglePrimarySize1));
-        assertThat(e1.getMessage(), equalTo("Cannot set both [number_of_shards] and [max_single_primary_size]"));
+    public void testMaxPrimaryShardSize() {
+        ByteSizeValue maxPrimaryShardSize1 = new ByteSizeValue(10);
+        Exception e1 = expectThrows(Exception.class, () -> new ShrinkAction(randomIntBetween(1, 100), maxPrimaryShardSize1));
+        assertThat(e1.getMessage(), equalTo("Cannot set both [number_of_shards] and [max_primary_shard_size]"));
 
-        ByteSizeValue maxSinglePrimarySize2 = new ByteSizeValue(0);
-        Exception e2 = expectThrows(Exception.class, () -> new ShrinkAction(null, maxSinglePrimarySize2));
-        assertThat(e2.getMessage(), equalTo("[max_single_primary_size] must be greater than 0"));
+        ByteSizeValue maxPrimaryShardSize2 = new ByteSizeValue(0);
+        Exception e2 = expectThrows(Exception.class, () -> new ShrinkAction(null, maxPrimaryShardSize2));
+        assertThat(e2.getMessage(), equalTo("[max_primary_shard_size] must be greater than 0"));
     }
 
     public void testPerformActionWithSkip() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ShrinkStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ShrinkStepTests.java
@@ -33,14 +33,14 @@ public class ShrinkStepTests extends AbstractStepTestCase<ShrinkStep> {
         StepKey stepKey = randomStepKey();
         StepKey nextStepKey = randomStepKey();
         Integer numberOfShards = null;
-        ByteSizeValue maxSinglePrimarySize = null;
+        ByteSizeValue maxPrimaryShardSize = null;
         if (randomBoolean()) {
             numberOfShards = randomIntBetween(1, 20);
         } else {
-            maxSinglePrimarySize = new ByteSizeValue(between(1,100));
+            maxPrimaryShardSize = new ByteSizeValue(between(1,100));
         }
         String shrunkIndexPrefix = randomAlphaOfLength(10);
-        return new ShrinkStep(stepKey, nextStepKey, client, numberOfShards, maxSinglePrimarySize, shrunkIndexPrefix);
+        return new ShrinkStep(stepKey, nextStepKey, client, numberOfShards, maxPrimaryShardSize, shrunkIndexPrefix);
     }
 
     @Override
@@ -48,7 +48,7 @@ public class ShrinkStepTests extends AbstractStepTestCase<ShrinkStep> {
         StepKey key = instance.getKey();
         StepKey nextKey = instance.getNextStepKey();
         Integer numberOfShards = instance.getNumberOfShards();
-        ByteSizeValue maxSinglePrimarySize = instance.getMaxSinglePrimarySize();
+        ByteSizeValue maxPrimaryShardSize = instance.getMaxPrimaryShardSize();
         String shrunkIndexPrefix = instance.getShrunkIndexPrefix();
 
         switch (between(0, 3)) {
@@ -62,8 +62,8 @@ public class ShrinkStepTests extends AbstractStepTestCase<ShrinkStep> {
             if (numberOfShards != null) {
                 numberOfShards = numberOfShards + 1;
             }
-            if (maxSinglePrimarySize != null) {
-                maxSinglePrimarySize = new ByteSizeValue(maxSinglePrimarySize.getBytes() + 1);
+            if (maxPrimaryShardSize != null) {
+                maxPrimaryShardSize = new ByteSizeValue(maxPrimaryShardSize.getBytes() + 1);
             }
             break;
         case 3:
@@ -73,13 +73,13 @@ public class ShrinkStepTests extends AbstractStepTestCase<ShrinkStep> {
             throw new AssertionError("Illegal randomisation branch");
         }
 
-        return new ShrinkStep(key, nextKey, instance.getClient(), numberOfShards, maxSinglePrimarySize, shrunkIndexPrefix);
+        return new ShrinkStep(key, nextKey, instance.getClient(), numberOfShards, maxPrimaryShardSize, shrunkIndexPrefix);
     }
 
     @Override
     public ShrinkStep copyInstance(ShrinkStep instance) {
         return new ShrinkStep(instance.getKey(), instance.getNextStepKey(), instance.getClient(), instance.getNumberOfShards(),
-            instance.getMaxSinglePrimarySize(), instance.getShrunkIndexPrefix());
+            instance.getMaxPrimaryShardSize(), instance.getShrunkIndexPrefix());
     }
 
     public void testPerformAction() throws Exception {
@@ -118,7 +118,7 @@ public class ShrinkStepTests extends AbstractStepTestCase<ShrinkStep> {
                 assertThat(request.getTargetIndexRequest().settings()
                     .getAsInt(IndexMetadata.SETTING_NUMBER_OF_SHARDS, -1), equalTo(step.getNumberOfShards()));
             }
-            request.setMaxSinglePrimarySize(step.getMaxSinglePrimarySize());
+            request.setMaxPrimaryShardSize(step.getMaxPrimaryShardSize());
             listener.onResponse(new ResizeResponse(true, true, sourceIndexMetadata.getIndex().getName()));
             return null;
         }).when(indicesClient).resizeIndex(Mockito.any(), Mockito.any());

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForRolloverReadyStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForRolloverReadyStepTests.java
@@ -13,7 +13,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.rollover.Condition;
 import org.elasticsearch.action.admin.indices.rollover.MaxAgeCondition;
 import org.elasticsearch.action.admin.indices.rollover.MaxDocsCondition;
-import org.elasticsearch.action.admin.indices.rollover.MaxSinglePrimarySizeCondition;
+import org.elasticsearch.action.admin.indices.rollover.MaxPrimaryShardSizeCondition;
 import org.elasticsearch.action.admin.indices.rollover.MaxSizeCondition;
 import org.elasticsearch.action.admin.indices.rollover.RolloverInfo;
 import org.elasticsearch.action.admin.indices.rollover.RolloverRequest;
@@ -52,14 +52,14 @@ public class WaitForRolloverReadyStepTests extends AbstractStepTestCase<WaitForR
         ByteSizeUnit maxSizeUnit = randomFrom(ByteSizeUnit.values());
         ByteSizeValue maxSize = randomBoolean() ? null :
             new ByteSizeValue(randomNonNegativeLong() / maxSizeUnit.toBytes(1), maxSizeUnit);
-        ByteSizeUnit maxSinglePrimarySizeUnit = randomFrom(ByteSizeUnit.values());
-        ByteSizeValue maxSinglePrimarySize = randomBoolean() ? null :
-            new ByteSizeValue(randomNonNegativeLong() / maxSinglePrimarySizeUnit.toBytes(1), maxSinglePrimarySizeUnit);
+        ByteSizeUnit maxPrimaryShardSizeUnit = randomFrom(ByteSizeUnit.values());
+        ByteSizeValue maxPrimaryShardSize = randomBoolean() ? null :
+            new ByteSizeValue(randomNonNegativeLong() / maxPrimaryShardSizeUnit.toBytes(1), maxPrimaryShardSizeUnit);
         Long maxDocs = randomBoolean() ? null : randomNonNegativeLong();
         TimeValue maxAge = (maxDocs == null && maxSize == null || randomBoolean())
             ? TimeValue.parseTimeValue(randomPositiveTimeValue(), "rollover_action_test")
             : null;
-        return new WaitForRolloverReadyStep(stepKey, nextStepKey, client, maxSize, maxSinglePrimarySize, maxAge, maxDocs);
+        return new WaitForRolloverReadyStep(stepKey, nextStepKey, client, maxSize, maxPrimaryShardSize, maxAge, maxDocs);
     }
 
     @Override
@@ -67,7 +67,7 @@ public class WaitForRolloverReadyStepTests extends AbstractStepTestCase<WaitForR
         Step.StepKey key = instance.getKey();
         Step.StepKey nextKey = instance.getNextStepKey();
         ByteSizeValue maxSize = instance.getMaxSize();
-        ByteSizeValue maxSinglePrimarySize = instance.getMaxSinglePrimarySize();
+        ByteSizeValue maxPrimaryShardSize = instance.getMaxPrimaryShardSize();
         TimeValue maxAge = instance.getMaxAge();
         Long maxDocs = instance.getMaxDocs();
 
@@ -85,9 +85,9 @@ public class WaitForRolloverReadyStepTests extends AbstractStepTestCase<WaitForR
                 });
                 break;
             case 3:
-                maxSinglePrimarySize = randomValueOtherThan(maxSinglePrimarySize, () -> {
-                    ByteSizeUnit maxSinglePrimarySizeUnit = randomFrom(ByteSizeUnit.values());
-                    return new ByteSizeValue(randomNonNegativeLong() / maxSinglePrimarySizeUnit.toBytes(1), maxSinglePrimarySizeUnit);
+                maxPrimaryShardSize = randomValueOtherThan(maxPrimaryShardSize, () -> {
+                    ByteSizeUnit maxPrimaryShardSizeUnit = randomFrom(ByteSizeUnit.values());
+                    return new ByteSizeValue(randomNonNegativeLong() / maxPrimaryShardSizeUnit.toBytes(1), maxPrimaryShardSizeUnit);
                 });
                 break;
             case 4:
@@ -99,13 +99,13 @@ public class WaitForRolloverReadyStepTests extends AbstractStepTestCase<WaitForR
             default:
                 throw new AssertionError("Illegal randomisation branch");
         }
-        return new WaitForRolloverReadyStep(key, nextKey, instance.getClient(), maxSize, maxSinglePrimarySize, maxAge, maxDocs);
+        return new WaitForRolloverReadyStep(key, nextKey, instance.getClient(), maxSize, maxPrimaryShardSize, maxAge, maxDocs);
     }
 
     @Override
     protected WaitForRolloverReadyStep copyInstance(WaitForRolloverReadyStep instance) {
         return new WaitForRolloverReadyStep(instance.getKey(), instance.getNextStepKey(), instance.getClient(),
-            instance.getMaxSize(), instance.getMaxSinglePrimarySize(), instance.getMaxAge(), instance.getMaxDocs());
+            instance.getMaxSize(), instance.getMaxPrimaryShardSize(), instance.getMaxAge(), instance.getMaxDocs());
     }
 
     private static void assertRolloverIndexRequest(RolloverRequest request, String rolloverTarget, Set<Condition<?>> expectedConditions) {
@@ -234,8 +234,8 @@ public class WaitForRolloverReadyStepTests extends AbstractStepTestCase<WaitForR
             if (step.getMaxSize() != null) {
                 expectedConditions.add(new MaxSizeCondition(step.getMaxSize()));
             }
-            if (step.getMaxSinglePrimarySize() != null) {
-                expectedConditions.add(new MaxSinglePrimarySizeCondition(step.getMaxSinglePrimarySize()));
+            if (step.getMaxPrimaryShardSize() != null) {
+                expectedConditions.add(new MaxPrimaryShardSizeCondition(step.getMaxPrimaryShardSize()));
             }
             if (step.getMaxAge() != null) {
                 expectedConditions.add(new MaxAgeCondition(step.getMaxAge()));
@@ -406,8 +406,8 @@ public class WaitForRolloverReadyStepTests extends AbstractStepTestCase<WaitForR
             if (step.getMaxSize() != null) {
                 expectedConditions.add(new MaxSizeCondition(step.getMaxSize()));
             }
-            if (step.getMaxSinglePrimarySize() != null) {
-                expectedConditions.add(new MaxSinglePrimarySizeCondition(step.getMaxSinglePrimarySize()));
+            if (step.getMaxPrimaryShardSize() != null) {
+                expectedConditions.add(new MaxPrimaryShardSizeCondition(step.getMaxPrimaryShardSize()));
             }
             if (step.getMaxAge() != null) {
                 expectedConditions.add(new MaxAgeCondition(step.getMaxAge()));
@@ -460,8 +460,8 @@ public class WaitForRolloverReadyStepTests extends AbstractStepTestCase<WaitForR
             if (step.getMaxSize() != null) {
                 expectedConditions.add(new MaxSizeCondition(step.getMaxSize()));
             }
-            if (step.getMaxSinglePrimarySize() != null) {
-                expectedConditions.add(new MaxSinglePrimarySizeCondition(step.getMaxSinglePrimarySize()));
+            if (step.getMaxPrimaryShardSize() != null) {
+                expectedConditions.add(new MaxPrimaryShardSizeCondition(step.getMaxPrimaryShardSize()));
             }
             if (step.getMaxAge() != null) {
                 expectedConditions.add(new MaxAgeCondition(step.getMaxAge()));

--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/TimeSeriesLifecycleActionsIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/TimeSeriesLifecycleActionsIT.java
@@ -229,7 +229,7 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
         }, 30, TimeUnit.SECONDS);
     }
 
-    public void testRolloverActionWithMaxSinglePrimarySize() throws Exception {
+    public void testRolloverActionWithMaxPrimaryShardSize() throws Exception {
         String originalIndex = index + "-000001";
         String secondIndex = index + "-000002";
         createIndexWithSettings(client(), originalIndex, alias, Settings.builder()


### PR DESCRIPTION
See https://github.com/elastic/elasticsearch/issues/63026#issuecomment-780248913. `max_primary_shard_size` does indeed seem like a better name than `max_single_primary_size` to me.

Changes the naming from as added in #67705, #67842, and #68917. This'll need backporting to 7.x **and 7.12**.