### PR TITLE
Do not over-allocate when resizing in GeoGridTiler

### DIFF
--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoTileGridTiler.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoTileGridTiler.java
@@ -121,7 +121,8 @@ public class GeoTileGridTiler implements GeoGridTiler {
                         values.resizeCell(valuesIndex + 1);
                         values.add(valuesIndex++, GeoTileUtils.longEncodeTiles(zTile, nextX, nextY));
                     } else {
-                        values.resizeCell(valuesIndex +  1 << ( 2 * (targetPrecision - zTile)) + 1);
+                        final int numTilesAtPrecision  = 1 << (2 * (targetPrecision - zTile));
+                        values.resizeCell(valuesIndex + numTilesAtPrecision + 1);
                         valuesIndex = setValuesForFullyContainedTile(nextX, nextY, zTile, values, valuesIndex, targetPrecision);
                     }
                 } else if (GeoRelation.QUERY_CROSSES == relation) {

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoGridTilerTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoGridTilerTests.java
@@ -46,6 +46,7 @@ import static org.elasticsearch.xpack.spatial.util.GeoTestUtils.encodeDecodeLon;
 import static org.elasticsearch.xpack.spatial.util.GeoTestUtils.geoShapeValue;
 import static org.elasticsearch.xpack.spatial.util.GeoTestUtils.randomBBox;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
 public class GeoGridTilerTests extends ESTestCase {
     private static final GeoTileGridTiler GEOTILE = new GeoTileGridTiler();
@@ -144,6 +145,8 @@ public class GeoGridTilerTests extends ESTestCase {
             int numTiles = GEOTILE.setValues(unboundedCellValues, value, precision);
             int expected = numTiles(value, precision);
             assertThat(numTiles, equalTo(expected));
+            // make sure we are not over-allocating
+            assertThat(4 * numTiles + 1, greaterThanOrEqualTo(unboundedCellValues.getValues().length));
         }
     }
 


### PR DESCRIPTION
A missing parenthesis is missing when calculating the size of the array which might lead to an oversize array.