### PR TITLE
[7.x] Fix GeoIpProcessorNonIngestNodeIT.testLazyLoading (#69499)

### DIFF
--- a/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/AbstractGeoIpIT.java
+++ b/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/AbstractGeoIpIT.java
@@ -57,6 +57,7 @@ public abstract class AbstractGeoIpIT extends ESIntegTestCase {
         }
         return Settings.builder()
             .put("ingest.geoip.database_path", databasePath)
+            .put(GeoIpDownloaderTaskExecutor.ENABLED_SETTING.getKey(), false)
             .put(super.nodeSettings(nodeOrdinal))
             .build();
     }

--- a/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderIT.java
+++ b/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderIT.java
@@ -24,6 +24,7 @@ import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 import org.elasticsearch.test.ESIntegTestCase.Scope;
+import org.junit.After;
 
 import java.io.BufferedOutputStream;
 import java.io.ByteArrayInputStream;
@@ -47,14 +48,21 @@ public class GeoIpDownloaderIT extends AbstractGeoIpIT {
 
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {
-        Settings.Builder settings = Settings.builder()
-            .put(super.nodeSettings(nodeOrdinal))
-            .put(GeoIpDownloaderTaskExecutor.ENABLED_SETTING.getKey(), false);
+        Settings.Builder settings = Settings.builder().put(super.nodeSettings(nodeOrdinal));
         String endpoint = System.getProperty("geoip_endpoint");
         if (endpoint != null) {
             settings.put(GeoIpDownloader.ENDPOINT_SETTING.getKey(), endpoint);
         }
         return settings.build();
+    }
+
+    @After
+    public void disableDownloader(){
+        ClusterUpdateSettingsResponse settingsResponse = client().admin().cluster()
+            .prepareUpdateSettings()
+            .setPersistentSettings(Settings.builder().put(GeoIpDownloaderTaskExecutor.ENABLED_SETTING.getKey(), false))
+            .get();
+        assertTrue(settingsResponse.isAcknowledged());
     }
 
     public void testGeoIpDatabasesDownload() throws Exception {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fix GeoIpProcessorNonIngestNodeIT.testLazyLoading (#69499)