### PR TITLE
[7.12] Tweak WatcherIndexTemplateRegistry bwc logic 

### DIFF
--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/support/WatcherIndexTemplateRegistry.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/support/WatcherIndexTemplateRegistry.java
@@ -93,7 +93,7 @@ public class WatcherIndexTemplateRegistry extends IndexTemplateRegistry {
 
     @Override
     protected List<IndexTemplateConfig> getLegacyTemplateConfigs() {
-        if (clusterService.state().nodes().getMinNodeVersion().onOrAfter(Version.V_7_9_0)) {
+        if (clusterService.state().nodes().getMinNodeVersion().onOrAfter(Version.V_7_10_0)) {
             return Collections.emptyList();
         } else if (clusterService.state().nodes().getMinNodeVersion().onOrAfter(Version.V_7_7_0)) {
             return Arrays.asList(
@@ -136,12 +136,10 @@ public class WatcherIndexTemplateRegistry extends IndexTemplateRegistry {
     }
 
     public static boolean validate(ClusterState state) {
-        final Stream<String> watcherHistoryTemplateIds;
-        if (state.nodes().getMinNodeVersion().onOrAfter(Version.V_7_9_0)){
-            watcherHistoryTemplateIds = state.getMetadata().templatesV2().keySet().stream();
-        } else {
-            watcherHistoryTemplateIds = Arrays.stream(state.getMetadata().getTemplates().keys().toArray(String.class));
-        }
+        // A .watch-history should exist, whether it is a legacy or composable index template
+        // that doesn't matter when deciding to start watcher.
+        final Stream<String> watcherHistoryTemplateIds = Stream.concat(state.getMetadata().templatesV2().keySet().stream(),
+            Arrays.stream(state.getMetadata().getTemplates().keys().toArray(String.class)));
         return watcherHistoryTemplateIds.filter(s -> s.startsWith(".watch-history-"))
             .map(s -> Integer.valueOf(s.substring(s.lastIndexOf('-') + 1)))
             .anyMatch(version -> version >= 9);

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/WatcherRestartIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/WatcherRestartIT.java
@@ -32,7 +32,6 @@ public class WatcherRestartIT extends AbstractUpgradeTestCase {
 
     private static final String templatePrefix = ".watch-history-";
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/69918")
     public void testWatcherRestart() throws Exception {
         client().performRequest(new Request("POST", "/_watcher/_stop"));
         ensureWatcherStopped();


### PR DESCRIPTION
Backporting #69998 to 7.12 branch.

* The WatcherIndexTemplateRegistry moved from legacy templates to composable index templates in version 7.10.0 and not 7.9.0
* The WatcherIndexTemplateRegistry#validate(...) method should only care whether a template for watcher history indices exist and
not whether that template is a composable index template or a legacy template. This shouldn't matter whether to determine if watcher can be started on a node. The content of the templates didn't change in a breaking manner (since version 6.8.0).

Should resolve #69918