### PR TITLE
Script: unthrottle ingest pipeline definition.

### DIFF
--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MustacheScriptEngine.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MustacheScriptEngine.java
@@ -75,7 +75,7 @@ public final class MustacheScriptEngine implements ScriptEngine {
 
     @Override
     public Set<ScriptContext<?>> getSupportedContexts() {
-        return Collections.singleton(TemplateScript.CONTEXT);
+        return org.elasticsearch.common.collect.Set.of(TemplateScript.CONTEXT, TemplateScript.INGEST_CONTEXT);
     }
 
     private CustomMustacheFactory createMustacheFactory(Map<String, String> options) {

--- a/server/src/main/java/org/elasticsearch/ingest/ValueSource.java
+++ b/server/src/main/java/org/elasticsearch/ingest/ValueSource.java
@@ -71,7 +71,7 @@ public interface ValueSource {
                 Script script = new Script(
                     ScriptType.INLINE, DEFAULT_TEMPLATE_LANG, (String) value, scriptOptions, org.elasticsearch.common.collect.Map.of()
                 );
-                return new TemplatedValue(scriptService.compile(script, TemplateScript.CONTEXT));
+                return new TemplatedValue(scriptService.compile(script, TemplateScript.INGEST_CONTEXT));
             } else {
                 return new ObjectValue(value);
             }

--- a/server/src/main/java/org/elasticsearch/script/ScriptModule.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptModule.java
@@ -46,6 +46,7 @@ public class ScriptModule {
             SimilarityScript.CONTEXT,
             SimilarityWeightScript.CONTEXT,
             TemplateScript.CONTEXT,
+            TemplateScript.INGEST_CONTEXT,
             MovingFunctionScript.CONTEXT,
             ScriptedMetricAggContexts.InitScript.CONTEXT,
             ScriptedMetricAggContexts.MapScript.CONTEXT,

--- a/server/src/main/java/org/elasticsearch/script/TemplateScript.java
+++ b/server/src/main/java/org/elasticsearch/script/TemplateScript.java
@@ -8,6 +8,8 @@
 
 package org.elasticsearch.script;
 
+import org.elasticsearch.common.unit.TimeValue;
+
 import java.util.Map;
 
 /**
@@ -35,4 +37,10 @@ public abstract class TemplateScript {
     }
 
     public static final ScriptContext<Factory> CONTEXT = new ScriptContext<>("template", Factory.class);
+
+    // Remove compilation rate limit for ingest.  Ingest pipelines may use many mustache templates, triggering compilation
+    // rate limiting.  MustacheScriptEngine explicitly checks for TemplateScript.  Rather than complicating the implementation there by
+    // creating a new Script class (as would be customary), this context is used to avoid the default rate limit.
+    public static final ScriptContext<Factory> INGEST_CONTEXT = new ScriptContext<>("ingest_template", Factory.class,
+            200, TimeValue.timeValueMillis(0), ScriptCache.UNLIMITED_COMPILATION_RATE.asTuple());
 }


### PR DESCRIPTION
Scripts in ingest pipelines may be throttled on startup
or when beats starts up.  This causes pipelines to be
stuck in a broken state.

Pipelines with many mustache templates are particularly impacted.

Creates a new context, `ingest_template`, with an unlimited
compilation rate limit.

The `template` context is used in many places so it cannot be
exempted from rate limits.

Fixes: #64595
Backport: 9370b1c
