### PR TITLE
[7.12] [DOCS] Fix Lucene's stop words links (#70405)

### DIFF
--- a/docs/reference/analysis.asciidoc
+++ b/docs/reference/analysis.asciidoc
@@ -2,7 +2,8 @@
 = Text analysis
 
 :lucene-analysis-docs:  https://lucene.apache.org/core/{lucene_version_path}/analyzers-common/org/apache/lucene/analysis
-:lucene-stop-word-link: https://github.com/apache/lucene-solr/blob/master/lucene/analysis/common/src/resources/org/apache/lucene/analysis
+:lucene-gh-main-link:   https://github.com/apache/lucene/blob/main/lucene
+:lucene-stop-word-link: {lucene-gh-main-link}/analysis/common/src/resources/org/apache/lucene/analysis
 
 [partintro]
 --

--- a/docs/reference/analysis/tokenfilters/stop-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/stop-tokenfilter.asciidoc
@@ -282,11 +282,11 @@ parameter and a link to their predefined stop words in Lucene.
 
 [[english-stop-words]]
 `_english_`::
-https://github.com/apache/lucene-solr/blob/master/lucene/analysis/common/src/java/org/apache/lucene/analysis/en/EnglishAnalyzer.java#L46[English stop words]
+{lucene-gh-main-link}/analysis/common/src/java/org/apache/lucene/analysis/en/EnglishAnalyzer.java#L48[English stop words]
 
 [[estonian-stop-words]]
 `_estonian_`::
-https://github.com/apache/lucene-solr/blob/master/lucene/analysis/common/src/resources/org/apache/lucene/analysis/et/stopwords.txt[Estonian stop words]
+{lucene-stop-word-link}/et/stopwords.txt[Estonian stop words]
 
 [[finnish-stop-words]]
 `_finnish_`::


### PR DESCRIPTION
Backports the following commits to 7.12:
 - [DOCS] Fix Lucene's stop words links (#70405)