### PR TITLE
[7.x] Add support for regex in REST test warnings and allowed_warnings (#69501)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/README.asciidoc
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/README.asciidoc
@@ -234,8 +234,22 @@ somevalue with whatever is the response in the same position."
 
 === `warnings`
 
-The runner can assert the warnings headers returned by Elasticsearch through the `warning:` assertations
-under `do:`  operations.
+The runner can assert specific warnings headers are returned by Elasticsearch through the `warning:` assertations
+under `do:`  operations. The test will fail if the warning is not found.
+
+=== `warnings_regex`
+
+The same as `warnings`, but matches warning headers with the given regular expression.
+
+
+=== `allowed_warnings`
+
+The runner will allow specific warnings headers to be returned by Elasticsearch through the `allowed_warning:` assertations
+under `do:`  operations. The test will not fail if the warning is not found.
+
+=== `allowed_warnings_regex`
+
+The same as `allowed_warnings`, but matches warning headers with the given regular expression.
 
 === `yaml`
 

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -1606,6 +1606,7 @@ public abstract class ESRestTestCase extends ESTestCase {
         });
     }
 
+    //TODO: replace usages of this with warning_regex or allowed_warnings_regex
     static final Pattern CREATE_INDEX_MULTIPLE_MATCHING_TEMPLATES = Pattern.compile("^index \\[(.+)\\] matches multiple legacy " +
         "templates \\[(.+)\\], composable templates will only match a single template$");
 

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/Features.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/Features.java
@@ -41,7 +41,7 @@ public final class Features {
             "transform_and_set",
             "arbitrary_key",
             "allowed_warnings",
-            "allowed_warnings_regex");
+            "allowed_warnings_regex"));
     private static final String SPI_ON_CLASSPATH_SINCE_JDK_9 = "spi_on_classpath_jdk9";
 
     private Features() {

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/Features.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/Features.java
@@ -35,12 +35,13 @@ public final class Features {
             "stash_in_path",
             "stash_path_replace",
             "warnings",
+            "warnings_regex",
             "yaml",
             "contains",
             "transform_and_set",
             "arbitrary_key",
-            "allowed_warnings"));
-
+            "allowed_warnings",
+            "allowed_warnings_regex");
     private static final String SPI_ON_CLASSPATH_SINCE_JDK_9 = "spi_on_classpath_jdk9";
 
     private Features() {

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/ClientYamlTestSuite.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/ClientYamlTestSuite.java
@@ -153,12 +153,29 @@ public class ClientYamlTestSuite {
                 "section can skip the test at line [" + section.getLocation().lineNumber + "]");
 
         errors = Stream.concat(errors, sections.stream().filter(section -> section instanceof DoSection)
+            .map(section -> (DoSection) section)
+            .filter(section -> false == section.getExpectedWarningHeadersRegex()
+                .isEmpty())
+            .filter(section -> false == hasSkipFeature("warnings_regex", testSection, setupSection, teardownSection))
+            .map(section -> "attempted to add a [do] with a [warnings_regex] section " +
+                "without a corresponding [\"skip\": \"features\": \"warnings_regex\"] so runners that do not support the [warnings_regex] "+
+                "section can skip the test at line [" + section.getLocation().lineNumber + "]"));
+
+        errors = Stream.concat(errors, sections.stream().filter(section -> section instanceof DoSection)
                 .map(section -> (DoSection) section)
                 .filter(section -> false == section.getAllowedWarningHeaders().isEmpty())
                 .filter(section -> false == hasSkipFeature("allowed_warnings", testSection, setupSection, teardownSection))
                 .map(section -> "attempted to add a [do] with a [allowed_warnings] section " +
                     "without a corresponding [\"skip\": \"features\": \"allowed_warnings\"] so runners that do not " +
                     "support the [allowed_warnings] section can skip the test at line [" + section.getLocation().lineNumber + "]"));
+
+        errors = Stream.concat(errors, sections.stream().filter(section -> section instanceof DoSection)
+            .map(section -> (DoSection) section)
+            .filter(section -> false == section.getAllowedWarningHeadersRegex().isEmpty())
+            .filter(section -> false == hasSkipFeature("allowed_warnings_regex", testSection, setupSection, teardownSection))
+            .map(section -> "attempted to add a [do] with a [allowed_warnings_regex] section " +
+                "without a corresponding [\"skip\": \"features\": \"allowed_warnings_regex\"] so runners that do not " +
+                "support the [allowed_warnings_regex] section can skip the test at line [" + section.getLocation().lineNumber + "]"));
 
         errors = Stream.concat(errors, sections.stream().filter(section -> section instanceof DoSection)
             .map(section -> (DoSection) section)

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
@@ -31,6 +31,7 @@ import org.elasticsearch.test.rest.yaml.ClientYamlTestResponseException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -39,11 +40,11 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.unmodifiableList;
 import static java.util.stream.Collectors.toCollection;
-import static java.util.stream.Collectors.toSet;
 import static org.elasticsearch.common.collect.Tuple.tuple;
 import static org.elasticsearch.test.hamcrest.RegexMatcher.matches;
 import static org.hamcrest.Matchers.allOf;
@@ -62,13 +63,16 @@ import static org.junit.Assert.fail;
  *      headers:
  *          Authorization: Basic user:pass
  *          Content-Type: application/json
- *      warnings:
+ *      warnings|warnings_regex:
  *          - Stuff is deprecated, yo
  *          - Don't use deprecated stuff
  *          - Please, stop. It hurts.
- *      allowed_warnings:
+ *          - The non _regex version exact matches against the warning text and no need to worry about escaped quotes or backslashes
+ *          - The _regex version matches against the raw value of the warning text which may include backlashes and quotes escaped
+ *      allowed_warnings|allowed_warnings_regex:
  *          - Maybe this warning shows up
  *          - But it isn't actually required for the test to pass.
+ *          - The non _regex version should be preferred for simplicity and performance.
  *      update:
  *          index:  test_1
  *          type:   test
@@ -86,7 +90,9 @@ public class DoSection implements ExecutableSection {
         NodeSelector nodeSelector = NodeSelector.ANY;
         Map<String, String> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         List<String> expectedWarnings = new ArrayList<>();
+        List<Pattern> expectedWarningsRegex = new ArrayList<>();
         List<String> allowedWarnings = new ArrayList<>();
+        List<Pattern> allowedWarningsRegex = new ArrayList<>();
 
         if (parser.nextToken() != XContentParser.Token.START_OBJECT) {
             throw new IllegalArgumentException("expected [" + XContentParser.Token.START_OBJECT + "], " +
@@ -110,13 +116,29 @@ public class DoSection implements ExecutableSection {
                     if (token != XContentParser.Token.END_ARRAY) {
                         throw new ParsingException(parser.getTokenLocation(), "[warnings] must be a string array but saw [" + token + "]");
                     }
+                } else if ("warnings_regex".equals(currentFieldName)) {
+                    while ((token = parser.nextToken()) == XContentParser.Token.VALUE_STRING) {
+                        expectedWarningsRegex.add(Pattern.compile(parser.text()));
+                    }
+                    if (token != XContentParser.Token.END_ARRAY) {
+                        throw new ParsingException(parser.getTokenLocation(),
+                            "[warnings_regex] must be a string array but saw [" + token + "]");
+                    }
                 } else if ("allowed_warnings".equals(currentFieldName)) {
                     while ((token = parser.nextToken()) == XContentParser.Token.VALUE_STRING) {
                         allowedWarnings.add(parser.text());
                     }
                     if (token != XContentParser.Token.END_ARRAY) {
                         throw new ParsingException(parser.getTokenLocation(),
-                                "[allowed_warnings] must be a string array but saw [" + token + "]");
+                            "[allowed_warnings] must be a string array but saw [" + token + "]");
+                    }
+                } else if ("allowed_warnings_regex".equals(currentFieldName)) {
+                    while ((token = parser.nextToken()) == XContentParser.Token.VALUE_STRING) {
+                        allowedWarningsRegex.add(Pattern.compile(parser.text()));
+                    }
+                    if (token != XContentParser.Token.END_ARRAY) {
+                        throw new ParsingException(parser.getTokenLocation(),
+                            "[allowed_warnings_regex] must be a string array but saw [" + token + "]");
                     }
                 } else {
                     throw new ParsingException(parser.getTokenLocation(), "unknown array [" + currentFieldName + "]");
@@ -178,11 +200,18 @@ public class DoSection implements ExecutableSection {
                     throw new IllegalArgumentException("the warning [" + w + "] was both allowed and expected");
                 }
             }
+            for (Pattern p : expectedWarningsRegex) {
+                if (allowedWarningsRegex.contains(p)) {
+                    throw new IllegalArgumentException("the warning pattern [" + p + "] was both allowed and expected");
+                }
+            }
             apiCallSection.addHeaders(headers);
             apiCallSection.setNodeSelector(nodeSelector);
             doSection.setApiCallSection(apiCallSection);
             doSection.setExpectedWarningHeaders(unmodifiableList(expectedWarnings));
+            doSection.setExpectedWarningHeadersRegex(unmodifiableList(expectedWarningsRegex));
             doSection.setAllowedWarningHeaders(unmodifiableList(allowedWarnings));
+            doSection.setAllowedWarningHeadersRegex(unmodifiableList(allowedWarningsRegex));
         } finally {
             parser.nextToken();
         }
@@ -195,7 +224,9 @@ public class DoSection implements ExecutableSection {
     private String catchParam;
     private ApiCallSection apiCallSection;
     private List<String> expectedWarningHeaders = emptyList();
+    private List<Pattern> expectedWarningHeadersRegex = emptyList();
     private List<String> allowedWarningHeaders = emptyList();
+    private List<Pattern> allowedWarningHeadersRegex = emptyList();
 
     public DoSection(XContentLocation location) {
         this.location = location;
@@ -218,11 +249,21 @@ public class DoSection implements ExecutableSection {
     }
 
     /**
-     * Warning headers that we expect from this response. If the headers don't match exactly this request is considered to have failed.
+     * Warning headers patterns that we expect from this response.
+     * If the headers don't match exactly this request is considered to have failed.
      * Defaults to emptyList.
      */
     List<String> getExpectedWarningHeaders() {
         return expectedWarningHeaders;
+    }
+
+    /**
+     * Warning headers patterns that we expect from this response.
+     * If the headers don't match this request is considered to have failed.
+     * Defaults to emptyList.
+     */
+    List<Pattern> getExpectedWarningHeadersRegex() {
+        return expectedWarningHeadersRegex;
     }
 
     /**
@@ -234,6 +275,14 @@ public class DoSection implements ExecutableSection {
     }
 
     /**
+     * Set the warning headers patterns that we expect from this response. If the headers don't match this request is considered to have
+     * failed. Defaults to emptyList.
+     */
+    void setExpectedWarningHeadersRegex(List<Pattern> expectedWarningHeadersRegex) {
+        this.expectedWarningHeadersRegex = expectedWarningHeadersRegex;
+    }
+
+    /**
      * Warning headers that we allow from this response. These warning
      * headers don't cause the test to fail. Defaults to emptyList.
      */
@@ -242,11 +291,27 @@ public class DoSection implements ExecutableSection {
     }
 
     /**
+     * Warning headers that we allow from this response. These warning
+     * headers don't cause the test to fail. Defaults to emptyList.
+     */
+    List<Pattern> getAllowedWarningHeadersRegex() {
+        return allowedWarningHeadersRegex;
+    }
+
+    /**
      * Set the warning headers that we expect from this response. These
      * warning headers don't cause the test to fail. Defaults to emptyList.
      */
     void setAllowedWarningHeaders(List<String> allowedWarningHeaders) {
         this.allowedWarningHeaders = allowedWarningHeaders;
+    }
+
+    /**
+     * Set the warning headers pattern that we expect from this response. These
+     * warning headers don't cause the test to fail. Defaults to emptyList.
+     */
+    void setAllowedWarningHeadersRegex(List<Pattern> allowedWarningHeadersRegex) {
+        this.allowedWarningHeadersRegex = allowedWarningHeadersRegex;
     }
 
     @Override
@@ -308,13 +373,16 @@ public class DoSection implements ExecutableSection {
         final List<String> unexpected = new ArrayList<>();
         final List<String> unmatched = new ArrayList<>();
         final List<String> missing = new ArrayList<>();
-        Set<String> allowed = allowedWarningHeaders.stream()
-                .map(HeaderWarning::escapeAndEncode)
-                .collect(toSet());
+        final List<String> missingRegex = new ArrayList<>();
         // LinkedHashSet so that missing expected warnings come back in a predictable order which is nice for testing
+        final Set<String> allowed = allowedWarningHeaders.stream()
+                .map(HeaderWarning::escapeAndEncode)
+                .collect(toCollection(LinkedHashSet::new));
+        final Set<Pattern> allowedRegex = new LinkedHashSet<>(allowedWarningHeadersRegex);
         final Set<String> expected = expectedWarningHeaders.stream()
                 .map(HeaderWarning::escapeAndEncode)
                 .collect(toCollection(LinkedHashSet::new));
+        final Set<Pattern> expectedRegex = new LinkedHashSet<>(expectedWarningHeadersRegex);
         for (final String header : warningHeaders) {
             final Matcher matcher = HeaderWarning.WARNING_HEADER_PATTERN.matcher(header);
             final boolean matches = matcher.matches();
@@ -337,7 +405,26 @@ public class DoSection implements ExecutableSection {
                 if (allowed.contains(message)) {
                     continue;
                 }
+
                 if (expected.remove(message)) {
+                    continue;
+                }
+                boolean matchedRegex = false;
+
+                for(Pattern pattern : new HashSet<>(expectedRegex)){
+                    if(pattern.matcher(message).matches()){
+                        matchedRegex = true;
+                        expectedRegex.remove(pattern);
+                        break;
+                    }
+                }
+                for(Pattern pattern : allowedRegex){
+                    if(pattern.matcher(message).matches()){
+                        matchedRegex = true;
+                        break;
+                    }
+                }
+                if (matchedRegex){
                     continue;
                 }
                 unexpected.add(header);
@@ -350,15 +437,24 @@ public class DoSection implements ExecutableSection {
                 missing.add(header);
             }
         }
+        if (expectedRegex.isEmpty() == false) {
+            for (final Pattern headerPattern : expectedRegex) {
+                missingRegex.add(headerPattern.pattern());
+            }
+        }
 
-        if (unexpected.isEmpty() == false || unmatched.isEmpty() == false || missing.isEmpty() == false) {
+        if (unexpected.isEmpty() == false
+            || unmatched.isEmpty() == false
+            || missing.isEmpty() == false
+            || missingRegex.isEmpty() == false) {
             final StringBuilder failureMessage = new StringBuilder();
             appendBadHeaders(failureMessage, unexpected, "got unexpected warning header" + (unexpected.size() > 1 ? "s" : ""));
             appendBadHeaders(failureMessage, unmatched, "got unmatched warning header" + (unmatched.size() > 1 ? "s" : ""));
             appendBadHeaders(failureMessage, missing, "did not get expected warning header" + (missing.size() > 1 ? "s" : ""));
+            appendBadHeaders(failureMessage, missingRegex, "the following regular expression" + (missingRegex.size() > 1 ? "s" : "")
+                + " did not match any warning header");
             fail(failureMessage.toString());
         }
-
     }
 
     private void appendBadHeaders(final StringBuilder sb, final List<String> headers, final String message) {

--- a/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/ClientYamlTestSuiteTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/ClientYamlTestSuiteTests.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -437,6 +438,19 @@ public class ClientYamlTestSuiteTests extends AbstractClientYamlTestFragmentPars
             "at line [" + lineNumber + "]"));
     }
 
+    public void testAddingDoWithWarningRegexWithoutSkipWarnings() {
+        int lineNumber = between(1, 10000);
+        DoSection doSection = new DoSection(new XContentLocation(lineNumber, 0));
+        doSection.setExpectedWarningHeadersRegex(singletonList(Pattern.compile("foo")));
+        doSection.setApiCallSection(new ApiCallSection("test"));
+        ClientYamlTestSuite testSuite = createTestSuite(SkipSection.EMPTY, doSection);
+        Exception e = expectThrows(IllegalArgumentException.class, testSuite::validate);
+        assertThat(e.getMessage(),
+            containsString("api/name:\nattempted to add a [do] with a [warnings_regex] section without a corresponding " +
+            "[\"skip\": \"features\": \"warnings_regex\"] so runners that do not support the [warnings_regex] section can skip the test " +
+            "at line [" + lineNumber + "]"));
+    }
+
     public void testAddingDoWithAllowedWarningWithoutSkipAllowedWarnings() {
         int lineNumber = between(1, 10000);
         DoSection doSection = new DoSection(new XContentLocation(lineNumber, 0));
@@ -447,6 +461,18 @@ public class ClientYamlTestSuiteTests extends AbstractClientYamlTestFragmentPars
         assertThat(e.getMessage(), containsString("api/name:\nattempted to add a [do] with a [allowed_warnings] " +
             "section without a corresponding [\"skip\": \"features\": \"allowed_warnings\"] so runners that do not " +
             "support the [allowed_warnings] section can skip the test at line [" + lineNumber + "]"));
+    }
+
+    public void testAddingDoWithAllowedWarningRegexWithoutSkipAllowedWarnings() {
+        int lineNumber = between(1, 10000);
+        DoSection doSection = new DoSection(new XContentLocation(lineNumber, 0));
+        doSection.setAllowedWarningHeadersRegex(singletonList(Pattern.compile("foo")));
+        doSection.setApiCallSection(new ApiCallSection("test"));
+        ClientYamlTestSuite testSuite = createTestSuite(SkipSection.EMPTY, doSection);
+        Exception e = expectThrows(IllegalArgumentException.class, testSuite::validate);
+        assertThat(e.getMessage(), containsString("api/name:\nattempted to add a [do] with a [allowed_warnings_regex] " +
+            "section without a corresponding [\"skip\": \"features\": \"allowed_warnings_regex\"] so runners that do not " +
+            "support the [allowed_warnings_regex] section can skip the test at line [" + lineNumber + "]"));
     }
 
 
@@ -536,6 +562,15 @@ public class ClientYamlTestSuiteTests extends AbstractClientYamlTestFragmentPars
         doSection.setExpectedWarningHeaders(singletonList("foo"));
         doSection.setApiCallSection(new ApiCallSection("test"));
         SkipSection skipSection = new SkipSection(null, singletonList("warnings"), emptyList(), null);
+        createTestSuite(skipSection, doSection).validate();
+    }
+
+    public void testAddingDoWithWarningRegexWithSkip() {
+        int lineNumber = between(1, 10000);
+        DoSection doSection = new DoSection(new XContentLocation(lineNumber, 0));
+        doSection.setExpectedWarningHeadersRegex(singletonList(Pattern.compile("foo")));
+        doSection.setApiCallSection(new ApiCallSection("test"));
+        SkipSection skipSection = new SkipSection(null, singletonList("warnings_regex"), emptyList(), null);
         createTestSuite(skipSection, doSection).validate();
     }
 

--- a/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/DoSectionTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/DoSectionTests.java
@@ -161,7 +161,7 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
 
         //require multiple header, but none returned (plural error message)
         section = new DoSection(new XContentLocation(1, 1));
-        section.setExpectedWarningHeadersRegex(List.of(Pattern.compile("junk"), Pattern.compile("junk2")));
+        section.setExpectedWarningHeadersRegex(Arrays.asList(Pattern.compile("junk"), Pattern.compile("junk2")));
         DoSection finalSection2 = section;
         error =
             expectThrows(AssertionError.class, () -> finalSection2.checkWarningHeaders(emptyList(), Version.CURRENT));
@@ -185,7 +185,7 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
         section.setExpectedWarningHeadersRegex(singletonList(Pattern.compile("test")));
         DoSection finalSection4 = section;
         error = expectThrows(AssertionError.class, () ->
-            finalSection4.checkWarningHeaders(List.of(testHeader, realisticTestHeader), Version.CURRENT));
+            finalSection4.checkWarningHeaders(Arrays.asList(testHeader, realisticTestHeader), Version.CURRENT));
         assertTrue(error.getMessage().contains("got unexpected warning header") && error.getMessage().contains("precedence during"));
 
         //the non-regex version does not need to worry about escaping since it is an exact match, and the code ensures that both

--- a/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/DoSectionTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/DoSectionTests.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
@@ -51,7 +52,7 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
         }
 
         final String testHeader = HeaderWarning.formatWarning("test");
-        final String anotherHeader = HeaderWarning.formatWarning("another");
+        final String anotherHeader = HeaderWarning.formatWarning("another \"with quotes and \\ backslashes\"");
         final String someMoreHeader = HeaderWarning.formatWarning("some more");
         final String catHeader = HeaderWarning.formatWarning("cat");
         // Any warning headers fail
@@ -80,7 +81,7 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
         }
         {
             final DoSection section = new DoSection(new XContentLocation(1, 1));
-            section.setExpectedWarningHeaders(Arrays.asList("test", "another", "some more"));
+            section.setExpectedWarningHeaders(Arrays.asList("test", "another \"with quotes and \\ backslashes\"", "some more"));
             section.checkWarningHeaders(Arrays.asList(testHeader, anotherHeader, someMoreHeader), Version.CURRENT);
         }
 
@@ -124,6 +125,82 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
             // and don't throw exceptions if we don't receive them
             section.checkWarningHeaders(emptyList(), Version.CURRENT);
         }
