### PR TITLE
[Transform] fix itermittent problem in TransformIndexerTests/TransformIndexerFailureHandlingTests

### DIFF
--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerFailureHandlingTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerFailureHandlingTests.java
@@ -333,10 +333,11 @@ public class TransformIndexerFailureHandlingTests extends ESTestCase {
 
         // run indexer a 2nd time
         final CountDownLatch secondRunLatch = indexer.newLatch(1);
-        indexer.start();
         assertEquals(pageSizeAfterFirstReduction, indexer.getPageSize());
         assertThat(indexer.getState(), equalTo(IndexerState.STARTED));
-        assertTrue(indexer.maybeTriggerAsyncJob(System.currentTimeMillis()));
+
+        // when the indexer thread shuts down, it ignores the trigger, we might have to call it again
+        assertBusy(() -> assertTrue(indexer.maybeTriggerAsyncJob(System.currentTimeMillis())));
         assertThat(indexer.getState(), equalTo(IndexerState.INDEXING));
 
         secondRunLatch.countDown();


### PR DESCRIPTION
fix a race condition in the test: the indexer thread might still be in the
process of shutting down, when the test thread triggers it again.

relates #69551
fixes #70297


Note: The test suite has been renamed in `master/7.x/7.12` to `TransformIndexerFailureHandlingTests`, in the `7.11` branch the testsuite is called `TransformIndexerTests`, as in the issue (-> the 7.11 backport requires careful handling).