### PR TITLE
Always read footer checksum from FileInfo

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/BaseSearchableSnapshotIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/BaseSearchableSnapshotIndexInput.java
@@ -95,11 +95,11 @@ public abstract class BaseSearchableSnapshotIndexInput extends BufferedIndexInpu
      */
     private boolean maybeReadChecksumFromFileInfo(ByteBuffer b) throws IOException {
         final int remaining = b.remaining();
-        if (remaining != CodecUtil.footerLength()) {
+        if (remaining > CodecUtil.footerLength()) {
             return false;
         }
         final long position = getFilePointer() + this.offset;
-        if (position != fileInfo.length() - CodecUtil.footerLength()) {
+        if (position < fileInfo.length() - CodecUtil.footerLength()) {
             return false;
         }
         if (isClone) {
@@ -107,7 +107,8 @@ public abstract class BaseSearchableSnapshotIndexInput extends BufferedIndexInpu
         }
         boolean success = false;
         try {
-            b.put(checksumToBytesArray(fileInfo.checksum()));
+            final byte[] checksum = checksumToBytesArray(fileInfo.checksum());
+            b.put(checksum, CodecUtil.footerLength() - remaining, remaining);
             success = true;
         } catch (NumberFormatException e) {
             // tests disable this optimisation by passing an invalid checksum


### PR DESCRIPTION
Searchable snapshots IndexInput implementations detect 
read operations that are executed on the last 16 bytes of 
files which contain the footer checksum, and then serves 
them from memory (FileInfo) instead of relying on cache 
mechanisms.

But the current implementation expect an exact checksum 
read: ie a read operation that starts at file length - 16 bytes 
and expects to read exactly 16 bytes. This is not always the 
case as IndexInput implementations extend 
BufferedIndexInput which uses an internal buffer of 1024 
bytes: in some case the remaining length (ie, the last portion 
of the file) might be less than 16 bytes long and thus a very 
small read is engaged using cache (or direct) read where it 
could instead be also served from memory.

Backport of #69415