### PR TITLE
Rework RuntimeFieldType (#69365)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/RuntimeFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RuntimeFieldType.java
@@ -8,22 +8,46 @@
 
 package org.elasticsearch.index.mapper;
 
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.search.MultiTermQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.spans.SpanMultiTermQueryWrapper;
+import org.apache.lucene.search.spans.SpanQuery;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.CheckedBiConsumer;
+import org.elasticsearch.common.geo.ShapeRelation;
+import org.elasticsearch.common.time.DateMathParser;
+import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.query.SearchExecutionContext;
 
 import java.io.IOException;
+import java.time.ZoneId;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.function.BiFunction;
+
+import static org.elasticsearch.search.SearchService.ALLOW_EXPENSIVE_QUERIES;
 
 /**
  * Base implementation for a runtime field that can be defined as part of the runtime section of the index mappings
  */
 public abstract class RuntimeFieldType extends MappedFieldType implements ToXContentFragment {
 
-    protected RuntimeFieldType(String name, Map<String, String> meta) {
+    private final CheckedBiConsumer<XContentBuilder, Boolean, IOException> toXContent;
+
+    protected RuntimeFieldType(String name, RuntimeFieldType.Builder builder) {
+        this(name, builder.meta(), builder::toXContent);
+    }
+
+    protected RuntimeFieldType(String name, Map<String, String> meta, CheckedBiConsumer<XContentBuilder, Boolean, IOException> toXContent) {
         super(name, false, false, false, TextSearchInfo.SIMPLE_MATCH_WITHOUT_TERMS, meta);
+        this.toXContent = toXContent;
     }
 
     @Override
@@ -39,15 +63,194 @@ public abstract class RuntimeFieldType extends MappedFieldType implements ToXCon
     /**
      * Prints out the parameters that subclasses expose
      */
-    protected abstract void doXContentBody(XContentBuilder builder, boolean includeDefaults) throws IOException;
+    final void doXContentBody(XContentBuilder builder, boolean includeDefaults) throws IOException {
+        toXContent.accept(builder, includeDefaults);
+    }
+
+    @Override
+    public final boolean isSearchable() {
+        return true;
+    }
+
+    @Override
+    public final boolean isAggregatable() {
+        return true;
+    }
+
+    @Override
+    public final Query rangeQuery(
+        Object lowerTerm,
+        Object upperTerm,
+        boolean includeLower,
+        boolean includeUpper,
+        ShapeRelation relation,
+        ZoneId timeZone,
+        DateMathParser parser,
+        SearchExecutionContext context
+    ) {
+        if (relation == ShapeRelation.DISJOINT) {
+            String message = "Runtime field [%s] of type [%s] does not support DISJOINT ranges";
+            throw new IllegalArgumentException(String.format(Locale.ROOT, message, name(), typeName()));
+        }
+        return rangeQuery(lowerTerm, upperTerm, includeLower, includeUpper, timeZone, parser, context);
+    }
+
+    protected abstract Query rangeQuery(
+        Object lowerTerm,
+        Object upperTerm,
+        boolean includeLower,
+        boolean includeUpper,
+        ZoneId timeZone,
+        DateMathParser parser,
+        SearchExecutionContext context
+    );
+
+    @Override
+    public Query fuzzyQuery(
+        Object value,
+        Fuzziness fuzziness,
+        int prefixLength,
+        int maxExpansions,
+        boolean transpositions,
+        SearchExecutionContext context
+    ) {
+        throw new IllegalArgumentException(unsupported("fuzzy", "keyword and text"));
+    }
+
+    @Override
+    public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive, SearchExecutionContext context) {
+        throw new IllegalArgumentException(unsupported("prefix", "keyword, text and wildcard"));
+    }
+
+    @Override
+    public Query wildcardQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive, SearchExecutionContext context) {
+        throw new IllegalArgumentException(unsupported("wildcard", "keyword, text and wildcard"));
+    }
+
+    @Override
+    public Query regexpQuery(
+        String value,
+        int syntaxFlags,
+        int matchFlags,
+        int maxDeterminizedStates,
+        MultiTermQuery.RewriteMethod method,
+        SearchExecutionContext context
+    ) {
+        throw new IllegalArgumentException(unsupported("regexp", "keyword and text"));
+    }
+
+    @Override
+    public Query phraseQuery(TokenStream stream, int slop, boolean enablePositionIncrements) {
+        throw new IllegalArgumentException(unsupported("phrase", "text"));
+    }
+
+    @Override
+    public Query multiPhraseQuery(TokenStream stream, int slop, boolean enablePositionIncrements) {
+        throw new IllegalArgumentException(unsupported("phrase", "text"));
+    }
+
+    @Override
+    public Query phrasePrefixQuery(TokenStream stream, int slop, int maxExpansions) {
+        throw new IllegalArgumentException(unsupported("phrase prefix", "text"));
+    }
+
+    @Override
+    public SpanQuery spanPrefixQuery(String value, SpanMultiTermQueryWrapper.SpanRewriteMethod method, SearchExecutionContext context) {
+        throw new IllegalArgumentException(unsupported("span prefix", "text"));
+    }
+
+    private String unsupported(String query, String supported) {
+        return String.format(
+            Locale.ROOT,
+            "Can only use %s queries on %s fields - not on [%s] which is a runtime field of type [%s]",
+            query,
+            supported,
+            name(),
+            typeName()
+        );
+    }
+
+    protected final void checkAllowExpensiveQueries(SearchExecutionContext context) {
+        if (context.allowExpensiveQueries() == false) {
+            throw new ElasticsearchException(
+                "queries cannot be executed against runtime fields while [" + ALLOW_EXPENSIVE_QUERIES.getKey() + "] is set to [false]."
+            );
+        }
+    }
+
+    @Override
+    public final ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
+        return new DocValueFetcher(docValueFormat(format, null), context.getForField(this));
+    }
+
+    /**
+     *  For runtime fields the {@link RuntimeFieldType.Parser} returns directly the {@link MappedFieldType}.
+     *  Internally we still create a {@link RuntimeFieldType.Builder} so we reuse the {@link FieldMapper.Parameter} infrastructure,
+     *  but {@link RuntimeFieldType.Builder#init(FieldMapper)} and {@link RuntimeFieldType.Builder#build(ContentPath)} are never called as
+     *  {@link RuntimeFieldType.Parser#parse(String, Map, Mapper.TypeParser.ParserContext)} calls
+     *  {@link RuntimeFieldType.Builder#parse(String, Mapper.TypeParser.ParserContext, Map)} and returns the corresponding
+     *  {@link MappedFieldType}.
+     */
+    public abstract static class Builder extends FieldMapper.Builder {
+        final FieldMapper.Parameter<Map<String, String>> meta = FieldMapper.Parameter.metaParam();
+
+        protected Builder(String name) {
+            super(name);
+        }
+
+        public Map<String, String> meta() {
+            return meta.getValue();
+        }
+
+        @Override
+        protected List<FieldMapper.Parameter<?>> getParameters() {
+            return Collections.singletonList(meta);
+        }
+
+        @Override
+        public FieldMapper.Builder init(FieldMapper initializer) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public final FieldMapper build(ContentPath context) {
+            throw new UnsupportedOperationException();
+        }
+
+        protected abstract RuntimeFieldType buildFieldType();
+
+        private void validate() {
+            ContentPath contentPath = parentPath(name());
+            FieldMapper.MultiFields multiFields = multiFieldsBuilder.build(this, contentPath);
+            if (multiFields.iterator().hasNext()) {
+                throw new IllegalArgumentException("runtime field [" + name + "] does not support [fields]");
+            }
+            FieldMapper.CopyTo copyTo = this.copyTo.build();
+            if (copyTo.copyToFields().isEmpty() == false) {
+                throw new IllegalArgumentException("runtime field [" + name + "] does not support [copy_to]");
+            }
+        }
+    }
 
     /**
      * Parser for a runtime field. Creates the appropriate {@link RuntimeFieldType} for a runtime field,
      * as defined in the runtime section of the index mappings.
      */
