### PR TITLE
Resurrect _xpack/watcher routes

### DIFF
--- a/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-watcher.ack_watch.json
+++ b/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-watcher.ack_watch.json
@@ -1,0 +1,55 @@
+{
+  "xpack-watcher.ack_watch":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-ack-watch.html",
+      "description":"Acknowledges a watch, manually throttling the execution of the watch's actions."
+    },
+    "stability":"stable",
+    "visibility":"public",
+    "headers":{
+      "accept": [ "application/vnd.elasticsearch+json;compatible-with=7"]
+    },
+    "url":{
+      "paths":[
+        {
+          "path":"/_xpack/watcher/watch/{watch_id}/_ack",
+          "methods":[
+            "PUT",
+            "POST"
+          ],
+          "parts":{
+            "watch_id":{
+              "type":"string",
+              "description":"Watch ID"
+            }
+          },
+          "deprecated":{
+            "version":"7.0.0",
+            "description":"all _xpack prefix have been deprecated"
+          }
+        },
+        {
+          "path":"/_xpack/watcher/watch/{watch_id}/_ack/{action_id}",
+          "methods":[
+            "PUT",
+            "POST"
+          ],
+          "parts":{
+            "watch_id":{
+              "type":"string",
+              "description":"Watch ID"
+            },
+            "action_id":{
+              "type":"list",
+              "description":"A comma-separated list of the action ids to be acked"
+            }
+          },
+          "deprecated":{
+            "version":"7.0.0",
+            "description":"all _xpack prefix have been deprecated"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-watcher.activate_watch.json
+++ b/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-watcher.activate_watch.json
@@ -1,8 +1,8 @@
 {
-  "xpack-watcher.get_watch":{
+  "xpack-watcher.activate_watch":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-get-watch.html",
-      "description":"Retrieves a watch by its ID."
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-activate-watch.html",
+      "description":"Activates a currently inactive watch."
     },
     "stability":"stable",
     "visibility":"public",
@@ -12,12 +12,13 @@
     "url":{
       "paths":[
         {
-          "path":"/_xpack/watcher/watch/{id}",
+          "path":"/_xpack/watcher/watch/{watch_id}/_activate",
           "methods":[
-            "GET"
+            "PUT",
+            "POST"
           ],
           "parts":{
-            "id":{
+            "watch_id":{
               "type":"string",
               "description":"Watch ID"
             }
@@ -28,7 +29,6 @@
           }
         }
       ]
-    },
-    "params":{}
+    }
   }
 }

--- a/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-watcher.deactivate_watch.json
+++ b/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-watcher.deactivate_watch.json
@@ -1,8 +1,8 @@
 {
-  "xpack-watcher.get_watch":{
+  "xpack-watcher.deactivate_watch":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-get-watch.html",
-      "description":"Retrieves a watch by its ID."
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-deactivate-watch.html",
+      "description":"Deactivates a currently active watch."
     },
     "stability":"stable",
     "visibility":"public",
@@ -12,12 +12,13 @@
     "url":{
       "paths":[
         {
-          "path":"/_xpack/watcher/watch/{id}",
+          "path":"/_xpack/watcher/watch/{watch_id}/_deactivate",
           "methods":[
-            "GET"
+            "PUT",
+            "POST"
           ],
           "parts":{
-            "id":{
+            "watch_id":{
               "type":"string",
               "description":"Watch ID"
             }
@@ -28,7 +29,6 @@
           }
         }
       ]
-    },
-    "params":{}
+    }
   }
 }

--- a/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-watcher.delete_watch.json
+++ b/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-watcher.delete_watch.json
@@ -1,0 +1,33 @@
+{
+  "xpack-watcher.delete_watch":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-delete-watch.html",
+      "description":"Removes a watch from Watcher."
+    },
+    "stability":"stable",
+    "visibility":"public",
+    "headers":{
+      "accept": [ "application/vnd.elasticsearch+json;compatible-with=7"]
+    },
+    "url":{
+      "paths":[
+        {
+          "path":"/_xpack/watcher/watch/{id}",
+          "methods":[
+            "DELETE"
+          ],
+          "parts":{
+            "id":{
+              "type":"string",
+              "description":"Watch ID"
+            }
+          },
+          "deprecated" : {
+            "version" : "7.0.0",
+            "description" : "all _xpack prefix have been deprecated"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-watcher.delete_watch.json
+++ b/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-watcher.delete_watch.json
@@ -22,9 +22,9 @@
               "description":"Watch ID"
             }
           },
-          "deprecated" : {
-            "version" : "7.0.0",
-            "description" : "all _xpack prefix have been deprecated"
+          "deprecated":{
+            "version":"7.0.0",
+            "description":"all _xpack prefix have been deprecated"
           }
         }
       ]

--- a/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-watcher.execute_watch.json
+++ b/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-watcher.execute_watch.json
@@ -1,0 +1,57 @@
+{
+  "xpack-watcher.execute_watch":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-execute-watch.html",
+      "description":"Forces the execution of a stored watch."
+    },
+    "stability":"stable",
+    "visibility":"public",
+    "headers":{
+      "accept": [ "application/vnd.elasticsearch+json;compatible-with=7"],
+      "content_type": ["application/vnd.elasticsearch+json;compatible-with=7"]
+    },
+    "url":{
+      "paths":[
+        {
+          "path":"/_xpack/watcher/watch/{id}/_execute",
+          "methods":[
+            "PUT",
+            "POST"
+          ],
+          "parts":{
+            "id":{
+              "type":"string",
+              "description":"Watch ID"
+            }
+          },
+          "deprecated":{
+            "version":"7.0.0",
+            "description":"all _xpack prefix have been deprecated"
+          }
+        },
+        {
+          "path":"/_xpack/watcher/watch/_execute",
+          "methods":[
+            "PUT",
+            "POST"
+          ],
+          "deprecated":{
+            "version":"7.0.0",
+            "description":"all _xpack prefix have been deprecated"
+          }
+        }
+      ]
+    },
+    "params":{
+      "debug":{
+        "type":"boolean",
+        "description":"indicates whether the watch should execute in debug mode",
+        "required":false
+      }
+    },
+    "body":{
+      "description":"Execution control",
+      "required":false
+    }
+  }
+}

--- a/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-watcher.get_watch.json
+++ b/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-watcher.get_watch.json
@@ -1,0 +1,34 @@
+{
+  "xpack-watcher.get_watch":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-get-watch.html",
+      "description":"Retrieves a watch by its ID."
+    },
+    "stability":"stable",
+    "visibility":"public",
+    "headers":{
+      "accept": [ "application/vnd.elasticsearch+json;compatible-with=7"]
+    },
+    "url":{
+      "paths":[
+        {
+          "path":"/_xpack/watcher/watch/{id}",
+          "methods":[
+            "GET"
+          ],
+          "parts":{
+            "id":{
+              "type":"string",
+              "description":"Watch ID"
+            }
+          },
+          "deprecated": {
+            "version": "7.0.0",
+            "description": "all _xpack prefix have been deprecated"
+          }
+        }
+      ]
+    },
+    "params":{}
+  }
+}

