### PR TITLE
Improve error messages around detecting Java installations

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,4 +15,4 @@ systemProp.jdk.tls.client.protocols=TLSv1.2
 
 # java homes resolved by environment variables
 org.gradle.java.installations.auto-detect=false
-org.gradle.java.installations.fromEnv=JAVA_HOME,RUNTIME_JAVA_HOME,JAVA15_HOME,JAVA14_HOME,JAVA13_HOME,JAVA12_HOME,JAVA11_HOME,JAVA8_HOME
+org.gradle.java.installations.fromEnv=JAVA_HOME,RUNTIME_JAVA_HOME,JAVA16_HOME,JAVA15_HOME,JAVA14_HOME,JAVA13_HOME,JAVA12_HOME,JAVA11_HOME,JAVA8_HOME


### PR DESCRIPTION
There are a few scenarios in which our java installation detection logic can fail. In these scenarios, our error handling is a bit poor and you get unuseful messages like this:

```
* What went wrong:
An exception occurred applying plugin request [id: 'elasticsearch.global-build-info']
> Failed to apply plugin 'elasticsearch.global-build-info'.
   > No value present
```

In a specific case, this will fail if we haven't added the relevant Java environment variable entry to the `gradle.properties file`. This has been improved so the error now looks like this:

```
* What went wrong:
An exception occurred applying plugin request [id: 'elasticsearch.global-build-info']
> Failed to apply plugin 'elasticsearch.global-build-info'.
   > Environment variable 'JAVA16_HOME' is not registered with Gradle installation supplier. Ensure 'org.gradle.java.installations.fromEnv' is updated in gradle.properties file.
```

In the fall back scenario, in case something unanticipated went wrong we can at least tell the users this:

```
* What went wrong:
An exception occurred applying plugin request [id: 'elasticsearch.global-build-info']
> Failed to apply plugin 'elasticsearch.global-build-info'.
   > Could not locate available Java installation in Gradle registry at: /home/mark/.sdkman/candidates/java/16.ea.33-open
```