### PR TITLE
Remove Redundant BytesArray Copy in SourceToParse

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceToParse.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceToParse.java
@@ -32,7 +32,7 @@ public class SourceToParse {
         this.id = Objects.requireNonNull(id);
         // we always convert back to byte array, since we store it and Field only supports bytes..
         // so, we might as well do it here, and improve the performance of working with direct byte arrays
-        this.source = new BytesArray(Objects.requireNonNull(source).toBytesRef());
+        this.source = source instanceof BytesArray ? source : new BytesArray(Objects.requireNonNull(source).toBytesRef());
         this.xContentType = Objects.requireNonNull(xContentType);
         this.routing = routing;
     }


### PR DESCRIPTION
source appears to mostly be a BytesArray already and we can skip the copy
step in this case.

