### PR TITLE
Remove "frozen" from read only tests

### DIFF
--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/ReadonlyActionIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/ReadonlyActionIT.java
@@ -53,7 +53,7 @@ public class ReadonlyActionIT extends ESRestTestCase {
         createIndexWithSettings(client(), index, alias, Settings.builder()
             .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
             .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0));
-        String phaseName = randomFrom("warm", "cold", "frozen");
+        String phaseName = randomFrom("warm", "cold");
         createNewSingletonPolicy(client(), policy, phaseName, new ReadOnlyAction());
         updatePolicy(client(), index, policy);
         assertBusy(() -> {


### PR DESCRIPTION
The action was recently removed from the list of acceptable actions (#70158), the test shouldn't use
it any more.
