### PR TITLE
Adjust the length of blob cache docs for Lucene metadata files

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/blobstore/cache/SearchableSnapshotsBlobStoreCacheIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/blobstore/cache/SearchableSnapshotsBlobStoreCacheIntegTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.action.admin.indices.forcemerge.ForceMergeResponse;
 import org.elasticsearch.action.admin.indices.refresh.RefreshResponse;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.OriginSettingClient;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -28,23 +29,31 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.IndexNotFoundException;
-import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.shard.IndexingStats;
 import org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot;
 import org.elasticsearch.plugins.ClusterPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.repositories.blobstore.BlobStoreRepository;
 import org.elasticsearch.snapshots.SnapshotId;
+import org.elasticsearch.snapshots.SnapshotsService;
 import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.xpack.cluster.routing.allocation.DataTierAllocationDecider;
 import org.elasticsearch.xpack.core.ClientHelper;
+import org.elasticsearch.xpack.core.searchablesnapshots.MountSearchableSnapshotRequest.Storage;
 import org.elasticsearch.xpack.core.searchablesnapshots.SearchableSnapshotShardStats;
 import org.elasticsearch.xpack.searchablesnapshots.BaseSearchableSnapshotsIntegTestCase;
 import org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshots;
 import org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsConstants;
 import org.elasticsearch.xpack.searchablesnapshots.action.SearchableSnapshotsStatsAction;
 import org.elasticsearch.xpack.searchablesnapshots.action.SearchableSnapshotsStatsRequest;
+import org.elasticsearch.xpack.searchablesnapshots.cache.ByteRange;
 import org.elasticsearch.xpack.searchablesnapshots.cache.CacheService;
+import org.elasticsearch.xpack.searchablesnapshots.cache.FrozenCacheService;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -69,6 +78,35 @@ import static org.hamcrest.Matchers.is;
 
 public class SearchableSnapshotsBlobStoreCacheIntegTests extends BaseSearchableSnapshotsIntegTestCase {
 
+    private static Settings cacheSettings = null;
+    private static ByteSizeValue blobCacheMaxLength = null;
+
+    @BeforeClass
+    public static void setUpCacheSettings() {
+        blobCacheMaxLength = new ByteSizeValue(randomLongBetween(64L, 128L), ByteSizeUnit.KB);
+
+        final Settings.Builder builder = Settings.builder();
+        // Cold (full copy) cache should be unlimited to not cause evictions
+        builder.put(CacheService.SNAPSHOT_CACHE_SIZE_SETTING.getKey(), new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES));
+        // Align ranges to match the blob cache max length
+        builder.put(CacheService.SNAPSHOT_CACHE_RANGE_SIZE_SETTING.getKey(), blobCacheMaxLength);
+        builder.put(CacheService.SNAPSHOT_CACHE_RECOVERY_RANGE_SIZE_SETTING.getKey(), blobCacheMaxLength);
+
+        // Frozen (shared cache) cache should be large enough to not cause direct reads
+        builder.put(SnapshotsService.SNAPSHOT_CACHE_SIZE_SETTING.getKey(), ByteSizeValue.ofMb(128));
+        // Align ranges to match the blob cache max length
+        builder.put(SnapshotsService.SNAPSHOT_CACHE_REGION_SIZE_SETTING.getKey(), blobCacheMaxLength);
+        builder.put(SnapshotsService.SHARED_CACHE_RANGE_SIZE_SETTING.getKey(), blobCacheMaxLength);
+        builder.put(FrozenCacheService.FROZEN_CACHE_RECOVERY_RANGE_SIZE_SETTING.getKey(), blobCacheMaxLength);
+        cacheSettings = builder.build();
+    }
+
+    @AfterClass
+    public static void tearDownCacheSettings() {
+        blobCacheMaxLength = null;
+        cacheSettings = null;
+    }
+
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
         return CollectionUtils.appendToCopy(super.nodePlugins(), WaitForSnapshotBlobCacheShardsActivePlugin.class);
@@ -81,30 +119,25 @@ public class SearchableSnapshotsBlobStoreCacheIntegTests extends BaseSearchableS
 
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {
-        return Settings.builder()
-            .put(super.nodeSettings(nodeOrdinal))
-            .put(
-                CacheService.SNAPSHOT_CACHE_RANGE_SIZE_SETTING.getKey(),
-                randomLongBetween(new ByteSizeValue(4, ByteSizeUnit.KB).getBytes(), new ByteSizeValue(20, ByteSizeUnit.KB).getBytes()) + "b"
-            )
-            .put(CacheService.SNAPSHOT_CACHE_SIZE_SETTING.getKey(), new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES))
-            .build();
+        return Settings.builder().put(super.nodeSettings(nodeOrdinal)).put(cacheSettings).build();
     }
 
     public void testBlobStoreCache() throws Exception {
         final String indexName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
         createIndex(indexName);
 
-        final List<IndexRequestBuilder> indexRequestBuilders = new ArrayList<>();
-        for (int i = scaledRandomIntBetween(0, 10_000); i >= 0; i--) {
-            indexRequestBuilders.add(
-                client().prepareIndex(indexName, SINGLE_MAPPING_NAME).setSource("text", randomUnicodeOfLength(10), "num", i)
-            );
-        }
-        indexRandom(true, false, true, indexRequestBuilders);
-        final long numberOfDocs = indexRequestBuilders.size();
         final NumShards numberOfShards = getNumShards(indexName);
 
+        final int numberOfDocs = scaledRandomIntBetween(0, 20_000);
+        if (numberOfDocs > 0) {
+            final List<IndexRequestBuilder> indexRequestBuilders = new ArrayList<>();
+            for (int i = numberOfDocs; i > 0; i--) {
+                XContentBuilder builder = XContentFactory.smileBuilder();
+                builder.startObject().field("text", randomRealisticUnicodeOfCodepointLengthBetween(5, 50)).field("num", i).endObject();
+                indexRequestBuilders.add(client().prepareIndex(indexName, SINGLE_MAPPING_NAME).setSource(builder));
+            }
+            indexRandom(true, true, true, indexRequestBuilders);
+        }
         if (randomBoolean()) {
             logger.info("--> force-merging index before snapshotting");
             final ForceMergeResponse forceMergeResponse = client().admin()
@@ -133,15 +166,25 @@ public class SearchableSnapshotsBlobStoreCacheIntegTests extends BaseSearchableS
             () -> systemClient().admin().indices().prepareGetIndex().addIndices(SNAPSHOT_BLOB_CACHE_INDEX).get()
         );
 
-        logger.info("--> mount snapshot [{}] as an index for the first time", snapshot);
-        final String restoredIndex = mountSnapshot(
+        Storage storage = randomFrom(Storage.values());
+        logger.info(
+            "--> mount snapshot [{}] as an index for the first time [storage={}, max length={}]",
+            snapshot,
+            storage,
+            blobCacheMaxLength.getStringRep()
+        );
+        final String restoredIndex = randomBoolean() ? indexName : randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
+        mountSnapshot(
             repositoryName,
             snapshot.getName(),
             indexName,
+            restoredIndex,
             Settings.builder()
                 .put(SearchableSnapshots.SNAPSHOT_CACHE_ENABLED_SETTING.getKey(), true)
                 .put(SearchableSnapshots.SNAPSHOT_CACHE_PREWARM_ENABLED_SETTING.getKey(), false)
-                .build()
+                .put(SearchableSnapshots.SNAPSHOT_BLOB_CACHE_METADATA_FILES_MAX_LENGTH, blobCacheMaxLength)
+                .build(),
+            storage
         );
         ensureGreen(restoredIndex);
 
@@ -167,59 +210,61 @@ public class SearchableSnapshotsBlobStoreCacheIntegTests extends BaseSearchableS
         }
 
         logger.info("--> verifying cached documents in system index [{}]", SNAPSHOT_BLOB_CACHE_INDEX);
-        assertCachedBlobsInSystemIndex(repositoryName, blobsInSnapshot);
+        if (numberOfDocs > 0) {
+            assertCachedBlobsInSystemIndex(repositoryName, blobsInSnapshot);
 
-        logger.info("--> verifying system index [{}] data tiers preference", SNAPSHOT_BLOB_CACHE_INDEX);
-        assertThat(
-            systemClient().admin()
-                .indices()
-                .prepareGetSettings(SNAPSHOT_BLOB_CACHE_INDEX)
-                .get()
-                .getSetting(SNAPSHOT_BLOB_CACHE_INDEX, DataTierAllocationDecider.INDEX_ROUTING_PREFER),
-            equalTo(DATA_TIERS_CACHE_INDEX_PREFERENCE)
-        );
+            logger.info("--> verifying system index [{}] data tiers preference", SNAPSHOT_BLOB_CACHE_INDEX);
+            assertThat(
+                systemClient().admin()
+                    .indices()
+                    .prepareGetSettings(SNAPSHOT_BLOB_CACHE_INDEX)
+                    .get()
+                    .getSetting(SNAPSHOT_BLOB_CACHE_INDEX, DataTierAllocationDecider.INDEX_ROUTING_PREFER),
+                equalTo(DATA_TIERS_CACHE_INDEX_PREFERENCE)
+            );
+        }
 
-        final long numberOfCachedBlobs = systemClient().prepareSearch(SNAPSHOT_BLOB_CACHE_INDEX).get().getHits().getTotalHits().value;
-        final long numberOfCacheWrites = systemClient().admin()
+        final long numberOfCachedBlobs = systemClient().prepareSearch(SNAPSHOT_BLOB_CACHE_INDEX)
+            .setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN)
+            .get()
+            .getHits()
+            .getTotalHits().value;
+        IndexingStats indexingStats = systemClient().admin()
             .indices()
             .prepareStats(SNAPSHOT_BLOB_CACHE_INDEX)
+            .setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN)
             .clear()
             .setIndexing(true)
             .get()
-            .getTotal().indexing.getTotal().getIndexCount();
+            .getTotal()
+            .getIndexing();
+        final long numberOfCacheWrites = indexingStats != null ? indexingStats.getTotal().getIndexCount() : 0L;
 
-        logger.info("--> verifying documents in index [{}]", restoredIndex);
+        logger.info("--> verifying number of documents in index [{}]", restoredIndex);
         assertHitCount(client().prepareSearch(restoredIndex).setSize(0).setTrackTotalHits(true).get(), numberOfDocs);
-        assertHitCount(
-            client().prepareSearch(restoredIndex)
-                .setQuery(QueryBuilders.rangeQuery("num").lte(numberOfDocs))
-                .setSize(0)
-                .setTrackTotalHits(true)
-                .get(),
-            numberOfDocs
-        );
-        assertHitCount(
-            client().prepareSearch(restoredIndex)
-                .setQuery(QueryBuilders.rangeQuery("num").gt(numberOfDocs + 1))
-                .setSize(0)
-                .setTrackTotalHits(true)
-                .get(),
-            0L
-        );
-
         assertAcked(client().admin().indices().prepareDelete(restoredIndex));
 
