### PR TITLE
Correctly Wait for Cluster State Recovery in Encrypted Repo Test

### DIFF
--- a/server/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
@@ -507,7 +507,7 @@ public class RepositoriesService extends AbstractLifecycleComponent implements C
      * @return the current collection of registered repositories, keyed by name.
      */
     public Map<String, Repository> getRepositories() {
-        return unmodifiableMap(repositories);
+        return repositories;
     }
 
     public List<RepositoryStatsSnapshot> repositoriesStats() {

--- a/server/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
@@ -507,7 +507,7 @@ public class RepositoriesService extends AbstractLifecycleComponent implements C
      * @return the current collection of registered repositories, keyed by name.
      */
     public Map<String, Repository> getRepositories() {
-        return repositories;
+        return unmodifiableMap(repositories);
     }
 
     public List<RepositoryStatsSnapshot> repositoriesStats() {

--- a/x-pack/plugin/repository-encrypted/src/internalClusterTest/java/org/elasticsearch/repositories/encrypted/EncryptedRepositorySecretIntegTests.java
+++ b/x-pack/plugin/repository-encrypted/src/internalClusterTest/java/org/elasticsearch/repositories/encrypted/EncryptedRepositorySecretIntegTests.java
@@ -574,7 +574,7 @@ public final class EncryptedRepositorySecretIntegTests extends ESIntegTestCase {
         );
 
         internalCluster().fullRestart();
-        ensureStableCluster(2);
+        ensureGreen();
         // maybe recreate the repository
         if (randomBoolean()) {
             deleteRepository(repositoryName);
@@ -617,7 +617,7 @@ public final class EncryptedRepositorySecretIntegTests extends ESIntegTestCase {
             goodPassword
         );
         internalCluster().fullRestart();
-        ensureStableCluster(2);
+        ensureGreen();
         // ensure get snapshot works
         getSnapshotResponse = client().admin().cluster().prepareGetSnapshots(repositoryName).get();
         assertThat(getSnapshotResponse.getFailedResponses().keySet(), empty());


### PR DESCRIPTION
Waiting for a connected cluster is not enough, we must wait for green to ensure
that state recovery has happened which causes the repository to be created.

Closes #67834
