### PR TITLE
[DOCS] Removes beta from latest Transform docs

### DIFF
--- a/docs/reference/transform/apis/preview-transform.asciidoc
+++ b/docs/reference/transform/apis/preview-transform.asciidoc
@@ -83,7 +83,6 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=frequency]
 //Begin latest
 `latest`::
 (Required^*^, object)
-beta:[]
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-latest]
 +
 .Properties of `latest`

--- a/docs/reference/transform/apis/put-transform.asciidoc
+++ b/docs/reference/transform/apis/put-transform.asciidoc
@@ -114,7 +114,6 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=frequency]
 //Begin latest
 `latest`::
 (Required^*^, object)
-beta:[]
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-latest]
 +
 .Properties of `latest`

--- a/docs/reference/transform/overview.asciidoc
+++ b/docs/reference/transform/overview.asciidoc
@@ -75,8 +75,6 @@ image::images/pivot-preview.png["Example of a pivot {transform} preview in {kib}
 [[latest-transform-overview]]
 == Latest {transforms}
 
-beta::[]
-
 You can use the `latest` type of {transform} to copy the most recent documents
 into a new index. You must identify one or more fields as the unique key for
 grouping your data, as well as a date field that sorts the data chronologically.


### PR DESCRIPTION
## Overview

As the `latest` function becomes GA from 7.12, this PR removes the `beta` tag from the latest related Transform docs.

### Preview

[Transform overview](https://elasticsearch_69964.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/transform-overview.html)
[PUT Transform API docs](https://elasticsearch_69964.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/put-transform.html)
[Preview Transform API docs](https://elasticsearch_69964.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/preview-transform.html)