### PR TITLE
Some Enhancements to ActionListener (#69103)

### DIFF
--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/TransportRankEvalAction.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/TransportRankEvalAction.java
@@ -18,7 +18,6 @@ import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -63,8 +62,7 @@ public class TransportRankEvalAction extends HandledTransportAction<RankEvalRequ
     @Inject
     public TransportRankEvalAction(ActionFilters actionFilters, Client client, TransportService transportService,
                                    ScriptService scriptService, NamedXContentRegistry namedXContentRegistry) {
-        super(RankEvalAction.NAME, transportService, actionFilters,
-              (Writeable.Reader<RankEvalRequest>) RankEvalRequest::new);
+        super(RankEvalAction.NAME, transportService, actionFilters, RankEvalRequest::new);
         this.scriptService = scriptService;
         this.namedXContentRegistry = namedXContentRegistry;
         this.client = client;
@@ -126,9 +124,8 @@ public class TransportRankEvalAction extends HandledTransportAction<RankEvalRequ
                 ratedRequestsInSearch.toArray(new RatedRequest[ratedRequestsInSearch.size()]), errors));
     }
 
-    class RankEvalActionListener implements ActionListener<MultiSearchResponse> {
+    static class RankEvalActionListener extends ActionListener.Delegating<MultiSearchResponse, RankEvalResponse> {
 
-        private final ActionListener<RankEvalResponse> listener;
         private final RatedRequest[] specifications;
 
         private final Map<String, Exception> errors;
@@ -136,7 +133,7 @@ public class TransportRankEvalAction extends HandledTransportAction<RankEvalRequ
 
         RankEvalActionListener(ActionListener<RankEvalResponse> listener, EvaluationMetric metric, RatedRequest[] specifications,
                 Map<String, Exception> errors) {
-            this.listener = listener;
+            super(listener);
             this.metric = metric;
             this.errors = errors;
             this.specifications = specifications;
@@ -157,12 +154,7 @@ public class TransportRankEvalAction extends HandledTransportAction<RankEvalRequ
                 }
                 responsePosition++;
             }
-            listener.onResponse(new RankEvalResponse(this.metric.combine(responseDetails.values()), responseDetails, this.errors));
-        }
-
-        @Override
-        public void onFailure(Exception exception) {
-            listener.onFailure(exception);
+            delegate.onResponse(new RankEvalResponse(this.metric.combine(responseDetails.values()), responseDetails, this.errors));
         }
     }
 }

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/BulkByScrollParallelizationHelper.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/BulkByScrollParallelizationHelper.java
@@ -57,17 +57,8 @@ class BulkByScrollParallelizationHelper {
         Client client,
         DiscoveryNode node,
         Runnable workerAction) {
-        initTaskState(task, request, client, new ActionListener<Void>() {
-            @Override
-            public void onResponse(Void aVoid) {
-                executeSlicedAction(task, request, action, listener, client, node, workerAction);
-            }
-
-            @Override
-            public void onFailure(Exception e) {
-                listener.onFailure(e);
-            }
-        });
+        initTaskState(task, request, client, listener.delegateFailure(
+                (l, v) -> executeSlicedAction(task, request, action, l, client, node, workerAction)));
     }
 
     /**
@@ -114,18 +105,10 @@ class BulkByScrollParallelizationHelper {
         if (configuredSlices == AbstractBulkByScrollRequest.AUTO_SLICES) {
             ClusterSearchShardsRequest shardsRequest = new ClusterSearchShardsRequest();
             shardsRequest.indices(request.getSearchRequest().indices());
-            client.admin().cluster().searchShards(shardsRequest, new ActionListener<ClusterSearchShardsResponse>() {
-                @Override
-                public void onResponse(ClusterSearchShardsResponse response) {
-                    setWorkerCount(request, task, countSlicesBasedOnShards(response));
-                    listener.onResponse(null);
-                }
-
-                @Override
-                public void onFailure(Exception e) {
-                    listener.onFailure(e);
-                }
-            });
+            client.admin().cluster().searchShards(shardsRequest, listener.delegateFailure((l, response) -> {
+                setWorkerCount(request, task, countSlicesBasedOnShards(response));
+                l.onResponse(null);
+            }));
         } else {
             setWorkerCount(request, task, configuredSlices);
             listener.onResponse(null);

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/TransportReindexAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/TransportReindexAction.java
@@ -60,17 +60,8 @@ public class TransportReindexAction extends HandledTransportAction<ReindexReques
     protected void doExecute(Task task, ReindexRequest request, ActionListener<BulkByScrollResponse> listener) {
         validate(request);
         BulkByScrollTask bulkByScrollTask = (BulkByScrollTask) task;
-        reindexer.initTask(bulkByScrollTask, request, new ActionListener<Void>() {
-            @Override
-            public void onResponse(Void v) {
-                reindexer.execute(bulkByScrollTask, request, getBulkClient(), listener);
-            }
-
-            @Override
-            public void onFailure(Exception e) {
-                listener.onFailure(e);
-            }
-        });
+        reindexer.initTask(bulkByScrollTask, request,
+                listener.delegateFailure((l, v) -> reindexer.execute(bulkByScrollTask, request, getBulkClient(), l)));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/ActionListener.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionListener.java
@@ -52,15 +52,32 @@ public interface ActionListener<Response> {
         return new MappedActionListener<>(fn, this);
     }
 
-    final class MappedActionListener<Response, MappedResponse> implements ActionListener<Response> {
+    abstract class Delegating<Response, DelegateResponse> implements ActionListener<Response> {
+
+        protected final ActionListener<DelegateResponse> delegate;
+
+        protected Delegating(ActionListener<DelegateResponse> delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void onFailure(Exception e) {
+            delegate.onFailure(e);
+        }
+
+        @Override
+        public String toString() {
+            return getClass().getName() + "/" + delegate;
+        }
+    }
+
+    final class MappedActionListener<Response, MappedResponse> extends Delegating<Response, MappedResponse> {
 
         private final CheckedFunction<Response, MappedResponse, Exception> fn;
 
-        private final ActionListener<MappedResponse> delegate;
-
         private MappedActionListener(CheckedFunction<Response, MappedResponse, Exception> fn, ActionListener<MappedResponse> delegate) {
+            super(delegate);
             this.fn = fn;
-            this.delegate = delegate;
         }
 
         @Override
@@ -94,6 +111,11 @@ public interface ActionListener<Response> {
         }
 
         @Override
+        public String toString() {
+            return super.toString() + "/" + fn;
+        }
+
+        @Override
         public <T> ActionListener<T> map(CheckedFunction<T, Response, Exception> fn) {
             return new MappedActionListener<>(t -> this.fn.apply(fn.apply(t)), this.delegate);
         }
@@ -124,54 +146,78 @@ public interface ActionListener<Response> {
             public void onFailure(Exception e) {
                 onFailure.accept(e);
             }
+
+            @Override
+            public String toString() {
+                return "WrappedActionListener{" + onResponse + "}{" + onFailure + "}";
+            }
         };
     }
 
     /**
-     * Creates a listener that delegates all responses it receives to another listener.
+     * Creates a listener that delegates all responses it receives to this instance.
      *
-     * @param delegate ActionListener to wrap and delegate any exception to
      * @param bc BiConsumer invoked with delegate listener and exception
-     * @param <T> Type of the listener
      * @return Delegating listener
      */
