### PR TITLE
[DOCS] Edits machine learning settings

### DIFF
--- a/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
@@ -224,7 +224,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=categorization-examples-limit]
 
 `model_memory_limit`:::
 (long or string) 
-include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-memory-limit]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-memory-limit-ad]
 ====
 //End analysis_limits
 

--- a/docs/reference/ml/anomaly-detection/apis/update-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/update-job.asciidoc
@@ -53,7 +53,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=analysis-limits]
 ====
 `model_memory_limit`:::
 (long or string) 
-include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-memory-limit]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-memory-limit-ad]
 +
 --
 NOTE: You can update the `analysis_limits` only while the job is closed. The 

--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics.asciidoc
@@ -128,7 +128,7 @@ to `ml`.
 (string) The unique identifier of the {dfanalytics-job}.
 
 `model_memory_limit`:::
-(string) The `model_memory_limit` that has been set to the {dfanalytics-job}.
+(string) The `model_memory_limit` that has been set for the {dfanalytics-job}.
 
 `source`:::
 (object) The configuration of how the analysis data is sourced. It has an

--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -513,12 +513,7 @@ functionality other than the analysis itself.
 
 `model_memory_limit`::
 (Optional, string)
-The approximate maximum amount of memory resources that are permitted for
-analytical processing. The default value for {dfanalytics-jobs} is `1gb`. If
-your `elasticsearch.yml` file contains an `xpack.ml.max_model_memory_limit`
-setting, an error occurs when you try to create {dfanalytics-jobs} that have
-`model_memory_limit` values greater than that setting. For more information, see
-<<ml-settings>>.
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-memory-limit-dfa]
 
 `source`::
 (object)

--- a/docs/reference/ml/df-analytics/apis/update-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/update-dfanalytics.asciidoc
@@ -78,12 +78,7 @@ functionality other than the analysis itself.
 
 `model_memory_limit`::
 (Optional, string)
-The approximate maximum amount of memory resources that are permitted for 
-analytical processing. The default value for {dfanalytics-jobs} is `1gb`. If 
-your `elasticsearch.yml` file contains an `xpack.ml.max_model_memory_limit` 
-setting, an error occurs when you try to create {dfanalytics-jobs} that have 
-`model_memory_limit` values greater than that setting. For more information, see 
-<<ml-settings>>.
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-memory-limit-dfa]
 
 [[ml-update-dfanalytics-example]]
 == {api-examples-title}

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -1153,7 +1153,7 @@ tag::model-id-or-alias[]
 The unique identifier of the trained model or a model alias.
 end::model-id-or-alias[]
 
-tag::model-memory-limit[]
+tag::model-memory-limit-ad[]
 The approximate maximum amount of memory resources that are required for
 analytical processing. Once this limit is approached, data pruning becomes
 more aggressive. Upon exceeding this limit, new entities are not modeled. The
@@ -1174,11 +1174,20 @@ supported byte size units, see <<byte-units>>.
 If you specify a value for the `xpack.ml.max_model_memory_limit` setting, an
 error occurs when you try to create jobs that have `model_memory_limit` values
 greater than that setting value. For more information, see <<ml-settings>>.
-end::model-memory-limit[]
+end::model-memory-limit-ad[]
 
 tag::model-memory-limit-anomaly-jobs[]
 The upper limit for model memory usage, checked on increasing values.
 end::model-memory-limit-anomaly-jobs[]
+
+tag::model-memory-limit-dfa[]
+The approximate maximum amount of memory resources that are permitted for
+analytical processing. The default value for {dfanalytics-jobs} is `1gb`. If
+you specify a value for the `xpack.ml.max_model_memory_limit` setting, an error
+occurs when you try to create jobs that have `model_memory_limit` values greater
+than that setting value. For more information, see
+<<ml-settings>>.
+end::model-memory-limit-dfa[]
 
 tag::model-memory-status[]
 The status of the mathematical models, which can have one of the following

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -1157,11 +1157,12 @@ tag::model-memory-limit[]
 The approximate maximum amount of memory resources that are required for
 analytical processing. Once this limit is approached, data pruning becomes
 more aggressive. Upon exceeding this limit, new entities are not modeled. The
