### PR TITLE
More aggressive deletion in the async search system index

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncTaskIndexService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncTaskIndexService.java
@@ -55,6 +55,8 @@ import java.util.Map;
 import java.util.function.Function;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.index.MergePolicyConfig.INDEX_MERGE_POLICY_DELETES_PCT_ALLOWED_SETTING;
+import static org.elasticsearch.index.engine.EngineConfig.INDEX_CODEC_SETTING;
 import static org.elasticsearch.index.mapper.MapperService.SINGLE_MAPPING_NAME;
 import static org.elasticsearch.xpack.core.ClientHelper.ASYNC_SEARCH_ORIGIN;
 import static org.elasticsearch.xpack.core.security.authc.AuthenticationField.AUTHENTICATION_KEY;
@@ -77,7 +79,8 @@ public final class AsyncTaskIndexService<R extends AsyncResponse<R>> {
 
     static Settings settings() {
         return Settings.builder()
-            .put("index.codec", "best_compression")
+            .put(INDEX_CODEC_SETTING.getKey(), "best_compression")
+            .put(INDEX_MERGE_POLICY_DELETES_PCT_ALLOWED_SETTING.getKey(), 20.0d)
             .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
             .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
             .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-1")

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncTaskMaintenanceService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncTaskMaintenanceService.java
@@ -42,12 +42,12 @@ public class AsyncTaskMaintenanceService extends AbstractLifecycleComponent impl
 
     /**
      * Controls the interval at which the cleanup is scheduled.
-     * Defaults to 1h. It is an undocumented/expert setting that
+     * Defaults to 5m. It is an undocumented/expert setting that
      * is mainly used by integration tests to make the garbage
      * collection of search responses more reactive.
      */
     public static final Setting<TimeValue> ASYNC_SEARCH_CLEANUP_INTERVAL_SETTING =
-        Setting.timeSetting("async_search.index_cleanup_interval", TimeValue.timeValueHours(1), Setting.Property.NodeScope);
+        Setting.timeSetting("async_search.index_cleanup_interval", TimeValue.timeValueMinutes(5), Setting.Property.NodeScope);
 
     private static final Logger logger = LogManager.getLogger(AsyncTaskMaintenanceService.class);
 


### PR DESCRIPTION
This commit changes the frequency at which the maintenance service deletes
document in the async search to 5 minutes (previously 1h).
This change also sets the percentage of deleted document allowed in the index
to its minimum value (20%).
This is done to ensure that the async search index doesn't occupy more spaces than
needed. Kibana will switch to always storing the result for async searches so
we need to perform clean ups more aggressively.