### PR TITLE
[7.x][Transfrom] prevent transform from looping forever if delete by query fails permanently

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TimeRetentionPolicyConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TimeRetentionPolicyConfig.java
@@ -40,6 +40,7 @@ public class TimeRetentionPolicyConfig implements RetentionPolicyConfig {
         ConstructingObjectParser<TimeRetentionPolicyConfig, Void> parser = new ConstructingObjectParser<>(NAME, lenient, args -> {
             String field = (String) args[0];
             TimeValue maxAge = (TimeValue) args[1];
+
             return new TimeRetentionPolicyConfig(field, maxAge);
         });
         parser.declareString(constructorArg(), TransformField.FIELD);
@@ -74,10 +75,18 @@ public class TimeRetentionPolicyConfig implements RetentionPolicyConfig {
     public ActionRequestValidationException validate(ActionRequestValidationException validationException) {
         if (maxAge.getSeconds() < MIN_AGE_SECONDS) {
             validationException = addValidationError(
-                "retention_policy.time.max_age must be more than " + MIN_AGE_SECONDS + "s, found [" + maxAge + "]",
+                "retention_policy.time.max_age must be greater than " + MIN_AGE_SECONDS + "s, found [" + maxAge + "]",
                 validationException
             );
         }
+
+        if (maxAge.compareTo(TimeValue.MAX_VALUE) > 0) {
+            validationException = addValidationError(
+                "retention_policy.time.max_age must not be greater than [" + TimeValue.MAX_VALUE + "]",
+                validationException
+            );
+        }
+
         return validationException;
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TimeRetentionPolicyConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TimeRetentionPolicyConfigTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.core.transform.transforms;
 
+import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -17,7 +18,10 @@ import java.io.IOException;
 public class TimeRetentionPolicyConfigTests extends AbstractSerializingTestCase<TimeRetentionPolicyConfig> {
 
     public static TimeRetentionPolicyConfig randomTimeRetentionPolicyConfig() {
-        return new TimeRetentionPolicyConfig(randomAlphaOfLengthBetween(1, 10), new TimeValue(randomLongBetween(60000, Long.MAX_VALUE)));
+        return new TimeRetentionPolicyConfig(
+            randomAlphaOfLengthBetween(1, 10),
+            new TimeValue(randomLongBetween(60000, 1_000_000_000L))
+        );
     }
 
     @Override
@@ -33,5 +37,29 @@ public class TimeRetentionPolicyConfigTests extends AbstractSerializingTestCase<
     @Override
     protected Reader<TimeRetentionPolicyConfig> instanceReader() {
         return TimeRetentionPolicyConfig::new;
+    }
+
+    public void testValidationMin() {
+        TimeRetentionPolicyConfig timeRetentionPolicyConfig = new TimeRetentionPolicyConfig(
+            randomAlphaOfLengthBetween(1, 10),
+            TimeValue.timeValueSeconds(10)
+        );
+
+        ActionRequestValidationException e = timeRetentionPolicyConfig.validate(null);
+        assertNotNull(e);
+        assertEquals(1, e.validationErrors().size());
+        assertEquals("retention_policy.time.max_age must be greater than 60s, found [10s]", e.validationErrors().get(0));
+    }
+
+    public void testValidationMax() {
+        TimeRetentionPolicyConfig timeRetentionPolicyConfig = new TimeRetentionPolicyConfig(
+            randomAlphaOfLengthBetween(1, 10),
+            TimeValue.parseTimeValue("600000000000d", "time value")
+        );
+
+        ActionRequestValidationException e = timeRetentionPolicyConfig.validate(null);
+        assertNotNull(e);
+        assertEquals(1, e.validationErrors().size());
+        assertEquals("retention_policy.time.max_age must not be greater than [106751.9d]", e.validationErrors().get(0));
     }
 }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/RetentionPolicyToDeleteByQueryRequestConverter.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/RetentionPolicyToDeleteByQueryRequestConverter.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.transform.transforms;
 
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.reindex.AbstractBulkByScrollRequest;
@@ -26,6 +27,9 @@ import java.time.Instant;
  * All implementations of `retention_policy` are converted to a {@link DeleteByQueryRequest}, which is then executed by the indexer.
  */
 public final class RetentionPolicyToDeleteByQueryRequestConverter {
+
+    private static final String DATE_FORMAT = "strict_date_optional_time";
+    private static final DateFormatter DATE_FORMATER = DateFormatter.forPattern(DATE_FORMAT);
 
     public static class RetentionPolicyException extends ElasticsearchException {
         RetentionPolicyException(String msg, Object... args) {
@@ -92,6 +96,6 @@ public final class RetentionPolicyToDeleteByQueryRequestConverter {
         TransformCheckpoint checkpoint
     ) {
         Instant cutOffDate = Instant.ofEpochMilli(checkpoint.getTimestamp()).minusMillis(config.getMaxAge().getMillis());
-        return QueryBuilders.rangeQuery(config.getField()).lt(cutOffDate.toEpochMilli()).format("epoch_millis");
+        return QueryBuilders.rangeQuery(config.getField()).lt(DATE_FORMATER.format(cutOffDate)).format(DATE_FORMAT);
     }
 }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformContext.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformContext.java
@@ -96,6 +96,10 @@ class TransformContext {
         return numFailureRetries;
     }
 
+    int getFailureCount() {
+        return failureCount.get();
+    }
+
     int getAndIncrementFailureCount() {
         return failureCount.getAndIncrement();
     }

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/RetentionPolicyConfigToDeleteByQueryTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/RetentionPolicyConfigToDeleteByQueryTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.transform.transforms;
 
+import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.RangeQueryBuilder;
@@ -88,8 +89,7 @@ public class RetentionPolicyConfigToDeleteByQueryTests extends ESTestCase {
         QueryBuilder query = deleteByQueryRequest.getSearchRequest().source().query();
         assertThat(query, instanceOf(RangeQueryBuilder.class));
         RangeQueryBuilder rangeQuery = (RangeQueryBuilder) query;
-
-        assertThat(rangeQuery.to(), equalTo(9_940_000L));
+        assertThat(rangeQuery.to(), equalTo(DateFormatter.forPattern("strict_date_optional_time").formatMillis(9_940_000L)));
         assertTrue(rangeQuery.includeLower());
     }
 

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerFailureHandlingTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerFailureHandlingTests.java
@@ -691,14 +691,14 @@ public class TransformIndexerFailureHandlingTests extends ESTestCase {
         assertBusy(() -> assertThat(indexer.getState(), equalTo(IndexerState.STARTED)), 10, TimeUnit.SECONDS);
         assertTrue(failIndexerCalled.get());
         verify(contextListener, times(1)).fail(
-            matches("task encountered irrecoverable failure: org.elasticsearch.ElasticsearchParseException: failed to parse date field;.*"),
+            matches("task encountered irrecoverable failure: ElasticsearchParseException\\[failed to parse date field\\].*"),
             any()
         );
 
         assertThat(
             failureMessage.get(),
             matchesRegex(
-                "task encountered irrecoverable failure: org.elasticsearch.ElasticsearchParseException: failed to parse date field;.*"
+                "task encountered irrecoverable failure: ElasticsearchParseException\\[failed to parse date field\\].*"
             )
         );
     }


### PR DESCRIPTION
the yet unreleased retention policy feature uses delete by query to delete expired data. In
case of a failure its possible the indexer loops forever trying to finish a checkpoint. This
change has 2 parts: avoid the known misconfiguration that lead to the error, call the error
handler if retention policy execution fails. This correctly connects the retention policy
execution to failure handling: A permanent error immediately sets the failed state, a
temporary issue enters the retry loop, only ending in failed state after a maximum number
of retries.

fixes #69274
backport #69741
