### PR TITLE
Filter out older versions when running bwc tests on aarch64 (#68532) (7.x backport)

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/BwcVersions.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/BwcVersions.java
@@ -28,15 +28,15 @@ import static java.util.Collections.unmodifiableList;
 
 /**
  * A container for elasticsearch supported version information used in BWC testing.
- *
+ * <p>
  * Parse the Java source file containing the versions declarations and use the known rules to figure out which are all
  * the version the current one is wire and index compatible with.
  * On top of this, figure out which of these are unreleased and provide the branch they can be built from.
- *
+ * <p>
  * Note that in this context, currentVersion is the unreleased version this build operates on.
  * At any point in time there will surely be four such unreleased versions being worked on,
  * thus currentVersion will be one of these.
- *
+ * <p>
  * Considering:
  * <dl>
  *     <dt>M, M &gt; 0</dt>
@@ -56,11 +56,11 @@ import static java.util.Collections.unmodifiableList;
  * <ul>
  * <li>the unreleased <b>staged</b>, M.N-2.0 (N &gt; 2) on the `M.(N-2)` branch</li>
  * </ul>
- *
+ * <p>
  * Each build is only concerned with versions before it, as those are the ones that need to be tested
  * for backwards compatibility. We never look forward, and don't add forward facing version number to branches of previous
  * version.
- *
+ * <p>
  * Each branch has a current version, and expected compatible versions are parsed from the server code's Version` class.
  * We can reliably figure out which the unreleased versions are due to the convention of always adding the next unreleased
  * version number to server in all branches when a version is released.
@@ -162,8 +162,8 @@ public class BwcVersions {
     }
 
     /**
-      * Returns info about the unreleased version, or {@code null} if the version is released.
-      */
+     * Returns info about the unreleased version, or {@code null} if the version is released.
+     */
     public UnreleasedVersionInfo unreleasedInfo(Version version) {
         return unreleased.get(version);
     }
@@ -330,16 +330,17 @@ public class BwcVersions {
 
     public List<Version> getIndexCompatible() {
         return unmodifiableList(
-            Stream.concat(groupByMajor.get(currentVersion.getMajor() - 1).stream(), groupByMajor.get(currentVersion.getMajor()).stream())
-                .filter(version -> version.equals(currentVersion) == false)
-                .collect(Collectors.toList())
+            filterSupportedVersions(
+                Stream.concat(
+                    groupByMajor.get(currentVersion.getMajor() - 1).stream(),
+                    groupByMajor.get(currentVersion.getMajor()).stream()
+                ).filter(version -> version.equals(currentVersion) == false).collect(Collectors.toList())
+            )
         );
-
     }
 
     public List<Version> getWireCompatible() {
         List<Version> wireCompat = new ArrayList<>();
-
         List<Version> prevMajors = groupByMajor.get(currentVersion.getMajor() - 1);
         int minor = prevMajors.get(prevMajors.size() - 1).getMinor();
         for (int i = prevMajors.size() - 1; i > 0 && prevMajors.get(i).getMinor() == minor; i--) {
@@ -349,7 +350,13 @@ public class BwcVersions {
         wireCompat.remove(currentVersion);
         wireCompat.sort(Version::compareTo);
 
-        return unmodifiableList(wireCompat);
+        return unmodifiableList(filterSupportedVersions(wireCompat));
+    }
+
+    private List<Version> filterSupportedVersions(List<Version> wireCompat) {
+        return Architecture.current() == Architecture.AARCH64
+            ? wireCompat.stream().filter(version -> version.onOrAfter("7.12.0")).collect(Collectors.toList())
+            : wireCompat;
     }
 
     public List<Version> getUnreleasedIndexCompatible() {


### PR DESCRIPTION
backport of #68532 to 7.x branch