### PR TITLE
[7.12] [DOCS] Remove pipeline param from delete API (#70177)

### DIFF
--- a/docs/reference/docs/delete.asciidoc
+++ b/docs/reference/docs/delete.asciidoc
@@ -156,8 +156,6 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=if_seq_no]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=if_primary_term]
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=pipeline]
-
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=refresh]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=routing]


### PR DESCRIPTION
Backports the following commits to 7.12:
 - [DOCS] Remove pipeline param from delete API (#70177)