### PR TITLE
Allow file read permissions in plugins

### DIFF
--- a/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/PolicyUtilTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/PolicyUtilTests.java
@@ -210,6 +210,9 @@ public class PolicyUtilTests extends ESTestCase {
     }
 
     static final List<String> PLUGIN_TEST_PERMISSIONS = List.of(
+        // TODO: move this back to module test permissions, see https://github.com/elastic/elasticsearch/issues/69464
+        "java.io.FilePermission /foo/bar read",
+
         "java.lang.reflect.ReflectPermission suppressAccessChecks",
         "java.lang.RuntimePermission createClassLoader",
         "java.lang.RuntimePermission getClassLoader",
@@ -270,7 +273,6 @@ public class PolicyUtilTests extends ESTestCase {
     }
 
     static final List<String> MODULE_TEST_PERMISSIONS = List.of(
-        "java.io.FilePermission /foo/bar read",
         "java.io.FilePermission /foo/bar write",
         "java.lang.RuntimePermission getFileStoreAttributes",
         "java.lang.RuntimePermission accessUserInformation"

--- a/server/src/main/java/org/elasticsearch/bootstrap/PolicyUtil.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/PolicyUtil.java
@@ -91,6 +91,9 @@ public class PolicyUtil {
     private static final PermissionMatcher ALLOWED_MODULE_PERMISSIONS;
     static {
         List<Permission> namedPermissions = List.of(
+            // TODO: remove read permission, see https://github.com/elastic/elasticsearch/issues/69464
+            createFilePermission("<<ALL FILES>>", "read"),
+
             new ReflectPermission("suppressAccessChecks"),
             new RuntimePermission("createClassLoader"),
             new RuntimePermission("getClassLoader"),


### PR DESCRIPTION
FilePermissions were restricted from plugins, with the intention of allowing plugins to still read their own configuration directory. While this works for files directly in the directory, it does not allow symlinks to other special files in the system, for example cloud tokens that exist on their own outside of Elasticsearch.

This commit adds back allowing FilePermission for reading files in plugins. This is a temporary measure until plugins are automatically granted read permissions for files within their own configuration directory.

closes #69464