### PR TITLE
Take into account range start to compute the current stream end on URL repositories

### DIFF
--- a/modules/repository-url/src/main/java/org/elasticsearch/common/blobstore/url/http/HttpURLBlobContainer.java
+++ b/modules/repository-url/src/main/java/org/elasticsearch/common/blobstore/url/http/HttpURLBlobContainer.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.blobstore.BlobPath;
 import org.elasticsearch.common.blobstore.url.URLBlobContainer;
 import org.elasticsearch.common.blobstore.url.URLBlobStore;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -33,6 +34,10 @@ public class HttpURLBlobContainer extends URLBlobContainer {
 
     @Override
     public InputStream readBlob(String name, long position, long length) throws IOException {
+        if (length == 0) {
+            return new ByteArrayInputStream(new byte[0]);
+        }
+
         return new RetryingHttpInputStream(name,
             getURIForBlob(name),
             position,

--- a/modules/repository-url/src/main/java/org/elasticsearch/common/blobstore/url/http/RetryingHttpInputStream.java
+++ b/modules/repository-url/src/main/java/org/elasticsearch/common/blobstore/url/http/RetryingHttpInputStream.java
@@ -220,7 +220,7 @@ class RetryingHttpInputStream extends InputStream {
                             " Status code: [" + statusCode + "] - Body: " + body));
                     }
 
-                    currentStreamLastOffset = getStreamLength(response);
+                    currentStreamLastOffset = Math.addExact(Math.addExact(start, totalBytesRead), getStreamLength(response));
 
                     return response.getInputStream();
                 } catch (URLHttpClientException e) {

--- a/modules/repository-url/src/test/java/org/elasticsearch/common/blobstore/url/URLBlobContainerRetriesTests.java
+++ b/modules/repository-url/src/test/java/org/elasticsearch/common/blobstore/url/URLBlobContainerRetriesTests.java
@@ -42,12 +42,6 @@ public class URLBlobContainerRetriesTests extends AbstractBlobContainerRetriesTe
     }
 
     @Override
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/70310")
-    public void testReadRangeBlobWithRetries() {
-
-    }
-
-    @Override
     protected String downloadStorageEndpoint(String blob) {
         return "/" + blob;
     }


### PR DESCRIPTION
This helps to abort the underlying http request if there's still pending data to be consumed.

Closes #70310