### PR TITLE
[7.12] Add missing copied tests to default sourceset outputdir (#69381)

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/RestResourcesPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/RestResourcesPlugin.java
@@ -156,5 +156,6 @@ public class RestResourcesPlugin implements Plugin<Project> {
             });
 
         defaultSourceSet.getOutput().dir(copyRestYamlApiTask.map(CopyRestApiTask::getOutputResourceDir));
+        defaultSourceSet.getOutput().dir(copyRestYamlTestTask.map(CopyRestTestsTask::getOutputResourceDir));
     }
 }


### PR DESCRIPTION
Backports the following commits to 7.12:
 - Add missing copied tests to default sourceset outputdir (#69381)