### PR TITLE
Fix testRestoredIndexManagedByLocalPolicySkipsIllegalActions

### DIFF
--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/SearchableSnapshotActionIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/SearchableSnapshotActionIT.java
@@ -304,9 +304,8 @@ public class SearchableSnapshotActionIT extends ESRestTestCase {
         );
 
         // rolling over the data stream so we can apply the searchable snapshot policy to a backing index that's not the write index
-        for (int i = 0; i < randomIntBetween(5, 10); i++) {
-            indexDocument(client(), dataStream, true);
-        }
+        // indexing only one document as we want only one rollover to be triggered
+        indexDocument(client(), dataStream, true);
 
         String searchableSnapMountedIndexName = SearchableSnapshotAction.FULL_RESTORED_INDEX_PREFIX +
             DataStream.getDefaultBackingIndexName(dataStream, 1L);
@@ -352,6 +351,7 @@ public class SearchableSnapshotActionIT extends ESRestTestCase {
         assertOK(client().performRequest(restoreSnapshot));
 
         assertThat(indexExists(searchableSnapMountedIndexName), is(true));
+        ensureGreen(searchableSnapMountedIndexName);
 
         // the restored index is now managed by the now updated ILM policy and needs to go through the warm and cold phase
         assertBusy(() -> {


### PR DESCRIPTION
This fixes a flakiness that might appear if the data stream ends up being rolled
over multiple times. This would cause later (than the first) generations to be
mounted as searchable snapshots. We didn't expect that (or wait for it) and
when attempting to delete the data stream, these backing indices would not be
able to be deleted as they are still being snapshotted.

The failing exception would be :
"snapshot_in_progress_exception",
"reason":"Cannot delete indices that are being snapshotted:

Fixes https://gradle-enterprise.elastic.co/s/rugtsy4id4e7q
