### PR TITLE
[7.x] Mute failing RollupActionIT.testRollupIndexAndSetNewRollupPolicy test

### DIFF
--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/RollupActionIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/RollupActionIT.java
@@ -65,6 +65,7 @@ public class RollupActionIT extends ESRestTestCase {
         assertBusy(() -> assertTrue(indexExists(index)));
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/69934")
     public void testRollupIndexAndSetNewRollupPolicy() throws Exception {
         createIndexWithSettings(client(), index, alias, Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
             .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0));


### PR DESCRIPTION
Relates to #69934

Backport of #69935
