### PR TITLE
[7.12] [DOCS] Fix `prefix_length` data type (#70075)

### DIFF
--- a/docs/reference/query-dsl/intervals-query.asciidoc
+++ b/docs/reference/query-dsl/intervals-query.asciidoc
@@ -189,7 +189,7 @@ edit distance defined by <<fuzziness>>.  If the fuzzy expansion matches more tha
 (Required, string) The term to match
 
 `prefix_length`::
-(Optional, string) Number of beginning characters left unchanged when creating
+(Optional, integer) Number of beginning characters left unchanged when creating
 expansions. Defaults to `0`.
 
 `transpositions`::


### PR DESCRIPTION
Backports the following commits to 7.12:
 - [DOCS] Fix `prefix_length` data type (#70075)