### PR TITLE
Fix clean up of old entries in DatabaseRegistry.initialize

### DIFF
--- a/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/AbstractGeoIpIT.java
+++ b/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/AbstractGeoIpIT.java
@@ -10,11 +10,9 @@ package org.elasticsearch.ingest.geoip;
 
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.env.Environment;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.StreamsUtils;
-import org.junit.After;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -27,7 +25,6 @@ import java.util.Collections;
 import java.util.List;
 
 public abstract class AbstractGeoIpIT extends ESIntegTestCase {
-
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
         return Arrays.asList(IngestGeoIpPlugin.class, IngestGeoIpSettingsPlugin.class);
@@ -62,24 +59,6 @@ public abstract class AbstractGeoIpIT extends ESIntegTestCase {
         @Override
         public List<Setting<?>> getSettings() {
             return Collections.singletonList(Setting.simpleString("ingest.geoip.database_path", Setting.Property.NodeScope));
-        }
-    }
-
-    @After
-    public void cleanDatabases() throws Exception {
-        super.tearDown();
-        Path path = internalCluster().getInstance(Environment.class).tmpFile();
-        Path databases = path.resolve("geoip-databases");
-        if (Files.exists(databases)) {
-            Files.walk(databases)
-                .filter(Files::isRegularFile)
-                .forEach(path1 -> {
-                    try {
-                        Files.delete(path1);
-                    } catch (IOException e) {
-                        throw new UncheckedIOException(e);
-                    }
-                });
         }
     }
 }

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/DatabaseRegistry.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/DatabaseRegistry.java
@@ -36,6 +36,7 @@ import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.FileVisitor;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
@@ -125,7 +126,9 @@ final class DatabaseRegistry implements Closeable {
 
             @Override
             public FileVisitResult visitFileFailed(Path file, IOException e) {
-                LOGGER.warn("can't delete stale file [" + file + "]", e);
+                if(e instanceof NoSuchFileException == false) {
+                    LOGGER.warn("can't delete stale file [" + file + "]", e);
+                }
                 return FileVisitResult.CONTINUE;
             }
 

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/DatabaseRegistry.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/DatabaseRegistry.java
@@ -55,20 +55,20 @@ import java.util.zip.GZIPInputStream;
 /**
  * A component that is responsible for making the databases maintained by {@link GeoIpDownloader}
  * available for ingest processors.
- * <p>
+ *
  * Also provided a lookup mechanism for geoip processors with fallback to {@link LocalDatabases}.
  * All databases are downloaded into a geoip tmp directory, which is created at node startup.
- * <p>
+ *
  * The following high level steps are executed after each cluster state update:
  * 1) Check which databases are available in {@link GeoIpTaskState},
- * which is part of the geoip downloader persistent task.
+ *    which is part of the geoip downloader persistent task.
  * 2) For each database check whether the databases have changed
- * by comparing the local and remote md5 hash or are locally missing.
+ *    by comparing the local and remote md5 hash or are locally missing.
  * 3) For each database identified in step 2 start downloading the database
- * chunks. Each chunks is appended to a tmp file (inside geoip tmp dir) and
- * after all chunks have been downloaded, the database is uncompressed and
- * renamed to the final filename.After this the database is loaded and
- * if there is an old instance of this database then that is closed.
+ *    chunks. Each chunks is appended to a tmp file (inside geoip tmp dir) and
+ *    after all chunks have been downloaded, the database is uncompressed and
+ *    renamed to the final filename.After this the database is loaded and
+ *    if there is an old instance of this database then that is closed.
  * 4) Cleanup locally loaded databases that are no longer mentioned in {@link GeoIpTaskState}.
  */
 final class DatabaseRegistry implements Closeable {


### PR DESCRIPTION
This change switches clean up in `DatabaseRegistry.initialize` from using `Files.walk` and stream operations to `Files.walkFileTree` which can be made more robust in case of errors