### PR TITLE
Do not throttle deprecated field logs

### DIFF
--- a/qa/logging-config/src/test/resources/org/elasticsearch/common/logging/json_layout/log4j2.properties
+++ b/qa/logging-config/src/test/resources/org/elasticsearch/common/logging/json_layout/log4j2.properties
@@ -37,7 +37,7 @@ appender.plaintext.filter.rate_limit.type = RateLimitingFilter
 appender.header_warning.type = HeaderWarningAppender
 appender.header_warning.name = header_warning
 
-logger.deprecation.name = deprecation.test
+logger.deprecation.name = org.elasticsearch.deprecation
 logger.deprecation.level = deprecation
 logger.deprecation.appenderRef.deprecation_rolling.ref = deprecated
 logger.deprecation.appenderRef.deprecatedconsole.ref = deprecatedconsole

--- a/server/src/main/java/org/elasticsearch/common/xcontent/LoggingDeprecationHandler.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/LoggingDeprecationHandler.java
@@ -42,21 +42,21 @@ public class LoggingDeprecationHandler implements DeprecationHandler {
     @Override
     public void usedDeprecatedName(String parserName, Supplier<XContentLocation> location, String usedName, String modernName) {
         String prefix = parserName == null ? "" : "[" + parserName + "][" + location.get() + "] ";
-        deprecationLogger.deprecate(DeprecationCategory.API, "deprecated_field",
+        deprecationLogger.deprecate(DeprecationCategory.API, "deprecated_field_"+usedName,
             "{}Deprecated field [{}] used, expected [{}] instead", prefix, usedName, modernName);
     }
 
     @Override
     public void usedDeprecatedField(String parserName, Supplier<XContentLocation> location, String usedName, String replacedWith) {
         String prefix = parserName == null ? "" : "[" + parserName + "][" + location.get() + "] ";
-        deprecationLogger.deprecate(DeprecationCategory.API, "deprecated_field",
+        deprecationLogger.deprecate(DeprecationCategory.API, "deprecated_field_"+usedName,
             "{}Deprecated field [{}] used, replaced by [{}]", prefix, usedName, replacedWith);
     }
 
     @Override
     public void usedDeprecatedField(String parserName, Supplier<XContentLocation> location, String usedName) {
         String prefix = parserName == null ? "" : "[" + parserName + "][" + location.get() + "] ";
-        deprecationLogger.deprecate(DeprecationCategory.API, "deprecated_field",
+        deprecationLogger.deprecate(DeprecationCategory.API, "deprecated_field_"+usedName,
             "{}Deprecated field [{}] used, this field is unused and will be removed entirely", prefix, usedName);
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/xcontent/LoggingDeprecationHandler.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/LoggingDeprecationHandler.java
@@ -42,21 +42,21 @@ public class LoggingDeprecationHandler implements DeprecationHandler {
     @Override
     public void usedDeprecatedName(String parserName, Supplier<XContentLocation> location, String usedName, String modernName) {
         String prefix = parserName == null ? "" : "[" + parserName + "][" + location.get() + "] ";
-        deprecationLogger.deprecate(DeprecationCategory.API, "deprecated_field_"+usedName,
+        deprecationLogger.deprecate(DeprecationCategory.API, "deprecated_field_" + usedName,
             "{}Deprecated field [{}] used, expected [{}] instead", prefix, usedName, modernName);
     }
 
     @Override
     public void usedDeprecatedField(String parserName, Supplier<XContentLocation> location, String usedName, String replacedWith) {
         String prefix = parserName == null ? "" : "[" + parserName + "][" + location.get() + "] ";
-        deprecationLogger.deprecate(DeprecationCategory.API, "deprecated_field_"+usedName,
+        deprecationLogger.deprecate(DeprecationCategory.API, "deprecated_field_" + usedName,
             "{}Deprecated field [{}] used, replaced by [{}]", prefix, usedName, replacedWith);
     }
 
     @Override
     public void usedDeprecatedField(String parserName, Supplier<XContentLocation> location, String usedName) {
         String prefix = parserName == null ? "" : "[" + parserName + "][" + location.get() + "] ";
-        deprecationLogger.deprecate(DeprecationCategory.API, "deprecated_field_"+usedName,
+        deprecationLogger.deprecate(DeprecationCategory.API, "deprecated_field_" + usedName,
             "{}Deprecated field [{}] used, this field is unused and will be removed entirely", prefix, usedName);
     }
 }


### PR DESCRIPTION
The commit #55115 removed the possibility to directly force deprecation
log to be emitted. This means that usage of deprecated fields was
throttled and only one deprecation was logged. The key was common for
all fields = "deprecated_field".

This commit appends a used deprecated field name to prevent that
throttled.

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
