### PR TITLE
[7.x] [DOCS] Add request body parameters to put Logstash pipeline API docs (#69151)

### DIFF
--- a/x-pack/docs/en/rest-api/logstash/delete-pipeline.asciidoc
+++ b/x-pack/docs/en/rest-api/logstash/delete-pipeline.asciidoc
@@ -1,9 +1,14 @@
 [role="xpack"]
 [testenv="basic"]
 [[logstash-api-delete-pipeline]]
-=== Delete Pipeline API
+=== Delete {ls} pipeline API
+++++
+<titleabbrev>Delete {ls} pipeline</titleabbrev>
+++++
 
-This API deletes Pipelines used for Logstash Central Management.
+This API deletes a pipeline used for
+{logstash-ref}/logstash-centralized-pipeline-management.html[{ls} Central
+Management].
 
 [[logstash-api-delete-pipeline-request]]
 ==== {api-request-title}
@@ -19,7 +24,7 @@ This API deletes Pipelines used for Logstash Central Management.
 [[logstash-api-delete-pipeline-desc]]
 ==== {api-description-title}
 
-Delete a Logstash Pipelines.
+Deletes a {ls} pipeline.
 
 [[logstash-api-delete-pipeline-params]]
 ==== {api-path-parms-title}

--- a/x-pack/docs/en/rest-api/logstash/get-pipeline.asciidoc
+++ b/x-pack/docs/en/rest-api/logstash/get-pipeline.asciidoc
@@ -1,9 +1,14 @@
 [role="xpack"]
 [testenv="basic"]
 [[logstash-api-get-pipeline]]
-=== Get Pipeline API
+=== Get pipeline API
+++++
+<titleabbrev>Get {ls} pipeline</titleabbrev>
+++++
 
-This API retrieves Pipelines used for Logstash Central Management.
+This API retrieves pipelines used for
+{logstash-ref}/logstash-centralized-pipeline-management.html[{ls} Central
+Management].
 
 [[logstash-api-get-pipeline-request]]
 ==== {api-request-title}
@@ -21,18 +26,18 @@ This API retrieves Pipelines used for Logstash Central Management.
 [[logstash-api-get-pipeline-desc]]
 ==== {api-description-title}
 
-Retrieve one or more Logstash Pipelines.
+Retrieve one or more {ls} pipelines.
 
 [[logstash-api-get-pipeline-params]]
 ==== {api-path-parms-title}
 
 `<pipeline_id>`::
-  (Optional, string) Comma-separated list of Pipeline identifiers.
+  (Optional, string) Comma-separated list of pipeline identifiers.
 
 [[logstash-api-get-pipeline-example]]
 ==== {api-examples-title}
 
-The following example retrieves the Pipeline named `my_pipeline`:
+The following example retrieves the pipeline named `my_pipeline`:
 
 //////////////////////////
 
@@ -40,7 +45,7 @@ The following example retrieves the Pipeline named `my_pipeline`:
 --------------------------------------------------
 PUT _logstash/pipeline/my_pipeline
 {
-  "description": "Sample Pipeline for illustration purposes",
+  "description": "Sample pipeline for illustration purposes",
   "last_modified": "2021-01-02T02:50:51.250Z",
   "pipeline_metadata": {
     "type": "logstash_pipeline",
@@ -69,13 +74,13 @@ GET _logstash/pipeline/my_pipeline
 // TEST[continued]
 
 
-If the request succeeds, the body of the response contains the Pipeline definition:
+If the request succeeds, the body of the response contains the pipeline definition:
 
 [source,console-result]
 --------------------------------------------------
 {
   "my_pipeline": {
-    "description": "Sample Pipeline for illustration purposes",
+    "description": "Sample pipeline for illustration purposes",
     "last_modified": "2021-01-02T02:50:51.250Z",
     "pipeline_metadata": {
       "type": "logstash_pipeline",

--- a/x-pack/docs/en/rest-api/logstash/index.asciidoc
+++ b/x-pack/docs/en/rest-api/logstash/index.asciidoc
@@ -1,9 +1,10 @@
 [role="xpack"]
 [[logstash-apis]]
-== Logstash APIs
+== {ls} APIs
 
-The following APIs are used to manage Pipelines used by Logstash Central
-Management:
+The following APIs are used to manage pipelines used by
+{logstash-ref}/logstash-centralized-pipeline-management.html[{ls} Central
+Management]:
 
 * <<logstash-api-put-pipeline>>
 * <<logstash-api-get-pipeline>>

--- a/x-pack/docs/en/rest-api/logstash/put-pipeline.asciidoc
+++ b/x-pack/docs/en/rest-api/logstash/put-pipeline.asciidoc
@@ -1,9 +1,14 @@
 [role="xpack"]
 [testenv="basic"]
 [[logstash-api-put-pipeline]]
-=== Put Pipeline API
+=== Put {ls} pipeline API
+++++
+<titleabbrev>Put {ls} pipeline</titleabbrev>
+++++
 
-This API creates or updates Pipelines used for Logstash Central Management.
+This API creates or updates a {ls} pipeline used for
+{logstash-ref}/logstash-centralized-pipeline-management.html[{ls} Central
+Management].
 
 [[logstash-api-put-pipeline-request]]
 ==== {api-request-title}
@@ -19,25 +24,58 @@ This API creates or updates Pipelines used for Logstash Central Management.
 [[logstash-api-put-pipeline-desc]]
 ==== {api-description-title}
 
-Creates a Logstash Pipeline. If the specified Pipeline exists, the pipeline is
+Creates a {ls} pipeline. If the specified pipeline exists, the pipeline is
 replaced.
 
 [[logstash-api-put-pipeline-params]]
 ==== {api-path-parms-title}
 
 `<pipeline_id>`::
-  (Required, string) Identifier for the Pipeline.
+  (Required, string) Identifier for the pipeline.
+
+[[logstash-api-put-pipeline-request-body]]
+==== {api-request-body-title}
+
+`description`::
+(Optional, string)
+Description of the pipeline. This description is not used by {es} or {ls}.
+
+`last_modified`::
+(Required, string)
+Date the pipeline was last updated. Must be in the `yyyy-MM-dd'T'HH:mm:ss.SSSZZ`
+<<mapping-date-format,`strict_date_time`>> format.
+
+`pipeline`::
+(Required, string)
+Configuration for the pipeline. For supported syntax, see the
+{logstash-ref}/configuration-file-structure.html[{ls} configuration
+documentation].
+
+`pipeline_metadata`::
+(Required, object)
+Optional metadata about the pipeline. May have any contents. This metadata is
+not generated or used by {es} or {ls}.
+
+`pipeline_settings`::
+(Required, object)
+Settings for the pipeline. Supports only flat keys in dot notation. For
+supported settings, see the {logstash-ref}/logstash-settings-file.html[{ls}
+settings documentation].
+
+`username`::
+(Required, string)
+User who last updated the pipeline.
 
 [[logstash-api-put-pipeline-example]]
 ==== {api-examples-title}
 
-The following example creates a new Pipeline named `my_pipeline`:
+The following example creates a new pipeline named `my_pipeline`:
 
 [source,console]
 --------------------------------------------------
 PUT _logstash/pipeline/my_pipeline
 {
-  "description": "Sample Pipeline for illustration purposes",
+  "description": "Sample pipeline for illustration purposes",
   "last_modified": "2021-01-02T02:50:51.250Z",
   "pipeline_metadata": {
     "type": "logstash_pipeline",


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Add request body parameters to put Logstash pipeline API docs (#69151)