### PR TITLE
Enforce minimumCompilerVersion when building Elasticsearch

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/info/GlobalBuildInfoPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/info/GlobalBuildInfoPlugin.java
@@ -118,6 +118,9 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
             }
         });
 
+        // When building Elasticsearch, enforce the minimum compiler version
+        BuildParams.withInternalBuild(() -> assertMinimumCompilerVersion(minimumCompilerVersion));
+
         // Print global build info header just before task execution
         project.getGradle().getTaskGraph().whenReady(graph -> logGlobalBuildInfo());
     }
@@ -240,6 +243,15 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
         );
 
         throw new GradleException(message);
+    }
+
+    private static void assertMinimumCompilerVersion(JavaVersion minimumCompilerVersion) {
+        JavaVersion currentVersion = Jvm.current().getJavaVersion();
+        if (minimumCompilerVersion.compareTo(currentVersion) > 0) {
+            throw new GradleException(
+                "Project requires Java version of " + minimumCompilerVersion + " or newer but Gradle JAVA_HOME is " + currentVersion
+            );
+        }
     }
 
     private static File findRuntimeJavaHome() {


### PR DESCRIPTION
Turns out somewhere along the line we lost the actual _enforcement_ of `minimumCompilerVersion`. This pull request adds the check back in, such that the build immediately fails when the current Gradle build JVM does not meet the minimum version requirement. This is only enforced for the Elasticsearch build, external users of `build-tools` will not be forced to meet this requirement.

This should help us discover scenarios where we aren't building with the expected Java version, as was the case for release manager.

```
* What went wrong:
An exception occurred applying plugin request [id: 'elasticsearch.global-build-info']
> Failed to apply plugin 'elasticsearch.global-build-info'.
   > Project requires Java version of 15 or newer but JAVA_HOME is 14
```