### PR TITLE
[7.x] [DOCS] Note `case_sensitive` param was added in 7.10 (#69405)

### DIFF
--- a/docs/reference/query-dsl/prefix-query.asciidoc
+++ b/docs/reference/query-dsl/prefix-query.asciidoc
@@ -41,8 +41,8 @@ provided `<field>`.
 (Optional, string) Method used to rewrite the query. For valid values and more
 information, see the <<query-dsl-multi-term-rewrite, `rewrite` parameter>>.
 
-`case_insensitive`::
-(Optional, Boolean) allows ASCII case insensitive matching of the
+`case_insensitive` added:[7.10.0] ::
+(Optional, Boolean) Allows ASCII case insensitive matching of the
 value with the indexed field values when set to true. Default is false which means
 the case sensitivity of matching depends on the underlying field's mapping.
 

--- a/docs/reference/query-dsl/regexp-query.asciidoc
+++ b/docs/reference/query-dsl/regexp-query.asciidoc
@@ -68,8 +68,8 @@ provided. To improve performance, avoid using wildcard patterns, such as `.*` or
 valid values and more information, see <<regexp-optional-operators, Regular
 expression syntax>>.
 
-`case_insensitive`::
-(Optional, Boolean) allows case insensitive matching of the regular expression
+`case_insensitive` added:[7.10.0]::
+(Optional, Boolean) Allows case insensitive matching of the regular expression
 value with the indexed field values when set to true. Default is false which means
 the case sensitivity of matching depends on the underlying field's mapping.
 

--- a/docs/reference/query-dsl/term-query.asciidoc
+++ b/docs/reference/query-dsl/term-query.asciidoc
@@ -62,10 +62,10 @@ Boost values are relative to the default value of `1.0`. A boost value between
 `0` and `1.0` decreases the relevance score. A value greater than `1.0`
 increases the relevance score.
 
-`case_insensitive`::
-(Optional, Boolean) allows ASCII case insensitive matching of the
+`case_insensitive` added:[7.10.0]::
+(Optional, Boolean) Allows ASCII case insensitive matching of the
 value with the indexed field values when set to true. Default is false which means
-the case sensitivity of matching depends on the underlying field's mapping
+the case sensitivity of matching depends on the underlying field's mapping.
 
 [[term-query-notes]]
 ==== Notes

--- a/docs/reference/query-dsl/wildcard-query.asciidoc
+++ b/docs/reference/query-dsl/wildcard-query.asciidoc
@@ -69,8 +69,8 @@ increases the relevance score.
 (Optional, string) Method used to rewrite the query. For valid values and more information, see the
 <<query-dsl-multi-term-rewrite, `rewrite` parameter>>.
 
-`case_insensitive`::
-(Optional, Boolean) allows case insensitive matching of the
+`case_insensitive` added:[7.10.0]::
+(Optional, Boolean) Allows case insensitive matching of the
 pattern with the indexed field values when set to true. Default is false which means
 the case sensitivity of matching depends on the underlying field's mapping.
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Note `case_sensitive` param was added in 7.10 (#69405)