### PR TITLE
Add delta for double comparison in AvgAggregatorTests.testSummationAccuracy

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/AvgAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/AvgAggregatorTests.java
@@ -188,7 +188,7 @@ public class AvgAggregatorTests extends AggregatorTestCase {
     public void testSummationAccuracy() throws IOException {
         // Summing up a normal array and expect an accurate value
         double[] values = new double[]{0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.9, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7};
-        verifyAvgOfDoubles(values, 0.9, 0d);
+        verifyAvgOfDoubles(values, 0.9, 1e-10);
 
         // Summing up an array which contains NaN and infinities and expect a result same as naive summation
         int n = randomIntBetween(5, 10);


### PR DESCRIPTION
Fixes #69906.
