### PR TITLE
[7.x] [DOCS] Disambiguate logs and data in path settings docs (#70629)

### DIFF
--- a/docs/reference/setup/important-settings/path-settings.asciidoc
+++ b/docs/reference/setup/important-settings/path-settings.asciidoc
@@ -2,10 +2,14 @@
 [discrete]
 === Path settings
 
+{es} writes the data you index to indices and data streams to a `data`
+directory. {es} writes its own application logs, which contain information about
+cluster health and operations, to a `logs` directory.
+
 For <<targz,macOS `.tar.gz`>>, <<targz,Linux `.tar.gz`>>, and
-<<zip-windows,Windows `.zip`>> installations, {es} writes data and logs to the
-respective `data` and `logs` subdirectories of `$ES_HOME` by default.
-However, files in `$ES_HOME` risk deletion during an upgrade.
+<<zip-windows,Windows `.zip`>> installations, `data` and `logs` are
+subdirectories of `$ES_HOME` by default. However, files in `$ES_HOME` risk
+deletion during an upgrade.
 
 In production, we strongly recommend you set the `path.data` and `path.logs` in
 `elasticsearch.yml` to locations outside of `$ES_HOME`.


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Disambiguate logs and data in path settings docs (#70629)