### PR TITLE
[DOCS] Add missing end tag for breaking changes

### DIFF
--- a/docs/reference/migration/migrate_7_12.asciidoc
+++ b/docs/reference/migration/migrate_7_12.asciidoc
@@ -80,3 +80,4 @@ To find out if you are using any deprecated functionality,
 enable <<deprecation-logging, deprecation logging>>.
 
 ////
+//end::notable-breaking-changes[]


### PR DESCRIPTION
This PR fixes the following error when the 7.12 Elasticsearch breaking changes are re-used in the Installation and Upgrade Guide:

> WARNING: breaking.asciidoc: line 59: detected unclosed tag 'notable-breaking-changes' starting at line 33 of include file: 