### PR TITLE
Adjust BWC version after backport of #69692

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/blobstore/cache/BlobStoreCacheService.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/blobstore/cache/BlobStoreCacheService.java
@@ -52,9 +52,9 @@ public class BlobStoreCacheService {
     private static final Logger logger = LogManager.getLogger(BlobStoreCacheService.class);
 
     /**
-     * Before 8.0.0 blobs were cached using a 4KB or 8KB maximum length.
+     * Before 7.12.0 blobs were cached using a 4KB or 8KB maximum length.
      */
-    private static final Version OLD_CACHED_BLOB_SIZE_VERSION = Version.V_7_13_0; // TODO adjust after backport
+    private static final Version OLD_CACHED_BLOB_SIZE_VERSION = Version.V_7_12_0;
 
     public static final int DEFAULT_CACHED_BLOB_SIZE = ByteSizeUnit.KB.toIntBytes(1);
     private static final Cache<String, String> LOG_EXCEEDING_FILES_CACHE = CacheBuilder.<String, String>builder()


### PR DESCRIPTION
Now #69692 has been merged in branch `7.12` we can adjust the BWC version in the `BlobStoreCacheService` in branch `7.x`.