### PR TITLE
[7.x] [DOCS] Document `*` path parameter for security cache APIs (#70081)

### DIFF
--- a/x-pack/docs/en/rest-api/security/clear-api-key-cache.asciidoc
+++ b/x-pack/docs/en/rest-api/security/clear-api-key-cache.asciidoc
@@ -28,8 +28,10 @@ For more information about API keys, see <<security-api-create-api-key>>,
 [[security-api-clear-api-key-cache-path-params]]
 ==== {api-path-parms-title}
 
-`ids`::
-(string) comma separated list of API key IDs. If empty, all keys are evicted from the cache.
+`<ids>`::
+(Required, string)
+Comma-separated list of API key IDs to evict from the API key cache. To evict
+all API keys, use `*`. Does not support other wildcard patterns.
 
 [[security-api-clear-api-key-cache-example]]
 ==== {api-examples-title}
@@ -41,3 +43,17 @@ For example, to clear the entry of API key with ID `yVGMr3QByxdh1MSaicYx`.
 --------------------------------------------------
 POST /_security/api_key/yVGMr3QByxdh1MSaicYx/_clear_cache
 --------------------------------------------------
+
+Specify multiple API keys as a comma-separated list.
+
+[source,console]
+----
+POST /_security/api_key/yVGMr3QByxdh1MSaicYx,YoiMaqREw0YVpjn40iMg/_clear_cache
+----
+
+To clear all entries from the API key cache, use `*`.
+
+[source,console]
+----
+POST /_security/api_key/*/_clear_cache
+----

--- a/x-pack/docs/en/rest-api/security/clear-cache.asciidoc
+++ b/x-pack/docs/en/rest-api/security/clear-cache.asciidoc
@@ -35,8 +35,10 @@ To evict API keys from the API key cache, see the
 [[security-api-clear-path-params]]
 ==== {api-path-parms-title}
 
-`realms`::
-  (Required, list) A comma-separated list of the realms to clear.
+`<realms>`::
+(Required, string)
+Comma-separated list of realms to clear. To clear all realms, use `*`. Does not
+support other wildcard patterns.
 
 `usernames`::
   (Optional, list) A comma-separated list of the users to clear from the cache.
@@ -67,3 +69,10 @@ list:
 ------------------------------------------------------------
 POST /_security/realm/default_file,ldap1/_clear_cache
 ------------------------------------------------------------
+
+To clear the caches for all realms, use `*`.
+
+[source,console]
+----
+POST /_security/realm/*/_clear_cache
+----

--- a/x-pack/docs/en/rest-api/security/clear-privileges-cache.asciidoc
+++ b/x-pack/docs/en/rest-api/security/clear-privileges-cache.asciidoc
@@ -11,7 +11,7 @@ The cache is also automatically cleared for applications that have their privile
 [[security-api-clear-privilege-cache-request]]
 ==== {api-request-title}
 
-`POST /_security/privilege/<application>/_clear_cache`
+`POST /_security/privilege/<applications>/_clear_cache`
 
 [[security-api-clear-privilege-cache-prereqs]]
 ==== {api-prereq-title}
@@ -28,8 +28,10 @@ For more information about the native realm, see
 [[security-api-clear-privilege-cache-path-params]]
 ==== {api-path-parms-title}
 
-`application`::
-  (string) The name of the application. If omitted, all entries are evicted from the cache.
+`<applications>`::
+(Required, string)
+Comma-separated list of applications to clear. To clear all applications, use
+`*`. Does not support other wildcard patterns.
 
 [[security-api-clear-privilege-cache-example]]
 ==== {api-examples-title}
@@ -41,3 +43,17 @@ For example, to clear the cache for `myapp`:
 --------------------------------------------------
 POST /_security/privilege/myapp/_clear_cache
 --------------------------------------------------
+
+Specify multiple applications as a comma-separated list.
+
+[source,console]
+--------------------------------------------------
+POST /_security/privilege/myapp,my-other-app/_clear_cache
+--------------------------------------------------
+
+To clear the cache for all applications, use `*`.
+
+[source,console]
+----
+POST /_security/privilege/*/_clear_cache
+----

--- a/x-pack/docs/en/rest-api/security/clear-roles-cache.asciidoc
+++ b/x-pack/docs/en/rest-api/security/clear-roles-cache.asciidoc
@@ -10,7 +10,7 @@ Evicts roles from the native role cache.
 [[security-api-clear-role-cache-request]]
 ==== {api-request-title}
 
-`POST /_security/role/<name>/_clear_cache` 
+`POST /_security/role/<roles>/_clear_cache` 
 
 [[security-api-clear-role-cache-prereqs]]
 ==== {api-prereq-title}
@@ -27,8 +27,10 @@ For more information about the native realm, see
 [[security-api-clear-role-cache-path-params]]
 ==== {api-path-parms-title}
 
-`name`::
-  (string) The name of the role. 
+`<roles>`::
+(Required, string)
+Comma-separated list of roles to evict from the role cache. To evict all
+roles, use `*`. Does not support other wildcard patterns.
 
 [[security-api-clear-role-cache-example]]
 ==== {api-examples-title}
@@ -40,3 +42,17 @@ to clear the cache for `my_admin_role`:
 --------------------------------------------------
 POST /_security/role/my_admin_role/_clear_cache
 --------------------------------------------------
+
+Specify multiple roles as a comma-separated list.
+
+[source,console]
+----
+POST /_security/role/my_admin_role,my_test_role/_clear_cache
+----
+
+To clear all roles from the cache, use `*`.
+
+[source,console]
+----
+POST /_security/role/*/_clear_cache
+----


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Document `*` path parameter for security cache APIs (#70081)