### PR TITLE
Add RateLimitingFiltering to plaintext deprecation logs backport(#69190)

### DIFF
--- a/distribution/src/config/log4j2.properties
+++ b/distribution/src/config/log4j2.properties
@@ -82,6 +82,7 @@ appender.deprecation_rolling_old.name = deprecation_rolling_old
 appender.deprecation_rolling_old.fileName = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_deprecation.log
 appender.deprecation_rolling_old.layout.type = PatternLayout
 appender.deprecation_rolling_old.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] [%node_name]%marker %m%n
+appender.deprecation_rolling_old.filter.rate_limit.type = RateLimitingFilter
 
 appender.deprecation_rolling_old.filePattern = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}\
   _deprecation-%i.log.gz

--- a/qa/logging-config/src/test/java/org/elasticsearch/common/logging/JsonLoggerTests.java
+++ b/qa/logging-config/src/test/java/org/elasticsearch/common/logging/JsonLoggerTests.java
@@ -28,6 +28,7 @@ import org.hamcrest.Matchers;
 import org.junit.BeforeClass;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -40,6 +41,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.core.IsEqual.equalTo;
 
 /**
  * This test confirms JSON log structure is properly formatted and can be parsed.
@@ -290,6 +292,9 @@ public class JsonLoggerTests extends ESTestCase {
                     )
                 );
             }
+
+            long oldStyleDeprecationLogCount = oldStyleDeprecationLogCount();
+            assertThat(oldStyleDeprecationLogCount, equalTo(1L));
         });
 
         // For the same key and different X-Opaque-ID should be multiple times per key/x-opaque-id
@@ -330,8 +335,18 @@ public class JsonLoggerTests extends ESTestCase {
                         )
                     )
                 );
+
+                long oldStyleDeprecationLogCount = oldStyleDeprecationLogCount();
+                assertThat(oldStyleDeprecationLogCount, equalTo(2L));
             }
         });
+    }
+
+    private long oldStyleDeprecationLogCount() throws IOException {
+        try(Stream<String> lines = Files.lines(PathUtils.get(System.getProperty("es.logs.base_path"),
+            System.getProperty("es.logs.cluster_name") + "_deprecated.log"))){
+            return lines.count();
+        }
     }
 
     private List<JsonLogLine> collectLines(Stream<JsonLogLine> stream) {

--- a/qa/logging-config/src/test/resources/org/elasticsearch/common/logging/json_layout/log4j2.properties
+++ b/qa/logging-config/src/test/resources/org/elasticsearch/common/logging/json_layout/log4j2.properties
@@ -17,6 +17,13 @@ appender.deprecated.layout.type_name = deprecation
 appender.deprecated.layout.esmessagefields = x-opaque-id
 appender.deprecated.filter.rate_limit.type = RateLimitingFilter
 
+appender.deprecation_rolling_old.type = File
+appender.deprecation_rolling_old.name = deprecation_rolling_old
+appender.deprecation_rolling_old.fileName = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_deprecated.log
+appender.deprecation_rolling_old.layout.type = PatternLayout
+appender.deprecation_rolling_old.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] [%node_name]%marker %m%n
+appender.deprecation_rolling_old.filter.rate_limit.type = RateLimitingFilter
+
 appender.deprecatedconsole.type = Console
 appender.deprecatedconsole.name = deprecatedconsole
 appender.deprecatedconsole.layout.type = ESJsonLayout
@@ -44,6 +51,7 @@ logger.deprecation.level = deprecation
 logger.deprecation.appenderRef.console.ref = console
 logger.deprecation.appenderRef.file.ref = file
 logger.deprecation.appenderRef.deprecation_rolling.ref = deprecated
+logger.deprecation.appenderRef.deprecation_rolling_old.ref = deprecation_rolling_old
 logger.deprecation.appenderRef.deprecatedconsole.ref = deprecatedconsole
 logger.deprecation.appenderRef.header_warning.ref = header_warning
 logger.deprecation.additivity = false


### PR DESCRIPTION
The #61474 changed the way we throttle deprecation logs, but missed a
filter to plaintext deprecation logs

closes #69188
backport(#69190)
