### PR TITLE
[DOCS] Reword node roles docs

### DIFF
--- a/docs/reference/cluster.asciidoc
+++ b/docs/reference/cluster.asciidoc
@@ -46,9 +46,6 @@ means that filters such as `master:false` which remove nodes from the chosen
 subset are only useful if they come after some other filters. When used on its
 own, `master:false` selects no nodes.
 
-NOTE: The `voting_only` role requires the {default-dist} of Elasticsearch and
-is not supported in the {oss-dist}.
-
 Here are some examples of the use of node filters with the
 <<cluster-nodes-info,Nodes Info>> APIs.
 

--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -35,9 +35,9 @@ set `node.roles`, the node is assigned the following roles:
 
 [IMPORTANT]
 ====
-IMPORTANT: If you set `node.roles`, ensure you specify every node role your
-cluster needs. To access most {stack} features, a minimal cluster requires nodes
-with the following roles:
+If you set `node.roles`, ensure you specify every node role your cluster needs.
+To access most {stack} features, a minimal cluster requires nodes with the
+following roles:
 
 - `master`
 - `ingest`

--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -18,8 +18,8 @@ requests to the appropriate node.
 ==== Node roles
 
 You define a node's roles by setting `node.roles` in `elasticsearch.yml`. If you
-set `node.roles`, the node is only assigned the roles you specify. If
-you don't set `node.roles`, the node is assigned the following roles:
+set `node.roles`, the node is only assigned the roles you specify. If you don't
+set `node.roles`, the node is assigned the following roles:
 
 * `master`
 * `data`

--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -44,10 +44,6 @@ with the following roles:
 - `transform`
 - `data`, `data_content`, or a combination of the `data_hot`, `data_warm`,
   `data_cold`, and `data_frozen` roles
-
-For resiliency, production clusters must have at least three nodes with the
-`master` role and at least two nodes of each needed role. See
-<<high-availability-cluster-design>>.
 ====
 
 As the cluster grows and in particular if you have large {ml} jobs or

--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -45,8 +45,6 @@ with the following roles:
 - `data`, `data_content`, or a combination of the `data_hot`, `data_warm`,
   `data_cold`, and `data_frozen` roles
 
-Additional roles may be needed for advanced features, such as {ml}.
-
 For resiliency, production clusters must have at least three nodes with the
 `master` role and at least two nodes of each needed role. See
 <<high-availability-cluster-design>>.

--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -33,11 +33,24 @@ set `node.roles`, the node is assigned the following roles:
 * `remote_cluster_client`
 * `transform`
 
+[IMPORTANT]
+====
 IMPORTANT: If you set `node.roles`, ensure you specify every node role your
-cluster needs. For example, to use {transforms}, you must specify the
-`transform` role for one or more nodes in your cluster. For resiliency,
-production {es} clusters require an elected `master` node and at least one node
-for each role. See <<high-availability-cluster-design>>.
+cluster needs. To access most {stack} features, a minimal cluster requires nodes
+with the following roles:
+
+- `master`
+- `ingest`
+- `transform`
+- `data`, `data_content`, or a combination of the `data_hot`, `data_warm`,
+  `data_cold`, and `data_frozen` roles
+
+Additional roles may be needed for advanced features, such as {ml}.
+
+For resiliency, production clusters must have at least three nodes with the
+`master` role and at least two nodes of each needed role. See
+<<high-availability-cluster-design>>.
+====
 
 As the cluster grows and in particular if you have large {ml} jobs or
 {ctransforms}, consider separating dedicated master-eligible nodes from

--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -40,8 +40,9 @@ Some {stack} features require specific node roles:
 
 - {ccs-cap} and {ccr} require the `remote_cluster_client` role.
 - {stack-monitor-app} and ingest pipelines require the `ingest` role.
-- The {security-app} and {transforms} require the `transform` role. The
-  `remote_cluster_client` role is also required to use {ccs} with these features.
+- The {fleet}, {security-app}, and {transforms} require the `transform` role.
+  The `remote_cluster_client` role is also required to use {ccs} with these
+  features.
 - {ml-cap} features, such as {anomaly-detect}, require the `ml` role.
 ====
 

--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -40,7 +40,7 @@ Some {stack} features require specific node roles:
 
 - {ccs-cap} and {ccr} require the `remote_cluster_client` role.
 - {stack-monitor-app} and ingest pipelines require the `ingest` role.
-- The {fleet}, {security-app}, and {transforms} require the `transform` role.
+- {fleet}, the {security-app}, and {transforms} require the `transform` role.
   The `remote_cluster_client` role is also required to use {ccs} with these
   features.
 - {ml-cap} features, such as {anomaly-detect}, require the `ml` role.

--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -33,23 +33,29 @@ set `node.roles`, the node is assigned the following roles:
 * `remote_cluster_client`
 * `transform`
 
+IMPORTANT: If you set `node.roles`, ensure you specify every node role your
+cluster needs. For example, to use {transforms}, you must specify the
+`transform` role for one or more nodes in your cluster. For resiliency,
+production {es} clusters require an elected `master` node and at least one node
+for each role. See <<high-availability-cluster-design>>.
+
 As the cluster grows and in particular if you have large {ml} jobs or
 {ctransforms}, consider separating dedicated master-eligible nodes from
 dedicated data nodes, {ml} nodes, and {transform} nodes.
 
 <<master-node,Master-eligible node>>::
 
-A node that has the `master` role (default), which makes it eligible to be
+A node that has the `master` role, which makes it eligible to be
 <<modules-discovery,elected as the _master_ node>>, which controls the cluster.
 
 <<data-node,Data node>>::
 
