### PR TITLE
[7.12] [DOCS] Fix typo  (#69838)

### DIFF
--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -83,7 +83,7 @@ the {stack}].
 <<transform-node,{transform-cap} node>>::
 
 A node that has the `transform` role. If you want to use {transforms}, there
-be at least one {transform} node in your cluster. For more information, see
+must be at least one {transform} node in your cluster. For more information, see
 <<transform-settings>> and <<transforms>>.
 
 [NOTE]


### PR DESCRIPTION
Backports the following commits to 7.12:
 - [DOCS] Fix typo  (#69838)