-default value for jobs created in version 6.1 and later is `1024mb`.
-This value will need to be increased for jobs that are expected to analyze high
-cardinality fields, but the default is set to a relatively small size to ensure
-that high resource usage is a conscious decision. The default value for jobs
-created in versions earlier than 6.1 is `4096mb`.
+default value for jobs created in version 6.1 and later is `1024mb`. If the
+`xpack.ml.max_model_memory_limit` setting has a value greater than `0` and less
+than `1024mb`, however, that value is used instead. The default value is
+relatively small to ensure that high resource usage is a conscious decision. If
+you have jobs that are expected to analyze high cardinality fields, you will
+likely need to use a higher value. 
 +
 If you specify a number instead of a string, the units are assumed to be MiB.
 Specifying a string is recommended for clarity. If you specify a byte size unit
@@ -1170,10 +1171,9 @@ it is rounded down to the closest MiB. The minimum valid value is 1 MiB. If you
 specify a value less than 1 MiB, an error occurs. For more information about
 supported byte size units, see <<byte-units>>.
 +
-If your `elasticsearch.yml` file contains an `xpack.ml.max_model_memory_limit`
-setting, an error occurs when you try to create jobs that have
-`model_memory_limit` values greater than that setting. For more information,
-see <<ml-settings>>.
+If you specify a value for the `xpack.ml.max_model_memory_limit` setting, an
+error occurs when you try to create jobs that have `model_memory_limit` values
+greater than that setting value. For more information, see <<ml-settings>>.
 end::model-memory-limit[]
 
 tag::model-memory-limit-anomaly-jobs[]

--- a/docs/reference/settings/ml-settings.asciidoc
+++ b/docs/reference/settings/ml-settings.asciidoc
@@ -135,7 +135,7 @@ concurrently be in the `opening` state on each node. Typically, jobs spend a
 small amount of time in this state before they move to `open` state. Jobs that
 must restore large models when they are opening spend more time in the `opening`
 state. When the {operator-feature} is enabled, this setting can be updated only 
-by operator users. The minimum value is `0`. Defaults to `2`.
+by operator users. Defaults to `2`.
 
 [discrete]
 [[advanced-ml-settings]]

--- a/docs/reference/settings/ml-settings.asciidoc
+++ b/docs/reference/settings/ml-settings.asciidoc
@@ -159,7 +159,7 @@ this setting has a value greater than zero and there are no nodes that can
 accept the job, the job stays in the `OPENING` state until a new {ml} node is 
 added to the cluster and the job is assigned to run on that node. When the
 {operator-feature} is enabled, this setting can be updated only by operator
-users. The maximum value is `3`. Defaults to `0`.
+users. Defaults to `0`.
 +
 IMPORTANT: This setting assumes some external process is capable of adding {ml}
 nodes to the cluster. This setting is only useful when used in conjunction with

--- a/docs/reference/settings/ml-settings.asciidoc
+++ b/docs/reference/settings/ml-settings.asciidoc
@@ -172,7 +172,7 @@ cluster scaling. If you set it to the maximum possible size of future {ml} nodes
 when a {ml} job is assigned to a lazy node it can check (and fail quickly) when
 scaling cannot support the size of the job. When the {operator-feature} is
 enabled, this setting can be updated only by operator users. Defaults to `0b`,
-which means this value is ignored. 
+which means it will be assumed that automatic cluster scaling can add arbitrarily large nodes to the cluster. 
 
 `xpack.ml.persist_results_max_retries`::
 (<<cluster-update-settings,Dynamic>>) The maximum number of times to retry bulk

--- a/docs/reference/settings/ml-settings.asciidoc
+++ b/docs/reference/settings/ml-settings.asciidoc
@@ -98,11 +98,14 @@ general best practice is to not use swap on {es} nodes.
 
 `xpack.ml.max_model_memory_limit`::
 (<<cluster-update-settings,Dynamic>>) The maximum `model_memory_limit` property
