### PR TITLE
[7.12] [DOCS] Replace version-specific links in release highlights (#70317)

### DIFF
--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -4,11 +4,9 @@
 coming[{minor-version}]
 
 Here are the highlights of what's new and improved in {es} {minor-version}!
-ifeval::["{release-state}"!="unreleased"]
-For detailed information about this release, see the
-<<release-notes-{elasticsearch_version}, Release notes >> and
-<<breaking-changes-{minor-version}, Breaking changes>>.
-endif::[]
+
+For detailed information about this release, see the <<es-release-notes>> and
+<<breaking-changes>>.
 
 // Add previous release to the list
 Other versions:


### PR DESCRIPTION
Backports the following commits to 7.12:
 - [DOCS] Replace version-specific links in release highlights (#70317)