### PR TITLE
[7.x] add test framework for json schema validation of rest spec body's (#69902)

### DIFF
--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -23,6 +23,8 @@ jna               = 5.7.0-1
 netty             = 4.1.49.Final
 joda              = 2.10.4
 
+commons_lang3                   = 3.9
+
 # when updating this version, you need to ensure compatibility with:
 #  - plugins/ingest-attachment (transitive dependency, check the upstream POM)
 #  - distribution/tools/plugin-cli
@@ -47,3 +49,6 @@ jmh               = 1.26
 # when updating this version, also update :qa:evil-tests
 jimfs = 1.2
 jimfs_guava = 30.1-jre
+
+# test framework
+networknt_json_schema_validator = 1.0.48

--- a/plugins/ingest-attachment/build.gradle
+++ b/plugins/ingest-attachment/build.gradle
@@ -59,7 +59,7 @@ dependencies {
   api "org.apache.james:apache-mime4j-core:${versions.mime4j}"
   api "org.apache.james:apache-mime4j-dom:${versions.mime4j}"
   // EPUB books
-  api 'org.apache.commons:commons-lang3:3.9'
+  api "org.apache.commons:commons-lang3:${versions.commons_lang3}"
   // Microsoft Word files with visio diagrams
   api 'org.apache.commons:commons-math3:3.6.1'
   // POIs dependency

--- a/test/framework/build.gradle
+++ b/test/framework/build.gradle
@@ -26,6 +26,14 @@ dependencies {
   api "commons-codec:commons-codec:${versions.commonscodec}"
   api "org.elasticsearch:securemock:${versions.securemock}"
   api "org.elasticsearch:mocksocket:${versions.mocksocket}"
+
+  // json schema validation dependencies
+  api "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
+  api "com.networknt:json-schema-validator:${versions.networknt_json_schema_validator}"
+  api "com.fasterxml.jackson.core:jackson-databind:${versions.jackson}"
+  api "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}"
+  api "org.apache.commons:commons-compress:1.19"
+  api "org.apache.commons:commons-lang3:${versions.commons_lang3}"
 }
 
 tasks.named("compileJava").configure { options.compilerArgs << '-Xlint:-cast,-unchecked' }
@@ -42,6 +50,11 @@ tasks.named("dependenciesInfo").configure { enabled = false }
 tasks.named("thirdPartyAudit").configure {
   ignoreMissingClasses(
           // classes are missing
+          'com.github.luben.zstd.ZstdInputStream',
+          'com.github.luben.zstd.ZstdOutputStream',
+          'java.util.jar.Pack200',
+          'java.util.jar.Pack200$Packer',
+          'java.util.jar.Pack200$Unpacker',
           'javax.servlet.ServletContextEvent',
           'javax.servlet.ServletContextListener',
           'org.apache.avalon.framework.logger.Logger',
@@ -50,7 +63,33 @@ tasks.named("thirdPartyAudit").configure {
           'org.apache.log4j.Category',
           'org.apache.log4j.Level',
           'org.apache.log4j.Logger',
-          'org.apache.log4j.Priority'
+          'org.apache.log4j.Priority',
+          'org.brotli.dec.BrotliInputStream',
+          'org.jcodings.specific.UTF8Encoding',
+          'org.joni.Matcher',
+          'org.joni.Regex',
+          'org.joni.Syntax',
+          'org.slf4j.Logger',
+          'org.slf4j.LoggerFactory',
+          'org.tukaani.xz.ARMOptions',
+          'org.tukaani.xz.ARMThumbOptions',
+          'org.tukaani.xz.DeltaOptions',
+          'org.tukaani.xz.FilterOptions',
+          'org.tukaani.xz.FinishableWrapperOutputStream',
+          'org.tukaani.xz.IA64Options',
+          'org.tukaani.xz.LZMA2InputStream',
+          'org.tukaani.xz.LZMA2Options',
+          'org.tukaani.xz.LZMAInputStream',
+          'org.tukaani.xz.LZMAOutputStream',
+          'org.tukaani.xz.MemoryLimitException',
+          'org.tukaani.xz.PowerPCOptions',
+          'org.tukaani.xz.SPARCOptions',
+          'org.tukaani.xz.SingleXZInputStream',
+          'org.tukaani.xz.UnsupportedOptionsException',
+          'org.tukaani.xz.X86Options',
+          'org.tukaani.xz.XZ',
+          'org.tukaani.xz.XZInputStream',
+          'org.tukaani.xz.XZOutputStream'
   )
 }
 

--- a/test/framework/build.gradle
+++ b/test/framework/build.gradle
@@ -52,9 +52,6 @@ tasks.named("thirdPartyAudit").configure {
           // classes are missing
           'com.github.luben.zstd.ZstdInputStream',
           'com.github.luben.zstd.ZstdOutputStream',
-          'java.util.jar.Pack200',
-          'java.util.jar.Pack200$Packer',
-          'java.util.jar.Pack200$Unpacker',
           'javax.servlet.ServletContextEvent',
           'javax.servlet.ServletContextListener',
           'org.apache.avalon.framework.logger.Logger',
@@ -91,6 +88,13 @@ tasks.named("thirdPartyAudit").configure {
           'org.tukaani.xz.XZInputStream',
           'org.tukaani.xz.XZOutputStream'
   )
+  if (BuildParams.runtimeJavaVersion > JavaVersion.VERSION_1_8) {
+      ignoreMissingClasses(
+          'java.util.jar.Pack200',
+          'java.util.jar.Pack200$Packer',
+          'java.util.jar.Pack200$Unpacker'
+      )
+  }
 }
 
 tasks.named("test").configure {

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractSchemaValidationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractSchemaValidationTestCase.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.networknt.schema.AdditionalPropertiesValidator;
+import com.networknt.schema.ItemsValidator;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.JsonValidator;
+import com.networknt.schema.PropertiesValidator;
+import com.networknt.schema.SchemaValidatorsConfig;
+import com.networknt.schema.SpecVersion;
+import com.networknt.schema.ValidationMessage;
+
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.PathUtils;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentType;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Test case for validating {@link ToXContent} objects against a json schema.
+ */
+public abstract class AbstractSchemaValidationTestCase<T extends ToXContent> extends ESTestCase {
+    protected static final int NUMBER_OF_TEST_RUNS = 20;
+
+    public final void testSchema() throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        SchemaValidatorsConfig config = new SchemaValidatorsConfig();
+        JsonSchemaFactory factory = initializeSchemaFactory();
+
+        Path p = getDataPath(PathUtils.get(getSchemaLocation(), getJsonSchemaFileName()).toString());
+        logger.debug("loading schema from: [{}]", p);
+
+        JsonSchema jsonSchema = factory.getSchema(mapper.readTree(Files.newInputStream(p)), config);
+
+        // ensure the schema meets certain criteria like not empty, strictness
+        assertTrue("found empty schema", jsonSchema.getValidators().size() > 0);
+        assertTrue("schema lacks at least 1 required field", jsonSchema.hasRequiredValidator());
+        assertSchemaStrictness(jsonSchema.getValidators().values(), jsonSchema.getSchemaPath());
+
+        for (int runs = 0; runs < NUMBER_OF_TEST_RUNS; runs++) {
+            BytesReference xContent = XContentHelper.toXContent(createTestInstance(), XContentType.JSON, getToXContentParams(), false);
+            JsonNode jsonTree = mapper.readTree(xContent.streamInput());
+
+            Set<ValidationMessage> errors = jsonSchema.validate(jsonTree);
+            assertThat("Schema validation failed for: " + jsonTree.toPrettyString(), errors, is(empty()));
+        }
+    }
+
+    /**
+     * Creates a random instance to use in the schema tests.
+     * Override this method to return the random instance that you build
+     * which must implement {@link ToXContent}.
+     */
+    protected abstract T createTestInstance();
+
+    /**
+     * Return the filename of the schema file used for testing.
+     */
+    protected abstract String getJsonSchemaFileName();
+
+    /**
+     * Params that have to be provided when calling {@link ToXContent#toXContent(XContentBuilder, ToXContent.Params)}
+     */
+    protected ToXContent.Params getToXContentParams() {
+        return ToXContent.EMPTY_PARAMS;
+    }
+
+    /**
+     * Root folder for all schema files.
+     */
+    protected String getSchemaLocation() {
+        return "/rest-api-spec/schema/";
+    }
+
+    /**
+     * Version of the Json Schema Spec to be used by the test.
+     */
+    protected SpecVersion.VersionFlag getSchemaVersion() {
+        return SpecVersion.VersionFlag.V7;
+    }
+
+    /**
+     * Loader for the schema factory.
+     *
+     * Uses the ootb factory but replaces the loader for sub schema's stored on the file system.
+     */
+    private JsonSchemaFactory initializeSchemaFactory() {
+        JsonSchemaFactory factory = JsonSchemaFactory.builder(JsonSchemaFactory.getInstance(getSchemaVersion())).uriFetcher(uri -> {
+            String fileName = uri.toString().substring(uri.getScheme().length() + 1);
+            Path path = getDataPath(PathUtils.get(getSchemaLocation(), fileName).toString());
+            logger.debug("loading sub-schema [{}] from: [{}]", uri, path);
+            return Files.newInputStream(path);
+        }, "file").build();
+
+        return factory;
+    }
+
+    /**
+     * Enforce that the schema as well as all sub schemas define all properties.
+     *
+     * This uses an implementation detail of the schema validation library: If
+     * strict validation is turned on (`"additionalProperties": false`), the schema
+     * validator injects an instance of AdditionalPropertiesValidator.
+     *
+     * The check loops through the validator tree and checks for instances of
+     * AdditionalPropertiesValidator. If it is absent at expected places the test fails.
+     *
+     * Note: we might not catch all places, but at least it works for nested objects and
+     * array items.
+     */
+    private void assertSchemaStrictness(Collection<JsonValidator> validatorSet, String path) {
+        boolean additionalPropertiesValidatorFound = false;
+        boolean subSchemaFound = false;
+
+        for (JsonValidator validator : validatorSet) {
+            if (validator instanceof PropertiesValidator) {
+                subSchemaFound = true;
+                PropertiesValidator propertiesValidator = (PropertiesValidator) validator;
+                for (Entry<String, JsonSchema> subSchema : propertiesValidator.getSchemas().entrySet()) {
+                    assertSchemaStrictness(subSchema.getValue().getValidators().values(), propertiesValidator.getSchemaPath());
+                }
+            } else if (validator instanceof ItemsValidator) {
+                ItemsValidator itemValidator = (ItemsValidator) validator;
+                if (itemValidator.getSchema() != null) {
+                    assertSchemaStrictness(itemValidator.getSchema().getValidators().values(), itemValidator.getSchemaPath());
+                }
+                if (itemValidator.getTupleSchema() != null) {
+                    for (JsonSchema subSchema : itemValidator.getTupleSchema()) {
+                        assertSchemaStrictness(subSchema.getValidators().values(), itemValidator.getSchemaPath());
+                    }
+                }
+            } else if (validator instanceof AdditionalPropertiesValidator) {
+                additionalPropertiesValidatorFound = true;
+            }
+        }
+
+        // if not a leaf, additional property strictness must be set
+        assertTrue(
+            "the schema must have additional properties set to false (\"additionalProperties\": false) in all (sub) schemas, "
+                + "missing at least for path: "
+                + path,
+            subSchemaFound == false || additionalPropertiesValidatorFound
+        );
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/action/GetTransformActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/action/GetTransformActionResponseTests.java
@@ -25,6 +25,16 @@ import java.util.Map;
 
 public class GetTransformActionResponseTests extends AbstractWireSerializingTransformTestCase<Response> {
 
+    public static Response randomTransformResponse() {
+        List<TransformConfig> configs = new ArrayList<>();
+        int totalConfigs = randomInt(10);
+        for (int i = 0; i < totalConfigs; ++i) {
+            configs.add(TransformConfigTests.randomTransformConfig());
+        }
+
+        return new Response(configs, randomNonNegativeLong());
+    }
+
     public void testInvalidTransforms() throws IOException {
         List<TransformConfig> transforms = new ArrayList<>();
 
@@ -48,8 +58,9 @@ public class GetTransformActionResponseTests extends AbstractWireSerializingTran
     @SuppressWarnings("unchecked")
     public void testNoHeaderInResponse() throws IOException {
         List<TransformConfig> transforms = new ArrayList<>();
+        int totalConfigs = randomInt(10);
 
-        for (int i = 0; i < randomIntBetween(1, 10); ++i) {
+        for (int i = 0; i < totalConfigs; ++i) {
             transforms.add(TransformConfigTests.randomTransformConfig());
         }
 
@@ -76,12 +87,7 @@ public class GetTransformActionResponseTests extends AbstractWireSerializingTran
 
     @Override
     protected Response createTestInstance() {
-        List<TransformConfig> configs = new ArrayList<>();
-        for (int i = 0; i < randomInt(10); ++i) {
-            configs.add(TransformConfigTests.randomTransformConfig());
-        }
-
-        return new Response(configs, randomNonNegativeLong());
+        return randomTransformResponse();
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/action/GetTransformStatsActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/action/GetTransformStatsActionResponseTests.java
@@ -19,8 +19,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class GetTransformStatsActionResponseTests extends AbstractWireSerializingTransformTestCase<Response> {
-    @Override
-    protected Response createTestInstance() {
+
+    public static Response randomTransformStatsResponse() {
         List<TransformStats> stats = new ArrayList<>();
         int totalStats = randomInt(10);
         for (int i = 0; i < totalStats; ++i) {
@@ -34,6 +34,11 @@ public class GetTransformStatsActionResponseTests extends AbstractWireSerializin
             nodeFailures.add(new FailedNodeException("node1", "message", new Exception("error")));
         }
         return new Response(stats, randomLongBetween(stats.size(), 10_000_000L), taskFailures, nodeFailures);
+    }
+
+    @Override
+    protected Response createTestInstance() {
+        return randomTransformStatsResponse();
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/action/schema/GetTransformStatsActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/action/schema/GetTransformStatsActionResponseTests.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.transform.action.schema;
+
+import org.elasticsearch.test.AbstractSchemaValidationTestCase;
+import org.elasticsearch.xpack.core.transform.action.GetTransformStatsAction.Response;
+
+import static org.elasticsearch.xpack.core.transform.action.GetTransformStatsActionResponseTests.randomTransformStatsResponse;
+
+public class GetTransformStatsActionResponseTests extends AbstractSchemaValidationTestCase<Response> {
+
+    @Override
+    protected Response createTestInstance() {
+        return randomTransformStatsResponse();
+    }
+
+    @Override
+    protected String getJsonSchemaFileName() {
+        return "transform.get_transform_stats.schema.json";
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/schema/TransformConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/schema/TransformConfigTests.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.transform.transforms.schema;
+
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.ToXContent.Params;
+import org.elasticsearch.test.AbstractSchemaValidationTestCase;
+import org.elasticsearch.xpack.core.transform.TransformField;
+import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
+
+import java.util.Collections;
+
+import static org.elasticsearch.xpack.core.transform.transforms.TransformConfigTests.randomTransformConfig;
+
+public class TransformConfigTests extends AbstractSchemaValidationTestCase<TransformConfig> {
+
+    protected static Params TO_XCONTENT_PARAMS = new ToXContent.MapParams(
+        Collections.singletonMap(TransformField.EXCLUDE_GENERATED, "true")
+    );
+
+    @Override
+    protected TransformConfig createTestInstance() {
+        return randomTransformConfig();
+    }
+
+    @Override
+    protected String getJsonSchemaFileName() {
+        return "transform_config.schema.json";
+    }
+
+    @Override
+    protected ToXContent.Params getToXContentParams() {
+        return TO_XCONTENT_PARAMS;
+    }
+}

--- a/x-pack/plugin/core/src/test/resources/rest-api-spec/schema/transform.get_transform_stats.schema.json
+++ b/x-pack/plugin/core/src/test/resources/rest-api-spec/schema/transform.get_transform_stats.schema.json
@@ -1,0 +1,41 @@
+{
+  "definitions": {},
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/elastic/elasticsearch/master/x-pack/plugin/core/src/test/resources/rest-api-spec/schema/transform.get_transform_stats.schema.json",
+  "description": "schema definition for transform stats",
+  "additionalProperties": false,
+  "title": "Root",
+  "type": "object",
+  "required": [
+    "count",
+    "transforms"
+  ],
+  "properties": {
+    "count": {
+      "$id": "#root/count",
+      "title": "number of transforms",
+      "type": "integer"
+    },
+    "transforms": {
+      "$id": "#root/transforms",
+      "title": "transforms",
+      "type": "array",
+      "items": [
+        {
+          "$ref": "file:transform_stats.schema.json",
+          "uniqueItems": true
+        }
+      ]
+    },
+    "task_failures": {
+      "$id": "#root/task_failures",
+      "title": "task_failures",
+      "type": "array"
+    },
+    "node_failures": {
+      "$id": "#root/node_failures",
+      "title": "node_failures",
+      "type": "array"
+    }
+  }
+}

--- a/x-pack/plugin/core/src/test/resources/rest-api-spec/schema/transform_config.schema.json
+++ b/x-pack/plugin/core/src/test/resources/rest-api-spec/schema/transform_config.schema.json
@@ -1,0 +1,269 @@
+{
+  "definitions": {},
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/elastic/elasticsearch/master/x-pack/plugin/core/src/test/resources/rest-api-spec/schema/transform_config.schema.json",
+  "description": "schema definition for transform configuration object",
+  "additionalProperties": false,
+  "title": "Root",
+  "type": "object",
+  "oneOf": [
+    {
+      "required": [
+        "pivot"
+      ]
+    },
+    {
+      "required": [
+        "latest"
+      ]
+    }
+  ],
+  "required": [
+    "source",
+    "dest"
+  ],
+  "properties": {
+    "source": {
+      "$id": "#root/source",
+      "title": "Source",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "index"
+      ],
+      "properties": {
+        "index": {
+          "$id": "#root/source/index",
+          "title": "Index",
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "examples": [
+            "kibana_sample_data_ecommerce"
+          ],
+          "pattern": "^.*$"
+        },
+        "query": {
+          "$id": "#root/source/query",
+          "title": "query",
+          "type": "object"
+        },
+        "runtime_mappings": {
+          "$id": "#root/source/runtime_mappings",
+          "title": "runtime mappings",
+          "type": "object"
+        }
+      }
+    },
+    "pivot": {
+      "$id": "#root/pivot",
+      "title": "Pivot",
+      "type": "object",
+      "oneOf": [
+        {
+          "required": [
+            "aggregations"
+          ]
+        },
+        {
+          "required": [
+            "aggs"
+          ]
+        }
+      ],
+      "required": [
+        "group_by"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "group_by": {
+          "$id": "#root/pivot/group_by",
+          "title": "Group_by",
+          "type": "object"
+        },
+        "aggregations": {
+          "$id": "#root/pivot/aggregations",
+          "title": "Aggregations",
+          "type": "object"
+        }
+      }
+    },
+    "latest": {
+      "$id": "#root/latest",
+      "title": "Latest",
+      "type": "object",
+      "required": [
+        "sort",
+        "unique_key"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "sort": {
+          "$id": "#root/latest/sort",
+          "title": "Sort",
+          "type": "string"
+        },
+        "unique_key": {
+          "$id": "#root/latest/unique_key",
+          "title": "Unique key",
+          "type": "array"
+        }
+      }
+    },
+    "description": {
+      "$id": "#root/description",
+      "title": "Description",
+      "type": "string",
+      "pattern": "^.*$"
+    },
+    "dest": {
+      "$id": "#root/dest",
+      "title": "Dest",
+      "type": "object",
+      "required": [
+        "index"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "index": {
+          "$id": "#root/dest/index",
+          "title": "Index",
+          "type": "string",
+          "pattern": "^.*$"
+        },
+        "pipeline": {
+          "$id": "#root/dest/pipeline",
+          "title": "Pipeline",
+          "type": "string",
+          "pattern": "^.*$"
+        }
+      }
+    },
+    "frequency": {
+      "$id": "#root/frequency",
+      "title": "Frequency",
+      "type": "string",
+      "default": "60s",
+      "examples": [
+        "5m"
+      ],
+      "pattern": "^.*$"
+    },
+    "id": {
+      "$id": "#root/id",
+      "title": "Id",
+      "type": "string",
+      "pattern": "^.*$"
+    },
+    "settings": {
+      "$id": "#root/settings",
+      "title": "Settings",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "dates_as_epoch_millis": {
+          "$id": "#root/settings/dates_as_epoch_millis",
+          "title": "Dates as epoch millis",
+          "type": "boolean",
+          "default": false
+        },
+        "docs_per_second": {
+          "$id": "#root/settings/docs_per_second",
+          "title": "docs per second",
+          "type": "number"
+        },
+        "max_page_search_size": {
+          "$id": "#root/settings/max_page_search_size",
+          "title": "max page search size",
+          "type": "integer",
+          "default": 500
+        }
+      }
+    },
+    "retention_policy": {
+      "$id": "#root/retention_policy",
+      "title": "Retention Policy",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "time": {
+          "$id": "#root/retention_policy/time",
+          "title": "Time",
+          "type": "object",
+          "required": [
+            "field",
+            "max_age"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "field": {
+              "$id": "#root/retention_policy/time/field",
+              "title": "Field",
+              "type": "string",
+              "examples": [
+                "@timestamp"
+              ],
+              "pattern": "^.*$"
+            },
+            "max_age": {
+              "$id": "#root/retention_policy/time/max_age",
+              "title": "Max age",
+              "type": "string",
+              "default": "60s",
+              "examples": [
+                "10s"
+              ],
+              "pattern": "^.*$"
+            }
+          }
+        }
+      }
+    },
+    "sync": {
+      "$id": "#root/sync",
+      "title": "Sync",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "time": {
+          "$id": "#root/sync/time",
+          "title": "Time",
+          "type": "object",
+          "required": [
+            "field"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "field": {
+              "$id": "#root/sync/time/field",
+              "title": "Field",
+              "type": "string",
+              "examples": [
+                "@timestamp"
+              ],
+              "pattern": "^.*$"
+            },
+            "delay": {
+              "$id": "#root/sync/time/delay",
+              "title": "Delay",
+              "type": "string",
+              "default": "60s",
+              "examples": [
+                "10s"
+              ],
+              "pattern": "^.*$"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/x-pack/plugin/core/src/test/resources/rest-api-spec/schema/transform_stats.schema.json
+++ b/x-pack/plugin/core/src/test/resources/rest-api-spec/schema/transform_stats.schema.json
@@ -26,7 +26,8 @@
         "stopping",
         "indexing",
         "failed",
-        "aborting"
+        "aborting",
+        "waiting"
       ],
       "description": "The transform state"
     },

--- a/x-pack/plugin/core/src/test/resources/rest-api-spec/schema/transform_stats.schema.json
+++ b/x-pack/plugin/core/src/test/resources/rest-api-spec/schema/transform_stats.schema.json
@@ -1,0 +1,69 @@
+{
+  "definitions": {},
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/elastic/elasticsearch/master/x-pack/plugin/core/src/test/resources/rest-api-spec/schema/transform_stats.schema.json",
+  "description": "schema definition for a single transform stats",
+  "additionalProperties": false,
+  "title": "Root",
+  "type": "object",
+  "required": [
+    "id"
+  ],
+  "properties": {
+    "checkpointing": {
+      "type": "object",
+      "description": "TODO"
+    },
+    "id": {
+      "type": "string",
+      "description": "The transform id"
+    },
+    "state": {
+      "type": "string",
+      "enum": [
+        "started",
+        "stopped",
+        "stopping",
+        "indexing",
+        "failed",
+        "aborting"
+      ],
+      "description": "The transform state"
+    },
+    "stats": {
+      "type": "object",
+      "description": "TODO"
+    },
+    "node": {
+      "type": "object",
+      "description": "TODO: move this into a separate schema file",
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "the node id"
+        },
+        "name": {
+          "type": "string",
+          "description": "the node name"
+        },
+        "ephemeral_id": {
+          "type": "string",
+          "description": "the node ephemeral id"
+        },
+        "transport_address": {
+          "type": "string",
+          "description": "the node transport address"
+        },
+        "attributes": {
+          "type": "object",
+          "description": "TODO"
+        }
+      }
+    },
+    "reason": {
+      "type": "string",
+      "description": "reason if failed"
+    }
+  }
+}


### PR DESCRIPTION
Rest API specs define the API's used at the rest level, however these specs
only define the endpoint and the parameters. We miss definitions for the
body, especially when it comes to rich bodies like they are used in ML. 

This change introduces an abstract testcase for json schema validation. This
allows developers to validate any object that is serializable to JSON - using
the `ToXContent` - to be tested against a json schema. You can use it for REST
input and outputs, but also for internal objects(documents) and 
`ToXContentFragments`.

As the overall goal is to ensure it validates properly, the testcase enforces
strictness. A schema file must spec all properties. This will ensure that once
a schema test has been added, it won't go out of sync. Every change to the
pojo enforces a schema update as otherwise the test would fail.

Schemas can load sub-schemas from extra files. That way you can re-use schemas
e.g. in hierarchies or re-use a schema for similar but not same interfaces.<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.

backport #69902