### PR TITLE
Fix Reference Counting in SecurityServerTransportInterceptor (#69797)

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/SecurityServerTransportInterceptor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/SecurityServerTransportInterceptor.java
@@ -17,6 +17,7 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.common.util.concurrent.RunOnce;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.gateway.GatewayService;
 import org.elasticsearch.license.XPackLicenseState;
@@ -237,6 +238,8 @@ public class SecurityServerTransportInterceptor implements TransportInterceptor 
         }
 
         AbstractRunnable getReceiveRunnable(T request, TransportChannel channel, Task task) {
+            final Runnable releaseRequest = new RunOnce(request::decRef);
+            request.incRef();
             return new AbstractRunnable() {
                 @Override
                 public boolean isForceExecution() {
@@ -257,6 +260,11 @@ public class SecurityServerTransportInterceptor implements TransportInterceptor 
                 protected void doRun() throws Exception {
                     handler.messageReceived(request, channel, task);
                 }
+
+                @Override
+                public void onAfter() {
+                    releaseRequest.run();
+                }
             };
         }
 
@@ -271,7 +279,6 @@ public class SecurityServerTransportInterceptor implements TransportInterceptor 
 
         @Override
         public void messageReceived(T request, TransportChannel channel, Task task) throws Exception {
-            final AbstractRunnable receiveMessage = getReceiveRunnable(request, channel, task);
             try (ThreadContext.StoredContext ctx = threadContext.newStoredContext(true)) {
                 if (licenseState.isSecurityEnabled()) {
                     String profile = channel.getProfileName();
@@ -289,6 +296,7 @@ public class SecurityServerTransportInterceptor implements TransportInterceptor 
                     assert filter != null;
                     final Thread executingThread = Thread.currentThread();
 
+                    final AbstractRunnable receiveMessage = getReceiveRunnable(request, channel, task);
                     CheckedConsumer<Void, Exception> consumer = (x) -> {
                         final Executor executor;
                         if (executingThread == Thread.currentThread()) {
@@ -313,7 +321,7 @@ public class SecurityServerTransportInterceptor implements TransportInterceptor 
                     ActionListener<Void> filterListener = ActionListener.wrap(consumer, receiveMessage::onFailure);
                     filter.inbound(action, request, channel, filterListener);
                 } else {
-                    receiveMessage.run();
+                    getReceiveRunnable(request, channel, task).run();
                 }
             }
         }


### PR DESCRIPTION
This method is potentially escaping the request from a thread
without incrementing the ref count. This only happens for node
local client requests as far as I can tell and hasn't caused a
bug yet but it's technically incorrect and shows up as an issue
when making use of ref-couting in bulk requests in #67502

backport o #69797