### PR TITLE
[7.x] Fix testRestoredIndexManagedByLocalPolicySkipsIllegalActions (#69792)

### DIFF
--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/SearchableSnapshotActionIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/SearchableSnapshotActionIT.java
@@ -302,9 +302,8 @@ public class SearchableSnapshotActionIT extends ESRestTestCase {
         );
 
         // rolling over the data stream so we can apply the searchable snapshot policy to a backing index that's not the write index
-        for (int i = 0; i < randomIntBetween(5, 10); i++) {
-            indexDocument(client(), dataStream, true);
-        }
+        // indexing only one document as we want only one rollover to be triggered
+        indexDocument(client(), dataStream, true);
 
         String searchableSnapMountedIndexName = SearchableSnapshotAction.FULL_RESTORED_INDEX_PREFIX +
             DataStream.getDefaultBackingIndexName(dataStream, 1L);
@@ -351,6 +350,7 @@ public class SearchableSnapshotActionIT extends ESRestTestCase {
         assertOK(client().performRequest(restoreSnapshot));
 
         assertThat(indexExists(searchableSnapMountedIndexName), is(true));
+        ensureGreen(searchableSnapMountedIndexName);
 
         // the restored index is now managed by the now updated ILM policy and needs to go through the warm and cold phase
         assertBusy(() -> {


### PR DESCRIPTION
This fixes a flakiness that might appear if the data stream ends up being rolled
over multiple times. This would cause later (than the first) generations to be
mounted as searchable snapshots. We didn't expect that (or wait for it) and
when attempting to delete the data stream, this backing indices would not be
able to be deleted as they are still being snapshotted.

The failing exception would be :
"snapshot_in_progress_exception",
"reason":"Cannot delete indices that are being snapshotted:

(cherry picked from commit a7b104f708a5ed050dbcd5bca2ba63b500190b9f)
Signed-off-by: Andrei Dan <andrei.dan@elastic.co>

Backport of #69792