### PR TITLE
[Test] Remove some watcher indices from comparison

### DIFF
--- a/modules/transport-netty4/src/javaRestTest/java/org/elasticsearch/rest/Netty4HeadBodyIsEmptyIT.java
+++ b/modules/transport-netty4/src/javaRestTest/java/org/elasticsearch/rest/Netty4HeadBodyIsEmptyIT.java
@@ -115,10 +115,10 @@ public class Netty4HeadBodyIsEmptyIT extends ESRestTestCase {
             if (inFipsJvm()) {
                 request.setOptions(expectWarnings(
                     "legacy template [template] has index patterns [*] matching patterns from existing composable templates " +
-                    "[.deprecation-indexing-template,.slm-history,.triggered_watches,.watch-history-14,.watches,ilm-history,logs," +
+                    "[.deprecation-indexing-template,.slm-history,.watch-history-14,ilm-history,logs," +
                     "metrics,synthetics] with patterns (.deprecation-indexing-template => [.logs-deprecation-elasticsearch]," +
-                    ".slm-history => [.slm-history-5*],.triggered_watches => [.triggered_watches*]," +
-                    ".watch-history-14 => [.watcher-history-14*],.watches => [.watches*],ilm-history => [ilm-history-5*]," +
+                    ".slm-history => [.slm-history-5*]," +
+                    ".watch-history-14 => [.watcher-history-14*],ilm-history => [ilm-history-5*]," +
                     "logs => [logs-*-*],metrics => [metrics-*-*],synthetics => [synthetics-*-*]" +
                     "); this template [template] may be ignored in favor of a composable template at index creation time"));
             }


### PR DESCRIPTION
Since #67588, `.triggered_watches` and `.watches` indices are no longer created on node startup. This PR removing them from the warnings for comparison.

Resolves: #66820