### PR TITLE
Add doc reference for client_auth_method

### DIFF
--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -1644,7 +1644,7 @@ or `client_secret_jwt`. Defaults to `client_secret_basic`.
 // tag::rp-client-auth-jwt-signature-algorithm[]
 `rp.client_auth_signature_algorithm` {ess-icon}::
 (<<static-cluster-setting, Static>>)
-The signature algorithm tat {es} uses to sign the JWT with which it authenticates
+The signature algorithm that {es} uses to sign the JWT with which it authenticates
 as a Client to the OpenID Connect Provider when `client_secret_jwt` is selected for
 `rp.client_auth_method`. Can be either `HS256`, `HS384`, or `HS512`. Defaults to 
 `HS384`. 

--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -1636,7 +1636,7 @@ at the OpenID Connect Provider.
 // tag::rp-client-auth-method-tag[]
 `rp.client_auth_method` {ess-icon}::
 (<<static-cluster-setting, Static>>)
-The Client authentication method used by elasticsearch as a client to authenticate
+The client authentication method used by {es} to authenticate
 to the OpenID Connect Provider. Can be `client_secret_basic`, `client_secret_post`,
 or `client_secret_jwt`. Defaults to `client_secret_basic`.
 // end::rp-client-auth-method-tag[]
@@ -1645,7 +1645,7 @@ or `client_secret_jwt`. Defaults to `client_secret_basic`.
 `rp.client_auth_signature_algorithm` {ess-icon}::
 (<<static-cluster-setting, Static>>)
 The signature algorithm that {es} uses to sign the JWT with which it authenticates
-as a Client to the OpenID Connect Provider when `client_secret_jwt` is selected for
+as a client to the OpenID Connect Provider when `client_secret_jwt` is selected for
 `rp.client_auth_method`. Can be either `HS256`, `HS384`, or `HS512`. Defaults to 
 `HS384`. 
 // end::rp-client-auth-jwt-signature-algorithm[]

--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -1641,6 +1641,15 @@ to the OpenID Connect Provider. Can be `client_secret_basic`, `client_secret_pos
 or `client_secret_jwt`. Defaults to `client_secret_basic`.
 // end::rp-client-auth-method-tag[]
 
+// tag::rp-client-auth-jwt-signature-algorithm[]
+`rp.client_auth_signature_algorithm` {ess-icon}::
+(<<static-cluster-setting, Static>>)
+The signature algorithm tat {es} uses to sign the JWT with which it authenticates
+as a Client to the OpenID Connect Provider when `client_secret_jwt` is selected for
+`rp.client_auth_method`. Can be either `HS256`, `HS384`, or `HS512`. Defaults to 
+`HS384`. 
+// end::rp-client-auth-jwt-signature-algorithm[]
+
 // tag::rp-redirect-uri-tag[]
 `rp.redirect_uri` {ess-icon}::
 (<<static-cluster-setting,Static>>)

--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -1633,6 +1633,14 @@ at the OpenID Connect Provider.
 The OAuth 2.0 Client Secret that was assigned to {es} during registration
 at the OpenID Connect Provider.
 
+// tag::rp-client-auth-method-tag[]
+`rp.client_auth_method` {ess-icon}::
+(<<static-cluster-setting, Static>>)
+The Client authentication method used by elasticsearch as a client to authenticate
+to the OpenID Connect Provider. Can be `client_secret_basic`, `client_secret_post`,
+or `client_secret_jwt`. Defaults to `client_secret_basic`.
+// end::rp-client-auth-method-tag[]
+
 // tag::rp-redirect-uri-tag[]
 `rp.redirect_uri` {ess-icon}::
 (<<static-cluster-setting,Static>>)


### PR DESCRIPTION
Support for additional Client authentication methods was added in
the OIDC realm in #58708. This change adds the `rp.client_auth_method`
in the realm settings reference doc.
