### PR TITLE
[7.10] Add doc reference for client_auth_method (#70124)

### DIFF
--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -1629,6 +1629,23 @@ at the OpenID Connect Provider.
 The OAuth 2.0 Client Secret that was assigned to {es} during registration
 at the OpenID Connect Provider.
 
+// tag::rp-client-auth-method-tag[]
+`rp.client_auth_method` {ess-icon}::
+(<<static-cluster-setting, Static>>)
+The client authentication method used by {es} to authenticate
+to the OpenID Connect Provider. Can be `client_secret_basic`, `client_secret_post`,
+or `client_secret_jwt`. Defaults to `client_secret_basic`.
+// end::rp-client-auth-method-tag[]
+
+// tag::rp-client-auth-jwt-signature-algorithm[]
+`rp.client_auth_signature_algorithm` {ess-icon}::
+(<<static-cluster-setting, Static>>)
+The signature algorithm that {es} uses to sign the JWT with which it authenticates
+as a client to the OpenID Connect Provider when `client_secret_jwt` is selected for
+`rp.client_auth_method`. Can be either `HS256`, `HS384`, or `HS512`. Defaults to 
+`HS384`. 
+// end::rp-client-auth-jwt-signature-algorithm[]
+
 // tag::rp-redirect-uri-tag[]
 `rp.redirect_uri` {ess-icon}::
 (<<static-cluster-setting,Static>>)


### PR DESCRIPTION
Backports the following commits to 7.10:
 - Add doc reference for client_auth_method (#70124)