### PR TITLE
Make field_range optimization work with FrozenEngine

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/engine/ReadOnlyEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/ReadOnlyEngine.java
@@ -57,6 +57,8 @@ import java.util.stream.Stream;
  */
 public class ReadOnlyEngine extends Engine {
 
+    public static final String FIELD_RANGE_SEARCH_SOURCE = "field_range";
+
     /**
      * Reader attributes used for read only engines. These attributes prevent loading term dictionaries on-heap even if the field is an
      * ID field.
@@ -542,7 +544,7 @@ public class ReadOnlyEngine extends Engine {
      */
     @Override
     public ShardLongFieldRange getRawFieldRange(String field) throws IOException {
-        try (Searcher searcher = acquireSearcher("field_range")) {
+        try (Searcher searcher = acquireSearcher(FIELD_RANGE_SEARCH_SOURCE)) {
             final DirectoryReader directoryReader = searcher.getDirectoryReader();
 
             final byte[] minPackedValue = PointValues.getMinPackedValue(directoryReader, field);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/index/engine/FrozenEngine.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/index/engine/FrozenEngine.java
@@ -222,6 +222,7 @@ public final class FrozenEngine extends ReadOnlyEngine {
             case "segments":
             case "segments_stats":
             case "completion_stats":
+            case FIELD_RANGE_SEARCH_SOURCE: // special case for field_range - we use the cached point values reader
             case CAN_MATCH_SEARCH_SOURCE: // special case for can_match phase - we use the cached point values reader
                 maybeOpenReader = false;
                 break;
@@ -230,7 +231,7 @@ public final class FrozenEngine extends ReadOnlyEngine {
         }
         ElasticsearchDirectoryReader reader = maybeOpenReader ? getOrOpenReader() : getReader();
         if (reader == null) {
-            if (CAN_MATCH_SEARCH_SOURCE.equals(source)) {
+            if (CAN_MATCH_SEARCH_SOURCE.equals(source) || FIELD_RANGE_SEARCH_SOURCE.equals(source)) {
                 canMatchReader.incRef();
                 return new Searcher(source, canMatchReader, engineConfig.getSimilarity(), engineConfig.getQueryCache(),
                     engineConfig.getQueryCachingPolicy(), canMatchReader::decRef);

--- a/x-pack/plugin/frozen-indices/src/internalClusterTest/java/org/elasticsearch/index/engine/FrozenIndexTests.java
+++ b/x-pack/plugin/frozen-indices/src/internalClusterTest/java/org/elasticsearch/index/engine/FrozenIndexTests.java
@@ -532,8 +532,8 @@ public class FrozenIndexTests extends ESSingleNodeTestCase {
         assertThat(timestampFieldRange.getMax(), equalTo(Instant.parse("2010-01-06T02:03:04.567Z").toEpochMilli()));
 
         for (ShardStats shardStats : client().admin().indices().prepareStats("index").clear().setRefresh(true).get().getShards()) {
-            assertThat("shard " + shardStats.getShardRouting() + " refreshed to get the timestamp range",
-                    shardStats.getStats().refresh.getTotal(), greaterThanOrEqualTo(1L));
+            assertThat("shard " + shardStats.getShardRouting() + " not refreshed to get the timestamp range",
+                    shardStats.getStats().refresh.getTotal(), equalTo(0L));
         }
     }
 
@@ -567,8 +567,8 @@ public class FrozenIndexTests extends ESSingleNodeTestCase {
             equalTo(resolution.convert(Instant.parse("2010-01-06T02:03:04.567890123Z"))));
 
         for (ShardStats shardStats : client().admin().indices().prepareStats("index").clear().setRefresh(true).get().getShards()) {
-            assertThat("shard " + shardStats.getShardRouting() + " refreshed to get the timestamp range",
-                    shardStats.getStats().refresh.getTotal(), greaterThanOrEqualTo(1L));
+            assertThat("shard " + shardStats.getShardRouting() + " not refreshed to get the timestamp range",
+                    shardStats.getStats().refresh.getTotal(), equalTo(0L));
         }
     }
 

--- a/x-pack/plugin/frozen-indices/src/internalClusterTest/java/org/elasticsearch/index/engine/FrozenIndexTests.java
+++ b/x-pack/plugin/frozen-indices/src/internalClusterTest/java/org/elasticsearch/index/engine/FrozenIndexTests.java
@@ -10,7 +10,6 @@ import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.OriginalIndices;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
-import org.elasticsearch.action.admin.indices.stats.ShardStats;
 import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.search.SearchRequest;
@@ -530,11 +529,6 @@ public class FrozenIndexTests extends ESSingleNodeTestCase {
         assertTrue(timestampFieldRange.isComplete());
         assertThat(timestampFieldRange.getMin(), equalTo(Instant.parse("2010-01-05T01:02:03.456Z").toEpochMilli()));
         assertThat(timestampFieldRange.getMax(), equalTo(Instant.parse("2010-01-06T02:03:04.567Z").toEpochMilli()));
-
-        for (ShardStats shardStats : client().admin().indices().prepareStats("index").clear().setRefresh(true).get().getShards()) {
-            assertThat("shard " + shardStats.getShardRouting() + " not refreshed to get the timestamp range",
-                    shardStats.getStats().refresh.getTotal(), equalTo(0L));
-        }
     }
 
     public void testComputesTimestampRangeFromNanoseconds() throws IOException {
@@ -565,11 +559,6 @@ public class FrozenIndexTests extends ESSingleNodeTestCase {
             equalTo(resolution.convert(Instant.parse("2010-01-05T01:02:03.456789012Z"))));
         assertThat(timestampFieldRange.getMax(),
             equalTo(resolution.convert(Instant.parse("2010-01-06T02:03:04.567890123Z"))));
-
-        for (ShardStats shardStats : client().admin().indices().prepareStats("index").clear().setRefresh(true).get().getShards()) {
-            assertThat("shard " + shardStats.getShardRouting() + " not refreshed to get the timestamp range",
-                    shardStats.getStats().refresh.getTotal(), equalTo(0L));
-        }
     }
 
 }

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsCanMatchOnCoordinatorIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsCanMatchOnCoordinatorIntegTests.java
@@ -132,7 +132,7 @@ public class SearchableSnapshotsCanMatchOnCoordinatorIntegTests extends BaseSear
             restoredIndexSettings,
             Strings.EMPTY_ARRAY,
             false,
-            MountSearchableSnapshotRequest.Storage.FULL_COPY
+            randomFrom(MountSearchableSnapshotRequest.Storage.values())
         );
         client().execute(MountSearchableSnapshotAction.INSTANCE, mountRequest).actionGet();
 
@@ -267,7 +267,7 @@ public class SearchableSnapshotsCanMatchOnCoordinatorIntegTests extends BaseSear
             restoredIndexSettings,
             Strings.EMPTY_ARRAY,
             false,
-            MountSearchableSnapshotRequest.Storage.FULL_COPY
+            randomFrom(MountSearchableSnapshotRequest.Storage.values())
         );
         client().execute(MountSearchableSnapshotAction.INSTANCE, mountRequest).actionGet();
         final int searchableSnapshotShardCount = indexOutsideSearchRangeShardCount;
@@ -380,7 +380,7 @@ public class SearchableSnapshotsCanMatchOnCoordinatorIntegTests extends BaseSear
             restoredIndexSettings,
             Strings.EMPTY_ARRAY,
             false,
-            MountSearchableSnapshotRequest.Storage.FULL_COPY
+            randomFrom(MountSearchableSnapshotRequest.Storage.values())
         );
         client().execute(MountSearchableSnapshotAction.INSTANCE, mountRequest).actionGet();
 

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
@@ -118,7 +118,6 @@ import static org.hamcrest.Matchers.sameInstance;
 
 public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegTestCase {
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/69336")
     public void testCreateAndRestoreSearchableSnapshot() throws Exception {
         final String fsRepoName = randomAlphaOfLength(10);
         final String indexName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
@@ -118,6 +118,7 @@ import static org.hamcrest.Matchers.sameInstance;
 
 public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegTestCase {
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/69336")
     public void testCreateAndRestoreSearchableSnapshot() throws Exception {
         final String fsRepoName = randomAlphaOfLength(10);
         final String indexName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);


### PR DESCRIPTION
Searchable snapshot indices that are mounted using the shared_cache option are now using the FrozenEngine. This engine does not properly implement `getRawFieldRange`, however, resulting in the index to be loaded on the cluster state applier thread. 

Marked as non-issue as unreleased code.