### PR TITLE
Stop Ignoring Exceptions on Close in Network Code

### DIFF
--- a/libs/core/src/main/java/org/elasticsearch/common/lease/Releasable.java
+++ b/libs/core/src/main/java/org/elasticsearch/common/lease/Releasable.java
@@ -8,12 +8,10 @@
 
 package org.elasticsearch.common.lease;
 
-import org.elasticsearch.ElasticsearchException;
-
 import java.io.Closeable;
 
 /**
- * Specialization of {@link AutoCloseable} that may only throw an {@link ElasticsearchException}.
+ * Specialization of {@link Closeable} that may only throw a {@link RuntimeException}.
  */
 public interface Releasable extends Closeable {
 

--- a/libs/core/src/main/java/org/elasticsearch/common/lease/Releasables.java
+++ b/libs/core/src/main/java/org/elasticsearch/common/lease/Releasables.java
@@ -60,6 +60,16 @@ public enum Releasables {
         }
     }
 
+    /** Release the provided {@link Releasable} expecting no exception to by thrown. */
+    public static void closeExpectNoException(Releasable releasable) {
+        try {
+            close(releasable);
+        } catch (RuntimeException e) {
+            assert false : e;
+            throw e;
+        }
+    }
+
     /** Release the provided {@link Releasable}s, ignoring exceptions. */
     public static void closeWhileHandlingException(Releasable... releasables) {
         close(Arrays.asList(releasables), true);

--- a/libs/nio/src/main/java/org/elasticsearch/nio/Page.java
+++ b/libs/nio/src/main/java/org/elasticsearch/nio/Page.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.nio;
 
 import org.elasticsearch.common.lease.Releasable;
+import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.util.concurrent.AbstractRefCounted;
 
 import java.nio.ByteBuffer;
@@ -70,12 +71,7 @@ public class Page implements Releasable {
 
         @Override
         protected void closeInternal() {
-            try {
-                closeable.close();
-            } catch (RuntimeException e) {
-                assert false : e;
-                throw e;
-            }
+            Releasables.close(closeable);
         }
     }
 }

--- a/libs/nio/src/main/java/org/elasticsearch/nio/Page.java
+++ b/libs/nio/src/main/java/org/elasticsearch/nio/Page.java
@@ -8,12 +8,12 @@
 
 package org.elasticsearch.nio;
 
+import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.util.concurrent.AbstractRefCounted;
 
-import java.io.Closeable;
 import java.nio.ByteBuffer;
 