-value that can be set for any job on this node. If you try to create a job with
-a `model_memory_limit` property value that is greater than this setting value,
-an error occurs. Existing jobs are not affected when you update this setting.
-If this setting is `0` or unset, the maximum `model_memory_limit` value is `1gb`.
-For more information about the `model_memory_limit` property, see
+value that can be set for any {ml} jobs in this cluster. If you try to create a
+job with a `model_memory_limit` property value that is greater than this setting
+value, an error occurs. Existing jobs are not affected when you update this
+setting. If this setting is `0` or unset, there is no maximum
+`model_memory_limit` value. If there are no nodes that meet the memory
+requirements for a job, this lack of a maximum memory limit means it's possible
+to create jobs that cannot be assigned to any available nodes. For more
+information about the `model_memory_limit` property, see
 <<put-analysislimits,`analysis_limits`>>. Defaults to `0`.
 
 [[xpack.ml.max_open_jobs]]

--- a/docs/reference/settings/ml-settings.asciidoc
+++ b/docs/reference/settings/ml-settings.asciidoc
@@ -204,21 +204,19 @@ nodes in your cluster, you shouldn't use this setting.
 ==== {ml-cap} circuit breaker settings
 
 `breaker.model_inference.limit`::
-(<<cluster-update-settings,Dynamic>>) Limit for the model inference breaker. If
-the parent circuit breaker is less than 50% of the JVM heap, it is bound to that
-limit instead.
-//TBD: Is that sentence apply only when using the default value?
-See <<circuit-breaker>>. Defaults to 50% of the JVM heap.
-//TBD: Is a valid value "40%", "40", or is it a byte value?
+(<<cluster-update-settings,Dynamic>>) The limit for the trained model circuit
+breaker. This value is defined as a percentage of the JVM heap. Defaults to
+`50%`. If the <<parent-circuit-breaker,parent circuit breaker>> is set to a
+value less than `50%`, this setting uses that value as its default instead.
 
 `breaker.model_inference.overhead`::
-(<<cluster-update-settings,Dynamic>>) A constant that all accounting estimations
-are multiplied by to determine a final estimation. See <<circuit-breaker>>.
-Defaults to `1`.
+(<<cluster-update-settings,Dynamic>>) A constant that all trained model
+estimations are multiplied by to determine a final estimation. See
+<<circuit-breaker>>. Defaults to `1`.
 
 `breaker.model_inference.type`::
 (<<static-cluster-setting,Static>>) The underlying type of the circuit breaker.
 There are two valid options: `noop` and `memory`. `noop` means the circuit
 breaker does nothing to prevent too much memory usage. `memory` means the
-circuit breaker tracks the memory used by inference models and can potentially
+circuit breaker tracks the memory used by trained models and can potentially
 break and prevent `OutOfMemory` errors. The default value is `memory`.

--- a/docs/reference/settings/ml-settings.asciidoc
+++ b/docs/reference/settings/ml-settings.asciidoc
@@ -56,8 +56,8 @@ coordinating nodes.
 (<<static-cluster-setting,Static>>) The maximum inference cache size allowed.
 The inference cache exists in the JVM heap on each ingest node. The cache
 affords faster processing times for the `inference` processor. The value can be
-a static byte sized value (i.e. "2gb") or a percentage of total allocated heap.
-The default is "40%". See also <<model-inference-circuit-breaker>>.
+a static byte sized value (such as `2gb`) or a percentage of total allocated
+heap. Defaults to `40%`. See also <<model-inference-circuit-breaker>>.
 
 [[xpack-interference-model-ttl]]
 // tag::interference-model-ttl-tag[]
@@ -77,12 +77,12 @@ adding an `inference` processor to a pipeline is disallowed. Defaults to `50`.
 
 `xpack.ml.max_machine_memory_percent`::
 (<<cluster-update-settings,Dynamic>>) The maximum percentage of the machine's
