### PR TITLE
[Draft] Improve usage of blob store cache during searchable snapshots shard recovery

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/apache/lucene/codecs/lucene50/CompoundReaderUtils.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/apache/lucene/codecs/lucene50/CompoundReaderUtils.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.apache.lucene.codecs.lucene50;
+
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.codecs.CompoundDirectory;
+import org.apache.lucene.index.CorruptIndexException;
+import org.apache.lucene.index.IndexFileNames;
+import org.apache.lucene.index.SegmentCommitInfo;
+import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.index.SegmentInfos;
+import org.apache.lucene.store.ChecksumIndexInput;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.elasticsearch.common.collect.Tuple;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class CompoundReaderUtils {
+
+    private CompoundReaderUtils() {}
+
+    public static Map<String, Map<String, Tuple<Long, Long>>> extractCompoundFiles(Directory directory) throws IOException {
+        final Map<String, Map<String, Tuple<Long, Long>>> compoundFiles = new HashMap<>();
+        final SegmentInfos segmentInfos = SegmentInfos.readLatestCommit(directory);
+        for (SegmentCommitInfo segmentCommitInfo : segmentInfos) {
+            final SegmentInfo segmentInfo = segmentCommitInfo.info;
+            if (segmentInfo.getUseCompoundFile()) {
+                final Codec codec = segmentInfo.getCodec();
+                try (CompoundDirectory compoundDir = codec.compoundFormat().getCompoundReader(directory, segmentInfo, IOContext.DEFAULT)) {
+                    String className = compoundDir.getClass().getName();
+                    switch (className) {
+                        case "org.apache.lucene.codecs.lucene50.Lucene50CompoundReader":
+                            compoundFiles.put(segmentInfo.name, readEntries(directory, segmentCommitInfo.info));
+                            break;
+                        default:
+                            assert false : "please implement readEntries() for this format of compound files: " + className;
+                            throw new IllegalStateException("This format of compound files is not supported: " + className);
+                    }
+                }
+            }
+        }
+        return Collections.unmodifiableMap(compoundFiles);
+    }
+
+    private static Map<String, Tuple<Long, Long>> readEntries(Directory directory, SegmentInfo segmentInfo) throws IOException {
+        final String entriesFileName = IndexFileNames.segmentFileName(segmentInfo.name, "", Lucene50CompoundFormat.ENTRIES_EXTENSION);
+        try (ChecksumIndexInput entriesStream = directory.openChecksumInput(entriesFileName, IOContext.READONCE)) {
+            Map<String, Tuple<Long, Long>> mapping = new HashMap<>();
+            Throwable trowable = null;
+            try {
+                CodecUtil.checkIndexHeader(
+                    entriesStream,
+                    Lucene50CompoundFormat.ENTRY_CODEC,
+                    Lucene50CompoundFormat.VERSION_START,
+                    Lucene50CompoundFormat.VERSION_CURRENT,
+                    segmentInfo.getId(),
+                    ""
+                );
+
+                final int numEntries = entriesStream.readVInt();
+                final Set<String> seen = new HashSet<>(numEntries);
+                for (int i = 0; i < numEntries; i++) {
+                    final String id = entriesStream.readString();
+                    if (seen.add(id) == false) {
+                        throw new CorruptIndexException("Duplicate cfs entry id=" + id + " in CFS ", entriesStream);
+                    }
+                    long offset = entriesStream.readLong();
+                    long length = entriesStream.readLong();
+                    mapping.put(id, Tuple.tuple(offset, length));
+                }
+                assert mapping.size() == numEntries;
+            } catch (Throwable exception) {
+                trowable = exception;
+            } finally {
+                CodecUtil.checkFooter(entriesStream, trowable);
+            }
+            return Collections.unmodifiableMap(mapping);
+        }
+    }
+}

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/blobstore/cache/SearchableSnapshotsBlobStoreCacheIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/blobstore/cache/SearchableSnapshotsBlobStoreCacheIntegTests.java
@@ -180,7 +180,7 @@ public class SearchableSnapshotsBlobStoreCacheIntegTests extends BaseSearchableS
             restoredIndex,
             Settings.builder()
                 .put(SearchableSnapshots.SNAPSHOT_CACHE_ENABLED_SETTING.getKey(), cacheEnabled)
