### PR TITLE
[DOCS] Disambiguate logs and data in path settings docs

### DIFF
--- a/docs/reference/setup/important-settings/path-settings.asciidoc
+++ b/docs/reference/setup/important-settings/path-settings.asciidoc
@@ -2,10 +2,14 @@
 [discrete]
 === Path settings
 
+{es} writes the data you index to indices and data streams to a `data`
+directory. {es} writes its own application logs, which contain information about
+cluster health and operations, to a `logs` directory.
+
 For <<targz,macOS `.tar.gz`>>, <<targz,Linux `.tar.gz`>>, and
-<<zip-windows,Windows `.zip`>> installations, {es} writes data and logs to the
-respective `data` and `logs` subdirectories of `$ES_HOME` by default.
-However, files in `$ES_HOME` risk deletion during an upgrade.
+<<zip-windows,Windows `.zip`>> installations, the `data` and `logs` are
+subdirectories of `$ES_HOME` by default. However, files in `$ES_HOME` risk
+deletion during an upgrade.
 
 In production, we strongly recommend you set the `path.data` and `path.logs` in
 `elasticsearch.yml` to locations outside of `$ES_HOME`.

--- a/docs/reference/setup/important-settings/path-settings.asciidoc
+++ b/docs/reference/setup/important-settings/path-settings.asciidoc
@@ -7,7 +7,7 @@ directory. {es} writes its own application logs, which contain information about
 cluster health and operations, to a `logs` directory.
 
 For <<targz,macOS `.tar.gz`>>, <<targz,Linux `.tar.gz`>>, and
-<<zip-windows,Windows `.zip`>> installations, the `data` and `logs` are
+<<zip-windows,Windows `.zip`>> installations, `data` and `logs` are
 subdirectories of `$ES_HOME` by default. However, files in `$ES_HOME` risk
 deletion during an upgrade.
 


### PR DESCRIPTION
The current [Path settings](https://www.elastic.co/guide/en/elasticsearch/reference/7.11/important-settings.html#path-settings) section of [Important Elasticsearch configuration](https://www.elastic.co/guide/en/elasticsearch/reference/7.11/important-settings.html) doesn't distinguish between logs you ingest and ES's own application logs. This could be confusing for users using ES to ingest logs.

This adds a couple of sentences to clarify.

Closes #70615