### PR TITLE
Revert "mute test"

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.nodes/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.nodes/10_basic.yml
@@ -1,8 +1,5 @@
 ---
 "Test cat nodes output":
-  - skip:
-      version: "all"
-      reason: "Awaits fix: https://github.com/elastic/elasticsearch/issues/69757"
 
   - do:
       cat.nodes: {}


### PR DESCRIPTION
This reverts commit ee3673e8240b65d6e5cf51e13f59ee0fa28a13a2.

With the change on https://github.com/elastic/elasticsearch/pull/69768
this test should no longer timeout. 

closes #69757