### PR TITLE
Serialize nested BWC build tasks

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/internal/BwcSetupExtension.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/internal/BwcSetupExtension.java
@@ -37,17 +37,20 @@ public class BwcSetupExtension {
 
     private static final String MINIMUM_COMPILER_VERSION_PATH = "buildSrc/src/main/resources/minimumCompilerVersion";
     private final Project project;
-
     private final Provider<BwcVersions.UnreleasedVersionInfo> unreleasedVersionInfo;
+    private final Provider<InternalDistributionBwcSetupPlugin.BwcTaskThrottle> bwcTaskThrottleProvider;
+
     private Provider<File> checkoutDir;
 
     public BwcSetupExtension(
         Project project,
         Provider<BwcVersions.UnreleasedVersionInfo> unreleasedVersionInfo,
+        Provider<InternalDistributionBwcSetupPlugin.BwcTaskThrottle> bwcTaskThrottleProvider,
         Provider<File> checkoutDir
     ) {
         this.project = project;
         this.unreleasedVersionInfo = unreleasedVersionInfo;
+        this.bwcTaskThrottleProvider = bwcTaskThrottleProvider;
         this.checkoutDir = checkoutDir;
     }
 
@@ -58,6 +61,7 @@ public class BwcSetupExtension {
     private TaskProvider<LoggedExec> createRunBwcGradleTask(Project project, String name, Action<LoggedExec> configAction) {
         return project.getTasks().register(name, LoggedExec.class, loggedExec -> {
             loggedExec.dependsOn("checkoutBwcBranch");
+            loggedExec.usesService(bwcTaskThrottleProvider);
             loggedExec.setSpoolOutput(true);
             loggedExec.setWorkingDir(checkoutDir.get());
             loggedExec.doFirst(t -> {

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
@@ -205,7 +205,7 @@ public class InternalDistributionBwcSetupPlugin implements InternalPlugin {
     private static String buildBwcTaskName(String projectName) {
         return "buildBwc"
             + stream(projectName.split("-")).map(i -> i.substring(0, 1).toUpperCase(Locale.ROOT) + i.substring(1))
-            .collect(Collectors.joining());
+                .collect(Collectors.joining());
     }
 
     static void createBuildBwcTask(
@@ -312,6 +312,5 @@ public class InternalDistributionBwcSetupPlugin implements InternalPlugin {
         }
     }
 
-    public abstract class BwcTaskThrottle implements BuildService<BuildServiceParameters.None> {
-    }
+    public abstract class BwcTaskThrottle implements BuildService<BuildServiceParameters.None> {}
 }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
@@ -12,7 +12,6 @@ import org.elasticsearch.gradle.BwcVersions;
 import org.elasticsearch.gradle.Version;
 import org.elasticsearch.gradle.info.BuildParams;
 import org.elasticsearch.gradle.info.GlobalBuildInfoPlugin;
-import org.elasticsearch.gradle.util.GradleUtils;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
@@ -32,7 +31,6 @@ import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
 import static java.util.Arrays.stream;
-import static org.elasticsearch.gradle.util.GradleUtils.noop;
 
 /**
  * We want to be able to do BWC tests for unreleased versions without relying on and waiting for snapshots.


### PR DESCRIPTION
We've observed weird lock contention issues in builds that run "nested" builds on BWC branches. It's not clear why Gradle isn't able to handle this level or parallelism but for now to workaround this issue we should simply serialize these tasks so we aren't trying to run 4 Gradle builds all using max-workers concurrently. In practice this should actually _improve_ build times as the current situation has many builds _stalled_ waiting for locks.

**Before (4m 37s):** https://gradle-enterprise.elastic.co/s/djjmnbku6vwpu/timeline
**After (46s):** https://gradle-enterprise.elastic.co/s/fheiegyw6tngy/timeline

Closes #70043