### PR TITLE
Test: Clean up a stray NPE (backport of #69566)

### DIFF
--- a/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/RestMultiSearchTemplateActionTests.java
+++ b/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/RestMultiSearchTemplateActionTests.java
@@ -7,6 +7,7 @@
  */
 package org.elasticsearch.script.mustache;
 
+import org.elasticsearch.action.search.MultiSearchResponse;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentType;
@@ -35,7 +36,7 @@ public class RestMultiSearchTemplateActionTests extends RestActionTestCase {
             .withContent(bytesContent, XContentType.JSON)
             .build();
         // We're not actually testing anything to do with the client, but need to set this so it doesn't fail the test for being unset.
-        verifyingClient.setExecuteVerifier((arg1, arg2) -> {});
+        verifyingClient.setExecuteVerifier((arg1, arg2) -> new MultiSearchResponse(new MultiSearchResponse.Item[0], 10));
 
         dispatchRequest(request);
         assertWarnings(RestMultiSearchTemplateAction.TYPES_DEPRECATION_MESSAGE);
@@ -51,7 +52,7 @@ public class RestMultiSearchTemplateActionTests extends RestActionTestCase {
             .withContent(bytesContent, XContentType.JSON)
             .build();
         // We're not actually testing anything to do with the client, but need to set this so it doesn't fail the test for being unset.
-        verifyingClient.setExecuteVerifier((arg1, arg2) -> {});
+        verifyingClient.setExecuteVerifier((arg1, arg2) -> new MultiSearchResponse(new MultiSearchResponse.Item[0], 10));
 
         dispatchRequest(request);
         assertWarnings(RestMultiSearchTemplateAction.TYPES_DEPRECATION_MESSAGE);

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetFieldMappingsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetFieldMappingsResponse.java
@@ -76,7 +76,7 @@ public class GetFieldMappingsResponse extends ActionResponse implements ToXConte
 
     private final Map<String, Map<String, Map<String, FieldMappingMetadata>>> mappings;
 
-    GetFieldMappingsResponse(Map<String, Map<String, Map<String, FieldMappingMetadata>>> mappings) {
+    public GetFieldMappingsResponse(Map<String, Map<String, Map<String, FieldMappingMetadata>>> mappings) {
         this.mappings = mappings;
     }
 

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/forcemerge/RestForceMergeActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/forcemerge/RestForceMergeActionTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.test.rest.FakeRestRequest;
 import org.elasticsearch.test.rest.RestActionTestCase;
 import org.junit.Before;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -75,7 +76,7 @@ public class RestForceMergeActionTests extends RestActionTestCase {
             .build();
 
         // We're not actually testing anything to do with the client, but need to set this so it doesn't fail the test for being unset.
-        verifyingClient.setExecuteVerifier((arg1, arg2) -> {});
+        verifyingClient.setExecuteVerifier((arg1, arg2) -> new ForceMergeResponse(1, 1, 0, new ArrayList<>()));
 
         dispatchRequest(request);
         assertWarnings("setting only_expunge_deletes and max_num_segments at the same time is deprecated " +

--- a/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestGetFieldMappingActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestGetFieldMappingActionTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.rest.action.admin.indices;
 
+import org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsResponse;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.rest.RestRequest;
@@ -41,7 +42,7 @@ public class RestGetFieldMappingActionTests extends RestActionTestCase {
         }
 
         // We're not actually testing anything to do with the client, but need to set this so it doesn't fail the test for being unset.
-        verifyingClient.setExecuteVerifier((arg1, arg2) -> {});
+        verifyingClient.setExecuteVerifier((arg1, arg2) -> new GetFieldMappingsResponse(new HashMap<>()));
 
         RestRequest deprecatedRequest = new FakeRestRequest.Builder(xContentRegistry())
             .withMethod(RestRequest.Method.GET)
@@ -70,7 +71,7 @@ public class RestGetFieldMappingActionTests extends RestActionTestCase {
             .build();
 
         // We're not actually testing anything to do with the client, but need to set this so it doesn't fail the test for being unset.
-        verifyingClient.setExecuteVerifier((arg1, arg2) -> {});
+        verifyingClient.setExecuteVerifier((arg1, arg2) -> new GetFieldMappingsResponse(new HashMap<>()));
 
         FakeRestChannel channel = new FakeRestChannel(request, false, 1);
         ThreadContext threadContext = new ThreadContext(Settings.EMPTY);

--- a/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestGetMappingActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestGetMappingActionTests.java
@@ -8,7 +8,9 @@
 
 package org.elasticsearch.rest.action.admin.indices;
 
+import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse;
 import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.rest.RestRequest;
@@ -68,7 +70,7 @@ public class RestGetMappingActionTests extends RestActionTestCase {
             .build();
 
         // We're not actually testing anything to do with the client, but need to set this so it doesn't fail the test for being unset.
-        verifyingClient.setExecuteVerifier((arg1, arg2) -> {});
+        verifyingClient.setExecuteVerifier((action, r) -> new GetMappingsResponse(ImmutableOpenMap.of()));
 
         FakeRestChannel channel = new FakeRestChannel(request, false, 1);
         ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
@@ -91,7 +93,7 @@ public class RestGetMappingActionTests extends RestActionTestCase {
             .build();
 
         // We're not actually testing anything to do with the client, but need to set this so it doesn't fail the test for being unset.
-        verifyingClient.setExecuteVerifier((arg1, arg2) -> {});
+        verifyingClient.setExecuteVerifier((action, r) -> new GetMappingsResponse(ImmutableOpenMap.of()));
 
         FakeRestChannel channel = new FakeRestChannel(request, false, 1);
         ThreadContext threadContext = new ThreadContext(Settings.EMPTY);

--- a/server/src/test/java/org/elasticsearch/rest/action/document/RestDeleteActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/document/RestDeleteActionTests.java
@@ -8,6 +8,9 @@
 
 package org.elasticsearch.rest.action.document;
 
+import org.elasticsearch.action.delete.DeleteResponse;
+import org.elasticsearch.action.support.replication.ReplicationResponse.ShardInfo;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestRequest.Method;
 import org.elasticsearch.test.rest.FakeRestRequest;
@@ -23,7 +26,11 @@ public class RestDeleteActionTests extends RestActionTestCase {
 
     public void testTypeInPath() {
         // We're not actually testing anything to do with the client, but need to set this so it doesn't fail the test for being unset.
-        verifyingClient.setExecuteVerifier((arg1, arg2) -> {});
+        verifyingClient.setExecuteVerifier((arg1, arg2) -> {
+            DeleteResponse response = new DeleteResponse(new ShardId("index", "uuid", 0), "_doc", "id", 0, 1, 1, true);
+            response.setShardInfo(new ShardInfo(1, 1));
+            return response;
+        });
 
         RestRequest deprecatedRequest = new FakeRestRequest.Builder(xContentRegistry())
             .withMethod(Method.DELETE)

--- a/server/src/test/java/org/elasticsearch/rest/action/document/RestGetActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/document/RestGetActionTests.java
@@ -8,6 +8,9 @@
 
 package org.elasticsearch.rest.action.document;
 
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.index.get.GetResult;
 import org.elasticsearch.rest.RestRequest.Method;
 import org.elasticsearch.test.rest.FakeRestRequest;
 import org.elasticsearch.test.rest.RestActionTestCase;
@@ -22,7 +25,9 @@ public class RestGetActionTests extends RestActionTestCase {
 
     public void testTypeInPathWithGet() {
         // We're not actually testing anything to do with the client, but need to set this so it doesn't fail the test for being unset.
-        verifyingClient.setExecuteVerifier((arg1, arg2) -> {});
+        verifyingClient.setExecuteVerifier(
+            (arg1, arg2) -> new GetResponse(new GetResult("index", "_doc", "id", 0, 1, 0, true, new BytesArray("{}"), null, null))
+        );
 
         FakeRestRequest.Builder deprecatedRequest = new FakeRestRequest.Builder(xContentRegistry())
             .withPath("/some_index/some_type/some_id");
@@ -36,7 +41,9 @@ public class RestGetActionTests extends RestActionTestCase {
 
     public void testTypeInPathWithHead() {
         // We're not actually testing anything to do with the client, but need to set this so it doesn't fail the test for being unset.
-        verifyingClient.setExecuteVerifier((arg1, arg2) -> {});
+        verifyingClient.setExecuteVerifier(
+            (arg1, arg2) -> new GetResponse(new GetResult("index", "_doc", "id", 0, 1, 0, true, new BytesArray("{}"), null, null))
+        );
 
         FakeRestRequest.Builder deprecatedRequest = new FakeRestRequest.Builder(xContentRegistry())
             .withPath("/some_index/some_type/some_id");

--- a/server/src/test/java/org/elasticsearch/rest/action/document/RestGetSourceActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/document/RestGetSourceActionTests.java
@@ -56,12 +56,13 @@ public class RestGetSourceActionTests extends RestActionTestCase {
      */
     public void testTypeInPath() {
         // We're not actually testing anything to do with the client, but need to set this so it doesn't fail the test for being unset.
-        verifyingClient.setExecuteVerifier((arg1, arg2) -> {});
+        verifyingClient.setExecuteVerifier(
+            (action, r) -> new GetResponse(new GetResult("index", "_doc", "id", 0, 1, 0, true, new BytesArray("{}"), null, null))
+        );
         for (Method method : Arrays.asList(Method.GET, Method.HEAD)) {
             // Ensure we have a fresh context for each request so we don't get duplicate headers
             try (ThreadContext.StoredContext ignore = verifyingClient.threadPool().getThreadContext().stashContext()) {
-                RestRequest request = new FakeRestRequest.Builder(xContentRegistry())
-                    .withMethod(method)
+                RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(method)
                     .withPath("/some_index/some_type/id/_source")
                     .build();
 
@@ -76,19 +77,20 @@ public class RestGetSourceActionTests extends RestActionTestCase {
      */
     public void testTypeParameter() {
         // We're not actually testing anything to do with the client, but need to set this so it doesn't fail the test for being unset.
-        verifyingClient.setExecuteVerifier((arg1, arg2) -> {});
+        verifyingClient.setExecuteVerifier(
+            (action, r) -> new GetResponse(new GetResult("index", "_doc", "id", 0, 1, 0, true, new BytesArray("{}"), null, null))
+        );
         Map<String, String> params = new HashMap<>();
         params.put("type", "some_type");
         for (Method method : Arrays.asList(Method.GET, Method.HEAD)) {
             // Ensure we have a fresh context for each request so we don't get duplicate headers
             try (ThreadContext.StoredContext ignore = verifyingClient.threadPool().getThreadContext().stashContext()) {
-            RestRequest request = new FakeRestRequest.Builder(xContentRegistry())
-                    .withMethod(method)
+                RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(method)
                     .withPath("/some_index/_source/id")
                     .withParams(params)
                     .build();
-            dispatchRequest(request);
-            assertWarnings(RestGetSourceAction.TYPES_DEPRECATION_MESSAGE);
+                dispatchRequest(request);
+                assertWarnings(RestGetSourceAction.TYPES_DEPRECATION_MESSAGE);
             }
         }
     }

--- a/server/src/test/java/org/elasticsearch/rest/action/document/RestIndexActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/document/RestIndexActionTests.java
@@ -12,12 +12,14 @@ import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.document.RestIndexAction.AutoIdHandler;
 import org.elasticsearch.rest.action.document.RestIndexAction.CreateHandler;
@@ -98,6 +100,7 @@ public class RestIndexActionTests extends RestActionTestCase {
             assertThat(request, instanceOf(IndexRequest.class));
             assertThat(((IndexRequest) request).opType(), equalTo(expectedOpType));
             executeCalled.set(true);
+            return new IndexResponse(new ShardId("test", "test", 0), "_doc", "id", 0, 0, 0, true);
         });
         RestRequest autoIdRequest = new FakeRestRequest.Builder(xContentRegistry())
             .withMethod(RestRequest.Method.POST)

--- a/server/src/test/java/org/elasticsearch/rest/action/document/RestMultiGetActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/document/RestMultiGetActionTests.java
@@ -8,6 +8,8 @@
 
 package org.elasticsearch.rest.action.document;
 
+import org.elasticsearch.action.get.MultiGetItemResponse;
+import org.elasticsearch.action.get.MultiGetResponse;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -28,7 +30,7 @@ public class RestMultiGetActionTests extends RestActionTestCase {
 
     public void testTypeInPath() {
         // We're not actually testing anything to do with the client, but need to set this so it doesn't fail the test for being unset.
-        verifyingClient.setExecuteVerifier((arg1, arg2) -> {});
+        verifyingClient.setExecuteVerifier((arg1, arg2) -> new MultiGetResponse(new MultiGetItemResponse[0]));
 
         RestRequest deprecatedRequest = new FakeRestRequest.Builder(xContentRegistry())
             .withMethod(Method.GET)
@@ -60,7 +62,7 @@ public class RestMultiGetActionTests extends RestActionTestCase {
             .endObject();
 
         // We're not actually testing anything to do with the client, but need to set this so it doesn't fail the test for being unset.
-        verifyingClient.setExecuteVerifier((arg1, arg2) -> {});
+        verifyingClient.setExecuteVerifier((arg1, arg2) -> new MultiGetResponse(new MultiGetItemResponse[0]));
 
         RestRequest request = new FakeRestRequest.Builder(xContentRegistry())
             .withPath("_mget")

--- a/server/src/test/java/org/elasticsearch/rest/action/document/RestMultiTermVectorsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/document/RestMultiTermVectorsActionTests.java
@@ -8,6 +8,8 @@
 
 package org.elasticsearch.rest.action.document;
 
+import org.elasticsearch.action.termvectors.MultiTermVectorsItemResponse;
+import org.elasticsearch.action.termvectors.MultiTermVectorsResponse;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
@@ -36,7 +38,7 @@ public class RestMultiTermVectorsActionTests extends RestActionTestCase {
             .build();
 
         // We're not actually testing anything to do with the client, but need to set this so it doesn't fail the test for being unset.
-        verifyingClient.setExecuteVerifier((arg1, arg2) -> {});
+        verifyingClient.setExecuteVerifier((action, r) -> new MultiTermVectorsResponse(new MultiTermVectorsItemResponse[0]));
 
         dispatchRequest(request);
         assertWarnings(RestMultiTermVectorsAction.TYPES_DEPRECATION_MESSAGE);
@@ -53,7 +55,7 @@ public class RestMultiTermVectorsActionTests extends RestActionTestCase {
             .build();
 
         // We're not actually testing anything to do with the client, but need to set this so it doesn't fail the test for being unset.
-        verifyingClient.setExecuteVerifier((arg1, arg2) -> {});
+        verifyingClient.setExecuteVerifier((action, r) -> new MultiTermVectorsResponse(new MultiTermVectorsItemResponse[0]));
 
         dispatchRequest(request);
         assertWarnings(RestMultiTermVectorsAction.TYPES_DEPRECATION_MESSAGE);
@@ -76,7 +78,7 @@ public class RestMultiTermVectorsActionTests extends RestActionTestCase {
             .build();
 
         // We're not actually testing anything to do with the client, but need to set this so it doesn't fail the test for being unset.
-        verifyingClient.setExecuteVerifier((arg1, arg2) -> {});
+        verifyingClient.setExecuteVerifier((action, r) -> new MultiTermVectorsResponse(new MultiTermVectorsItemResponse[0]));
 
         dispatchRequest(request);
         assertWarnings(RestTermVectorsAction.TYPES_DEPRECATION_MESSAGE);

--- a/server/src/test/java/org/elasticsearch/rest/action/document/RestTermVectorsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/document/RestTermVectorsActionTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.rest.action.document;
 
+import org.elasticsearch.action.termvectors.TermVectorsResponse;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
@@ -34,7 +35,7 @@ public class RestTermVectorsActionTests extends RestActionTestCase {
             .build();
 
         // We're not actually testing anything to do with the client, but need to set this so it doesn't fail the test for being unset.
-        verifyingClient.setExecuteVerifier((arg1, arg2) -> {});
+        verifyingClient.setExecuteVerifier((arg1, arg2) -> new TermVectorsResponse("index", "_doc", "id"));
 
         dispatchRequest(request);
         assertWarnings(RestTermVectorsAction.TYPES_DEPRECATION_MESSAGE);
@@ -46,14 +47,13 @@ public class RestTermVectorsActionTests extends RestActionTestCase {
             .field("_id", 1)
         .endObject();
 
-        RestRequest request = new FakeRestRequest.Builder(xContentRegistry())
-            .withMethod(Method.GET)
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(Method.GET)
             .withPath("/some_index/_termvectors/some_id")
             .withContent(BytesReference.bytes(content), XContentType.JSON)
             .build();
 
-         // We're not actually testing anything to do with the client, but need to set this so it doesn't fail the test for being unset.
-         verifyingClient.setExecuteVerifier((arg1, arg2) -> {});
+        // We're not actually testing anything to do with the client, but need to set this so it doesn't fail the test for being unset.
+        verifyingClient.setExecuteVerifier((arg1, arg2) -> new TermVectorsResponse("index", "_doc", "id"));
 
         dispatchRequest(request);
         assertWarnings(RestTermVectorsAction.TYPES_DEPRECATION_MESSAGE);

--- a/server/src/test/java/org/elasticsearch/rest/action/document/RestUpdateActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/document/RestUpdateActionTests.java
@@ -9,10 +9,12 @@
 package org.elasticsearch.rest.action.document;
 
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.VersionType;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestRequest.Method;
 import org.elasticsearch.test.rest.FakeRestRequest;
@@ -37,7 +39,9 @@ public class RestUpdateActionTests extends RestActionTestCase {
 
     public void testTypeInPath() {
         // We're not actually testing anything to do with the client, but need to set this so it doesn't fail the test for being unset.
-        verifyingClient.setExecuteVerifier((arg1, arg2) -> {});
+        verifyingClient.setExecuteVerifier(
+            (arg1, arg2) -> new UpdateResponse(new ShardId("index", "uuid", 0), "_doc", "id", 0, 1, 1, UpdateResponse.Result.UPDATED)
+        );
 
         RestRequest deprecatedRequest = new FakeRestRequest.Builder(xContentRegistry())
             .withMethod(Method.POST)

--- a/server/src/test/java/org/elasticsearch/rest/action/search/RestCountActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/search/RestCountActionTests.java
@@ -8,8 +8,14 @@
 
 package org.elasticsearch.rest.action.search;
 
+import org.apache.lucene.search.TotalHits;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.SearchResponseSections;
+import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestRequest.Method;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.test.rest.FakeRestRequest;
 import org.elasticsearch.test.rest.RestActionTestCase;
 import org.junit.Before;
@@ -31,7 +37,26 @@ public class RestCountActionTests extends RestActionTestCase {
             .build();
 
         // We're not actually testing anything to do with the client, but need to set this so it doesn't fail the test for being unset.
-        verifyingClient.setExecuteVerifier((arg1, arg2) -> {});
+        verifyingClient.setExecuteVerifier(
+            (arg1, arg2) -> new SearchResponse(
+                new SearchResponseSections(
+                    new SearchHits(new SearchHit[0], new TotalHits(5, TotalHits.Relation.EQUAL_TO), 0.0f),
+                    null,
+                    null,
+                    false,
+                    null,
+                    null,
+                    1
+                ),
+                null,
+                1,
+                1,
+                0,
+                10,
+                new ShardSearchFailure[0],
+                null
+            )
+        );
 
         dispatchRequest(request);
         assertWarnings(RestCountAction.TYPES_DEPRECATION_MESSAGE);
@@ -48,7 +73,26 @@ public class RestCountActionTests extends RestActionTestCase {
             .build();
 
         // We're not actually testing anything to do with the client, but need to set this so it doesn't fail the test for being unset.
-        verifyingClient.setExecuteVerifier((arg1, arg2) -> {});
+        verifyingClient.setExecuteVerifier(
+            (arg1, arg2) -> new SearchResponse(
+                new SearchResponseSections(
+                    new SearchHits(new SearchHit[0], new TotalHits(5, TotalHits.Relation.EQUAL_TO), 0.0f),
+                    null,
+                    null,
+                    false,
+                    null,
+                    null,
+                    1
+                ),
+                null,
+                1,
+                1,
+                0,
+                10,
+                new ShardSearchFailure[0],
+                null
+            )
+        );
 
         dispatchRequest(request);
         assertWarnings(RestCountAction.TYPES_DEPRECATION_MESSAGE);

--- a/server/src/test/java/org/elasticsearch/rest/action/search/RestExplainActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/search/RestExplainActionTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.rest.action.search;
 
+import org.elasticsearch.action.explain.ExplainResponse;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.test.rest.FakeRestRequest;
 import org.elasticsearch.test.rest.RestActionTestCase;
@@ -22,7 +23,7 @@ public class RestExplainActionTests extends RestActionTestCase {
 
     public void testTypeInPath() {
         // We're not actually testing anything to do with the client, but need to set this so it doesn't fail the test for being unset.
-        verifyingClient.setExecuteVerifier((arg1, arg2) -> {});
+        verifyingClient.setExecuteVerifier((action, request) -> new ExplainResponse("test", "_doc", "id", true));
 
         RestRequest deprecatedRequest = new FakeRestRequest.Builder(xContentRegistry())
             .withMethod(RestRequest.Method.GET)

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/RestActionTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/RestActionTestCase.java
@@ -28,7 +28,6 @@ import org.junit.Before;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 
 /**
@@ -78,7 +77,7 @@ public abstract class RestActionTestCase extends ESTestCase {
      * {@link #setExecuteVerifier} or {@link #setExecuteLocallyVerifier}.
      */
     public static class VerifyingClient extends NoOpNodeClient {
-        AtomicReference<BiConsumer<ActionType<?>, ActionRequest>> executeVerifier = new AtomicReference<>();
+        AtomicReference<BiFunction<ActionType<?>, ActionRequest, ActionResponse>> executeVerifier = new AtomicReference<>();
         AtomicReference<BiFunction<ActionType<?>, ActionRequest, ActionResponse>> executeLocallyVerifier = new AtomicReference<>();
 
         public VerifyingClient(String testName) {
@@ -107,18 +106,32 @@ public abstract class RestActionTestCase extends ESTestCase {
 
         /**
          * Sets the function that will be called when {@link #doExecute(ActionType, ActionRequest, ActionListener)} is called. The given
-         * function should return either a subclass of {@link ActionResponse} or {@code null}.
+         * function should return a subclass of {@link ActionResponse} that is appropriate for the action.
          * @param verifier A function which is called in place of {@link #doExecute(ActionType, ActionRequest, ActionListener)}
          */
-        public void setExecuteVerifier(BiConsumer<ActionType<?>, ActionRequest> verifier) {
-            executeVerifier.set(verifier);
+        public <R extends ActionResponse> void setExecuteVerifier(BiFunction<ActionType<R>, ActionRequest, R> verifier) {
+            /*
+             * Perform a little generics dance to force the callers to mock
+             * a return type appropriate for the action even though we can't
+             * declare such types. We have force the caller to be specific
+             * and then throw away their specificity. Then we case back
+             * to the specific erased type in the method below.
+             */
+            BiFunction<?, ?, ?> dropTypeInfo = (BiFunction<?, ?, ?>) verifier;
+            @SuppressWarnings("unchecked")
+            BiFunction<ActionType<?>, ActionRequest, ActionResponse> pasteGenerics = (BiFunction<
+                ActionType<?>,
+                ActionRequest,
+                ActionResponse>) dropTypeInfo;
+            executeVerifier.set(pasteGenerics);
         }
 
         @Override
         public <Request extends ActionRequest, Response extends ActionResponse>
         void doExecute(ActionType<Response> action, Request request, ActionListener<Response> listener) {
-            executeVerifier.get().accept(action, request);
-            listener.onResponse(null);
+            @SuppressWarnings("unchecked") // The method signature of setExecuteVerifier forces this case to work
+            Response response = (Response) executeVerifier.get().apply(action, request);
+            listener.onResponse(response);
         }
 
         /**

--- a/x-pack/plugin/graph/src/test/java/org/elasticsearch/xpack/graph/rest/action/RestGraphActionTests.java
+++ b/x-pack/plugin/graph/src/test/java/org/elasticsearch/xpack/graph/rest/action/RestGraphActionTests.java
@@ -7,12 +7,16 @@
 
 package org.elasticsearch.xpack.graph.rest.action;
 
+import org.elasticsearch.action.ShardOperationFailedException;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.protocol.xpack.graph.GraphExploreResponse;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.test.rest.FakeRestRequest;
 import org.elasticsearch.test.rest.RestActionTestCase;
 import org.junit.Before;
+
+import java.util.HashMap;
 
 public class RestGraphActionTests extends RestActionTestCase {
 
@@ -28,7 +32,16 @@ public class RestGraphActionTests extends RestActionTestCase {
             .withContent(new BytesArray("{}"), XContentType.JSON)
             .build();
         // We're not actually testing anything to do with the client, but need to set this so it doesn't fail the test for being unset.
-        verifyingClient.setExecuteVerifier((arg1, arg2) -> {});
+        verifyingClient.setExecuteVerifier(
+            (arg1, arg2) -> new GraphExploreResponse(
+                0,
+                false,
+                new ShardOperationFailedException[0],
+                new HashMap<>(),
+                new HashMap<>(),
+                false
+            )
+        );
 
         dispatchRequest(request);
         assertWarnings(RestGraphAction.TYPES_DEPRECATION_MESSAGE);


### PR DESCRIPTION
When we test the REST actions we assumed that they'd produce a result
but one of the mocking/verification mechanisms didn't. This forces it to
produce a result. It uses some generics dancing to force the calling
code to mock things with the appropriate type even though we don't its
only a compile time guarantee. So long as callers aren't rude its safe.
