### PR TITLE
[DOCS] Fix nori tokenizer link

### DIFF
--- a/docs/reference/analysis/token-graphs.asciidoc
+++ b/docs/reference/analysis/token-graphs.asciidoc
@@ -40,7 +40,7 @@ record the `positionLength` for multi-position tokens. This filters include:
 * <<analysis-word-delimiter-graph-tokenfilter,`word_delimiter_graph`>>
 
 Some tokenizers, such as the
-{plugin}/analysis-nori-tokenizer.html[`nori_tokenizer`], also accurately
+{plugins}/analysis-nori-tokenizer.html[`nori_tokenizer`], also accurately
 decompose compound tokens into multi-position tokens.
 
 In the following graph, `domain name system` and its synonym, `dns`, both have a


### PR DESCRIPTION
The current link is malformed:

<img width="712" alt="Screen Shot 2021-03-18 at 10 51 20 AM" src="https://user-images.githubusercontent.com/40268737/111646287-e551e500-87d7-11eb-8984-cb800ea703fd.PNG">
