### PR TITLE
[Monitoring] Update monitoring template versions (7.x backport)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/monitoring/exporter/MonitoringTemplateUtils.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/monitoring/exporter/MonitoringTemplateUtils.java
@@ -28,8 +28,11 @@ public final class MonitoringTemplateUtils {
      * The last version of X-Pack that updated the templates and pipelines.
      * <p>
      * It may be possible for this to diverge between templates and pipelines, but for now they're the same.
+     *
+     * Note that the templates were last updated in 7.11.0, but the versions were not updated, meaning that upgrades
+     * to 7.11.0 would not have updated the templates. See https://github.com/elastic/elasticsearch/pull/69317.
      */
-    public static final int LAST_UPDATED_VERSION = Version.V_7_0_1.id;
+    public static final int LAST_UPDATED_VERSION = Version.V_7_12_0.id;
 
     /**
      * Current version of templates used in their name to differentiate from breaking changes (separate from product version).

--- a/x-pack/plugin/core/src/main/resources/monitoring-alerts-7.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-alerts-7.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": [ ".monitoring-alerts-${monitoring.template.version}" ],
-  "version": 7000199,
+  "version": 7120099,
   "settings": {
     "index": {
       "number_of_shards": 1,

--- a/x-pack/plugin/core/src/main/resources/monitoring-beats.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-beats.json
@@ -9,7 +9,7 @@
     "index.number_of_replicas": 0,
     "index.number_of_shards": 1
   },
-  "version": 7000199,
+  "version": 7120099,
   "mappings": {
     "_doc": {
       "dynamic": false,

--- a/x-pack/plugin/core/src/main/resources/monitoring-es.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-es.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": [ ".monitoring-es-${monitoring.template.version}-*" ],
-  "version": 7000199,
+  "version": 7120099,
   "settings": {
     "index.number_of_shards": 1,
     "index.number_of_replicas": 0,

--- a/x-pack/plugin/core/src/main/resources/monitoring-kibana.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-kibana.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": [ ".monitoring-kibana-${monitoring.template.version}-*" ],
-  "version": 7000199,
+  "version": 7120099,
   "settings": {
     "index.number_of_shards": 1,
     "index.number_of_replicas": 0,

--- a/x-pack/plugin/core/src/main/resources/monitoring-logstash.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-logstash.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": [ ".monitoring-logstash-${monitoring.template.version}-*" ],
-  "version": 7000199,
+  "version": 7120099,
   "settings": {
     "index.number_of_shards": 1,
     "index.number_of_replicas": 0,


### PR DESCRIPTION
Backport https://github.com/elastic/elasticsearch/pull/69317 to 7.x