### PR TITLE
[DOCS] Audit community plugins and integrations

### DIFF
--- a/docs/plugins/analysis.asciidoc
+++ b/docs/plugins/analysis.asciidoc
@@ -52,8 +52,6 @@ A number of analysis plugins have been contributed by our community:
 * https://github.com/medcl/elasticsearch-analysis-ik[IK Analysis Plugin] (by Medcl)
 * https://github.com/medcl/elasticsearch-analysis-pinyin[Pinyin Analysis Plugin] (by Medcl)
 * https://github.com/duydo/elasticsearch-analysis-vietnamese[Vietnamese Analysis Plugin] (by Duy Do)
-* https://github.com/ofir123/elasticsearch-network-analysis[Network Addresses Analysis Plugin] (by Ofir123)
-* https://github.com/ZarHenry96/elasticsearch-dandelion-plugin[Dandelion Analysis Plugin] (by ZarHenry96)
 * https://github.com/medcl/elasticsearch-analysis-stconvert[STConvert Analysis Plugin] (by Medcl)
 
 include::analysis-icu.asciidoc[]

--- a/docs/plugins/api.asciidoc
+++ b/docs/plugins/api.asciidoc
@@ -17,16 +17,5 @@ A number of plugins have been contributed by our community:
 * https://github.com/wikimedia/search-highlighter[Elasticsearch Experimental Highlighter]:
   (by Wikimedia Foundation/Nik Everett)
 
-* https://github.com/YannBrrd/elasticsearch-entity-resolution[Entity Resolution Plugin]:
-  Uses https://github.com/larsga/Duke[Duke] for duplication detection (by Yann Barraud)
-  
 * https://github.com/zentity-io/zentity[Entity Resolution Plugin] (https://zentity.io[zentity]):
   Real-time entity resolution with pure Elasticsearch (by Dave Moore)
-
-* https://github.com/ritesh-kapoor/elasticsearch-pql[PQL language Plugin]:
-  Allows Elasticsearch to be queried with simple pipeline query syntax.
-
-* https://github.com/codelibs/elasticsearch-taste[Elasticsearch Taste Plugin]:
-  Mahout Taste-based Collaborative Filtering implementation (by CodeLibs Project)
-
-* https://github.com/jurgc11/es-change-feed-plugin[WebSocket Change Feed Plugin] (by ForgeRock/Chris Clifton)

--- a/docs/plugins/discovery.asciidoc
+++ b/docs/plugins/discovery.asciidoc
@@ -25,13 +25,6 @@ addresses of seed hosts.
 The Google Compute Engine discovery plugin uses the GCE API to identify the
 addresses of seed hosts.
 
-[discrete]
-==== Community contributed discovery plugins
-
-The following discovery plugins have been contributed by our community:
-
-* https://github.com/fabric8io/elasticsearch-cloud-kubernetes[Kubernetes Discovery Plugin] (by Jimmi Dyson, https://fabric8.io[fabric8])
-
 include::discovery-ec2.asciidoc[]
 
 include::discovery-azure-classic.asciidoc[]

--- a/docs/plugins/ingest.asciidoc
+++ b/docs/plugins/ingest.asciidoc
@@ -29,11 +29,4 @@ A processor that extracts details from the User-Agent header value. The
 distributed by default with Elasticsearch. See
 {ref}/user-agent-processor.html[User Agent processor] for more details.
 
-[discrete]
-=== Community contributed ingest plugins
-
-The following plugin has been contributed by our community:
-
-* https://github.com/johtani/elasticsearch-ingest-csv[Ingest CSV Processor Plugin] (by Jun Ohtani)
-
 include::ingest-attachment.asciidoc[]

--- a/docs/plugins/integrations.asciidoc
+++ b/docs/plugins/integrations.asciidoc
@@ -11,17 +11,8 @@ Integrations are not plugins, but are external tools or modules that make it eas
 [discrete]
 ==== Supported by the community:
 
-* https://drupal.org/project/search_api_elasticsearch[Drupal]:
-  Drupal Elasticsearch integration via Search API.
-
-* https://drupal.org/project/elasticsearch_connector[Drupal]:
-  Drupal Elasticsearch integration.
-
 * https://wordpress.org/plugins/elasticpress/[ElasticPress]:
   Elasticsearch WordPress Plugin
