### PR TITLE
[DOCs] Add tip for `index_options` parameter

### DIFF
--- a/docs/reference/mapping/params/index-options.asciidoc
+++ b/docs/reference/mapping/params/index-options.asciidoc
@@ -10,7 +10,7 @@ The `index_options` parameter is intended for use with <<text,`text`>> fields
 only. Avoid using `index_options` with other field data types.
 ====
 
-The parameter accepts one of the following values. Each value contains
+The parameter accepts one of the following values. Each value retrieves
 information from the previous listed values. For example, `freqs` contains
 `docs`; `positions` contains both `freqs` and `docs`.
 

--- a/docs/reference/mapping/params/index-options.asciidoc
+++ b/docs/reference/mapping/params/index-options.asciidoc
@@ -10,7 +10,9 @@ The `index_options` parameter is intended for use with <<text,`text`>> fields
 only. Avoid using `index_options` with other field data types.
 ====
 
-It accepts the following values:
+The parameter accepts one of the following values. Each value contains
+information from the previous listed values. For example, `freqs` contains
+`docs`; `positions` contains both `freqs` and `docs`.
 
 `docs`::
 Only the doc number is indexed.  Can answer the question _Does this term

--- a/docs/reference/mapping/params/index-options.asciidoc
+++ b/docs/reference/mapping/params/index-options.asciidoc
@@ -30,6 +30,10 @@ Doc number, term frequencies, positions, and start and end character
 offsets (which map the term back to the original string) are indexed.
 Offsets are used by the <<unified-highlighter,unified highlighter>> to speed up highlighting.
 
+[TIP]
+====
+Each value contains the previous value. eg. `freqs` contains `docs`, `positions` contains `freqs`.
+
 [source,console]
 --------------------------------------------------
 PUT my-index-000001

--- a/docs/reference/mapping/params/index-options.asciidoc
+++ b/docs/reference/mapping/params/index-options.asciidoc
@@ -15,26 +15,22 @@ information from the previous listed values. For example, `freqs` contains
 `docs`; `positions` contains both `freqs` and `docs`.
 
 `docs`::
-Only the doc number is indexed.  Can answer the question _Does this term
-exist in this field?_
+Only the doc number is indexed. Can answer the question _Does this term exist in
+this field?_
 
 `freqs`::
-Doc number and term frequencies are indexed.  Term frequencies are used to
-score repeated terms higher than single terms.
+Doc number and term frequencies are indexed. Term frequencies are used to score
+repeated terms higher than single terms.
 
 `positions` (default)::
 Doc number, term frequencies, and term positions (or order) are indexed.
-Positions can be used for
-<<query-dsl-match-query-phrase,proximity or phrase queries>>.
+Positions can be used for <<query-dsl-match-query-phrase,proximity or phrase
+queries>>.
 
 `offsets`::
-Doc number, term frequencies, positions, and start and end character
-offsets (which map the term back to the original string) are indexed.
-Offsets are used by the <<unified-highlighter,unified highlighter>> to speed up highlighting.
-
-[TIP]
-====
-Each value contains the previous value. eg. `freqs` contains `docs`, `positions` contains `freqs`.
+Doc number, term frequencies, positions, and start and end character offsets
+(which map the term back to the original string) are indexed. Offsets are used
+by the <<unified-highlighter,unified highlighter>> to speed up highlighting.
 
 [source,console]
 --------------------------------------------------


### PR DESCRIPTION
Prompt the reader that there is a progressive relationship between these values.

I didn't realize this progressive relationship when I first view the document, and I even thought that this parameter could be multiple choices. 
When someone prompted me later, I get that these values have an inclusive relationship: each value includes the previous value.
