### PR TITLE
Test: Clean up a stray NPE

### DIFF
--- a/server/src/test/java/org/elasticsearch/rest/action/document/RestIndexActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/document/RestIndexActionTests.java
@@ -12,12 +12,14 @@ import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.document.RestIndexAction.AutoIdHandler;
 import org.elasticsearch.rest.action.document.RestIndexAction.CreateHandler;
@@ -68,6 +70,7 @@ public class RestIndexActionTests extends RestActionTestCase {
             assertThat(request, instanceOf(IndexRequest.class));
             assertThat(((IndexRequest) request).opType(), equalTo(expectedOpType));
             executeCalled.set(true);
+            return new IndexResponse(new ShardId("test", "test", 0), "id", 0, 0, 0, true);
         });
         RestRequest autoIdRequest = new FakeRestRequest.Builder(xContentRegistry())
             .withMethod(RestRequest.Method.POST)

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/RestActionTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/RestActionTestCase.java
@@ -28,7 +28,6 @@ import org.junit.Before;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 
 /**
@@ -78,7 +77,7 @@ public abstract class RestActionTestCase extends ESTestCase {
      * {@link #setExecuteVerifier} or {@link #setExecuteLocallyVerifier}.
      */
     public static class VerifyingClient extends NoOpNodeClient {
-        AtomicReference<BiConsumer<ActionType<?>, ActionRequest>> executeVerifier = new AtomicReference<>();
+        AtomicReference<BiFunction<ActionType<?>, ActionRequest, ActionResponse>> executeVerifier = new AtomicReference<>();
         AtomicReference<BiFunction<ActionType<?>, ActionRequest, ActionResponse>> executeLocallyVerifier = new AtomicReference<>();
 
         public VerifyingClient(String testName) {
@@ -107,18 +106,25 @@ public abstract class RestActionTestCase extends ESTestCase {
 
         /**
          * Sets the function that will be called when {@link #doExecute(ActionType, ActionRequest, ActionListener)} is called. The given
-         * function should return either a subclass of {@link ActionResponse} or {@code null}.
+         * function should return a subclass of {@link ActionResponse} that is appropriate for the action.
          * @param verifier A function which is called in place of {@link #doExecute(ActionType, ActionRequest, ActionListener)}
          */
-        public void setExecuteVerifier(BiConsumer<ActionType<?>, ActionRequest> verifier) {
-            executeVerifier.set(verifier);
+        public <R extends ActionResponse> void setExecuteVerifier(BiFunction<ActionType<R>, ActionRequest, R> verifier) {
+            BiFunction<?, ?, ?> dropTypeInfo = (BiFunction<?, ?, ?>) verifier;
+            @SuppressWarnings("unchecked")
+            BiFunction<ActionType<?>, ActionRequest, ActionResponse> pasteGenerics = (BiFunction<
+                ActionType<?>,
+                ActionRequest,
+                ActionResponse>) dropTypeInfo;
+            executeVerifier.set(pasteGenerics);
         }
 
         @Override
         public <Request extends ActionRequest, Response extends ActionResponse>
         void doExecute(ActionType<Response> action, Request request, ActionListener<Response> listener) {
-            executeVerifier.get().accept(action, request);
-            listener.onResponse(null);
+            @SuppressWarnings("unchecked") // The method signature of setExecuteVerifier forces this case to work
+            Response response = (Response) executeVerifier.get().apply(action, request);
+            listener.onResponse(response);
         }
 
         /**

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/RestActionTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/RestActionTestCase.java
@@ -110,6 +110,13 @@ public abstract class RestActionTestCase extends ESTestCase {
          * @param verifier A function which is called in place of {@link #doExecute(ActionType, ActionRequest, ActionListener)}
          */
         public <R extends ActionResponse> void setExecuteVerifier(BiFunction<ActionType<R>, ActionRequest, R> verifier) {
+            /*
+             * Perform a little generics dance to force the callers to mock
+             * a return type appropriate for the action even though we can't
+             * declare such types. We have force the caller to be specific
+             * and then throw away their specificity. Then we case back
+             * to the specific erased type in the method below.
+             */
             BiFunction<?, ?, ?> dropTypeInfo = (BiFunction<?, ?, ?>) verifier;
             @SuppressWarnings("unchecked")
             BiFunction<ActionType<?>, ActionRequest, ActionResponse> pasteGenerics = (BiFunction<


### PR DESCRIPTION
When we test the REST actions we assumed that they'd produce a result
but one of the mocking/verification mechanisms didn't. This forces it to
produce a result. It uses some generics dancing to force the calling
code to mock things with the appropriate type even though we don't its
only a compile time guarantee. So long as callers aren't rude its safe.
