### PR TITLE
[7.11] [DOCS] Fix nori tokenizer link (#70564)

### DIFF
--- a/docs/reference/analysis/token-graphs.asciidoc
+++ b/docs/reference/analysis/token-graphs.asciidoc
@@ -40,7 +40,7 @@ record the `positionLength` for multi-position tokens. This filters include:
 * <<analysis-word-delimiter-graph-tokenfilter,`word_delimiter_graph`>>
 
 Some tokenizers, such as the
-{plugin}/analysis-nori-tokenizer.html[`nori_tokenizer`], also accurately
+{plugins}/analysis-nori-tokenizer.html[`nori_tokenizer`], also accurately
 decompose compound tokens into multi-position tokens.
 
 In the following graph, `domain name system` and its synonym, `dns`, both have a


### PR DESCRIPTION
Backports the following commits to 7.11:
 - [DOCS] Fix nori tokenizer link (#70564)