-memory that {ml} may use for running analytics processes. (These processes are
-separate to the {es} JVM.) Defaults to `30` percent. The limit is based on the
-total memory of the machine, not current free memory. Jobs are not allocated to
-a node if doing so would cause the estimated memory use of {ml} jobs to exceed
-the limit. When the {operator-feature} is enabled, this setting can be updated
-only by operator users.
+memory that {ml} may use for running analytics processes. These processes are
+separate to the {es} JVM. The limit is based on the total memory of the machine, 
+not current free memory. Jobs are not allocated to a node if doing so would
+cause the estimated memory use of {ml} jobs to exceed the limit. When the
+{operator-feature} is enabled, this setting can be updated only by operator
+users. The minimum value is `5`; the maximum value is `200`. Defaults to `30`.
 
 `xpack.ml.max_model_memory_limit`::
 (<<cluster-update-settings,Dynamic>>) The maximum `model_memory_limit` property
@@ -91,18 +91,19 @@ a `model_memory_limit` property value that is greater than this setting value,
 an error occurs. Existing jobs are not affected when you update this setting.
 For more information about the `model_memory_limit` property, see
 <<put-analysislimits>>.
+//TBD: Default?
 
 [[xpack.ml.max_open_jobs]]
 `xpack.ml.max_open_jobs`::
 (<<cluster-update-settings,Dynamic>>) The maximum number of jobs that can run
-simultaneously on a node. Defaults to `20`. In this context, jobs include both
-{anomaly-jobs} and {dfanalytics-jobs}. The maximum number of jobs is also
-constrained by memory usage. Thus if the estimated memory usage of the jobs
-would be higher than allowed, fewer jobs will run on a node. Prior to version
-7.1, this setting was a per-node non-dynamic setting. It became a cluster-wide
-dynamic setting in version 7.1. As a result, changes to its value after node
-startup are used only after every node in the cluster is running version 7.1 or
-higher. The maximum permitted value is `512`.
+simultaneously on a node. In this context, jobs include both {anomaly-jobs} and 
+{dfanalytics-jobs}. The maximum number of jobs is also constrained by memory 
+usage. Thus if the estimated memory usage of the jobs would be higher than 
+allowed, fewer jobs will run on a node. Prior to version 7.1, this setting was a 
+per-node non-dynamic setting. It became a cluster-wide dynamic setting in
+version 7.1. As a result, changes to its value after node startup are used only 
+after every node in the cluster is running version 7.1 or higher. The minimum
+value is `1`; the maximum value is `512`. Defaults to `20`.
 
 `xpack.ml.nightly_maintenance_requests_per_second`::
 (<<cluster-update-settings,Dynamic>>) The rate at which the nightly maintenance 
@@ -110,7 +111,7 @@ task deletes expired model snapshots and results. The setting is a proxy to the
 <<docs-delete-by-query-throttle,requests_per_second>> parameter used in the 
 delete by query requests and controls throttling. When the {operator-feature} is 
 enabled, this setting can be updated only by operator users. Valid values must
-be greater than `0.0` or equal to `-1.0` where `-1.0` means a default value is
+be greater than `0.0` or equal to `-1.0`, where `-1.0` means a default value is
 used. Defaults to `-1.0`
 
 `xpack.ml.node_concurrent_job_allocations`::
@@ -119,7 +120,7 @@ concurrently be in the `opening` state on each node. Typically, jobs spend a
 small amount of time in this state before they move to `open` state. Jobs that
 must restore large models when they are opening spend more time in the `opening`
 state. When the {operator-feature} is enabled, this setting can be updated only 
-by operator users. Defaults to `2`.
+by operator users. The minimum value is `0`. Defaults to `2`.
 
 [discrete]
 [[advanced-ml-settings]]
@@ -134,19 +135,19 @@ enabled, this setting can be updated only by operator users.
 
 `xpack.ml.max_anomaly_records`::
 (<<cluster-update-settings,Dynamic>>) The maximum number of records that are
-output per bucket. The default value is `500`.
+output per bucket. Defaults to `500`.
 
 `xpack.ml.max_lazy_ml_nodes`::
 (<<cluster-update-settings,Dynamic>>) The number of lazily spun up {ml} nodes.
 Useful in situations where {ml} nodes are not desired until the first {ml} job
