### PR TITLE
[Transfrom] prevent transform from looping forever if delete by query fails permanently

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TimeRetentionPolicyConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TimeRetentionPolicyConfig.java
@@ -40,6 +40,7 @@ public class TimeRetentionPolicyConfig implements RetentionPolicyConfig {
         ConstructingObjectParser<TimeRetentionPolicyConfig, Void> parser = new ConstructingObjectParser<>(NAME, lenient, args -> {
             String field = (String) args[0];
             TimeValue maxAge = (TimeValue) args[1];
+
             return new TimeRetentionPolicyConfig(field, maxAge);
         });
         parser.declareString(constructorArg(), TransformField.FIELD);
@@ -78,6 +79,14 @@ public class TimeRetentionPolicyConfig implements RetentionPolicyConfig {
                 validationException
             );
         }
+
+        if (maxAge.compareTo(TimeValue.MAX_VALUE) > 0) {
+            validationException = addValidationError(
+                "retention_policy.time.max_age must not be greater than [" + TimeValue.MAX_VALUE + "]",
+                validationException
+            );
+        }
+
         return validationException;
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TimeRetentionPolicyConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TimeRetentionPolicyConfig.java
@@ -75,7 +75,7 @@ public class TimeRetentionPolicyConfig implements RetentionPolicyConfig {
     public ActionRequestValidationException validate(ActionRequestValidationException validationException) {
         if (maxAge.getSeconds() < MIN_AGE_SECONDS) {
             validationException = addValidationError(
-                "retention_policy.time.max_age must be more than " + MIN_AGE_SECONDS + "s, found [" + maxAge + "]",
+                "retention_policy.time.max_age must be greater than " + MIN_AGE_SECONDS + "s, found [" + maxAge + "]",
                 validationException
             );
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TimeRetentionPolicyConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TimeRetentionPolicyConfigTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.core.transform.transforms;
 
+import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -17,7 +18,10 @@ import java.io.IOException;
 public class TimeRetentionPolicyConfigTests extends AbstractSerializingTestCase<TimeRetentionPolicyConfig> {
 
     public static TimeRetentionPolicyConfig randomTimeRetentionPolicyConfig() {
-        return new TimeRetentionPolicyConfig(randomAlphaOfLengthBetween(1, 10), new TimeValue(randomLongBetween(60000, Long.MAX_VALUE)));
+        return new TimeRetentionPolicyConfig(
+            randomAlphaOfLengthBetween(1, 10),
+            new TimeValue(randomLongBetween(60000, Long.MAX_VALUE - 1))
+        );
     }
 
     @Override
@@ -33,5 +37,29 @@ public class TimeRetentionPolicyConfigTests extends AbstractSerializingTestCase<
     @Override
     protected Reader<TimeRetentionPolicyConfig> instanceReader() {
         return TimeRetentionPolicyConfig::new;
+    }
+
+    public void testValidationMin() {
+        TimeRetentionPolicyConfig timeRetentionPolicyConfig = new TimeRetentionPolicyConfig(
+            randomAlphaOfLengthBetween(1, 10),
+            TimeValue.timeValueSeconds(10)
+        );
+
+        ActionRequestValidationException e = timeRetentionPolicyConfig.validate(null);
+        assertNotNull(e);
+        assertEquals(1, e.validationErrors().size());
+        assertEquals("retention_policy.time.max_age must be more than 60s, found [10s]", e.validationErrors().get(0));
+    }
+
+    public void testValidationMax() {
+        TimeRetentionPolicyConfig timeRetentionPolicyConfig = new TimeRetentionPolicyConfig(
+            randomAlphaOfLengthBetween(1, 10),
+            TimeValue.parseTimeValue("600000000000d", "time value")
+        );
+
+        ActionRequestValidationException e = timeRetentionPolicyConfig.validate(null);
+        assertNotNull(e);
+        assertEquals(1, e.validationErrors().size());
+        assertEquals("retention_policy.time.max_age must not be greater than [106751.9d]", e.validationErrors().get(0));
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TimeRetentionPolicyConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TimeRetentionPolicyConfigTests.java
@@ -20,7 +20,7 @@ public class TimeRetentionPolicyConfigTests extends AbstractSerializingTestCase<
     public static TimeRetentionPolicyConfig randomTimeRetentionPolicyConfig() {
         return new TimeRetentionPolicyConfig(
             randomAlphaOfLengthBetween(1, 10),
-            new TimeValue(randomLongBetween(60000, Long.MAX_VALUE - 1))
+            new TimeValue(randomLongBetween(60000, 1_000_000_000L))
         );
     }
 
@@ -48,7 +48,7 @@ public class TimeRetentionPolicyConfigTests extends AbstractSerializingTestCase<
         ActionRequestValidationException e = timeRetentionPolicyConfig.validate(null);
         assertNotNull(e);
         assertEquals(1, e.validationErrors().size());
-        assertEquals("retention_policy.time.max_age must be more than 60s, found [10s]", e.validationErrors().get(0));
+        assertEquals("retention_policy.time.max_age must be greater than 60s, found [10s]", e.validationErrors().get(0));
     }
 
     public void testValidationMax() {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/RetentionPolicyToDeleteByQueryRequestConverter.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/RetentionPolicyToDeleteByQueryRequestConverter.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.transform.transforms;
 
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.reindex.AbstractBulkByScrollRequest;
@@ -26,6 +27,9 @@ import java.time.Instant;
  * All implementations of `retention_policy` are converted to a {@link DeleteByQueryRequest}, which is then executed by the indexer.
  */
 public final class RetentionPolicyToDeleteByQueryRequestConverter {
+
+    private static final String DATE_FORMAT = "strict_date_optional_time";
+    private static final DateFormatter DATE_FORMATER = DateFormatter.forPattern(DATE_FORMAT);
 
     public static class RetentionPolicyException extends ElasticsearchException {
         RetentionPolicyException(String msg, Object... args) {
@@ -92,6 +96,6 @@ public final class RetentionPolicyToDeleteByQueryRequestConverter {
         TransformCheckpoint checkpoint
     ) {
         Instant cutOffDate = Instant.ofEpochMilli(checkpoint.getTimestamp()).minusMillis(config.getMaxAge().getMillis());
-        return QueryBuilders.rangeQuery(config.getField()).lt(cutOffDate.toEpochMilli()).format("epoch_millis");
+        return QueryBuilders.rangeQuery(config.getField()).lt(DATE_FORMATER.format(cutOffDate)).format(DATE_FORMAT);
     }
 }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformContext.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformContext.java
@@ -96,6 +96,10 @@ class TransformContext {
         return numFailureRetries;
     }
 
+    int getFailureCount() {
+        return failureCount.get();
+    }
+
     int getAndIncrementFailureCount() {
         return failureCount.getAndIncrement();
     }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
@@ -424,20 +424,29 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
             return;
         }
 
-        refreshDestinationIndex(ActionListener.wrap(response -> {
-            if (response.getFailedShards() > 0) {
-                logger.warn(
-                    "[{}] failed to refresh transform destination index, not all data might be available after checkpoint.",
-                    getJobId()
-                );
-            }
-            // delete data defined by retention policy
-            if (transformConfig.getRetentionPolicyConfig() != null) {
-                executeRetentionPolicy(listener);
-            } else {
-                finalizeCheckpoint(listener);
-            }
-        }, listener::onFailure));
+        ActionListener<Void> failureHandlingListener = ActionListener.wrap(listener::onResponse, failure -> {
+            handleFailure(failure);
+            listener.onFailure(failure);
+        });
+
+        try {
+            refreshDestinationIndex(ActionListener.wrap(response -> {
+                if (response.getFailedShards() > 0) {
+                    logger.warn(
+                        "[{}] failed to refresh transform destination index, not all data might be available after checkpoint.",
+                        getJobId()
+                    );
+                }
+                // delete data defined by retention policy
+                if (transformConfig.getRetentionPolicyConfig() != null) {
+                    executeRetentionPolicy(failureHandlingListener);
+                } else {
+                    finalizeCheckpoint(failureHandlingListener);
+                }
+            }, failureHandlingListener::onFailure));
+        } catch (Exception e) {
+            failureHandlingListener.onFailure(e);
+        }
     }
 
     private void executeRetentionPolicy(ActionListener<Void> listener) {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
@@ -801,7 +801,7 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
 
             auditor.warning(
                 getJobId(),
-                "Transform encountered an exception: " + message + " Will attempt again at next scheduled trigger."
+                "Transform encountered an exception: " + message + "; Will attempt again at next scheduled trigger."
             );
             lastAuditedExceptionMessage = message;
         }

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/RetentionPolicyConfigToDeleteByQueryTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/RetentionPolicyConfigToDeleteByQueryTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.transform.transforms;
 
+import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.RangeQueryBuilder;
@@ -88,8 +89,7 @@ public class RetentionPolicyConfigToDeleteByQueryTests extends ESTestCase {
         QueryBuilder query = deleteByQueryRequest.getSearchRequest().source().query();
         assertThat(query, instanceOf(RangeQueryBuilder.class));
         RangeQueryBuilder rangeQuery = (RangeQueryBuilder) query;
-
-        assertThat(rangeQuery.to(), equalTo(9_940_000L));
+        assertThat(rangeQuery.to(), equalTo(DateFormatter.forPattern("strict_date_optional_time").formatMillis(9_940_000L)));
         assertTrue(rangeQuery.includeLower());
     }
 

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerFailureHandlingTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerFailureHandlingTests.java
@@ -770,7 +770,7 @@ public class TransformIndexerFailureHandlingTests extends ESTestCase {
                 "timed out during dbq",
                 Level.WARNING,
                 transformId,
-                "Transform encountered an exception: org.elasticsearch.ElasticsearchTimeoutException: timed out during dbq Will attempt again at next scheduled trigger."
+                "Transform encountered an exception: org.elasticsearch.ElasticsearchTimeoutException: timed out during dbq; Will attempt again at next scheduled trigger."
             )
         );
         TransformContext.Listener contextListener = mock(TransformContext.Listener.class);

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerFailureHandlingTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerFailureHandlingTests.java
@@ -770,7 +770,8 @@ public class TransformIndexerFailureHandlingTests extends ESTestCase {
                 "timed out during dbq",
                 Level.WARNING,
                 transformId,
-                "Transform encountered an exception: org.elasticsearch.ElasticsearchTimeoutException: timed out during dbq; Will attempt again at next scheduled trigger."
+                "Transform encountered an exception: org.elasticsearch.ElasticsearchTimeoutException: timed out during dbq;"
+                    + " Will attempt again at next scheduled trigger."
             )
         );
         TransformContext.Listener contextListener = mock(TransformContext.Listener.class);

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerFailureHandlingTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerFailureHandlingTests.java
@@ -8,6 +8,8 @@
 package org.elasticsearch.xpack.transform.transforms;
 
 import org.apache.lucene.search.TotalHits;
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.refresh.RefreshResponse;
 import org.elasticsearch.action.bulk.BulkItemResponse;
@@ -22,7 +24,6 @@ import org.elasticsearch.common.breaker.CircuitBreaker.Durability;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.reindex.BulkByScrollResponse;
-import org.elasticsearch.index.reindex.BulkByScrollTask;
 import org.elasticsearch.index.reindex.DeleteByQueryRequest;
 import org.elasticsearch.script.ScriptException;
 import org.elasticsearch.search.SearchHit;
@@ -41,6 +42,7 @@ import org.elasticsearch.xpack.core.transform.transforms.QueryConfigTests;
 import org.elasticsearch.xpack.core.transform.transforms.SettingsConfig;
 import org.elasticsearch.xpack.core.transform.transforms.SourceConfig;
 import org.elasticsearch.xpack.core.transform.transforms.SyncConfig;
+import org.elasticsearch.xpack.core.transform.transforms.TimeRetentionPolicyConfig;
 import org.elasticsearch.xpack.core.transform.transforms.TimeSyncConfig;
 import org.elasticsearch.xpack.core.transform.transforms.TransformCheckpoint;
 import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
@@ -96,6 +98,8 @@ public class TransformIndexerFailureHandlingTests extends ESTestCase {
 
         private final Function<SearchRequest, SearchResponse> searchFunction;
         private final Function<BulkRequest, BulkResponse> bulkFunction;
+        private final Function<DeleteByQueryRequest, BulkByScrollResponse> deleteByQueryFunction;
+
         private final Consumer<String> failureConsumer;
 
         // used for synchronizing with the test
@@ -115,6 +119,7 @@ public class TransformIndexerFailureHandlingTests extends ESTestCase {
             TransformContext context,
             Function<SearchRequest, SearchResponse> searchFunction,
             Function<BulkRequest, BulkResponse> bulkFunction,
+            Function<DeleteByQueryRequest, BulkByScrollResponse> deleteByQueryFunction,
             Consumer<String> failureConsumer
         ) {
             super(
@@ -134,6 +139,7 @@ public class TransformIndexerFailureHandlingTests extends ESTestCase {
             );
             this.searchFunction = searchFunction;
             this.bulkFunction = bulkFunction;
+            this.deleteByQueryFunction = deleteByQueryFunction;
             this.failureConsumer = failureConsumer;
         }
 
@@ -147,7 +153,8 @@ public class TransformIndexerFailureHandlingTests extends ESTestCase {
 
         @Override
         protected void createCheckpoint(ActionListener<TransformCheckpoint> listener) {
-            listener.onResponse(TransformCheckpoint.EMPTY);
+            final long timestamp = System.currentTimeMillis();
+            listener.onResponse(new TransformCheckpoint(getJobId(), timestamp, 1, Collections.emptyMap(), timestamp));
         }
 
         @Override
@@ -208,12 +215,6 @@ public class TransformIndexerFailureHandlingTests extends ESTestCase {
         }
 
         @Override
-        protected void onFinish(ActionListener<Void> listener) {
-            super.onFinish(listener);
-            listener.onResponse(null);
-        }
-
-        @Override
         protected void onAbort() {
             fail("onAbort should not be called");
         }
@@ -255,15 +256,12 @@ public class TransformIndexerFailureHandlingTests extends ESTestCase {
 
         @Override
         void doDeleteByQuery(DeleteByQueryRequest deleteByQueryRequest, ActionListener<BulkByScrollResponse> responseListener) {
-            responseListener.onResponse(
-                new BulkByScrollResponse(
-                    TimeValue.ZERO,
-                    new BulkByScrollTask.Status(Collections.emptyList(), null),
-                    Collections.emptyList(),
-                    Collections.emptyList(),
-                    false
-                )
-            );
+            try {
+                BulkByScrollResponse response = deleteByQueryFunction.apply(deleteByQueryRequest);
+                responseListener.onResponse(response);
+            } catch (Exception e) {
+                responseListener.onFailure(e);
+            }
         }
 
         @Override
@@ -322,6 +320,7 @@ public class TransformIndexerFailureHandlingTests extends ESTestCase {
             state,
             searchFunction,
             bulkFunction,
+            null,
             null,
             threadPool,
             ThreadPool.Names.GENERIC,
@@ -405,6 +404,7 @@ public class TransformIndexerFailureHandlingTests extends ESTestCase {
             searchFunction,
             bulkFunction,
             null,
+            null,
             threadPool,
             ThreadPool.Names.GENERIC,
             auditor,
@@ -472,6 +472,7 @@ public class TransformIndexerFailureHandlingTests extends ESTestCase {
             state,
             searchFunction,
             bulkFunction,
+            null,
             failureConsumer,
             threadPool,
             ThreadPool.Names.GENERIC,
@@ -542,7 +543,7 @@ public class TransformIndexerFailureHandlingTests extends ESTestCase {
         );
         TransformContext.Listener contextListener = mock(TransformContext.Listener.class);
         TransformContext context = new TransformContext(TransformTaskState.STARTED, "", 0, contextListener);
-        createMockIndexer(config, null, null, null, null, threadPool, ThreadPool.Names.GENERIC, auditor, context);
+        createMockIndexer(config, null, null, null, null, null, threadPool, ThreadPool.Names.GENERIC, auditor, context);
         auditor.assertAllExpectationsMatched();
     }
 
@@ -597,8 +598,210 @@ public class TransformIndexerFailureHandlingTests extends ESTestCase {
         );
         TransformContext.Listener contextListener = mock(TransformContext.Listener.class);
         TransformContext context = new TransformContext(TransformTaskState.STARTED, "", 0, contextListener);
-        createMockIndexer(config, null, null, null, null, threadPool, ThreadPool.Names.GENERIC, auditor, context);
+        createMockIndexer(config, null, null, null, null, null, threadPool, ThreadPool.Names.GENERIC, auditor, context);
         auditor.assertAllExpectationsMatched();
+    }
+
+    public void testRetentionPolicyDeleteByQueryThrowsIrrecoverable() throws Exception {
+        String transformId = randomAlphaOfLength(10);
+        TransformConfig config = new TransformConfig(
+            transformId,
+            randomSourceConfig(),
+            randomDestConfig(),
+            null,
+            null,
+            null,
+            randomPivotConfig(),
+            null,
+            randomBoolean() ? null : randomAlphaOfLengthBetween(1, 1000),
+            null,
+            new TimeRetentionPolicyConfig(randomAlphaOfLength(10), TimeValue.timeValueSeconds(10)),
+            null,
+            null
+        );
+
+        final SearchResponse searchResponse = new SearchResponse(
+            new InternalSearchResponse(
+                new SearchHits(new SearchHit[] { new SearchHit(1) }, new TotalHits(1L, TotalHits.Relation.EQUAL_TO), 1.0f),
+                // Simulate completely null aggs
+                null,
+                new Suggest(Collections.emptyList()),
+                new SearchProfileShardResults(Collections.emptyMap()),
+                false,
+                false,
+                1
+            ),
+            "",
+            1,
+            1,
+            0,
+            0,
+            ShardSearchFailure.EMPTY_ARRAY,
+            SearchResponse.Clusters.EMPTY
+        );
+
+        AtomicReference<IndexerState> state = new AtomicReference<>(IndexerState.STOPPED);
+        Function<SearchRequest, SearchResponse> searchFunction = searchRequest -> searchResponse;
+
+        Function<BulkRequest, BulkResponse> bulkFunction = bulkRequest -> new BulkResponse(new BulkItemResponse[0], 100);
+
+        Function<DeleteByQueryRequest, BulkByScrollResponse> deleteByQueryFunction = deleteByQueryRequest -> {
+            throw new SearchPhaseExecutionException(
+                "query",
+                "Partial shards failure",
+                new ShardSearchFailure[] {
+                    new ShardSearchFailure(
+                        new ElasticsearchParseException("failed to parse date field", new IllegalArgumentException("illegal format"))
+                    ) }
+            );
+        };
+
+        final AtomicBoolean failIndexerCalled = new AtomicBoolean(false);
+        final AtomicReference<String> failureMessage = new AtomicReference<>();
+        Consumer<String> failureConsumer = message -> {
+            failIndexerCalled.compareAndSet(false, true);
+            failureMessage.compareAndSet(null, message);
+        };
+
+        MockTransformAuditor auditor = MockTransformAuditor.createMockAuditor();
+        TransformContext.Listener contextListener = mock(TransformContext.Listener.class);
+        TransformContext context = new TransformContext(TransformTaskState.STARTED, "", 0, contextListener);
+
+        MockedTransformIndexer indexer = createMockIndexer(
+            config,
+            state,
+            searchFunction,
+            bulkFunction,
+            deleteByQueryFunction,
+            failureConsumer,
+            threadPool,
+            ThreadPool.Names.GENERIC,
+            auditor,
+            context
+        );
+
+        final CountDownLatch latch = indexer.newLatch(1);
+
+        indexer.start();
+        assertThat(indexer.getState(), equalTo(IndexerState.STARTED));
+        assertTrue(indexer.maybeTriggerAsyncJob(System.currentTimeMillis()));
+        assertThat(indexer.getState(), equalTo(IndexerState.INDEXING));
+
+        latch.countDown();
+        assertBusy(() -> assertThat(indexer.getState(), equalTo(IndexerState.STARTED)), 10, TimeUnit.SECONDS);
+        assertTrue(failIndexerCalled.get());
+        verify(contextListener, times(1)).fail(
+            matches("task encountered irrecoverable failure: org.elasticsearch.ElasticsearchParseException: failed to parse date field;.*"),
+            any()
+        );
+
+        assertThat(
+            failureMessage.get(),
+            matchesRegex(
+                "task encountered irrecoverable failure: org.elasticsearch.ElasticsearchParseException: failed to parse date field;.*"
+            )
+        );
+    }
+
+    public void testRetentionPolicyDeleteByQueryThrowsTemporaryProblem() throws Exception {
+        String transformId = randomAlphaOfLength(10);
+        TransformConfig config = new TransformConfig(
+            transformId,
+            randomSourceConfig(),
+            randomDestConfig(),
+            null,
+            null,
+            null,
+            randomPivotConfig(),
+            null,
+            randomBoolean() ? null : randomAlphaOfLengthBetween(1, 1000),
+            null,
+            new TimeRetentionPolicyConfig(randomAlphaOfLength(10), TimeValue.timeValueSeconds(10)),
+            null,
+            null
+        );
+
+        final SearchResponse searchResponse = new SearchResponse(
+            new InternalSearchResponse(
+                new SearchHits(new SearchHit[] { new SearchHit(1) }, new TotalHits(1L, TotalHits.Relation.EQUAL_TO), 1.0f),
+                // Simulate completely null aggs
+                null,
+                new Suggest(Collections.emptyList()),
+                new SearchProfileShardResults(Collections.emptyMap()),
+                false,
+                false,
+                1
+            ),
+            "",
+            1,
+            1,
+            0,
+            0,
+            ShardSearchFailure.EMPTY_ARRAY,
+            SearchResponse.Clusters.EMPTY
+        );
+
+        AtomicReference<IndexerState> state = new AtomicReference<>(IndexerState.STOPPED);
+        Function<SearchRequest, SearchResponse> searchFunction = searchRequest -> searchResponse;
+
+        Function<BulkRequest, BulkResponse> bulkFunction = bulkRequest -> new BulkResponse(new BulkItemResponse[0], 100);
+
+        Function<DeleteByQueryRequest, BulkByScrollResponse> deleteByQueryFunction = deleteByQueryRequest -> {
+            throw new SearchPhaseExecutionException(
+                "query",
+                "Partial shards failure",
+                new ShardSearchFailure[] {
+                    new ShardSearchFailure(
+                        new ElasticsearchTimeoutException("timed out during dbq")
+                    ) }
+            );
+        };
+
+        final AtomicBoolean failIndexerCalled = new AtomicBoolean(false);
+        final AtomicReference<String> failureMessage = new AtomicReference<>();
+        Consumer<String> failureConsumer = message -> {
+            failIndexerCalled.compareAndSet(false, true);
+            failureMessage.compareAndSet(null, message);
+        };
+
+        MockTransformAuditor auditor = MockTransformAuditor.createMockAuditor();
+        auditor.addExpectation(
+            new MockTransformAuditor.SeenAuditExpectation(
+                "timed out during dbq",
+                Level.WARNING,
+                transformId,
+                "Transform encountered an exception: org.elasticsearch.ElasticsearchTimeoutException: timed out during dbq Will attempt again at next scheduled trigger."
+            )
+        );
+        TransformContext.Listener contextListener = mock(TransformContext.Listener.class);
+        TransformContext context = new TransformContext(TransformTaskState.STARTED, "", 0, contextListener);
+
+        MockedTransformIndexer indexer = createMockIndexer(
+            config,
+            state,
+            searchFunction,
+            bulkFunction,
+            deleteByQueryFunction,
+            failureConsumer,
+            threadPool,
+            ThreadPool.Names.GENERIC,
+            auditor,
+            context
+        );
+
+        final CountDownLatch latch = indexer.newLatch(1);
+
+        indexer.start();
+        assertThat(indexer.getState(), equalTo(IndexerState.STARTED));
+        assertTrue(indexer.maybeTriggerAsyncJob(System.currentTimeMillis()));
+        assertThat(indexer.getState(), equalTo(IndexerState.INDEXING));
+
+        latch.countDown();
+        assertBusy(() -> assertThat(indexer.getState(), equalTo(IndexerState.STARTED)), 10, TimeUnit.SECONDS);
+        assertFalse(failIndexerCalled.get());
+        assertThat(indexer.getState(), equalTo(IndexerState.STARTED));
+        auditor.assertAllExpectationsMatched();
+        assertEquals(1, context.getFailureCount());
     }
 
     private MockedTransformIndexer createMockIndexer(
@@ -606,6 +809,7 @@ public class TransformIndexerFailureHandlingTests extends ESTestCase {
         AtomicReference<IndexerState> state,
         Function<SearchRequest, SearchResponse> searchFunction,
         Function<BulkRequest, BulkResponse> bulkFunction,
+        Function<DeleteByQueryRequest, BulkByScrollResponse> deleteByQueryFunction,
         Consumer<String> failureConsumer,
         ThreadPool threadPool,
         String executorName,
@@ -626,6 +830,7 @@ public class TransformIndexerFailureHandlingTests extends ESTestCase {
             context,
             searchFunction,
             bulkFunction,
+            deleteByQueryFunction,
             failureConsumer
         );
 


### PR DESCRIPTION
the yet unreleased retention policy feature uses delete by query to delete expired data. In
case of a failure its possible the indexer loops forever trying to finish a checkpoint. This
change has 2 parts: avoid the known misconfiguration that lead to the error, call the error 
handler if retention policy execution fails. This correctly connects the retention policy
execution to failure handling: A permanent error immediately sets the failed state, a
temporary issue enters the retry loop, only ending in failed state after a maximum number
of retries.

fixes #69274

Marking this as "non-issue", because retention policy is an unreleased feature, nevertheless this is a bug fix that should go into 7.12