+    }
+
+    public void testWarningHeadersRegex() {
+
+        final String testHeader = HeaderWarning.formatWarning("test");
+        final String realisticTestHeader = HeaderWarning.formatWarning("index template [my-it] has index patterns [test-*] matching " +
+            "patterns from existing older templates [global] with patterns (global => [*]); this template [my-it] will take " +
+            "precedence during new index creation");
+        final String testHeaderWithQuotesAndBackslashes = HeaderWarning.formatWarning("test \"with quotes and \\ backslashes\"");
+
+
+        //require header and it matches (basic example)
+        DoSection section = new DoSection(new XContentLocation(1, 1));
+        section.setExpectedWarningHeadersRegex(singletonList(Pattern.compile(".*")));
+        section.checkWarningHeaders(singletonList(testHeader), Version.CURRENT);
+
+        //require header and it matches (realistic example)
+        section = new DoSection(new XContentLocation(1, 1));
+
+
+        section.setExpectedWarningHeadersRegex(
+            singletonList(Pattern.compile("^index template \\[(.+)\\] has index patterns \\[(.+)\\] matching patterns from existing " +
+                "older templates \\[(.+)\\] with patterns \\((.+)\\); this template \\[(.+)\\] will " +
+                "take precedence during new index creation$")));
+        section.checkWarningHeaders(singletonList(realisticTestHeader), Version.CURRENT);
+
+        //require header, but no headers returned
+        section = new DoSection(new XContentLocation(1, 1));
+        section.setExpectedWarningHeadersRegex(singletonList(Pattern.compile("junk")));
+        DoSection finalSection = section;
+        AssertionError error =
+            expectThrows(AssertionError.class, () -> finalSection.checkWarningHeaders(emptyList(), Version.CURRENT));
+        assertEquals("the following regular expression did not match any warning header [\n\tjunk\n]\n", error.getMessage());
+
+        //require multiple header, but none returned (plural error message)
+        section = new DoSection(new XContentLocation(1, 1));
+        section.setExpectedWarningHeadersRegex(List.of(Pattern.compile("junk"), Pattern.compile("junk2")));
+        DoSection finalSection2 = section;
+        error =
+            expectThrows(AssertionError.class, () -> finalSection2.checkWarningHeaders(emptyList(), Version.CURRENT));
+        assertEquals("the following regular expressions did not match any warning header [\n\tjunk\n\tjunk2\n]\n", error.getMessage());
+
+        //require header, got one back, but not matched
+        section = new DoSection(new XContentLocation(1, 1));
+        section.setExpectedWarningHeadersRegex(singletonList(Pattern.compile("junk")));
+        DoSection finalSection3 = section;
+        error = expectThrows(AssertionError.class, () -> finalSection3.checkWarningHeaders(singletonList(testHeader), Version.CURRENT));
+        assertTrue(error.getMessage().contains("got unexpected warning header") && error.getMessage().contains("test"));
+        assertTrue(error.getMessage().contains("the following regular expression did not match any warning header [\n\tjunk\n]\n"));
+
+        //allow header
+        section = new DoSection(new XContentLocation(1, 1));
+        section.setAllowedWarningHeadersRegex(singletonList(Pattern.compile("test")));
+        section.checkWarningHeaders(singletonList(testHeader), Version.CURRENT);
+
+        //allow only one header
+        section = new DoSection(new XContentLocation(1, 1));
+        section.setExpectedWarningHeadersRegex(singletonList(Pattern.compile("test")));
+        DoSection finalSection4 = section;
+        error = expectThrows(AssertionError.class, () ->
+            finalSection4.checkWarningHeaders(List.of(testHeader, realisticTestHeader), Version.CURRENT));
+        assertTrue(error.getMessage().contains("got unexpected warning header") && error.getMessage().contains("precedence during"));
+
+        //the non-regex version does not need to worry about escaping since it is an exact match, and the code ensures that both
+        //sides of the match are escaped the same... however for the regex version, it is done against the raw string minus the
+        //prefix. For example, the raw string looks like this:
+        //299 Elasticsearch-8.0.0-SNAPSHOT-d0ea206e300dab312f47611e22850bf799ca6192 "test"
+        //where 299 Elasticsearch-8.0.0-SNAPSHOT-d0ea206e300dab312f47611e22850bf799ca6192 is the prefix,
+        //so the match is against [test] (no brackets). If the message itself has quotes/backslashes then the raw string will look like:
+        //299 Elasticsearch-8.0.0-SNAPSHOT-d0ea206e300dab312f47611e22850bf799ca6192 "test \"with quotes and \\ backslashes\""
+        //and the match is against [test \"with quotes and \\ backslashes\"] (no brackets) .. so the regex needs account for the extra
+        //backslashes. Escaping escape characters is annoying but it should be very rare and the non-regex version should be preferred
+        section = new DoSection(new XContentLocation(1, 1));
+        section.setAllowedWarningHeadersRegex(singletonList(
+            Pattern.compile("^test \\\\\"with quotes and \\\\\\\\ backslashes\\\\\"$")));
+        section.checkWarningHeaders(singletonList(testHeaderWithQuotesAndBackslashes), Version.CURRENT);
     }
 
     public void testIgnoreTypesWarnings() {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add support for regex in REST test warnings and allowed_warnings (#69501)