### PR TITLE
[7.x] [DOCS] Remove added admons (#69452)

### DIFF
--- a/docs/java-rest/high-level/index.asciidoc
+++ b/docs/java-rest/high-level/index.asciidoc
@@ -5,7 +5,6 @@
 
 [partintro]
 --
-added[6.0.0-beta1]
 
 The Java High Level REST Client works on top of the Java Low Level REST client.
 Its main goal is to expose API specific methods, that accept request objects as

--- a/docs/reference/cluster/state.asciidoc
+++ b/docs/reference/cluster/state.asciidoc
@@ -41,7 +41,7 @@ The response provides the cluster state itself, which can be filtered to only
 retrieve the parts of interest as described below.
 
 The cluster's `cluster_uuid` is also returned as part of the top-level response,
-in addition to the `metadata` section. added[6.4.0]
+in addition to the `metadata` section.
 
 NOTE: While the cluster is still forming, it is possible for the `cluster_uuid`
       to be `_na_` as well as the cluster state's version to be `-1`.

--- a/docs/reference/mapping/fields/ignored-field.asciidoc
+++ b/docs/reference/mapping/fields/ignored-field.asciidoc
@@ -1,8 +1,6 @@
 [[mapping-ignored-field]]
 === `_ignored` field
 
-added[6.4.0]
-
 The `_ignored` field indexes and stores the names of every field in a document
 that has been ignored because it was malformed and
 <<ignore-malformed,`ignore_malformed`>> was turned on.


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Remove added admons (#69452)