### PR TITLE
Fix overlapping task outputs with test-with-dep gradle plugin

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/TestWithDependenciesPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/TestWithDependenciesPlugin.java
@@ -53,7 +53,7 @@ public class TestWithDependenciesPlugin implements Plugin<Project> {
     }
 
     private static void addPluginResources(final Project project, final Project pluginProject) {
-        final File outputDir = new File(project.getBuildDir(), "/generated-resources/" + pluginProject.getName());
+        final File outputDir = new File(project.getBuildDir(), "/generated-test-resources/" + pluginProject.getName());
         String camelProjectName = stream(pluginProject.getName().split("-")).map(t -> StringUtils.capitalize(t))
             .collect(Collectors.joining());
         String taskName = "copy" + camelProjectName + "Metadata";


### PR DESCRIPTION
The test-with-dependencies gradle plugin copies test dependencies
into build/generated-resources. This folder is also the output directory
of the `pluginProperties` task of the plugin build plugin. 

These overlapping outputs folders result in 

a) falsely added test dependency metadata in the `bundlePlugin` of the plugin
b) build failures due to deprecation warning with Gradle >= 7.0 due to 
implicit task output usage in `bundlePlugin` task when running bundlePlugin
in combination with test tasks of that project

The fix is simply to use a different output folder for copied test dependencies