### PR TITLE
[DOCS] Add runtime fields to index templates

### DIFF
--- a/docs/reference/indices/index-templates.asciidoc
+++ b/docs/reference/indices/index-templates.asciidoc
@@ -72,21 +72,11 @@ for `logs-*-*`.
 [[create-index-templates]]
 == Create index template
 
-To create an index template from Stack Management in {kib}, select
-*Index Management* in the side navigation, choose *Index Templates*, and click *Create Template*. You
-can then select the component templates you want to use, or define the index settings, mappings, and alias configurations directly.
+Use the <<indices-put-template,index template>> and <<indices-component-template,put component template>> APIs to create and update index templates.
+You can also <<index-mgmt,manage index templates>> from Stack
+Management in {kib}.
 
-When defining mappings, you can add mapped fields and create
-<<runtime-mapping-fields,runtime fields>>. These fields work like any other
-field, but are evaluated only at query time. When an index is created that
-matches the index template, {es} uses the index template to configure the index
-and add the runtime field to the mappings. When you create the runtime field,
-you optionally specify a Painless script. If you don't include a script,
-runtime fields retrieve values from `_source`.
-
-You can also use the <<indices-put-template, index template>> and <<indices-component-template,put component template>> APIs to create and update index templates.
-The following requests create two
-component templates.
+The following requests create two component templates.
 
 [source,console]
 ----
@@ -124,11 +114,11 @@ PUT _component_template/runtime_component_template
   }
 }
 ----
-<1> This component template adds a runtime field named `day_of_week` to the
-mappings when a new index matches the template.
+<1> This component template adds a <<runtime-mapping-fields,runtime field>>
+named `day_of_week` to the mappings when a new index matches the template.
 
-The following request creates an index template that is _composed of_  these
-component templates. 
+The following request creates an index template that is _composed of_ these
+component templates.
 
 [source,console]
 ----

--- a/docs/reference/indices/index-templates.asciidoc
+++ b/docs/reference/indices/index-templates.asciidoc
@@ -104,11 +104,6 @@ PUT _component_template/runtime_component_template
             "source": "emit(doc['@timestamp'].value.dayOfWeekEnum.getDisplayName(TextStyle.FULL, Locale.ROOT))"
           }
         }
-      },
-      "properties": {
-        "@timestamp": {
-          "type": "date"
-        }
       }
     }
   }
