### PR TITLE
[DOCS] Replace version-specific links in release highlights

### DIFF
--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -4,7 +4,7 @@
 Here are the highlights of what's new and improved in {es} {minor-version}!
 
 For detailed information about this release, see the <<es-release-notes>> and
-<<breaking-changes>.
+<<breaking-changes>>.
 
 // Add previous release to the list
 Other versions:

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -2,11 +2,9 @@
 == What's new in {minor-version}
 
 Here are the highlights of what's new and improved in {es} {minor-version}!
-ifeval::["{release-state}"!="unreleased"]
-For detailed information about this release, see the
-<<release-notes-{elasticsearch_version}, Release notes >> and
-<<breaking-changes-{minor-version}, Breaking changes>>.
-endif::[]
+
+For detailed information about this release, see the <<es-release-notes>> and
+<<breaking-changes>.
 
 // Add previous release to the list
 Other versions:


### PR DESCRIPTION
Replaces several version-specific links in our release highlights docs.

Currently, our release highlights use version-specific xrefs to other release docs. This makes it impossible to build a preview for a doc release until those ES release docs are available. This PR lets us build previews for docs releases in advance of ES release docs.

### Preview
https://elasticsearch_70317.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/current/release-highlights.html