### PR TITLE
Report shared_cache shards as zero size on disk

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
@@ -515,11 +515,7 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
                         shardStats.getStats().getStore().getReservedSize().getBytes(),
                         equalTo(0L)
                     );
-                    assertThat(
-                        shardStats.getShardRouting().toString(),
-                        shardStats.getStats().getStore().getSize().getBytes(),
-                        equalTo(0L)
-                    );
+                    assertThat(shardStats.getShardRouting().toString(), shardStats.getStats().getStore().getSize().getBytes(), equalTo(0L));
                 }
             }
         }, "test-stats-watcher");

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
@@ -515,6 +515,11 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
                         shardStats.getStats().getStore().getReservedSize().getBytes(),
                         equalTo(0L)
                     );
+                    assertThat(
+                        shardStats.getShardRouting().toString(),
+                        shardStats.getStats().getStore().getSize().getBytes(),
+                        equalTo(0L)
+                    );
                 }
             }
         }, "test-stats-watcher");


### PR DESCRIPTION
Searchable snapshot shards that are using the shared_cache are not actually consuming as much disk space as they report today in the "store" section of the node/indices stats. This blocks plan changes on Cloud as they check if the new nodes have enough disk space to host all the (at least primary) shards from the old nodes. With this change here, searchable snapshot shards that are using the shared_cache will report 0 as store size.