### PR TITLE
Document searchable snapshots supported repos

### DIFF
--- a/docs/reference/searchable-snapshots/index.asciidoc
+++ b/docs/reference/searchable-snapshots/index.asciidoc
@@ -82,7 +82,8 @@ You can use any of the following repository types with searchable snapshots:
 * <<snapshots-filesystem-repository,Shared filesystems>> such as NFS
 
 You can also use alternative implementations of these repository types, for
-instance {plugins}/repository-s3.html#repository-s3-compatible-services[Minio],
+instance
+{plugins}/repository-s3-client.html#repository-s3-compatible-services[Minio],
 as long as they are fully compatible.
 
 [discrete]

--- a/docs/reference/searchable-snapshots/index.asciidoc
+++ b/docs/reference/searchable-snapshots/index.asciidoc
@@ -72,6 +72,15 @@ For more complex or time-consuming searches, you can use <<async-search>> with
 {search-snaps}.
 ====
 
+[[searchable-snapshots-repository-types]]
+You can use any of the following repository types with searchable snapshots:
+
+* {plugins}/repository-s3.html[AWS S3]
+* {plugins}/repository-gcs.html[Google Cloud Storage]
+* {plugins}/repository-azure.html[Azure Blob Storage]
+* {plugins}/repository-hdfs.html[Hadoop Distributed File Store (HDFS)]
+* <<snapshots-filesystem-repository,Shared filesystems>> such as NFS
+
 [discrete]
 [[how-searchable-snapshots-work]]
 === How {search-snaps} work

--- a/docs/reference/searchable-snapshots/index.asciidoc
+++ b/docs/reference/searchable-snapshots/index.asciidoc
@@ -81,6 +81,10 @@ You can use any of the following repository types with searchable snapshots:
 * {plugins}/repository-hdfs.html[Hadoop Distributed File Store (HDFS)]
 * <<snapshots-filesystem-repository,Shared filesystems>> such as NFS
 
+You can also use alternative implementations of these repository types, for
+instance {plugins}/repository-s3.html#repository-s3-compatible-services[Minio],
+as long as they are fully compatible.
+
 [discrete]
 [[how-searchable-snapshots-work]]
 === How {search-snaps} work


### PR DESCRIPTION
Adds a note listing the repository types that can be used with
searchable snapshots.