### PR TITLE
Fix skip test message in in parent agg test with sorting

### DIFF
--- a/modules/parent-join/src/yamlRestTest/resources/rest-api-spec/test/50_order_by.yml
+++ b/modules/parent-join/src/yamlRestTest/resources/rest-api-spec/test/50_order_by.yml
@@ -1,8 +1,8 @@
 ---
 "order by sub agg containing join":
   - skip:
-      reason: "It was fixed it 7.12.0"
-      version: " - 7.11.99"
+      reason: "https://github.com/elastic/elasticsearch/issues/66876"
+      version: "7.11.1 - "
   - do:
       indices.create:
           index: test_1
@@ -72,8 +72,8 @@
 ---
 "order by sub agg containing join and nested":
   - skip:
-      reason: "It was fixed it 7.12.0"
-      version: " - 7.11.99"
+      reason: "https://github.com/elastic/elasticsearch/issues/66876"
+      version: "7.11.1 - "
   - do:
       indices.create:
           index: test_1
@@ -152,8 +152,8 @@
 ---
 "order by sub agg containing join and nested and filter":
   - skip:
-      reason: "It was fixed it 7.12.0"
-      version: " - 7.11.99"
+      reason: "https://github.com/elastic/elasticsearch/issues/66876"
+      version: "7.11.1 - "
   - do:
       indices.create:
           index: test_1


### PR DESCRIPTION
I fat-fingered this change during 7.11 backport, these
tests shouldn't have been enabled since the key underlying
issue is still need to be fixed in #66876

Closes #70270
