### PR TITLE
Forbid ActionListener#onFailure to Throw in more Places (#69420)

### DIFF
--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/remote/RemoteScrollableHitSourceTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/remote/RemoteScrollableHitSourceTests.java
@@ -88,6 +88,8 @@ public class RemoteScrollableHitSourceTests extends ESTestCase {
 
     private final Queue<ScrollableHitSource.AsyncResponse> responseQueue = new LinkedBlockingQueue<>();
 
+    private final Queue<Throwable> failureQueue = new LinkedBlockingQueue<>();
+
     @Before
     @Override
     public void setUp() throws Exception {
@@ -121,7 +123,8 @@ public class RemoteScrollableHitSourceTests extends ESTestCase {
 
     @After
     public void validateAllConsumed() {
-        assertTrue(responseQueue.isEmpty());
+        assertThat(failureQueue, empty());
+        assertThat(responseQueue, empty());
     }
 
     public void testLookupRemoteVersion() throws Exception {
@@ -336,8 +339,8 @@ public class RemoteScrollableHitSourceTests extends ESTestCase {
         for (int i = 0; i < retriesAllowed + 2; i++) {
             paths[i] = "fail:rejection.json";
         }
-        RuntimeException e = expectThrows(RuntimeException.class, () -> sourceWithMockedRemoteCall(paths).start());
-        assertEquals("failed", e.getMessage());
+        sourceWithMockedRemoteCall(paths).start();
+        assertNotNull(failureQueue.poll());
         assertTrue(responseQueue.isEmpty());
         assertEquals(retriesAllowed, retries);
         retries = 0;
@@ -348,8 +351,8 @@ public class RemoteScrollableHitSourceTests extends ESTestCase {
         assertThat(response.response().getFailures(), empty());
         assertTrue(responseQueue.isEmpty());
 
-        e = expectThrows(RuntimeException.class, () -> response.done(timeValueMillis(0)));
-        assertEquals("failed", e.getMessage());
+        response.done(timeValueMillis(0));
+        assertNotNull(failureQueue.poll());
         assertTrue(responseQueue.isEmpty());
         assertEquals(retriesAllowed, retries);
     }
@@ -431,11 +434,8 @@ public class RemoteScrollableHitSourceTests extends ESTestCase {
         });
         RemoteScrollableHitSource source = sourceWithMockedClient(true, httpClient);
 
-        Throwable e = expectThrows(RuntimeException.class, source::start);
-        // Unwrap the some artifacts from the test
-        while (e.getMessage().equals("failed")) {
-            e = e.getCause();
-        }
+        source.start();
+        Throwable e = failureQueue.poll();
         // This next exception is what the user sees
         assertEquals("Remote responded with a chunk that was too large. Use a smaller batch size.", e.getMessage());
         // And that exception is reported as being caused by the underlying exception returned by the client
@@ -449,17 +449,17 @@ public class RemoteScrollableHitSourceTests extends ESTestCase {
         assertThat(e.getMessage(), containsString("Response didn't include Content-Type: body={"));
     }
 
-    public void testInvalidJsonThinksRemoteIsNotES() throws IOException {
-        Exception e = expectThrows(RuntimeException.class, () -> sourceWithMockedRemoteCall("some_text.txt").start());
-        assertEquals("Error parsing the response, remote is likely not an Elasticsearch instance",
-                e.getCause().getCause().getCause().getMessage());
+    public void testInvalidJsonThinksRemoteIsNotES() throws Exception {
+        sourceWithMockedRemoteCall("some_text.txt").start();
+        Throwable e = failureQueue.poll();
+        assertEquals("Error parsing the response, remote is likely not an Elasticsearch instance", e.getMessage());
     }
 
-    public void testUnexpectedJsonThinksRemoteIsNotES() throws IOException {
+    public void testUnexpectedJsonThinksRemoteIsNotES() throws Exception {
         // Use the response from a main action instead of a proper start response to generate a parse error
-        Exception e = expectThrows(RuntimeException.class, () -> sourceWithMockedRemoteCall("main/2_3_3.json").start());
-        assertEquals("Error parsing the response, remote is likely not an Elasticsearch instance",
-                e.getCause().getCause().getCause().getMessage());
+        sourceWithMockedRemoteCall("main/2_3_3.json").start();
+        Throwable e = failureQueue.poll();
+        assertEquals("Error parsing the response, remote is likely not an Elasticsearch instance", e.getMessage());
     }
 
     public void testCleanupSuccessful() throws Exception {
@@ -567,15 +567,11 @@ public class RemoteScrollableHitSourceTests extends ESTestCase {
         retries += 1;
     }
 
-    private void failRequest(Throwable t) {
-        throw new RuntimeException("failed", t);
-    }
-
     private class TestRemoteScrollableHitSource extends RemoteScrollableHitSource {
         TestRemoteScrollableHitSource(RestClient client) {
             super(RemoteScrollableHitSourceTests.this.logger, backoff(), RemoteScrollableHitSourceTests.this.threadPool,
                 RemoteScrollableHitSourceTests.this::countRetry,
-                responseQueue::add, RemoteScrollableHitSourceTests.this::failRequest,
+                responseQueue::add, failureQueue::add,
                 client, new BytesArray("{}"), RemoteScrollableHitSourceTests.this.searchRequest);
         }
     }

--- a/server/src/main/java/org/elasticsearch/action/ActionListener.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionListener.java
@@ -62,7 +62,15 @@ public interface ActionListener<Response> {
 
         @Override
         public void onFailure(Exception e) {
-            delegate.onFailure(e);
+            try {
+                delegate.onFailure(e);
+            } catch (RuntimeException ex) {
+                if (ex != e) {
+                    ex.addSuppressed(e);
+                }
+                assert false : new AssertionError("listener.onFailure failed", ex);
+                throw ex;
+            }
         }
 
         @Override
@@ -94,19 +102,6 @@ public interface ActionListener<Response> {
             } catch (RuntimeException e) {
                 assert false : new AssertionError("map: listener.onResponse failed", e);
                 throw e;
-            }
-        }
-
-        @Override
-        public void onFailure(Exception e) {
-            try {
-                delegate.onFailure(e);
-            } catch (RuntimeException ex) {
-                if (ex != e) {
-                    ex.addSuppressed(e);
-                }
-                assert false : new AssertionError("map: listener.onFailure failed", ex);
-                throw ex;
             }
         }
 
@@ -191,7 +186,15 @@ public interface ActionListener<Response> {
 
         @Override
         public void onFailure(Exception e) {
-            bc.accept(delegate, e);
+            try {
+                bc.accept(delegate, e);
+            } catch (RuntimeException ex) {
+                if (ex != e) {
+                    ex.addSuppressed(e);
+                }
+                assert false : new AssertionError("listener.onFailure failed", ex);
+                throw ex;
+            }
         }
 
         @Override
@@ -316,7 +319,7 @@ public interface ActionListener<Response> {
         @Override
         public void onFailure(Exception e) {
             try {
-                delegate.onFailure(e);
+                super.onFailure(e);
             } finally {
                 runAfter.run();
             }
@@ -352,7 +355,7 @@ public interface ActionListener<Response> {
             try {
                 runBefore.run();
             } catch (Exception ex) {
-                delegate.onFailure(ex);
+                super.onFailure(ex);
                 return;
             }
             delegate.onResponse(response);
@@ -365,7 +368,7 @@ public interface ActionListener<Response> {
             } catch (Exception ex) {
                 e.addSuppressed(ex);
             }
-            delegate.onFailure(e);
+            super.onFailure(e);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/action/bulk/Retry.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/Retry.java
@@ -111,7 +111,7 @@ public class Retry {
                 retry(currentBulkRequest);
             } else {
                 try {
-                    delegate.onFailure(e);
+                    super.onFailure(e);
                 } finally {
                     if (retryCancellable != null) {
                         retryCancellable.cancel();

--- a/server/src/main/java/org/elasticsearch/action/support/GroupedActionListener.java
+++ b/server/src/main/java/org/elasticsearch/action/support/GroupedActionListener.java
@@ -48,7 +48,7 @@ public final class GroupedActionListener<T> extends ActionListener.Delegating<T,
         results.setOnce(pos.incrementAndGet() - 1, element);
         if (countDown.countDown()) {
             if (failure.get() != null) {
-                delegate.onFailure(failure.get());
+                super.onFailure(failure.get());
             } else {
                 List<T> collect = this.results.asList();
                 delegate.onResponse(Collections.unmodifiableList(collect));
@@ -68,7 +68,7 @@ public final class GroupedActionListener<T> extends ActionListener.Delegating<T,
             });
         }
         if (countDown.countDown()) {
-            delegate.onFailure(failure.get());
+            super.onFailure(failure.get());
         }
     }
 }


### PR DESCRIPTION
Same assertion we have in `.map` we can extend to more places
with recent changes to prevent unexpected listener behavior going forward.

backport of #69420