### PR TITLE
Lower resource reload interval in geoip tests

### DIFF
--- a/modules/ingest-geoip/qa/file-based-update/build.gradle
+++ b/modules/ingest-geoip/qa/file-based-update/build.gradle
@@ -11,6 +11,7 @@ apply plugin: 'elasticsearch.rest-test'
 
 testClusters.all {
   testDistribution = 'DEFAULT'
+  setting 'resource.reload.interval.high', '100ms'
 }
 
 tasks.named("integTest").configure {

--- a/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/ReloadingDatabasesWhilePerformingGeoLookupsIT.java
+++ b/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/ReloadingDatabasesWhilePerformingGeoLookupsIT.java
@@ -10,6 +10,7 @@ package org.elasticsearch.ingest.geoip;
 
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.ingest.IngestDocument;
@@ -48,7 +49,8 @@ public class ReloadingDatabasesWhilePerformingGeoLookupsIT extends ESTestCase {
      */
     public void test() throws Exception {
         ThreadPool threadPool = new TestThreadPool("test");
-        ResourceWatcherService resourceWatcherService = new ResourceWatcherService(Settings.EMPTY, threadPool);
+        Settings settings = Settings.builder().put("resource.reload.interval.high", TimeValue.timeValueMillis(100)).build();
+        ResourceWatcherService resourceWatcherService = new ResourceWatcherService(settings, threadPool);
         try {
             final Path geoIpDir = createTempDir();
             copyDatabaseFiles(geoIpDir);

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/LocalDatabasesTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/LocalDatabasesTests.java
@@ -11,6 +11,7 @@ package org.elasticsearch.ingest.geoip;
 import com.maxmind.geoip2.model.CityResponse;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -33,7 +34,8 @@ public class LocalDatabasesTests extends ESTestCase {
     @Before
     public void setup() {
         threadPool = new TestThreadPool(LocalDatabases.class.getSimpleName());
-        resourceWatcherService = new ResourceWatcherService(Settings.EMPTY, threadPool);
+        Settings settings = Settings.builder().put("resource.reload.interval.high", TimeValue.timeValueMillis(100)).build();
+        resourceWatcherService = new ResourceWatcherService(settings, threadPool);
     }
 
     @After


### PR DESCRIPTION
Lower resource reload interval setting for tests that reload config maxmind databases.

Closes #69475