### PR TITLE
[7.11] [DOCS] Remove duplicate index alias filter def (#69716)

### DIFF
--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -31,14 +31,6 @@ tag::aliases[]
 index. See <<indices-aliases>>.
 end::aliases[]
 
-tag::index-alias-filter[]
-<<query-dsl-bool-query, Filter query>>
-used to limit the index alias.
-+
-If specified,
-the index alias only applies to documents returned by the filter.
-end::index-alias-filter[]
-
 tag::target-index-aliases[]
 `aliases`::
 (Optional, <<indices-aliases,alias object>>)


### PR DESCRIPTION
Backports the following commits to 7.11:
 - [DOCS] Remove duplicate index alias filter def (#69716)