### PR TITLE
Search - make wildcard field use constant scoring queries for wildcard queries

### DIFF
--- a/docs/reference/mapping/types/wildcard.asciidoc
+++ b/docs/reference/mapping/types/wildcard.asciidoc
@@ -5,7 +5,7 @@
 === Wildcard field type
 
 The `wildcard` field type is a specialized keyword field for unstructured
-machine-generated content you plan to search using grep-like 
+machine-generated content you plan to search using grep-like
 <<query-dsl-wildcard-query,`wildcard`>> and <<query-dsl-regexp-query,`regexp`>>
 queries. The `wildcard` type is optimized for fields with large values or high
 cardinality.
@@ -130,4 +130,5 @@ The following parameters are accepted by `wildcard` fields:
 ==== Limitations
 
 * `wildcard` fields are untokenized like keyword fields, so do not support queries that rely on word positions such as phrase queries.
+* When running `wildcard` queries any `rewrite` parameter is ignored. The scoring is always a constant score.
 

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/AutomatonQueryOnBinaryDv.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/AutomatonQueryOnBinaryDv.java
@@ -25,7 +25,6 @@ import org.apache.lucene.util.automaton.ByteRunAutomaton;
 
 import java.io.IOException;
 import java.util.Objects;
-import java.util.function.Supplier;
 
 /**
  * Query that runs an Automaton across all binary doc values.
@@ -35,19 +34,17 @@ public class AutomatonQueryOnBinaryDv extends Query {
 
     private final String field;
     private final String matchPattern;
-    private final Supplier<Automaton> automatonSupplier;
+    private final Automaton automaton;
 
-    public AutomatonQueryOnBinaryDv(String field, String matchPattern, Supplier<Automaton> automatonSupplier) {
+    public AutomatonQueryOnBinaryDv(String field, String matchPattern, Automaton automaton) {
         this.field = field;
         this.matchPattern = matchPattern;
-        this.automatonSupplier = automatonSupplier;
+        this.automaton = automaton;
     }
 
     @Override
     public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
-
-
-        ByteRunAutomaton bytesMatcher = new ByteRunAutomaton(automatonSupplier.get());
+        ByteRunAutomaton bytesMatcher = new ByteRunAutomaton(automaton);
 
         return new ConstantScoreWeight(this, boost) {
 
@@ -99,12 +96,13 @@ public class AutomatonQueryOnBinaryDv extends Query {
             return false;
           }
         AutomatonQueryOnBinaryDv other = (AutomatonQueryOnBinaryDv) obj;
-        return Objects.equals(field, other.field)  && Objects.equals(matchPattern, other.matchPattern);
+        return Objects.equals(field, other.field)  && Objects.equals(matchPattern, other.matchPattern)
+            && Objects.equals(automaton, other.automaton);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(field, matchPattern);
+        return Objects.hash(field, matchPattern, automaton);
     }
 
 }

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/AutomatonQueryOnBinaryDv.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/AutomatonQueryOnBinaryDv.java
@@ -97,12 +97,12 @@ public class AutomatonQueryOnBinaryDv extends Query {
           }
         AutomatonQueryOnBinaryDv other = (AutomatonQueryOnBinaryDv) obj;
         return Objects.equals(field, other.field)  && Objects.equals(matchPattern, other.matchPattern)
-            && Objects.equals(automaton, other.automaton);
+            && Objects.equals(new ByteRunAutomaton(automaton), new ByteRunAutomaton(other.automaton));
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(field, matchPattern, automaton);
+        return Objects.hash(field, matchPattern, new ByteRunAutomaton(automaton));
     }
 
 }

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/AutomatonQueryOnBinaryDv.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/AutomatonQueryOnBinaryDv.java
@@ -34,18 +34,16 @@ public class AutomatonQueryOnBinaryDv extends Query {
 
     private final String field;
     private final String matchPattern;
-    private final Automaton automaton;
+    private final ByteRunAutomaton bytesMatcher;
 
     public AutomatonQueryOnBinaryDv(String field, String matchPattern, Automaton automaton) {
         this.field = field;
         this.matchPattern = matchPattern;
-        this.automaton = automaton;
+        bytesMatcher = new ByteRunAutomaton(automaton);
     }
 
     @Override
     public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
-        ByteRunAutomaton bytesMatcher = new ByteRunAutomaton(automaton);
-
         return new ConstantScoreWeight(this, boost) {
 
             @Override
@@ -97,12 +95,12 @@ public class AutomatonQueryOnBinaryDv extends Query {
           }
         AutomatonQueryOnBinaryDv other = (AutomatonQueryOnBinaryDv) obj;
         return Objects.equals(field, other.field)  && Objects.equals(matchPattern, other.matchPattern)
-            && Objects.equals(new ByteRunAutomaton(automaton), new ByteRunAutomaton(other.automaton));
+            && Objects.equals(bytesMatcher, other.bytesMatcher);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(field, matchPattern, new ByteRunAutomaton(automaton));
+        return Objects.hash(field, matchPattern, bytesMatcher);
     }
 
 }

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
@@ -337,7 +337,7 @@ public class WildcardFieldMapper extends FieldMapper {
                 // We have no concrete characters and we're not a pure length query e.g. ???
                 return new DocValuesFieldExistsQuery(name());
             }
-            return new ConstantScoreQuery(verifyingQuery);
+            return verifyingQuery;
 
         }
 

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
@@ -336,12 +336,12 @@ public class WildcardFieldMapper extends FieldMapper {
                 BooleanQuery.Builder verifyingBuilder = new BooleanQuery.Builder();
                 verifyingBuilder.add(new BooleanClause(approxQuery, Occur.MUST));
                 verifyingBuilder.add(new BooleanClause(verifyingQuery, Occur.MUST));
-                return verifyingBuilder.build();
+                return new ConstantScoreQuery(verifyingBuilder.build());
             } else if (numWildcardChars == 0 || numWildcardStrings > 0) {
                 // We have no concrete characters and we're not a pure length query e.g. ???
                 return new DocValuesFieldExistsQuery(name());
             }
-            return verifyingQuery;
+            return new ConstantScoreQuery(verifyingQuery);
 
         }
 

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
@@ -322,14 +322,10 @@ public class WildcardFieldMapper extends FieldMapper {
                 addClause(string, rewritten, Occur.MUST);
                 clauseCount++;
             }
-            Supplier<Automaton> deferredAutomatonSupplier = () -> {
-                if(caseInsensitive) {
-                    return AutomatonQueries.toCaseInsensitiveWildcardAutomaton(new Term(name(), wildcardPattern), Integer.MAX_VALUE);
-                } else {
-                    return WildcardQuery.toAutomaton(new Term(name(), wildcardPattern));
-                }
-            };
-            AutomatonQueryOnBinaryDv verifyingQuery = new AutomatonQueryOnBinaryDv(name(), wildcardPattern, deferredAutomatonSupplier);
+            Automaton automaton = caseInsensitive
+                ? AutomatonQueries.toCaseInsensitiveWildcardAutomaton(new Term(name(), wildcardPattern), Integer.MAX_VALUE)
+                : WildcardQuery.toAutomaton(new Term(name(), wildcardPattern));
+            AutomatonQueryOnBinaryDv verifyingQuery = new AutomatonQueryOnBinaryDv(name(), wildcardPattern, automaton);
             if (clauseCount > 0) {
                 // We can accelerate execution with the ngram query
                 BooleanQuery approxQuery = rewritten.build();
@@ -362,12 +358,9 @@ public class WildcardFieldMapper extends FieldMapper {
             if (approxNgramQuery instanceof MatchAllDocsQuery) {
                 return existsQuery(context);
             }
-            Supplier<Automaton> deferredAutomatonSupplier = ()-> {
-                RegExp regex = new RegExp(value, syntaxFlags, matchFlags);
-                return regex.toAutomaton(maxDeterminizedStates);
-            };
-
-            AutomatonQueryOnBinaryDv verifyingQuery = new AutomatonQueryOnBinaryDv(name(), value, deferredAutomatonSupplier);
+            RegExp regex = new RegExp(value, syntaxFlags, matchFlags);
+            Automaton automaton = regex.toAutomaton(maxDeterminizedStates);
+            AutomatonQueryOnBinaryDv verifyingQuery = new AutomatonQueryOnBinaryDv(name(), value, automaton);
 
             // MatchAllButRequireVerificationQuery is a special case meaning the regex is reduced to a single
             // clause which we can't accelerate at all and needs verification. Example would be ".."
@@ -746,9 +739,8 @@ public class WildcardFieldMapper extends FieldMapper {
                     }
                 }
             }
-            Supplier <Automaton> deferredAutomatonSupplier
-                = () -> TermRangeQuery.toAutomaton(lower, upper, includeLower, includeUpper);
-            AutomatonQueryOnBinaryDv slowQuery = new AutomatonQueryOnBinaryDv(name(), lower + "-" + upper, deferredAutomatonSupplier);
+            Automaton automaton =  TermRangeQuery.toAutomaton(lower, upper, includeLower, includeUpper);
+            AutomatonQueryOnBinaryDv slowQuery = new AutomatonQueryOnBinaryDv(name(), lower + "-" + upper, automaton);
 
             if (accelerationQuery == null) {
                 return slowQuery;
@@ -831,18 +823,15 @@ public class WildcardFieldMapper extends FieldMapper {
                     bqBuilder.add(ngramQ, Occur.MUST);
                 }
 
-                Supplier <Automaton> deferredAutomatonSupplier = ()->{
-                    // Verification query
-                    FuzzyQuery fq = new FuzzyQuery(
-                        new Term(name(), searchTerm),
-                        fuzziness.asDistance(searchTerm),
-                        prefixLength,
-                        maxExpansions,
-                        transpositions
-                    );
-                    return fq.getAutomata().automaton;
-                };
-                bqBuilder.add(new AutomatonQueryOnBinaryDv(name(), searchTerm, deferredAutomatonSupplier), Occur.MUST);
+                // Verification query
+                FuzzyQuery fq = new FuzzyQuery(
+                    new Term(name(), searchTerm),
+                    fuzziness.asDistance(searchTerm),
+                    prefixLength,
+                    maxExpansions,
+                    transpositions
+                );
+                bqBuilder.add(new AutomatonQueryOnBinaryDv(name(), searchTerm, fq.getAutomata().automaton), Occur.MUST);
 
                 return bqBuilder.build();
             } catch (IOException ioe) {

--- a/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
+++ b/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
@@ -19,8 +19,6 @@ import org.apache.lucene.index.RandomIndexWriter;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.queryparser.classic.ParseException;
 import org.apache.lucene.queryparser.classic.QueryParser;
-import org.apache.lucene.queryparser.xml.builders.BooleanQueryBuilder;
-import org.apache.lucene.search.AutomatonQuery;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
@@ -59,7 +57,6 @@ import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperTestCase;
 import org.elasticsearch.index.mapper.ParseContext;
-import org.elasticsearch.index.mapper.BinaryFieldMapper.CustomBinaryDocValuesField;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.search.lookup.SearchLookup;
@@ -71,7 +68,6 @@ import org.junit.Before;
 import org.mockito.Mockito;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -120,138 +116,6 @@ public class WildcardFieldMapperTests extends MapperTestCase {
         keywordFieldType = kwBuilder.build(new ContentPath(0));
         super.setUp();
     }
-    
-    
-    // TODO - remove this. Was trying to get to bottom of suspected Lucene bug by recreating 
-    // the problem encountered with PR https://github.com/elastic/elasticsearch/pull/70452#issue-593845984
-    // So far this code did not reproduce the issue seen in testSearchResultsVersusKeywordField with seed
-    // -Dtests.seed=722EAA9077BDA6AE - need to dig more.
-    public void testConstantScoreWeirdness() throws IOException {
-        Directory dir = newDirectory();
-        IndexWriterConfig iwc = newIndexWriterConfig(WildcardFieldMapper.WILDCARD_ANALYZER_7_10);
-        iwc.setMergePolicy(newTieredMergePolicy(random()));
-        RandomIndexWriter iw = new RandomIndexWriter(random(), dir, iwc);
-
-        String []docContents = {"WOODCUTTER HENRY KISSINGER",
-            "WISDOM J. EHRLICHMAN",
-            "WINDSTONE REAGAN RESIDENCE, CALIFORNIA",
-            "WHEELS UP PRESIDENTIAL AIRCRAFT HAS TAKEN OFF",
-            "WHEELS DOWN PRESIDENTIAL AIRCRAFT HAS LANDED ",
-            "WHALEBOAT RON ZIEGLER",
-            "WELCOME J.R. HALDEMAN",
-            "WAREHOUSE SHERATON CENTER, NEW YORK",
-            "VOLUNTEER LYNDON JOHNSON",
-            "VOLCANO LBJ RANCH, TEXAS",
-            "VICTORIA LADYBIRD JOHNSON",
-            "UNKNOWN",
-            "UNICORN PRINCE CHARLES",
-            "TUNER MARVIN BUSH",
-            "TUMBLER GEORGE BUSH, JR.",
-            "TRIPPER J. BUSH",
-            "TREASURE SHIP AIR FORCE TWO",
-            "TRAPLINE NEIL BUSH",
-            "TRANQUILITY BARBARA BUSH",
-            "TRAIL BREAKER VICE PRESIDENT'S OFFICIAL LIMO",
-            "TRACKER VICE PRESIDENT'S FOLLOW VEHICLE",
-            "TRACER VICE PRESIDENT'S LEAD VEHICLE",
-            "TOWER ANDREWS AIR FORCE BASE, MARYLAND",
-            "TOOL ROOM VICE PRESIDENT'S OFFICE",
-            "TIMBERWOLF GEORGE BUSH",
-            "TILLER DOROTHY BUSH",
-            "THUNDER JESSE JACKSON",
-            "SWORDFISH PHILLIP CRANE",
-            "SUPERVISOR DAN QUAYLE",
-            "SUNSHINE MARILYN QUAYLE",
-            "SUNDANCE ETHEL KENNEDY",
-            "SUNBURN TED KENNEDY",
-            "SUGARFOOT ",
-            "STUTTER ",
-            "STRAWBERRY ROSEMARY WOODS",
-            "STORM KING NIXON RESIDENCE, NEW JERSEY",
-            "STORE ROOM TRUMAN LIBRARY, MISSOURI",
-            "STARLIGHT PAT NIXON",
-            "STARDUST JOHN ANDERSON",
-            "STARBURST JOHN ANDERSON",
-            "STAIRCASE FIRST FAMILY DETAIL OFFICER",
-            "STAGECOACH PRESIDENT'S LIMOUSINE",
-            "SPRINGTIME MAMIE EISENHOWER",
-            "SPECTATOR ",
-            "SOFTPACK A SHOTGUN",
-            "SNOWSTORM GEORGE BUSH",
-            "SNOWBANK BARBARA BUSH",
-            "SNAPSHOT HOWARD BAKER",
-            "SMELTER ",
-            "SKYMASTER ANDREWS AIR FORCE BASE COMMAND POST",
-            "SIGNATURE PRESS HELICOPTER",
-            "SHOTGUN NEW YORK CITY COMMAND POST",
-            "SHEEPSKIN GEORGE BUSH",
-            "SHADOW ",
-            "SEARCHLIGHT RICHARD NIXON"};
-        
-        for (String docContent:docContents)
-        {
-            Document doc = new Document();
-            ParseContext.Document parseDoc = new ParseContext.Document();
-            
-            // Add keyword fields too
-    //        doc.add(new StringField(KEYWORD_FIELD_NAME, docContent, Field.Store.YES));
-            
-            String[] parts = docContent.split(" ");
-            for (String part : parts) {
-                doc.add(new StringField(KEYWORD_FIELD_NAME, WildcardFieldMapper.TOKEN_START_OR_END_CHAR+part, Field.Store.YES));        
-            }
-            
-            
-            CustomBinaryDocValuesField dvField = new CustomBinaryDocValuesField(WILDCARD_FIELD_NAME, docContent.getBytes(StandardCharsets.UTF_8));
-            parseDoc.addWithKey(WILDCARD_FIELD_NAME, dvField);
-            
-            
-    //        addFields(parseDoc, doc, docContent);
-            indexDoc(parseDoc, doc, iw);
-        }
-        iw.forceMerge(1);
-        DirectoryReader reader = iw.getReader();
-        IndexSearcher searcher = newSearcher(reader);
-        iw.close();
-
-        for (String docContent:docContents) {
-                String[] parts = docContent.split(" ");
-        
-                BooleanQuery.Builder approxQueryBuilder = new BooleanQuery.Builder();
-                for (String part : parts) {
-                    approxQueryBuilder.add(new BooleanClause(new TermQuery(new Term(KEYWORD_FIELD_NAME, WildcardFieldMapper.TOKEN_START_OR_END_CHAR+part)), Occur.MUST));
-                }
-        //        approxQueryBuilder.add(new BooleanClause(new TermQuery(new Term(KEYWORD_FIELD_NAME, "york")), Occur.MUST));
-        
-                
-                Query approxQuery = approxQueryBuilder.build();
-                Term wildcardTerm = new Term(WILDCARD_FIELD_NAME, docContent.replaceAll(" ", "*"));
-                
-                Supplier<Automaton> deferredAutomatonSupplier = () -> {
-        
-                        return WildcardQuery.toAutomaton(wildcardTerm);
-                };
-                AutomatonQueryOnBinaryDv verifyingQuery = new AutomatonQueryOnBinaryDv(wildcardTerm.field(), wildcardTerm.text(), deferredAutomatonSupplier);
-                
-                
-        //        Query verifyingQuery = new AutomatonQuery(wildcardTerm, WildcardQuery.toAutomaton(wildcardTerm));
-        
-                BooleanQuery.Builder verifyingBuilder = new BooleanQuery.Builder();
-                verifyingBuilder.add(new BooleanClause(approxQuery, Occur.MUST));
-                verifyingBuilder.add(new BooleanClause(verifyingQuery, Occur.MUST));
-                Query q = verifyingBuilder.build();
-                q = new ConstantScoreQuery(q);
-        
-        //        Query wildcardFieldQuery = wildcardFieldType.fieldType().wildcardQuery("*a*", null, null);
-//                TopDocs wildcardFieldTopDocs = searcher.search(q, 10, Sort.INDEXORDER);
-                TopDocs wildcardFieldTopDocs = searcher.search(q, 10, Sort.RELEVANCE);
-                System.err.println(docContent);
-                assertThat(wildcardFieldTopDocs.totalHits.value, equalTo(1L));
-        }
-        reader.close();
-        dir.close();
-    }    
-    
 
     public void testTooBigKeywordField() throws IOException {
         Directory dir = newDirectory();
@@ -486,9 +350,7 @@ public class WildcardFieldMapperTests extends MapperTestCase {
 
             }
             TopDocs kwTopDocs = searcher.search(keywordFieldQuery, values.size() + 1, Sort.RELEVANCE);
-            // TODO - why does this line below produce zero results after I introduced a ConstantScoreQuery wrapper for wildcard queries?
-            // TopDocs wildcardFieldTopDocs = searcher.search(wildcardFieldQuery, values.size() + 1, Sort.RELEVANCE);
-            TopDocs wildcardFieldTopDocs = searcher.search(wildcardFieldQuery, values.size() + 1);
+            TopDocs wildcardFieldTopDocs = searcher.search(wildcardFieldQuery, values.size() + 1, Sort.RELEVANCE);
             assertThat(keywordFieldQuery + "\n" + wildcardFieldQuery,
                 wildcardFieldTopDocs.totalHits.value, equalTo(kwTopDocs.totalHits.value));
 
@@ -702,6 +564,23 @@ public class WildcardFieldMapperTests extends MapperTestCase {
             );
         }
 
+    }
+    
+    public void testQueryCachingEquality() throws IOException, ParseException {
+        String pattern = "A*b*B?a";
+        // Case sensitivity matters when it comes to caching
+        Automaton caseSensitiveAutomaton = AutomatonQueries.toCaseInsensitiveWildcardAutomaton(new Term("field", pattern), Integer.MAX_VALUE);
+        Automaton caseInSensitiveAutomaton = AutomatonQueries.toCaseInsensitiveWildcardAutomaton(new Term("field", pattern), Integer.MAX_VALUE);
+        AutomatonQueryOnBinaryDv csQ = new AutomatonQueryOnBinaryDv("field", pattern, caseSensitiveAutomaton);
+        AutomatonQueryOnBinaryDv ciQ = new AutomatonQueryOnBinaryDv("field", pattern, caseInSensitiveAutomaton);
+        assertNotEquals(csQ, ciQ);
+        assertNotEquals(csQ.hashCode(), ciQ.hashCode());
+        
+        // Same query should be equal
+        Automaton caseSensitiveAutomaton2 = AutomatonQueries.toCaseInsensitiveWildcardAutomaton(new Term("field", pattern), Integer.MAX_VALUE);
+        AutomatonQueryOnBinaryDv csQ2 = new AutomatonQueryOnBinaryDv("field", pattern, caseSensitiveAutomaton2);
+        assertNotEquals(csQ, csQ2);
+        assertNotEquals(csQ.hashCode(), csQ2.hashCode());
     }
 
     @Override

--- a/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
+++ b/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
@@ -569,10 +569,7 @@ public class WildcardFieldMapperTests extends MapperTestCase {
     public void testQueryCachingEquality() throws IOException, ParseException {
         String pattern = "A*b*B?a";
         // Case sensitivity matters when it comes to caching
-        Automaton caseSensitiveAutomaton = AutomatonQueries.toCaseInsensitiveWildcardAutomaton(
-            new Term("field", pattern),
-            Integer.MAX_VALUE
-        );
+        Automaton caseSensitiveAutomaton = WildcardQuery.toAutomaton(new Term("field", pattern));
         Automaton caseInSensitiveAutomaton = AutomatonQueries.toCaseInsensitiveWildcardAutomaton(
             new Term("field", pattern),
             Integer.MAX_VALUE
@@ -583,13 +580,10 @@ public class WildcardFieldMapperTests extends MapperTestCase {
         assertNotEquals(csQ.hashCode(), ciQ.hashCode());
 
         // Same query should be equal
-        Automaton caseSensitiveAutomaton2 = AutomatonQueries.toCaseInsensitiveWildcardAutomaton(
-            new Term("field", pattern),
-            Integer.MAX_VALUE
-        );
+        Automaton caseSensitiveAutomaton2 = WildcardQuery.toAutomaton(new Term("field", pattern));
         AutomatonQueryOnBinaryDv csQ2 = new AutomatonQueryOnBinaryDv("field", pattern, caseSensitiveAutomaton2);
-        assertNotEquals(csQ, csQ2);
-        assertNotEquals(csQ.hashCode(), csQ2.hashCode());
+        assertEquals(csQ, csQ2);
+        assertEquals(csQ.hashCode(), csQ2.hashCode());
     }
 
     @Override

--- a/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
+++ b/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
@@ -569,15 +569,24 @@ public class WildcardFieldMapperTests extends MapperTestCase {
     public void testQueryCachingEquality() throws IOException, ParseException {
         String pattern = "A*b*B?a";
         // Case sensitivity matters when it comes to caching
-        Automaton caseSensitiveAutomaton = AutomatonQueries.toCaseInsensitiveWildcardAutomaton(new Term("field", pattern), Integer.MAX_VALUE);
-        Automaton caseInSensitiveAutomaton = AutomatonQueries.toCaseInsensitiveWildcardAutomaton(new Term("field", pattern), Integer.MAX_VALUE);
+        Automaton caseSensitiveAutomaton = AutomatonQueries.toCaseInsensitiveWildcardAutomaton(
+            new Term("field", pattern),
+            Integer.MAX_VALUE
+        );
+        Automaton caseInSensitiveAutomaton = AutomatonQueries.toCaseInsensitiveWildcardAutomaton(
+            new Term("field", pattern),
+            Integer.MAX_VALUE
+        );
         AutomatonQueryOnBinaryDv csQ = new AutomatonQueryOnBinaryDv("field", pattern, caseSensitiveAutomaton);
         AutomatonQueryOnBinaryDv ciQ = new AutomatonQueryOnBinaryDv("field", pattern, caseInSensitiveAutomaton);
         assertNotEquals(csQ, ciQ);
         assertNotEquals(csQ.hashCode(), ciQ.hashCode());
-        
+
         // Same query should be equal
-        Automaton caseSensitiveAutomaton2 = AutomatonQueries.toCaseInsensitiveWildcardAutomaton(new Term("field", pattern), Integer.MAX_VALUE);
+        Automaton caseSensitiveAutomaton2 = AutomatonQueries.toCaseInsensitiveWildcardAutomaton(
+            new Term("field", pattern),
+            Integer.MAX_VALUE
+        );
         AutomatonQueryOnBinaryDv csQ2 = new AutomatonQueryOnBinaryDv("field", pattern, caseSensitiveAutomaton2);
         assertNotEquals(csQ, csQ2);
         assertNotEquals(csQ.hashCode(), csQ2.hashCode());

--- a/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
+++ b/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
@@ -22,6 +22,7 @@ import org.apache.lucene.queryparser.classic.QueryParser;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
@@ -348,7 +349,9 @@ public class WildcardFieldMapperTests extends MapperTestCase {
 
             }
             TopDocs kwTopDocs = searcher.search(keywordFieldQuery, values.size() + 1, Sort.RELEVANCE);
-            TopDocs wildcardFieldTopDocs = searcher.search(wildcardFieldQuery, values.size() + 1, Sort.RELEVANCE);
+            // TODO - why does this line below produce zero results after I introduced a ConstantScoreQuery wrapper for wildcard queries?
+            // TopDocs wildcardFieldTopDocs = searcher.search(wildcardFieldQuery, values.size() + 1, Sort.RELEVANCE);
+            TopDocs wildcardFieldTopDocs = searcher.search(wildcardFieldQuery, values.size() + 1);
             assertThat(keywordFieldQuery + "\n" + wildcardFieldQuery,
                 wildcardFieldTopDocs.totalHits.value, equalTo(kwTopDocs.totalHits.value));
 
@@ -548,13 +551,14 @@ public class WildcardFieldMapperTests extends MapperTestCase {
             String expectedAccelerationQueryString = test[1].replaceAll("_", "" + WildcardFieldMapper.TOKEN_START_OR_END_CHAR);
             Query wildcardFieldQuery = wildcardFieldType.fieldType().wildcardQuery(pattern, null, MOCK_CONTEXT);
             testExpectedAccelerationQuery(pattern, wildcardFieldQuery, expectedAccelerationQueryString);
-            assertTrue(wildcardFieldQuery instanceof BooleanQuery);
+            assertTrue(unwrapAnyConstantScore(wildcardFieldQuery) instanceof BooleanQuery);
         }
 
         // TODO All these expressions have no acceleration at all and could be improved
         String slowPatterns[] = { "??" };
         for (String pattern : slowPatterns) {
             Query wildcardFieldQuery = wildcardFieldType.fieldType().wildcardQuery(pattern, null, MOCK_CONTEXT);
+            wildcardFieldQuery = unwrapAnyConstantScore(wildcardFieldQuery);
             assertTrue(
                 pattern + " was not as slow as we assumed " + formatQuery(wildcardFieldQuery),
                 wildcardFieldQuery instanceof AutomatonQueryOnBinaryDv
@@ -719,8 +723,18 @@ public class WildcardFieldMapperTests extends MapperTestCase {
         Query expectedAccelerationQuery = qsp.parse(expectedAccelerationQueryString);
         testExpectedAccelerationQuery(regex, combinedQuery, expectedAccelerationQuery);
     }
+    
+    private Query unwrapAnyConstantScore(Query q) {
+        if (q instanceof ConstantScoreQuery) {
+            ConstantScoreQuery csq = (ConstantScoreQuery) q;
+            return csq.getQuery();
+        } else {
+            return q;
+        }
+    }
+
     void testExpectedAccelerationQuery(String regex, Query combinedQuery, Query expectedAccelerationQuery) throws ParseException {
-        BooleanQuery cq = (BooleanQuery) combinedQuery;
+        BooleanQuery cq = (BooleanQuery) unwrapAnyConstantScore(combinedQuery);
         assert cq.clauses().size() == 2;
         Query approximationQuery = null;
         boolean verifyQueryFound = false;


### PR DESCRIPTION
Wrap the wildcard queries produced by the wildcard field as a constant scoring query because there is no sensible index to use for scoring terms with their frequencies.
Added a note about ignoring rewrite parameters on wildcard queries.

Also includes fix where case insensitive/sensitive wildcard queries cached on same key. Run WIldcardFieldMapperTest with  seed `-Dtests.seed=722EAA9077BDA6AE` to reveal the issue.

Closes #69604
