### PR TITLE
[7.12] [DOCS] Adds beta tag to anomaly detection alert docs. (#70013)

### DIFF
--- a/docs/reference/ml/anomaly-detection/ml-configuring-alerts.asciidoc
+++ b/docs/reference/ml/anomaly-detection/ml-configuring-alerts.asciidoc
@@ -2,6 +2,8 @@
 [[ml-configuring-alerts]]
 = Configuring {anomaly-detect} alerts
 
+beta::[]
+
 {anomaly-detect-cap} alerts run scheduled checks on an {anomaly-job} or a group 
 of jobs to detect anomalies with certain conditions. If an anomaly meets the 
 conditions, the alert triggers the defined action. For example, you can create 


### PR DESCRIPTION
Backports the following commits to 7.12:
 - [DOCS] Adds beta tag to anomaly detection alert docs. (#70013)