### PR TITLE
Test: Fix error in assumption around accuracy (backport of #69932)

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/AvgAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/AvgAggregatorTests.java
@@ -14,6 +14,7 @@ import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.MultiReader;
 import org.apache.lucene.index.RandomIndexWriter;
 import org.apache.lucene.search.DocValuesFieldExistsQuery;
@@ -243,9 +244,23 @@ public class AvgAggregatorTests extends AggregatorTestCase {
         MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType("number", NumberFieldMapper.NumberType.DOUBLE);
         testAggregation(aggregationBuilder, new MatchAllDocsQuery(),
             iw -> {
+                List<List<IndexableField>> docs = new ArrayList<>();
                 for (double value : values) {
-                    iw.addDocument(singleton(new NumericDocValuesField("number", NumericUtils.doubleToSortableLong(value))));
+                    docs.add(
+                        org.elasticsearch.common.collect.List.of(
+                            new NumericDocValuesField("number", NumericUtils.doubleToSortableLong(value))
+                        )
+                    );
                 }
+                /*
+                 * Use add documents to force us to collect from a single segment
+                 * so we don't break the collection across the shrads. We can't do
+                 * *that* because we don't bring back the compensations for the sum
+                 * back in the shard results. If we don't bring back the compensations
+                 * errors can creep in. Not big errors, but big enough to upset this
+                 * test.
+                 */
+                iw.addDocuments(docs);
             },
             avg -> assertEquals(expected, avg.getValue(), delta),
             fieldType


### PR DESCRIPTION
In our test for the accuracy of the `avg` aggregation we assumed that
you could just run it across any number of leaves. But our tests
sometimes split those leaves as though they were separate shards. And,
that gets us inaccurate results because we don't send the compensations
back across the results for each shard. That is probably a bug. I
opened #69931 to talk more about it.
