### PR TITLE
[7.11] [DOCS] Remove `type` glossary xrefs (#70520)

### DIFF
--- a/docs/reference/glossary.asciidoc
+++ b/docs/reference/glossary.asciidoc
@@ -113,7 +113,7 @@ In the delete phase, an index is no longer needed and can safely be deleted.
 
 A document is a JSON document which is stored in Elasticsearch. It is
 like a row in a table in a relational database. Each document is
-stored in an <<glossary-index,index>> and has a <<glossary-type,type>> and an
+stored in an <<glossary-index,index>> and has a type and an
 <<glossary-id,id>>.
 +
 A document is a JSON object (also known in other languages as a hash /
@@ -140,7 +140,7 @@ date), or a nested structure like an array or an object. A field is
 similar to a column in a table in a relational database.
 +
 The <<glossary-mapping,mapping>> for each field has a field _type_ (not to
-be confused with document <<glossary-type,type>>) which indicates the type
+be confused with document type) which indicates the type
 of data that can be stored in that field, eg `integer`, `string`,
 `object`. The mapping also allows you to define (amongst other things)
 how the value for a field should be analyzed.
@@ -311,7 +311,7 @@ The cluster that pulls data from a <<glossary-remote-cluster,remote cluster>> in
 [[glossary-mapping]] mapping ::
 
 A mapping is like a _schema definition_ in a relational database. Each
-<<glossary-index,index>> has a mapping, which defines a <<glossary-type,type>>,
+<<glossary-index,index>> has a mapping, which defines a type,
 plus a number of index-wide settings.
 +
 A mapping can either be defined explicitly, or it will be generated


### PR DESCRIPTION
Backports the following commits to 7.11:
 - [DOCS] Remove `type` glossary xrefs (#70520)