### PR TITLE
[7.12] [DOCS] Reviews ML decider conceptual docs (#69524)

### DIFF
--- a/docs/reference/autoscaling/deciders/machine-learning-decider.asciidoc
+++ b/docs/reference/autoscaling/deciders/machine-learning-decider.asciidoc
@@ -3,47 +3,46 @@
 [[autoscaling-machine-learning-decider]]
 === Machine learning decider
 
-The {ml} decider (`ml`) calculates the memory required to run
-{ml} jobs created by users.
+The {ml} decider (`ml`) calculates the memory required to run {ml} jobs.
 
 The {ml} decider is enabled for policies governing `ml` nodes.
 
 NOTE: For {ml} jobs to open when the cluster is not appropriately
-scaled, `xpack.ml.max_lazy_ml_nodes` should be set to the largest
-number of possible {ml} jobs (see <<advanced-ml-settings>>). In
-{ess} this is already handled.
+scaled, set `xpack.ml.max_lazy_ml_nodes` to the largest number of possible {ml} 
+jobs (refer to <<advanced-ml-settings>> for more information). In {ess}, this is 
+automatically set.
 
 [[autoscaling-machine-learning-decider-settings]]
 ==== Configuration settings
 
-Both `num_anomaly_jobs_in_queue` and `num_analytics_jobs_in_queue`
-are designed to be used to delay a scale-up event. They indicate how many jobs
-of that type can be unassigned from a node due to the cluster being
-too small. Both settings are only considered for jobs that could
-eventually be fully opened given the current scale. If a job is too
-large for any node size or if a job couldn't ever be assigned without
-user intervention (for example, a user calling `_stop` against a real-time 
+Both `num_anomaly_jobs_in_queue` and `num_analytics_jobs_in_queue` are designed 
+to delay a scale-up event. If the cluster is too small, these settings indicate how many jobs of each type can be 
+unassigned from a node. Both settings are 
+only considered for jobs that can be opened given the current scale. If a job is 
+too large for any node size or if a job can't be assigned without user 
+intervention (for example, a user calling `_stop` against a real-time 
 {anomaly-job}), the numbers are ignored for that particular job.
 
 `num_anomaly_jobs_in_queue`::
 (Optional, integer)
-Number of queued anomaly jobs to allow. Defaults to `0`.
+Specifies the number of queued {anomaly-jobs} to allow. Defaults to `0`.
 
 `num_analytics_jobs_in_queue`::
 (Optional, integer)
-Number of queued analytics jobs to allow. Defaults to `0`.
+Specifies the number of queued {dfanalytics-jobs} to allow. Defaults to `0`.
 
 `down_scale_delay`::
 (Optional, <<time-units,time value>>)
-Delay before scaling down. Defaults to 1 hour. If a scale down is possible
-for the entire time window, then a scale down is requested. If the cluster
-requires a scale up during the window, the window is reset.
+Specifies the time to delay before scaling down. Defaults to 1 hour. If a scale 
+down is possible for the entire time window, then a scale down is requested. If 
+the cluster requires a scale up during the window, the window is reset.
+
 
 [[autoscaling-machine-learning-decider-examples]]
 ==== {api-examples-title}
 
-This example puts an autoscaling policy named `my_autoscaling_policy`,
-overriding the machine learning decider's configuration.
+This example creates an autoscaling policy named `my_autoscaling_policy` that 
+overrides the default configuration of the {ml} decider.
 
 [source,console]
 --------------------------------------------------
@@ -61,6 +60,7 @@ PUT /_autoscaling/policy/my_autoscaling_policy
 --------------------------------------------------
 // TEST
 
+
 The API returns the following result:
 
 [source,console-result]
@@ -69,6 +69,7 @@ The API returns the following result:
   "acknowledged": true
 }
 --------------------------------------------------
+
 
 //////////////////////////
 


### PR DESCRIPTION
Backports the following commits to 7.12:
 - [DOCS] Reviews ML decider conceptual docs (#69524)