### PR TITLE
Remove AwaitsFix from #69325

### DIFF
--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/ShrinkActionIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/ShrinkActionIT.java
@@ -105,7 +105,6 @@ public class ShrinkActionIT extends ESRestTestCase {
         });
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/69325")
     public void testShrinkDuringSnapshot() throws Exception {
         String shrunkenIndex = ShrinkAction.SHRUNKEN_INDEX_PREFIX + index;
         // Create the repository before taking the snapshot.


### PR DESCRIPTION
This failure was actually related to a separate assertion trip that caused the node to shut
down (hence the timeout). The failed assertion was:

```
[2021-02-22T07:31:26,842][WARN ][o.e.c.s.ClusterApplierService] [javaRestTest-0] failed to apply updated cluster state in [0s]:
version [2695], uuid [LEExkxqaR3qhDXvNEq6ypQ], source [Publication{term=6, version=2695}]
java.io.UncheckedIOException: org.apache.lucene.index.CorruptIndexException: codec footer mismatch (file truncated?): actual footer=0 vs expected footer=-1071082520 (resource=BufferedChecksumIndexInput(FrozenIndexInput(_0.cfe)[length=405, file pointer=0, offset=0]))
	at org.elasticsearch.index.engine.FrozenEngine$2.acquireSearcherInternal(FrozenEngine.java:194) ~[?:?]
	at org.elasticsearch.index.engine.Engine$SearcherSupplier.acquireSearcher(Engine.java:1187) ~[elasticsearch-8.0.0-SNAPSHOT.jar:8.0.0-SNAPSHOT]
Caused by: org.apache.lucene.index.CorruptIndexException: codec footer mismatch (file truncated?): actual footer=0 vs expected footer=-1071082520 (resource=BufferedChecksumIndexInput(FrozenIndexInput(_0.cfe)[length=405, file pointer=0, offset=0]))
	at org.apache.lucene.codecs.CodecUtil.validateFooter(CodecUtil.java:523) ~[lucene-core-8.8.0.jar:8.8.0 b10659f0fc18b58b90929cfdadde94544d202c4a - noble - 2021-01-25 19:07:45]
	Suppressed: java.lang.AssertionError: current thread [Thread[elasticsearch[javaRestTest-0][clusterApplierService#updateTask][T#1],5,main]] may not read [name: __Rp_bk_o3QnydJkc1kB2l1w, numberOfParts: 1, partSize: 8192pb, partBytes: 9223372036854775807, metadata: name [_0.cfe], length [405], checksum [1x9s817], writtenBy [8.8.0]]
		at org.elasticsearch.index.store.BaseSearchableSnapshotIndexInput.assertCurrentThreadMayAccessBlobStore(BaseSearchableSnapshotIndexInput.java:263) ~[?:?]
		at org.elasticsearch.index.store.BaseSearchableSnapshotIndexInput.openInputStreamFromBlobStore(BaseSearchableSnapshotIndexInput.java:128) ~[?:?]
		at org.elasticsearch.index.store.cache.FrozenIndexInput.readDirectlyIfAlreadyClosed(FrozenIndexInput.java:424) ~[?:?]
		at org.elasticsearch.index.store.cache.FrozenIndexInput.doReadInternal(FrozenIndexInput.java:391) ~[?:?]
[2021-02-22T07:31:26,847][ERROR][o.e.b.ElasticsearchUncaughtExceptionHandler] [javaRestTest-0] fatal error in thread [elasticsearch[javaRestTest-0][clusterApplierService#updateTask][T#1]], exiting
java.lang.AssertionError: null
	at org.elasticsearch.cluster.service.ClusterApplierService.runTask(ClusterApplierService.java:427) ~[elasticsearch-8.0.0-SNAPSHOT.jar:8.0.0-SNAPSHOT]
	at org.elasticsearch.cluster.service.ClusterApplierService$UpdateTask.run(ClusterApplierService.java:151) ~[elasticsearch-8.0.0-SNAPSHOT.jar:8.0.0-SNAPSHOT]
```

Tanguy has recently fixed the underlying issue in a separate PR, so this can be unmuted now.

Resolves #69325