-A node that has the `data` role (default). Data nodes hold data and perform data
+A node that has the `data` role. Data nodes hold data and perform data
 related operations such as CRUD, search, and aggregations. A node with the `data` role can fill any of the specialised data node roles.
 
 <<node-ingest-node,Ingest node>>::
 
-A node that has the `ingest` role (default). Ingest nodes are able to apply an
+A node that has the `ingest` role. Ingest nodes are able to apply an
 <<pipeline,ingest pipeline>> to a document in order to transform and enrich the
 document before indexing. With a heavy ingest load, it makes sense to use
 dedicated ingest nodes and to not include the `ingest` role from nodes that have
@@ -57,16 +63,15 @@ the `master` or `data` roles.
 
 <<remote-node,Remote-eligible node>>::
 
-A node that has the `remote_cluster_client` role (default), which makes it
-eligible to act as a remote client. By default, any node in the cluster can act
-as a cross-cluster client and connect to remote clusters.
+A node that has the `remote_cluster_client` role, which makes it eligible to act
+as a remote client.
 
 <<ml-node,Machine learning node>>::
 
-A node that has `xpack.ml.enabled` and the `ml` role, which is the default
-behavior in the {es} {default-dist}. If you want to use {ml-features}, there
-must be at least one {ml} node in your cluster. For more information about
-{ml-features}, see {ml-docs}/index.html[Machine learning in the {stack}].
+A node that has `xpack.ml.enabled` and the `ml` role. If you want to use
+{ml-features}, there must be at least one {ml} node in your cluster. For more
+information about {ml-features}, see {ml-docs}/index.html[Machine learning in
+the {stack}].
 
 <<transform-node,{transform-cap} node>>::
 
@@ -160,10 +165,8 @@ node:
 node.roles: [ data, master, voting_only ]
 -------------------
 
-IMPORTANT: The `voting_only` role requires the {default-dist} of {es} and is not
-supported in the {oss-dist}. If you use the {oss-dist} and add the `voting_only`
-role then the node will fail to start.  Also note that only nodes with the
-`master` role can be marked as having the `voting_only` role.
+IMPORTANT: Only nodes with the `master` role can be marked as having the
+`voting_only` role.
 
 High availability (HA) clusters require at least three master-eligible nodes, at
 least two of which are not voting-only nodes. Such a cluster will be able to
@@ -180,7 +183,7 @@ Voting-only master-eligible nodes may also fill other roles in your cluster.
 For instance, a node may be both a data node and a voting-only master-eligible
 node. A _dedicated_ voting-only master-eligible nodes is a voting-only
 master-eligible node that fills no other roles in the cluster. To create a
-dedicated voting-only master-eligible node in the {default-dist}, set:
+dedicated voting-only master-eligible node, set:
 
 [source,yaml]
 -------------------
@@ -316,8 +319,8 @@ node.roles: [ ]
 [[remote-node]]
 ==== Remote-eligible node
 
-By default, any node in a cluster can act as a cross-cluster client and connect
-to <<modules-remote-clusters,remote clusters>>. Once connected, you can search
+A remote-eligible node acts as a cross-cluster client and connects to
+<<modules-remote-clusters,remote clusters>>. Once connected, you can search
 remote clusters using <<modules-cross-cluster-search,{ccs}>>. You can also sync
 data between clusters using <<xpack-ccr,{ccr}>>.
 
@@ -357,7 +360,7 @@ Otherwise, {ccs} fails when used in {ml} jobs or {dfeeds}. See <<remote-node>>.
 {transform-cap} nodes run {transforms} and handle {transform} API requests. For
 more information, see <<transform-settings>>.
 
-To create a dedicated {transform} node in the {default-dist}, set:
+To create a dedicated {transform} node, set:
 
 [source,yaml]
 ----

--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -17,8 +17,9 @@ requests to the appropriate node.
 [[node-roles]]
 ==== Node roles
 
-You can define the roles of a node by setting `node.roles`. If you don't
-configure this setting, the node has the following roles by default:
+You define a node's roles by setting `node.roles` in `elasticsearch.yml`. If you
+set `node.roles`, the node is only assigned the roles you specify. If
+you don't set `node.roles`, the node is assigned the following roles:
 
 * `master`
 * `data`
@@ -31,8 +32,6 @@ configure this setting, the node has the following roles by default:
 * `ml`
 * `remote_cluster_client`
 * `transform`
-
-NOTE: If you set `node.roles`, the node is assigned only the roles you specify.
 
 As the cluster grows and in particular if you have large {ml} jobs or
 {ctransforms}, consider separating dedicated master-eligible nodes from

--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -36,14 +36,13 @@ set `node.roles`, the node is assigned the following roles:
 [IMPORTANT]
 ====
 If you set `node.roles`, ensure you specify every node role your cluster needs.
-To access most {stack} features, a minimal cluster requires nodes with the
-following roles:
+Some {stack} features require specific node roles:
 
-- `master`
-- `ingest`
-- `transform`
-- `data`, `data_content`, or a combination of the `data_hot`, `data_warm`,
-  `data_cold`, and `data_frozen` roles
+- {ccs-cap} and {ccr} require the `remote_cluster_client` role.
+- {stack-monitor-app} and ingest pipelines require the `ingest` role.
+- The {security-app} and {transforms} require the `transform` role. The
+  `remote_cluster_client` role is also required to use {ccs} with these features.
+- {ml-cap} features, such as {anomaly-detect}, require the `ml` role.
 ====
 
 As the cluster grows and in particular if you have large {ml} jobs or


### PR DESCRIPTION
Rewords the node roles introduction to better emphasize that node roles much be explicitly set.
Also de-emphasizes the default roles.

### Preview
https://elasticsearch_69301.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/modules-node.html#node-roles