### PR TITLE
Rename JAVA_HOME to ES_JAVA_HOME in environment

### DIFF
--- a/distribution/packages/src/common/env/elasticsearch
+++ b/distribution/packages/src/common/env/elasticsearch
@@ -6,7 +6,7 @@
 #ES_HOME=/usr/share/elasticsearch
 
 # Elasticsearch Java path
-#JAVA_HOME=
+#ES_JAVA_HOME=
 
 # Elasticsearch configuration directory
 # Note: this setting will be shared with command-line tools


### PR DESCRIPTION
This commit renames JAVA_HOME to ES_JAVA_HOME in the default environment file that ships with the Debian and RPM package. This commented out environment variable should use our preferred name here.