### PR TITLE
Create archive with all rest api specs and yaml tests

### DIFF
--- a/x-pack/rest-resources-zip/build.gradle
+++ b/x-pack/rest-resources-zip/build.gradle
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+apply plugin: 'java'
+apply plugin: 'elasticsearch.rest-resources'
+
+restResources {
+  restApi {
+    includeCore '*'
+    includeXpack '*'
+  }
+  restTests {
+    includeCore '*'
+    includeXpack '*'
+  }
+}
+
+tasks.register('restResourcesZip', Zip).configure {
+  description = 'Build archive containing all REST API specifications and YAML tests'
+
+  destinationDirectory = layout.buildDirectory.dir('distributions')
+  from sourceSets.test.output
+}
+
+tasks.named("assemble").configure { dependsOn 'restResourcesZip' }


### PR DESCRIPTION
This pull request introduces a `rest-resources-zip` (not set on the name) that includes a number of items:

1. All core REST API specifications which currently live in `/rest-api-spec`
2. All core REST API tests which also live in `/rest-api-spec` 
3. All x-pack REST API specifications which currently live in `/x-pack/plugin/src/test`
4. All x-pack REST API tests which currently live in `/x-pack/plugin/src/test`

I use the term _currently_ here since this is going to change with https://github.com/elastic/elasticsearch/pull/70036, but the point here is so that changes will be completely transparent to consumers of this artifact. This allows us to refactor sources within the Elasticsearch repository w/o breaking downstream folks.

We'll need to follow up this PR with an addition to release manager to actually _publish_ this artifact w/ snapshot builds.

Closes #68541