### PR TITLE
[7.x] Add info on each HTTP client to HTTP stats

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -189,9 +189,9 @@ tasks.register("verifyVersions") {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = true
+boolean bwc_tests_enabled = false
 // place a PR link here when committing bwc changes:
-String bwc_tests_disabled_issue = ""
+String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/64561"
 /*
  * FIPS 140-2 behavior was fixed in 7.11.0. Before that there is no way to run elasticsearch in a
  * JVM that is properly configured to be in fips mode with BCFIPS. For now we need to disable

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/nodes.stats/11_indices_metrics.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/nodes.stats/11_indices_metrics.yml
@@ -226,6 +226,36 @@
   - is_true:   nodes.$node_id.indices.segments.file_sizes
 
 ---
+"Metric - segments include_unloaded_segments":
+  - skip:
+      features: [arbitrary_key]
+      version: " - 7.12.99"
+      reason: "support for include_unloaded_segments only added in 7.13"
+  - do:
+      nodes.info: {}
+  - set:
+      nodes._arbitrary_key_: node_id
+
+  - do:
+      nodes.stats: { metric: indices, index_metric: segments, include_unloaded_segments: true }
+
+  - is_false:  nodes.$node_id.indices.docs
+  - is_false:  nodes.$node_id.indices.store
+  - is_false:  nodes.$node_id.indices.indexing
+  - is_false:  nodes.$node_id.indices.get
+  - is_false:  nodes.$node_id.indices.search
+  - is_false:  nodes.$node_id.indices.merges
+  - is_false:  nodes.$node_id.indices.refresh
+  - is_false:  nodes.$node_id.indices.flush
+  - is_false:  nodes.$node_id.indices.warmer
+  - is_false:  nodes.$node_id.indices.query_cache
+  - is_false:  nodes.$node_id.indices.fielddata
+  - is_false:  nodes.$node_id.indices.completion
+  - is_true:   nodes.$node_id.indices.segments
+  - is_false:  nodes.$node_id.indices.translog
+  - is_false:  nodes.$node_id.indices.recovery
+
+---
 "Metric - _all include_unloaded_segments":
   - skip:
       features: [arbitrary_key]
@@ -256,31 +286,31 @@
   - is_true:   nodes.$node_id.indices.recovery
 
 ---
-"Metric - segments include_unloaded_segments":
+"Metric - http":
   - skip:
       features: [arbitrary_key]
-      version: " - 7.12.99"
-      reason: "support for include_unloaded_segments only added in 7.13"
+      version: " - 7.99.99"
+      reason: "change after backporting"
   - do:
       nodes.info: {}
   - set:
       nodes._arbitrary_key_: node_id
 
   - do:
-      nodes.stats: { metric: indices, index_metric: segments, include_unloaded_segments: true }
+      nodes.stats: { metric: http }
 
-  - is_false:  nodes.$node_id.indices.docs
-  - is_false:  nodes.$node_id.indices.store
-  - is_false:  nodes.$node_id.indices.indexing
-  - is_false:  nodes.$node_id.indices.get
-  - is_false:  nodes.$node_id.indices.search
-  - is_false:  nodes.$node_id.indices.merges
-  - is_false:  nodes.$node_id.indices.refresh
-  - is_false:  nodes.$node_id.indices.flush
-  - is_false:  nodes.$node_id.indices.warmer
-  - is_false:  nodes.$node_id.indices.query_cache
-  - is_false:  nodes.$node_id.indices.fielddata
-  - is_false:  nodes.$node_id.indices.completion
-  - is_true:   nodes.$node_id.indices.segments
-  - is_false:  nodes.$node_id.indices.translog
-  - is_false:  nodes.$node_id.indices.recovery
+  - is_true:  nodes.$node_id
+  - gte: { nodes.$node_id.http.current_open: 1 }
+  - gte: { nodes.$node_id.http.total_opened: 1 }
+  - is_true:  nodes.$node_id.http.clients
+  - gte: { nodes.$node_id.http.clients.0.id: 1 }
+  - match: { nodes.$node_id.http.clients.0.agent: "/.*/" }
+  - match: { nodes.$node_id.http.clients.0.local_address: "/.*/" }
+  - match: { nodes.$node_id.http.clients.0.remote_address: "/.*/" }
+  - is_true:  nodes.$node_id.http.clients.0.last_uri
+  - gte: { nodes.$node_id.http.clients.0.opened_time_millis: 1614028911317 }
+  - gte: { nodes.$node_id.http.clients.0.last_request_time_millis: 1614028911317 }
+  - gte: { nodes.$node_id.http.clients.0.request_count: 1 }
+  - gte: { nodes.$node_id.http.clients.0.request_size_bytes: 0 }
+  # values for clients.0.closed_time_millis, clients.0.x_forwarded_for, and clients.0.x_opaque_id are often
+  # null and cannot be tested here

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/nodes.stats/11_indices_metrics.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/nodes.stats/11_indices_metrics.yml
@@ -289,7 +289,7 @@
 "Metric - http":
   - skip:
       features: [arbitrary_key]
-      version: " - 7.99.99"
+      version: " - 7.12.99"
       reason: "change after backporting"
   - do:
       nodes.info: {}

--- a/server/src/main/java/org/elasticsearch/http/AbstractHttpServerTransport.java
+++ b/server/src/main/java/org/elasticsearch/http/AbstractHttpServerTransport.java
@@ -147,7 +147,7 @@ public abstract class AbstractHttpServerTransport extends AbstractLifecycleCompo
     void pruneClientStats(boolean throttled) {
         if (throttled == false || (threadPool.relativeTimeInMillis() - lastClientStatsPruneTime > PRUNE_THROTTLE_INTERVAL)) {
             long nowMillis = threadPool.absoluteTimeInMillis();
-            for (var statsEntry : httpChannelStats.entrySet()) {
+            for (Map.Entry<Integer, HttpStats.ClientStats> statsEntry : httpChannelStats.entrySet()) {
                 long closedTimeMillis = statsEntry.getValue().closedTimeMillis;
                 if (closedTimeMillis > 0 && (nowMillis - closedTimeMillis > MAX_CLIENT_STATS_AGE)) {
                     httpChannelStats.remove(statsEntry.getKey());

--- a/server/src/main/java/org/elasticsearch/http/HttpStats.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpStats.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.http;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -15,26 +16,42 @@ import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.atomic.LongAdder;
 
 public class HttpStats implements Writeable, ToXContentFragment {
 
     private final long serverOpen;
     private final long totalOpen;
+    private final List<ClientStats> clientStats;
 
-    public HttpStats(long serverOpen, long totalOpened) {
+    public HttpStats(List<ClientStats> clientStats, long serverOpen, long totalOpened) {
+        this.clientStats = clientStats;
         this.serverOpen = serverOpen;
         this.totalOpen = totalOpened;
+    }
+
+    public HttpStats(long serverOpen, long totalOpened) {
+        this(List.of(), serverOpen, totalOpened);
     }
 
     public HttpStats(StreamInput in) throws IOException {
         serverOpen = in.readVLong();
         totalOpen = in.readVLong();
+        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+            clientStats = in.readList(ClientStats::new);
+        } else {
+            clientStats = List.of();
+        }
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeVLong(serverOpen);
         out.writeVLong(totalOpen);
+        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+            out.writeList(clientStats);
+        }
     }
 
     public long getServerOpen() {
@@ -49,6 +66,19 @@ public class HttpStats implements Writeable, ToXContentFragment {
         static final String HTTP = "http";
         static final String CURRENT_OPEN = "current_open";
         static final String TOTAL_OPENED = "total_opened";
+        static final String CLIENTS = "clients";
+        static final String CLIENT_ID = "id";
+        static final String CLIENT_AGENT = "agent";
+        static final String CLIENT_LOCAL_ADDRESS = "local_address";
+        static final String CLIENT_REMOTE_ADDRESS = "remote_address";
+        static final String CLIENT_LAST_URI = "last_uri";
+        static final String CLIENT_OPENED_TIME_MILLIS = "opened_time_millis";
+        static final String CLIENT_CLOSED_TIME_MILLIS = "closed_time_millis";
+        static final String CLIENT_LAST_REQUEST_TIME_MILLIS = "last_request_time_millis";
+        static final String CLIENT_REQUEST_COUNT = "request_count";
+        static final String CLIENT_REQUEST_SIZE_BYTES = "request_size_bytes";
+        static final String CLIENT_FORWARDED_FOR = "x_forwarded_for";
+        static final String CLIENT_OPAQUE_ID = "x_opaque_id";
     }
 
     @Override
@@ -56,7 +86,114 @@ public class HttpStats implements Writeable, ToXContentFragment {
         builder.startObject(Fields.HTTP);
         builder.field(Fields.CURRENT_OPEN, serverOpen);
         builder.field(Fields.TOTAL_OPENED, totalOpen);
+        builder.startArray(Fields.CLIENTS);
+        for (ClientStats clientStats : this.clientStats) {
+            clientStats.toXContent(builder, params);
+        }
+        builder.endArray();
         builder.endObject();
         return builder;
+    }
+
+    public static class ClientStats implements Writeable, ToXContentFragment {
+        final int id;
+        String agent;
+        String localAddress;
+        String remoteAddress;
+        String lastUri;
+        String forwardedFor;
+        String opaqueId;
+        long openedTimeMillis;
+        long closedTimeMillis = -1;
+        volatile long lastRequestTimeMillis = -1;
+        final LongAdder requestCount = new LongAdder();
+        final LongAdder requestSizeBytes = new LongAdder();
+
+        ClientStats(long openedTimeMillis) {
+            this.id = System.identityHashCode(this);
+            this.openedTimeMillis = openedTimeMillis;
+        }
+
+        // visible for testing
+        public ClientStats(String agent, String localAddress, String remoteAddress, String lastUri, String forwardedFor, String opaqueId,
+            long openedTimeMillis, long closedTimeMillis, long lastRequestTimeMillis, long requestCount, long requestSizeBytes) {
+            this.id = System.identityHashCode(this);
+            this.agent = agent;
+            this.localAddress = localAddress;
+            this.remoteAddress = remoteAddress;
+            this.lastUri = lastUri;
+            this.forwardedFor = forwardedFor;
+            this.opaqueId = opaqueId;
+            this.openedTimeMillis = openedTimeMillis;
+            this.closedTimeMillis = closedTimeMillis;
+            this.lastRequestTimeMillis = lastRequestTimeMillis;
+            this.requestCount.add(requestCount);
+            this.requestSizeBytes.add(requestSizeBytes);
+        }
+
+        ClientStats(StreamInput in) throws IOException {
+            this.id = in.readInt();
+            this.agent = in.readOptionalString();
+            this.localAddress = in.readString();
+            this.remoteAddress = in.readString();
+            this.lastUri = in.readString();
+            this.forwardedFor = in.readOptionalString();
+            this.opaqueId = in.readOptionalString();
+            this.openedTimeMillis = in.readLong();
+            this.closedTimeMillis = in.readLong();
+            this.lastRequestTimeMillis = in.readLong();
+            this.requestCount.add(in.readLong());
+            this.requestSizeBytes.add(in.readLong());
+        }
+
+        @Override public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            builder.field(Fields.CLIENT_ID, id);
+            if (agent != null) {
+                builder.field(Fields.CLIENT_AGENT, agent);
+            }
+            builder.field(Fields.CLIENT_LOCAL_ADDRESS, localAddress);
+            builder.field(Fields.CLIENT_REMOTE_ADDRESS, remoteAddress);
+            builder.field(Fields.CLIENT_LAST_URI, lastUri);
+            if (forwardedFor != null) {
+                builder.field(Fields.CLIENT_FORWARDED_FOR, forwardedFor);
+            }
+            if (opaqueId != null) {
+                builder.field(Fields.CLIENT_OPAQUE_ID, opaqueId);
+            }
+            builder.field(Fields.CLIENT_OPENED_TIME_MILLIS, openedTimeMillis);
+            if (closedTimeMillis != -1) {
+                builder.field(Fields.CLIENT_CLOSED_TIME_MILLIS, closedTimeMillis);
+            }
+            builder.field(Fields.CLIENT_LAST_REQUEST_TIME_MILLIS, lastRequestTimeMillis);
+            builder.field(Fields.CLIENT_REQUEST_COUNT, requestCount.longValue());
+            builder.field(Fields.CLIENT_REQUEST_SIZE_BYTES, requestSizeBytes.longValue());
+            builder.endObject();
+            return builder;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeInt(id);
+            out.writeOptionalString(agent);
+            out.writeString(localAddress);
+            out.writeString(remoteAddress);
+            out.writeString(lastUri);
+            out.writeOptionalString(forwardedFor);
+            out.writeOptionalString(opaqueId);
+            out.writeLong(openedTimeMillis);
+            out.writeLong(closedTimeMillis);
+            out.writeLong(lastRequestTimeMillis);
+            out.writeLong(requestCount.longValue());
+            out.writeLong(requestSizeBytes.longValue());
+        }
+
+        /**
+         * Returns a key suitable for use in a hash table for the specified HttpChannel
+         */
+        public static int getChannelKey(HttpChannel channel) {
+            // always use an identity-based hash code rather than one based on object state
+            return System.identityHashCode(channel);
+        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/http/HttpStats.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpStats.java
@@ -32,16 +32,16 @@ public class HttpStats implements Writeable, ToXContentFragment {
     }
 
     public HttpStats(long serverOpen, long totalOpened) {
-        this(List.of(), serverOpen, totalOpened);
+        this(org.elasticsearch.common.collect.List.of(), serverOpen, totalOpened);
     }
 
     public HttpStats(StreamInput in) throws IOException {
         serverOpen = in.readVLong();
         totalOpen = in.readVLong();
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_13_0)) {
             clientStats = in.readList(ClientStats::new);
         } else {
-            clientStats = List.of();
+            clientStats = org.elasticsearch.common.collect.List.of();
         }
     }
 
@@ -49,7 +49,7 @@ public class HttpStats implements Writeable, ToXContentFragment {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeVLong(serverOpen);
         out.writeVLong(totalOpen);
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_13_0)) {
             out.writeList(clientStats);
         }
     }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
@@ -437,7 +437,7 @@ public class NodeStatsTests extends ESTestCase {
             int numClients = randomIntBetween(0, 50);
             List<HttpStats.ClientStats> clientStats = new ArrayList<>(numClients);
             for (int k = 0; k < numClients; k++) {
-                var cs = new HttpStats.ClientStats(
+                HttpStats.ClientStats cs = new HttpStats.ClientStats(
                     randomAlphaOfLength(6),
                     randomAlphaOfLength(6),
                     randomAlphaOfLength(6),

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
@@ -432,7 +432,28 @@ public class NodeStatsTests extends ESTestCase {
         }
         TransportStats transportStats = frequently() ? new TransportStats(randomNonNegativeLong(), randomNonNegativeLong(),
                 randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong()) : null;
-        HttpStats httpStats = frequently() ? new HttpStats(randomNonNegativeLong(), randomNonNegativeLong()) : null;
+        HttpStats httpStats = null;
+        if (frequently()) {
+            int numClients = randomIntBetween(0, 50);
+            List<HttpStats.ClientStats> clientStats = new ArrayList<>(numClients);
+            for (int k = 0; k < numClients; k++) {
+                var cs = new HttpStats.ClientStats(
+                    randomAlphaOfLength(6),
+                    randomAlphaOfLength(6),
+                    randomAlphaOfLength(6),
+                    randomAlphaOfLength(6),
+                    randomAlphaOfLength(6),
+                    randomAlphaOfLength(6),
+                    randomNonNegativeLong(),
+                    randomBoolean() ? -1 : randomNonNegativeLong(),
+                    randomBoolean() ? -1 : randomNonNegativeLong(),
+                    randomLongBetween(0, 100),
+                    randomLongBetween(0, 99999999)
+                );
+                clientStats.add(cs);
+            }
+            httpStats = new HttpStats(clientStats, randomNonNegativeLong(), randomNonNegativeLong());
+        }
         AllCircuitBreakerStats allCircuitBreakerStats = null;
         if (frequently()) {
             int numCircuitBreakerStats = randomIntBetween(0, 10);


### PR DESCRIPTION
Elasticsearch currently provides only the count of HTTP clients currently holding an open connection and the number of HTTP connections that have been opened on the node. This is less than what is reported for [transport clients](https://github.com/elastic/elasticsearch/blob/master/server/src/main/java/org/elasticsearch/transport/TcpChannel.java#L82) and, as #61609 points out, additional information on connected HTTP clients would be very helpful in a number of troubleshooting and monitoring scenarios.

This change adds the following to the "http" section of node stats:

```
"http" : {
  "current_open" : 14,
  "total_opened" : 2735,
  "clients" : [
    {
      "agent" : "kibana",
      "local_address" : "/192.168.5.60:9200",
      "remote_address" : "/192.168.5.60:58156",
      "last_uri" : "/_nodes?filter_path=nodes.*.version%2Cnodes.*.http.publish_address%2Cnodes.*.ip",
      "opened_time_millis" : 1604420317590,
      "closed_time_millis" : -1,
      "last_request_time_millis" : 1604438560498,
      "request_count" : 4408,
      "request_size_bytes" : 261106
    },
    {
      "agent" : "curl/7.68.0",
      "local_address" : "/192.168.5.60:9200",
      "remote_address" : "/192.168.5.203:35834",
      "last_uri" : "/_nodes/stats/http?pretty",
      "opened_time_millis" : 1604438562302,
      "closed_time_millis" : 1604438562302,
      "last_request_time_millis" : 1604438562302,
      "request_count" : 1,
      "request_size_bytes" : 0
    }
    ...
  ]
```

Some notes about the fields above:
- `agent`: This is pulled from the `x-elastic-product-origin` or `User-Agent` HTTP header if either is present. Note that it would be nice if Elastic products identified themselves with a user-friendly tag. The `User-Agent` header reports the Go client or the JS client for Beats and Kibana, respectively, which is better than nothing but not as nice as "filebeat" or "kibana", etc. The `x-elastic-product-origin` header reports a friendly "kibana" value for Kibana, but I don't believe that its purpose nor is it consistent across Elastic products.
- `closed_time_millis`: This reports `-1` for clients that are currently connected. As implemented, clients that disconnected within the last 5 minutes are still included to aid with tracking either clients such as curl that intentionally disconnect immediately or clients that are dropping connections for other reasons.
- `request_size_bytes`: This tracks cumulative request size.

Backport of #64561
