### PR TITLE
[DOCS] Improve docs for `geo_shape` field type's `circle` type 

### DIFF
--- a/docs/reference/mapping/types/geo-shape.asciidoc
+++ b/docs/reference/mapping/types/geo-shape.asciidoc
@@ -651,8 +651,20 @@ does not support the `circle` type. Instead, use a
 a <<geo-polygon,`polygon`>>.
 
 [source,console]
---------------------------------------------------
-POST /example/_doc
+----
+PUT /circle-example
+{
+  "mappings": {
+    "properties": {
+      "location": {
+        "type": "geo_shape",
+        "strategy": "recursive"
+      }
+    }
+  }
+}
+
+POST /circle-example/_doc
 {
   "location" : {
     "type" : "circle",
@@ -660,8 +672,8 @@ POST /example/_doc
     "radius" : "100m"
   }
 }
---------------------------------------------------
-// TEST[skip:not supported in default]
+----
+// TEST[skip:uses deprecated strategy parameter]
 
 Note: The inner `radius` field is required. If not specified, then
 the units of the `radius` will default to `METERS`.

--- a/docs/reference/mapping/types/geo-shape.asciidoc
+++ b/docs/reference/mapping/types/geo-shape.asciidoc
@@ -642,13 +642,15 @@ POST /example/_doc
 ===== Circle
 
 Elasticsearch supports a `circle` type, which consists of a center
-point with a radius. Note that this circle representation can only
-be indexed when using the `recursive` Prefix Tree strategy.
+point with a radius.
 
 IMPORTANT: The default <<geoshape-indexing-approach,BKD tree indexing approach>>
 does not support the `circle` type. Instead, use a
 <<ingest-circle-processor,circle ingest processor>> to approximate the circle as
 a <<geo-polygon,`polygon`>>.
+
+The `circle` type requires a `geo_shape` field mapping with the deprecated
+`recursive` Prefix Tree strategy.
 
 [source,console]
 ----
@@ -665,6 +667,8 @@ PUT /circle-example
 }
 ----
 // TEST[warning:Parameter [strategy] is deprecated and will be removed in a future version]
+
+The following request indexes a `circle` geo-shape.
 
 [source,console]
 ----

--- a/docs/reference/mapping/types/geo-shape.asciidoc
+++ b/docs/reference/mapping/types/geo-shape.asciidoc
@@ -643,9 +643,12 @@ POST /example/_doc
 
 Elasticsearch supports a `circle` type, which consists of a center
 point with a radius. Note that this circle representation can only
-be indexed when using the `recursive` Prefix Tree strategy. For
-the default <<geoshape-indexing-approach>> circles should be approximated using
-a `POLYGON`.
+be indexed when using the `recursive` Prefix Tree strategy.
+
+IMPORTANT: The default <<geoshape-indexing-approach,BKD tree indexing approach>>
+does not support the `circle` type. Instead, use a
+<<ingest-circle-processor,circle ingest processor>> to approximate the circle as
+a <<geo-polygon,`polygon`>>.
 
 [source,console]
 --------------------------------------------------

--- a/docs/reference/mapping/types/geo-shape.asciidoc
+++ b/docs/reference/mapping/types/geo-shape.asciidoc
@@ -663,7 +663,11 @@ PUT /circle-example
     }
   }
 }
+----
+// TEST[warning:Parameter [strategy] is deprecated and will be removed in a future version]
 
+[source,console]
+----
 POST /circle-example/_doc
 {
   "location" : {
@@ -673,7 +677,7 @@ POST /circle-example/_doc
   }
 }
 ----
-// TEST[skip:uses deprecated strategy parameter]
+// TEST[continued]
 
 Note: The inner `radius` field is required. If not specified, then
 the units of the `radius` will default to `METERS`.

--- a/docs/reference/mapping/types/geo-shape.asciidoc
+++ b/docs/reference/mapping/types/geo-shape.asciidoc
@@ -644,8 +644,8 @@ POST /example/_doc
 Elasticsearch supports a `circle` type, which consists of a center
 point with a radius.
 
-IMPORTANT: The default <<geoshape-indexing-approach,BKD tree indexing approach>>
-does not support the `circle` type. Instead, use a
+IMPORTANT: You cannot index the `circle` type using the default
+<<geoshape-indexing-approach,BKD tree indexing approach>>. Instead, use a
 <<ingest-circle-processor,circle ingest processor>> to approximate the circle as
 a <<geo-polygon,`polygon`>>.
 


### PR DESCRIPTION
Changes:
- Notes that the default BKD tree indexing approach does not support the `circle` type.
- Adds an xref to the circle ingest processor.
- Adds a mapping request to the example circle snippet

Fixes #69184
Fixes #50375