### PR TITLE
[7.12] Fix rollover alias definition in templates validation (#70259)

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverService.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverService.java
@@ -308,15 +308,6 @@ public class MetadataRolloverService {
      */
     static void checkNoDuplicatedAliasInIndexTemplate(Metadata metadata, String rolloverIndexName, String rolloverRequestAlias,
                                                       @Nullable Boolean isHidden) {
-        final List<IndexTemplateMetadata> matchedTemplates = findV1Templates(metadata, rolloverIndexName, isHidden);
-        for (IndexTemplateMetadata template : matchedTemplates) {
-            if (template.aliases().containsKey(rolloverRequestAlias)) {
-                throw new IllegalArgumentException(String.format(Locale.ROOT,
-                    "Rollover alias [%s] can point to multiple indices, found duplicated alias [%s] in index template [%s]",
-                    rolloverRequestAlias, template.aliases().keys(), template.name()));
-            }
-        }
-
         final String matchedV2Template = findV2Template(metadata, rolloverIndexName, isHidden == null ? false : isHidden);
         if (matchedV2Template != null) {
             List<Map<String, AliasMetadata>> aliases = MetadataIndexTemplateService.resolveAliases(metadata, matchedV2Template, false);
@@ -326,6 +317,16 @@ public class MetadataRolloverService {
                         "Rollover alias [%s] can point to multiple indices, found duplicated alias [%s] in index template [%s]",
                         rolloverRequestAlias, aliasConfig.keySet(), matchedV2Template));
                 }
+            }
+            return;
+        }
+
+        final List<IndexTemplateMetadata> matchedTemplates = findV1Templates(metadata, rolloverIndexName, isHidden);
+        for (IndexTemplateMetadata template : matchedTemplates) {
+            if (template.aliases().containsKey(rolloverRequestAlias)) {
+                throw new IllegalArgumentException(String.format(Locale.ROOT,
+                    "Rollover alias [%s] can point to multiple indices, found duplicated alias [%s] in index template [%s]",
+                    rolloverRequestAlias, template.aliases().keys(), template.name()));
             }
         }
     }

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverServiceTests.java
@@ -392,6 +392,25 @@ public class MetadataRolloverServiceTests extends ESTestCase {
         assertThat(ex.getMessage(), containsString("index template [test-template]"));
     }
 
+    public void testRolloverDoesntRejectOperationIfValidComposableTemplateOverridesLegacyTemplate() {
+        final IndexTemplateMetadata legacyTemplate = IndexTemplateMetadata.builder("legacy-template")
+            .patterns(Arrays.asList("foo-*", "bar-*"))
+            .putAlias(AliasMetadata.builder("foo-write")).putAlias(AliasMetadata.builder("bar-write").writeIndex(randomBoolean()))
+            .build();
+
+        // v2 template overrides the v1 template and does not define the rollover aliases
+        final ComposableIndexTemplate composableTemplate = new ComposableIndexTemplate.Builder().indexPatterns(Arrays.asList("foo-*",
+            "bar-*")).template(new Template(null, null, null)).build();
+
+        final Metadata metadata = Metadata.builder().put(createMetadata(randomAlphaOfLengthBetween(5, 7)), false)
+            .put(legacyTemplate).put("composable-template", composableTemplate).build();
+        String indexName = randomFrom("foo-123", "bar-xyz");
+        String aliasName = randomFrom("foo-write", "bar-write");
+
+        // the valid v2 template takes priority over the v1 template so the validation should not throw any exception
+        MetadataRolloverService.checkNoDuplicatedAliasInIndexTemplate(metadata, indexName, aliasName, randomBoolean());
+    }
+
     public void testHiddenAffectsResolvedTemplates() {
         final IndexTemplateMetadata template = IndexTemplateMetadata.builder("test-template")
             .patterns(Collections.singletonList("*"))


### PR DESCRIPTION
This fixes the case where a valid composable template overrides/shadows a
legacy template that defines the rollover alias. This is a valid configuration
and rollover should not fail.

(cherry picked from commit 3ea34bf205466db5cecc07e6f09ac11e62717a45)
Signed-off-by: Andrei Dan <andrei.dan@elastic.co>

Backport of #70259