### PR TITLE
Filter unsupported BWC tasks on ARM

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/BwcVersions.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/BwcVersions.java
@@ -169,12 +169,13 @@ public class BwcVersions {
     }
 
     public void forPreviousUnreleased(Consumer<UnreleasedVersionInfo> consumer) {
-        List<UnreleasedVersionInfo> collect = getUnreleased().stream()
-            .filter(version -> version.equals(currentVersion) == false)
+        List<UnreleasedVersionInfo> collect = filterSupportedVersions(
+            getUnreleased().stream().filter(version -> version.equals(currentVersion) == false).collect(Collectors.toList())
+        ).stream()
             .map(version -> new UnreleasedVersionInfo(version, getBranchFor(version), getGradleProjectPathFor(version)))
             .collect(Collectors.toList());
 
-        collect.forEach(uvi -> consumer.accept(uvi));
+        collect.forEach(consumer::accept);
     }
 
     private String getGradleProjectPathFor(Version version) {


### PR DESCRIPTION
We are only supporting BWC testing for ARM back to 7.12. We filter out earlier versions in various places but not others. This pull request filters these out for other purposes as well, such as building BWC tasks used for resolving dependencies that is leveraged by our `packer_cache.sh` script.