### PR TITLE
Test: Fix error in assumption around accuracy (backport of #69932)

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/AvgAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/AvgAggregatorTests.java
@@ -246,7 +246,11 @@ public class AvgAggregatorTests extends AggregatorTestCase {
             iw -> {
                 List<List<IndexableField>> docs = new ArrayList<>();
                 for (double value : values) {
-                    docs.add(List.of(new NumericDocValuesField("number", NumericUtils.doubleToSortableLong(value))));
+                    docs.add(
+                        org.elasticsearch.common.collect.List.of(
+                            new NumericDocValuesField("number", NumericUtils.doubleToSortableLong(value))
+                        )
+                    );
                 }
                 /*
                  * Use add documents to force us to collect from a single segment


### PR DESCRIPTION
In our test for the accuracy of the `avg` aggregation we assumed that
you could just run it across any number of leaves. But our tests
sometimes split those leaves as though they were separate shards. And,
that gets us inaccurate results because we don't send the compensations
back across the results for each shard. That is probably a bug. I
opened #69931 to talk more about it.
