### PR TITLE
Adjust GeoIpTaskParams and GeoIpTaskState versions

### DIFF
--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpTaskParams.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpTaskParams.java
@@ -44,7 +44,7 @@ class GeoIpTaskParams implements PersistentTaskParams {
 
     @Override
     public Version getMinimalSupportedVersion() {
-        return Version.V_8_0_0;
+        return Version.V_7_13_0;
     }
 
     @Override

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpTaskState.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpTaskState.java
@@ -116,7 +116,7 @@ class GeoIpTaskState implements PersistentTaskState, VersionedNamedWriteable {
 
     @Override
     public Version getMinimalSupportedVersion() {
-        return Version.V_8_0_0;
+        return Version.V_7_13_0;
     }
 
     @Override


### PR DESCRIPTION
This change adjust versions in `GeoIpTaskParams` and `GeoIpTaskState` after backporting https://github.com/elastic/elasticsearch/pull/68424 to `7.x`