### PR TITLE
[Tests] Handle escape char correctly in wildcard patterns (#69850)

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/support/StringMatcherTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/support/StringMatcherTests.java
@@ -45,7 +45,7 @@ public class StringMatcherTests extends ESTestCase {
 
     public void testUnicodeWildcard() throws Exception {
         // Lucene automatons don't work correctly on strings with high surrogates
-        final String prefix = randomValueOtherThanMany(StringMatcherTests::hasHighSurrogate,
+        final String prefix = randomValueOtherThanMany(s -> StringMatcherTests.hasHighSurrogate(s) || s.contains("\\"),
             () -> randomRealisticUnicodeOfLengthBetween(3, 5));
         final StringMatcher matcher = StringMatcher.of(prefix + "*");
         for (int i = 0; i < 10; i++) {


### PR DESCRIPTION
Escape char is handled specially while building automaton. It should also be handled 
when buidling the target text for matching.