### PR TITLE
Expose Backing Byte Array for ReleasableBytesReference (#69660)

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkRequestParser.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkRequestParser.java
@@ -14,7 +14,6 @@ import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
-import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
@@ -308,8 +307,8 @@ public final class BulkRequestParser {
     }
 
     private static XContentParser createParser(BytesReference data, XContent xContent) throws IOException {
-        if (data instanceof BytesArray) {
-            return parseBytesArray(xContent, (BytesArray) data, 0, data.length());
+        if (data.hasArray()) {
+            return parseBytesArray(xContent, data, 0, data.length());
         } else {
             return xContent.createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, data.streamInput());
         }
@@ -318,13 +317,13 @@ public final class BulkRequestParser {
     // Create an efficient parser of the given bytes, trying to directly parse a byte array if possible and falling back to stream wrapping
     // otherwise.
     private static XContentParser createParser(BytesReference data, XContent xContent, int from, int nextMarker) throws IOException {
-        if (data instanceof BytesArray) {
-            return parseBytesArray(xContent, (BytesArray) data, from, nextMarker);
+        if (data.hasArray()) {
+            return parseBytesArray(xContent, data, from, nextMarker);
         } else {
             final int length = nextMarker - from;
             final BytesReference slice = data.slice(from, length);
-            if (slice instanceof BytesArray) {
-                return parseBytesArray(xContent, (BytesArray) slice, 0, length);
+            if (slice.hasArray()) {
+                return parseBytesArray(xContent, slice, 0, length);
             } else {
                 // EMPTY is safe here because we never call namedObject
                 return xContent.createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, slice.streamInput());
@@ -332,8 +331,9 @@ public final class BulkRequestParser {
         }
     }
 
-    private static XContentParser parseBytesArray(XContent xContent, BytesArray array, int from, int nextMarker) throws IOException {
-        final int offset = array.offset();
+    private static XContentParser parseBytesArray(XContent xContent, BytesReference array, int from, int nextMarker) throws IOException {
+        assert array.hasArray();
+        final int offset = array.arrayOffset();
         // EMPTY is safe here because we never call namedObject
         return xContent.createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, array.array(),
                 offset + from, nextMarker - from);

--- a/server/src/main/java/org/elasticsearch/common/bytes/BytesArray.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/BytesArray.java
@@ -87,11 +87,18 @@ public final class BytesArray extends AbstractBytesReference {
         return new BytesArray(bytes, offset + from, length);
     }
 
+    @Override
+    public boolean hasArray() {
+        return true;
+    }
+
+    @Override
     public byte[] array() {
         return bytes;
     }
 
-    public int offset() {
+    @Override
+    public int arrayOffset() {
         return offset;
     }
 

--- a/server/src/main/java/org/elasticsearch/common/bytes/BytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/BytesReference.java
@@ -174,4 +174,25 @@ public interface BytesReference extends Comparable<BytesReference>, ToXContentFr
      * @see BytesRefIterator
      */
     BytesRefIterator iterator();
+
+    /**
+     * @return {@code true} if this instance is backed by a byte array
+     */
+    default boolean hasArray() {
+        return false;
+    }
+
+    /**
+     * @return backing byte array for this instance
+     */
+    default byte[] array() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * @return offset of the first byte of this instance in the backing byte array
+     */
+    default int arrayOffset() {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/server/src/main/java/org/elasticsearch/common/bytes/ReleasableBytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/ReleasableBytesReference.java
@@ -84,16 +84,19 @@ public final class ReleasableBytesReference implements RefCounted, Releasable, B
 
     @Override
     public byte get(int index) {
+        assert refCount() > 0;
         return delegate.get(index);
     }
 
     @Override
     public int getInt(int index) {
+        assert refCount() > 0;
         return delegate.getInt(index);
     }
 
     @Override
     public int indexOf(byte marker, int from) {
+        assert refCount() > 0;
         return delegate.indexOf(marker, from);
     }
 
@@ -155,6 +158,7 @@ public final class ReleasableBytesReference implements RefCounted, Releasable, B
 
     @Override
     public int compareTo(BytesReference o) {
+        assert refCount() > 0;
         return delegate.compareTo(o);
     }
 
@@ -179,6 +183,24 @@ public final class ReleasableBytesReference implements RefCounted, Releasable, B
     public int hashCode() {
         assert refCount() > 0;
         return delegate.hashCode();
+    }
+
+    @Override
+    public boolean hasArray() {
+        assert refCount() > 0;
+        return delegate.hasArray();
+    }
+
+    @Override
+    public byte[] array() {
+        assert refCount() > 0;
+        return delegate.array();
+    }
+
+    @Override
+    public int arrayOffset() {
+        assert refCount() > 0;
+        return delegate.arrayOffset();
     }
 
     private static final class RefCountedReleasable extends AbstractRefCounted {

--- a/server/src/main/java/org/elasticsearch/common/xcontent/XContentHelper.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/XContentHelper.java
@@ -65,10 +65,9 @@ public class XContentHelper {
             }
             return XContentFactory.xContent(xContentType).createParser(xContentRegistry, deprecationHandler, compressedInput);
         } else {
-            if (bytes instanceof BytesArray) {
-                final BytesArray array = (BytesArray) bytes;
+            if (bytes.hasArray()) {
                 return xContentType.xContent().createParser(
-                        xContentRegistry, deprecationHandler, array.array(), array.offset(), array.length());
+                        xContentRegistry, deprecationHandler, bytes.array(), bytes.arrayOffset(), bytes.length());
             }
             return xContentType.xContent().createParser(xContentRegistry, deprecationHandler, bytes.streamInput());
         }
@@ -101,11 +100,10 @@ public class XContentHelper {
                 }
                 input = compressedStreamInput;
                 contentType = xContentType != null ? xContentType : XContentFactory.xContentType(input);
-            } else if (bytes instanceof BytesArray) {
-                final BytesArray arr = (BytesArray) bytes;
-                final byte[] raw = arr.array();
-                final int offset = arr.offset();
-                final int length = arr.length();
+            } else if (bytes.hasArray()) {
+                final byte[] raw = bytes.array();
+                final int offset = bytes.arrayOffset();
+                final int length = bytes.length();
                 contentType = xContentType != null ? xContentType : XContentFactory.xContentType(raw, offset, length);
                 return new Tuple<>(Objects.requireNonNull(contentType),
                         convertToMap(XContentFactory.xContent(contentType), raw, offset, length, ordered));
@@ -201,10 +199,9 @@ public class XContentHelper {
         }
 
         // It is safe to use EMPTY here because this never uses namedObject
-        if (bytes instanceof BytesArray) {
-            final BytesArray array = (BytesArray) bytes;
+        if (bytes.hasArray()) {
             try (XContentParser parser = XContentFactory.xContent(xContentType).createParser(NamedXContentRegistry.EMPTY,
-                         DeprecationHandler.THROW_UNSUPPORTED_OPERATION, array.array(), array.offset(), array.length())) {
+                         DeprecationHandler.THROW_UNSUPPORTED_OPERATION, bytes.array(), bytes.arrayOffset(), bytes.length())) {
                 return toJsonString(prettyPrint, parser);
             }
         } else {
@@ -411,9 +408,8 @@ public class XContentHelper {
      */
     @Deprecated
     public static XContentType xContentType(BytesReference bytes) {
-        if (bytes instanceof BytesArray) {
-            final BytesArray array = (BytesArray) bytes;
-            return XContentFactory.xContentType(array.array(), array.offset(), array.length());
+        if (bytes.hasArray()) {
+            return XContentFactory.xContentType(bytes.array(), bytes.arrayOffset(), bytes.length());
         }
         try {
             final InputStream inputStream = bytes.streamInput();

--- a/server/src/test/java/org/elasticsearch/common/bytes/BytesArrayTests.java
+++ b/server/src/test/java/org/elasticsearch/common/bytes/BytesArrayTests.java
@@ -45,7 +45,7 @@ public class BytesArrayTests extends AbstractBytesReferenceTestCase {
             BytesArray pbr = (BytesArray) newBytesReference(sizes[i]);
             byte[] array = pbr.array();
             assertNotNull(array);
-            assertEquals(sizes[i], array.length - pbr.offset());
+            assertEquals(sizes[i], array.length - pbr.arrayOffset());
             assertSame(array, pbr.array());
         }
     }
@@ -53,6 +53,6 @@ public class BytesArrayTests extends AbstractBytesReferenceTestCase {
     public void testArrayOffset() throws IOException {
         int length = randomInt(PAGE_SIZE * randomIntBetween(2, 5));
         BytesArray pbr = (BytesArray) newBytesReferenceWithOffsetOfZero(length);
-        assertEquals(0, pbr.offset());
+        assertEquals(0, pbr.arrayOffset());
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -45,7 +45,6 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.CheckedRunnable;
 import org.elasticsearch.common.SuppressForbidden;
-import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.PathUtils;
 import org.elasticsearch.common.io.PathUtilsForTesting;
@@ -1384,10 +1383,9 @@ public abstract class ESTestCase extends LuceneTestCase {
      */
     protected final XContentParser createParser(NamedXContentRegistry namedXContentRegistry, XContent xContent,
                                                 BytesReference data) throws IOException {
-        if (data instanceof BytesArray) {
-            final BytesArray array = (BytesArray) data;
+        if (data.hasArray()) {
             return xContent.createParser(
-                    namedXContentRegistry, LoggingDeprecationHandler.INSTANCE, array.array(), array.offset(), array.length());
+                    namedXContentRegistry, LoggingDeprecationHandler.INSTANCE, data.array(), data.arrayOffset(), data.length());
         }
         return xContent.createParser(namedXContentRegistry, LoggingDeprecationHandler.INSTANCE, data.streamInput());
     }


### PR DESCRIPTION
Unwrapping the `byte[]` in a `BytesArray` can be generalized
so that releasable bytes references can make use of the optimizations
that use the bytes directly as well.

Relates #67502 but already saves a few cycles here and there around
`BytesRequest` (publish and recovery actions)

backport of #69660