### PR TITLE
docs: Add reference to reporting warning customization

### DIFF
--- a/docs/reference/settings/notification-settings.asciidoc
+++ b/docs/reference/settings/notification-settings.asciidoc
@@ -282,6 +282,7 @@ include::ssl-settings.asciidoc[]
 (<<dynamic-cluster-setting,Dynamic>>) 
 Specifies a custom message to be sent if the formula verification criteria
 for CSV files, from kibana `xpack.reporting.csv.checkForFormulas`, is true.
+Use %s in the message as a placeholder for the filename.  
 
 [[slack-notification-settings]]
 ==== Slack Notification Settings

--- a/docs/reference/settings/notification-settings.asciidoc
+++ b/docs/reference/settings/notification-settings.asciidoc
@@ -278,6 +278,11 @@ Defaults to `true`.
 
 include::ssl-settings.asciidoc[]
 
+`xpack.notification.reporting.warning.kbn-csv-contains-formulas.text`::
+(<<dynamic-cluster-setting,Dynamic>>) 
+Specifies a custom message to be sent if the formula verification criteria
+for CSV files, from kibana `xpack.reporting.csv.checkForFormulas`, is true.
+
 [[slack-notification-settings]]
 ==== Slack Notification Settings
 You can configure the following Slack notification settings in


### PR DESCRIPTION
The setting `xpack.notification.reporting.warning.kbn-csv-contains-formulas.text` [is already implemented to create custom messages](https://github.com/elastic/elasticsearch/blob/master/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/email/attachment/ReportingAttachmentParser.java#L115) in case `checkForFormulas` is true, but there's no reference to it on documentation.

Example:
```
PUT _cluster/settings
{
  "persistent": {"xpack.notification.reporting.warning.kbn-csv-contains-formulas.text": "Custom Warning: foo bar"}
}
```