### PR TITLE
Remove flavor field from Distribution packaging tests

### DIFF
--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/ArchiveTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/ArchiveTests.java
@@ -26,7 +26,6 @@ import static java.nio.file.StandardOpenOption.CREATE;
 import static org.elasticsearch.packaging.util.Archives.ARCHIVE_OWNER;
 import static org.elasticsearch.packaging.util.Archives.installArchive;
 import static org.elasticsearch.packaging.util.Archives.verifyArchiveInstallation;
-import static org.elasticsearch.packaging.util.FileExistenceMatchers.fileDoesNotExist;
 import static org.elasticsearch.packaging.util.FileExistenceMatchers.fileExists;
 import static org.elasticsearch.packaging.util.FileUtils.append;
 import static org.elasticsearch.packaging.util.FileUtils.mv;
@@ -364,22 +363,18 @@ public class ArchiveTests extends PackagingTestCase {
     public void test90SecurityCliPackaging() throws Exception {
         final Installation.Executables bin = installation.executables();
 
-        if (distribution().isDefault()) {
-            assertThat(installation.lib.resolve("tools").resolve("security-cli"), fileExists());
-            final Platforms.PlatformAction action = () -> {
-                Result result = sh.run(bin.certutilTool + " --help");
-                assertThat(result.stdout, containsString("Simplifies certificate creation for use with the Elastic Stack"));
+        assertThat(installation.lib.resolve("tools").resolve("security-cli"), fileExists());
+        final Platforms.PlatformAction action = () -> {
+            Result result = sh.run(bin.certutilTool + " --help");
+            assertThat(result.stdout, containsString("Simplifies certificate creation for use with the Elastic Stack"));
 
-                // Ensure that the exit code from the java command is passed back up through the shell script
-                result = sh.runIgnoreExitCode(bin.certutilTool + " invalid-command");
-                assertThat(result.exitCode, is(not(0)));
-                assertThat(result.stderr, containsString("Unknown command [invalid-command]"));
-            };
-            Platforms.onLinux(action);
-            Platforms.onWindows(action);
-        } else {
-            assertThat(installation.lib.resolve("tools").resolve("security-cli"), fileDoesNotExist());
-        }
+            // Ensure that the exit code from the java command is passed back up through the shell script
+            result = sh.runIgnoreExitCode(bin.certutilTool + " invalid-command");
+            assertThat(result.exitCode, is(not(0)));
+            assertThat(result.stderr, containsString("Unknown command [invalid-command]"));
+        };
+        Platforms.onLinux(action);
+        Platforms.onWindows(action);
     }
 
     public void test91ElasticsearchShardCliPackaging() throws Exception {
@@ -390,11 +385,8 @@ public class ArchiveTests extends PackagingTestCase {
             assertThat(result.stdout, containsString("A CLI tool to remove corrupted parts of unrecoverable shards"));
         };
 
-        // TODO: this should be checked on all distributions
-        if (distribution().isDefault()) {
-            Platforms.onLinux(action);
-            Platforms.onWindows(action);
-        }
+        Platforms.onLinux(action);
+        Platforms.onWindows(action);
     }
 
     public void test92ElasticsearchNodeCliPackaging() throws Exception {
@@ -405,11 +397,8 @@ public class ArchiveTests extends PackagingTestCase {
             assertThat(result.stdout, containsString("A CLI tool to do unsafe cluster and index manipulations on current node"));
         };
 
-        // TODO: this should be checked on all distributions
-        if (distribution().isDefault()) {
-            Platforms.onLinux(action);
-            Platforms.onWindows(action);
-        }
+        Platforms.onLinux(action);
+        Platforms.onWindows(action);
     }
 
     public void test93ElasticsearchNodeCustomDataPathAndNotEsHomeWorkDir() throws Exception {
@@ -446,10 +435,7 @@ public class ArchiveTests extends PackagingTestCase {
             assertThat(result.stdout, containsString("Manages elasticsearch file users"));
         };
 
-        // TODO: this should be checked on all distributions
-        if (distribution().isDefault()) {
-            Platforms.onLinux(action);
-            Platforms.onWindows(action);
-        }
+        Platforms.onLinux(action);
+        Platforms.onWindows(action);
     }
 }

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/CertGenCliTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/CertGenCliTests.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.packaging.test;
 
 import org.apache.http.client.fluent.Request;
