### PR TITLE
Synchronize methods to match the synchronization on other one

### DIFF
--- a/client/rest/src/main/java/org/elasticsearch/client/RestClient.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/RestClient.java
@@ -228,7 +228,7 @@ public class RestClient implements Closeable {
      * Get the list of nodes that the client knows about. The list is
      * unmodifiable.
      */
-    public List<Node> getNodes() {
+    public synchronized List<Node> getNodes() {
         return nodeTuple.nodes;
     }
 

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/AbstractAsyncTask.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/AbstractAsyncTask.java
@@ -50,7 +50,7 @@ public abstract class AbstractAsyncTask implements Runnable, Closeable {
         }
     }
 
-    public TimeValue getInterval() {
+    public synchronized TimeValue getInterval() {
         return interval;
     }
 


### PR DESCRIPTION
Add of 'synchronized' keyword to methods, to match with neighbor methods which use 'synchronized'. Done in order to avoid bugs of synchronization (underlined for instance by Sonarqube).