-                .put(SearchableSnapshots.SNAPSHOT_CACHE_PREWARM_ENABLED_SETTING.getKey(), false)
+                .put(SearchableSnapshots.SNAPSHOT_CACHE_PREWARM_ENABLED_SETTING.getKey(), randomBoolean())
                 .build(),
             storage
         );

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/BaseSearchableSnapshotsIntegTestCase.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/BaseSearchableSnapshotsIntegTestCase.java
@@ -26,6 +26,7 @@ import org.elasticsearch.snapshots.AbstractSnapshotIntegTestCase;
 import org.elasticsearch.snapshots.SnapshotsService;
 import org.elasticsearch.xpack.core.searchablesnapshots.MountSearchableSnapshotAction;
 import org.elasticsearch.xpack.core.searchablesnapshots.MountSearchableSnapshotRequest;
+import org.elasticsearch.xpack.core.searchablesnapshots.MountSearchableSnapshotRequest.Storage;
 import org.elasticsearch.xpack.searchablesnapshots.cache.CacheService;
 import org.elasticsearch.xpack.searchablesnapshots.cache.FrozenCacheService;
 
@@ -117,6 +118,17 @@ public abstract class BaseSearchableSnapshotsIntegTestCase extends AbstractSnaps
         String restoredIndexName,
         Settings restoredIndexSettings
     ) throws Exception {
+        mountSnapshot(repositoryName, snapshotName, indexName, restoredIndexName, restoredIndexSettings, Storage.FULL_COPY);
+    }
+
+    protected void mountSnapshot(
+        String repositoryName,
+        String snapshotName,
+        String indexName,
+        String restoredIndexName,
+        Settings restoredIndexSettings,
+        final Storage storage
+    ) throws Exception {
         final MountSearchableSnapshotRequest mountRequest = new MountSearchableSnapshotRequest(
             restoredIndexName,
             repositoryName,
@@ -128,7 +140,7 @@ public abstract class BaseSearchableSnapshotsIntegTestCase extends AbstractSnaps
                 .build(),
             Strings.EMPTY_ARRAY,
             true,
-            MountSearchableSnapshotRequest.Storage.FULL_COPY
+            storage
         );
 
         final RestoreSnapshotResponse restoreResponse = client().execute(MountSearchableSnapshotAction.INSTANCE, mountRequest).get();

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/blobstore/cache/CachedBlob.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/blobstore/cache/CachedBlob.java
@@ -121,6 +121,10 @@ public class CachedBlob implements ToXContent {
         return bytes;
     }
 
+    public Version version() {
+        return version;
+    }
+
     public static String generateId(String repository, String name, String path, long offset) {
         return String.join("/", repository, path, name, "@" + offset);
     }
@@ -186,5 +190,28 @@ public class CachedBlob implements ToXContent {
             from.longValue(),
             to.longValue()
         );
+    }
+
+    @Override
+    public String toString() {
+        return "CachedBlob ["
+            + "creationTime="
+            + creationTime
+            + ", version="
+            + version
+            + ", repository='"
+            + repository
+            + '\''
+            + ", name='"
+            + name
+            + '\''
+            + ", path='"
+            + path
+            + '\''
+            + ", from="
+            + from
+            + ", to="
+            + to
+            + ']';
     }
 }

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/SearchableSnapshotDirectory.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/SearchableSnapshotDirectory.java
@@ -419,14 +419,7 @@ public class SearchableSnapshotDirectory extends BaseDirectory {
                 );
             }
         } else {
-            return new DirectBlobContainerIndexInput(
-                blobContainer(),
-                fileInfo,
-                context,
-                inputStats,
-                getUncachedChunkSize(),
-                bufferSize(context)
-            );
+            return new DirectBlobContainerIndexInput(this, fileInfo, context, inputStats, getUncachedChunkSize(), bufferSize(context));
         }
     }
 

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/FrozenIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/FrozenIndexInput.java
@@ -13,12 +13,8 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
-import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.BytesRefIterator;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.StepListener;
-import org.elasticsearch.blobstore.cache.BlobStoreCacheService;
-import org.elasticsearch.blobstore.cache.CachedBlob;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.unit.ByteSizeUnit;
@@ -34,6 +30,7 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -48,7 +45,6 @@ public class FrozenIndexInput extends BaseSearchableSnapshotIndexInput {
     private static final Logger logger = LogManager.getLogger(FrozenIndexInput.class);
     private static final int COPY_BUFFER_SIZE = ByteSizeUnit.KB.toIntBytes(8);
 
-    private final SearchableSnapshotDirectory directory;
     private final FrozenCacheFile frozenCacheFile;
     private final int defaultRangeSize;
     private final int recoveryRangeSize;
@@ -76,9 +72,9 @@ public class FrozenIndexInput extends BaseSearchableSnapshotIndexInput {
             fileInfo.length(),
             directory.getFrozenCacheFile(fileInfo.physicalName(), fileInfo.length()),
             rangeSize,
-            recoveryRangeSize
+            recoveryRangeSize,
+            blobCacheByteRanges(fileInfo.physicalName(), fileInfo.length())
         );
-        assert getBufferSize() <= BlobStoreCacheService.DEFAULT_CACHED_BLOB_SIZE; // must be able to cache at least one buffer's worth
         stats.incrementOpenCount();
     }
 
