### PR TITLE
[7.12] [DOCS] Add xref for runtime fields (#69738)

### DIFF
--- a/docs/reference/search/search-your-data/retrieve-selected-fields.asciidoc
+++ b/docs/reference/search/search-your-data/retrieve-selected-fields.asciidoc
@@ -64,7 +64,9 @@ The `fields` parameter allows for retrieving a list of document fields in
 the search response. It consults both the document `_source` and the index
 mappings to return each value in a standardized way that matches its mapping
 type. By default, date fields are formatted according to the
-<<mapping-date-format,date format>> parameter in their mappings.
+<<mapping-date-format,date format>> parameter in their mappings. You can also
+use the `fields` parameter to retrieve <<runtime-retrieving-fields,runtime field
+values>>.
 
 The following search request uses the `fields` parameter to retrieve values
 for the `user.id` field, all fields starting with `http.response.`, and the


### PR DESCRIPTION
Backports the following commits to 7.12:
 - [DOCS] Add xref for runtime fields (#69738)