### PR TITLE
SQL: Replace JDBC qualified array types with a generic one

### DIFF
--- a/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/EsType.java
+++ b/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/EsType.java
@@ -49,23 +49,7 @@ public enum EsType implements SQLType {
     GEO_POINT(                ExtraTypes.GEOMETRY),
     GEO_SHAPE(                ExtraTypes.GEOMETRY),
     SHAPE(                    ExtraTypes.GEOMETRY),
-    BOOLEAN_ARRAY(            Types.ARRAY),
-    BYTE_ARRAY(               Types.ARRAY),
-    SHORT_ARRAY(              Types.ARRAY),
-    INTEGER_ARRAY(            Types.ARRAY),
-    LONG_ARRAY(               Types.ARRAY),
-    DOUBLE_ARRAY(             Types.ARRAY),
-    FLOAT_ARRAY(              Types.ARRAY),
-    HALF_FLOAT_ARRAY(         Types.ARRAY),
-    SCALED_FLOAT_ARRAY(       Types.ARRAY),
-    KEYWORD_ARRAY(            Types.ARRAY),
-    TEXT_ARRAY(               Types.ARRAY),
-    DATETIME_ARRAY(           Types.ARRAY),
-    IP_ARRAY(                 Types.ARRAY),
-    BINARY_ARRAY(             Types.ARRAY),
-    GEO_SHAPE_ARRAY(          Types.ARRAY),
-    GEO_POINT_ARRAY(          Types.ARRAY),
-    SHAPE_ARRAY(              Types.ARRAY);
+    ARRAY(                    Types.ARRAY);
 
     private final Integer type;
 

--- a/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/JdbcColumnInfo.java
+++ b/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/JdbcColumnInfo.java
@@ -19,8 +19,13 @@ class JdbcColumnInfo {
     public final String name;
     public final int displaySize;
     public final EsType type;
+    public final boolean isArray;
 
     JdbcColumnInfo(String name, EsType type, String table, String catalog, String schema, String label, int displaySize) {
+        this(name, type, false, table, catalog, schema, label, displaySize);
+    }
+
+    JdbcColumnInfo(String name, EsType type, boolean isArray, String table, String catalog, String schema, String label, int displaySize) {
         if (name == null) {
             throw new IllegalArgumentException("[name] must not be null");
         }
@@ -41,6 +46,7 @@ class JdbcColumnInfo {
         }
         this.name = name;
         this.type = type;
+        this.isArray = isArray;
         this.table = table;
         this.catalog = catalog;
         this.schema = schema;

--- a/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/JdbcHttpClient.java
+++ b/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/JdbcHttpClient.java
@@ -22,6 +22,7 @@ import org.elasticsearch.xpack.sql.proto.SqlVersion;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import static java.util.Collections.emptyMap;
 import static org.elasticsearch.xpack.sql.client.StringUtils.EMPTY;
@@ -116,7 +117,13 @@ class JdbcHttpClient {
     private List<JdbcColumnInfo> toJdbcColumnInfo(List<ColumnInfo> columns) throws SQLException {
         List<JdbcColumnInfo> cols = new ArrayList<>(columns.size());
         for (ColumnInfo info : columns) {
-            cols.add(new JdbcColumnInfo(info.name(), TypeUtils.of(info.esType()), EMPTY, EMPTY, EMPTY, EMPTY, info.displaySize()));
+            String typeName = info.esType().toLowerCase(Locale.ROOT);
+            boolean isArray = false;
+            if (typeName.endsWith("_array")) {
+                isArray = true;
+                typeName = typeName.substring(0, typeName.length() - "_array".length());
+            }
+            cols.add(new JdbcColumnInfo(info.name(), TypeUtils.of(typeName), isArray, EMPTY, EMPTY, EMPTY, EMPTY, info.displaySize()));
         }
         return cols;
     }

--- a/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/JdbcResultSetMetaData.java
+++ b/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/JdbcResultSetMetaData.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.sql.jdbc;
 
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+import java.sql.Types;
 import java.util.List;
 import java.util.Locale;
 
@@ -110,12 +111,12 @@ class JdbcResultSetMetaData implements ResultSetMetaData, JdbcWrapper {
 
     @Override
     public int getColumnType(int column) throws SQLException {
-        return column(column).type.getVendorTypeNumber();
+        return column(column).isArray ? Types.ARRAY : column(column).type.getVendorTypeNumber();
     }
 
     @Override
     public String getColumnTypeName(int column) throws SQLException {
-        return column(column).type.getName();
+        return column(column).type.getName() + (column(column).isArray ? "_ARRAY" : "");
     }
 
     @Override

--- a/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/JdbcResultSetMetaData.java
+++ b/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/JdbcResultSetMetaData.java
@@ -139,7 +139,7 @@ class JdbcResultSetMetaData implements ResultSetMetaData, JdbcWrapper {
 
     @Override
     public String getColumnClassName(int column) throws SQLException {
-        return TypeUtils.classOf(column(column).type).getName();
+        return column(column).isArray ? JdbcArray.class.getName() : TypeUtils.classOf(column(column).type).getName();
     }
 
     private void checkOpen() throws SQLException {

--- a/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/JdbcResultSetMetaData.java
+++ b/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/JdbcResultSetMetaData.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.sql.jdbc;
 
+import java.sql.Array;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Types;
@@ -139,7 +140,7 @@ class JdbcResultSetMetaData implements ResultSetMetaData, JdbcWrapper {
 
     @Override
     public String getColumnClassName(int column) throws SQLException {
-        return column(column).isArray ? JdbcArray.class.getName() : TypeUtils.classOf(column(column).type).getName();
+        return column(column).isArray ? Array.class.getName() : TypeUtils.classOf(column(column).type).getName();
     }
 
     private void checkOpen() throws SQLException {

--- a/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/TypeConverter.java
+++ b/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/TypeConverter.java
@@ -48,7 +48,6 @@ import static org.elasticsearch.xpack.sql.jdbc.EsType.DATETIME;
 import static org.elasticsearch.xpack.sql.jdbc.EsType.TIME;
 import static org.elasticsearch.xpack.sql.jdbc.JdbcDateUtils.asDateTimeField;
 import static org.elasticsearch.xpack.sql.jdbc.JdbcDateUtils.timeAsTime;
-import static org.elasticsearch.xpack.sql.jdbc.TypeUtils.baseType;
 
 /**
  * Conversion utilities for conversion of JDBC types to Java type and back
@@ -210,6 +209,15 @@ final class TypeConverter {
         return failConversion(val, columnType, typeString, type);
     }
 
+    static List<Object> convertArray(Object v, EsType columnBaseType, String typeString) throws SQLException {
+        List<Object> values = new ArrayList<>();
+        for (Object o : (List<?>) v) {
+            // null value expects a NULL type in the converter
+            values.add(o == null ? null : convert(o, columnBaseType, typeString));
+        }
+        return values;
+    }
+
     /**
      * Converts the object from JSON representation to the specified JDBCType
      */
@@ -266,32 +274,8 @@ final class TypeConverter {
                 }
             case IP:
                 return v.toString();
-            case BOOLEAN_ARRAY:
-            case BYTE_ARRAY:
-            case SHORT_ARRAY:
-            case INTEGER_ARRAY:
-            case LONG_ARRAY:
-            case DOUBLE_ARRAY:
-            case FLOAT_ARRAY:
-            case HALF_FLOAT_ARRAY:
-            case SCALED_FLOAT_ARRAY:
-            case KEYWORD_ARRAY:
-            case TEXT_ARRAY:
-            case DATETIME_ARRAY:
-            case IP_ARRAY:
-            case BINARY_ARRAY:
-            case GEO_SHAPE_ARRAY:
-            case GEO_POINT_ARRAY:
-            case SHAPE_ARRAY:
-                List<Object> values = new ArrayList<>();
-                for (Object o : (List<?>) v) {
-                    // null value expects a NULL type in the converter
-                    values.add(o == null ? null : convert(o, baseType(columnType), typeString.substring(0, "_ARRAY".length())));
-                }
-                return values;
             default:
                 throw new SQLException("Unexpected column type [" + typeString + "]");
-
         }
     }
 

--- a/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/TypeUtils.java
+++ b/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/TypeUtils.java
@@ -12,7 +12,6 @@ import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.sql.SQLType;
 import java.sql.Timestamp;
-import java.sql.Types;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.Period;
@@ -176,23 +175,5 @@ final class TypeUtils {
             throw new SQLFeatureNotSupportedException("Objects of type [" + clazz.getName() + "] are not supported");
         }
         return dataType;
-    }
-
-    static EsType baseType(EsType type) throws SQLException {
-        String typeName = type.getName();
-        return isArray(type)
-            ? of(typeName.substring(0, typeName.length() - "_ARRAY".length()).toLowerCase(Locale.ROOT))
-            : type;
-    }
-
-    static EsType arrayOf(EsType type) throws SQLException {
-        if (isArray(type)) {
-            throw new SQLException("multidimentional array types not supported");
-        }
-        return ENUM_NAME_TO_TYPE.get(type.name().toLowerCase(Locale.ROOT) + "_array");
-    }
-
-    static boolean isArray(EsType type) {
-        return type.getVendorTypeNumber() == Types.ARRAY;
     }
 }

--- a/x-pack/plugin/sql/qa/jdbc/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/ResultSetMetaDataTestCase.java
+++ b/x-pack/plugin/sql/qa/jdbc/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/ResultSetMetaDataTestCase.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.sql.qa.jdbc;
 import org.elasticsearch.common.CheckedConsumer;
 
 import java.io.IOException;
+import java.sql.Array;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -64,8 +65,7 @@ public abstract class ResultSetMetaDataTestCase extends JdbcIntegrationTestCase 
                 typeName = typeName.equals("DATE") ? "DATETIME" : typeName;
                 typeName += "_ARRAY";
                 assertEquals(typeName, md.getColumnTypeName(i + 1));
-                // JdbcArray is not a public class
-                assertEquals("org.elasticsearch.xpack.sql.jdbc.JdbcArray", md.getColumnClassName(i + 1));
+                assertEquals(Array.class.getName(), md.getColumnClassName(i + 1));
             }
         });
     }

--- a/x-pack/plugin/sql/qa/jdbc/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/ResultSetMetaDataTestCase.java
+++ b/x-pack/plugin/sql/qa/jdbc/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/ResultSetMetaDataTestCase.java
@@ -64,6 +64,8 @@ public abstract class ResultSetMetaDataTestCase extends JdbcIntegrationTestCase 
                 typeName = typeName.equals("DATE") ? "DATETIME" : typeName;
                 typeName += "_ARRAY";
                 assertEquals(typeName, md.getColumnTypeName(i + 1));
+                // JdbcArray is not a public class
+                assertEquals("org.elasticsearch.xpack.sql.jdbc.JdbcArray", md.getColumnClassName(i + 1));
             }
         });
     }