--- a/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-watcher.put_watch.json
+++ b/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-watcher.put_watch.json
@@ -1,0 +1,61 @@
+{
+  "xpack-watcher.put_watch": {
+    "documentation": {
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-put-watch.html",
+      "description": "Creates a new watch, or updates an existing one."
+    },
+    "stability": "stable",
+    "visibility": "public",
+    "headers": {
+      "accept": [
+        "application/vnd.elasticsearch+json;compatible-with=7"
+      ],
+      "content-type": [
+        "application/vnd.elasticsearch+json;compatible-with=7"
+      ]
+    },
+    "url": {
+      "paths": [
+        {
+          "path": "/_xpack/watcher/watch/{id}",
+          "methods": [
+            "PUT",
+            "POST"
+          ],
+          "parts": {
+            "id": {
+              "type": "string",
+              "description": "Watch ID"
+            }
+          },
+          "deprecated": {
+            "version": "7.0.0",
+            "description": "all _xpack prefix have been deprecated"
+          }
+        }
+      ]
+    },
+    "params": {
+      "active": {
+        "type": "boolean",
+        "description": "Specify whether the watch is in/active by default"
+      },
+      "version": {
+        "type": "number",
+        "description": "Explicit version number for concurrency control"
+      },
+      "if_seq_no": {
+        "type": "number",
+        "description": "only update the watch if the last operation that has changed the watch has the specified sequence number"
+      },
+      "if_primary_term": {
+        "type": "number",
+        "description": "only update the watch if the last operation that has changed the watch has the specified primary term"
+      }
+    },
+    "body": {
+      "description": "The watch",
+      "required": false
+    }
+  }
+}

