### PR TITLE
[DOCS] More information on allowed profile names

### DIFF
--- a/docs/reference/modules/transport.asciidoc
+++ b/docs/reference/modules/transport.asciidoc
@@ -132,7 +132,8 @@ transport.profiles.dmz.bind_host: 172.16.1.2
 The `default` profile is special. It is used as a fallback for any other
 profiles, if those do not have a specific configuration setting set, and is how
 this node connects to other nodes in the cluster.
-All other profiles can have any name and are used to handle incomming connections.
+The other profiles can have any name, and can be used to set up specific 
+endpoints for incoming client connections.
 
 The following parameters can be configured on each transport profile, as in the
 example above:

--- a/docs/reference/modules/transport.asciidoc
+++ b/docs/reference/modules/transport.asciidoc
@@ -132,8 +132,8 @@ transport.profiles.dmz.bind_host: 172.16.1.2
 The `default` profile is special. It is used as a fallback for any other
 profiles, if those do not have a specific configuration setting set, and is how
 this node connects to other nodes in the cluster.
-The other profiles can have any name, and can be used to set up specific 
-endpoints for incoming client connections.
+Other profiles can have any name and can be used to set up specific endpoints
+for incoming connections.
 
 The following parameters can be configured on each transport profile, as in the
 example above:

--- a/docs/reference/modules/transport.asciidoc
+++ b/docs/reference/modules/transport.asciidoc
@@ -132,6 +132,7 @@ transport.profiles.dmz.bind_host: 172.16.1.2
 The `default` profile is special. It is used as a fallback for any other
 profiles, if those do not have a specific configuration setting set, and is how
 this node connects to other nodes in the cluster.
+All other profiles can have any name and are used to handle incomming connections.
 
 The following parameters can be configured on each transport profile, as in the
 example above:


### PR DESCRIPTION
I did not find it clear in the existing documentation that while the `default` profile is special, other profiles could have any name, and are used for incoming connections (as the `default` profile is used for inter-node communication). I hope with this additional line it is a bit clearer.
