### PR TITLE
[7.x][ML] Expand usage stats for data frame analytics and trained mod…

### DIFF
--- a/docs/reference/rest-api/usage.asciidoc
+++ b/docs/reference/rest-api/usage.asciidoc
@@ -127,6 +127,15 @@ GET /_xpack/usage
     "data_frame_analytics_jobs" : {
       "_all" : {
         "count" : 0
+      },
+      "analysis_counts": { },
+      "memory_usage": {
+        "peak_usage_bytes": {
+          "min": 0.0,
+          "max": 0.0,
+          "avg": 0.0,
+          "total": 0.0
+        }
       }
     },
     "inference" : {
@@ -155,6 +164,25 @@ GET /_xpack/usage
       "trained_models" : {
         "_all" : {
           "count" : 0
+        },
+        "count": {
+          "total": 1,
+          "classification": 0,
+          "regression": 0,
+          "prepackaged": 1,
+          "other": 0
+        },
+        "estimated_heap_memory_usage_bytes": {
+          "min": 0.0,
+          "max": 0.0,
+          "avg": 0.0,
+          "total": 0.0
+        },
+        "estimated_operations": {
+          "min": 0.0,
+          "max": 0.0,
+          "avg": 0.0,
+          "total": 0.0
         }
       }
     },

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/AbstractTransportGetResourcesAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/AbstractTransportGetResourcesAction.java
@@ -56,8 +56,6 @@ public abstract class AbstractTransportGetResourcesAction<Resource extends ToXCo
     Request extends AbstractGetResourcesRequest, Response extends AbstractGetResourcesResponse<Resource>>
     extends HandledTransportAction<Request, Response> {
 
-    private static final String ALL = "_all";
-
     private final Client client;
     private final NamedXContentRegistry xContentRegistry;
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/stats/common/MemoryUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/stats/common/MemoryUsage.java
@@ -95,6 +95,10 @@ public class MemoryUsage implements Writeable, ToXContentObject {
         }
     }
 
