### PR TITLE
[7.12] docs: Add reference to reporting warning customization (#70515)

### DIFF
--- a/docs/reference/settings/notification-settings.asciidoc
+++ b/docs/reference/settings/notification-settings.asciidoc
@@ -278,6 +278,12 @@ Defaults to `true`.
 
 include::ssl-settings.asciidoc[]
 
+`xpack.notification.reporting.warning.kbn-csv-contains-formulas.text`::
+(<<dynamic-cluster-setting,Dynamic>>) 
+Specifies a custom message to be sent if the formula verification criteria
+for CSV files, from kibana `xpack.reporting.csv.checkForFormulas`, is true.
+Use %s in the message as a placeholder for the filename.  
+
 [[slack-notification-settings]]
 ==== Slack Notification Settings
 You can configure the following Slack notification settings in


### PR DESCRIPTION
Backports the following commits to 7.12:
 - docs: Add reference to reporting warning customization (#70515)