### PR TITLE
Fix string replacement in certutil http test

### DIFF
--- a/x-pack/plugin/security/cli/src/test/java/org/elasticsearch/xpack/security/cli/HttpCertificateCommandTests.java
+++ b/x-pack/plugin/security/cli/src/test/java/org/elasticsearch/xpack/security/cli/HttpCertificateCommandTests.java
@@ -184,10 +184,11 @@ public class HttpCertificateCommandTests extends ESTestCase {
         // Verify the key
         assertMatchingPair(getPublicKey(csr), privateKey);
 
-        final String crtName = keyPath.getFileName().toString().replace(".csr", ".crt");
+        final String csrName = csrPath.getFileName().toString();
+        final String crtName = csrName.substring(0, csrName.length() - 4) + ".crt";
 
         // Verify the README
-        assertThat(esReadme, containsString(csrPath.getFileName().toString()));
+        assertThat(esReadme, containsString(csrName));
         assertThat(esReadme, containsString(crtName));
         assertThat(esReadme, containsString(keyPath.getFileName().toString()));
         assertThat(esReadme, containsString(ymlPath.getFileName().toString()));
@@ -196,7 +197,7 @@ public class HttpCertificateCommandTests extends ESTestCase {
         }
 
         // Verify the yml
-        assertThat(yml, not(containsString(csrPath.getFileName().toString())));
+        assertThat(yml, not(containsString(csrName)));
         assertThat(yml, containsString(crtName));
         assertThat(yml, containsString(keyPath.getFileName().toString()));
         if ("".equals(password) == false) {
@@ -209,7 +210,7 @@ public class HttpCertificateCommandTests extends ESTestCase {
         // No CA in CSR mode
 
         verifyKibanaDirectory(zipRoot, false, List.of("Certificate Signing Request"),
-            Stream.of(password, csrPath.getFileName().toString())
+            Stream.of(password, csrName)
             .filter(s -> "".equals(s) == false).collect(Collectors.toList()));
     }
 


### PR DESCRIPTION
This test had 2 issues:
1. It performed a replacement using a string literal on a randomly
generated string. It is possible that the filename had ".csr"
somewhere in the basename, which would then produce incorrect results
2. It used the wrong base file for the substitution (key vs csr).

This fixes the bug by using an index based replacement rather than a
textual one.

Resolves: #67328
