### PR TITLE
Mute failing SetProcessorTests.testCopyFromOtherField (#69877)

### DIFF
--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/SetProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/SetProcessorTests.java
@@ -135,6 +135,7 @@ public class SetProcessorTests extends ESTestCase {
         assertThat(ingestDocument.getFieldValue(Metadata.IF_PRIMARY_TERM.getFieldName(), Long.class), Matchers.equalTo(ifPrimaryTerm));
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/69876")
     public void testCopyFromOtherField() throws Exception {
         Map<String, Object> document = new HashMap<>();
         Object fieldValue = RandomDocumentPicks.randomFieldValue(random());


### PR DESCRIPTION
Relates to #69876

Backport of #69877
