### PR TITLE
[ML] Improve messages related to assigning machine learning jobs

### DIFF
--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/TooManyJobsIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/TooManyJobsIT.java
@@ -171,13 +171,13 @@ public class TooManyJobsIT extends BaseMlIntegTestCase {
                 if (expectMemoryLimitBeforeCountLimit) {
                     int expectedJobsAlreadyOpenOnNode = (i - 1) / numNodes;
                     assertTrue(detailedMessage,
-                        detailedMessage.endsWith("because this node has insufficient available memory. Available memory for ML [" +
+                        detailedMessage.endsWith("node has insufficient available memory. Available memory for ML [" +
                             maxMlMemoryPerNode + "], memory required by existing jobs [" +
                             (expectedJobsAlreadyOpenOnNode * memoryFootprintPerJob) + "], estimated memory required for this job [" +
-                            memoryFootprintPerJob + "]]"));
+                            memoryFootprintPerJob + "]]."));
                 } else {
-                    assertTrue(detailedMessage, detailedMessage.endsWith("because this node is full. Number of opened jobs [" +
-                        maxNumberOfJobsPerNode + "], xpack.ml.max_open_jobs [" + maxNumberOfJobsPerNode + "]]"));
+                    assertTrue(detailedMessage, detailedMessage.endsWith("node is full. Number of opened jobs [" +
+                        maxNumberOfJobsPerNode + "], xpack.ml.max_open_jobs [" + maxNumberOfJobsPerNode + "]]."));
                 }
                 logger.info("good news everybody --> reached maximum number of allowed opened jobs, after trying to open the {}th job", i);
 

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/TooManyJobsIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/TooManyJobsIT.java
@@ -174,10 +174,10 @@ public class TooManyJobsIT extends BaseMlIntegTestCase {
                         detailedMessage.endsWith("node has insufficient available memory. Available memory for ML [" +
                             maxMlMemoryPerNode + "], memory required by existing jobs [" +
                             (expectedJobsAlreadyOpenOnNode * memoryFootprintPerJob) + "], estimated memory required for this job [" +
-                            memoryFootprintPerJob + "]]."));
+                            memoryFootprintPerJob + "].]"));
                 } else {
                     assertTrue(detailedMessage, detailedMessage.endsWith("node is full. Number of opened jobs [" +
-                        maxNumberOfJobsPerNode + "], xpack.ml.max_open_jobs [" + maxNumberOfJobsPerNode + "]]."));
+                        maxNumberOfJobsPerNode + "], xpack.ml.max_open_jobs [" + maxNumberOfJobsPerNode + "].]"));
                 }
                 logger.info("good news everybody --> reached maximum number of allowed opened jobs, after trying to open the {}th job", i);
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobNodeSelector.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobNodeSelector.java
@@ -59,7 +59,7 @@ public class JobNodeSelector {
     private static String createReason(String job, String node, String msg, Object... params) {
         String preamble =  String.format(
             Locale.ROOT,
-            "Not opening job [%s] on node [%s], because ",
+            "Not opening job [%s] on node [%s]. Reason: ",
             job,
             node);
         return preamble + ParameterizedMessage.format(msg, params);
@@ -93,7 +93,7 @@ public class JobNodeSelector {
             if (MachineLearning.isMlNode(node)) {
                 return (nodeFilter != null) ? nodeFilter.apply(node) : null;
             }
-            return createReason(jobId, nodeNameOrId(node), "this node isn't a ml node.");
+            return createReason(jobId, nodeNameOrId(node), "This node isn't a machine learning node.");
         };
     }
 
@@ -177,7 +177,7 @@ public class JobNodeSelector {
             if (currentLoad.getNumAllocatingJobs() >= maxConcurrentJobAllocations) {
                 reason = createReason(jobId,
                     nodeNameAndMlAttributes(node),
-                    "node exceeds [{}] the maximum number of jobs [{}] in opening state",
+                    "Node exceeds [{}] the maximum number of jobs [{}] in opening state.",
                     currentLoad.getNumAllocatingJobs(),
                     maxConcurrentJobAllocations);
                 logger.trace(reason);
@@ -189,7 +189,7 @@ public class JobNodeSelector {
             if (availableCount == 0) {
                 reason = createReason(jobId,
                     nodeNameAndMlAttributes(node),
-                    "this node is full. Number of opened jobs [{}], {} [{}]",
+                    "This node is full. Number of opened jobs [{}], {} [{}].",
                     currentLoad.getNumAssignedJobs(),
                     MAX_OPEN_JOBS_PER_NODE.getKey(),
                     maxNumberOfOpenJobs);
@@ -216,9 +216,9 @@ public class JobNodeSelector {
                         if (estimatedMemoryFootprint > availableMemory) {
                             reason = createReason(jobId,
                                 nodeNameAndMlAttributes(node),
-                                "this node has insufficient available memory. Available memory for ML [{} ({})], "
+                                "This node has insufficient available memory. Available memory for ML [{} ({})], "
                                     + "memory required by existing jobs [{} ({})], "
-                                    + "estimated memory required for this job [{} ({})]",
+                                    + "estimated memory required for this job [{} ({})].",
                                 currentLoad.getMaxMlMemory(),
                                 ByteSizeValue.ofBytes(currentLoad.getMaxMlMemory()).toString(),
                                 currentLoad.getAssignedJobMemory(),

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsActionTests.java
@@ -92,9 +92,9 @@ public class TransportStartDataFrameAnalyticsActionTests extends ESTestCase {
         assertThat(
             assignment.getExplanation(),
             allOf(
-                containsString("Not opening job [data_frame_id] on node [_node_name0], because this node isn't a ml node."),
-                containsString("Not opening job [data_frame_id] on node [_node_name1], because this node isn't a ml node."),
-                containsString("Not opening job [data_frame_id] on node [_node_name2], because this node isn't a ml node.")));
+                containsString("Not opening job [data_frame_id] on node [_node_name0]. Reason: This node isn't a machine learning node."),
+                containsString("Not opening job [data_frame_id] on node [_node_name1]. Reason: This node isn't a machine learning node."),
+                containsString("Not opening job [data_frame_id] on node [_node_name2]. Reason: This node isn't a machine learning node.")));
     }
 
     // Cannot assign the node because none of the existing nodes is appropriate:

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/JobNodeSelectorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/JobNodeSelectorTests.java
@@ -159,7 +159,7 @@ public class JobNodeSelectorTests extends ESTestCase {
             isMemoryTrackerRecentlyRefreshed,
             false);
         assertNull(result.getExecutorNode());
-        assertThat(result.getExplanation(), containsString("because this node is full. Number of opened jobs ["
+        assertThat(result.getExplanation(), containsString("node is full. Number of opened jobs ["
             + maxRunningJobsPerNode + "], xpack.ml.max_open_jobs [" + maxRunningJobsPerNode + "]"));
     }
 
@@ -187,7 +187,7 @@ public class JobNodeSelectorTests extends ESTestCase {
             isMemoryTrackerRecentlyRefreshed,
             false);
         assertNull(result.getExecutorNode());
-        assertThat(result.getExplanation(), containsString("because this node is full. Number of opened jobs ["
+        assertThat(result.getExplanation(), containsString("node is full. Number of opened jobs ["
             + maxRunningJobsPerNode + "], xpack.ml.max_open_jobs [" + maxRunningJobsPerNode + "]"));
     }
 
@@ -220,7 +220,7 @@ public class JobNodeSelectorTests extends ESTestCase {
             isMemoryTrackerRecentlyRefreshed,
             false);
         assertNull(result.getExecutorNode());
-        assertThat(result.getExplanation(), containsString("because this node has insufficient available memory. "
+        assertThat(result.getExplanation(), containsString("node has insufficient available memory. "
             + "Available memory for ML [" + currentlyRunningJobMemory + " (" + ByteSizeValue.ofBytes(currentlyRunningJobMemory)
             + ")], memory required by existing jobs ["
             + currentlyRunningJobMemory + " (" + ByteSizeValue.ofBytes(currentlyRunningJobMemory)
@@ -277,7 +277,7 @@ public class JobNodeSelectorTests extends ESTestCase {
             isMemoryTrackerRecentlyRefreshed,
             false);
         assertNull(result.getExecutorNode());
-        assertThat(result.getExplanation(), containsString("because this node has insufficient available memory. "
+        assertThat(result.getExplanation(), containsString("node has insufficient available memory. "
             + "Available memory for ML [" + (firstJobTotalMemory - 1) + " (" + ByteSizeValue.ofBytes((firstJobTotalMemory - 1))
             + ")], memory required by existing jobs [0 (0b)], estimated memory required for this job ["
             + firstJobTotalMemory + " (" + ByteSizeValue.ofBytes(firstJobTotalMemory) + ")]"));
@@ -314,7 +314,7 @@ public class JobNodeSelectorTests extends ESTestCase {
             isMemoryTrackerRecentlyRefreshed,
             false);
         assertNull(result.getExecutorNode());
-        assertThat(result.getExplanation(), containsString("because this node has insufficient available memory. "
+        assertThat(result.getExplanation(), containsString("node has insufficient available memory. "
             + "Available memory for ML [" + currentlyRunningJobMemory + " (" + ByteSizeValue.ofBytes(currentlyRunningJobMemory)
             +")], memory required by existing jobs [" + currentlyRunningJobMemory + " (" + ByteSizeValue.ofBytes(currentlyRunningJobMemory)
             +")], estimated memory required for this job [" + JOB_MEMORY_REQUIREMENT.getBytes() + " ("
@@ -347,7 +347,7 @@ public class JobNodeSelectorTests extends ESTestCase {
             isMemoryTrackerRecentlyRefreshed,
             false);
         assertNull(result.getExecutorNode());
-        assertThat(result.getExplanation(), containsString("because this node has insufficient available memory. "
+        assertThat(result.getExplanation(), containsString("node has insufficient available memory. "
             + "Available memory for ML [" + (firstJobTotalMemory - 1) + " (" + ByteSizeValue.ofBytes(firstJobTotalMemory - 1)
             + ")], memory required by existing jobs [0 (0b)], estimated memory required for this job ["
             + firstJobTotalMemory + " (" + ByteSizeValue.ofBytes(firstJobTotalMemory) + ")]"));
@@ -382,7 +382,7 @@ public class JobNodeSelectorTests extends ESTestCase {
             MAX_JOB_BYTES,
             isMemoryTrackerRecentlyRefreshed,
             false);
-        assertTrue(result.getExplanation().contains("because this node isn't a ml node"));
+        assertTrue(result.getExplanation().contains("node isn't a machine learning node"));
         assertNull(result.getExecutorNode());
     }
 
@@ -447,7 +447,7 @@ public class JobNodeSelectorTests extends ESTestCase {
             isMemoryTrackerRecentlyRefreshed,
             false);
         assertNull("no node selected, because OPENING state", result.getExecutorNode());
-        assertTrue(result.getExplanation().contains("because node exceeds [2] the maximum number of jobs [2] in opening state"));
+        assertTrue(result.getExplanation().contains("node exceeds [2] the maximum number of jobs [2] in opening state"));
 
         tasksBuilder = PersistentTasksCustomMetadata.builder(tasks);
         tasksBuilder.reassignTask(MlTasks.jobTaskId(job6.getId()),
@@ -461,7 +461,7 @@ public class JobNodeSelectorTests extends ESTestCase {
             node -> nodeFilter(node, job7));
         result = jobNodeSelector.selectNode(10, 2, 30, MAX_JOB_BYTES, isMemoryTrackerRecentlyRefreshed, false);
         assertNull("no node selected, because stale task", result.getExecutorNode());
-        assertTrue(result.getExplanation().contains("because node exceeds [2] the maximum number of jobs [2] in opening state"));
+        assertTrue(result.getExplanation().contains("node exceeds [2] the maximum number of jobs [2] in opening state"));
 
         tasksBuilder = PersistentTasksCustomMetadata.builder(tasks);
         tasksBuilder.updateTaskState(MlTasks.jobTaskId(job6.getId()), null);
@@ -475,7 +475,7 @@ public class JobNodeSelectorTests extends ESTestCase {
             node -> nodeFilter(node, job7));
         result = jobNodeSelector.selectNode(10, 2, 30, MAX_JOB_BYTES, isMemoryTrackerRecentlyRefreshed, false);
         assertNull("no node selected, because null state", result.getExecutorNode());
-        assertTrue(result.getExplanation().contains("because node exceeds [2] the maximum number of jobs [2] in opening state"));
+        assertTrue(result.getExplanation().contains("node exceeds [2] the maximum number of jobs [2] in opening state"));
     }
 
     public void testSelectLeastLoadedMlNode_concurrentOpeningJobsAndStaleFailedJob() {
@@ -537,7 +537,7 @@ public class JobNodeSelectorTests extends ESTestCase {
             node -> nodeFilter(node, job8));
         result = jobNodeSelector.selectNode(10, 2, 30, MAX_JOB_BYTES, isMemoryTrackerRecentlyRefreshed, false);
         assertNull("no node selected, because OPENING state", result.getExecutorNode());
-        assertTrue(result.getExplanation().contains("because node exceeds [2] the maximum number of jobs [2] in opening state"));
+        assertTrue(result.getExplanation().contains("node exceeds [2] the maximum number of jobs [2] in opening state"));
     }
 
     public void testSelectLeastLoadedMlNode_noCompatibleJobTypeNodes() {
@@ -576,7 +576,7 @@ public class JobNodeSelectorTests extends ESTestCase {
             MAX_JOB_BYTES,
             isMemoryTrackerRecentlyRefreshed,
             false);
-        assertThat(result.getExplanation(), containsString("because this node does not support jobs of type [incompatible_type]"));
+        assertThat(result.getExplanation(), containsString("node does not support jobs of type [incompatible_type]"));
         assertNull(result.getExecutorNode());
     }
 
@@ -614,7 +614,7 @@ public class JobNodeSelectorTests extends ESTestCase {
             isMemoryTrackerRecentlyRefreshed,
             false);
         assertThat(result.getExplanation(), containsString(
-            "because the job's model snapshot requires a node of version [6.3.0] or higher"));
+            "job's model snapshot requires a node of version [6.3.0] or higher"));
         assertNull(result.getExecutorNode());
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/JobNodeSelectorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/JobNodeSelectorTests.java
@@ -447,7 +447,7 @@ public class JobNodeSelectorTests extends ESTestCase {
             isMemoryTrackerRecentlyRefreshed,
             false);
         assertNull("no node selected, because OPENING state", result.getExecutorNode());
-        assertTrue(result.getExplanation().contains("node exceeds [2] the maximum number of jobs [2] in opening state"));
+        assertTrue(result.getExplanation().contains("Node exceeds [2] the maximum number of jobs [2] in opening state"));
 
         tasksBuilder = PersistentTasksCustomMetadata.builder(tasks);
         tasksBuilder.reassignTask(MlTasks.jobTaskId(job6.getId()),
@@ -461,7 +461,7 @@ public class JobNodeSelectorTests extends ESTestCase {
             node -> nodeFilter(node, job7));
         result = jobNodeSelector.selectNode(10, 2, 30, MAX_JOB_BYTES, isMemoryTrackerRecentlyRefreshed, false);
         assertNull("no node selected, because stale task", result.getExecutorNode());
-        assertTrue(result.getExplanation().contains("node exceeds [2] the maximum number of jobs [2] in opening state"));
+        assertTrue(result.getExplanation().contains("Node exceeds [2] the maximum number of jobs [2] in opening state"));
 
         tasksBuilder = PersistentTasksCustomMetadata.builder(tasks);
         tasksBuilder.updateTaskState(MlTasks.jobTaskId(job6.getId()), null);
@@ -475,7 +475,7 @@ public class JobNodeSelectorTests extends ESTestCase {
             node -> nodeFilter(node, job7));
         result = jobNodeSelector.selectNode(10, 2, 30, MAX_JOB_BYTES, isMemoryTrackerRecentlyRefreshed, false);
         assertNull("no node selected, because null state", result.getExecutorNode());
-        assertTrue(result.getExplanation().contains("node exceeds [2] the maximum number of jobs [2] in opening state"));
+        assertTrue(result.getExplanation().contains("Node exceeds [2] the maximum number of jobs [2] in opening state"));
     }
 
     public void testSelectLeastLoadedMlNode_concurrentOpeningJobsAndStaleFailedJob() {
@@ -537,7 +537,7 @@ public class JobNodeSelectorTests extends ESTestCase {
             node -> nodeFilter(node, job8));
         result = jobNodeSelector.selectNode(10, 2, 30, MAX_JOB_BYTES, isMemoryTrackerRecentlyRefreshed, false);
         assertNull("no node selected, because OPENING state", result.getExecutorNode());
-        assertTrue(result.getExplanation().contains("node exceeds [2] the maximum number of jobs [2] in opening state"));
+        assertTrue(result.getExplanation().contains("Node exceeds [2] the maximum number of jobs [2] in opening state"));
     }
 
     public void testSelectLeastLoadedMlNode_noCompatibleJobTypeNodes() {


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/69629

This PR further edits the messages related to assigning machine learning jobs to nodes. In particular, it spells out "ML" and it splits the "reason" for the failure into a separate sentence. IMO the latter makes those strings simpler to translate.