### PR TITLE
Add Transform associated indices

### DIFF
--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/Transform.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/Transform.java
@@ -121,6 +121,8 @@ import java.util.Set;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 
+import static org.elasticsearch.xpack.core.transform.transforms.persistence.TransformInternalIndexConstants.AUDIT_INDEX_PATTERN;
+
 public class Transform extends Plugin implements SystemIndexPlugin, PersistentTaskPlugin {
 
     public static final String NAME = "transform";
@@ -369,6 +371,10 @@ public class Transform extends Plugin implements SystemIndexPlugin, PersistentTa
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+    }
+
+    @Override public Collection<String> getAssociatedIndexPatterns() {
+        return List.of(AUDIT_INDEX_PATTERN);
     }
 
     @Override


### PR DESCRIPTION
These somehow got dropped from the initial Feature States PR, so this
commit adds them again.

---

Note for reviewers: If you are not familiar with associated indices, they are new as of #63513. See this comment:
https://github.com/elastic/elasticsearch/blob/4e429afb4b545e6e92029ff03c7f4d684558ca1a/server/src/main/java/org/elasticsearch/plugins/SystemIndexPlugin.java#L43-L48

They are currently only used for ensuring all of a feature's indices are included in snapshots that specify they should include that feature's state - that is, if a plugin's system indices are included in a snapshot, that plugin's associated indices will be as well. They will also be used for the upcoming reset API (see #69469).