### PR TITLE
[7.x] [DOCS] Removes beta from latest Transform docs. (#69964)

### DIFF
--- a/docs/reference/transform/apis/preview-transform.asciidoc
+++ b/docs/reference/transform/apis/preview-transform.asciidoc
@@ -83,7 +83,6 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=frequency]
 //Begin latest
 `latest`::
 (Required^*^, object)
-beta:[]
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-latest]
 +
 .Properties of `latest`

--- a/docs/reference/transform/apis/put-transform.asciidoc
+++ b/docs/reference/transform/apis/put-transform.asciidoc
@@ -114,7 +114,6 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=frequency]
 //Begin latest
 `latest`::
 (Required^*^, object)
-beta:[]
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-latest]
 +
 .Properties of `latest`

--- a/docs/reference/transform/overview.asciidoc
+++ b/docs/reference/transform/overview.asciidoc
@@ -75,8 +75,6 @@ image::images/pivot-preview.png["Example of a pivot {transform} preview in {kib}
 [[latest-transform-overview]]
 == Latest {transforms}
 
-beta::[]
-
 You can use the `latest` type of {transform} to copy the most recent documents
 into a new index. You must identify one or more fields as the unique key for
 grouping your data, as well as a date field that sorts the data chronologically.


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Removes beta from latest Transform docs. (#69964)