### PR TITLE
Update test fixture to avoid writing to /etc/hosts file

### DIFF
--- a/test/fixtures/krb5kdc-fixture/Dockerfile
+++ b/test/fixtures/krb5kdc-fixture/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:14.04
 ADD . /fixture
-RUN echo kerberos.build.elastic.co > /etc/hostname && echo "127.0.0.1 kerberos.build.elastic.co" >> /etc/hosts
+RUN echo kerberos.build.elastic.co > /etc/hostname
 RUN bash /fixture/src/main/resources/provision/installkdc.sh
 
 EXPOSE 88

--- a/test/fixtures/krb5kdc-fixture/docker-compose.yml
+++ b/test/fixtures/krb5kdc-fixture/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    extra_hosts:
+      - "kerberos.build.elastic.co:127.0.0.1"
     command: "bash /fixture/src/main/resources/provision/peppa.sh"
     volumes:
       - ./testfixtures_shared/shared/peppa:/fixture/build
@@ -18,6 +20,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    extra_hosts:
+      - "kerberos.build.elastic.co:127.0.0.1"
     command: "bash /fixture/src/main/resources/provision/hdfs.sh"
     volumes:
       - ./testfixtures_shared/shared/hdfs:/fixture/build


### PR DESCRIPTION
When trying to build some of our docker-based test fixtures on an Apple silicon mac I received the [following error](https://gradle-enterprise.elastic.co/s/l4f52osn5zzum/console-log?task=:test:fixtures:krb5kdc-fixture:composeUp):

```
#7 1.011 /bin/sh: 1: cannot create /etc/hosts: Read-only file system
```

Some googling brought me to [this issue](https://github.com/moby/moby/issues/1951) which suggested using the `extra_hosts` parameter in the docker compose file.