### PR TITLE
Add missing copied tests to default sourceset outputdir

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/RestResourcesPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/RestResourcesPlugin.java
@@ -156,5 +156,6 @@ public class RestResourcesPlugin implements Plugin<Project> {
             });
 
         defaultSourceSet.getOutput().dir(copyRestYamlApiTask.map(CopyRestApiTask::getOutputResourceDir));
+        defaultSourceSet.getOutput().dir(copyRestYamlTestTask.map(CopyRestTestsTask::getOutputResourceDir));
     }
 }


### PR DESCRIPTION
For all projects that use copied YAML tests AND use the 
default sourceset (`test`) the YAML tests are no longer on 
the test class path. 

This commit adds them back to the classpath after the 
refactoring on #68943 

---
This should be applied to any branches that also have #68943 
