### PR TITLE
Break number field tests into different classes per type

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/mapper/ByteFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ByteFieldMapperTests.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.mapper.NumberFieldMapper.NumberType;
+import org.elasticsearch.index.mapper.NumberFieldTypeTests.OutOfRangeSpec;
+
+import java.io.IOException;
+import java.util.List;
+
+public class ByteFieldMapperTests extends WholeNumberFieldMapperTests {
+    @Override
+    protected Number missingValue() {
+        return 123;
+    }
+
+    @Override
+    protected List<OutOfRangeSpec> outOfRangeSpecs() {
+        return List.of(
+            OutOfRangeSpec.of(NumberType.BYTE, "128", "is out of range for a byte"),
+            OutOfRangeSpec.of(NumberType.BYTE, "-129", "is out of range for a byte"),
+            OutOfRangeSpec.of(NumberType.BYTE, 128, "is out of range for a byte"),
+            OutOfRangeSpec.of(NumberType.BYTE, -129, "is out of range for a byte")
+        );
+    }
+
+    @Override
+    protected void minimalMapping(XContentBuilder b) throws IOException {
+        b.field("type", "byte");
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/mapper/DoubleFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DoubleFieldMapperTests.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.mapper.NumberFieldTypeTests.OutOfRangeSpec;
+
+import java.io.IOException;
+import java.util.List;
+
+public class DoubleFieldMapperTests extends NumberFieldMapperTests {
+
+    @Override
+    protected Number missingValue() {
+        return 123d;
+    }
+
+    @Override
+    protected List<OutOfRangeSpec> outOfRangeSpecs() {
+        return List.of(
+            OutOfRangeSpec.of(NumberFieldMapper.NumberType.DOUBLE, "1.7976931348623157E309", "[double] supports only finite values"),
+            OutOfRangeSpec.of(NumberFieldMapper.NumberType.DOUBLE, "-1.7976931348623157E309", "[double] supports only finite values"),
+            OutOfRangeSpec.of(NumberFieldMapper.NumberType.DOUBLE, Double.NaN, "[double] supports only finite values"),
+            OutOfRangeSpec.of(NumberFieldMapper.NumberType.DOUBLE, Double.POSITIVE_INFINITY, "[double] supports only finite values"),
+            OutOfRangeSpec.of(NumberFieldMapper.NumberType.DOUBLE, Double.NEGATIVE_INFINITY, "[double] supports only finite values")
+        );
+    }
+
+    @Override
+    protected void minimalMapping(XContentBuilder b) throws IOException {
+        b.field("type", "double");
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/mapper/FloatFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FloatFieldMapperTests.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.mapper.NumberFieldTypeTests.OutOfRangeSpec;
+
+import java.io.IOException;
+import java.util.List;
+
+public class FloatFieldMapperTests extends NumberFieldMapperTests {
+
+    @Override
+    protected Number missingValue() {
+        return 123f;
+    }
+
+    @Override
+    protected List<OutOfRangeSpec> outOfRangeSpecs() {
+        return List.of(
+            OutOfRangeSpec.of(NumberFieldMapper.NumberType.FLOAT, "3.4028235E39", "[float] supports only finite values"),
+            OutOfRangeSpec.of(NumberFieldMapper.NumberType.FLOAT, "-3.4028235E39", "[float] supports only finite values"),
+            OutOfRangeSpec.of(NumberFieldMapper.NumberType.FLOAT, Float.NaN, "[float] supports only finite values"),
+            OutOfRangeSpec.of(NumberFieldMapper.NumberType.FLOAT, Float.POSITIVE_INFINITY, "[float] supports only finite values"),
+            OutOfRangeSpec.of(NumberFieldMapper.NumberType.FLOAT, Float.NEGATIVE_INFINITY, "[float] supports only finite values")
+        );
+    }
+
+    @Override
+    protected void minimalMapping(XContentBuilder b) throws IOException {
+        b.field("type", "float");
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/mapper/HalfFloatFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/HalfFloatFieldMapperTests.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.mapper.NumberFieldMapper.NumberType;
+import org.elasticsearch.index.mapper.NumberFieldTypeTests.OutOfRangeSpec;
+
+import java.io.IOException;
+import java.util.List;
+
+public class HalfFloatFieldMapperTests extends NumberFieldMapperTests {
+
+    @Override
+    protected Number missingValue() {
+        return 123f;
+    }
+
+    @Override
+    protected List<OutOfRangeSpec> outOfRangeSpecs() {
+        return List.of(
+            OutOfRangeSpec.of(NumberType.HALF_FLOAT, "65520", "[half_float] supports only finite values"),
+            OutOfRangeSpec.of(NumberType.HALF_FLOAT, "-65520", "[half_float] supports only finite values"),
+            OutOfRangeSpec.of(NumberType.HALF_FLOAT, "-65520", "[half_float] supports only finite values"),
+            OutOfRangeSpec.of(NumberType.HALF_FLOAT, Float.NaN, "[half_float] supports only finite values"),
+            OutOfRangeSpec.of(NumberType.HALF_FLOAT, Float.POSITIVE_INFINITY, "[half_float] supports only finite values"),
+            OutOfRangeSpec.of(NumberType.HALF_FLOAT, Float.NEGATIVE_INFINITY, "[half_float] supports only finite values")
+        );
+    }
+
+    @Override
+    protected void minimalMapping(XContentBuilder b) throws IOException {
+        b.field("type", "half_float");
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/mapper/IntegerFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IntegerFieldMapperTests.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.mapper.NumberFieldMapper.NumberType;
+import org.elasticsearch.index.mapper.NumberFieldTypeTests.OutOfRangeSpec;
+
+import java.io.IOException;
+import java.util.List;
+
+public class IntegerFieldMapperTests extends WholeNumberFieldMapperTests {
+
+    @Override
+    protected Number missingValue() {
+        return 123;
+    }
+
+    @Override
+    protected List<OutOfRangeSpec> outOfRangeSpecs() {
+        return List.of(
+            OutOfRangeSpec.of(NumberType.INTEGER, "2147483648", "is out of range for an integer"),
+            OutOfRangeSpec.of(NumberType.INTEGER, "-2147483649", "is out of range for an integer"),
+            OutOfRangeSpec.of(NumberType.INTEGER, 2147483648L, " out of range of int"),
+            OutOfRangeSpec.of(NumberType.INTEGER, -2147483649L, " out of range of int")
+        );
+    }
+
+    @Override
+    protected void minimalMapping(XContentBuilder b) throws IOException {
+        b.field("type", "integer");
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/mapper/LongFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/LongFieldMapperTests.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.mapper.NumberFieldTypeTests.OutOfRangeSpec;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.List;
+
+import static org.hamcrest.Matchers.arrayWithSize;
+
+public class LongFieldMapperTests extends WholeNumberFieldMapperTests {
+
+    @Override
+    protected Number missingValue() {
+        return 123L;
+    }
+
+    @Override
+    protected List<OutOfRangeSpec> outOfRangeSpecs() {
+        return List.of(
+            OutOfRangeSpec.of(NumberFieldMapper.NumberType.LONG, "9223372036854775808", "out of range for a long"),
+            OutOfRangeSpec.of(NumberFieldMapper.NumberType.LONG, "1e999999999", "out of range for a long"),
+            OutOfRangeSpec.of(NumberFieldMapper.NumberType.LONG, "-9223372036854775809", "out of range for a long"),
+            OutOfRangeSpec.of(NumberFieldMapper.NumberType.LONG, "-1e999999999", "out of range for a long"),
+            OutOfRangeSpec.of(NumberFieldMapper.NumberType.LONG, new BigInteger("9223372036854775808"), "out of range of long"),
+            OutOfRangeSpec.of(NumberFieldMapper.NumberType.LONG, new BigInteger("-9223372036854775809"), "out of range of long")
+        );
+    }
+
+    @Override
+    protected void minimalMapping(XContentBuilder b) throws IOException {
+        b.field("type", "long");
+    }
+
+    public void testLongIndexingOutOfRange() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", "long").field("ignore_malformed", true)));
+        ParsedDocument doc = mapper.parse(
+            source(b -> b.rawField("field", new BytesArray("9223372036854775808").streamInput(), XContentType.JSON))
+        );
+        assertEquals(0, doc.rootDoc().getFields("field").length);
+    }
+
+    public void testLongIndexingCoercesIntoRange() throws Exception {
+        // the following two strings are in-range for a long after coercion
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
+        ParsedDocument doc = mapper.parse(source(b -> b.field("field", "9223372036854775807.9")));
+        assertThat(doc.rootDoc().getFields("field"), arrayWithSize(2));
+        doc = mapper.parse(source(b -> b.field("field", "-9223372036854775808.9")));
+        assertThat(doc.rootDoc().getFields("field"), arrayWithSize(2));
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldMapperTests.java
@@ -11,38 +11,26 @@ package org.elasticsearch.index.mapper;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.IndexableField;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.index.mapper.NumberFieldMapper.NumberType;
 import org.elasticsearch.index.mapper.NumberFieldTypeTests.OutOfRangeSpec;
 import org.elasticsearch.index.termvectors.TermVectorsService;
 
 import java.io.IOException;
-import java.math.BigInteger;
-import java.util.Arrays;
 import java.util.List;
-import java.util.Set;
 
-import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.containsString;
 
-public class NumberFieldMapperTests extends AbstractNumericFieldMapperTestCase {
+public abstract class NumberFieldMapperTests extends MapperTestCase {
 
-    @Override
-    protected Set<String> types() {
-        return Set.of("byte", "short", "integer", "long", "float", "double", "half_float");
-    }
+    /**
+     * @return a List of OutOfRangeSpec to test for this number type
+     */
+    protected abstract List<OutOfRangeSpec> outOfRangeSpecs();
 
-    @Override
-    protected Set<String> wholeTypes() {
-        return Set.of("byte", "short", "integer", "long");
-    }
-
-    @Override
-    protected void minimalMapping(XContentBuilder b) throws IOException {
-        b.field("type", "long");
-    }
+    /**
+     * @return an appropriate value to use for a missing value for this number type
+     */
+    protected abstract Number missingValue();
 
     @Override
     protected void registerParameters(ParameterChecker checker) throws IOException {
@@ -70,9 +58,8 @@ public class NumberFieldMapperTests extends AbstractNumericFieldMapperTestCase {
         assertParseMinimalWarnings();
     }
 
-    @Override
-    public void doTestDefaults(String type) throws Exception {
-        XContentBuilder mapping = fieldMapping(b -> b.field("type", type));
+    public void testDefaults() throws Exception {
+        XContentBuilder mapping = fieldMapping(this::minimalMapping);
         DocumentMapper mapper = createDocumentMapper(mapping);
         assertEquals(Strings.toString(mapping), mapper.mappingSource().toString());
 
@@ -89,9 +76,11 @@ public class NumberFieldMapperTests extends AbstractNumericFieldMapperTestCase {
         assertFalse(dvField.fieldType().stored());
     }
 
-    @Override
-    public void doTestNotIndexed(String type) throws Exception {
-        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", type).field("index", false)));
+    public void testNotIndexed() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
+            minimalMapping(b);
+            b.field("index", false);
+        }));
         ParsedDocument doc = mapper.parse(source(b -> b.field("field", 123)));
 
         IndexableField[] fields = doc.rootDoc().getFields("field");
@@ -100,9 +89,11 @@ public class NumberFieldMapperTests extends AbstractNumericFieldMapperTestCase {
         assertEquals(DocValuesType.SORTED_NUMERIC, dvField.fieldType().docValuesType());
     }
 
-    @Override
-    public void doTestNoDocValues(String type) throws Exception {
-        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", type).field("doc_values", false)));
+    public void testNoDocValues() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
+            minimalMapping(b);
+            b.field("doc_values", false);
+        }));
         ParsedDocument doc = mapper.parse(source(b -> b.field("field", 123)));
 
         IndexableField[] fields = doc.rootDoc().getFields("field");
@@ -112,9 +103,11 @@ public class NumberFieldMapperTests extends AbstractNumericFieldMapperTestCase {
         assertEquals(123, pointField.numericValue().doubleValue(), 0d);
     }
 
-    @Override
-    public void doTestStore(String type) throws Exception {
-        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", type).field("store", true)));
+    public void testStore() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
+            minimalMapping(b);
+            b.field("store", true);
+        }));
         ParsedDocument doc = mapper.parse(source(b -> b.field("field", 123)));
 
         IndexableField[] fields = doc.rootDoc().getFields("field");
@@ -129,9 +122,8 @@ public class NumberFieldMapperTests extends AbstractNumericFieldMapperTestCase {
         assertEquals(123, storedField.numericValue().doubleValue(), 0d);
     }
 
-    @Override
-    public void doTestCoerce(String type) throws IOException {
-        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", type)));
+    public void testCoerce() throws IOException {
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
         ParsedDocument doc = mapper.parse(source(b -> b.field("field", "123")));
 
         IndexableField[] fields = doc.rootDoc().getFields("field");
@@ -142,39 +134,34 @@ public class NumberFieldMapperTests extends AbstractNumericFieldMapperTestCase {
         IndexableField dvField = fields[1];
         assertEquals(DocValuesType.SORTED_NUMERIC, dvField.fieldType().docValuesType());
 
-        DocumentMapper mapper2 = createDocumentMapper(fieldMapping(b -> b.field("type", type).field("coerce", false)));
+        DocumentMapper mapper2 = createDocumentMapper(fieldMapping(b -> {
+            minimalMapping(b);
+            b.field("coerce", false);
+        }));
         MapperParsingException e = expectThrows(MapperParsingException.class, () -> mapper2.parse(source(b -> b.field("field", "123"))));
         assertThat(e.getCause().getMessage(), containsString("passed as String"));
     }
 
-    @Override
-    protected void doTestDecimalCoerce(String type) throws IOException {
-        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", type)));
-        ParsedDocument doc = mapper.parse(source(b -> b.field("field", "7.89")));
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        IndexableField pointField = fields[0];
-        assertEquals(7, pointField.numericValue().doubleValue(), 0d);
-    }
-
     public void testIgnoreMalformed() throws Exception {
-        for (String type : types()) {
-            DocumentMapper notIgnoring = createDocumentMapper(fieldMapping(b -> b.field("type", type)));
-            DocumentMapper ignoring = createDocumentMapper(fieldMapping(b -> b.field("type", type).field("ignore_malformed", true)));
-            for (Object malformedValue : new Object[] { "a", Boolean.FALSE }) {
-                SourceToParse source = source(b -> b.field("field", malformedValue));
-                MapperParsingException e = expectThrows(MapperParsingException.class, () -> notIgnoring.parse(source));
-                if (malformedValue instanceof String) {
-                    assertThat(e.getCause().getMessage(), containsString("For input string: \"a\""));
-                } else {
-                    assertThat(e.getCause().getMessage(), containsString("Current token"));
-                    assertThat(e.getCause().getMessage(), containsString("not numeric, can not use numeric value accessors"));
-                }
-
-                ParsedDocument doc = ignoring.parse(source);
-                IndexableField[] fields = doc.rootDoc().getFields("field");
-                assertEquals(0, fields.length);
-                assertArrayEquals(new String[] { "field" }, TermVectorsService.getValues(doc.rootDoc().getFields("_ignored")));
+        DocumentMapper notIgnoring = createDocumentMapper(fieldMapping(this::minimalMapping));
+        DocumentMapper ignoring = createDocumentMapper(fieldMapping(b -> {
+            minimalMapping(b);
+            b.field("ignore_malformed", true);
+        }));
+        for (Object malformedValue : new Object[]{"a", Boolean.FALSE}) {
+            SourceToParse source = source(b -> b.field("field", malformedValue));
+            MapperParsingException e = expectThrows(MapperParsingException.class, () -> notIgnoring.parse(source));
+            if (malformedValue instanceof String) {
+                assertThat(e.getCause().getMessage(), containsString("For input string: \"a\""));
+            } else {
+                assertThat(e.getCause().getMessage(), containsString("Current token"));
+                assertThat(e.getCause().getMessage(), containsString("not numeric, can not use numeric value accessors"));
             }
+
+            ParsedDocument doc = ignoring.parse(source);
+            IndexableField[] fields = doc.rootDoc().getFields("field");
+            assertEquals(0, fields.length);
+            assertArrayEquals(new String[]{"field"}, TermVectorsService.getValues(doc.rootDoc().getFields("_ignored")));
         }
     }
 
@@ -183,27 +170,30 @@ public class NumberFieldMapperTests extends AbstractNumericFieldMapperTestCase {
      */
     public void testIgnoreMalformedWithObject() throws Exception {
         SourceToParse malformed = source(b -> b.startObject("field").field("foo", "bar").endObject());
-        for (String type : types()) {
-            for (Boolean ignoreMalformed : new Boolean[] { true, false }) {
-                DocumentMapper mapper = createDocumentMapper(
-                    fieldMapping(b -> b.field("type", type).field("ignore_malformed", ignoreMalformed))
-                );
-                MapperParsingException e = expectThrows(MapperParsingException.class, () -> mapper.parse(malformed));
-                assertThat(e.getCause().getMessage(), containsString("Current token"));
-                assertThat(e.getCause().getMessage(), containsString("not numeric, can not use numeric value accessors"));
-            }
+        for (Boolean ignoreMalformed : new Boolean[]{true, false}) {
+            DocumentMapper mapper = createDocumentMapper(
+                fieldMapping(b -> {
+                    minimalMapping(b);
+                    b.field("ignore_malformed", ignoreMalformed);
+                })
+            );
+            MapperParsingException e = expectThrows(MapperParsingException.class, () -> mapper.parse(malformed));
+            assertThat(e.getCause().getMessage(), containsString("Current token"));
+            assertThat(e.getCause().getMessage(), containsString("not numeric, can not use numeric value accessors"));
         }
     }
 
-    @Override
-    protected void doTestNullValue(String type) throws IOException {
-        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", type)));
+    protected void testNullValue() throws IOException {
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
         SourceToParse source = source(b -> b.nullField("field"));
         ParsedDocument doc = mapper.parse(source);
         assertArrayEquals(new IndexableField[0], doc.rootDoc().getFields("field"));
 
-        Object missing = Arrays.asList("float", "double", "half_float").contains(type) ? 123d : 123L;
-        mapper = createDocumentMapper(fieldMapping(b -> b.field("type", type).field("null_value", missing)));
+        Number missing = missingValue();
+        mapper = createDocumentMapper(fieldMapping(b -> {
+            minimalMapping(b);
+            b.field("null_value", missing);
+        }));
         doc = mapper.parse(source);
         IndexableField[] fields = doc.rootDoc().getFields("field");
         assertEquals(2, fields.length);
@@ -215,53 +205,10 @@ public class NumberFieldMapperTests extends AbstractNumericFieldMapperTestCase {
         assertEquals(DocValuesType.SORTED_NUMERIC, dvField.fieldType().docValuesType());
         assertFalse(dvField.fieldType().stored());
     }
-
+    
     public void testOutOfRangeValues() throws IOException {
-        final List<OutOfRangeSpec> inputs = Arrays.asList(
-            OutOfRangeSpec.of(NumberType.BYTE, "128", "is out of range for a byte"),
-            OutOfRangeSpec.of(NumberType.SHORT, "32768", "is out of range for a short"),
-            OutOfRangeSpec.of(NumberType.INTEGER, "2147483648", "is out of range for an integer"),
-            OutOfRangeSpec.of(NumberType.LONG, "9223372036854775808", "out of range for a long"),
-            OutOfRangeSpec.of(NumberType.LONG, "1e999999999", "out of range for a long"),
 
-            OutOfRangeSpec.of(NumberType.BYTE, "-129", "is out of range for a byte"),
-            OutOfRangeSpec.of(NumberType.SHORT, "-32769", "is out of range for a short"),
-            OutOfRangeSpec.of(NumberType.INTEGER, "-2147483649", "is out of range for an integer"),
-            OutOfRangeSpec.of(NumberType.LONG, "-9223372036854775809", "out of range for a long"),
-            OutOfRangeSpec.of(NumberType.LONG, "-1e999999999", "out of range for a long"),
-
-            OutOfRangeSpec.of(NumberType.BYTE, 128, "is out of range for a byte"),
-            OutOfRangeSpec.of(NumberType.SHORT, 32768, "out of range of Java short"),
-            OutOfRangeSpec.of(NumberType.INTEGER, 2147483648L, " out of range of int"),
-            OutOfRangeSpec.of(NumberType.LONG, new BigInteger("9223372036854775808"), "out of range of long"),
-
-            OutOfRangeSpec.of(NumberType.BYTE, -129, "is out of range for a byte"),
-            OutOfRangeSpec.of(NumberType.SHORT, -32769, "out of range of Java short"),
-            OutOfRangeSpec.of(NumberType.INTEGER, -2147483649L, " out of range of int"),
-            OutOfRangeSpec.of(NumberType.LONG, new BigInteger("-9223372036854775809"), "out of range of long"),
-
-            OutOfRangeSpec.of(NumberType.HALF_FLOAT, "65520", "[half_float] supports only finite values"),
-            OutOfRangeSpec.of(NumberType.FLOAT, "3.4028235E39", "[float] supports only finite values"),
-            OutOfRangeSpec.of(NumberType.DOUBLE, "1.7976931348623157E309", "[double] supports only finite values"),
-
-            OutOfRangeSpec.of(NumberType.HALF_FLOAT, "-65520", "[half_float] supports only finite values"),
-            OutOfRangeSpec.of(NumberType.FLOAT, "-3.4028235E39", "[float] supports only finite values"),
-            OutOfRangeSpec.of(NumberType.DOUBLE, "-1.7976931348623157E309", "[double] supports only finite values"),
-
-            OutOfRangeSpec.of(NumberType.HALF_FLOAT, Float.NaN, "[half_float] supports only finite values"),
-            OutOfRangeSpec.of(NumberType.FLOAT, Float.NaN, "[float] supports only finite values"),
-            OutOfRangeSpec.of(NumberType.DOUBLE, Double.NaN, "[double] supports only finite values"),
-
-            OutOfRangeSpec.of(NumberType.HALF_FLOAT, Float.POSITIVE_INFINITY, "[half_float] supports only finite values"),
-            OutOfRangeSpec.of(NumberType.FLOAT, Float.POSITIVE_INFINITY, "[float] supports only finite values"),
-            OutOfRangeSpec.of(NumberType.DOUBLE, Double.POSITIVE_INFINITY, "[double] supports only finite values"),
-
-            OutOfRangeSpec.of(NumberType.HALF_FLOAT, Float.NEGATIVE_INFINITY, "[half_float] supports only finite values"),
-            OutOfRangeSpec.of(NumberType.FLOAT, Float.NEGATIVE_INFINITY, "[float] supports only finite values"),
-            OutOfRangeSpec.of(NumberType.DOUBLE, Double.NEGATIVE_INFINITY, "[double] supports only finite values")
-        );
-
-        for(OutOfRangeSpec item: inputs) {
+        for(OutOfRangeSpec item : outOfRangeSpecs()) {
             DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", item.type.typeName())));
             try {
                 mapper.parse(source(item::write));
@@ -272,19 +219,5 @@ public class NumberFieldMapperTests extends AbstractNumericFieldMapperTestCase {
             }
         }
 
-        // the following two strings are in-range for a long after coercion
-        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", "long")));
-        ParsedDocument doc = mapper.parse(source(b -> b.field("field", "9223372036854775807.9")));
-        assertThat(doc.rootDoc().getFields("field"), arrayWithSize(2));
-        doc = mapper.parse(source(b -> b.field("field", "-9223372036854775808.9")));
-        assertThat(doc.rootDoc().getFields("field"), arrayWithSize(2));
-    }
-
-    public void testLongIndexingOutOfRange() throws Exception {
-        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", "long").field("ignore_malformed", true)));
-        ParsedDocument doc = mapper.parse(
-            source(b -> b.rawField("field", new BytesArray("9223372036854775808").streamInput(), XContentType.JSON))
-        );
-        assertEquals(0, doc.rootDoc().getFields("field").length);
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/ShortFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ShortFieldMapperTests.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.mapper.NumberFieldMapper.NumberType;
+import org.elasticsearch.index.mapper.NumberFieldTypeTests.OutOfRangeSpec;
+
+import java.io.IOException;
+import java.util.List;
+
+public class ShortFieldMapperTests extends WholeNumberFieldMapperTests {
+
+    @Override
+    protected Number missingValue() {
+        return 123;
+    }
+
+    @Override
+    protected List<OutOfRangeSpec> outOfRangeSpecs() {
+        return List.of(
+            OutOfRangeSpec.of(NumberType.SHORT, "32768", "is out of range for a short"),
+            OutOfRangeSpec.of(NumberType.SHORT, "-32769", "is out of range for a short"),
+            OutOfRangeSpec.of(NumberType.SHORT, 32768, "out of range of Java short"),
+            OutOfRangeSpec.of(NumberType.SHORT, -32769, "out of range of Java short")
+        );
+    }
+
+    @Override
+    protected void minimalMapping(XContentBuilder b) throws IOException {
+        b.field("type", "short");
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/mapper/WholeNumberFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/WholeNumberFieldMapperTests.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.index.IndexableField;
+
+import java.io.IOException;
+
+public abstract class WholeNumberFieldMapperTests extends NumberFieldMapperTests {
+
+    protected void testDecimalCoerce() throws IOException {
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
+        ParsedDocument doc = mapper.parse(source(b -> b.field("field", "7.89")));
+        IndexableField[] fields = doc.rootDoc().getFields("field");
+        IndexableField pointField = fields[0];
+        assertEquals(7, pointField.numericValue().doubleValue(), 0d);
+    }
+
+}


### PR DESCRIPTION
The various number mapper types are currently all tested in a single class,
looping over the various types.  This has the drawback that the generic
MapperTestCase tests are only applied to the `long` mapper type, as well
as making it difficult to find type-specific tests.

This commit splits things out so that each mapper type has a separate test
class, with common functionality in `NumberFieldMapperTestCase` and
`WholeNumberFieldMapperTestCase` base classes.