### PR TITLE
Avoid concurrent execution issues when running packer cache script

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/RestResourcesPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/RestResourcesPlugin.java
@@ -90,40 +90,63 @@ public class RestResourcesPlugin implements Plugin<Project> {
         // tests
         Configuration testConfig = project.getConfigurations().create("restTestConfig");
         Configuration xpackTestConfig = project.getConfigurations().create("restXpackTestConfig");
+        if (BuildParams.isInternal()) {
+            // core
+            Dependency restTestdependency = project.getDependencies()
+                .project(Map.of("path", ":rest-api-spec", "configuration", "restTests"));
+            project.getDependencies().add(testConfig.getName(), restTestdependency);
+            // x-pack
+            Dependency restXPackTestdependency = project.getDependencies()
+                .project(Map.of("path", ":x-pack:plugin", "configuration", "restXpackTests"));
+            project.getDependencies().add(xpackTestConfig.getName(), restXPackTestdependency);
+        } else {
+            Dependency dependency = project.getDependencies()
+                .create("org.elasticsearch:rest-api-spec:" + VersionProperties.getElasticsearch());
+            project.getDependencies().add(testConfig.getName(), dependency);
+        }
+
         project.getConfigurations().create("restTests");
         project.getConfigurations().create("restXpackTests");
+
         Provider<CopyRestTestsTask> copyRestYamlTestTask = project.getTasks()
             .register(COPY_YAML_TESTS_TASK, CopyRestTestsTask.class, task -> {
+                if (BuildParams.isInternal()) {
+                    task.dependsOn(xpackTestConfig);
+                    task.setXpackConfig(xpackTestConfig);
+                }
                 task.getIncludeCore().set(extension.restTests.getIncludeCore());
                 task.getIncludeXpack().set(extension.restTests.getIncludeXpack());
                 task.setCoreConfig(testConfig);
                 task.getOutputResourceDir().set(project.getLayout().getBuildDirectory().dir("restResources/yamlTests"));
-                if (BuildParams.isInternal()) {
-                    // core
-                    Dependency restTestdependency = project.getDependencies()
-                        .project(Map.of("path", ":rest-api-spec", "configuration", "restTests"));
-                    project.getDependencies().add(testConfig.getName(), restTestdependency);
-                    // x-pack
-                    task.setXpackConfig(xpackTestConfig);
-                    Dependency restXPackTestdependency = project.getDependencies()
-                        .project(Map.of("path", ":x-pack:plugin", "configuration", "restXpackTests"));
-                    project.getDependencies().add(xpackTestConfig.getName(), restXPackTestdependency);
-                    task.dependsOn(task.getXpackConfig());
-                } else {
-                    Dependency dependency = project.getDependencies()
-                        .create("org.elasticsearch:rest-api-spec:" + VersionProperties.getElasticsearch());
-                    project.getDependencies().add(testConfig.getName(), dependency);
-                }
                 task.dependsOn(testConfig);
             });
 
         // api
         Configuration specConfig = project.getConfigurations().create("restSpec"); // name chosen for passivity
         Configuration xpackSpecConfig = project.getConfigurations().create("restXpackSpec");
+        if (BuildParams.isInternal()) {
+            Dependency restSpecDependency = project.getDependencies()
+                .project(Map.of("path", ":rest-api-spec", "configuration", "restSpecs"));
+            project.getDependencies().add(specConfig.getName(), restSpecDependency);
+
+            Dependency restXpackSpecDependency = project.getDependencies()
+                .project(Map.of("path", ":x-pack:plugin", "configuration", "restXpackSpecs"));
+            project.getDependencies().add(xpackSpecConfig.getName(), restXpackSpecDependency);
+        } else {
+            Dependency dependency = project.getDependencies()
+                .create("org.elasticsearch:rest-api-spec:" + VersionProperties.getElasticsearch());
+            project.getDependencies().add(specConfig.getName(), dependency);
+        }
+
         project.getConfigurations().create("restSpecs");
         project.getConfigurations().create("restXpackSpecs");
+
         Provider<CopyRestApiTask> copyRestYamlApiTask = project.getTasks()
             .register(COPY_REST_API_SPECS_TASK, CopyRestApiTask.class, task -> {
+                if (BuildParams.isInternal()) {
+                    task.dependsOn(xpackSpecConfig);
+                    task.setXpackConfig(xpackSpecConfig);
+                }
                 task.dependsOn(copyRestYamlTestTask);
                 task.getIncludeCore().set(extension.restApi.getIncludeCore());
                 task.getIncludeXpack().set(extension.restApi.getIncludeXpack());
@@ -138,20 +161,6 @@ public class RestResourcesPlugin implements Plugin<Project> {
                         .findFirst()
                         .orElse(null)
                 );
-                if (BuildParams.isInternal()) {
-                    Dependency restSpecDependency = project.getDependencies()
-                        .project(Map.of("path", ":rest-api-spec", "configuration", "restSpecs"));
-                    project.getDependencies().add(specConfig.getName(), restSpecDependency);
-                    task.setXpackConfig(xpackSpecConfig);
-                    Dependency restXpackSpecDependency = project.getDependencies()
-                        .project(Map.of("path", ":x-pack:plugin", "configuration", "restXpackSpecs"));
-                    project.getDependencies().add(xpackSpecConfig.getName(), restXpackSpecDependency);
-                    task.dependsOn(task.getXpackConfig());
-                } else {
-                    Dependency dependency = project.getDependencies()
-                        .create("org.elasticsearch:rest-api-spec:" + VersionProperties.getElasticsearch());
-                    project.getDependencies().add(specConfig.getName(), dependency);
-                }
                 task.dependsOn(xpackSpecConfig);
             });
 


### PR DESCRIPTION
I've seen some builds fail running our `packer_cache.sh` script. There seem to be two main causes:

1. Complaints about modifying configurations after they've been resolved related to our `RestResourcesPlugin`. I believe the source of this is the fact that we add dependencies to those configurations inside a lazy task configuration block. This has simply been moved out.
2. `ConcurrentModificationExceptions` within `DefaultTaskContainer` related to task creation which I can only presume is triggered by multiple concurrently executing `ResolveAllDependencies` tasks both calling `resolve()` on a configuration which triggers the lazy creation of the same task.

https://gradle-enterprise.elastic.co/s/5mbtangtydijq/failure#1

For item (2) my "solution" is instead of explicitly calling `resolve()` on these configurations inside task action, expose the configurations themselves as a task input, implicitly forcing Gradle to resolve them. The presumption here is that Gradle has more  guarantees there vs when done from a task action, and also there's likely ordering issues around locally built artifacts that this addresses as well. Local testing seems to confirm this alleviates the problem. This does add some overhead given we now _snapshot_ all these artifacts but that seems a fine tradeoff for stability.