### PR TITLE
Throw IAE for runtime mappings in _field_caps for older nodes

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesIndexRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesIndexRequest.java
@@ -118,6 +118,12 @@ public class FieldCapabilitiesIndexRequest extends ActionRequest implements Indi
         }
         if (out.getVersion().onOrAfter(Version.V_7_12_0)) {
             out.writeMap(runtimeFields);
+        } else {
+            if (false == runtimeFields.isEmpty()) {
+                throw new IllegalArgumentException(
+                    "Versions before 7.12.0 don't support [runtime_mappings], but trying to send _field_caps request to a node "
+                    + "with version [" + out.getVersion()+ "]");
+            }
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesRequest.java
@@ -96,6 +96,12 @@ public final class FieldCapabilitiesRequest extends ActionRequest implements Ind
         }
         if (out.getVersion().onOrAfter(Version.V_7_12_0)) {
             out.writeMap(runtimeFields);
+        } else {
+            if (false == runtimeFields.isEmpty()) {
+                throw new IllegalArgumentException(
+                    "Versions before 7.12.0 don't support [runtime_mappings], but trying to send _field_caps request to a node "
+                    + "with version [" + out.getVersion() + "]");
+            }
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesIndexRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesIndexRequestTests.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.fieldcaps;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.action.OriginalIndices;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.VersionUtils;
+
+import static java.util.Collections.singletonMap;
+import static org.hamcrest.Matchers.equalTo;
+
+public class FieldCapabilitiesIndexRequestTests extends ESTestCase {
+
+    public void testSerializingWithRuntimeFieldsBeforeSupportedThrows() {
+        FieldCapabilitiesIndexRequest request = new FieldCapabilitiesIndexRequest(
+            new String[] { "field" },
+            "index",
+            new OriginalIndices(new String[] { "original_index" }, IndicesOptions.LENIENT_EXPAND_OPEN),
+            null,
+            0L,
+            singletonMap("day_of_week", singletonMap("type", "keyword"))
+        );
+        Version v = VersionUtils.randomVersionBetween(random(), Version.V_7_0_0, VersionUtils.getPreviousVersion(Version.V_7_12_0));
+        Exception e = expectThrows(
+            IllegalArgumentException.class,
+            () -> copyWriteable(request, writableRegistry(), FieldCapabilitiesRequest::new, v)
+        );
+        assertThat(e.getMessage(), equalTo("Versions before 7.12.0 don't support [runtime_mappings], but trying to send _field_caps "
+            + "request to a node with version [" + v + "]"));
+    }
+}

--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesRequestTests.java
@@ -150,7 +150,7 @@ public class FieldCapabilitiesRequestTests extends AbstractWireSerializingTestCa
             IllegalArgumentException.class,
             () -> copyWriteable(request, writableRegistry(), FieldCapabilitiesRequest::new, v)
         );
-        assertThat(e.getMessage(), equalTo("Versions before 7.12.0 don't support [runtime_mappings], but trying to send _field_caps request "
-            + "to a node with version [" + v + "]"));
+        assertThat(e.getMessage(), equalTo("Versions before 7.12.0 don't support [runtime_mappings], but trying to send _field_caps "
+            + "request to a node with version [" + v + "]"));
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesRequestTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.action.fieldcaps;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -22,6 +23,7 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.test.VersionUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -30,6 +32,7 @@ import java.util.List;
 import java.util.function.Consumer;
 
 import static java.util.Collections.singletonMap;
+import static org.hamcrest.Matchers.equalTo;
 
 public class FieldCapabilitiesRequestTests extends AbstractWireSerializingTestCase<FieldCapabilitiesRequest> {
 
@@ -137,5 +140,17 @@ public class FieldCapabilitiesRequestTests extends AbstractWireSerializingTestCa
             .indices("index2");
         ActionRequestValidationException exception = request.validate();
         assertNotNull(exception);
+    }
+
+    public void testSerializingWithRuntimeFieldsBeforeSupportedThrows() {
+        FieldCapabilitiesRequest request = new FieldCapabilitiesRequest();
+        request.runtimeFields(singletonMap("day_of_week", singletonMap("type", "keyword")));
+        Version v = VersionUtils.randomVersionBetween(random(), Version.V_7_0_0, VersionUtils.getPreviousVersion(Version.V_7_12_0));
+        Exception e = expectThrows(
+            IllegalArgumentException.class,
+            () -> copyWriteable(request, writableRegistry(), FieldCapabilitiesRequest::new, v)
+        );
+        assertThat(e.getMessage(), equalTo("Versions before 7.12.0 don't support [runtime_mappings], but trying to send _field_caps request "
+            + "to a node with version [" + v + "]"));
     }
 }


### PR DESCRIPTION
Typically we silently ignore nodes below a certain version that don't support a
specific feature when serializing requests between nodes. With runtime fields we
chose to throw errors instead when one of the nodes a search request is sent to
has a version that does not support the runtime fields feature. This change adds
the same behaviour for support of the "runtime_mappings" section introduced in #68904
in the "_field_caps" API.

Relates to #68904