### PR TITLE
Clarify remote_cluster_client role

### DIFF
--- a/docs/reference/ccr/getting-started.asciidoc
+++ b/docs/reference/ccr/getting-started.asciidoc
@@ -57,17 +57,6 @@ response time
 In this guide, you'll learn how to:
 
 * Configure a <<modules-remote-clusters,remote cluster>> with a leader index
-
-[IMPORTANT]
-====
-In the local cluster, all nodes with the `master` <<node-roles,node role>> must
-also have the <<remote-node,`remote_cluster_client`>> role. The local cluster
-must also have at least one node with both a data role and the
-<<remote-node,`remote_cluster_client`>> role. Individual tasks for coordinating
-replication scale based on the number of data nodes with the
-`remote_cluster_client` role in the local cluster.
-====
-
 * Create a follower index on a local cluster
 * Create an auto-follow pattern to automatically follow time series indices
 that are periodically created in a remote cluster
@@ -94,6 +83,12 @@ indices on the local cluster. <<stack-management-ccr-local,Configure local clust
 * An index on the remote cluster that contains the data you want to replicate.
 This tutorial uses the sample eCommerce orders data set.
 {kibana-ref}/get-started.html#gs-get-data-into-kibana[Load sample data].
+* In the local cluster, all nodes with the `master` <<node-roles,node role>> must
+  also have the <<remote-node,`remote_cluster_client`>> role. The local cluster
+  must also have at least one node with both a data role and the
+  <<remote-node,`remote_cluster_client`>> role. Individual tasks for coordinating
+  replication scale based on the number of data nodes with the
+  `remote_cluster_client` role in the local cluster.
 
 [[ccr-getting-started-remote-cluster]]
 ==== Connect to a remote cluster

--- a/docs/reference/ccr/getting-started.asciidoc
+++ b/docs/reference/ccr/getting-started.asciidoc
@@ -64,8 +64,8 @@ In the local cluster, all nodes with the `master` <<node-roles,node role>> must
 also have the <<remote-node,`remote_cluster_client`>> role. The local cluster
 must also have at least one node with both a data role and the
 <<remote-node,`remote_cluster_client`>> role. Individual tasks for coordinating
-replication scale based on the number of data nodes with the `remote_cluster_client`
-role in the local cluster.
+replication scale based on the number of data nodes with the
+`remote_cluster_client` role in the local cluster.
 ====
 
 * Create a follower index on a local cluster

--- a/docs/reference/ccr/getting-started.asciidoc
+++ b/docs/reference/ccr/getting-started.asciidoc
@@ -57,6 +57,16 @@ response time
 In this guide, you'll learn how to:
 
 * Configure a <<modules-remote-clusters,remote cluster>> with a leader index
+
+[IMPORTANT]
+====
+* In the local cluster, the <<remote-node,`remote_cluster_client`>>
+  <<node-roles,role>> must be configured on nodes with the `master` role, and on
+  at least one data node in the local cluster. Note that individual tasks for
+  coordinating replication scales with the number of data nodes in the local
+  cluster that have the `remote_cluster_client` role.
+====
+
 * Create a follower index on a local cluster
 * Create an auto-follow pattern to automatically follow time series indices
 that are periodically created in a remote cluster

--- a/docs/reference/ccr/getting-started.asciidoc
+++ b/docs/reference/ccr/getting-started.asciidoc
@@ -60,11 +60,12 @@ In this guide, you'll learn how to:
 
 [IMPORTANT]
 ====
-* In the local cluster, the <<remote-node,`remote_cluster_client`>>
-  <<node-roles,role>> must be configured on nodes with the `master` role, and on
-  at least one data node in the local cluster. Note that individual tasks for
-  coordinating replication scales with the number of data nodes in the local
-  cluster that have the `remote_cluster_client` role.
+In the local cluster, all nodes with the `master` <<node-roles,node role>> must
+also have the <<remote-node,`remote_cluster_client`>> role. The local cluster
+must also have at least one node with both a data role and the
+<<remote-node,`remote_cluster_client`>> role. Individual tasks for coordinating
+replication scale based on the number of data nodes with the `remote_cluster_client`
+role in the local cluster.
 ====
 
 * Create a follower index on a local cluster

--- a/docs/reference/modules/remote-clusters.asciidoc
+++ b/docs/reference/modules/remote-clusters.asciidoc
@@ -262,10 +262,10 @@ separately.
 
   By default, any node in the cluster can act as a cross-cluster client and
   connect to remote clusters. The `remote_cluster_client` role can be excluded
- from the list of <<node-roles,roles> to prevent certain nodes from
-  connecting to remote clusters. Search requests targeting remote clusters must
-  be sent to a node that is allowed to act as a cross-cluster client.
-  Other features such as {ml} <<general-ml-settings,data feeds>>,
+  from the list of <<node-roles,roles> to prevent certain nodes from connecting
+  to remote clusters. Search requests targeting remote clusters must be sent to
+  node that is allowed to act as a cross-cluster client. Other features such as
+  {ml} <<general-ml-settings,data feeds>>,
   <<general-transform-settings,transforms>> and <<ccr-getting-started,{ccr}>>
   have additional requirements around the usage of the `remote_cluster_client`
   role.

