### PR TITLE
Recommend no requests to dedicated masters

### DIFF
--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -130,16 +130,19 @@ restarts.
 
 It is important for the health of the cluster that the elected master node has
 the resources it needs to fulfill its responsibilities. If the elected master
-node is overloaded with other tasks then the cluster may not operate well. In
-particular, indexing and searching your data can be very resource-intensive, so
-in large or high-throughput clusters you should avoid using the master-eligible
-nodes for other tasks such as indexing and searching. You can do this by
-configuring three of your nodes to be dedicated master-eligible nodes.
-Dedicated master-eligible nodes only have the `master` role, allowing them to
-focus on managing the cluster. Master-eligible nodes will still also behave as
+node is overloaded with other tasks then the cluster will not operate well. The
+most reliable way to avoid overloading the master with other tasks is to
+configure all the master-eligible nodes to be _dedicated master-eligible nodes_
+which only have the `master` role, allowing them to focus on managing the
+cluster. Master-eligible nodes will still also behave as
 <<coordinating-node,coordinating nodes>> that route requests from clients to
 the other nodes in the cluster, but you should _not_ use dedicated master nodes
 for this purpose.
+
+A small or lightly-loaded cluster may operate well if its master-eligible nodes
+have other roles and responsibilities, but once your cluster comprises more
+than a handful of nodes it usually makes sense to use dedicated master-eligible
+nodes.
 
 To create a dedicated master-eligible node, set:
 

--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -132,14 +132,14 @@ It is important for the health of the cluster that the elected master node has
 the resources it needs to fulfill its responsibilities. If the elected master
 node is overloaded with other tasks then the cluster may not operate well. In
 particular, indexing and searching your data can be very resource-intensive, so
-in large or high-throughput clusters it is a good idea to avoid using the
-master-eligible nodes for tasks such as indexing and searching. You can do this
-by configuring three of your nodes to be dedicated master-eligible nodes.
+in large or high-throughput clusters you should avoid using the master-eligible
+nodes for other tasks such as indexing and searching. You can do this by
+configuring three of your nodes to be dedicated master-eligible nodes.
 Dedicated master-eligible nodes only have the `master` role, allowing them to
-focus on managing the cluster. While master nodes can also behave as
-<<coordinating-node,coordinating nodes>> and route search and indexing requests
-from clients to data nodes, it is better _not_ to use dedicated master nodes for
-this purpose.
+focus on managing the cluster. Master-eligible nodes will still also behave as
+<<coordinating-node,coordinating nodes>> that route requests from clients to
+the other nodes in the cluster, but you should _not_ use dedicated master nodes
+for this purpose.
 
 To create a dedicated master-eligible node, set:
 


### PR DESCRIPTION
Today the docs on node roles say that you shouldn't use dedicated
masters for heavy requests such as indexing and searching, but as per
the "designing for resilience" docs this guidance applies to all client
requests. This commit generalises the node roles docs slightly to
clarify this.

Relates #70435