### PR TITLE
Autoscaling: non-operator use of read-only APIs

### DIFF
--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
@@ -13,8 +13,8 @@ public class Constants {
 
     public static final Set<String> NON_OPERATOR_ACTIONS = Set.of(
         // "cluster:admin/autoscaling/delete_autoscaling_policy",
-         "cluster:admin/autoscaling/get_autoscaling_capacity",
-         "cluster:admin/autoscaling/get_autoscaling_policy",
+        "cluster:admin/autoscaling/get_autoscaling_capacity",
+        "cluster:admin/autoscaling/get_autoscaling_policy",
         // "cluster:admin/autoscaling/put_autoscaling_policy",
         "cluster:admin/component_template/delete",
         "cluster:admin/component_template/get",

--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
@@ -13,8 +13,8 @@ public class Constants {
 
     public static final Set<String> NON_OPERATOR_ACTIONS = Set.of(
         // "cluster:admin/autoscaling/delete_autoscaling_policy",
-        // "cluster:admin/autoscaling/get_autoscaling_capacity",
-        // "cluster:admin/autoscaling/get_autoscaling_policy",
+         "cluster:admin/autoscaling/get_autoscaling_capacity",
+         "cluster:admin/autoscaling/get_autoscaling_policy",
         // "cluster:admin/autoscaling/put_autoscaling_policy",
         "cluster:admin/component_template/delete",
         "cluster:admin/component_template/get",

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/operator/OperatorOnlyRegistry.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/operator/OperatorOnlyRegistry.java
@@ -32,8 +32,6 @@ public class OperatorOnlyRegistry {
         // Autoscaling does not publish its actions to core, literal strings are needed.
         "cluster:admin/autoscaling/put_autoscaling_policy",
         "cluster:admin/autoscaling/delete_autoscaling_policy",
-        "cluster:admin/autoscaling/get_autoscaling_policy",
-        "cluster:admin/autoscaling/get_autoscaling_capacity",
         // Repository analysis actions are not mentioned in core, literal strings are needed.
         "cluster:admin/repository/analyze",
         "cluster:admin/repository/analyze/blob",


### PR DESCRIPTION
The capacity API is generally useful as a debugging tool and should
therefore be available for non-operators too. Furthermore, to help
understand the setup from the Elasticsearch side, reading out the policy
definitions should also be available for non-operators.