+    public long getPeakUsageBytes() {
+        return peakUsageBytes;
+    }
+
     public Status getStatus() {
         return status;
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearningFeatureSet.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearningFeatureSet.java
@@ -15,8 +15,6 @@ import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
 import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsAction;
 import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsRequest;
 import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsResponse;
-import org.elasticsearch.action.search.SearchRequestBuilder;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.Metadata;
@@ -25,24 +23,28 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.env.Environment;
-import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.ingest.IngestStats;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.plugins.Platforms;
-import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.XPackFeatureSet;
 import org.elasticsearch.xpack.core.XPackField;
 import org.elasticsearch.xpack.core.XPackPlugin;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.action.util.PageParams;
 import org.elasticsearch.xpack.core.ml.MachineLearningFeatureSetUsage;
+import org.elasticsearch.xpack.core.ml.action.GetDataFrameAnalyticsAction;
 import org.elasticsearch.xpack.core.ml.action.GetDataFrameAnalyticsStatsAction;
 import org.elasticsearch.xpack.core.ml.action.GetDatafeedsStatsAction;
 import org.elasticsearch.xpack.core.ml.action.GetJobsStatsAction;
+import org.elasticsearch.xpack.core.ml.action.GetTrainedModelsAction;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedState;
+import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfig;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsState;
+import org.elasticsearch.xpack.core.ml.dataframe.stats.common.MemoryUsage;
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelConfig;
-import org.elasticsearch.xpack.core.ml.inference.persistence.InferenceIndexConstants;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ClassificationConfig;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfig;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.RegressionConfig;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.config.JobState;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSizeStats;
@@ -298,20 +300,6 @@ public class MachineLearningFeatureSet implements XPackFeatureSet {
             return usage;
         }
 
-        private void addDataFrameAnalyticsUsage(GetDataFrameAnalyticsStatsAction.Response response,
-                                                Map<String, Object> dataframeAnalyticsUsage) {
-            Map<DataFrameAnalyticsState, Counter> dataFrameAnalyticsStateCounterMap = new HashMap<>();
-
-            for(GetDataFrameAnalyticsStatsAction.Response.Stats stats : response.getResponse().results()) {
-                dataFrameAnalyticsStateCounterMap.computeIfAbsent(stats.getState(), ds -> Counter.newCounter()).addAndGet(1);
-            }
-            dataframeAnalyticsUsage.put(MachineLearningFeatureSetUsage.ALL, createCountUsageEntry(response.getResponse().count()));
-            for (DataFrameAnalyticsState state : dataFrameAnalyticsStateCounterMap.keySet()) {
-                dataframeAnalyticsUsage.put(state.name().toLowerCase(Locale.ROOT),
-                    createCountUsageEntry(dataFrameAnalyticsStateCounterMap.get(state).get()));
-            }
-        }
-
         private static void updateStats(Map<String, Long> statsMap, Long value) {
             statsMap.compute("sum", (k, v) -> v + value);
             statsMap.compute("min", (k, v) -> Math.min(v, value));
@@ -342,43 +330,48 @@ public class MachineLearningFeatureSet implements XPackFeatureSet {
                 return;
             }
 
-            // Step 5. extract trained model config count and then return results
-            ActionListener<SearchResponse> trainedModelConfigCountListener = ActionListener.wrap(
+            // Step 6. extract trained model config count and then return results
+            ActionListener<GetTrainedModelsAction.Response> trainedModelsListener = ActionListener.wrap(
                 response -> {
                     addTrainedModelStats(response, inferenceUsage);
-                    MachineLearningFeatureSetUsage usage = new MachineLearningFeatureSetUsage(available,
-                        enabled, jobsUsage, datafeedsUsage, analyticsUsage, inferenceUsage, nodeCount);
+                    MachineLearningFeatureSetUsage usage = new MachineLearningFeatureSetUsage(
+                        available, enabled, jobsUsage, datafeedsUsage, analyticsUsage, inferenceUsage, nodeCount);
                     listener.onResponse(usage);
                 },
                 listener::onFailure
             );
 
-            // Step 4. Extract usage from ingest statistics and gather trained model config count
+            // Step 5. Extract usage from ingest statistics and gather trained model config count
             ActionListener<NodesStatsResponse> nodesStatsListener = ActionListener.wrap(
                 response -> {
                     addInferenceIngestUsage(response, inferenceUsage);
-                    SearchRequestBuilder requestBuilder = client.prepareSearch(InferenceIndexConstants.INDEX_PATTERN)
-                        .setSize(0)
-                        .setQuery(QueryBuilders.boolQuery()
-                            .filter(QueryBuilders.termQuery(InferenceIndexConstants.DOC_TYPE.getPreferredName(), TrainedModelConfig.NAME)))
-                        .setTrackTotalHits(true);
-                    ClientHelper.executeAsyncWithOrigin(client.threadPool().getThreadContext(),
-                        ClientHelper.ML_ORIGIN,
-                        requestBuilder.request(),
-                        trainedModelConfigCountListener,
-                        client::search);
+                    GetTrainedModelsAction.Request getModelsRequest = new GetTrainedModelsAction.Request("*", Collections.emptyList(),
+                        Collections.emptySet());
+                    getModelsRequest.setPageParams(new PageParams(0, 10_000));
+                    client.execute(GetTrainedModelsAction.INSTANCE, getModelsRequest, trainedModelsListener);
                 },
                 listener::onFailure
             );
 
-            // Step 3. Extract usage from data frame analytics stats and then request ingest node stats
-            ActionListener<GetDataFrameAnalyticsStatsAction.Response> dataframeAnalyticsListener = ActionListener.wrap(
+            // Step 4. Extract usage from data frame analytics configs and then request ingest node stats
+            ActionListener<GetDataFrameAnalyticsAction.Response> dataframeAnalyticsListener = ActionListener.wrap(
                 response -> {
                     addDataFrameAnalyticsUsage(response, analyticsUsage);
                     String[] ingestNodes = ingestNodes(state);
-                    NodesStatsRequest nodesStatsRequest =
-                        new NodesStatsRequest(ingestNodes).clear().addMetric(NodesStatsRequest.Metric.INGEST.metricName());
+                    NodesStatsRequest nodesStatsRequest = new NodesStatsRequest(ingestNodes).clear()
+                        .addMetric(NodesStatsRequest.Metric.INGEST.metricName());
                     client.execute(NodesStatsAction.INSTANCE, nodesStatsRequest, nodesStatsListener);
+                },
+                listener::onFailure
+            );
+
+            // Step 3. Extract usage from data frame analytics stats and then request data frame analytics configs
+            ActionListener<GetDataFrameAnalyticsStatsAction.Response> dataframeAnalyticsStatsListener = ActionListener.wrap(
+                response -> {
+                    addDataFrameAnalyticsStatsUsage(response, analyticsUsage);
+                    GetDataFrameAnalyticsAction.Request getDfaRequest = new GetDataFrameAnalyticsAction.Request(Metadata.ALL);
+                    getDfaRequest.setPageParams(new PageParams(0, 10_000));
+                    client.execute(GetDataFrameAnalyticsAction.INSTANCE, getDfaRequest, dataframeAnalyticsListener);
                 },
                 listener::onFailure
             );
@@ -390,7 +383,8 @@ public class MachineLearningFeatureSet implements XPackFeatureSet {
                     GetDataFrameAnalyticsStatsAction.Request dataframeAnalyticsStatsRequest =
                         new GetDataFrameAnalyticsStatsAction.Request(GetDatafeedsStatsAction.ALL);
                     dataframeAnalyticsStatsRequest.setPageParams(new PageParams(0, 10_000));
-                    client.execute(GetDataFrameAnalyticsStatsAction.INSTANCE, dataframeAnalyticsStatsRequest, dataframeAnalyticsListener);
+                    client.execute(GetDataFrameAnalyticsStatsAction.INSTANCE, dataframeAnalyticsStatsRequest,
+                        dataframeAnalyticsStatsListener);
                 },
                 listener::onFailure);
 
@@ -410,11 +404,82 @@ public class MachineLearningFeatureSet implements XPackFeatureSet {
             client.execute(GetJobsStatsAction.INSTANCE, jobStatsRequest, jobStatsListener);
         }
 
+        private void addDataFrameAnalyticsStatsUsage(GetDataFrameAnalyticsStatsAction.Response response,
+                                                     Map<String, Object> dataframeAnalyticsUsage) {
+            Map<DataFrameAnalyticsState, Counter> dataFrameAnalyticsStateCounterMap = new HashMap<>();
+
+            StatsAccumulator memoryUsagePeakBytesStats = new StatsAccumulator();
+            for(GetDataFrameAnalyticsStatsAction.Response.Stats stats : response.getResponse().results()) {
+                dataFrameAnalyticsStateCounterMap.computeIfAbsent(stats.getState(), ds -> Counter.newCounter()).addAndGet(1);
+                MemoryUsage memoryUsage = stats.getMemoryUsage();
+                if (memoryUsage != null && memoryUsage.getPeakUsageBytes() > 0) {
+                    memoryUsagePeakBytesStats.add(memoryUsage.getPeakUsageBytes());
+                }
+            }
+            dataframeAnalyticsUsage.put("memory_usage",
+                Collections.singletonMap(MemoryUsage.PEAK_USAGE_BYTES.getPreferredName(), memoryUsagePeakBytesStats.asMap()));
+
+            dataframeAnalyticsUsage.put(MachineLearningFeatureSetUsage.ALL, createCountUsageEntry(response.getResponse().count()));
+            for (DataFrameAnalyticsState state : dataFrameAnalyticsStateCounterMap.keySet()) {
+                dataframeAnalyticsUsage.put(state.name().toLowerCase(Locale.ROOT),
+                    createCountUsageEntry(dataFrameAnalyticsStateCounterMap.get(state).get()));
+            }
+        }
+
+        private void addDataFrameAnalyticsUsage(GetDataFrameAnalyticsAction.Response response,
+                                                Map<String, Object> dataframeAnalyticsUsage) {
+            Map<String, Integer> perAnalysisTypeCounterMap = new HashMap<>();
+
+            for(DataFrameAnalyticsConfig config : response.getResources().results()) {
+                int count = perAnalysisTypeCounterMap.computeIfAbsent(config.getAnalysis().getWriteableName(), k -> 0);
+                perAnalysisTypeCounterMap.put(config.getAnalysis().getWriteableName(), ++count);
+            }
+            dataframeAnalyticsUsage.put("analysis_counts", perAnalysisTypeCounterMap);
+        }
+
         //TODO separate out ours and users models possibly regression vs classification
-        private void addTrainedModelStats(SearchResponse response, Map<String, Object> inferenceUsage) {
-            inferenceUsage.put("trained_models",
-                Collections.singletonMap(MachineLearningFeatureSetUsage.ALL,
-                    createCountUsageEntry(response.getHits().getTotalHits().value)));
+        private void addTrainedModelStats(GetTrainedModelsAction.Response response, Map<String, Object> inferenceUsage) {
+            List<TrainedModelConfig> trainedModelConfigs = response.getResources().results();
+            Map<String, Object> trainedModelsUsage = new HashMap<>();
+            trainedModelsUsage.put(MachineLearningFeatureSetUsage.ALL, createCountUsageEntry(trainedModelConfigs.size()));
+
+            StatsAccumulator estimatedOperations = new StatsAccumulator();
+            StatsAccumulator estimatedMemoryUsageBytes = new StatsAccumulator();
+            int createdByAnalyticsCount = 0;
+            int regressionCount = 0;
+            int classificationCount = 0;
+            int prepackagedCount = 0;
+            for (TrainedModelConfig trainedModelConfig : trainedModelConfigs) {
+                if (trainedModelConfig.getTags().contains("prepackaged")) {
+                    prepackagedCount++;
+                    continue;
+                }
+                InferenceConfig inferenceConfig = trainedModelConfig.getInferenceConfig();
+                if (inferenceConfig instanceof RegressionConfig) {
+                    regressionCount++;
+                } else if (inferenceConfig instanceof ClassificationConfig) {
+                    classificationCount++;
+                }
+                if (trainedModelConfig.getMetadata() != null && trainedModelConfig.getMetadata().containsKey("analytics_config")) {
+                    createdByAnalyticsCount++;
+                }
+                estimatedOperations.add(trainedModelConfig.getEstimatedOperations());
+                estimatedMemoryUsageBytes.add(trainedModelConfig.getEstimatedHeapMemory());
+            }
+
+            Map<String, Object> counts = new HashMap<>();
+            counts.put("total", trainedModelConfigs.size());
+            counts.put("classification", classificationCount);
+            counts.put("regression", regressionCount);
+            counts.put("prepackaged", prepackagedCount);
+            counts.put("other", trainedModelConfigs.size() - createdByAnalyticsCount - prepackagedCount);
+
+            trainedModelsUsage.put("count", counts);
+            trainedModelsUsage.put(TrainedModelConfig.ESTIMATED_OPERATIONS.getPreferredName(), estimatedOperations.asMap());
+            trainedModelsUsage.put(TrainedModelConfig.ESTIMATED_HEAP_MEMORY_USAGE_BYTES.getPreferredName(),
+                estimatedMemoryUsageBytes.asMap());
+
+            inferenceUsage.put("trained_models", trainedModelsUsage);
         }
 
         //TODO separate out ours and users models possibly regression vs classification

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningFeatureSetTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningFeatureSetTests.java
@@ -9,13 +9,9 @@ package org.elasticsearch.xpack.ml;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
-import org.apache.lucene.search.TotalHits;
 import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
 import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsAction;
 import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsResponse;
-import org.elasticsearch.action.search.SearchAction;
-import org.elasticsearch.action.search.SearchRequestBuilder;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterName;
@@ -25,11 +21,11 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
-import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
@@ -37,10 +33,7 @@ import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.ingest.IngestStats;
 import org.elasticsearch.license.XPackLicenseState;
-import org.elasticsearch.search.SearchHit;
-import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.XPackFeatureSet;
 import org.elasticsearch.xpack.core.XPackFeatureSet.Usage;
 import org.elasticsearch.xpack.core.XPackField;
@@ -51,10 +44,17 @@ import org.elasticsearch.xpack.core.ml.action.GetDataFrameAnalyticsAction;
 import org.elasticsearch.xpack.core.ml.action.GetDataFrameAnalyticsStatsAction;
 import org.elasticsearch.xpack.core.ml.action.GetDatafeedsStatsAction;
 import org.elasticsearch.xpack.core.ml.action.GetJobsStatsAction;
+import org.elasticsearch.xpack.core.ml.action.GetTrainedModelsAction;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedState;
+import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfig;
+import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfigTests;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsState;
-import org.elasticsearch.xpack.core.ml.inference.persistence.InferenceIndexConstants;
+import org.elasticsearch.xpack.core.ml.dataframe.stats.common.MemoryUsage;
+import org.elasticsearch.xpack.core.ml.inference.TrainedModelConfig;
+import org.elasticsearch.xpack.core.ml.inference.TrainedModelConfigTests;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ClassificationConfig;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.RegressionConfig;
 import org.elasticsearch.xpack.core.ml.job.config.AnalysisConfig;
 import org.elasticsearch.xpack.core.ml.job.config.DataDescription;
 import org.elasticsearch.xpack.core.ml.job.config.Detector;
@@ -116,9 +116,9 @@ public class MachineLearningFeatureSetTests extends ESTestCase {
         when(clusterService.state()).thenReturn(clusterState);
         givenJobs(Collections.emptyList(), Collections.emptyList());
         givenDatafeeds(Collections.emptyList());
-        givenDataFrameAnalytics(Collections.emptyList());
+        givenDataFrameAnalytics(Collections.emptyList(), Collections.emptyList());
         givenProcessorStats(Collections.emptyList());
-        givenTrainedModelConfigCount(0);
+        givenTrainedModels(Collections.emptyList());
     }
 
     public void testIsRunningOnMlPlatform() {
@@ -201,11 +201,23 @@ public class MachineLearningFeatureSetTests extends ESTestCase {
                 buildDatafeedStats(DatafeedState.STOPPED)
         ));
 
-        givenDataFrameAnalytics(Arrays.asList(
-            buildDataFrameAnalyticsStats(DataFrameAnalyticsState.STOPPED),
-            buildDataFrameAnalyticsStats(DataFrameAnalyticsState.STOPPED),
-            buildDataFrameAnalyticsStats(DataFrameAnalyticsState.STARTED)
+        DataFrameAnalyticsConfig dfa1 = DataFrameAnalyticsConfigTests.createRandom("dfa_1");
+        DataFrameAnalyticsConfig dfa2 = DataFrameAnalyticsConfigTests.createRandom("dfa_2");
+        DataFrameAnalyticsConfig dfa3 = DataFrameAnalyticsConfigTests.createRandom("dfa_3");
+
+        List<DataFrameAnalyticsConfig> dataFrameAnalytics = Arrays.asList(dfa1, dfa2, dfa3);
+        givenDataFrameAnalytics(dataFrameAnalytics, Arrays.asList(
+            buildDataFrameAnalyticsStats(dfa1.getId(), DataFrameAnalyticsState.STOPPED, null),
+            buildDataFrameAnalyticsStats(dfa2.getId(), DataFrameAnalyticsState.STOPPED, 100L),
+            buildDataFrameAnalyticsStats(dfa3.getId(), DataFrameAnalyticsState.STARTED, 200L)
         ));
+
+        Map<String, Integer> expectedDfaCountByAnalysis = new HashMap<>();
+        dataFrameAnalytics.forEach(dfa -> {
+            String analysisName = dfa.getAnalysis().getWriteableName();
+            Integer analysisCount = expectedDfaCountByAnalysis.computeIfAbsent(analysisName, c -> 0);
+            expectedDfaCountByAnalysis.put(analysisName, ++analysisCount);
+        });
 
         givenProcessorStats(Arrays.asList(
             buildNodeStats(
@@ -244,7 +256,38 @@ public class MachineLearningFeatureSetTests extends ESTestCase {
                     )
                 ))
         ));
-        givenTrainedModelConfigCount(100);
+
+        TrainedModelConfig trainedModel1 = TrainedModelConfigTests.createTestInstance("model_1")
+            .setEstimatedHeapMemory(100)
+            .setEstimatedOperations(200)
+            .setMetadata(Collections.singletonMap("analytics_config", "anything"))
+            .build();
+        TrainedModelConfig trainedModel2 = TrainedModelConfigTests.createTestInstance("model_2")
+            .setEstimatedHeapMemory(200)
+            .setEstimatedOperations(400)
+            .setMetadata(Collections.singletonMap("analytics_config", "anything"))
+            .build();
+        TrainedModelConfig trainedModel3 = TrainedModelConfigTests.createTestInstance("model_3")
+            .setEstimatedHeapMemory(300)
+            .setEstimatedOperations(600)
+            .build();
+        TrainedModelConfig trainedModel4 = TrainedModelConfigTests.createTestInstance("model_4")
+            .setTags(Collections.singletonList("prepackaged"))
+            .setEstimatedHeapMemory(1000)
+            .setEstimatedOperations(2000)
+            .build();
+        givenTrainedModels(Arrays.asList(trainedModel1, trainedModel2, trainedModel3, trainedModel4));
+
+        Map<String, Integer> trainedModelsCountByAnalysis = new HashMap<>();
+        trainedModelsCountByAnalysis.put("classification", 0);
+        trainedModelsCountByAnalysis.put("regression", 0);
+        for (TrainedModelConfig trainedModel : Arrays.asList(trainedModel1, trainedModel2, trainedModel3)) {
+            if (trainedModel.getInferenceConfig() instanceof ClassificationConfig) {
+                trainedModelsCountByAnalysis.put("classification", trainedModelsCountByAnalysis.get("classification") + 1);
+            } else if (trainedModel.getInferenceConfig() instanceof RegressionConfig) {
+                trainedModelsCountByAnalysis.put("regression", trainedModelsCountByAnalysis.get("regression") + 1);
+            }
+        }
 
         MachineLearningFeatureSet featureSet = new MachineLearningFeatureSet(TestEnvironment.newEnvironment(settings.build()),
             clusterService, client, licenseState, jobManagerHolder);
@@ -314,6 +357,11 @@ public class MachineLearningFeatureSetTests extends ESTestCase {
             assertThat(source.getValue("data_frame_analytics_jobs._all.count"), equalTo(3));
             assertThat(source.getValue("data_frame_analytics_jobs.started.count"), equalTo(1));
             assertThat(source.getValue("data_frame_analytics_jobs.stopped.count"), equalTo(2));
+            assertThat(source.getValue("data_frame_analytics_jobs.analysis_counts"), equalTo(expectedDfaCountByAnalysis));
+            assertThat(source.getValue("data_frame_analytics_jobs.memory_usage.peak_usage_bytes.min"), equalTo(100.0));
+            assertThat(source.getValue("data_frame_analytics_jobs.memory_usage.peak_usage_bytes.max"), equalTo(200.0));
+            assertThat(source.getValue("data_frame_analytics_jobs.memory_usage.peak_usage_bytes.total"), equalTo(300.0));
+            assertThat(source.getValue("data_frame_analytics_jobs.memory_usage.peak_usage_bytes.avg"), equalTo(150.0));
 
             assertThat(source.getValue("jobs._all.forecasts.total"), equalTo(11));
             assertThat(source.getValue("jobs._all.forecasts.forecasted_jobs"), equalTo(2));
@@ -324,7 +372,23 @@ public class MachineLearningFeatureSetTests extends ESTestCase {
             assertThat(source.getValue("jobs.opened.forecasts.total"), equalTo(11));
             assertThat(source.getValue("jobs.opened.forecasts.forecasted_jobs"), equalTo(2));
 
-            assertThat(source.getValue("inference.trained_models._all.count"), equalTo(100));
+            assertThat(source.getValue("inference.trained_models._all.count"), equalTo(4));
+            assertThat(source.getValue("inference.trained_models.estimated_heap_memory_usage_bytes.min"), equalTo(100.0));
+            assertThat(source.getValue("inference.trained_models.estimated_heap_memory_usage_bytes.max"), equalTo(300.0));
+            assertThat(source.getValue("inference.trained_models.estimated_heap_memory_usage_bytes.total"), equalTo(600.0));
+            assertThat(source.getValue("inference.trained_models.estimated_heap_memory_usage_bytes.avg"), equalTo(200.0));
+            assertThat(source.getValue("inference.trained_models.estimated_operations.min"), equalTo(200.0));
+            assertThat(source.getValue("inference.trained_models.estimated_operations.max"), equalTo(600.0));
+            assertThat(source.getValue("inference.trained_models.estimated_operations.total"), equalTo(1200.0));
+            assertThat(source.getValue("inference.trained_models.estimated_operations.avg"), equalTo(400.0));
+            assertThat(source.getValue("inference.trained_models.count.total"), equalTo(4));
+            assertThat(source.getValue("inference.trained_models.count.classification"),
+                equalTo(trainedModelsCountByAnalysis.get("classification")));
+            assertThat(source.getValue("inference.trained_models.count.regression"),
+                equalTo(trainedModelsCountByAnalysis.get("regression")));
+            assertThat(source.getValue("inference.trained_models.count.prepackaged"), equalTo(1));
+            assertThat(source.getValue("inference.trained_models.count.other"), equalTo(1));
+
             assertThat(source.getValue("inference.ingest_processors._all.pipelines.count"), equalTo(2));
             assertThat(source.getValue("inference.ingest_processors._all.num_docs_processed.sum"), equalTo(130));
             assertThat(source.getValue("inference.ingest_processors._all.num_docs_processed.min"), equalTo(0));
@@ -548,14 +612,28 @@ public class MachineLearningFeatureSetTests extends ESTestCase {
         }).when(client).execute(same(GetDatafeedsStatsAction.INSTANCE), any(), any());
     }
 
-    private void givenDataFrameAnalytics(List<GetDataFrameAnalyticsStatsAction.Response.Stats> dataFrameAnalyticsStats) {
+    private void givenDataFrameAnalytics(List<DataFrameAnalyticsConfig> configs,
+                                         List<GetDataFrameAnalyticsStatsAction.Response.Stats> stats) {
+        assert configs.size() == stats.size();
+
+        doAnswer(invocationOnMock -> {
+            @SuppressWarnings("unchecked")
+            ActionListener<GetDataFrameAnalyticsAction.Response> listener =
+                (ActionListener<GetDataFrameAnalyticsAction.Response>) invocationOnMock.getArguments()[2];
+            listener.onResponse(new GetDataFrameAnalyticsAction.Response(
+                new QueryPage<>(configs,
+                    configs.size(),
+                    GetDataFrameAnalyticsAction.Response.RESULTS_FIELD)));
+            return Void.TYPE;
+        }).when(client).execute(same(GetDataFrameAnalyticsAction.INSTANCE), any(), any());
+
         doAnswer(invocationOnMock -> {
             @SuppressWarnings("unchecked")
             ActionListener<GetDataFrameAnalyticsStatsAction.Response> listener =
                 (ActionListener<GetDataFrameAnalyticsStatsAction.Response>) invocationOnMock.getArguments()[2];
             listener.onResponse(new GetDataFrameAnalyticsStatsAction.Response(
-                new QueryPage<>(dataFrameAnalyticsStats,
-                    dataFrameAnalyticsStats.size(),
+                new QueryPage<>(stats,
+                    stats.size(),
                     GetDataFrameAnalyticsAction.Response.RESULTS_FIELD)));
             return Void.TYPE;
         }).when(client).execute(same(GetDataFrameAnalyticsStatsAction.INSTANCE), any(), any());
@@ -571,22 +649,17 @@ public class MachineLearningFeatureSetTests extends ESTestCase {
         }).when(client).execute(same(NodesStatsAction.INSTANCE), any(), any());
     }
 
-    private void givenTrainedModelConfigCount(long count) {
-        when(client.prepareSearch(InferenceIndexConstants.INDEX_PATTERN))
-            .thenReturn(new SearchRequestBuilder(client, SearchAction.INSTANCE));
-        ThreadPool pool = mock(ThreadPool.class);
-        when(pool.getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));
-        when(client.threadPool()).thenReturn(pool);
+    private void givenTrainedModels(List<TrainedModelConfig> trainedModels) {
         doAnswer(invocationOnMock -> {
             @SuppressWarnings("unchecked")
-            ActionListener<SearchResponse> listener =
-                (ActionListener<SearchResponse>) invocationOnMock.getArguments()[1];
-            SearchHits searchHits = new SearchHits(new SearchHit[0], new TotalHits(count, TotalHits.Relation.EQUAL_TO), (float)0.0);
-            SearchResponse searchResponse = mock(SearchResponse.class);
-            when(searchResponse.getHits()).thenReturn(searchHits);
-            listener.onResponse(searchResponse);
+            ActionListener<GetTrainedModelsAction.Response> listener =
+                (ActionListener<GetTrainedModelsAction.Response>) invocationOnMock.getArguments()[2];
+            listener.onResponse(new GetTrainedModelsAction.Response(
+                new QueryPage<>(trainedModels,
+                    trainedModels.size(),
+                    GetDataFrameAnalyticsAction.Response.RESULTS_FIELD)));
             return Void.TYPE;
-        }).when(client).search(any(), any());
+        }).when(client).execute(same(GetTrainedModelsAction.INSTANCE), any(), any());
     }
 
     private static Detector buildMinDetector(String fieldName) {
@@ -629,9 +702,13 @@ public class MachineLearningFeatureSetTests extends ESTestCase {
         return stats;
     }
 
-    private static GetDataFrameAnalyticsStatsAction.Response.Stats buildDataFrameAnalyticsStats(DataFrameAnalyticsState state) {
+    private static GetDataFrameAnalyticsStatsAction.Response.Stats buildDataFrameAnalyticsStats(String jobId,
+            DataFrameAnalyticsState state, @Nullable Long peakUsageBytes) {
         GetDataFrameAnalyticsStatsAction.Response.Stats stats = mock(GetDataFrameAnalyticsStatsAction.Response.Stats.class);
         when(stats.getState()).thenReturn(state);
+        if (peakUsageBytes != null) {
+            when(stats.getMemoryUsage()).thenReturn(new MemoryUsage(jobId, Instant.now(), peakUsageBytes, null, null));
+        }
         return stats;
     }
 


### PR DESCRIPTION
…els (#69477)

This adds additional statistics into the usage API for data frame analytics
and trained models.

For data frame analytics the added stats are:

  - count of jobs by analysis type
  - stats for peak_usage_bytes

For trained models the added stats are:
  - counts of: total, prepackaged, other (not created by data frame analytics)
  - counts by analysis type based on the inference config
  - stats for estimated heap usage
  - stats for estimated number of operations

Backport of #69477