-
-* https://wordpress.org/plugins/wpsolr-search-engine/[WPSOLR]:
-  Elasticsearch (and Apache Solr) WordPress Plugin
 
 * https://doc.tiki.org/Elasticsearch[Tiki Wiki CMS Groupware]:
   Tiki has native support for Elasticsearch. This provides faster & better
@@ -53,21 +44,15 @@ releases 2.0 and later do not support rivers.
 [discrete]
 ==== Supported by the community:
 
-* https://github.com/jprante/elasticsearch-jdbc[JDBC importer]:
-  The Java Database Connection (JDBC) importer allows to fetch data from JDBC sources for indexing into Elasticsearch (by Jörg Prante)
+* https://github.com/spinscale/cookiecutter-elasticsearch-ingest-processor[Ingest processor template]:
+  A template for creating new ingest processors.
 
 * https://github.com/BigDataDevs/kafka-elasticsearch-consumer[Kafka Standalone Consumer (Indexer)]:
   Kafka Standalone Consumer [Indexer] will read messages from Kafka in batches, processes(as implemented) and bulk-indexes them into Elasticsearch. Flexible and scalable. More documentation in above GitHub repo's Wiki.
 
-* https://github.com/ozlerhakan/mongolastic[Mongolastic]:
-  A tool that clones data from Elasticsearch to MongoDB and vice versa
-
 * https://github.com/Aconex/scrutineer[Scrutineer]:
   A high performance consistency checker to compare what you've indexed
   with your source of truth content (e.g. DB)
-
-* https://github.com/salyh/elasticsearch-imap[IMAP/POP3/Mail importer]:
-  The Mail importer allows to fetch data from IMAP and POP3 servers for indexing into Elasticsearch (by Hendrik Saly)
 
 * https://github.com/dadoonet/fscrawler[FS Crawler]:
   The File System (FS) crawler allows to index documents (PDF, Open Office...) from your local file system and over SSH. (by David Pilato)
@@ -112,9 +97,6 @@ releases 2.0 and later do not support rivers.
 * https://plugins.grails.org/plugin/puneetbehl/elasticsearch[Grails]:
   Elasticsearch Grails plugin.
 
-* https://haystacksearch.org/[Haystack]:
-  Modular search for Django
-
 * https://hibernate.org/search/[Hibernate Search]
   Integration with Hibernate ORM, from the Hibernate team. Automatic synchronization of write operations, yet exposes full Elasticsearch capabilities for queries. Can return either Elasticsearch native or re-map queries back into managed entities loaded within transaction from the reference database.
 
@@ -123,9 +105,6 @@ releases 2.0 and later do not support rivers.
 
 * https://github.com/dadoonet/spring-elasticsearch[Spring Elasticsearch]:
   Spring Factory for Elasticsearch
-
-* https://github.com/twitter/storehaus[Twitter Storehaus]:
-  Thin asynchronous Scala client for Storehaus.
 
 * https://zeebe.io[Zeebe]:
   An Elasticsearch exporter acts as a bridge between Zeebe and Elasticsearch
@@ -142,9 +121,6 @@ releases 2.0 and later do not support rivers.
 
 * https://metamodel.apache.org/[Apache MetaModel]:
   Providing a common interface for discovery, exploration of metadata and querying of different types of data sources.
-
-* https://jooby.org/doc/elasticsearch/[Jooby Framework]:
-  Scalable, fast and modular micro web framework for Java.
 
 * https://micrometer.io[Micrometer]:
   Vendor-neutral application metrics facade. Think SLF4j, but for metrics.
@@ -173,9 +149,6 @@ releases 2.0 and later do not support rivers.
 
 [discrete]
 ==== Supported by the community:
-
-* https://github.com/radu-gheorghe/check-es[check-es]:
-  Nagios/Shinken plugins for checking on Elasticsearch
 
 * https://sematext.com/spm/index.html[SPM for Elasticsearch]:
   Performance monitoring with live charts showing cluster and node stats, integrated


### PR DESCRIPTION
Removes any community plugins or integrations that:

- Haven't been updated in the last two years
- Are not compatible with a 7.x version of ES
- Have been explicitly deprecated/abandoned

Closes #69300