### PR TITLE
[Transform] Enhance transform role checks 

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/transform/transforms/TransformStats.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/transform/transforms/TransformStats.java
@@ -117,7 +117,7 @@ public class TransformStats {
 
     public enum State {
 
-        STARTED, INDEXING, ABORTING, STOPPING, STOPPED, FAILED;
+        STARTED, INDEXING, ABORTING, STOPPING, STOPPED, FAILED, WAITING;
 
         public static State fromString(String name) {
             return valueOf(name.trim().toUpperCase(Locale.ROOT));

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformMessages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformMessages.java
@@ -30,6 +30,8 @@ public class TransformMessages {
     public static final String UNKNOWN_TRANSFORM_STATS = "Statistics for transform [{0}] could not be found";
 
     public static final String REST_DEPRECATED_ENDPOINT = "[_data_frame/transforms/] is deprecated, use [_transform/] in the future.";
+    public static final String REST_WARN_NO_TRANSFORM_NODES =
+        "Transform requires the transform node role for at least 1 node, found [{0}] transform nodes";
 
     public static final String CANNOT_STOP_FAILED_TRANSFORM = "Unable to stop transform [{0}] as it is in a failed state with reason [{1}]."
         + " Use force stop to stop the transform.";

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformMessages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformMessages.java
@@ -31,7 +31,7 @@ public class TransformMessages {
 
     public static final String REST_DEPRECATED_ENDPOINT = "[_data_frame/transforms/] is deprecated, use [_transform/] in the future.";
     public static final String REST_WARN_NO_TRANSFORM_NODES =
-        "Transform requires the transform node role for at least 1 node, found [{0}] transform nodes";
+        "Transform requires the transform node role for at least 1 node, found no transform nodes";
 
     public static final String CANNOT_STOP_FAILED_TRANSFORM = "Unable to stop transform [{0}] as it is in a failed state with reason [{1}]."
         + " Use force stop to stop the transform.";

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformStatsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformStatsTests.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.util.function.Predicate;
 
 import static org.elasticsearch.xpack.core.transform.transforms.TransformStats.State.STARTED;
+import static org.elasticsearch.xpack.core.transform.transforms.TransformStats.State.WAITING;
 import static org.hamcrest.Matchers.equalTo;
 
 public class TransformStatsTests extends AbstractSerializingTestCase<TransformStats> {
@@ -116,6 +117,35 @@ public class TransformStatsTests extends AbstractSerializingTestCase<TransformSt
                     in.setVersion(Version.V_7_6_0);
                     TransformStats statsFromOld = new TransformStats(in);
                     assertThat(statsFromOld, equalTo(stats));
+                }
+            }
+        }
+    }
+
+    public void testBwcWith712() throws IOException {
+        for (int i = 0; i < NUMBER_OF_TEST_RUNS; i++) {
+            TransformStats stats = new TransformStats(
+                "bwc-id",
+                WAITING,
+                randomBoolean() ? null : randomAlphaOfLength(100),
+                randomBoolean() ? null : NodeAttributeTests.randomNodeAttributes(),
+                new TransformIndexerStats(1, 2, 3, 0, 5, 6, 7, 0, 0, 10, 11, 0, 13, 14, 15.0, 16.0, 17.0),
+                new TransformCheckpointingInfo(
+                    new TransformCheckpointStats(0, null, null, 10, 100),
+                    new TransformCheckpointStats(0, null, null, 100, 1000),
+                    // changesLastDetectedAt aren't serialized back
+                    100,
+                    null,
+                    null
+                )
+            );
+            try (BytesStreamOutput output = new BytesStreamOutput()) {
+                output.setVersion(Version.V_7_12_0);
+                stats.writeTo(output);
+                try (StreamInput in = output.bytes().streamInput()) {
+                    in.setVersion(Version.V_8_0_0); // TODO: V_7_13_0
+                    TransformStats statsFromOld = new TransformStats(in);
+                    assertThat(statsFromOld.getState(), equalTo(STARTED));
                 }
             }
         }

--- a/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/TransformSingleNodeTestCase.java
+++ b/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/TransformSingleNodeTestCase.java
@@ -13,7 +13,9 @@ import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksAction;
 import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksRequest;
 import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksResponse;
 import org.elasticsearch.common.CheckedConsumer;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.reindex.ReindexPlugin;
+import org.elasticsearch.node.NodeRoleSettings;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.tasks.TaskInfo;
 import org.elasticsearch.test.ESSingleNodeTestCase;
@@ -30,6 +32,11 @@ public abstract class TransformSingleNodeTestCase extends ESSingleNodeTestCase {
     @Override
     protected Collection<Class<? extends Plugin>> getPlugins() {
         return pluginList(LocalStateTransform.class, ReindexPlugin.class);
+    }
+
+    @Override
+    protected Settings nodeSettings() {
+        return Settings.builder().put(NodeRoleSettings.NODE_ROLES_SETTING.getKey(), "master, data, ingest, transform").build();
     }
 
     protected <T> void assertAsync(Consumer<ActionListener<T>> function, T expected, CheckedConsumer<T, ? extends Exception> onAnswer,

--- a/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/integration/TransformNoTransformNodeIT.java
+++ b/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/integration/TransformNoTransformNodeIT.java
@@ -19,22 +19,23 @@ public class TransformNoTransformNodeIT extends TransformSingleNodeTestCase {
         return Settings.builder().put(NodeRoleSettings.NODE_ROLES_SETTING.getKey(), "master, data, ingest").build();
     }
 
-    public void testWarning() {
-        if (randomBoolean()) {
-            GetTransformStatsAction.Request getTransformStatsRequest = new GetTransformStatsAction.Request("_all");
-            GetTransformStatsAction.Response getTransformStatsResponse = client().execute(
-                GetTransformStatsAction.INSTANCE,
-                getTransformStatsRequest
-            ).actionGet();
+    public void testWarningForStats() {
+        GetTransformStatsAction.Request getTransformStatsRequest = new GetTransformStatsAction.Request("_all");
+        GetTransformStatsAction.Response getTransformStatsResponse = client().execute(
+            GetTransformStatsAction.INSTANCE,
+            getTransformStatsRequest
+        ).actionGet();
 
-            assertEquals(0, getTransformStatsResponse.getTransformsStats().size());
-        } else {
-            GetTransformAction.Request getTransformRequest = new GetTransformAction.Request("_all");
-            GetTransformAction.Response getTransformResponse = client().execute(GetTransformAction.INSTANCE, getTransformRequest)
-                .actionGet();
-            assertEquals(0, getTransformResponse.getTransformConfigurations().size());
+        assertEquals(0, getTransformStatsResponse.getTransformsStats().size());
 
-        }
+        assertWarnings("Transform requires the transform node role for at least 1 node, found no transform nodes");
+    }
+
+    public void testWarningForGet() {
+        GetTransformAction.Request getTransformRequest = new GetTransformAction.Request("_all");
+        GetTransformAction.Response getTransformResponse = client().execute(GetTransformAction.INSTANCE, getTransformRequest).actionGet();
+        assertEquals(0, getTransformResponse.getTransformConfigurations().size());
+
         assertWarnings("Transform requires the transform node role for at least 1 node, found no transform nodes");
     }
 }

--- a/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/integration/TransformNoTransformNodeIT.java
+++ b/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/integration/TransformNoTransformNodeIT.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.transform.integration;
 
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.node.NodeRoleSettings;
+import org.elasticsearch.xpack.core.transform.action.GetTransformAction;
 import org.elasticsearch.xpack.core.transform.action.GetTransformStatsAction;
 import org.elasticsearch.xpack.transform.TransformSingleNodeTestCase;
 
@@ -19,13 +20,21 @@ public class TransformNoTransformNodeIT extends TransformSingleNodeTestCase {
     }
 
     public void testWarning() {
-        GetTransformStatsAction.Request getTransformStatsRequest = new GetTransformStatsAction.Request("_all");
-        GetTransformStatsAction.Response getTransformStatsResponse = client().execute(
-            GetTransformStatsAction.INSTANCE,
-            getTransformStatsRequest
-        ).actionGet();
+        if (randomBoolean()) {
+            GetTransformStatsAction.Request getTransformStatsRequest = new GetTransformStatsAction.Request("_all");
+            GetTransformStatsAction.Response getTransformStatsResponse = client().execute(
+                GetTransformStatsAction.INSTANCE,
+                getTransformStatsRequest
+            ).actionGet();
 
-        assertEquals(0, getTransformStatsResponse.getTransformsStats().size());
+            assertEquals(0, getTransformStatsResponse.getTransformsStats().size());
+        } else {
+            GetTransformAction.Request getTransformRequest = new GetTransformAction.Request("_all");
+            GetTransformAction.Response getTransformResponse = client().execute(GetTransformAction.INSTANCE, getTransformRequest)
+                .actionGet();
+            assertEquals(0, getTransformResponse.getTransformConfigurations().size());
+
+        }
         assertWarnings("Transform requires the transform node role for at least 1 node, found no transform nodes");
     }
 }

--- a/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/integration/TransformNoTransformNodeIT.java
+++ b/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/integration/TransformNoTransformNodeIT.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.transform.integration;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.node.NodeRoleSettings;
+import org.elasticsearch.xpack.core.transform.action.GetTransformStatsAction;
+import org.elasticsearch.xpack.transform.TransformSingleNodeTestCase;
+
+public class TransformNoTransformNodeIT extends TransformSingleNodeTestCase {
+    @Override
+    protected Settings nodeSettings() {
+        return Settings.builder().put(NodeRoleSettings.NODE_ROLES_SETTING.getKey(), "master, data, ingest").build();
+    }
+
+    public void testWarning() {
+        GetTransformStatsAction.Request getTransformStatsRequest = new GetTransformStatsAction.Request("_all");
+        GetTransformStatsAction.Response getTransformStatsResponse = client().execute(
+            GetTransformStatsAction.INSTANCE,
+            getTransformStatsRequest
+        ).actionGet();
+
+        assertEquals(0, getTransformStatsResponse.getTransformsStats().size());
+        assertWarnings("Transform requires the transform node role for at least 1 node, found no transform nodes");
+    }
+}

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransformNodes.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransformNodes.java
@@ -78,7 +78,7 @@ public final class TransformNodes {
      *
      * @param transformId The transform or a wildcard pattern, including '_all' to match against transform tasks.
      * @param clusterState State
-     * @return  The {@link TransformNodeAssignments} for the given pattern.
+     * @return The {@link TransformNodeAssignments} for the given pattern.
      */
     public static TransformNodeAssignments findPersistentTasks(String transformId, ClusterState clusterState) {
         Set<String> executorNodes = new HashSet<>();
@@ -144,7 +144,7 @@ public final class TransformNodes {
     public static void warnIfNoTransformNodes(ClusterState clusterState) {
         long transformNodes = getNumberOfTransformNodes(clusterState);
         if (transformNodes == 0) {
-            HeaderWarning.addWarning(TransformMessages.getMessage(TransformMessages.REST_WARN_NO_TRANSFORM_NODES, transformNodes));
+            HeaderWarning.addWarning(TransformMessages.REST_WARN_NO_TRANSFORM_NODES);
         }
     }
 }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransformNodes.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransformNodes.java
@@ -72,15 +72,15 @@ public final class TransformNodes {
     }
 
     /**
-     * Get node assignments for a given list of transform or transform pattern.
+     * Get node assignments for a given transform pattern.
      *
-     * Note: This only returns active assignments, stopped transforms are not reported. Active means running or waiting for a node.
+     * Note: This only returns p-task assignments, stopped transforms are not reported. P-Tasks can be running or waiting for a node.
      *
-     * @param transformId The transform or a simply wildcard pattern.
+     * @param transformId The transform or a wildcard pattern, including '_all' to match against transform tasks.
      * @param clusterState State
-     * @return  The {@link TransformNodeAssignments} for the given transforms.
+     * @return  The {@link TransformNodeAssignments} for the given pattern.
      */
-    public static TransformNodeAssignments findActiveTasks(String transformId, ClusterState clusterState) {
+    public static TransformNodeAssignments findPersistentTasks(String transformId, ClusterState clusterState) {
         Set<String> executorNodes = new HashSet<>();
         Set<String> assigned = new HashSet<>();
         Set<String> waitingForAssignment = new HashSet<>();
@@ -105,9 +105,8 @@ public final class TransformNodes {
         return new TransformNodeAssignments(executorNodes, assigned, waitingForAssignment, Collections.emptySet());
     }
 
-
     /**
-     * Get the assignment of a specific transform
+     * Get the assignment of a specific transform.
      *
      * @param transformId the transform id
      * @param clusterState state
@@ -138,7 +137,7 @@ public final class TransformNodes {
 
     /**
      * Check if cluster has at least 1 transform nodes and add a header warning if not.
-     * To be used by transport actions.
+     * To be used by transport actions only.
      *
      * @param clusterState state
      */

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransformNodes.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransformNodes.java
@@ -8,25 +8,36 @@
 package org.elasticsearch.xpack.transform.action;
 
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.logging.HeaderWarning;
+import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
+import org.elasticsearch.persistent.PersistentTasksCustomMetadata.Assignment;
+import org.elasticsearch.persistent.PersistentTasksCustomMetadata.PersistentTask;
 import org.elasticsearch.xpack.core.transform.TransformField;
+import org.elasticsearch.xpack.core.transform.TransformMessages;
+import org.elasticsearch.xpack.core.transform.transforms.TransformTaskParams;
+import org.elasticsearch.xpack.transform.Transform;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 public final class TransformNodes {
 
     private TransformNodes() {}
 
     /**
-     * Get the list of nodes transforms are executing on
+     * Get node assignments for a given list of transforms.
      *
      * @param transformIds The transforms.
      * @param clusterState State
-     * @return The executor nodes
+     * @return The {@link TransformNodeAssignments} for the given transforms.
      */
     public static TransformNodeAssignments transformTaskNodes(List<String> transformIds, ClusterState clusterState) {
 
@@ -59,5 +70,87 @@ public final class TransformNodes {
             .collect(Collectors.toSet());
 
         return new TransformNodeAssignments(executorNodes, assigned, waitingForAssignment, stopped);
+    }
+
+    /**
+     * Get node assignments for a given list of transform or transform pattern.
+     *
+     * Note: This only returns active assignments, stopped transforms are not reported. Active means running or waiting for a node.
+     *
+     * @param transformId The transform or a simply wildcard pattern.
+     * @param clusterState State
+     * @return  The {@link TransformNodeAssignments} for the given transforms.
+     */
+    public static TransformNodeAssignments findActiveTasks(String transformId, ClusterState clusterState) {
+
+        Set<String> executorNodes = new HashSet<>();
+        Set<String> assigned = new HashSet<>();
+        Set<String> waitingForAssignment = new HashSet<>();
+
+        PersistentTasksCustomMetadata tasksMetadata = PersistentTasksCustomMetadata.getPersistentTasksCustomMetadata(clusterState);
+
+        if (tasksMetadata != null) {
+            Predicate<PersistentTask<?>> taskMatcher = Strings.isAllOrWildcard(new String[] { transformId }) ? t -> true : t -> {
+                TransformTaskParams transformParams = (TransformTaskParams) t.getParams();
+                return Regex.simpleMatch(transformId, transformParams.getId());
+            };
+
+            for (PersistentTasksCustomMetadata.PersistentTask<?> task : tasksMetadata.findTasks(TransformField.TASK_NAME, taskMatcher)) {
+                if (task.isAssigned()) {
+                    executorNodes.add(task.getExecutorNode());
+                    assigned.add(task.getId());
+                } else {
+                    waitingForAssignment.add(task.getId());
+                }
+            }
+        }
+
+        return new TransformNodeAssignments(executorNodes, assigned, waitingForAssignment, Collections.emptySet());
+    }
+
+
+    /**
+     * Get the assignment of a specific transform
+     *
+     * @param transformId the transform id
+     * @param clusterState state
+     * @return {@link Assignment} of task
+     */
+    public static Assignment getAssignment(String transformId, ClusterState clusterState) {
+        PersistentTasksCustomMetadata tasksMetadata = PersistentTasksCustomMetadata.getPersistentTasksCustomMetadata(clusterState);
+
+        PersistentTask<?> task = tasksMetadata.getTask(transformId);
+
+        if (task != null) {
+            return task.getAssignment();
+        }
+
+        return PersistentTasksCustomMetadata.INITIAL_ASSIGNMENT;
+
+    }
+
+    /**
+     * Get the number of transform nodes in the cluster
+     *
+     * @param clusterState state
+     * @return number of transform nodes
+     */
+    public static long getNumberOfTransformNodes(ClusterState clusterState) {
+        return StreamSupport.stream(clusterState.getNodes().spliterator(), false)
+            .filter(node -> node.getRoles().contains(Transform.TRANSFORM_ROLE))
+            .count();
+    }
+
+    /**
+     * Check if cluster has at least 1 transform nodes and add a header warning if not.
+     * To be used by transport actions.
+     *
+     * @param clusterState state
+     */
+    public static void warnIfNoTransformNodes(ClusterState clusterState) {
+        long transformNodes = getNumberOfTransformNodes(clusterState);
+        if (transformNodes == 0) {
+            HeaderWarning.addWarning(TransformMessages.getMessage(TransformMessages.REST_WARN_NO_TRANSFORM_NODES, transformNodes));
+        }
     }
 }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransformNodes.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransformNodes.java
@@ -40,7 +40,6 @@ public final class TransformNodes {
      * @return The {@link TransformNodeAssignments} for the given transforms.
      */
     public static TransformNodeAssignments transformTaskNodes(List<String> transformIds, ClusterState clusterState) {
-
         Set<String> executorNodes = new HashSet<>();
         Set<String> assigned = new HashSet<>();
         Set<String> waitingForAssignment = new HashSet<>();
@@ -82,7 +81,6 @@ public final class TransformNodes {
      * @return  The {@link TransformNodeAssignments} for the given transforms.
      */
     public static TransformNodeAssignments findActiveTasks(String transformId, ClusterState clusterState) {
-
         Set<String> executorNodes = new HashSet<>();
         Set<String> assigned = new HashSet<>();
         Set<String> waitingForAssignment = new HashSet<>();
@@ -104,7 +102,6 @@ public final class TransformNodes {
                 }
             }
         }
-
         return new TransformNodeAssignments(executorNodes, assigned, waitingForAssignment, Collections.emptySet());
     }
 
@@ -118,7 +115,6 @@ public final class TransformNodes {
      */
     public static Assignment getAssignment(String transformId, ClusterState clusterState) {
         PersistentTasksCustomMetadata tasksMetadata = PersistentTasksCustomMetadata.getPersistentTasksCustomMetadata(clusterState);
-
         PersistentTask<?> task = tasksMetadata.getTask(transformId);
 
         if (task != null) {
@@ -126,7 +122,6 @@ public final class TransformNodes {
         }
 
         return PersistentTasksCustomMetadata.INITIAL_ASSIGNMENT;
-
     }
 
     /**

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportGetTransformStatsAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportGetTransformStatsAction.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
+import org.elasticsearch.persistent.PersistentTasksCustomMetadata.Assignment;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -131,17 +132,18 @@ public class TransportGetTransformStatsAction extends TransportTasksAction<Trans
 
     @Override
     protected void doExecute(Task task, Request request, ActionListener<Response> finalListener) {
+        final ClusterState state = clusterService.state();
+        TransformNodes.warnIfNoTransformNodes(state);
+
         transformConfigManager.expandTransformIds(
             request.getId(),
             request.getPageParams(),
             request.isAllowNoMatch(),
             ActionListener.wrap(hitsAndIds -> {
                 request.setExpandedIds(hitsAndIds.v2());
-                final ClusterState state = clusterService.state();
-                TransformNodeAssignments transformNodeAssignments = TransformNodes.transformTaskNodes(hitsAndIds.v2(), state);
-                // TODO: if empty the request is send to all nodes(benign but superfluous)
-                request.setNodes(transformNodeAssignments.getExecutorNodes().toArray(new String[0]));
-                super.doExecute(task, request, ActionListener.wrap(response -> {
+                final TransformNodeAssignments transformNodeAssignments = TransformNodes.transformTaskNodes(hitsAndIds.v2(), state);
+
+                ActionListener<Response> doExecuteListener = ActionListener.wrap(response -> {
                     PersistentTasksCustomMetadata tasksInProgress = state.getMetadata().custom(PersistentTasksCustomMetadata.TYPE);
                     if (tasksInProgress != null) {
                         // Mutates underlying state object with the assigned node attributes
@@ -150,6 +152,8 @@ public class TransportGetTransformStatsAction extends TransportTasksAction<Trans
                     collectStatsForTransformsWithoutTasks(
                         request,
                         response,
+                        transformNodeAssignments.getWaitingForAssignment(),
+                        state,
                         ActionListener.wrap(
                             finalResponse -> finalListener.onResponse(
                                 new Response(
@@ -162,7 +166,14 @@ public class TransportGetTransformStatsAction extends TransportTasksAction<Trans
                             finalListener::onFailure
                         )
                     );
-                }, finalListener::onFailure));
+                }, finalListener::onFailure);
+
+                if (transformNodeAssignments.getExecutorNodes().size() > 0) {
+                    request.setNodes(transformNodeAssignments.getExecutorNodes().toArray(new String[0]));
+                    super.doExecute(task, request, doExecuteListener);
+                } else {
+                    doExecuteListener.onResponse(new Response(Collections.emptyList(), 0L));
+                }
             },
                 e -> {
                     // If the index to search, or the individual config is not there, just return empty
@@ -210,7 +221,13 @@ public class TransportGetTransformStatsAction extends TransportTasksAction<Trans
         );
     }
 
-    private void collectStatsForTransformsWithoutTasks(Request request, Response response, ActionListener<Response> listener) {
+    private void collectStatsForTransformsWithoutTasks(
+        Request request,
+        Response response,
+        Set<String> transformsWaitingForAssignment,
+        ClusterState clusterState,
+        ActionListener<Response> listener
+    ) {
         // We gathered all there is, no need to continue
         if (request.getExpandedIds().size() == response.getTransformsStats().size()) {
             listener.onResponse(response);
@@ -226,23 +243,30 @@ public class TransportGetTransformStatsAction extends TransportTasksAction<Trans
         // There is a potential race condition where the saved document does not actually have a STOPPED state
         // as the task is cancelled before we persist state.
         ActionListener<List<TransformStoredDoc>> searchStatsListener = ActionListener.wrap(statsForTransformsWithoutTasks -> {
-            List<TransformStats> allStateAndStats = response.getTransformsStats();
-            addCheckpointingInfoForTransformsWithoutTasks(allStateAndStats, statsForTransformsWithoutTasks, ActionListener.wrap(aVoid -> {
-                transformsWithoutTasks.removeAll(
-                    statsForTransformsWithoutTasks.stream().map(TransformStoredDoc::getId).collect(Collectors.toSet())
-                );
+            // copy the list as it might be immutable
+            List<TransformStats> allStateAndStats = new ArrayList<>(response.getTransformsStats());
+            addCheckpointingInfoForTransformsWithoutTasks(
+                allStateAndStats,
+                statsForTransformsWithoutTasks,
+                transformsWaitingForAssignment,
+                clusterState,
+                ActionListener.wrap(aVoid -> {
+                    transformsWithoutTasks.removeAll(
+                        statsForTransformsWithoutTasks.stream().map(TransformStoredDoc::getId).collect(Collectors.toSet())
+                    );
 
-                // Transforms that have not been started and have no state or stats.
-                transformsWithoutTasks.forEach(transformId -> allStateAndStats.add(TransformStats.initialStats(transformId)));
+                    // Transforms that have not been started and have no state or stats.
+                    transformsWithoutTasks.forEach(transformId -> allStateAndStats.add(TransformStats.initialStats(transformId)));
 
-                // Any transform in collection could NOT have a task, so, even though the list is initially sorted
-                // it can easily become arbitrarily ordered based on which transforms don't have a task or stats docs
-                allStateAndStats.sort(Comparator.comparing(TransformStats::getId));
+                    // Any transform in collection could NOT have a task, so, even though the list is initially sorted
+                    // it can easily become arbitrarily ordered based on which transforms don't have a task or stats docs
+                    allStateAndStats.sort(Comparator.comparing(TransformStats::getId));
 
-                listener.onResponse(
-                    new Response(allStateAndStats, allStateAndStats.size(), response.getTaskFailures(), response.getNodeFailures())
-                );
-            }, listener::onFailure));
+                    listener.onResponse(
+                        new Response(allStateAndStats, allStateAndStats.size(), response.getTaskFailures(), response.getNodeFailures())
+                    );
+                }, listener::onFailure)
+            );
         }, e -> {
             if (e instanceof IndexNotFoundException) {
                 listener.onResponse(response);
@@ -271,6 +295,8 @@ public class TransportGetTransformStatsAction extends TransportTasksAction<Trans
     private void addCheckpointingInfoForTransformsWithoutTasks(
         List<TransformStats> allStateAndStats,
         List<TransformStoredDoc> statsForTransformsWithoutTasks,
+        Set<String> transformsWaitingForAssignment,
+        ClusterState clusterState,
         ActionListener<Void> listener
     ) {
 
@@ -285,9 +311,31 @@ public class TransportGetTransformStatsAction extends TransportTasksAction<Trans
 
         statsForTransformsWithoutTasks.forEach(stat -> populateSingleStoppedTransformStat(stat, ActionListener.wrap(checkpointingInfo -> {
             synchronized (allStateAndStats) {
-                allStateAndStats.add(
-                    new TransformStats(stat.getId(), TransformStats.State.STOPPED, null, null, stat.getTransformStats(), checkpointingInfo)
-                );
+                if (transformsWaitingForAssignment.contains(stat.getId())) {
+                    // corner case: as we
+                    Assignment assignment = TransformNodes.getAssignment(stat.getId(), clusterState);
+                    allStateAndStats.add(
+                        new TransformStats(
+                            stat.getId(),
+                            TransformStats.State.WAITING,
+                            assignment.getExplanation(),
+                            null,
+                            stat.getTransformStats(),
+                            checkpointingInfo
+                        )
+                    );
+                } else {
+                    allStateAndStats.add(
+                        new TransformStats(
+                            stat.getId(),
+                            TransformStats.State.STOPPED,
+                            null,
+                            null,
+                            stat.getTransformStats(),
+                            checkpointingInfo
+                        )
+                    );
+                }
             }
             if (numberRemaining.decrementAndGet() == 0) {
                 listener.onResponse(null);

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportGetTransformStatsAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportGetTransformStatsAction.java
@@ -312,7 +312,6 @@ public class TransportGetTransformStatsAction extends TransportTasksAction<Trans
         statsForTransformsWithoutTasks.forEach(stat -> populateSingleStoppedTransformStat(stat, ActionListener.wrap(checkpointingInfo -> {
             synchronized (allStateAndStats) {
                 if (transformsWaitingForAssignment.contains(stat.getId())) {
-                    // corner case: as we
                     Assignment assignment = TransformNodes.getAssignment(stat.getId(), clusterState);
                     allStateAndStats.add(
                         new TransformStats(

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPreviewTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPreviewTransformAction.java
@@ -120,7 +120,8 @@ public class TransportPreviewTransformAction extends HandledTransportAction<
 
     @Override
     protected void doExecute(Task task, PreviewTransformAction.Request request, ActionListener<PreviewTransformAction.Response> listener) {
-        ClusterState clusterState = clusterService.state();
+        final ClusterState clusterState = clusterService.state();
+        TransformNodes.warnIfNoTransformNodes(clusterState);
 
         final TransformConfig config = request.getConfig();
         sourceDestValidator.validate(

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPutTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPutTransformAction.java
@@ -192,6 +192,7 @@ public class TransportPutTransformAction extends AcknowledgedTransportMasterNode
     @Override
     protected void masterOperation(Task task, Request request, ClusterState clusterState, ActionListener<AcknowledgedResponse> listener) {
         XPackPlugin.checkReadyForXPackCustomMetadata(clusterState);
+        TransformNodes.warnIfNoTransformNodes(clusterState);
 
         // set headers to run transform as calling user
         Map<String, String> filteredHeaders = ClientHelper.filterSecurityHeaders(threadPool.getThreadContext().getHeaders());

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStartTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStartTransformAction.java
@@ -148,6 +148,8 @@ public class TransportStartTransformAction extends TransportMasterNodeAction<Sta
         ClusterState state,
         ActionListener<StartTransformAction.Response> listener
     ) throws Exception {
+        TransformNodes.warnIfNoTransformNodes(state);
+
         final AtomicReference<TransformTaskParams> transformTaskHolder = new AtomicReference<>();
         final AtomicReference<TransformConfig> transformConfigHolder = new AtomicReference<>();
 

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStopTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStopTransformAction.java
@@ -180,7 +180,10 @@ public class TransportStopTransformAction extends TransportTasksAction<Transform
                     }
                 }, e -> {
                     if (e instanceof ResourceNotFoundException) {
-                        final TransformNodeAssignments transformNodeAssignments = TransformNodes.findActiveTasks(request.getId(), state);
+                        final TransformNodeAssignments transformNodeAssignments = TransformNodes.findPersistentTasks(
+                            request.getId(),
+                            state
+                        );
 
                         if (transformNodeAssignments.getAssigned().isEmpty()
                             && transformNodeAssignments.getWaitingForAssignment().isEmpty()) {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStopTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStopTransformAction.java
@@ -23,10 +23,8 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.logging.LoggerMessageFormat;
-import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.discovery.MasterNotDiscoveredException;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
@@ -37,13 +35,11 @@ import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.action.util.PageParams;
-import org.elasticsearch.xpack.core.transform.TransformField;
 import org.elasticsearch.xpack.core.transform.TransformMessages;
 import org.elasticsearch.xpack.core.transform.action.StopTransformAction;
 import org.elasticsearch.xpack.core.transform.action.StopTransformAction.Request;
 import org.elasticsearch.xpack.core.transform.action.StopTransformAction.Response;
 import org.elasticsearch.xpack.core.transform.transforms.TransformState;
-import org.elasticsearch.xpack.core.transform.transforms.TransformTaskParams;
 import org.elasticsearch.xpack.core.transform.transforms.TransformTaskState;
 import org.elasticsearch.xpack.transform.TransformServices;
 import org.elasticsearch.xpack.transform.persistence.TransformConfigManager;
@@ -55,7 +51,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -134,27 +129,6 @@ public class TransportStopTransformAction extends TransportTasksAction<Transform
         }
     }
 
-    static Tuple<Set<String>, Set<String>> findTasksWithoutConfig(ClusterState state, String transformId) {
-        PersistentTasksCustomMetadata tasks = state.metadata().custom(PersistentTasksCustomMetadata.TYPE);
-
-        Set<String> taskIds = new HashSet<>();
-        Set<String> executorNodes = new HashSet<>();
-
-        if (tasks != null) {
-            Predicate<PersistentTask<?>> taskMatcher = Strings.isAllOrWildcard(new String[] { transformId }) ? t -> true : t -> {
-                TransformTaskParams transformParams = (TransformTaskParams) t.getParams();
-                return Regex.simpleMatch(transformId, transformParams.getId());
-            };
-
-            for (PersistentTasksCustomMetadata.PersistentTask<?> pTask : tasks.findTasks(TransformField.TASK_NAME, taskMatcher)) {
-                executorNodes.add(pTask.getExecutorNode());
-                taskIds.add(pTask.getId());
-            }
-        }
-
-        return new Tuple<>(taskIds, executorNodes);
-    }
-
     @Override
     protected void doExecute(Task task, Request request, ActionListener<Response> listener) {
         final ClusterState state = clusterService.state();
@@ -173,6 +147,8 @@ public class TransportStopTransformAction extends TransportTasksAction<Transform
                 );
             }
         } else {
+            TransformNodes.warnIfNoTransformNodes(state);
+
             final ActionListener<Response> finalListener;
             if (request.waitForCompletion()) {
                 finalListener = waitForStopListener(request, listener);
@@ -204,21 +180,39 @@ public class TransportStopTransformAction extends TransportTasksAction<Transform
                     }
                 }, e -> {
                     if (e instanceof ResourceNotFoundException) {
-                        Tuple<Set<String>, Set<String>> runningTasksAndNodes = findTasksWithoutConfig(state, request.getId());
-                        if (runningTasksAndNodes.v1().isEmpty()) {
+                        final TransformNodeAssignments transformNodeAssignments = TransformNodes.findActiveTasks(request.getId(), state);
+
+                        if (transformNodeAssignments.getAssigned().isEmpty()
+                            && transformNodeAssignments.getWaitingForAssignment().isEmpty()) {
                             listener.onFailure(e);
                             // found transforms without a config
                         } else if (request.isForce()) {
-                            // TODO: handle tasks waiting for assignment
-                            request.setExpandedIds(runningTasksAndNodes.v1());
-                            request.setNodes(runningTasksAndNodes.v2().toArray(new String[0]));
-                            super.doExecute(task, request, finalListener);
+                            final ActionListener<Response> doExecuteListener;
+
+                            if (transformNodeAssignments.getWaitingForAssignment().size() > 0) {
+                                doExecuteListener = cancelTransformTasksWithNoAssignment(finalListener, transformNodeAssignments);
+                            } else {
+                                doExecuteListener = finalListener;
+                            }
+
+                            if (transformNodeAssignments.getExecutorNodes().size() > 0) {
+                                request.setExpandedIds(transformNodeAssignments.getAssigned());
+                                request.setNodes(transformNodeAssignments.getExecutorNodes().toArray(new String[0]));
+                                super.doExecute(task, request, doExecuteListener);
+                            } else {
+                                doExecuteListener.onResponse(new Response(true));
+                            }
                         } else {
+                            Set<String> transformsWithoutConfig = Stream.concat(
+                                transformNodeAssignments.getAssigned().stream(),
+                                transformNodeAssignments.getWaitingForAssignment().stream()
+                            ).collect(Collectors.toSet());
+
                             listener.onFailure(
                                 new ElasticsearchStatusException(
                                     TransformMessages.getMessage(
                                         TransformMessages.REST_STOP_TRANSFORM_WITHOUT_CONFIG,
-                                        Strings.arrayToCommaDelimitedString(runningTasksAndNodes.v1().toArray(new String[0]))
+                                        Strings.collectionToCommaDelimitedString(transformsWithoutConfig)
                                     ),
                                     RestStatus.CONFLICT
                                 )

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpdateTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpdateTransformAction.java
@@ -181,6 +181,8 @@ public class TransportUpdateTransformAction extends TransportTasksAction<Transfo
             }
             return;
         }
+        TransformNodes.warnIfNoTransformNodes(clusterState);
+
         // set headers to run transform as calling user
         Map<String, String> filteredHeaders = ClientHelper.filterSecurityHeaders(threadPool.getThreadContext().getHeaders());
 

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/compat/TransportGetTransformActionDeprecated.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/compat/TransportGetTransformActionDeprecated.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.transform.action.compat;
 
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.transport.TransportService;
@@ -18,9 +19,14 @@ import org.elasticsearch.xpack.transform.action.TransportGetTransformAction;
 public class TransportGetTransformActionDeprecated extends TransportGetTransformAction {
 
     @Inject
-    public TransportGetTransformActionDeprecated(TransportService transportService, ActionFilters actionFilters, Client client,
-            NamedXContentRegistry xContentRegistry) {
-        super(GetTransformActionDeprecated.NAME, transportService, actionFilters, client, xContentRegistry);
+    public TransportGetTransformActionDeprecated(
+        TransportService transportService,
+        ActionFilters actionFilters,
+        ClusterService clusterService,
+        Client client,
+        NamedXContentRegistry xContentRegistry
+    ) {
+        super(GetTransformActionDeprecated.NAME, transportService, actionFilters, clusterService, client, xContentRegistry);
     }
 
 }

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransformNodesTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransformNodesTests.java
@@ -109,10 +109,7 @@ public class TransformNodesTests extends ESTestCase {
         assertEquals(1, transformNodeAssignments.getStopped().size());
         assertTrue(transformNodeAssignments.getStopped().contains(transformIdStopped));
 
-        transformNodeAssignments = TransformNodes.transformTaskNodes(
-            Arrays.asList(transformIdFoo, transformIdFailed),
-            cs
-        );
+        transformNodeAssignments = TransformNodes.transformTaskNodes(Arrays.asList(transformIdFoo, transformIdFailed), cs);
 
         assertEquals(1, transformNodeAssignments.getExecutorNodes().size());
         assertTrue(transformNodeAssignments.getExecutorNodes().contains("node-1"));
@@ -121,6 +118,68 @@ public class TransformNodesTests extends ESTestCase {
         assertEquals(1, transformNodeAssignments.getAssigned().size());
         assertTrue(transformNodeAssignments.getAssigned().contains(transformIdFoo));
         assertFalse(transformNodeAssignments.getAssigned().contains(transformIdFailed));
+        assertEquals(0, transformNodeAssignments.getStopped().size());
+
+        // test simple matching
+        transformNodeAssignments = TransformNodes.findActiveTasks("df-id-f*", cs);
+        assertEquals(1, transformNodeAssignments.getExecutorNodes().size());
+        assertTrue(transformNodeAssignments.getExecutorNodes().contains("node-1"));
+        assertEquals(1, transformNodeAssignments.getWaitingForAssignment().size());
+        assertTrue(transformNodeAssignments.getWaitingForAssignment().contains(transformIdFailed));
+        assertEquals(1, transformNodeAssignments.getAssigned().size());
+        assertTrue(transformNodeAssignments.getAssigned().contains(transformIdFoo));
+        assertFalse(transformNodeAssignments.getAssigned().contains(transformIdFailed));
+        assertEquals(0, transformNodeAssignments.getStopped().size());
+
+        // test matching none
+        transformNodeAssignments = TransformNodes.findActiveTasks("df-id-z*", cs);
+        assertEquals(0, transformNodeAssignments.getExecutorNodes().size());
+        assertEquals(0, transformNodeAssignments.getWaitingForAssignment().size());
+        assertEquals(0, transformNodeAssignments.getAssigned().size());
+        assertEquals(0, transformNodeAssignments.getStopped().size());
+
+        // test matching all
+        transformNodeAssignments = TransformNodes.findActiveTasks("df-id-*", cs);
+        assertEquals(3, transformNodeAssignments.getExecutorNodes().size());
+        assertTrue(transformNodeAssignments.getExecutorNodes().contains("node-1"));
+        assertTrue(transformNodeAssignments.getExecutorNodes().contains("node-2"));
+        assertTrue(transformNodeAssignments.getExecutorNodes().contains("node-3"));
+        assertEquals(1, transformNodeAssignments.getWaitingForAssignment().size());
+        assertTrue(transformNodeAssignments.getWaitingForAssignment().contains(transformIdFailed));
+        assertEquals(4, transformNodeAssignments.getAssigned().size());
+        assertTrue(transformNodeAssignments.getAssigned().contains(transformIdFoo));
+        assertTrue(transformNodeAssignments.getAssigned().contains(transformIdBar));
+        assertTrue(transformNodeAssignments.getAssigned().contains(transformIdBaz));
+        assertTrue(transformNodeAssignments.getAssigned().contains(transformIdOther));
+        assertFalse(transformNodeAssignments.getAssigned().contains(transformIdFailed));
+        // stopped tasks are not reported when matching against _running_ tasks
+        assertEquals(0, transformNodeAssignments.getStopped().size());
+
+        // test matching all with _all
+        transformNodeAssignments = TransformNodes.findActiveTasks("_all", cs);
+        assertEquals(3, transformNodeAssignments.getExecutorNodes().size());
+        assertTrue(transformNodeAssignments.getExecutorNodes().contains("node-1"));
+        assertTrue(transformNodeAssignments.getExecutorNodes().contains("node-2"));
+        assertTrue(transformNodeAssignments.getExecutorNodes().contains("node-3"));
+        assertEquals(1, transformNodeAssignments.getWaitingForAssignment().size());
+        assertTrue(transformNodeAssignments.getWaitingForAssignment().contains(transformIdFailed));
+        assertEquals(4, transformNodeAssignments.getAssigned().size());
+        assertTrue(transformNodeAssignments.getAssigned().contains(transformIdFoo));
+        assertTrue(transformNodeAssignments.getAssigned().contains(transformIdBar));
+        assertTrue(transformNodeAssignments.getAssigned().contains(transformIdBaz));
+        assertTrue(transformNodeAssignments.getAssigned().contains(transformIdOther));
+        assertFalse(transformNodeAssignments.getAssigned().contains(transformIdFailed));
+        // stopped tasks are not reported when matching against _running_ tasks
+        assertEquals(0, transformNodeAssignments.getStopped().size());
+
+        // test matching exact
+        transformNodeAssignments = TransformNodes.findActiveTasks(transformIdFoo, cs);
+        assertEquals(1, transformNodeAssignments.getExecutorNodes().size());
+        assertTrue(transformNodeAssignments.getExecutorNodes().contains("node-1"));
+        assertEquals(0, transformNodeAssignments.getWaitingForAssignment().size());
+        assertEquals(1, transformNodeAssignments.getAssigned().size());
+        assertTrue(transformNodeAssignments.getAssigned().contains(transformIdFoo));
+        // stopped tasks are not reported when matching against _running_ tasks
         assertEquals(0, transformNodeAssignments.getStopped().size());
     }
 
@@ -134,5 +193,12 @@ public class TransformNodesTests extends ESTestCase {
         assertEquals(0, transformNodeAssignments.getExecutorNodes().size());
         assertEquals(1, transformNodeAssignments.getStopped().size());
         assertTrue(transformNodeAssignments.getStopped().contains("df-id"));
+
+        transformNodeAssignments = TransformNodes.findActiveTasks("df-*", emptyState);
+
+        assertEquals(0, transformNodeAssignments.getExecutorNodes().size());
+        assertEquals(0, transformNodeAssignments.getWaitingForAssignment().size());
+        assertEquals(0, transformNodeAssignments.getAssigned().size());
+        assertEquals(0, transformNodeAssignments.getStopped().size());
     }
 }

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransformNodesTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransformNodesTests.java
@@ -121,7 +121,7 @@ public class TransformNodesTests extends ESTestCase {
         assertEquals(0, transformNodeAssignments.getStopped().size());
 
         // test simple matching
-        transformNodeAssignments = TransformNodes.findActiveTasks("df-id-f*", cs);
+        transformNodeAssignments = TransformNodes.findPersistentTasks("df-id-f*", cs);
         assertEquals(1, transformNodeAssignments.getExecutorNodes().size());
         assertTrue(transformNodeAssignments.getExecutorNodes().contains("node-1"));
         assertEquals(1, transformNodeAssignments.getWaitingForAssignment().size());
@@ -132,14 +132,14 @@ public class TransformNodesTests extends ESTestCase {
         assertEquals(0, transformNodeAssignments.getStopped().size());
 
         // test matching none
-        transformNodeAssignments = TransformNodes.findActiveTasks("df-id-z*", cs);
+        transformNodeAssignments = TransformNodes.findPersistentTasks("df-id-z*", cs);
         assertEquals(0, transformNodeAssignments.getExecutorNodes().size());
         assertEquals(0, transformNodeAssignments.getWaitingForAssignment().size());
         assertEquals(0, transformNodeAssignments.getAssigned().size());
         assertEquals(0, transformNodeAssignments.getStopped().size());
 
         // test matching all
-        transformNodeAssignments = TransformNodes.findActiveTasks("df-id-*", cs);
+        transformNodeAssignments = TransformNodes.findPersistentTasks("df-id-*", cs);
         assertEquals(3, transformNodeAssignments.getExecutorNodes().size());
         assertTrue(transformNodeAssignments.getExecutorNodes().contains("node-1"));
         assertTrue(transformNodeAssignments.getExecutorNodes().contains("node-2"));
@@ -156,7 +156,7 @@ public class TransformNodesTests extends ESTestCase {
         assertEquals(0, transformNodeAssignments.getStopped().size());
 
         // test matching all with _all
-        transformNodeAssignments = TransformNodes.findActiveTasks("_all", cs);
+        transformNodeAssignments = TransformNodes.findPersistentTasks("_all", cs);
         assertEquals(3, transformNodeAssignments.getExecutorNodes().size());
         assertTrue(transformNodeAssignments.getExecutorNodes().contains("node-1"));
         assertTrue(transformNodeAssignments.getExecutorNodes().contains("node-2"));
@@ -173,7 +173,7 @@ public class TransformNodesTests extends ESTestCase {
         assertEquals(0, transformNodeAssignments.getStopped().size());
 
         // test matching exact
-        transformNodeAssignments = TransformNodes.findActiveTasks(transformIdFoo, cs);
+        transformNodeAssignments = TransformNodes.findPersistentTasks(transformIdFoo, cs);
         assertEquals(1, transformNodeAssignments.getExecutorNodes().size());
         assertTrue(transformNodeAssignments.getExecutorNodes().contains("node-1"));
         assertEquals(0, transformNodeAssignments.getWaitingForAssignment().size());
@@ -194,7 +194,7 @@ public class TransformNodesTests extends ESTestCase {
         assertEquals(1, transformNodeAssignments.getStopped().size());
         assertTrue(transformNodeAssignments.getStopped().contains("df-id"));
 
-        transformNodeAssignments = TransformNodes.findActiveTasks("df-*", emptyState);
+        transformNodeAssignments = TransformNodes.findPersistentTasks("df-*", emptyState);
 
         assertEquals(0, transformNodeAssignments.getExecutorNodes().size());
         assertEquals(0, transformNodeAssignments.getWaitingForAssignment().size());


### PR DESCRIPTION
improve robustness and ux in case of a missing transform node:
 - warn if cluster lacks a transform node in all API's (except DELETE)
 - report waiting state in stats if transform waits for assignment
 - cancel p-task on stop transform even if config has been deleted

relates #69518