### PR TITLE
Correctly Wait for Cluster State Recovery in Encrypted Repo Test (#69547)

### DIFF
--- a/x-pack/plugin/repository-encrypted/src/internalClusterTest/java/org/elasticsearch/repositories/encrypted/EncryptedRepositorySecretIntegTests.java
+++ b/x-pack/plugin/repository-encrypted/src/internalClusterTest/java/org/elasticsearch/repositories/encrypted/EncryptedRepositorySecretIntegTests.java
@@ -574,7 +574,7 @@ public final class EncryptedRepositorySecretIntegTests extends ESIntegTestCase {
         );
 
         internalCluster().fullRestart();
-        ensureStableCluster(2);
+        ensureGreen();
         // maybe recreate the repository
         if (randomBoolean()) {
             deleteRepository(repositoryName);
@@ -612,7 +612,7 @@ public final class EncryptedRepositorySecretIntegTests extends ESIntegTestCase {
             goodPassword
         );
         internalCluster().fullRestart();
-        ensureStableCluster(2);
+        ensureGreen();
         // ensure get snapshot works
         GetSnapshotsResponse getSnapshotResponse = client().admin().cluster().prepareGetSnapshots(repositoryName).get();
         assertThat(getSnapshotResponse.getSnapshots(), hasSize(1));


### PR DESCRIPTION
Waiting for a connected cluster is not enough, we must wait for green to ensure
that state recovery has happened which causes the repository to be created.

Closes #67834

backport of #69547