### PR TITLE
[DOCS] Fix link in machine learning nightly maintenance setting

### DIFF
--- a/docs/reference/docs/delete-by-query.asciidoc
+++ b/docs/reference/docs/delete-by-query.asciidoc
@@ -114,6 +114,7 @@ shards to become available. Both work exactly the way they work in the
 specify the `scroll` parameter to control how long it keeps the search context
 alive, for example `?scroll=10m`. The default is 5 minutes.
 
+[[docs-delete-by-query-throttle]]
 ===== Throttling delete requests
 
 To control the rate at which delete by query issues batches of delete operations,

--- a/docs/reference/settings/ml-settings.asciidoc
+++ b/docs/reference/settings/ml-settings.asciidoc
@@ -104,12 +104,12 @@ startup are used only after every node in the cluster is running version 7.1 or
 higher. The maximum permitted value is `512`.
 
 `xpack.ml.nightly_maintenance_requests_per_second`::
-(<<cluster-update-settings,Dynamic>>) The rate at which the nightly maintenance task
-deletes expired model snapshots and results. The setting is a proxy to the
-[requests_per_second](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html#_throttling_delete_requests)
-parameter used in the Delete by query requests and controls throttling.
-Valid values must be greater than `0.0` or equal to `-1.0` where `-1.0` means a default value
-is used. Defaults to `-1.0`
+(<<cluster-update-settings,Dynamic>>) The rate at which the nightly maintenance 
+task deletes expired model snapshots and results. The setting is a proxy to the
+<<docs-delete-by-query-throttle,requests_per_second>> parameter used in the 
+delete by query requests and controls throttling. Valid values must be greater 
+than `0.0` or equal to `-1.0` where `-1.0` means a default value is used. 
+Defaults to `-1.0`
 
 `xpack.ml.node_concurrent_job_allocations`::
 (<<cluster-update-settings,Dynamic>>) The maximum number of jobs that can


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/63252

This PR fixes a broken link in the description for the xpack.ml.nightly_maintenance_requests_per_second setting.
