### PR TITLE
[DOCS] Remove performance warning for script fields

### DIFF
--- a/docs/reference/how-to/search-speed.asciidoc
+++ b/docs/reference/how-to/search-speed.asciidoc
@@ -165,7 +165,7 @@ include::../mapping/types/numeric.asciidoc[tag=map-ids-as-keyword]
 [discrete]
 === Avoid scripts
 
-If possible, avoid using <<modules-scripting,scripts>> in aggregations,
+If possible, avoid <<modules-scripting,scripts>> in aggregations,
 script-based sorting, and the <<query-dsl-script-score-query,`script_score`>>
 query. See <<scripts-and-search-speed>>.
 

--- a/docs/reference/how-to/search-speed.asciidoc
+++ b/docs/reference/how-to/search-speed.asciidoc
@@ -165,9 +165,9 @@ include::../mapping/types/numeric.asciidoc[tag=map-ids-as-keyword]
 [discrete]
 === Avoid scripts
 
-If possible, avoid <<modules-scripting,scripts>> in aggregations,
-script-based sorting, and the <<query-dsl-script-score-query,`script_score`>>
-query. See <<scripts-and-search-speed>>.
+If possible, avoid using <<modules-scripting,scripts>>-based sorting, scripts in
+aggregations, and the <<query-dsl-script-score-query,`script_score`>> query. See
+<<scripts-and-search-speed>>.
 
 
 [discrete]

--- a/docs/reference/how-to/search-speed.asciidoc
+++ b/docs/reference/how-to/search-speed.asciidoc
@@ -165,7 +165,7 @@ include::../mapping/types/numeric.asciidoc[tag=map-ids-as-keyword]
 [discrete]
 === Avoid scripts
 
-If possible, avoid using <<modules-scripting,scripts>>-based sorting, scripts in
+If possible, avoid using <<modules-scripting,script>>-based sorting, scripts in
 aggregations, and the <<query-dsl-script-score-query,`script_score`>> query. See
 <<scripts-and-search-speed>>.
 

--- a/docs/reference/how-to/search-speed.asciidoc
+++ b/docs/reference/how-to/search-speed.asciidoc
@@ -165,9 +165,9 @@ include::../mapping/types/numeric.asciidoc[tag=map-ids-as-keyword]
 [discrete]
 === Avoid scripts
 
-If possible, avoid using <<modules-scripting,scripts>> or
-<<script-fields,scripted fields>> in searches. See
-<<scripts-and-search-speed>>.
+If possible, avoid using <<modules-scripting,scripts>> in aggregations,
+script-based sorting, and the <<query-dsl-script-score-query,`script_score`>>
+query. See <<scripts-and-search-speed>>.
 
 
 [discrete]

--- a/docs/reference/search/search-your-data/retrieve-selected-fields.asciidoc
+++ b/docs/reference/search/search-your-data/retrieve-selected-fields.asciidoc
@@ -43,10 +43,8 @@ such as keywords and dates.
 get the values for specific stored fields (fields that use the
 <<mapping-store,`store`>> mapping option).
 
-If needed, you can use the <<script-fields,`script_field`>> parameter to
-transform field values in the response using a script. However, scripts can’t
-make use of {es}'s index structures or related optimizations. This can sometimes
-result in slower search speeds.
+You can also use the <<script-fields,`script_field`>> parameter to transform
+field values in the response using a script.
 
 You can find more detailed information on each of these methods in the
 following sections:


### PR DESCRIPTION
Scripts for script fields are applied only to the top `N` hits. As such, they aren't really a big performance consideration.

This removes a couple of unneeded warnings from the docs.