### PR TITLE
[DOCS] Add more details of writing to disk.

### DIFF
--- a/docs/reference/modules/indices/indexing_buffer.asciidoc
+++ b/docs/reference/modules/indices/indexing_buffer.asciidoc
@@ -2,7 +2,7 @@
 === Indexing Buffer
 
 The indexing buffer is used to store newly indexed documents.  When it fills
-up, the documents in the buffer are written to a segment on disk. It is divided
+up, the documents in the buffer are written to a segment on disk(written to the page cache before writing to disk). It is divided
 between all shards on the node.
 
 The following settings are _static_ and must be configured on every data node


### PR DESCRIPTION
`write` contains `refresh` and `flush`.
Maybe It's a good idea to tell the reader when we say `write to disk`, it means to write to the page cache before writing to the disk.
What's your opinion?