### PR TITLE
Adjust RolloverAction serialization of maxPrimaryShardSize during an upgrade

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/RolloverAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/RolloverAction.java
@@ -96,12 +96,22 @@ public class RolloverAction implements LifecycleAction {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         boolean hasMaxSize = maxSize != null;
-        out.writeBoolean(hasMaxSize);
+        boolean hasMaxPrimaryShardSize = maxPrimaryShardSize != null;
         if (hasMaxSize) {
+            out.writeBoolean(true);
             maxSize.writeTo(out);
+        } else if (hasMaxPrimaryShardSize && out.getVersion().before(Version.V_7_13_0)) {
+            // In the case that the outgoing node is on a version that doesn't support maxPrimaryShardSize then
+            // serialize it as maxSize. When the outgoing node receives that node-to-node response there is no validation
+            // taking place (see constructors_ and otherwise we could end up with a rollover action instance without any conditions.
+            // If the node is rebooted then it would be unable to read the cluster state and fail starting up.
+            // (ilm policies are part of cluster state)
+            out.writeBoolean(true);
+            maxPrimaryShardSize.writeTo(out);
+        } else {
+            out.writeBoolean(false);
         }
         if (out.getVersion().onOrAfter(Version.V_7_13_0)) {
-            boolean hasMaxPrimaryShardSize = maxPrimaryShardSize != null;
             out.writeBoolean(hasMaxPrimaryShardSize);
             if (hasMaxPrimaryShardSize) {
                 maxPrimaryShardSize.writeTo(out);


### PR DESCRIPTION
Backport #70076 to 7.x branch.

If node doesn't support maxPrimaryShardSize then serialize maxPrimaryShardSize as maxSize.
This should fix a problematic situation if an older node doesn't support maxPrimaryShardSize
and this is the only condition specified then the older node ends up with a instance without
any conditions. This could lead to upgrade failures, new nodes not able to start because
local cluster state can't be read.

Relates to #69918