-opens. It defaults to `0` and has a maximum acceptable value of `3`. If the
-current number of {ml} nodes is greater than or equal to this setting, it is
-assumed that there are no more lazy nodes available as the desired number
-of nodes have already been provisioned. If a job is opened and this setting has
-a value greater than zero and there are no nodes that can accept the job, the
-job stays in the `OPENING` state until a new {ml} node is added to the cluster
-and the job is assigned to run on that node. When the {operator-feature} is
-enabled, this setting can be updated only by operator users.
+opens. If the current number of {ml} nodes is greater than or equal to this 
+setting, it is assumed that there are no more lazy nodes available as the
+desired number of nodes have already been provisioned. If a job is opened and 
+this setting has a value greater than zero and there are no nodes that can
+accept the job, the job stays in the `OPENING` state until a new {ml} node is 
+added to the cluster and the job is assigned to run on that node. When the
+{operator-feature} is enabled, this setting can be updated only by operator
+users. The maximum value is `3`. Defaults to `0`.
 +
 IMPORTANT: This setting assumes some external process is capable of adding {ml}
 nodes to the cluster. This setting is only useful when used in conjunction with
@@ -155,65 +156,69 @@ such an external process.
 `xpack.ml.max_ml_node_size`::
 (<<cluster-update-settings,Dynamic>>)
 The maximum node size for {ml} nodes in a deployment that supports automatic
-cluster scaling. Defaults to `0b`, which means this value is ignored. If you set
-it to the maximum possible size of future {ml} nodes, when a {ml} job is
-assigned to a lazy node it can check (and fail quickly) when scaling cannot 
-support the size of the job. When the {operator-feature} is enabled, this
-setting can be updated only by operator users.
+cluster scaling. If you set it to the maximum possible size of future {ml} nodes,
+when a {ml} job is assigned to a lazy node it can check (and fail quickly) when
+scaling cannot support the size of the job. When the {operator-feature} is
+enabled, this setting can be updated only by operator users. Defaults to `0b`,
+which means this value is ignored. 
 
 `xpack.ml.persist_results_max_retries`::
 (<<cluster-update-settings,Dynamic>>) The maximum number of times to retry bulk
 indexing requests that fail while processing {ml} results. If the limit is
 reached, the {ml} job stops processing data and its status is `failed`. When the
 {operator-feature} is enabled, this setting can be updated only by operator
-users. Defaults to `20`. The maximum value for this setting is `50`. 
+users. The minimum value is `0`; the maximum value is `50`. Defaults to `20`.
 
 `xpack.ml.process_connect_timeout`::
 (<<cluster-update-settings,Dynamic>>) The connection timeout for {ml} processes
-that run separately from the {es} JVM. Defaults to `10s`. Some {ml} processing
-is done by processes that run separately to the {es} JVM. When such processes
-are started they must connect to the {es} JVM. If such a process does not
-connect within the time period specified by this setting then the process is
-assumed to have failed. When the {operator-feature} is enabled, this setting can
-be updated only by operator users. Defaults to `10s`. The minimum value for this 
-setting is `5s`. 
+that run separately from the {es} JVM. When such processes are started they must
+connect to the {es} JVM. If the process does not connect within the time period
+specified by this setting then the process is assumed to have failed. When the
+{operator-feature} is enabled, this setting can be updated only by operator
+users. The minimum value is `5s`. Defaults to `10s`.
 
 xpack.ml.use_auto_machine_memory_percent::
 (<<cluster-update-settings,Dynamic>>) If this setting is `true`, the
 `xpack.ml.max_machine_memory_percent` setting is ignored. Instead, the maximum
 percentage of the machine's memory that can be used for running {ml} analytics
 processes is calculated automatically and takes into account the total node size
-and the size of the JVM on the node. The default value is `false`. If this
-setting differs between nodes, the value on the current master node is heeded.
-When the {operator-feature} is enabled, this setting can be updated only by
-operator users.
+and the size of the JVM on the node. If this setting differs between nodes, the
+value on the current master node is heeded. When the {operator-feature} is
+enabled, this setting can be updated only by operator users. The default value
+is `false`. 
 +
