### PR TITLE
[7.x] [DOCS] Fix name of `cluster_version` parameter (#69615)

### DIFF
--- a/docs/reference/repositories-metering-api/apis/repositories-meterings-body.asciidoc
+++ b/docs/reference/repositories-metering-api/apis/repositories-meterings-body.asciidoc
@@ -106,7 +106,7 @@ When a repository is closed or updated the repository metering information
 is archived and kept for a certain period of time. This allows retrieving
 the repository metering information of previous repository instantiations.
 
-`archive_version`::
+`cluster_version`::
 (Optional, long)
 The cluster state version when this object was archived, this field
 can be used as a logical timestamp to delete all the archived metrics up


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Fix name of `cluster_version` parameter (#69615)