### PR TITLE
[DOCS] Improve tip about updating search_analyzer

### DIFF
--- a/docs/reference/mapping/params/search-analyzer.asciidoc
+++ b/docs/reference/mapping/params/search-analyzer.asciidoc
@@ -7,7 +7,7 @@ the terms in the inverted index.
 
 Sometimes, though, it can make sense to use a different analyzer at search
 time, such as when using the  <<analysis-edgengram-tokenizer,`edge_ngram`>>
-tokenizer for autocomplete.
+tokenizer for autocomplete or when using search-time synonyms.
 
 By default, queries will use the `analyzer` defined in the field mapping, but
 this can be overridden with the `search_analyzer` setting:
@@ -76,4 +76,5 @@ See {defguide}/_index_time_search_as_you_type.html[Index time search-as-you-
 type] for a full explanation of this example.
 
 TIP: The `search_analyzer` setting can be updated on existing fields
-using the <<indices-put-mapping,PUT mapping API>>.
+using the <<indices-put-mapping,PUT mapping API>>. Note, that in order to do so,
+any existing "analyzer" setting and "type" need to be repeated in the updated field definition.


### PR DESCRIPTION
The tip about updating a `search_analyzer` currently does not mention that most
of the time (when the current analyzer is not "default"), user need to repeat
the currently set "analyzer" parameter in the field definition. Adding this as a
short note.

Relates to #40008