### PR TITLE
Mute failing PermissionsIT.testCanManageIndexWithNoPermissions test

### DIFF
--- a/x-pack/plugin/ilm/qa/with-security/src/javaRestTest/java/org/elasticsearch/xpack/security/PermissionsIT.java
+++ b/x-pack/plugin/ilm/qa/with-security/src/javaRestTest/java/org/elasticsearch/xpack/security/PermissionsIT.java
@@ -125,6 +125,7 @@ public class PermissionsIT extends ESRestTestCase {
      * but then not have permissions to operate on an index that was later associated with that policy by another
      * user
      */
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/69925")
     @SuppressWarnings("unchecked")
     public void testCanManageIndexWithNoPermissions() throws Exception {
         createIndexAsAdmin("not-ilm", indexSettingsWithPolicy, "");


### PR DESCRIPTION
Relates to #69925
