### PR TITLE
[Tests] Handle escape char correctly in wildcard patterns

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/support/StringMatcherTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/support/StringMatcherTests.java
@@ -26,11 +26,10 @@ public class StringMatcherTests extends ESTestCase {
     public void testSingleWildcard() throws Exception {
         final String prefix = randomAlphaOfLengthBetween(3, 5);
         final StringMatcher matcher = StringMatcher.of(prefix + "*");
-        final String normalisedPrefix = prefix.replace("\\", "");
         for (int i = 0; i < 10; i++) {
-            assertMatch(matcher, normalisedPrefix + randomAlphaOfLengthBetween(i, 20));
-            assertNoMatch(matcher, randomAlphaOfLengthBetween(1, normalisedPrefix.length() - 1));
-            assertNoMatch(matcher, randomValueOtherThanMany(s -> s.startsWith(normalisedPrefix), () -> randomAlphaOfLengthBetween(1, 8)));
+            assertMatch(matcher, prefix + randomAlphaOfLengthBetween(i, 20));
+            assertNoMatch(matcher, randomAlphaOfLengthBetween(1, prefix.length() - 1));
+            assertNoMatch(matcher, randomValueOtherThanMany(s -> s.startsWith(prefix), () -> randomAlphaOfLengthBetween(1, 8)));
         }
     }
 
@@ -46,14 +45,13 @@ public class StringMatcherTests extends ESTestCase {
 
     public void testUnicodeWildcard() throws Exception {
         // Lucene automatons don't work correctly on strings with high surrogates
-        final String prefix = randomValueOtherThanMany(StringMatcherTests::hasHighSurrogate,
+        final String prefix = randomValueOtherThanMany(s -> StringMatcherTests.hasHighSurrogate(s) || s.contains("\\"),
             () -> randomRealisticUnicodeOfLengthBetween(3, 5));
         final StringMatcher matcher = StringMatcher.of(prefix + "*");
-        final String normalisedPrefix = prefix.replace("\\", "");
         for (int i = 0; i < 10; i++) {
-            assertMatch(matcher, normalisedPrefix + randomRealisticUnicodeOfLengthBetween(i, 20));
-            assertNoMatch(matcher, randomRealisticUnicodeOfLengthBetween(1, normalisedPrefix.length() - 1));
-            assertNoMatch(matcher, randomValueOtherThanMany(s -> s.startsWith(normalisedPrefix), () -> randomUnicodeOfLengthBetween(1, 8)));
+            assertMatch(matcher, prefix + randomRealisticUnicodeOfLengthBetween(i, 20));
+            assertNoMatch(matcher, randomRealisticUnicodeOfLengthBetween(1, prefix.length() - 1));
+            assertNoMatch(matcher, randomValueOtherThanMany(s -> s.startsWith(prefix), () -> randomUnicodeOfLengthBetween(1, 8)));
         }
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/support/StringMatcherTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/support/StringMatcherTests.java
@@ -26,10 +26,11 @@ public class StringMatcherTests extends ESTestCase {
     public void testSingleWildcard() throws Exception {
         final String prefix = randomAlphaOfLengthBetween(3, 5);
         final StringMatcher matcher = StringMatcher.of(prefix + "*");
+        final String normalisedPrefix = prefix.replace("\\", "");
         for (int i = 0; i < 10; i++) {
-            assertMatch(matcher, prefix + randomAlphaOfLengthBetween(i, 20));
-            assertNoMatch(matcher, randomAlphaOfLengthBetween(1, prefix.length() - 1));
-            assertNoMatch(matcher, randomValueOtherThanMany(s -> s.startsWith(prefix), () -> randomAlphaOfLengthBetween(1, 8)));
+            assertMatch(matcher, normalisedPrefix + randomAlphaOfLengthBetween(i, 20));
+            assertNoMatch(matcher, randomAlphaOfLengthBetween(1, normalisedPrefix.length() - 1));
+            assertNoMatch(matcher, randomValueOtherThanMany(s -> s.startsWith(normalisedPrefix), () -> randomAlphaOfLengthBetween(1, 8)));
         }
     }
 
@@ -48,10 +49,11 @@ public class StringMatcherTests extends ESTestCase {
         final String prefix = randomValueOtherThanMany(StringMatcherTests::hasHighSurrogate,
             () -> randomRealisticUnicodeOfLengthBetween(3, 5));
         final StringMatcher matcher = StringMatcher.of(prefix + "*");
+        final String normalisedPrefix = prefix.replace("\\", "");
         for (int i = 0; i < 10; i++) {
-            assertMatch(matcher, prefix + randomRealisticUnicodeOfLengthBetween(i, 20));
-            assertNoMatch(matcher, randomRealisticUnicodeOfLengthBetween(1, prefix.length() - 1));
-            assertNoMatch(matcher, randomValueOtherThanMany(s -> s.startsWith(prefix), () -> randomUnicodeOfLengthBetween(1, 8)));
+            assertMatch(matcher, normalisedPrefix + randomRealisticUnicodeOfLengthBetween(i, 20));
+            assertNoMatch(matcher, randomRealisticUnicodeOfLengthBetween(1, normalisedPrefix.length() - 1));
+            assertNoMatch(matcher, randomValueOtherThanMany(s -> s.startsWith(normalisedPrefix), () -> randomUnicodeOfLengthBetween(1, 8)));
         }
     }
 


### PR DESCRIPTION
Escape char is handled specially while building automaton. It should also be handled when buidling the target text for matching.

Resolves: #69837