### PR TITLE
Extend searchable snapshots feature usage stats

### DIFF
--- a/docs/reference/rest-api/usage.asciidoc
+++ b/docs/reference/rest-api/usage.asciidoc
@@ -293,7 +293,9 @@ GET /_xpack/usage
   "searchable_snapshots" : {
     "available" : true,
     "enabled" : true,
-    "indices_count" : 0
+    "indices_count" : 0,
+    "full_copy_indices_count" : 0,
+    "shared_cache_indices_count" : 0
   },
   "frozen_indices" : {
     "available" : true,

--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -112,6 +112,7 @@ testClusters.all {
   setting 'indices.lifecycle.history_index_enabled', 'false'
   keystore 'bootstrap.password', 'x-pack-test-password'
   keystore 'xpack.security.transport.ssl.secure_key_passphrase', 'testnode'
+  setting 'xpack.searchable.snapshot.shared_cache.size', '10mb'
 
   user username: "x_pack_rest_user", password: "x-pack-test-password"
   user username: "cat_test_user", password: "cat-test-password", role: "cat_test_role"

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/searchablesnapshots/SearchableSnapshotFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/searchablesnapshots/SearchableSnapshotFeatureSetUsage.java
@@ -64,7 +64,7 @@ public class SearchableSnapshotFeatureSetUsage extends XPackFeatureSet.Usage {
     protected void innerXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
         super.innerXContent(builder, params);
         builder.field("indices_count", numberOfSearchableSnapshotIndices);
-        builder.field("fully_copy_indices_count", numberOfFullCopySearchableSnapshotIndices);
+        builder.field("full_copy_indices_count", numberOfFullCopySearchableSnapshotIndices);
         builder.field("shared_cache_indices_count", numberOfSharedCacheSearchableSnapshotIndices);
     }
 
@@ -81,20 +81,25 @@ public class SearchableSnapshotFeatureSetUsage extends XPackFeatureSet.Usage {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        SearchableSnapshotFeatureSetUsage that = (SearchableSnapshotFeatureSetUsage) o;
-        return numberOfSearchableSnapshotIndices == that.numberOfSearchableSnapshotIndices &&
-            numberOfFullCopySearchableSnapshotIndices == that.numberOfFullCopySearchableSnapshotIndices &&
-            numberOfSharedCacheSearchableSnapshotIndices == that.numberOfSharedCacheSearchableSnapshotIndices;
-    }
-
-    @Override
     public int hashCode() {
-        return Objects.hash(numberOfSearchableSnapshotIndices, numberOfFullCopySearchableSnapshotIndices,
+        return Objects.hash(available, enabled, numberOfSearchableSnapshotIndices, numberOfFullCopySearchableSnapshotIndices,
             numberOfSharedCacheSearchableSnapshotIndices);
     }
 
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        SearchableSnapshotFeatureSetUsage other = (SearchableSnapshotFeatureSetUsage) obj;
+        return available == other.available &&
+            enabled == other.enabled &&
+            numberOfSearchableSnapshotIndices == other.numberOfSearchableSnapshotIndices &&
+            numberOfFullCopySearchableSnapshotIndices == other.numberOfFullCopySearchableSnapshotIndices &&
+            numberOfSharedCacheSearchableSnapshotIndices == other.numberOfSharedCacheSearchableSnapshotIndices;
+    }
 
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/searchablesnapshots/SearchableSnapshotsFeatureSetUsageTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/searchablesnapshots/SearchableSnapshotsFeatureSetUsageTests.java
@@ -16,24 +16,31 @@ public class SearchableSnapshotsFeatureSetUsageTests extends AbstractWireSeriali
     @Override
     protected SearchableSnapshotFeatureSetUsage createTestInstance() {
         boolean available = randomBoolean();
-        return new SearchableSnapshotFeatureSetUsage(available, randomIntBetween(0, 100000));
+        return new SearchableSnapshotFeatureSetUsage(available, randomIntBetween(0, 100000), randomIntBetween(0, 100000));
     }
 
     @Override
     protected SearchableSnapshotFeatureSetUsage mutateInstance(SearchableSnapshotFeatureSetUsage instance) throws IOException {
         boolean available = instance.available();
-        int numSearchableSnapshotIndices = instance.getNumberOfSearchableSnapshotIndices();
-        switch (between(0, 1)) {
+        int numFullCopySearchableSnapshotIndices = instance.getNumberOfFullCopySearchableSnapshotIndices();
+        int numSharedCacheSearchableSnapshotIndices = instance.getNumberOfSharedCacheSearchableSnapshotIndices();
+        switch (between(0, 2)) {
             case 0:
                 available = available == false;
                 break;
             case 1:
-                numSearchableSnapshotIndices = randomValueOtherThan(numSearchableSnapshotIndices, () -> randomIntBetween(0, 100000));
+                numFullCopySearchableSnapshotIndices = randomValueOtherThan(numFullCopySearchableSnapshotIndices,
+                    () -> randomIntBetween(0, 100000));
+                break;
+            case 2:
+                numSharedCacheSearchableSnapshotIndices = randomValueOtherThan(numSharedCacheSearchableSnapshotIndices,
+                    () -> randomIntBetween(0, 100000));
                 break;
             default:
                 throw new AssertionError("Illegal randomisation branch");
         }
-        return new SearchableSnapshotFeatureSetUsage(available, numSearchableSnapshotIndices);
+        return new SearchableSnapshotFeatureSetUsage(available, numFullCopySearchableSnapshotIndices,
+            numSharedCacheSearchableSnapshotIndices);
     }
 
     @Override

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsUsageTransportAction.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsUsageTransportAction.java
@@ -55,17 +55,23 @@ public class SearchableSnapshotsUsageTransportAction extends XPackUsageFeatureTr
         ClusterState state,
         ActionListener<XPackUsageFeatureResponse> listener
     ) {
-        int numSnapIndices = 0;
+        int numFullCopySnapIndices = 0;
+        int numSharedCacheSnapIndices = 0;
         for (IndexMetadata indexMetadata : state.metadata()) {
             if (SearchableSnapshotsConstants.isSearchableSnapshotStore(indexMetadata.getSettings())) {
-                numSnapIndices++;
+                if (SearchableSnapshotsConstants.SNAPSHOT_PARTIAL_SETTING.get(indexMetadata.getSettings())) {
+                    numSharedCacheSnapIndices++;
+                } else {
+                    numFullCopySnapIndices++;
+                }
             }
         }
         listener.onResponse(
             new XPackUsageFeatureResponse(
                 new SearchableSnapshotFeatureSetUsage(
                     licenseState.isAllowed(XPackLicenseState.Feature.SEARCHABLE_SNAPSHOTS),
-                    numSnapIndices
+                    numFullCopySnapIndices,
+                    numSharedCacheSnapIndices
                 )
             )
         );

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/searchable_snapshots/10_usage.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/searchable_snapshots/10_usage.yml
@@ -95,3 +95,62 @@ teardown:
   - match: { searchable_snapshots.available: true }
   - match: { searchable_snapshots.enabled: true }
   - match: { searchable_snapshots.indices_count: 1 }
+
+---
+"Tests searchable snapshots usage stats with full_copy and shared_cache indices":
+  - skip:
+      version: " - 7.99.99"
+      reason:  storage flag introduced in 8.0.0
+
+  - do:
+      xpack.usage: {}
+
+  - match: { searchable_snapshots.available: true }
+  - match: { searchable_snapshots.enabled: true }
+  - match: { searchable_snapshots.indices_count: 0 }
+
+  - do:
+      searchable_snapshots.mount:
+        repository: repository-fs
+        snapshot: snapshot
+        wait_for_completion: true
+        storage: full_copy
+        body:
+          index: docs
+          renamed_index: docs_full_copy
+
+  - match: { snapshot.snapshot: snapshot }
+  - match: { snapshot.shards.failed: 0 }
+  - match: { snapshot.shards.successful: 1 }
+
+  - do:
+      xpack.usage: {}
+
+  - match: { searchable_snapshots.available: true }
+  - match: { searchable_snapshots.enabled: true }
+  - match: { searchable_snapshots.indices_count: 1 }
+  - match: { searchable_snapshots.full_copy_indices_count: 1 }
+  - match: { searchable_snapshots.shared_cache_indices_count: 0 }
+
+  - do:
+      searchable_snapshots.mount:
+        repository: repository-fs
+        snapshot: snapshot
+        wait_for_completion: true
+        storage: shared_cache
+        body:
+          index: docs
+          renamed_index: docs_shared_cache
+
+  - match: { snapshot.snapshot: snapshot }
+  - match: { snapshot.shards.failed: 0 }
+  - match: { snapshot.shards.successful: 1 }
+
+  - do:
+      xpack.usage: {}
+
+  - match: { searchable_snapshots.available: true }
+  - match: { searchable_snapshots.enabled: true }
+  - match: { searchable_snapshots.indices_count: 2 }
+  - match: { searchable_snapshots.full_copy_indices_count: 1 }
+  - match: { searchable_snapshots.shared_cache_indices_count: 1 }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/searchable_snapshots/10_usage.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/searchable_snapshots/10_usage.yml
@@ -100,7 +100,7 @@ teardown:
 "Tests searchable snapshots usage stats with full_copy and shared_cache indices":
   - skip:
       version: " - 7.99.99"
-      reason:  storage flag introduced in 8.0.0
+      reason:  "extra full_copy and shared_cache fields introduced in 8.0.0"
 
   - do:
       xpack.usage: {}
@@ -108,6 +108,8 @@ teardown:
   - match: { searchable_snapshots.available: true }
   - match: { searchable_snapshots.enabled: true }
   - match: { searchable_snapshots.indices_count: 0 }
+  - match: { searchable_snapshots.full_copy_indices_count: 0 }
+  - match: { searchable_snapshots.shared_cache_indices_count: 0 }
 
   - do:
       searchable_snapshots.mount:


### PR DESCRIPTION
Extends the feature usage stats, distinguishing between full_copy and shared_cache style searchable snapshot indices.