### PR TITLE
[7.x] Update rest tests skip version after backport (#69216)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/20_terms.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/20_terms.yml
@@ -1012,8 +1012,8 @@ setup:
 ---
 "min_doc_count":
   - skip:
-      version: " - 7.99.99"
-      reason: broken in 7.9.1, not yet backported
+      version: " - 7.9.2"
+      reason: broken in 7.9.1, was fixed in 7.9.2
 
   - do:
       bulk:
@@ -1177,8 +1177,8 @@ setup:
 ---
 "order by sub agg containing nested":
   - skip:
-        version: " - 7.11.99"
-        reason: "https://github.com/elastic/elasticsearch/issues/66876"
+        version: " - 7.11.2"
+        reason: "It was fixed in 7.11.2"
 
   - do:
       bulk:


### PR DESCRIPTION
Updates versions after fix backports

Relates to #66876 and #62130
