### PR TITLE
Update skip after backport of #70493

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/20_terms.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/20_terms.yml
@@ -1284,10 +1284,6 @@ setup:
 
 ---
 precise size:
-  - skip:
-      version: " - 7.99.99"
-      reason:  "Fixed in 8.0.0, to be backported to 7.13. Once backported this should *always* pass without a need for a skip"
-
   - do:
       bulk:
         index: test_1


### PR DESCRIPTION
Now that #70493 has landed we can run bwc tests against it.