### PR TITLE
[DOCS] HTTP client stats

### DIFF
--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -1904,7 +1904,7 @@ Remote address for the HTTP client.
 (string)
 Value from the client's `x-forwarded-for` HTTP header. If unavailable, this
 property is not included in the response.
-`opqaue_id`::
+`x_opqaue_id`::
 (string)
 Value from the client's `x-opaque-id` HTTP header. If unavailable, this property
 is not included in the response.

--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -1892,7 +1892,8 @@ Information on current and recently-closed HTTP client connections.
 Unique ID for the HTTP client.
 `agent`::
 (string)
-Reported agent for the HTTP client, if available.
+Reported agent for the HTTP client. If unavailable, this property is not
+included in the response.
 `local_address`::
 (string)
 Local address for the HTTP client.

--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -1881,13 +1881,45 @@ Current number of open HTTP connections for the node.
 Total number of HTTP connections opened for the node.
 
 `clients`::
-(object)
-Information on current and recently-closed HTTP connections.
+(array of objects)
+Information on current and recently-closed HTTP client connections.
 +
 .Properties of `clients`
 [%collapsible%open]
 ======
-
+`id`::
+(integer)
+Unique ID for the HTTP client.
+`agent`::
+(string)
+Reported agent for the HTTP client, if available.
+`local_address`::
+(string)
+Local address for the HTTP client.
+`remote_address`::
+(string)
+Remote address for the HTTP client.
+`forwarded_for`::
+(string)
+Value from the client's `x-forwarded-for` HTTP header, if available.
+`opqaue_id`::
+(string)
+Value from the client's `x-opaque-id` HTTP header, if available.
+`opened_time_millis`::
+(integer)
+Time at which the client opened the connection.
+`closed_time_millis`::
+(integer)
+Time at which the client closed the connection if the connection is closed.
+`last_request_time_millis`::
+(integer)
+Time of the most recent request from this client.
+`request_count`::
+(integer)
+Number of requests from this client.
+`request_size_bytes`::
+(integer)
+Cumulative size in bytes of all requests from this client
 
 ======
 

--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -1906,7 +1906,8 @@ Value from the client's `x-forwarded-for` HTTP header. If unavailable, this
 property is not included in the response.
 `opqaue_id`::
 (string)
-Value from the client's `x-opaque-id` HTTP header, if available.
+Value from the client's `x-opaque-id` HTTP header. If unavailable, this property
+is not included in the response.
 `opened_time_millis`::
 (integer)
 Time at which the client opened the connection.

--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -1890,39 +1890,50 @@ Information on current and recently-closed HTTP client connections.
 `id`::
 (integer)
 Unique ID for the HTTP client.
+
 `agent`::
 (string)
 Reported agent for the HTTP client. If unavailable, this property is not
 included in the response.
+
 `local_address`::
 (string)
 Local address for the HTTP client.
+
 `remote_address`::
 (string)
 Remote address for the HTTP client.
+
 `last_uri`::
 (string)
 The URI of the client's most recent request.
+
 `x_forwarded_for`::
 (string)
 Value from the client's `x-forwarded-for` HTTP header. If unavailable, this
 property is not included in the response.
+
 `x_opaque_id`::
 (string)
 Value from the client's `x-opaque-id` HTTP header. If unavailable, this property
 is not included in the response.
+
 `opened_time_millis`::
 (integer)
 Time at which the client opened the connection.
+
 `closed_time_millis`::
 (integer)
 Time at which the client closed the connection if the connection is closed.
+
 `last_request_time_millis`::
 (integer)
 Time of the most recent request from this client.
+
 `request_count`::
 (integer)
 Number of requests from this client.
+
 `request_size_bytes`::
 (integer)
 Cumulative size in bytes of all requests from this client.

--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -1879,6 +1879,16 @@ Current number of open HTTP connections for the node.
 `total_opened`::
 (integer)
 Total number of HTTP connections opened for the node.
+
+`clients`::
+(object)
+Information on current and recently-closed HTTP connections.
++
+.Properties of `clients`
+[%collapsible%open]
+======
+
+
 ======
 
 [[cluster-nodes-stats-api-response-body-breakers]]

--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -1922,7 +1922,7 @@ Time of the most recent request from this client.
 Number of requests from this client.
 `request_size_bytes`::
 (integer)
-Cumulative size in bytes of all requests from this client
+Cumulative size in bytes of all requests from this client.
 =======
 ======
 

--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -1900,7 +1900,7 @@ Local address for the HTTP client.
 `remote_address`::
 (string)
 Remote address for the HTTP client.
-`forwarded_for`::
+`x_forwarded_for`::
 (string)
 Value from the client's `x-forwarded-for` HTTP header. If unavailable, this
 property is not included in the response.

--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -1902,7 +1902,8 @@ Local address for the HTTP client.
 Remote address for the HTTP client.
 `forwarded_for`::
 (string)
-Value from the client's `x-forwarded-for` HTTP header, if available.
+Value from the client's `x-forwarded-for` HTTP header. If unavailable, this
+property is not included in the response.
 `opqaue_id`::
 (string)
 Value from the client's `x-opaque-id` HTTP header, if available.

--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -1907,7 +1907,7 @@ The URI of the client's most recent request.
 (string)
 Value from the client's `x-forwarded-for` HTTP header. If unavailable, this
 property is not included in the response.
-`x_opqaue_id`::
+`x_opaque_id`::
 (string)
 Value from the client's `x-opaque-id` HTTP header. If unavailable, this property
 is not included in the response.

--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -1886,7 +1886,7 @@ Information on current and recently-closed HTTP client connections.
 +
 .Properties of `clients`
 [%collapsible%open]
-======
+=======
 `id`::
 (integer)
 Unique ID for the HTTP client.
@@ -1920,7 +1920,7 @@ Number of requests from this client.
 `request_size_bytes`::
 (integer)
 Cumulative size in bytes of all requests from this client
-
+=======
 ======
 
 [[cluster-nodes-stats-api-response-body-breakers]]

--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -1900,6 +1900,9 @@ Local address for the HTTP client.
 `remote_address`::
 (string)
 Remote address for the HTTP client.
+`last_uri`::
+(string)
+The URI of the client's most recent request.
 `x_forwarded_for`::
 (string)
 Value from the client's `x-forwarded-for` HTTP header. If unavailable, this


### PR DESCRIPTION
Adds documentation for the stats added in #64561.

Preview: https://elasticsearch_70512.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/cluster-nodes-stats.html