### PR TITLE
[7.x] [ML] validate remote cluster version when datafeed contains runtime_mappings (#69489)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java
@@ -16,6 +16,7 @@ import org.elasticsearch.cluster.AbstractDiffable;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.unit.TimeValue;
@@ -50,6 +51,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
@@ -65,6 +67,8 @@ import static org.elasticsearch.xpack.core.ml.utils.ToXContentParams.EXCLUDE_GEN
  * values.
  */
 public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements ToXContentObject {
+
+    private static final Version RUNTIME_MAPPINGS_INTRODUCED = Version.V_7_11_0;
 
     public static final int DEFAULT_SCROLL_SIZE = 1000;
 
@@ -311,6 +315,12 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
 
     public Integer getScrollSize() {
         return scrollSize;
+    }
+
+    public Optional<Tuple<Version, String>> minRequiredClusterVersion() {
+        return runtimeMappings.isEmpty() ?
+            Optional.empty() :
+            Optional.of(Tuple.tuple(RUNTIME_MAPPINGS_INTRODUCED, SearchSourceBuilder.RUNTIME_MAPPINGS_FIELD.getPreferredName()));
     }
 
     /**
@@ -845,9 +855,10 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
             return this.indicesOptions;
         }
 
-        public void setRuntimeMappings(Map<String, Object> runtimeMappings) {
+        public Builder setRuntimeMappings(Map<String, Object> runtimeMappings) {
             this.runtimeMappings = ExceptionsHelper.requireNonNull(runtimeMappings,
                 SearchSourceBuilder.RUNTIME_MAPPINGS_FIELD.getPreferredName());
+            return this;
         }
 
         public DatafeedConfig build() {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
@@ -11,6 +11,7 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.ResourceAlreadyExistsException;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
@@ -23,6 +24,7 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
@@ -38,6 +40,7 @@ import org.elasticsearch.persistent.PersistentTasksService;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.RemoteClusterService;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.XPackField;
 import org.elasticsearch.xpack.core.ml.MlTasks;
@@ -65,9 +68,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import static org.elasticsearch.xpack.core.common.validation.SourceDestValidator.REMOTE_CLUSTERS_TOO_OLD;
 
 /* This class extends from TransportMasterNodeAction for cluster state observing purposes.
  The stop datafeed api also redirect the elected master node.
@@ -176,7 +184,8 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
 
         // Verify data extractor factory can be created, then start persistent task
         Consumer<Job> createDataExtractor = job -> {
-                if (RemoteClusterLicenseChecker.containsRemoteIndex(params.getDatafeedIndices())) {
+            final List<String> remoteIndices = RemoteClusterLicenseChecker.remoteIndices(params.getDatafeedIndices());
+                if (remoteIndices.isEmpty() == false) {
                     final RemoteClusterLicenseChecker remoteClusterLicenseChecker =
                             new RemoteClusterLicenseChecker(client, XPackLicenseState::isMachineLearningAllowedForOperationMode);
                     remoteClusterLicenseChecker.checkRemoteClusterLicenses(
@@ -195,6 +204,16 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
                                                     RemoteClusterLicenseChecker.remoteIndices(datafeedConfigHolder.get().getIndices()),
                                                     clusterService.getNodeName())));
                                         } else {
+                                            final RemoteClusterService remoteClusterService = transportService.getRemoteClusterService();
+                                            List<String> remoteAliases = RemoteClusterLicenseChecker.remoteClusterAliases(
+                                                remoteClusterService.getRegisteredRemoteClusterNames(),
+                                                remoteIndices
+                                            );
+                                            checkRemoteClusterVersions(
+                                                datafeedConfigHolder.get(),
+                                                remoteAliases,
+                                                (cn) -> remoteClusterService.getConnection(cn).getVersion()
+                                            );
                                             createDataExtractor(job, datafeedConfigHolder.get(), params, waitForTaskListener);
                                         }
                                     },
@@ -240,6 +259,33 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
         );
 
         datafeedConfigProvider.getDatafeedConfig(params.getDatafeedId(), datafeedListener);
+    }
+
+    static void checkRemoteClusterVersions(DatafeedConfig config,
+                                           List<String> remoteClusters,
+                                           Function<String, Version> clusterVersionSupplier) {
+        Optional<Tuple<Version, String>> minVersionAndReason = config.minRequiredClusterVersion();
+        if (minVersionAndReason.isPresent() == false) {
+            return;
+        }
+        final String reason = minVersionAndReason.get().v2();
+        final Version minVersion = minVersionAndReason.get().v1();
+
+        List<String> clustersTooOld = remoteClusters.stream()
+            .filter(cn -> clusterVersionSupplier.apply(cn).before(minVersion))
+            .collect(Collectors.toList());
+        if (clustersTooOld.isEmpty()) {
+            return;
+        }
+
+        throw ExceptionsHelper.badRequestException(
+            Messages.getMessage(
+                REMOTE_CLUSTERS_TOO_OLD,
+                minVersion.toString(),
+                reason,
+                Strings.collectionToCommaDelimitedString(clustersTooOld)
+            )
+        );
     }
 
     /** Creates {@link DataExtractorFactory} solely for the purpose of validation i.e. verifying that it can be created. */

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedActionTests.java
@@ -8,6 +8,8 @@
 package org.elasticsearch.xpack.ml.action;
 
 import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
@@ -16,17 +18,21 @@ import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.ml.action.StartDatafeedAction;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfigTests;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.config.JobState;
 import org.elasticsearch.xpack.ml.datafeed.DatafeedManager;
 import org.elasticsearch.xpack.ml.datafeed.DatafeedManagerTests;
 import org.elasticsearch.xpack.ml.notifications.AnomalyDetectionAuditor;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
+import java.util.Map;
 
 import static org.elasticsearch.persistent.PersistentTasksCustomMetadata.INITIAL_ASSIGNMENT;
 import static org.elasticsearch.xpack.ml.job.task.OpenJobPersistentTasksExecutorTests.addJobTask;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doReturn;
@@ -99,6 +105,56 @@ public class TransportStartDatafeedActionTests extends ESTestCase {
         TransportStartDatafeedAction.auditDeprecations(config, job1, auditor, xContentRegistry());
 
         verify(auditor, never()).warning(any(), any());
+    }
+
+    public void testRemoteClusterVersionCheck() {
+        Map<String, Version> clusterVersions = MapBuilder.<String, Version>newMapBuilder()
+            .put("modern_cluster_1", Version.CURRENT)
+            .put("modern_cluster_2", Version.CURRENT)
+            .put("old_cluster_1", Version.V_7_0_0)
+            .map();
+
+        Map<String, Object> field = Collections.singletonMap(
+            "runtime_field_foo",
+            MapBuilder.<String, Object>newMapBuilder()
+                .put("type", "keyword")
+                .put("script", "")
+                .map());
+
+        DatafeedConfig config = new DatafeedConfig.Builder(DatafeedConfigTests.createRandomizedDatafeedConfig("foo"))
+            .setRuntimeMappings(field)
+            .build();
+        ElasticsearchStatusException ex = expectThrows(ElasticsearchStatusException.class,
+            () -> TransportStartDatafeedAction.checkRemoteClusterVersions(
+                config,
+                Arrays.asList("old_cluster_1", "modern_cluster_2"),
+                clusterVersions::get
+            )
+        );
+        assertThat(
+            ex.getMessage(),
+            containsString(
+                "remote clusters are expected to run at least version [7.11.0] (reason: [runtime_mappings]), "
+                    + "but the following clusters were too old: [old_cluster_1]"
+            )
+        );
+
+        // The rest should not throw
+        TransportStartDatafeedAction.checkRemoteClusterVersions(
+            config,
+            Arrays.asList("modern_cluster_1", "modern_cluster_2"),
+            clusterVersions::get
+        );
+
+        DatafeedConfig configWithoutRuntimeMappings = new DatafeedConfig.Builder()
+            .setId("foo-datafeed")
+            .setIndices(Collections.singletonList("bar"))
+            .setJobId("foo").build();
+        TransportStartDatafeedAction.checkRemoteClusterVersions(
+            configWithoutRuntimeMappings,
+            Arrays.asList("old_cluster_1", "modern_cluster_2"),
+            clusterVersions::get
+        );
     }
 
     public static TransportStartDatafeedAction.DatafeedTask createDatafeedTask(long id, String type, String action,


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ML] validate remote cluster version when datafeed contains runtime_mappings (#69489)