### PR TITLE
[master] [DOCS] Use consistent @timestamp field name (#69435)

### DIFF
--- a/docs/painless/painless-guide/painless-runtime-fields.asciidoc
+++ b/docs/painless/painless-guide/painless-runtime-fields.asciidoc
@@ -26,7 +26,7 @@ Add a `runtime` section under the {ref}/runtime-mapping-fields.html[mapping defi
 
 The script in the following request extracts the day of the week from the
 `@timestamp` field, which is defined as a `date` type. The script calculates
-the day of the week based on the value of `timestamp`, and uses `emit` to
+the day of the week based on the value of `@timestamp`, and uses `emit` to
 return the calculated value.
 
 [source,console]
@@ -45,7 +45,7 @@ PUT my-index/
       }
     },
     "properties": {
-      "timestamp": {"type": "date"}
+      "@timestamp": {"type": "date"}
     }
   }
 }

--- a/docs/reference/mapping/runtime.asciidoc
+++ b/docs/reference/mapping/runtime.asciidoc
@@ -83,7 +83,7 @@ When defining a Painless script to use with runtime fields, you must include
 `emit` to emit calculated values. For example, the script in the following
 request extracts the day of the week from the `@timestamp` field, which is
 defined as a `date` type. The script calculates the day of the week based on
-the value of `timestamp`, and uses `emit` to return the calculated value.
+the value of `@timestamp`, and uses `emit` to return the calculated value.
 
 [source,console]
 ----
@@ -99,7 +99,7 @@ PUT my-index/
       }
     },
     "properties": {
-      "timestamp": {"type": "date"}
+      "@timestamp": {"type": "date"}
     }
   }
 }
@@ -131,7 +131,7 @@ PUT my-index
   "mappings": {
     "dynamic": "runtime",
     "properties": {
-      "timestamp": {
+      "@timestamp": {
         "type": "date"
       }
     }
@@ -254,17 +254,17 @@ For example, let's say you indexed the following documents into `my-index`:
 ----
 POST my-index/_bulk?refresh=true
 {"index":{}}
-{"timestamp":1516729294000,"model_number":"QVKC92Q","measures":{"voltage":5.2}}
+{"@timestamp":1516729294000,"model_number":"QVKC92Q","measures":{"voltage":5.2}}
 {"index":{}}
-{"timestamp":1516642894000,"model_number":"QVKC92Q","measures":{"voltage":5.8}}
+{"@timestamp":1516642894000,"model_number":"QVKC92Q","measures":{"voltage":5.8}}
 {"index":{}}
-{"timestamp":1516556494000,"model_number":"QVKC92Q","measures":{"voltage":5.1}}
+{"@timestamp":1516556494000,"model_number":"QVKC92Q","measures":{"voltage":5.1}}
 {"index":{}}
-{"timestamp":1516470094000,"model_number":"QVKC92Q","measures":{"voltage":5.6}}
+{"@timestamp":1516470094000,"model_number":"QVKC92Q","measures":{"voltage":5.6}}
 {"index":{}}
-{"timestamp":1516383694000,"model_number":"HG537PU","measures":{"voltage":4.2}}
+{"@timestamp":1516383694000,"model_number":"HG537PU","measures":{"voltage":4.2}}
 {"index":{}}
-{"timestamp":1516297294000,"model_number":"HG537PU","measures":{"voltage":4.0}}
+{"@timestamp":1516297294000,"model_number":"HG537PU","measures":{"voltage":4.0}}
 ----
 
 You later realize that the `HG537PU` sensors aren't reporting their true
@@ -307,7 +307,7 @@ The response includes indexed values for documents matching model number
         "_id" : "F1BeSXYBg_szTodcYCmk",
         "_score" : 1.0296195,
         "_source" : {
-          "timestamp" : 1516383694000,
+          "@timestamp" : 1516383694000,
           "model_number" : "HG537PU",
           "measures" : {
             "voltage" : 4.2
@@ -319,7 +319,7 @@ The response includes indexed values for documents matching model number
         "_id" : "l02aSXYBkpNf6QRDO62Q",
         "_score" : 1.0296195,
         "_source" : {
-          "timestamp" : 1516297294000,
+          "@timestamp" : 1516297294000,
           "model_number" : "HG537PU",
           "measures" : {
             "voltage" : 4.0
@@ -388,7 +388,7 @@ which still returns in the response:
         "_id" : "F1BeSXYBg_szTodcYCmk",
         "_score" : 1.0296195,
         "_source" : {
-          "timestamp" : 1516383694000,
+          "@timestamp" : 1516383694000,
           "model_number" : "HG537PU",
           "measures" : {
             "voltage" : 4.2
@@ -405,7 +405,7 @@ which still returns in the response:
         "_id" : "l02aSXYBkpNf6QRDO62Q",
         "_score" : 1.0296195,
         "_source" : {
-          "timestamp" : 1516297294000,
+          "@timestamp" : 1516297294000,
           "model_number" : "HG537PU",
           "measures" : {
             "voltage" : 4.0
@@ -456,7 +456,7 @@ PUT my-index/
       }
     },
     "properties": {
-      "timestamp": {"type": "date"}
+      "@timestamp": {"type": "date"}
     }
   }
 }


### PR DESCRIPTION
Backports the following commits to master:
 - [DOCS] Use consistent @timestamp field name (#69435)