### PR TITLE
Clarify persistence on master-eligible nodes

### DIFF
--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -121,9 +121,11 @@ Any master-eligible node that is not a <<voting-only-node,voting-only node>> may
 be elected to become the master node by the <<modules-discovery,master election
 process>>.
 
-IMPORTANT: Master nodes must have access to the `data/` directory (just like
-`data` nodes) as this is where the cluster state is persisted between node
-restarts.
+IMPORTANT: Master nodes must have a `path.data` directory whose contents
+persist across restarts, just like data nodes, because this is where the
+cluster metadata is stored. The cluster metadata descibes how to read the data
+stored on the data nodes, so if it is lost then the data stored on the data
+nodes cannot be read.
 
 [[dedicated-master-node]]
 ===== Dedicated master-eligible node

--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -123,7 +123,7 @@ process>>.
 
 IMPORTANT: Master nodes must have a `path.data` directory whose contents
 persist across restarts, just like data nodes, because this is where the
-cluster metadata is stored. The cluster metadata descibes how to read the data
+cluster metadata is stored. The cluster metadata describes how to read the data
 stored on the data nodes, so if it is lost then the data stored on the data
 nodes cannot be read.
 


### PR DESCRIPTION
We document that master nodes should have a persistent data path but
it's a bit hard to understand that this is what the docs are saying and
we don't really say why it's important. This commit clarifies this
paragraph.

Relates 49d0f3406c274b6ef814ca4aa6a4ae9dec73a8bb