### PR TITLE
Avoid blocking can_match phase on FrozenEngine

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/index/engine/FrozenEngine.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/index/engine/FrozenEngine.java
@@ -173,9 +173,10 @@ public final class FrozenEngine extends ReadOnlyEngine {
     }
 
     @SuppressForbidden(reason = "we manage references explicitly here")
-    private synchronized ElasticsearchDirectoryReader getReader() {
-        if (lastOpenedReader != null && lastOpenedReader.tryIncRef()) {
-            return lastOpenedReader;
+    private ElasticsearchDirectoryReader getReader() {
+        final ElasticsearchDirectoryReader readerRef = lastOpenedReader; // volatile read
+        if (readerRef != null && readerRef.tryIncRef()) {
+            return readerRef;
         }
         return null;
     }

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.searchablesnapshots;
 import com.carrotsearch.hppc.cursors.ObjectCursor;
 import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.store.AlreadyClosedException;
-import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResponse;
@@ -117,7 +116,6 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.oneOf;
 import static org.hamcrest.Matchers.sameInstance;
 
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/69336")
 public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegTestCase {
 
     public void testCreateAndRestoreSearchableSnapshot() throws Exception {


### PR DESCRIPTION
Integrating the FrozenEngine with searchable snapshots found an interesting (existing) bug in FrozenEngine, namely that when the Lucene index was being loaded as part of a query phase, another search in the can_match phase would be blocked, as loading the index is done under a mutex that is also acquired during the can_match phase.

This led to the SearchableSnapshotsIntegTests being very slow, and failing an assertBusy due to the slowness, see https://gradle-enterprise.elastic.co/s/b4w4w7hplq6lc/tests/:x-pack:plugin:searchable-snapshots:internalClusterTest/org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsIntegTests/testCreateAndRestorePartialSearchableSnapshot

Closes #69336