### PR TITLE
Remove redundant methods from DocumentMapper

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -21,7 +21,6 @@ import org.elasticsearch.index.analysis.IndexAnalyzers;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Map;
 import java.util.stream.Stream;
 
 public class DocumentMapper {
@@ -59,11 +58,11 @@ public class DocumentMapper {
 
         final Collection<String> deleteTombstoneMetadataFields = Arrays.asList(VersionFieldMapper.NAME, IdFieldMapper.NAME,
             SeqNoFieldMapper.NAME, SeqNoFieldMapper.PRIMARY_TERM_NAME, SeqNoFieldMapper.TOMBSTONE_NAME);
-        this.deleteTombstoneMetadataFieldMappers = Stream.of(mapping.metadataMappers)
+        this.deleteTombstoneMetadataFieldMappers = Stream.of(mapping.metadataMappers())
             .filter(field -> deleteTombstoneMetadataFields.contains(field.name())).toArray(MetadataFieldMapper[]::new);
         final Collection<String> noopTombstoneMetadataFields = Arrays.asList(
             VersionFieldMapper.NAME, SeqNoFieldMapper.NAME, SeqNoFieldMapper.PRIMARY_TERM_NAME, SeqNoFieldMapper.TOMBSTONE_NAME);
-        this.noopTombstoneMetadataFieldMappers = Stream.of(mapping.metadataMappers)
+        this.noopTombstoneMetadataFieldMappers = Stream.of(mapping.metadataMappers())
             .filter(field -> noopTombstoneMetadataFields.contains(field.name())).toArray(MetadataFieldMapper[]::new);
     }
 
@@ -75,16 +74,8 @@ public class DocumentMapper {
         return this.type;
     }
 
-    public Map<String, Object> meta() {
-        return mapping().meta;
-    }
-
     public CompressedXContent mappingSource() {
         return this.mappingSource;
-    }
-
-    public RootObjectMapper root() {
-        return mapping().root;
     }
 
     public <T extends MetadataFieldMapper> T metadataMapper(Class<T> type) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -46,7 +46,7 @@ public class DocumentMapper {
                    IndexAnalyzers indexAnalyzers,
                    DocumentParser documentParser,
                    Mapping mapping) {
-        this.type = mapping.root().name();
+        this.type = mapping.getRoot().name();
         this.documentParser = documentParser;
         this.mappingLookup = MappingLookup.fromMapping(mapping, documentParser, indexSettings, indexAnalyzers);
 
@@ -58,11 +58,11 @@ public class DocumentMapper {
 
         final Collection<String> deleteTombstoneMetadataFields = Arrays.asList(VersionFieldMapper.NAME, IdFieldMapper.NAME,
             SeqNoFieldMapper.NAME, SeqNoFieldMapper.PRIMARY_TERM_NAME, SeqNoFieldMapper.TOMBSTONE_NAME);
-        this.deleteTombstoneMetadataFieldMappers = Stream.of(mapping.metadataMappers())
+        this.deleteTombstoneMetadataFieldMappers = Stream.of(mapping.getSortedMetadataMappers())
             .filter(field -> deleteTombstoneMetadataFields.contains(field.name())).toArray(MetadataFieldMapper[]::new);
         final Collection<String> noopTombstoneMetadataFields = Arrays.asList(
             VersionFieldMapper.NAME, SeqNoFieldMapper.NAME, SeqNoFieldMapper.PRIMARY_TERM_NAME, SeqNoFieldMapper.TOMBSTONE_NAME);
-        this.noopTombstoneMetadataFieldMappers = Stream.of(mapping.metadataMappers())
+        this.noopTombstoneMetadataFieldMappers = Stream.of(mapping.getSortedMetadataMappers())
             .filter(field -> noopTombstoneMetadataFields.contains(field.name())).toArray(MetadataFieldMapper[]::new);
     }
 
@@ -79,7 +79,7 @@ public class DocumentMapper {
     }
 
     public <T extends MetadataFieldMapper> T metadataMapper(Class<T> type) {
-        return mapping().metadataMapper(type);
+        return mapping().getMetadataMapperByClass(type);
     }
 
     public SourceFieldMapper sourceMapper() {

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -45,7 +45,7 @@ final class DocumentParser {
 
     ParsedDocument parseDocument(SourceToParse source,
                                  MappingLookup mappingLookup) throws MapperParsingException {
-        return parseDocument(source, mappingLookup.getMapping().metadataMappers(), mappingLookup);
+        return parseDocument(source, mappingLookup.getMapping().getSortedMetadataMappers(), mappingLookup);
     }
 
     ParsedDocument parseDocument(SourceToParse source,
@@ -61,7 +61,7 @@ final class DocumentParser {
                 source,
                 parser);
             validateStart(parser);
-            internalParseDocument(mappingLookup.getMapping().root(), metadataFieldsMappers, context, parser);
+            internalParseDocument(mappingLookup.getMapping().getRoot(), metadataFieldsMappers, context, parser);
             validateEnd(parser);
         } catch (Exception e) {
             throw wrapInMapperParsingException(source, e);
@@ -204,7 +204,7 @@ final class DocumentParser {
         if (dynamicMappers.isEmpty() == false) {
             root = createDynamicUpdate(mappingLookup, dynamicMappers);
         } else {
-            root = mappingLookup.getMapping().root().copyAndReset();
+            root = mappingLookup.getMapping().getRoot().copyAndReset();
         }
         root.addRuntimeFields(dynamicRuntimeFields);
         return mappingLookup.getMapping().mappingUpdate(root);
@@ -220,7 +220,7 @@ final class DocumentParser {
         Iterator<Mapper> dynamicMapperItr = dynamicMappers.iterator();
         List<ObjectMapper> parentMappers = new ArrayList<>();
         Mapper firstUpdate = dynamicMapperItr.next();
-        parentMappers.add(createUpdate(mappingLookup.getMapping().root(), splitAndValidatePath(firstUpdate.name()), 0, firstUpdate));
+        parentMappers.add(createUpdate(mappingLookup.getMapping().getRoot(), splitAndValidatePath(firstUpdate.name()), 0, firstUpdate));
         Mapper previousMapper = null;
         while (dynamicMapperItr.hasNext()) {
             Mapper newMapper = dynamicMapperItr.next();

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -45,7 +45,7 @@ final class DocumentParser {
 
     ParsedDocument parseDocument(SourceToParse source,
                                  MappingLookup mappingLookup) throws MapperParsingException {
-        return parseDocument(source, mappingLookup.getMapping().metadataMappers, mappingLookup);
+        return parseDocument(source, mappingLookup.getMapping().metadataMappers(), mappingLookup);
     }
 
     ParsedDocument parseDocument(SourceToParse source,

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -151,7 +151,7 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
             }
 
         } else {
-            metadataMappers.putAll(existingMapper.mapping().metadataMappersMap);
+            metadataMappers.putAll(existingMapper.mapping().metadataMappersMap());
         }
         return metadataMappers;
     }
@@ -297,7 +297,7 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
 
     private DocumentMapper newDocumentMapper(Mapping mapping, MergeReason reason) {
         DocumentMapper newMapper = new DocumentMapper(indexSettings, indexAnalyzers, documentParser, mapping);
-        newMapper.root().fixRedundantIncludes();
+        newMapper.mapping().root().fixRedundantIncludes();
         newMapper.validate(indexSettings, reason != MergeReason.MAPPING_RECOVERY);
         return newMapper;
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -151,7 +151,7 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
             }
 
         } else {
-            metadataMappers.putAll(existingMapper.mapping().metadataMappersMap());
+            metadataMappers.putAll(existingMapper.mapping().getMetadataMappersMap());
         }
         return metadataMappers;
     }
@@ -297,7 +297,7 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
 
     private DocumentMapper newDocumentMapper(Mapping mapping, MergeReason reason) {
         DocumentMapper newMapper = new DocumentMapper(indexSettings, indexAnalyzers, documentParser, mapping);
-        newMapper.mapping().root().fixRedundantIncludes();
+        newMapper.mapping().getRoot().fixRedundantIncludes();
         newMapper.validate(indexSettings, reason != MergeReason.MAPPING_RECOVERY);
         return newMapper;
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/Mapping.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/Mapping.java
@@ -65,26 +65,36 @@ public final class Mapping implements ToXContentFragment {
         this.meta = meta;
     }
 
-    RootObjectMapper root() {
+    /**
+     * Returns the root object for the current mapping
+     */
+    RootObjectMapper getRoot() {
         return root;
     }
 
-    public Map<String, Object> meta() {
+    /**
+     * Returns the meta section for the current mapping
+     */
+    public Map<String, Object> getMeta() {
         return meta;
     }
 
-    MetadataFieldMapper[] metadataMappers() {
+    MetadataFieldMapper[] getSortedMetadataMappers() {
         return metadataMappers;
     }
 
-    Map<Class<? extends MetadataFieldMapper>, MetadataFieldMapper> metadataMappersMap() {
+    Map<Class<? extends MetadataFieldMapper>, MetadataFieldMapper> getMetadataMappersMap() {
         return metadataMappersMap;
     }
 
-    /** Get the root mapper with the given class. */
+    /** Get the metadata mapper with the given class. */
     @SuppressWarnings("unchecked")
-    <T extends MetadataFieldMapper> T metadataMapper(Class<T> clazz) {
+    <T extends MetadataFieldMapper> T getMetadataMapperByClass(Class<T> clazz) {
         return (T) metadataMappersMap.get(clazz);
+    }
+
+    MetadataFieldMapper getMetadataMapperByName(String mapperName) {
+        return metadataMappersByName.get(mapperName);
     }
 
     void validate(MappingLookup mappers) {
@@ -140,10 +150,6 @@ public final class Mapping implements ToXContentFragment {
         }
 
         return new Mapping(mergedRoot, mergedMetadataMappers.values().toArray(new MetadataFieldMapper[0]), mergedMeta);
-    }
-
-    MetadataFieldMapper getMetadataMapper(String mapperName) {
-        return metadataMappersByName.get(mapperName);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/Mapping.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/Mapping.java
@@ -38,11 +38,11 @@ public final class Mapping implements ToXContentFragment {
         new MetadataFieldMapper[0],
         Collections.emptyMap());
 
-    final RootObjectMapper root;
-    final MetadataFieldMapper[] metadataMappers;
-    final Map<Class<? extends MetadataFieldMapper>, MetadataFieldMapper> metadataMappersMap;
-    final Map<String, MetadataFieldMapper> metadataMappersByName;
-    final Map<String, Object> meta;
+    private final RootObjectMapper root;
+    private final Map<String, Object> meta;
+    private final MetadataFieldMapper[] metadataMappers;
+    private final Map<Class<? extends MetadataFieldMapper>, MetadataFieldMapper> metadataMappersMap;
+    private final Map<String, MetadataFieldMapper> metadataMappersByName;
 
     public Mapping(RootObjectMapper rootObjectMapper, MetadataFieldMapper[] metadataMappers, Map<String, Object> meta) {
         this.metadataMappers = metadataMappers;
@@ -65,9 +65,26 @@ public final class Mapping implements ToXContentFragment {
         this.meta = meta;
     }
 
-    /** Return the root object mapper. */
     RootObjectMapper root() {
         return root;
+    }
+
+    public Map<String, Object> meta() {
+        return meta;
+    }
+
+    MetadataFieldMapper[] metadataMappers() {
+        return metadataMappers;
+    }
+
+    Map<Class<? extends MetadataFieldMapper>, MetadataFieldMapper> metadataMappersMap() {
+        return metadataMappersMap;
+    }
+
+    /** Get the root mapper with the given class. */
+    @SuppressWarnings("unchecked")
+    <T extends MetadataFieldMapper> T metadataMapper(Class<T> clazz) {
+        return (T) metadataMappersMap.get(clazz);
     }
 
     void validate(MappingLookup mappers) {
@@ -82,12 +99,6 @@ public final class Mapping implements ToXContentFragment {
      */
     Mapping mappingUpdate(RootObjectMapper rootObjectMapper) {
         return new Mapping(rootObjectMapper, metadataMappers, meta);
-    }
-
-    /** Get the root mapper with the given class. */
-    @SuppressWarnings("unchecked")
-    <T extends MetadataFieldMapper> T metadataMapper(Class<T> clazz) {
-        return (T) metadataMappersMap.get(clazz);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
@@ -67,12 +67,12 @@ public final class MappingLookup {
         List<ObjectMapper> newObjectMappers = new ArrayList<>();
         List<FieldMapper> newFieldMappers = new ArrayList<>();
         List<FieldAliasMapper> newFieldAliasMappers = new ArrayList<>();
-        for (MetadataFieldMapper metadataMapper : mapping.metadataMappers()) {
+        for (MetadataFieldMapper metadataMapper : mapping.getSortedMetadataMappers()) {
             if (metadataMapper != null) {
                 newFieldMappers.add(metadataMapper);
             }
         }
-        for (Mapper child : mapping.root()) {
+        for (Mapper child : mapping.getRoot()) {
             collect(child, newObjectMappers, newFieldMappers, newFieldAliasMappers);
         }
         return new MappingLookup(
@@ -148,7 +148,7 @@ public final class MappingLookup {
             }
         }
 
-        this.fieldTypeLookup = new FieldTypeLookup(mappers, aliasMappers, mapping.root().runtimeFieldTypes());
+        this.fieldTypeLookup = new FieldTypeLookup(mappers, aliasMappers, mapping.getRoot().runtimeFieldTypes());
         this.fieldMappers = Collections.unmodifiableMap(fieldMappers);
         this.objectMappers = Collections.unmodifiableMap(objects);
     }
@@ -189,7 +189,7 @@ public final class MappingLookup {
     }
 
     private void checkFieldLimit(long limit) {
-        if (fieldMappers.size() + objectMappers.size() - mapping.metadataMappers().length > limit) {
+        if (fieldMappers.size() + objectMappers.size() - mapping.getSortedMetadataMappers().length > limit) {
             throw new IllegalArgumentException("Limit of total fields [" + limit + "] has been exceeded");
         }
     }
@@ -305,7 +305,7 @@ public final class MappingLookup {
     }
 
     public boolean isSourceEnabled() {
-        SourceFieldMapper sfm = mapping.metadataMapper(SourceFieldMapper.class);
+        SourceFieldMapper sfm = mapping.getMetadataMapperByClass(SourceFieldMapper.class);
         return sfm != null && sfm.enabled();
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
@@ -67,12 +67,12 @@ public final class MappingLookup {
         List<ObjectMapper> newObjectMappers = new ArrayList<>();
         List<FieldMapper> newFieldMappers = new ArrayList<>();
         List<FieldAliasMapper> newFieldAliasMappers = new ArrayList<>();
-        for (MetadataFieldMapper metadataMapper : mapping.metadataMappers) {
+        for (MetadataFieldMapper metadataMapper : mapping.metadataMappers()) {
             if (metadataMapper != null) {
                 newFieldMappers.add(metadataMapper);
             }
         }
-        for (Mapper child : mapping.root) {
+        for (Mapper child : mapping.root()) {
             collect(child, newObjectMappers, newFieldMappers, newFieldAliasMappers);
         }
         return new MappingLookup(
@@ -189,7 +189,7 @@ public final class MappingLookup {
     }
 
     private void checkFieldLimit(long limit) {
-        if (fieldMappers.size() + objectMappers.size() - mapping.metadataMappers.length > limit) {
+        if (fieldMappers.size() + objectMappers.size() - mapping.metadataMappers().length > limit) {
             throw new IllegalArgumentException("Limit of total fields [" + limit + "] has been exceeded");
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/ParseContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ParseContext.java
@@ -380,7 +380,7 @@ public abstract class ParseContext {
 
         @Override
         public RootObjectMapper root() {
-            return this.mappingLookup.getMapping().root();
+            return this.mappingLookup.getMapping().getRoot();
         }
 
         @Override
@@ -390,7 +390,7 @@ public abstract class ParseContext {
 
         @Override
         public MetadataFieldMapper getMetadataMapper(String mapperName) {
-            return mappingLookup.getMapping().getMetadataMapper(mapperName);
+            return mappingLookup.getMapping().getMetadataMapperByName(mapperName);
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentMapperTests.java
@@ -65,13 +65,13 @@ public class DocumentMapperTests extends MapperServiceTestCase {
 
     public void testMergeObjectDynamic() throws Exception {
         DocumentMapper mapper = createDocumentMapper(mapping(b -> { }));
-        assertNull(mapper.mapping().root().dynamic());
+        assertNull(mapper.mapping().getRoot().dynamic());
 
         DocumentMapper withDynamicMapper = createDocumentMapper(topMapping(b -> b.field("dynamic", "false")));
-        assertThat(withDynamicMapper.mapping().root().dynamic(), equalTo(ObjectMapper.Dynamic.FALSE));
+        assertThat(withDynamicMapper.mapping().getRoot().dynamic(), equalTo(ObjectMapper.Dynamic.FALSE));
 
         Mapping merged = MapperService.mergeMappings(mapper, withDynamicMapper.mapping(), MergeReason.MAPPING_UPDATE);
-        assertThat(merged.root().dynamic(), equalTo(ObjectMapper.Dynamic.FALSE));
+        assertThat(merged.getRoot().dynamic(), equalTo(ObjectMapper.Dynamic.FALSE));
     }
 
     public void testMergeObjectAndNested() throws Exception {
@@ -220,17 +220,17 @@ public class DocumentMapperTests extends MapperServiceTestCase {
 
     public void testMergeMeta() throws IOException {
         DocumentMapper initMapper = createDocumentMapper(topMapping(b -> b.startObject("_meta").field("foo", "bar").endObject()));
-        assertThat(initMapper.mapping().meta().get("foo"), equalTo("bar"));
+        assertThat(initMapper.mapping().getMeta().get("foo"), equalTo("bar"));
 
         DocumentMapper updatedMapper = createDocumentMapper(fieldMapping(b -> b.field("type", "text")));
 
         Mapping merged = MapperService.mergeMappings(initMapper, updatedMapper.mapping(), MergeReason.MAPPING_UPDATE);
-        assertThat(merged.meta().get("foo"), equalTo("bar"));
+        assertThat(merged.getMeta().get("foo"), equalTo("bar"));
 
         updatedMapper
             = createDocumentMapper(topMapping(b -> b.startObject("_meta").field("foo", "new_bar").endObject()));
         merged = MapperService.mergeMappings(initMapper, updatedMapper.mapping(), MergeReason.MAPPING_UPDATE);
-        assertThat(merged.meta().get("foo"), equalTo("new_bar"));
+        assertThat(merged.getMeta().get("foo"), equalTo("new_bar"));
     }
 
     public void testMergeMetaForIndexTemplate() throws IOException {
@@ -250,11 +250,11 @@ public class DocumentMapperTests extends MapperServiceTestCase {
 
         Map<String, Object> expected = Map.of("field", "value",
             "object", Map.of("field1", "value1", "field2", "value2"));
-        assertThat(initMapper.mapping().meta(), equalTo(expected));
+        assertThat(initMapper.mapping().getMeta(), equalTo(expected));
 
         DocumentMapper updatedMapper = createDocumentMapper(fieldMapping(b -> b.field("type", "text")));
         Mapping merged = MapperService.mergeMappings(initMapper, updatedMapper.mapping(), MergeReason.INDEX_TEMPLATE);
-        assertThat(merged.meta(), equalTo(expected));
+        assertThat(merged.getMeta(), equalTo(expected));
 
         updatedMapper = createDocumentMapper(topMapping(b -> {
             b.startObject("_meta");
@@ -273,6 +273,6 @@ public class DocumentMapperTests extends MapperServiceTestCase {
 
         expected = Map.of("field", "value",
             "object", Map.of("field1", "value1", "field2", "new_value", "field3", "value3"));
-        assertThat(merged.meta(), equalTo(expected));
+        assertThat(merged.getMeta(), equalTo(expected));
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentMapperTests.java
@@ -65,10 +65,10 @@ public class DocumentMapperTests extends MapperServiceTestCase {
 
     public void testMergeObjectDynamic() throws Exception {
         DocumentMapper mapper = createDocumentMapper(mapping(b -> { }));
-        assertNull(mapper.root().dynamic());
+        assertNull(mapper.mapping().root().dynamic());
 
         DocumentMapper withDynamicMapper = createDocumentMapper(topMapping(b -> b.field("dynamic", "false")));
-        assertThat(withDynamicMapper.root().dynamic(), equalTo(ObjectMapper.Dynamic.FALSE));
+        assertThat(withDynamicMapper.mapping().root().dynamic(), equalTo(ObjectMapper.Dynamic.FALSE));
 
         Mapping merged = MapperService.mergeMappings(mapper, withDynamicMapper.mapping(), MergeReason.MAPPING_UPDATE);
         assertThat(merged.root().dynamic(), equalTo(ObjectMapper.Dynamic.FALSE));
@@ -220,17 +220,17 @@ public class DocumentMapperTests extends MapperServiceTestCase {
 
     public void testMergeMeta() throws IOException {
         DocumentMapper initMapper = createDocumentMapper(topMapping(b -> b.startObject("_meta").field("foo", "bar").endObject()));
-        assertThat(initMapper.meta().get("foo"), equalTo("bar"));
+        assertThat(initMapper.mapping().meta().get("foo"), equalTo("bar"));
 
         DocumentMapper updatedMapper = createDocumentMapper(fieldMapping(b -> b.field("type", "text")));
 
         Mapping merged = MapperService.mergeMappings(initMapper, updatedMapper.mapping(), MergeReason.MAPPING_UPDATE);
-        assertThat(merged.meta.get("foo"), equalTo("bar"));
+        assertThat(merged.meta().get("foo"), equalTo("bar"));
 
         updatedMapper
             = createDocumentMapper(topMapping(b -> b.startObject("_meta").field("foo", "new_bar").endObject()));
         merged = MapperService.mergeMappings(initMapper, updatedMapper.mapping(), MergeReason.MAPPING_UPDATE);
-        assertThat(merged.meta.get("foo"), equalTo("new_bar"));
+        assertThat(merged.meta().get("foo"), equalTo("new_bar"));
     }
 
     public void testMergeMetaForIndexTemplate() throws IOException {
@@ -250,11 +250,11 @@ public class DocumentMapperTests extends MapperServiceTestCase {
 
         Map<String, Object> expected = Map.of("field", "value",
             "object", Map.of("field1", "value1", "field2", "value2"));
-        assertThat(initMapper.meta(), equalTo(expected));
+        assertThat(initMapper.mapping().meta(), equalTo(expected));
 
         DocumentMapper updatedMapper = createDocumentMapper(fieldMapping(b -> b.field("type", "text")));
         Mapping merged = MapperService.mergeMappings(initMapper, updatedMapper.mapping(), MergeReason.INDEX_TEMPLATE);
-        assertThat(merged.meta, equalTo(expected));
+        assertThat(merged.meta(), equalTo(expected));
 
         updatedMapper = createDocumentMapper(topMapping(b -> {
             b.startObject("_meta");
@@ -273,6 +273,6 @@ public class DocumentMapperTests extends MapperServiceTestCase {
 
         expected = Map.of("field", "value",
             "object", Map.of("field1", "value1", "field2", "new_value", "field3", "value3"));
-        assertThat(merged.meta, equalTo(expected));
+        assertThat(merged.meta(), equalTo(expected));
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
@@ -657,7 +657,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         assertNotNull(mapping);
         Mapper xMapper = mapping.root().getMapper("x");
         assertNull(xMapper);
-        assertNotNull(mapping.root.getRuntimeFieldType("x.foo"));
+        assertNotNull(mapping.root().getRuntimeFieldType("x.foo"));
     }
 
     public void testMultipleSubfieldMappingUpdate() throws Exception {
@@ -803,7 +803,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         DocumentMapper mapper = createDocumentMapper(topMapping(b -> b.field("dynamic", "runtime")));
         ParsedDocument doc = mapper.parse(source(b -> b.startArray("foo").value(0).value(1).endArray()));
         assertEquals(0, doc.rootDoc().getFields("foo").length);
-        RuntimeFieldType foo = doc.dynamicMappingsUpdate().root.getRuntimeFieldType("foo");
+        RuntimeFieldType foo = doc.dynamicMappingsUpdate().root().getRuntimeFieldType("foo");
         assertEquals("long", foo.typeName());
     }
 
@@ -811,7 +811,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         DocumentMapper mapper = createDocumentMapper(topMapping(b -> b.field("dynamic", "runtime")));
         ParsedDocument doc = mapper.parse(source(b -> b.startArray("foo").value(0.25).value(1.43).endArray()));
         assertEquals(0, doc.rootDoc().getFields("foo").length);
-        RuntimeFieldType foo = doc.dynamicMappingsUpdate().root.getRuntimeFieldType("foo");
+        RuntimeFieldType foo = doc.dynamicMappingsUpdate().root().getRuntimeFieldType("foo");
         assertEquals("double", foo.typeName());
     }
 
@@ -819,7 +819,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         DocumentMapper mapper = createDocumentMapper(topMapping(b -> b.field("dynamic", "runtime")));
         ParsedDocument doc = mapper.parse(source(b -> b.startArray("foo").value("test1").value("test2").endArray()));
         assertEquals(0, doc.rootDoc().getFields("foo").length);
-        RuntimeFieldType foo = doc.dynamicMappingsUpdate().root.getRuntimeFieldType("foo");
+        RuntimeFieldType foo = doc.dynamicMappingsUpdate().root().getRuntimeFieldType("foo");
         assertEquals("keyword", foo.typeName());
     }
 
@@ -827,7 +827,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         DocumentMapper mapper = createDocumentMapper(topMapping(b -> b.field("dynamic", "runtime")));
         ParsedDocument doc = mapper.parse(source(b -> b.startArray("foo").value(true).value(false).endArray()));
         assertEquals(0, doc.rootDoc().getFields("foo").length);
-        RuntimeFieldType foo = doc.dynamicMappingsUpdate().root.getRuntimeFieldType("foo");
+        RuntimeFieldType foo = doc.dynamicMappingsUpdate().root().getRuntimeFieldType("foo");
         assertEquals("boolean", foo.typeName());
     }
 
@@ -835,7 +835,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         DocumentMapper mapper = createDocumentMapper(topMapping(b -> b.field("dynamic", "runtime")));
         ParsedDocument doc = mapper.parse(source(b -> b.startArray("foo").value("2020-12-15").value("2020-12-09").endArray()));
         assertEquals(0, doc.rootDoc().getFields("foo").length);
-        RuntimeFieldType foo = doc.dynamicMappingsUpdate().root.getRuntimeFieldType("foo");
+        RuntimeFieldType foo = doc.dynamicMappingsUpdate().root().getRuntimeFieldType("foo");
         assertEquals("date", foo.typeName());
     }
 
@@ -1331,7 +1331,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         String mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/simple/test-mapping.json");
         DocumentMapper docMapper = createDocumentMapper(mapping);
 
-        assertThat((String) docMapper.meta().get("param1"), equalTo("value1"));
+        assertThat((String) docMapper.mapping().meta().get("param1"), equalTo("value1"));
 
         BytesReference json = new BytesArray(copyToBytesFromClasspath("/org/elasticsearch/index/mapper/simple/test1.json"));
         Document doc = docMapper.parse(new SourceToParse("test", "1", json, XContentType.JSON)).rootDoc();
@@ -1353,11 +1353,11 @@ public class DocumentParserTests extends MapperServiceTestCase {
 
         DocumentMapper docMapper = createDocumentMapper(mapping);
 
-        assertThat((String) docMapper.meta().get("param1"), equalTo("value1"));
+        assertThat((String) docMapper.mapping().meta().get("param1"), equalTo("value1"));
 
         String builtMapping = docMapper.mappingSource().string();
         DocumentMapper builtDocMapper = createDocumentMapper(builtMapping);
-        assertThat((String) builtDocMapper.meta().get("param1"), equalTo("value1"));
+        assertThat((String) builtDocMapper.mapping().meta().get("param1"), equalTo("value1"));
     }
 
     public void testNoDocumentSent() throws Exception {

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
@@ -626,7 +626,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         List<Mapper> updates = Collections.singletonList(new MockFieldMapper("foo"));
         Mapping mapping = DocumentParser.createDynamicUpdate(docMapper.mappers(), updates, Collections.emptyList());
         assertNotNull(mapping);
-        assertNotNull(mapping.root().getMapper("foo"));
+        assertNotNull(mapping.getRoot().getMapper("foo"));
     }
 
     public void testSingleRuntimeFieldMappingUpdate() throws Exception {
@@ -634,8 +634,8 @@ public class DocumentParserTests extends MapperServiceTestCase {
         List<RuntimeFieldType> updates = Collections.singletonList(new TestRuntimeField("foo", "any"));
         Mapping mapping = DocumentParser.createDynamicUpdate(docMapper.mappers(), Collections.emptyList(), updates);
         assertNotNull(mapping);
-        assertNull(mapping.root().getMapper("foo"));
-        assertNotNull(mapping.root().getRuntimeFieldType("foo"));
+        assertNull(mapping.getRoot().getMapper("foo"));
+        assertNotNull(mapping.getRoot().getRuntimeFieldType("foo"));
     }
 
     public void testSubfieldMappingUpdate() throws Exception {
@@ -643,7 +643,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         List<Mapper> updates = Collections.singletonList(new MockFieldMapper("x.foo"));
         Mapping mapping = DocumentParser.createDynamicUpdate(docMapper.mappers(), updates, Collections.emptyList());
         assertNotNull(mapping);
-        Mapper xMapper = mapping.root().getMapper("x");
+        Mapper xMapper = mapping.getRoot().getMapper("x");
         assertNotNull(xMapper);
         assertTrue(xMapper instanceof ObjectMapper);
         assertNotNull(((ObjectMapper)xMapper).getMapper("foo"));
@@ -655,9 +655,9 @@ public class DocumentParserTests extends MapperServiceTestCase {
         List<RuntimeFieldType> updates = Collections.singletonList(new TestRuntimeField("x.foo", "any"));
         Mapping mapping = DocumentParser.createDynamicUpdate(docMapper.mappers(), Collections.emptyList(), updates);
         assertNotNull(mapping);
-        Mapper xMapper = mapping.root().getMapper("x");
+        Mapper xMapper = mapping.getRoot().getMapper("x");
         assertNull(xMapper);
-        assertNotNull(mapping.root().getRuntimeFieldType("x.foo"));
+        assertNotNull(mapping.getRoot().getRuntimeFieldType("x.foo"));
     }
 
     public void testMultipleSubfieldMappingUpdate() throws Exception {
@@ -667,7 +667,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         updates.add(new MockFieldMapper("x.bar"));
         Mapping mapping = DocumentParser.createDynamicUpdate(docMapper.mappers(), updates, Collections.emptyList());
         assertNotNull(mapping);
-        Mapper xMapper = mapping.root().getMapper("x");
+        Mapper xMapper = mapping.getRoot().getMapper("x");
         assertNotNull(xMapper);
         assertTrue(xMapper instanceof ObjectMapper);
         assertNotNull(((ObjectMapper)xMapper).getMapper("foo"));
@@ -680,7 +680,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         List<Mapper> updates = Collections.singletonList(new MockFieldMapper("x.subx.foo"));
         Mapping mapping = DocumentParser.createDynamicUpdate(docMapper.mappers(), updates, Collections.emptyList());
         assertNotNull(mapping);
-        Mapper xMapper = mapping.root().getMapper("x");
+        Mapper xMapper = mapping.getRoot().getMapper("x");
         assertNotNull(xMapper);
         assertTrue(xMapper instanceof ObjectMapper);
         Mapper subxMapper = ((ObjectMapper)xMapper).getMapper("subx");
@@ -696,7 +696,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         updates.add(new MockFieldMapper("x.subx.b"));
         Mapping mapping = DocumentParser.createDynamicUpdate(docMapper.mappers(), updates, Collections.emptyList());
         assertNotNull(mapping);
-        Mapper xMapper = mapping.root().getMapper("x");
+        Mapper xMapper = mapping.getRoot().getMapper("x");
         assertNotNull(xMapper);
         assertTrue(xMapper instanceof ObjectMapper);
         assertNotNull(((ObjectMapper)xMapper).getMapper("a"));
@@ -715,7 +715,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         updates.add(new MockFieldMapper("foo.field"));
         Mapping mapping = DocumentParser.createDynamicUpdate(docMapper.mappers(), updates, Collections.emptyList());
         assertNotNull(mapping);
-        Mapper fooMapper = mapping.root().getMapper("foo");
+        Mapper fooMapper = mapping.getRoot().getMapper("foo");
         assertNotNull(fooMapper);
         assertTrue(fooMapper instanceof ObjectMapper);
         assertNotNull(((ObjectMapper)fooMapper).getMapper("field"));
@@ -803,7 +803,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         DocumentMapper mapper = createDocumentMapper(topMapping(b -> b.field("dynamic", "runtime")));
         ParsedDocument doc = mapper.parse(source(b -> b.startArray("foo").value(0).value(1).endArray()));
         assertEquals(0, doc.rootDoc().getFields("foo").length);
-        RuntimeFieldType foo = doc.dynamicMappingsUpdate().root().getRuntimeFieldType("foo");
+        RuntimeFieldType foo = doc.dynamicMappingsUpdate().getRoot().getRuntimeFieldType("foo");
         assertEquals("long", foo.typeName());
     }
 
@@ -811,7 +811,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         DocumentMapper mapper = createDocumentMapper(topMapping(b -> b.field("dynamic", "runtime")));
         ParsedDocument doc = mapper.parse(source(b -> b.startArray("foo").value(0.25).value(1.43).endArray()));
         assertEquals(0, doc.rootDoc().getFields("foo").length);
-        RuntimeFieldType foo = doc.dynamicMappingsUpdate().root().getRuntimeFieldType("foo");
+        RuntimeFieldType foo = doc.dynamicMappingsUpdate().getRoot().getRuntimeFieldType("foo");
         assertEquals("double", foo.typeName());
     }
 
@@ -819,7 +819,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         DocumentMapper mapper = createDocumentMapper(topMapping(b -> b.field("dynamic", "runtime")));
         ParsedDocument doc = mapper.parse(source(b -> b.startArray("foo").value("test1").value("test2").endArray()));
         assertEquals(0, doc.rootDoc().getFields("foo").length);
-        RuntimeFieldType foo = doc.dynamicMappingsUpdate().root().getRuntimeFieldType("foo");
+        RuntimeFieldType foo = doc.dynamicMappingsUpdate().getRoot().getRuntimeFieldType("foo");
         assertEquals("keyword", foo.typeName());
     }
 
@@ -827,7 +827,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         DocumentMapper mapper = createDocumentMapper(topMapping(b -> b.field("dynamic", "runtime")));
         ParsedDocument doc = mapper.parse(source(b -> b.startArray("foo").value(true).value(false).endArray()));
         assertEquals(0, doc.rootDoc().getFields("foo").length);
-        RuntimeFieldType foo = doc.dynamicMappingsUpdate().root().getRuntimeFieldType("foo");
+        RuntimeFieldType foo = doc.dynamicMappingsUpdate().getRoot().getRuntimeFieldType("foo");
         assertEquals("boolean", foo.typeName());
     }
 
@@ -835,7 +835,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         DocumentMapper mapper = createDocumentMapper(topMapping(b -> b.field("dynamic", "runtime")));
         ParsedDocument doc = mapper.parse(source(b -> b.startArray("foo").value("2020-12-15").value("2020-12-09").endArray()));
         assertEquals(0, doc.rootDoc().getFields("foo").length);
-        RuntimeFieldType foo = doc.dynamicMappingsUpdate().root().getRuntimeFieldType("foo");
+        RuntimeFieldType foo = doc.dynamicMappingsUpdate().getRoot().getRuntimeFieldType("foo");
         assertEquals("date", foo.typeName());
     }
 
@@ -995,7 +995,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
 
         ParsedDocument doc = mapper.parse(source(b -> b.startArray("foo.bar.baz").value(0).value(1).endArray()));
         assertEquals(4, doc.rootDoc().getFields("foo.bar.baz").length);
-        Mapper fooMapper = doc.dynamicMappingsUpdate().root().getMapper("foo");
+        Mapper fooMapper = doc.dynamicMappingsUpdate().getRoot().getMapper("foo");
         assertNotNull(fooMapper);
         assertThat(fooMapper, instanceOf(ObjectMapper.class));
         Mapper barMapper = ((ObjectMapper) fooMapper).getMapper("bar");
@@ -1026,7 +1026,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
 
         ParsedDocument doc = mapper.parse(source(b -> b.startArray("foo.bar.baz").value(0).value(1).endArray()));
         assertEquals(4, doc.rootDoc().getFields("foo.bar.baz").length);
-        Mapper fooMapper = doc.dynamicMappingsUpdate().root().getMapper("foo");
+        Mapper fooMapper = doc.dynamicMappingsUpdate().getRoot().getMapper("foo");
         assertNotNull(fooMapper);
         assertThat(fooMapper, instanceOf(ObjectMapper.class));
         Mapper barMapper = ((ObjectMapper) fooMapper).getMapper("bar");
@@ -1042,7 +1042,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         ParsedDocument doc = mapper.parse(source(b -> b.startArray("field.bar.baz").value(0).value(1).endArray()));
 
         assertEquals(4, doc.rootDoc().getFields("field.bar.baz").length);
-        Mapper fooMapper = doc.dynamicMappingsUpdate().root().getMapper("field");
+        Mapper fooMapper = doc.dynamicMappingsUpdate().getRoot().getMapper("field");
         assertNotNull(fooMapper);
         assertThat(fooMapper, instanceOf(ObjectMapper.class));
         Mapper barMapper = ((ObjectMapper) fooMapper).getMapper("bar");
@@ -1078,7 +1078,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         DocumentMapper mapper = createDocumentMapper(mapping(b -> {}));
         ParsedDocument doc = mapper.parse(source(b -> b.field("foo.bar.baz", 0)));
         assertEquals(2, doc.rootDoc().getFields("foo.bar.baz").length);
-        Mapper fooMapper = doc.dynamicMappingsUpdate().root().getMapper("foo");
+        Mapper fooMapper = doc.dynamicMappingsUpdate().getRoot().getMapper("foo");
         assertNotNull(fooMapper);
         assertThat(fooMapper, instanceOf(ObjectMapper.class));
         Mapper barMapper = ((ObjectMapper) fooMapper).getMapper("bar");
@@ -1109,7 +1109,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
 
         ParsedDocument doc = mapper.parse(source(b -> b.field("foo.bar.baz", 0)));
         assertEquals(2, doc.rootDoc().getFields("foo.bar.baz").length);
-        Mapper fooMapper = doc.dynamicMappingsUpdate().root().getMapper("foo");
+        Mapper fooMapper = doc.dynamicMappingsUpdate().getRoot().getMapper("foo");
         assertNotNull(fooMapper);
         assertThat(fooMapper, instanceOf(ObjectMapper.class));
         Mapper barMapper = ((ObjectMapper) fooMapper).getMapper("bar");
@@ -1124,7 +1124,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", "object")));
         ParsedDocument doc = mapper.parse(source(b -> b.field("field.bar.baz", 0)));
         assertEquals(2, doc.rootDoc().getFields("field.bar.baz").length);
-        Mapper fooMapper = doc.dynamicMappingsUpdate().root().getMapper("field");
+        Mapper fooMapper = doc.dynamicMappingsUpdate().getRoot().getMapper("field");
         assertNotNull(fooMapper);
         assertThat(fooMapper, instanceOf(ObjectMapper.class));
         Mapper barMapper = ((ObjectMapper) fooMapper).getMapper("bar");
@@ -1160,7 +1160,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         DocumentMapper mapper = createDocumentMapper(mapping(b -> {}));
         ParsedDocument doc = mapper.parse(source(b -> b.startObject("foo.bar.baz").field("a", 0).endObject()));
         assertEquals(2, doc.rootDoc().getFields("foo.bar.baz.a").length);
-        Mapper fooMapper = doc.dynamicMappingsUpdate().root().getMapper("foo");
+        Mapper fooMapper = doc.dynamicMappingsUpdate().getRoot().getMapper("foo");
         assertNotNull(fooMapper);
         assertThat(fooMapper, instanceOf(ObjectMapper.class));
         Mapper barMapper = ((ObjectMapper) fooMapper).getMapper("bar");
@@ -1195,7 +1195,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         ParsedDocument doc = mapper.parse(source(b -> b.startObject("foo.bar.baz").field("a", 0).endObject()));
 
         assertEquals(2, doc.rootDoc().getFields("foo.bar.baz.a").length);
-        Mapper fooMapper = doc.dynamicMappingsUpdate().root().getMapper("foo");
+        Mapper fooMapper = doc.dynamicMappingsUpdate().getRoot().getMapper("foo");
         assertNotNull(fooMapper);
         assertThat(fooMapper, instanceOf(ObjectMapper.class));
         Mapper barMapper = ((ObjectMapper) fooMapper).getMapper("bar");
@@ -1213,7 +1213,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", "object")));
         ParsedDocument doc = mapper.parse(source(b -> b.startObject("field.bar.baz").field("a", 0).endObject()));
         assertEquals(2, doc.rootDoc().getFields("field.bar.baz.a").length);
-        Mapper fooMapper = doc.dynamicMappingsUpdate().root().getMapper("field");
+        Mapper fooMapper = doc.dynamicMappingsUpdate().getRoot().getMapper("field");
         assertNotNull(fooMapper);
         assertThat(fooMapper, instanceOf(ObjectMapper.class));
         Mapper barMapper = ((ObjectMapper) fooMapper).getMapper("bar");
@@ -1331,7 +1331,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         String mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/simple/test-mapping.json");
         DocumentMapper docMapper = createDocumentMapper(mapping);
 
-        assertThat((String) docMapper.mapping().meta().get("param1"), equalTo("value1"));
+        assertThat((String) docMapper.mapping().getMeta().get("param1"), equalTo("value1"));
 
         BytesReference json = new BytesArray(copyToBytesFromClasspath("/org/elasticsearch/index/mapper/simple/test1.json"));
         Document doc = docMapper.parse(new SourceToParse("test", "1", json, XContentType.JSON)).rootDoc();
@@ -1353,11 +1353,11 @@ public class DocumentParserTests extends MapperServiceTestCase {
 
         DocumentMapper docMapper = createDocumentMapper(mapping);
 
-        assertThat((String) docMapper.mapping().meta().get("param1"), equalTo("value1"));
+        assertThat((String) docMapper.mapping().getMeta().get("param1"), equalTo("value1"));
 
         String builtMapping = docMapper.mappingSource().string();
         DocumentMapper builtDocMapper = createDocumentMapper(builtMapping);
-        assertThat((String) builtDocMapper.mapping().meta().get("param1"), equalTo("value1"));
+        assertThat((String) builtDocMapper.mapping().getMeta().get("param1"), equalTo("value1"));
     }
 
     public void testNoDocumentSent() throws Exception {
@@ -1559,7 +1559,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         ParsedDocument doc = mapper.parse(source(b -> b.field("foo", "2016")));
         Mapping update = doc.dynamicMappingsUpdate();
         assertNotNull(update);
-        Mapper dateMapper = update.root().getMapper("foo");
+        Mapper dateMapper = update.getRoot().getMapper("foo");
         assertNotNull(dateMapper);
         assertThat(dateMapper, not(instanceOf(DateFieldMapper.class)));
     }
@@ -1571,7 +1571,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         ParsedDocument doc = mapper.parse(source(b -> b.field("foo", "2016 12")));
         Mapping update = doc.dynamicMappingsUpdate();
         assertNotNull(update);
-        Mapper dateMapper = update.root().getMapper("foo");
+        Mapper dateMapper = update.getRoot().getMapper("foo");
         assertNotNull(dateMapper);
         assertThat(dateMapper, instanceOf(DateFieldMapper.class));
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/DynamicMappingTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DynamicMappingTests.java
@@ -193,12 +193,12 @@ public class DynamicMappingTests extends MapperServiceTestCase {
         ParsedDocument doc = mapperService.documentMapper().parse(source(b -> b.field("test", "value")));
         assertEquals("{\"_doc\":{\"properties\":{" +
             "\"test\":{\"type\":\"text\",\"fields\":{\"keyword\":{\"type\":\"keyword\",\"ignore_above\":256}}}}}}",
-            Strings.toString(doc.dynamicMappingsUpdate().root()));
+            Strings.toString(doc.dynamicMappingsUpdate().getRoot()));
         merge(mapperService, dynamicMapping(doc.dynamicMappingsUpdate()));
         Mapping merged = mapperService.documentMapper().mapping();
-        assertNotNull(merged.root().getMapper("test"));
-        assertEquals(1, merged.root().runtimeFieldTypes().size());
-        assertNotNull(merged.root().getRuntimeFieldType("field"));
+        assertNotNull(merged.getRoot().getMapper("test"));
+        assertEquals(1, merged.getRoot().runtimeFieldTypes().size());
+        assertNotNull(merged.getRoot().getRuntimeFieldType("field"));
     }
 
     public void testDynamicUpdateWithRuntimeFieldDottedName() throws Exception {
@@ -209,7 +209,7 @@ public class DynamicMappingTests extends MapperServiceTestCase {
             b.field("field", "value");
             b.endObject().endObject().endObject();
         }));
-        RootObjectMapper root = doc.dynamicMappingsUpdate().root();
+        RootObjectMapper root = doc.dynamicMappingsUpdate().getRoot();
         assertEquals(0, root.runtimeFieldTypes().size());
         {
             //the runtime field is defined but the object structure is not, hence it is defined under properties
@@ -225,7 +225,7 @@ public class DynamicMappingTests extends MapperServiceTestCase {
         merge(mapperService, dynamicMapping(doc.dynamicMappingsUpdate()));
         Mapping merged = mapperService.documentMapper().mapping();
         {
-            Mapper path1 = merged.root().getMapper("path1");
+            Mapper path1 = merged.getRoot().getMapper("path1");
             assertThat(path1, instanceOf(ObjectMapper.class));
             Mapper path2 = ((ObjectMapper) path1).getMapper("path2");
             assertThat(path2, instanceOf(ObjectMapper.class));
@@ -233,8 +233,8 @@ public class DynamicMappingTests extends MapperServiceTestCase {
             assertThat(path3, instanceOf(ObjectMapper.class));
             assertFalse(path3.iterator().hasNext());
         }
-        assertEquals(1, merged.root().runtimeFieldTypes().size());
-        assertNotNull(merged.root().getRuntimeFieldType("path1.path2.path3.field"));
+        assertEquals(1, merged.getRoot().runtimeFieldTypes().size());
+        assertNotNull(merged.getRoot().getRuntimeFieldType("path1.path2.path3.field"));
     }
 
     public void testIncremental() throws Exception {
@@ -469,10 +469,10 @@ public class DynamicMappingTests extends MapperServiceTestCase {
             source, builder.contentType()));
         Mapping update = parsedDocument.dynamicMappingsUpdate();
         assertNotNull(update);
-        assertThat(((FieldMapper) update.root().getMapper("foo")).fieldType().typeName(), equalTo("float"));
-        assertThat(((FieldMapper) update.root().getMapper("bar")).fieldType().typeName(), equalTo("float"));
-        assertThat(((FieldMapper) update.root().getMapper("baz")).fieldType().typeName(), equalTo("float"));
-        assertThat(((FieldMapper) update.root().getMapper("quux")).fieldType().typeName(), equalTo("float"));
+        assertThat(((FieldMapper) update.getRoot().getMapper("foo")).fieldType().typeName(), equalTo("float"));
+        assertThat(((FieldMapper) update.getRoot().getMapper("bar")).fieldType().typeName(), equalTo("float"));
+        assertThat(((FieldMapper) update.getRoot().getMapper("baz")).fieldType().typeName(), equalTo("float"));
+        assertThat(((FieldMapper) update.getRoot().getMapper("quux")).fieldType().typeName(), equalTo("float"));
     }
 
     public void testNumericDetectionEnabled() throws Exception {

--- a/server/src/test/java/org/elasticsearch/index/mapper/DynamicMappingTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DynamicMappingTests.java
@@ -193,12 +193,12 @@ public class DynamicMappingTests extends MapperServiceTestCase {
         ParsedDocument doc = mapperService.documentMapper().parse(source(b -> b.field("test", "value")));
         assertEquals("{\"_doc\":{\"properties\":{" +
             "\"test\":{\"type\":\"text\",\"fields\":{\"keyword\":{\"type\":\"keyword\",\"ignore_above\":256}}}}}}",
-            Strings.toString(doc.dynamicMappingsUpdate().root));
+            Strings.toString(doc.dynamicMappingsUpdate().root()));
         merge(mapperService, dynamicMapping(doc.dynamicMappingsUpdate()));
         Mapping merged = mapperService.documentMapper().mapping();
-        assertNotNull(merged.root.getMapper("test"));
-        assertEquals(1, merged.root.runtimeFieldTypes().size());
-        assertNotNull(merged.root.getRuntimeFieldType("field"));
+        assertNotNull(merged.root().getMapper("test"));
+        assertEquals(1, merged.root().runtimeFieldTypes().size());
+        assertNotNull(merged.root().getRuntimeFieldType("field"));
     }
 
     public void testDynamicUpdateWithRuntimeFieldDottedName() throws Exception {
@@ -209,7 +209,7 @@ public class DynamicMappingTests extends MapperServiceTestCase {
             b.field("field", "value");
             b.endObject().endObject().endObject();
         }));
-        RootObjectMapper root = doc.dynamicMappingsUpdate().root;
+        RootObjectMapper root = doc.dynamicMappingsUpdate().root();
         assertEquals(0, root.runtimeFieldTypes().size());
         {
             //the runtime field is defined but the object structure is not, hence it is defined under properties
@@ -225,7 +225,7 @@ public class DynamicMappingTests extends MapperServiceTestCase {
         merge(mapperService, dynamicMapping(doc.dynamicMappingsUpdate()));
         Mapping merged = mapperService.documentMapper().mapping();
         {
-            Mapper path1 = merged.root.getMapper("path1");
+            Mapper path1 = merged.root().getMapper("path1");
             assertThat(path1, instanceOf(ObjectMapper.class));
             Mapper path2 = ((ObjectMapper) path1).getMapper("path2");
             assertThat(path2, instanceOf(ObjectMapper.class));
@@ -233,8 +233,8 @@ public class DynamicMappingTests extends MapperServiceTestCase {
             assertThat(path3, instanceOf(ObjectMapper.class));
             assertFalse(path3.iterator().hasNext());
         }
-        assertEquals(1, merged.root.runtimeFieldTypes().size());
-        assertNotNull(merged.root.getRuntimeFieldType("path1.path2.path3.field"));
+        assertEquals(1, merged.root().runtimeFieldTypes().size());
+        assertNotNull(merged.root().getRuntimeFieldType("path1.path2.path3.field"));
     }
 
     public void testIncremental() throws Exception {

--- a/server/src/test/java/org/elasticsearch/index/mapper/MappingParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/MappingParserTests.java
@@ -56,7 +56,7 @@ public class MappingParserTests extends MapperServiceTestCase {
         });
         Mapping mapping = createMappingParser(Settings.EMPTY).parse("_doc", new CompressedXContent(BytesReference.bytes(builder)));
 
-        Mapper object = mapping.root().getMapper("foo");
+        Mapper object = mapping.getRoot().getMapper("foo");
         assertThat(object, CoreMatchers.instanceOf(ObjectMapper.class));
         ObjectMapper objectMapper = (ObjectMapper) object;
         assertNotNull(objectMapper.getMapper("bar"));

--- a/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperTests.java
@@ -111,14 +111,11 @@ public class ObjectMapperTests extends MapperServiceTestCase {
         MergeReason reason = randomFrom(MergeReason.values());
         MapperService mapperService = createMapperService(fieldMapping(b -> b.field("type", "keyword")));
         DocumentMapper mapper = mapperService.documentMapper();
-        assertNull(mapper.root().dynamic());
-        // Call mapperService.merge directly here, because we may randomly pick PREFLIGHT_CHECK
-        // as a merge reason, in which case the mapper does not get updated in-place.
-        mapper = mapperService.merge(
-            "_doc",
-            new CompressedXContent(BytesReference.bytes(topMapping(b -> b.field("dynamic", "strict")))),
-            reason);
-        assertEquals(Dynamic.STRICT, mapper.root().dynamic());
+        assertNull(mapper.mapping().root().dynamic());
+        Mapping mergeWith = mapperService.parseMapping("_doc",
+            new CompressedXContent(BytesReference.bytes(topMapping(b -> b.field("dynamic", "strict")))));
+        Mapping merged = mapper.mapping().merge(mergeWith, reason);
+        assertEquals(Dynamic.STRICT, merged.root().dynamic());
     }
 
     public void testMergeEnabledForIndexTemplates() throws IOException {
@@ -133,7 +130,7 @@ public class ObjectMapperTests extends MapperServiceTestCase {
         }));
 
         DocumentMapper mapper = mapperService.documentMapper();
-        assertNull(mapper.root().dynamic());
+        assertNull(mapper.mapping().root().dynamic());
 
         // If we don't explicitly set 'enabled', then the mapping should not change.
         String update = Strings.toString(XContentFactory.jsonBuilder().startObject()

--- a/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperTests.java
@@ -111,11 +111,11 @@ public class ObjectMapperTests extends MapperServiceTestCase {
         MergeReason reason = randomFrom(MergeReason.values());
         MapperService mapperService = createMapperService(fieldMapping(b -> b.field("type", "keyword")));
         DocumentMapper mapper = mapperService.documentMapper();
-        assertNull(mapper.mapping().root().dynamic());
+        assertNull(mapper.mapping().getRoot().dynamic());
         Mapping mergeWith = mapperService.parseMapping("_doc",
             new CompressedXContent(BytesReference.bytes(topMapping(b -> b.field("dynamic", "strict")))));
         Mapping merged = mapper.mapping().merge(mergeWith, reason);
-        assertEquals(Dynamic.STRICT, merged.root().dynamic());
+        assertEquals(Dynamic.STRICT, merged.getRoot().dynamic());
     }
 
     public void testMergeEnabledForIndexTemplates() throws IOException {
@@ -130,7 +130,7 @@ public class ObjectMapperTests extends MapperServiceTestCase {
         }));
 
         DocumentMapper mapper = mapperService.documentMapper();
-        assertNull(mapper.mapping().root().dynamic());
+        assertNull(mapper.mapping().getRoot().dynamic());
 
         // If we don't explicitly set 'enabled', then the mapping should not change.
         String update = Strings.toString(XContentFactory.jsonBuilder().startObject()

--- a/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldMapperTests.java
@@ -325,7 +325,7 @@ public class RangeFieldMapperTests extends AbstractNumericFieldMapperTestCase {
     public void testSerializeDefaults() throws Exception {
         for (String type : types()) {
             DocumentMapper docMapper = createDocumentMapper(fieldMapping(b -> b.field("type", type)));
-            RangeFieldMapper mapper = (RangeFieldMapper) docMapper.root().getMapper("field");
+            RangeFieldMapper mapper = (RangeFieldMapper) docMapper.mapping().root().getMapper("field");
             XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
             mapper.doXContentBody(builder, true, ToXContent.EMPTY_PARAMS);
             String got = Strings.toString(builder.endObject());

--- a/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldMapperTests.java
@@ -325,7 +325,7 @@ public class RangeFieldMapperTests extends AbstractNumericFieldMapperTestCase {
     public void testSerializeDefaults() throws Exception {
         for (String type : types()) {
             DocumentMapper docMapper = createDocumentMapper(fieldMapping(b -> b.field("type", type)));
-            RangeFieldMapper mapper = (RangeFieldMapper) docMapper.mapping().root().getMapper("field");
+            RangeFieldMapper mapper = (RangeFieldMapper) docMapper.mapping().getRoot().getMapper("field");
             XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
             mapper.doXContentBody(builder, true, ToXContent.EMPTY_PARAMS);
             String got = Strings.toString(builder.endObject());

--- a/server/src/test/java/org/elasticsearch/index/mapper/RootObjectMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RootObjectMapperTests.java
@@ -195,7 +195,7 @@ public class RootObjectMapperTests extends MapperServiceTestCase {
         DocumentMapper mapper = mapperService.merge(MapperService.SINGLE_MAPPING_NAME,
             new CompressedXContent(mapping), MergeReason.INDEX_TEMPLATE);
 
-        DynamicTemplate[] templates = mapper.root().dynamicTemplates();
+        DynamicTemplate[] templates = mapper.mapping().root().dynamicTemplates();
         assertEquals(2, templates.length);
         assertEquals("first_template", templates[0].name());
         assertEquals("first", templates[0].pathMatch());
@@ -225,7 +225,7 @@ public class RootObjectMapperTests extends MapperServiceTestCase {
         .endObject());
         mapper = mapperService.merge(MapperService.SINGLE_MAPPING_NAME, new CompressedXContent(mapping), MergeReason.INDEX_TEMPLATE);
 
-        templates = mapper.root().dynamicTemplates();
+        templates = mapper.mapping().root().dynamicTemplates();
         assertEquals(3, templates.length);
         assertEquals("first_template", templates[0].name());
         assertEquals("first", templates[0].pathMatch());
@@ -575,7 +575,7 @@ public class RootObjectMapperTests extends MapperServiceTestCase {
             assertThat(field, instanceOf(LongScriptFieldType.class));
             assertNull(mapperService.fieldType("another_field"));
             assertEquals("{\"_doc\":{\"runtime\":{\"field\":{\"type\":\"long\"}},\"properties\":{\"concrete\":{\"type\":\"keyword\"}}}}",
-                Strings.toString(mapperService.documentMapper().mapping().root));
+                Strings.toString(mapperService.documentMapper().mapping().root()));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/RootObjectMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RootObjectMapperTests.java
@@ -195,7 +195,7 @@ public class RootObjectMapperTests extends MapperServiceTestCase {
         DocumentMapper mapper = mapperService.merge(MapperService.SINGLE_MAPPING_NAME,
             new CompressedXContent(mapping), MergeReason.INDEX_TEMPLATE);
 
-        DynamicTemplate[] templates = mapper.mapping().root().dynamicTemplates();
+        DynamicTemplate[] templates = mapper.mapping().getRoot().dynamicTemplates();
         assertEquals(2, templates.length);
         assertEquals("first_template", templates[0].name());
         assertEquals("first", templates[0].pathMatch());
@@ -225,7 +225,7 @@ public class RootObjectMapperTests extends MapperServiceTestCase {
         .endObject());
         mapper = mapperService.merge(MapperService.SINGLE_MAPPING_NAME, new CompressedXContent(mapping), MergeReason.INDEX_TEMPLATE);
 
-        templates = mapper.mapping().root().dynamicTemplates();
+        templates = mapper.mapping().getRoot().dynamicTemplates();
         assertEquals(3, templates.length);
         assertEquals("first_template", templates[0].name());
         assertEquals("first", templates[0].pathMatch());
@@ -575,7 +575,7 @@ public class RootObjectMapperTests extends MapperServiceTestCase {
             assertThat(field, instanceOf(LongScriptFieldType.class));
             assertNull(mapperService.fieldType("another_field"));
             assertEquals("{\"_doc\":{\"runtime\":{\"field\":{\"type\":\"long\"}},\"properties\":{\"concrete\":{\"type\":\"keyword\"}}}}",
-                Strings.toString(mapperService.documentMapper().mapping().root()));
+                Strings.toString(mapperService.documentMapper().mapping().getRoot()));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/UpdateMappingTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/UpdateMappingTests.java
@@ -98,7 +98,7 @@ public class UpdateMappingTests extends ESSingleNodeTestCase {
             mapperService.merge("type", new CompressedXContent(Strings.toString(update)), MapperService.MergeReason.MAPPING_UPDATE));
         assertThat(e.getMessage(), containsString("mapper [foo] cannot be changed from type [long] to [double]"));
 
-        assertThat(((FieldMapper) mapperService.documentMapper().mapping().root().getMapper("foo")).fieldType().typeName(),
+        assertThat(((FieldMapper) mapperService.documentMapper().mapping().getRoot().getMapper("foo")).fieldType().typeName(),
                 equalTo("long"));
     }
 
@@ -116,7 +116,7 @@ public class UpdateMappingTests extends ESSingleNodeTestCase {
             mapperService.merge("type", new CompressedXContent(Strings.toString(update)), MapperService.MergeReason.MAPPING_UPDATE));
         assertThat(e.getMessage(), containsString("mapper [foo] cannot be changed from type [long] to [double]"));
 
-        assertThat(((FieldMapper) mapperService.documentMapper().mapping().root().getMapper("foo")).fieldType().typeName(),
+        assertThat(((FieldMapper) mapperService.documentMapper().mapping().getRoot().getMapper("foo")).fieldType().typeName(),
                 equalTo("long"));
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/snapshots/SourceOnlySnapshotShardTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/snapshots/SourceOnlySnapshotShardTests.java
@@ -282,7 +282,7 @@ public class SourceOnlySnapshotShardTests extends IndexShardTestCase {
             }
             expectThrows(UnsupportedOperationException.class, () -> searcher.search(new TermQuery(new Term("boom", "boom")), 1));
             targetShard = reindex(searcher.getDirectoryReader(), new MappingMetadata("_doc",
-                restoredShard.mapperService().documentMapper().meta()));
+                restoredShard.mapperService().documentMapper().mapping().meta()));
         }
 
         for (int i = 0; i < numInitialDocs; i++) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/snapshots/SourceOnlySnapshotShardTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/snapshots/SourceOnlySnapshotShardTests.java
@@ -282,7 +282,7 @@ public class SourceOnlySnapshotShardTests extends IndexShardTestCase {
             }
             expectThrows(UnsupportedOperationException.class, () -> searcher.search(new TermQuery(new Term("boom", "boom")), 1));
             targetShard = reindex(searcher.getDirectoryReader(), new MappingMetadata("_doc",
-                restoredShard.mapperService().documentMapper().mapping().meta()));
+                restoredShard.mapperService().documentMapper().mapping().getMeta()));
         }
 
         for (int i = 0; i < numInitialDocs; i++) {


### PR DESCRIPTION
DocumentMapper exposes root() and meta() methods, which can be accessed through the mapping() method that exposes the entire Mapping instance.

This commit removes such redundant methods in favour of accessing mapping and retrieving root and meta from them. Additionally, access to Mapping's members is made consistent through getters rather than package private fields in some cases and getters is some other case.