--- a/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/DataLoader.java
+++ b/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/DataLoader.java
@@ -438,6 +438,60 @@ public class DataLoader {
         client.performRequest(request); // fails by exception
     }
 
+    // TODO: functionalize index creation (settings+mapping) and bulk builder throughout class?
+    protected static void loadEcommerceDatasetIntoEs(RestClient client, String index, String fileName) throws Exception {
+        XContentBuilder createIndex = JsonXContent.contentBuilder().startObject();
+        createIndex.startObject("settings");
+        {
+            createIndex.field("number_of_shards", 1);
+            createIndex.field("number_of_replicas", 1);
+        }
+        createIndex.endObject();
+        createIndex.startObject("mappings");
+        {
+            createIndex.startObject("properties");
+            {
+                createIndex.startObject("id").field("type", "integer").endObject();
+                createIndex.startObject("date").field("type", "date").endObject();
+                createString("product", createIndex);
+                createString("sku", createIndex);
+                createIndex.startObject("price").field("type", "integer").endObject();
+                createIndex.startObject("tax").field("type", "double").endObject();
+                createIndex.startObject("shipped").field("type", "date").endObject();
+            }
+            createIndex.endObject();
+        }
+        createIndex.endObject().endObject();
+
+        Request request = new Request("PUT", "/" + index);
+        request.setJsonEntity(Strings.toString(createIndex));
+        client.performRequest(request);
+
+        StringBuilder builder = new StringBuilder();
+        csvToLines(fileName, (headers, values) -> {
+            builder.append("{\"index\":{\"_id\":" + values.get(0) + "}}\n");
+            builder.append("{");
+            for (int i = 0; i < headers.size(); i++) {
+                String value = values.get(i);
+                if (i == 1) { // date: [2020-...]
+                    value = '"' + value + '"';
+                } else if (i == 6) { // shipped: [2020-..,2020-...] or [null,2020-...]
+                    String[] tokens = value.substring(1, value.length() - 1).split(",");
+                    value = Arrays.stream(tokens).map(x -> x.equals("null") ? x : '"' + x + '"').collect(Collectors.joining(","));
+                    value = '[' + value + ']';
+                }
+                builder.append('"').append(headers.get(i)).append('"').append(':').append(value);
+                builder.append(",");
+            }
+            builder.deleteCharAt(builder.length() - 1); // trailing comma
+            builder.append("}").append("\n");
+        });
+
+        request = new Request("POST", "/" + index + "/_bulk?refresh=true");
+        request.setJsonEntity(builder.toString());
+        client.performRequest(request); // fails by exception
+    }
+
     public static void makeAlias(RestClient client, String aliasName, String... indices) throws Exception {
         for (String index : indices) {
             client.performRequest(new Request("POST", "/" + index + "/_alias/" + aliasName));
@@ -475,6 +529,43 @@ public class DataLoader {
                 consumeLine.accept(titles, values);
             }
         }
+    }
+
+    private static List<String> splitCsvLine(String line) {
+        List<String> values = new ArrayList<>();
+        StringBuilder buff = new StringBuilder();
+        boolean quoteOn = false;
+        char crr, prev = 0;
+        for (int i = 0; i < line.length(); i++, prev = crr) {
+            switch ((crr = line.charAt(i))) {
+                case ',':
+                    if (quoteOn) {
+                        buff.append(crr);
+                    } else {
+                        values.add(buff.toString());
+                        buff = new StringBuilder();
+                    }
+                    break;
+                case '"':
+                    if (quoteOn) {
+                        quoteOn = false;
+                    } else {
+                        if (prev == '"') { // double `"` == escaped `"`
+                            buff.append('"');
+                        } // else: no if (prev != 0 && prev != ',') check => ...,foo"bar"baz,... -> foobarbaz
+                        quoteOn = true;
+                    }
+                    break;
+                default:
+                    buff.append(crr);
+                    break;
+            }
+        }
+        if (quoteOn) {
+            throw new IllegalArgumentException("Quote not closed in badly formatted CSV line: [" + line + "]");
+        }
+        values.add(buff.toString());
+        return values;
     }
 
     private static List<String> splitCsvLine(String line) {


### PR DESCRIPTION
This replaces the qualified JDBC array enum types with a single ARRAY
type, which is then further qualified within the JDBC column info.

The name of the type reported through the metadata primitives is still
the composition of the base type and "_array".
