### PR TITLE
[DOCS] Changes deprecated syntax to node.role style in datafeed docs

### DIFF
--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -863,8 +863,8 @@ An array of index names. Wildcards are supported. For example:
 `["it_ops_metrics", "server*"]`.
 +
 --
-NOTE: If any indices are in remote clusters then `node.remote_cluster_client`
-must not be set to `false` on any {ml} nodes.
+NOTE: If any indices are in remote clusters then the {ml} nodes need to have the 
+`remote_cluster_client` role.
 
 --
 end::indices[]


### PR DESCRIPTION
## Overview

A note in the datafeed docs used the old, deprecated node settings, this PR changes it to the new syntax.

## Preview

[PUT datafeed docs](https://elasticsearch_70201.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ml-put-datafeed.html) (Search for `indices`.)