### PR TITLE
[7.12] [DOCS] Changes deprecated syntax to node.role style in datafeed docs. (#70201)

### DIFF
--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -858,8 +858,8 @@ An array of index names. Wildcards are supported. For example:
 `["it_ops_metrics", "server*"]`.
 +
 --
-NOTE: If any indices are in remote clusters then `node.remote_cluster_client`
-must not be set to `false` on any {ml} nodes.
+NOTE: If any indices are in remote clusters then the {ml} nodes need to have the 
+`remote_cluster_client` role.
 
 --
 end::indices[]


### PR DESCRIPTION
Backports the following commits to 7.12:
 - [DOCS] Changes deprecated syntax to node.role style in datafeed docs. (#70201)