### PR TITLE
[DOCS] Document `index.query.default_field` index setting

### DIFF
--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -255,14 +255,14 @@ are ignored for this index.
 --
 (string or array of strings)
 Wildcard (`*`) patterns matching one or more fields. The following query types
-search these fields by default:
+search these matching fields by default:
 
 * <<query-dsl-mlt-query>>
 * <<query-dsl-multi-match-query>>
 * <<query-dsl-query-string-query>>
 * <<query-dsl-simple-query-string-query>>
 
-Defaults to `*`, which extracts all fields eligible for
+Defaults to `*`, which matches all fields eligible for
 <<term-level-queries,term-level queries>>, excluding metadata fields.
 --
 

--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -262,8 +262,8 @@ search these fields by default:
 * <<query-dsl-query-string-query>>
 * <<query-dsl-simple-query-string-query>>
 
-Defaults to `*`, which extracts all fields eligible for term queries, excluding
-metadata fields.
+Defaults to `*`, which extracts all fields eligible for
+<<term-level-queries,term-level queries>>, excluding metadata fields.
 --
 
  `index.routing.allocation.enable`::

--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -2,9 +2,6 @@
 [[index-modules]]
 = Index modules
 
-[partintro]
---
-
 Index Modules are modules created per index and control all aspects related to
 an index.
 
@@ -252,14 +249,22 @@ are ignored for this index.
     The maximum length of regex that can be used in Regexp Query.
     Defaults to `1000`.
 
+
 `index.query.default_field`::
++
+--
 (string or array of strings)
-Wildcard (`*`) patterns matching one or more fields. Defaults to `*` (all
-fields). The following query types search these fields by default:
+Wildcard (`*`) patterns matching one or more fields. The following query types
+search these fields by default:
+
 * <<query-dsl-mlt-query>>
 * <<query-dsl-multi-match-query>>
 * <<query-dsl-query-string-query>>
 * <<query-dsl-simple-query-string-query>>
+
+Defaults to `*`, which extracts all fields eligible for term queries, excluding
+metadata fields.
+--
 
  `index.routing.allocation.enable`::
 
@@ -350,7 +355,6 @@ Other index settings are available in index modules:
 <<ilm-settings,{ilm-cap}>>::
 
     Specify the lifecycle policy and rollover alias for an index.
---
 
 include::index-modules/analysis.asciidoc[]
 

--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -252,6 +252,15 @@ are ignored for this index.
     The maximum length of regex that can be used in Regexp Query.
     Defaults to `1000`.
 
+`index.query.default_field`::
+(string or array of strings)
+Wildcard (`*`) patterns matching one or more fields. Defaults to `*` (all
+fields). The following query types search these fields by default:
+* <<query-dsl-mlt-query>>
+* <<query-dsl-multi-match-query>>
+* <<query-dsl-query-string-query>>
+* <<query-dsl-simple-query-string-query>>
+
  `index.routing.allocation.enable`::
 
     Controls shard allocation for this index. It can be set to:

--- a/docs/reference/query-dsl/mlt-query.asciidoc
+++ b/docs/reference/query-dsl/mlt-query.asciidoc
@@ -177,8 +177,8 @@ is the same as `like`.
 `fields`::
 A list of fields to fetch and analyze the text from. Defaults to the
 `index.query.default_field` index setting, which has a default value of `*`. The
-`*` value extracts all fields eligible for term queries, excluding metadata
-fields.
+`*` value extracts all fields eligible for <<term-level-queries,term-level
+queries>>, excluding metadata fields.
 
 [discrete]
 [[mlt-query-term-selection]]

--- a/docs/reference/query-dsl/mlt-query.asciidoc
+++ b/docs/reference/query-dsl/mlt-query.asciidoc
@@ -175,7 +175,9 @@ for documents `like: "Apple"`, but `unlike: "cake crumble tree"`. The syntax
 is the same as `like`.
 
 `fields`::
-A list of fields to fetch and analyze the text from.
+A list of fields to fetch and analyze the text from. Defaults to the
+`index.query.default_field` index setting, which has a default value of `*` (all
+fields).
 
 [discrete]
 [[mlt-query-term-selection]]

--- a/docs/reference/query-dsl/mlt-query.asciidoc
+++ b/docs/reference/query-dsl/mlt-query.asciidoc
@@ -177,7 +177,7 @@ is the same as `like`.
 `fields`::
 A list of fields to fetch and analyze the text from. Defaults to the
 `index.query.default_field` index setting, which has a default value of `*`. The
-`*` value extracts all fields eligible for <<term-level-queries,term-level
+`*` value matches all fields eligible for <<term-level-queries,term-level
 queries>>, excluding metadata fields.
 
 [discrete]

--- a/docs/reference/query-dsl/mlt-query.asciidoc
+++ b/docs/reference/query-dsl/mlt-query.asciidoc
@@ -176,8 +176,9 @@ is the same as `like`.
 
 `fields`::
 A list of fields to fetch and analyze the text from. Defaults to the
-`index.query.default_field` index setting, which has a default value of `*` (all
-fields).
+`index.query.default_field` index setting, which has a default value of `*`. The
+`*` value extracts all fields eligible for term queries, excluding metadata
+fields.
 
 [discrete]
 [[mlt-query-term-selection]]


### PR DESCRIPTION
Changes:
- Add docs for the `index.query.default_field` index setting to the [Index modules](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html) page.
- Note in the MLT query docs that `index.query.default_field` is the default `fields` value. Other affected query types already mention the `index.query.default_field` index setting.

Closes #69770.

### Previews
* Index modules docs: https://elasticsearch_69922.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/index-modules.html#index-max-regex-length
* MLT query docs: https://elasticsearch_69922.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/query-dsl-mlt-query.html#_parameters_2