-    static <T> ActionListener<T> delegateResponse(ActionListener<T> delegate, BiConsumer<ActionListener<T>, Exception> bc) {
-        return new ActionListener<T>() {
-
-            @Override
-            public void onResponse(T r) {
-                delegate.onResponse(r);
-            }
-
-            @Override
-            public void onFailure(Exception e) {
-                bc.accept(delegate, e);
-            }
-        };
+    default ActionListener<Response> delegateResponse(BiConsumer<ActionListener<Response>, Exception> bc) {
+        return new DelegatingActionListener<>(this, bc);
     }
 
     /**
      * Creates a listener that delegates all exceptions it receives to another listener.
      *
-     * @param delegate ActionListener to wrap and delegate any exception to
      * @param bc BiConsumer invoked with delegate listener and response
      * @param <T> Type of the delegating listener's response
-     * @param <R> Type of the wrapped listeners
      * @return Delegating listener
      */
-    static <T, R> ActionListener<T> delegateFailure(ActionListener<R> delegate, BiConsumer<ActionListener<R>, T> bc) {
-        return new ActionListener<T>() {
+    default <T> ActionListener<T> delegateFailure(BiConsumer<ActionListener<Response>, T> bc) {
+        return new DelegatingFailureActionListener<>(this, bc);
+    }
 
-            @Override
-            public void onResponse(T r) {
-                bc.accept(delegate, r);
-            }
+    final class DelegatingActionListener<T> extends Delegating<T, T> {
 
-            @Override
-            public void onFailure(Exception e) {
-                delegate.onFailure(e);
-            }
-        };
+        private final BiConsumer<ActionListener<T>, Exception> bc;
+
+        DelegatingActionListener(ActionListener<T> delegate, BiConsumer<ActionListener<T>, Exception> bc) {
+            super(delegate);
+            this.bc = bc;
+        }
+
+        @Override
+        public void onResponse(T t) {
+            delegate.onResponse(t);
+        }
+
+        @Override
+        public void onFailure(Exception e) {
+            bc.accept(delegate, e);
+        }
+
+        @Override
+        public String toString() {
+            return super.toString() + "/" + bc;
+        }
+    }
+
+    final class DelegatingFailureActionListener<T, R> extends Delegating<T, R> {
+
+        private final BiConsumer<ActionListener<R>, T> bc;
+
+        DelegatingFailureActionListener(ActionListener<R> delegate, BiConsumer<ActionListener<R>, T> bc) {
+            super(delegate);
+            this.bc = bc;
+        }
+
+        @Override
+        public void onResponse(T t) {
+            bc.accept(delegate, t);
+        }
+
+        @Override
+        public String toString() {
+            return super.toString() + "/" + bc;
+        }
     }
 
     /**
@@ -246,25 +292,40 @@ public interface ActionListener<Response> {
      * callback when the listener is notified via either {@code #onResponse} or {@code #onFailure}.
      */
     static <Response> ActionListener<Response> runAfter(ActionListener<Response> delegate, Runnable runAfter) {
-        return new ActionListener<Response>() {
-            @Override
-            public void onResponse(Response response) {
-                try {
-                    delegate.onResponse(response);
-                } finally {
-                    runAfter.run();
-                }
-            }
+        return new RunAfterActionListener<>(delegate, runAfter);
+    }
 
-            @Override
-            public void onFailure(Exception e) {
-                try {
-                    delegate.onFailure(e);
-                } finally {
-                    runAfter.run();
-                }
+    final class RunAfterActionListener<T> extends Delegating<T, T> {
+
+        private final Runnable runAfter;
+
+        protected RunAfterActionListener(ActionListener<T> delegate, Runnable runAfter) {
+            super(delegate);
+            this.runAfter = runAfter;
+        }
+
+        @Override
+        public void onResponse(T response) {
+            try {
+                delegate.onResponse(response);
+            } finally {
+                runAfter.run();
             }
-        };
+        }
+
+        @Override
+        public void onFailure(Exception e) {
+            try {
+                delegate.onFailure(e);
+            } finally {
+                runAfter.run();
+            }
+        }
+
+        @Override
+        public String toString() {
+            return super.toString() + "/" + runAfter;
+        }
     }
 
     /**
@@ -274,28 +335,43 @@ public interface ActionListener<Response> {
      * not be executed.
      */
     static <Response> ActionListener<Response> runBefore(ActionListener<Response> delegate, CheckedRunnable<?> runBefore) {
-        return new ActionListener<Response>() {
-            @Override
-            public void onResponse(Response response) {
-                try {
-                    runBefore.run();
-                } catch (Exception ex) {
-                    delegate.onFailure(ex);
-                    return;
-                }
-                delegate.onResponse(response);
-            }
+        return new RunBeforeActionListener<>(delegate, runBefore);
+    }
 
-            @Override
-            public void onFailure(Exception e) {
-                try {
-                    runBefore.run();
-                } catch (Exception ex) {
-                    e.addSuppressed(ex);
-                }
-                delegate.onFailure(e);
+    final class RunBeforeActionListener<T> extends Delegating<T, T> {
+
+        private final CheckedRunnable<?> runBefore;
+
+        protected RunBeforeActionListener(ActionListener<T> delegate, CheckedRunnable<?> runBefore) {
+            super(delegate);
+            this.runBefore = runBefore;
+        }
+
+        @Override
+        public void onResponse(T response) {
+            try {
+                runBefore.run();
+            } catch (Exception ex) {
+                delegate.onFailure(ex);
+                return;
             }
-        };
+            delegate.onResponse(response);
+        }
+
+        @Override
+        public void onFailure(Exception e) {
+            try {
+                runBefore.run();
+            } catch (Exception ex) {
+                e.addSuppressed(ex);
+            }
+            delegate.onFailure(e);
+        }
+
+        @Override
+        public String toString() {
+            return super.toString() + "/" + runBefore;
+        }
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/ActionRunnable.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionRunnable.java
@@ -76,4 +76,9 @@ public abstract class ActionRunnable<Response> extends AbstractRunnable {
     public void onFailure(Exception e) {
         listener.onFailure(e);
     }
+
+    @Override
+    public String toString() {
+        return getClass().getName() + "/" + listener;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/get/TransportGetTaskAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/get/TransportGetTaskAction.java
@@ -141,7 +141,7 @@ public class TransportGetTaskAction extends HandledTransportAction<GetTaskReques
      */
     void waitedForCompletion(Task thisTask, GetTaskRequest request, TaskInfo snapshotOfRunningTask,
             ActionListener<GetTaskResponse> listener) {
-        getFinishedTaskFromIndex(thisTask, request, ActionListener.delegateResponse(listener, (delegatedListener, e) -> {
+        getFinishedTaskFromIndex(thisTask, request, listener.delegateResponse((delegatedListener, e) -> {
                 /*
                  * We couldn't load the task from the task index. Instead of 404 we should use the snapshot we took after it finished. If
                  * the error isn't a 404 then we'll just throw it back to the user.

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/TransportRestoreSnapshotAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/TransportRestoreSnapshotAction.java
@@ -51,13 +51,12 @@ public class TransportRestoreSnapshotAction extends TransportMasterNodeAction<Re
     @Override
     protected void masterOperation(final RestoreSnapshotRequest request, final ClusterState state,
                                    final ActionListener<RestoreSnapshotResponse> listener) {
-        restoreService.restoreSnapshot(request, ActionListener.delegateFailure(listener,
-            (delegatedListener, restoreCompletionResponse) -> {
-                if (restoreCompletionResponse.getRestoreInfo() == null && request.waitForCompletion()) {
-                    RestoreClusterStateListener.createAndRegisterListener(clusterService, restoreCompletionResponse, delegatedListener);
-                } else {
-                    delegatedListener.onResponse(new RestoreSnapshotResponse(restoreCompletionResponse.getRestoreInfo()));
-                }
-            }));
+        restoreService.restoreSnapshot(request, listener.delegateFailure((delegatedListener, restoreCompletionResponse) -> {
+            if (restoreCompletionResponse.getRestoreInfo() == null && request.waitForCompletion()) {
+                RestoreClusterStateListener.createAndRegisterListener(clusterService, restoreCompletionResponse, delegatedListener);
+            } else {
+                delegatedListener.onResponse(new RestoreSnapshotResponse(restoreCompletionResponse.getRestoreInfo()));
+            }
+        }));
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
@@ -134,18 +134,10 @@ public class TransportIndicesAliasesAction extends AcknowledgedTransportMasterNo
         IndicesAliasesClusterStateUpdateRequest updateRequest = new IndicesAliasesClusterStateUpdateRequest(unmodifiableList(finalActions))
                 .ackTimeout(request.timeout()).masterNodeTimeout(request.masterNodeTimeout());
 
-        indexAliasesService.indicesAliases(updateRequest, new ActionListener<AcknowledgedResponse>() {
-            @Override
-            public void onResponse(AcknowledgedResponse response) {
-                listener.onResponse(response);
-            }
-
-            @Override
-            public void onFailure(Exception t) {
-                logger.debug("failed to perform aliases", t);
-                listener.onFailure(t);
-            }
-        });
+        indexAliasesService.indicesAliases(updateRequest, listener.delegateResponse((l, e) -> {
+            logger.debug("failed to perform aliases", e);
+            l.onFailure(e);
+        }));
     }
 
     private static String[] concreteAliases(AliasActions action, Metadata metadata, String concreteIndex) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/close/TransportCloseIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/close/TransportCloseIndexAction.java
@@ -103,7 +103,7 @@ public class TransportCloseIndexAction extends TransportMasterNodeAction<CloseIn
             .masterNodeTimeout(request.masterNodeTimeout())
             .waitForActiveShards(request.waitForActiveShards())
             .indices(concreteIndices);
-        indexStateService.closeIndices(closeRequest, ActionListener.delegateResponse(listener, (delegatedListener, t) -> {
+        indexStateService.closeIndices(closeRequest, listener.delegateResponse((delegatedListener, t) -> {
             logger.debug(() -> new ParameterizedMessage("failed to close indices [{}]", (Object) concreteIndices), t);
             delegatedListener.onFailure(t);
         }));

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/delete/TransportDeleteIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/delete/TransportDeleteIndexAction.java
@@ -76,18 +76,9 @@ public class TransportDeleteIndexAction extends AcknowledgedTransportMasterNodeA
             .ackTimeout(request.timeout()).masterNodeTimeout(request.masterNodeTimeout())
             .indices(concreteIndices.toArray(new Index[concreteIndices.size()]));
 
-        deleteIndexService.deleteIndices(deleteRequest, new ActionListener<AcknowledgedResponse>() {
-
-            @Override
-            public void onResponse(AcknowledgedResponse response) {
-                listener.onResponse(response);
-            }
-
-            @Override
-            public void onFailure(Exception t) {
-                logger.debug(() -> new ParameterizedMessage("failed to delete indices [{}]", concreteIndices), t);
-                listener.onFailure(t);
-            }
-        });
+        deleteIndexService.deleteIndices(deleteRequest, listener.delegateResponse((l, e) -> {
+            logger.debug(() -> new ParameterizedMessage("failed to delete indices [{}]", concreteIndices), e);
+            listener.onFailure(e);
+        }));
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/TransportPutMappingAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/TransportPutMappingAction.java
@@ -130,20 +130,11 @@ public class TransportPutMappingAction extends AcknowledgedTransportMasterNodeAc
                     .indices(concreteIndices).type(request.type())
                     .source(request.source());
 
-        metadataMappingService.putMapping(updateRequest, new ActionListener<AcknowledgedResponse>() {
-
-            @Override
-            public void onResponse(AcknowledgedResponse response) {
-                listener.onResponse(response);
-            }
-
-            @Override
-            public void onFailure(Exception t) {
-                logger.debug(() -> new ParameterizedMessage("failed to put mappings on indices [{}]",
-                    Arrays.asList(concreteIndices)), t);
-                listener.onFailure(t);
-            }
-        });
+        metadataMappingService.putMapping(updateRequest, listener.delegateResponse((l, e) -> {
+            logger.debug(() -> new ParameterizedMessage("failed to put mappings on indices [{}]",
+                    Arrays.asList(concreteIndices)), e);
+            l.onFailure(e);
+        }));
     }
 
     static String checkForSystemIndexViolations(SystemIndices systemIndices, Index[] concreteIndices, PutMappingRequest request) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/readonly/TransportAddIndexBlockAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/readonly/TransportAddIndexBlockAction.java
@@ -93,7 +93,7 @@ public class TransportAddIndexBlockAction extends TransportMasterNodeAction<AddI
             .ackTimeout(request.timeout())
             .masterNodeTimeout(request.masterNodeTimeout())
             .indices(concreteIndices);
-        indexStateService.addIndexBlock(addBlockRequest, ActionListener.delegateResponse(listener, (delegatedListener, t) -> {
+        indexStateService.addIndexBlock(addBlockRequest, listener.delegateResponse((delegatedListener, t) -> {
             logger.debug(() -> new ParameterizedMessage("failed to mark indices as readonly [{}]", (Object) concreteIndices), t);
             delegatedListener.onFailure(t);
         }));

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/settings/put/TransportUpdateSettingsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/settings/put/TransportUpdateSettingsAction.java
@@ -101,18 +101,10 @@ public class TransportUpdateSettingsAction extends AcknowledgedTransportMasterNo
                 .ackTimeout(request.timeout())
                 .masterNodeTimeout(request.masterNodeTimeout());
 
-        updateSettingsService.updateSettings(clusterStateUpdateRequest, new ActionListener<AcknowledgedResponse>() {
-            @Override
-            public void onResponse(AcknowledgedResponse response) {
-                listener.onResponse(response);
-            }
-
-            @Override
-            public void onFailure(Exception t) {
-                logger.debug(() -> new ParameterizedMessage("failed to update settings on indices [{}]", (Object) concreteIndices), t);
-                listener.onFailure(t);
-            }
-        });
+        updateSettingsService.updateSettings(clusterStateUpdateRequest, listener.delegateResponse((l, e) -> {
+            logger.debug(() -> new ParameterizedMessage("failed to update settings on indices [{}]", (Object) concreteIndices), e);
+            l.onFailure(e);
+        }));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/shrink/TransportResizeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/shrink/TransportResizeAction.java
@@ -89,7 +89,7 @@ public class TransportResizeAction extends TransportMasterNodeAction<ResizeReque
 
         // TODO: only fetch indices stats for shrink type resize requests
         client.admin().indices().prepareStats(sourceIndex).clear().setDocs(true).setStore(true).execute(
-            ActionListener.delegateFailure(listener, (delegatedListener, indicesStatsResponse) -> {
+            listener.delegateFailure((delegatedListener, indicesStatsResponse) -> {
                 final CreateIndexClusterStateUpdateRequest updateRequest;
                 try {
                     StoreStats indexStoreStats = indicesStatsResponse.getPrimaries().store;

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/upgrade/post/TransportUpgradeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/upgrade/post/TransportUpgradeAction.java
@@ -180,7 +180,7 @@ public class TransportUpgradeAction extends TransportBroadcastByNodeAction<Upgra
 
     private void updateSettings(final UpgradeResponse upgradeResponse, final ActionListener<UpgradeResponse> listener) {
         UpgradeSettingsRequest upgradeSettingsRequest = new UpgradeSettingsRequest(upgradeResponse.versions());
-        client.executeLocally(UpgradeSettingsAction.INSTANCE, upgradeSettingsRequest, ActionListener.delegateFailure(
-            listener, (delegatedListener, updateSettingsResponse) -> delegatedListener.onResponse(upgradeResponse)));
+        client.executeLocally(UpgradeSettingsAction.INSTANCE, upgradeSettingsRequest,
+            listener.delegateFailure((delegatedListener, updateSettingsResponse) -> delegatedListener.onResponse(upgradeResponse)));
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/bulk/Retry.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/Retry.java
@@ -63,13 +63,12 @@ public class Retry {
         return future;
     }
 
-    static class RetryHandler implements ActionListener<BulkResponse> {
+    static class RetryHandler extends ActionListener.Delegating<BulkResponse, BulkResponse> {
         private static final RestStatus RETRY_STATUS = RestStatus.TOO_MANY_REQUESTS;
         private static final Logger logger = LogManager.getLogger(RetryHandler.class);
 
         private final Scheduler scheduler;
         private final BiConsumer<BulkRequest, ActionListener<BulkResponse>> consumer;
-        private final ActionListener<BulkResponse> listener;
         private final Iterator<TimeValue> backoff;
         // Access only when holding a client-side lock, see also #addResponses()
         private final List<BulkItemResponse> responses = new ArrayList<>();
@@ -81,9 +80,9 @@ public class Retry {
 
         RetryHandler(BackoffPolicy backoffPolicy, BiConsumer<BulkRequest, ActionListener<BulkResponse>> consumer,
                      ActionListener<BulkResponse> listener, Scheduler scheduler) {
+            super(listener);
             this.backoff = backoffPolicy.iterator();
             this.consumer = consumer;
-            this.listener = listener;
             this.scheduler = scheduler;
             // in contrast to System.currentTimeMillis(), nanoTime() uses a monotonic clock under the hood
             this.startTimestampNanos = System.nanoTime();
@@ -112,7 +111,7 @@ public class Retry {
                 retry(currentBulkRequest);
             } else {
                 try {
-                    listener.onFailure(e);
+                    delegate.onFailure(e);
                 } finally {
                     if (retryCancellable != null) {
                         retryCancellable.cancel();
@@ -157,7 +156,7 @@ public class Retry {
 
         private void finishHim() {
             try {
-                listener.onResponse(getAccumulatedResponse());
+                delegate.onResponse(getAccumulatedResponse());
             } finally {
                 if (retryCancellable != null) {
                     retryCancellable.cancel();

--- a/server/src/main/java/org/elasticsearch/action/search/SearchExecutionStatsCollector.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchExecutionStatsCollector.java
@@ -22,9 +22,8 @@ import java.util.function.BiFunction;
  * result to get the piggybacked queue size and service time EWMA, adding those
  * values to the coordinating nodes' {@link ResponseCollectorService}.
  */
-public final class SearchExecutionStatsCollector implements ActionListener<SearchPhaseResult> {
+public final class SearchExecutionStatsCollector extends ActionListener.Delegating<SearchPhaseResult, SearchPhaseResult> {
 
-    private final ActionListener<SearchPhaseResult> listener;
     private final String nodeId;
     private final ResponseCollectorService collector;
     private final long startNanos;
@@ -32,7 +31,7 @@ public final class SearchExecutionStatsCollector implements ActionListener<Searc
     SearchExecutionStatsCollector(ActionListener<SearchPhaseResult> listener,
                                   ResponseCollectorService collector,
                                   String nodeId) {
-        this.listener = Objects.requireNonNull(listener, "listener cannot be null");
+        super(Objects.requireNonNull(listener, "listener cannot be null"));
         this.collector = Objects.requireNonNull(collector, "response collector cannot be null");
         this.startNanos = System.nanoTime();
         this.nodeId = nodeId;
@@ -54,11 +53,6 @@ public final class SearchExecutionStatsCollector implements ActionListener<Searc
                 collector.addNodeStatistics(nodeId, queueSize, responseDuration, serviceTimeEWMA);
             }
         }
-        listener.onResponse(response);
-    }
-
-    @Override
-    public void onFailure(Exception e) {
-        listener.onFailure(e);
+        delegate.onResponse(response);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/support/ChannelActionListener.java
+++ b/server/src/main/java/org/elasticsearch/action/support/ChannelActionListener.java
@@ -39,4 +39,9 @@ public final class ChannelActionListener<
     public void onFailure(Exception e) {
         TransportChannel.sendErrorResponse(channel, actionName, request, e);
     }
+
+    @Override
+    public String toString() {
+        return "ChannelActionListener{" + channel + "}{" + request + "}{" + actionName + "}";
+    }
 }

--- a/server/src/main/java/org/elasticsearch/action/support/ContextPreservingActionListener.java
+++ b/server/src/main/java/org/elasticsearch/action/support/ContextPreservingActionListener.java
@@ -16,13 +16,12 @@ import java.util.function.Supplier;
  * Restores the given {@link org.elasticsearch.common.util.concurrent.ThreadContext.StoredContext}
  * once the listener is invoked
  */
-public final class ContextPreservingActionListener<R> implements ActionListener<R> {
+public final class ContextPreservingActionListener<R> extends ActionListener.Delegating<R, R> {
 
-    private final ActionListener<R> delegate;
     private final Supplier<ThreadContext.StoredContext> context;
 
     public ContextPreservingActionListener(Supplier<ThreadContext.StoredContext> contextSupplier, ActionListener<R> delegate) {
-        this.delegate = delegate;
+        super(delegate);
         this.context = contextSupplier;
     }
 
@@ -38,11 +37,6 @@ public final class ContextPreservingActionListener<R> implements ActionListener<
         try (ThreadContext.StoredContext ignore = context.get()) {
             delegate.onFailure(e);
         }
-    }
-
-    @Override
-    public String toString() {
-        return getClass().getName() + "/" + delegate.toString();
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/support/GroupedActionListener.java
+++ b/server/src/main/java/org/elasticsearch/action/support/GroupedActionListener.java
@@ -23,11 +23,10 @@ import java.util.concurrent.atomic.AtomicReference;
  * tasks to be forked off in a loop with the same listener and respond to a
  * higher level listener once all tasks responded.
  */
-public final class GroupedActionListener<T> implements ActionListener<T> {
+public final class GroupedActionListener<T> extends ActionListener.Delegating<T, Collection<T>> {
     private final CountDown countDown;
     private final AtomicInteger pos = new AtomicInteger();
     private final AtomicArray<T> results;
-    private final ActionListener<Collection<T>> delegate;
     private final AtomicReference<Exception> failure = new AtomicReference<>();
 
     /**
@@ -36,12 +35,12 @@ public final class GroupedActionListener<T> implements ActionListener<T> {
      * @param groupSize the group size
      */
     public GroupedActionListener(ActionListener<Collection<T>> delegate, int groupSize) {
+        super(delegate);
         if (groupSize <= 0) {
             throw new IllegalArgumentException("groupSize must be greater than 0 but was " + groupSize);
         }
         results = new AtomicArray<>(groupSize);
         countDown = new CountDown(groupSize);
-        this.delegate = delegate;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeAction.java
@@ -142,7 +142,7 @@ public abstract class TransportMasterNodeAction<Request extends MasterNodeReques
                             });
                         }
                     } else {
-                        ActionListener<Response> delegate = ActionListener.delegateResponse(listener, (delegatedListener, t) -> {
+                        ActionListener<Response> delegate = listener.delegateResponse((delegatedListener, t) -> {
                             if (t instanceof FailedToCommitClusterStateException || t instanceof NotMasterException) {
                                 logger.debug(() -> new ParameterizedMessage("master could not publish cluster state or " +
                                     "stepped down before publishing action [{}], scheduling a retry", actionName), t);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexStateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexStateService.java
@@ -567,22 +567,14 @@ public class MetadataIndexStateService {
             if (request.ackTimeout() != null) {
                 shardRequest.timeout(request.ackTimeout());
             }
-            transportVerifyShardBeforeCloseAction.execute(shardRequest, new ActionListener<ReplicationResponse>() {
-                @Override
-                public void onResponse(ReplicationResponse replicationResponse) {
-                    final TransportVerifyShardBeforeCloseAction.ShardRequest shardRequest =
+            transportVerifyShardBeforeCloseAction.execute(shardRequest, listener.delegateFailure((delegate, replicationResponse) -> {
+                final TransportVerifyShardBeforeCloseAction.ShardRequest req =
                         new TransportVerifyShardBeforeCloseAction.ShardRequest(shardId, closingBlock, false, parentTaskId);
-                    if (request.ackTimeout() != null) {
-                        shardRequest.timeout(request.ackTimeout());
-                    }
-                    transportVerifyShardBeforeCloseAction.execute(shardRequest, listener);
+                if (request.ackTimeout() != null) {
+                    req.timeout(request.ackTimeout());
                 }
-
-                @Override
-                public void onFailure(Exception e) {
-                    listener.onFailure(e);
-                }
-            });
+                transportVerifyShardBeforeCloseAction.execute(req, delegate);
+            }));
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/discovery/HandshakingTransportAddressConnector.java
+++ b/server/src/main/java/org/elasticsearch/discovery/HandshakingTransportAddressConnector.java
@@ -26,7 +26,6 @@ import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.discovery.PeerFinder.TransportAddressConnector;
 import org.elasticsearch.transport.ConnectTransportException;
 import org.elasticsearch.transport.ConnectionProfile;
-import org.elasticsearch.transport.Transport.Connection;
 import org.elasticsearch.transport.TransportRequestOptions.Type;
 import org.elasticsearch.transport.TransportService;
 
@@ -74,73 +73,63 @@ public class HandshakingTransportAddressConnector implements TransportAddressCon
                 logger.trace("[{}] opening probe connection", thisConnectionAttempt);
                 transportService.openConnection(targetNode,
                     ConnectionProfile.buildSingleChannelProfile(Type.REG, probeConnectTimeout, probeHandshakeTimeout,
-                        TimeValue.MINUS_ONE, null), new ActionListener<Connection>() {
-                        @Override
-                        public void onResponse(Connection connection) {
-                            logger.trace("[{}] opened probe connection", thisConnectionAttempt);
+                        TimeValue.MINUS_ONE, null), listener.delegateFailure((l, connection) -> {
+                        logger.trace("[{}] opened probe connection", thisConnectionAttempt);
 
-                            // use NotifyOnceListener to make sure the following line does not result in onFailure being called when
-                            // the connection is closed in the onResponse handler
-                            transportService.handshake(connection, probeHandshakeTimeout, new NotifyOnceListener<DiscoveryNode>() {
+                        // use NotifyOnceListener to make sure the following line does not result in onFailure being called when
+                        // the connection is closed in the onResponse handler
+                        transportService.handshake(connection, probeHandshakeTimeout, new NotifyOnceListener<DiscoveryNode>() {
 
-                                @Override
-                                protected void innerOnResponse(DiscoveryNode remoteNode) {
-                                    try {
-                                        // success means (amongst other things) that the cluster names match
-                                        logger.trace("[{}] handshake successful: {}", thisConnectionAttempt, remoteNode);
-                                        IOUtils.closeWhileHandlingException(connection);
+                            @Override
+                            protected void innerOnResponse(DiscoveryNode remoteNode) {
+                                try {
+                                    // success means (amongst other things) that the cluster names match
+                                    logger.trace("[{}] handshake successful: {}", thisConnectionAttempt, remoteNode);
+                                    IOUtils.closeWhileHandlingException(connection);
 
-                                        if (remoteNode.equals(transportService.getLocalNode())) {
-                                            listener.onFailure(new ConnectTransportException(remoteNode, "local node found"));
-                                        } else if (remoteNode.isMasterNode() == false) {
-                                            listener.onFailure(new ConnectTransportException(remoteNode, "non-master-eligible node found"));
-                                        } else {
-                                            transportService.connectToNode(remoteNode, new ActionListener<Void>() {
-                                                @Override
-                                                public void onResponse(Void ignored) {
-                                                    logger.trace("[{}] completed full connection with [{}]",
+                                    if (remoteNode.equals(transportService.getLocalNode())) {
+                                        listener.onFailure(new ConnectTransportException(remoteNode, "local node found"));
+                                    } else if (remoteNode.isMasterNode() == false) {
+                                        listener.onFailure(new ConnectTransportException(remoteNode, "non-master-eligible node found"));
+                                    } else {
+                                        transportService.connectToNode(remoteNode, new ActionListener<Void>() {
+                                            @Override
+                                            public void onResponse(Void ignored) {
+                                                logger.trace("[{}] completed full connection with [{}]",
                                                         thisConnectionAttempt, remoteNode);
-                                                    listener.onResponse(remoteNode);
-                                                }
+                                                listener.onResponse(remoteNode);
+                                            }
 
-                                                @Override
-                                                public void onFailure(Exception e) {
-                                                    // we opened a connection and successfully performed a handshake, so we're definitely
-                                                    // talking to a master-eligible node with a matching cluster name and a good version,
-                                                    // but the attempt to open a full connection to its publish address failed; a common
-                                                    // reason is that the remote node is listening on 0.0.0.0 but has made an inappropriate
-                                                    // choice for its publish address.
-                                                    logger.warn(new ParameterizedMessage(
+                                            @Override
+                                            public void onFailure(Exception e) {
+                                                // we opened a connection and successfully performed a handshake, so we're definitely
+                                                // talking to a master-eligible node with a matching cluster name and a good version, but
+                                                // the attempt to open a full connection to its publish address failed; a common reason is
+                                                // that the remote node is listening on 0.0.0.0 but has made an inappropriate choice for its
+                                                // publish address.
+                                                logger.warn(new ParameterizedMessage(
                                                         "[{}] completed handshake with [{}] but followup connection failed",
                                                         thisConnectionAttempt, remoteNode), e);
-                                                    listener.onFailure(e);
-                                                }
-                                            });
-                                        }
-                                    } catch (Exception e) {
-                                        listener.onFailure(e);
+                                                listener.onFailure(e);
+                                            }
+                                        });
                                     }
-                                }
-
-                                @Override
-                                protected void innerOnFailure(Exception e) {
-                                    // we opened a connection and successfully performed a low-level handshake, so we were definitely
-                                    // talking to an Elasticsearch node, but the high-level handshake failed indicating some kind of
-                                    // mismatched configurations (e.g. cluster name) that the user should address
-                                    logger.warn(new ParameterizedMessage("handshake failed for [{}]", thisConnectionAttempt), e);
-                                    IOUtils.closeWhileHandlingException(connection);
+                                } catch (Exception e) {
                                     listener.onFailure(e);
                                 }
+                            }
 
-                            });
-
-                        }
-
-                        @Override
-                        public void onFailure(Exception e) {
-                            listener.onFailure(e);
-                        }
-                    });
+                            @Override
+                            protected void innerOnFailure(Exception e) {
+                                // we opened a connection and successfully performed a low-level handshake, so we were definitely
+                                // talking to an Elasticsearch node, but the high-level handshake failed indicating some kind of
+                                // mismatched configurations (e.g. cluster name) that the user should address
+                                logger.warn(new ParameterizedMessage("handshake failed for [{}]", thisConnectionAttempt), e);
+                                IOUtils.closeWhileHandlingException(connection);
+                                listener.onFailure(e);
+                            }
+                        });
+                }));
             }
 
             @Override

--- a/server/src/main/java/org/elasticsearch/index/query/AbstractGeometryQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/AbstractGeometryQueryBuilder.java
@@ -14,7 +14,6 @@ import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.get.GetRequest;
-import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
@@ -393,54 +392,42 @@ public abstract class AbstractGeometryQueryBuilder<QB extends AbstractGeometryQu
      */
     private void fetch(Client client, GetRequest getRequest, String path, ActionListener<Geometry> listener) {
         getRequest.preference("_local");
-        client.get(getRequest, new ActionListener<GetResponse>(){
+        client.get(getRequest, listener.delegateFailure((l, response) -> {
+            try {
+                if (response.isExists() == false) {
+                    throw new IllegalArgumentException("Shape with ID [" + getRequest.id() + "] not found");
+                }
+                if (response.isSourceEmpty()) {
+                    throw new IllegalArgumentException("Shape with ID [" + getRequest.id() + "] source disabled");
+                }
+                String[] pathElements = path.split("\\.");
+                int currentPathSlot = 0;
 
-            @Override
-            public void onResponse(GetResponse response) {
-                try {
-                    if (response.isExists() == false) {
-                        throw new IllegalArgumentException("Shape with ID [" + getRequest.id() + "] in type [" + getRequest.type()
-                            + "] not found");
-                    }
-                    if (response.isSourceEmpty()) {
-                        throw new IllegalArgumentException("Shape with ID [" + getRequest.id() + "] in type [" + getRequest.type() +
-                            "] source disabled");
-                    }
-
-                    String[] pathElements = path.split("\\.");
-                    int currentPathSlot = 0;
-
-                    // It is safe to use EMPTY here because this never uses namedObject
-                    try (XContentParser parser = XContentHelper
+                // It is safe to use EMPTY here because this never uses namedObject
+                try (XContentParser parser = XContentHelper
                         .createParser(NamedXContentRegistry.EMPTY,
-                            LoggingDeprecationHandler.INSTANCE, response.getSourceAsBytesRef())) {
-                        XContentParser.Token currentToken;
-                        while ((currentToken = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-                            if (currentToken == XContentParser.Token.FIELD_NAME) {
-                                if (pathElements[currentPathSlot].equals(parser.currentName())) {
-                                    parser.nextToken();
-                                    if (++currentPathSlot == pathElements.length) {
-                                        listener.onResponse(new GeometryParser(true, true, true).parse(parser));
-                                        return;
-                                    }
-                                } else {
-                                    parser.nextToken();
-                                    parser.skipChildren();
+                                LoggingDeprecationHandler.INSTANCE, response.getSourceAsBytesRef())) {
+                    XContentParser.Token currentToken;
+                    while ((currentToken = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+                        if (currentToken == XContentParser.Token.FIELD_NAME) {
+                            if (pathElements[currentPathSlot].equals(parser.currentName())) {
+                                parser.nextToken();
+                                if (++currentPathSlot == pathElements.length) {
+                                    l.onResponse(new GeometryParser(true, true, true).parse(parser));
+                                    return;
                                 }
+                            } else {
+                                parser.nextToken();
+                                parser.skipChildren();
                             }
                         }
-                        throw new IllegalStateException("Shape with name [" + getRequest.id() + "] found but missing " + path + " field");
                     }
-                } catch (Exception e) {
-                    onFailure(e);
+                    throw new IllegalStateException("Shape with name [" + getRequest.id() + "] found but missing " + path + " field");
                 }
+            } catch (Exception e) {
+                l.onFailure(e);
             }
-
-            @Override
-            public void onFailure(Exception e) {
-                listener.onFailure(e);
-            }
-        });
+        }));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/query/AbstractGeometryQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/AbstractGeometryQueryBuilder.java
@@ -395,10 +395,12 @@ public abstract class AbstractGeometryQueryBuilder<QB extends AbstractGeometryQu
         client.get(getRequest, listener.delegateFailure((l, response) -> {
             try {
                 if (response.isExists() == false) {
-                    throw new IllegalArgumentException("Shape with ID [" + getRequest.id() + "] not found");
+                    throw new IllegalArgumentException("Shape with ID [" + getRequest.id() + "] in type [" + getRequest.type()
+                            + "] not found");
                 }
                 if (response.isSourceEmpty()) {
-                    throw new IllegalArgumentException("Shape with ID [" + getRequest.id() + "] source disabled");
+                    throw new IllegalArgumentException("Shape with ID [" + getRequest.id() + "] in type [" + getRequest.type() +
+                            "] source disabled");
                 }
                 String[] pathElements = path.split("\\.");
                 int currentPathSlot = 0;

--- a/server/src/main/java/org/elasticsearch/index/reindex/RetryListener.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/RetryListener.java
@@ -18,32 +18,27 @@ import org.elasticsearch.threadpool.ThreadPool;
 import java.util.Iterator;
 import java.util.function.Consumer;
 
-class RetryListener implements RejectAwareActionListener<ScrollableHitSource.Response> {
+class RetryListener extends ActionListener.Delegating<ScrollableHitSource.Response, ScrollableHitSource.Response>
+        implements RejectAwareActionListener<ScrollableHitSource.Response> {
     private final Logger logger;
     private final Iterator<TimeValue> retries;
     private final ThreadPool threadPool;
     private final Consumer<RejectAwareActionListener<ScrollableHitSource.Response>> retryScrollHandler;
-    private final ActionListener<ScrollableHitSource.Response> delegate;
     private int retryCount = 0;
 
     RetryListener(Logger logger, ThreadPool threadPool, BackoffPolicy backoffPolicy,
-                          Consumer<RejectAwareActionListener<ScrollableHitSource.Response>> retryScrollHandler,
-                          ActionListener<ScrollableHitSource.Response> delegate) {
+                  Consumer<RejectAwareActionListener<ScrollableHitSource.Response>> retryScrollHandler,
+                  ActionListener<ScrollableHitSource.Response> delegate) {
+        super(delegate);
         this.logger = logger;
         this.threadPool = threadPool;
         this.retries = backoffPolicy.iterator();
         this.retryScrollHandler = retryScrollHandler;
-        this.delegate = delegate;
     }
 
     @Override
     public void onResponse(ScrollableHitSource.Response response) {
         delegate.onResponse(response);
-    }
-
-    @Override
-    public void onFailure(Exception e) {
-        delegate.onFailure(e);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseActions.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseActions.java
@@ -84,7 +84,7 @@ public class RetentionLeaseActions {
             final IndexService indexService = indicesService.indexServiceSafe(shardId.getIndex());
             final IndexShard indexShard = indexService.getShard(shardId.id());
             indexShard.acquirePrimaryOperationPermit(
-                ActionListener.delegateFailure(listener, (delegatedListener, releasable) -> {
+                listener.delegateFailure((delegatedListener, releasable) -> {
                     try (Releasable ignore = releasable) {
                         doRetentionLeaseAction(indexShard, request, delegatedListener);
                     }

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -3010,8 +3010,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
      * @return the wrapped listener
      */
     private ActionListener<Releasable> wrapPrimaryOperationPermitListener(final ActionListener<Releasable> listener) {
-        return ActionListener.delegateFailure(
-                listener,
+        return listener.delegateFailure(
                 (l, r) -> {
                     if (replicationTracker.isPrimaryMode()) {
                         l.onResponse(r);
@@ -3186,7 +3185,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         // primary term update. Since indexShardOperationPermits doesn't guarantee that async submissions are executed
         // in the order submitted, combining both operations ensure that the term is updated before the operation is
         // executed. It also has the side effect of acquiring all the permits one time instead of two.
-        final ActionListener<Releasable> operationListener = ActionListener.delegateFailure(onPermitAcquired,
+        final ActionListener<Releasable> operationListener = onPermitAcquired.delegateFailure(
             (delegatedListener, releasable) -> {
                 if (opPrimaryTerm < getOperationPrimaryTerm()) {
                     releasable.close();

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShardOperationPermits.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShardOperationPermits.java
@@ -215,7 +215,7 @@ final class IndexShardOperationPermits implements Closeable {
                     final Supplier<StoredContext> contextSupplier = threadPool.getThreadContext().newRestorableContext(false);
                     final ActionListener<Releasable> wrappedListener;
                     if (executorOnDelay != null) {
-                        wrappedListener = ActionListener.delegateFailure(new ContextPreservingActionListener<>(contextSupplier, onAcquired),
+                        wrappedListener = new ContextPreservingActionListener<>(contextSupplier, onAcquired).delegateFailure(
                             (l, r) -> threadPool.executor(executorOnDelay).execute(new ActionRunnable<Releasable>(l) {
                                 @Override
                                 public boolean isForceExecution() {

--- a/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
@@ -423,11 +423,11 @@ public class PeerRecoveryTargetService implements IndexEventListener {
                 }
 
                 recoveryRef.target().cleanFiles(request.totalTranslogOps(), request.getGlobalCheckpoint(), request.sourceMetaSnapshot(),
-                        ActionListener.delegateFailure(listener, (r, l) -> {
+                    listener.delegateFailure((l, r) -> {
                             Releasable reenableMonitor = recoveryRef.target().disableRecoveryMonitor();
                             recoveryRef.target().indexShard().afterCleanFiles(() -> {
                                 reenableMonitor.close();
-                                listener.onResponse(null);
+                                l.onResponse(null);
                             });
                         }));
             }

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryRequestTracker.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryRequestTracker.java
@@ -50,19 +50,10 @@ public class RecoveryRequestTracker {
             checkpointTracker.markSeqNoAsProcessed(requestSeqNo);
             final ListenableFuture<Void> future = new ListenableFuture<>();
             ongoingRequests.put(requestSeqNo, future);
-            future.addListener(new ActionListener<Void>() {
-                @Override
-                public void onResponse(Void v) {
-                    ongoingRequests.remove(requestSeqNo);
-                    listener.onResponse(v);
-                }
-
-                @Override
-                public void onFailure(Exception e) {
-                    // We do not remove the future to cache the error for retried requests
-                    listener.onFailure(e);
-                }
-            }, EsExecutors.newDirectExecutorService());
+            future.addListener(listener.delegateFailure((l, v) -> {
+                ongoingRequests.remove(requestSeqNo);
+                l.onResponse(v);
+            }), EsExecutors.newDirectExecutorService());
             return future;
         }
     }

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -775,7 +775,7 @@ public class RecoverySourceHandler {
                 maxSeqNoOfUpdatesOrDeletes,
                 retentionLeases,
                 mappingVersion,
-                ActionListener.delegateFailure(listener, (l, newCheckpoint) -> {
+                listener.delegateFailure((l, newCheckpoint) -> {
                     targetLocalCheckpoint.updateAndGet(curr -> SequenceNumbers.max(curr, newCheckpoint));
                     l.onResponse(null);
                 }));
@@ -976,7 +976,7 @@ public class RecoverySourceHandler {
         // are deleted
         cancellableThreads.checkForCancel();
         recoveryTarget.cleanFiles(translogOps.getAsInt(), globalCheckpoint, sourceMetadata,
-            ActionListener.delegateResponse(listener, (l, e) -> ActionListener.completeWith(l, () -> {
+            listener.delegateResponse((l, e) -> ActionListener.completeWith(l, () -> {
                 StoreFileMetadata[] mds = StreamSupport.stream(sourceMetadata.spliterator(), false).toArray(StoreFileMetadata[]::new);
                 ArrayUtil.timSort(mds, Comparator.comparingLong(StoreFileMetadata::length)); // check small files first
                 handleErrorOnSendFiles(store, e, mds);

--- a/server/src/main/java/org/elasticsearch/persistent/StartPersistentTaskAction.java
+++ b/server/src/main/java/org/elasticsearch/persistent/StartPersistentTaskAction.java
@@ -196,8 +196,7 @@ public class StartPersistentTaskAction extends ActionType<PersistentTaskResponse
         protected final void masterOperation(final Request request, ClusterState state,
                                              final ActionListener<PersistentTaskResponse> listener) {
             persistentTasksClusterService.createPersistentTask(request.taskId, request.taskName, request.params,
-                ActionListener.delegateFailure(listener,
-                    (delegatedListener, task) -> delegatedListener.onResponse(new PersistentTaskResponse(task))));
+                listener.delegateFailure((delegatedListener, task) -> delegatedListener.onResponse(new PersistentTaskResponse(task))));
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
@@ -349,7 +349,7 @@ public class RepositoriesService extends AbstractLifecycleComponent implements C
                 final String verificationToken = repository.startVerification();
                 if (verificationToken != null) {
                     try {
-                        verifyAction.verify(repositoryName, verificationToken, ActionListener.delegateFailure(listener,
+                        verifyAction.verify(repositoryName, verificationToken, listener.delegateFailure(
                             (delegatedListener, verifyResponse) -> threadPool.executor(ThreadPool.Names.SNAPSHOT).execute(() -> {
                                 try {
                                     repository.endVerification(verificationToken);

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -2375,7 +2375,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
     public void restoreShard(Store store, SnapshotId snapshotId, IndexId indexId, ShardId snapshotShardId,
                              RecoveryState recoveryState, ActionListener<Void> listener) {
         final ShardId shardId = store.shardId();
-        final ActionListener<Void> restoreListener = ActionListener.delegateResponse(listener,
+        final ActionListener<Void> restoreListener = listener.delegateResponse(
             (l, e) -> l.onFailure(new IndexShardRestoreFailedException(shardId, "failed to restore snapshot [" + snapshotId + "]", e)));
         final Executor executor = threadPool.executor(ThreadPool.Names.SNAPSHOT);
         final BlobContainer container = shardContainer(indexId, snapshotShardId);
@@ -2481,7 +2481,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
 
     private static ActionListener<Void> fileQueueListener(BlockingQueue<BlobStoreIndexShardSnapshot.FileInfo> files, int workers,
                                                           ActionListener<Collection<Void>> listener) {
-        return ActionListener.delegateResponse(new GroupedActionListener<>(listener, workers), (l, e) -> {
+        return new GroupedActionListener<>(listener, workers).delegateResponse((l, e) -> {
             files.clear(); // Stop uploading the remaining files if we run into any exception
             l.onFailure(e);
         });

--- a/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -484,7 +484,7 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
         }
     }
 
-    class ThreadedRunnable implements Runnable {
+    static class ThreadedRunnable implements Runnable {
 
         private final Runnable runnable;
 

--- a/server/src/main/java/org/elasticsearch/transport/TransportRequest.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportRequest.java
@@ -58,4 +58,9 @@ public abstract class TransportRequest extends TransportMessage implements TaskA
     public void writeTo(StreamOutput out) throws IOException {
         parentTaskId.writeTo(out);
     }
+
+    @Override
+    public String toString() {
+        return getClass().getName() + "/" + getParentTask();
+    }
 }

--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -489,28 +489,17 @@ public class TransportService extends AbstractLifecycleComponent
         final DiscoveryNode node = connection.getNode();
         sendRequest(connection, HANDSHAKE_ACTION_NAME, HandshakeRequest.INSTANCE,
             TransportRequestOptions.timeout(handshakeTimeout),
-            new ActionListenerResponseHandler<>(
-                new ActionListener<HandshakeResponse>() {
-                    @Override
-                    public void onResponse(HandshakeResponse response) {
-                        if (clusterNamePredicate.test(response.clusterName) == false) {
-                            listener.onFailure(new IllegalStateException("handshake with [" + node + "] failed: remote cluster name ["
+                new ActionListenerResponseHandler<>(listener.delegateFailure((l, response) -> {
+                    if (clusterNamePredicate.test(response.clusterName) == false) {
+                        l.onFailure(new IllegalStateException("handshake with [" + node + "] failed: remote cluster name ["
                                 + response.clusterName.value() + "] does not match " + clusterNamePredicate));
-                        } else if (response.version.isCompatible(localNode.getVersion()) == false) {
-                            listener.onFailure(new IllegalStateException("handshake with [" + node + "] failed: remote node version ["
+                    } else if (response.version.isCompatible(localNode.getVersion()) == false) {
+                        l.onFailure(new IllegalStateException("handshake with [" + node + "] failed: remote node version ["
                                 + response.version + "] is incompatible with local node version [" + localNode.getVersion() + "]"));
-                        } else {
-                            listener.onResponse(response);
-                        }
+                    } else {
+                        l.onResponse(response);
                     }
-
-                    @Override
-                    public void onFailure(Exception e) {
-                        listener.onFailure(e);
-                    }
-                }
-                , in -> new HandshakeResponse(in, requireCompatibleBuild), ThreadPool.Names.GENERIC
-            ));
+                }), in -> new HandshakeResponse(in, requireCompatibleBuild), ThreadPool.Names.GENERIC));
     }
 
     public ConnectionManager getConnectionManager() {

--- a/server/src/test/java/org/elasticsearch/client/transport/TransportClientNodesServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/client/transport/TransportClientNodesServiceTests.java
@@ -355,11 +355,10 @@ public class TransportClientNodesServiceTests extends ESTestCase {
                 final List<Transport.Connection> establishedConnections = new CopyOnWriteArrayList<>();
 
                 clientService.addConnectBehavior(remoteService, (transport, discoveryNode, profile, listener) ->
-                    transport.openConnection(discoveryNode, profile,
-                        ActionListener.delegateFailure(listener, (delegatedListener, connection) -> {
-                            establishedConnections.add(connection);
-                            delegatedListener.onResponse(connection);
-                        })));
+                    transport.openConnection(discoveryNode, profile, listener.delegateFailure((delegatedListener, connection) -> {
+                        establishedConnections.add(connection);
+                        delegatedListener.onResponse(connection);
+                    })));
 
                 clientService.start();
                 clientService.acceptIncomingRequests();

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -391,7 +391,7 @@ public class IndexShardTests extends IndexShardTestCase {
         IndexShard indexShard = newShard(false);
         expectThrows(IndexShardNotStartedException.class, () ->
             randomReplicaOperationPermitAcquisition(indexShard, indexShard.getPendingPrimaryTerm() + randomIntBetween(1, 100),
-                UNASSIGNED_SEQ_NO, randomNonNegativeLong(), null, ""));
+                UNASSIGNED_SEQ_NO, randomNonNegativeLong(), PlainActionFuture.newFuture(), ""));
         closeShards(indexShard);
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/index/replication/ESIndexLevelReplicationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/replication/ESIndexLevelReplicationTestCase.java
@@ -694,7 +694,7 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
                     getPrimaryShard().getPendingPrimaryTerm(),
                     globalCheckpoint,
                     maxSeqNoOfUpdatesOrDeletes,
-                    ActionListener.delegateFailure(listener, (delegatedListener, releasable) -> {
+                    listener.delegateFailure((delegatedListener, releasable) -> {
                         try {
                             performOnReplica(request, replica);
                             releasable.close();

--- a/test/framework/src/main/java/org/elasticsearch/test/transport/StubbableTransport.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/transport/StubbableTransport.java
@@ -140,8 +140,7 @@ public class StubbableTransport implements Transport {
         OpenConnectionBehavior behavior = connectBehaviors.getOrDefault(address, defaultConnectBehavior);
 
         ActionListener<Connection> wrappedListener =
-            ActionListener.delegateFailure(listener,
-                (delegatedListener, connection) -> delegatedListener.onResponse(new WrappedConnection(connection)));
+            listener.delegateFailure((delegatedListener, connection) -> delegatedListener.onResponse(new WrappedConnection(connection)));
 
         if (behavior == null) {
             delegate.openConnection(node, profile, wrappedListener);

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportPutFollowAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportPutFollowAction.java
@@ -184,10 +184,8 @@ public final class TransportPutFollowAction
 
             @Override
             protected void doRun() {
-                ActionListener<RestoreService.RestoreCompletionResponse> delegatelistener = ActionListener.delegateFailure(
-                    listener,
-                    (delegatedListener, response) -> afterRestoreStarted(clientWithHeaders, request, delegatedListener, response)
-                );
+                ActionListener<RestoreService.RestoreCompletionResponse> delegatelistener = listener.delegateFailure(
+                        (delegatedListener, response) -> afterRestoreStarted(clientWithHeaders, request, delegatedListener, response));
                 if (remoteDataStream == null) {
                     restoreService.restoreSnapshot(restoreRequest, delegatelistener);
                 } else {
@@ -228,8 +226,8 @@ public final class TransportPutFollowAction
             listener = originalListener;
         }
 
-        RestoreClusterStateListener.createAndRegisterListener(clusterService, response,
-            ActionListener.delegateFailure(listener, (delegatedListener, restoreSnapshotResponse) -> {
+        RestoreClusterStateListener.createAndRegisterListener(clusterService, response, listener.delegateFailure(
+            (delegatedListener, restoreSnapshotResponse) -> {
                 RestoreInfo restoreInfo = restoreSnapshotResponse.getRestoreInfo();
                 if (restoreInfo == null) {
                     // If restoreInfo is null then it is possible there was a master failure during the

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
@@ -336,7 +336,7 @@ public class CcrRepository extends AbstractLifecycleComponent implements Reposit
                              ActionListener<Void> listener) {
         final ShardId shardId = store.shardId();
         final LinkedList<Closeable> toClose = new LinkedList<>();
-        final ActionListener<Void> restoreListener = ActionListener.runBefore(ActionListener.delegateResponse(listener,
+        final ActionListener<Void> restoreListener = ActionListener.runBefore(listener.delegateResponse(
             (l, e) -> l.onFailure(new IndexShardRestoreFailedException(shardId, "failed to restore snapshot [" + snapshotId + "]", e))),
             () -> IOUtils.close(toClose));
         try {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/TransportDeleteLicenseAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/TransportDeleteLicenseAction.java
@@ -42,16 +42,7 @@ public class TransportDeleteLicenseAction extends AcknowledgedTransportMasterNod
     @Override
     protected void masterOperation(final DeleteLicenseRequest request, ClusterState state, final ActionListener<AcknowledgedResponse>
             listener) throws ElasticsearchException {
-        licenseService.removeLicense(request, new ActionListener<PostStartBasicResponse>() {
-            @Override
-            public void onResponse(PostStartBasicResponse postStartBasicResponse) {
-                listener.onResponse(AcknowledgedResponse.of(postStartBasicResponse.isAcknowledged()));
-            }
-
-            @Override
-            public void onFailure(Exception e) {
-                listener.onFailure(e);
-            }
-        });
+        licenseService.removeLicense(request, listener.delegateFailure((l, postStartBasicResponse) ->
+                l.onResponse(AcknowledgedResponse.of(postStartBasicResponse.isAcknowledged()))));
     }
 }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/AsEventListener.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/AsEventListener.java
@@ -12,21 +12,14 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.xpack.eql.execution.payload.EventPayload;
 import org.elasticsearch.xpack.eql.session.Payload;
 
-public class AsEventListener implements ActionListener<SearchResponse> {
-
-    private final ActionListener<Payload> listener;
+public class AsEventListener extends ActionListener.Delegating<SearchResponse, Payload> {
 
     public AsEventListener(ActionListener<Payload> listener) {
-        this.listener = listener;
+        super(listener);
     }
 
     @Override
     public void onResponse(SearchResponse response) {
-        listener.onResponse(new EventPayload(response));
-    }
-
-    @Override
-    public void onFailure(Exception e) {
-        listener.onFailure(e);
+        delegate.onResponse(new EventPayload(response));
     }
 }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/TumblingWindow.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/TumblingWindow.java
@@ -554,8 +554,8 @@ public class TumblingWindow implements Executable {
     }
 
     private void close(ActionListener<Payload> listener) {
-            matcher.clear();
-        client.close(ActionListener.delegateFailure(listener, (l, r) -> {}));
+        matcher.clear();
+        client.close(listener.delegateFailure((l, r) -> {}));
     }
 
     private TimeValue timeTook() {

--- a/x-pack/plugin/frozen-indices/src/main/java/org/elasticsearch/xpack/frozen/action/TransportFreezeIndexAction.java
+++ b/x-pack/plugin/frozen-indices/src/main/java/org/elasticsearch/xpack/frozen/action/TransportFreezeIndexAction.java
@@ -16,8 +16,6 @@ import org.elasticsearch.action.admin.indices.close.CloseIndexResponse;
 import org.elasticsearch.action.admin.indices.open.OpenIndexClusterStateUpdateRequest;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.DestructiveOperations;
-import org.elasticsearch.action.support.master.AcknowledgedResponse;
-import org.elasticsearch.action.support.master.ShardsAcknowledgedResponse;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterState;
@@ -131,31 +129,14 @@ public final class TransportFreezeIndexAction extends
     private void toggleFrozenSettings(final Index[] concreteIndices, final FreezeRequest request,
                                       final ActionListener<FreezeResponse> listener) {
         clusterService.submitStateUpdateTask("toggle-frozen-settings",
-            new AckedClusterStateUpdateTask(Priority.URGENT, request, new ActionListener<AcknowledgedResponse>() {
-                @Override
-                public void onResponse(AcknowledgedResponse acknowledgedResponse) {
+                new AckedClusterStateUpdateTask(Priority.URGENT, request, listener.delegateFailure((delegate, acknowledgedResponse) -> {
                     OpenIndexClusterStateUpdateRequest updateRequest = new OpenIndexClusterStateUpdateRequest()
-                        .ackTimeout(request.timeout()).masterNodeTimeout(request.masterNodeTimeout())
-                        .indices(concreteIndices).waitForActiveShards(request.waitForActiveShards());
-                    indexStateService.openIndex(updateRequest, new ActionListener<ShardsAcknowledgedResponse>() {
-                        @Override
-                        public void onResponse(ShardsAcknowledgedResponse openIndexClusterStateUpdateResponse) {
-                            listener.onResponse(new FreezeResponse(openIndexClusterStateUpdateResponse.isAcknowledged(),
-                                openIndexClusterStateUpdateResponse.isShardsAcknowledged()));
-                        }
-
-                        @Override
-                        public void onFailure(Exception e) {
-                            listener.onFailure(e);
-                        }
-                    });
-                }
-
-                @Override
-                public void onFailure(Exception e) {
-                    listener.onFailure(e);
-                }
-            }) {
+                            .ackTimeout(request.timeout()).masterNodeTimeout(request.masterNodeTimeout())
+                            .indices(concreteIndices).waitForActiveShards(request.waitForActiveShards());
+                    indexStateService.openIndex(updateRequest, delegate.delegateFailure((l, openIndexClusterStateUpdateResponse) ->
+                            l.onResponse(new FreezeResponse(openIndexClusterStateUpdateResponse.isAcknowledged(),
+                                    openIndexClusterStateUpdateResponse.isShardsAcknowledged()))));
+                })) {
             @Override
             public ClusterState execute(ClusterState currentState) {
                 final Metadata.Builder builder = Metadata.builder(currentState.metadata());

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/aggs/InferencePipelineAggregationBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/aggs/InferencePipelineAggregationBuilder.java
@@ -201,7 +201,7 @@ public class InferencePipelineAggregationBuilder extends AbstractPipelineAggrega
 
         SetOnce<LocalModel> loadedModel = new SetOnce<>();
         BiConsumer<Client, ActionListener<?>> modelLoadAction = (client, listener) ->
-            modelLoadingService.get().getModelForSearch(modelId, ActionListener.delegateFailure(listener, (delegate, model) -> {
+            modelLoadingService.get().getModelForSearch(modelId, listener.delegateFailure((delegate, model) -> {
                 loadedModel.set(model);
 
                 boolean isLicensed = licenseState.checkFeature(XPackLicenseState.Feature.MACHINE_LEARNING) ||

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/filter/SecurityActionFilter.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/filter/SecurityActionFilter.java
@@ -156,15 +156,12 @@ public class SecurityActionFilter implements ActionFilter {
                     if (authc != null) {
                         final String requestId = AuditUtil.extractRequestId(threadContext);
                         assert Strings.hasText(requestId);
-                        authorizeRequest(authc, securityAction, request, ActionListener.delegateFailure(listener,
-                                (ignore, aVoid) -> {
-                                    chain.proceed(task, action, request, ActionListener.delegateFailure(listener,
-                                            (ignore2, response) -> {
-                                                auditTrailService.get().coordinatingActionResponse(requestId, authc, action, request,
-                                                        response);
-                                                listener.onResponse(response);
-                                            }));
-                                }));
+                        authorizeRequest(authc, securityAction, request, listener.delegateFailure(
+                                (ll, aVoid) -> chain.proceed(task, action, request, ll.delegateFailure((l, response) -> {
+                                    auditTrailService.get().coordinatingActionResponse(requestId, authc, action, request,
+                                            response);
+                                    l.onResponse(response);
+                                }))));
                     } else if (licenseState.isSecurityEnabled() == false) {
                         listener.onResponse(null);
                     } else {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
@@ -394,11 +394,11 @@ public class ApiKeyService {
         final String docId = credentials.getId();
 
         Consumer<ApiKeyDoc> validator = apiKeyDoc ->
-            validateApiKeyCredentials(docId, apiKeyDoc, credentials, clock, ActionListener.delegateResponse(listener, (l, e) -> {
+            validateApiKeyCredentials(docId, apiKeyDoc, credentials, clock, listener.delegateResponse((l, e) -> {
                 if (ExceptionsHelper.unwrapCause(e) instanceof EsRejectedExecutionException) {
-                    listener.onResponse(AuthenticationResult.terminate("server is too busy to respond", e));
+                    l.onResponse(AuthenticationResult.terminate("server is too busy to respond", e));
                 } else {
-                    listener.onFailure(e);
+                    l.onFailure(e);
                 }
             }));
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/apikey/RestGrantApiKeyAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/apikey/RestGrantApiKeyAction.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.security.rest.action.apikey;
 
 import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.ExceptionsHelper;
-import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.ParseField;
@@ -24,6 +23,7 @@ import org.elasticsearch.rest.RestRequestFilter;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.core.security.action.CreateApiKeyRequestBuilder;
+import org.elasticsearch.xpack.core.security.action.CreateApiKeyResponse;
 import org.elasticsearch.xpack.core.security.action.GrantApiKeyAction;
 import org.elasticsearch.xpack.core.security.action.GrantApiKeyRequest;
 import org.elasticsearch.xpack.security.rest.action.SecurityBaseRestHandler;
@@ -86,7 +86,7 @@ public final class RestGrantApiKeyAction extends SecurityBaseRestHandler impleme
                 grantRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.parse(refresh));
             }
             return channel -> client.execute(GrantApiKeyAction.INSTANCE, grantRequest,
-                ActionListener.delegateResponse(new RestToXContentListener<>(channel), (listener, ex) -> {
+                new RestToXContentListener<CreateApiKeyResponse>(channel).delegateResponse((listener, ex) -> {
                     RestStatus status = ExceptionsHelper.status(ex);
                     if (status == RestStatus.UNAUTHORIZED) {
                         listener.onFailure(


### PR DESCRIPTION
This adds best effort `toString` rendering the various wrapping
action listeners to make `TRACE` logging, that will currently only print the
top level listener `toString` which isn't helpful to find the original of a listener
in case of wrapped listeners, more useful (e.g. when logging rejected executions).
Also this change makes the `delegateX` methods less verbose to use and makes use of them
in a few spots where they weren't yet used.

backport of #69103