### PR TITLE
Add a random snippet as suffix to names of backing indices.

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -66,7 +66,6 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -79,7 +78,6 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
 
     public static final String ALL = "_all";
     public static final String UNKNOWN_CLUSTER_UUID = "_na_";
-    public static final Pattern BACKING_INDEX_SUFFIX = Pattern.compile("(\\d{4}\\.\\d{2}\\.\\d{2}-)?[0-9]+$");
 
     public enum XContentContext {
         /* Custom metadata should be returns as part of API call */
@@ -1436,33 +1434,14 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
         }
 
         /**
-         * Validates there isn't any index with a name that could clash with the future backing indices of the existing data streams.
-         *
-         * E.g., if data stream `foo` has backing indices [`.ds-foo-yyyy.MM.dd-000001`, `.ds-foo-yyyy.MM.dd-000002`] and the indices lookup
-         * contains indices `.ds-foo-yyyy-MM.dd.000001`, `.ds-foo-yyyy.MM.dd-000002` and `.ds-foo-yyyy.MM.dd-000006` this will throw an
-         * IllegalStateException as attempting to rollover the `foo` data stream from generation 5 to 6 may not be possible
+         * Validates the {@link DataStreamMetadata} before the actual {@link Metadata} is built. Currently only validates
+         * that no aliases refer to backing indices.
          *
          * @param indicesLookup the indices in the system including the data stream backing indices
          * @param dsMetadata    the data streams in the system
          */
         static void validateDataStreams(SortedMap<String, IndexAbstraction> indicesLookup, @Nullable DataStreamMetadata dsMetadata) {
             if (dsMetadata != null) {
-                for (DataStream ds : dsMetadata.dataStreams().values()) {
-                    String prefix = DataStream.BACKING_INDEX_PREFIX + ds.getName() + "-";
-                    Set<String> conflicts =
-                        indicesLookup.subMap(prefix, DataStream.BACKING_INDEX_PREFIX + ds.getName() + ".") // '.' is the char after '-'
-                            .keySet().stream()
-                            .filter(s -> BACKING_INDEX_SUFFIX.matcher(s.substring(prefix.length())).matches())
-                            .filter(s -> IndexMetadata.parseIndexNameCounter(s) > ds.getGeneration())
-                            .collect(Collectors.toSet());
-
-                    if (conflicts.size() > 0) {
-                        throw new IllegalStateException("data stream [" + ds.getName() +
-                            "] could create backing indices that conflict with " + conflicts.size() + " existing index(s) or alias(s)" +
-                            " including '" + conflicts.iterator().next() + "'");
-                    }
-                }
-
                 // Sanity check, because elsewhere a more user friendly error should have occurred:
                 List<String> conflictingAliases = indicesLookup.values().stream()
                     .filter(ia -> ia.getType() == IndexAbstraction.Type.ALIAS)

--- a/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTests.java
@@ -174,7 +174,7 @@ public class TransportBulkActionTests extends ESTestCase {
         Metadata metadata = clusterState.metadata();
 
         // Testing create op against backing index fails:
-        String backingIndexName = DataStream.getDefaultBackingIndexName(dataStreamName, 1);
+        String backingIndexName = clusterState.metadata().dataStreams().get(dataStreamName).getWriteIndex().getName();
         IndexRequest invalidRequest1 = new IndexRequest(backingIndexName).opType(DocWriteRequest.OpType.CREATE);
         Exception e = expectThrows(IllegalArgumentException.class,
             () -> TransportBulkAction.prohibitAppendWritesInBackingIndices(invalidRequest1, metadata));

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
@@ -41,6 +41,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.cluster.DataStreamTestHelper.backingIndexEqualTo;
 import static org.elasticsearch.cluster.DataStreamTestHelper.createBackingIndex;
 import static org.elasticsearch.cluster.DataStreamTestHelper.createTimestampField;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_HIDDEN_SETTING;
@@ -1915,8 +1916,8 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
             IndicesOptions indicesOptions = IndicesOptions.STRICT_EXPAND_OPEN;
             Index[] result = indexNameExpressionResolver.concreteIndices(state, indicesOptions, true, dataStreamName);
             assertThat(result.length, equalTo(2));
-            assertThat(result[0].getName(), equalTo(DataStream.getDefaultBackingIndexName(dataStreamName, 1, epochMillis)));
-            assertThat(result[1].getName(), equalTo(DataStream.getDefaultBackingIndexName(dataStreamName, 2, epochMillis)));
+            assertThat(result[0].getName(), backingIndexEqualTo(dataStreamName, 1, epochMillis));
+            assertThat(result[1].getName(), backingIndexEqualTo(dataStreamName, 2, epochMillis));
         }
     }
 
@@ -1935,8 +1936,8 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
             IndicesOptions indicesOptions = IndicesOptions.STRICT_EXPAND_OPEN;
             Index[] result = indexNameExpressionResolver.concreteIndices(state, indicesOptions, true, "my-data-stream");
             assertThat(result.length, equalTo(2));
-            assertThat(result[0].getName(), equalTo(DataStream.getDefaultBackingIndexName(dataStreamName, 1, epochMillis)));
-            assertThat(result[1].getName(), equalTo(DataStream.getDefaultBackingIndexName(dataStreamName, 2, epochMillis)));
+            assertThat(result[0].getName(), backingIndexEqualTo(dataStreamName, 1, epochMillis));
+            assertThat(result[1].getName(), backingIndexEqualTo(dataStreamName, 2, epochMillis));
         }
         {
             // Ignore data streams
@@ -1963,7 +1964,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
         {
             IndicesOptions indicesOptions = IndicesOptions.STRICT_EXPAND_OPEN;
             Index result = indexNameExpressionResolver.concreteWriteIndex(state, indicesOptions, "my-data-stream", false, true);
-            assertThat(result.getName(), equalTo(DataStream.getDefaultBackingIndexName(dataStreamName, 2, epochMillis)));
+            assertThat(result.getName(), backingIndexEqualTo(dataStreamName, 2, epochMillis));
         }
         {
             // Ignore data streams
@@ -2011,10 +2012,10 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
             Index[] result = indexNameExpressionResolver.concreteIndices(state, indicesOptions, true, "logs-*");
             Arrays.sort(result, Comparator.comparing(Index::getName));
             assertThat(result.length, equalTo(4));
-            assertThat(result[0].getName(), equalTo(DataStream.getDefaultBackingIndexName(dataStream1, 1, epochMillis)));
-            assertThat(result[1].getName(), equalTo(DataStream.getDefaultBackingIndexName(dataStream1, 2, epochMillis)));
-            assertThat(result[2].getName(), equalTo(DataStream.getDefaultBackingIndexName(dataStream2, 1, epochMillis)));
-            assertThat(result[3].getName(), equalTo(DataStream.getDefaultBackingIndexName(dataStream2, 2, epochMillis)));;
+            assertThat(result[0].getName(), backingIndexEqualTo(dataStream1, 1, epochMillis));
+            assertThat(result[1].getName(), backingIndexEqualTo(dataStream1, 2, epochMillis));
+            assertThat(result[2].getName(), backingIndexEqualTo(dataStream2, 1, epochMillis));
+            assertThat(result[3].getName(), backingIndexEqualTo(dataStream2, 2, epochMillis));
         }
         {
             IndicesOptions indicesOptions = IndicesOptions.STRICT_EXPAND_OPEN;
@@ -2022,18 +2023,18 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
                 randomFrom(new String[]{"*"}, new String[]{"_all"}, new String[0]));
             Arrays.sort(result, Comparator.comparing(Index::getName));
             assertThat(result.length, equalTo(4));
-            assertThat(result[0].getName(), equalTo(DataStream.getDefaultBackingIndexName(dataStream1, 1, epochMillis)));
-            assertThat(result[1].getName(), equalTo(DataStream.getDefaultBackingIndexName(dataStream1, 2, epochMillis)));
-            assertThat(result[2].getName(), equalTo(DataStream.getDefaultBackingIndexName(dataStream2, 1, epochMillis)));
-            assertThat(result[3].getName(), equalTo(DataStream.getDefaultBackingIndexName(dataStream2, 2, epochMillis)));;
+            assertThat(result[0].getName(), backingIndexEqualTo(dataStream1, 1, epochMillis));
+            assertThat(result[1].getName(), backingIndexEqualTo(dataStream1, 2, epochMillis));
+            assertThat(result[2].getName(), backingIndexEqualTo(dataStream2, 1, epochMillis));
+            assertThat(result[3].getName(), backingIndexEqualTo(dataStream2, 2, epochMillis));
         }
         {
             IndicesOptions indicesOptions = IndicesOptions.STRICT_EXPAND_OPEN;
             Index[] result = indexNameExpressionResolver.concreteIndices(state, indicesOptions, true, "logs-m*");
             Arrays.sort(result, Comparator.comparing(Index::getName));
             assertThat(result.length, equalTo(2));
-            assertThat(result[0].getName(), equalTo(DataStream.getDefaultBackingIndexName(dataStream1, 1, epochMillis)));
-            assertThat(result[1].getName(), equalTo(DataStream.getDefaultBackingIndexName(dataStream1, 2, epochMillis)));
+            assertThat(result[0].getName(), backingIndexEqualTo(dataStream1, 1, epochMillis));
+            assertThat(result[1].getName(), backingIndexEqualTo(dataStream1, 2, epochMillis));
         }
         {
             IndicesOptions indicesOptions = IndicesOptions.STRICT_EXPAND_OPEN; // without include data streams
@@ -2063,15 +2064,15 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
             Index[] result = indexNameExpressionResolver.concreteIndices(state, indicesOptions, true, "logs-*");
             Arrays.sort(result, Comparator.comparing(Index::getName));
             assertThat(result.length, equalTo(2));
-            assertThat(result[0].getName(), equalTo(DataStream.getDefaultBackingIndexName(dataStream1, 2, epochMillis)));
-            assertThat(result[1].getName(), equalTo(DataStream.getDefaultBackingIndexName(dataStream2, 2, epochMillis)));
+            assertThat(result[0].getName(), backingIndexEqualTo(dataStream1, 2, epochMillis));
+            assertThat(result[1].getName(), backingIndexEqualTo(dataStream2, 2, epochMillis));
         }
         {
             Index[] result = indexNameExpressionResolver.concreteIndices(state, indicesOptions, true, "*");
             Arrays.sort(result, Comparator.comparing(Index::getName));
             assertThat(result.length, equalTo(2));
-            assertThat(result[0].getName(), equalTo(DataStream.getDefaultBackingIndexName(dataStream1, 2, epochMillis)));
-            assertThat(result[1].getName(), equalTo(DataStream.getDefaultBackingIndexName(dataStream2, 2, epochMillis)));
+            assertThat(result[0].getName(), backingIndexEqualTo(dataStream1, 2, epochMillis));
+            assertThat(result[1].getName(), backingIndexEqualTo(dataStream2, 2, epochMillis));
         }
     }
 
