### PR TITLE
[7.11] [DOCS] Fix typo (#69654)

### DIFF
--- a/docs/reference/modules/cluster/shards_allocation.asciidoc
+++ b/docs/reference/modules/cluster/shards_allocation.asciidoc
@@ -62,7 +62,7 @@ an automatic process called _rebalancing_ which moves shards between the nodes
 in your cluster to improve its balance. Rebalancing obeys all other shard
 allocation rules such as <<cluster-shard-allocation-filtering,allocation
 filtering>> and <<forced-awareness,forced awareness>> which may prevent it from
-completely balancing the cluster. In that case, rebalancing strives to acheve
+completely balancing the cluster. In that case, rebalancing strives to achieve
 the most balanced cluster possible within the rules you have configured. If you
 are using <<data-tiers,data tiers>> then {es} automatically applies allocation
 filtering rules to place each shard within the appropriate tier. These rules


### PR DESCRIPTION
Backports the following commits to 7.11:
 - [DOCS] Fix typo (#69654)