### PR TITLE
[7.12] Mute failing searchable snapshot test (#69915)

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/SearchableSnapshotDirectoryTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/SearchableSnapshotDirectoryTests.java
@@ -651,6 +651,7 @@ public class SearchableSnapshotDirectoryTests extends AbstractSearchableSnapshot
         });
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/69914")
     public void testClearCache() throws Exception {
         try (CacheService cacheService = defaultCacheService()) {
             cacheService.start();


### PR DESCRIPTION
Relates to #69914

Backport of #69915
