### PR TITLE
Reenable BWC test for searchable snapshots usage stats (#70439)

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/searchable_snapshots/10_usage.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/searchable_snapshots/10_usage.yml
@@ -66,8 +66,8 @@ teardown:
 ---
 "Tests searchable snapshots usage stats":
   - skip:
-      version: " - 7.99.99"
-      reason:  storage flag introduced in 8.0.0
+      version: " - 7.11.99"
+      reason:  storage flag introduced in 7.12.0
 
   - do:
       xpack.usage: {}


### PR DESCRIPTION
Reenables BWC for the searchable snapshot usage stats test.

Relates #68509