### PR TITLE
[Transform] Fix transform internal index test

### DIFF
--- a/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/TransformSingleNodeTestCase.java
+++ b/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/TransformSingleNodeTestCase.java
@@ -9,9 +9,13 @@ package org.elasticsearch.xpack.transform;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.LatchedActionListener;
+import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksAction;
+import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksRequest;
+import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksResponse;
 import org.elasticsearch.common.CheckedConsumer;
 import org.elasticsearch.index.reindex.ReindexPlugin;
 import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.tasks.TaskInfo;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 
 import java.util.Collection;
@@ -55,4 +59,27 @@ public abstract class TransformSingleNodeTestCase extends ESSingleNodeTestCase {
         assertTrue("timed out after 20s", latch.await(20, TimeUnit.SECONDS));
     }
 
+    protected void waitForPendingTasks() throws Exception {
+        assertBusy(() -> {
+            try {
+                final ListTasksRequest request = new ListTasksRequest().setDetailed(true);
+                final ListTasksResponse response = client().execute(ListTasksAction.INSTANCE, request).actionGet();
+
+                // Check to see if there are outstanding tasks; we exclude the list task itself.
+                StringBuilder tasksListString = new StringBuilder();
+                int activeTasks = 0;
+                for (TaskInfo task : response.getTasks()) {
+                    if (task.getAction().startsWith(ListTasksAction.NAME)) {
+                        continue;
+                    }
+                    ++activeTasks;
+                    tasksListString.append(task.toString());
+                    tasksListString.append('\n');
+                }
+                assertEquals(activeTasks + " active tasks found:\n" + tasksListString, 0, activeTasks);
+            } catch (final Exception e) {
+                throw new AssertionError("error getting active tasks list", e);
+            }
+        }, 30L, TimeUnit.SECONDS);
+    }
 }

--- a/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/integration/TransformInternalIndexIT.java
+++ b/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/integration/TransformInternalIndexIT.java
@@ -26,6 +26,7 @@ import org.elasticsearch.xpack.core.transform.transforms.TransformConfigUpdate;
 import org.elasticsearch.xpack.core.transform.transforms.persistence.TransformInternalIndexConstants;
 import org.elasticsearch.xpack.transform.TransformSingleNodeTestCase;
 import org.elasticsearch.xpack.transform.persistence.TransformInternalIndex;
+import org.junit.After;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -35,6 +36,14 @@ public class TransformInternalIndexIT extends TransformSingleNodeTestCase {
 
     private static final String CURRENT_INDEX = TransformInternalIndexConstants.LATEST_INDEX_NAME;
     private static final String OLD_INDEX = TransformInternalIndexConstants.INDEX_PATTERN + "001";
+
+    @After
+    public void preCleanup() throws Exception {
+        // Updating a transform will leave indexing an audit message in-flight, so
+        // we need to wait for that to complete or it could interfere with deleting
+        // all the indices
+        waitForPendingTasks();
+    }
 
     public void testUpdateDeletesOldTransformConfig() throws Exception {
 


### PR DESCRIPTION
Fixes an internal cluster test that was migrated from being
a REST test by the system indices project.

The REST test framework waits for pending tasks between tests
whereas the internal cluster test framework does not.  The
particular test that was migrated requires this functionality,
as updating a transform triggers an async side effect: writing
an audit message.

This PR does not add the wait for pending tasks step to all
internal cluster tests.  Clearly it is not required for most,
and could slow down tests that don't require it.  The new
method can be called from elsewhere or moved up the class
hierarchy in the future if it is needed elsewhere in the
future.

Closes #69057