@@ -131,7 +126,7 @@ PUT _index_template/template_1
     },
     "mappings": {
       "_source": {
-        "enabled": false
+        "enabled": true
       },
       "properties": {
         "host_name": {

--- a/docs/reference/indices/index-templates.asciidoc
+++ b/docs/reference/indices/index-templates.asciidoc
@@ -1,25 +1,38 @@
 [[index-templates]]
 = Index templates
 
-NOTE: This topic describes the composable index templates introduced in {es} 7.8. 
-For information about how index templates worked previously, 
+NOTE: This topic describes the composable index templates introduced in {es} 7.8.
+For information about how index templates worked previously,
 see the <<indices-templates-v1,legacy template documentation>>.
 
 [[getting]]
-An index template is a way to tell {es} how to configure an index when it is created.
-For data streams, the index template configures the stream's backing indices as they
-are created. Templates are configured prior to index creation and then when an
-index is created either manually or through indexing a document, the template
-settings are used as a basis for creating the index.
+An index template is a way to tell {es} how to configure an index when it is
+created. For data streams, the index template configures the stream's backing
+indices as they are created. Templates are configured
+*prior to index creation*. When an index is created - either manually or
+through indexing a document - the template settings are used as a basis for
+creating the index.
 
-There are two types of templates, index templates and <<indices-component-template,component
-templates>>. Component templates are reusable building blocks that configure mappings, settings, and
-aliases. You use component templates to construct index templates, they aren't directly applied to a
-set of indices. Index templates can contain a collection of component templates, as well as directly
-specify settings, mappings, and aliases.
+There are two types of templates: index templates and <<indices-component-template,component templates>>. Component templates are reusable building
+blocks that configure mappings, settings, and aliases. While you can use
+component templates to construct index templates, they aren't directly applied
+to a set of indices. Index templates can contain a collection of component
+templates, as well as directly specify settings, mappings, and aliases.
 
-If a new data stream or index matches more than one index template, the index template with the highest priority is used.
+The following conditions apply to index templates:
 
+* Composable templates take precedence over legacy templates. If no composable
+template matches a given index, a legacy template may still match and be
+applied.
+* If an index is created with explicit settings and also matches an index
+template, the settings from the <<indices-create-index,create index>> request
+take precedence over settings specified in the index template and its component
+templates.
+* If a new data stream or index matches more than one index template, the index
+template with the highest priority is used.
+
+.Using index templates with {fleet} or the {agent}
+****
 // tag::built-in-index-templates[]
 [IMPORTANT]
 ====
@@ -53,16 +66,31 @@ template for the `logs-*` index pattern, assign your template a priority of
 for `logs-*-*`.
 ====
 // end::built-in-index-templates[]
+****
 
-When a composable template matches a given index
-it always takes precedence over a legacy template. If no composable template matches, a legacy
-template may still match and be applied.
+[discrete]
+[[create-index-templates]]
+== Create composable index templates
 
-If an index is created with explicit settings and also matches an index template,
-the settings from the create index request take precedence over settings specified in the index template and its component templates.
+To create a component template from Stack Management in {kib}, select
+*Index Management* in the side navigation and choose *Component Templates*. You
+can then define the index settings, mappings, and alias configurations for the
+component template.
+
+When defining mappings, you can add mapped fields and create
+<<runtime-mapping-fields,runtime fields>>. These fields work like any other
+field, but are evaluated only at query time. When an index is created that
+matches the index template, {es} uses the index template to configure the index
+and add the runtime field to the mappings. When you create the runtime field,
+you optionally specify a Painless script. If you don't include a script,
+runtime fields retrieve values from `_source`.
+
+You can also use the <<indices-component-template,put component template API>>
+to create or update a component template. The following requests create two
+composable templates.
 
 [source,console]
---------------------------------------------------
+----
 PUT _component_template/component_template1
 {
   "template": {
@@ -76,19 +104,36 @@ PUT _component_template/component_template1
   }
 }
 
-PUT _component_template/other_component_template
+PUT _component_template/runtime_component_template
 {
   "template": {
     "mappings": {
+      "runtime": { <1>
+        "day_of_week": {
+          "type": "keyword",
+          "script": {
+            "source": "emit(doc['@timestamp'].value.dayOfWeekEnum.getDisplayName(TextStyle.FULL, Locale.ROOT))"
+          }
+        }
+      },
       "properties": {
-        "ip_address": {
-          "type": "ip"
+        "@timestamp": {
+          "type": "date"
         }
       }
     }
   }
 }
+----
+<1> This composable template adds a runtime field named `day_of_week` to the
+mappings when a new index matches the template.
 
+The following request creates an index template that contains the previous
+composable templates. Specify `"composed_of"` in the request to indicate the
+component templates that this index template contains.
+
+[source,console]
+----
 PUT _index_template/template_1
 {
   "index_patterns": ["te*", "bar*"],
@@ -115,23 +160,23 @@ PUT _index_template/template_1
     }
   },
   "priority": 500,
-  "composed_of": ["component_template1", "other_component_template"],
+  "composed_of": ["component_template1", "runtime_component_template"], <1>
   "version": 3,
   "_meta": {
     "description": "my custom"
   }
 }
---------------------------------------------------
-// TESTSETUP
+----
+// TEST[continued]
 
 ////
 
 [source,console]
---------------------------------------------------
+----
 DELETE _index_template/*
 DELETE _component_template/*
---------------------------------------------------
-// TEARDOWN
+----
+// TEST[continued]
 
 ////
 

--- a/docs/reference/indices/index-templates.asciidoc
+++ b/docs/reference/indices/index-templates.asciidoc
@@ -31,7 +31,7 @@ templates.
 * If a new data stream or index matches more than one index template, the index
 template with the highest priority is used.
 
-.Using index templates with {fleet} or the {agent}
+.Using index templates with {fleet} or {agent}
 ****
 // tag::built-in-index-templates[]
 [IMPORTANT]
@@ -70,12 +70,11 @@ for `logs-*-*`.
 
 [discrete]
 [[create-index-templates]]
-== Create composable index templates
+== Create index template
 
-To create a component template from Stack Management in {kib}, select
-*Index Management* in the side navigation and choose *Component Templates*. You
-can then define the index settings, mappings, and alias configurations for the
-component template.
+To create an index template from Stack Management in {kib}, select
+*Index Management* in the side navigation, choose *Index Templates*, and click *Create Template*. You
+can then select the component templates you want to use, or define the index settings, mappings, and alias configurations directly.
 
 When defining mappings, you can add mapped fields and create
 <<runtime-mapping-fields,runtime fields>>. These fields work like any other
@@ -85,9 +84,9 @@ and add the runtime field to the mappings. When you create the runtime field,
 you optionally specify a Painless script. If you don't include a script,
 runtime fields retrieve values from `_source`.
 
-You can also use the <<indices-component-template,put component template API>>
-to create or update a component template. The following requests create two
-composable templates.
+You can also use the <<indices-put-template, index template>> and <<indices-component-template,put component template>> APIs to create and update index templates.
+The following requests create two
+component templates.
 
 [source,console]
 ----
@@ -125,12 +124,11 @@ PUT _component_template/runtime_component_template
   }
 }
 ----
-<1> This composable template adds a runtime field named `day_of_week` to the
+<1> This component template adds a runtime field named `day_of_week` to the
 mappings when a new index matches the template.
 
-The following request creates an index template that contains the previous
-composable templates. Specify `"composed_of"` in the request to indicate the
-component templates that this index template contains.
+The following request creates an index template that is _composed of_  these
+component templates. 
 
 [source,console]
 ----


### PR DESCRIPTION
This PR adds a mention of runtime fields to the index templates page to inform users of how to create runtime fields in Kibana. Additionally, expands the example section and clarifies the admonition for Fleet and Elastic Agent.

Preview link: https://elasticsearch_70172.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/index-templates.html