### PR TITLE
Extend socket timeout in AbstractUpgradeTestCase

### DIFF
--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/AbstractUpgradeTestCase.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/AbstractUpgradeTestCase.java
@@ -91,6 +91,12 @@ public abstract class AbstractUpgradeTestCase extends ESRestTestCase {
     protected Settings restClientSettings() {
         return Settings.builder()
                 .put(ThreadContext.PREFIX + ".Authorization", BASIC_AUTH_VALUE)
+
+                // increase the timeout here to 90 seconds to handle long waits for a green
+                // cluster health. the waits for green need to be longer than a minute to
+                // account for delayed shards
+                .put(ESRestTestCase.CLIENT_SOCKET_TIMEOUT, "90s")
+
                 .build();
     }
 


### PR DESCRIPTION
Some test suites underneath `AbstractUpgradeTestCase` have a 70s timeout
when waiting for green health, which is longer than the usual socket
timeout of 60s, so a failure yields no useful information. The
longer-than-usual timeout is to allow time for delayed allocation.

This commit extends the timeout to 90s in line with other similar test
cases.

Relates #69704