### PR TITLE
[7.11] Made small modifications to ESRestTestCase.

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -613,12 +613,12 @@ public abstract class ESRestTestCase extends ESTestCase {
                             .collect(Collectors.toList());
                         for (String name : names) {
                             if (isXPackTemplate(name)) {
-                            continue;
+                                continue;
                             }
-                        try {
-                            adminClient().performRequest(new Request("DELETE", "_index_template/" + name));
-                        } catch (ResponseException e) {
-                            logger.debug(new ParameterizedMessage("unable to remove index template {}", name), e);
+                            try {
+                                adminClient().performRequest(new Request("DELETE", "_index_template/" + name));
+                            } catch (ResponseException e) {
+                                logger.warn(new ParameterizedMessage("unable to remove index template {}", name), e);
                             }
                         }
                     } catch (Exception e) {
@@ -640,7 +640,7 @@ public abstract class ESRestTestCase extends ESTestCase {
                                 }
                                 adminClient().performRequest(new Request("DELETE", "_component_template/" + componentTemplate));
                             } catch (ResponseException e) {
-                                logger.debug(new ParameterizedMessage("unable to remove component template {}", componentTemplate), e);
+                                logger.warn(new ParameterizedMessage("unable to remove component template {}", componentTemplate), e);
                             }
                         }
                     } catch (Exception e) {
@@ -660,7 +660,7 @@ public abstract class ESRestTestCase extends ESTestCase {
                     try {
                         adminClient().performRequest(new Request("DELETE", "_template/" + name));
                     } catch (ResponseException e) {
-                        logger.debug(new ParameterizedMessage("unable to remove index template {}", name), e);
+                        logger.warn(new ParameterizedMessage("unable to remove index template {}", name), e);
                     }
                 }
             } else {
@@ -1397,6 +1397,9 @@ public abstract class ESRestTestCase extends ESTestCase {
         if (name.startsWith(".transform-")) {
             return true;
         }
+        if (name.startsWith(".deprecation-")) {
+            return true;
+        }
         switch (name) {
             case ".watches":
             case "logstash-index-template":
@@ -1405,7 +1408,6 @@ public abstract class ESRestTestCase extends ESTestCase {
             case ".slm-history":
             case ".async-search":
             case "saml-service-provider":
-            case "ilm-history":
             case "logs":
             case "logs-settings":
             case "logs-mappings":
@@ -1416,7 +1418,7 @@ public abstract class ESRestTestCase extends ESTestCase {
             case "synthetics-settings":
             case "synthetics-mappings":
             case ".snapshot-blob-cache":
-            case ".deprecation-indexing-template":
+            case "ilm-history":
             case "security-index-template":
                 return true;
             default:


### PR DESCRIPTION
Backporting #70531 to the 7.11 branch.

* Don't try to invoke delete component/index templates APIs if there are no templates to delete.
* Don't delete deprecation templates by marking these as xpack templates.

Relates to #69973