### PR TITLE
Fix GeoIpProcessorNonIngestNodeIT.testLazyLoading

### DIFF
--- a/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/AbstractGeoIpIT.java
+++ b/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/AbstractGeoIpIT.java
@@ -49,6 +49,7 @@ public abstract class AbstractGeoIpIT extends ESIntegTestCase {
         }
         return Settings.builder()
             .put("ingest.geoip.database_path", databasePath)
+            .put(GeoIpDownloaderTaskExecutor.ENABLED_SETTING.getKey(), false)
             .put(super.nodeSettings(nodeOrdinal))
             .build();
     }

--- a/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderIT.java
+++ b/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderIT.java
@@ -25,6 +25,7 @@ import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 import org.elasticsearch.test.ESIntegTestCase.Scope;
+import org.junit.After;
 
 import java.io.BufferedOutputStream;
 import java.io.ByteArrayInputStream;
@@ -56,14 +57,21 @@ public class GeoIpDownloaderIT extends AbstractGeoIpIT {
 
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {
-        Settings.Builder settings = Settings.builder()
-            .put(super.nodeSettings(nodeOrdinal))
-            .put(GeoIpDownloaderTaskExecutor.ENABLED_SETTING.getKey(), false);
+        Settings.Builder settings = Settings.builder().put(super.nodeSettings(nodeOrdinal));
         String endpoint = System.getProperty("geoip_endpoint");
         if (endpoint != null) {
             settings.put(GeoIpDownloader.ENDPOINT_SETTING.getKey(), endpoint);
         }
         return settings.build();
+    }
+
+    @After
+    public void disableDownloader(){
+        ClusterUpdateSettingsResponse settingsResponse = client().admin().cluster()
+            .prepareUpdateSettings()
+            .setPersistentSettings(Settings.builder().put(GeoIpDownloaderTaskExecutor.ENABLED_SETTING.getKey(), false))
+            .get();
+        assertTrue(settingsResponse.isAcknowledged());
     }
 
     public void testGeoIpDatabasesDownload() throws Exception {


### PR DESCRIPTION
This change disables GeoIP downlaoder in `GeoIpProcessorNonIngestNodeIT` which should fix failure from https://github.com/elastic/elasticsearch/issues/69496
It also adds clean up in `GeoIpDownloaderIT`  which disables downloader after test which should prevent similar failures in that class.

Closes https://github.com/elastic/elasticsearch/issues/69496