-import org.elasticsearch.packaging.util.Distribution;
 import org.elasticsearch.packaging.util.FileUtils;
 import org.elasticsearch.packaging.util.Platforms;
 import org.elasticsearch.packaging.util.ServerUtils;
@@ -30,7 +29,6 @@ import static org.elasticsearch.packaging.util.FileMatcher.file;
 import static org.elasticsearch.packaging.util.FileMatcher.p600;
 import static org.elasticsearch.packaging.util.FileUtils.escapePath;
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assume.assumeTrue;
 
 public class CertGenCliTests extends PackagingTestCase {
     private static final Path instancesFile = getRootTempDir().resolve("instances.yml");
@@ -38,7 +36,6 @@ public class CertGenCliTests extends PackagingTestCase {
 
     @Before
     public void filterDistros() {
-        assumeTrue("only default distro", distribution.flavor == Distribution.Flavor.DEFAULT);
         assumeFalse("no docker", distribution.isDocker());
     }
 

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/CronEvalCliTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/CronEvalCliTests.java
@@ -8,19 +8,16 @@
 
 package org.elasticsearch.packaging.test;
 
-import org.elasticsearch.packaging.util.Distribution;
 import org.elasticsearch.packaging.util.Shell;
 import org.junit.Before;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assume.assumeFalse;
-import static org.junit.Assume.assumeTrue;
 
 public class CronEvalCliTests extends PackagingTestCase {
 
     @Before
     public void filterDistros() {
-        assumeTrue("only default distro", distribution.flavor == Distribution.Flavor.DEFAULT);
         assumeFalse("no docker", distribution.isDocker());
     }
 

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/DebMetadataTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/DebMetadataTests.java
@@ -42,11 +42,7 @@ public class DebMetadataTests extends PackagingTestCase {
 
         TestCase.assertTrue(Pattern.compile("(?m)^ Depends:.*bash.*").matcher(result.stdout).find());
 
-        String oppositePackageName = "elasticsearch";
-        if (distribution().isDefault()) {
-            oppositePackageName += "-oss";
-        }
-
+        String oppositePackageName = "elasticsearch-oss";
         TestCase.assertTrue(Pattern.compile("(?m)^ Conflicts: " + oppositePackageName + "$").matcher(result.stdout).find());
     }
 }

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/DebPreservationTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/DebPreservationTests.java
@@ -55,15 +55,13 @@ public class DebPreservationTests extends PackagingTestCase {
             installation.config(Paths.get("jvm.options.d", "heap.options"))
         );
 
-        if (distribution().isDefault()) {
-            assertPathsExist(
-                installation.config,
-                installation.config("role_mapping.yml"),
-                installation.config("roles.yml"),
-                installation.config("users"),
-                installation.config("users_roles")
-            );
-        }
+        assertPathsExist(
+            installation.config,
+            installation.config("role_mapping.yml"),
+            installation.config("roles.yml"),
+            installation.config("users"),
+            installation.config("users_roles")
+        );
 
         // keystore was removed
 
@@ -71,10 +69,7 @@ public class DebPreservationTests extends PackagingTestCase {
 
         // doc files were removed
 
-        assertPathsDoNotExist(
-            Paths.get("/usr/share/doc/" + distribution().flavor.name),
-            Paths.get("/usr/share/doc/" + distribution().flavor.name + "/copyright")
-        );
+        assertPathsDoNotExist(Paths.get("/usr/share/doc/elasticsearch"), Paths.get("/usr/share/doc/elasticsearch/copyright"));
 
         // defaults file was not removed
         assertThat(installation.envFile, fileExists());
@@ -83,7 +78,7 @@ public class DebPreservationTests extends PackagingTestCase {
     public void test30Purge() throws Exception {
         append(installation.config(Paths.get("jvm.options.d", "heap.options")), "# foo");
 
-        sh.run("dpkg --purge " + distribution().flavor.name);
+        sh.run("dpkg --purge elasticsearch");
 
         assertRemoved(distribution());
 

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/PasswordToolsTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/PasswordToolsTests.java
@@ -28,7 +28,6 @@ import java.util.stream.Stream;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.collection.IsMapContaining.hasKey;
 import static org.junit.Assume.assumeFalse;
-import static org.junit.Assume.assumeTrue;
 
 public class PasswordToolsTests extends PackagingTestCase {
 
@@ -37,7 +36,6 @@ public class PasswordToolsTests extends PackagingTestCase {
 
     @Before
     public void filterDistros() {
-        assumeTrue("only default distro", distribution.flavor == Distribution.Flavor.DEFAULT);
         assumeFalse("no docker", distribution.isDocker());
     }
 

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/QuotaAwareFsTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/QuotaAwareFsTests.java
@@ -12,7 +12,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.client.fluent.Request;
 import org.elasticsearch.common.CheckedRunnable;
-import org.elasticsearch.packaging.util.Distribution;
 import org.elasticsearch.packaging.util.ServerUtils;
 import org.elasticsearch.packaging.util.Shell;
 import org.junit.After;
@@ -49,7 +48,6 @@ public class QuotaAwareFsTests extends PackagingTestCase {
     @BeforeClass
     public static void filterDistros() {
         assumeTrue("only archives", distribution.isArchive());
-        assumeTrue("only default distribution", distribution.flavor == Distribution.Flavor.DEFAULT);
     }
 
     @After

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/RpmMetadataTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/RpmMetadataTests.java
@@ -38,11 +38,7 @@ public class RpmMetadataTests extends PackagingTestCase {
 
         final Shell.Result conflicts = sh.run("rpm -qp --conflicts " + getDistributionFile(distribution()));
 
-        String oppositePackageName = "elasticsearch";
-        if (distribution().isDefault()) {
-            oppositePackageName += "-oss";
-        }
-
+        String oppositePackageName = "elasticsearch-oss";
         TestCase.assertTrue(Pattern.compile("(?m)^" + oppositePackageName + "\\s*$").matcher(conflicts.stdout).find());
     }
 }

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/RpmPreservationTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/RpmPreservationTests.java
@@ -71,11 +71,9 @@ public class RpmPreservationTests extends PackagingTestCase {
             .map(each -> installation.config(each))
             .forEach(path -> append(path, "# foo"));
         append(installation.config(Paths.get("jvm.options.d", "heap.options")), "# foo");
-        if (distribution().isDefault()) {
-            Stream.of("role_mapping.yml", "roles.yml", "users", "users_roles")
-                .map(each -> installation.config(each))
-                .forEach(path -> append(path, "# foo"));
-        }
+        Stream.of("role_mapping.yml", "roles.yml", "users", "users_roles")
+            .map(each -> installation.config(each))
+            .forEach(path -> append(path, "# foo"));
 
         remove(distribution());
         assertRemoved(distribution());
@@ -101,9 +99,7 @@ public class RpmPreservationTests extends PackagingTestCase {
         Stream.of("elasticsearch.yml", "jvm.options", "log4j2.properties").forEach(this::assertConfFilePreserved);
         assertThat(installation.config(Paths.get("jvm.options.d", "heap.options")), fileExists());
 
-        if (distribution().isDefault()) {
-            Stream.of("role_mapping.yml", "roles.yml", "users", "users_roles").forEach(this::assertConfFilePreserved);
-        }
+        Stream.of("role_mapping.yml", "roles.yml", "users", "users_roles").forEach(this::assertConfFilePreserved);
     }
 
     private void assertConfFilePreserved(String configFile) {

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/SqlCliTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/SqlCliTests.java
@@ -8,18 +8,11 @@
 
 package org.elasticsearch.packaging.test;
 
-import org.elasticsearch.packaging.util.Distribution;
 import org.elasticsearch.packaging.util.Shell;
-import org.junit.Before;
 
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assume.assumeTrue;
 
 public class SqlCliTests extends PackagingTestCase {
-    @Before
-    public void filterDistros() {
-        assumeTrue("only default distro", distribution.flavor == Distribution.Flavor.DEFAULT);
-    }
 
     public void test010Install() throws Exception {
         install();

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Archives.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Archives.java
@@ -147,9 +147,7 @@ public class Archives {
 
     public static void verifyArchiveInstallation(Installation installation, Distribution distribution) {
         verifyOssInstallation(installation, distribution, ARCHIVE_OWNER);
-        if (distribution.flavor == Distribution.Flavor.DEFAULT) {
-            verifyDefaultInstallation(installation, distribution, ARCHIVE_OWNER);
-        }
+        verifyDefaultInstallation(installation, distribution, ARCHIVE_OWNER);
     }
 
     private static void verifyOssInstallation(Installation es, Distribution distribution, String owner) {

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Distribution.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Distribution.java
@@ -16,7 +16,6 @@ public class Distribution {
     public final Path path;
     public final Packaging packaging;
     public final Platform platform;
-    public final Flavor flavor;
     public final boolean hasJdk;
     public final String version;
 
@@ -36,21 +35,12 @@ public class Distribution {
         }
 
         this.platform = filename.contains("windows") ? Platform.WINDOWS : Platform.LINUX;
-        this.flavor = filename.contains("oss") ? Flavor.OSS : Flavor.DEFAULT;
         this.hasJdk = filename.contains("no-jdk") == false;
         String version = filename.split("-", 3)[1];
         if (filename.contains("-SNAPSHOT")) {
             version += "-SNAPSHOT";
         }
         this.version = version;
-    }
-
-    public boolean isDefault() {
-        return flavor.equals(Flavor.DEFAULT);
-    }
-
-    public boolean isOSS() {
-        return flavor.equals(Flavor.OSS);
     }
 
     public boolean isArchive() {

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Docker.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Docker.java
@@ -446,9 +446,7 @@ public class Docker {
      */
     public static void verifyContainerInstallation(Installation installation, Distribution distribution) {
         verifyOssInstallation(installation);
-        if (distribution.flavor == Distribution.Flavor.DEFAULT) {
-            verifyDefaultInstallation(installation);
-        }
+        verifyDefaultInstallation(installation);
     }
 
     private static void verifyOssInstallation(Installation es) {
@@ -593,6 +591,6 @@ public class Docker {
     }
 
     public static String getImageName(Distribution distribution) {
-        return distribution.flavor.name + (distribution.packaging == Distribution.Packaging.DOCKER_UBI ? "-ubi8" : "") + ":test";
+        return "elasticsearch" + (distribution.packaging == Distribution.Packaging.DOCKER_UBI ? "-ubi8" : "") + ":test";
     }
 }

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/DockerRun.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/DockerRun.java
@@ -130,6 +130,6 @@ public class DockerRun {
     }
 
     static String getImageName(Distribution distribution) {
-        return distribution.flavor.name + (distribution.packaging == Distribution.Packaging.DOCKER_UBI ? "-ubi8" : "") + ":test";
+        return "elasticsearch" + (distribution.packaging == Distribution.Packaging.DOCKER_UBI ? "-ubi8" : "") + ":test";
     }
 }

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Packages.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Packages.java
@@ -112,7 +112,7 @@ public class Packages {
 
     private static Result runPackageManager(Distribution distribution, Shell sh, PackageManagerCommand command) {
         final String distributionArg = command == PackageManagerCommand.QUERY || command == PackageManagerCommand.REMOVE
-            ? distribution.flavor.name
+            ? "elasticsearch"
             : distribution.path.toString();
 
         if (Platforms.isRPM()) {
@@ -150,9 +150,7 @@ public class Packages {
 
     public static void verifyPackageInstallation(Installation installation, Distribution distribution, Shell sh) {
         verifyOssInstallation(installation, distribution, sh);
-        if (distribution.flavor == Distribution.Flavor.DEFAULT) {
-            verifyDefaultInstallation(installation, distribution);
-        }
+        verifyDefaultInstallation(installation, distribution);
     }
 
     private static void verifyOssInstallation(Installation es, Distribution distribution, Shell sh) {
@@ -194,7 +192,7 @@ public class Packages {
         if (distribution.packaging == Distribution.Packaging.RPM) {
             assertThat(es.home.resolve("LICENSE.txt"), file(File, "root", "root", p644));
         } else {
-            Path copyrightDir = Paths.get(sh.run("readlink -f /usr/share/doc/" + distribution.flavor.name).stdout.trim());
+            Path copyrightDir = Paths.get(sh.run("readlink -f /usr/share/doc/elasticsearch").stdout.trim());
             assertThat(copyrightDir, file(Directory, "root", "root", p755));
             assertThat(copyrightDir.resolve("copyright"), file(File, "root", "root", p644));
         }


### PR DESCRIPTION
- More cleanup on QA tests after removing oss packaging
- Related to https://github.com/elastic/elasticsearch/issues/68797

