### PR TITLE
Overwrite database with different file in test.

### DIFF
--- a/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/ReloadingDatabasesWhilePerformingGeoLookupsIT.java
+++ b/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/ReloadingDatabasesWhilePerformingGeoLookupsIT.java
@@ -21,6 +21,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.watcher.ResourceWatcherService;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -47,7 +48,6 @@ public class ReloadingDatabasesWhilePerformingGeoLookupsIT extends ESTestCase {
      * This failure can be avoided by ensuring that a database is only closed when no
      * geoip processor instance is using the related {@link DatabaseReaderLazyLoader} instance
      */
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/69475")
     public void test() throws Exception {
         ThreadPool threadPool = new TestThreadPool("test");
         Settings settings = Settings.builder().put("resource.reload.interval.high", TimeValue.timeValueMillis(100)).build();
@@ -104,15 +104,16 @@ public class ReloadingDatabasesWhilePerformingGeoLookupsIT extends ESTestCase {
                 for (int i = 0; i < numberOfDatabaseUpdates; i++) {
                     try {
                         DatabaseReaderLazyLoader previous1 = localDatabases.configDatabases.get("GeoLite2-City.mmdb");
-                        if (Files.exists(geoIpConfigDir.resolve("GeoLite2-City.mmdb")) && randomBoolean()) {
+                        if (Files.exists(geoIpConfigDir.resolve("GeoLite2-City.mmdb"))) {
                             Files.delete(geoIpConfigDir.resolve("GeoLite2-City.mmdb"));
                         } else {
                             Files.copy(LocalDatabases.class.getResourceAsStream("/GeoLite2-City-Test.mmdb"),
                                 geoIpConfigDir.resolve("GeoLite2-City.mmdb"), StandardCopyOption.REPLACE_EXISTING);
                         }
                         DatabaseReaderLazyLoader previous2 = localDatabases.configDatabases.get("GeoLite2-City-Test.mmdb");
-                        Files.copy(LocalDatabases.class.getResourceAsStream("/GeoLite2-City-Test.mmdb"),
-                            geoIpConfigDir.resolve("GeoLite2-City-Test.mmdb"), StandardCopyOption.REPLACE_EXISTING);
+                        InputStream source = LocalDatabases.class.getResourceAsStream(i % 2 == 0 ? "/GeoIP2-City-Test.mmdb" :
+                            "/GeoLite2-City-Test.mmdb");
+                        Files.copy(source, geoIpConfigDir.resolve("GeoLite2-City-Test.mmdb"), StandardCopyOption.REPLACE_EXISTING);
                         assertBusy(() -> {
                             DatabaseReaderLazyLoader current1 = localDatabases.configDatabases.get("GeoLite2-City.mmdb");
                             DatabaseReaderLazyLoader current2 = localDatabases.configDatabases.get("GeoLite2-City-Test.mmdb");

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
@@ -36,7 +36,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 
 import static org.elasticsearch.ingest.ConfigurationUtils.newConfigurationException;

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
@@ -398,13 +398,19 @@ public final class GeoIpProcessor extends AbstractProcessor {
                         + databaseType + "]");
                 }
             }
-
             CheckedSupplier<DatabaseReaderLazyLoader, IOException> supplier = () -> {
                 DatabaseReaderLazyLoader loader = localDatabases.getDatabase(databaseFile);
                 if (loader == null) {
                     throw new ResourceNotFoundException("database_file", "database file [" + databaseFile + "] doesn't exist");
                 }
-                assert Objects.equals(databaseType, loader.getDatabaseType());
+
+                // Only check whether the suffix has changed and not the entire database type.
+                // To sanity check whether a city db isn't overwriting with a country or asn db.
+                // For example overwriting a geoip lite city db with geoip city db is a valid change, but the db type is slightly different,
+                // by checking just the suffix this assertion doesn't fail.
+                String expectedSuffix = databaseType.substring(databaseType.lastIndexOf('-'));
+                assert loader.getDatabaseType().endsWith(expectedSuffix) : "database type [" + loader.getDatabaseType() +
+                    "] doesn't match with expected suffix [" + expectedSuffix + "]";
                 return loader;
             };
             return new GeoIpProcessor(processorTag, description, ipField, supplier, targetField, properties, ignoreMissing, firstOnly);


### PR DESCRIPTION
When running with java 8 runtime, when overwriting a db file with the same content in a short time window,
the change isn't detected and no reload happens which makes the test fail.
This change overwrites files using different source files.

Closes #69475

(I will forward port this to master, if this is approved and CI didn't break the test for at least 24h)