### PR TITLE
[DOCS] Update the example for the serial_diff aggregation

### DIFF
--- a/docs/reference/aggregations/pipeline/serial-diff-aggregation.asciidoc
+++ b/docs/reference/aggregations/pipeline/serial-diff-aggregation.asciidoc
@@ -43,7 +43,7 @@ A `serial_diff` aggregation looks like this in isolation:
 {
   "serial_diff": {
     "buckets_path": "the_sum",
-    "lag": "7"
+    "lag": 7
   }
 }
 --------------------------------------------------


### PR DESCRIPTION
Use an integer instead of a string for the `lag` parameter.

