### PR TITLE
[7.x] Pass runtime_fields from FieldCapabilitiesRequest to FieldCapabilitiesIndexRequest (#69853)

### DIFF
--- a/qa/multi-cluster-search/src/test/resources/rest-api-spec/test/multi_cluster/30_field_caps.yml
+++ b/qa/multi-cluster-search/src/test/resources/rest-api-spec/test/multi_cluster/30_field_caps.yml
@@ -73,6 +73,19 @@
   - match: {fields.number.double.searchable:            true}
   - match: {fields.number.double.aggregatable:          true}
 
+  # make sure runtime_mappings section gets propagated
+  - do:
+      field_caps:
+        index: 'my_remote_cluster:field_caps_index_1'
+        fields: [number]
+        body:
+          runtime_mappings:
+            number:
+              type: keyword
+  - match: {fields.number.keyword.searchable:           true}
+  - match: {fields.number.keyword.aggregatable:         true}
+  - match: {fields.number.keyword.type:                 keyword}
+
 ---
 "Get field caps from remote cluster with index filter":
   - skip:

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesIndexRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesIndexRequest.java
@@ -33,7 +33,7 @@ public class FieldCapabilitiesIndexRequest extends ActionRequest implements Indi
     private final OriginalIndices originalIndices;
     private final QueryBuilder indexFilter;
     private final long nowInMillis;
-    private Map<String, Object> runtimeFields;
+    private final Map<String, Object> runtimeFields;
 
     private ShardId shardId;
 

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesRequest.java
@@ -48,11 +48,7 @@ public final class FieldCapabilitiesRequest extends ActionRequest implements Ind
         indices = in.readStringArray();
         indicesOptions = IndicesOptions.readIndicesOptions(in);
         mergeResults = in.readBoolean();
-        if (in.getVersion().onOrAfter(Version.V_7_2_0)) {
-            includeUnmapped = in.readBoolean();
-        } else {
-            includeUnmapped = false;
-        }
+        includeUnmapped = in.getVersion().onOrAfter(Version.V_7_2_0) ? in.readBoolean() : false;
         indexFilter = in.getVersion().onOrAfter(Version.V_7_9_0) ? in.readOptionalNamedWriteable(QueryBuilder.class) : null;
         nowInMillis = in.getVersion().onOrAfter(Version.V_7_9_0) ? in.readOptionalLong() : null;
         runtimeFields = in.getVersion().onOrAfter(Version.V_7_12_0) ? in.readMap() : Collections.emptyMap();

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
@@ -115,6 +115,7 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
                 remoteRequest.indicesOptions(originalIndices.indicesOptions());
                 remoteRequest.indices(originalIndices.indices());
                 remoteRequest.fields(request.fields());
+                remoteRequest.runtimeFields(request.runtimeFields());
                 remoteRequest.indexFilter(request.indexFilter());
                 remoteRequest.nowInMillis(nowInMillis);
                 remoteClusterClient.fieldCaps(remoteRequest,  ActionListener.wrap(response -> {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Pass runtime_fields from FieldCapabilitiesRequest to FieldCapabilitiesIndexRequest  (#69853)