### PR TITLE
[7.12] [DOCS] Document `index.query.default_field` index setting (#69922)

### DIFF
--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -2,9 +2,6 @@
 [[index-modules]]
 = Index modules
 
-[partintro]
---
-
 Index Modules are modules created per index and control all aspects related to
 an index.
 
@@ -249,6 +246,23 @@ specific index module:
     The maximum length of regex that can be used in Regexp Query.
     Defaults to `1000`.
 
+
+`index.query.default_field`::
++
+--
+(string or array of strings)
+Wildcard (`*`) patterns matching one or more fields. The following query types
+search these matching fields by default:
+
+* <<query-dsl-mlt-query>>
+* <<query-dsl-multi-match-query>>
+* <<query-dsl-query-string-query>>
+* <<query-dsl-simple-query-string-query>>
+
+Defaults to `*`, which matches all fields eligible for
+<<term-level-queries,term-level queries>>, excluding metadata fields.
+--
+
  `index.routing.allocation.enable`::
 
     Controls shard allocation for this index. It can be set to:
@@ -340,7 +354,6 @@ Other index settings are available in index modules:
 <<ilm-settings,{ilm-cap}>>::
 
     Specify the lifecycle policy and rollover alias for an index.
---
 
 include::index-modules/analysis.asciidoc[]
 

--- a/docs/reference/query-dsl/mlt-query.asciidoc
+++ b/docs/reference/query-dsl/mlt-query.asciidoc
@@ -175,7 +175,10 @@ for documents `like: "Apple"`, but `unlike: "cake crumble tree"`. The syntax
 is the same as `like`.
 
 `fields`::
-A list of fields to fetch and analyze the text from.
+A list of fields to fetch and analyze the text from. Defaults to the
+`index.query.default_field` index setting, which has a default value of `*`. The
+`*` value matches all fields eligible for <<term-level-queries,term-level
+queries>>, excluding metadata fields.
 
 [discrete]
 [[mlt-query-term-selection]]


### PR DESCRIPTION
Backports the following commits to 7.12:
 - [DOCS] Document `index.query.default_field` index setting (#69922)