### PR TITLE
Improve shard level request cache efficiency (#69505)

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/internal/ShardSearchLocalRequest.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/ShardSearchLocalRequest.java
@@ -171,6 +171,11 @@ public class ShardSearchLocalRequest implements ShardSearchRequest {
     }
 
     @Override
+    public void requestCache(Boolean requestCache) {
+        this.requestCache = requestCache;
+    }
+
+    @Override
     public Boolean allowPartialSearchResults() {
         return allowPartialSearchResults;
     }

--- a/server/src/main/java/org/elasticsearch/search/internal/ShardSearchRequest.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/ShardSearchRequest.java
@@ -69,6 +69,8 @@ public interface ShardSearchRequest {
 
     Boolean requestCache();
 
+    void requestCache(Boolean requestCache);
+
     Boolean allowPartialSearchResults();
 
     Scroll scroll();

--- a/server/src/main/java/org/elasticsearch/search/internal/ShardSearchTransportRequest.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/ShardSearchTransportRequest.java
@@ -138,6 +138,11 @@ public class ShardSearchTransportRequest extends TransportRequest implements Sha
     }
 
     @Override
+    public void requestCache(Boolean requestCache) {
+        shardSearchLocalRequest.requestCache(requestCache);
+    }
+
+    @Override
     public Boolean allowPartialSearchResults() {
         return shardSearchLocalRequest.allowPartialSearchResults();
     }

--- a/server/src/test/java/org/elasticsearch/index/SearchSlowLogTests.java
+++ b/server/src/test/java/org/elasticsearch/index/SearchSlowLogTests.java
@@ -146,6 +146,10 @@ public class SearchSlowLogTests extends ESSingleNodeTestCase {
                 }
 
                 @Override
+                public void requestCache(Boolean requestCache) {
+                }
+
+                @Override
                 public Boolean allowPartialSearchResults() {
                     return null;
                 }

--- a/server/src/test/java/org/elasticsearch/search/slice/SliceBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/slice/SliceBuilderTests.java
@@ -163,6 +163,10 @@ public class SliceBuilderTests extends ESTestCase {
         }
 
         @Override
+        public void requestCache(Boolean requestCache) {
+        }
+
+        @Override
         public Boolean allowPartialSearchResults() {
             return null;
         }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/FieldAndDocumentLevelSecurityRequestInterceptor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/FieldAndDocumentLevelSecurityRequestInterceptor.java
@@ -11,6 +11,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.transport.TransportActionProxy;
 import org.elasticsearch.xpack.core.security.authz.AuthorizationEngine;
 import org.elasticsearch.xpack.core.security.authz.AuthorizationEngine.AuthorizationInfo;
 import org.elasticsearch.xpack.core.security.authz.AuthorizationEngine.RequestInfo;
@@ -36,7 +37,7 @@ abstract class FieldAndDocumentLevelSecurityRequestInterceptor implements Reques
     @Override
     public void intercept(RequestInfo requestInfo, AuthorizationEngine authorizationEngine, AuthorizationInfo authorizationInfo,
                           ActionListener<Void> listener) {
-        if (requestInfo.getRequest() instanceof IndicesRequest) {
+        if (requestInfo.getRequest() instanceof IndicesRequest && false == TransportActionProxy.isProxyAction(requestInfo.getAction())) {
             IndicesRequest indicesRequest = (IndicesRequest) requestInfo.getRequest();
             if (supports(indicesRequest) && licenseState.isDocumentAndFieldLevelSecurityAllowed()) {
                 final IndicesAccessControl indicesAccessControl =

--- a/x-pack/qa/multi-cluster-search-security/src/test/resources/rest-api-spec/test/multi_cluster/110_dls_fls.yml
+++ b/x-pack/qa/multi-cluster-search-security/src/test/resources/rest-api-spec/test/multi_cluster/110_dls_fls.yml
@@ -1,0 +1,48 @@
+---
+setup:
+  - skip:
+      features: headers
+
+  - do:
+      cluster.health:
+        wait_for_status: yellow
+
+  - do:
+      xpack.security.put_user:
+        username: "dls_fls_user"
+        body:  >
+          {
+            "password": "s3krit-password",
+            "roles" : [ "dls_fls_role" ]
+          }
+
+---
+teardown:
+  - do:
+      xpack.security.delete_user:
+        username: "dls_fls_user"
+        ignore: 404
+
+---
+"Search with document and field level security":
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        request_cache: true
+        index: my_remote_cluster:shared_index
+
+  - match: { hits.total: 2}
+  - length: { hits.hits.0._source: 3 }
+  - match: { hits.hits.0._source.secret: "sesame" }
+
+  - do:
+      headers: { Authorization: "Basic ZGxzX2Zsc191c2VyOnMza3JpdC1wYXNzd29yZA==" }
+      search:
+        rest_total_hits_as_int: true
+        request_cache: true
+        index: my_remote_cluster:shared_index
+
+  - match: { hits.total: 1}
+  - length: { hits.hits.0._source: 2 }
+  - is_true: hits.hits.0._source.public
+  - match: { hits.hits.0._source.name: "doc 1" }

--- a/x-pack/qa/multi-cluster-search-security/src/test/resources/rest-api-spec/test/remote_cluster/10_basic.yml
+++ b/x-pack/qa/multi-cluster-search-security/src/test/resources/rest-api-spec/test/remote_cluster/10_basic.yml
@@ -28,6 +28,22 @@ setup:
                 }
               ]
             }
+
+  - do:
+      xpack.security.put_role:
+        name: "dls_fls_role"
+        body: >
+          {
+            "cluster": ["monitor"],
+            "indices": [
+              {
+                "names": ["shared_index"],
+                "privileges": ["read", "read_cross_cluster"],
+                "query": "{ \"term\": { \"public\" : true } }",
+                "field_security": { "grant": ["*"], "except": ["secret"] }
+              }
+            ]
+          }
 ---
 "Index data and search on the remote cluster":
 
@@ -196,3 +212,21 @@ setup:
               "roles" : [ ]
             }
   - match: { user: { created: false } }
+
+  - do:
+      indices.create:
+        index: shared_index
+        body:
+          settings:
+            index:
+              number_of_shards: 1
+              number_of_replicas: 0
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - '{"index": {"_index": "shared_index", "_id": 1, "_type": "test_type"}}'
+          - '{"public": true, "name": "doc 1", "secret": "sesame"}'
+          - '{"index": {"_index": "shared_index", "_id": 2, "_type": "test_type"}}'
+          - '{"public": false, "name": "doc 2", "secret": "sesame"}'


### PR DESCRIPTION
Shard level request cache is improved to work correctly at all time. Also ensure profiling and suggester are properly disabled when not supported.