### PR TITLE
Remove deprecated jcenter repository from our build (#69517) (7.x backport)

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -83,7 +83,8 @@ tasks.withType(JavaCompile).configureEach {
  *****************************************************************************/
 
 repositories {
-  jcenter()
+  mavenCentral()
+  gradlePluginPortal()
 }
 
 dependencies {

--- a/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/ElasticsearchTestBasePluginFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/ElasticsearchTestBasePluginFuncTest.groovy
@@ -32,7 +32,7 @@ class ElasticsearchTestBasePluginFuncTest extends AbstractGradleFuncTest {
             }
 
             repositories {
-                jcenter()
+                mavenCentral()
             }
 
             dependencies {

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/RepositoriesSetupPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/RepositoriesSetupPlugin.java
@@ -58,7 +58,7 @@ public class RepositoriesSetupPlugin implements Plugin<Project> {
             // such that we don't have to pass hardcoded files to gradle
             repos.mavenLocal();
         }
-        repos.jcenter();
+        repos.mavenCentral();
 
         String luceneVersion = VersionProperties.getLucene();
         if (luceneVersion.contains("-snapshot")) {

--- a/buildSrc/src/testKit/elasticsearch.build/build.gradle
+++ b/buildSrc/src/testKit/elasticsearch.build/build.gradle
@@ -32,7 +32,7 @@ repositories {
       artifact()
     }
   }
-  jcenter()
+  mavenCentral()
 }
 
 repositories {
@@ -46,7 +46,7 @@ repositories {
       artifact()
     }
   }
-  jcenter()
+  mavenCentral()
 }
 
 // todo remove offending rules

--- a/buildSrc/src/testKit/testingConventions/build.gradle
+++ b/buildSrc/src/testKit/testingConventions/build.gradle
@@ -7,7 +7,7 @@ allprojects {
   apply plugin: org.elasticsearch.gradle.internal.precommit.TestingConventionsPrecommitPlugin
 
   repositories {
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     testImplementation "junit:junit:4.12"

--- a/buildSrc/src/testKit/thirdPartyAudit/build.gradle
+++ b/buildSrc/src/testKit/thirdPartyAudit/build.gradle
@@ -25,7 +25,7 @@ repositories {
       artifact()
     }
   }
-  jcenter()
+  mavenCentral()
 }
 
 dependencies {

--- a/distribution/docker/transform-log4j-config/build.gradle
+++ b/distribution/docker/transform-log4j-config/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'elasticsearch.build'
 
 repositories {
-  jcenter()
+  mavenCentral()
 }
 
 dependencies {


### PR DESCRIPTION
- JCenter has been deprecated in Gradle
- JCenter was announced to be sunset by JFrog
- Use Gradle plugin portal as maven repository for build dependencies
- Use mavenCentral as general replacement for jcenter

Fixes #68476