### PR TITLE
[DOCS] EQL: Add 7.12 release highlight for case-insensitive `~` variants

### DIFF
--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -30,7 +30,7 @@ Other versions:
 [[eql-case-insensitivity]]
 === EQL: Case-insensitive `in` lookups and functions
 
-The `in` and `not in` {ref}/eql-syntax-lookup-operators[lookup operators] now
+The `in` and `not in` {ref}/eql-syntax.html#lookup-operators[lookup operators] now
 support case-insensitive variants: `in~` and `not in~`. You can also
 {ref}/eql-syntax.html#eql-case-insensitive-functions[make an EQL function
 case-insensitive] by adding `~` after the function name, such as

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -27,6 +27,16 @@ Other versions:
 
 // tag::notable-highlights[]
 [discrete]
+[[eql-case-insensitivity]]
+=== EQL: Case-insensitive `in` lookups and functions
+
+The `in` and `not in` {ref}/eql-syntax-lookup-operators[lookup operators] now
+support case-insensitive variants: `in~` and `not in~`. You can also
+{ref}/eql-syntax.html#eql-case-insensitive-functions[make an EQL function
+case-insensitive] by adding `~` after the function name, such as
+`endsWith~(process_name, ".exe")`.
+
+[discrete]
 [[eql-like-regex-keywords]]
 === EQL: `like` and `regex` keywords
 

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -30,9 +30,9 @@ Other versions:
 [[eql-case-insensitivity]]
 === EQL: Case-insensitive `in` lookups and functions
 
-The `in` and `not in` {ref}/eql-syntax.html#lookup-operators[lookup operators] now
-support case-insensitive variants: `in~` and `not in~`. You can also
-{ref}/eql-syntax.html#eql-case-insensitive-functions[make an EQL function
+The `in` and `not in` {ref}/eql-syntax.html#eql-syntax-lookup-operators[lookup
+operators] now support case-insensitive variants: `in~` and `not in~`. You can
+also {ref}/eql-syntax.html#eql-case-insensitive-functions[make an EQL function
 case-insensitive] by adding `~` after the function name, such as
 `endsWith~(process_name, ".exe")`.
 


### PR DESCRIPTION
Adds a release highlight for #68204

### Preview
https://elasticsearch_69561.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.12/release-highlights.html#eql-case-insensitivity