### PR TITLE
[7.x] Set processor's copy_from should deep copy non-primitive mutable types

### DIFF
--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/SetProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/SetProcessor.java
@@ -74,7 +74,7 @@ public final class SetProcessor extends AbstractProcessor {
         if (overrideEnabled || document.hasField(field) == false || document.getFieldValue(field, Object.class) == null) {
             if (copyFrom != null) {
                 Object fieldValue = document.getFieldValue(copyFrom, Object.class, ignoreEmptyValue);
-                document.setFieldValue(field, fieldValue, ignoreEmptyValue);
+                document.setFieldValue(field, IngestDocument.deepCopy(fieldValue), ignoreEmptyValue);
             } else {
                 document.setFieldValue(field, value, ignoreEmptyValue);
             }

--- a/server/src/main/java/org/elasticsearch/ingest/IngestDocument.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestDocument.java
@@ -716,7 +716,7 @@ public final class IngestDocument {
         return (Map<K, V>) deepCopy(source);
     }
 
-    private static Object deepCopy(Object value) {
+    public static Object deepCopy(Object value) {
         if (value instanceof Map) {
             Map<?, ?> mapValue = (Map<?, ?>) value;
             Map<Object, Object> copy = new HashMap<>(mapValue.size());


### PR DESCRIPTION
Fixes #69348

Backport of #69349
