### PR TITLE
Always validate geo shapes when fetching (#69104)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/AbstractGeometryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/AbstractGeometryFieldMapper.java
@@ -72,9 +72,7 @@ public abstract class AbstractGeometryFieldMapper<Parsed, Processed> extends Fie
         /**
          * Parses the given value, then formats it according to the 'format' string.
          *
-         * By default, this method simply parses the value using {@link Parser#parse}, then formats
-         * it with {@link Parser#format}. However some {@link Parser} implementations override this
-         * as they can avoid parsing the value if it is already in the right format.
+         * Used by value fetchers to validate and format geo objects
          */
         public Object parseAndFormatObject(Object value, String format) {
             Parsed geometry;

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeParser.java
@@ -8,19 +8,12 @@
 
 package org.elasticsearch.index.mapper;
 
-import org.elasticsearch.common.geo.GeometryFormat;
 import org.elasticsearch.common.geo.GeometryParser;
-import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
-import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.common.xcontent.support.MapXContentParser;
 import org.elasticsearch.geometry.Geometry;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.text.ParseException;
-import java.util.Collections;
 
 public class GeoShapeParser extends AbstractGeometryFieldMapper.Parser<Geometry> {
     private final GeometryParser geometryParser;
@@ -39,25 +32,4 @@ public class GeoShapeParser extends AbstractGeometryFieldMapper.Parser<Geometry>
         return geometryParser.geometryFormat(format).toXContentAsObject(value);
     }
 
-    @Override
-    public Object parseAndFormatObject(Object value, String format) {
-        try (XContentParser parser = new MapXContentParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE,
-            Collections.singletonMap("dummy_field", value), XContentType.JSON)) {
-            parser.nextToken(); // start object
-            parser.nextToken(); // field name
-            parser.nextToken(); // field value
-
-            GeometryFormat<Geometry> geometryFormat = geometryParser.geometryFormat(parser);
-            if (geometryFormat.name().equals(format)) {
-                return value;
-            }
-
-            Geometry geometry = geometryFormat.fromXContent(parser);
-            return format(geometry, format);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        } catch (ParseException e) {
-            throw new RuntimeException(e);
-        }
-    }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/GeoPointFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/GeoPointFieldTypeTests.java
@@ -43,6 +43,13 @@ public class GeoPointFieldTypeTests extends FieldTypeTestCase {
         assertEquals(Arrays.asList(jsonPoint, otherJsonPoint), fetchSourceValue(mapper, sourceValue, null));
         assertEquals(Arrays.asList(wktPoint, otherWktPoint), fetchSourceValue(mapper, sourceValue, "wkt"));
 
+        // Test a list of points in [lat,lon] array format with one malformed
+        // TODO Point Field parsers have a weird `ignore_malformed` impl that still throws errors
+        // on many types of malformed input
+        // sourceValue = List.of(List.of(42,0, 27.1), List.of("a", "b"), List.of(30.0, 50.0));
+        // assertEquals(List.of(jsonPoint, otherJsonPoint), fetchSourceValue(mapper, sourceValue, null));
+        // assertEquals(List.of(wktPoint, otherWktPoint), fetchSourceValue(mapper, sourceValue, "wkt"));
+
         // Test a single point in well-known text format.
         sourceValue = "POINT (42.0 27.1)";
         assertEquals(Collections.singletonList(jsonPoint), fetchSourceValue(mapper, sourceValue, null));

--- a/server/src/test/java/org/elasticsearch/index/mapper/GeoShapeFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/GeoShapeFieldTypeTests.java
@@ -17,7 +17,7 @@ public class GeoShapeFieldTypeTests extends FieldTypeTestCase {
 
     public void testFetchSourceValue() throws IOException {
         MappedFieldType mapper
-            = new GeoShapeFieldMapper.Builder("field", false, true).build(new ContentPath()).fieldType();
+            = new GeoShapeFieldMapper.Builder("field", true, true).build(new ContentPath()).fieldType();
 
         Map<String, Object> jsonLineString = org.elasticsearch.common.collect.Map.of(
             "type", "LineString",
@@ -25,26 +25,52 @@ public class GeoShapeFieldTypeTests extends FieldTypeTestCase {
         Map<String, Object> jsonPoint = org.elasticsearch.common.collect.Map.of(
             "type", "Point",
             "coordinates", Arrays.asList(14.0, 15.0));
+        Map<String, Object> jsonMalformed = org.elasticsearch.common.collect.Map.of("type", "Point", "coordinates", "foo");
         String wktLineString = "LINESTRING (42.0 27.1, 30.0 50.0)";
         String wktPoint = "POINT (14.0 15.0)";
+        String wktMalformed = "POINT foo";
 
         // Test a single shape in geojson format.
         Object sourceValue = jsonLineString;
         assertEquals(Collections.singletonList(jsonLineString), fetchSourceValue(mapper, sourceValue, null));
         assertEquals(Collections.singletonList(wktLineString), fetchSourceValue(mapper, sourceValue, "wkt"));
 
+        // Test a malformed single shape in geojson format
+        sourceValue = jsonMalformed;
+        assertEquals(Collections.emptyList(), fetchSourceValue(mapper, sourceValue, null));
+        assertEquals(Collections.emptyList(), fetchSourceValue(mapper, sourceValue, "wkt"));
+
         // Test a list of shapes in geojson format.
         sourceValue = Arrays.asList(jsonLineString, jsonPoint);
         assertEquals(Arrays.asList(jsonLineString, jsonPoint), fetchSourceValue(mapper, sourceValue, null));
         assertEquals(Arrays.asList(wktLineString, wktPoint), fetchSourceValue(mapper, sourceValue, "wkt"));
+
+        // Test a list of shapes including one malformed in geojson format
+        sourceValue = org.elasticsearch.common.collect.List.of(jsonLineString, jsonMalformed, jsonPoint);
+        assertEquals(
+            org.elasticsearch.common.collect.List.of(jsonLineString, jsonPoint),
+            fetchSourceValue(mapper, sourceValue, null));
+        assertEquals(
+            org.elasticsearch.common.collect.List.of(wktLineString, wktPoint),
+            fetchSourceValue(mapper, sourceValue, "wkt"));
 
         // Test a single shape in wkt format.
         sourceValue = wktLineString;
         assertEquals(Collections.singletonList(jsonLineString), fetchSourceValue(mapper, sourceValue, null));
         assertEquals(Collections.singletonList(wktLineString), fetchSourceValue(mapper, sourceValue, "wkt"));
 
+        // Test a single malformed shape in wkt format
+        sourceValue = wktMalformed;
+        assertEquals(Collections.emptyList(), fetchSourceValue(mapper, sourceValue, null));
+        assertEquals(Collections.emptyList(), fetchSourceValue(mapper, sourceValue, "wkt"));
+
         // Test a list of shapes in wkt format.
         sourceValue = Arrays.asList(wktLineString, wktPoint);
+        assertEquals(Arrays.asList(jsonLineString, jsonPoint), fetchSourceValue(mapper, sourceValue, null));
+        assertEquals(Arrays.asList(wktLineString, wktPoint), fetchSourceValue(mapper, sourceValue, "wkt"));
+
+        // Test a list of shapes including one malformed in wkt format
+        sourceValue = Arrays.asList(wktLineString, wktMalformed, wktPoint);
         assertEquals(Arrays.asList(jsonLineString, jsonPoint), fetchSourceValue(mapper, sourceValue, null));
         assertEquals(Arrays.asList(wktLineString, wktPoint), fetchSourceValue(mapper, sourceValue, "wkt"));
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/LegacyGeoShapeFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/LegacyGeoShapeFieldTypeTests.java
@@ -41,16 +41,29 @@ public class LegacyGeoShapeFieldTypeTests extends FieldTypeTestCase {
         Map<String, Object> jsonPoint = org.elasticsearch.common.collect.Map.of(
             "type", "Point",
             "coordinates", Arrays.asList(14.0, 15.0));
+        Map<String, Object> jsonMalformed = org.elasticsearch.common.collect.Map.of(
+            "type", "LineString",
+            "coordinates", "foo");
         String wktLineString = "LINESTRING (42.0 27.1, 30.0 50.0)";
         String wktPoint = "POINT (14.0 15.0)";
+        String wktMalformed = "POINT foo";
 
         // Test a single shape in geojson format.
         Object sourceValue = jsonLineString;
         assertEquals(Collections.singletonList(jsonLineString), fetchSourceValue(mapper, sourceValue, null));
         assertEquals(Collections.singletonList(wktLineString), fetchSourceValue(mapper, sourceValue, "wkt"));
 
+        // Test a malformed single shape in geojson format
+        assertEquals(Collections.emptyList(), fetchSourceValue(mapper, jsonMalformed, null));
+        assertEquals(Collections.emptyList(), fetchSourceValue(mapper, "POINT (a,b)", "wkt"));
+
         // Test a list of shapes in geojson format.
         sourceValue = Arrays.asList(jsonLineString, jsonPoint);
+        assertEquals(Arrays.asList(jsonLineString, jsonPoint), fetchSourceValue(mapper, sourceValue, null));
+        assertEquals(Arrays.asList(wktLineString, wktPoint), fetchSourceValue(mapper, sourceValue, "wkt"));
+
+        // Test a list of shapes with one malformed in geojson format
+        sourceValue = Arrays.asList(jsonLineString, jsonMalformed, jsonPoint);
         assertEquals(Arrays.asList(jsonLineString, jsonPoint), fetchSourceValue(mapper, sourceValue, null));
         assertEquals(Arrays.asList(wktLineString, wktPoint), fetchSourceValue(mapper, sourceValue, "wkt"));
 
@@ -59,8 +72,17 @@ public class LegacyGeoShapeFieldTypeTests extends FieldTypeTestCase {
         assertEquals(Collections.singletonList(jsonLineString), fetchSourceValue(mapper, sourceValue, null));
         assertEquals(Collections.singletonList(wktLineString), fetchSourceValue(mapper, sourceValue, "wkt"));
 
+        // Test a malformed single shape in wkt format
+        assertEquals(Collections.emptyList(), fetchSourceValue(mapper, wktMalformed, null));
+        assertEquals(Collections.emptyList(), fetchSourceValue(mapper, wktMalformed, "wkt"));
+
         // Test a list of shapes in wkt format.
         sourceValue = Arrays.asList(wktLineString, wktPoint);
+        assertEquals(Arrays.asList(jsonLineString, jsonPoint), fetchSourceValue(mapper, sourceValue, null));
+        assertEquals(Arrays.asList(wktLineString, wktPoint), fetchSourceValue(mapper, sourceValue, "wkt"));
+
+        // Test a list of shapes with one malformed in wkt format
+        sourceValue = Arrays.asList(wktLineString, wktMalformed, wktPoint);
         assertEquals(Arrays.asList(jsonLineString, jsonPoint), fetchSourceValue(mapper, sourceValue, null));
         assertEquals(Arrays.asList(wktLineString, wktPoint), fetchSourceValue(mapper, sourceValue, "wkt"));
     }

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/PointFieldTypeTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/PointFieldTypeTests.java
@@ -40,6 +40,11 @@ public class PointFieldTypeTests extends FieldTypeTestCase {
         assertEquals(Collections.singletonList(jsonPoint), fetchSourceValue(mapper, sourceValue, null));
         assertEquals(Collections.singletonList(wktPoint), fetchSourceValue(mapper, sourceValue, "wkt"));
 
+        // Test a malformed single point
+        sourceValue = "foo";
+        assertEquals(Collections.emptyList(), fetchSourceValue(mapper, sourceValue, null));
+        assertEquals(Collections.emptyList(), fetchSourceValue(mapper, sourceValue, "wkt"));
+
         // Test a list of points in [x, y] array format.
         sourceValue = Arrays.asList(Arrays.asList(42.0, 27.1), Arrays.asList(30.0, 50.0));
         assertEquals(Arrays.asList(jsonPoint, otherJsonPoint), fetchSourceValue(mapper, sourceValue, null));
@@ -49,5 +54,12 @@ public class PointFieldTypeTests extends FieldTypeTestCase {
         sourceValue = "POINT (42.0 27.1)";
         assertEquals(Collections.singletonList(jsonPoint), fetchSourceValue(mapper, sourceValue, null));
         assertEquals(Collections.singletonList(wktPoint), fetchSourceValue(mapper, sourceValue, "wkt"));
+
+        // Test a list of points in [x, y] array format with a malformed entry
+        // TODO Point Field parsers have a weird `ignore_malformed` impl that still throws errors
+        // on many types of malformed input
+        // sourceValue = List.of(List.of(42.0, 27.1), List.of("a", "b"), List.of(30.0, 50.0));
+        // assertEquals(List.of(jsonPoint, otherJsonPoint), fetchSourceValue(mapper, sourceValue, null));
+        // assertEquals(List.of(wktPoint, otherWktPoint), fetchSourceValue(mapper, sourceValue, "wkt"));
     }
 }

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldTypeTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldTypeTests.java
@@ -21,21 +21,37 @@ public class ShapeFieldTypeTests extends FieldTypeTestCase {
     public void testFetchSourceValue() throws IOException {
         MappedFieldType mapper = new ShapeFieldMapper.Builder("field", false, true).build(new ContentPath()).fieldType();
 
-        Map<String, Object> jsonLineString = org.elasticsearch.common.collect.Map.of("type", "LineString", "coordinates",
+        Map<String, Object> jsonLineString = org.elasticsearch.common.collect.Map.of(
+            "type", "LineString",
+            "coordinates",
             Arrays.asList(Arrays.asList(42.0, 27.1), Arrays.asList(30.0, 50.0)));
         Map<String, Object> jsonPoint = org.elasticsearch.common.collect.Map.of(
             "type", "Point",
             "coordinates", Arrays.asList(14.3, 15.0));
+        Map<String, Object> jsonMalformed = org.elasticsearch.common.collect.Map.of(
+            "type", "Point",
+            "coordinates", "foo");
         String wktLineString = "LINESTRING (42.0 27.1, 30.0 50.0)";
         String wktPoint = "POINT (14.3 15.0)";
+        String wktMalformed = "POINT foo";
 
         // Test a single shape in geojson format.
         Object sourceValue = jsonLineString;
         assertEquals(Collections.singletonList(jsonLineString), fetchSourceValue(mapper, sourceValue, null));
         assertEquals(Collections.singletonList(wktLineString), fetchSourceValue(mapper, sourceValue, "wkt"));
 
+        // Test a malformed single shape in geojson format
+        sourceValue = jsonMalformed;
+        assertEquals(Collections.emptyList(), fetchSourceValue(mapper, sourceValue, null));
+        assertEquals(Collections.emptyList(), fetchSourceValue(mapper, sourceValue, "wkt"));
+
         // Test a list of shapes in geojson format.
         sourceValue = Arrays.asList(jsonLineString, jsonPoint);
+        assertEquals(Arrays.asList(jsonLineString, jsonPoint), fetchSourceValue(mapper, sourceValue, null));
+        assertEquals(Arrays.asList(wktLineString, wktPoint), fetchSourceValue(mapper, sourceValue, "wkt"));
+
+        // Test a list of shapes including one malformed in geojson format
+        sourceValue = Arrays.asList(jsonLineString, jsonMalformed, jsonPoint);
         assertEquals(Arrays.asList(jsonLineString, jsonPoint), fetchSourceValue(mapper, sourceValue, null));
         assertEquals(Arrays.asList(wktLineString, wktPoint), fetchSourceValue(mapper, sourceValue, "wkt"));
 
@@ -44,8 +60,18 @@ public class ShapeFieldTypeTests extends FieldTypeTestCase {
         assertEquals(Collections.singletonList(jsonLineString), fetchSourceValue(mapper, sourceValue, null));
         assertEquals(Collections.singletonList(wktLineString), fetchSourceValue(mapper, sourceValue, "wkt"));
 
+        // Test a single malformed shape in wkt format
+        sourceValue = wktMalformed;
+        assertEquals(Collections.emptyList(), fetchSourceValue(mapper, sourceValue, null));
+        assertEquals(Collections.emptyList(), fetchSourceValue(mapper, sourceValue, "wkt"));
+
         // Test a list of shapes in wkt format.
         sourceValue = Arrays.asList(wktLineString, wktPoint);
+        assertEquals(Arrays.asList(jsonLineString, jsonPoint), fetchSourceValue(mapper, sourceValue, null));
+        assertEquals(Arrays.asList(wktLineString, wktPoint), fetchSourceValue(mapper, sourceValue, "wkt"));
+
+        // Test a list of shapes including one malformed in wkt format
+        sourceValue = Arrays.asList(wktLineString, wktMalformed, wktPoint);
         assertEquals(Arrays.asList(jsonLineString, jsonPoint), fetchSourceValue(mapper, sourceValue, null));
         assertEquals(Arrays.asList(wktLineString, wktPoint), fetchSourceValue(mapper, sourceValue, "wkt"));
     }

--- a/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/FieldExtractorTestCase.java
+++ b/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/FieldExtractorTestCase.java
@@ -436,7 +436,6 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
      *       "ignore_malformed": true/false
      *    }
      */
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/69071")
     public void testGeoShapeField() throws IOException {
         String query = "SELECT geo_shape_field FROM test";
         String actualValue = "[-77.03653, 38.897676]";

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/extractor/FieldHitExtractor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/extractor/FieldHitExtractor.java
@@ -10,6 +10,7 @@ import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.GeoUtils;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.xcontent.XContentParseException;
 import org.elasticsearch.xpack.ql.execution.search.extractor.AbstractFieldHitExtractor;
 import org.elasticsearch.xpack.ql.execution.search.extractor.HitExtractor;
 import org.elasticsearch.xpack.ql.type.DataType;
@@ -106,7 +107,7 @@ public class FieldHitExtractor extends AbstractFieldHitExtractor {
         if (dataType == GEO_SHAPE) {
             try {
                 return new GeoShape(values);
-            } catch (IOException ex) {
+            } catch (IOException | XContentParseException ex) {
                 throw new SqlIllegalArgumentException("Cannot read geo_shape value [{}] (returned by [{}])", values, fieldName());
             }
         }


### PR DESCRIPTION
The ValueFetcher for geo_shape will shortcut the validation of its
source value if it detects that the source format and the requested
format are the same. This worked fine when malformed values were
dealt with by checking the _ignored metadata, but since #68738
we need to always validate source values at fetch time.

This commit removes this special shortcut logic, and adds tests
to check that geo_shape value fetchers do not return malformed
source inputs.

Fixes #69071