### PR TITLE
[7.x][ML] Prevent node potentially going out of memory due to loading quantiles 

### DIFF
--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/JobResultsProviderIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/JobResultsProviderIT.java
@@ -654,19 +654,23 @@ public class JobResultsProviderIT extends MlSingleNodeTestCase {
         indexModelSnapshot(new ModelSnapshot.Builder(jobId).setSnapshotId("snap_2")
             .setTimestamp(Date.from(Instant.ofEpochMilli(10)))
             .setMinVersion(Version.V_7_4_0)
+            .setQuantiles(new Quantiles(jobId, Date.from(Instant.ofEpochMilli(10)), randomAlphaOfLength(20)))
             .build());
         indexModelSnapshot(new ModelSnapshot.Builder(jobId).setSnapshotId("snap_1")
             .setTimestamp(Date.from(Instant.ofEpochMilli(11)))
             .setMinVersion(Version.V_7_2_0)
+            .setQuantiles(new Quantiles(jobId, Date.from(Instant.ofEpochMilli(11)), randomAlphaOfLength(20)))
             .build());
         indexModelSnapshot(new ModelSnapshot.Builder(jobId).setSnapshotId("other_snap")
             .setTimestamp(Date.from(Instant.ofEpochMilli(12)))
             .setMinVersion(Version.V_7_3_0)
+            .setQuantiles(new Quantiles(jobId, Date.from(Instant.ofEpochMilli(12)), randomAlphaOfLength(20)))
             .build());
         createJob("other_job");
         indexModelSnapshot(new ModelSnapshot.Builder("other_job").setSnapshotId("other_snap")
             .setTimestamp(Date.from(Instant.ofEpochMilli(10)))
             .setMinVersion(Version.V_7_9_0)
+            .setQuantiles(new Quantiles("other_job", Date.from(Instant.ofEpochMilli(10)), randomAlphaOfLength(20)))
             .build());
         // Add a snapshot WITHOUT a min version.
         client().prepareIndex(AnomalyDetectorsIndex.jobResultsAliasedName("other_job"), MapperService.SINGLE_MAPPING_NAME)
@@ -682,13 +686,17 @@ public class JobResultsProviderIT extends MlSingleNodeTestCase {
         jobProvider.modelSnapshots(jobId, 0, 4, "9", "15", "", false, "snap_2,snap_1", future::onResponse, future::onFailure);
         List<ModelSnapshot> snapshots = future.actionGet().results();
         assertThat(snapshots.get(0).getSnapshotId(), equalTo("snap_2"));
+        assertNull(snapshots.get(0).getQuantiles());
         assertThat(snapshots.get(1).getSnapshotId(), equalTo("snap_1"));
+        assertNull(snapshots.get(1).getQuantiles());
 
         future = new PlainActionFuture<>();
         jobProvider.modelSnapshots(jobId, 0, 4, "9", "15", "", false, "snap_*", future::onResponse, future::onFailure);
         snapshots = future.actionGet().results();
         assertThat(snapshots.get(0).getSnapshotId(), equalTo("snap_2"));
         assertThat(snapshots.get(1).getSnapshotId(), equalTo("snap_1"));
+        assertNull(snapshots.get(0).getQuantiles());
+        assertNull(snapshots.get(1).getQuantiles());
 
         future = new PlainActionFuture<>();
         jobProvider.modelSnapshots(jobId, 0, 4, "9", "15", "", false, "snap_*,other_snap", future::onResponse, future::onFailure);
@@ -721,6 +729,14 @@ public class JobResultsProviderIT extends MlSingleNodeTestCase {
         assertThat(snapshots.get(2).getSnapshotId(), equalTo("other_snap"));
         assertThat(snapshots.get(3).getSnapshotId(), equalTo("snap_2"));
         assertThat(snapshots.get(4).getSnapshotId(), equalTo("other_snap"));
+
+        // assert that quantiles are not loaded
+        assertNull(snapshots.get(0).getQuantiles());
+        assertNull(snapshots.get(1).getQuantiles());
+        assertNull(snapshots.get(2).getQuantiles());
+        assertNull(snapshots.get(3).getQuantiles());
+        assertNull(snapshots.get(4).getQuantiles());
+
     }
 
     public void testGetAutodetectParams() throws Exception {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetModelSnapshotsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetModelSnapshotsAction.java
@@ -17,12 +17,8 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.ml.action.GetModelSnapshotsAction;
-import org.elasticsearch.xpack.core.action.util.QueryPage;
-import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSnapshot;
 import org.elasticsearch.xpack.ml.job.JobManager;
 import org.elasticsearch.xpack.ml.job.persistence.JobResultsProvider;
-
-import java.util.stream.Collectors;
 
 public class TransportGetModelSnapshotsAction extends HandledTransportAction<GetModelSnapshotsAction.Request,
         GetModelSnapshotsAction.Response> {
@@ -74,16 +70,7 @@ public class TransportGetModelSnapshotsAction extends HandledTransportAction<Get
             request.getSort(),
             request.getDescOrder(),
             request.getSnapshotId(),
-            page -> listener.onResponse(new GetModelSnapshotsAction.Response(clearQuantiles(page))),
+            page -> listener.onResponse(new GetModelSnapshotsAction.Response(page)),
             listener::onFailure);
-    }
-
-    public static QueryPage<ModelSnapshot> clearQuantiles(QueryPage<ModelSnapshot> page) {
-        if (page.results() == null) {
-            return page;
-        }
-        return new QueryPage<>(page.results().stream().map(snapshot ->
-                new ModelSnapshot.Builder(snapshot).setQuantiles(null).build())
-                .collect(Collectors.toList()), page.count(), page.getResultsField());
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/modelsnapshots/GetModelSnapshotsTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/modelsnapshots/GetModelSnapshotsTests.java
@@ -6,17 +6,9 @@
  */
 package org.elasticsearch.xpack.ml.modelsnapshots;
 
-import org.elasticsearch.common.ParseField;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xpack.core.ml.action.GetModelSnapshotsAction;
-import org.elasticsearch.xpack.ml.action.TransportGetModelSnapshotsAction;
 import org.elasticsearch.xpack.core.action.util.PageParams;
-import org.elasticsearch.xpack.core.action.util.QueryPage;
-import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSnapshot;
-import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.Quantiles;
-
-import java.util.Arrays;
-import java.util.Date;
+import org.elasticsearch.xpack.core.ml.action.GetModelSnapshotsAction;
 
 public class GetModelSnapshotsTests extends ESTestCase {
 
@@ -30,18 +22,5 @@ public class GetModelSnapshotsTests extends ESTestCase {
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
                 () -> new GetModelSnapshotsAction.Request("foo", null).setPageParams(new PageParams(10, -5)));
         assertEquals("Parameter [size] cannot be < 0", e.getMessage());
-    }
-
-    public void testModelSnapshots_clearQuantiles() {
-        ModelSnapshot m1 = new ModelSnapshot.Builder("jobId").setQuantiles(
-                new Quantiles("jobId", new Date(), "quantileState")).build();
-        ModelSnapshot m2 = new ModelSnapshot.Builder("jobId").build();
-
-        QueryPage<ModelSnapshot> page = new QueryPage<>(Arrays.asList(m1, m2), 2, new ParseField("field"));
-        page = TransportGetModelSnapshotsAction.clearQuantiles(page);
-        assertEquals(2, page.results().size());
-        for (ModelSnapshot modelSnapshot : page.results()) {
-            assertNull(modelSnapshot.getQuantiles());
-        }
     }
 }


### PR DESCRIPTION
Large jobs with lots of partitions can get very big, retrieving snapshots
for such a job can cause a node to go out of memory.

With this change do not fetch quantiles when querying for (multiple)
modelSnapshots to avoid memory overhead. Quantiles aren't needed for
the API's using JobResultsProvider.modelSnapshots(...)

fixes #70372
backport #70376