### PR TITLE
Ensure running precommit task compiles all project source sets

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/PrecommitPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/PrecommitPlugin.java
@@ -12,7 +12,6 @@ import org.elasticsearch.gradle.util.GradleUtils;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
-import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskProvider;
 
 /**
@@ -34,9 +33,8 @@ public abstract class PrecommitPlugin implements Plugin<Project> {
                 "java",
                 p -> {
                     // We want to get any compilation error before running the pre-commit checks.
-                    for (SourceSet sourceSet : GradleUtils.getJavaSourceSets(project)) {
-                        task.configure(t -> t.shouldRunAfter(sourceSet.getClassesTaskName()));
-                    }
+                    GradleUtils.getJavaSourceSets(project)
+                        .all(sourceSet -> task.configure(t -> t.shouldRunAfter(sourceSet.getClassesTaskName())));
                 }
             );
     }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/PrecommitTaskPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/PrecommitTaskPlugin.java
@@ -13,7 +13,6 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.plugins.JavaBasePlugin;
-import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.testing.Test;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
@@ -37,9 +36,8 @@ public class PrecommitTaskPlugin implements Plugin<Project> {
                 "java",
                 p -> {
                     // run compilation as part of precommit
-                    for (SourceSet sourceSet : GradleUtils.getJavaSourceSets(project)) {
-                        precommit.configure(t -> t.dependsOn(sourceSet.getClassesTaskName()));
-                    }
+                    GradleUtils.getJavaSourceSets(project)
+                        .all(sourceSet -> precommit.configure(t -> t.dependsOn(sourceSet.getClassesTaskName())));
 
                     // make sure tests run after all precommit tasks
                     project.getTasks().withType(Test.class).configureEach(t -> t.mustRunAfter(precommit));


### PR DESCRIPTION
When configuring the `precommit` task we attach any source set compile tasks as dependencies so that running `precommit` verifies that all code in the repository can at least correctly compile. This was done via simply iterating over the `SourceSetContainer` as a simple collection, which is susceptible to configuration ordering issues if a subsequently applied plugin registers a new source set, which is often the case for our REST testing plugins. This pull request refactors this logic to use the lazy `all()` callback approach so that we ensure any source sets added later will also be properly wired up to the `precommit` task.

Closes #69715