### PR TITLE
Fix Incorrect Cast in Bulk Handler Failure Handling (#69773)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BulkProcessorClusterSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BulkProcessorClusterSettingsIT.java
@@ -8,13 +8,17 @@
 
 package org.elasticsearch.action.bulk;
 
+import org.elasticsearch.action.support.AutoCreateIndex;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 import org.elasticsearch.test.ESIntegTestCase.Scope;
 
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 
 @ClusterScope(scope = Scope.TEST, numDataNodes = 0)
 public class BulkProcessorClusterSettingsIT extends ESIntegTestCase {
@@ -40,5 +44,13 @@ public class BulkProcessorClusterSettingsIT extends ESIntegTestCase {
             responses[1].getFailureMessage(),
             equalTo("[wontwork] IndexNotFoundException[no such index [wontwork] and [action.auto_create_index] is [false]]"));
         assertFalse("Operation on existing index should succeed", responses[2].isFailed());
+    }
+
+    public void testIndexWithDisabledAutoCreateIndex() {
+        assertAcked(client().admin().cluster().prepareUpdateSettings().setTransientSettings(Settings.builder()
+                .put(AutoCreateIndex.AUTO_CREATE_INDEX_SETTING.getKey(), randomFrom("-*", "+.*")).build()).get());
+        final BulkItemResponse itemResponse =
+                client().prepareBulk().add(client().prepareIndex("test-index", "type1").setSource("foo", "bar")).get().getItems()[0];
+        assertThat(itemResponse.getFailure().getCause(), instanceOf(IndexNotFoundException.class));
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
@@ -260,7 +260,7 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
                     public void onFailure(Exception e) {
                         final Throwable cause = ExceptionsHelper.unwrapCause(e);
                         if (cause instanceof IndexNotFoundException) {
-                            indicesThatCannotBeCreated.put(index, (IndexNotFoundException) e);
+                            indicesThatCannotBeCreated.put(index, (IndexNotFoundException) cause);
                         }
                         else if ((cause instanceof ResourceAlreadyExistsException) == false) {
                             // fail all requests involving this index, if create didn't work


### PR DESCRIPTION
We need to cast the cause and not the original exception here.

backport of #69773