### PR TITLE
Wait for rollover to happen in testShrinkActionInPolicyWithoutHotPhase

### DIFF
--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/TimeSeriesRestDriver.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/TimeSeriesRestDriver.java
@@ -351,7 +351,7 @@ public final class TimeSeriesRestDriver {
 
                 Map<String, Map<String, Object>> indexResponse = ((Map<String, Map<String, Object>>) responseMap.get("indices"));
                 Map<String, Object> explainIndexResponse = indexResponse.get(originalIndex);
-                if(explainIndexResponse == null) {
+                if (explainIndexResponse == null) {
                     // maybe we swapped the alias from the original index to the shrunken one already
                     for (Map.Entry<String, Map<String, Object>> indexToExplainMap : indexResponse.entrySet()) {
                         // we don't know the exact name of the shrunken index, but we know it starts with the configured prefix

--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/TimeSeriesDataStreamsIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/TimeSeriesDataStreamsIT.java
@@ -13,7 +13,6 @@ import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Template;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.IndexSettings;
@@ -39,7 +38,6 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.xpack.TimeSeriesRestDriver.createComposableTemplate;
-import static org.elasticsearch.xpack.TimeSeriesRestDriver.createFullPolicy;
 import static org.elasticsearch.xpack.TimeSeriesRestDriver.createNewSingletonPolicy;
 import static org.elasticsearch.xpack.TimeSeriesRestDriver.createSnapshotRepo;
 import static org.elasticsearch.xpack.TimeSeriesRestDriver.explainIndex;
@@ -48,7 +46,6 @@ import static org.elasticsearch.xpack.TimeSeriesRestDriver.getStepKeyForIndex;
 import static org.elasticsearch.xpack.TimeSeriesRestDriver.indexDocument;
 import static org.elasticsearch.xpack.TimeSeriesRestDriver.rolloverMaxOneDocCondition;
 import static org.elasticsearch.xpack.TimeSeriesRestDriver.waitAndGetShrinkIndexName;
-import static org.elasticsearch.xpack.core.ilm.ShrinkIndexNameSupplier.SHRUNKEN_INDEX_PREFIX;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -103,7 +100,6 @@ public class TimeSeriesDataStreamsIT extends ESRestTestCase {
             equalTo(PhaseCompleteStep.finalStep("hot").getKey())), 30, TimeUnit.SECONDS);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/70595")
     public void testShrinkActionInPolicyWithoutHotPhase() throws Exception {
         createNewSingletonPolicy(client(), policyName, "warm", new ShrinkAction(1, null));
         createComposableTemplate(client(), template,  dataStream + "*", getTemplate(policyName));
@@ -116,26 +112,14 @@ public class TimeSeriesDataStreamsIT extends ESRestTestCase {
 
         // Manual rollover the original index such that it's not the write index in the data stream anymore
         rolloverMaxOneDocCondition(client(), dataStream);
+        // Wait for rollover to happen
+        String rolloverIndex = DataStream.getDefaultBackingIndexName(dataStream, 2);
+        assertBusy(() -> assertTrue("the rollover action created the rollover index", indexExists(rolloverIndex)), 30, TimeUnit.SECONDS);
 
         String shrunkenIndex = waitAndGetShrinkIndexName(client(), backingIndexName);
         assertBusy(() -> assertTrue(indexExists(shrunkenIndex)), 30, TimeUnit.SECONDS);
         assertBusy(() -> assertThat(getStepKeyForIndex(client(), shrunkenIndex), equalTo(PhaseCompleteStep.finalStep("warm").getKey())));
         assertBusy(() -> assertThat("the original index must've been deleted", indexExists(backingIndexName), is(false)));
-    }
-
-    public void testShrinkAfterRollover() throws Exception {
-        createFullPolicy(client(), policyName, TimeValue.ZERO);
-        createComposableTemplate(client(), template,  dataStream + "*", getTemplate(policyName));
-        indexDocument(client(), dataStream, true);
-
-        String backingIndexName = DataStream.getDefaultBackingIndexName(dataStream, 1);
-        String rolloverIndex = DataStream.getDefaultBackingIndexName(dataStream, 2);
-        String shrunkenIndex = SHRUNKEN_INDEX_PREFIX + backingIndexName;
-        assertBusy(() -> assertTrue("the rollover action created the rollover index", indexExists(rolloverIndex)));
-        assertBusy(() -> assertFalse("the original index was deleted by the shrink action", indexExists(backingIndexName)),
-            60, TimeUnit.SECONDS);
-        assertBusy(() -> assertFalse("the shrunken index was deleted by the delete action", indexExists(shrunkenIndex)),
-            30, TimeUnit.SECONDS);
     }
 
     public void testSearchableSnapshotAction() throws Exception {


### PR DESCRIPTION
This adds an extra step in `testShrinkActionInPolicyWithoutHotPhase` to wait for the
rollover to happen before trying to read the shrink index name from the execution
state.

This also removes `testShrinkAfterRollover` because it was passing for the
wrong reasons (the shrunk index name it was composing never existed
anymore) and the scenario is already extensively tested in
`ShrinkActionIT`, without using a full policy that is subject to
flakiness as the managed index might get deleted before we pick up the
shrink index name from the execution state.

Fixes #70595