### PR TITLE
[7.12] Relax the testRequestResetAndAbort assertion (#70308)

### DIFF
--- a/client/rest/src/test/java/org/elasticsearch/client/RestClientSingleHostIntegTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/RestClientSingleHostIntegTests.java
@@ -295,11 +295,10 @@ public class RestClientSingleHostIntegTests extends RestClientTestCase {
                 httpGet.abort();
                 assertTrue(httpGet.isAborted());
                 try {
-                    assertTrue(future.isCancelled());
+                    assertTrue(future.isDone());
                     future.get();
-                    throw new AssertionError("exception should have been thrown");
                 } catch(CancellationException e) {
-                    //expected
+                    //expected sometimes - if the future was cancelled before executing successfully
                 }
             }
             {


### PR DESCRIPTION
This relaxes the assertion to account for the case when the client
executes the request successfully before we cancel the underlying http
request.

(cherry picked from commit 4b02e840587e6d194e223195a884d2cb40a53d31)
Signed-off-by: Andrei Dan <andrei.dan@elastic.co>

Backport of #70308