### PR TITLE
Fix fetch_fields yaml test result order

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/330_fetch_fields.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/330_fetch_fields.yml
@@ -532,6 +532,7 @@ Test nested field inside object structure:
            index: test
            body:
               _source: false
+              sort: "obj.other_obj_field"
               fields: [ "*" ]
   - length: { hits.hits.0.fields : 2 }
   - match:
@@ -551,10 +552,13 @@ Test nested field inside object structure:
         search:
            index: test
            body:
+              sort: "obj.other_obj_field"
               _source: false
               fields: ["obj.other_obj_field"]
   - match:
         hits.hits.0.fields.obj\.other_obj_field.0: other_value
+  - match:
+        hits.hits.1.fields.obj\.other_obj_field.0: other_value2
 
   -  do:
         search:


### PR DESCRIPTION
The test failing in #69985 does so because under rare circumstance the result
order for match_all can be different. If we want to make assertions on specific
entries in the result, we should sort by a field that imposes a fixed result
ordering.

Closes #69985