### PR TITLE
[7.x] Summary option for listing ingest pipelines without their definitions

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.get_pipeline.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.get_pipeline.json
@@ -32,6 +32,10 @@
       ]
     },
     "params":{
+      "summary":{
+        "type":"boolean",
+        "description":"Return pipelines without their definitions (default: false)"
+      },
       "master_timeout":{
         "type":"time",
         "description":"Explicit operation timeout for connection to master node"

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/ingest/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/ingest/10_basic.yml
@@ -152,3 +152,35 @@
             "processors": [],
             "invalid_field" : {}
           }
+
+---
+"Test Get Summarized Pipelines":
+  - skip:
+      version: " - 7.99.99"
+      reason:  "change to appropriate 7.x release after backport"
+
+  - do:
+      ingest.put_pipeline:
+        id: "first_pipeline"
+        body:  >
+          {
+            "description": "first",
+            "processors": []
+          }
+  - do:
+      ingest.put_pipeline:
+        id: "second_pipeline"
+        body:  >
+          {
+            "description": "second",
+            "processors": []
+          }
+
+  - do:
+      ingest.get_pipeline:
+        summary: true
+
+  - is_true:  first_pipeline
+  - is_false: first_pipeline.description
+  - is_true:  second_pipeline
+  - is_false: second_pipeline.description

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/ingest/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/ingest/10_basic.yml
@@ -156,8 +156,8 @@
 ---
 "Test Get Summarized Pipelines":
   - skip:
-      version: " - 7.99.99"
-      reason:  "change to appropriate 7.x release after backport"
+      version: " - 7.12.99"
+      reason:  "summary option added in 7.13"
 
   - do:
       ingest.put_pipeline:

--- a/server/src/main/java/org/elasticsearch/action/ingest/GetPipelineRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/GetPipelineRequest.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.action.ingest;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.master.MasterNodeReadRequest;
 import org.elasticsearch.common.Strings;
@@ -19,31 +20,45 @@ import java.io.IOException;
 public class GetPipelineRequest extends MasterNodeReadRequest<GetPipelineRequest> {
 
     private String[] ids;
+    private final boolean summary;
 
-    public GetPipelineRequest(String... ids) {
+    public GetPipelineRequest(boolean summary, String... ids) {
         if (ids == null) {
             throw new IllegalArgumentException("ids cannot be null");
         }
         this.ids = ids;
+        this.summary = summary;
+    }
+
+    public GetPipelineRequest(String... ids) {
+        this(false, ids);
     }
 
     GetPipelineRequest() {
-        this.ids = Strings.EMPTY_ARRAY;
+        this(false, Strings.EMPTY_ARRAY);
     }
 
     public GetPipelineRequest(StreamInput in) throws IOException {
         super(in);
         ids = in.readStringArray();
+        summary = in.getVersion().onOrAfter(Version.V_8_0_0) ? in.readBoolean() : false;
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeStringArray(ids);
+        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+            out.writeBoolean(summary);
+        }
     }
 
     public String[] getIds() {
         return ids;
+    }
+
+    public boolean isSummary() {
+        return summary;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/ingest/GetPipelineRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/GetPipelineRequest.java
@@ -41,14 +41,14 @@ public class GetPipelineRequest extends MasterNodeReadRequest<GetPipelineRequest
     public GetPipelineRequest(StreamInput in) throws IOException {
         super(in);
         ids = in.readStringArray();
-        summary = in.getVersion().onOrAfter(Version.V_8_0_0) ? in.readBoolean() : false;
+        summary = in.getVersion().onOrAfter(Version.V_7_13_0) ? in.readBoolean() : false;
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeStringArray(ids);
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_13_0)) {
             out.writeBoolean(summary);
         }
     }

--- a/server/src/main/java/org/elasticsearch/action/ingest/GetPipelineResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/GetPipelineResponse.java
@@ -42,7 +42,7 @@ public class GetPipelineResponse extends ActionResponse implements StatusToXCont
         for (int i = 0; i < size; i++) {
             pipelines.add(PipelineConfiguration.readFrom(in));
         }
-        summary = in.getVersion().onOrAfter(Version.V_8_0_0) ? in.readBoolean() : false;
+        summary = in.getVersion().onOrAfter(Version.V_7_13_0) ? in.readBoolean() : false;
     }
 
     public GetPipelineResponse(List<PipelineConfiguration> pipelines, boolean summary) {
@@ -69,7 +69,7 @@ public class GetPipelineResponse extends ActionResponse implements StatusToXCont
         for (PipelineConfiguration pipeline : pipelines) {
             pipeline.writeTo(out);
         }
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_13_0)) {
             out.writeBoolean(summary);
         }
     }

--- a/server/src/main/java/org/elasticsearch/action/ingest/GetPipelineResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/GetPipelineResponse.java
@@ -91,7 +91,7 @@ public class GetPipelineResponse extends ActionResponse implements StatusToXCont
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         for (PipelineConfiguration pipeline : pipelines) {
-            builder.field(pipeline.getId(), summary ? Map.of() : pipeline.getConfigAsMap());
+            builder.field(pipeline.getId(), summary ? org.elasticsearch.common.collect.Map.of() : pipeline.getConfigAsMap());
         }
         builder.endObject();
         return builder;

--- a/server/src/main/java/org/elasticsearch/action/ingest/GetPipelineTransportAction.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/GetPipelineTransportAction.java
@@ -34,7 +34,7 @@ public class GetPipelineTransportAction extends TransportMasterNodeReadAction<Ge
     @Override
     protected void masterOperation(GetPipelineRequest request, ClusterState state, ActionListener<GetPipelineResponse> listener)
             throws Exception {
-        listener.onResponse(new GetPipelineResponse(IngestService.getPipelines(state, request.getIds())));
+        listener.onResponse(new GetPipelineResponse(IngestService.getPipelines(state, request.getIds()), request.isSummary()));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/rest/action/ingest/RestGetPipelineAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/ingest/RestGetPipelineAction.java
@@ -38,7 +38,10 @@ public class RestGetPipelineAction extends BaseRestHandler {
 
     @Override
     public RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
-        GetPipelineRequest request = new GetPipelineRequest(Strings.splitStringByCommaToArray(restRequest.param("id")));
+        GetPipelineRequest request = new GetPipelineRequest(
+            restRequest.paramAsBoolean("summary", false),
+            Strings.splitStringByCommaToArray(restRequest.param("id"))
+        );
         request.masterNodeTimeout(restRequest.paramAsTime("master_timeout", request.masterNodeTimeout()));
         return channel -> client.admin().cluster().getPipeline(request, new RestStatusToXContentListener<>(channel));
     }


### PR DESCRIPTION
Addresses the need (mentioned [here](https://github.com/elastic/elasticsearch/issues/31954#issuecomment-475255468)) for a compact listing of ingest pipelines without including their potentially long definitions by adding a `summary` option to the existing API so that this information is available in a stable format that is both machine and human-readable:

`GET _ingest/pipeline?summary` returns
```
{
  "my_pipeline_2" : { },
  "my_pipeline_3" : { },
  "my_pipeline_1" : { }
}
```

Relates to #31954

Backport of #69756
