### PR TITLE
[7.x] Fix GeoIpDwonloaderExecutor.setEnabled (#70111)

### DIFF
--- a/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderIT.java
+++ b/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderIT.java
@@ -67,8 +67,6 @@ public class GeoIpDownloaderIT extends AbstractGeoIpIT {
     }
 
     public void testGeoIpDatabasesDownload() throws Exception {
-        // use short wait for local fixture, longer when we hit real service
-        int waitTime = ENDPOINT == null ? 120 : 10;
         ClusterUpdateSettingsResponse settingsResponse = client().admin().cluster()
             .prepareUpdateSettings()
             .setPersistentSettings(Settings.builder().put(GeoIpDownloaderTaskExecutor.ENABLED_SETTING.getKey(), true))
@@ -80,7 +78,7 @@ public class GeoIpDownloaderIT extends AbstractGeoIpIT {
             GeoIpTaskState state = (GeoIpTaskState) task.getState();
             assertNotNull(state);
             assertEquals(Set.of("GeoLite2-ASN.mmdb", "GeoLite2-City.mmdb", "GeoLite2-Country.mmdb"), state.getDatabases().keySet());
-        }, waitTime, TimeUnit.SECONDS);
+        }, 2, TimeUnit.MINUTES);
 
         GeoIpTaskState state = (GeoIpTaskState) getTask().getState();
         for (String id : org.elasticsearch.common.collect.List.of("GeoLite2-ASN.mmdb", "GeoLite2-City.mmdb", "GeoLite2-Country.mmdb")) {

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderTaskExecutor.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderTaskExecutor.java
@@ -65,11 +65,13 @@ final class GeoIpDownloaderTaskExecutor extends PersistentTasksExecutor<GeoIpTas
     }
 
     private void setEnabled(boolean enabled) {
+        if (clusterService.state().nodes().isLocalNodeElectedMaster() == false) {
+            // we should only start/stop task from single node, master is the best as it will go through it anyway
+            return;
+        }
         if (enabled) {
-            if (clusterService.state().nodes().isLocalNodeElectedMaster()) {
-                startTask(() -> {
-                });
-            }
+            startTask(() -> {
+            });
         } else {
             persistentTasksService.sendRemoveRequest(GEOIP_DOWNLOADER, ActionListener.wrap(r -> {
             }, e -> logger.error("failed to remove geoip task", e)));


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fix GeoIpDwonloaderExecutor.setEnabled (#70111)