### PR TITLE
Update Docker image used by minio test fixture to support Arm

### DIFF
--- a/test/fixtures/minio-fixture/Dockerfile
+++ b/test/fixtures/minio-fixture/Dockerfile
@@ -1,4 +1,4 @@
-FROM minio/minio:RELEASE.2019-01-23T23-18-58Z
+FROM minio/minio:RELEASE.2021-03-01T04-20-55Z
 
 ARG bucket
 ARG accessKey


### PR DESCRIPTION
The minio Docker image used by our test fixture used an old tag which didn't support the aarch64 architecture. To be able to test on Arm we need to bump this to a tag which provided an aarch64 image.

Would be nice if docker would fail on `pull` here, instead of just pulling down the `x86_64` image and then failing to execute commands in it.