### PR TITLE
[Tests] Fix De-/serialization tests of HighlightBuilder

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightBuilderTests.java
@@ -681,7 +681,9 @@ public class HighlightBuilderTests extends ESTestCase {
                 highlightBuilder.requireFieldMatch(toggleOrSet(highlightBuilder.requireFieldMatch()));
                 break;
             case 17:
-                highlightBuilder.maxAnalyzedOffset(randomIntBetween(1, 100));
+                highlightBuilder.maxAnalyzedOffset(
+                    randomValueOtherThan(highlightBuilder.maxAnalyzedOffset(), () -> randomIntBetween(1, 100))
+                );
                 break;
         }
     }


### PR DESCRIPTION
Assign a value different that the original when testing
mutation of the builder.

Previously reproduced with:
```
2> REPRODUCE WITH: ./gradlew ':server:test' --tests "org.elasticsearch.search.fetch.subphase.highlight.HighlightBuilderTests.testEqualsAndHashcode" -Dtests.seed=5BFC4C9C89309FA8 -Dtests.security.manager=true -Dtests.locale=is-IS -Dtests.timezone=America/Sao_Paulo -Druntime.java=11 |  
-- | --
  | 2> java.lang.AssertionError: HighlightBuilder mutation should not be equal to original

```

Follows: #67325

