### PR TITLE
Script: no compile rate limit for ingest templates

### DIFF
--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MustacheScriptEngine.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MustacheScriptEngine.java
@@ -75,7 +75,7 @@ public final class MustacheScriptEngine implements ScriptEngine {
 
     @Override
     public Set<ScriptContext<?>> getSupportedContexts() {
-        return Set.of(TemplateScript.CONTEXT);
+        return Set.of(TemplateScript.CONTEXT, TemplateScript.INGEST_CONTEXT);
     }
 
     private CustomMustacheFactory createMustacheFactory(Map<String, String> options) {

--- a/server/src/main/java/org/elasticsearch/ingest/ValueSource.java
+++ b/server/src/main/java/org/elasticsearch/ingest/ValueSource.java
@@ -69,7 +69,7 @@ public interface ValueSource {
             // modified if templating is not available
             if (scriptService.isLangSupported(DEFAULT_TEMPLATE_LANG) && ((String) value).contains("{{")) {
                 Script script = new Script(ScriptType.INLINE, DEFAULT_TEMPLATE_LANG, (String) value, scriptOptions, Map.of());
-                return new TemplatedValue(scriptService.compile(script, TemplateScript.CONTEXT));
+                return new TemplatedValue(scriptService.compile(script, TemplateScript.INGEST_CONTEXT));
             } else {
                 return new ObjectValue(value);
             }

--- a/server/src/main/java/org/elasticsearch/script/ScriptModule.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptModule.java
@@ -53,6 +53,7 @@ public class ScriptModule {
             SimilarityScript.CONTEXT,
             SimilarityWeightScript.CONTEXT,
             TemplateScript.CONTEXT,
+            TemplateScript.INGEST_CONTEXT,
             MovingFunctionScript.CONTEXT,
             ScriptedMetricAggContexts.InitScript.CONTEXT,
             ScriptedMetricAggContexts.MapScript.CONTEXT,

--- a/server/src/main/java/org/elasticsearch/script/TemplateScript.java
+++ b/server/src/main/java/org/elasticsearch/script/TemplateScript.java
@@ -38,7 +38,9 @@ public abstract class TemplateScript {
 
     public static final ScriptContext<Factory> CONTEXT = new ScriptContext<>("template", Factory.class);
 
-    // Remove compilation rate limit for ingest
+    // Remove compilation rate limit for ingest.  Ingest pipelines may use many mustache templates, triggering compilation
+    // rate limiting.  MustacheScriptEngine explicitly checks for TemplateScript.  Rather than complicating the implementation there by
+    // creating a new Script class (as would be customary), this context is used to avoid the default rate limit.
     public static final ScriptContext<Factory> INGEST_CONTEXT = new ScriptContext<>("ingest_template", Factory.class,
             200, TimeValue.timeValueMillis(0), ScriptCache.UNLIMITED_COMPILATION_RATE.asTuple());
 }

--- a/server/src/main/java/org/elasticsearch/script/TemplateScript.java
+++ b/server/src/main/java/org/elasticsearch/script/TemplateScript.java
@@ -8,6 +8,8 @@
 
 package org.elasticsearch.script;
 
+import org.elasticsearch.common.unit.TimeValue;
+
 import java.util.Map;
 
 /**
@@ -35,4 +37,8 @@ public abstract class TemplateScript {
     }
 
     public static final ScriptContext<Factory> CONTEXT = new ScriptContext<>("template", Factory.class);
+
+    // Remove compilation rate limit for ingest
+    public static final ScriptContext<Factory> INGEST_CONTEXT = new ScriptContext<>("ingest_template", Factory.class,
+            200, TimeValue.timeValueMillis(0), ScriptCache.UNLIMITED_COMPILATION_RATE.asTuple());
 }


### PR DESCRIPTION
Remove the compilation rate limit for ingest templates.

Creates a new context, `ingest_template`, with an unlimited
compilation rate limit.

The `template` context is used in many places so it cannot be
exempted from rate limits.

Fixes: #64595