### PR TITLE
[7.12] [DOCS] Update example for `serial_diff` agg (#69635)

### DIFF
--- a/docs/reference/aggregations/pipeline/serial-diff-aggregation.asciidoc
+++ b/docs/reference/aggregations/pipeline/serial-diff-aggregation.asciidoc
@@ -43,7 +43,7 @@ A `serial_diff` aggregation looks like this in isolation:
 {
   "serial_diff": {
     "buckets_path": "the_sum",
-    "lag": "7"
+    "lag": 7
   }
 }
 --------------------------------------------------


### PR DESCRIPTION
Backports the following commits to 7.12:
 - [DOCS] Update example for `serial_diff` agg (#69635)