### PR TITLE
Written to disk OR page cache?

### DIFF
--- a/docs/reference/modules/indices/indexing_buffer.asciidoc
+++ b/docs/reference/modules/indices/indexing_buffer.asciidoc
@@ -2,7 +2,7 @@
 === Indexing Buffer
 
 The indexing buffer is used to store newly indexed documents.  When it fills
-up, the documents in the buffer are written to a segment on disk. It is divided
+up, the documents in the buffer are written to a segment on page cache by `refresh`. It is divided
 between all shards on the node.
 
 The following settings are _static_ and must be configured on every data node


### PR DESCRIPTION
When the indexing buffer fills up, the `refresh` happens, the docs are written to page cache, not to the disk.
After `refresh`, the `flush` will write the page cache to the disk finally.

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
