### PR TITLE
Add earlier validation for some SearchSourceBuilder settings (#69548)

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/core/CountRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/core/CountRequestTests.java
@@ -66,7 +66,7 @@ public class CountRequestTests extends AbstractRequestTestCase<CountRequest, Que
         assertNotNull(countRequest.indicesOptions());
         assertNotNull(countRequest.types());
 
-        NullPointerException e = expectThrows(NullPointerException.class, () -> countRequest.indices((String[]) null));
+        Exception e = expectThrows(NullPointerException.class, () -> countRequest.indices((String[]) null));
         assertEquals("indices must not be null", e.getMessage());
         e = expectThrows(NullPointerException.class, () -> countRequest.indices((String) null));
         assertEquals("index must not be null", e.getMessage());
@@ -84,6 +84,9 @@ public class CountRequestTests extends AbstractRequestTestCase<CountRequest, Que
 
         e = expectThrows(NullPointerException.class, () -> countRequest.query(null));
         assertEquals("query must not be null", e.getMessage());
+
+        e = expectThrows(IllegalArgumentException.class, () -> countRequest.terminateAfter(-(randomIntBetween(1, 100))));
+        assertEquals("terminateAfter must be > 0", e.getMessage());
     }
 
     public void testEqualsAndHashcode() {

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/count/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/count/10_basic.yml
@@ -59,3 +59,11 @@ setup:
         body:
           match:
             foo: bar
+---
+"test negative terminate_after throws IAE":
+
+  - do:
+      catch: /terminateAfter must be > 0/
+      count:
+        index: index1
+        terminate_after: -1

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/260_parameter_validation.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/260_parameter_validation.yml
@@ -1,0 +1,56 @@
+setup:
+
+  - do:
+      indices.create:
+        index: index1
+        body:
+          settings:
+            number_of_replicas: 0
+          mappings:
+            properties:
+              foo:
+                type: keyword
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+        - '{ "index" : { "_index" : "index1", "_id" : "1" } }'
+        - '{ "foo": "bar"}'
+
+---
+"test size=-1 is deprecated":
+  - skip:
+      version: " - 7.12.99"
+      reason: deprecation added in 7.13
+      features: allowed_warnings
+
+  - do:
+      allowed_warnings:
+        - "Using search size of -1 is deprecated and will be removed in future versions. Instead, don't use the `size` parameter if you don't want to set it explicitely."
+      search:
+        rest_total_hits_as_int: true
+        index: index1
+        size: -1
+
+  - length: { hits.hits: 1 }
+
+---
+"test negative size throws IAE":
+
+  - do:
+      catch: /\[size\] parameter cannot be negative, found \[-5\]/
+      search:
+        index: index1
+        rest_total_hits_as_int: true
+        size: -5
+
+---
+"test negative terminate_after throws IAE":
+
+  - do:
+      catch: /illegal_argument_exception/
+      search:
+        index: index1
+        rest_total_hits_as_int: true
+        terminate_after: -1

--- a/server/src/main/java/org/elasticsearch/rest/action/search/RestCountAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/search/RestCountAction.java
@@ -87,11 +87,7 @@ public class RestCountAction extends BaseRestHandler {
         countRequest.preference(request.param("preference"));
 
         final int terminateAfter = request.paramAsInt("terminate_after", DEFAULT_TERMINATE_AFTER);
-        if (terminateAfter < 0) {
-            throw new IllegalArgumentException("terminateAfter must be > 0");
-        } else if (terminateAfter > 0) {
-            searchSourceBuilder.terminateAfter(terminateAfter);
-        }
+        searchSourceBuilder.terminateAfter(terminateAfter);
         return channel -> client.search(countRequest, new RestBuilderListener<SearchResponse>(channel) {
             @Override
             public RestResponse buildResponse(SearchResponse response, XContentBuilder builder) throws Exception {

--- a/server/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
@@ -207,9 +207,18 @@ public class RestSearchAction extends BaseRestHandler {
         if (from != -1) {
             searchSourceBuilder.from(from);
         }
-        int size = request.paramAsInt("size", -1);
-        if (size != -1) {
-            setSize.accept(size);
+        if (request.hasParam("size")) {
+            int size = request.paramAsInt("size", -1);
+            if (size != -1) {
+                setSize.accept(size);
+            } else {
+                deprecationLogger.deprecate(
+                    DeprecationCategory.API,
+                    "search-api-size-1",
+                    "Using search size of -1 is deprecated and will be removed in future versions. Instead, don't use the `size` parameter "
+                        + "if you don't want to set it explicitely."
+                );
+            }
         }
 
         if (request.hasParam("explain")) {
@@ -225,13 +234,8 @@ public class RestSearchAction extends BaseRestHandler {
             searchSourceBuilder.timeout(request.paramAsTime("timeout", null));
         }
         if (request.hasParam("terminate_after")) {
-            int terminateAfter = request.paramAsInt("terminate_after",
-                    SearchContext.DEFAULT_TERMINATE_AFTER);
-            if (terminateAfter < 0) {
-                throw new IllegalArgumentException("terminateAfter must be > 0");
-            } else if (terminateAfter > 0) {
-                searchSourceBuilder.terminateAfter(terminateAfter);
-            }
+            int terminateAfter = request.paramAsInt("terminate_after", SearchContext.DEFAULT_TERMINATE_AFTER);
+            searchSourceBuilder.terminateAfter(terminateAfter);
         }
 
         StoredFieldsContext storedFieldsContext =

--- a/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -1152,11 +1152,23 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
                 if (FROM_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                     from = parser.intValue();
                 } else if (SIZE_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
-                    size = parser.intValue();
+                    int parsedSize = parser.intValue();
+                    // we treat -1 as not-set, but deprecate it to be able to later remove this funny extra treatment
+                    if (parsedSize != -1) {
+                        size(parsedSize);
+                    } else {
+                        deprecationLogger.deprecate(
+                            DeprecationCategory.API,
+                            "search-api-size-1",
+                            "Using search size of -1 is deprecated and will be removed in future versions. "
+                            + "Instead, don't use the `size` parameter if you don't want to set it explicitely."
+                        );
+                    }
+
                 } else if (TIMEOUT_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                     timeout = TimeValue.parseTimeValue(parser.text(), null, TIMEOUT_FIELD.getPreferredName());
                 } else if (TERMINATE_AFTER_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
-                    terminateAfter = parser.intValue();
+                    terminateAfter(parser.intValue());
                 } else if (MIN_SCORE_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                     minScore = parser.floatValue();
                 } else if (VERSION_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
@@ -1170,9 +1182,9 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
                 } else if (TRACK_TOTAL_HITS_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                     if (token == XContentParser.Token.VALUE_BOOLEAN ||
                         (token == XContentParser.Token.VALUE_STRING && Booleans.isBoolean(parser.text()))) {
-                        trackTotalHitsUpTo = parser.booleanValue() ? TRACK_TOTAL_HITS_ACCURATE : TRACK_TOTAL_HITS_DISABLED;
+                        trackTotalHits(parser.booleanValue());
                     } else {
-                        trackTotalHitsUpTo = parser.intValue();
+                        trackTotalHitsUpTo(parser.intValue());
                     }
                 } else if (_SOURCE_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                     fetchSourceContext = FetchSourceContext.fromXContent(parser);

--- a/server/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
@@ -473,13 +473,54 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
         assertEquals("[from] parameter cannot be negative", expected.getMessage());
     }
 
-    public void testNegativeSizeErrors() {
+    public void testNegativeSizeErrors() throws IOException {
         int randomSize = randomIntBetween(-100000, -2);
         IllegalArgumentException expected = expectThrows(IllegalArgumentException.class,
                 () -> new SearchSourceBuilder().size(randomSize));
         assertEquals("[size] parameter cannot be negative, found [" + randomSize + "]", expected.getMessage());
         expected = expectThrows(IllegalArgumentException.class, () -> new SearchSourceBuilder().size(-1));
         assertEquals("[size] parameter cannot be negative, found [-1]", expected.getMessage());
+
+        // we don't want to error on -1 for bwc reasons, this is treated as if the value is unset later
+        String restContent = "{\"size\" : -1}";
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, restContent)) {
+            SearchSourceBuilder searchSourceBuilder = SearchSourceBuilder.fromXContent(parser);
+            assertEquals(-1, searchSourceBuilder.size());
+        }
+        assertWarnings("Using search size of -1 is deprecated and will be removed in future versions. Instead, don't use the `size` "
+            + "parameter if you don't want to set it explicitely.");
+
+        restContent = "{\"size\" : " + randomSize + "}";
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, restContent)) {
+            IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> SearchSourceBuilder.fromXContent(parser));
+            assertThat(ex.getMessage(), containsString(Integer.toString(randomSize)));
+        }
+    }
+
+    public void testNegativeTerminateAfter() throws IOException {
+        int randomNegativeValue = randomIntBetween(-100000, -1);
+        IllegalArgumentException expected = expectThrows(IllegalArgumentException.class,
+                () -> new SearchSourceBuilder().terminateAfter(randomNegativeValue));
+        assertEquals("terminateAfter must be > 0", expected.getMessage());
+
+        String restContent = "{\"terminate_after\" :" + randomNegativeValue + "}";
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, restContent)) {
+            IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> SearchSourceBuilder.fromXContent(parser));
+            assertThat(ex.getMessage(), containsString("terminateAfter must be > 0"));
+        }
+    }
+
+    public void testNegativeTrackTotalHits() throws IOException {
+        int randomNegativeValue = randomIntBetween(-100000, -2);
+        IllegalArgumentException expected = expectThrows(IllegalArgumentException.class,
+                () -> new SearchSourceBuilder().trackTotalHitsUpTo(randomNegativeValue));
+        assertEquals("[track_total_hits] parameter must be positive or equals to -1, got " + randomNegativeValue, expected.getMessage());
+
+        String restContent = "{\"track_total_hits\" :" + randomNegativeValue + "}";
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, restContent)) {
+            IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> SearchSourceBuilder.fromXContent(parser));
+            assertEquals("[track_total_hits] parameter must be positive or equals to -1, got " + randomNegativeValue, ex.getMessage());
+        }
     }
 
     private void assertIndicesBoostParseErrorMessage(String restContent, String expectedErrorMessage) throws IOException {


### PR DESCRIPTION
Currently we check several search parameters for illegal values in their
SearchSourceBuilder setters, e.g. negative values throw IAE for: `size`,
`terminateAfter` and `trackTotalHits`.

The validation in the builder setters are used when parsing the above as rest
request parameters, however we currently don't check values when parsing them
from the search request body. This leads to builders with invalid parameters
that sometimes get caucht later (e.g. a negative size is triggering an
IllegalArgumentException in TotalHitCountCollector), but we should validate and
throw errors early.

This PR changes the parsing in SearchSourceBuilder to use the setters, adds
tests and also adds a deprecation for allowing a size parameter of -1, currently
meaning an "unset" value.

Closes #54958
