### PR TITLE
Also mmap field data (.fdt) files for hybridfs

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/store/FsDirectoryFactory.java
+++ b/server/src/main/java/org/elasticsearch/index/store/FsDirectoryFactory.java
@@ -178,6 +178,9 @@ public class FsDirectoryFactory implements IndexStorePlugin.DirectoryFactory {
                 // are not mmaping them as queries that leverage positions are more costly and the decoding of postings
                 // tends to be less a bottleneck.
                 case "doc":
+                //loadStoredFields need to decompress the data,When the number of segments is less but the concurrency is very more,
+                //The Threads wait for nio FileChannel lock
+                case "fdt":
                     return true;
                 // Other files are either less performance-sensitive (e.g. stored field index, norms metadata)
                 // or are large and have a random access pattern and mmap leads to page cache trashing


### PR DESCRIPTION
This change adds the terms index (.fdt) to the list of extensions
that are memory-mapped by hybridfs.

When the shard merge to single segments, and there are many concurrent queries, many search thread will wait on `nio.ch.FileChannelImpl.readInternal` for loadStoredFields . Because they using the same file reader.

in this case, the search will be  slower after force merge.

![image](https://user-images.githubusercontent.com/23521001/110139530-16acd700-7e0e-11eb-8f2d-3ff99ee3a534.png)


so we can mmap the fdt file for hybridfs.

I ran the same benchmark for merged index(_forcemerge?max_num_segments=1) , use `term` operation with size:100，and clients:48 for challenges, the query latency is significantly reduced

```
|                                                        Metric |   Task |    Baseline |   Contender |     Diff |   Unit |
|--------------------------------------------------------------:|-------:|------------:|------------:|---------:|-------:|
|                                                    Store size |        |     89.5487 |     6.61721 | -82.9314 |     GB |
|                                                 Translog size |        | 2.20258e-06 | 7.68341e-07 |       -0 |     GB |
|                                        Heap used for segments |        |     48.5703 |     8.96341 | -39.6069 |     MB |
|                                      Heap used for doc values |        |    0.170841 |   0.0307388 |  -0.1401 |     MB |
|                                           Heap used for terms |        |      23.787 |     7.32935 | -16.4577 |     MB |
|                                           Heap used for norms |        |   0.0970459 |   0.0722046 | -0.02484 |     MB |
|                                          Heap used for points |        |           0 |           0 |        0 |     MB |
|                                   Heap used for stored fields |        |     24.5154 |     1.53112 | -22.9843 |     MB |
|                                                 Segment count |        |         129 |          92 |      -37 |        |
|                                                Min Throughput |   term |     1414.96 |        1996 |  581.037 |  ops/s |
|                                               Mean Throughput |   term |     1442.53 |     2000.07 |  557.539 |  ops/s |
|                                             Median Throughput |   term |     1446.34 |     1999.66 |  553.315 |  ops/s |
|                                                Max Throughput |   term |     1451.13 |     2003.93 |  552.805 |  ops/s |
|                                       50th percentile latency |   term |     6438.94 |     4.87244 | -6434.07 |     ms |
|                                       90th percentile latency |   term |     10012.7 |     5.99424 | -10006.7 |     ms |
|                                       99th percentile latency |   term |     10863.9 |     22.4411 | -10841.5 |     ms |
|                                     99.9th percentile latency |   term |     11084.3 |     50.0183 | -11034.3 |     ms |
|                                    99.99th percentile latency |   term |     11144.5 |     69.8108 | -11074.7 |     ms |
|                                      100th percentile latency |   term |     11163.8 |     70.4458 | -11093.3 |     ms |
|                                  50th percentile service time |   term |     32.0711 |     3.91603 | -28.1551 |     ms |
|                                  90th percentile service time |   term |     39.9306 |     4.89072 | -35.0399 |     ms |
|                                  99th percentile service time |   term |     49.9024 |     16.0866 | -33.8158 |     ms |
|                                99.9th percentile service time |   term |     78.8434 |     38.3506 | -40.4927 |     ms |
|                               99.99th percentile service time |   term |     97.0518 |     68.6928 |  -28.359 |     ms |
|                                 100th percentile service time |   term |     102.925 |     69.2111 |  -33.714 |     ms |
|                                                    error rate |   term |           0 |           0 |        0 |      % |


```

