### PR TITLE
Fix Searchable Snapshot Cache Test Settings Conflict

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsCanMatchOnCoordinatorIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsCanMatchOnCoordinatorIntegTests.java
@@ -29,6 +29,7 @@ import org.elasticsearch.indices.recovery.RecoveryState;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.snapshots.SnapshotId;
+import org.elasticsearch.snapshots.SnapshotsService;
 import org.elasticsearch.snapshots.mockstore.MockRepository;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.transport.MockTransportService;
@@ -68,6 +69,8 @@ public class SearchableSnapshotsCanMatchOnCoordinatorIntegTests extends BaseSear
             .put(super.nodeSettings(nodeOrdinal))
             // Use an unbound cache so we can recover the searchable snapshot completely all the times
             .put(CacheService.SNAPSHOT_CACHE_SIZE_SETTING.getKey(), new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES))
+            // Have a shared cache of reasonable size available on each node because tests randomize over frozen and cold allocation
+            .put(SnapshotsService.SNAPSHOT_CACHE_SIZE_SETTING.getKey(), ByteSizeValue.ofMb(randomLongBetween(1, 10)))
             .build();
     }
 


### PR DESCRIPTION
The broken test randomized over frozen and cold allocation on a specific node.
This randomly ran into the combination of trying to allocate a frozen shard
to a node that had no shared cache available which broke tests expectations.

-> fix by just having a shared cache available on each node to keep tests using specific data nodes
to specific nodes simple.

closes #68591
