### PR TITLE
Removes duplicate alias definitions from cat API's

### DIFF
--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestHealthAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestHealthAction.java
@@ -64,7 +64,7 @@ public class RestHealthAction extends AbstractCatAction {
         t.addCell("status", "alias:st;desc:health status");
         t.addCell("node.total", "alias:nt,nodeTotal;text-align:right;desc:total number of nodes");
         t.addCell("node.data", "alias:nd,nodeData;text-align:right;desc:number of nodes that can store data");
-        t.addCell("shards", "alias:t,sh,shards.total,shardsTotal;text-align:right;desc:total number of shards");
+        t.addCell("shards", "alias:s,sh,shards.total,shardsTotal;text-align:right;desc:total number of shards");
         t.addCell("pri", "alias:p,shards.primary,shardsPrimary;text-align:right;desc:number of primary shards");
         t.addCell("relo", "alias:r,shards.relocating,shardsRelocating;text-align:right;desc:number of relocating nodes");
         t.addCell("init", "alias:i,shards.initializing,shardsInitializing;text-align:right;desc:number of initializing nodes");

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
@@ -252,7 +252,7 @@ public class RestIndicesAction extends AbstractCatAction {
         table.addCell("health", "alias:h;desc:current health status");
         table.addCell("status", "alias:s;desc:open/close status");
         table.addCell("index", "alias:i,idx;desc:index name");
-        table.addCell("uuid", "alias:id,uuid;desc:index uuid");
+        table.addCell("uuid", "alias:id;desc:index uuid");
         table.addCell("pri", "alias:p,shards.primary,shardsPrimary;text-align:right;desc:number of primary shards");
         table.addCell("rep", "alias:r,shards.replica,shardsReplica;text-align:right;desc:number of replica shards");
         table.addCell("docs.count", "alias:dc,docsCount;text-align:right;desc:available docs");
@@ -391,11 +391,11 @@ public class RestIndicesAction extends AbstractCatAction {
         table.addCell("pri.refresh.time", "default:false;text-align:right;desc:time spent in refreshes");
 
         table.addCell("refresh.external_total",
-            "sibling:pri;alias:rto,refreshTotal;default:false;text-align:right;desc:total external refreshes");
+            "sibling:pri;alias:reto;default:false;text-align:right;desc:total external refreshes");
         table.addCell("pri.refresh.external_total", "default:false;text-align:right;desc:total external refreshes");
 
         table.addCell("refresh.external_time",
-            "sibling:pri;alias:rti,refreshTime;default:false;text-align:right;desc:time spent in external refreshes");
+            "sibling:pri;alias:reti;default:false;text-align:right;desc:time spent in external refreshes");
         table.addCell("pri.refresh.external_time", "default:false;text-align:right;desc:time spent in external refreshes");
 
         table.addCell("refresh.listeners",

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
@@ -119,7 +119,7 @@ public class RestNodesAction extends AbstractCatAction {
     protected Table getTableWithHeader(final RestRequest request) {
         Table table = new Table();
         table.startHeaders();
-        table.addCell("id", "default:false;alias:id,nodeId;desc:unique node id");
+        table.addCell("id", "default:false;alias:nodeId;desc:unique node id");
         table.addCell("pid", "default:false;alias:p;desc:process id");
         table.addCell("ip", "alias:i;desc:ip address");
         table.addCell("port", "default:false;alias:po;desc:bound transport port");
@@ -145,10 +145,10 @@ public class RestNodesAction extends AbstractCatAction {
             "default:false;alias:fdp,fileDescriptorPercent;text-align:right;desc:used file descriptor ratio");
         table.addCell("file_desc.max", "default:false;alias:fdm,fileDescriptorMax;text-align:right;desc:max file descriptors");
 
-        table.addCell("cpu", "alias:cpu;text-align:right;desc:recent cpu usage");
-        table.addCell("load_1m", "alias:l;text-align:right;desc:1m load avg");
-        table.addCell("load_5m", "alias:l;text-align:right;desc:5m load avg");
-        table.addCell("load_15m", "alias:l;text-align:right;desc:15m load avg");
+        table.addCell("cpu", "text-align:right;desc:recent cpu usage");
+        table.addCell("load_1m", "alias:l1;text-align:right;desc:1m load avg");
+        table.addCell("load_5m", "alias:l5;text-align:right;desc:5m load avg");
+        table.addCell("load_15m", "alias:l15,l;text-align:right;desc:15m load avg");
         table.addCell("uptime", "default:false;alias:u;text-align:right;desc:node uptime");
         table.addCell("node.role",
             "alias:r,role,nodeRole;desc:m:master eligible node, d:data node, i:ingest node, -:coordinating node only");
@@ -207,9 +207,9 @@ public class RestNodesAction extends AbstractCatAction {
 
         table.addCell("refresh.total", "alias:rto,refreshTotal;default:false;text-align:right;desc:total refreshes");
         table.addCell("refresh.time", "alias:rti,refreshTime;default:false;text-align:right;desc:time spent in refreshes");
-        table.addCell("refresh.external_total", "alias:rto,refreshTotal;default:false;text-align:right;desc:total external refreshes");
+        table.addCell("refresh.external_total", "alias:reto,refreshTotal;default:false;text-align:right;desc:total external refreshes");
         table.addCell("refresh.external_time",
-            "alias:rti,refreshTime;default:false;text-align:right;desc:time spent in external refreshes");
+            "alias:reti,refreshTime;default:false;text-align:right;desc:time spent in external refreshes");
         table.addCell("refresh.listeners", "alias:rli,refreshListeners;default:false;text-align:right;"
                 + "desc:number of pending refresh listeners");
 

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestRepositoriesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestRepositoriesAction.java
@@ -62,8 +62,8 @@ public class RestRepositoriesAction extends AbstractCatAction {
     protected Table getTableWithHeader(RestRequest request) {
         return new Table()
                 .startHeaders()
-                .addCell("id", "alias:id,repoId;desc:unique repository id")
-                .addCell("type", "alias:t,type;text-align:right;desc:repository type")
+                .addCell("id", "alias:repoId;desc:unique repository id")
+                .addCell("type", "alias:t;text-align:right;desc:repository type")
                 .endHeaders();
     }
 

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestShardsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestShardsAction.java
@@ -110,7 +110,7 @@ public class RestShardsAction extends AbstractCatAction {
                 .addCell("id", "default:false;desc:unique id of node where it lives")
                 .addCell("node", "default:true;alias:n;desc:name of node where it lives");
 
-        table.addCell("sync_id", "alias:sync_id;default:false;desc:sync id");
+        table.addCell("sync_id", "default:false;desc:sync id");
 
         table.addCell("unassigned.reason", "alias:ur;default:false;desc:reason shard is unassigned");
         table.addCell("unassigned.at", "alias:ua;default:false;desc:time shard became unassigned (UTC)");

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestSnapshotAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestSnapshotAction.java
@@ -76,19 +76,19 @@ public class RestSnapshotAction extends AbstractCatAction {
     protected Table getTableWithHeader(RestRequest request) {
         return new Table()
                 .startHeaders()
-                .addCell("id", "alias:id,snapshot;desc:unique snapshot")
+                .addCell("id", "alias:snapshot;desc:unique snapshot")
                 .addCell("repository", "alias:re,repo;desc:repository name")
-                .addCell("status", "alias:s,status;text-align:right;desc:snapshot name")
+                .addCell("status", "alias:s;text-align:right;desc:snapshot name")
                 .addCell("start_epoch", "alias:ste,startEpoch;desc:start time in seconds since 1970-01-01 00:00:00")
                 .addCell("start_time", "alias:sti,startTime;desc:start time in HH:MM:SS")
                 .addCell("end_epoch", "alias:ete,endEpoch;desc:end time in seconds since 1970-01-01 00:00:00")
                 .addCell("end_time", "alias:eti,endTime;desc:end time in HH:MM:SS")
-                .addCell("duration", "alias:dur,duration;text-align:right;desc:duration")
-                .addCell("indices", "alias:i,indices;text-align:right;desc:number of indices")
-                .addCell("successful_shards", "alias:ss,successful_shards;text-align:right;desc:number of successful shards")
-                .addCell("failed_shards", "alias:fs,failed_shards;text-align:right;desc:number of failed shards")
-                .addCell("total_shards", "alias:ts,total_shards;text-align:right;desc:number of total shards")
-                .addCell("reason", "default:false;alias:r,reason;desc:reason for failures")
+                .addCell("duration", "alias:dur;text-align:right;desc:duration")
+                .addCell("indices", "alias:i;text-align:right;desc:number of indices")
+                .addCell("successful_shards", "alias:ss;text-align:right;desc:number of successful shards")
+                .addCell("failed_shards", "alias:fs;text-align:right;desc:number of failed shards")
+                .addCell("total_shards", "alias:ts;text-align:right;desc:number of total shards")
+                .addCell("reason", "default:false;alias:r;desc:reason for failures")
                 .endHeaders();
     }
 

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestTasksAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestTasksAction.java
@@ -99,7 +99,7 @@ public class RestTasksAction extends AbstractCatAction {
         table.addCell("type", "alias:ty;desc:task type");
         table.addCell("start_time", "alias:start;desc:start time in ms");
         table.addCell("timestamp", "alias:ts,hms,hhmmss;desc:start time in HH:MM:SS");
-        table.addCell("running_time_ns", "default:false;alias:time;desc:running time ns");
+        table.addCell("running_time_ns", "default:false;alias:time_ns;desc:running time ns");
         table.addCell("running_time", "default:true;alias:time;desc:running time");
 
         // Node info

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/cat/RestCatJobsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/cat/RestCatJobsAction.java
@@ -209,7 +209,7 @@ public class RestCatJobsAction extends AbstractCatAction {
                 .build());
         table.addCell("model.frequent_category_count",
             TableColumnAttributeBuilder.builder("count of frequent categories", false)
-                .setAliases("mfcc", "modelFrequentCategoryCount")
+                .setAliases("modelFrequentCategoryCount")
                 .build());
         table.addCell("model.rare_category_count",
             TableColumnAttributeBuilder.builder("count of rare categories", false)

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/RestCatTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/RestCatTransformAction.java
@@ -149,7 +149,7 @@ public class RestCatTransformAction extends AbstractCatAction {
             .addCell("max_page_search_size", TableColumnAttributeBuilder.builder("max page search size", false).setAliases("mpsz").build())
             .addCell("docs_per_second", TableColumnAttributeBuilder.builder("docs per second", false).setAliases("dps").build())
 
-            .addCell("reason", TableColumnAttributeBuilder.builder("reason for the current state", false).setAliases("r", "reason").build())
+            .addCell("reason", TableColumnAttributeBuilder.builder("reason for the current state", false).setAliases("r").build())
 
             .addCell("search_total", TableColumnAttributeBuilder.builder("total number of search phases", false).setAliases("st").build())
             .addCell(


### PR DESCRIPTION
Either declared multiple times as alias or the alias was the same as the
canonical name.

Duplicated alias definitions overwrite eachother so the last column to
claim it will win.

This includes breaking changes for `RestNodesAction`

```diff
+        table.addCell("refresh.external_total", "alias:reto,refreshTotal;default:false;text-align:right;desc:total external refreshes");
         table.addCell("refresh.external_time",
-            "alias:rti,refreshTime;default:false;text-align:right;desc:time spent in external refreshes");
+            "alias:reti,refreshTime;default:false;text-align:right;desc:time spent in external refreshes");
```

The `external_` has the same alias as the default but was stealing the
alias away.

Keen to hear if this can be considered a bug fix instead

cc @elastic/clients-team 
