### PR TITLE
Exclude partially cached .cfs file from SearchableSnapshotDirectoryStatsTests

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/common/lucene/store/ESIndexInputTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/common/lucene/store/ESIndexInputTestCase.java
@@ -72,7 +72,8 @@ public class ESIndexInputTestCase extends ESTestCase {
                 case 3:
                     // Read using slice
                     len = randomIntBetween(1, length - readPos);
-                    IndexInput slice = indexInput.slice(randomAlphaOfLength(10) + randomFileExtension(), readPos, len);
+                    final String sliceExtension = randomValueOtherThan(".cfs", ESIndexInputTestCase::randomFileExtension);
+                    IndexInput slice = indexInput.slice(randomAlphaOfLength(10) + sliceExtension, readPos, len);
                     temp = randomReadAndSlice(slice, len);
                     // assert that position in the original input didn't change
                     assertEquals(readPos, indexInput.getFilePointer());
@@ -121,7 +122,8 @@ public class ESIndexInputTestCase extends ESTestCase {
                                     clone = indexInput.clone();
                                 } else {
                                     final int sliceEnd = between(readEnd, length);
-                                    clone = indexInput.slice("slice" + randomAlphaOfLength(10) + randomFileExtension(), 0L, sliceEnd);
+                                    final String sliceExtension = randomValueOtherThan(".cfs", ESIndexInputTestCase::randomFileExtension);
+                                    clone = indexInput.slice("slice" + randomAlphaOfLength(10) + sliceExtension, 0L, sliceEnd);
                                 }
                                 startLatch.countDown();
                                 startLatch.await();

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/SearchableSnapshotDirectoryStatsTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/SearchableSnapshotDirectoryStatsTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.cluster.routing.TestShardRouting;
 import org.elasticsearch.common.TriConsumer;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.blobstore.BlobContainer;
+import org.elasticsearch.common.lucene.store.ESIndexInputTestCase;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
@@ -604,8 +605,14 @@ public class SearchableSnapshotDirectoryStatsTests extends AbstractSearchableSna
         final TriConsumer<String, byte[], SearchableSnapshotDirectory> test
     ) throws Exception {
 
+        final String fileName;
+        if (SearchableSnapshots.SNAPSHOT_PARTIAL_SETTING.get(indexSettings)) {
+             fileName = randomAlphaOfLength(10) + randomValueOtherThan(".cfs", ESIndexInputTestCase::randomFileExtension);
+        } else {
+            fileName = randomAlphaOfLength(10) + randomFileExtension();
+        }
+
         final byte[] fileContent = randomByteArrayOfLength(randomIntBetween(10, MAX_FILE_LENGTH));
-        final String fileName = randomAlphaOfLength(10) + randomFileExtension();
         final SnapshotId snapshotId = new SnapshotId("_name", "_uuid");
         final IndexId indexId = new IndexId("_name", "_uuid");
         final ShardId shardId = new ShardId("_name", "_uuid", 0);

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/SearchableSnapshotDirectoryStatsTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/SearchableSnapshotDirectoryStatsTests.java
@@ -607,7 +607,7 @@ public class SearchableSnapshotDirectoryStatsTests extends AbstractSearchableSna
 
         final String fileName;
         if (SearchableSnapshots.SNAPSHOT_PARTIAL_SETTING.get(indexSettings)) {
-             fileName = randomAlphaOfLength(10) + randomValueOtherThan(".cfs", ESIndexInputTestCase::randomFileExtension);
+            fileName = randomAlphaOfLength(10) + randomValueOtherThan(".cfs", ESIndexInputTestCase::randomFileExtension);
         } else {
             fileName = randomAlphaOfLength(10) + randomFileExtension();
         }


### PR DESCRIPTION
Since #69861 CFS files read from `FrozenIndexInput` create dedicated frozen shared cache files when they are sliced. This does not play well with some tests that use the `randomReadAndSlice` to read files: this method can create overlapping slice/clone reads operations which makes it difficult to assert anything about CFS files with partial cache.

This commit prevent the tests to generate a .cfs file name when the partial cache is randomly picked up. As a follow up we should rework those test to make them more realistic with the new behavior.

Closes #70000