### PR TITLE
[7.x] [DOCS] Replace external links with xrefs (#70667)

### DIFF
--- a/docs/reference/glossary.asciidoc
+++ b/docs/reference/glossary.asciidoc
@@ -97,8 +97,7 @@ Collection of <<glossary-node,nodes>> with the same {ref}/modules-node.html[data
 role] that typically share the same hardware profile. Data tiers include the
 <<glossary-content-tier, content tier>>, <<glossary-hot-tier, hot tier>>,
 <<glossary-warm-tier, warm tier>>, <<glossary-cold-tier, cold tier>>, and
-{ref}/glossary.html#glossary-frozen-tier[frozen tier]. See
-{ref}/data-tiers.html[Data tiers].
+<<glossary-frozen-tier,frozen tier>>. See {ref}/data-tiers.html[Data tiers].
 // end::data-tier-def[]
 
 [[glossary-delete-phase]] delete phase::
@@ -235,7 +234,7 @@ an index alias in place of an index name. See the
 // tag::index-lifecycle-def[]
 Five phases an <<glossary-index,index>> can transition through:
 <<glossary-hot-phase,hot>>, <<glossary-warm-phase,warm>>,
-<<glossary-cold-phase,cold>>, {ref}/glossary.html#glossary-frozen-phase[frozen],
+<<glossary-cold-phase,cold>>, <<glossary-frozen-phase,frozen>>,
 and <<glossary-delete-phase,delete>>. See {ref}/ilm-policy-definition.html[Index
 lifecycle].
 // end::index-lifecycle-def[]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Replace external links with xrefs (#70667)