### PR TITLE
Suppress illegal reflective access in shared cache

### DIFF
--- a/distribution/src/config/jvm.options
+++ b/distribution/src/config/jvm.options
@@ -79,3 +79,7 @@ ${error.file}
 
 ## GC logging
 -Xlog:gc*,gc+age=trace,safepoint:file=${loggc}:utctime,pid,tags:filecount=32,filesize=64m
+
+# temporarily suppress illegal reflective access in searchable snapshots shared
+# cache preallocation; this is temporary while we explore alternatives
+--add-opens=java.base/java.io=ALL-UNNAMED

--- a/distribution/src/config/jvm.options
+++ b/distribution/src/config/jvm.options
@@ -79,7 +79,3 @@ ${error.file}
 
 ## GC logging
 -Xlog:gc*,gc+age=trace,safepoint:file=${loggc}:utctime,pid,tags:filecount=32,filesize=64m
-
-# temporarily suppress illegal reflective access in searchable snapshots shared
-# cache preallocation; this is temporary while we explore alternatives
---add-opens=java.base/java.io=ALL-UNNAMED

--- a/distribution/tools/launchers/src/main/java/org/elasticsearch/tools/launchers/SystemJvmOptions.java
+++ b/distribution/tools/launchers/src/main/java/org/elasticsearch/tools/launchers/SystemJvmOptions.java
@@ -56,7 +56,14 @@ final class SystemJvmOptions {
              * Due to internationalization enhancements in JDK 9 Elasticsearch need to set the provider to COMPAT otherwise time/date
              * parsing will break in an incompatible way for some date patterns and locales.
              */
-            "-Djava.locale.providers=SPI,COMPAT"
+            "-Djava.locale.providers=SPI,COMPAT",
+            /*
+             * Temporarily suppress illegal reflective access in searchable snapshots shared cache preallocation; this is temporary while we
+             * explore alternatives. See org.elasticsearch.xpack.searchablesnapshots.preallocate.Preallocate.
+             *
+             * TODO: either modularlize Elasticsearch so that we can limit the opening of this module, or find an alternative
+             */
+            "--add-opens=java.base/java.io=ALL-UNNAMED"
         ).stream().filter(e -> e.isEmpty() == false).collect(Collectors.toList());
     }
 


### PR DESCRIPTION
This commit temporarily supressess an illegal reflective access warning by opening the java.io module to all unnamed modules. This is needed when using the searchable snapshots shared cache due to some reflective access that occurs there. This is temporary while we explore alternatives.

Relates #70285