### PR TITLE
Fix testRepositoryAnalysis

### DIFF
--- a/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/RepositoryAnalysisSuccessIT.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/RepositoryAnalysisSuccessIT.java
@@ -66,7 +66,6 @@ public class RepositoryAnalysisSuccessIT extends AbstractSnapshotIntegTestCase {
         return List.of(TestPlugin.class, LocalStateCompositeXPackPlugin.class, SnapshotRepositoryTestKit.class);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/69219")
     public void testRepositoryAnalysis() {
 
         createRepositoryNoVerify("test-repo", TestPlugin.ASSERTING_REPO_TYPE);
@@ -99,7 +98,9 @@ public class RepositoryAnalysisSuccessIT extends AbstractSnapshotIntegTestCase {
         }
 
         if (usually()) {
-            request.maxTotalDataSize(new ByteSizeValue(between(1, 1 << 20)));
+            request.maxTotalDataSize(
+                new ByteSizeValue(request.getMaxBlobSize().getBytes() + request.getBlobCount() - 1 + between(0, 1 << 20))
+            );
             blobStore.ensureMaxTotalBlobSize(request.getMaxTotalDataSize().getBytes());
         }
 


### PR DESCRIPTION
This test would occasionally generate an invalid request in which the
max total data size cannot be satisfied. This commit ensures the max
total data size is always sufficiently large.

Relates #67247
Closes #69219