-    public interface Parser {
+    public static final class Parser {
+        private final BiFunction<String, Mapper.TypeParser.ParserContext, RuntimeFieldType.Builder> builderFunction;
+
+        public Parser(BiFunction<String, Mapper.TypeParser.ParserContext, RuntimeFieldType.Builder> builderFunction) {
+            this.builderFunction = builderFunction;
+        }
+
         RuntimeFieldType parse(String name, Map<String, Object> node, Mapper.TypeParser.ParserContext parserContext)
-            throws MapperParsingException;
+            throws MapperParsingException {
+
+            RuntimeFieldType.Builder builder = builderFunction.apply(name, parserContext);
+            builder.parse(name, parserContext, node);
+            builder.validate();
+            return builder.buildFieldType();
+        }
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/runtimefields/mapper/AbstractScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/runtimefields/mapper/AbstractScriptFieldType.java
@@ -8,51 +8,36 @@
 
 package org.elasticsearch.runtimefields.mapper;
 
-import org.apache.lucene.analysis.TokenStream;
-import org.apache.lucene.search.MultiTermQuery;
-import org.apache.lucene.search.Query;
-import org.apache.lucene.search.spans.SpanMultiTermQueryWrapper;
-import org.apache.lucene.search.spans.SpanQuery;
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.CheckedBiConsumer;
 import org.elasticsearch.common.TriFunction;
-import org.elasticsearch.common.geo.ShapeRelation;
-import org.elasticsearch.common.time.DateMathParser;
-import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.mapper.ContentPath;
-import org.elasticsearch.index.mapper.DocValueFetcher;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
-import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.RuntimeFieldType;
-import org.elasticsearch.index.mapper.ValueFetcher;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.io.IOException;
-import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 
-import static org.elasticsearch.search.SearchService.ALLOW_EXPENSIVE_QUERIES;
-
 /**
- * Abstract base {@linkplain MappedFieldType} for scripted fields.
+ * Abstract base {@linkplain MappedFieldType} for runtime fields based on a script.
  */
 abstract class AbstractScriptFieldType<LeafFactory> extends RuntimeFieldType {
     protected final Script script;
     private final TriFunction<String, Map<String, Object>, SearchLookup, LeafFactory> factory;
-    private final CheckedBiConsumer<XContentBuilder, Boolean, IOException> toXContent;
 
     AbstractScriptFieldType(String name, TriFunction<String, Map<String, Object>, SearchLookup, LeafFactory> factory, Builder builder) {
-        this(name, factory, builder.getScript(), builder.meta.getValue(), builder::toXContent);
+        super(name, builder);
+        this.factory = factory;
+        this.script = builder.getScript();
     }
 
     AbstractScriptFieldType(
@@ -62,20 +47,9 @@ abstract class AbstractScriptFieldType<LeafFactory> extends RuntimeFieldType {
         Map<String, String> meta,
         CheckedBiConsumer<XContentBuilder, Boolean, IOException> toXContent
     ) {
-        super(name, meta);
+        super(name, meta, toXContent);
         this.factory = factory;
         this.script = script;
-        this.toXContent = toXContent;
-    }
-
-    @Override
-    public final boolean isSearchable() {
-        return true;
-    }
-
-    @Override
-    public final boolean isAggregatable() {
-        return true;
     }
 
     /**
@@ -97,131 +71,11 @@ abstract class AbstractScriptFieldType<LeafFactory> extends RuntimeFieldType {
         return leafFactory(context.lookup().forkAndTrackFieldReferences(name()));
     }
 
-    @Override
-    public final Query rangeQuery(
-        Object lowerTerm,
-        Object upperTerm,
-        boolean includeLower,
-        boolean includeUpper,
-        ShapeRelation relation,
-        ZoneId timeZone,
-        DateMathParser parser,
-        SearchExecutionContext context
-    ) {
-        if (relation == ShapeRelation.DISJOINT) {
-            String message = "Runtime field [%s] of type [%s] does not support DISJOINT ranges";
-            throw new IllegalArgumentException(String.format(Locale.ROOT, message, name(), typeName()));
-        }
-        return rangeQuery(lowerTerm, upperTerm, includeLower, includeUpper, timeZone, parser, context);
-    }
-
-    protected abstract Query rangeQuery(
-        Object lowerTerm,
-        Object upperTerm,
-        boolean includeLower,
-        boolean includeUpper,
-        ZoneId timeZone,
-        DateMathParser parser,
-        SearchExecutionContext context
-    );
-
-    @Override
-    public Query fuzzyQuery(
-        Object value,
-        Fuzziness fuzziness,
-        int prefixLength,
-        int maxExpansions,
-        boolean transpositions,
-        SearchExecutionContext context
-    ) {
-        throw new IllegalArgumentException(unsupported("fuzzy", "keyword and text"));
-    }
-
-    @Override
-    public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive, SearchExecutionContext context) {
-        throw new IllegalArgumentException(unsupported("prefix", "keyword, text and wildcard"));
-    }
-
-    @Override
-    public Query wildcardQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive, SearchExecutionContext context) {
-        throw new IllegalArgumentException(unsupported("wildcard", "keyword, text and wildcard"));
-    }
-
-    @Override
-    public Query regexpQuery(
-        String value,
-        int syntaxFlags,
-        int matchFlags,
-        int maxDeterminizedStates,
-        MultiTermQuery.RewriteMethod method,
-        SearchExecutionContext context
-    ) {
-        throw new IllegalArgumentException(unsupported("regexp", "keyword and text"));
-    }
-
-    @Override
-    public Query phraseQuery(TokenStream stream, int slop, boolean enablePositionIncrements) {
-        throw new IllegalArgumentException(unsupported("phrase", "text"));
-    }
-
-    @Override
-    public Query multiPhraseQuery(TokenStream stream, int slop, boolean enablePositionIncrements) {
-        throw new IllegalArgumentException(unsupported("phrase", "text"));
-    }
-
-    @Override
-    public Query phrasePrefixQuery(TokenStream stream, int slop, int maxExpansions) {
-        throw new IllegalArgumentException(unsupported("phrase prefix", "text"));
-    }
-
-    @Override
-    public SpanQuery spanPrefixQuery(String value, SpanMultiTermQueryWrapper.SpanRewriteMethod method, SearchExecutionContext context) {
-        throw new IllegalArgumentException(unsupported("span prefix", "text"));
-    }
-
-    private String unsupported(String query, String supported) {
-        return String.format(
-            Locale.ROOT,
-            "Can only use %s queries on %s fields - not on [%s] which is a runtime field of type [%s]",
-            query,
-            supported,
-            name(),
-            typeName()
-        );
-    }
-
-    protected final void checkAllowExpensiveQueries(SearchExecutionContext context) {
-        if (context.allowExpensiveQueries() == false) {
-            throw new ElasticsearchException(
-                "queries cannot be executed against runtime fields while [" + ALLOW_EXPENSIVE_QUERIES.getKey() + "] is set to [false]."
-            );
-        }
-    }
-
-    @Override
-    public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
-        return new DocValueFetcher(docValueFormat(format, null), context.getForField(this));
-    }
-
-    @Override
-    protected final void doXContentBody(XContentBuilder builder, boolean includeDefaults) throws IOException {
-        toXContent.accept(builder, includeDefaults);
-    }
-
     // Placeholder Script for source-only fields
     // TODO rework things so that we don't need this
     private static final Script DEFAULT_SCRIPT = new Script("");
 
-    /**
-     *  For runtime fields the {@link RuntimeFieldType.Parser} returns directly the {@link MappedFieldType}.
-     *  Internally we still create a {@link Builder} so we reuse the {@link FieldMapper.Parameter} infrastructure,
-     *  but {@link Builder#init(FieldMapper)} and {@link Builder#build(ContentPath)} are never called as
-     *  {@link RuntimeFieldTypeParser#parse(String, Map, Mapper.TypeParser.ParserContext)} calls
-     *  {@link Builder#parse(String, Mapper.TypeParser.ParserContext, Map)} and returns the corresponding
-     *  {@link MappedFieldType}.
-     */
-    abstract static class Builder extends FieldMapper.Builder {
-        final FieldMapper.Parameter<Map<String, String>> meta = FieldMapper.Parameter.metaParam();
+    abstract static class Builder extends RuntimeFieldType.Builder {
         final FieldMapper.Parameter<Script> script = new FieldMapper.Parameter<>(
             "script",
             true,
@@ -236,38 +90,16 @@ abstract class AbstractScriptFieldType<LeafFactory> extends RuntimeFieldType {
 
         @Override
         protected List<FieldMapper.Parameter<?>> getParameters() {
-            return org.elasticsearch.common.collect.List.of(meta, script);
+            List<FieldMapper.Parameter<?>> parameters = new ArrayList<>(super.getParameters());
+            parameters.add(script);
+            return Collections.unmodifiableList(parameters);
         }
-
-        protected abstract AbstractScriptFieldType<?> buildFieldType();
 
         protected final Script getScript() {
             if (script.get() == null) {
                 return DEFAULT_SCRIPT;
             }
             return script.get();
-        }
-
-        @Override
-        public FieldMapper.Builder init(FieldMapper initializer) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public FieldMapper build(ContentPath context) {
-            throw new UnsupportedOperationException();
-        }
-
-        private void validate() {
-            ContentPath contentPath = parentPath(name());
-            FieldMapper.MultiFields multiFields = multiFieldsBuilder.build(this, contentPath);
-            if (multiFields.iterator().hasNext()) {
-                throw new IllegalArgumentException("runtime field [" + name + "] does not support [fields]");
-            }
-            FieldMapper.CopyTo copyTo = this.copyTo.build();
-            if (copyTo.copyToFields().isEmpty() == false) {
-                throw new IllegalArgumentException("runtime field [" + name + "] does not support [copy_to]");
-            }
         }
 
         private static Script parseScript(String name, Mapper.TypeParser.ParserContext parserContext, Object scriptObject) {
@@ -281,23 +113,5 @@ abstract class AbstractScriptFieldType<LeafFactory> extends RuntimeFieldType {
 
     static <T> Function<FieldMapper, T> initializerNotSupported() {
         return mapper -> { throw new UnsupportedOperationException(); };
-    }
-
-    static final class RuntimeFieldTypeParser implements RuntimeFieldType.Parser {
-        private final BiFunction<String, Mapper.TypeParser.ParserContext, Builder> builderFunction;
-
-        RuntimeFieldTypeParser(BiFunction<String, Mapper.TypeParser.ParserContext, Builder> builderFunction) {
-            this.builderFunction = builderFunction;
-        }
-
-        @Override
-        public RuntimeFieldType parse(String name, Map<String, Object> node, Mapper.TypeParser.ParserContext parserContext)
-            throws MapperParsingException {
-
-            Builder builder = builderFunction.apply(name, parserContext);
-            builder.parse(name, parserContext, node);
-            builder.validate();
-            return builder.buildFieldType();
-        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/runtimefields/mapper/BooleanScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/runtimefields/mapper/BooleanScriptFieldType.java
@@ -36,7 +36,7 @@ import java.util.function.Supplier;
 
 public final class BooleanScriptFieldType extends AbstractScriptFieldType<BooleanFieldScript.LeafFactory> {
 
-    public static final RuntimeFieldType.Parser PARSER = new RuntimeFieldTypeParser((name, parserContext) -> new Builder(name) {
+    public static final RuntimeFieldType.Parser PARSER = new RuntimeFieldType.Parser((name, parserContext) -> new Builder(name) {
         @Override
         protected AbstractScriptFieldType<?> buildFieldType() {
             if (script.get() == null) {

--- a/server/src/main/java/org/elasticsearch/runtimefields/mapper/DateScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/runtimefields/mapper/DateScriptFieldType.java
@@ -48,7 +48,7 @@ import java.util.function.Supplier;
 
 public class DateScriptFieldType extends AbstractScriptFieldType<DateFieldScript.LeafFactory> {
 
-    public static final RuntimeFieldType.Parser PARSER = new RuntimeFieldTypeParser((name, parserContext) -> new Builder(name) {
+    public static final RuntimeFieldType.Parser PARSER = new RuntimeFieldType.Parser((name, parserContext) -> new Builder(name) {
         private final FieldMapper.Parameter<String> format = FieldMapper.Parameter.stringParam(
             "format",
             true,

--- a/server/src/main/java/org/elasticsearch/runtimefields/mapper/DoubleScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/runtimefields/mapper/DoubleScriptFieldType.java
@@ -36,7 +36,7 @@ import java.util.function.Supplier;
 
 public final class DoubleScriptFieldType extends AbstractScriptFieldType<DoubleFieldScript.LeafFactory> {
 
-    public static final RuntimeFieldType.Parser PARSER = new RuntimeFieldTypeParser((name, parserContext) -> new Builder(name) {
+    public static final RuntimeFieldType.Parser PARSER = new RuntimeFieldType.Parser((name, parserContext) -> new Builder(name) {
         @Override
         protected AbstractScriptFieldType<?> buildFieldType() {
             if (script.get() == null) {

--- a/server/src/main/java/org/elasticsearch/runtimefields/mapper/GeoPointScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/runtimefields/mapper/GeoPointScriptFieldType.java
@@ -40,7 +40,7 @@ import java.util.function.Supplier;
 
 public final class GeoPointScriptFieldType extends AbstractScriptFieldType<GeoPointFieldScript.LeafFactory> implements GeoShapeQueryable {
 
-    public static final RuntimeFieldType.Parser PARSER = new RuntimeFieldTypeParser((name, parserContext) -> new Builder(name) {
+    public static final RuntimeFieldType.Parser PARSER = new RuntimeFieldType.Parser((name, parserContext) -> new Builder(name) {
         @Override
         protected AbstractScriptFieldType<?> buildFieldType() {
             if (script.get() == null) {

--- a/server/src/main/java/org/elasticsearch/runtimefields/mapper/IpScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/runtimefields/mapper/IpScriptFieldType.java
@@ -45,7 +45,7 @@ import java.util.function.Supplier;
 
 public final class IpScriptFieldType extends AbstractScriptFieldType<IpFieldScript.LeafFactory> {
 
-    public static final RuntimeFieldType.Parser PARSER = new RuntimeFieldTypeParser((name, parserContext) -> new Builder(name) {
+    public static final RuntimeFieldType.Parser PARSER = new RuntimeFieldType.Parser((name, parserContext) -> new Builder(name) {
         @Override
         protected AbstractScriptFieldType<?> buildFieldType() {
             if (script.get() == null) {

--- a/server/src/main/java/org/elasticsearch/runtimefields/mapper/KeywordScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/runtimefields/mapper/KeywordScriptFieldType.java
@@ -44,7 +44,7 @@ import static java.util.stream.Collectors.toSet;
 
 public final class KeywordScriptFieldType extends AbstractScriptFieldType<StringFieldScript.LeafFactory> {
 
-    public static final RuntimeFieldType.Parser PARSER = new RuntimeFieldTypeParser((name, parserContext) -> new Builder(name) {
+    public static final RuntimeFieldType.Parser PARSER = new RuntimeFieldType.Parser((name, parserContext) -> new Builder(name) {
         @Override
         protected AbstractScriptFieldType<?> buildFieldType() {
             if (script.get() == null) {

--- a/server/src/main/java/org/elasticsearch/runtimefields/mapper/LongScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/runtimefields/mapper/LongScriptFieldType.java
@@ -36,7 +36,7 @@ import java.util.function.Supplier;
 
 public final class LongScriptFieldType extends AbstractScriptFieldType<LongFieldScript.LeafFactory> {
 
-    public static final RuntimeFieldType.Parser PARSER = new RuntimeFieldTypeParser((name, parserContext) -> new Builder(name) {
+    public static final RuntimeFieldType.Parser PARSER = new RuntimeFieldType.Parser((name, parserContext) -> new Builder(name) {
         @Override
         protected AbstractScriptFieldType<?> buildFieldType() {
             if (script.get() == null) {

--- a/server/src/test/java/org/elasticsearch/index/IndexSortSettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexSortSettingsTests.java
@@ -10,12 +10,11 @@ package org.elasticsearch.index;
 
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.time.DateMathParser;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldDataService;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.RuntimeFieldType;
-import org.elasticsearch.index.mapper.ValueFetcher;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.indices.fielddata.cache.IndicesFieldDataCache;
@@ -24,6 +23,7 @@ import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.test.ESTestCase;
 
+import java.time.ZoneId;
 import java.util.Collections;
 import java.util.function.Supplier;
 
@@ -141,9 +141,10 @@ public class IndexSortSettingsTests extends ESTestCase {
         IndicesFieldDataCache cache = new IndicesFieldDataCache(Settings.EMPTY, null);
         NoneCircuitBreakerService circuitBreakerService = new NoneCircuitBreakerService();
         final IndexFieldDataService indexFieldDataService = new IndexFieldDataService(indexSettings, cache, circuitBreakerService, null);
-        MappedFieldType fieldType = new RuntimeFieldType("field", Collections.emptyMap()) {
+        MappedFieldType fieldType = new RuntimeFieldType("field", Collections.emptyMap(), null) {
             @Override
-            public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
+            protected Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, ZoneId timeZone,
+                                       DateMathParser parser, SearchExecutionContext context) {
                 throw new UnsupportedOperationException();
             }
 
@@ -160,11 +161,6 @@ public class IndexSortSettingsTests extends ESTestCase {
 
             @Override
             public Query termQuery(Object value, SearchExecutionContext context) {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            protected void doXContentBody(XContentBuilder builder, boolean includeDefaults) {
                 throw new UnsupportedOperationException();
             }
         };

--- a/server/src/test/java/org/elasticsearch/index/mapper/TestRuntimeField.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TestRuntimeField.java
@@ -9,10 +9,10 @@
 package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.search.Query;
-import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.time.DateMathParser;
 import org.elasticsearch.index.query.SearchExecutionContext;
 
-import java.io.IOException;
+import java.time.ZoneId;
 import java.util.Collections;
 
 public class TestRuntimeField extends RuntimeFieldType {
@@ -20,17 +20,8 @@ public class TestRuntimeField extends RuntimeFieldType {
     private final String type;
 
     public TestRuntimeField(String name, String type) {
-        super(name, Collections.emptyMap());
+        super(name, Collections.emptyMap(), null);
         this.type = type;
-    }
-
-    @Override
-    protected void doXContentBody(XContentBuilder builder, boolean includeDefaults) throws IOException {
-    }
-
-    @Override
-    public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
-        return null;
     }
 
     @Override
@@ -41,5 +32,11 @@ public class TestRuntimeField extends RuntimeFieldType {
     @Override
     public Query termQuery(Object value, SearchExecutionContext context) {
         return null;
+    }
+
+    @Override
+    protected Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper,
+                               ZoneId timeZone, DateMathParser parser, SearchExecutionContext context) {
+        throw new UnsupportedOperationException();
     }
 }

--- a/server/src/test/java/org/elasticsearch/indices/IndicesModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndicesModuleTests.java
@@ -188,7 +188,7 @@ public class IndicesModuleTests extends ESTestCase {
         MapperPlugin plugin = new MapperPlugin() {
             @Override
             public Map<String, RuntimeFieldType.Parser> getRuntimeFieldTypes() {
-                return Collections.singletonMap("test", (name, node, parserContext) -> null);
+                return Collections.singletonMap("test", new RuntimeFieldType.Parser((s, parserContext) -> null));
             }
         };
         List<MapperPlugin> plugins = Arrays.asList(plugin, plugin);
@@ -201,7 +201,7 @@ public class IndicesModuleTests extends ESTestCase {
         MapperPlugin plugin = new MapperPlugin() {
             @Override
             public Map<String, RuntimeFieldType.Parser> getRuntimeFieldTypes() {
-                return Collections.singletonMap(KeywordFieldMapper.CONTENT_TYPE, (name, node, parserContext) -> null);
+                return Collections.singletonMap(KeywordFieldMapper.CONTENT_TYPE, new RuntimeFieldType.Parser((s, parserContext) -> null));
             }
         };
         List<MapperPlugin> plugins = Collections.singletonList(plugin);


### PR DESCRIPTION
RuntimeFieldType is currently light and most of its concrete implementation is in AbstractScriptFieldType. Now that they both live in the same module, some members that don't have to do with scripting can be pushed to the base class RuntimeFieldType for other implementors to use.
