### PR TITLE
Restrict ml-cpp artifact to fake ivy repo

### DIFF
--- a/x-pack/plugin/ml/build.gradle
+++ b/x-pack/plugin/ml/build.gradle
@@ -12,15 +12,22 @@ esplugin {
 
 
 repositories {
-  ivy {
-    name "ml-cpp"
-    url System.getProperty('build.ml_cpp.repo', 'https://prelert-artifacts.s3.amazonaws.com')
-    metadataSources {
-      // no repository metadata, look directly for the artifact
-      artifact()
+  exclusiveContent {
+    forRepository {
+      ivy {
+        name "ml-cpp"
+        url System.getProperty('build.ml_cpp.repo', 'https://prelert-artifacts.s3.amazonaws.com')
+        metadataSources {
+          // no repository metadata, look directly for the artifact
+          artifact()
+        }
+        patternLayout {
+          artifact "maven/org/elasticsearch/ml/ml-cpp/[revision]/ml-cpp-[revision].[ext]"
+        }
+      }
     }
-    patternLayout {
-      artifact "maven/org/elasticsearch/ml/ml-cpp/[revision]/ml-cpp-[revision].[ext]"
+    filter {
+      includeGroup 'org.elasticsearch.ml'
     }
   }
 }


### PR DESCRIPTION
We use a fake ivy repository to resolve the CI built version of ml-cpp.
This commit restricts the fake group name to only come from this fake
ivy repository, since it should not exist anywhere else.