### PR TITLE
Clarify data replication docs to mention in-sync replicas

### DIFF
--- a/docs/reference/docs/data-replication.asciidoc
+++ b/docs/reference/docs/data-replication.asciidoc
@@ -42,7 +42,7 @@ The primary shard follows this basic flow:
 . Execute the operation locally i.e. indexing or deleting the relevant document. This will also validate the content of fields
    and reject if needed (Example: a keyword value is too long for indexing in Lucene).
 . Forward the operation to each replica in the current in-sync copies set. If there are multiple replicas, this is done in parallel.
-. Once all replicas have successfully performed the operation and responded to the primary, the primary acknowledges the successful
+. Once all in-sync replicas have successfully performed the operation and responded to the primary, the primary acknowledges the successful
    completion of the request to the client.
 
 Each in-sync replica copy performs the indexing operation locally so that it has a copy. This stage of indexing is the


### PR DESCRIPTION
Clarifies the write model section of the replication reference docs to indicate that in-sync replicas must ack a write.
