### PR TITLE
Tweak WatcherIndexTemplateRegistry bwc logic

### DIFF
--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/UpgradeClusterClientYamlTestSuiteIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/UpgradeClusterClientYamlTestSuiteIT.java
@@ -60,8 +60,7 @@ public class UpgradeClusterClientYamlTestSuiteIT extends ESClientYamlSuiteTestCa
                 }
             }, 1, TimeUnit.MINUTES);
         } catch (AssertionError e) {
-            // AwaitsFix: https://github.com/elastic/elasticsearch/issues/69918
-//            throw new AssertionError("Failure in test setup: Failed to initialize at least 3 watcher nodes", e);
+            throw new AssertionError("Failure in test setup: Failed to initialize at least 3 watcher nodes", e);
         }
     }
 

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/WatcherRestartIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/WatcherRestartIT.java
@@ -32,7 +32,6 @@ public class WatcherRestartIT extends AbstractUpgradeTestCase {
 
     private static final String templatePrefix = ".watch-history-";
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/69918")
     public void testWatcherRestart() throws Exception {
         client().performRequest(new Request("POST", "/_watcher/_stop"));
         ensureWatcherStopped();


### PR DESCRIPTION
* The WatcherIndexTemplateRegistry moved from legacy templates to composable index templates in version 7.10.0 and not 7.9.0
* The WatcherIndexTemplateRegistry#validate(...) method should only care whether a template for watcher history indices exist and
not whether that template is a composable index template or a legacy template. This shouldn't matter whether to determine if watcher can be started on a node. The content of the templates didn't change in a breaking manner (since version 6.8.0).

(marking as non-issue, as this hasn't yet been released)

Closes #69918