### PR TITLE
[7.12] [DOCS] Fix URI processor title (#66068)

### DIFF
--- a/docs/reference/ingest/processors/uri-parts.asciidoc
+++ b/docs/reference/ingest/processors/uri-parts.asciidoc
@@ -3,7 +3,7 @@
 [[uri-parts-processor]]
 === URI parts processor
 ++++
-<titleabbrev>URI Parts</titleabbrev>
+<titleabbrev>URI parts</titleabbrev>
 ++++
 
 Parses a Uniform Resource Identifier (URI) string and extracts its components as


### PR DESCRIPTION
Backports the following commits to 7.12:
 - [DOCS] Fix URI processor title (#66068)