### PR TITLE
[Transform] Fix failing unit test

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/pivot/GroupConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/pivot/GroupConfigTests.java
@@ -42,7 +42,7 @@ public class GroupConfigTests extends AbstractSerializingTestCase<GroupConfig> {
         return randomGroupConfig(() -> randomSingleGroupSource(version));
     }
 
-    public static GroupConfig randomGroupConfig(Supplier<SingleGroupSource> groupSupplier) {
+    public static GroupConfig randomGroupConfig(Supplier<SingleGroupSource> singleGroupSourceSupplier) {
         Map<String, Object> source = new LinkedHashMap<>();
         Map<String, SingleGroupSource> groups = new LinkedHashMap<>();
 
@@ -51,7 +51,7 @@ public class GroupConfigTests extends AbstractSerializingTestCase<GroupConfig> {
         for (int i = 0; i < randomIntBetween(1, 20); ++i) {
             String targetFieldName = randomAlphaOfLengthBetween(1, 20);
             if (names.add(targetFieldName)) {
-                SingleGroupSource groupBy = groupSupplier.get();
+                SingleGroupSource groupBy = singleGroupSourceSupplier.get();
                 source.put(targetFieldName, Collections.singletonMap(groupBy.getType().value(), getSource(groupBy)));
                 groups.put(targetFieldName, groupBy);
             }
@@ -61,25 +61,19 @@ public class GroupConfigTests extends AbstractSerializingTestCase<GroupConfig> {
     }
 
     private static SingleGroupSource randomSingleGroupSource(Version version) {
-        SingleGroupSource groupBy = null;
         Type type = randomFrom(SingleGroupSource.Type.values());
         switch (type) {
             case TERMS:
-                groupBy = TermsGroupSourceTests.randomTermsGroupSource(version);
-                break;
+                return TermsGroupSourceTests.randomTermsGroupSource(version);
             case HISTOGRAM:
-                groupBy = HistogramGroupSourceTests.randomHistogramGroupSource(version);
-                break;
+                return HistogramGroupSourceTests.randomHistogramGroupSource(version);
             case DATE_HISTOGRAM:
-                groupBy = DateHistogramGroupSourceTests.randomDateHistogramGroupSource(version);
-                break;
+                return DateHistogramGroupSourceTests.randomDateHistogramGroupSource(version);
             case GEOTILE_GRID:
-                groupBy = GeoTileGroupSourceTests.randomGeoTileGroupSource(version);
-                break;
+                return GeoTileGroupSourceTests.randomGeoTileGroupSource(version);
             default:
                 fail("unknown group source type, please implement tests and add support here");
         }
-        return groupBy;
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/pivot/GroupConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/pivot/GroupConfigTests.java
@@ -22,13 +22,12 @@ import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.elasticsearch.xpack.core.transform.transforms.pivot.SingleGroupSource.Type;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 
 public class GroupConfigTests extends AbstractSerializingTestCase<GroupConfig> {
 
@@ -40,10 +39,10 @@ public class GroupConfigTests extends AbstractSerializingTestCase<GroupConfig> {
     }
 
     public static GroupConfig randomGroupConfig(Version version) {
-        return randomGroupConfig(version, Arrays.asList(SingleGroupSource.Type.values()));
+        return randomGroupConfig(() -> randomSingleGroupSource(version));
     }
 
-    public static GroupConfig randomGroupConfig(Version version, List<Type> allowedTypes) {
+    public static GroupConfig randomGroupConfig(Supplier<SingleGroupSource> groupSupplier) {
         Map<String, Object> source = new LinkedHashMap<>();
         Map<String, SingleGroupSource> groups = new LinkedHashMap<>();
 
@@ -52,30 +51,35 @@ public class GroupConfigTests extends AbstractSerializingTestCase<GroupConfig> {
         for (int i = 0; i < randomIntBetween(1, 20); ++i) {
             String targetFieldName = randomAlphaOfLengthBetween(1, 20);
             if (names.add(targetFieldName)) {
-                SingleGroupSource groupBy = null;
-                Type type = randomFrom(allowedTypes);
-                switch (type) {
-                    case TERMS:
-                        groupBy = TermsGroupSourceTests.randomTermsGroupSource(version);
-                        break;
-                    case HISTOGRAM:
-                        groupBy = HistogramGroupSourceTests.randomHistogramGroupSource(version);
-                        break;
-                    case DATE_HISTOGRAM:
-                        groupBy = DateHistogramGroupSourceTests.randomDateHistogramGroupSource(version);
-                        break;
-                    case GEOTILE_GRID:
-                        groupBy = GeoTileGroupSourceTests.randomGeoTileGroupSource(version);
-                        break;
-                    default:
-                        fail("unknown group source type, please implement tests and add support here");
-                }
-                source.put(targetFieldName, Collections.singletonMap(type.value(), getSource(groupBy)));
+                SingleGroupSource groupBy = groupSupplier.get();
+                source.put(targetFieldName, Collections.singletonMap(groupBy.getType().value(), getSource(groupBy)));
                 groups.put(targetFieldName, groupBy);
             }
         }
 
         return new GroupConfig(source, groups);
+    }
+
+    private static SingleGroupSource randomSingleGroupSource(Version version) {
+        SingleGroupSource groupBy = null;
+        Type type = randomFrom(SingleGroupSource.Type.values());
+        switch (type) {
+            case TERMS:
+                groupBy = TermsGroupSourceTests.randomTermsGroupSource(version);
+                break;
+            case HISTOGRAM:
+                groupBy = HistogramGroupSourceTests.randomHistogramGroupSource(version);
+                break;
+            case DATE_HISTOGRAM:
+                groupBy = DateHistogramGroupSourceTests.randomDateHistogramGroupSource(version);
+                break;
+            case GEOTILE_GRID:
+                groupBy = GeoTileGroupSourceTests.randomGeoTileGroupSource(version);
+                break;
+            default:
+                fail("unknown group source type, please implement tests and add support here");
+        }
+        return groupBy;
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/pivot/GroupConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/pivot/GroupConfigTests.java
@@ -74,6 +74,7 @@ public class GroupConfigTests extends AbstractSerializingTestCase<GroupConfig> {
             default:
                 fail("unknown group source type, please implement tests and add support here");
         }
+        return null;
     }
 
     @Override

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransformConfigLinterTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransformConfigLinterTests.java
@@ -19,8 +19,9 @@ import org.elasticsearch.xpack.core.transform.transforms.TimeSyncConfigTests;
 import org.elasticsearch.xpack.core.transform.transforms.latest.LatestConfig;
 import org.elasticsearch.xpack.core.transform.transforms.pivot.AggregationConfigTests;
 import org.elasticsearch.xpack.core.transform.transforms.pivot.GroupConfigTests;
+import org.elasticsearch.xpack.core.transform.transforms.pivot.HistogramGroupSource;
 import org.elasticsearch.xpack.core.transform.transforms.pivot.PivotConfig;
-import org.elasticsearch.xpack.core.transform.transforms.pivot.SingleGroupSource;
+import org.elasticsearch.xpack.core.transform.transforms.pivot.TermsGroupSource;
 import org.elasticsearch.xpack.transform.transforms.Function;
 import org.elasticsearch.xpack.transform.transforms.latest.Latest;
 import org.elasticsearch.xpack.transform.transforms.pivot.Pivot;
@@ -39,7 +40,7 @@ public class TransformConfigLinterTests extends ESTestCase {
     public void testGetWarnings_Pivot_WithScriptBasedRuntimeFields() {
         PivotConfig pivotConfig =
             new PivotConfig(
-                GroupConfigTests.randomGroupConfig(Version.CURRENT, singletonList(SingleGroupSource.Type.TERMS)),
+                GroupConfigTests.randomGroupConfig(() -> new TermsGroupSource(randomAlphaOfLengthBetween(1, 20), null, false)),
                 AggregationConfigTests.randomAggregationConfig(),
                 null);
         Function function = new Pivot(pivotConfig, new SettingsConfig(), Version.CURRENT);
@@ -47,6 +48,7 @@ public class TransformConfigLinterTests extends ESTestCase {
         assertThat(TransformConfigLinter.getWarnings(function, sourceConfig, null), is(empty()));
 
         SyncConfig syncConfig = TimeSyncConfigTests.randomTimeSyncConfig();
+
         assertThat(TransformConfigLinter.getWarnings(function, sourceConfig, syncConfig), is(empty()));
 
         Map<String, Object> runtimeMappings = new HashMap<>() {{
@@ -91,7 +93,9 @@ public class TransformConfigLinterTests extends ESTestCase {
     public void testGetWarnings_Pivot_CouldNotFindAnyOptimization() {
         PivotConfig pivotConfig =
             new PivotConfig(
-                GroupConfigTests.randomGroupConfig(Version.CURRENT, singletonList(SingleGroupSource.Type.HISTOGRAM)),
+                GroupConfigTests.randomGroupConfig(
+                    () -> new HistogramGroupSource(
+                        randomAlphaOfLengthBetween(1, 20), null, false, randomDoubleBetween(Math.nextUp(0), Double.MAX_VALUE, false))),
                 AggregationConfigTests.randomAggregationConfig(),
                 null);
         Function function = new Pivot(pivotConfig, new SettingsConfig(), Version.CURRENT);


### PR DESCRIPTION
This PR fixes `TransformConfigLinterTests.testGetWarnings_Pivot_WithScriptBasedRuntimeFields` unit test case by ensuring that a terms group source is never script-based and, consequently, produces a collector.

Relates https://github.com/elastic/elasticsearch/issues/70059
Closes https://github.com/elastic/elasticsearch/issues/70074