--- a/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-watcher.put_watch.json
+++ b/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-watcher.put_watch.json
@@ -1,61 +1,57 @@
 {
-  "xpack-watcher.put_watch": {
-    "documentation": {
-      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-put-watch.html",
-      "description": "Creates a new watch, or updates an existing one."
+  "xpack-watcher.put_watch":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-put-watch.html",
+      "description":"Creates a new watch, or updates an existing one."
     },
-    "stability": "stable",
-    "visibility": "public",
-    "headers": {
-      "accept": [
-        "application/vnd.elasticsearch+json;compatible-with=7"
-      ],
-      "content-type": [
-        "application/vnd.elasticsearch+json;compatible-with=7"
-      ]
+    "stability":"stable",
+    "visibility":"public",
+    "headers":{
+      "accept": [ "application/vnd.elasticsearch+json;compatible-with=7"],
+      "content_type": ["application/vnd.elasticsearch+json;compatible-with=7"]
     },
-    "url": {
-      "paths": [
+    "url":{
+      "paths":[
         {
-          "path": "/_xpack/watcher/watch/{id}",
-          "methods": [
+          "path":"/_xpack/watcher/watch/{id}",
+          "methods":[
             "PUT",
             "POST"
           ],
-          "parts": {
-            "id": {
-              "type": "string",
-              "description": "Watch ID"
+          "parts":{
+            "id":{
+              "type":"string",
+              "description":"Watch ID"
             }
           },
-          "deprecated": {
-            "version": "7.0.0",
-            "description": "all _xpack prefix have been deprecated"
+          "deprecated":{
+            "version":"7.0.0",
+            "description":"all _xpack prefix have been deprecated"
           }
         }
       ]
     },
-    "params": {
-      "active": {
-        "type": "boolean",
-        "description": "Specify whether the watch is in/active by default"
+    "params":{
+      "active":{
+        "type":"boolean",
+        "description":"Specify whether the watch is in/active by default"
       },
-      "version": {
-        "type": "number",
-        "description": "Explicit version number for concurrency control"
+      "version":{
+        "type":"number",
+        "description":"Explicit version number for concurrency control"
       },
-      "if_seq_no": {
-        "type": "number",
-        "description": "only update the watch if the last operation that has changed the watch has the specified sequence number"
+      "if_seq_no":{
+        "type":"number",
+        "description":"only update the watch if the last operation that has changed the watch has the specified sequence number"
       },
-      "if_primary_term": {
-        "type": "number",
-        "description": "only update the watch if the last operation that has changed the watch has the specified primary term"
+      "if_primary_term":{
+        "type":"number",
+        "description":"only update the watch if the last operation that has changed the watch has the specified primary term"
       }
     },
-    "body": {
-      "description": "The watch",
-      "required": false
+    "body":{
+      "description":"The watch",
+      "required":false
     }
   }
 }

--- a/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-watcher.start.json
+++ b/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-watcher.start.json
@@ -1,8 +1,8 @@
 {
-  "xpack-watcher.get_watch":{
+  "xpack-watcher.start":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-get-watch.html",
-      "description":"Retrieves a watch by its ID."
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-start.html",
+      "description":"Starts Watcher if it is not already running."
     },
     "stability":"stable",
     "visibility":"public",
@@ -12,16 +12,10 @@
     "url":{
       "paths":[
         {
-          "path":"/_xpack/watcher/watch/{id}",
+          "path":"/_xpack/watcher/_start",
           "methods":[
-            "GET"
+            "POST"
           ],
-          "parts":{
-            "id":{
-              "type":"string",
-              "description":"Watch ID"
-            }
-          },
           "deprecated":{
             "version":"7.0.0",
             "description":"all _xpack prefix have been deprecated"

--- a/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-watcher.stats.json
+++ b/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-watcher.stats.json
@@ -1,0 +1,66 @@
+{
+  "xpack-watcher.stats":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stats.html",
+      "description":"Retrieves the current Watcher metrics."
+    },
+    "stability":"stable",
+    "visibility":"public",
+    "headers":{
+      "accept": [ "application/vnd.elasticsearch+json;compatible-with=7"]
+    },
+    "url":{
+      "paths":[
+        {
+          "path":"/_xpack/watcher/stats",
+          "methods":[
+            "GET"
+          ],
+          "deprecated":{
+            "version":"7.0.0",
+            "description":"all _xpack prefix have been deprecated"
+          }
+        },
+        {
+          "path":"/_xpack/watcher/stats/{metric}",
+          "methods":[
+            "GET"
+          ],
+          "parts":{
+            "metric":{
+              "type":"list",
+              "options":[
+                "_all",
+                "queued_watches",
+                "current_watches",
+                "pending_watches"
+              ],
+              "description":"Controls what additional stat metrics should be include in the response"
+            }
+          },
+          "deprecated":{
+            "version":"7.0.0",
+            "description":"all _xpack prefix have been deprecated"
+          }
+        }
+      ]
+    },
+    "params":{
+      "metric":{
+        "type":"list",
+        "options":[
+          "_all",
+          "queued_watches",
+          "current_watches",
+          "pending_watches"
+        ],
+        "description":"Controls what additional stat metrics should be include in the response"
+      },
+      "emit_stacktraces":{
+        "type":"boolean",
+        "description":"Emits stack traces of currently running watches",
+        "required":false
+      }
+    }
+  }
+}

--- a/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-watcher.stop.json
+++ b/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-watcher.stop.json
@@ -1,8 +1,8 @@
 {
-  "xpack-watcher.get_watch":{
+  "xpack-watcher.stop":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-get-watch.html",
-      "description":"Retrieves a watch by its ID."
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stop.html",
+      "description":"Stops Watcher if it is running."
     },
     "stability":"stable",
     "visibility":"public",
@@ -12,16 +12,10 @@
     "url":{
       "paths":[
         {
-          "path":"/_xpack/watcher/watch/{id}",
+          "path":"/_xpack/watcher/_stop",
           "methods":[
-            "GET"
+            "POST"
           ],
-          "parts":{
-            "id":{
-              "type":"string",
-              "description":"Watch ID"
-            }
-          },
           "deprecated":{
             "version":"7.0.0",
             "description":"all _xpack prefix have been deprecated"

--- a/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/test/v7compat/10_basic_compat.yml
+++ b/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/test/v7compat/10_basic_compat.yml
@@ -1,0 +1,79 @@
+---
+setup:
+  - skip:
+      features:
+        - allowed_warnings
+        - warnings
+        - headers
+  - do:
+      cluster.health:
+          wait_for_status: yellow
+---
+teardown:
+  - skip:
+      features:
+        - warnings
+        - headers
+  - do:
+      headers:
+        Accept: "application/vnd.elasticsearch+json;compatible-with=7"
+        Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
+      warnings:
+        - "[DELETE /_xpack/watcher/watch/{id}] is deprecated! Use [DELETE /_watcher/watch/{id}] instead."
+      xpack-watcher.delete_watch:
+        id: "my_watch"
+        ignore: 404
+
+---
+"Test put, get, and delete watch with 7.x compatibilty":
+  - do:
+      headers:
+        Accept: "application/vnd.elasticsearch+json;compatible-with=7"
+        Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
+      allowed_warnings:
+        - "[POST /_xpack/watcher/watch/{id}] is deprecated! Use [POST /_watcher/watch/{id}] instead."
+        - "[PUT /_xpack/watcher/watch/{id}] is deprecated! Use [PUT /_watcher/watch/{id}] instead."
+      xpack-watcher.put_watch:
+        id: "my_watch"
+        body:  >
+          {
+            "trigger": {
+              "schedule": {
+                "hourly": {
+                  "minute": [ 0, 5 ]
+                  }
+                }
+            },
+            "input": {
+              "simple": {
+                "payload": {
+                  "send": "yes"
+                }
+              }
+            },
+            "condition": {
+              "always": {}
+            },
+            "actions": {
+                "test_index": {
+                  "index": {
+                    "index": "test"
+                  }
+                }
+              }
+            }
+  - match: { _id: "my_watch" }
+  - match: { created: true }
+
+  - do:
+      headers:
+        Accept: "application/vnd.elasticsearch+json;compatible-with=7"
+        Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
+      warnings:
+        - "[GET /_xpack/watcher/watch/{id}] is deprecated! Use [GET /_watcher/watch/{id}] instead."
+      xpack-watcher.get_watch:
+        id: "my_watch"
+  - match: { found : true}
+  - match: { _id: "my_watch" }
+  - is_true:  watch
+  - is_false: watch.status

--- a/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/test/v7compat/ack_watch/10_basic.yml
+++ b/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/test/v7compat/ack_watch/10_basic.yml
@@ -1,0 +1,99 @@
+---
+setup:
+  - skip:
+      features:
+        - allowed_warnings
+        - warnings
+        - headers
+  - do:
+      cluster.health:
+        wait_for_status: yellow
+
+---
+"Test ack watch api":
+  - do:
+      headers:
+        Accept: "application/vnd.elasticsearch+json;compatible-with=7"
+        Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
+      allowed_warnings:
+        - "[POST /_xpack/watcher/watch/{id}] is deprecated! Use [POST /_watcher/watch/{id}] instead."
+        - "[PUT /_xpack/watcher/watch/{id}] is deprecated! Use [PUT /_watcher/watch/{id}] instead."
+      xpack-watcher.put_watch:
+        id: "my_watch"
+        body:  >
+          {
+            "trigger" : {
+              "schedule" : { "cron" : "0 0 0 1 * ? 2099" }
+            },
+            "input": {
+              "simple": {
+                "payload": {
+                  "send": "yes"
+                }
+              }
+            },
+            "condition": {
+              "always": {}
+            },
+            "actions": {
+              "test_index": {
+                "index": {
+                  "index": "test"
+                }
+              }
+            }
+          }
+
+  - match: { _id: "my_watch" }
+
+  - do:
+      cluster.health:
+          wait_for_status: yellow
+
+  - do:
+      headers:
+        Accept: "application/vnd.elasticsearch+json;compatible-with=7"
+        Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
+      allowed_warnings:
+        - "[POST /_xpack/watcher/watch/{id}/_ack] is deprecated! Use [POST /_watcher/watch/{id}/_ack] instead."
+        - "[PUT /_xpack/watcher/watch/{id}/_ack] is deprecated! Use [PUT /_watcher/watch/{id}/_ack] instead."
+      xpack-watcher.ack_watch:
+        watch_id: "my_watch"
+
+  - match: { "status.actions.test_index.ack.state" : "awaits_successful_execution" }
+
+  - do:
+      headers:
+        Accept: "application/vnd.elasticsearch+json;compatible-with=7"
+        Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
+      warnings:
+        - "[GET /_xpack/watcher/watch/{id}] is deprecated! Use [GET /_watcher/watch/{id}] instead."
+      xpack-watcher.get_watch:
+        id: "my_watch"
+  - match: { found: true }
+  - match: { _id: "my_watch" }
+  - match: { status.actions.test_index.ack.state: "awaits_successful_execution" }
+
+  - do:
+      headers:
+        Accept: "application/vnd.elasticsearch+json;compatible-with=7"
+        Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
+      warnings:
+        - "[DELETE /_xpack/watcher/watch/{id}] is deprecated! Use [DELETE /_watcher/watch/{id}] instead."
+      xpack-watcher.delete_watch:
+        id: "my_watch"
+
+  - match: { found: true }
+
+---
+"Non existent watch returns 404":
+  - do:
+      headers:
+        Accept: "application/vnd.elasticsearch+json;compatible-with=7"
+        Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
+      allowed_warnings:
+        - "[POST /_xpack/watcher/watch/{id}/_ack] is deprecated! Use [POST /_watcher/watch/{id}/_ack] instead."
+        - "[PUT /_xpack/watcher/watch/{id}/_ack] is deprecated! Use [PUT /_watcher/watch/{id}/_ack] instead."
+      xpack-watcher.ack_watch:
+        watch_id: "non-existent-watch"
+      catch: missing

--- a/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/test/v7compat/activate_watch/10_basic.yml
+++ b/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/test/v7compat/activate_watch/10_basic.yml
@@ -1,0 +1,144 @@
+---
+setup:
+  - skip:
+      features:
+        - allowed_warnings
+        - warnings
+        - headers
+  - do:
+      cluster.health:
+        wait_for_status: yellow
+
+---
+"Test activate watch api":
+  - do:
+      headers:
+        Accept: "application/vnd.elasticsearch+json;compatible-with=7"
+        Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
+      allowed_warnings:
+        - "[POST /_xpack/watcher/watch/{id}] is deprecated! Use [POST /_watcher/watch/{id}] instead."
+        - "[PUT /_xpack/watcher/watch/{id}] is deprecated! Use [PUT /_watcher/watch/{id}] instead."
+      xpack-watcher.put_watch:
+        id: "my_watch"
+        body:  >
+          {
+            "trigger" : {
+              "schedule" : { "cron" : "0 0 0 1 * ? 2099" }
+            },
+            "input": {
+              "simple": {
+                "payload": {
+                  "send": "yes"
+                }
+              }
+            },
+            "condition": {
+              "always": {}
+            },
+            "actions": {
+              "test_index": {
+                "index": {
+                  "index": "test"
+                }
+              }
+            }
+          }
+
+  - match: { _id: "my_watch" }
+
+  - do:
+      headers:
+        Accept: "application/vnd.elasticsearch+json;compatible-with=7"
+        Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
+      warnings:
+        - "[GET /_xpack/watcher/watch/{id}] is deprecated! Use [GET /_watcher/watch/{id}] instead."
+      xpack-watcher.get_watch:
+        id: "my_watch"
+
+  - match: { found : true}
+  - match: { _id: "my_watch" }
+  - match: { status.state.active: true }
+
+  - do:
+      headers:
+        Accept: "application/vnd.elasticsearch+json;compatible-with=7"
+        Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
+      allowed_warnings:
+        - "[POST /_xpack/watcher/watch/{id}/_deactivate] is deprecated! Use [POST /_watcher/watch/{id}/_deactivate] instead."
+        - "[PUT /_xpack/watcher/watch/{id}/_deactivate] is deprecated! Use [PUT /_watcher/watch/{id}/_deactivate] instead."
+      xpack-watcher.deactivate_watch:
+        watch_id: "my_watch"
+
+  - match: { status.state.active : false }
+
+  - do:
+      headers:
+        Accept: "application/vnd.elasticsearch+json;compatible-with=7"
+        Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
+      warnings:
+        - "[GET /_xpack/watcher/watch/{id}] is deprecated! Use [GET /_watcher/watch/{id}] instead."
+      xpack-watcher.get_watch:
+        id: "my_watch"
+  - match: { found : true}
+  - match: { _id: "my_watch" }
+  - match: { status.state.active: false }
+
+  - do:
+      headers:
+        Accept: "application/vnd.elasticsearch+json;compatible-with=7"
+        Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
+      allowed_warnings:
+        - "[POST /_xpack/watcher/watch/{id}/_activate] is deprecated! Use [POST /_watcher/watch/{id}/_activate] instead."
+        - "[PUT /_xpack/watcher/watch/{id}/_activate] is deprecated! Use [PUT /_watcher/watch/{id}/_activate] instead."
+      xpack-watcher.activate_watch:
+        watch_id: "my_watch"
+
+  - match: { status.state.active : true }
+
+  - do:
+      headers:
+        Accept: "application/vnd.elasticsearch+json;compatible-with=7"
+        Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
+      warnings:
+        - "[GET /_xpack/watcher/watch/{id}] is deprecated! Use [GET /_watcher/watch/{id}] instead."
+      xpack-watcher.get_watch:
+        id: "my_watch"
+
+  - match: { found : true}
+  - match: { _id: "my_watch" }
+  - match: { status.state.active: true }
+
+  - do:
+      headers:
+        Accept: "application/vnd.elasticsearch+json;compatible-with=7"
+        Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
+      warnings:
+        - "[DELETE /_xpack/watcher/watch/{id}] is deprecated! Use [DELETE /_watcher/watch/{id}] instead."
+      xpack-watcher.delete_watch:
+        id: "my_watch"
+
+  - match: { found: true }
+
+---
+"Non existent watch returns 404":
+  - do:
+      headers:
+        Accept: "application/vnd.elasticsearch+json;compatible-with=7"
+        Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
+      allowed_warnings:
+        - "[POST /_xpack/watcher/watch/{id}/_activate] is deprecated! Use [POST /_watcher/watch/{id}/_activate] instead."
+        - "[PUT /_xpack/watcher/watch/{id}/_activate] is deprecated! Use [PUT /_watcher/watch/{id}/_activate] instead."
+      xpack-watcher.activate_watch:
+        watch_id: "non-existent-watch"
+      catch: missing
+
+  - do:
+      headers:
+        Accept: "application/vnd.elasticsearch+json;compatible-with=7"
+        Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
+      allowed_warnings:
+        - "[POST /_xpack/watcher/watch/{id}/_deactivate] is deprecated! Use [POST /_watcher/watch/{id}/_deactivate] instead."
+        - "[PUT /_xpack/watcher/watch/{id}/_deactivate] is deprecated! Use [PUT /_watcher/watch/{id}/_deactivate] instead."
+      xpack-watcher.deactivate_watch:
+        watch_id: "non-existent-watch"
+      catch: missing

--- a/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/test/v7compat/delete_watch/10_basic.yml
+++ b/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/test/v7compat/delete_watch/10_basic.yml
@@ -26,7 +26,7 @@ teardown:
         ignore: 404
 
 ---
-"Test put, get, and delete watch with 7.x compatibilty":
+"Test delete watch api":
   - do:
       headers:
         Accept: "application/vnd.elasticsearch+json;compatible-with=7"
@@ -56,13 +56,13 @@ teardown:
               "always": {}
             },
             "actions": {
-                "test_index": {
-                  "index": {
-                    "index": "test"
-                  }
+              "test_index": {
+                "index": {
+                  "index": "test"
                 }
               }
             }
+          }
   - match: { _id: "my_watch" }
   - match: { created: true }
 
@@ -74,7 +74,39 @@ teardown:
         - "[GET /_xpack/watcher/watch/{id}] is deprecated! Use [GET /_watcher/watch/{id}] instead."
       xpack-watcher.get_watch:
         id: "my_watch"
-  - match: { found : true}
+  - match: { found: true }
   - match: { _id: "my_watch" }
-  - is_true:  watch
-  - is_false: watch.status
+
+  - do:
+      headers:
+        Accept: "application/vnd.elasticsearch+json;compatible-with=7"
+        Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
+      warnings:
+        - "[DELETE /_xpack/watcher/watch/{id}] is deprecated! Use [DELETE /_watcher/watch/{id}] instead."
+      xpack-watcher.delete_watch:
+        id: "my_watch"
+  - match: { found: true }
+
+  - do:
+      headers:
+        Accept: "application/vnd.elasticsearch+json;compatible-with=7"
+        Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
+      warnings:
+        - "[GET /_xpack/watcher/watch/{id}] is deprecated! Use [GET /_watcher/watch/{id}] instead."
+      xpack-watcher.get_watch:
+        id: "my_watch"
+      catch: missing
+  - match: { found: false }
+  - match: { _id: "my_watch" }
+
+---
+"Non existent watch returns 404":
+  - do:
+      headers:
+        Accept: "application/vnd.elasticsearch+json;compatible-with=7"
+        Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
+      warnings:
+        - "[DELETE /_xpack/watcher/watch/{id}] is deprecated! Use [DELETE /_watcher/watch/{id}] instead."
+      xpack-watcher.delete_watch:
+        id: "non-existent-watch"
+      catch: missing

--- a/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/test/v7compat/execute_watch/10_basic.yml
+++ b/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/test/v7compat/execute_watch/10_basic.yml
@@ -1,0 +1,210 @@
+---
+setup:
+  - skip:
+      features:
+        - allowed_warnings
+        - warnings
+        - headers
+  - do:
+      cluster.health:
+        wait_for_status: yellow
+
+---
+teardown:
+  - skip:
+      features:
+        - warnings
+        - headers
+  - do:
+      headers:
+        Accept: "application/vnd.elasticsearch+json;compatible-with=7"
+        Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
+      warnings:
+        - "[DELETE /_xpack/watcher/watch/{id}] is deprecated! Use [DELETE /_watcher/watch/{id}] instead."
+      xpack-watcher.delete_watch:
+        id: "test_watch"
+        ignore: 404
+
+---
+"Test execute watch api with configured trigger data timestamps":
+  - do:
+      headers:
+        Accept: "application/vnd.elasticsearch+json;compatible-with=7"
+        Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
+      allowed_warnings:
+        - "[POST /_xpack/watcher/watch/{id}] is deprecated! Use [POST /_watcher/watch/{id}] instead."
+        - "[PUT /_xpack/watcher/watch/{id}] is deprecated! Use [PUT /_watcher/watch/{id}] instead."
+      xpack-watcher.put_watch:
+        id: "test_watch"
+        body:  >
+          {
+            "trigger": {
+              "schedule" : { "cron" : "0 0 0 1 * ? 2099" }
+            },
+            "input": {
+              "simple": {
+                "foo": "bar"
+              }
+            },
+            "condition": {
+              "always": {}
+            },
+            "actions": {
+              "indexme" : {
+                "index" : {
+                  "index" : "my_test_index",
+                  "doc_id": "my-id"
+                }
+              }
+            }
+          }
+  - match: { _id: "test_watch" }
+  - match: { created: true }
+
+  - do:
+      headers:
+        Accept: "application/vnd.elasticsearch+json;compatible-with=7"
+        Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
+      allowed_warnings:
+        - "[POST /_xpack/watcher/watch/{id}/_execute] is deprecated! Use [POST /_watcher/watch/{id}/_execute] instead."
+        - "[PUT /_xpack/watcher/watch/{id}/_execute] is deprecated! Use [PUT /_watcher/watch/{id}/_execute] instead."
+      xpack-watcher.execute_watch:
+        id: "test_watch"
+        body: >
+          {
+            "trigger_data" : {
+              "triggered_time" : "2012-12-12T12:12:12.120Z",
+              "scheduled_time" : "2000-12-12T12:12:12.120Z"
+            }
+          }
+
+  - match: { watch_record.watch_id: "test_watch" }
+  - match: { watch_record.trigger_event.type: "manual" }
+  - match: { watch_record.trigger_event.triggered_time: "2012-12-12T12:12:12.120Z" }
+  - match: { watch_record.trigger_event.manual.schedule.scheduled_time: "2000-12-12T12:12:12.120Z" }
+  - match: { watch_record.state: "executed" }
+  - match: { watch_record.status.execution_state: "executed" }
+  - match: { watch_record.status.state.active: true }
+  - is_true: watch_record.node
+  - match: { watch_record.status.actions.indexme.ack.state: "ackable" }
+  - gt: { watch_record.result.execution_duration: 0 }
+
+---
+"Test execute watch API with user supplied watch":
+
+  - do:
+      headers:
+        Accept: "application/vnd.elasticsearch+json;compatible-with=7"
+        Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
+      allowed_warnings:
+        - "[POST /_xpack/watcher/watch/_execute] is deprecated! Use [POST /_watcher/watch/_execute] instead."
+        - "[PUT /_xpack/watcher/watch/_execute] is deprecated! Use [PUT /_watcher/watch/_execute] instead."
+      xpack-watcher.execute_watch:
+        body: >
+          {
+            "watch" : {
+              "trigger": {
+                "schedule" : { "cron" : "0 0 0 1 * ? 2099" }
+              },
+              "input": {
+                "simple": {
+                  "foo": "bar"
+                }
+              },
+              "condition": {
+                "always": {}
+              },
+              "actions": {
+                "indexme" : {
+                  "index" : {
+                    "index" : "my_test_index",
+                    "doc_id": "my-id"
+                  }
+                }
+              }
+            }
+          }
+
+  - match: { watch_record.watch_id: "_inlined_" }
+  - match: { watch_record.trigger_event.type: "manual" }
+  - match: { watch_record.state: "executed" }
+  - match: { watch_record.status.execution_state: "executed" }
+  - match: { watch_record.status.state.active: true }
+  - match: { watch_record.status.actions.indexme.ack.state: "ackable" }
+
+---
+"Execute unknown watch results in 404":
+  - do:
+      headers:
+        Accept: "application/vnd.elasticsearch+json;compatible-with=7"
+        Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
+      allowed_warnings:
+        - "[POST /_xpack/watcher/watch/{id}/_execute] is deprecated! Use [POST /_watcher/watch/{id}/_execute] instead."
+        - "[PUT /_xpack/watcher/watch/{id}/_execute] is deprecated! Use [PUT /_watcher/watch/{id}/_execute] instead."
+      xpack-watcher.execute_watch:
+        id: "non-existent-watch"
+      catch: missing
+
+---
+"Test execute watch with alternative input":
+  - do:
+      headers:
+        Accept: "application/vnd.elasticsearch+json;compatible-with=7"
+        Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
+      allowed_warnings:
+        - "[POST /_xpack/watcher/watch/{id}] is deprecated! Use [POST /_watcher/watch/{id}] instead."
+        - "[PUT /_xpack/watcher/watch/{id}] is deprecated! Use [PUT /_watcher/watch/{id}] instead."
+      xpack-watcher.put_watch:
+        id: "test_watch"
+        body:  >
+          {
+            "trigger": {
+              "schedule" : { "cron" : "0 0 0 1 * ? 2099" }
+            },
+            "input": {
+              "simple": {
+                "foo": "bar"
+              }
+            },
+            "actions": {
+              "indexme" : {
+                "index" : {
+                  "index" : "my_test_index",
+                  "refresh" : "wait_for",
+                  "doc_id": "my-id"
+                }
+              }
+            }
+          }
+  - match: { _id: "test_watch" }
+  - match: { created: true }
+
+  - do:
+      headers:
+        Accept: "application/vnd.elasticsearch+json;compatible-with=7"
+        Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
+      allowed_warnings:
+        - "[POST /_xpack/watcher/watch/{id}/_execute] is deprecated! Use [POST /_watcher/watch/{id}/_execute] instead."
+        - "[PUT /_xpack/watcher/watch/{id}/_execute] is deprecated! Use [PUT /_watcher/watch/{id}/_execute] instead."
+      xpack-watcher.execute_watch:
+        id: "test_watch"
+        body: >
+          {
+            "alternative_input" : {
+              "spam" : "eggs"
+            }
+          }
+
+  - match: { watch_record.watch_id: "test_watch" }
+  - match: { watch_record.state: "executed" }
+  - match: { watch_record.status.execution_state: "executed" }
+  - match: { watch_record.status.state.active: true }
+  - is_true: watch_record.node
+  - is_false: watch_record.result.input.payload.foo
+  - is_true: watch_record.result.input.payload.spam
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: my_test_index
+  - match: { hits.total : 1 }

--- a/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/test/v7compat/get_watch/10_basic.yml
+++ b/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/test/v7compat/get_watch/10_basic.yml
@@ -26,7 +26,7 @@ teardown:
         ignore: 404
 
 ---
-"Test put, get, and delete watch with 7.x compatibilty":
+"Test get watch api":
   - do:
       headers:
         Accept: "application/vnd.elasticsearch+json;compatible-with=7"

--- a/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/test/v7compat/put_watch/10_basic.yml
+++ b/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/test/v7compat/put_watch/10_basic.yml
@@ -10,23 +10,7 @@ setup:
         wait_for_status: yellow
 
 ---
-teardown:
-  - skip:
-      features:
-        - warnings
-        - headers
-  - do:
-      headers:
-        Accept: "application/vnd.elasticsearch+json;compatible-with=7"
-        Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
-      warnings:
-        - "[DELETE /_xpack/watcher/watch/{id}] is deprecated! Use [DELETE /_watcher/watch/{id}] instead."
-      xpack-watcher.delete_watch:
-        id: "my_watch"
-        ignore: 404
-
----
-"Test put, get, and delete watch with 7.x compatibilty":
+"Test put watch api":
   - do:
       headers:
         Accept: "application/vnd.elasticsearch+json;compatible-with=7"
@@ -56,25 +40,26 @@ teardown:
               "always": {}
             },
             "actions": {
-                "test_index": {
-                  "index": {
-                    "index": "test"
-                  }
+              "test_index": {
+                "index": {
+                  "index": "test"
                 }
               }
             }
+          }
   - match: { _id: "my_watch" }
-  - match: { created: true }
 
+---
+"Test empty body is rejected by put watch":
   - do:
       headers:
         Accept: "application/vnd.elasticsearch+json;compatible-with=7"
         Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
-      warnings:
-        - "[GET /_xpack/watcher/watch/{id}] is deprecated! Use [GET /_watcher/watch/{id}] instead."
-      xpack-watcher.get_watch:
+      allowed_warnings:
+        - "[POST /_xpack/watcher/watch/{id}] is deprecated! Use [POST /_watcher/watch/{id}] instead."
+        - "[PUT /_xpack/watcher/watch/{id}] is deprecated! Use [PUT /_watcher/watch/{id}] instead."
+      xpack-watcher.put_watch:
         id: "my_watch"
-  - match: { found : true}
-  - match: { _id: "my_watch" }
-  - is_true:  watch
-  - is_false: watch.status
+      catch: bad_request
+  - match: { error.root_cause.0.type: "action_request_validation_exception" }
+  - match: { error.root_cause.0.reason: "Validation Failed: 1: request body is missing;" }

--- a/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/test/v7compat/start_watcher/10_basic.yml
+++ b/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/test/v7compat/start_watcher/10_basic.yml
@@ -1,0 +1,21 @@
+---
+setup:
+  - skip:
+      features:
+        - allowed_warnings
+        - warnings
+        - headers
+  - do:
+      cluster.health:
+        wait_for_status: yellow
+
+---
+"Test start watcher api":
+  - do:
+      headers:
+        Accept: "application/vnd.elasticsearch+json;compatible-with=7"
+        Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
+      warnings:
+        - "[POST /_xpack/watcher/_start] is deprecated! Use [POST /_watcher/_start] instead."
+      xpack-watcher.start: {}
+  - match: { acknowledged: true }

--- a/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/test/v7compat/stats/10_basic.yml
+++ b/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/test/v7compat/stats/10_basic.yml
@@ -1,0 +1,97 @@
+---
+setup:
+  - skip:
+      features:
+        - allowed_warnings
+        - warnings
+        - headers
+  - do:
+      cluster.health:
+        wait_for_status: yellow
+
+---
+"Test watcher stats output":
+  - do:
+      headers:
+        Accept: "application/vnd.elasticsearch+json;compatible-with=7"
+        Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
+      warnings:
+        - "[GET /_xpack/watcher/stats] is deprecated! Use [GET /_watcher/stats] instead."
+      xpack-watcher.stats: {}
+  - match: { "manually_stopped": false }
+  - match: { "stats.0.watcher_state": "started" }
+
+---
+"Test watcher stats supports emit_stacktraces parameter":
+  - do:
+      headers:
+        Accept: "application/vnd.elasticsearch+json;compatible-with=7"
+        Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
+      warnings:
+        - "[GET /_xpack/watcher/stats/{metric}] is deprecated! Use [GET /_watcher/stats/{metric}] instead."
+      xpack-watcher.stats:
+        metric: "all"
+        emit_stacktraces: "true"
+  - match: { "manually_stopped": false }
+  - match: { "stats.0.watcher_state": "started" }
+
+---
+"Test watcher stats current watches":
+  - do:
+      headers:
+        Accept: "application/vnd.elasticsearch+json;compatible-with=7"
+        Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
+      warnings:
+        - "[GET /_xpack/watcher/stats/{metric}] is deprecated! Use [GET /_watcher/stats/{metric}] instead."
+      xpack-watcher.stats:
+        metric: "current_watches"
+
+  - is_false: stats.0.queued_watches
+  - is_true: stats.0.current_watches
+
+---
+"Test watcher stats queued watches":
+  - do:
+      headers:
+        Accept: "application/vnd.elasticsearch+json;compatible-with=7"
+        Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
+      warnings:
+        - "[GET /_xpack/watcher/stats/{metric}] is deprecated! Use [GET /_watcher/stats/{metric}] instead."
+      xpack-watcher.stats:
+        metric: "queued_watches"
+
+  - is_false: stats.0.current_watches
+  - is_true: stats.0.queued_watches
+
+---
+"Test watcher stats queued watches using pending_watches":
+  - skip:
+      reason:  metrics were fixed in 7.0.0
+      features: warnings
+
+  - do:
+      headers:
+        Accept: "application/vnd.elasticsearch+json;compatible-with=7"
+        Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
+      warnings:
+        - "[GET /_xpack/watcher/stats/{metric}] is deprecated! Use [GET /_watcher/stats/{metric}] instead."
+        - 'The pending_watches parameter is deprecated, use queued_watches instead'
+      xpack-watcher.stats:
+        metric: "pending_watches"
+
+  - is_false: stats.0.current_watches
+  - is_true: stats.0.queued_watches
+
+---
+"Test watcher stats all watches":
+  - do:
+      headers:
+        Accept: "application/vnd.elasticsearch+json;compatible-with=7"
+        Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
+      warnings:
+        - "[GET /_xpack/watcher/stats/{metric}] is deprecated! Use [GET /_watcher/stats/{metric}] instead."
+      xpack-watcher.stats:
+        metric: "_all"
+
+  - is_true: stats.0.current_watches
+  - is_true: stats.0.queued_watches

--- a/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/test/v7compat/stop_watcher/10_basic.yml
+++ b/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/test/v7compat/stop_watcher/10_basic.yml
@@ -1,0 +1,30 @@
+---
+setup:
+  - skip:
+      features:
+        - allowed_warnings
+        - warnings
+        - headers
+  - do:
+      cluster.health:
+        wait_for_status: yellow
+
+---
+"Test stop watcher api":
+  - do:
+      headers:
+        Accept: "application/vnd.elasticsearch+json;compatible-with=7"
+        Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
+      warnings:
+        - "[POST /_xpack/watcher/_stop] is deprecated! Use [POST /_watcher/_stop] instead."
+      xpack-watcher.stop: {}
+  - match: { acknowledged: true }
+
+  - do:
+      headers:
+        Accept: "application/vnd.elasticsearch+json;compatible-with=7"
+        Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
+      warnings:
+        - "[POST /_xpack/watcher/_start] is deprecated! Use [POST /_watcher/_start] instead."
+      xpack-watcher.start: {}
+  - match: { acknowledged: true }

--- a/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/test/v7compat/usage/10_basic.yml
+++ b/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/test/v7compat/usage/10_basic.yml
@@ -1,0 +1,82 @@
+---
+setup:
+  - skip:
+      features:
+        - allowed_warnings
+        - warnings
+        - headers
+  - do:
+      cluster.health:
+        wait_for_status: yellow
+
+---
+"Test watcher usage stats output":
+  - do:
+      headers:
+        Accept: "application/vnd.elasticsearch+json;compatible-with=7"
+        Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
+      warnings:
+        - "[DELETE /_xpack/watcher/watch/{id}] is deprecated! Use [DELETE /_watcher/watch/{id}] instead."
+      xpack-watcher.delete_watch:
+        id: "usage_stats_watch"
+      catch: missing
+
+  - do: {xpack.usage: {}}
+  - set: { "watcher.count.active": watch_count_active }
+  - set: { "watcher.count.total": watch_count_total }
+
+  - do:
+      headers:
+        Accept: "application/vnd.elasticsearch+json;compatible-with=7"
+        Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
+      allowed_warnings:
+        - "[POST /_xpack/watcher/watch/{id}] is deprecated! Use [POST /_watcher/watch/{id}] instead."
+        - "[PUT /_xpack/watcher/watch/{id}] is deprecated! Use [PUT /_watcher/watch/{id}] instead."
+      xpack-watcher.put_watch:
+        id: "usage_stats_watch"
+        body:  >
+          {
+            "trigger": {
+              "schedule" : { "cron" : "0 0 0 1 * ? 2099" }
+            },
+            "input": {
+              "search" : {
+                "request" : {
+                  "indices" : [ "my_test_index" ],
+                  "body" :{
+                    "query" : { "match_all": {} }
+                  }
+                }
+              }
+            },
+            "condition" : {
+              "compare" : {
+                "ctx.payload.hits.total" : {
+                  "gte" : 1
+                }
+              }
+            },
+            "actions": {
+              "logging": {
+                "logging": {
+                  "text": "Successfully ran my_watch to test for search input"
+                }
+              }
+            }
+          }
+  - match: { _id: "usage_stats_watch" }
+
+  - do: {xpack.usage: {}}
+  - gt: { "watcher.count.active": $watch_count_active }
+  - gt: { "watcher.count.total": $watch_count_total }
+  - gte: { "watcher.watch.action._all.active": 1 }
+  - gte: { "watcher.watch.action.logging.active": 1 }
+  - gte: { "watcher.watch.condition._all.active": 1 }
+  - gte: { "watcher.watch.condition.compare.active": 1 }
+  - gte: { "watcher.watch.input._all.active": 1 }
+  - gte: { "watcher.watch.input.search.active": 1 }
+  - gte: { "watcher.watch.trigger._all.active": 1 }
+  - gte: { "watcher.watch.trigger.schedule.active": 1 }
+  - gte: { "watcher.watch.trigger.schedule.cron.active": 1 }
+  - gte: { "watcher.watch.trigger.schedule._all.active": 1 }
+

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/rest/action/RestAckWatchAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/rest/action/RestAckWatchAction.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.watcher.rest.action;
 
 import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.RestApiVersion;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.BytesRestResponse;
@@ -34,10 +35,15 @@ public class RestAckWatchAction extends BaseRestHandler {
     @Override
     public List<Route> routes() {
         return List.of(
-            new Route(POST, "/_watcher/watch/{id}/_ack"),
-            new Route(PUT, "/_watcher/watch/{id}/_ack"),
-            new Route(POST, "/_watcher/watch/{id}/_ack/{actions}"),
-            new Route(PUT, "/_watcher/watch/{id}/_ack/{actions}"));
+            Route.builder(POST, "/_watcher/watch/{id}/_ack")
+                .replaces(POST, "/_xpack/watcher/watch/{id}/_ack", RestApiVersion.V_7).build(),
+            Route.builder(PUT, "/_watcher/watch/{id}/_ack")
+                .replaces(PUT, "/_xpack/watcher/watch/{id}/_ack", RestApiVersion.V_7).build(),
+            Route.builder(POST, "/_watcher/watch/{id}/_ack/{actions}")
+                .replaces(POST, "/_xpack/watcher/watch/{id}/_ack/{actions}", RestApiVersion.V_7).build(),
+            Route.builder(PUT, "/_watcher/watch/{id}/_ack/{actions}")
+                .replaces(PUT, "/_xpack/watcher/watch/{id}/_ack/{actions}", RestApiVersion.V_7).build()
+        );
     }
 
     @Override

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/rest/action/RestActivateWatchAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/rest/action/RestActivateWatchAction.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.watcher.rest.action;
 
 import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.RestApiVersion;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.BytesRestResponse;
@@ -34,8 +35,11 @@ public class RestActivateWatchAction extends BaseRestHandler {
     @Override
     public List<Route> routes() {
         return List.of(
-            new Route(POST, "/_watcher/watch/{id}/_activate"),
-            new Route(PUT, "/_watcher/watch/{id}/_activate"));
+            Route.builder(POST, "/_watcher/watch/{id}/_activate")
+                .replaces(POST, "/_xpack/watcher/watch/{id}/_activate", RestApiVersion.V_7).build(),
+            Route.builder(PUT, "/_watcher/watch/{id}/_activate")
+                .replaces(PUT, "/_xpack/watcher/watch/{id}/_activate", RestApiVersion.V_7).build()
+        );
     }
 
     @Override
@@ -63,8 +67,11 @@ public class RestActivateWatchAction extends BaseRestHandler {
         @Override
         public List<Route> routes() {
             return List.of(
-                new Route(POST, "/_watcher/watch/{id}/_deactivate"),
-                new Route(PUT, "/_watcher/watch/{id}/_deactivate"));
+                Route.builder(POST, "/_watcher/watch/{id}/_deactivate")
+                    .replaces(POST, "/_xpack/watcher/watch/{id}/_deactivate", RestApiVersion.V_7).build(),
+                Route.builder(PUT, "/_watcher/watch/{id}/_deactivate")
+                    .replaces(PUT, "/_xpack/watcher/watch/{id}/_deactivate", RestApiVersion.V_7).build()
+            );
         }
 
         @Override

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/rest/action/RestDeleteWatchAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/rest/action/RestDeleteWatchAction.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.watcher.rest.action;
 
 import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.RestApiVersion;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.protocol.xpack.watcher.DeleteWatchRequest;
 import org.elasticsearch.protocol.xpack.watcher.DeleteWatchResponse;
@@ -29,7 +30,10 @@ public class RestDeleteWatchAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return List.of(new Route(DELETE, "/_watcher/watch/{id}"));
+        return List.of(
+            Route.builder(DELETE, "/_watcher/watch/{id}")
+                .replaces(DELETE, "/_xpack/watcher/watch/{id}", RestApiVersion.V_7).build()
+        );
     }
 
     @Override

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/rest/action/RestExecuteWatchAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/rest/action/RestExecuteWatchAction.java
@@ -11,6 +11,7 @@ import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.RestApiVersion;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -51,10 +52,15 @@ public class RestExecuteWatchAction extends BaseRestHandler implements RestReque
     @Override
     public List<Route> routes() {
         return List.of(
-            new Route(POST, "/_watcher/watch/{id}/_execute"),
-            new Route(PUT, "/_watcher/watch/{id}/_execute"),
-            new Route(POST, "/_watcher/watch/_execute"),
-            new Route(PUT, "/_watcher/watch/_execute"));
+            Route.builder(POST, "/_watcher/watch/{id}/_execute")
+                .replaces(POST, "/_xpack/watcher/watch/{id}/_execute", RestApiVersion.V_7).build(),
+            Route.builder(PUT, "/_watcher/watch/{id}/_execute")
+                .replaces(PUT, "/_xpack/watcher/watch/{id}/_execute", RestApiVersion.V_7).build(),
+            Route.builder(POST, "/_watcher/watch/_execute")
+                .replaces(POST, "/_xpack/watcher/watch/_execute", RestApiVersion.V_7).build(),
+            Route.builder(PUT, "/_watcher/watch/_execute")
+                .replaces(PUT, "/_xpack/watcher/watch/_execute", RestApiVersion.V_7).build()
+        );
     }
 
     @Override

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/rest/action/RestGetWatchAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/rest/action/RestGetWatchAction.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.watcher.rest.action;
 
 import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.RestApiVersion;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.BytesRestResponse;
@@ -29,7 +30,10 @@ public class RestGetWatchAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return List.of(new Route(GET, "/_watcher/watch/{id}"));
+        return List.of(
+            Route.builder(GET, "/_watcher/watch/{id}")
+                .replaces(GET, "/_xpack/watcher/watch/{id}", RestApiVersion.V_7).build()
+        );
     }
 
     @Override

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/rest/action/RestPutWatchAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/rest/action/RestPutWatchAction.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.watcher.rest.action;
 
 import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.RestApiVersion;
 import org.elasticsearch.common.lucene.uid.Versions;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -36,8 +37,11 @@ public class RestPutWatchAction extends BaseRestHandler implements RestRequestFi
     @Override
     public List<Route> routes() {
         return List.of(
-            new Route(POST, "/_watcher/watch/{id}"),
-            new Route(PUT, "/_watcher/watch/{id}"));
+            Route.builder(POST, "/_watcher/watch/{id}")
+                .replaces(POST, "/_xpack/watcher/watch/{id}", RestApiVersion.V_7).build(),
+            Route.builder(PUT, "/_watcher/watch/{id}")
+                .replaces(PUT, "/_xpack/watcher/watch/{id}", RestApiVersion.V_7).build()
+        );
     }
 
     @Override

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/rest/action/RestWatchServiceAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/rest/action/RestWatchServiceAction.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.watcher.rest.action;
 
 import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.RestApiVersion;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
@@ -22,7 +23,10 @@ public class RestWatchServiceAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return List.of(new Route(POST, "/_watcher/_start"));
+        return List.of(
+            Route.builder(POST, "/_watcher/_start")
+                .replaces(POST, "/_xpack/watcher/_start", RestApiVersion.V_7).build()
+        );
     }
 
     @Override
@@ -40,7 +44,10 @@ public class RestWatchServiceAction extends BaseRestHandler {
 
         @Override
         public List<Route> routes() {
-            return List.of(new Route(POST, "/_watcher/_stop"));
+            return List.of(
+                Route.builder(POST, "/_watcher/_stop")
+                    .replaces(POST, "/_xpack/watcher/_stop", RestApiVersion.V_7).build()
+            );
         }
 
         @Override

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/rest/action/RestWatcherStatsAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/rest/action/RestWatcherStatsAction.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.watcher.rest.action;
 
 import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.RestApiVersion;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
@@ -29,8 +30,11 @@ public class RestWatcherStatsAction extends BaseRestHandler {
     @Override
     public List<Route> routes() {
         return List.of(
-            new Route(GET, "/_watcher/stats"),
-            new Route(GET, "/_watcher/stats/{metric}"));
+            Route.builder(GET, "/_watcher/stats")
+                .replaces(GET, "/_xpack/watcher/stats", RestApiVersion.V_7).build(),
+            Route.builder(GET, "/_watcher/stats/{metric}")
+                .replaces(GET, "/_xpack/watcher/stats/{metric}", RestApiVersion.V_7).build()
+        );
     }
 
     @Override


### PR DESCRIPTION
Related to #51816 / #68905.

Adds back the `_xpack/watcher` routes when using rest compatibility for a request.

```
# no change here
joegallo@galactic:~/Code/elastic/elasticsearch $ curl http://localhost:9200/_watcher/stats
{"_nodes":{"total":1,"successful":1,"failed":0},"cluster_name":"runTask","manually_stopped":false,"stats":[{"node_id":"oPIII6_ZS4eP9-wUj3l8NA","watcher_state":"started","watch_count":0,"execution_thread_pool":{"queue_size":0,"max_size":0}}]}%

# _xpack/watcher doesn't exist
joegallo@galactic:~/Code/elastic/elasticsearch $ curl http://localhost:9200/_xpack/watcher/stats
{"error":"no handler found for uri [/_xpack/watcher/stats] and method [GET]"}%

# unless...
joegallo@galactic:~/Code/elastic/elasticsearch $ curl -H'accept:application/json;compatible-with=7' http://localhost:9200/_xpack/watcher/stats
{"_nodes":{"total":1,"successful":1,"failed":0},"cluster_name":"runTask","manually_stopped":false,"stats":[{"node_id":"oPIII6_ZS4eP9-wUj3l8NA","watcher_state":"started","watch_count":0,"execution_thread_pool":{"queue_size":0,"max_size":0}}]}%
```