### PR TITLE
Fix HLRC MigrateAction equals

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ilm/MigrateAction.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ilm/MigrateAction.java
@@ -56,6 +56,10 @@ public class MigrateAction implements LifecycleAction, ToXContentObject {
         return NAME;
     }
 
+    boolean isEnabled() {
+        return enabled;
+    }
+
     @Override
     public int hashCode() {
         return Objects.hashCode(enabled);
@@ -69,7 +73,7 @@ public class MigrateAction implements LifecycleAction, ToXContentObject {
         if (obj.getClass() != getClass()) {
             return false;
         }
-        return true;
+        return enabled == ((MigrateAction) obj).enabled;
     }
 
     @Override

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ilm/MigrateActionTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ilm/MigrateActionTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.client.ilm;
 
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.test.AbstractXContentTestCase;
+import org.elasticsearch.test.EqualsHashCodeTestUtils;
 
 import java.io.IOException;
 
@@ -31,5 +32,11 @@ public class MigrateActionTests extends AbstractXContentTestCase<MigrateAction> 
     @Override
     protected boolean supportsUnknownFields() {
         return false;
+    }
+
+    public void testEqualsHashCode() {
+        EqualsHashCodeTestUtils.checkEqualsAndHashCode(createTestInstance(),
+            m -> new MigrateAction(m.isEnabled()),
+            m -> new MigrateAction(m.isEnabled() == false));
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/MigrateActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/MigrateActionTests.java
@@ -42,7 +42,12 @@ public class MigrateActionTests extends AbstractActionTestCase<MigrateAction> {
 
     @Override
     protected MigrateAction createTestInstance() {
-        return new MigrateAction();
+        return new MigrateAction(randomBoolean());
+    }
+
+    @Override
+    protected MigrateAction mutateInstance(MigrateAction instance) throws IOException {
+        return new MigrateAction(instance.isEnabled() == false);
     }
 
     @Override


### PR DESCRIPTION
HLRC MigrateAction.equals did not consider the `enabled` flag, fixed
