### PR TITLE
[7.x] [DOCs] Add tip for `index_options` parameter (#70450)

### DIFF
--- a/docs/reference/mapping/params/index-options.asciidoc
+++ b/docs/reference/mapping/params/index-options.asciidoc
@@ -10,25 +10,27 @@ The `index_options` parameter is intended for use with <<text,`text`>> fields
 only. Avoid using `index_options` with other field data types.
 ====
 
-It accepts the following values:
+The parameter accepts one of the following values. Each value retrieves
+information from the previous listed values. For example, `freqs` contains
+`docs`; `positions` contains both `freqs` and `docs`.
 
 `docs`::
-Only the doc number is indexed.  Can answer the question _Does this term
-exist in this field?_
+Only the doc number is indexed. Can answer the question _Does this term exist in
+this field?_
 
 `freqs`::
-Doc number and term frequencies are indexed.  Term frequencies are used to
-score repeated terms higher than single terms.
+Doc number and term frequencies are indexed. Term frequencies are used to score
+repeated terms higher than single terms.
 
 `positions` (default)::
 Doc number, term frequencies, and term positions (or order) are indexed.
-Positions can be used for
-<<query-dsl-match-query-phrase,proximity or phrase queries>>.
+Positions can be used for <<query-dsl-match-query-phrase,proximity or phrase
+queries>>.
 
 `offsets`::
-Doc number, term frequencies, positions, and start and end character
-offsets (which map the term back to the original string) are indexed.
-Offsets are used by the <<unified-highlighter,unified highlighter>> to speed up highlighting.
+Doc number, term frequencies, positions, and start and end character offsets
+(which map the term back to the original string) are indexed. Offsets are used
+by the <<unified-highlighter,unified highlighter>> to speed up highlighting.
 
 [source,console]
 --------------------------------------------------


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCs] Add tip for `index_options` parameter (#70450)