### PR TITLE
Fix lower size bounds in RandomBlobContent*Tests

### DIFF
--- a/x-pack/plugin/snapshot-repo-test-kit/src/test/java/org/elasticsearch/repositories/blobstore/testkit/RandomBlobContentBytesReferenceTests.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/test/java/org/elasticsearch/repositories/blobstore/testkit/RandomBlobContentBytesReferenceTests.java
@@ -46,7 +46,7 @@ public class RandomBlobContentBytesReferenceTests extends ESTestCase {
     }
 
     private static int randomSize() {
-        return between(0, 30000);
+        return between(1, 30000);
     }
 
 }

--- a/x-pack/plugin/snapshot-repo-test-kit/src/test/java/org/elasticsearch/repositories/blobstore/testkit/RandomBlobContentStreamTests.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/test/java/org/elasticsearch/repositories/blobstore/testkit/RandomBlobContentStreamTests.java
@@ -130,7 +130,7 @@ public class RandomBlobContentStreamTests extends ESTestCase {
     }
 
     private static int randomSize() {
-        return between(0, 30000);
+        return between(1, 30000);
     }
 
 }


### PR DESCRIPTION
The repository analyzer does not write empty blobs to the repository,
and we assert that the blobs are nonempty, but the tests randomly check
for the empty case anyway. This commit ensures that the blobs used in
tests are always nonempty.

Relates #67247