### PR TITLE
Don't remove component templates in test,

### DIFF
--- a/docs/reference/indices/index-templates.asciidoc
+++ b/docs/reference/indices/index-templates.asciidoc
@@ -157,7 +157,6 @@ PUT _index_template/template_1
 [source,console]
 ----
 DELETE _index_template/*
-DELETE _component_template/*
 ----
 // TEST[continued]
 


### PR DESCRIPTION
but let the test framework for this (ESRestTestCase).

It is not possible to remove component templates that are in use by composable index templates.
Deleting all component templates, also removes builtin component templates used by builtin 
index templates (which are automatically managed, immediately re-added if removed).

The ESRestTestCase has logic that skips builtin component and composable index templates instead
of deleting them. 


Test failure was introduced via #70379