### PR TITLE
[Transform] remove index refresh workardounds from test cases

### DIFF
--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TransformContinuousIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TransformContinuousIT.java
@@ -277,9 +277,6 @@ public class TransformContinuousIT extends ESRestTestCase {
             waitUntilTransformsProcessedNewData(ContinuousTestCase.SYNC_DELAY, run);
             stopTransforms();
 
-            // TODO: the transform dest index requires a refresh, see gh#51154
-            refreshAllIndices();
-
             // test the output
             for (ContinuousTestCase testCase : transformTestCases) {
                 try {

--- a/x-pack/qa/multi-cluster-tests-with-security/src/test/resources/rest-api-spec/test/multi_cluster/80_transform.yml
+++ b/x-pack/qa/multi-cluster-tests-with-security/src/test/resources/rest-api-spec/test/multi_cluster/80_transform.yml
@@ -105,12 +105,6 @@ teardown:
   - match: { transforms.0.state: "stopped" }
   - match: { transforms.0.checkpointing.last.checkpoint: 1 }
 
-  # workaround: refresh dest index, to be removed, see gh #51154
-  - do:
-      headers: { Authorization: "Basic am9lOnRyYW5zZm9ybS1wYXNzd29yZA==" }
-      indices.refresh:
-        index: simple-remote-transform
-
   - do:
       headers: { Authorization: "Basic am9lOnRyYW5zZm9ybS1wYXNzd29yZA==" }
       search:
@@ -272,12 +266,6 @@ teardown:
   - match: { transforms.0.id: "simple-local-remote-transform" }
   - match: { transforms.0.state: "stopped" }
   - match: { transforms.0.checkpointing.last.checkpoint: 1 }
-
-  # workaround: refresh dest index, to be removed, see gh #51154
-  - do:
-      headers: { Authorization: "Basic am9lOnRyYW5zZm9ybS1wYXNzd29yZA==" }
-      indices.refresh:
-        index: simple-local-remote-transform
 
   - do:
       headers: { Authorization: "Basic am9lOnRyYW5zZm9ybS1wYXNzd29yZA==" }


### PR DESCRIPTION
When using wait_for_checkpoint the destination index should be searchable when the call returns.
This issue has been fixed as part of #67832. This change removes the index refresh workarounds still
present.

fixes #51154