### PR TITLE
Fix doc url and Api description

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/features.get_features.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/features.get_features.json
@@ -1,8 +1,8 @@
 {
   "features.get_features":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html",
-      "description":"Returns a list of features which can be snapshotted in this cluster."
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/get-features-api.html",
+      "description":"Gets a list of features which can be included in snapshots using the feature_states field when creating a snapshot"
     },
     "stability":"stable",
     "visibility":"public",


### PR DESCRIPTION
The documentation URL and description of the `features.get_features` API was not pointing to the correct documentation and the description was not correct.