### PR TITLE
[7.12] [DOCS] Remove 7.11.2 coming tag (#70232)

### DIFF
--- a/docs/reference/release-notes/7.11.asciidoc
+++ b/docs/reference/release-notes/7.11.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-7.11.2]]
 == {es} version 7.11.2
 
-coming[7.11.2]
-
 Also see <<breaking-changes-7.11,Breaking changes in 7.11>>.
 
 [[enhancement-7.11.2]]


### PR DESCRIPTION
Backports the following commits to 7.12:
 - [DOCS] Remove 7.11.2 coming tag (#70232)