### PR TITLE
[DOCS] EQL: Document Unicode escape sequences

### DIFF
--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -411,9 +411,9 @@ double quote (`"`), must be escaped with a preceding backslash (`\`).
 |====
 
 You can escape Unicode characters using a case-insensitive hexadecimal
-`\u{XXXXXXXX}` escape sequence. You can use these escape sequences to include
-non-printable or right-to-left (RTL) characters in your strings. Hexadecimal
-values shorter than 8 characters are zero-padded. For example, you can escape a
+`\u{XXXXXXXX}` escape sequence. Hexadecimal values shorter than 8 characters are
+zero-padded. You can use these escape sequences to include non-printable or
+right-to-left (RTL) characters in your strings. For example, you can escape a
 {wikipedia}/Right-to-left_mark[right-to-left mark (RLM)] as `\u{200f}`,
 `\u{200F}`, or `\u{0000200f}`.
 

--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -410,10 +410,11 @@ double quote (`"`), must be escaped with a preceding backslash (`\`).
 |`\"`             | Double quote (`"`)
 |====
 
-You can escape Unicode characters using a case-insensitive hexadecimal
-`\u{XXXXXXXX}` escape sequence. Hexadecimal values shorter than 8 characters are
-zero-padded. You can use these escape sequences to include non-printable or
-right-to-left (RTL) characters in your strings. For example, you can escape a
+You can escape Unicode characters using a hexadecimal `\u{XXXXXXXX}` escape
+sequence. The hexadecimal value can be 2-8 characters and is case-insensitive.
+Values shorter than 8 characters are zero-padded. You can use these escape
+sequences to include non-printable or right-to-left (RTL) characters in your
+strings. For example, you can escape a
 {wikipedia}/Right-to-left_mark[right-to-left mark (RLM)] as `\u{200f}`,
 `\u{200F}`, or `\u{0000200f}`.
 
@@ -834,7 +835,7 @@ sub-fields of a `nested` field. However, data streams and indices containing
 follows:
 
 * In {es} EQL, most operators are case-sensitive. For example,
-`process_name == "cmd.exe"` is not equivalent to 
+`process_name == "cmd.exe"` is not equivalent to
 `process_name == "Cmd.exe"`.
 
 * In {es} EQL, functions are case-sensitive. To make a function

--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -410,11 +410,12 @@ double quote (`"`), must be escaped with a preceding backslash (`\`).
 |`\"`             | Double quote (`"`)
 |====
 
-You can escape Unicode characters using a `\u{XXXXXXXX}` case-insensitive
-hexadecimal escape sequence. You can use these escape sequences to include
-non-printable or right-to-left (RTL) characters in your strings. For example,
-you can escape a {wikipedia}/Right-to-left_mark[right-to-left mark (RLM)] as
-`\u{200f}`, `\u{200F}`, or `\u{0000200f}`.
+You can escape Unicode characters using a case-insensitive hexadecimal
+`\u{XXXXXXXX}` escape sequence. You can use these escape sequences to include
+non-printable or right-to-left (RTL) characters in your strings. Hexadecimal
+values shorter than 8 characters are zero-padded. For example, you can escape a
+{wikipedia}/Right-to-left_mark[right-to-left mark (RLM)] as `\u{200f}`,
+`\u{200F}`, or `\u{0000200f}`.
 
 IMPORTANT: The single quote (`'`) character is reserved for future use. You
 cannot use an escaped single quote (`\'`) for literal strings. Use an escaped

--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -410,12 +410,10 @@ double quote (`"`), must be escaped with a preceding backslash (`\`).
 |`\"`             | Double quote (`"`)
 |====
 
-You can escape Unicode characters using a 4-character `\uXXXX` or
-variable-length `\u{XXXXXXXX}` escape sequence. You can use these escape
+You can escape Unicode characters using a `\u{XXXXXXXX}` escape sequence. You can use these escape
 sequences to include non-printable or right-to-left (RTL) characters in your
 strings. For example, you can escape a
-{wikipedia}/Right-to-left_mark[right-to-left mark (RLM)] as `\u200F` or
-`\u{200F}`.
+{wikipedia}/Right-to-left_mark[right-to-left mark (RLM)] as `\u{200F}`.
 
 IMPORTANT: The single quote (`'`) character is reserved for future use. You
 cannot use an escaped single quote (`\'`) for literal strings. Use an escaped

--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -410,10 +410,11 @@ double quote (`"`), must be escaped with a preceding backslash (`\`).
 |`\"`             | Double quote (`"`)
 |====
 
-You can escape Unicode characters using a `\u{XXXXXXXX}` escape sequence. You can use these escape
-sequences to include non-printable or right-to-left (RTL) characters in your
-strings. For example, you can escape a
-{wikipedia}/Right-to-left_mark[right-to-left mark (RLM)] as `\u{200F}`.
+You can escape Unicode characters using a `\u{XXXXXXXX}` case-insensitive
+hexadecimal escape sequence. You can use these escape sequences to include
+non-printable or right-to-left (RTL) characters in your strings. For example,
+you can escape a {wikipedia}/Right-to-left_mark[right-to-left mark (RLM)] as
+`\u{200f}`, `\u{200F}`, or `\u{0000200f}`.
 
 IMPORTANT: The single quote (`'`) character is reserved for future use. You
 cannot use an escaped single quote (`\'`) for literal strings. Use an escaped

--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -410,6 +410,13 @@ double quote (`"`), must be escaped with a preceding backslash (`\`).
 |`\"`             | Double quote (`"`)
 |====
 
+You can escape Unicode characters using a 4-character `\uXXXX` or
+variable-length `\u{XXXXXXXX}` escape sequence. You can use these escape
+sequences to include non-printable or right-to-left (RTL) characters in your
+strings. For example, you can escape a
+{wikipedia}/Right-to-left_mark[right-to-left mark (RLM)] as `\u200F` or
+`\u{200F}`.
+
 IMPORTANT: The single quote (`'`) character is reserved for future use. You
 cannot use an escaped single quote (`\'`) for literal strings. Use an escaped
 double quote (`\"`) instead.


### PR DESCRIPTION
Documents escape sequences for Unicode characters in EQL.

Relates to #70514 and #62832.

### Preview

https://elasticsearch_70694.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/eql-syntax.html#eql-syntax-escape-characters