-TIP: If you do not have dedicated {ml} nodes (that is to say, the node has
+--
+[IMPORTANT]
+====
+* If you do not have dedicated {ml} nodes (that is to say, the node has
 multiple roles), do not enable this setting. Its calculations assume that {ml}
 analytics are the main purpose of the node.
-+
-IMPORTANT: The calculation assumes that dedicated {ml} nodes have at least
+* The calculation assumes that dedicated {ml} nodes have at least
 `256MB` memory reserved outside of the JVM. If you have tiny {ml}
 nodes in your cluster, you shouldn't use this setting.
+====
+--
 
 [discrete]
 [[model-inference-circuit-breaker]]
 ==== {ml-cap} circuit breaker settings
 
 `breaker.model_inference.limit`::
-(<<cluster-update-settings,Dynamic>>) Limit for the model inference breaker,
-which defaults to 50% of the JVM heap. If the parent circuit breaker is less
-than 50% of the JVM heap, it is bound to that limit instead. See
-<<circuit-breaker>>.
+(<<cluster-update-settings,Dynamic>>) Limit for the model inference breaker. If
+the parent circuit breaker is less than 50% of the JVM heap, it is bound to that
+limit instead.
+//TBD: Is that sentence apply only when using the default value?
+See <<circuit-breaker>>. Defaults to 50% of the JVM heap.
+//TBD: Is a valid value "40%", "40", or is it a byte value?
 
 `breaker.model_inference.overhead`::
 (<<cluster-update-settings,Dynamic>>) A constant that all accounting estimations
-are multiplied by to determine a final estimation. Defaults to 1. See
-<<circuit-breaker>>.
+are multiplied by to determine a final estimation. See <<circuit-breaker>>.
+Defaults to `1`.
 
 `breaker.model_inference.type`::
 (<<static-cluster-setting,Static>>) The underlying type of the circuit breaker.
 There are two valid options: `noop` and `memory`. `noop` means the circuit
 breaker does nothing to prevent too much memory usage. `memory` means the
 circuit breaker tracks the memory used by inference models and can potentially
-break and prevent `OutOfMemory` errors. The default is `memory`.
+break and prevent `OutOfMemory` errors. The default value is `memory`.

--- a/docs/reference/settings/ml-settings.asciidoc
+++ b/docs/reference/settings/ml-settings.asciidoc
@@ -62,12 +62,13 @@ heap. Defaults to `40%`. See also <<model-inference-circuit-breaker>>.
 [[xpack-interference-model-ttl]]
 // tag::interference-model-ttl-tag[]
 `xpack.ml.inference_model.time_to_live` {ess-icon}::
-(<<static-cluster-setting,Static>>) The time to live (TTL) for models in the
-inference model cache. The TTL is calculated from last access. The `inference`
-processor attempts to load the model from cache. If the `inference` processor
-does not receive any documents for the duration of the TTL, the referenced model
-is flagged for eviction from the cache. If a document is processed later, the
-model is again loaded into the cache. To update this setting in {ess}, see 
+(<<static-cluster-setting,Static>>) The time to live (TTL) for trained models in 
+the inference model cache. The TTL is calculated from last access. Users of the 
+cache (such as the inference processor or inference aggregator) cache a model on
+its first use and reset the TTL on every use. If a cached model is not accessed
+for the duration of the TTL, it is flagged for eviction from the cache. If a 
+document is processed later, the model is again loaded into the cache. To update 
+this setting in {ess}, see
 {cloud}/ec-add-user-settings.html[Add {es} user settings]. Defaults to `5m`.
 // end::interference-model-ttl-tag[]
 

--- a/docs/reference/settings/ml-settings.asciidoc
+++ b/docs/reference/settings/ml-settings.asciidoc
@@ -89,9 +89,9 @@ users. The minimum value is `5`; the maximum value is `200`. Defaults to `30`.
 value that can be set for any job on this node. If you try to create a job with
 a `model_memory_limit` property value that is greater than this setting value,
 an error occurs. Existing jobs are not affected when you update this setting.
+If this setting is `0` or unset, the maximum `model_memory_limit` value is `1gb`.
 For more information about the `model_memory_limit` property, see
-<<put-analysislimits>>.
-//TBD: Default?
+<<put-analysislimits>>. Defaults to `0`.
 
 [[xpack.ml.max_open_jobs]]
 `xpack.ml.max_open_jobs`::

--- a/docs/reference/settings/ml-settings.asciidoc
+++ b/docs/reference/settings/ml-settings.asciidoc
@@ -67,7 +67,8 @@ inference model cache. The TTL is calculated from last access. The `inference`
 processor attempts to load the model from cache. If the `inference` processor
 does not receive any documents for the duration of the TTL, the referenced model
 is flagged for eviction from the cache. If a document is processed later, the
-model is again loaded into the cache. Defaults to `5m`.
+model is again loaded into the cache. To update this setting in {ess}, see 
+{cloud}/ec-add-user-settings.html[Add {es} user settings]. Defaults to `5m`.
 // end::interference-model-ttl-tag[]
 
 `xpack.ml.max_inference_processors`::
@@ -91,7 +92,7 @@ a `model_memory_limit` property value that is greater than this setting value,
 an error occurs. Existing jobs are not affected when you update this setting.
 If this setting is `0` or unset, the maximum `model_memory_limit` value is `1gb`.
 For more information about the `model_memory_limit` property, see
-<<put-analysislimits>>. Defaults to `0`.
+<<put-analysislimits,`analysis_limits`>>. Defaults to `0`.
 
 [[xpack.ml.max_open_jobs]]
 `xpack.ml.max_open_jobs`::
@@ -108,7 +109,7 @@ value is `1`; the maximum value is `512`. Defaults to `20`.
 `xpack.ml.nightly_maintenance_requests_per_second`::
 (<<cluster-update-settings,Dynamic>>) The rate at which the nightly maintenance 
 task deletes expired model snapshots and results. The setting is a proxy to the
-<<docs-delete-by-query-throttle,requests_per_second>> parameter used in the 
+<<docs-delete-by-query-throttle,`requests_per_second`>> parameter used in the 
 delete by query requests and controls throttling. When the {operator-feature} is 
 enabled, this setting can be updated only by operator users. Valid values must
 be greater than `0.0` or equal to `-1.0`, where `-1.0` means a default value is

--- a/docs/reference/settings/ml-settings.asciidoc
+++ b/docs/reference/settings/ml-settings.asciidoc
@@ -106,7 +106,7 @@ setting. If this setting is `0` or unset, there is no maximum
 requirements for a job, this lack of a maximum memory limit means it's possible
 to create jobs that cannot be assigned to any available nodes. For more
 information about the `model_memory_limit` property, see
-<<put-analysislimits,`analysis_limits`>>. Defaults to `0`.
+<<ml-put-job,Create {anomaly-jobs}>> or <<put-dfanalytics>>. Defaults to `0`.
 
 [[xpack.ml.max_open_jobs]]
 `xpack.ml.max_open_jobs`::

--- a/docs/reference/settings/ml-settings.asciidoc
+++ b/docs/reference/settings/ml-settings.asciidoc
@@ -85,6 +85,16 @@ not current free memory. Jobs are not allocated to a node if doing so would
 cause the estimated memory use of {ml} jobs to exceed the limit. When the
 {operator-feature} is enabled, this setting can be updated only by operator
 users. The minimum value is `5`; the maximum value is `200`. Defaults to `30`.
++
+--
+TIP: Do not configure this setting to a value higher than the amount of memory
+left over after running the {es} JVM unless you have enough swap space to
+accommodate it and have determined this is an appropriate configuration for a
+specialist use case. The maximum setting value is for the special case where it
+has been determined that using swap space for {ml} jobs is acceptable. The
+general best practice is to not use swap on {es} nodes.
+
+--
 
 `xpack.ml.max_model_memory_limit`::
 (<<cluster-update-settings,Dynamic>>) The maximum `model_memory_limit` property


### PR DESCRIPTION
This PR edits the descriptions for machine learning settings and adds some missing minimum, maximum, and default values.

### Preview

https://elasticsearch_69947.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ml-settings.html