### PR TITLE
[ML] Prevent node potentially going out of memory due to loading quantiles

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetModelSnapshotsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetModelSnapshotsAction.java
@@ -17,12 +17,8 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.ml.action.GetModelSnapshotsAction;
-import org.elasticsearch.xpack.core.action.util.QueryPage;
-import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSnapshot;
 import org.elasticsearch.xpack.ml.job.JobManager;
 import org.elasticsearch.xpack.ml.job.persistence.JobResultsProvider;
-
-import java.util.stream.Collectors;
 
 public class TransportGetModelSnapshotsAction extends HandledTransportAction<GetModelSnapshotsAction.Request,
         GetModelSnapshotsAction.Response> {
@@ -74,16 +70,7 @@ public class TransportGetModelSnapshotsAction extends HandledTransportAction<Get
             request.getSort(),
             request.getDescOrder(),
             request.getSnapshotId(),
-            page -> listener.onResponse(new GetModelSnapshotsAction.Response(clearQuantiles(page))),
+            page -> listener.onResponse(new GetModelSnapshotsAction.Response(page)),
             listener::onFailure);
-    }
-
-    public static QueryPage<ModelSnapshot> clearQuantiles(QueryPage<ModelSnapshot> page) {
-        if (page.results() == null) {
-            return page;
-        }
-        return new QueryPage<>(page.results().stream().map(snapshot ->
-                new ModelSnapshot.Builder(snapshot).setQuantiles(null).build())
-                .collect(Collectors.toList()), page.count(), page.getResultsField());
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/modelsnapshots/GetModelSnapshotsTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/modelsnapshots/GetModelSnapshotsTests.java
@@ -6,17 +6,9 @@
  */
 package org.elasticsearch.xpack.ml.modelsnapshots;
 
-import org.elasticsearch.common.ParseField;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xpack.core.ml.action.GetModelSnapshotsAction;
-import org.elasticsearch.xpack.ml.action.TransportGetModelSnapshotsAction;
 import org.elasticsearch.xpack.core.action.util.PageParams;
-import org.elasticsearch.xpack.core.action.util.QueryPage;
-import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSnapshot;
-import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.Quantiles;
-
-import java.util.Arrays;
-import java.util.Date;
+import org.elasticsearch.xpack.core.ml.action.GetModelSnapshotsAction;
 
 public class GetModelSnapshotsTests extends ESTestCase {
 
@@ -30,18 +22,5 @@ public class GetModelSnapshotsTests extends ESTestCase {
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
                 () -> new GetModelSnapshotsAction.Request("foo", null).setPageParams(new PageParams(10, -5)));
         assertEquals("Parameter [size] cannot be < 0", e.getMessage());
-    }
-
-    public void testModelSnapshots_clearQuantiles() {
-        ModelSnapshot m1 = new ModelSnapshot.Builder("jobId").setQuantiles(
-                new Quantiles("jobId", new Date(), "quantileState")).build();
-        ModelSnapshot m2 = new ModelSnapshot.Builder("jobId").build();
-
-        QueryPage<ModelSnapshot> page = new QueryPage<>(Arrays.asList(m1, m2), 2, new ParseField("field"));
-        page = TransportGetModelSnapshotsAction.clearQuantiles(page);
-        assertEquals(2, page.results().size());
-        for (ModelSnapshot modelSnapshot : page.results()) {
-            assertNull(modelSnapshot.getQuantiles());
-        }
     }
 }


### PR DESCRIPTION
Large jobs with lots of partitions can get very big, retrieving snapshots
for such a job can cause a node to go out of memory.

With this change do not fetch quantiles when querying for (multiple) 
modelSnapshots to avoid memory overhead. Quantiles aren't needed for
the API's using `JobResultsProvider.modelSnapshots(...)`

fixes #70372