@@ -2098,8 +2099,8 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
         Index[] result = indexNameExpressionResolver.concreteIndices(state, indicesOptions, true, "logs-*");
         Arrays.sort(result, Comparator.comparing(Index::getName));
         assertThat(result.length, equalTo(3));
-        assertThat(result[0].getName(), equalTo(DataStream.getDefaultBackingIndexName(dataStream1, 1, epochMillis)));
-        assertThat(result[1].getName(), equalTo(DataStream.getDefaultBackingIndexName(dataStream1, 2, epochMillis)));
+        assertThat(result[0].getName(), backingIndexEqualTo(dataStream1, 1, epochMillis));
+        assertThat(result[1].getName(), backingIndexEqualTo(dataStream1, 2, epochMillis));
         assertThat(result[2].getName(), equalTo("logs-foobarbaz-0"));
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamServiceTests.java
@@ -25,6 +25,7 @@ import static org.elasticsearch.cluster.DataStreamTestHelper.createTimestampFiel
 import static org.elasticsearch.cluster.DataStreamTestHelper.generateMapping;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
@@ -48,9 +49,12 @@ public class MetadataCreateDataStreamServiceTests extends ESTestCase {
         ClusterState newState = MetadataCreateDataStreamService.createDataStream(metadataCreateIndexService, cs, req);
         assertThat(newState.metadata().dataStreams().size(), equalTo(1));
         assertThat(newState.metadata().dataStreams().get(dataStreamName).getName(), equalTo(dataStreamName));
-        assertThat(newState.metadata().index(DataStream.getDefaultBackingIndexName(dataStreamName, 1)), notNullValue());
-        assertThat(newState.metadata().index(DataStream.getDefaultBackingIndexName(dataStreamName, 1)).getSettings().get("index.hidden"),
-            equalTo("true"));
+
+        DataStream dataStream = newState.metadata().dataStreams().get(dataStreamName);
+        assertThat(dataStream.getIndices(), hasSize(1));
+        IndexMetadata backingIndexMetadata = newState.metadata().index(dataStream.getIndices().get(0));
+        assertThat(backingIndexMetadata, notNullValue());
+        assertThat(backingIndexMetadata.getSettings().get("index.hidden"), equalTo("true"));
     }
 
     public void testCreateDuplicateDataStream() throws Exception {

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataDeleteIndexServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataDeleteIndexServiceTests.java
@@ -110,9 +110,9 @@ public class MetadataDeleteIndexServiceTests extends ESTestCase {
         ClusterState before = DataStreamTestHelper.getClusterStateWithDataStreams(
             List.of(new Tuple<>(dataStreamName, numBackingIndices)), List.of());
 
-        int numIndexToDelete = randomIntBetween(1, numBackingIndices - 1);
+        int numIndexToDelete = randomIntBetween(0, numBackingIndices - 2);
 
-        Index indexToDelete = before.metadata().index(DataStream.getDefaultBackingIndexName(dataStreamName, numIndexToDelete)).getIndex();
+        Index indexToDelete = before.metadata().dataStreams().get(dataStreamName).getIndices().get(numIndexToDelete);
         ClusterState after = service.deleteIndices(before, Set.of(indexToDelete));
 
         assertThat(after.metadata().getIndices().get(indexToDelete.getName()), IsNull.nullValue());
@@ -129,11 +129,11 @@ public class MetadataDeleteIndexServiceTests extends ESTestCase {
             List.of(new Tuple<>(dataStreamName, numBackingIndices)), List.of());
 
         List<Integer> indexNumbersToDelete =
-            randomSubsetOf(numBackingIndicesToDelete, IntStream.rangeClosed(1, numBackingIndices - 1).boxed().collect(Collectors.toList()));
+            randomSubsetOf(numBackingIndicesToDelete, IntStream.rangeClosed(0, numBackingIndices - 2).boxed().collect(Collectors.toList()));
 
         Set<Index> indicesToDelete = new HashSet<>();
         for (int k : indexNumbersToDelete) {
-            indicesToDelete.add(before.metadata().index(DataStream.getDefaultBackingIndexName(dataStreamName, k)).getIndex());
+            indicesToDelete.add(before.metadata().dataStreams().get(dataStreamName).getIndices().get(k));
         }
         ClusterState after = service.deleteIndices(before, indicesToDelete);
 
@@ -153,7 +153,7 @@ public class MetadataDeleteIndexServiceTests extends ESTestCase {
         ClusterState before = DataStreamTestHelper.getClusterStateWithDataStreams(
             List.of(new Tuple<>(dataStreamName, numBackingIndices)), List.of());
 
-        Index indexToDelete = before.metadata().index(DataStream.getDefaultBackingIndexName(dataStreamName, numBackingIndices)).getIndex();
+        Index indexToDelete = before.metadata().dataStreams().get(dataStreamName).getWriteIndex();
         Exception e = expectThrows(IllegalArgumentException.class, () -> service.deleteIndices(before, Set.of(indexToDelete)));
 
         assertThat(e.getMessage(), containsString("index [" + indexToDelete.getName() + "] is the write index for data stream [" +

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexStateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexStateServiceTests.java
@@ -320,18 +320,18 @@ public class MetadataIndexStateServiceTests extends ESTestCase {
     public void testCloseCurrentWriteIndexForDataStream() {
         int numDataStreams = randomIntBetween(1, 3);
         List<Tuple<String, Integer>> dataStreamsToCreate = new ArrayList<>();
-        List<String> writeIndices = new ArrayList<>();
         for (int k = 0; k < numDataStreams; k++) {
             String dataStreamName = randomAlphaOfLength(6).toLowerCase(Locale.ROOT);
             int numBackingIndices = randomIntBetween(1, 5);
             dataStreamsToCreate.add(new Tuple<>(dataStreamName, numBackingIndices));
-            writeIndices.add(DataStream.getDefaultBackingIndexName(dataStreamName, numBackingIndices));
         }
         ClusterState cs = DataStreamTestHelper.getClusterStateWithDataStreams(dataStreamsToCreate, List.of());
 
         ClusterService clusterService = mock(ClusterService.class);
         when(clusterService.state()).thenReturn(cs);
 
+        List<String> writeIndices = new ArrayList<>();
+        cs.metadata().dataStreams().values().forEach(dataStream -> writeIndices.add(dataStream.getWriteIndex().getName()));
         List<String> indicesToDelete = randomSubsetOf(randomIntBetween(1, numDataStreams), writeIndices);
         Index[] indicesToDeleteArray = new Index[indicesToDelete.size()];
         for (int k = 0; k < indicesToDelete.size(); k++) {

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/WildcardExpressionResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/WildcardExpressionResolverTests.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
+import static org.elasticsearch.cluster.DataStreamTestHelper.backingIndexEqualTo;
 import static org.elasticsearch.cluster.DataStreamTestHelper.createBackingIndex;
 import static org.elasticsearch.cluster.DataStreamTestHelper.createTimestampField;
 import static org.elasticsearch.common.util.set.Sets.newHashSet;
@@ -245,15 +246,24 @@ public class WildcardExpressionResolverTests extends ESTestCase {
 
             // data stream's corresponding backing indices are resolved
             List<String> indices = resolver.resolve(indicesAliasesAndDataStreamsContext, Collections.singletonList("foo_*"));
-            assertThat(indices, containsInAnyOrder("foo_index", "bar_index", "foo_foo",
-                DataStream.getDefaultBackingIndexName("foo_logs", 1, epochMillis),
-                DataStream.getDefaultBackingIndexName("foo_logs", 2, epochMillis)));
+            assertThat(indices, containsInAnyOrder(
+                equalTo("foo_index"),
+                equalTo("bar_index"),
+                equalTo("foo_foo"),
+                backingIndexEqualTo("foo_logs", 1, epochMillis),
+                backingIndexEqualTo("foo_logs", 2, epochMillis)
+            ));
 
             // include all wildcard adds the data stream's backing indices
             indices = resolver.resolve(indicesAliasesAndDataStreamsContext, Collections.singletonList("*"));
-            assertThat(indices, containsInAnyOrder("foo_index", "bar_index", "foo_foo", "bar_bar",
-                DataStream.getDefaultBackingIndexName("foo_logs", 1, epochMillis),
-                DataStream.getDefaultBackingIndexName("foo_logs", 2, epochMillis)));
+            assertThat(indices, containsInAnyOrder(
+                equalTo("foo_index"),
+                equalTo("bar_index"),
+                equalTo("foo_foo"),
+                equalTo("bar_bar"),
+                backingIndexEqualTo("foo_logs", 1, epochMillis),
+                backingIndexEqualTo("foo_logs", 2, epochMillis)
+            ));
         }
 
         {
@@ -264,15 +274,24 @@ public class WildcardExpressionResolverTests extends ESTestCase {
 
             // data stream's corresponding backing indices are resolved
             List<String> indices = resolver.resolve(indicesAliasesDataStreamsAndHiddenIndices, Collections.singletonList("foo_*"));
-            assertThat(indices, containsInAnyOrder("foo_index", "bar_index", "foo_foo",
-                DataStream.getDefaultBackingIndexName("foo_logs", 1, epochMillis),
-                DataStream.getDefaultBackingIndexName("foo_logs", 2, epochMillis)));
+            assertThat(indices, containsInAnyOrder(
+                equalTo("foo_index"),
+                equalTo("bar_index"),
+                equalTo("foo_foo"),
+                backingIndexEqualTo("foo_logs", 1, epochMillis),
+                backingIndexEqualTo("foo_logs", 2, epochMillis)
+            ));
 
             // include all wildcard adds the data stream's backing indices
             indices = resolver.resolve(indicesAliasesDataStreamsAndHiddenIndices, Collections.singletonList("*"));
-            assertThat(indices, containsInAnyOrder("foo_index", "bar_index", "foo_foo", "bar_bar",
-                DataStream.getDefaultBackingIndexName("foo_logs", 1, epochMillis),
-                DataStream.getDefaultBackingIndexName("foo_logs", 2, epochMillis)));
+            assertThat(indices, containsInAnyOrder(
+                equalTo("foo_index"),
+                equalTo("bar_index"),
+                equalTo("foo_foo"),
+                equalTo("bar_bar"),
+                backingIndexEqualTo("foo_logs", 1, epochMillis),
+                backingIndexEqualTo("foo_logs", 2, epochMillis)
+            ));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/snapshots/RestoreServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/RestoreServiceTests.java
@@ -70,7 +70,12 @@ public class RestoreServiceTests extends ESTestCase {
         String dataStreamName = "data-stream-1";
         String renamedDataStreamName = "data-stream-2";
         String backingIndexName = DataStream.getDefaultBackingIndexName(dataStreamName, 1);
+
+        // Ensure keep using same random suffix:
         String renamedBackingIndexName = DataStream.getDefaultBackingIndexName(renamedDataStreamName, 1);
+        renamedBackingIndexName = renamedBackingIndexName.substring(0, renamedBackingIndexName.lastIndexOf('-'));
+        renamedBackingIndexName += backingIndexName.substring(backingIndexName.lastIndexOf('-'));
+
         List<Index> indices = Collections.singletonList(new Index(backingIndexName, "uuid"));
 
         DataStream dataStream = new DataStream(dataStreamName, createTimestampField("@timestamp"), indices);
@@ -93,7 +98,12 @@ public class RestoreServiceTests extends ESTestCase {
         String dataStreamName = "ds-000001";
         String renamedDataStreamName = "ds2-000001";
         String backingIndexName = DataStream.getDefaultBackingIndexName(dataStreamName, 1);
+
+        // Ensure keep using same random suffix:
         String renamedBackingIndexName = DataStream.getDefaultBackingIndexName(renamedDataStreamName, 1);
+        renamedBackingIndexName = renamedBackingIndexName.substring(0, renamedBackingIndexName.lastIndexOf('-'));
+        renamedBackingIndexName += backingIndexName.substring(backingIndexName.lastIndexOf('-'));
+
         List<Index> indices = Collections.singletonList(new Index(backingIndexName, "uuid"));
 
         DataStream dataStream = new DataStream(dataStreamName, createTimestampField("@timestamp"), indices);

--- a/test/framework/src/main/java/org/elasticsearch/cluster/DataStreamTestHelper.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/DataStreamTestHelper.java
@@ -17,6 +17,7 @@ import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.test.ESTestCase;
+import org.hamcrest.Matcher;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,6 +29,7 @@ import static org.elasticsearch.cluster.metadata.DataStream.getDefaultBackingInd
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_INDEX_UUID;
 import static org.elasticsearch.test.ESTestCase.randomAlphaOfLength;
 import static org.elasticsearch.test.ESTestCase.randomBoolean;
+import static org.hamcrest.Matchers.startsWith;
 
 public final class DataStreamTestHelper {
 
@@ -170,4 +172,21 @@ public final class DataStreamTestHelper {
         return String.format(Locale.ROOT, "\\.ds-%s-(\\d{4}\\.\\d{2}\\.\\d{2}-)?%06d",dataStreamName, generation);
     }
 
+    public static String getBackingIndexPrefix(String dataStreamName, int generation) {
+        String backingIndex = getDefaultBackingIndexName(dataStreamName, generation);
+        return backingIndex.substring(0, backingIndex.lastIndexOf('-'));
+    }
+
+    public static String getBackingIndexPrefix(String dataStreamName, int generation, long epochMillis) {
+        String backingIndex = getDefaultBackingIndexName(dataStreamName, generation, epochMillis);
+        return backingIndex.substring(0, backingIndex.lastIndexOf('-'));
+    }
+
+    public static Matcher<String> backingIndexEqualTo(String dataStreamName, int generation) {
+        return startsWith(getBackingIndexPrefix(dataStreamName, generation));
+    }
+
+    public static Matcher<String> backingIndexEqualTo(String dataStreamName, int generation, long epochMillis) {
+        return startsWith(getBackingIndexPrefix(dataStreamName, generation, epochMillis));
+    }
 }

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderService.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderService.java
@@ -40,6 +40,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.snapshots.SnapshotShardSizeInfo;
 import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingCapacity;
 import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingDeciderContext;
@@ -511,7 +512,8 @@ public class ReactiveStorageDeciderService implements AutoscalingDeciderService 
             DataStream dataStream = stream.getDataStream();
             for (int i = 0; i < numberNewIndices; ++i) {
                 final String uuid = UUIDs.randomBase64UUID();
-                dataStream = dataStream.rollover(uuid, Version.CURRENT);
+                String newWriteIndexName = dataStream.nextWriteIndexName(Version.CURRENT);
+                dataStream = dataStream.rollover(new Index(newWriteIndexName, uuid), Version.CURRENT);
                 IndexMetadata newIndex = IndexMetadata.builder(writeIndex)
                     .index(dataStream.getWriteIndex().getName())
                     .settings(Settings.builder().put(writeIndex.getSettings()).put(IndexMetadata.SETTING_INDEX_UUID, uuid))

--- a/x-pack/plugin/data-streams/src/internalClusterTest/java/org/elasticsearch/xpack/datastreams/DataTierDataStreamIT.java
+++ b/x-pack/plugin/data-streams/src/internalClusterTest/java/org/elasticsearch/xpack/datastreams/DataTierDataStreamIT.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.datastreams;
 
 import org.elasticsearch.action.admin.indices.template.put.PutComposableIndexTemplateAction;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
-import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -22,6 +21,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 
+import static org.elasticsearch.datastreams.DataStreamIT.getBackingIndexName;
 import static org.hamcrest.Matchers.equalTo;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0, numClientNodes = 0)
@@ -59,7 +59,7 @@ public class DataTierDataStreamIT extends ESIntegTestCase {
             .addIndices(index)
             .get()
             .getSettings()
-            .get(DataStream.getDefaultBackingIndexName(index, 1));
+            .get(getBackingIndexName(index, 1));
         assertThat(DataTierAllocationDecider.INDEX_ROUTING_PREFER_SETTING.get(idxSettings), equalTo(DataTier.DATA_HOT));
 
         logger.info("--> waiting for {} to be yellow", index);
@@ -67,13 +67,7 @@ public class DataTierDataStreamIT extends ESIntegTestCase {
 
         // Roll over index and ensure the second index also went to the "hot" tier
         client().admin().indices().prepareRolloverIndex(index).get();
-        idxSettings = client().admin()
-            .indices()
-            .prepareGetIndex()
-            .addIndices(index)
-            .get()
-            .getSettings()
-            .get(DataStream.getDefaultBackingIndexName(index, 2));
+        idxSettings = client().admin().indices().prepareGetIndex().addIndices(index).get().getSettings().get(getBackingIndexName(index, 2));
         assertThat(DataTierAllocationDecider.INDEX_ROUTING_PREFER_SETTING.get(idxSettings), equalTo(DataTier.DATA_HOT));
 
         client().execute(DeleteDataStreamAction.INSTANCE, new DeleteDataStreamAction.Request(new String[] { index }));

--- a/x-pack/plugin/data-streams/src/test/java/org/elasticsearch/xpack/datastreams/DataStreamsStatsTests.java
+++ b/x-pack/plugin/data-streams/src/test/java/org/elasticsearch/xpack/datastreams/DataStreamsStatsTests.java
@@ -130,7 +130,7 @@ public class DataStreamsStatsTests extends ESSingleNodeTestCase {
         createDocument(dataStreamName);
         assertTrue(client().admin().indices().rolloverIndex(new RolloverRequest(dataStreamName, null)).get().isAcknowledged());
         assertTrue(
-            client().admin().indices().close(new CloseIndexRequest(".ds-" + dataStreamName + "-*-000001")).actionGet().isAcknowledged()
+            client().admin().indices().close(new CloseIndexRequest(".ds-" + dataStreamName + "-*-000001-*")).actionGet().isAcknowledged()
         );
 
         assertBusy(

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/data_stream/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/data_stream/10_basic.yml
@@ -335,7 +335,7 @@ setup:
 
   - do:
       indices.get:
-        index: ['.ds-simple-data-stream1-*000001', 'test_index']
+        index: ['.ds-simple-data-stream1-*000001-*', 'test_index']
 
   - is_true: test_index.settings
   - is_true: .$idx0name.settings
@@ -346,7 +346,7 @@ setup:
   - match: { data_streams.0.timestamp_field.name: '@timestamp' }
   - match: { data_streams.0.generation: 1 }
   - length: { data_streams.0.indices: 1 }
-  - match: { data_streams.0.indices.0.index_name: '/\.ds-simple-data-stream1-(\d{4}\.\d{2}\.\d{2}-)?000001/' }
+  - match: { data_streams.0.indices.0.index_name: '/\.ds-simple-data-stream1-(\d{4}\.\d{2}\.\d{2}-)?000001-(.{6})/' }
 
   - do:
       indices.delete_data_stream:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/data_stream/20_unsupported_apis.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/data_stream/20_unsupported_apis.yml
@@ -166,7 +166,7 @@
   - do:
       catch: bad_request
       indices.close:
-        index: ".ds-simple-data-stream1-*000001"
+        index: ".ds-simple-data-stream1-*000001-*"
       allowed_warnings:
         - "the default value for the ?wait_for_active_shards parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour"
 

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/data_stream/50_delete_backing_indices.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/data_stream/50_delete_backing_indices.yml
@@ -102,11 +102,11 @@ setup:
   - do:
       catch: bad_request
       indices.delete:
-        index: .ds-simple-data-stream-*000002
+        index: .ds-simple-data-stream-*000002-*
 
   - do:
       indices.exists:
-        index: .ds-simple-data-stream-*000002
+        index: .ds-simple-data-stream-*000002-*
 
   - is_true: ''
 

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/data_stream/60_get_backing_indices.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/data_stream/60_get_backing_indices.yml
@@ -35,7 +35,7 @@
 
   - do:
       indices.get:
-        index: ['.ds-data-stream1-*000001', 'test_index']
+        index: ['.ds-data-stream1-*-000001-*', 'test_index']
 
   - is_true: .$idx0name.settings
   - is_true: .$idx0name.data_stream


### PR DESCRIPTION
Previous format: `.ds-[ds-name]-[yyyy.MM.dd]-[generation]`
Previous backing index name example: `.ds-foobar-2021.03.01-000001`

New format: `.ds-[ds-name]-[yyyy.MM.dd]-[generation]-[random-snippet]`
New backing index name example: `.ds-foobar-2021.03.01-000001-hjd1lk`

The random snippet will only contain lowercase alphanumeric characters and
the length of snippet is always 6 characters long.

This commit also removes the validation in `Metadata#validateDataStreams(...)`
that checks whether indices collide with future backing indices of data streams.
A subtle bug (#69625) in the validation caused new nodes to fail to join the cluster
during an upgrade. While the bug was minor, the place where the validation occurs
makes even the smallest bug, a potential production hazard. The reason this location
was chosen is that this guarantees that the validation would always be executed.
Moving the validation in the mentioned method elsewhere, meant that in multiple places
we would need to check whether other indices collide with future backing indices
of data streams.

This change tries a different approach, by adding a random snippet as suffix to
the backing index name the chances that a new backing index would collide with
another index would be very small. To make it impossible both the rollover and
create data stream api retry with a different random suffix if a backing index
happens to already exist.