### PR TITLE
Re-enable MonitoringIT.testMonitoringService

### DIFF
--- a/x-pack/plugin/monitoring/src/internalClusterTest/java/org/elasticsearch/xpack/monitoring/integration/MonitoringIT.java
+++ b/x-pack/plugin/monitoring/src/internalClusterTest/java/org/elasticsearch/xpack/monitoring/integration/MonitoringIT.java
@@ -180,7 +180,6 @@ public class MonitoringIT extends ESSingleNodeTestCase {
      * This test waits for the monitoring service to collect monitoring documents and then checks that all expected documents
      * have been indexed with the expected information.
      */
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/29880")
     public void testMonitoringService() throws Exception {
         final boolean createAPMIndex = randomBoolean();
         final String indexName = createAPMIndex ? "apm-2017.11.06" : "books";


### PR DESCRIPTION
The test failure issue for this test has been open for over two years, but this test has been muted
so long that we don't have any actual failure information.

This unmutes it so either it ceases to fail (yay), or else it fails and we have a gradle buildscan
link that provides us with a bit more information.

Relates to #29880