@@ -92,10 +88,10 @@ public class FrozenIndexInput extends BaseSearchableSnapshotIndexInput {
         long length,
         FrozenCacheFile frozenCacheFile,
         int rangeSize,
-        int recoveryRangeSize
+        int recoveryRangeSize,
+        List<ByteRange> blobCacheByteRanges
     ) {
-        super(logger, resourceDesc, directory.blobContainer(), fileInfo, context, stats, offset, length);
-        this.directory = directory;
+        super(logger, resourceDesc, directory, fileInfo, context, stats, offset, length, blobCacheByteRanges);
         this.frozenCacheFile = frozenCacheFile;
         this.lastReadPosition = this.offset;
         this.lastSeekPosition = this.offset;
@@ -124,7 +120,7 @@ public class FrozenIndexInput extends BaseSearchableSnapshotIndexInput {
     @Override
     protected void doReadInternal(ByteBuffer b) throws IOException {
         ensureContext(ctx -> ctx != CACHE_WARMING_CONTEXT);
-        final long position = getFilePointer() + this.offset;
+        final long position = getAbsolutePosition();
         final int length = b.remaining();
 
         final ReentrantReadWriteLock luceneByteBufLock = new ReentrantReadWriteLock();
@@ -144,132 +140,44 @@ public class FrozenIndexInput extends BaseSearchableSnapshotIndexInput {
         logger.trace("readInternal: read [{}-{}] ([{}] bytes) from [{}]", position, position + length, length, this);
 
         try {
-            // Can we serve the read directly from disk? If so, do so and don't worry about anything else.
-
-            final StepListener<Integer> waitingForRead = frozenCacheFile.readIfAvailableOrPending(
-                ByteRange.of(position, position + length),
-                (channel, pos, relativePos, len) -> {
-                    final int read = readCacheFile(channel, pos, relativePos, len, b, position, true, luceneByteBufLock, stopAsyncReads);
-                    assert read <= length : read + " vs " + length;
-                    return read;
-                }
-            );
-
-            if (waitingForRead != null) {
-                final Integer read = waitingForRead.asFuture().get();
-                assert read == length;
-                assert luceneByteBufLock.getReadHoldCount() == 0;
-                preventAsyncBufferChanges.run();
-                b.position(read); // mark all bytes as accounted for
-                readComplete(position, length);
-                return;
-            }
-
-            // Requested data is not on disk, so try the cache index next.
-
+            // Are we trying to read data that should be present in blob cache index?
             final ByteRange indexCacheMiss; // null if not a miss
-
-            // We try to use the cache index if:
-            // - the file is small enough to be fully cached
-            final boolean canBeFullyCached = fileInfo.length() <= BlobStoreCacheService.DEFAULT_CACHED_BLOB_SIZE * 2;
-            // - we're reading the first N bytes of the file
-            final boolean isStartOfFile = (position + length <= BlobStoreCacheService.DEFAULT_CACHED_BLOB_SIZE);
-
-            if (canBeFullyCached || isStartOfFile) {
-                final CachedBlob cachedBlob = directory.getCachedBlob(fileInfo.physicalName(), 0L, length);
-
-                if (cachedBlob == CachedBlob.CACHE_MISS || cachedBlob == CachedBlob.CACHE_NOT_READY) {
-                    // We would have liked to find a cached entry but we did not find anything: the cache on the disk will be requested
-                    // so we compute the region of the file we would like to have the next time. The region is expressed as a tuple of
-                    // {start, end} where positions are relative to the whole file.
-
-                    if (canBeFullyCached) {
-                        // if the index input is smaller than twice the size of the blob cache, it will be fully indexed
-                        indexCacheMiss = ByteRange.of(0L, fileInfo.length());
-                    } else {
-                        // the index input is too large to fully cache, so just cache the initial range
-                        indexCacheMiss = ByteRange.of(0L, (long) BlobStoreCacheService.DEFAULT_CACHED_BLOB_SIZE);
-                    }
-
-                    // We must fill in a cache miss even if CACHE_NOT_READY since the cache index is only created on the first put.
-                    // TODO TBD use a different trigger for creating the cache index and avoid a put in the CACHE_NOT_READY case.
-                } else {
-                    logger.trace(
-                        "reading [{}] bytes of file [{}] at position [{}] using cache index",
-                        length,
-                        fileInfo.physicalName(),
-                        position
-                    );
-                    stats.addIndexCacheBytesRead(cachedBlob.length());
-
-                    preventAsyncBufferChanges.run();
-
-                    final BytesRefIterator cachedBytesIterator = cachedBlob.bytes().slice(toIntBytes(position), length).iterator();
-                    int copiedBytes = 0;
-                    BytesRef bytesRef;
-                    while ((bytesRef = cachedBytesIterator.next()) != null) {
-                        b.put(bytesRef.bytes, bytesRef.offset, bytesRef.length);
-                        copiedBytes += bytesRef.length;
-                    }
-                    assert copiedBytes == length : "copied " + copiedBytes + " but expected " + length;
-
-                    try {
-                        final ByteRange cachedRange = ByteRange.of(cachedBlob.from(), cachedBlob.to());
-                        frozenCacheFile.populateAndRead(
-                            cachedRange,
-                            cachedRange,
-                            (channel, channelPos, relativePos, len) -> Math.toIntExact(len),
-                            (channel, channelPos, relativePos, len, progressUpdater) -> {
-                                assert len <= cachedBlob.to() - cachedBlob.from();
-                                final long startTimeNanos = stats.currentTimeNanos();
-                                final BytesRefIterator iterator = cachedBlob.bytes()
-                                    .slice(toIntBytes(relativePos), toIntBytes(len))
-                                    .iterator();
-                                long writePosition = channelPos;
-                                long bytesCopied = 0L;
-                                BytesRef current;
-                                while ((current = iterator.next()) != null) {
-                                    final ByteBuffer byteBuffer = ByteBuffer.wrap(current.bytes, current.offset, current.length);
-                                    while (byteBuffer.remaining() > 0) {
-                                        final long bytesWritten = positionalWrite(channel, writePosition, byteBuffer);
-                                        bytesCopied += bytesWritten;
-                                        writePosition += bytesWritten;
-                                        progressUpdater.accept(bytesCopied);
-                                    }
-                                }
-                                long channelTo = channelPos + len;
-                                assert writePosition == channelTo : writePosition + " vs " + channelTo;
-                                final long endTimeNanos = stats.currentTimeNanos();
-                                stats.addCachedBytesWritten(len, endTimeNanos - startTimeNanos);
-                                logger.trace(
-                                    "copied bytes [{}-{}] of file [{}] from cache index to disk",
-                                    relativePos,
-                                    relativePos + len,
-                                    fileInfo
-                                );
-                            },
-                            directory.cacheFetchAsyncExecutor()
-                        );
-                    } catch (Exception e) {
-                        logger.debug(
-                            new ParameterizedMessage(
-                                "failed to store bytes [{}-{}] of file [{}] obtained from index cache",
-                                cachedBlob.from(),
-                                cachedBlob.to(),
-                                fileInfo
-                            ),
-                            e
-                        );
-                        // oh well, no big deal, at least we can return them to the caller.
-                    }
-
-                    readComplete(position, length);
-
-                    return;
-                }
+            if (tryReadFromBlobCache()) {
+                indexCacheMiss = getBlobCacheByteRange(position, length);
             } else {
                 // requested range is not eligible for caching
                 indexCacheMiss = null;
+
+                // Can we serve the read directly from disk? If so, do so and don't worry about anything else.
+
+                final StepListener<Integer> waitingForRead = frozenCacheFile.readIfAvailableOrPending(
+                    ByteRange.of(position, position + length),
+                    (channel, pos, relativePos, len) -> {
+                        final int read = readCacheFile(
+                            channel,
+                            pos,
+                            relativePos,
+                            len,
+                            b,
+                            position,
+                            true,
+                            luceneByteBufLock,
+                            stopAsyncReads
+                        );
+                        assert read <= length : read + " vs " + length;
+                        return read;
+                    }
+                );
+
+                if (waitingForRead != null) {
+                    final Integer read = waitingForRead.asFuture().get();
+                    assert read == length;
+                    assert luceneByteBufLock.getReadHoldCount() == 0;
+                    preventAsyncBufferChanges.run();
+                    b.position(read); // mark all bytes as accounted for
+                    onReadComplete(position, length);
+                    return;
+                }
             }
 
             // Requested data is also not in the cache index, so we must visit the blob store to satisfy both the target range and any
@@ -316,11 +224,12 @@ public class FrozenIndexInput extends BaseSearchableSnapshotIndexInput {
             if (indexCacheMiss != null) {
                 final Releasable onCacheFillComplete = stats.addIndexCacheFill();
                 final int indexCacheMissLength = toIntBytes(indexCacheMiss.length());
+                // Revisit this:
                 // We assume that we only cache small portions of blobs so that we do not need to:
                 // - use a BigArrays for allocation
                 // - use an intermediate copy buffer to read the file in sensibly-sized chunks
                 // - release the buffer once the indexing operation is complete
-                assert indexCacheMissLength <= COPY_BUFFER_SIZE : indexCacheMiss;
+                // assert indexCacheMissLength <= COPY_BUFFER_SIZE : indexCacheMiss;
 
                 final ByteBuffer byteBuffer = ByteBuffer.allocate(indexCacheMissLength);
 
@@ -395,10 +304,11 @@ public class FrozenIndexInput extends BaseSearchableSnapshotIndexInput {
             // already a rare case caused by an overfull/undersized cache.
         }
 
-        readComplete(position, length);
+        onReadComplete(position, length);
     }
 
-    private void readComplete(long position, int length) {
+    @Override
+    protected void onReadComplete(long position, int length) {
         stats.incrementBytesRead(lastReadPosition, position, length);
         lastReadPosition = position + length;
         lastSeekPosition = lastReadPosition;
@@ -642,7 +552,8 @@ public class FrozenIndexInput extends BaseSearchableSnapshotIndexInput {
             length,
             frozenCacheFile,
             defaultRangeSize,
-            recoveryRangeSize
+            recoveryRangeSize,
+            getBlobCacheByteRangesForSlice(sliceDescription, offset, length)
         );
         slice.isClone = true;
         return slice;

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/ByteRange.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/ByteRange.java
@@ -65,6 +65,14 @@ public final class ByteRange implements Comparable<ByteRange> {
         return start >= range.start() && end <= range.end();
     }
 
+    public boolean contains(long start, long end) {
+        return start() <= start && end <= end();
+    }
+
+    public ByteRange withOffset(long offset) {
+        return ByteRange.of(offset + start(), offset + end());
+    }
+
     @Override
     public int hashCode() {
         return 31 * Long.hashCode(start) + Long.hashCode(end);

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/SearchableSnapshotDirectoryStatsTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/SearchableSnapshotDirectoryStatsTests.java
@@ -605,8 +605,7 @@ public class SearchableSnapshotDirectoryStatsTests extends AbstractSearchableSna
     ) throws Exception {
 
         final byte[] fileContent = randomByteArrayOfLength(randomIntBetween(10, MAX_FILE_LENGTH));
-        final String fileExtension = randomAlphaOfLength(3);
-        final String fileName = randomAlphaOfLength(10) + '.' + fileExtension;
+        final String fileName = randomAlphaOfLength(5) + randomFileExtension();
         final SnapshotId snapshotId = new SnapshotId("_name", "_uuid");
         final IndexId indexId = new IndexId("_name", "_uuid");
         final ShardId shardId = new ShardId("_name", "_uuid", 0);

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/SearchableSnapshotDirectoryTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/SearchableSnapshotDirectoryTests.java
@@ -659,8 +659,7 @@ public class SearchableSnapshotDirectoryTests extends AbstractSearchableSnapshot
 
             final Path shardSnapshotDir = createTempDir();
             for (int i = 0; i < nbRandomFiles; i++) {
-                final String fileName = "file_" + randomAlphaOfLength(10);
-
+                final String fileName = randomAlphaOfLength(5) + randomFileExtension();
                 final Tuple<String, byte[]> bytes = randomChecksumBytes(randomIntBetween(1, 100_000));
                 final byte[] input = bytes.v2();
                 final String checksum = bytes.v1();

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/CachedBlobContainerIndexInputTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/CachedBlobContainerIndexInputTests.java
@@ -63,7 +63,7 @@ public class CachedBlobContainerIndexInputTests extends AbstractSearchableSnapsh
             ShardId shardId = new ShardId("_name", "_uuid", 0);
 
             for (int i = 0; i < 5; i++) {
-                final String fileName = randomAlphaOfLength(10);
+                final String fileName = randomAlphaOfLength(5) + randomFileExtension();
                 final Tuple<String, byte[]> bytes = randomChecksumBytes(randomIntBetween(1, 100_000));
 
                 final byte[] input = bytes.v2();
@@ -178,7 +178,7 @@ public class CachedBlobContainerIndexInputTests extends AbstractSearchableSnapsh
             IndexId indexId = new IndexId("_name", "_uuid");
             ShardId shardId = new ShardId("_name", "_uuid", 0);
 
-            final String fileName = randomAlphaOfLength(10);
+            final String fileName = randomAlphaOfLength(5) + randomFileExtension();
             final Tuple<String, byte[]> bytes = randomChecksumBytes(randomIntBetween(1, 1000));
 
             final byte[] input = bytes.v2();

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/FrozenIndexInputTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/FrozenIndexInputTests.java
@@ -34,7 +34,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Locale;
 
 import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.Mockito.mock;
@@ -44,7 +43,7 @@ public class FrozenIndexInputTests extends AbstractSearchableSnapshotsTestCase {
     private static final ShardId SHARD_ID = new ShardId(new Index("_index_name", "_index_id"), 0);
 
     public void testRandomReads() throws IOException {
-        final String fileName = randomAlphaOfLengthBetween(5, 10).toLowerCase(Locale.ROOT);
+        final String fileName = randomAlphaOfLength(5) + randomFileExtension();
         final Tuple<String, byte[]> bytes = randomChecksumBytes(randomIntBetween(1, 100_000));
 
         final byte[] fileData = bytes.v2();

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/direct/DirectBlobContainerIndexInputTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/direct/DirectBlobContainerIndexInputTests.java
@@ -8,6 +8,7 @@ package org.elasticsearch.index.store.direct;
 
 import org.apache.lucene.store.BufferedIndexInput;
 import org.apache.lucene.util.Version;
+import org.elasticsearch.blobstore.cache.CachedBlob;
 import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.lucene.store.ESIndexInputTestCase;
@@ -15,6 +16,7 @@ import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot.FileInfo;
 import org.elasticsearch.index.store.IndexInputStats;
+import org.elasticsearch.index.store.SearchableSnapshotDirectory;
 import org.elasticsearch.index.store.StoreFileMetadata;
 
 import java.io.ByteArrayInputStream;
@@ -25,6 +27,7 @@ import java.io.InputStream;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.elasticsearch.xpack.searchablesnapshots.AbstractSearchableSnapshotsTestCase.randomChecksumBytes;
+import static org.elasticsearch.xpack.searchablesnapshots.AbstractSearchableSnapshotsTestCase.randomFileExtension;
 import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsUtils.toIntBytes;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
@@ -59,9 +62,10 @@ public class DirectBlobContainerIndexInputTests extends ESIndexInputTestCase {
         String checksum,
         Runnable onReadBlob
     ) throws IOException {
+        final String fileName = randomAlphaOfLength(5) + randomFileExtension();
         final FileInfo fileInfo = new FileInfo(
             randomAlphaOfLength(5),
-            new StoreFileMetadata("test", input.length, checksum, Version.LATEST),
+            new StoreFileMetadata(fileName, input.length, checksum, Version.LATEST),
             partSize == input.length
                 ? randomFrom(
                     new ByteSizeValue(partSize, ByteSizeUnit.BYTES),
@@ -116,8 +120,13 @@ public class DirectBlobContainerIndexInputTests extends ESIndexInputTestCase {
                 };
             }
         });
+
+        final SearchableSnapshotDirectory directory = mock(SearchableSnapshotDirectory.class);
+        when(directory.getCachedBlob(anyString(), anyLong(), anyInt())).thenReturn(CachedBlob.CACHE_NOT_READY);
+        when(directory.blobContainer()).thenReturn(blobContainer);
+
         final DirectBlobContainerIndexInput indexInput = new DirectBlobContainerIndexInput(
-            blobContainer,
+            directory,
             fileInfo,
             newIOContext(random()),
             new IndexInputStats(1, 0L, () -> 0L),

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsTestCase.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsTestCase.java
@@ -333,4 +333,35 @@ public abstract class AbstractSearchableSnapshotsTestCase extends ESIndexInputTe
         }
         return Tuple.tuple(checksum, out.toArrayCopy());
     }
+
+    public static String randomFileExtension() {
+        return randomFrom(
+            ".cfe",
+            ".cfs",
+            ".dii",
+            ".dim",
+            ".doc",
+            ".dvd",
+            ".dvm",
+            ".fdt",
+            ".fdx",
+            ".fdm",
+            ".fnm",
+            ".kdd",
+            ".kdi",
+            ".kdm",
+            ".liv",
+            ".nvd",
+            ".nvm",
+            ".pay",
+            ".pos",
+            ".tim",
+            ".tip",
+            ".tmd",
+            ".tvd",
+            ".tvx",
+            ".vec",
+            ".vem"
+        );
+    }
 }


### PR DESCRIPTION
The blob store cache was introduced in #60522 to speed up searchable snapshots shard recovery by caching (in a system index) the first `4096` bytes, sometimes `8192`, of every Lucene files that compose a shard.

Recent experiments using large snapshots suggest that we could maybe adjust the current caching strategy by caching less data (ie `1024` bytes) by default for most of the files and cache more data (up to `64KB`) for Lucene metadata files.

This draft pull request addresses this point by introducing a `BlobStoreCacheService#computeHeaderByteRange()` that computes the range of bytes to put in blob store cache depending of the Lucene file type.

We also noticed that compound files could represent a non negligeable amount of the total size of a shard (~30% in our tests) and that it may be worth to avoid random seeks and reads by also caching the files that compose `.cfs` files.

This pull request addresses this point by caching headers and footers of `.cfs` inner files in the blob store cache. The size of the data to cache for the header is computed using `computeHeaderByteRange()`. The footer is `16` bytes long.

Finally, we found that concurrent prewarming and directory opening could prevent some file parts to be effectively cached in the blob store cache the first time an index is mounted, forcing some bytes to be redownloaded again the next times that index will be mounted.

This pull request addresses this point by detecting when using the blob store cache index should be preferred rather than using the disk based cache. Blob store cache is always preferred when the recovery is not finalized yet, and completely bypassed when the recovery is done.

I'm opening this PR as a draft to show the complexity introduced by this change. It's possible that we decide to move forward with only a subset of the changes.