### PR TITLE
Expose Backing Byte Array for ReleasableBytesReference

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/bytes/BytesArray.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/BytesArray.java
@@ -87,11 +87,18 @@ public final class BytesArray extends AbstractBytesReference {
         return new BytesArray(bytes, offset + from, length);
     }
 
+    @Override
+    public boolean hasArray() {
+        return true;
+    }
+
+    @Override
     public byte[] array() {
         return bytes;
     }
 
-    public int offset() {
+    @Override
+    public int arrayOffset() {
         return offset;
     }
 

--- a/server/src/main/java/org/elasticsearch/common/bytes/BytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/BytesReference.java
@@ -174,4 +174,25 @@ public interface BytesReference extends Comparable<BytesReference>, ToXContentFr
      * @see BytesRefIterator
      */
     BytesRefIterator iterator();
+
+    /**
+     * @return {@code true} if this instance is backed by a byte array
+     */
+    default boolean hasArray() {
+        return false;
+    }
+
+    /**
+     * @return backing byte array for this instance
+     */
+    default byte[] array() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * @return offset of the first byte of this instance in the backing byte array
+     */
+    default int arrayOffset() {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/server/src/main/java/org/elasticsearch/common/bytes/ReleasableBytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/ReleasableBytesReference.java
@@ -83,16 +83,19 @@ public final class ReleasableBytesReference implements RefCounted, Releasable, B
 
     @Override
     public byte get(int index) {
+        assert refCount() > 0;
         return delegate.get(index);
     }
 
     @Override
     public int getInt(int index) {
+        assert refCount() > 0;
         return delegate.getInt(index);
     }
 
     @Override
     public int indexOf(byte marker, int from) {
+        assert refCount() > 0;
         return delegate.indexOf(marker, from);
     }
 
@@ -154,6 +157,7 @@ public final class ReleasableBytesReference implements RefCounted, Releasable, B
 
     @Override
     public int compareTo(BytesReference o) {
+        assert refCount() > 0;
         return delegate.compareTo(o);
     }
 
@@ -178,6 +182,24 @@ public final class ReleasableBytesReference implements RefCounted, Releasable, B
     public int hashCode() {
         assert refCount() > 0;
         return delegate.hashCode();
+    }
+
+    @Override
+    public boolean hasArray() {
+        assert refCount() > 0;
+        return delegate.hasArray();
+    }
+
+    @Override
+    public byte[] array() {
+        assert refCount() > 0;
+        return delegate.array();
+    }
+
+    @Override
+    public int arrayOffset() {
+        assert refCount() > 0;
+        return delegate.arrayOffset();
     }
 
     private static final class RefCountedReleasable extends AbstractRefCounted {

--- a/server/src/main/java/org/elasticsearch/common/xcontent/XContentHelper.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/XContentHelper.java
@@ -67,10 +67,9 @@ public class XContentHelper {
             }
             return XContentFactory.xContent(xContentType).createParser(xContentRegistry, deprecationHandler, compressedInput);
         } else {
-            if (bytes instanceof BytesArray) {
-                final BytesArray array = (BytesArray) bytes;
+            if (bytes.hasArray()) {
                 return xContentType.xContent().createParser(
-                        xContentRegistry, deprecationHandler, array.array(), array.offset(), array.length());
+                        xContentRegistry, deprecationHandler, bytes.array(), bytes.arrayOffset(), bytes.length());
             }
             return xContentType.xContent().createParser(xContentRegistry, deprecationHandler, bytes.streamInput());
         }
@@ -103,11 +102,10 @@ public class XContentHelper {
                 }
                 input = compressedStreamInput;
                 contentType = xContentType != null ? xContentType : XContentFactory.xContentType(input);
-            } else if (bytes instanceof BytesArray) {
-                final BytesArray arr = (BytesArray) bytes;
-                final byte[] raw = arr.array();
-                final int offset = arr.offset();
-                final int length = arr.length();
+            } else if (bytes.hasArray()) {
+                final byte[] raw = bytes.array();
+                final int offset = bytes.arrayOffset();
+                final int length = bytes.length();
                 contentType = xContentType != null ? xContentType : XContentFactory.xContentType(raw, offset, length);
                 return new Tuple<>(Objects.requireNonNull(contentType),
                         convertToMap(XContentFactory.xContent(contentType), raw, offset, length, ordered));
@@ -203,10 +201,9 @@ public class XContentHelper {
         }
 
         // It is safe to use EMPTY here because this never uses namedObject
-        if (bytes instanceof BytesArray) {
-            final BytesArray array = (BytesArray) bytes;
+        if (bytes.hasArray()) {
             try (XContentParser parser = XContentFactory.xContent(xContentType).createParser(NamedXContentRegistry.EMPTY,
-                         DeprecationHandler.THROW_UNSUPPORTED_OPERATION, array.array(), array.offset(), array.length())) {
+                         DeprecationHandler.THROW_UNSUPPORTED_OPERATION, bytes.array(), bytes.arrayOffset(), bytes.length())) {
                 return toJsonString(prettyPrint, parser);
             }
         } else {
@@ -412,9 +409,8 @@ public class XContentHelper {
      */
     @Deprecated
     public static XContentType xContentType(BytesReference bytes) {
-        if (bytes instanceof BytesArray) {
-            final BytesArray array = (BytesArray) bytes;
-            return XContentFactory.xContentType(array.array(), array.offset(), array.length());
+        if (bytes.hasArray()) {
+            return XContentFactory.xContentType(bytes.array(), bytes.arrayOffset(), bytes.length());
         }
         try {
             final InputStream inputStream = bytes.streamInput();

--- a/server/src/test/java/org/elasticsearch/common/bytes/BytesArrayTests.java
+++ b/server/src/test/java/org/elasticsearch/common/bytes/BytesArrayTests.java
@@ -45,7 +45,7 @@ public class BytesArrayTests extends AbstractBytesReferenceTestCase {
             BytesArray pbr = (BytesArray) newBytesReference(sizes[i]);
             byte[] array = pbr.array();
             assertNotNull(array);
-            assertEquals(sizes[i], array.length - pbr.offset());
+            assertEquals(sizes[i], array.length - pbr.arrayOffset());
             assertSame(array, pbr.array());
         }
     }
@@ -53,6 +53,6 @@ public class BytesArrayTests extends AbstractBytesReferenceTestCase {
     public void testArrayOffset() throws IOException {
         int length = randomInt(PAGE_SIZE * randomIntBetween(2, 5));
         BytesArray pbr = (BytesArray) newBytesReferenceWithOffsetOfZero(length);
-        assertEquals(0, pbr.offset());
+        assertEquals(0, pbr.arrayOffset());
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -45,7 +45,6 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.CheckedRunnable;
 import org.elasticsearch.common.SuppressForbidden;
-import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compatibility.RestApiCompatibleVersion;
 import org.elasticsearch.common.io.PathUtils;
@@ -1330,10 +1329,9 @@ public abstract class ESTestCase extends LuceneTestCase {
      */
     protected final XContentParser createParser(NamedXContentRegistry namedXContentRegistry, XContent xContent,
                                                 BytesReference data) throws IOException {
-        if (data instanceof BytesArray) {
-            final BytesArray array = (BytesArray) data;
+        if (data.hasArray()) {
             return xContent.createParser(
-                    namedXContentRegistry, LoggingDeprecationHandler.INSTANCE, array.array(), array.offset(), array.length());
+                    namedXContentRegistry, LoggingDeprecationHandler.INSTANCE, data.array(), data.arrayOffset(), data.length());
         }
         return xContent.createParser(namedXContentRegistry, LoggingDeprecationHandler.INSTANCE, data.streamInput());
     }


### PR DESCRIPTION
Unwrapping the `byte[]` in a `BytesArray` can be generalized
so that releasable bytes references can make use of the optimizations
that use the bytes directly as well.

Relates #67502 but already saves a few cycles here and there around
`BytesRequest` (publish and recovery actions)
