### PR TITLE
Update skip after backport

### DIFF
--- a/rest-api-spec/build.gradle
+++ b/rest-api-spec/build.gradle
@@ -325,7 +325,6 @@ tasks.named("yamlRestCompatTest").configure {
     'search.aggregation/280_geohash_grid/Basic test',
     'search.aggregation/290_geotile_grid/Basic test',
     'search.aggregation/51_filter_with_types/Filter aggs with terms lookup and ensure it\'s cached',
-    'search.aggregation/370_doc_count_field/Test filters agg with doc_count',
     'search.inner_hits/10_basic/Nested doc version and seqIDs',
     'search.inner_hits/10_basic/Nested inner hits',
     'search/100_stored_fields/Stored fields',

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/370_doc_count_field.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/370_doc_count_field.yml
@@ -150,9 +150,9 @@ setup:
 ---
 "Test filters agg with doc_count":
   - skip:
-      version: " - 7.99.99"
+      version: " - 7.12.99"
       features: default_shards
-      reason: "name changed in 8.0.0, backporting to 7.13"
+      reason: "name changed in 7.13"
   - do:
       search:
         body:


### PR DESCRIPTION
Now that we've backported #69377 to 7.x we can run backwards
compatibility tests against it.
