### PR TITLE
Export ES_JAVA_HOME in Sys V init scripts

### DIFF
--- a/distribution/packages/src/deb/init.d/elasticsearch
+++ b/distribution/packages/src/deb/init.d/elasticsearch
@@ -72,6 +72,7 @@ DAEMON=$ES_HOME/bin/elasticsearch
 DAEMON_OPTS="-d -p $PID_FILE"
 
 export ES_JAVA_OPTS
+export ES_JAVA_HOME
 export JAVA_HOME
 export ES_PATH_CONF
 

--- a/distribution/packages/src/rpm/init.d/elasticsearch
+++ b/distribution/packages/src/rpm/init.d/elasticsearch
@@ -56,6 +56,7 @@ prog="elasticsearch"
 pidfile="$PID_DIR/${prog}.pid"
 
 export ES_JAVA_OPTS
+export ES_JAVA_HOME
 export JAVA_HOME
 export ES_PATH_CONF
 export ES_STARTUP_SLEEP_TIME


### PR DESCRIPTION
This commit exports the ES_JAVA_HOME environment variable in the Sys V init scripts. This is needed so that if a user configures ES_JAVA_HOME in their environment via /etc/default/elasticsearch (the Debian package) /etc/sysconfig/elasticsearch (the RPM package), then it is exported and visible to the elasticsearch-env script that determines the location of Java from this environment variable.

Closes #69271