### PR TITLE
[DOCS] Adds model alias to inference processor and aggregation

### DIFF
--- a/docs/reference/aggregations/pipeline/inference-bucket-aggregation.asciidoc
+++ b/docs/reference/aggregations/pipeline/inference-bucket-aggregation.asciidoc
@@ -12,7 +12,7 @@ A parent pipeline aggregation which loads a pre-trained model and performs
 {infer} on the collated result fields from the parent bucket aggregation.
 
 To use the {infer} bucket aggregation, you need to have the same security
-privileges that are required for using the <<get-trained-models>>.
+privileges that are required for using the <<get-trained-models,get trained models API>>.
 
 [[inference-bucket-agg-syntax]]
 ==== Syntax
@@ -37,7 +37,7 @@ A `inference` aggregation looks like this in isolation:
 }
 --------------------------------------------------
 // NOTCONSOLE
-<1> The ID of model to use.
+<1> The unique identifier or alias for the trained model.
 <2> The optional inference config which overrides the model's default settings
 <3> Map the value of `avg_agg` to the model's input field `avg_cost`
 
@@ -47,7 +47,7 @@ A `inference` aggregation looks like this in isolation:
 [options="header"]
 |===
 |Parameter Name |Description |Required |Default Value
-| `model_id`         | The ID of the model to load and infer against       | Required  | -
+| `model_id`         | The ID or alias for the trained model.      | Required  | -
 | `inference_config` | Contains the inference type and its options. There are two types: <<inference-agg-regression-opt,`regression`>> and <<inference-agg-classification-opt,`classification`>>  | Optional | -
 | `buckets_path`     | Defines the paths to the input aggregations and maps the aggregation names to the field names expected by the model.
 See <<buckets-path-syntax>> for more details | Required       | -
@@ -181,5 +181,5 @@ GET kibana_sample_data_logs/_search
 
 <1> A composite bucket aggregation that aggregates the data by `client_ip`.
 <2> A series of metrics and bucket sub-aggregations.
-<3> {infer-cap} bucket aggregation that contains the model ID and maps the
+<3> {infer-cap} bucket aggregation that specifies the trained model and maps the
 aggregation names to the model's input fields.

--- a/docs/reference/ingest/processors/inference.asciidoc
+++ b/docs/reference/ingest/processors/inference.asciidoc
@@ -17,7 +17,7 @@ ingested in the pipeline.
 [options="header"]
 |======
 | Name               | Required  | Default                        | Description
-| `model_id`         | yes       | -                              | (String) The ID of the model to load and infer against.
+| `model_id`         | yes       | -                              | (String) The ID or alias for the trained model.
 | `target_field`     | no        | `ml.inference.<processor_tag>` | (String) Field added to incoming documents to contain results objects.
 | `field_map`        | no        | If defined the model's default field map | (Object) Maps the document field names to the known field names of the model. This mapping takes precedence over any default mappings provided in the model configuration.
 | `inference_config` | no        | The default settings defined in the model  | (Object) Contains the inference type and its options. There are two types: <<inference-processor-regression-opt,`regression`>> and <<inference-processor-classification-opt,`classification`>>.


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/68922

This PR updates the [inference processor](https://www.elastic.co/guide/en/elasticsearch/reference/master/inference-processor.html) and [inference bucket aggregation](https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-pipeline-inference-bucket-aggregation.html) documentation to indicate that the model_id setting supports trained model aliases too.