### PR TITLE
SQL: Removed the always on total hit tracking (#70319)

### DIFF
--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/Querier.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/Querier.java
@@ -144,7 +144,6 @@ public class Querier {
 
     public static SearchRequest prepareRequest(Client client, SearchSourceBuilder source, TimeValue timeout, boolean includeFrozen,
             String... indices) {
-        source.trackTotalHits(true);
         source.timeout(timeout);
 
         SearchRequest searchRequest = new SearchRequest(SWITCH_TO_FIELDS_API_VERSION);


### PR DESCRIPTION
If the query uses `COUNT(*)` the total hits are automatically tracked:
https://github.com/elastic/elasticsearch/blob/a92a647b9f17d1bddf5c707490a19482c273eda3/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/planner/QueryFolder.java#L639

Otherwise, the `track_total_hits` is only useful for scrolling.

If the query is translated to:
- a scroll query (all the non-agg only queries), ES will automatically provide accurate total hits
without us having to flip the `track_total_hits`
- agg-only query, the `track_total_hits` does not affect these queries (implicit group by (result 
is single record) or composite aggregation), it can only affect document search hits

See translation at: https://github.com/elastic/elasticsearch/blob/ee5cc5442a8e01d7d8fa426748d0b086959bf99d/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/Querier.java#L130

Closes #52787