### PR TITLE
[ML] Unmute memory-dependent ML YAML tests

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_crud.yml
@@ -113,9 +113,7 @@
 ---
 "Test put job with model_memory_limit as string and lazy open":
   - skip:
-      version: "all"
       features: headers
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/66885"
   - do:
       ml.put_job:
         job_id: job-model-memory-limit-as-string

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/ml_info.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/ml_info.yml
@@ -8,11 +8,6 @@ teardown:
 
 ---
 "Test ml info":
-
-  - skip:
-      version: "all"
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/66885"
-
   - do:
       ml.info: {}
   - match: { defaults.anomaly_detectors.categorization_analyzer.tokenizer: "ml_classic" }


### PR DESCRIPTION
Unmute the YAML tests that were muted due to the problem
of #66885.

The underlying problem was fixed by #68542.