### PR TITLE
Add Singleton Empty ReleasableBytesReference (#69661)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/bytes/ReleasableBytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/ReleasableBytesReference.java
@@ -27,8 +27,16 @@ import java.io.OutputStream;
 public final class ReleasableBytesReference implements RefCounted, Releasable, BytesReference {
 
     public static final Releasable NO_OP = () -> {};
+
+    private static final ReleasableBytesReference EMPTY = new ReleasableBytesReference(BytesArray.EMPTY, NO_OP);
+
     private final BytesReference delegate;
     private final AbstractRefCounted refCounted;
+
+    public static ReleasableBytesReference empty() {
+        EMPTY.incRef();
+        return EMPTY;
+    }
 
     public ReleasableBytesReference(BytesReference delegate, Releasable releasable) {
         this(delegate, new RefCountedReleasable(releasable));
@@ -41,7 +49,7 @@ public final class ReleasableBytesReference implements RefCounted, Releasable, B
     }
 
     public static ReleasableBytesReference wrap(BytesReference reference) {
-        return new ReleasableBytesReference(reference, NO_OP);
+        return reference.length() == 0 ? empty() : new ReleasableBytesReference(reference, NO_OP);
     }
 
     public int refCount() {

--- a/server/src/main/java/org/elasticsearch/index/translog/TranslogWriter.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/TranslogWriter.java
@@ -452,7 +452,7 @@ public class TranslogWriter extends BaseTranslogReader implements Closeable {
             this.bufferedBytes = 0;
             return new ReleasableBytesReference(toWrite.bytes(), toWrite);
         } else {
-            return ReleasableBytesReference.wrap(BytesArray.EMPTY);
+            return ReleasableBytesReference.empty();
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/transport/InboundAggregator.java
+++ b/server/src/main/java/org/elasticsearch/transport/InboundAggregator.java
@@ -10,7 +10,6 @@ package org.elasticsearch.transport;
 
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
-import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.bytes.CompositeBytesReference;
 import org.elasticsearch.common.bytes.ReleasableBytesReference;
@@ -86,7 +85,7 @@ public class InboundAggregator implements Releasable {
         ensureOpen();
         final ReleasableBytesReference releasableContent;
         if (isFirstContent()) {
-            releasableContent = ReleasableBytesReference.wrap(BytesArray.EMPTY);
+            releasableContent = ReleasableBytesReference.empty();
         } else if (contentAggregation == null) {
             releasableContent = firstContent;
         } else {


### PR DESCRIPTION
We create quite a few of these empty instances. Just sharing a
singleton version of this and incrementing its ref count every time
it's used should have the same behavior (assertion- and otherwise)
as wrapping `BytesArray.EMPTY` over and over.

backport of #69661