### PR TITLE
Follow-up fix to reuse FrozenIndexInput.writeCacheFile

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/FrozenIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/FrozenIndexInput.java
@@ -231,7 +231,7 @@ public class FrozenIndexInput extends BaseSearchableSnapshotIndexInput {
                                 final long startTimeNanos = stats.currentTimeNanos();
                                 writeCacheFile(
                                     channel,
-                                    cachedBlob.bytes().streamInput(),
+                                    cachedBlob.bytes().slice(toIntBytes(relativePos), toIntBytes(len)).streamInput(),
                                     channelPos,
                                     relativePos,
                                     len,


### PR DESCRIPTION
Follow-up to #70545 which introduced a subtle bug in the refactoring.

Marked as non-issue as unreleased bug

Closes #70592