### PR TITLE
[7.11] [DOCS] Remove outdated default distro refs (#69465)

### DIFF
--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -335,7 +335,7 @@ coordinating nodes.
 
 For more information about these settings, see <<ml-settings>>.
 
-To create a dedicated {ml} node in the {default-dist}, set:
+To create a dedicated {ml} node, set:
 
 [source,yaml]
 ----


### PR DESCRIPTION
Backports the following commits to 7.11:
 - [DOCS] Remove outdated default distro refs (#69465)