### PR TITLE
[7.x] Only install templates for deprecation indices from elected master node

### DIFF
--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/logging/DeprecationIndexingTemplateRegistry.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/logging/DeprecationIndexingTemplateRegistry.java
@@ -92,4 +92,12 @@ public class DeprecationIndexingTemplateRegistry extends IndexTemplateRegistry {
     protected String getOrigin() {
         return DEPRECATION_ORIGIN;
     }
+
+    @Override
+    protected boolean requiresMasterNode() {
+        // These installs a composable index template which is only supported from version 7.8
+        // In mixed cluster without this set to true can result in errors in the logs during rolling upgrades.
+        // If these template(s) are only installed via elected master node then composable templates are available.
+        return true;
+    }
 }


### PR DESCRIPTION
Backport of #70057 to 7.x branch

When running in a mixed cluster with node with version pre 7.8 and post 7.8 then
attempting the install composable index templates from any node can cause many
error logs indicating that put composable and component index template apis don't exist.
These APIs are always redirect to the elected master and as long as this node
is on a pre 7.8 version then attempting to install these templates will always fail.

Relates to #69918