### PR TITLE
Disable bwc version logic unit tests on arm

### DIFF
--- a/test/framework/src/test/java/org/elasticsearch/test/VersionUtilsTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/VersionUtilsTests.java
@@ -7,6 +7,7 @@
  */
 package org.elasticsearch.test;
 
+import org.apache.lucene.util.Constants;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.Booleans;
 import org.elasticsearch.common.collect.Tuple;
@@ -313,6 +314,8 @@ public class VersionUtilsTests extends ESTestCase {
      * agree with the list of wire and index compatible versions we build in gradle.
      */
     public void testGradleVersionsMatchVersionUtils() {
+        assumeFalse("We have limited backward compatibility testing for ARM", Constants.OS_ARCH.equals("aarch64"));
+
         // First check the index compatible versions
         VersionsFromProperty indexCompatible = new VersionsFromProperty("tests.gradle_index_compat_versions");
         List<Version> released = VersionUtils.allReleasedVersions().stream()


### PR DESCRIPTION
Our build logic for determining compatible versions is different on ARM due to disparity between ARM artifact availability and various forms of compatibility. For example, 7.x is index compatible with all versions of 6.x but no ARM distributions exist there. We simply don't test BWC on ARM where those artifacts don't exist, so this unit test, which explicitly asserts that Gradle is determining BWC versions correctly isn't applicable on ARM.