### PR TITLE
Split JarHell gradle task classpath

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/JarHellPrecommitPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/JarHellPrecommitPlugin.java
@@ -29,8 +29,8 @@ public class JarHellPrecommitPlugin extends PrecommitPlugin {
         TaskProvider<JarHellTask> jarHell = project.getTasks().register("jarHell", JarHellTask.class);
         jarHell.configure(t -> {
             SourceSet testSourceSet = Util.getJavaTestSourceSet(project).get();
-            t.setClasspath(testSourceSet.getRuntimeClasspath().plus(jarHellConfig));
-            t.dependsOn(jarHellConfig);
+            t.setClasspath(testSourceSet.getRuntimeClasspath());
+            t.setJarHellRuntimeClasspath(jarHellConfig);
         });
 
         return jarHell;

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/JarHellTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/JarHellTask.java
@@ -11,6 +11,7 @@ package org.elasticsearch.gradle.precommit;
 import org.elasticsearch.gradle.LoggedExec;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.tasks.CacheableTask;
+import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.CompileClasspath;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.process.ExecOperations;
@@ -24,6 +25,8 @@ import java.io.File;
 @CacheableTask
 public class JarHellTask extends PrecommitTask {
 
+    private FileCollection jarHellRuntimeClasspath;
+
     private FileCollection classpath;
     private ExecOperations execOperations;
 
@@ -36,7 +39,7 @@ public class JarHellTask extends PrecommitTask {
     @TaskAction
     public void runJarHellCheck() {
         LoggedExec.javaexec(execOperations, spec -> {
-            spec.environment("CLASSPATH", getClasspath().getAsPath());
+            spec.environment("CLASSPATH", getJarHellRuntimeClasspath().plus(getClasspath()).getAsPath());
             spec.setMain("org.elasticsearch.bootstrap.JarHell");
         });
     }
@@ -52,4 +55,12 @@ public class JarHellTask extends PrecommitTask {
         this.classpath = classpath;
     }
 
+    @Classpath
+    public FileCollection getJarHellRuntimeClasspath() {
+        return jarHellRuntimeClasspath;
+    }
+
+    public void setJarHellRuntimeClasspath(FileCollection jarHellRuntimeClasspath) {
+        this.jarHellRuntimeClasspath = jarHellRuntimeClasspath;
+    }
 }


### PR DESCRIPTION
This fixes an issue implementation (non ABI) changes in JarHell not detected by gradle up-to-date
checks. 
This also seems to fix this task dependency issue we've seen and raised at https://github.com/gradle/gradle/issues/16207 