### PR TITLE
Add RollupAction support for AggregateDoubleMetric fields

### DIFF
--- a/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateDoubleMetricFieldMapper.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateDoubleMetricFieldMapper.java
@@ -270,6 +270,10 @@ public class AggregateDoubleMetricFieldMapper extends FieldMapper {
             metricFields.put(m, subfield);
         }
 
+        public Collection<NumberFieldMapper.NumberFieldType> getMetricFields() {
+            return metricFields.values();
+        }
+
         public void setDefaultMetric(Metric defaultMetric) {
             this.defaultMetric = defaultMetric;
         }


### PR DESCRIPTION
this commit adds support for aggregate_metric_double fields
in the RollupShardIndexer.

Previously, rollups of rollups were failing because the indexer
did not know how to fetch field values for aggregate metric fields and
the respective _doc_count fields