### PR TITLE
Change Get Snapshottable Features endpoint to `_features` (#69755)

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/FeaturesClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/FeaturesClient.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.client;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.client.snapshots.GetFeaturesRequest;
+import org.elasticsearch.client.snapshots.GetFeaturesResponse;
+
+import java.io.IOException;
+
+import static java.util.Collections.emptySet;
+
+/**
+ * A wrapper for the {@link RestHighLevelClient} that provides methods for accessing the Snapshot API.
+ * <p>
+ * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/features-apis.html">Snapshot API on elastic.co</a>
+ */
+public class FeaturesClient {
+    private final RestHighLevelClient restHighLevelClient;
+
+    FeaturesClient(RestHighLevelClient restHighLevelClient) {
+        this.restHighLevelClient = restHighLevelClient;
+    }
+
+    /**
+     * Get a list of features which can be included in a snapshot as feature states.
+     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/get-features-api.html"> Get Snapshottable
+     * Features API on elastic.co</a>
+     *
+     * @param getFeaturesRequest the request
+     * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
+     * @return the response
+     * @throws IOException in case there is a problem sending the request or parsing back the response
+     */
+    public GetFeaturesResponse getFeatures(GetFeaturesRequest getFeaturesRequest, RequestOptions options)
+        throws IOException {
+        return restHighLevelClient.performRequestAndParseEntity(
+            getFeaturesRequest,
+            FeaturesRequestConverters::getFeatures,
+            options,
+            GetFeaturesResponse::parse,
+            emptySet()
+        );
+    }
+
+    /**
+     * Asynchronously get a list of features which can be included in a snapshot as feature states.
+     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/get-features-api.html"> Get Snapshottable
+     * Features API on elastic.co</a>
+     *
+     * @param getFeaturesRequest the request
+     * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
+     * @param listener the listener to be notified upon request completion
+     * @return cancellable that may be used to cancel the request
+     */
+    public Cancellable getFeaturesAsync(
+        GetFeaturesRequest getFeaturesRequest, RequestOptions options,
+        ActionListener<GetFeaturesResponse> listener) {
+        return restHighLevelClient.performRequestAsyncAndParseEntity(
+            getFeaturesRequest,
+            FeaturesRequestConverters::getFeatures,
+            options,
+            GetFeaturesResponse::parse,
+            listener,
+            emptySet()
+        );
+    }
+}

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/FeaturesRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/FeaturesRequestConverters.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.client;
+
+import org.apache.http.client.methods.HttpGet;
+import org.elasticsearch.client.snapshots.GetFeaturesRequest;
+
+public class FeaturesRequestConverters {
+
+    private FeaturesRequestConverters() {}
+
+    static Request getFeatures(GetFeaturesRequest getFeaturesRequest) {
+        String endpoint = "/_features";
+        Request request = new Request(HttpGet.METHOD_NAME, endpoint);
+        RequestConverters.Params parameters = new RequestConverters.Params();
+        parameters.withMasterTimeout(getFeaturesRequest.masterNodeTimeout());
+        request.addParameters(parameters.asMap());
+        return request;
+    }
+}

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
@@ -265,6 +265,7 @@ public class RestHighLevelClient implements Closeable {
     private final AsyncSearchClient asyncSearchClient = new AsyncSearchClient(this);
     private final TextStructureClient textStructureClient = new TextStructureClient(this);
     private final SearchableSnapshotsClient searchableSnapshotsClient = new SearchableSnapshotsClient(this);
+    private final FeaturesClient featuresClient = new FeaturesClient(this);
 
     /**
      * Creates a {@link RestHighLevelClient} given the low level {@link RestClientBuilder} that allows to build the
@@ -463,6 +464,16 @@ public class RestHighLevelClient implements Closeable {
      */
     public SearchableSnapshotsClient searchableSnapshots() {
         return searchableSnapshotsClient;
+    }
+
+    /**
+     * A wrapper for the {@link RestHighLevelClient} that provides methods for accessing the Searchable Snapshots APIs.
+     * <p>
+     * See the <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/searchable-snapshots-apis.html">Searchable Snapshots
+     * APIs on elastic.co</a> for more information.
+     */
+    public FeaturesClient features() {
+        return featuresClient;
     }
 
     /**

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/SnapshotClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/SnapshotClient.java
@@ -28,8 +28,6 @@ import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotR
 import org.elasticsearch.action.admin.cluster.snapshots.status.SnapshotsStatusRequest;
 import org.elasticsearch.action.admin.cluster.snapshots.status.SnapshotsStatusResponse;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
-import org.elasticsearch.client.snapshots.GetSnapshottableFeaturesRequest;
-import org.elasticsearch.client.snapshots.GetSnapshottableFeaturesResponse;
 
 import java.io.IOException;
 
@@ -379,48 +377,5 @@ public final class SnapshotClient {
         return restHighLevelClient.performRequestAsyncAndParseEntity(deleteSnapshotRequest,
             SnapshotRequestConverters::deleteSnapshot, options,
             AcknowledgedResponse::fromXContent, listener, emptySet());
-    }
-
-    /**
-     * Get a list of features which can be included in a snapshot as feature states.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/get-snapshottable-features-api.html"> Get Snapshottable
-     * Features API on elastic.co</a>
-     *
-     * @param getFeaturesRequest the request
-     * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
-     * @return the response
-     * @throws IOException in case there is a problem sending the request or parsing back the response
-     */
-    public GetSnapshottableFeaturesResponse getFeatures(GetSnapshottableFeaturesRequest getFeaturesRequest, RequestOptions options)
-        throws IOException {
-        return restHighLevelClient.performRequestAndParseEntity(
-            getFeaturesRequest,
-            SnapshotRequestConverters::getSnapshottableFeatures,
-            options,
-            GetSnapshottableFeaturesResponse::parse,
-            emptySet()
-        );
-    }
-
-    /**
-     * Asynchronously get a list of features which can be included in a snapshot as feature states.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/get-snapshottable-features-api.html"> Get Snapshottable
-     * Features API on elastic.co</a>
-     *
-     * @param getFeaturesRequest the request
-     * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
-     * @param listener the listener to be notified upon request completion
-     * @return cancellable that may be used to cancel the request
-     */
-    public Cancellable getFeaturesAsync(GetSnapshottableFeaturesRequest getFeaturesRequest, RequestOptions options,
-                            ActionListener<GetSnapshottableFeaturesResponse> listener) {
-        return restHighLevelClient.performRequestAsyncAndParseEntity(
-            getFeaturesRequest,
-            SnapshotRequestConverters::getSnapshottableFeatures,
-            options,
-            GetSnapshottableFeaturesResponse::parse,
-            listener,
-            emptySet()
-        );
     }
 }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/SnapshotRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/SnapshotRequestConverters.java
@@ -23,7 +23,6 @@ import org.elasticsearch.action.admin.cluster.snapshots.delete.DeleteSnapshotReq
 import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsRequest;
 import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotRequest;
 import org.elasticsearch.action.admin.cluster.snapshots.status.SnapshotsStatusRequest;
-import org.elasticsearch.client.snapshots.GetSnapshottableFeaturesRequest;
 import org.elasticsearch.common.Strings;
 
 import java.io.IOException;
@@ -188,15 +187,6 @@ final class SnapshotRequestConverters {
 
         RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withMasterTimeout(deleteSnapshotRequest.masterNodeTimeout());
-        request.addParameters(parameters.asMap());
-        return request;
-    }
-
-    static Request getSnapshottableFeatures(GetSnapshottableFeaturesRequest getSnapshottableFeaturesRequest) {
-        String endpoint = "/_snapshottable_features";
-        Request request = new Request(HttpGet.METHOD_NAME, endpoint);
-        RequestConverters.Params parameters = new RequestConverters.Params();
-        parameters.withMasterTimeout(getSnapshottableFeaturesRequest.masterNodeTimeout());
         request.addParameters(parameters.asMap());
         return request;
     }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/snapshots/GetFeaturesRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/snapshots/GetFeaturesRequest.java
@@ -13,5 +13,5 @@ import org.elasticsearch.client.TimedRequest;
 /**
  * A {@link TimedRequest} to get the list of features available to be included in snapshots in the cluster.
  */
-public class GetSnapshottableFeaturesRequest extends TimedRequest {
+public class GetFeaturesRequest extends TimedRequest {
 }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/snapshots/GetFeaturesResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/snapshots/GetFeaturesResponse.java
@@ -16,22 +16,22 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import java.util.List;
 import java.util.Objects;
 
-public class GetSnapshottableFeaturesResponse {
+public class GetFeaturesResponse {
 
     private final List<SnapshottableFeature> features;
 
     private static final ParseField FEATURES = new ParseField("features");
 
     @SuppressWarnings("unchecked")
-    private static final ConstructingObjectParser<GetSnapshottableFeaturesResponse, Void> PARSER = new ConstructingObjectParser<>(
-        "snapshottable_features_response", true, (a, ctx) -> new GetSnapshottableFeaturesResponse((List<SnapshottableFeature>) a[0])
+    private static final ConstructingObjectParser<GetFeaturesResponse, Void> PARSER = new ConstructingObjectParser<>(
+        "snapshottable_features_response", true, (a, ctx) -> new GetFeaturesResponse((List<SnapshottableFeature>) a[0])
     );
 
     static {
         PARSER.declareObjectArray(ConstructingObjectParser.constructorArg(), SnapshottableFeature::parse, FEATURES);
     }
 
-    public GetSnapshottableFeaturesResponse(List<SnapshottableFeature> features) {
+    public GetFeaturesResponse(List<SnapshottableFeature> features) {
         this.features = features;
     }
 
@@ -39,15 +39,15 @@ public class GetSnapshottableFeaturesResponse {
         return features;
     }
 
-    public static GetSnapshottableFeaturesResponse parse(XContentParser parser) {
+    public static GetFeaturesResponse parse(XContentParser parser) {
         return PARSER.apply(parser, null);
     }
 
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if ((o instanceof GetSnapshottableFeaturesResponse) == false) return false;
-        GetSnapshottableFeaturesResponse that = (GetSnapshottableFeaturesResponse) o;
+        if ((o instanceof GetFeaturesResponse) == false) return false;
+        GetFeaturesResponse that = (GetFeaturesResponse) o;
         return getFeatures().equals(that.getFeatures());
     }
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/FeaturesIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/FeaturesIT.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.client;
+
+import org.elasticsearch.client.snapshots.GetFeaturesRequest;
+import org.elasticsearch.client.snapshots.GetFeaturesResponse;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class FeaturesIT extends ESRestHighLevelClientTestCase {
+    public void testGetFeatures() throws IOException {
+        GetFeaturesRequest request = new GetFeaturesRequest();
+
+        GetFeaturesResponse response = execute(request,
+            highLevelClient().features()::getFeatures, highLevelClient().features()::getFeaturesAsync);
+
+        assertThat(response, notNullValue());
+        assertThat(response.getFeatures(), notNullValue());
+        assertThat(response.getFeatures().size(), greaterThan(1));
+        assertTrue(response.getFeatures().stream().anyMatch(feature -> "tasks".equals(feature.getFeatureName())));
+    }
+}

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/SnapshotIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/SnapshotIT.java
@@ -28,8 +28,6 @@ import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotR
 import org.elasticsearch.action.admin.cluster.snapshots.status.SnapshotsStatusRequest;
 import org.elasticsearch.action.admin.cluster.snapshots.status.SnapshotsStatusResponse;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
-import org.elasticsearch.client.snapshots.GetSnapshottableFeaturesRequest;
-import org.elasticsearch.client.snapshots.GetSnapshottableFeaturesResponse;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentType;
@@ -52,7 +50,6 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
 
 public class SnapshotIT extends ESRestHighLevelClientTestCase {
 
@@ -382,18 +379,6 @@ public class SnapshotIT extends ESRestHighLevelClientTestCase {
         AcknowledgedResponse response = execute(request, highLevelClient().snapshot()::clone, highLevelClient().snapshot()::cloneAsync);
 
         assertTrue(response.isAcknowledged());
-    }
-
-    public void testGetFeatures() throws IOException {
-        GetSnapshottableFeaturesRequest request = new GetSnapshottableFeaturesRequest();
-
-        GetSnapshottableFeaturesResponse response = execute(request,
-            highLevelClient().snapshot()::getFeatures, highLevelClient().snapshot()::getFeaturesAsync);
-
-        assertThat(response, notNullValue());
-        assertThat(response.getFeatures(), notNullValue());
-        assertThat(response.getFeatures().size(), greaterThan(1));
-        assertTrue(response.getFeatures().stream().anyMatch(feature -> "tasks".equals(feature.getFeatureName())));
     }
 
     private static Map<String, Object> randomUserMetadata() {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/snapshots/GetFeaturesResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/snapshots/GetFeaturesResponseTests.java
@@ -21,9 +21,8 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.is;
 
-public class GetSnapshottableFeaturesResponseTests extends AbstractResponseTestCase<
-    org.elasticsearch.action.admin.cluster.snapshots.features.GetSnapshottableFeaturesResponse,
-    GetSnapshottableFeaturesResponse> {
+public class GetFeaturesResponseTests extends AbstractResponseTestCase<
+    org.elasticsearch.action.admin.cluster.snapshots.features.GetSnapshottableFeaturesResponse, GetFeaturesResponse> {
 
     @Override
     protected org.elasticsearch.action.admin.cluster.snapshots.features.GetSnapshottableFeaturesResponse createServerTestInstance(
@@ -41,14 +40,14 @@ public class GetSnapshottableFeaturesResponseTests extends AbstractResponseTestC
     }
 
     @Override
-    protected GetSnapshottableFeaturesResponse doParseToClientInstance(XContentParser parser) throws IOException {
-        return GetSnapshottableFeaturesResponse.parse(parser);
+    protected GetFeaturesResponse doParseToClientInstance(XContentParser parser) throws IOException {
+        return GetFeaturesResponse.parse(parser);
     }
 
     @Override
     protected void assertInstances(
         org.elasticsearch.action.admin.cluster.snapshots.features.GetSnapshottableFeaturesResponse serverTestInstance,
-        GetSnapshottableFeaturesResponse clientInstance
+        GetFeaturesResponse clientInstance
     ) {
         assertNotNull(serverTestInstance.getSnapshottableFeatures());
         assertNotNull(serverTestInstance.getSnapshottableFeatures());

--- a/docs/reference/features/apis/features-apis.asciidoc
+++ b/docs/reference/features/apis/features-apis.asciidoc
@@ -1,0 +1,11 @@
+[[features-apis]]
+== Features APIs
+
+You can use the following APIs to introspect and manage Features provided
+by Elasticsearch and Elasticsearch plugins.
+
+[discrete]
+=== Features APIs
+* <<get-features-api,Get Features API>>
+
+include::get-features-api.asciidoc[]

--- a/docs/reference/features/apis/get-features-api.asciidoc
+++ b/docs/reference/features/apis/get-features-api.asciidoc
@@ -1,7 +1,7 @@
-[[get-snapshottable-features-api]]
-=== Get Snapshottable Features API
+[[get-features-api]]
+=== Get Features API
 ++++
-<titleabbrev>Get snapshottable features</titleabbrev>
+<titleabbrev>Get features</titleabbrev>
 ++++
 
 Gets a list of features which can be included in snapshots using the
@@ -10,19 +10,19 @@ snapshot.
 
 [source,console]
 -----------------------------------
-GET /_snapshottable_features
+GET /_features
 -----------------------------------
 
-[[get-snapshottable-features-api-request]]
+[[get-features-api-request]]
 ==== {api-request-title}
 
-`GET /_snapshottable_features`
+`GET /_features`
 
 
-[[get-snapshottable-features-api-desc]]
+[[get-features-api-desc]]
 ==== {api-description-title}
 
-You can use the get snapshottable features API to determine which feature states
+You can use the get features API to determine which feature states
 to include when <<snapshots-take-snapshot,taking a snapshot>>. By default, all
 feature states are included in a snapshot if that snapshot includes the global
 state, or none if it does not.

--- a/docs/reference/rest-api/index.asciidoc
+++ b/docs/reference/rest-api/index.asciidoc
@@ -14,6 +14,7 @@ not be included yet.
 * <<autoscaling-apis, Autoscaling APIs>>
 * <<cat, cat APIs>>
 * <<cluster, Cluster APIs>>
+* <<features-apis,Features APIs>>
 * <<ccr-apis,{ccr-cap} APIs>>
 * <<data-stream-apis,Data stream APIs>>
 * <<docs, Document APIs>>
@@ -50,6 +51,7 @@ include::{es-repo-dir}/ccr/apis/ccr-apis.asciidoc[]
 include::{es-repo-dir}/data-streams/data-stream-apis.asciidoc[]
 include::{es-repo-dir}/docs.asciidoc[]
 include::{es-repo-dir}/ingest/apis/enrich/index.asciidoc[]
+include::{es-repo-dir}/features/apis/features-apis.asciidoc[]
 include::{es-repo-dir}/text-structure/apis/find-structure.asciidoc[leveloffset=+1]
 include::{es-repo-dir}/graph/explore.asciidoc[]
 include::{es-repo-dir}/indices.asciidoc[]

--- a/docs/reference/snapshot-restore/apis/create-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/create-snapshot-api.asciidoc
@@ -119,7 +119,7 @@ IMPORTANT: By default, the entire snapshot will fail if one or more indices incl
 (Optional, array of strings)
 A list of feature states to be included in this snapshot. A list of features
 available for inclusion in the snapshot and their descriptions be can be
-retrieved using the <<get-snapshottable-features-api,get snapshottable features API>>.
+retrieved using the <<get-features-api,get features API>>.
 Each feature state includes one or more system indices containing data necessary
 for the function of that feature. Providing an empty array will include no feature
 states in the snapshot, regardless of the value of `include_global_state`.

--- a/docs/reference/snapshot-restore/apis/snapshot-restore-apis.asciidoc
+++ b/docs/reference/snapshot-restore/apis/snapshot-restore-apis.asciidoc
@@ -37,4 +37,4 @@ include::get-snapshot-api.asciidoc[]
 include::get-snapshot-status-api.asciidoc[]
 include::restore-snapshot-api.asciidoc[]
 include::delete-snapshot-api.asciidoc[]
-include::get-snapshottable-features-api.asciidoc[]
+

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/features.get_features.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/features.get_features.json
@@ -1,5 +1,5 @@
 {
-  "snapshot.get_features":{
+  "features.get_features":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html",
       "description":"Returns a list of features which can be snapshotted in this cluster."
@@ -12,7 +12,7 @@
     "url":{
       "paths":[
         {
-          "path":"/_snapshottable_features",
+          "path":"/_features",
           "methods":[
             "GET"
           ]

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/features.get_features/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/features.get_features/10_basic.yml
@@ -4,5 +4,5 @@
       features: contains
       version: " - 7.99.99" # Adjust this after backport
       reason: "This API was added in 7.12.0"
-  - do: { snapshot.get_features: {}}
+  - do: { features.get_features: {}}
   - contains: {'features': {'name': 'tasks'}}

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/features/SnapshottableFeaturesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/features/SnapshottableFeaturesAction.java
@@ -13,7 +13,7 @@ import org.elasticsearch.action.ActionType;
 public class SnapshottableFeaturesAction extends ActionType<GetSnapshottableFeaturesResponse> {
 
     public static final SnapshottableFeaturesAction INSTANCE = new SnapshottableFeaturesAction();
-    public static final String NAME = "cluster:admin/snapshot/features/get";
+    public static final String NAME = "cluster:admin/features/get";
 
     private SnapshottableFeaturesAction() {
         super(NAME, GetSnapshottableFeaturesResponse::new);

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestSnapshottableFeaturesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestSnapshottableFeaturesAction.java
@@ -21,7 +21,7 @@ import java.util.List;
 public class RestSnapshottableFeaturesAction extends BaseRestHandler {
     @Override
     public List<Route> routes() {
-        return org.elasticsearch.common.collect.List.of(new Route(RestRequest.Method.GET, "/_snapshottable_features"));
+        return org.elasticsearch.common.collect.List.of(new Route(RestRequest.Method.GET, "/_features"));
     }
 
     @Override

--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
@@ -80,7 +80,7 @@ public class Constants {
         "cluster:admin/snapshot/mount",
         "cluster:admin/snapshot/restore",
         "cluster:admin/snapshot/status",
-        "cluster:admin/snapshot/features/get",
+        "cluster:admin/features/get",
         "cluster:admin/tasks/cancel",
         "cluster:admin/transform/delete",
         "cluster:admin/transform/preview",


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Change Get Snapshottable Features endpoint to `_features` (#69755)