### PR TITLE
[7.12] [DOCS] Remove  audit log rollover mention from 7.x docs (#70316)

### DIFF
--- a/x-pack/docs/en/security/auditing/output-logfile.asciidoc
+++ b/x-pack/docs/en/security/auditing/output-logfile.asciidoc
@@ -55,4 +55,3 @@ the https://github.com/elastic/elasticsearch/blob/{branch}/x-pack/plugin/core/sr
 By default, audit information is appended to the
 `<clustername>_audit.json` file located in the standard Elasticsearch `logs` directory
 (typically located at `$ES_HOME/logs`).
-The file is also rotated and archived daily or upon reaching the 1GB file size limit.


### PR DESCRIPTION
Backports the following commits to 7.12:
 - [DOCS] Remove  audit log rollover mention from 7.x docs (#70316)