### PR TITLE
Transport client needs to know about pluggable roles

### DIFF
--- a/server/src/main/java/org/elasticsearch/client/transport/TransportClient.java
+++ b/server/src/main/java/org/elasticsearch/client/transport/TransportClient.java
@@ -16,6 +16,7 @@ import org.elasticsearch.action.ActionType;
 import org.elasticsearch.client.support.AbstractClient;
 import org.elasticsearch.cluster.ClusterModule;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.component.LifecycleComponent;
@@ -57,6 +58,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -161,6 +163,13 @@ public abstract class TransportClient extends AbstractClient {
                     pluginsService.filterPlugins(Plugin.class).stream()
                             .flatMap(p -> p.getNamedXContent().stream())
                     ).flatMap(Function.identity()).collect(toList()));
+
+            final Set<DiscoveryNodeRole> additionalRoles = pluginsService.filterPlugins(Plugin.class)
+                .stream()
+                .map(Plugin::getRoles)
+                .flatMap(Set::stream)
+                .collect(Collectors.toSet());
+            DiscoveryNode.setAdditionalRoles(additionalRoles);
 
             ModulesBuilder modules = new ModulesBuilder();
             // plugin modules must be added here, before others or we can get crazy injection errors...

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/build.gradle
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/build.gradle
@@ -52,6 +52,8 @@ testClusters.all {
   setting 'slm.history_index_enabled', 'false'
   // To spice things up a bit, one of the nodes is not an ML node
   nodes.'javaRestTest-0'.setting 'node.roles', '["master","data","ingest"]'
+  nodes.'javaRestTest-1'.setting 'node.roles', '["master","data","ingest","ml"]'
+  nodes.'javaRestTest-2'.setting 'node.roles', '["master","data","ingest","ml"]'
 
   keystore 'bootstrap.password', 'x-pack-test-password'
   keystore 'xpack.security.transport.ssl.secure_key_passphrase', 'testnode'


### PR DESCRIPTION
If you call isDataNode() or isMasterNode() on a
DiscoveryNode object returned by an action called
within a program using the transport client then
the code that runs needs to be aware of any pluggable
roles that exist on the node represented by that
DiscoveryNode. For example, if there is an ML node
in a cluster defined by "node.roles: [ ml ]" and you
get a DiscoveryNode for it in your program that's
using the transport client and call its isDataNode()
method then you'll get an exception if your transport
client hasn't registered the pluggable ML role.

This change makes the transport client register all
pluggable roles for the plugins passed to its
constructor. (The code is the same as that used in
Node's constructor.)

Backport of #68226