### PR TITLE
Docs: Call out that you can't update analyzer (backport of #69889)

### DIFF
--- a/docs/reference/mapping/params/analyzer.asciidoc
+++ b/docs/reference/mapping/params/analyzer.asciidoc
@@ -19,6 +19,9 @@ We recommend testing analyzers before using them in production. See
 <<test-analyzer>>.
 ====
 
+TIP: The `analyzer` setting can *not* be updated on existing fields
+using the <<indices-put-mapping,PUT mapping API>>.
+
 [[search-quote-analyzer]]
 ==== `search_quote_analyzer`
 
@@ -93,6 +96,9 @@ GET my-index-000001/_search
    }
 }
 --------------------------------------------------
+
+TIP: The `search_quote_analyzer` setting can be updated on existing fields
+using the <<indices-put-mapping,PUT mapping API>>.
 
 <1> `my_analyzer` analyzer which tokens all terms including stop words
 <2> `my_stop_analyzer` analyzer which removes stop words


### PR DESCRIPTION
You can't update the `analyzer` parameter in the PUT mappings API even if
the index is closed. This adds a TIP to call that out. And adds a TIP
for `search_quote_analyzer` which you *can* update.
