### PR TITLE
Ensure docker images for current architecture are built for testing

### DIFF
--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -233,7 +233,7 @@ elasticsearch_distributions {
 }
 
 tasks.named("preProcessFixture").configure {
-  dependsOn elasticsearch_distributions.docker_default, elasticsearch_distributions.docker_oss
+  dependsOn elasticsearch_distributions.matching { it.architecture == Architecture.current() }
   dependsOn "copyNodeKeyMaterial"
   doLast {
     // tests expect to have an empty repo

--- a/gradle/build-scan.gradle
+++ b/gradle/build-scan.gradle
@@ -1,3 +1,4 @@
+import org.elasticsearch.gradle.Architecture
 import org.elasticsearch.gradle.OS
 import org.elasticsearch.gradle.info.BuildParams
 import org.gradle.initialization.BuildRequestMetaData
@@ -15,6 +16,7 @@ buildScan {
     String nodeName = System.getenv('NODE_NAME')
 
     tag OS.current().name()
+    tag Architecture.current().name()
 
     // Tag if this build is run in FIPS mode
     if (BuildParams.inFipsJvm) {


### PR DESCRIPTION
Ensure that when building the docker images necessary for running our docker distribution integration tests that we build the images for the current system architecture.