### PR TITLE
Describe why testFailedTasksCount fails

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TransportTasksActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TransportTasksActionTests.java
@@ -516,9 +516,20 @@ public class TransportTasksActionTests extends TaskManagerTestCase {
             };
         }
 
+        final StringBuilder taskDescriptions = new StringBuilder();
         for (TestNode testNode : testNodes) {
-            assertEquals(0, testNode.transportService.getTaskManager().getTasks().size());
+            final Map<Long, Task> tasks = testNode.transportService.getTaskManager().getTasks();
+            if (tasks.isEmpty() == false) {
+                taskDescriptions.append("still running tasks on node [").append(testNode.getNodeId()).append("]\n");
+                for (Map.Entry<Long, Task> entry : tasks.entrySet()) {
+                    final Task task = entry.getValue();
+                    taskDescriptions.append(entry.getKey()).append(": [").append(task.getId()).append("][").append(task.getAction())
+                            .append("] started at ").append(task.getStartTime()).append('\n');
+                }
+            }
         }
+        assertTrue(taskDescriptions.toString(), taskDescriptions.isEmpty());
+
         NodesRequest request = new NodesRequest("Test Request");
         NodesResponse responses = ActionTestUtils.executeBlocking(actions[0], request);
         assertEquals(nodesCount, responses.failureCount());

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TransportTasksActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TransportTasksActionTests.java
@@ -61,6 +61,7 @@ import java.util.stream.Collectors;
 import static org.elasticsearch.action.support.PlainActionFuture.newFuture;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
@@ -528,7 +529,7 @@ public class TransportTasksActionTests extends TaskManagerTestCase {
                 }
             }
         }
-        assertTrue(taskDescriptions.toString(), taskDescriptions.isEmpty());
+        assertThat(taskDescriptions.toString(), taskDescriptions.length(), equalTo(0));
 
         NodesRequest request = new NodesRequest("Test Request");
         NodesResponse responses = ActionTestUtils.executeBlocking(actions[0], request);


### PR DESCRIPTION
Today TransportTasksActionTests#testFailedTasksCount fails reporting an
unexpectedly-running task, but doesn't tell us anything about what that
task might be or where it's running. This commit adds a much more
descriptive message on failure to help us understand why this test fails
sometimes.

Relates #69731