### PR TITLE
Switch built-in policies to max_primary_shard_size

### DIFF
--- a/docs/reference/data-streams/change-mappings-and-settings.asciidoc
+++ b/docs/reference/data-streams/change-mappings-and-settings.asciidoc
@@ -35,7 +35,7 @@ PUT /_ilm/policy/my-data-stream-policy
       "hot": {
         "actions": {
           "rollover": {
-            "max_size": "25GB"
+            "max_primary_shard_size": "25GB"
           }
         }
       },

--- a/docs/reference/data-streams/set-up-a-data-stream.asciidoc
+++ b/docs/reference/data-streams/set-up-a-data-stream.asciidoc
@@ -40,7 +40,7 @@ PUT /_ilm/policy/my-data-stream-policy
       "hot": {
         "actions": {
           "rollover": {
-            "max_size": "25GB"
+            "max_primary_shard_size": "25GB"
           }
         }
       },

--- a/docs/reference/ilm/actions/ilm-rollover.asciidoc
+++ b/docs/reference/ilm/actions/ilm-rollover.asciidoc
@@ -84,6 +84,29 @@ shard is a primary (`p`) or a replica (`r`).
 [[ilm-rollover-ex]]
 ==== Example
 
+[[ilm-rollover-primar-shardsize-ex]]
+===== Roll over based on largest primary shard size
+
+This example rolls the index over when its largest primary shard is at least 50 gigabytes.
+
+[source,console]
+--------------------------------------------------
+PUT _ilm/policy/my_policy
+{
+  "policy": {
+    "phases": {
+      "hot": {
+        "actions": {
+          "rollover" : {
+            "max_primary_shard_size": "50GB"
+          }
+        }
+      }
+    }
+  }
+}
+--------------------------------------------------
+
 [[ilm-rollover-size-ex]]
 ===== Roll over based on index size
 

--- a/docs/reference/ilm/ilm-tutorial.asciidoc
+++ b/docs/reference/ilm/ilm-tutorial.asciidoc
@@ -51,7 +51,7 @@ and the actions to perform in each phase. A lifecycle can have up to five phases
 For example, you might define a `timeseries_policy` that has two phases:
 
 * A `hot` phase that defines a rollover action to specify that an index rolls over when it
-reaches either a `max_size` of 50 gigabytes or a `max_age` of 30 days.
+reaches either a `max_primary_shard_size` of 50 gigabytes or a `max_age` of 30 days.
 * A `delete` phase that sets `min_age` to remove the index 90 days after rollover.
 Note that this value is relative to the rollover time, not the index creation time.
 
@@ -72,18 +72,18 @@ PUT _ilm/policy/timeseries_policy
 {
   "policy": {
     "phases": {
-      "hot": {                      <1>
+      "hot": {                                <1>
         "actions": {
           "rollover": {
-            "max_size": "50GB",     <2>
+            "max_primary_shard_size": "50GB", <2>
             "max_age": "30d"
           }
         }
       },
       "delete": {
-        "min_age": "90d",           <3>
+        "min_age": "90d",                     <3>
         "actions": {
-          "delete": {}              <4>
+          "delete": {}                        <4>
         }
       }
     }
@@ -232,7 +232,7 @@ is met.
           "min_age": "0ms",
           "actions": {
             "rollover": {
-              "max_size": "50gb",
+              "max_primary_shard_size": "50gb",
               "max_age": "30d"
             }
           }

--- a/docs/reference/ilm/set-up-lifecycle-policy.asciidoc
+++ b/docs/reference/ilm/set-up-lifecycle-policy.asciidoc
@@ -49,7 +49,7 @@ PUT _ilm/policy/my_policy
       "hot": {
         "actions": {
           "rollover": {
-            "max_size": "25GB" <1>
+            "max_primary_shard_size": "25GB" <1>
           }
         }
       },

--- a/docs/reference/indices/get-data-stream.asciidoc
+++ b/docs/reference/indices/get-data-stream.asciidoc
@@ -18,7 +18,7 @@ PUT /_ilm/policy/my-lifecycle-policy
       "hot": {
         "actions": {
           "rollover": {
-            "max_size": "25GB"
+            "max_primary_shard_size": "25GB"
           }
         }
       },

--- a/x-pack/plugin/core/src/main/resources/ilm-history-ilm-policy.json
+++ b/x-pack/plugin/core/src/main/resources/ilm-history-ilm-policy.json
@@ -3,7 +3,7 @@
     "hot": {
       "actions": {
         "rollover": {
-          "max_size": "50GB",
+          "max_primary_shard_size": "50gb",
           "max_age": "30d"
         }
       }

--- a/x-pack/plugin/core/src/main/resources/logs-policy.json
+++ b/x-pack/plugin/core/src/main/resources/logs-policy.json
@@ -3,7 +3,7 @@
     "hot": {
       "actions": {
         "rollover": {
-          "max_size": "50gb",
+          "max_primary_shard_size": "50gb",
           "max_age": "30d"
         }
       }

--- a/x-pack/plugin/core/src/main/resources/metrics-policy.json
+++ b/x-pack/plugin/core/src/main/resources/metrics-policy.json
@@ -3,7 +3,7 @@
     "hot": {
       "actions": {
         "rollover": {
-          "max_size": "50gb",
+          "max_primary_shard_size": "50gb",
           "max_age": "30d"
         }
       }

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/core/ml/size_based_ilm_policy.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/core/ml/size_based_ilm_policy.json
@@ -3,7 +3,7 @@
     "hot": {
       "actions": {
         "rollover": {
-          "max_size": "50GB"
+          "max_primary_shard_size": "50gb"
         }
       }
     }

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/deprecation/deprecation-indexing-ilm-policy.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/deprecation/deprecation-indexing-ilm-policy.json
@@ -3,7 +3,7 @@
     "hot": {
       "actions": {
         "rollover": {
-          "max_size": "50gb",
+          "max_primary_shard_size": "50gb",
           "max_age": "30d"
         }
       }

--- a/x-pack/plugin/core/src/main/resources/slm-history-ilm-policy.json
+++ b/x-pack/plugin/core/src/main/resources/slm-history-ilm-policy.json
@@ -3,7 +3,7 @@
     "hot": {
       "actions": {
         "rollover": {
-          "max_size": "50GB",
+          "max_primary_shard_size": "50gb",
           "max_age": "30d"
         }
       }

--- a/x-pack/plugin/core/src/main/resources/synthetics-policy.json
+++ b/x-pack/plugin/core/src/main/resources/synthetics-policy.json
@@ -3,7 +3,7 @@
     "hot": {
       "actions": {
         "rollover": {
-          "max_size": "50gb",
+          "max_primary_shard_size": "50gb",
           "max_age": "30d"
         }
       }


### PR DESCRIPTION
Related to #63026

Also some changes to the docs so that `max_primary_shard_size` is advertised a little more.