### PR TITLE
[Tests] Remove deprecation index template from comparison

### DIFF
--- a/modules/transport-netty4/src/javaRestTest/java/org/elasticsearch/rest/Netty4HeadBodyIsEmptyIT.java
+++ b/modules/transport-netty4/src/javaRestTest/java/org/elasticsearch/rest/Netty4HeadBodyIsEmptyIT.java
@@ -128,6 +128,8 @@ public class Netty4HeadBodyIsEmptyIT extends ESRestTestCase {
             builder.endObject();
 
             Request request = new Request("PUT", "/_template/template");
+            // The warnings only need to be checked in FIPS mode because we run default distribution for FIPS,
+            // while the integ-test distribution is used otherwise.
             if (inFipsJvm()) {
                 request.setOptions(expectWarnings(
                     "legacy template [template] has index patterns [*] matching patterns from existing composable templates " +

--- a/modules/transport-netty4/src/javaRestTest/java/org/elasticsearch/rest/Netty4HeadBodyIsEmptyIT.java
+++ b/modules/transport-netty4/src/javaRestTest/java/org/elasticsearch/rest/Netty4HeadBodyIsEmptyIT.java
@@ -131,8 +131,8 @@ public class Netty4HeadBodyIsEmptyIT extends ESRestTestCase {
             if (inFipsJvm()) {
                 request.setOptions(expectWarnings(
                     "legacy template [template] has index patterns [*] matching patterns from existing composable templates " +
-                    "[.deprecation-indexing-template,.slm-history,.triggered_watches,.watch-history-13,.watches,ilm-history,logs," +
-                    "metrics,synthetics] with patterns (.deprecation-indexing-template => [.logs-deprecation-elasticsearch]," +
+                    "[.slm-history,.triggered_watches,.watch-history-13,.watches,ilm-history,logs," +
+                    "metrics,synthetics] with patterns (" +
                     ".slm-history => [.slm-history-5*],.triggered_watches => [.triggered_watches*]," +
                     ".watch-history-13 => [.watcher-history-13*],.watches => [.watches*],ilm-history => [ilm-history-5*]," +
                     "logs => [logs-*-*],metrics => [metrics-*-*],synthetics => [synthetics-*-*]" +


### PR DESCRIPTION
The deprecation index is removed from branch 7.12 (#69537) so is the index template. As such it needs to be removed from the test comparison as well.

Resolves: #66820