### PR TITLE
Make ActionListener.wrap(Runnable) more Predictable

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/ActionListener.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionListener.java
@@ -232,7 +232,33 @@ public interface ActionListener<Response> {
      * @return a listener that listens for responses and invokes the runnable when received
      */
     static <Response> ActionListener<Response> wrap(Runnable runnable) {
-        return wrap(r -> runnable.run(), e -> runnable.run());
+        return new ActionListener<>() {
+            @Override
+            public void onResponse(Response response) {
+                try {
+                    runnable.run();
+                } catch (Exception e) {
+                    assert false : e;
+                    throw e;
+                }
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                try {
+                    runnable.run();
+                } catch (Exception ex) {
+                    ex.addSuppressed(e);
+                    assert false : ex;
+                    throw ex;
+                }
+            }
+
+            @Override
+            public String toString() {
+                return "RunnableWrappingActionListener{" + runnable + "}";
+            }
+        };
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/ActionListener.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionListener.java
@@ -237,7 +237,7 @@ public interface ActionListener<Response> {
             public void onResponse(Response response) {
                 try {
                     runnable.run();
-                } catch (Exception e) {
+                } catch (RuntimeException e) {
                     assert false : e;
                     throw e;
                 }
@@ -247,7 +247,7 @@ public interface ActionListener<Response> {
             public void onFailure(Exception e) {
                 try {
                     runnable.run();
-                } catch (Exception ex) {
+                } catch (RuntimeException ex) {
                     ex.addSuppressed(e);
                     assert false : ex;
                     throw ex;


### PR DESCRIPTION
The current implementation behaved in a non-obvious manner.
If the runnable throws but is executed in `onResponse` then it will
actually be executed twice and the exception be lost.
This means that the exception during the first call will simply be quietly swallowed.
in case the runnable (as is often the case) is a `RunOnce` or similar, where the second
execution in `onFailure` is a noop this means any exception is completely swallowed.

Mainly motivated by how tricky it was to reason through possible failure modes in resource releasing around the searchable snapshots cache.

Relates efforts like #69420