### PR TITLE
[DOCS] Remove beta qualifier from transform tutorial

### DIFF
--- a/docs/reference/transform/ecommerce-tutorial.asciidoc
+++ b/docs/reference/transform/ecommerce-tutorial.asciidoc
@@ -267,7 +267,6 @@ image::images/ecommerce-results.png["Exploring the new index in {kib}"]
 . Optional: Create another {transform}, this time using the `latest` method.
 +
 --
-beta::[]
 
 This method populates the destination index with the latest documents for each
 unique key value. For example, you might want to find the latest orders (sorted


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/69964, this PR removes the "beta" tag from the [transform tutorial](https://www.elastic.co/guide/en/elasticsearch/reference/master/ecommerce-transforms.html).