### PR TITLE
[DOCS] Expands transforms docs with CCS info

### DIFF
--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -919,7 +919,7 @@ end::source_includes[]
 tag::source-transforms[]
 The source of the data for the {transform}.
 
-INFO: {transforms-cap} support <<modules-cross-cluster-search,{ccs}>>.
+NOTE: {transforms-cap} support <<modules-cross-cluster-search,{ccs}>>.
 end::source-transforms[]
 
 tag::source-index-transforms[]

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -918,8 +918,10 @@ end::source_includes[]
 
 tag::source-transforms[]
 The source of the data for the {transform}.
-
++
+--
 NOTE: {transforms-cap} support <<modules-cross-cluster-search,{ccs}>>.
+--
 end::source-transforms[]
 
 tag::source-index-transforms[]

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -918,20 +918,17 @@ end::source_includes[]
 
 tag::source-transforms[]
 The source of the data for the {transform}.
-+
---
-NOTE: {transforms-cap} support <<modules-cross-cluster-search,{ccs}>>.
---
 end::source-transforms[]
 
 tag::source-index-transforms[]
 The _source indices_ for the {transform}. It can be a single index, an index
 pattern (for example, `"my-index-*"`), an array of indices (for example,
 `["my-index-000001", "my-index-000002"]`), or an array of index patterns (for 
-example, `["my-index-*", "my-other-index-*"]`.
+example, `["my-index-*", "my-other-index-*"]`. For remote indices use the syntax 
+`"remote_name:index_name"`.
 
-NOTE: If any indices are in remote clusters then `node.remote_cluster_client`
-must not be set to `false` on any {ml} nodes.
+NOTE: If any indices are in remote clusters then the master node and at least 
+one transform node must have the `remote_cluster_client` node role.
 end::source-index-transforms[]
 
 tag::source-query-transforms[]
@@ -940,9 +937,9 @@ A query clause that retrieves a subset of data from the source index. See
 end::source-query-transforms[]
 
 tag::source-runtime-mappings-transforms[]
-Definitions of search-time runtime fields that can be used by the transform. If 
-you use <<modules-cross-cluster-search,{ccs}>>, the version of the remote 
-cluster must be newer than 7.12.
+Definitions of search-time runtime fields that can be used by the transform. For 
+search runtime fields all data nodes, including remote nodes, must be 7.12 or 
+later.
 end::source-runtime-mappings-transforms[]
 
 tag::state-transform[]

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -918,13 +918,18 @@ end::source_includes[]
 
 tag::source-transforms[]
 The source of the data for the {transform}.
+
+INFO: {transforms-cap} support <<modules-cross-cluster-search,{ccs}>>.
 end::source-transforms[]
 
 tag::source-index-transforms[]
 The _source indices_ for the {transform}. It can be a single index, an index
 pattern (for example, `"my-index-*"`), an array of indices (for example,
-`["my-index-000001", "my-index-000002"]`), or an array of index patterns (for example,
-`["my-index-*", "my-other-index-*"]`.
+`["my-index-000001", "my-index-000002"]`), or an array of index patterns (for 
+example, `["my-index-*", "my-other-index-*"]`.
+
+NOTE: If any indices are in remote clusters then `node.remote_cluster_client`
+must not be set to `false` on any {ml} nodes.
 end::source-index-transforms[]
 
 tag::source-query-transforms[]
@@ -933,7 +938,9 @@ A query clause that retrieves a subset of data from the source index. See
 end::source-query-transforms[]
 
 tag::source-runtime-mappings-transforms[]
-Definitions of search-time runtime fields that can be used by the transform.
+Definitions of search-time runtime fields that can be used by the transform. If 
+you use <<modules-cross-cluster-search,{ccs}>>, the version of the remote 
+cluster must be newer than 7.12.
 end::source-runtime-mappings-transforms[]
 
 tag::state-transform[]

--- a/docs/reference/transform/apis/put-transform.asciidoc
+++ b/docs/reference/transform/apis/put-transform.asciidoc
@@ -44,18 +44,17 @@ structure (known as a {dataframe}). The ID for each document in the {dataframe}
 is generated from a hash of the entity, so there is a unique row per entity. For 
 more information, see <<transforms>>.
 
-When the {transform} is created, a series of validations occur to
-ensure its success. For example, there is a check for the existence of the
-source indices and a check that the destination index is not part of the source
-index pattern. You can use the `defer_validation` parameter to skip these
-checks.
+When the {transform} is created, a series of validations occur to ensure its 
+success. For example, there is a check for the existence of the source indices 
+and a check that the destination index is not part of the source index pattern. 
+You can use the `defer_validation` parameter to skip these checks.
 
-Deferred validations are always run when the {transform} is started,
-with the exception of privilege checks. When {es} {security-features} are
-enabled, the {transform} remembers which roles the user that created
-it had at the time of creation and uses those same roles. If those roles do not
-have the required privileges on the source and destination indices, the
-{transform} fails when it attempts unauthorized operations.
+Deferred validations are always run when the {transform} is started, with the 
+exception of privilege checks. When {es} {security-features} are enabled, the 
+{transform} remembers which roles the user that created it had at the time of 
+creation and uses those same roles. If those roles do not have the required 
+privileges on the source and destination indices, the {transform} fails when it 
+attempts unauthorized operations.
 
 IMPORTANT: You must use {kib} or this API to create a {transform}. Do not put a
 {transform} directly into any `.transform-internal*` indices using the {es}

--- a/docs/reference/transform/limitations.asciidoc
+++ b/docs/reference/transform/limitations.asciidoc
@@ -279,9 +279,9 @@ slow the {transform}. Use an indexed field as a time field when using
 
 [discrete]
 [[transforms-ccs-limitation]]
-=== {transforms-cap} supports {ccs} if the remote cluster configured properly
+=== {transforms-cap} support {ccs} if the remote cluster is configured properly
 
 If you use <<modules-cross-cluster-search,{ccs}>>, the remote cluster must 
 support the search and aggregations you use in your {transforms}. 
-{transforms-cap} validate their configuration, if it fails and you use {ccs}, 
+{transforms-cap} validate their configuration; if you use {ccs} and the validation fails, 
 make sure that the remote cluster supports the query and aggregations you use.

--- a/docs/reference/transform/limitations.asciidoc
+++ b/docs/reference/transform/limitations.asciidoc
@@ -275,3 +275,13 @@ accessed. If the time field is a {ref}/runtime.html[runtime field], the
 performance impact of calculating field values at query time can significantly 
 slow the {transform}. Use an indexed field as a time field when using 
 {transforms}.
+
+
+[discrete]
+[[transforms-ccs-limitation]]
+=== {transforms-cap} supports {ccs} if the remote cluster configured properly
+
+If you use <<modules-cross-cluster-search,{ccs}>>, the remote cluster must 
+support the search and aggregations you use in your {transforms}. 
+{transforms-cap} validate their configuration, if it fails and you use {ccs}, 
+make sure that the remote cluster supports the query and aggregations you use.


### PR DESCRIPTION
## Overview

This PR adds information on CCS support to transforms docs:
* a note on CCS is supported to the `source` setting of the PUT/Preview/cat/Update Transforms API
* a note on how to set the remote clusters if you use remote indices,
* additional CCS info related to runtime mappings
* a limitation item on CCS.

### Preview

[PUT Transforms API](https://elasticsearch_70156.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/put-transform.html)
[Limitations](https://elasticsearch_70156.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/transform-limitations.html#transforms-ccs-limitation)