### PR TITLE
Wraps YAML tests values with colon in quotes

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/20_terms.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/20_terms.yml
@@ -798,9 +798,9 @@ setup:
   - match: { profile.shards.0.aggregations.0.description: str_terms }
   - match: { profile.shards.0.aggregations.0.breakdown.collect_count: 0 }
   - match: { profile.shards.0.aggregations.0.debug.delegate: FiltersAggregator.FilterByFilter }
-  - match: { profile.shards.0.aggregations.0.debug.delegate_debug.filters.0.query: str:cow }
-  - match: { profile.shards.0.aggregations.0.debug.delegate_debug.filters.1.query: str:pig }
-  - match: { profile.shards.0.aggregations.0.debug.delegate_debug.filters.2.query: str:sheep }
+  - match: { profile.shards.0.aggregations.0.debug.delegate_debug.filters.0.query: "str:cow" }
+  - match: { profile.shards.0.aggregations.0.debug.delegate_debug.filters.1.query: "str:pig" }
+  - match: { profile.shards.0.aggregations.0.debug.delegate_debug.filters.2.query: "str:sheep" }
   - match: { profile.shards.0.aggregations.0.children.0.type: MaxAggregator }
   - match: { profile.shards.0.aggregations.0.children.0.description: max_number }
   - match: { profile.shards.0.aggregations.0.children.0.breakdown.collect_count: 4 }


### PR DESCRIPTION
The Ruby client's YAML parser fails to parse values with `:` when they're not wrapped in quotes.