### PR TITLE
Allow terms to run as filters (backport of #68871)

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/AdaptingAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AdaptingAggregator.java
@@ -37,17 +37,19 @@ public abstract class AdaptingAggregator extends Aggregator {
         /*
          * Lock the parent of the sub-aggregators to *this* instead of to
          * the delegate. This keeps the parent link shaped like the requested
-         * agg tree. Thisis how it has always been and some aggs rely on it.
+         * agg tree the rate aggregator needs this or it will die.
          */
         this.delegate = delegate.apply(subAggregators.fixParent(this));
-        assert this.delegate.parent() == parent : "invalid parent set on delegate";
+        if (this.delegate.parent() != parent) {
+            throw new IllegalStateException("invalid parent set on delegate");
+        }
     }
 
     /**
      * Adapt the result from the collecting {@linkplain Aggregator} into the
      * result expected by this {@linkplain Aggregator}.
      */
-    protected abstract InternalAggregation adapt(InternalAggregation delegateResult);
+    protected abstract InternalAggregation adapt(InternalAggregation delegateResult) throws IOException;
 
     @Override
     public final void close() {
@@ -101,7 +103,12 @@ public abstract class AdaptingAggregator extends Aggregator {
 
     @Override
     public final InternalAggregation buildEmptyAggregation() {
-        return adapt(delegate.buildEmptyAggregation());
+        try {
+            return adapt(delegate.buildEmptyAggregation());
+        } catch (IOException e) {
+            // We don't expect this to happen, but computers are funny.
+            throw new AggregationExecutionException("io error while building empty agg", e);
+        }
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/InternalFilters.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/InternalFilters.java
@@ -11,7 +11,6 @@ package org.elasticsearch.search.aggregations.bucket.filter;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
@@ -71,7 +70,7 @@ public class InternalFilters extends InternalMultiBucketAggregation<InternalFilt
         }
 
         @Override
-        public Aggregations getAggregations() {
+        public InternalAggregations getAggregations() {
             return aggregations;
         }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsAggregatorFromFilters.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsAggregatorFromFilters.java
@@ -159,6 +159,9 @@ public class StringTermsAggregatorFromFilters extends AdaptingAggregator {
             };
             OrdBucket spare = null;
             for (InternalFilters.InternalBucket b : filters.getBuckets()) {
+                if (b.getDocCount() < bucketCountThresholds.getShardMinDocCount()) {
+                    continue;
+                }
                 if (spare == null) {
                     spare = new OrdBucket(showTermDocCountError, format);
                 } else {
@@ -194,6 +197,9 @@ public class StringTermsAggregatorFromFilters extends AdaptingAggregator {
         } else {
             buckets = new ArrayList<>(filters.getBuckets().size());
             for (InternalFilters.InternalBucket b : filters.getBuckets()) {
+                if (b.getDocCount() < bucketCountThresholds.getShardMinDocCount()) {
+                    continue;
+                }
                 buckets.add(buildBucket(b));
             }
             Collections.sort(buckets, reduceOrder.comparator());

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsAggregatorFromFilters.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsAggregatorFromFilters.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.search.aggregations.bucket.terms;
+
+import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.PriorityQueue;
+import org.elasticsearch.common.CheckedFunction;
+import org.elasticsearch.index.query.TermQueryBuilder;
+import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.aggregations.AdaptingAggregator;
+import org.elasticsearch.search.aggregations.Aggregator;
+import org.elasticsearch.search.aggregations.AggregatorFactories;
+import org.elasticsearch.search.aggregations.BucketOrder;
+import org.elasticsearch.search.aggregations.CardinalityUpperBound;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.InternalOrder;
+import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation.Bucket;
+import org.elasticsearch.search.aggregations.bucket.filter.FiltersAggregator;
+import org.elasticsearch.search.aggregations.bucket.filter.InternalFilters;
+import org.elasticsearch.search.aggregations.bucket.terms.GlobalOrdinalsStringTermsAggregator.OrdBucket;
+import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregator.BucketCountThresholds;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
+import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.LongPredicate;
+
+import static org.elasticsearch.search.aggregations.InternalOrder.isKeyOrder;
+
+/**
+ * Adapts a {@code terms} aggregation into a {@code filters} aggregation.
+ * Its possible that we could lovingly hand craft an {@link Aggregator} that
+ * uses similar tricks that'd have lower memory overhead but generally we reach
+ * for this when we know that there aren't many distinct values so it doesn't
+ * have particularly high memory cost anyway. And we expect to be able to
+ * further optimize the {@code filters} aggregation in more cases than a
+ * special purpose {@code terms} aggregator.
+ */
+public class StringTermsAggregatorFromFilters extends AdaptingAggregator {
+    static StringTermsAggregatorFromFilters adaptIntoFiltersOrNull(
+        String name,
+        AggregatorFactories factories,
+        AggregationContext context,
+        Aggregator parent,
+        boolean showTermDocCountError,
+        CardinalityUpperBound cardinality,
+        Map<String, Object> metadata,
+        ValuesSourceConfig valuesSourceConfig,
+        BucketOrder order,
+        BucketCountThresholds bucketCountThresholds,
+        LongPredicate acceptedOrds,
+        SortedSetDocValues values
+    ) throws IOException {
+        if (false == valuesSourceConfig.alignesWithSearchIndex()) {
+            return null;
+        }
+        if (false == FiltersAggregator.canUseFilterByFilter(parent, factories, null)) {
+            return null;
+        }
+        List<String> keys = new ArrayList<>();
+        List<Query> filters = new ArrayList<>();
+        TermsEnum terms = values.termsEnum();
+        for (long ord = 0; ord < values.getValueCount(); ord++) {
+            if (acceptedOrds.test(ord) == false) {
+                continue;
+            }
+            terms.seekExact(ord);
+            keys.add(Long.toString(ord));
+            /*
+             * It *feels* like there should be a query that operates
+             * directly on the global ordinals but there isn't. Building
+             * one would be tricky because there isn't mapping from
+             * every global ordinal to its segment ordinal - only from
+             * the segment ordinal to the global ordinal. You could
+             * search the mapping to get it but, like I said, tricky.
+             */
+            TermQueryBuilder b = new TermQueryBuilder(
+                valuesSourceConfig.fieldContext().field(),
+                valuesSourceConfig.format().format(terms.term())
+            );
+            filters.add(context.buildQuery(b));
+        }
+        StringTermsAggregatorFromFilters adapted = new StringTermsAggregatorFromFilters(
+            parent,
+            factories,
+            subAggs -> FiltersAggregator.buildFilterByFilter(
+                name,
+                subAggs,
+                keys.toArray(new String[0]),
+                filters.toArray(new Query[0]),
+                false,
+                null,
+                context,
+                parent,
+                cardinality,
+                metadata
+            ),
+            showTermDocCountError,
+            valuesSourceConfig.format(),
+            order,
+            bucketCountThresholds,
+            terms
+        );
+        return adapted.delegate() == null ? null : adapted;
+    }
+
+    private final boolean showTermDocCountError;
+    private final DocValueFormat format;
+    private final BucketOrder order;
+    private final BucketCountThresholds bucketCountThresholds;
+    private final TermsEnum terms;
+
+    public StringTermsAggregatorFromFilters(
+        Aggregator parent,
+        AggregatorFactories subAggregators,
+        CheckedFunction<AggregatorFactories, Aggregator, IOException> delegate,
+        boolean showTermDocCountError,
+        DocValueFormat format,
+        BucketOrder order,
+        BucketCountThresholds bucketCountThresholds,
+        TermsEnum terms
+    ) throws IOException {
+        super(parent, subAggregators, delegate);
+        this.showTermDocCountError = showTermDocCountError;
+        this.format = format;
+        this.order = order;
+        this.bucketCountThresholds = bucketCountThresholds;
+        this.terms = terms;
+    }
+
+    @Override
+    protected InternalAggregation adapt(InternalAggregation delegateResult) throws IOException {
+        InternalFilters filters = (InternalFilters) delegateResult;
+        List<StringTerms.Bucket> buckets;
+        long otherDocsCount = 0;
+        BucketOrder reduceOrder = isKeyOrder(order) ? order : InternalOrder.key(true);
+        if (filters.getBuckets().size() > bucketCountThresholds.getShardSize()) {
+            PriorityQueue<OrdBucket> queue = new PriorityQueue<OrdBucket>(bucketCountThresholds.getShardSize()) {
+                private final Comparator<Bucket> comparator = order.comparator();
+
+                @Override
+                protected boolean lessThan(OrdBucket a, OrdBucket b) {
+                    return comparator.compare(a, b) > 0;
+                }
+            };
+            OrdBucket spare = null;
+            for (InternalFilters.InternalBucket b : filters.getBuckets()) {
+                if (spare == null) {
+                    spare = new OrdBucket(showTermDocCountError, format);
+                } else {
+                    otherDocsCount += spare.docCount;
+                }
+                spare.globalOrd = Long.parseLong(b.getKey());
+                spare.docCount = b.getDocCount();
+                spare.aggregations = b.getAggregations();
+                spare = queue.insertWithOverflow(spare);
+            }
+            if (spare != null) {
+                otherDocsCount += spare.docCount;
+            }
+            buckets = new ArrayList<>(queue.size());
+            if (isKeyOrder(order) == false) {
+                for (OrdBucket b : queue) {
+                    buckets.add(buildBucket(b));
+                }
+                Collections.sort(buckets, reduceOrder.comparator());
+            } else {
+                /*
+                 * Note for the curious: you can just use a for loop to iterate
+                 * the PriorityQueue to get all of the buckets. But they don't
+                 * come off in order. This gets them in order. It's also O(n*log(n))
+                 * instead of O(n), but such is life. And n shouldn't be too big.
+                 */
+                while (queue.size() > 0) {
+                    buckets.add(buildBucket(queue.pop()));
+                }
+                // The buckets come off last to first so we need to flip them.
+                Collections.reverse(buckets);
+            }
+        } else {
+            buckets = new ArrayList<>(filters.getBuckets().size());
+            for (InternalFilters.InternalBucket b : filters.getBuckets()) {
+                buckets.add(buildBucket(b));
+            }
+            Collections.sort(buckets, reduceOrder.comparator());
+        }
+        return new StringTerms(
+            filters.getName(),
+            reduceOrder,
+            order,
+            bucketCountThresholds.getRequiredSize(),
+            bucketCountThresholds.getMinDocCount(),
+            filters.getMetadata(),
+            format,
+            bucketCountThresholds.getShardSize(),
+            showTermDocCountError,
+            otherDocsCount,
+            buckets,
+            0
+        );
+    }
+
+    private StringTerms.Bucket buildBucket(OrdBucket b) throws IOException {
+        terms.seekExact(b.globalOrd);
+        return new StringTerms.Bucket(BytesRef.deepCopyOf(terms.term()), b.getDocCount(), b.aggregations, showTermDocCountError, 0, format);
+    }
+
+    private StringTerms.Bucket buildBucket(InternalFilters.InternalBucket b) throws IOException {
+        terms.seekExact(Long.parseLong(b.getKey()));
+        return new StringTerms.Bucket(
+            BytesRef.deepCopyOf(terms.term()),
+            b.getDocCount(),
+            b.getAggregations(),
+            showTermDocCountError,
+            0,
+            format
+        );
+    }
+}

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorFactory.java
@@ -8,6 +8,9 @@
 
 package org.elasticsearch.search.aggregations.bucket.terms;
 
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.search.IndexSearcher;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.search.DocValueFormat;
@@ -36,6 +39,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.function.LongPredicate;
 
 public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory {
     static Boolean REMAP_GLOBAL_ORDS, COLLECT_SEGMENT_ORDS;
@@ -51,6 +55,22 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory {
     }
 
     /**
+     * The maximum number of global ordinals a field can have for us to try
+     * aggregating it "filter by filter". "Filter by filter" aggregation is
+     * generally faster when possible but takes more memory because we have
+     * to build the filters.
+     * <p>
+     * The value that we have here is a fairly wild guess. At the time of
+     * writing we figure each filter clause takes a couple of kb worth of
+     * accounting so this is in the neighborhood of one megabyte of memory.
+     * <p>
+     * Secondly, this is a fairly crude heuristic. If the terms agg was going
+     * to take up nearly as much memory anyway it might be worth it to use
+     * filters. More experiment is required.
+     */
+    static final long MAX_ORDS_TO_TRY_FILTERS = 1000;
+
+    /**
      * This supplier is used for all the field types that should be aggregated as bytes/strings,
      * including those that need global ordinals
      */
@@ -59,9 +79,8 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory {
             @Override
             public Aggregator build(String name,
                                     AggregatorFactories factories,
-                                    ValuesSource valuesSource,
+                                    ValuesSourceConfig valuesSourceConfig,
                                     BucketOrder order,
-                                    DocValueFormat format,
                                     TermsAggregator.BucketCountThresholds bucketCountThresholds,
                                     IncludeExclude includeExclude,
                                     String executionHint,
@@ -71,6 +90,7 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory {
                                     boolean showTermDocCountError,
                                     CardinalityUpperBound cardinality,
                                     Map<String, Object> metadata) throws IOException {
+                ValuesSource valuesSource = valuesSourceConfig.getValuesSource();
                 ExecutionMode execution = null;
                 if (executionHint != null) {
                     execution = ExecutionMode.fromString(executionHint);
@@ -87,7 +107,7 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory {
                     subAggCollectMode = pickSubAggColectMode(factories, bucketCountThresholds.getShardSize(), maxOrd);
                 }
 
-                if ((includeExclude != null) && (includeExclude.isRegexBased()) && format != DocValueFormat.RAW) {
+                if ((includeExclude != null) && (includeExclude.isRegexBased()) && valuesSourceConfig.format() != DocValueFormat.RAW) {
                     // TODO this exception message is not really accurate for the string case.  It's really disallowing regex + formatter
                     throw new AggregationExecutionException("Aggregation [" + name + "] cannot support regular expression style "
                         + "include/exclude settings as they can only be applied to string fields. Use an array of values for "
@@ -95,7 +115,7 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory {
                 }
 
                 // TODO: [Zach] we might want refactor and remove ExecutionMode#create(), moving that logic outside the enum
-                return execution.create(name, factories, valuesSource, order, format, bucketCountThresholds, includeExclude,
+                return execution.create(name, factories, valuesSourceConfig, order, bucketCountThresholds, includeExclude,
                     context, parent, subAggCollectMode, showTermDocCountError, cardinality, metadata);
 
             }
@@ -111,9 +131,8 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory {
             @Override
             public Aggregator build(String name,
                                     AggregatorFactories factories,
-                                    ValuesSource valuesSource,
+                                    ValuesSourceConfig valuesSourceConfig,
                                     BucketOrder order,
-                                    DocValueFormat format,
                                     TermsAggregator.BucketCountThresholds bucketCountThresholds,
                                     IncludeExclude includeExclude,
                                     String executionHint,
@@ -134,7 +153,7 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory {
                     subAggCollectMode = pickSubAggColectMode(factories, bucketCountThresholds.getShardSize(), -1);
                 }
 
-                ValuesSource.Numeric numericValuesSource = (ValuesSource.Numeric) valuesSource;
+                ValuesSource.Numeric numericValuesSource = (ValuesSource.Numeric) valuesSourceConfig.getValuesSource();
                 IncludeExclude.LongFilter longFilter = null;
                 Function<NumericTermsAggregator, ResultStrategy<?, ?>> resultStrategy;
                 if (numericValuesSource.isFloatingPoint()) {
@@ -144,11 +163,11 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory {
                     resultStrategy = agg -> agg.new DoubleTermsResults(showTermDocCountError);
                 } else {
                     if (includeExclude != null) {
-                        longFilter = includeExclude.convertToLongFilter(format);
+                        longFilter = includeExclude.convertToLongFilter(valuesSourceConfig.format());
                     }
                     resultStrategy = agg -> agg.new LongTermsResults(showTermDocCountError);
                 }
-                return new NumericTermsAggregator(name, factories, resultStrategy, numericValuesSource, format, order,
+                return new NumericTermsAggregator(name, factories, resultStrategy, numericValuesSource, valuesSourceConfig.format(), order,
                     bucketCountThresholds, context, parent, subAggCollectMode, longFilter, cardinality, metadata);
             }
         };
@@ -230,9 +249,8 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory {
         return aggregatorSupplier.build(
             name,
             factories,
-            config.getValuesSource(),
+            config,
             order,
-            config.format(),
             bucketCountThresholds,
             includeExclude,
             executionHint,
@@ -291,9 +309,8 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory {
             @Override
             Aggregator create(String name,
                               AggregatorFactories factories,
-                              ValuesSource valuesSource,
+                              ValuesSourceConfig valuesSourceConfig,
                               BucketOrder order,
-                              DocValueFormat format,
                               TermsAggregator.BucketCountThresholds bucketCountThresholds,
                               IncludeExclude includeExclude,
                               AggregationContext context,
@@ -302,14 +319,16 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory {
                               boolean showTermDocCountError,
                               CardinalityUpperBound cardinality,
                               Map<String, Object> metadata) throws IOException {
-                final IncludeExclude.StringFilter filter = includeExclude == null ? null : includeExclude.convertToStringFilter(format);
+                IncludeExclude.StringFilter filter = includeExclude == null
+                    ? null
+                    : includeExclude.convertToStringFilter(valuesSourceConfig.format());
                 return new MapStringTermsAggregator(
                     name,
                     factories,
-                    new MapStringTermsAggregator.ValuesSourceCollectorSource(valuesSource),
-                    a -> a.new StandardTermsResults(valuesSource),
+                    new MapStringTermsAggregator.ValuesSourceCollectorSource(valuesSourceConfig.getValuesSource()),
+                    a -> a.new StandardTermsResults(valuesSourceConfig.getValuesSource()),
                     order,
-                    format,
+                    valuesSourceConfig.format(),
                     bucketCountThresholds,
                     filter,
                     context,
@@ -326,9 +345,8 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory {
             @Override
             Aggregator create(String name,
                               AggregatorFactories factories,
-                              ValuesSource valuesSource,
+                              ValuesSourceConfig valuesSourceConfig,
                               BucketOrder order,
-                              DocValueFormat format,
                               TermsAggregator.BucketCountThresholds bucketCountThresholds,
                               IncludeExclude includeExclude,
                               AggregationContext context, Aggregator parent,
@@ -337,13 +355,41 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory {
                               CardinalityUpperBound cardinality,
                               Map<String, Object> metadata) throws IOException {
 
-                final long maxOrd = getMaxOrd(valuesSource, context.searcher());
-                assert maxOrd != -1;
+                assert valuesSourceConfig.getValuesSource() instanceof ValuesSource.Bytes.WithOrdinals;
+                ValuesSource.Bytes.WithOrdinals ordinalsValuesSource = (ValuesSource.Bytes.WithOrdinals) valuesSourceConfig
+                    .getValuesSource();
+                SortedSetDocValues values = globalOrdsValues(context, ordinalsValuesSource);
+                long maxOrd = values.getValueCount();
+                if (maxOrd > 0 && maxOrd <= MAX_ORDS_TO_TRY_FILTERS) {
+                    StringTermsAggregatorFromFilters adapted = StringTermsAggregatorFromFilters.adaptIntoFiltersOrNull(
+                        name,
+                        factories,
+                        context,
+                        parent,
+                        showTermDocCountError,
+                        cardinality,
+                        metadata,
+                        valuesSourceConfig,
+                        order,
+                        bucketCountThresholds,
+                        gloabalOrdsFilter(includeExclude, valuesSourceConfig.format(), values),
+                        values
+                    );
+                    if (adapted != null) {
+                        /*
+                         * We don't check the estimated cost here because we're
+                         * fairly sure that any field that has global ordinals
+                         * is going to be able to query fairly quickly. Mostly
+                         * checking the cost is a defense against runtime fields
+                         * which *have* queries but they are slow and have high
+                         * cost. But runtime fields don't have global ords
+                         * so we won't have got here anyway.
+                         */
+                        return adapted;
+                    }
+                }
+
                 final double ratio = maxOrd / ((double) context.searcher().getIndexReader().numDocs());
-
-                assert valuesSource instanceof ValuesSource.Bytes.WithOrdinals;
-                ValuesSource.Bytes.WithOrdinals ordinalsValuesSource = (ValuesSource.Bytes.WithOrdinals) valuesSource;
-
                 if (factories == AggregatorFactories.EMPTY &&
                         includeExclude == null &&
                         cardinality == CardinalityUpperBound.ONE &&
@@ -359,13 +405,24 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory {
                      *  - the maximum global ordinal is less than 2048 (LOW_CARDINALITY has additional memory usage,
                      *  which directly linked to maxOrd, so we need to limit).
                      */
-                    return new GlobalOrdinalsStringTermsAggregator.LowCardinality(name, factories,
+                    return new GlobalOrdinalsStringTermsAggregator.LowCardinality(
+                        name,
+                        factories,
                         a -> a.new StandardTermsResults(),
-                        ordinalsValuesSource, order, format, bucketCountThresholds, context, parent, false,
-                        subAggCollectMode, showTermDocCountError, metadata);
+                        ordinalsValuesSource,
+                        values,
+                        order,
+                        valuesSourceConfig.format(),
+                        bucketCountThresholds,
+                        context,
+                        parent,
+                        false,
+                        subAggCollectMode,
+                        showTermDocCountError,
+                        metadata
+                    );
 
                 }
-                final IncludeExclude.OrdinalsFilter filter = includeExclude == null ? null : includeExclude.convertToOrdinalsFilter(format);
                 boolean remapGlobalOrds;
                 if (cardinality == CardinalityUpperBound.ONE && REMAP_GLOBAL_ORDS != null) {
                     /*
@@ -396,10 +453,11 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory {
                     factories,
                     a -> a.new StandardTermsResults(),
                     ordinalsValuesSource,
+                    values,
                     order,
-                    format,
+                    valuesSourceConfig.format(),
                     bucketCountThresholds,
-                    filter,
+                    gloabalOrdsFilter(includeExclude, valuesSourceConfig.format(), values),
                     context,
                     parent,
                     remapGlobalOrds,
@@ -430,9 +488,8 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory {
 
         abstract Aggregator create(String name,
                                    AggregatorFactories factories,
-                                   ValuesSource valuesSource,
+                                   ValuesSourceConfig valuesSourceConfig,
                                    BucketOrder order,
-                                   DocValueFormat format,
                                    TermsAggregator.BucketCountThresholds bucketCountThresholds,
                                    IncludeExclude includeExclude,
                                    AggregationContext context,
@@ -448,4 +505,24 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory {
         }
     }
 
+    public static SortedSetDocValues globalOrdsValues(AggregationContext context, ValuesSource.Bytes.WithOrdinals valuesSource)
+        throws IOException {
+        IndexReader reader = context.searcher().getIndexReader();
+        if (reader.leaves().isEmpty()) {
+            return DocValues.emptySortedSet();
+        }
+        return valuesSource.globalOrdinalsValues(reader.leaves().get(0));
+    }
+
+    public static LongPredicate gloabalOrdsFilter(
+        IncludeExclude includeExclude,
+        DocValueFormat format,
+        SortedSetDocValues values
+    ) throws IOException {
+
+        if (includeExclude == null) {
+            return GlobalOrdinalsStringTermsAggregator.ALWAYS_TRUE;
+        }
+        return includeExclude.convertToOrdinalsFilter(format).acceptedGlobalOrdinals(values)::get;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorSupplier.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorSupplier.java
@@ -7,13 +7,12 @@
  */
 package org.elasticsearch.search.aggregations.bucket.terms;
 
-import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.BucketOrder;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
-import org.elasticsearch.search.aggregations.support.ValuesSource;
+import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 
 import java.io.IOException;
 import java.util.Map;
@@ -21,9 +20,8 @@ import java.util.Map;
 interface TermsAggregatorSupplier {
     Aggregator build(String name,
                      AggregatorFactories factories,
-                     ValuesSource valuesSource,
+                     ValuesSourceConfig valuesSourceConfig,
                      BucketOrder order,
-                     DocValueFormat format,
                      TermsAggregator.BucketCountThresholds bucketCountThresholds,
                      IncludeExclude includeExclude,
                      String executionHint,

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/KeywordTermsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/KeywordTermsAggregatorTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.search.aggregations.bucket.terms;
 
 import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
 import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
@@ -87,11 +88,15 @@ public class KeywordTermsAggregatorTests extends AggregatorTestCase {
     private void testSearchCase(Query query, List<String> dataset,
                                 Consumer<TermsAggregationBuilder> configure,
                                 Consumer<InternalMappedTerms> verify, ValueType valueType) throws IOException {
+        MappedFieldType keywordFieldType = new KeywordFieldMapper.KeywordFieldType(KEYWORD_FIELD, randomBoolean(), true, null);
         try (Directory directory = newDirectory()) {
             try (RandomIndexWriter indexWriter = new RandomIndexWriter(random(), directory)) {
                 Document document = new Document();
                 for (String value : dataset) {
                     document.add(new SortedSetDocValuesField(KEYWORD_FIELD, new BytesRef(value)));
+                    if (keywordFieldType.isSearchable()) {
+                        document.add(new Field(KEYWORD_FIELD, new BytesRef(value), KeywordFieldMapper.Defaults.FIELD_TYPE));
+                    }
                     indexWriter.addDocument(document);
                     document.clear();
                 }
@@ -108,7 +113,6 @@ public class KeywordTermsAggregatorTests extends AggregatorTestCase {
                     configure.accept(aggregationBuilder);
                 }
 
-                MappedFieldType keywordFieldType = new KeywordFieldMapper.KeywordFieldType(KEYWORD_FIELD);
 
                 InternalMappedTerms rareTerms = searchAndReduce(indexSearcher, query, aggregationBuilder, keywordFieldType);
                 verify.accept(rareTerms);

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorTests.java
@@ -102,6 +102,7 @@ import org.elasticsearch.test.geo.RandomGeoGenerator;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -257,6 +258,33 @@ public class TermsAggregatorTests extends AggregatorTestCase {
             assertEquals(1L, result.getBuckets().get(4).getDocCount());
             assertTrue(AggregationInspectionHelper.hasValue(result));
         }, fieldType);
+    }
+
+    public void testStringShardMinDocCount() throws IOException {
+        MappedFieldType fieldType = new KeywordFieldMapper.KeywordFieldType("string", true, true, null);
+        for (TermsAggregatorFactory.ExecutionMode executionMode : TermsAggregatorFactory.ExecutionMode.values()) {
+            TermsAggregationBuilder aggregationBuilder = new TermsAggregationBuilder("_name")
+                .field("string")
+                .executionHint(executionMode.toString())
+                .size(2)
+                .minDocCount(2)
+                .shardMinDocCount(2)
+                .order(BucketOrder.key(true));
+            testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+                // force single shard/segment
+                iw.addDocuments(Arrays.asList(
+                    doc(fieldType, "a", "b"),
+                    doc(fieldType, "", "c", "d"),
+                    doc(fieldType, "b", "d"),
+                    doc(fieldType, "b")));
+            }, (InternalTerms<?, ?> result) -> {
+                assertEquals(2, result.getBuckets().size());
+                assertEquals("b", result.getBuckets().get(0).getKeyAsString());
+                assertEquals(3L, result.getBuckets().get(0).getDocCount());
+                assertEquals("d", result.getBuckets().get(1).getKeyAsString());
+                assertEquals(2L, result.getBuckets().get(1).getDocCount());
+            }, fieldType);
+        }
     }
 
     public void testManyUniqueTerms() throws Exception {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorTests.java
@@ -42,6 +42,7 @@ import org.elasticsearch.index.mapper.GeoPointFieldMapper;
 import org.elasticsearch.index.mapper.IdFieldMapper;
 import org.elasticsearch.index.mapper.IpFieldMapper;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
+import org.elasticsearch.index.mapper.KeywordFieldMapper.KeywordField;
 import org.elasticsearch.index.mapper.KeywordFieldMapper.KeywordFieldType;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
@@ -106,6 +107,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -231,283 +233,264 @@ public class TermsAggregatorTests extends AggregatorTestCase {
     }
 
     public void testSimple() throws Exception {
-        try (Directory directory = newDirectory()) {
-            try (RandomIndexWriter indexWriter = new RandomIndexWriter(random(), directory)) {
-                Document document = new Document();
-                document.add(new SortedSetDocValuesField("string", new BytesRef("a")));
-                document.add(new SortedSetDocValuesField("string", new BytesRef("b")));
-                indexWriter.addDocument(document);
-                document = new Document();
-                document.add(new SortedSetDocValuesField("string", new BytesRef("")));
-                document.add(new SortedSetDocValuesField("string", new BytesRef("c")));
-                document.add(new SortedSetDocValuesField("string", new BytesRef("a")));
-                indexWriter.addDocument(document);
-                document = new Document();
-                document.add(new SortedSetDocValuesField("string", new BytesRef("b")));
-                document.add(new SortedSetDocValuesField("string", new BytesRef("d")));
-                indexWriter.addDocument(document);
-                document = new Document();
-                document.add(new SortedSetDocValuesField("string", new BytesRef("")));
-                indexWriter.addDocument(document);
-                try (IndexReader indexReader = maybeWrapReaderEs(indexWriter.getReader())) {
-                    IndexSearcher indexSearcher = newIndexSearcher(indexReader);
-                    for (TermsAggregatorFactory.ExecutionMode executionMode : TermsAggregatorFactory.ExecutionMode.values()) {
-                        TermsAggregationBuilder aggregationBuilder = new TermsAggregationBuilder("_name")
-                            .userValueTypeHint(ValueType.STRING)
-                            .executionHint(executionMode.toString())
-                            .field("string")
-                            .order(BucketOrder.key(true));
-                        MappedFieldType fieldType = new KeywordFieldMapper.KeywordFieldType("string");
+        MappedFieldType fieldType = new KeywordFieldMapper.KeywordFieldType("string", randomBoolean(), true, null);
+        TermsAggregationBuilder aggregationBuilder = new TermsAggregationBuilder("_name")
+            .executionHint(randomFrom(TermsAggregatorFactory.ExecutionMode.values()).toString())
+            .field("string")
+            .order(BucketOrder.key(true));
+        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+            iw.addDocument(doc(fieldType, "a", "b"));
+            iw.addDocument(doc(fieldType, "", "c", "a"));
+            iw.addDocument(doc(fieldType, "b", "d"));
+            iw.addDocument(doc(fieldType, ""));
+        }, (InternalTerms<?, ?> result) -> {
+            assertEquals(5, result.getBuckets().size());
+            assertEquals("", result.getBuckets().get(0).getKeyAsString());
+            assertEquals(2L, result.getBuckets().get(0).getDocCount());
+            assertEquals("a", result.getBuckets().get(1).getKeyAsString());
+            assertEquals(2L, result.getBuckets().get(1).getDocCount());
+            assertEquals("b", result.getBuckets().get(2).getKeyAsString());
+            assertEquals(2L, result.getBuckets().get(2).getDocCount());
+            assertEquals("c", result.getBuckets().get(3).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(3).getDocCount());
+            assertEquals("d", result.getBuckets().get(4).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(4).getDocCount());
+            assertTrue(AggregationInspectionHelper.hasValue(result));
+        }, fieldType);
+    }
 
-                        AggregationContext context = createAggregationContext(indexSearcher, null, fieldType);
-                        TermsAggregator aggregator = createAggregator(aggregationBuilder, context);
-                        aggregator.preCollection();
-                        indexSearcher.search(new MatchAllDocsQuery(), aggregator);
-                        aggregator.postCollection();
-                        Terms result = reduce(aggregator, context.bigArrays());
-                        assertEquals(5, result.getBuckets().size());
-                        assertEquals("", result.getBuckets().get(0).getKeyAsString());
-                        assertEquals(2L, result.getBuckets().get(0).getDocCount());
-                        assertEquals("a", result.getBuckets().get(1).getKeyAsString());
-                        assertEquals(2L, result.getBuckets().get(1).getDocCount());
-                        assertEquals("b", result.getBuckets().get(2).getKeyAsString());
-                        assertEquals(2L, result.getBuckets().get(2).getDocCount());
-                        assertEquals("c", result.getBuckets().get(3).getKeyAsString());
-                        assertEquals(1L, result.getBuckets().get(3).getDocCount());
-                        assertEquals("d", result.getBuckets().get(4).getKeyAsString());
-                        assertEquals(1L, result.getBuckets().get(4).getDocCount());
-                        assertTrue(AggregationInspectionHelper.hasValue((InternalTerms)result));
-                    }
+    public void testManyUniqueTerms() throws Exception {
+        MappedFieldType fieldType = new KeywordFieldMapper.KeywordFieldType("string", randomBoolean(), true, null);
+        TermsAggregationBuilder aggregationBuilder = new TermsAggregationBuilder("_name")
+            .executionHint(randomFrom(TermsAggregatorFactory.ExecutionMode.values()).toString())
+            .field("string");
+        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+            for (int i = 0; i < TermsAggregatorFactory.MAX_ORDS_TO_TRY_FILTERS - 200; i++) {
+                String s = String.format(Locale.ROOT, "b%03d", i);
+                iw.addDocument(doc(fieldType, s));
+                if (i % 100 == 7) {
+                    iw.addDocument(doc(fieldType, s));
                 }
             }
+        }, (StringTerms result) -> {
+            assertThat(
+                result.getBuckets().stream().map(StringTerms.Bucket::getKey).collect(toList()),
+                equalTo(
+                    org.elasticsearch.common.collect.List.of("b007", "b107", "b207", "b307", "b407", "b507", "b607", "b707", "b000", "b001")
+                )
+            );
+        }, fieldType);
+    }
+
+    private List<IndexableField> doc(MappedFieldType ft, String... values) {
+        List<IndexableField> doc = new ArrayList<IndexableField>();
+        for (String v : values) {
+            BytesRef bytes = new BytesRef(v);
+            doc.add(new SortedSetDocValuesField("string", bytes));
+            if (ft.isSearchable()) {
+                doc.add(new KeywordField("string", bytes, KeywordFieldMapper.Defaults.FIELD_TYPE));
+            }
         }
+        return doc;
     }
 
     public void testStringIncludeExclude() throws Exception {
-        try (Directory directory = newDirectory()) {
-            try (RandomIndexWriter indexWriter = new RandomIndexWriter(random(), directory)) {
-                Document document = new Document();
-                document.add(new SortedSetDocValuesField("mv_field", new BytesRef("val000")));
-                document.add(new SortedSetDocValuesField("mv_field", new BytesRef("val001")));
-                document.add(new SortedDocValuesField("sv_field", new BytesRef("val001")));
-                indexWriter.addDocument(document);
-                document = new Document();
-                document.add(new SortedSetDocValuesField("mv_field", new BytesRef("val002")));
-                document.add(new SortedSetDocValuesField("mv_field", new BytesRef("val003")));
-                document.add(new SortedDocValuesField("sv_field", new BytesRef("val003")));
-                indexWriter.addDocument(document);
-                document = new Document();
-                document.add(new SortedSetDocValuesField("mv_field", new BytesRef("val004")));
-                document.add(new SortedSetDocValuesField("mv_field", new BytesRef("val005")));
-                document.add(new SortedDocValuesField("sv_field", new BytesRef("val005")));
-                indexWriter.addDocument(document);
-                document = new Document();
-                document.add(new SortedSetDocValuesField("mv_field", new BytesRef("val006")));
-                document.add(new SortedSetDocValuesField("mv_field", new BytesRef("val007")));
-                document.add(new SortedDocValuesField("sv_field", new BytesRef("val007")));
-                indexWriter.addDocument(document);
-                document = new Document();
-                document.add(new SortedSetDocValuesField("mv_field", new BytesRef("val008")));
-                document.add(new SortedSetDocValuesField("mv_field", new BytesRef("val009")));
-                document.add(new SortedDocValuesField("sv_field", new BytesRef("val009")));
-                indexWriter.addDocument(document);
-                document = new Document();
-                document.add(new SortedSetDocValuesField("mv_field", new BytesRef("val010")));
-                document.add(new SortedSetDocValuesField("mv_field", new BytesRef("val011")));
-                document.add(new SortedDocValuesField("sv_field", new BytesRef("val011")));
-                indexWriter.addDocument(document);
-                try (IndexReader indexReader = maybeWrapReaderEs(indexWriter.getReader())) {
-                    IndexSearcher indexSearcher = newIndexSearcher(indexReader);
-                    MappedFieldType fieldType = new KeywordFieldMapper.KeywordFieldType("mv_field");
+        MappedFieldType ft1 = new KeywordFieldMapper.KeywordFieldType("mv_field", randomBoolean(), true, null);
+        MappedFieldType ft2 = new KeywordFieldMapper.KeywordFieldType("sv_field", randomBoolean(), true, null);
+        CheckedConsumer<RandomIndexWriter, IOException> buildIndex = iw -> {
+            iw.addDocument(doc(ft1, ft2, "val000", "val001", "val001"));
+            iw.addDocument(doc(ft1, ft2, "val002", "val003", "val003"));
+            iw.addDocument(doc(ft1, ft2, "val004", "val005", "val005"));
+            iw.addDocument(doc(ft1, ft2, "val006", "val007", "val007"));
+            iw.addDocument(doc(ft1, ft2, "val008", "val009", "val009"));
+            iw.addDocument(doc(ft1, ft2, "val010", "val011", "val011"));
+        };
+        String executionHint = randomFrom(TermsAggregatorFactory.ExecutionMode.values()).toString();
 
-                    String executionHint = randomFrom(TermsAggregatorFactory.ExecutionMode.values()).toString();
-                    TermsAggregationBuilder aggregationBuilder = new TermsAggregationBuilder("_name")
-                        .userValueTypeHint(ValueType.STRING)
-                        .executionHint(executionHint)
-                        .includeExclude(new IncludeExclude("val00.+", null))
-                        .field("mv_field")
-                        .size(12)
-                        .order(BucketOrder.key(true));
+        AggregationBuilder builder = new TermsAggregationBuilder("_name").executionHint(executionHint)
+            .includeExclude(new IncludeExclude("val00.+", null))
+            .field("mv_field")
+            .size(12)
+            .order(BucketOrder.key(true));
+        testCase(builder, new MatchAllDocsQuery(), buildIndex, (StringTerms result) -> {
+            assertEquals(10, result.getBuckets().size());
+            assertEquals("val000", result.getBuckets().get(0).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(0).getDocCount());
+            assertEquals("val001", result.getBuckets().get(1).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(1).getDocCount());
+            assertEquals("val002", result.getBuckets().get(2).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(2).getDocCount());
+            assertEquals("val003", result.getBuckets().get(3).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(3).getDocCount());
+            assertEquals("val004", result.getBuckets().get(4).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(4).getDocCount());
+            assertEquals("val005", result.getBuckets().get(5).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(5).getDocCount());
+            assertEquals("val006", result.getBuckets().get(6).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(6).getDocCount());
+            assertEquals("val007", result.getBuckets().get(7).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(7).getDocCount());
+            assertEquals("val008", result.getBuckets().get(8).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(8).getDocCount());
+            assertEquals("val009", result.getBuckets().get(9).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(9).getDocCount());
+            assertTrue(AggregationInspectionHelper.hasValue(result));
+        }, ft1, ft2);
 
-                    AggregationContext context = createAggregationContext(indexSearcher, null, fieldType);
-                    TermsAggregator aggregator = createAggregator(aggregationBuilder, context);
-                    aggregator.preCollection();
-                    indexSearcher.search(new MatchAllDocsQuery(), aggregator);
-                    aggregator.postCollection();
-                    Terms result = reduce(aggregator, context.bigArrays());
-                    assertEquals(10, result.getBuckets().size());
-                    assertEquals("val000", result.getBuckets().get(0).getKeyAsString());
-                    assertEquals(1L, result.getBuckets().get(0).getDocCount());
-                    assertEquals("val001", result.getBuckets().get(1).getKeyAsString());
-                    assertEquals(1L, result.getBuckets().get(1).getDocCount());
-                    assertEquals("val002", result.getBuckets().get(2).getKeyAsString());
-                    assertEquals(1L, result.getBuckets().get(2).getDocCount());
-                    assertEquals("val003", result.getBuckets().get(3).getKeyAsString());
-                    assertEquals(1L, result.getBuckets().get(3).getDocCount());
-                    assertEquals("val004", result.getBuckets().get(4).getKeyAsString());
-                    assertEquals(1L, result.getBuckets().get(4).getDocCount());
-                    assertEquals("val005", result.getBuckets().get(5).getKeyAsString());
-                    assertEquals(1L, result.getBuckets().get(5).getDocCount());
-                    assertEquals("val006", result.getBuckets().get(6).getKeyAsString());
-                    assertEquals(1L, result.getBuckets().get(6).getDocCount());
-                    assertEquals("val007", result.getBuckets().get(7).getKeyAsString());
-                    assertEquals(1L, result.getBuckets().get(7).getDocCount());
-                    assertEquals("val008", result.getBuckets().get(8).getKeyAsString());
-                    assertEquals(1L, result.getBuckets().get(8).getDocCount());
-                    assertEquals("val009", result.getBuckets().get(9).getKeyAsString());
-                    assertEquals(1L, result.getBuckets().get(9).getDocCount());
-                    assertTrue(AggregationInspectionHelper.hasValue((InternalTerms)result));
+        builder = new TermsAggregationBuilder("_name").executionHint(executionHint)
+            .includeExclude(new IncludeExclude("val00.+", null))
+            .field("sv_field")
+            .order(BucketOrder.key(true));
+        testCase(builder, new MatchAllDocsQuery(), buildIndex, (StringTerms result) -> {
+            assertEquals(5, result.getBuckets().size());
+            assertEquals("val001", result.getBuckets().get(0).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(0).getDocCount());
+            assertEquals("val003", result.getBuckets().get(1).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(1).getDocCount());
+            assertEquals("val005", result.getBuckets().get(2).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(2).getDocCount());
+            assertEquals("val007", result.getBuckets().get(3).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(3).getDocCount());
+            assertEquals("val009", result.getBuckets().get(4).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(4).getDocCount());
+            assertTrue(AggregationInspectionHelper.hasValue(result));
+        }, ft1, ft2);
 
-                    MappedFieldType fieldType2 = new KeywordFieldMapper.KeywordFieldType("sv_field");
-                    aggregationBuilder = new TermsAggregationBuilder("_name").userValueTypeHint(ValueType.STRING)
-                        .executionHint(executionHint)
-                        .includeExclude(new IncludeExclude("val00.+", null))
-                        .field("sv_field")
-                        .order(BucketOrder.key(true));
+        builder = new TermsAggregationBuilder("_name").executionHint(executionHint)
+            .includeExclude(new IncludeExclude("val00.+", null))
+            .field("sv_field")
+            .order(BucketOrder.key(true));
+        testCase(builder, new MatchAllDocsQuery(), buildIndex, (StringTerms result) -> {
+            assertEquals(5, result.getBuckets().size());
+            assertEquals("val001", result.getBuckets().get(0).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(0).getDocCount());
+            assertEquals("val003", result.getBuckets().get(1).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(1).getDocCount());
+            assertEquals("val005", result.getBuckets().get(2).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(2).getDocCount());
+            assertEquals("val007", result.getBuckets().get(3).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(3).getDocCount());
+            assertEquals("val009", result.getBuckets().get(4).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(4).getDocCount());
+            assertTrue(AggregationInspectionHelper.hasValue(result));
+        }, ft1, ft2);
 
-                    context = createAggregationContext(indexSearcher, null, fieldType2);
-                    aggregator = createAggregator(aggregationBuilder, context);
-                    aggregator.preCollection();
-                    indexSearcher.search(new MatchAllDocsQuery(), aggregator);
-                    aggregator.postCollection();
-                    result = reduce(aggregator, context.bigArrays());
-                    assertEquals(5, result.getBuckets().size());
-                    assertEquals("val001", result.getBuckets().get(0).getKeyAsString());
-                    assertEquals(1L, result.getBuckets().get(0).getDocCount());
-                    assertEquals("val003", result.getBuckets().get(1).getKeyAsString());
-                    assertEquals(1L, result.getBuckets().get(1).getDocCount());
-                    assertEquals("val005", result.getBuckets().get(2).getKeyAsString());
-                    assertEquals(1L, result.getBuckets().get(2).getDocCount());
-                    assertEquals("val007", result.getBuckets().get(3).getKeyAsString());
-                    assertEquals(1L, result.getBuckets().get(3).getDocCount());
-                    assertEquals("val009", result.getBuckets().get(4).getKeyAsString());
-                    assertEquals(1L, result.getBuckets().get(4).getDocCount());
-                    assertTrue(AggregationInspectionHelper.hasValue((InternalTerms)result));
+        builder = new TermsAggregationBuilder("_name").executionHint(executionHint)
+            .includeExclude(new IncludeExclude("val00.+", "(val000|val001)"))
+            .field("mv_field")
+            .order(BucketOrder.key(true));
+        testCase(builder, new MatchAllDocsQuery(), buildIndex, (StringTerms result) -> {
+            assertEquals(8, result.getBuckets().size());
+            assertEquals("val002", result.getBuckets().get(0).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(0).getDocCount());
+            assertEquals("val003", result.getBuckets().get(1).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(1).getDocCount());
+            assertEquals("val004", result.getBuckets().get(2).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(2).getDocCount());
+            assertEquals("val005", result.getBuckets().get(3).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(3).getDocCount());
+            assertEquals("val006", result.getBuckets().get(4).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(4).getDocCount());
+            assertEquals("val007", result.getBuckets().get(5).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(5).getDocCount());
+            assertEquals("val008", result.getBuckets().get(6).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(6).getDocCount());
+            assertEquals("val009", result.getBuckets().get(7).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(7).getDocCount());
+            assertTrue(AggregationInspectionHelper.hasValue(result));
+        }, ft1, ft2);
 
-                    aggregationBuilder = new TermsAggregationBuilder("_name").userValueTypeHint(ValueType.STRING)
-                        .executionHint(executionHint)
-                        .includeExclude(new IncludeExclude("val00.+", "(val000|val001)"))
-                        .field("mv_field")
-                        .order(BucketOrder.key(true));
+        builder = new TermsAggregationBuilder("_name").executionHint(executionHint)
+            .includeExclude(new IncludeExclude(null, "val00.+"))
+            .field("mv_field")
+            .order(BucketOrder.key(true));
+        testCase(builder, new MatchAllDocsQuery(), buildIndex, (StringTerms result) -> {
+            assertEquals(2, result.getBuckets().size());
+            assertEquals("val010", result.getBuckets().get(0).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(0).getDocCount());
+            assertEquals("val011", result.getBuckets().get(1).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(1).getDocCount());
+            assertTrue(AggregationInspectionHelper.hasValue(result));
+        }, ft1, ft2);
 
-                    context = createAggregationContext(indexSearcher, null, fieldType);
-                    aggregator = createAggregator(aggregationBuilder, context);
-                    aggregator.preCollection();
-                    indexSearcher.search(new MatchAllDocsQuery(), aggregator);
-                    aggregator.postCollection();
-                    result = reduce(aggregator, context.bigArrays());
-                    assertEquals(8, result.getBuckets().size());
-                    assertEquals("val002", result.getBuckets().get(0).getKeyAsString());
-                    assertEquals(1L, result.getBuckets().get(0).getDocCount());
-                    assertEquals("val003", result.getBuckets().get(1).getKeyAsString());
-                    assertEquals(1L, result.getBuckets().get(1).getDocCount());
-                    assertEquals("val004", result.getBuckets().get(2).getKeyAsString());
-                    assertEquals(1L, result.getBuckets().get(2).getDocCount());
-                    assertEquals("val005", result.getBuckets().get(3).getKeyAsString());
-                    assertEquals(1L, result.getBuckets().get(3).getDocCount());
-                    assertEquals("val006", result.getBuckets().get(4).getKeyAsString());
-                    assertEquals(1L, result.getBuckets().get(4).getDocCount());
-                    assertEquals("val007", result.getBuckets().get(5).getKeyAsString());
-                    assertEquals(1L, result.getBuckets().get(5).getDocCount());
-                    assertEquals("val008", result.getBuckets().get(6).getKeyAsString());
-                    assertEquals(1L, result.getBuckets().get(6).getDocCount());
-                    assertEquals("val009", result.getBuckets().get(7).getKeyAsString());
-                    assertEquals(1L, result.getBuckets().get(7).getDocCount());
-                    assertTrue(AggregationInspectionHelper.hasValue((InternalTerms)result));
+        builder = new TermsAggregationBuilder("_name").executionHint(executionHint)
+            .includeExclude(new IncludeExclude(new String[] { "val000", "val010" }, null))
+            .field("mv_field")
+            .order(BucketOrder.key(true));
+        testCase(builder, new MatchAllDocsQuery(), buildIndex, (StringTerms result) -> {
+            assertEquals(2, result.getBuckets().size());
+            assertEquals("val000", result.getBuckets().get(0).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(0).getDocCount());
+            assertEquals("val010", result.getBuckets().get(1).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(1).getDocCount());
+            assertTrue(AggregationInspectionHelper.hasValue(result));
+        }, ft1, ft2);
 
-                    aggregationBuilder = new TermsAggregationBuilder("_name").userValueTypeHint(ValueType.STRING)
-                        .executionHint(executionHint)
-                        .includeExclude(new IncludeExclude(null, "val00.+"))
-                        .field("mv_field")
-                        .order(BucketOrder.key(true));
-                    context = createAggregationContext(indexSearcher, null, fieldType);
-                    aggregator = createAggregator(aggregationBuilder, context);
-                    aggregator.preCollection();
-                    indexSearcher.search(new MatchAllDocsQuery(), aggregator);
-                    aggregator.postCollection();
-                    result = reduce(aggregator, context.bigArrays());
-                    assertEquals(2, result.getBuckets().size());
-                    assertEquals("val010", result.getBuckets().get(0).getKeyAsString());
-                    assertEquals(1L, result.getBuckets().get(0).getDocCount());
-                    assertEquals("val011", result.getBuckets().get(1).getKeyAsString());
-                    assertEquals(1L, result.getBuckets().get(1).getDocCount());
-                    assertTrue(AggregationInspectionHelper.hasValue((InternalTerms)result));
+        builder = new TermsAggregationBuilder("_name").executionHint(executionHint)
+            .includeExclude(
+                new IncludeExclude(
+                    null,
+                    new String[] { "val001", "val002", "val003", "val004", "val005", "val006", "val007", "val008", "val009", "val011" }
+                )
+            )
+            .field("mv_field")
+            .order(BucketOrder.key(true));
+        testCase(builder, new MatchAllDocsQuery(), buildIndex, (StringTerms result) -> {
+            assertEquals(2, result.getBuckets().size());
+            assertEquals("val000", result.getBuckets().get(0).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(0).getDocCount());
+            assertEquals("val010", result.getBuckets().get(1).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(1).getDocCount());
+            assertTrue(AggregationInspectionHelper.hasValue(result));
+        }, ft1, ft2);
 
-                    aggregationBuilder = new TermsAggregationBuilder("_name").userValueTypeHint(ValueType.STRING)
-                        .executionHint(executionHint)
-                        .includeExclude(new IncludeExclude(new String[]{"val000", "val010"}, null))
-                        .field("mv_field")
-                        .order(BucketOrder.key(true));
-                    context = createAggregationContext(indexSearcher, null, fieldType);
-                    aggregator = createAggregator(aggregationBuilder, context);
-                    aggregator.preCollection();
-                    indexSearcher.search(new MatchAllDocsQuery(), aggregator);
-                    aggregator.postCollection();
-                    result = reduce(aggregator, context.bigArrays());
-                    assertEquals(2, result.getBuckets().size());
-                    assertEquals("val000", result.getBuckets().get(0).getKeyAsString());
-                    assertEquals(1L, result.getBuckets().get(0).getDocCount());
-                    assertEquals("val010", result.getBuckets().get(1).getKeyAsString());
-                    assertEquals(1L, result.getBuckets().get(1).getDocCount());
-                    assertTrue(AggregationInspectionHelper.hasValue((InternalTerms)result));
+        builder = new TermsAggregationBuilder("_name").executionHint(executionHint)
+            .includeExclude(
+                new IncludeExclude(
+                    "val00.+",
+                    null,
+                    null,
+                    new String[] { "val001", "val002", "val003", "val004", "val005", "val006", "val007", "val008" }
+                )
+            )
+            .field("mv_field")
+            .order(BucketOrder.key(true));
+        testCase(builder, new MatchAllDocsQuery(), buildIndex, (StringTerms result) -> {
+            assertEquals(2, result.getBuckets().size());
+            assertEquals("val000", result.getBuckets().get(0).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(0).getDocCount());
+            assertEquals("val009", result.getBuckets().get(1).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(1).getDocCount());
+            assertTrue(AggregationInspectionHelper.hasValue(result));
+        }, ft1, ft2);
 
-                    aggregationBuilder = new TermsAggregationBuilder("_name").userValueTypeHint(ValueType.STRING)
-                        .executionHint(executionHint)
-                        .includeExclude(new IncludeExclude(null, new String[]{"val001", "val002", "val003", "val004",
-                            "val005", "val006", "val007", "val008", "val009", "val011"}))
-                        .field("mv_field")
-                        .order(BucketOrder.key(true));
-                    context = createAggregationContext(indexSearcher, null, fieldType);
-                    aggregator = createAggregator(aggregationBuilder, context);
-                    aggregator.preCollection();
-                    indexSearcher.search(new MatchAllDocsQuery(), aggregator);
-                    aggregator.postCollection();
-                    result = reduce(aggregator, context.bigArrays());
-                    assertEquals(2, result.getBuckets().size());
-                    assertEquals("val000", result.getBuckets().get(0).getKeyAsString());
-                    assertEquals(1L, result.getBuckets().get(0).getDocCount());
-                    assertEquals("val010", result.getBuckets().get(1).getKeyAsString());
-                    assertEquals(1L, result.getBuckets().get(1).getDocCount());
-                    assertTrue(AggregationInspectionHelper.hasValue((InternalTerms)result));
+        builder = new TermsAggregationBuilder("_name").executionHint(executionHint)
+            .includeExclude(new IncludeExclude(null, "val01.+", new String[] { "val001", "val002", "val010" }, null))
+            .field("mv_field")
+            .order(BucketOrder.key(true));
+        testCase(builder, new MatchAllDocsQuery(), buildIndex, (StringTerms result) -> {
+            assertEquals(2, result.getBuckets().size());
+            assertEquals("val001", result.getBuckets().get(0).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(0).getDocCount());
+            assertEquals("val002", result.getBuckets().get(1).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(1).getDocCount());
+            assertTrue(AggregationInspectionHelper.hasValue(result));
+        }, ft1, ft2);
+    }
 
-                    aggregationBuilder = new TermsAggregationBuilder("_name").userValueTypeHint(ValueType.STRING)
-                        .executionHint(executionHint)
-                        .includeExclude(new IncludeExclude("val00.+", null, null,
-                            new String[]{"val001", "val002", "val003", "val004", "val005", "val006", "val007", "val008"}))
-                        .field("mv_field")
-                        .order(BucketOrder.key(true));
-                    aggregator = createAggregator(aggregationBuilder, indexSearcher, fieldType);
-                    aggregator.preCollection();
-                    indexSearcher.search(new MatchAllDocsQuery(), aggregator);
-                    aggregator.postCollection();
-                    result = reduce(aggregator, context.bigArrays());
-                    assertEquals(2, result.getBuckets().size());
-                    assertEquals("val000", result.getBuckets().get(0).getKeyAsString());
-                    assertEquals(1L, result.getBuckets().get(0).getDocCount());
-                    assertEquals("val009", result.getBuckets().get(1).getKeyAsString());
-                    assertEquals(1L, result.getBuckets().get(1).getDocCount());
-                    assertTrue(AggregationInspectionHelper.hasValue((InternalTerms)result));
-
-                    aggregationBuilder = new TermsAggregationBuilder("_name").userValueTypeHint(ValueType.STRING)
-                        .executionHint(executionHint)
-                        .includeExclude(new IncludeExclude(null, "val01.+", new String[]{"val001",
-                            "val002", "val010"}, null))
-                        .field("mv_field")
-                        .order(BucketOrder.key(true));
-                    aggregator = createAggregator(aggregationBuilder, indexSearcher, fieldType);
-                    aggregator.preCollection();
-                    indexSearcher.search(new MatchAllDocsQuery(), aggregator);
-                    aggregator.postCollection();
-                    result = reduce(aggregator, context.bigArrays());
-                    assertEquals(2, result.getBuckets().size());
-                    assertEquals("val001", result.getBuckets().get(0).getKeyAsString());
-                    assertEquals(1L, result.getBuckets().get(0).getDocCount());
-                    assertEquals("val002", result.getBuckets().get(1).getKeyAsString());
-                    assertEquals(1L, result.getBuckets().get(1).getDocCount());
-                    assertTrue(AggregationInspectionHelper.hasValue((InternalTerms)result));
-                }
-            }
+    private List<IndexableField> doc(MappedFieldType ft1, MappedFieldType ft2, String f1v1, String f1v2, String f2v) {
+        List<IndexableField> doc = new ArrayList<IndexableField>();
+        doc.add(new SortedSetDocValuesField(ft1.name(), new BytesRef(f1v1)));
+        doc.add(new SortedSetDocValuesField(ft1.name(), new BytesRef(f1v2)));
+        if (ft1.isSearchable()) {
+            doc.add(new KeywordField(ft1.name(), new BytesRef(f1v1), KeywordFieldMapper.Defaults.FIELD_TYPE));
+            doc.add(new KeywordField(ft1.name(), new BytesRef(f1v2), KeywordFieldMapper.Defaults.FIELD_TYPE));
         }
+        doc.add(new SortedDocValuesField(ft2.name(), new BytesRef(f2v)));
+        if (ft2.isSearchable()) {
+            doc.add(new KeywordField(ft2.name(), new BytesRef(f2v), KeywordFieldMapper.Defaults.FIELD_TYPE));
+        }
+        return doc;
     }
 
     public void testNumericIncludeExclude() throws Exception {
@@ -631,14 +614,19 @@ public class TermsAggregatorTests extends AggregatorTestCase {
     }
 
     public void testStringTermsAggregator() throws Exception {
-        BiFunction<String, Boolean, IndexableField> luceneFieldFactory = (val, mv) -> {
-          if (mv) {
-            return new SortedSetDocValuesField("field", new BytesRef(val));
-          } else {
-            return new SortedDocValuesField("field", new BytesRef(val));
-          }
-        };
         MappedFieldType fieldType = new KeywordFieldMapper.KeywordFieldType("field");
+        BiFunction<String, Boolean, List<IndexableField>> luceneFieldFactory = (val, mv) -> {
+            List<IndexableField> result = new ArrayList<>(2);
+            if (mv) {
+                result.add(new SortedSetDocValuesField("field", new BytesRef(val)));
+            } else {
+                result.add(new SortedDocValuesField("field", new BytesRef(val)));
+            }
+            if (fieldType.isSearchable()) {
+                result.add(new KeywordField("field", new BytesRef(val), KeywordFieldMapper.Defaults.FIELD_TYPE));
+            }
+            return result;
+        };
         termsAggregator(ValueType.STRING, fieldType, i -> Integer.toString(i),
             String::compareTo, luceneFieldFactory);
         termsAggregatorWithNestedMaxAgg(ValueType.STRING, fieldType, i -> Integer.toString(i),
@@ -646,11 +634,11 @@ public class TermsAggregatorTests extends AggregatorTestCase {
     }
 
     public void testLongTermsAggregator() throws Exception {
-        BiFunction<Long, Boolean, IndexableField> luceneFieldFactory = (val, mv) -> {
+        BiFunction<Long, Boolean, List<IndexableField>> luceneFieldFactory = (val, mv) -> {
             if (mv) {
-                return new SortedNumericDocValuesField("field", val);
+                return org.elasticsearch.common.collect.List.of(new SortedNumericDocValuesField("field", val));
             } else {
-                return new NumericDocValuesField("field", val);
+                return org.elasticsearch.common.collect.List.of(new NumericDocValuesField("field", val));
             }
         };
         MappedFieldType fieldType
@@ -660,11 +648,11 @@ public class TermsAggregatorTests extends AggregatorTestCase {
     }
 
     public void testDoubleTermsAggregator() throws Exception {
-        BiFunction<Double, Boolean, IndexableField> luceneFieldFactory = (val, mv) -> {
+        BiFunction<Double, Boolean, List<IndexableField>> luceneFieldFactory = (val, mv) -> {
             if (mv) {
-                return new SortedNumericDocValuesField("field", Double.doubleToRawLongBits(val));
+                return org.elasticsearch.common.collect.List.of(new SortedNumericDocValuesField("field", Double.doubleToRawLongBits(val)));
             } else {
-                return new NumericDocValuesField("field", Double.doubleToRawLongBits(val));
+                return org.elasticsearch.common.collect.List.of(new NumericDocValuesField("field", Double.doubleToRawLongBits(val)));
             }
         };
         MappedFieldType fieldType
@@ -675,26 +663,31 @@ public class TermsAggregatorTests extends AggregatorTestCase {
     }
 
     public void testIpTermsAggregator() throws Exception {
-        BiFunction<InetAddress, Boolean, IndexableField> luceneFieldFactory = (val, mv) -> {
+        IpFieldMapper.IpFieldType fieldType = new IpFieldMapper.IpFieldType("field");
+        BiFunction<InetAddress, Boolean, List<IndexableField>> luceneFieldFactory = (val, mv) -> {
+            List<IndexableField> result = new ArrayList<>(2);
             if (mv) {
-                return new SortedSetDocValuesField("field", new BytesRef(InetAddressPoint.encode(val)));
+                result.add(new SortedSetDocValuesField("field", new BytesRef(InetAddressPoint.encode(val))));
             } else {
-                return new SortedDocValuesField("field", new BytesRef(InetAddressPoint.encode(val)));
+                result.add(new SortedDocValuesField("field", new BytesRef(InetAddressPoint.encode(val))));
             }
+            if (fieldType.isSearchable()) {
+                result.add(new InetAddressPoint("field", val));
+            }
+            return result;
         };
-        InetAddress[] base = new InetAddress[] {InetAddresses.forString("192.168.0.0")};
+        InetAddress[] base = new InetAddress[] { InetAddresses.forString("192.168.0.0") };
         Comparator<InetAddress> comparator = (o1, o2) -> {
             BytesRef b1 = new BytesRef(InetAddressPoint.encode(o1));
             BytesRef b2 = new BytesRef(InetAddressPoint.encode(o2));
             return b1.compareTo(b2);
         };
-        termsAggregator(ValueType.IP, new IpFieldMapper.IpFieldType("field"), i -> base[0] = InetAddressPoint.nextUp(base[0]),
-            comparator, luceneFieldFactory);
+        termsAggregator(ValueType.IP, fieldType, i -> base[0] = InetAddressPoint.nextUp(base[0]), comparator, luceneFieldFactory);
     }
 
     private <T> void termsAggregator(ValueType valueType, MappedFieldType fieldType,
                                      Function<Integer, T> valueFactory, Comparator<T> keyComparator,
-                                     BiFunction<T, Boolean, IndexableField> luceneFieldFactory) throws Exception {
+                                     BiFunction<T, Boolean, List<IndexableField>> luceneFieldFactory) throws Exception {
         final Map<T, Integer> counts = new HashMap<>();
         final Map<T, Integer> filteredCounts = new HashMap<>();
         int numTerms = scaledRandomIntBetween(8, 128);
@@ -712,7 +705,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
                     for (Map.Entry<T, Integer> entry : counts.entrySet()) {
                         for (int i = 0; i < entry.getValue(); i++) {
                             Document document = new Document();
-                            document.add(luceneFieldFactory.apply(entry.getKey(), false));
+                            luceneFieldFactory.apply(entry.getKey(), false).forEach(document::add);
                             if (randomBoolean()) {
                                 document.add(new StringField("include", "yes", Field.Store.NO));
                                 filteredCounts.computeIfPresent(entry.getKey(), (key, integer) -> integer + 1);
@@ -736,9 +729,9 @@ public class TermsAggregatorTests extends AggregatorTestCase {
 
                         for (int i = 0; i < entry1.getValue(); i++) {
                             Document document = new Document();
-                            document.add(luceneFieldFactory.apply(entry1.getKey(), true));
+                            luceneFieldFactory.apply(entry1.getKey(), true).forEach(document::add);
                             if (entry2 != null && i < entry2.getValue()) {
-                                document.add(luceneFieldFactory.apply(entry2.getKey(), true));
+                                luceneFieldFactory.apply(entry2.getKey(), true).forEach(document::add);
                             }
                             indexWriter.addDocument(document);
                         }
@@ -776,7 +769,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
                         .field("field")
                         .order(bucketOrder);
 
-                    AggregationContext context = createAggregationContext(indexSearcher, null, fieldType);
+                    AggregationContext context = createAggregationContext(indexSearcher, new MatchAllDocsQuery(), fieldType);
                     Aggregator aggregator = createAggregator(aggregationBuilder, context);
                     aggregator.preCollection();
                     indexSearcher.search(new MatchAllDocsQuery(), aggregator);
@@ -1049,31 +1042,21 @@ public class TermsAggregatorTests extends AggregatorTestCase {
     }
 
     public void testIpField() throws Exception {
-        try (Directory directory = newDirectory()) {
-            final String field = "field";
-            try (RandomIndexWriter indexWriter = new RandomIndexWriter(random(), directory)) {
-                Document document = new Document();
-                document.add(new SortedSetDocValuesField("field",
-                    new BytesRef(InetAddressPoint.encode(InetAddresses.forString("192.168.100.42")))));
-                indexWriter.addDocument(document);
-                try (IndexReader indexReader = maybeWrapReaderEs(indexWriter.getReader())) {
-                    MappedFieldType fieldType = new IpFieldMapper.IpFieldType("field");
-                    IndexSearcher indexSearcher = newIndexSearcher(indexReader);
-                    TermsAggregationBuilder aggregationBuilder = new TermsAggregationBuilder("_name") .field(field);
-                    // Note - other places we throw IllegalArgumentException
-                    AggregationContext context = createAggregationContext(indexSearcher, null, fieldType);
-                    Aggregator aggregator = createAggregator(aggregationBuilder, context);
-                    aggregator.preCollection();
-                    indexSearcher.search(new MatchAllDocsQuery(), aggregator);
-                    aggregator.postCollection();
-                    Terms result = reduce(aggregator, context.bigArrays());
-                    assertEquals("_name", result.getName());
-                    assertEquals(1, result.getBuckets().size());
-                    assertEquals("192.168.100.42", result.getBuckets().get(0).getKey());
-                    assertEquals(1, result.getBuckets().get(0).getDocCount());
-                }
+        MappedFieldType fieldType = new IpFieldMapper.IpFieldType("field", randomBoolean(), false, true, null, null);
+        testCase(new TermsAggregationBuilder("_name").field("field"), new MatchAllDocsQuery(), iw -> {
+            Document document = new Document();
+            InetAddress point = InetAddresses.forString("192.168.100.42");
+            document.add(new SortedSetDocValuesField("field", new BytesRef(InetAddressPoint.encode(point))));
+            if (fieldType.isSearchable()) {
+                document.add(new InetAddressPoint("field", point));
             }
-        }
+            iw.addDocument(document);
+        }, (StringTerms result) -> {
+            assertEquals("_name", result.getName());
+            assertEquals(1, result.getBuckets().size());
+            assertEquals("192.168.100.42", result.getBuckets().get(0).getKey());
+            assertEquals(1, result.getBuckets().get(0).getDocCount());
+        }, fieldType);
     }
 
     public void testNestedTermsAgg() throws Exception {

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -184,7 +184,7 @@ public abstract class AggregatorTestCase extends ESTestCase {
     protected <A extends Aggregator> A createAggregator(AggregationBuilder aggregationBuilder,
                                                         IndexSearcher searcher,
                                                         MappedFieldType... fieldTypes) throws IOException {
-        return createAggregator(aggregationBuilder, createAggregationContext(searcher, null, fieldTypes));
+        return createAggregator(aggregationBuilder, createAggregationContext(searcher, new MatchAllDocsQuery(), fieldTypes));
     }
 
     protected <A extends Aggregator> A createAggregator(AggregationBuilder builder, AggregationContext context) throws IOException {

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/normalize/NormalizeAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/normalize/NormalizeAggregatorTests.java
@@ -153,7 +153,7 @@ public class NormalizeAggregatorTests extends AggregatorTestCase {
             // setup mapping
             DateFieldMapper.DateFieldType dateFieldType = new DateFieldMapper.DateFieldType(DATE_FIELD);
             MappedFieldType valueFieldType = new NumberFieldMapper.NumberFieldType(VALUE_FIELD, NumberFieldMapper.NumberType.LONG);
-            MappedFieldType termFieldType = new KeywordFieldMapper.KeywordFieldType(TERM_FIELD);
+            MappedFieldType termFieldType = new KeywordFieldMapper.KeywordFieldType(TERM_FIELD, false, true, null);
 
             try (IndexReader indexReader = DirectoryReader.open(directory)) {
                 IndexSearcher indexSearcher = newIndexSearcher(indexReader);

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/RollupResponseTranslationTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/RollupResponseTranslationTests.java
@@ -36,6 +36,7 @@ import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
+import org.elasticsearch.index.mapper.KeywordFieldMapper.KeywordField;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.TermQueryBuilder;
@@ -1155,7 +1156,9 @@ public class RollupResponseTranslationTests extends AggregatorTestCase {
 
     private Document stringValueDoc(String stringValue) {
         Document doc = new Document();
-        doc.add(new SortedSetDocValuesField("stringField", new BytesRef(stringValue)));
+        BytesRef bytes = new BytesRef(stringValue);
+        doc.add(new SortedSetDocValuesField("stringField", bytes));
+        doc.add(new KeywordField("stringField", bytes, KeywordFieldMapper.Defaults.FIELD_TYPE));
         return doc;
     }
 


### PR DESCRIPTION
This adds yet another terms aggregator that uses `term` filters to run
in similar speed to specialized low cardinality terms aggregator. It is
mostly useful as a stepping stone for some additional optimizations that
we can make later. So it doesn't have to be faster on its own. Just not
*slower*. And its about the same speed.
