### PR TITLE
In ARS, avoid updating local pending requests map

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/IndexShardRoutingTable.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/IndexShardRoutingTable.java
@@ -343,11 +343,6 @@ public class IndexShardRoutingTable implements Iterable<ShardRouting> {
                 Optional<ResponseCollectorService.ComputedNodeStats> maybeMinStats = nodeStats.get(minNodeId);
                 if (maybeMinStats.isPresent()) {
                     adjustStats(collector, nodeStats, minNodeId, maybeMinStats.get());
-                    // Increase the number of searches for the "winning" node by one.
-                    // Note that this doesn't actually affect the "real" counts, instead
-                    // it only affects the captured node search counts, which is
-                    // captured once for each query in TransportSearchAction
-                    nodeSearchCounts.compute(minNodeId, (id, conns) -> conns == null ? 1 : conns + 1);
                 }
             }
         }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/OperationRouting.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/OperationRouting.java
@@ -124,7 +124,7 @@ public class OperationRouting {
                                                         @Nullable ResponseCollectorService collectorService,
                                                         @Nullable Map<String, Long> nodeCounts) {
         if (preference == null || preference.isEmpty()) {
-            return shardRoutings(indexShard, nodes, collectorService, nodeCounts);
+            return shardRoutings(indexShard, collectorService, nodeCounts);
         }
         if (preference.charAt(0) == '_') {
             Preference preferenceType = Preference.parse(preference);
@@ -151,7 +151,7 @@ public class OperationRouting {
                 }
                 // no more preference
                 if (index == -1 || index == preference.length() - 1) {
-                    return shardRoutings(indexShard, nodes, collectorService, nodeCounts);
+                    return shardRoutings(indexShard, collectorService, nodeCounts);
                 } else {
                     // update the preference and continue
                     preference = preference.substring(index + 1);
@@ -181,8 +181,9 @@ public class OperationRouting {
         return indexShard.activeInitializingShardsIt(routingHash);
     }
 
-    private ShardIterator shardRoutings(IndexShardRoutingTable indexShard, DiscoveryNodes nodes,
-            @Nullable ResponseCollectorService collectorService, @Nullable Map<String, Long> nodeCounts) {
+    private ShardIterator shardRoutings(IndexShardRoutingTable indexShard,
+                                        @Nullable ResponseCollectorService collectorService,
+                                        @Nullable Map<String, Long> nodeCounts) {
         if (useAdaptiveReplicaSelection) {
             return indexShard.activeInitializingShardsRankedIt(collectorService, nodeCounts);
         } else {


### PR DESCRIPTION
When ranking nodes for adaptive replica selection, we consult
`SearchTransportService` for the number of pending search requests to each
node. After ranking shards, we update the local version of this map,
incrementing the 'winner' node's pending requests by 1.

There doesn't seem to be a reason to update this local copy -- it shouldn't
affect the algorithm logic, and these local stats are not reported anywhere. At
the same time, the update makes it harder to reason about behavior in tests.