### PR TITLE
Adjust the docs that comma-separated list of names in delete template APIs is not supported

### DIFF
--- a/docs/reference/indices/delete-component-template.asciidoc
+++ b/docs/reference/indices/delete-component-template.asciidoc
@@ -43,14 +43,14 @@ privilege>> to use this API.
 ==== {api-description-title}
 
 Use the delete component template API to delete one or more component templates
-Component templates are building blocks for constructing <<index-templates,index templates>>  
-that specify index mappings, settings, and aliases. 
+Component templates are building blocks for constructing <<index-templates,index templates>>
+that specify index mappings, settings, and aliases.
 
 [[delete-component-template-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=component-template]
-
+The name of the component template to delete. Wildcard (`*`)
+expressions are supported.
 
 [[delete-component-template-api-query-params]]
 ==== {api-query-parms-title}

--- a/docs/reference/indices/delete-index-template-v1.asciidoc
+++ b/docs/reference/indices/delete-index-template-v1.asciidoc
@@ -48,9 +48,8 @@ privilege>> to use this API.
 
 `<legacy-index-template>`::
 (Required, string)
-Comma-separated list of legacy index templates to delete. Wildcard (`*`)
+The name of the legacy index template to delete. Wildcard (`*`)
 expressions are supported.
-
 
 [[delete-template-api-v1-query-params]]
 ==== {api-query-parms-title}

--- a/docs/reference/indices/delete-index-template.asciidoc
+++ b/docs/reference/indices/delete-index-template.asciidoc
@@ -51,7 +51,7 @@ and <<indices-aliases,aliases>> that can be applied automatically to new indices
 [[delete-template-api-path-params]]
 ==== {api-path-parms-title}
 
-The name of the composable index template to delete. Wildcard (`*`)
+The name of the index template to delete. Wildcard (`*`)
 expressions are supported.
 
 [[delete-template-api-query-params]]

--- a/docs/reference/indices/delete-index-template.asciidoc
+++ b/docs/reference/indices/delete-index-template.asciidoc
@@ -44,15 +44,15 @@ privilege>> to use this API.
 ==== {api-description-title}
 
 Use the delete index template API to delete one or more index templates.
-Index templates define <<index-modules-settings,settings>>, <<mapping,mappings>>, 
-and <<indices-aliases,aliases>> that can be applied automatically to new indices. 
+Index templates define <<index-modules-settings,settings>>, <<mapping,mappings>>,
+and <<indices-aliases,aliases>> that can be applied automatically to new indices.
 
 
 [[delete-template-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-template]
-
+The name of the composable index template to delete. Wildcard (`*`)
+expressions are supported.
 
 [[delete-template-api-query-params]]
 ==== {api-query-parms-title}


### PR DESCRIPTION
The delete legacy template API doesn't support comma-separated list of names in any version.

For versions 7.12 and before, the delete component API and delete composable index template API
don't support comma-separated list of names.

From 7.13 and later, the delete component API and delete composable index template API do support
comma-separated list of names.

Relates to #70094 and #70314

(only the change to delete legacy template api doc will be forward ported to 7.x and master branches)