### PR TITLE
[ML] Do not add runtime section to DFA dest index mappings unnecessarily

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DestinationIndex.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DestinationIndex.java
@@ -185,8 +185,10 @@ public final class DestinationIndex {
         properties.putAll(createAdditionalMappings(config, fieldCapabilitiesResponse));
         Map<String, Object> metadata = getOrPutDefault(mappingsAsMap, META, HashMap::new);
         metadata.putAll(createMetadata(config.getId(), clock, Version.CURRENT));
-        Map<String, Object> runtimeMappings = getOrPutDefault(mappingsAsMap, RUNTIME, HashMap::new);
-        runtimeMappings.putAll(config.getSource().getRuntimeMappings());
+        if (config.getSource().getRuntimeMappings().isEmpty() == false) {
+            Map<String, Object> runtimeMappings = getOrPutDefault(mappingsAsMap, RUNTIME, HashMap::new);
+            runtimeMappings.putAll(config.getSource().getRuntimeMappings());
+        }
         return new CreateIndexRequest(destinationIndex, settings).mapping(mappingsAsMap);
     }
 
@@ -270,8 +272,11 @@ public final class DestinationIndex {
 
                 // Determine mappings to be added to the destination index
                 addedMappings.put(PROPERTIES, createAdditionalMappings(config, fieldCapabilitiesResponse));
+
                 // Also add runtime mappings
-                addedMappings.put(RUNTIME, config.getSource().getRuntimeMappings());
+                if (config.getSource().getRuntimeMappings().isEmpty() == false) {
+                    addedMappings.put(RUNTIME, config.getSource().getRuntimeMappings());
+                }
 
                 // Add the mappings to the destination index
                 PutMappingRequest putMappingRequest =


### PR DESCRIPTION
Since config runtime mappings were added to data frame analytics jobs
in  #69183, when we create the destination index we add a `runtime`
section in its mappings regardless of whether the job config contains
any runtime fields. This causes failures in the BWC tests when in a
mixed cluster where there are nodes versioned before runtime fields
were introduced.

This is the first part of the fix were we do not create a `runtime` section
in the destination index mappings unless necessary.
