### PR TITLE
Disable testingConventions tasks for BWC projects on ARM

### DIFF
--- a/gradle/bwc-test.gradle
+++ b/gradle/bwc-test.gradle
@@ -1,3 +1,4 @@
+import org.elasticsearch.gradle.Architecture
 import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.info.BuildParams
 
@@ -29,4 +30,8 @@ tasks.named("check").configure {
   dependsOn(bwcTestSnapshots)
 }
 
-tasks.matching{ it.name.equals("test") }.configureEach {enabled = false}
+tasks.matching { it.name.equals("test") }.configureEach { enabled = false }
+
+// Since the 7.12 branch has no backward compatible version on ARM don't complain about tests that won't execute
+// TODO: We can remove this as soon as 7.12.0 is released.
+tasks.named("testingConventions").configure { onlyIf { Architecture.current() == Architecture.X64 } }


### PR DESCRIPTION
Since we do not execute BWC tests on 7.12 due to us not having full support for ARM prior to that version we need to disable the testing convention checks for BWC projects since those test suites will never be run.