### PR TITLE
Reenable SearchableSnapshotsRollingUpgradeIT

### DIFF
--- a/x-pack/qa/rolling-upgrade/build.gradle
+++ b/x-pack/qa/rolling-upgrade/build.gradle
@@ -33,7 +33,9 @@ tasks.register("copyTestNodeKeyMaterial", Copy) {
 
 for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
   String baseName = "v${bwcVersion}"
-  String repositoryPath = "${buildDir}/cluster/shared/repo/${baseName}"
+
+  // SearchableSnapshotsRollingUpgradeIT uses a specific repository to not interfere with other tests
+  String searchableSnapshotRepository = "${buildDir}/cluster/shared/searchable-snapshots-repo/${baseName}"
 
   testClusters {
     "${baseName}" {
@@ -42,7 +44,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
       numberOfNodes = 3
 
       setting 'repositories.url.allowed_urls', 'http://snapshot.test*'
-      setting 'path.repo', repositoryPath
+      setting 'path.repo', "[ \"${buildDir}/cluster/shared/repo/${baseName}\", \"${searchableSnapshotRepository}\" ]"
       setting 'xpack.license.self_generated.type', 'trial'
       setting 'xpack.security.enabled', 'true'
       setting 'xpack.security.transport.ssl.enabled', 'true'
@@ -94,7 +96,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
     dependsOn "copyTestNodeKeyMaterial"
     systemProperty 'tests.rest.suite', 'old_cluster'
     systemProperty 'tests.upgrade_from_version', version.toString().replace('-SNAPSHOT', '')
-    systemProperty 'tests.path.repo', repositoryPath
+    systemProperty 'tests.path.searchable.snapshots.repo', searchableSnapshotRepository
     nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}".allHttpSocketURI.join(",")}")
     nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}".getName()}")
   }
@@ -111,7 +113,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
     systemProperty 'tests.rest.suite', 'mixed_cluster'
     systemProperty 'tests.first_round', 'true'
     systemProperty 'tests.upgrade_from_version', oldVersion
-    systemProperty 'tests.path.repo', repositoryPath
+    systemProperty 'tests.path.searchable.snapshots.repo', searchableSnapshotRepository
     // We only need to run these tests once so we may as well do it when we're two thirds upgraded
     systemProperty 'tests.rest.blacklist', [
       'mixed_cluster/10_basic/Start scroll in mixed cluster on upgraded node that we will continue after upgrade',
@@ -137,7 +139,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
     systemProperty 'tests.rest.suite', 'mixed_cluster'
     systemProperty 'tests.first_round', 'false'
     systemProperty 'tests.upgrade_from_version', oldVersion
-    systemProperty 'tests.path.repo', repositoryPath
+    systemProperty 'tests.path.searchable.snapshots.repo', searchableSnapshotRepository
   }
 
   tasks.register("${baseName}#upgradedClusterTest", StandaloneRestIntegTestTask) {
@@ -150,7 +152,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
     nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}".getName()}")
     systemProperty 'tests.rest.suite', 'upgraded_cluster'
     systemProperty 'tests.upgrade_from_version', oldVersion
-    systemProperty 'tests.path.repo', repositoryPath
+    systemProperty 'tests.path.searchable.snapshots.repo', searchableSnapshotRepository
   }
 
   tasks.register(bwcTaskName(bwcVersion)) {


### PR DESCRIPTION
The test SearchableSnapshotsRollingUpgradeIT caused CI failures at least two times (#69705) since it was merged into master. After looking at all node logs, I wasn't able to determine precisely the cause of the test suite timeout. 

After looking at the code I think it is preferable to use a dedicated path.repo for this test so that it does not interfere with existing and future tests that could wipe the repositories and snapshots of the default path.repo at any time. I also fixed an issue with the storage paramater that should only work starting 7.12.0. Finally, #69704 has been merged and it should provide more information if this test fails again.

Closes #69705