-        logger.info("--> mount snapshot [{}] as an index for the second time", snapshot);
-        final String restoredAgainIndex = mountSnapshot(
+        storage = randomFrom(Storage.values());
+        logger.info("--> mount snapshot [{}] as an index for the second time [storage={}]", snapshot, storage);
+        final String restoredAgainIndex = randomBoolean() ? indexName : randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
+        mountSnapshot(
             repositoryName,
             snapshot.getName(),
             indexName,
+            restoredAgainIndex,
             Settings.builder()
                 .put(SearchableSnapshots.SNAPSHOT_CACHE_ENABLED_SETTING.getKey(), true)
                 .put(SearchableSnapshots.SNAPSHOT_CACHE_PREWARM_ENABLED_SETTING.getKey(), false)
-                .build()
+                .put(SearchableSnapshots.SNAPSHOT_BLOB_CACHE_METADATA_FILES_MAX_LENGTH, blobCacheMaxLength)
+                .build(),
+            storage
         );
         ensureGreen(restoredAgainIndex);
+
+        logger.info("--> verifying cached documents (after second mount) in system index [{}]", SNAPSHOT_BLOB_CACHE_INDEX);
+        if (numberOfDocs > 0) {
+            assertCachedBlobsInSystemIndex(repositoryName, blobsInSnapshot);
+        }
 
         logger.info("--> verifying shards of [{}] were started without using the blob store more than necessary", restoredAgainIndex);
         for (final SearchableSnapshotShardStats shardStats : client().execute(
@@ -229,44 +274,33 @@ public class SearchableSnapshotsBlobStoreCacheIntegTests extends BaseSearchableS
             for (final SearchableSnapshotShardStats.CacheIndexInputStats indexInputStats : shardStats.getStats()) {
                 // we read the header of each file contained within the .cfs file, which could be anywhere
                 final boolean mayReadMoreThanHeader = indexInputStats.getFileExt().equals("cfs");
-                if (indexInputStats.getTotalSize() <= BlobStoreCacheService.DEFAULT_CACHED_BLOB_SIZE * 2
-                    || mayReadMoreThanHeader == false) {
+                if (mayReadMoreThanHeader == false) {
                     assertThat(Strings.toString(indexInputStats), indexInputStats.getBlobStoreBytesRequested().getCount(), equalTo(0L));
                 }
             }
         }
 
-        logger.info("--> verifying documents in index [{}]", restoredAgainIndex);
+        logger.info("--> verifying number of documents in index [{}]", restoredAgainIndex);
         assertHitCount(client().prepareSearch(restoredAgainIndex).setSize(0).setTrackTotalHits(true).get(), numberOfDocs);
-        assertHitCount(
-            client().prepareSearch(restoredAgainIndex)
-                .setQuery(QueryBuilders.rangeQuery("num").lte(numberOfDocs))
-                .setSize(0)
-                .setTrackTotalHits(true)
-                .get(),
-            numberOfDocs
-        );
-        assertHitCount(
-            client().prepareSearch(restoredAgainIndex)
-                .setQuery(QueryBuilders.rangeQuery("num").gt(numberOfDocs + 1))
-                .setSize(0)
-                .setTrackTotalHits(true)
-                .get(),
-            0L
-        );
-
-        logger.info("--> verifying cached documents (again) in system index [{}]", SNAPSHOT_BLOB_CACHE_INDEX);
-        assertCachedBlobsInSystemIndex(repositoryName, blobsInSnapshot);
 
         logger.info("--> verifying that no extra cached blobs were indexed [{}]", SNAPSHOT_BLOB_CACHE_INDEX);
-        refreshSystemIndex();
-        assertHitCount(systemClient().prepareSearch(SNAPSHOT_BLOB_CACHE_INDEX).setSize(0).get(), numberOfCachedBlobs);
-        assertThat(
-            systemClient().admin().indices().prepareStats(SNAPSHOT_BLOB_CACHE_INDEX).clear().setIndexing(true).get().getTotal().indexing
-                .getTotal()
-                .getIndexCount(),
-            equalTo(numberOfCacheWrites)
+        if (numberOfDocs > 0) {
+            refreshSystemIndex();
+        }
+        assertHitCount(
+            systemClient().prepareSearch(SNAPSHOT_BLOB_CACHE_INDEX).setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN).setSize(0).get(),
+            numberOfCachedBlobs
         );
+        indexingStats = systemClient().admin()
+            .indices()
+            .prepareStats(SNAPSHOT_BLOB_CACHE_INDEX)
+            .setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN)
+            .clear()
+            .setIndexing(true)
+            .get()
+            .getTotal()
+            .getIndexing();
+        assertThat(indexingStats != null ? indexingStats.getTotal().getIndexCount() : 0L, equalTo(numberOfCacheWrites));
 
         logger.info("--> restarting cluster");
         internalCluster().fullRestart(new InternalTestCluster.RestartCallback() {
@@ -280,36 +314,43 @@ public class SearchableSnapshotsBlobStoreCacheIntegTests extends BaseSearchableS
         });
         ensureGreen(restoredAgainIndex);
 
-        logger.info("--> verifying documents in index [{}]", restoredAgainIndex);
-        assertHitCount(client().prepareSearch(restoredAgainIndex).setSize(0).setTrackTotalHits(true).get(), numberOfDocs);
-        assertHitCount(
-            client().prepareSearch(restoredAgainIndex)
-                .setQuery(QueryBuilders.rangeQuery("num").lte(numberOfDocs))
-                .setSize(0)
-                .setTrackTotalHits(true)
-                .get(),
-            numberOfDocs
-        );
-        assertHitCount(
-            client().prepareSearch(restoredAgainIndex)
-                .setQuery(QueryBuilders.rangeQuery("num").gt(numberOfDocs + 1))
-                .setSize(0)
-                .setTrackTotalHits(true)
-                .get(),
-            0L
-        );
-
         logger.info("--> verifying cached documents (after restart) in system index [{}]", SNAPSHOT_BLOB_CACHE_INDEX);
-        assertCachedBlobsInSystemIndex(repositoryName, blobsInSnapshot);
+        if (numberOfDocs > 0) {
+            assertCachedBlobsInSystemIndex(repositoryName, blobsInSnapshot);
+        }
+
+        logger.info("--> shards of [{}] should start without downloading bytes from the blob store", restoredAgainIndex);
+        for (final SearchableSnapshotShardStats shardStats : client().execute(
+            SearchableSnapshotsStatsAction.INSTANCE,
+            new SearchableSnapshotsStatsRequest()
+        ).actionGet().getStats()) {
+            for (final SearchableSnapshotShardStats.CacheIndexInputStats indexInputStats : shardStats.getStats()) {
+                // we read the header of each file contained within the .cfs file, which could be anywhere
+                final boolean mayReadMoreThanHeader = indexInputStats.getFileExt().equals("cfs");
+                if (mayReadMoreThanHeader == false) {
+                    assertThat(Strings.toString(indexInputStats), indexInputStats.getBlobStoreBytesRequested().getCount(), equalTo(0L));
+                }
+            }
+        }
 
         logger.info("--> verifying that no cached blobs were indexed in system index [{}] after restart", SNAPSHOT_BLOB_CACHE_INDEX);
-        assertHitCount(systemClient().prepareSearch(SNAPSHOT_BLOB_CACHE_INDEX).setSize(0).get(), numberOfCachedBlobs);
-        assertThat(
-            systemClient().admin().indices().prepareStats(SNAPSHOT_BLOB_CACHE_INDEX).clear().setIndexing(true).get().getTotal().indexing
-                .getTotal()
-                .getIndexCount(),
-            equalTo(0L)
+        assertHitCount(
+            systemClient().prepareSearch(SNAPSHOT_BLOB_CACHE_INDEX).setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN).setSize(0).get(),
+            numberOfCachedBlobs
         );
+        indexingStats = systemClient().admin()
+            .indices()
+            .prepareStats(SNAPSHOT_BLOB_CACHE_INDEX)
+            .setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN)
+            .clear()
+            .setIndexing(true)
+            .get()
+            .getTotal()
+            .getIndexing();
+        assertThat(indexingStats != null ? indexingStats.getTotal().getIndexCount() : 0L, equalTo(0L));
+
+        logger.info("--> verifying number of documents in index [{}]", restoredAgainIndex);
+        assertHitCount(client().prepareSearch(restoredAgainIndex).setSize(0).setTrackTotalHits(true).get(), numberOfDocs);
 
         // TODO also test when the index is frozen
         // TODO also test when prewarming is enabled
@@ -356,6 +397,7 @@ public class SearchableSnapshotsBlobStoreCacheIntegTests extends BaseSearchableS
 
     private void assertCachedBlobsInSystemIndex(final String repositoryName, final Map<String, BlobStoreIndexShardSnapshot> blobsInSnapshot)
         throws Exception {
+        final BlobStoreCacheService blobCacheService = internalCluster().getDataNodeInstance(BlobStoreCacheService.class);
         assertBusy(() -> {
             refreshSystemIndex();
 
@@ -366,37 +408,18 @@ public class SearchableSnapshotsBlobStoreCacheIntegTests extends BaseSearchableS
                         continue;
                     }
 
-                    final String path = String.join("/", repositoryName, blob.getKey(), fileInfo.physicalName());
-                    if (fileInfo.length() <= BlobStoreCacheService.DEFAULT_CACHED_BLOB_SIZE * 2) {
-                        // file has been fully cached
-                        final GetResponse getResponse = systemClient().prepareGet(
-                            SNAPSHOT_BLOB_CACHE_INDEX,
-                            SINGLE_MAPPING_NAME,
-                            path + "/@0"
-                        ).get();
-                        assertThat("not cached: [" + path + "/@0] for blob [" + fileInfo + "]", getResponse.isExists(), is(true));
-                        final CachedBlob cachedBlob = CachedBlob.fromSource(getResponse.getSourceAsMap());
-                        assertThat(cachedBlob.from(), equalTo(0L));
-                        assertThat(cachedBlob.to(), equalTo(fileInfo.length()));
-                        assertThat((long) cachedBlob.length(), equalTo(fileInfo.length()));
-                        numberOfCachedBlobs += 1;
+                    final String fileName = fileInfo.physicalName();
+                    final long length = fileInfo.length();
+                    final ByteRange expectedByteRange = blobCacheService.computeBlobCacheByteRange(fileName, length, blobCacheMaxLength);
+                    final String path = String.join("/", repositoryName, blob.getKey(), fileName, "@" + expectedByteRange.start());
 
-                    } else {
-                        // first region of file has been cached
-                        GetResponse getResponse = systemClient().prepareGet(SNAPSHOT_BLOB_CACHE_INDEX, SINGLE_MAPPING_NAME, path + "/@0")
-                            .get();
-                        assertThat(
-                            "not cached: [" + path + "/@0] for first region of blob [" + fileInfo + "]",
-                            getResponse.isExists(),
-                            is(true)
-                        );
-
-                        CachedBlob cachedBlob = CachedBlob.fromSource(getResponse.getSourceAsMap());
-                        assertThat(cachedBlob.from(), equalTo(0L));
-                        assertThat(cachedBlob.to(), equalTo((long) BlobStoreCacheService.DEFAULT_CACHED_BLOB_SIZE));
-                        assertThat(cachedBlob.length(), equalTo(BlobStoreCacheService.DEFAULT_CACHED_BLOB_SIZE));
-                        numberOfCachedBlobs += 1;
-                    }
+                    final GetResponse getResponse = systemClient().prepareGet(SNAPSHOT_BLOB_CACHE_INDEX, SINGLE_MAPPING_NAME, path).get();
+                    assertThat("Expected cached blob [" + path + "] for blob [" + fileInfo + "]", getResponse.isExists(), is(true));
+                    final CachedBlob cachedBlob = CachedBlob.fromSource(getResponse.getSourceAsMap());
+                    assertThat(cachedBlob.from(), equalTo(expectedByteRange.start()));
+                    assertThat(cachedBlob.to(), equalTo(expectedByteRange.end()));
+                    assertThat((long) cachedBlob.length(), equalTo(expectedByteRange.length()));
+                    numberOfCachedBlobs += 1;
                 }
             }
 

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/BaseSearchableSnapshotsIntegTestCase.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/BaseSearchableSnapshotsIntegTestCase.java
@@ -27,6 +27,7 @@ import org.elasticsearch.snapshots.AbstractSnapshotIntegTestCase;
 import org.elasticsearch.snapshots.SnapshotsService;
 import org.elasticsearch.xpack.core.searchablesnapshots.MountSearchableSnapshotAction;
 import org.elasticsearch.xpack.core.searchablesnapshots.MountSearchableSnapshotRequest;
+import org.elasticsearch.xpack.core.searchablesnapshots.MountSearchableSnapshotRequest.Storage;
 import org.elasticsearch.xpack.searchablesnapshots.cache.CacheService;
 import org.elasticsearch.xpack.searchablesnapshots.cache.FrozenCacheService;
 
@@ -131,6 +132,17 @@ public abstract class BaseSearchableSnapshotsIntegTestCase extends AbstractSnaps
         String restoredIndexName,
         Settings restoredIndexSettings
     ) throws Exception {
+        mountSnapshot(repositoryName, snapshotName, indexName, restoredIndexName, restoredIndexSettings, Storage.FULL_COPY);
+    }
+
+    protected void mountSnapshot(
+        String repositoryName,
+        String snapshotName,
+        String indexName,
+        String restoredIndexName,
+        Settings restoredIndexSettings,
+        final Storage storage
+    ) throws Exception {
         final MountSearchableSnapshotRequest mountRequest = new MountSearchableSnapshotRequest(
             restoredIndexName,
             repositoryName,
@@ -142,7 +154,7 @@ public abstract class BaseSearchableSnapshotsIntegTestCase extends AbstractSnaps
                 .build(),
             Strings.EMPTY_ARRAY,
             true,
-            MountSearchableSnapshotRequest.Storage.FULL_COPY
+            storage
         );
 
         final RestoreSnapshotResponse restoreResponse = client().execute(MountSearchableSnapshotAction.INSTANCE, mountRequest).get();

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/blobstore/cache/BlobStoreCacheService.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/blobstore/cache/BlobStoreCacheService.java
@@ -52,9 +52,9 @@ public class BlobStoreCacheService {
     private static final Logger logger = LogManager.getLogger(BlobStoreCacheService.class);
 
     /**
-     * Before 8.0.0 blobs were cached using a 4KB or 8KB maximum length.
+     * Before 7.12.0 blobs were cached using a 4KB or 8KB maximum length.
      */
-    private static final Version OLD_CACHED_BLOB_SIZE_VERSION = Version.V_7_13_0; // TODO adjust after backport
+    private static final Version OLD_CACHED_BLOB_SIZE_VERSION = Version.V_7_12_0;
 
     public static final int DEFAULT_CACHED_BLOB_SIZE = ByteSizeUnit.KB.toIntBytes(1);
     private static final Cache<String, String> LOG_EXCEEDING_FILES_CACHE = CacheBuilder.<String, String>builder()

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/blobstore/cache/BlobStoreCacheService.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/blobstore/cache/BlobStoreCacheService.java
@@ -10,6 +10,7 @@ package org.elasticsearch.blobstore.cache;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.apache.lucene.index.IndexFileNames;
 import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.Version;
@@ -23,15 +24,24 @@ import org.elasticsearch.action.support.TransportActions;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.OriginSettingClient;
 import org.elasticsearch.cluster.block.ClusterBlockException;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.cache.Cache;
+import org.elasticsearch.common.cache.CacheBuilder;
 import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.node.NodeClosedException;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.ConnectTransportException;
+import org.elasticsearch.xpack.searchablesnapshots.cache.ByteRange;
 
 import java.time.Instant;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
@@ -41,14 +51,24 @@ public class BlobStoreCacheService {
 
     private static final Logger logger = LogManager.getLogger(BlobStoreCacheService.class);
 
-    public static final int DEFAULT_CACHED_BLOB_SIZE = ByteSizeUnit.KB.toIntBytes(4);
+    /**
+     * Before 8.0.0 blobs were cached using a 4KB or 8KB maximum length.
+     */
+    private static final Version OLD_CACHED_BLOB_SIZE_VERSION = Version.V_7_13_0; // TODO adjust after backport
 
+    public static final int DEFAULT_CACHED_BLOB_SIZE = ByteSizeUnit.KB.toIntBytes(1);
+    private static final Cache<String, String> LOG_EXCEEDING_FILES_CACHE = CacheBuilder.<String, String>builder()
+        .setExpireAfterAccess(TimeValue.timeValueMinutes(60L))
+        .build();
+
+    private final ClusterService clusterService;
     private final ThreadPool threadPool;
     private final Client client;
     private final String index;
 
-    public BlobStoreCacheService(ThreadPool threadPool, Client client, String index) {
+    public BlobStoreCacheService(ClusterService clusterService, ThreadPool threadPool, Client client, String index) {
         this.client = new OriginSettingClient(client, SEARCHABLE_SNAPSHOTS_ORIGIN);
+        this.clusterService = clusterService;
         this.threadPool = threadPool;
         this.index = index;
     }
@@ -153,6 +173,114 @@ public class BlobStoreCacheService {
         } catch (Exception e) {
             logger.warn(new ParameterizedMessage("cache fill failure: [{}]", CachedBlob.generateId(repository, name, path, offset)), e);
             listener.onFailure(e);
+        }
+    }
+
+    private static final Set<String> METADATA_FILES_EXTENSIONS;
+    private static final Set<String> OTHER_FILES_EXTENSIONS;
+    static {
+        // List of Lucene file extensions that are considered as "metadata" and should therefore be fully cached in the blob store cache.
+        // Those files are usually fully read by Lucene when it opens a Directory.
+        METADATA_FILES_EXTENSIONS = org.elasticsearch.common.collect.Set.of(
+            "cfe", // compound file's entry table
+            "dvm", // doc values metadata file
+            "fdm", // stored fields metadata file
+            "fnm", // field names metadata file
+            "kdm", // Lucene 8.6 point format metadata file
+            "nvm", // norms metadata file
+            "tmd", // Lucene 8.6 terms metadata file
+            "tvm", // terms vectors metadata file
+            "vem"  // Lucene 9.0 indexed vectors metadata
+        );
+
+        // List of extensions for which Lucene usually only reads the first 1024 byte and checks a header checksum when opening a Directory.
+        OTHER_FILES_EXTENSIONS = org.elasticsearch.common.collect.Set.of(
+            "cfs",
+            "dii",
+            "dim",
+            "doc",
+            "dvd",
+            "fdt",
+            "fdx",
+            "kdd",
+            "kdi",
+            "liv",
+            "nvd",
+            "pay",
+            "pos",
+            "tim",
+            "tip",
+            "tvd",
+            "tvx",
+            "vec"
+        );
+        assert Sets.intersection(METADATA_FILES_EXTENSIONS, OTHER_FILES_EXTENSIONS).isEmpty();
+    }
+
+    /**
+     * Computes the {@link ByteRange} corresponding to the header of a Lucene file. This range can vary depending of the type of the file
+     * which is indicated by the file's extension. The returned byte range can never be larger than the file's length but it can be smaller.
+     *
+     * For files that are declared as metadata files in {@link #METADATA_FILES_EXTENSIONS}, the header can be as large as the specified
+     * maximum metadata length parameter {@code maxMetadataLength}. Non-metadata files have a fixed length header of maximum 1KB.
+     *
+     * @param fileName the name of the file
+     * @param fileLength the length of the file
+     * @param maxMetadataLength the maximum accepted length for metadata files
+     *
+     * @return the header {@link ByteRange}
+     */
+    public ByteRange computeBlobCacheByteRange(String fileName, long fileLength, ByteSizeValue maxMetadataLength) {
+        final String fileExtension = IndexFileNames.getExtension(fileName);
+        assert fileExtension == null || METADATA_FILES_EXTENSIONS.contains(fileExtension) || OTHER_FILES_EXTENSIONS.contains(fileExtension)
+            : "unknown Lucene file extension [" + fileExtension + "] - should it be considered a metadata file?";
+
+        if (useLegacyCachedBlobSizes()) {
+            if (fileLength <= ByteSizeUnit.KB.toBytes(8L)) {
+                return ByteRange.of(0L, fileLength);
+            } else {
+                return ByteRange.of(0L, ByteSizeUnit.KB.toBytes(4L));
+            }
+        }
+
+        if (METADATA_FILES_EXTENSIONS.contains(fileExtension)) {
+            final long maxAllowedLengthInBytes = maxMetadataLength.getBytes();
+            if (fileLength > maxAllowedLengthInBytes) {
+                logExceedingFile(fileExtension, fileLength, maxMetadataLength);
+            }
+            return ByteRange.of(0L, Math.min(fileLength, maxAllowedLengthInBytes));
+        }
+        return ByteRange.of(0L, Math.min(fileLength, DEFAULT_CACHED_BLOB_SIZE));
+    }
+
+    protected boolean useLegacyCachedBlobSizes() {
+        final Version minNodeVersion = clusterService.state().nodes().getMinNodeVersion();
+        return minNodeVersion.before(OLD_CACHED_BLOB_SIZE_VERSION);
+    }
+
+    private static void logExceedingFile(String extension, long length, ByteSizeValue maxAllowedLength) {
+        if (logger.isWarnEnabled()) {
+            try {
+                // Use of a cache to prevent too many log traces per hour
+                LOG_EXCEEDING_FILES_CACHE.computeIfAbsent(extension, key -> {
+                    logger.warn(
+                        "file with extension [{}] is larger ([{}]) than the max. length allowed [{}] to cache metadata files in blob cache",
+                        extension,
+                        length,
+                        maxAllowedLength
+                    );
+                    return key;
+                });
+            } catch (ExecutionException e) {
+                logger.warn(
+                    () -> new ParameterizedMessage(
+                        "Failed to log information about exceeding file type [{}] with length [{}]",
+                        extension,
+                        length
+                    ),
+                    e
+                );
+            }
         }
     }
 }

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/blobstore/cache/CachedBlob.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/blobstore/cache/CachedBlob.java
@@ -187,4 +187,27 @@ public class CachedBlob implements ToXContent {
             to.longValue()
         );
     }
+
+    @Override
+    public String toString() {
+        return "CachedBlob ["
+            + "creationTime="
+            + creationTime
+            + ", version="
+            + version
+            + ", repository='"
+            + repository
+            + '\''
+            + ", name='"
+            + name
+            + '\''
+            + ", path='"
+            + path
+            + '\''
+            + ", from="
+            + from
+            + ", to="
+            + to
+            + ']';
+    }
 }

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/FrozenIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/FrozenIndexInput.java
@@ -48,7 +48,6 @@ public class FrozenIndexInput extends BaseSearchableSnapshotIndexInput {
     private static final Logger logger = LogManager.getLogger(FrozenIndexInput.class);
     private static final int COPY_BUFFER_SIZE = ByteSizeUnit.KB.toIntBytes(8);
 
-    private final SearchableSnapshotDirectory directory;
     private final FrozenCacheFile frozenCacheFile;
     private final int defaultRangeSize;
     private final int recoveryRangeSize;
@@ -76,7 +75,8 @@ public class FrozenIndexInput extends BaseSearchableSnapshotIndexInput {
             fileInfo.length(),
             directory.getFrozenCacheFile(fileInfo.physicalName(), fileInfo.length()),
             rangeSize,
-            recoveryRangeSize
+            recoveryRangeSize,
+            directory.getBlobCacheByteRange(fileInfo.physicalName(), fileInfo.length())
         );
         assert getBufferSize() <= BlobStoreCacheService.DEFAULT_CACHED_BLOB_SIZE; // must be able to cache at least one buffer's worth
         stats.incrementOpenCount();
@@ -92,10 +92,10 @@ public class FrozenIndexInput extends BaseSearchableSnapshotIndexInput {
         long length,
         FrozenCacheFile frozenCacheFile,
         int rangeSize,
-        int recoveryRangeSize
+        int recoveryRangeSize,
+        ByteRange blobCacheByteRange
     ) {
-        super(logger, resourceDesc, directory.blobContainer(), fileInfo, context, stats, offset, length);
-        this.directory = directory;
+        super(logger, resourceDesc, directory, fileInfo, context, stats, offset, length, blobCacheByteRange);
         this.frozenCacheFile = frozenCacheFile;
         this.lastReadPosition = this.offset;
         this.lastSeekPosition = this.offset;
@@ -166,30 +166,18 @@ public class FrozenIndexInput extends BaseSearchableSnapshotIndexInput {
             }
 
             // Requested data is not on disk, so try the cache index next.
-
             final ByteRange indexCacheMiss; // null if not a miss
 
-            // We try to use the cache index if:
-            // - the file is small enough to be fully cached
-            final boolean canBeFullyCached = fileInfo.length() <= BlobStoreCacheService.DEFAULT_CACHED_BLOB_SIZE * 2;
-            // - we're reading the first N bytes of the file
-            final boolean isStartOfFile = (position + length <= BlobStoreCacheService.DEFAULT_CACHED_BLOB_SIZE);
-
-            if (canBeFullyCached || isStartOfFile) {
-                final CachedBlob cachedBlob = directory.getCachedBlob(fileInfo.physicalName(), 0L, length);
+            if (blobCacheByteRange.contains(position, position + length)) {
+                final CachedBlob cachedBlob = directory.getCachedBlob(fileInfo.physicalName(), blobCacheByteRange);
+                assert cachedBlob == CachedBlob.CACHE_MISS || cachedBlob == CachedBlob.CACHE_NOT_READY || cachedBlob.from() <= position;
+                assert cachedBlob == CachedBlob.CACHE_MISS || cachedBlob == CachedBlob.CACHE_NOT_READY || length <= cachedBlob.length();
 
                 if (cachedBlob == CachedBlob.CACHE_MISS || cachedBlob == CachedBlob.CACHE_NOT_READY) {
                     // We would have liked to find a cached entry but we did not find anything: the cache on the disk will be requested
                     // so we compute the region of the file we would like to have the next time. The region is expressed as a tuple of
                     // {start, end} where positions are relative to the whole file.
-
-                    if (canBeFullyCached) {
-                        // if the index input is smaller than twice the size of the blob cache, it will be fully indexed
-                        indexCacheMiss = ByteRange.of(0L, fileInfo.length());
-                    } else {
-                        // the index input is too large to fully cache, so just cache the initial range
-                        indexCacheMiss = ByteRange.of(0L, (long) BlobStoreCacheService.DEFAULT_CACHED_BLOB_SIZE);
-                    }
+                    indexCacheMiss = blobCacheByteRange;
 
                     // We must fill in a cache miss even if CACHE_NOT_READY since the cache index is only created on the first put.
                     // TODO TBD use a different trigger for creating the cache index and avoid a put in the CACHE_NOT_READY case.
@@ -203,17 +191,17 @@ public class FrozenIndexInput extends BaseSearchableSnapshotIndexInput {
                     stats.addIndexCacheBytesRead(cachedBlob.length());
 
                     preventAsyncBufferChanges.run();
-
-                    final BytesRefIterator cachedBytesIterator = cachedBlob.bytes().slice(toIntBytes(position), length).iterator();
-                    int copiedBytes = 0;
-                    BytesRef bytesRef;
-                    while ((bytesRef = cachedBytesIterator.next()) != null) {
-                        b.put(bytesRef.bytes, bytesRef.offset, bytesRef.length);
-                        copiedBytes += bytesRef.length;
-                    }
-                    assert copiedBytes == length : "copied " + copiedBytes + " but expected " + length;
-
                     try {
+                        final int sliceOffset = toIntBytes(position - cachedBlob.from());
+                        final BytesRefIterator cachedBytesIterator = cachedBlob.bytes().slice(sliceOffset, length).iterator();
+                        int copiedBytes = 0;
+                        BytesRef bytesRef;
+                        while ((bytesRef = cachedBytesIterator.next()) != null) {
+                            b.put(bytesRef.bytes, bytesRef.offset, bytesRef.length);
+                            copiedBytes += bytesRef.length;
+                        }
+                        assert copiedBytes == length : "copied " + copiedBytes + " but expected " + length;
+
                         final ByteRange cachedRange = ByteRange.of(cachedBlob.from(), cachedBlob.to());
                         frozenCacheFile.populateAndRead(
                             cachedRange,
@@ -316,12 +304,11 @@ public class FrozenIndexInput extends BaseSearchableSnapshotIndexInput {
             if (indexCacheMiss != null) {
                 final Releasable onCacheFillComplete = stats.addIndexCacheFill();
                 final int indexCacheMissLength = toIntBytes(indexCacheMiss.length());
+
                 // We assume that we only cache small portions of blobs so that we do not need to:
                 // - use a BigArrays for allocation
                 // - use an intermediate copy buffer to read the file in sensibly-sized chunks
                 // - release the buffer once the indexing operation is complete
-                assert indexCacheMissLength <= COPY_BUFFER_SIZE : indexCacheMiss;
-
                 final ByteBuffer byteBuffer = ByteBuffer.allocate(indexCacheMissLength);
 
                 final StepListener<Integer> readListener = frozenCacheFile.readIfAvailableOrPending(
@@ -642,7 +629,8 @@ public class FrozenIndexInput extends BaseSearchableSnapshotIndexInput {
             length,
             frozenCacheFile,
             defaultRangeSize,
-            recoveryRangeSize
+            recoveryRangeSize,
+            ByteRange.EMPTY  // TODO implement blob cache for slices when it makes sense (like CFs)
         );
         slice.isClone = true;
         return slice;

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/direct/DirectBlobContainerIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/direct/DirectBlobContainerIndexInput.java
@@ -18,6 +18,8 @@ import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot.FileInfo;
 import org.elasticsearch.index.store.BaseSearchableSnapshotIndexInput;
 import org.elasticsearch.index.store.IndexInputStats;
+import org.elasticsearch.index.store.SearchableSnapshotDirectory;
+import org.elasticsearch.xpack.searchablesnapshots.cache.ByteRange;
 
 import java.io.Closeable;
 import java.io.EOFException;
@@ -67,7 +69,7 @@ public class DirectBlobContainerIndexInput extends BaseSearchableSnapshotIndexIn
     private static final int COPY_BUFFER_SIZE = 8192;
 
     public DirectBlobContainerIndexInput(
-        BlobContainer blobContainer,
+        SearchableSnapshotDirectory directory,
         FileInfo fileInfo,
         IOContext context,
         IndexInputStats stats,
@@ -76,7 +78,7 @@ public class DirectBlobContainerIndexInput extends BaseSearchableSnapshotIndexIn
     ) {
         this(
             "DirectBlobContainerIndexInput(" + fileInfo.physicalName() + ")",
-            blobContainer,
+            directory,
             fileInfo,
             context,
             stats,
@@ -91,7 +93,7 @@ public class DirectBlobContainerIndexInput extends BaseSearchableSnapshotIndexIn
 
     private DirectBlobContainerIndexInput(
         String resourceDesc,
-        BlobContainer blobContainer,
+        SearchableSnapshotDirectory directory,
         FileInfo fileInfo,
         IOContext context,
         IndexInputStats stats,
@@ -101,7 +103,7 @@ public class DirectBlobContainerIndexInput extends BaseSearchableSnapshotIndexIn
         long sequentialReadSize,
         int bufferSize
     ) {
-        super(logger, resourceDesc, blobContainer, fileInfo, context, stats, offset, length);
+        super(logger, resourceDesc, directory, fileInfo, context, stats, offset, length, ByteRange.EMPTY); // TODO should use blob cache
         this.position = position;
         assert sequentialReadSize >= 0;
         this.sequentialReadSize = sequentialReadSize;
@@ -271,7 +273,7 @@ public class DirectBlobContainerIndexInput extends BaseSearchableSnapshotIndexIn
     public DirectBlobContainerIndexInput clone() {
         final DirectBlobContainerIndexInput clone = new DirectBlobContainerIndexInput(
             "clone(" + this + ")",
-            blobContainer,
+            directory,
             fileInfo,
             context,
             stats,
@@ -292,7 +294,7 @@ public class DirectBlobContainerIndexInput extends BaseSearchableSnapshotIndexIn
         if ((offset >= 0L) && (length >= 0L) && (offset + length <= length())) {
             final DirectBlobContainerIndexInput slice = new DirectBlobContainerIndexInput(
                 getFullSliceDescription(sliceDescription),
-                blobContainer,
+                directory,
                 fileInfo,
                 context,
                 stats,

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.searchablesnapshots;
 
+import org.apache.lucene.store.BufferedIndexInput;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequest;
@@ -95,6 +96,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
@@ -190,6 +192,31 @@ public class SearchableSnapshots extends Plugin implements IndexStorePlugin, Eng
         Setting.Property.PrivateIndex,
         Setting.Property.NotCopyableOnResize
     );
+    public static final String SNAPSHOT_BLOB_CACHE_METADATA_FILES_MAX_LENGTH = "index.store.snapshot.blob_cache.metadata_files.max_length";
+    public static final Setting<ByteSizeValue> SNAPSHOT_BLOB_CACHE_METADATA_FILES_MAX_LENGTH_SETTING = new Setting<>(
+        new Setting.SimpleKey(SNAPSHOT_BLOB_CACHE_METADATA_FILES_MAX_LENGTH),
+        s -> new ByteSizeValue(64L, ByteSizeUnit.KB).getStringRep(),
+        s -> Setting.parseByteSize(
+            s,
+            new ByteSizeValue(1L, ByteSizeUnit.KB),
+            new ByteSizeValue(Long.MAX_VALUE),
+            SNAPSHOT_BLOB_CACHE_METADATA_FILES_MAX_LENGTH
+        ),
+        value -> {
+            if (value.getBytes() % BufferedIndexInput.BUFFER_SIZE != 0L) {
+                final String message = String.format(
+                    Locale.ROOT,
+                    "failed to parse value [%s] for setting [%s], must be a multiple of [%s] bytes",
+                    value.getStringRep(),
+                    SNAPSHOT_BLOB_CACHE_METADATA_FILES_MAX_LENGTH,
+                    BufferedIndexInput.BUFFER_SIZE
+                );
+                throw new IllegalArgumentException(message);
+            }
+        },
+        Setting.Property.IndexScope,
+        Setting.Property.NotCopyableOnResize
+    );
 
     /**
      * Prefer to allocate to the cold tier, then the frozen tier, then the warm tier, then the hot tier
@@ -270,6 +297,7 @@ public class SearchableSnapshots extends Plugin implements IndexStorePlugin, Eng
             SNAPSHOT_CACHE_EXCLUDED_FILE_TYPES_SETTING,
             SNAPSHOT_UNCACHED_CHUNK_SIZE_SETTING,
             SNAPSHOT_PARTIAL_SETTING,
+            SNAPSHOT_BLOB_CACHE_METADATA_FILES_MAX_LENGTH_SETTING,
             CacheService.SNAPSHOT_CACHE_SIZE_SETTING,
             CacheService.SNAPSHOT_CACHE_RANGE_SIZE_SETTING,
             CacheService.SNAPSHOT_CACHE_RECOVERY_RANGE_SIZE_SETTING,
@@ -311,7 +339,12 @@ public class SearchableSnapshots extends Plugin implements IndexStorePlugin, Eng
             final FrozenCacheService frozenCacheService = new FrozenCacheService(environment, threadPool);
             this.frozenCacheService.set(frozenCacheService);
             components.add(cacheService);
-            final BlobStoreCacheService blobStoreCacheService = new BlobStoreCacheService(threadPool, client, SNAPSHOT_BLOB_CACHE_INDEX);
+            final BlobStoreCacheService blobStoreCacheService = new BlobStoreCacheService(
+                clusterService,
+                threadPool,
+                client,
+                SNAPSHOT_BLOB_CACHE_INDEX
+            );
             this.blobStoreCacheService.set(blobStoreCacheService);
             components.add(blobStoreCacheService);
         } else {

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/ByteRange.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/ByteRange.java
@@ -65,6 +65,10 @@ public final class ByteRange implements Comparable<ByteRange> {
         return start >= range.start() && end <= range.end();
     }
 
+    public boolean contains(long start, long end) {
+        return start() <= start && end <= end();
+    }
+
     @Override
     public int hashCode() {
         return 31 * Long.hashCode(start) + Long.hashCode(end);
@@ -84,7 +88,7 @@ public final class ByteRange implements Comparable<ByteRange> {
 
     @Override
     public String toString() {
-        return "ByteRange{" + start + "}{" + end + "}";
+        return "ByteRange [" + start + "-" + end + ']';
     }
 
     @Override

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/SearchableSnapshotDirectoryStatsTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/SearchableSnapshotDirectoryStatsTests.java
@@ -79,7 +79,7 @@ public class SearchableSnapshotDirectoryStatsTests extends AbstractSearchableSna
                     IndexInputStats inputStats = directory.getStats(fileName);
                     assertThat(inputStats, (i == 0L) ? nullValue() : notNullValue());
 
-                    final IndexInput input = directory.openInput(fileName, newIOContext(random()));
+                    final IndexInput input = directory.openInput(fileName, randomIOContext());
                     inputStats = directory.getStats(fileName);
                     assertThat(inputStats.getOpened().longValue(), equalTo(i + 1L));
                     input.close();
@@ -94,7 +94,7 @@ public class SearchableSnapshotDirectoryStatsTests extends AbstractSearchableSna
         executeTestCase((fileName, fileContent, directory) -> {
             try {
                 for (long i = 0L; i < randomLongBetween(1L, 20L); i++) {
-                    final IndexInput input = directory.openInput(fileName, newIOContext(random()));
+                    final IndexInput input = directory.openInput(fileName, randomIOContext());
 
                     IndexInputStats inputStats = directory.getStats(fileName);
                     assertThat(inputStats, notNullValue());
@@ -115,7 +115,7 @@ public class SearchableSnapshotDirectoryStatsTests extends AbstractSearchableSna
         final ByteSizeValue cacheSize = new ByteSizeValue(10, ByteSizeUnit.MB);
 
         executeTestCaseWithCache(cacheSize, rangeSize, (fileName, fileContent, directory) -> {
-            try (IndexInput input = directory.openInput(fileName, newIOContext(random()))) {
+            try (IndexInput input = directory.openInput(fileName, randomIOContext())) {
                 final long length = input.length();
 
                 final IndexInputStats inputStats = directory.getStats(fileName);
@@ -167,7 +167,7 @@ public class SearchableSnapshotDirectoryStatsTests extends AbstractSearchableSna
     public void testCachedBytesReadsAndWritesNoCache() throws Exception {
         final ByteSizeValue uncachedChunkSize = new ByteSizeValue(randomIntBetween(512, MAX_FILE_LENGTH), ByteSizeUnit.BYTES);
         executeTestCaseWithoutCache(uncachedChunkSize, (fileName, fileContent, directory) -> {
-            try (IndexInput input = directory.openInput(fileName, newIOContext(random()))) {
+            try (IndexInput input = directory.openInput(fileName, randomIOContext())) {
                 final long length = input.length();
 
                 final IndexInputStats inputStats = directory.getStats(fileName);
@@ -193,7 +193,7 @@ public class SearchableSnapshotDirectoryStatsTests extends AbstractSearchableSna
         executeTestCaseWithCache(ByteSizeValue.ZERO, randomCacheRangeSize(), (fileName, fileContent, directory) -> {
             assertThat(directory.getStats(fileName), nullValue());
 
-            final IOContext ioContext = newIOContext(random());
+            final IOContext ioContext = randomIOContext();
             try {
                 IndexInput input = directory.openInput(fileName, ioContext);
                 if (randomBoolean()) {
@@ -246,7 +246,7 @@ public class SearchableSnapshotDirectoryStatsTests extends AbstractSearchableSna
         executeTestCaseWithoutCache(uncachedChunkSize, (fileName, fileContent, directory) -> {
             assertThat(directory.getStats(fileName), nullValue());
 
-            final IOContext ioContext = newIOContext(random());
+            final IOContext ioContext = randomIOContext();
             try (IndexInput original = directory.openInput(fileName, ioContext)) {
                 final IndexInput input = original.clone(); // always clone to only execute direct reads
                 final IndexInputStats inputStats = directory.getStats(fileName);
@@ -281,7 +281,7 @@ public class SearchableSnapshotDirectoryStatsTests extends AbstractSearchableSna
         // use a large uncached chunk size that allows to read the file in a single operation
         final ByteSizeValue uncachedChunkSize = new ByteSizeValue(1, ByteSizeUnit.GB);
         executeTestCaseWithoutCache(uncachedChunkSize, (fileName, fileContent, directory) -> {
-            final IOContext context = newIOContext(random());
+            final IOContext context = randomIOContext();
             try (IndexInput input = directory.openInput(fileName, context)) {
                 final IndexInputStats inputStats = directory.getStats(fileName);
                 assertThat(inputStats, notNullValue());
@@ -316,7 +316,7 @@ public class SearchableSnapshotDirectoryStatsTests extends AbstractSearchableSna
 
     public void testReadBytesContiguously() throws Exception {
         executeTestCaseWithDefaultCache((fileName, fileContent, cacheDirectory) -> {
-            final IOContext ioContext = newIOContext(random());
+            final IOContext ioContext = randomIOContext();
 
             try (IndexInput input = cacheDirectory.openInput(fileName, ioContext)) {
                 final IndexInputStats inputStats = cacheDirectory.getStats(fileName);
@@ -367,7 +367,7 @@ public class SearchableSnapshotDirectoryStatsTests extends AbstractSearchableSna
 
     public void testReadBytesNonContiguously() throws Exception {
         executeTestCaseWithDefaultCache((fileName, fileContent, cacheDirectory) -> {
-            final IOContext ioContext = newIOContext(random());
+            final IOContext ioContext = randomIOContext();
 
             try (IndexInput input = cacheDirectory.openInput(fileName, ioContext)) {
                 final IndexInputStats inputStats = cacheDirectory.getStats(fileName);
@@ -418,7 +418,7 @@ public class SearchableSnapshotDirectoryStatsTests extends AbstractSearchableSna
 
     public void testForwardSeeks() throws Exception {
         executeTestCaseWithDefaultCache((fileName, fileContent, cacheDirectory) -> {
-            final IOContext ioContext = newIOContext(random());
+            final IOContext ioContext = randomIOContext();
             try (IndexInput indexInput = cacheDirectory.openInput(fileName, ioContext)) {
                 IndexInput input = indexInput;
                 if (randomBoolean()) {
@@ -476,7 +476,7 @@ public class SearchableSnapshotDirectoryStatsTests extends AbstractSearchableSna
 
     public void testBackwardSeeks() throws Exception {
         executeTestCaseWithDefaultCache((fileName, fileContent, cacheDirectory) -> {
-            final IOContext ioContext = newIOContext(random());
+            final IOContext ioContext = randomIOContext();
             try (IndexInput indexInput = cacheDirectory.openInput(fileName, ioContext)) {
                 IndexInput input = indexInput;
                 if (randomBoolean()) {
@@ -606,8 +606,7 @@ public class SearchableSnapshotDirectoryStatsTests extends AbstractSearchableSna
     ) throws Exception {
 
         final byte[] fileContent = randomByteArrayOfLength(randomIntBetween(10, MAX_FILE_LENGTH));
-        final String fileExtension = randomAlphaOfLength(3);
-        final String fileName = randomAlphaOfLength(10) + '.' + fileExtension;
+        final String fileName = randomAlphaOfLength(10) + randomFileExtension();
         final SnapshotId snapshotId = new SnapshotId("_name", "_uuid");
         final IndexId indexId = new IndexId("_name", "_uuid");
         final ShardId shardId = new ShardId("_name", "_uuid", 0);

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/SearchableSnapshotDirectoryTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/SearchableSnapshotDirectoryTests.java
@@ -632,8 +632,8 @@ public class SearchableSnapshotDirectoryTests extends AbstractSearchableSnapshot
 
     private void testIndexInputs(final CheckedBiConsumer<IndexInput, IndexInput, Exception> consumer) throws Exception {
         testDirectories((directory, snapshotDirectory) -> {
-            for (String fileName : randomSubsetOf(asList(snapshotDirectory.listAll()))) {
-                final IOContext context = newIOContext(random());
+            for (String fileName : randomSubsetOf(Arrays.asList(snapshotDirectory.listAll()))) {
+                final IOContext context = randomIOContext();
                 try (IndexInput indexInput = directory.openInput(fileName, context)) {
                     final List<Closeable> closeables = new ArrayList<>();
                     try {
@@ -660,8 +660,7 @@ public class SearchableSnapshotDirectoryTests extends AbstractSearchableSnapshot
 
             final Path shardSnapshotDir = createTempDir();
             for (int i = 0; i < nbRandomFiles; i++) {
-                final String fileName = "file_" + randomAlphaOfLength(10);
-
+                final String fileName = randomAlphaOfLength(5) + randomFileExtension();
                 final Tuple<String, byte[]> bytes = randomChecksumBytes(randomIntBetween(1, 100_000));
                 final byte[] input = bytes.v2();
                 final String checksum = bytes.v1();
@@ -727,7 +726,7 @@ public class SearchableSnapshotDirectoryTests extends AbstractSearchableSnapshot
                     final BlobStoreIndexShardSnapshot.FileInfo fileInfo = randomFrom(randomFiles);
                     final int fileLength = toIntBytes(fileInfo.length());
 
-                    try (IndexInput input = directory.openInput(fileInfo.physicalName(), newIOContext(random()))) {
+                    try (IndexInput input = directory.openInput(fileInfo.physicalName(), randomIOContext())) {
                         assertThat(input.length(), equalTo((long) fileLength));
                         final int start = between(0, fileLength - 1);
                         final int end = between(start + 1, fileLength);

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/CachedBlobContainerIndexInputTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/CachedBlobContainerIndexInputTests.java
@@ -63,7 +63,7 @@ public class CachedBlobContainerIndexInputTests extends AbstractSearchableSnapsh
             ShardId shardId = new ShardId("_name", "_uuid", 0);
 
             for (int i = 0; i < 5; i++) {
-                final String fileName = randomAlphaOfLength(10);
+                final String fileName = randomAlphaOfLength(5) + randomFileExtension();
                 final Tuple<String, byte[]> bytes = randomChecksumBytes(randomIntBetween(1, 100_000));
 
                 final byte[] input = bytes.v2();
@@ -129,7 +129,7 @@ public class CachedBlobContainerIndexInputTests extends AbstractSearchableSnapsh
                     assertThat("Snapshot should be loaded", directory.snapshot(), notNullValue());
                     assertThat("BlobContainer should be loaded", directory.blobContainer(), notNullValue());
 
-                    try (IndexInput indexInput = directory.openInput(fileName, newIOContext(random()))) {
+                    try (IndexInput indexInput = directory.openInput(fileName, randomIOContext())) {
                         assertThat(indexInput, instanceOf(CachedBlobContainerIndexInput.class));
                         assertEquals(input.length, indexInput.length());
                         assertEquals(0, indexInput.getFilePointer());
@@ -178,7 +178,7 @@ public class CachedBlobContainerIndexInputTests extends AbstractSearchableSnapsh
             IndexId indexId = new IndexId("_name", "_uuid");
             ShardId shardId = new ShardId("_name", "_uuid", 0);
 
-            final String fileName = randomAlphaOfLength(10);
+            final String fileName = randomAlphaOfLength(5) + randomFileExtension();
             final Tuple<String, byte[]> bytes = randomChecksumBytes(randomIntBetween(1, 1000));
 
             final byte[] input = bytes.v2();
@@ -231,7 +231,7 @@ public class CachedBlobContainerIndexInputTests extends AbstractSearchableSnapsh
                 assertThat("Snapshot should be loaded", searchableSnapshotDirectory.snapshot(), notNullValue());
                 assertThat("BlobContainer should be loaded", searchableSnapshotDirectory.blobContainer(), notNullValue());
 
-                try (IndexInput indexInput = searchableSnapshotDirectory.openInput(fileName, newIOContext(random()))) {
+                try (IndexInput indexInput = searchableSnapshotDirectory.openInput(fileName, randomIOContext())) {
                     assertThat(indexInput, instanceOf(CachedBlobContainerIndexInput.class));
                     final byte[] buffer = new byte[input.length + 1];
                     final IOException exception = expectThrows(IOException.class, () -> indexInput.readBytes(buffer, 0, buffer.length));

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/FrozenIndexInputTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/FrozenIndexInputTests.java
@@ -34,7 +34,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
-import java.util.Locale;
 
 import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.Mockito.mock;
@@ -44,7 +43,7 @@ public class FrozenIndexInputTests extends AbstractSearchableSnapshotsTestCase {
     private static final ShardId SHARD_ID = new ShardId(new Index("_index_name", "_index_id"), 0);
 
     public void testRandomReads() throws IOException {
-        final String fileName = randomAlphaOfLengthBetween(5, 10).toLowerCase(Locale.ROOT);
+        final String fileName = randomAlphaOfLength(5) + randomFileExtension();
         final Tuple<String, byte[]> bytes = randomChecksumBytes(randomIntBetween(1, 100_000));
 
         final byte[] fileData = bytes.v2();
@@ -104,7 +103,7 @@ public class FrozenIndexInputTests extends AbstractSearchableSnapshotsTestCase {
             directory.loadSnapshot(createRecoveryState(true), ActionListener.wrap(() -> {}));
 
             // TODO does not test using the recovery range size
-            final IndexInput indexInput = directory.openInput(fileName, newIOContext(random()));
+            final IndexInput indexInput = directory.openInput(fileName, randomIOContext());
             assertThat(indexInput, instanceOf(FrozenIndexInput.class));
             assertEquals(fileData.length, indexInput.length());
             assertEquals(0, indexInput.getFilePointer());

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/TestUtils.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/TestUtils.java
@@ -314,7 +314,12 @@ public final class TestUtils {
     public static class NoopBlobStoreCacheService extends BlobStoreCacheService {
 
         public NoopBlobStoreCacheService() {
-            super(null, mockClient(), null);
+            super(null, null, mockClient(), null);
+        }
+
+        @Override
+        protected boolean useLegacyCachedBlobSizes() {
+            return false;
         }
 
         @Override
@@ -340,13 +345,18 @@ public final class TestUtils {
         private final ConcurrentHashMap<String, CachedBlob> blobs = new ConcurrentHashMap<>();
 
         public SimpleBlobStoreCacheService() {
-            super(null, mockClient(), null);
+            super(null, null, mockClient(), null);
         }
 
         private static Client mockClient() {
             final Client client = mock(Client.class);
             when(client.settings()).thenReturn(Settings.EMPTY);
             return client;
+        }
+
+        @Override
+        protected boolean useLegacyCachedBlobSizes() {
+            return false;
         }
 
         @Override

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/direct/DirectBlobContainerIndexInputTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/direct/DirectBlobContainerIndexInputTests.java
@@ -8,6 +8,7 @@ package org.elasticsearch.index.store.direct;
 
 import org.apache.lucene.store.BufferedIndexInput;
 import org.apache.lucene.util.Version;
+import org.elasticsearch.blobstore.cache.CachedBlob;
 import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.lucene.store.ESIndexInputTestCase;
@@ -15,7 +16,9 @@ import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot.FileInfo;
 import org.elasticsearch.index.store.IndexInputStats;
+import org.elasticsearch.index.store.SearchableSnapshotDirectory;
 import org.elasticsearch.index.store.StoreFileMetadata;
+import org.elasticsearch.xpack.searchablesnapshots.cache.ByteRange;
 
 import java.io.ByteArrayInputStream;
 import java.io.EOFException;
@@ -25,6 +28,8 @@ import java.io.InputStream;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.elasticsearch.xpack.searchablesnapshots.AbstractSearchableSnapshotsTestCase.randomChecksumBytes;
+import static org.elasticsearch.xpack.searchablesnapshots.AbstractSearchableSnapshotsTestCase.randomFileExtension;
+import static org.elasticsearch.xpack.searchablesnapshots.AbstractSearchableSnapshotsTestCase.randomIOContext;
 import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsUtils.toIntBytes;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
@@ -33,6 +38,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.startsWith;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.anyString;
@@ -59,9 +65,10 @@ public class DirectBlobContainerIndexInputTests extends ESIndexInputTestCase {
         String checksum,
         Runnable onReadBlob
     ) throws IOException {
+        final String fileName = randomAlphaOfLength(5) + randomFileExtension();
         final FileInfo fileInfo = new FileInfo(
             randomAlphaOfLength(5),
-            new StoreFileMetadata("test", input.length, checksum, Version.LATEST),
+            new StoreFileMetadata(fileName, input.length, checksum, Version.LATEST),
             partSize == input.length
                 ? randomFrom(
                     new ByteSizeValue(partSize, ByteSizeUnit.BYTES),
@@ -116,10 +123,15 @@ public class DirectBlobContainerIndexInputTests extends ESIndexInputTestCase {
                 };
             }
         });
+
+        final SearchableSnapshotDirectory directory = mock(SearchableSnapshotDirectory.class);
+        when(directory.getCachedBlob(anyString(), any(ByteRange.class))).thenReturn(CachedBlob.CACHE_NOT_READY);
+        when(directory.blobContainer()).thenReturn(blobContainer);
+
         final DirectBlobContainerIndexInput indexInput = new DirectBlobContainerIndexInput(
-            blobContainer,
+            directory,
             fileInfo,
-            newIOContext(random()),
+            randomIOContext(),
             new IndexInputStats(1, 0L, () -> 0L),
             minimumReadSize,
             randomBoolean() ? BufferedIndexInput.BUFFER_SIZE : between(BufferedIndexInput.MIN_BUFFER_SIZE, BufferedIndexInput.BUFFER_SIZE)

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsTestCase.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsTestCase.java
@@ -11,6 +11,7 @@ import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.store.ByteBuffersDataOutput;
 import org.apache.lucene.store.ByteBuffersIndexInput;
 import org.apache.lucene.store.ByteBuffersIndexOutput;
+import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
 import org.elasticsearch.Version;
@@ -332,5 +333,48 @@ public abstract class AbstractSearchableSnapshotsTestCase extends ESIndexInputTe
             checksum = Store.digestToString(CodecUtil.checksumEntireFile(input));
         }
         return Tuple.tuple(checksum, out.toArrayCopy());
+    }
+
+    public static String randomFileExtension() {
+        return randomFrom(
+            ".cfe",
+            ".cfs",
+            ".dii",
+            ".dim",
+            ".doc",
+            ".dvd",
+            ".dvm",
+            ".fdt",
+            ".fdx",
+            ".fdm",
+            ".fnm",
+            ".kdd",
+            ".kdi",
+            ".kdm",
+            ".liv",
+            ".nvd",
+            ".nvm",
+            ".pay",
+            ".pos",
+            ".tim",
+            ".tip",
+            ".tmd",
+            ".tvd",
+            ".tvx",
+            ".vec",
+            ".vem"
+        );
+    }
+
+    /**
+     * @return a random {@link IOContext} that corresponds to a default, read or read_once usage.
+     *
+     * It's important that the context returned by this method is not a "merge" once as {@link org.apache.lucene.store.BufferedIndexInput}
+     * uses a different buffer size for them.
+     */
+    public static IOContext randomIOContext() {
+        final IOContext ioContext = randomFrom(IOContext.DEFAULT, IOContext.READ, IOContext.READONCE);
+        assert ioContext.context != IOContext.Context.MERGE;
+        return ioContext;
     }
 }

--- a/x-pack/qa/rolling-upgrade/build.gradle
+++ b/x-pack/qa/rolling-upgrade/build.gradle
@@ -33,6 +33,7 @@ tasks.register("copyTestNodeKeyMaterial", Copy) {
 
 for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
   String baseName = "v${bwcVersion}"
+  String repositoryPath = "${buildDir}/cluster/shared/repo/${baseName}"
 
   testClusters {
     "${baseName}" {
@@ -41,7 +42,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
       numberOfNodes = 3
 
       setting 'repositories.url.allowed_urls', 'http://snapshot.test*'
-      setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
+      setting 'path.repo', repositoryPath
       setting 'http.content_type.required', 'true'
       setting 'xpack.license.self_generated.type', 'trial'
       setting 'xpack.security.enabled', 'true'
@@ -95,6 +96,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
     dependsOn "copyTestNodeKeyMaterial"
     systemProperty 'tests.rest.suite', 'old_cluster'
     systemProperty 'tests.upgrade_from_version', oldVersion
+    systemProperty 'tests.path.repo', repositoryPath
     nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}".allHttpSocketURI.join(",")}")
     nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}".getName()}")
     def toBlackList = []
@@ -129,6 +131,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
     systemProperty 'tests.rest.suite', 'mixed_cluster'
     systemProperty 'tests.first_round', 'true'
     systemProperty 'tests.upgrade_from_version', oldVersion
+    systemProperty 'tests.path.repo', repositoryPath
     // We only need to run these tests once so we may as well do it when we're two thirds upgraded
     def toBlackList = [
       'mixed_cluster/10_basic/Start scroll in mixed cluster on upgraded node that we will continue after upgrade',
@@ -201,6 +204,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
       systemProperty 'tests.rest.blacklist', toBlackList.join(',')
     }
     systemProperty 'tests.upgrade_from_version', oldVersion
+    systemProperty 'tests.path.repo', repositoryPath
   }
 
   tasks.register("${baseName}#upgradedClusterTest", StandaloneRestIntegTestTask) {
@@ -213,6 +217,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
     nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}".getName()}")
     systemProperty 'tests.rest.suite', 'upgraded_cluster'
     systemProperty 'tests.upgrade_from_version', oldVersion
+    systemProperty 'tests.path.repo', repositoryPath
     def toBlackList = []
     // Dataframe transforms were not added until 7.2.0
     if (Version.fromString(oldVersion).before('7.2.0')) {

--- a/x-pack/qa/rolling-upgrade/build.gradle
+++ b/x-pack/qa/rolling-upgrade/build.gradle
@@ -33,7 +33,9 @@ tasks.register("copyTestNodeKeyMaterial", Copy) {
 
 for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
   String baseName = "v${bwcVersion}"
-  String repositoryPath = "${buildDir}/cluster/shared/repo/${baseName}"
+
+  // SearchableSnapshotsRollingUpgradeIT uses a specific repository to not interfere with other tests
+  String searchableSnapshotRepository = "${buildDir}/cluster/shared/searchable-snapshots-repo/${baseName}"
 
   testClusters {
     "${baseName}" {
@@ -42,8 +44,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
       numberOfNodes = 3
 
       setting 'repositories.url.allowed_urls', 'http://snapshot.test*'
-      setting 'path.repo', repositoryPath
-      setting 'http.content_type.required', 'true'
+      setting 'path.repo', "[ \"${buildDir}/cluster/shared/repo/${baseName}\", \"${searchableSnapshotRepository}\" ]"
       setting 'xpack.license.self_generated.type', 'trial'
       setting 'xpack.security.enabled', 'true'
       setting 'xpack.security.transport.ssl.enabled', 'true'
@@ -96,7 +97,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
     dependsOn "copyTestNodeKeyMaterial"
     systemProperty 'tests.rest.suite', 'old_cluster'
     systemProperty 'tests.upgrade_from_version', oldVersion
-    systemProperty 'tests.path.repo', repositoryPath
+    systemProperty 'tests.path.searchable.snapshots.repo', searchableSnapshotRepository
     nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}".allHttpSocketURI.join(",")}")
     nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}".getName()}")
     def toBlackList = []
@@ -131,7 +132,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
     systemProperty 'tests.rest.suite', 'mixed_cluster'
     systemProperty 'tests.first_round', 'true'
     systemProperty 'tests.upgrade_from_version', oldVersion
-    systemProperty 'tests.path.repo', repositoryPath
+    systemProperty 'tests.path.searchable.snapshots.repo', searchableSnapshotRepository
     // We only need to run these tests once so we may as well do it when we're two thirds upgraded
     def toBlackList = [
       'mixed_cluster/10_basic/Start scroll in mixed cluster on upgraded node that we will continue after upgrade',
@@ -204,7 +205,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
       systemProperty 'tests.rest.blacklist', toBlackList.join(',')
     }
     systemProperty 'tests.upgrade_from_version', oldVersion
-    systemProperty 'tests.path.repo', repositoryPath
+    systemProperty 'tests.path.searchable.snapshots.repo', searchableSnapshotRepository
   }
 
   tasks.register("${baseName}#upgradedClusterTest", StandaloneRestIntegTestTask) {
@@ -217,7 +218,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
     nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}".getName()}")
     systemProperty 'tests.rest.suite', 'upgraded_cluster'
     systemProperty 'tests.upgrade_from_version', oldVersion
-    systemProperty 'tests.path.repo', repositoryPath
+    systemProperty 'tests.path.searchable.snapshots.repo', searchableSnapshotRepository
     def toBlackList = []
     // Dataframe transforms were not added until 7.2.0
     if (Version.fromString(oldVersion).before('7.2.0')) {

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/AbstractUpgradeTestCase.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/AbstractUpgradeTestCase.java
@@ -42,6 +42,11 @@ public abstract class AbstractUpgradeTestCase extends ESRestTestCase {
     }
 
     @Override
+    protected boolean preserveSnapshotsUponCompletion() {
+        return true;
+    }
+
+    @Override
     protected boolean preserveTemplatesUponCompletion() {
         return true;
     }

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/SearchableSnapshotsRollingUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/SearchableSnapshotsRollingUpgradeIT.java
@@ -1,0 +1,312 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.upgrades;
+
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.elasticsearch.Version;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.searchable_snapshots.MountSnapshotRequest.Storage;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.support.XContentMapValues;
+import org.elasticsearch.repositories.fs.FsRepository;
+import org.elasticsearch.rest.RestStatus;
+import org.hamcrest.Matcher;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.elasticsearch.common.xcontent.support.XContentMapValues.extractValue;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class SearchableSnapshotsRollingUpgradeIT extends AbstractUpgradeTestCase {
+
+    public void testMountFullCopyAndRecoversCorrectly() throws Exception {
+        final Storage storage = Storage.FULL_COPY;
+        assumeVersion(Version.V_7_10_0, storage);
+
+        executeMountAndRecoversCorrectlyTestCase(storage, 6789L);
+    }
+
+    public void testMountPartialCopyAndRecoversCorrectly() throws Exception {
+        final Storage storage = Storage.SHARED_CACHE;
+        assumeVersion(Version.V_7_12_0, Storage.SHARED_CACHE);
+
+        executeMountAndRecoversCorrectlyTestCase(storage, 5678L);
+    }
+
+    /**
+     * Test that a snapshot mounted as a searchable snapshot index in the previous version recovers correctly during rolling upgrade
+     */
+    private void executeMountAndRecoversCorrectlyTestCase(Storage storage, long numberOfDocs) throws Exception {
+        final String suffix = storage.storageName().toLowerCase(Locale.ROOT);
+        final String index = "mounted_index_" + suffix;
+
+        if (CLUSTER_TYPE.equals(ClusterType.OLD)) {
+            final String repository = "repository_" + suffix;
+            final String snapshot = "snapshot_" + suffix;
+
+            registerRepository(repository, FsRepository.TYPE, true,
+                Settings.builder().put("location", System.getProperty("tests.path.repo") + '/' + repository).build());
+
+            final String originalIndex = "logs_" + suffix;
+            createIndex(originalIndex, Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, randomIntBetween(3, 5))
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                .build());
+            indexDocs(originalIndex, numberOfDocs);
+            createSnapshot(repository, snapshot, originalIndex);
+            deleteIndex(originalIndex);
+
+            logger.info("mounting snapshot [repository={}, snapshot={}, index={}] as index [{}] with storage [{}] on version [{}]",
+                repository, snapshot, originalIndex, index, storage, UPGRADE_FROM_VERSION);
+            mountSnapshot(repository, snapshot, originalIndex, index, storage, Settings.EMPTY);
+        }
+
+        ensureGreen(index);
+        assertHitCount(index, equalTo(numberOfDocs));
+    }
+
+    public void testBlobStoreCacheWithFullCopyInMixedVersions() throws Exception {
+        final Storage storage = Storage.FULL_COPY;
+        assumeVersion(Version.V_7_10_0, storage);
+
+        executeBlobCacheCreationTestCase(storage, 9876L);
+    }
+
+    public void testBlobStoreCacheWithPartialCopyInMixedVersions() throws Exception {
+        final Storage storage = Storage.SHARED_CACHE;
+        assumeVersion(Version.V_7_12_0, Storage.SHARED_CACHE);
+
+        executeBlobCacheCreationTestCase(storage, 8765L);
+    }
+
+    /**
+     * Test the behavior of the blob store cache in mixed versions cluster. The idea is to mount a new snapshot as an index on a node with
+     * version X so that this node generates cached blobs documents in the blob cache system index, and then mount the snapshot again on
+     * a different node with version Y so that this other node is likely to use the previously generated cached blobs documents.
+     */
+    private void executeBlobCacheCreationTestCase(Storage storage, long numberOfDocs) throws Exception {
+        final String suffix = "blob_cache_" + storage.storageName().toLowerCase(Locale.ROOT);
+        final String repository = "repository_" + suffix;
+
+        if (CLUSTER_TYPE.equals(ClusterType.OLD)) {
+            registerRepository(repository, FsRepository.TYPE, true,
+                Settings.builder().put("location", System.getProperty("tests.path.repo") + '/' + repository).build());
+
+        } else if (CLUSTER_TYPE.equals(ClusterType.MIXED)) {
+            final int numberOfNodes = 3;
+            waitForNodes(numberOfNodes);
+
+            final Map<String, Version> nodesIdsAndVersions = nodesVersions();
+            assertThat("Cluster should have 3 nodes", nodesIdsAndVersions.size(), equalTo(numberOfNodes));
+
+            final Version minVersion = nodesIdsAndVersions.values().stream().min(Version::compareTo).get();
+            final Version maxVersion = nodesIdsAndVersions.values().stream().max(Version::compareTo).get();
+
+            final String nodeIdWithMinVersion = randomFrom(nodesIdsAndVersions.entrySet().stream()
+                .filter(node -> minVersion.equals(node.getValue())).map(Map.Entry::getKey)
+                .collect(Collectors.toSet()));
+
+            final String nodeIdWithMaxVersion = randomValueOtherThan(nodeIdWithMinVersion,
+                () -> randomFrom(nodesIdsAndVersions.entrySet().stream()
+                    .filter(node -> maxVersion.equals(node.getValue())).map(Map.Entry::getKey)
+                    .collect(Collectors.toSet())));
+
+            // The snapshot is mounted on the node with the min. version in order to force the node to populate the blob store cache index.
+            // Then the snapshot is mounted again on a different node with a higher version in order to verify that the docs in the cache
+            // index can be used.
+
+            final String firstIndex = "first_index_" + suffix;
+            createIndex(firstIndex, Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, randomIntBetween(3, 5))
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                .build());
+            indexDocs(firstIndex, numberOfDocs);
+
+            final String firstSnapshot = "first_snapshot_" + suffix;
+            createSnapshot(repository, firstSnapshot, firstIndex);
+            deleteIndex(firstIndex);
+
+            String index = "first_mount_" + suffix;
+            logger.info("mounting snapshot as index [{}] with storage [{}] on node [{}] with min. version [{}]",
+                index, storage, nodeIdWithMinVersion, minVersion);
+            mountSnapshot(repository, firstSnapshot, firstIndex, index, storage,
+                Settings.builder()
+                    // we want a specific node version to create docs in the blob cache index
+                    .put("index.routing.allocation.include._id", nodeIdWithMinVersion)
+                    // prevent interferences with blob cache when full_copy is used
+                    .put("index.store.snapshot.cache.prewarm.enabled", false)
+                    .build());
+            ensureGreen(index);
+            assertHitCount(index, equalTo(numberOfDocs));
+            deleteIndex(index);
+
+            index = "second_mount_" + suffix;
+            logger.info("mounting the same snapshot of index [{}] with storage [{}], this time on node [{}] with higher version [{}]",
+                index, storage, nodeIdWithMaxVersion, maxVersion);
+            mountSnapshot(repository, firstSnapshot, firstIndex, index, storage,
+                Settings.builder()
+                    // we want a specific node version to use the cached blobs created by the nodeIdWithMinVersion
+                    .put("index.routing.allocation.include._id", nodeIdWithMaxVersion)
+                    .put("index.routing.allocation.exclude._id", nodeIdWithMinVersion)
+                    // prevent interferences with blob cache when full_copy is used
+                    .put("index.store.snapshot.cache.prewarm.enabled", false)
+                    .build());
+            ensureGreen(index);
+            assertHitCount(index, equalTo(numberOfDocs));
+            deleteIndex(index);
+
+            deleteSnapshot(repository, firstSnapshot);
+
+            // Now the same thing but this time the docs in blob cache index are created from the upgraded version and mounted in a second
+            // time on the node with the minimum version.
+
+            final String secondIndex = "second_index_" + suffix;
+            createIndex(secondIndex, Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, randomIntBetween(3, 5))
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                .build());
+            indexDocs(secondIndex, numberOfDocs * 2L);
+
+            final String secondSnapshot = "second_snapshot_" + suffix;
+            createSnapshot(repository, secondSnapshot, secondIndex);
+            deleteIndex(secondIndex);
+
+            index = "first_mount_" + suffix;
+            logger.info("mounting snapshot as index [{}] with storage [{}] on node [{}] with max. version [{}]",
+                index, storage, nodeIdWithMaxVersion, maxVersion);
+            mountSnapshot(repository, secondSnapshot, secondIndex, index, storage,
+                Settings.builder()
+                    // we want a specific node version to create docs in the blob cache index
+                    .put("index.routing.allocation.include._id", nodeIdWithMaxVersion)
+                    // prevent interferences with blob cache when full_copy is used
+                    .put("index.store.snapshot.cache.prewarm.enabled", false)
+                    .build());
+            ensureGreen(index);
+            assertHitCount(index, equalTo(numberOfDocs * 2L));
+            deleteIndex(index);
+
+            index = "second_mount_" + suffix;
+            logger.info("mounting the same snapshot of index [{}] with storage [{}], this time on node [{}] with lower version [{}]",
+                index, storage, nodeIdWithMinVersion, minVersion);
+            mountSnapshot(repository, secondSnapshot, secondIndex, index, storage,
+                Settings.builder()
+                    // we want a specific node version to use the cached blobs created by the nodeIdWithMinVersion
+                    .put("index.routing.allocation.include._id", nodeIdWithMinVersion)
+                    .put("index.routing.allocation.exclude._id", nodeIdWithMaxVersion)
+                    // prevent interferences with blob cache when full_copy is used
+                    .put("index.store.snapshot.cache.prewarm.enabled", false)
+                    .build());
+            ensureGreen(index);
+            assertHitCount(index, equalTo(numberOfDocs * 2L));
+            deleteIndex(index);
+
+            deleteSnapshot(repository, secondSnapshot);
+
+        } else if (CLUSTER_TYPE.equals(ClusterType.UPGRADED)) {
+            deleteRepository(repository);
+        }
+    }
+
+    private static void assumeVersion(Version minSupportedVersion, Storage storageType) {
+        assumeTrue("Searchable snapshots with storage type [" + storageType + "] is supported since version [" + minSupportedVersion + ']',
+            UPGRADE_FROM_VERSION.onOrAfter(minSupportedVersion));
+    }
+
+    private static void indexDocs(String indexName, long numberOfDocs) throws IOException {
+        final StringBuilder builder = new StringBuilder();
+        for (long i = 0L; i < numberOfDocs; i++) {
+            builder.append("{\"create\":{\"_index\":\"").append(indexName).append("\"}}\n");
+            builder.append("{\"value\":").append(i).append("}\n");
+        }
+        final Request bulk = new Request(HttpPost.METHOD_NAME, "/_bulk");
+        bulk.addParameter("refresh", "true");
+        bulk.setJsonEntity(builder.toString());
+        final Response response = client().performRequest(bulk);
+        assertThat(response.getStatusLine().getStatusCode(), equalTo(RestStatus.OK.getStatus()));
+        assertFalse((Boolean) XContentMapValues.extractValue("errors", responseAsMap(response)));
+    }
+
+    private static void createSnapshot(String repositoryName, String snapshotName, String indexName) throws IOException {
+        final Request request = new Request(HttpPut.METHOD_NAME, "/_snapshot/" + repositoryName + '/' + snapshotName);
+        request.addParameter("wait_for_completion", "true");
+        request.setJsonEntity("{ \"indices\" : \"" + indexName + "\", \"include_global_state\": false}");
+        final Response response = client().performRequest(request);
+        assertThat(response.getStatusLine().getStatusCode(), equalTo(RestStatus.OK.getStatus()));
+    }
+
+    private static void waitForNodes(int numberOfNodes) throws IOException {
+        final Request request = new Request(HttpGet.METHOD_NAME, "/_cluster/health");
+        request.addParameter("wait_for_nodes", String.valueOf(numberOfNodes));
+        final Response response = client().performRequest(request);
+        assertThat(response.getStatusLine().getStatusCode(), equalTo(RestStatus.OK.getStatus()));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Version> nodesVersions() throws IOException {
+        final Response response = client().performRequest(new Request(HttpGet.METHOD_NAME, "_nodes/_all"));
+        assertThat(response.getStatusLine().getStatusCode(), equalTo(RestStatus.OK.getStatus()));
+        final Map<String, Object> nodes = (Map<String, Object>) extractValue(responseAsMap(response), "nodes");
+        assertNotNull("Nodes info is null", nodes);
+        final Map<String, Version> nodesVersions = new HashMap<>(nodes.size());
+        for (Map.Entry<String, Object> node : nodes.entrySet()) {
+            nodesVersions.put(node.getKey(), Version.fromString((String) extractValue((Map<?, ?>) node.getValue(), "version")));
+        }
+        return nodesVersions;
+    }
+
+    private static void deleteSnapshot(String repositoryName, String snapshotName) throws IOException {
+        final Request request = new Request(HttpDelete.METHOD_NAME, "/_snapshot/" + repositoryName + '/' + snapshotName);
+        final Response response = client().performRequest(request);
+        assertThat(response.getStatusLine().getStatusCode(), equalTo(RestStatus.OK.getStatus()));
+    }
+
+    private static void mountSnapshot(
+        String repositoryName,
+        String snapshotName,
+        String indexName,
+        String renamedIndex,
+        Storage storage,
+        Settings indexSettings
+    ) throws IOException {
+        final Request request = new Request(HttpPost.METHOD_NAME, "/_snapshot/" + repositoryName + '/' + snapshotName + "/_mount");
+        request.addParameter("storage", storage.storageName());
+        request.addParameter("wait_for_completion", "true");
+        request.setJsonEntity("{" +
+            "  \"index\": \"" + indexName + "\"," +
+            "  \"renamed_index\": \"" + renamedIndex + "\"," +
+            "  \"index_settings\": " + Strings.toString(indexSettings)
+            + "}");
+        final Response response = client().performRequest(request);
+        assertThat(
+            "Failed to mount snapshot [" + snapshotName + "] from repository [" + repositoryName + "]: " + response,
+            response.getStatusLine().getStatusCode(),
+            equalTo(RestStatus.OK.getStatus())
+        );
+    }
+
+    private static void assertHitCount(String indexName, Matcher<Long> countMatcher) throws IOException {
+        final Response response = client().performRequest(new Request(HttpGet.METHOD_NAME, "/" + indexName + "/_count"));
+        assertThat(response.getStatusLine().getStatusCode(), equalTo(RestStatus.OK.getStatus()));
+        final Map<String, Object> responseAsMap = responseAsMap(response);
+        final Number responseCount = (Number) extractValue("count", responseAsMap);
+        assertThat(responseAsMap + "", responseCount, notNullValue());
+        assertThat(((Number) extractValue("count", responseAsMap)).longValue(), countMatcher);
+        assertThat(((Number) extractValue("_shards.failed", responseAsMap)).intValue(), equalTo(0));
+    }
+}

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/SearchableSnapshotsRollingUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/SearchableSnapshotsRollingUpgradeIT.java
@@ -54,18 +54,16 @@ public class SearchableSnapshotsRollingUpgradeIT extends AbstractUpgradeTestCase
      */
     private void executeMountAndRecoversCorrectlyTestCase(Storage storage, long numberOfDocs) throws Exception {
         final String suffix = storage.storageName().toLowerCase(Locale.ROOT);
+        final String repository = "repository_" + suffix;
+        final String snapshot = "snapshot_" + suffix;
         final String index = "mounted_index_" + suffix;
 
         if (CLUSTER_TYPE.equals(ClusterType.OLD)) {
-            final String repository = "repository_" + suffix;
-            final String snapshot = "snapshot_" + suffix;
-
-            registerRepository(repository, FsRepository.TYPE, true,
-                Settings.builder().put("location", System.getProperty("tests.path.repo") + '/' + repository).build());
+            registerRepository(repository, FsRepository.TYPE, true, repositorySettings(repository));
 
             final String originalIndex = "logs_" + suffix;
             createIndex(originalIndex, Settings.builder()
-                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, randomIntBetween(3, 5))
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, randomIntBetween(1, 3))
                 .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
                 .build());
             indexDocs(originalIndex, numberOfDocs);
@@ -79,6 +77,12 @@ public class SearchableSnapshotsRollingUpgradeIT extends AbstractUpgradeTestCase
 
         ensureGreen(index);
         assertHitCount(index, equalTo(numberOfDocs));
+
+        if (CLUSTER_TYPE.equals(ClusterType.UPGRADED)) {
+            deleteIndex(index);
+            deleteSnapshot(repository, snapshot);
+            deleteRepository(repository);
+        }
     }
 
     public void testBlobStoreCacheWithFullCopyInMixedVersions() throws Exception {
@@ -104,9 +108,29 @@ public class SearchableSnapshotsRollingUpgradeIT extends AbstractUpgradeTestCase
         final String suffix = "blob_cache_" + storage.storageName().toLowerCase(Locale.ROOT);
         final String repository = "repository_" + suffix;
 
+        final int numberOfSnapshots = 2;
+        final String[] snapshots = new String[numberOfSnapshots];
+        final String[] indices = new String[numberOfSnapshots];
+        for (int i = 0; i < numberOfSnapshots; i++) {
+            snapshots[i] = "snapshot_" + i;
+            indices[i] = "index_" + i;
+        }
+
         if (CLUSTER_TYPE.equals(ClusterType.OLD)) {
-            registerRepository(repository, FsRepository.TYPE, true,
-                Settings.builder().put("location", System.getProperty("tests.path.repo") + '/' + repository).build());
+            registerRepository(repository, FsRepository.TYPE, true, repositorySettings(repository));
+
+            // snapshots must be created from indices on the lowest version, otherwise we won't be able
+            // to mount them again in the mixed version cluster (and we'll have IndexFormatTooNewException)
+            for (int i = 0; i < numberOfSnapshots; i++) {
+                createIndex(indices[i], Settings.builder()
+                    .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, randomIntBetween(1, 3))
+                    .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                    .build());
+                indexDocs(indices[i], numberOfDocs * (i + 1L));
+
+                createSnapshot(repository, snapshots[i], indices[i]);
+                deleteIndex(indices[i]);
+            }
 
         } else if (CLUSTER_TYPE.equals(ClusterType.MIXED)) {
             final int numberOfNodes = 3;
@@ -131,21 +155,10 @@ public class SearchableSnapshotsRollingUpgradeIT extends AbstractUpgradeTestCase
             // Then the snapshot is mounted again on a different node with a higher version in order to verify that the docs in the cache
             // index can be used.
 
-            final String firstIndex = "first_index_" + suffix;
-            createIndex(firstIndex, Settings.builder()
-                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, randomIntBetween(3, 5))
-                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
-                .build());
-            indexDocs(firstIndex, numberOfDocs);
-
-            final String firstSnapshot = "first_snapshot_" + suffix;
-            createSnapshot(repository, firstSnapshot, firstIndex);
-            deleteIndex(firstIndex);
-
-            String index = "first_mount_" + suffix;
+            String index = "first_mount_" + indices[0];
             logger.info("mounting snapshot as index [{}] with storage [{}] on node [{}] with min. version [{}]",
                 index, storage, nodeIdWithMinVersion, minVersion);
-            mountSnapshot(repository, firstSnapshot, firstIndex, index, storage,
+            mountSnapshot(repository, snapshots[0], indices[0], index, storage,
                 Settings.builder()
                     // we want a specific node version to create docs in the blob cache index
                     .put("index.routing.allocation.include._id", nodeIdWithMinVersion)
@@ -156,10 +169,10 @@ public class SearchableSnapshotsRollingUpgradeIT extends AbstractUpgradeTestCase
             assertHitCount(index, equalTo(numberOfDocs));
             deleteIndex(index);
 
-            index = "second_mount_" + suffix;
+            index = "second_mount_" + indices[0];
             logger.info("mounting the same snapshot of index [{}] with storage [{}], this time on node [{}] with higher version [{}]",
                 index, storage, nodeIdWithMaxVersion, maxVersion);
-            mountSnapshot(repository, firstSnapshot, firstIndex, index, storage,
+            mountSnapshot(repository, snapshots[0], indices[0], index, storage,
                 Settings.builder()
                     // we want a specific node version to use the cached blobs created by the nodeIdWithMinVersion
                     .put("index.routing.allocation.include._id", nodeIdWithMaxVersion)
@@ -171,26 +184,13 @@ public class SearchableSnapshotsRollingUpgradeIT extends AbstractUpgradeTestCase
             assertHitCount(index, equalTo(numberOfDocs));
             deleteIndex(index);
 
-            deleteSnapshot(repository, firstSnapshot);
-
             // Now the same thing but this time the docs in blob cache index are created from the upgraded version and mounted in a second
             // time on the node with the minimum version.
 
-            final String secondIndex = "second_index_" + suffix;
-            createIndex(secondIndex, Settings.builder()
-                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, randomIntBetween(3, 5))
-                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
-                .build());
-            indexDocs(secondIndex, numberOfDocs * 2L);
-
-            final String secondSnapshot = "second_snapshot_" + suffix;
-            createSnapshot(repository, secondSnapshot, secondIndex);
-            deleteIndex(secondIndex);
-
-            index = "first_mount_" + suffix;
+            index = "first_mount_" + indices[1];
             logger.info("mounting snapshot as index [{}] with storage [{}] on node [{}] with max. version [{}]",
                 index, storage, nodeIdWithMaxVersion, maxVersion);
-            mountSnapshot(repository, secondSnapshot, secondIndex, index, storage,
+            mountSnapshot(repository, snapshots[1], indices[1], index, storage,
                 Settings.builder()
                     // we want a specific node version to create docs in the blob cache index
                     .put("index.routing.allocation.include._id", nodeIdWithMaxVersion)
@@ -201,10 +201,10 @@ public class SearchableSnapshotsRollingUpgradeIT extends AbstractUpgradeTestCase
             assertHitCount(index, equalTo(numberOfDocs * 2L));
             deleteIndex(index);
 
-            index = "second_mount_" + suffix;
+            index = "second_mount_" + indices[1];
             logger.info("mounting the same snapshot of index [{}] with storage [{}], this time on node [{}] with lower version [{}]",
                 index, storage, nodeIdWithMinVersion, minVersion);
-            mountSnapshot(repository, secondSnapshot, secondIndex, index, storage,
+            mountSnapshot(repository, snapshots[1], indices[1], index, storage,
                 Settings.builder()
                     // we want a specific node version to use the cached blobs created by the nodeIdWithMinVersion
                     .put("index.routing.allocation.include._id", nodeIdWithMinVersion)
@@ -216,9 +216,10 @@ public class SearchableSnapshotsRollingUpgradeIT extends AbstractUpgradeTestCase
             assertHitCount(index, equalTo(numberOfDocs * 2L));
             deleteIndex(index);
 
-            deleteSnapshot(repository, secondSnapshot);
-
         } else if (CLUSTER_TYPE.equals(ClusterType.UPGRADED)) {
+            for (String snapshot : snapshots) {
+                deleteSnapshot(repository, snapshot);
+            }
             deleteRepository(repository);
         }
     }
@@ -285,8 +286,11 @@ public class SearchableSnapshotsRollingUpgradeIT extends AbstractUpgradeTestCase
         Settings indexSettings
     ) throws IOException {
         final Request request = new Request(HttpPost.METHOD_NAME, "/_snapshot/" + repositoryName + '/' + snapshotName + "/_mount");
-        request.addParameter("storage", storage.storageName());
-        request.addParameter("wait_for_completion", "true");
+        if (UPGRADE_FROM_VERSION.onOrAfter(Version.V_7_12_0)) {
+            request.addParameter("storage", storage.storageName());
+        } else {
+            assertThat("Parameter 'storage' was introduced in 7.12.0 with " + Storage.SHARED_CACHE, storage, equalTo(Storage.FULL_COPY));
+        }
         request.setJsonEntity("{" +
             "  \"index\": \"" + indexName + "\"," +
             "  \"renamed_index\": \"" + renamedIndex + "\"," +
@@ -308,5 +312,13 @@ public class SearchableSnapshotsRollingUpgradeIT extends AbstractUpgradeTestCase
         assertThat(responseAsMap + "", responseCount, notNullValue());
         assertThat(((Number) extractValue("count", responseAsMap)).longValue(), countMatcher);
         assertThat(((Number) extractValue("_shards.failed", responseAsMap)).intValue(), equalTo(0));
+    }
+
+    private static Settings repositorySettings(String repository) {
+        final String pathRepo = System.getProperty("tests.path.searchable.snapshots.repo");
+        assertThat("Searchable snapshots repository path is null", pathRepo, notNullValue());
+        return Settings.builder()
+            .put("location", pathRepo + '/' + repository)
+            .build();
     }
 }

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/UpgradeClusterClientYamlTestSuiteIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/UpgradeClusterClientYamlTestSuiteIT.java
@@ -89,6 +89,16 @@ public class UpgradeClusterClientYamlTestSuiteIT extends ESClientYamlSuiteTestCa
         return true;
     }
 
+    @Override
+    protected boolean preserveReposUponCompletion() {
+        return true;
+    }
+
+    @Override
+    protected boolean preserveSnapshotsUponCompletion() {
+        return true;
+    }
+
     public UpgradeClusterClientYamlTestSuiteIT(ClientYamlTestCandidate testCandidate) {
         super(testCandidate);
     }


### PR DESCRIPTION
Today searchable snapshots IndexInput implementations use the
blob store cache to cache the first 4096 bytes of every Lucene files.
After some experiments we think that we could adjust the length of
the cached data depending of the Lucene file that is read, caching
up to 64KB for Lucene metadata files (ie files that are fully read
when a Directory is opened) and only 1KB for other files.

The files that are cached up to 64KB are the following extensions:

        "cfe", // compound file's entry table
        "dvm", // doc values metadata file
        "fdm", // stored fields metadata file
        "fnm", // field names metadata file
        "kdm", // Lucene 8.6 point format metadata file
        "nvm", // norms metadata file
        "tmd", // Lucene 8.6 terms metadata file
        "tvm", // terms vectors metadata file
        "vem"  // Lucene 9.0 indexed vectors metadata

The 64KB limit can be configured on a per index basis through a new
index setting. This change is extracted from #69283 and does not
address the caching of CFS files.

Backport of #69431