--- a/docs/reference/modules/remote-clusters.asciidoc
+++ b/docs/reference/modules/remote-clusters.asciidoc
@@ -261,9 +261,10 @@ separately.
 `remote_cluster_client` <<node-roles,role>>::
 
   By default, any node in the cluster can act as a cross-cluster client and
-  connect to remote clusters. The `remote_cluster_client` role can be excluded
-  from the list of <<node-roles,roles> to prevent certain nodes from connecting
-  to remote clusters. Search requests targeting remote clusters must be sent to
+  connect to remote clusters. To prevent a node from connecting to remote
+  clusters, specify the <<node-roles,node.roles>> setting in `elasticsearch.yml`
+  and exclude `remote_cluster_client` from the listed roles. Search requests
+  targeting remote clusters must be sent to a
   node that is allowed to act as a cross-cluster client. Other features such as
   {ml} <<general-ml-settings,data feeds>>,
   <<general-transform-settings,transforms>> and <<ccr-getting-started,{ccr}>>

--- a/docs/reference/modules/remote-clusters.asciidoc
+++ b/docs/reference/modules/remote-clusters.asciidoc
@@ -262,7 +262,7 @@ separately.
 
   By default, any node in the cluster can act as a cross-cluster client and
   connect to remote clusters. The `remote_cluster_client` role can be excluded
-  excluded from the list of <<node-roles,roles> to prevent certain nodes from
+ from the list of <<node-roles,roles> to prevent certain nodes from
   connecting to remote clusters. Search requests targeting remote clusters must
   be sent to a node that is allowed to act as a cross-cluster client.
   Other features such as {ml} <<general-ml-settings,data feeds>>,

--- a/docs/reference/modules/remote-clusters.asciidoc
+++ b/docs/reference/modules/remote-clusters.asciidoc
@@ -267,9 +267,8 @@ separately.
   targeting remote clusters must be sent to a
   node that is allowed to act as a cross-cluster client. Other features such as
   {ml} <<general-ml-settings,data feeds>>,
-  <<general-transform-settings,transforms>> and <<ccr-getting-started,{ccr}>>
-  have additional requirements around the usage of the `remote_cluster_client`
-  role.
+  <<general-transform-settings,transforms>>, and <<ccr-getting-started,{ccr}>>
+  require the `remote_cluster_client` role.
 
 `cluster.remote.<cluster_alias>.skip_unavailable`::
 

--- a/docs/reference/modules/remote-clusters.asciidoc
+++ b/docs/reference/modules/remote-clusters.asciidoc
@@ -264,11 +264,10 @@ separately.
   connect to remote clusters. To prevent a node from connecting to remote
   clusters, specify the <<node-roles,node.roles>> setting in `elasticsearch.yml`
   and exclude `remote_cluster_client` from the listed roles. Search requests
-  targeting remote clusters must be sent to a
-  node that is allowed to act as a cross-cluster client. Other features such as
-  {ml} <<general-ml-settings,data feeds>>,
-  <<general-transform-settings,transforms>>, and <<ccr-getting-started,{ccr}>>
-  require the `remote_cluster_client` role.
+  targeting remote clusters must be sent to a node that is allowed to act as a
+  cross-cluster client. Other features such as {ml} <<general-ml-settings,data
+  feeds>>, <<general-transform-settings,transforms>>, and
+  <<ccr-getting-started,{ccr}>> require the `remote_cluster_client` role.
 
 `cluster.remote.<cluster_alias>.skip_unavailable`::
 

--- a/docs/reference/modules/remote-clusters.asciidoc
+++ b/docs/reference/modules/remote-clusters.asciidoc
@@ -258,13 +258,17 @@ separately.
   The time to wait for remote connections to be established when the node
   starts. The default is `30s`.
 
-`node.remote_cluster_client`::
+`remote_cluster_client` <<node-roles,role>>::
 
   By default, any node in the cluster can act as a cross-cluster client and
-  connect to remote clusters. The `node.remote_cluster_client` setting can be
-  set to `false` (defaults to `true`) to prevent certain nodes from connecting
-  to remote clusters. Remote cluster requests must be sent to a node that is
-  allowed to act as a cross-cluster client.
+  connect to remote clusters. The `remote_cluster_client` role can be excluded
+  excluded from the list of <<node-roles,roles> to prevent certain nodes from
+  connecting to remote clusters. Search requests targeting remote clusters must
+  be sent to a node that is allowed to act as a cross-cluster client.
+  Other features such as {ml} <<general-ml-settings,data feeds>>,
+  <<general-transform-settings,transforms>> and <<ccr-getting-started,{ccr}>>
+  have additional requirements around the usage of the `remote_cluster_client`
+  role.
 
 `cluster.remote.<cluster_alias>.skip_unavailable`::
 


### PR DESCRIPTION
This commit addresses two aspects of the description in the docs of configuring a local node to be a remote cluster client. First, the documentation was referring to the legacy setting for configuring a remote cluster client. Secondly, we clarify that additional features, not only cross-cluster search, have requirements around the usage of the remote_cluster_client role.