-public class Page implements Closeable {
+public class Page implements Releasable {
 
     private final ByteBuffer byteBuffer;
     // This is reference counted as some implementations want to retain the byte pages by calling
@@ -22,7 +22,7 @@ public class Page implements Closeable {
     // released.
     private final RefCountedCloseable refCountedCloseable;
 
-    public Page(ByteBuffer byteBuffer, Closeable closeable) {
+    public Page(ByteBuffer byteBuffer, Releasable closeable) {
         this(byteBuffer, new RefCountedCloseable(closeable));
     }
 
@@ -61,9 +61,9 @@ public class Page implements Closeable {
 
     private static class RefCountedCloseable extends AbstractRefCounted {
 
-        private final Closeable closeable;
+        private final Releasable closeable;
 
-        private RefCountedCloseable(Closeable closeable) {
+        private RefCountedCloseable(Releasable closeable) {
             super("byte array page");
             this.closeable = closeable;
         }

--- a/libs/nio/src/main/java/org/elasticsearch/nio/Page.java
+++ b/libs/nio/src/main/java/org/elasticsearch/nio/Page.java
@@ -22,7 +22,7 @@ public class Page implements Closeable {
     // released.
     private final RefCountedCloseable refCountedCloseable;
 
-    public Page(ByteBuffer byteBuffer, Runnable closeable) {
+    public Page(ByteBuffer byteBuffer, Closeable closeable) {
         this(byteBuffer, new RefCountedCloseable(closeable));
     }
 
@@ -61,16 +61,21 @@ public class Page implements Closeable {
 
     private static class RefCountedCloseable extends AbstractRefCounted {
 
-        private final Runnable closeable;
+        private final Closeable closeable;
 
-        private RefCountedCloseable(Runnable closeable) {
+        private RefCountedCloseable(Closeable closeable) {
             super("byte array page");
             this.closeable = closeable;
         }
 
         @Override
         protected void closeInternal() {
-            closeable.run();
+            try {
+                closeable.close();
+            } catch (Exception e) {
+                assert false : e;
+                throw new RuntimeException(e);
+            }
         }
     }
 }

--- a/libs/nio/src/main/java/org/elasticsearch/nio/Page.java
+++ b/libs/nio/src/main/java/org/elasticsearch/nio/Page.java
@@ -72,9 +72,9 @@ public class Page implements Releasable {
         protected void closeInternal() {
             try {
                 closeable.close();
-            } catch (Exception e) {
+            } catch (RuntimeException e) {
                 assert false : e;
-                throw new RuntimeException(e);
+                throw e;
             }
         }
     }

--- a/libs/nio/src/main/java/org/elasticsearch/nio/Page.java
+++ b/libs/nio/src/main/java/org/elasticsearch/nio/Page.java
@@ -71,7 +71,7 @@ public class Page implements Releasable {
 
         @Override
         protected void closeInternal() {
-            Releasables.close(closeable);
+            Releasables.closeExpectNoException(closeable);
         }
     }
 }

--- a/libs/nio/src/test/java/org/elasticsearch/nio/SocketChannelContextTests.java
+++ b/libs/nio/src/test/java/org/elasticsearch/nio/SocketChannelContextTests.java
@@ -14,6 +14,7 @@ import org.junit.Before;
 import org.mockito.ArgumentCaptor;
 import org.mockito.stubbing.Answer;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
@@ -328,13 +329,13 @@ public class SocketChannelContextTests extends ESTestCase {
         try (SocketChannel realChannel = SocketChannel.open()) {
             when(channel.getRawChannel()).thenReturn(realChannel);
             when(channel.isOpen()).thenReturn(true);
-            Runnable closer = mock(Runnable.class);
+            Closeable closer = mock(Closeable.class);
             IntFunction<Page> pageAllocator = (n) -> new Page(ByteBuffer.allocate(n), closer);
             InboundChannelBuffer buffer = new InboundChannelBuffer(pageAllocator);
             buffer.ensureCapacity(1);
             TestSocketChannelContext context = new TestSocketChannelContext(channel, selector, exceptionHandler, handler, buffer);
             context.closeFromSelector();
-            verify(closer).run();
+            verify(closer).close();
         }
     }
 

--- a/libs/nio/src/test/java/org/elasticsearch/nio/SocketChannelContextTests.java
+++ b/libs/nio/src/test/java/org/elasticsearch/nio/SocketChannelContextTests.java
@@ -9,12 +9,12 @@
 package org.elasticsearch.nio;
 
 import org.elasticsearch.common.SuppressForbidden;
+import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Before;
 import org.mockito.ArgumentCaptor;
 import org.mockito.stubbing.Answer;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
@@ -329,7 +329,7 @@ public class SocketChannelContextTests extends ESTestCase {
         try (SocketChannel realChannel = SocketChannel.open()) {
             when(channel.getRawChannel()).thenReturn(realChannel);
             when(channel.isOpen()).thenReturn(true);
-            Closeable closer = mock(Closeable.class);
+            Releasable closer = mock(Releasable.class);
             IntFunction<Page> pageAllocator = (n) -> new Page(ByteBuffer.allocate(n), closer);
             InboundChannelBuffer buffer = new InboundChannelBuffer(pageAllocator);
             buffer.ensureCapacity(1);

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4MessageChannelHandler.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4MessageChannelHandler.java
@@ -109,7 +109,7 @@ final class Netty4MessageChannelHandler extends ChannelDuplexHandler {
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
         assert Transports.assertDefaultThreadContext(transport.getThreadPool().getThreadContext());
         doFlush(ctx);
-        Releasables.close(pipeline);
+        Releasables.closeExpectNoException(pipeline);
         super.channelInactive(ctx);
     }
 

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4MessageChannelHandler.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4MessageChannelHandler.java
@@ -109,7 +109,7 @@ final class Netty4MessageChannelHandler extends ChannelDuplexHandler {
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
         assert Transports.assertDefaultThreadContext(transport.getThreadPool().getThreadContext());
         doFlush(ctx);
-        Releasables.closeWhileHandlingException(pipeline);
+        Releasables.close(pipeline);
         super.channelInactive(ctx);
     }
 

--- a/plugins/transport-nio/src/main/java/org/elasticsearch/transport/nio/PageAllocator.java
+++ b/plugins/transport-nio/src/main/java/org/elasticsearch/transport/nio/PageAllocator.java
@@ -29,7 +29,7 @@ public class PageAllocator implements IntFunction<Page> {
     public Page apply(int length) {
         if (length >= RECYCLE_LOWER_THRESHOLD && length <= PageCacheRecycler.BYTE_PAGE_SIZE){
             Recycler.V<byte[]> bytePage = recycler.bytePage(false);
-            return new Page(ByteBuffer.wrap(bytePage.v(), 0, length), bytePage::close);
+            return new Page(ByteBuffer.wrap(bytePage.v(), 0, length), bytePage);
         } else {
             return new Page(ByteBuffer.allocate(length), () -> {});
         }

--- a/plugins/transport-nio/src/main/java/org/elasticsearch/transport/nio/TcpReadWriteHandler.java
+++ b/plugins/transport-nio/src/main/java/org/elasticsearch/transport/nio/TcpReadWriteHandler.java
@@ -47,7 +47,7 @@ public class TcpReadWriteHandler extends BytesWriteHandler {
         for (int i = 0; i < pages.length; ++i) {
             references[i] = BytesReference.fromByteBuffer(pages[i].byteBuffer());
         }
-        Releasable releasable = pages.length == 1 ? pages[0] : () -> Releasables.close(pages);
+        Releasable releasable = pages.length == 1 ? pages[0] : () -> Releasables.closeExpectNoException(pages);
         try (ReleasableBytesReference reference = new ReleasableBytesReference(CompositeBytesReference.of(references), releasable)) {
             pipeline.handleBytes(channel, reference);
             return reference.length();
@@ -56,6 +56,6 @@ public class TcpReadWriteHandler extends BytesWriteHandler {
 
     @Override
     public void close() {
-        Releasables.close(pipeline, super::close);
+        Releasables.closeExpectNoException(pipeline, super::close);
     }
 }

--- a/plugins/transport-nio/src/main/java/org/elasticsearch/transport/nio/TcpReadWriteHandler.java
+++ b/plugins/transport-nio/src/main/java/org/elasticsearch/transport/nio/TcpReadWriteHandler.java
@@ -12,9 +12,9 @@ import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.bytes.CompositeBytesReference;
 import org.elasticsearch.common.bytes.ReleasableBytesReference;
+import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.util.PageCacheRecycler;
-import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.nio.BytesWriteHandler;
 import org.elasticsearch.nio.InboundChannelBuffer;
 import org.elasticsearch.nio.Page;
@@ -23,7 +23,6 @@ import org.elasticsearch.transport.InboundPipeline;
 import org.elasticsearch.transport.TcpTransport;
 import org.elasticsearch.transport.Transport;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.util.function.Supplier;
 
@@ -48,7 +47,7 @@ public class TcpReadWriteHandler extends BytesWriteHandler {
         for (int i = 0; i < pages.length; ++i) {
             references[i] = BytesReference.fromByteBuffer(pages[i].byteBuffer());
         }
-        Closeable releasable = pages.length == 1 ? pages[0] : () -> IOUtils.close(pages);
+        Releasable releasable = pages.length == 1 ? pages[0] : () -> Releasables.close(pages);
         try (ReleasableBytesReference reference = new ReleasableBytesReference(CompositeBytesReference.of(references), releasable)) {
             pipeline.handleBytes(channel, reference);
             return reference.length();

--- a/server/src/main/java/org/elasticsearch/common/bytes/ReleasableBytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/ReleasableBytesReference.java
@@ -12,6 +12,7 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefIterator;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.lease.Releasable;
+import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.util.concurrent.AbstractRefCounted;
 import org.elasticsearch.common.util.concurrent.RefCounted;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -191,7 +192,7 @@ public final class ReleasableBytesReference implements RefCounted, Releasable, B
 
         @Override
         protected void closeInternal() {
-            releasable.close();
+            Releasables.closeExpectNoException(releasable);
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/bytes/ReleasableBytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/ReleasableBytesReference.java
@@ -10,14 +10,12 @@ package org.elasticsearch.common.bytes;
 
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefIterator;
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.util.concurrent.AbstractRefCounted;
 import org.elasticsearch.common.util.concurrent.RefCounted;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.io.OutputStream;
 
@@ -31,7 +29,7 @@ public final class ReleasableBytesReference implements RefCounted, Releasable, B
     private final BytesReference delegate;
     private final AbstractRefCounted refCounted;
 
-    public ReleasableBytesReference(BytesReference delegate, Closeable releasable) {
+    public ReleasableBytesReference(BytesReference delegate, Releasable releasable) {
         this(delegate, new RefCountedReleasable(releasable));
     }
 
@@ -184,21 +182,16 @@ public final class ReleasableBytesReference implements RefCounted, Releasable, B
 
     private static final class RefCountedReleasable extends AbstractRefCounted {
 
-        private final Closeable releasable;
+        private final Releasable releasable;
 
-        RefCountedReleasable(Closeable releasable) {
+        RefCountedReleasable(Releasable releasable) {
             super("bytes-reference");
             this.releasable = releasable;
         }
 
         @Override
         protected void closeInternal() {
-            try {
-                releasable.close();
-            } catch (Exception e) {
-                assert false : e;
-                throw new ElasticsearchException(e);
-            }
+            releasable.close();
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/lease/Releasables.java
+++ b/server/src/main/java/org/elasticsearch/common/lease/Releasables.java
@@ -51,22 +51,13 @@ public enum Releasables {
     }
 
     /** Release the provided {@link Releasable}s, ignoring exceptions. */
-    public static void closeWhileHandlingException(Iterable<? extends Releasable> releasables) {
-        close(releasables, true);
-    }
-
-    /** Release the provided {@link Releasable}s, ignoring exceptions. */
     public static void closeWhileHandlingException(Releasable... releasables) {
-        closeWhileHandlingException(Arrays.asList(releasables));
+        close(Arrays.asList(releasables), true);
     }
 
     /** Release the provided {@link Releasable}s, ignoring exceptions if <code>success</code> is {@code false}. */
     public static void close(boolean success, Iterable<Releasable> releasables) {
-        if (success) {
-            close(releasables);
-        } else {
-            closeWhileHandlingException(releasables);
-        }
+        close(releasables, success == false);
     }
 
     /** Release the provided {@link Releasable}s, ignoring exceptions if <code>success</code> is {@code false}. */

--- a/server/src/main/java/org/elasticsearch/common/lease/Releasables.java
+++ b/server/src/main/java/org/elasticsearch/common/lease/Releasables.java
@@ -50,6 +50,16 @@ public enum Releasables {
         close(Arrays.asList(releasables));
     }
 
+    /** Release the provided {@link Releasable}s expecting no exception to by thrown by any of them. */
+    public static void closeExpectNoException(Releasable... releasables) {
+        try {
+            close(releasables);
+        } catch (RuntimeException e) {
+            assert false : e;
+            throw e;
+        }
+    }
+
     /** Release the provided {@link Releasable}s, ignoring exceptions. */
     public static void closeWhileHandlingException(Releasable... releasables) {
         close(Arrays.asList(releasables), true);

--- a/server/src/main/java/org/elasticsearch/common/util/BigArrays.java
+++ b/server/src/main/java/org/elasticsearch/common/util/BigArrays.java
@@ -451,11 +451,7 @@ public class BigArrays {
             success = true;
         } finally {
             if (success == false) {
-                try {
-                    array.close();
-                } catch (Exception e) {
-                    assert false : e;
-                }
+                Releasables.closeExpectNoException(array);
             }
         }
         return array;

--- a/server/src/main/java/org/elasticsearch/common/util/BigArrays.java
+++ b/server/src/main/java/org/elasticsearch/common/util/BigArrays.java
@@ -451,7 +451,11 @@ public class BigArrays {
             success = true;
         } finally {
             if (success == false) {
-                Releasables.closeWhileHandlingException(array);
+                try {
+                    array.close();
+                } catch (RuntimeException e) {
+                    assert false : e;
+                }
             }
         }
         return array;

--- a/server/src/main/java/org/elasticsearch/common/util/BigArrays.java
+++ b/server/src/main/java/org/elasticsearch/common/util/BigArrays.java
@@ -453,7 +453,7 @@ public class BigArrays {
             if (success == false) {
                 try {
                     array.close();
-                } catch (RuntimeException e) {
+                } catch (Exception e) {
                     assert false : e;
                 }
             }

--- a/server/src/main/java/org/elasticsearch/http/DefaultRestChannel.java
+++ b/server/src/main/java/org/elasticsearch/http/DefaultRestChannel.java
@@ -75,7 +75,7 @@ public class DefaultRestChannel extends AbstractRestChannel implements RestChann
     @Override
     public void sendResponse(RestResponse restResponse) {
         // We're sending a response so we know we won't be needing the request content again and release it
-        Releasables.closeWhileHandlingException(httpRequest::release);
+        httpRequest.release();
 
         final ArrayList<Releasable> toClose = new ArrayList<>(3);
         if (HttpUtils.shouldCloseConnection(httpRequest)) {

--- a/server/src/main/java/org/elasticsearch/transport/InboundDecoder.java
+++ b/server/src/main/java/org/elasticsearch/transport/InboundDecoder.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.transport;
 
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.bytes.ReleasableBytesReference;
@@ -116,10 +117,16 @@ public class InboundDecoder implements Releasable {
     }
 
     private void cleanDecodeState() {
-        IOUtils.closeWhileHandlingException(decompressor);
-        decompressor = null;
-        totalNetworkSize = -1;
-        bytesConsumed = 0;
+        try {
+            IOUtils.close(decompressor);
+        } catch (Exception e) {
+            assert false : e;
+            throw new ElasticsearchException(e);
+        } finally {
+            decompressor = null;
+            totalNetworkSize = -1;
+            bytesConsumed = 0;
+        }
     }
 
     private void decompress(ReleasableBytesReference content) throws IOException {

--- a/server/src/main/java/org/elasticsearch/transport/InboundDecoder.java
+++ b/server/src/main/java/org/elasticsearch/transport/InboundDecoder.java
@@ -8,14 +8,13 @@
 
 package org.elasticsearch.transport;
 
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.lease.Releasable;
+import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.util.PageCacheRecycler;
-import org.elasticsearch.core.internal.io.IOUtils;
 
 import java.io.IOException;
 import java.util.function.Consumer;
@@ -118,10 +117,7 @@ public class InboundDecoder implements Releasable {
 
     private void cleanDecodeState() {
         try {
-            IOUtils.close(decompressor);
-        } catch (Exception e) {
-            assert false : e;
-            throw new ElasticsearchException(e);
+            Releasables.closeExpectNoException(decompressor);
         } finally {
             decompressor = null;
             totalNetworkSize = -1;

--- a/server/src/main/java/org/elasticsearch/transport/InboundMessage.java
+++ b/server/src/main/java/org/elasticsearch/transport/InboundMessage.java
@@ -8,10 +8,10 @@
 
 package org.elasticsearch.transport;
 
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.lease.Releasable;
-import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.core.internal.io.IOUtils;
 
 import java.io.IOException;
@@ -91,8 +91,12 @@ public class InboundMessage implements Releasable {
 
     @Override
     public void close() {
-        IOUtils.closeWhileHandlingException(streamInput);
-        Releasables.closeWhileHandlingException(content, breakerRelease);
+        try {
+            IOUtils.close(streamInput, content, breakerRelease);
+        } catch (Exception e) {
+            assert false : e;
+            throw new ElasticsearchException(e);
+        }
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/transport/InboundPipeline.java
+++ b/server/src/main/java/org/elasticsearch/transport/InboundPipeline.java
@@ -58,9 +58,7 @@ public class InboundPipeline implements Releasable {
     @Override
     public void close() {
         isClosed = true;
-        Releasables.closeWhileHandlingException(decoder, aggregator);
-        Releasables.closeWhileHandlingException(pending);
-        pending.clear();
+        Releasables.close(decoder, aggregator, () -> Releasables.close(pending), pending::clear);
     }
 
     public void handleBytes(TcpChannel channel, ReleasableBytesReference reference) throws IOException {
@@ -152,7 +150,7 @@ public class InboundPipeline implements Releasable {
                 bytesReferences[index] = pendingReference.retain();
                 ++index;
             }
-            final Releasable releasable = () -> Releasables.closeWhileHandlingException(bytesReferences);
+            final Releasable releasable = () -> Releasables.close(bytesReferences);
             return new ReleasableBytesReference(CompositeBytesReference.of(bytesReferences), releasable);
         }
     }

--- a/server/src/main/java/org/elasticsearch/transport/InboundPipeline.java
+++ b/server/src/main/java/org/elasticsearch/transport/InboundPipeline.java
@@ -58,7 +58,7 @@ public class InboundPipeline implements Releasable {
     @Override
     public void close() {
         isClosed = true;
-        Releasables.close(decoder, aggregator, () -> Releasables.close(pending), pending::clear);
+        Releasables.closeExpectNoException(decoder, aggregator, () -> Releasables.close(pending), pending::clear);
     }
 
     public void handleBytes(TcpChannel channel, ReleasableBytesReference reference) throws IOException {
@@ -150,7 +150,7 @@ public class InboundPipeline implements Releasable {
                 bytesReferences[index] = pendingReference.retain();
                 ++index;
             }
-            final Releasable releasable = () -> Releasables.close(bytesReferences);
+            final Releasable releasable = () -> Releasables.closeExpectNoException(bytesReferences);
             return new ReleasableBytesReference(CompositeBytesReference.of(bytesReferences), releasable);
         }
     }

--- a/server/src/main/java/org/elasticsearch/transport/TransportDecompressor.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportDecompressor.java
@@ -14,16 +14,16 @@ import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.common.compress.CompressorFactory;
+import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.recycler.Recycler;
 import org.elasticsearch.common.util.PageCacheRecycler;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.zip.DataFormatException;
 import java.util.zip.Inflater;
 
-public class TransportDecompressor implements Closeable {
+public class TransportDecompressor implements Releasable {
 
     private final Inflater inflater;
     private final PageCacheRecycler recycler;


### PR DESCRIPTION
We should not be ignoring and suppressing exceptions on releasing
network resources quietly in these spots.
