### PR TITLE
Reduce Searchable Snapshots IndexInput resource descriptions (#68968)

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/BaseSearchableSnapshotIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/BaseSearchableSnapshotIndexInput.java
@@ -212,6 +212,20 @@ public abstract class BaseSearchableSnapshotIndexInput extends BufferedIndexInpu
         return clone;
     }
 
+    @Override
+    public String toString() {
+        return super.toString() + "[length=" + length() + ", file pointer=" + getFilePointer() + ", offset=" + offset + ']';
+    }
+
+    @Override
+    protected String getFullSliceDescription(String sliceDescription) {
+        final String resourceDesc = super.toString();
+        if (sliceDescription != null) {
+            return "slice(" + sliceDescription + ") of " + resourceDesc;
+        }
+        return resourceDesc;
+    }
+
     protected void ensureOpen() throws IOException {
         if (closed.get()) {
             throw new IOException(toString() + " is closed");

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/InMemoryNoOpCommitDirectory.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/InMemoryNoOpCommitDirectory.java
@@ -131,4 +131,8 @@ public class InMemoryNoOpCommitDirectory extends FilterDirectory {
         return name.startsWith("segments_") == false || Arrays.stream(realDirectory.listAll()).noneMatch(s -> s.equals(name));
     }
 
+    @Override
+    public String toString() {
+        return "InMemoryNoOpCommitDirectory(" + "real=" + realDirectory + ", delegate=" + in + '}';
+    }
 }

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/SearchableSnapshotDirectory.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/SearchableSnapshotDirectory.java
@@ -457,7 +457,7 @@ public class SearchableSnapshotDirectory extends BaseDirectory {
 
     @Override
     public String toString() {
-        return this.getClass().getSimpleName() + "@snapshotId=" + snapshotId + " lockFactory=" + lockFactory + " shard=" + shardId;
+        return this.getClass().getSimpleName() + "(snapshotId=" + snapshotId + ", indexId=" + indexId + " shardId=" + shardId + ')';
     }
 
     private void cleanExistingRegularShardFiles() {

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/CachedBlobContainerIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/CachedBlobContainerIndexInput.java
@@ -608,20 +608,20 @@ public class CachedBlobContainerIndexInput extends BaseSearchableSnapshotIndexIn
 
     @Override
     public String toString() {
-        return "CachedBlobContainerIndexInput{"
-            + "cacheFileReference="
-            + cacheFileReference
-            + ", offset="
-            + offset
-            + ", length="
-            + length()
-            + ", position="
-            + getFilePointer()
-            + ", rangeSize="
-            + getDefaultRangeSize()
-            + ", directory="
-            + directory
-            + '}';
+        final CacheFile cacheFile = cacheFileReference.cacheFile.get();
+        return super.toString()
+            + "[cache file="
+            + (cacheFile != null
+                ? String.join(
+                    "/",
+                    directory.getShardId().getIndex().getUUID(),
+                    String.valueOf(directory.getShardId().getId()),
+                    "snapshot_cache",
+                    directory.getSnapshotId().getUUID(),
+                    cacheFile.getFile().getFileName().toString()
+                )
+                : null)
+            + ']';
     }
 
     private static class CacheFileReference implements CacheFile.EvictionListener {

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/FrozenIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/FrozenIndexInput.java
@@ -648,24 +648,6 @@ public class FrozenIndexInput extends BaseSearchableSnapshotIndexInput {
         return slice;
     }
 
-    @Override
-    public String toString() {
-        return "CachedBlobContainerIndexInput{"
-            + "sharedCacheFile="
-            + frozenCacheFile
-            + ", offset="
-            + offset
-            + ", length="
-            + length()
-            + ", position="
-            + getFilePointer()
-            + ", rangeSize="
-            + getDefaultRangeSize()
-            + ", directory="
-            + directory
-            + '}';
-    }
-
     private static boolean assertCurrentThreadMayWriteCacheFile() {
         final String threadName = Thread.currentThread().getName();
         assert isCacheFetchAsyncThread(threadName) : "expected the current thread ["

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/direct/DirectBlobContainerIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/direct/DirectBlobContainerIndexInput.java
@@ -291,7 +291,7 @@ public class DirectBlobContainerIndexInput extends BaseSearchableSnapshotIndexIn
     public IndexInput slice(String sliceDescription, long offset, long length) throws IOException {
         if ((offset >= 0L) && (length >= 0L) && (offset + length <= length())) {
             final DirectBlobContainerIndexInput slice = new DirectBlobContainerIndexInput(
-                sliceDescription,
+                getFullSliceDescription(sliceDescription),
                 blobContainer,
                 fileInfo,
                 context,
@@ -330,18 +330,7 @@ public class DirectBlobContainerIndexInput extends BaseSearchableSnapshotIndexIn
 
     @Override
     public String toString() {
-        return "DirectBlobContainerIndexInput{"
-            + "resourceDesc="
-            + super.toString()
-            + ", fileInfo="
-            + fileInfo
-            + ", offset="
-            + offset
-            + ", length="
-            + length()
-            + ", position="
-            + position
-            + '}';
+        return super.toString() + "[read seq=" + (streamForSequentialReads != null ? "yes" : "no") + ']';
     }
 
     private InputStream openBlobStream(int part, long pos, long length) throws IOException {

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/FrozenCacheService.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/FrozenCacheService.java
@@ -701,9 +701,13 @@ public class FrozenCacheService implements Releasable {
         private final CacheKey cacheKey;
         private final long length;
 
-        public FrozenCacheFile(CacheKey cacheKey, long length) {
+        private FrozenCacheFile(CacheKey cacheKey, long length) {
             this.cacheKey = cacheKey;
             this.length = length;
+        }
+
+        public long getLength() {
+            return length;
         }
 
         public StepListener<Integer> populateAndRead(
@@ -784,7 +788,7 @@ public class FrozenCacheService implements Releasable {
 
         @Override
         public String toString() {
-            return "SharedCacheFile{" + "cacheKey=" + cacheKey + ", length=" + length + '}';
+            return "FrozenCacheFile{" + "cacheKey=" + cacheKey + ", length=" + length + '}';
         }
     }
 


### PR DESCRIPTION
We noticed that the resource descriptions of the IndexInput 
used for Searchable Snapshots can grow pretty large. This 
is due to the fact that resource descriptions tend to 
aggregate all kind of information, maybe more than really 
useful, and also that description of slices are based on the 
toString() computation rather than just picking up the 
parent's index input description.

This commit reduces the length of the description at 
various places.


Backport of #68968