### PR TITLE
Make index-templates.asciidoc console snippet more inline with master branch.

### DIFF
--- a/docs/reference/indices/index-templates.asciidoc
+++ b/docs/reference/indices/index-templates.asciidoc
@@ -156,7 +156,9 @@ PUT _index_template/template_1
 
 [source,console]
 ----
-DELETE _index_template/*
+DELETE _index_template/template_1
+DELETE _component_template/runtime_component_template
+DELETE _component_template/component_template1
 ----
 // TEST[continued]
 


### PR DESCRIPTION
This change is how in the master branch the component & index templates are removed. (not with wildcards)
So this is how #70446 should have been.