### PR TITLE
Remove size of dense_vector

### DIFF
--- a/docs/reference/mapping/types/dense-vector.asciidoc
+++ b/docs/reference/mapping/types/dense-vector.asciidoc
@@ -48,7 +48,3 @@ PUT my-index-000001/_doc/2
 --------------------------------------------------
 
 <1> dims—the number of dimensions in the vector, required parameter.
-
-Internally, each document's dense vector is encoded as a binary
-doc value. Its size in bytes is equal to
-`4 * dims + 4`, where `dims`—the number of the vector's dimensions.


### PR DESCRIPTION
Remove not completely correct statement about the size of dense_vectors

We do store a dense_vector as binary doc value  with size `4*dims+4`.
But this is size before compression. As compressed size depends on
data itself, it is better to remove completely any statement
about the size.
