### PR TITLE
Create Unique Slice Names in EsIndexInputTestCase

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/common/lucene/store/ESIndexInputTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/common/lucene/store/ESIndexInputTestCase.java
@@ -30,6 +30,8 @@ public class ESIndexInputTestCase extends ESTestCase {
 
     private static EsThreadPoolExecutor executor;
 
+    private AtomicLong uniqueIdGenerator;
+
     @BeforeClass
     public static void createExecutor() {
         final String name = "TEST-" + getTestClass().getSimpleName() + "#randomReadAndSlice";
@@ -39,6 +41,12 @@ public class ESIndexInputTestCase extends ESTestCase {
     @AfterClass
     public static void destroyExecutor() {
         executor.shutdown();
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        uniqueIdGenerator = new AtomicLong();
     }
 
     /**
@@ -181,12 +189,9 @@ public class ESIndexInputTestCase extends ESTestCase {
         return output;
     }
 
-
-    private static final AtomicLong uniqueIdGenerator = new AtomicLong();
-
     // generate unique slice names for slicing index inputs because using the same slice name together with different slice sizes
     // is not supported for .cfs files and thus we have to avoid slice name collisions
-    private static String randomUniqueSliceName() {
+    private String randomUniqueSliceName() {
         return randomAlphaOfLength(10) + uniqueIdGenerator.incrementAndGet();
     }
 


### PR DESCRIPTION
Low-effort fix (as compared to even more realistic solutions that would ensure non-overlapping of byte ranges for slices ... which would be very involved and currently not change anything functionally relativ to this solution as far as I can tell) for #70482 that makes sure that no two slices get created with the
same name but different byte ranges in a single test run which lead to conflicts with
the assumption that cfs file ranges are fixed for given names for the frozen index input.

closes #70482
