### PR TITLE
Increase search.max_bucket by one (#70645)

### DIFF
--- a/docs/reference/aggregations/bucket.asciidoc
+++ b/docs/reference/aggregations/bucket.asciidoc
@@ -15,7 +15,7 @@ define fixed number of multiple buckets, and others dynamically create the bucke
 
 NOTE: The maximum number of buckets allowed in a single response is limited by a
 dynamic cluster setting named
-<<search-settings-max-buckets,`search.max_buckets`>>. It defaults to 65,535.
+<<search-settings-max-buckets,`search.max_buckets`>>. It defaults to 65,536.
 Requests that try to return more than the limit will fail with an exception.
 
 include::bucket/adjacency-matrix-aggregation.asciidoc[]

--- a/server/src/main/java/org/elasticsearch/search/aggregations/MultiBucketConsumerService.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/MultiBucketConsumerService.java
@@ -24,10 +24,10 @@ import java.util.function.IntConsumer;
  * An aggregation service that creates instances of {@link MultiBucketConsumer}.
  * The consumer is used by {@link BucketsAggregator} and {@link InternalMultiBucketAggregation} to limit the number of buckets created
  * in {@link Aggregator#buildAggregations} and {@link InternalAggregation#reduce}.
- * The limit can be set by changing the `search.max_buckets` cluster setting and defaults to 65535.
+ * The limit can be set by changing the `search.max_buckets` cluster setting and defaults to 65536.
  */
 public class MultiBucketConsumerService {
-    public static final int DEFAULT_MAX_BUCKETS = 65535;
+    public static final int DEFAULT_MAX_BUCKETS = 65536;
     public static final Setting<Integer> MAX_BUCKET_SETTING =
         Setting.intSetting("search.max_buckets", DEFAULT_MAX_BUCKETS, 0, Setting.Property.NodeScope, Setting.Property.Dynamic);
 

--- a/x-pack/plugin/sql/qa/jdbc/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/JdbcErrorsTestCase.java
+++ b/x-pack/plugin/sql/qa/jdbc/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/JdbcErrorsTestCase.java
@@ -138,7 +138,7 @@ public abstract class JdbcErrorsTestCase extends JdbcIntegrationTestCase {
                 SQLException.class,
                 () -> c.prepareStatement("SELECT max(a) max FROM test GROUP BY b ORDER BY max LIMIT 120000").executeQuery()
             );
-            assertEquals("The maximum LIMIT for aggregate sorting is [65535], received [120000]", e.getMessage());
+            assertEquals("The maximum LIMIT for aggregate sorting is [65536], received [120000]", e.getMessage());
         }
     }
 }

--- a/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/cli/ErrorsTestCase.java
+++ b/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/cli/ErrorsTestCase.java
@@ -120,7 +120,7 @@ public abstract class ErrorsTestCase extends CliIntegrationTestCase implements o
         index("test", body -> body.field("a", 1).field("b", 2));
         String commandResult = command("SELECT max(a) max FROM test GROUP BY b ORDER BY max LIMIT 120000");
         assertEquals(
-            START + "Bad request [[3;33;22mThe maximum LIMIT for aggregate sorting is [65535], received [120000]" + END,
+            START + "Bad request [[3;33;22mThe maximum LIMIT for aggregate sorting is [65536], received [120000]" + END,
             commandResult
         );
     }

--- a/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/rest/RestSqlTestCase.java
+++ b/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/rest/RestSqlTestCase.java
@@ -485,7 +485,7 @@ public abstract class RestSqlTestCase extends BaseRestSqlTestCase implements Err
         index("{\"a\": 1, \"b\": 2}");
         expectBadRequest(
             () -> runSql(randomMode(), "SELECT max(a) max FROM test GROUP BY b ORDER BY max LIMIT 120000"),
-            containsString("The maximum LIMIT for aggregate sorting is [65535], received [120000]")
+            containsString("The maximum LIMIT for aggregate sorting is [65536], received [120000]")
         );
     }
 


### PR DESCRIPTION
In #57042, the default value for search.max_bucket was increased to 65,535. Unfortunately this value is short by one for some geo aggregations. For example if you want to aggregate on a geo tile with a scaling factor of 8, it means that you might be generating 256 * 256 buckets, which is one more than the default.

This PR increase the default by one (65,536).

backport #70645