### PR TITLE
Split RuntimeFieldType from corresponding MappedFieldType (#70695)

### DIFF
--- a/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentJoinFieldMapper.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentJoinFieldMapper.java
@@ -273,7 +273,7 @@ public final class ParentJoinFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected void doXContentBody(XContentBuilder builder, boolean includeDefaults, Params params) throws IOException {
+    protected void doXContentBody(XContentBuilder builder, Params params) throws IOException {
         builder.field("type", contentType());
         builder.field("eager_global_ordinals", eagerGlobalOrdinals);
         builder.startObject("relations");

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesIndexAction.java
@@ -128,6 +128,7 @@ public class TransportFieldCapabilitiesIndexAction
 
                     // Check the ancestor of the field to find nested and object fields.
                     // Runtime fields are excluded since they can override any path.
+                    //TODO find a way to do this that does not require an instanceof check
                     if (ft instanceof RuntimeFieldType == false) {
                         int dotIndex = ft.name().lastIndexOf('.');
                         while (dotIndex > -1) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -814,14 +814,14 @@ final class DocumentParser {
         String fieldPath = context.path().pathAsText(fieldName);
         RuntimeFieldType runtimeFieldType = context.root().getRuntimeFieldType(fieldPath);
         if (runtimeFieldType != null) {
-            return new NoOpFieldMapper(subfields[subfields.length - 1], runtimeFieldType);
+            return new NoOpFieldMapper(subfields[subfields.length - 1], runtimeFieldType.asMappedFieldType().name());
         }
         return null;
     }
 
     private static class NoOpFieldMapper extends FieldMapper {
-        NoOpFieldMapper(String simpleName, RuntimeFieldType runtimeField) {
-            super(simpleName, new MappedFieldType(runtimeField.name(), false, false, false, TextSearchInfo.NONE, Collections.emptyMap()) {
+        NoOpFieldMapper(String simpleName, String fullName) {
+            super(simpleName, new MappedFieldType(fullName, false, false, false, TextSearchInfo.NONE, Collections.emptyMap()) {
                 @Override
                 public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
                     throw new UnsupportedOperationException();

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -17,6 +17,7 @@ import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.support.AbstractXContentParser;
@@ -289,14 +290,13 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(simpleName());
-        boolean includeDefaults = params.paramAsBoolean("include_defaults", false);
-        doXContentBody(builder, includeDefaults, params);
+        doXContentBody(builder, params);
         return builder.endObject();
     }
 
-    protected void doXContentBody(XContentBuilder builder, boolean includeDefaults, Params params) throws IOException {
+    protected void doXContentBody(XContentBuilder builder, Params params) throws IOException {
         builder.field("type", contentType());
-        getMergeBuilder().toXContent(builder, includeDefaults);
+        getMergeBuilder().toXContent(builder, params);
         multiFields.toXContent(builder, params);
         copyTo.toXContent(builder, params);
     }
@@ -861,7 +861,7 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
     /**
      * A Builder for a ParametrizedFieldMapper
      */
-    public abstract static class Builder extends Mapper.Builder {
+    public abstract static class Builder extends Mapper.Builder implements ToXContentFragment {
 
         protected final MultiFields.Builder multiFieldsBuilder = new MultiFields.Builder();
         protected final CopyTo.Builder copyTo = new CopyTo.Builder();
@@ -921,10 +921,13 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
         /**
          * Writes the current builder parameter values as XContent
          */
-        public final void toXContent(XContentBuilder builder, boolean includeDefaults) throws IOException {
+        @Override
+        public final XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            boolean includeDefaults = params.paramAsBoolean("include_defaults", false);
             for (Parameter<?> parameter : getParameters()) {
                 parameter.toXContent(builder, includeDefaults);
             }
+            return builder;
         }
 
         /**

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
@@ -73,7 +73,8 @@ final class FieldTypeLookup {
             fullNameToFieldType.put(aliasName, fullNameToFieldType.get(path));
         }
 
-        for (RuntimeFieldType runtimeFieldType : runtimeFieldTypes) {
+        for (RuntimeFieldType runtimeField : runtimeFieldTypes) {
+            MappedFieldType runtimeFieldType = runtimeField.asMappedFieldType();
             //this will override concrete fields with runtime fields that have the same name
             fullNameToFieldType.put(runtimeFieldType.name(), runtimeFieldType);
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/MetadataFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MetadataFieldMapper.java
@@ -144,8 +144,7 @@ public abstract class MetadataFieldMapper extends FieldMapper {
             return builder;
         }
         builder.startObject(simpleName());
-        boolean includeDefaults = params.paramAsBoolean("include_defaults", false);
-        getMergeBuilder().toXContent(builder, includeDefaults);
+        getMergeBuilder().toXContent(builder, params);
         return builder.endObject();
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/RuntimeFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RuntimeFieldType.java
@@ -8,54 +8,27 @@
 
 package org.elasticsearch.index.mapper;
 
-import org.apache.lucene.analysis.TokenStream;
-import org.apache.lucene.search.MultiTermQuery;
-import org.apache.lucene.search.Query;
-import org.apache.lucene.search.spans.SpanMultiTermQueryWrapper;
-import org.apache.lucene.search.spans.SpanQuery;
-import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.common.CheckedBiConsumer;
-import org.elasticsearch.common.geo.ShapeRelation;
-import org.elasticsearch.common.time.DateMathParser;
-import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.query.SearchExecutionContext;
 
 import java.io.IOException;
-import java.time.ZoneId;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.function.BiFunction;
 
-import static org.elasticsearch.search.SearchService.ALLOW_EXPENSIVE_QUERIES;
-
 /**
- * Base implementation for a runtime field that can be defined as part of the runtime section of the index mappings
+ * Definition of a runtime field that can be defined as part of the runtime section of the index mappings
  */
-public abstract class RuntimeFieldType extends MappedFieldType implements ToXContentFragment {
-
-    private final CheckedBiConsumer<XContentBuilder, Boolean, IOException> toXContent;
-
-    protected RuntimeFieldType(String name, RuntimeFieldType.Builder builder) {
-        this(name, builder.meta(), builder::toXContent);
-    }
-
-    protected RuntimeFieldType(String name, Map<String, String> meta, CheckedBiConsumer<XContentBuilder, Boolean, IOException> toXContent) {
-        super(name, false, false, false, TextSearchInfo.SIMPLE_MATCH_WITHOUT_TERMS, meta);
-        this.toXContent = toXContent;
-    }
+public interface RuntimeFieldType extends ToXContentFragment {
 
     @Override
-    public final XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+    default XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(name());
         builder.field("type", typeName());
-        boolean includeDefaults = params.paramAsBoolean("include_defaults", false);
-        doXContentBody(builder, includeDefaults);
+        doXContentBody(builder, params);
         builder.endObject();
         return builder;
     }
@@ -63,125 +36,25 @@ public abstract class RuntimeFieldType extends MappedFieldType implements ToXCon
     /**
      * Prints out the parameters that subclasses expose
      */
-    final void doXContentBody(XContentBuilder builder, boolean includeDefaults) throws IOException {
-        toXContent.accept(builder, includeDefaults);
-    }
+    void doXContentBody(XContentBuilder builder, Params params) throws IOException;
 
-    @Override
-    public final boolean isSearchable() {
-        return true;
-    }
+    /**
+     * Exposes the name of the runtime field
+     * @return name of the field
+     */
+    String name();
 
-    @Override
-    public final boolean isAggregatable() {
-        return true;
-    }
+    /**
+     * Exposes the type of the runtime field
+     * @return type of the field
+     */
+    String typeName();
 
-    @Override
-    public final Query rangeQuery(
-        Object lowerTerm,
-        Object upperTerm,
-        boolean includeLower,
-        boolean includeUpper,
-        ShapeRelation relation,
-        ZoneId timeZone,
-        DateMathParser parser,
-        SearchExecutionContext context
-    ) {
-        if (relation == ShapeRelation.DISJOINT) {
-            String message = "Runtime field [%s] of type [%s] does not support DISJOINT ranges";
-            throw new IllegalArgumentException(String.format(Locale.ROOT, message, name(), typeName()));
-        }
-        return rangeQuery(lowerTerm, upperTerm, includeLower, includeUpper, timeZone, parser, context);
-    }
-
-    protected abstract Query rangeQuery(
-        Object lowerTerm,
-        Object upperTerm,
-        boolean includeLower,
-        boolean includeUpper,
-        ZoneId timeZone,
-        DateMathParser parser,
-        SearchExecutionContext context
-    );
-
-    @Override
-    public Query fuzzyQuery(
-        Object value,
-        Fuzziness fuzziness,
-        int prefixLength,
-        int maxExpansions,
-        boolean transpositions,
-        SearchExecutionContext context
-    ) {
-        throw new IllegalArgumentException(unsupported("fuzzy", "keyword and text"));
-    }
-
-    @Override
-    public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive, SearchExecutionContext context) {
-        throw new IllegalArgumentException(unsupported("prefix", "keyword, text and wildcard"));
-    }
-
-    @Override
-    public Query wildcardQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive, SearchExecutionContext context) {
-        throw new IllegalArgumentException(unsupported("wildcard", "keyword, text and wildcard"));
-    }
-
-    @Override
-    public Query regexpQuery(
-        String value,
-        int syntaxFlags,
-        int matchFlags,
-        int maxDeterminizedStates,
-        MultiTermQuery.RewriteMethod method,
-        SearchExecutionContext context
-    ) {
-        throw new IllegalArgumentException(unsupported("regexp", "keyword and text"));
-    }
-
-    @Override
-    public Query phraseQuery(TokenStream stream, int slop, boolean enablePositionIncrements) {
-        throw new IllegalArgumentException(unsupported("phrase", "text"));
-    }
-
-    @Override
-    public Query multiPhraseQuery(TokenStream stream, int slop, boolean enablePositionIncrements) {
-        throw new IllegalArgumentException(unsupported("phrase", "text"));
-    }
-
-    @Override
-    public Query phrasePrefixQuery(TokenStream stream, int slop, int maxExpansions) {
-        throw new IllegalArgumentException(unsupported("phrase prefix", "text"));
-    }
-
-    @Override
-    public SpanQuery spanPrefixQuery(String value, SpanMultiTermQueryWrapper.SpanRewriteMethod method, SearchExecutionContext context) {
-        throw new IllegalArgumentException(unsupported("span prefix", "text"));
-    }
-
-    private String unsupported(String query, String supported) {
-        return String.format(
-            Locale.ROOT,
-            "Can only use %s queries on %s fields - not on [%s] which is a runtime field of type [%s]",
-            query,
-            supported,
-            name(),
-            typeName()
-        );
-    }
-
-    protected final void checkAllowExpensiveQueries(SearchExecutionContext context) {
-        if (context.allowExpensiveQueries() == false) {
-            throw new ElasticsearchException(
-                "queries cannot be executed against runtime fields while [" + ALLOW_EXPENSIVE_QUERIES.getKey() + "] is set to [false]."
-            );
-        }
-    }
-
-    @Override
-    public final ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
-        return new DocValueFetcher(docValueFormat(format, null), context.getForField(this));
-    }
+    /**
+     * Exposes the {@link MappedFieldType} backing this runtime field, used to execute queries, run aggs etc.
+     * @return the {@link MappedFieldType} backing this runtime field
+     */
+    MappedFieldType asMappedFieldType();
 
     /**
      *  For runtime fields the {@link RuntimeFieldType.Parser} returns directly the {@link MappedFieldType}.
@@ -191,7 +64,7 @@ public abstract class RuntimeFieldType extends MappedFieldType implements ToXCon
      *  {@link RuntimeFieldType.Builder#parse(String, Mapper.TypeParser.ParserContext, Map)} and returns the corresponding
      *  {@link MappedFieldType}.
      */
-    public abstract static class Builder extends FieldMapper.Builder {
+    abstract class Builder extends FieldMapper.Builder {
         final FieldMapper.Parameter<Map<String, String>> meta = FieldMapper.Parameter.metaParam();
 
         protected Builder(String name) {
@@ -236,7 +109,7 @@ public abstract class RuntimeFieldType extends MappedFieldType implements ToXCon
      * Parser for a runtime field. Creates the appropriate {@link RuntimeFieldType} for a runtime field,
      * as defined in the runtime section of the index mappings.
      */
-    public static final class Parser {
+    final class Parser {
         private final BiFunction<String, Mapper.TypeParser.ParserContext, RuntimeFieldType.Builder> builderFunction;
 
         public Parser(BiFunction<String, Mapper.TypeParser.ParserContext, RuntimeFieldType.Builder> builderFunction) {
@@ -261,9 +134,9 @@ public abstract class RuntimeFieldType extends MappedFieldType implements ToXCon
      *                        translated to the removal of such runtime field
      * @return the parsed runtime fields
      */
-    public static Map<String, RuntimeFieldType> parseRuntimeFields(Map<String, Object> node,
-                                                                   Mapper.TypeParser.ParserContext parserContext,
-                                                                   boolean supportsRemoval) {
+    static Map<String, RuntimeFieldType> parseRuntimeFields(Map<String, Object> node,
+                                                            Mapper.TypeParser.ParserContext parserContext,
+                                                            boolean supportsRemoval) {
         Map<String, RuntimeFieldType> runtimeFields = new HashMap<>();
         Iterator<Map.Entry<String, Object>> iterator = node.entrySet().iterator();
         while (iterator.hasNext()) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -964,8 +964,9 @@ public class TextFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected void doXContentBody(XContentBuilder builder, boolean includeDefaults, Params params) throws IOException {
+    protected void doXContentBody(XContentBuilder builder, Params params) throws IOException {
         // this is a pain, but we have to do this to maintain BWC
+        boolean includeDefaults = params.paramAsBoolean("include_defaults", false);
         builder.field("type", contentType());
         this.builder.boost.toXContent(builder, includeDefaults);
         this.builder.index.toXContent(builder, includeDefaults);

--- a/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
@@ -123,7 +123,7 @@ public class SearchExecutionContext extends QueryRewriteContext {
     private boolean mapUnmappedFieldAsString;
     private NestedScope nestedScope;
     private final ValuesSourceRegistry valuesSourceRegistry;
-    private final Map<String, RuntimeFieldType> runtimeMappings;
+    private final Map<String, MappedFieldType> runtimeMappings;
 
     /**
      * Build a {@linkplain SearchExecutionContext}.
@@ -216,7 +216,7 @@ public class SearchExecutionContext extends QueryRewriteContext {
                                    Index fullyQualifiedIndex,
                                    BooleanSupplier allowExpensiveQueries,
                                    ValuesSourceRegistry valuesSourceRegistry,
-                                   Map<String, RuntimeFieldType> runtimeMappings) {
+                                   Map<String, MappedFieldType> runtimeMappings) {
         super(xContentRegistry, namedWriteableRegistry, client, nowInMillis);
         this.shardId = shardId;
         this.shardRequestIndex = shardRequestIndex;
@@ -647,11 +647,18 @@ public class SearchExecutionContext extends QueryRewriteContext {
         return fullyQualifiedIndex;
     }
 
-    private static Map<String, RuntimeFieldType> parseRuntimeMappings(Map<String, Object> runtimeMappings, MapperService mapperService) {
+    private static Map<String, MappedFieldType> parseRuntimeMappings(Map<String, Object> runtimeMappings, MapperService mapperService) {
         if (runtimeMappings.isEmpty()) {
             return Collections.emptyMap();
         }
-        return RuntimeFieldType.parseRuntimeFields(new HashMap<>(runtimeMappings), mapperService.parserContext(), false);
+        Map<String, RuntimeFieldType> runtimeFields = RuntimeFieldType.parseRuntimeFields(new HashMap<>(runtimeMappings),
+            mapperService.parserContext(), false);
+        Map<String, MappedFieldType> runtimeFieldTypes = new HashMap<>();
+        for (RuntimeFieldType runtimeFieldType : runtimeFields.values()) {
+            MappedFieldType fieldType = runtimeFieldType.asMappedFieldType();
+            runtimeFieldTypes.put(fieldType.name(), fieldType);
+        }
+        return Collections.unmodifiableMap(runtimeFieldTypes);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/runtimefields/mapper/AbstractScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/runtimefields/mapper/AbstractScriptFieldType.java
@@ -8,48 +8,186 @@
 
 package org.elasticsearch.runtimefields.mapper;
 
-import org.elasticsearch.common.CheckedBiConsumer;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.search.MultiTermQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.spans.SpanMultiTermQueryWrapper;
+import org.apache.lucene.search.spans.SpanQuery;
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.TriFunction;
+import org.elasticsearch.common.geo.ShapeRelation;
+import org.elasticsearch.common.time.DateMathParser;
+import org.elasticsearch.common.unit.Fuzziness;
+import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.mapper.DocValueFetcher;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.RuntimeFieldType;
+import org.elasticsearch.index.mapper.TextSearchInfo;
+import org.elasticsearch.index.mapper.ValueFetcher;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.io.IOException;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.function.Function;
+
+import static org.elasticsearch.search.SearchService.ALLOW_EXPENSIVE_QUERIES;
 
 /**
  * Abstract base {@linkplain MappedFieldType} for runtime fields based on a script.
  */
-abstract class AbstractScriptFieldType<LeafFactory> extends RuntimeFieldType {
+abstract class AbstractScriptFieldType<LeafFactory> extends MappedFieldType implements RuntimeFieldType {
     protected final Script script;
     private final TriFunction<String, Map<String, Object>, SearchLookup, LeafFactory> factory;
-
-    AbstractScriptFieldType(String name, TriFunction<String, Map<String, Object>, SearchLookup, LeafFactory> factory, Builder builder) {
-        super(name, builder);
-        this.factory = factory;
-        this.script = builder.getScript();
-    }
+    private final ToXContent toXContent;
 
     AbstractScriptFieldType(
         String name,
         TriFunction<String, Map<String, Object>, SearchLookup, LeafFactory> factory,
         Script script,
         Map<String, String> meta,
-        CheckedBiConsumer<XContentBuilder, Boolean, IOException> toXContent
+        ToXContent toXContent
     ) {
-        super(name, meta, toXContent);
+        super(name, false, false, false, TextSearchInfo.SIMPLE_MATCH_WITHOUT_TERMS, meta);
         this.factory = factory;
         this.script = script;
+        this.toXContent = toXContent;
+    }
+
+    @Override
+    public final MappedFieldType asMappedFieldType() {
+        return this;
+    }
+
+    @Override
+    public final void doXContentBody(XContentBuilder builder, Params params) throws IOException {
+        toXContent.toXContent(builder, params);
+    }
+
+    @Override
+    public final boolean isSearchable() {
+        return true;
+    }
+
+    @Override
+    public final boolean isAggregatable() {
+        return true;
+    }
+
+    @Override
+    public final Query rangeQuery(
+        Object lowerTerm,
+        Object upperTerm,
+        boolean includeLower,
+        boolean includeUpper,
+        ShapeRelation relation,
+        ZoneId timeZone,
+        DateMathParser parser,
+        SearchExecutionContext context
+    ) {
+        if (relation == ShapeRelation.DISJOINT) {
+            String message = "Runtime field [%s] of type [%s] does not support DISJOINT ranges";
+            throw new IllegalArgumentException(String.format(Locale.ROOT, message, name(), typeName()));
+        }
+        return rangeQuery(lowerTerm, upperTerm, includeLower, includeUpper, timeZone, parser, context);
+    }
+
+    protected abstract Query rangeQuery(
+        Object lowerTerm,
+        Object upperTerm,
+        boolean includeLower,
+        boolean includeUpper,
+        ZoneId timeZone,
+        DateMathParser parser,
+        SearchExecutionContext context
+    );
+
+    @Override
+    public Query fuzzyQuery(
+        Object value,
+        Fuzziness fuzziness,
+        int prefixLength,
+        int maxExpansions,
+        boolean transpositions,
+        SearchExecutionContext context
+    ) {
+        throw new IllegalArgumentException(unsupported("fuzzy", "keyword and text"));
+    }
+
+    @Override
+    public Query prefixQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive, SearchExecutionContext context) {
+        throw new IllegalArgumentException(unsupported("prefix", "keyword, text and wildcard"));
+    }
+
+    @Override
+    public Query wildcardQuery(String value, MultiTermQuery.RewriteMethod method, boolean caseInsensitive, SearchExecutionContext context) {
+        throw new IllegalArgumentException(unsupported("wildcard", "keyword, text and wildcard"));
+    }
+
+    @Override
+    public Query regexpQuery(
+        String value,
+        int syntaxFlags,
+        int matchFlags,
+        int maxDeterminizedStates,
+        MultiTermQuery.RewriteMethod method,
+        SearchExecutionContext context
+    ) {
+        throw new IllegalArgumentException(unsupported("regexp", "keyword and text"));
+    }
+
+    @Override
+    public Query phraseQuery(TokenStream stream, int slop, boolean enablePositionIncrements) {
+        throw new IllegalArgumentException(unsupported("phrase", "text"));
+    }
+
+    @Override
+    public Query multiPhraseQuery(TokenStream stream, int slop, boolean enablePositionIncrements) {
+        throw new IllegalArgumentException(unsupported("phrase", "text"));
+    }
+
+    @Override
+    public Query phrasePrefixQuery(TokenStream stream, int slop, int maxExpansions) {
+        throw new IllegalArgumentException(unsupported("phrase prefix", "text"));
+    }
+
+    @Override
+    public SpanQuery spanPrefixQuery(String value, SpanMultiTermQueryWrapper.SpanRewriteMethod method, SearchExecutionContext context) {
+        throw new IllegalArgumentException(unsupported("span prefix", "text"));
+    }
+
+    private String unsupported(String query, String supported) {
+        return String.format(
+            Locale.ROOT,
+            "Can only use %s queries on %s fields - not on [%s] which is a runtime field of type [%s]",
+            query,
+            supported,
+            name(),
+            typeName()
+        );
+    }
+
+    protected final void checkAllowExpensiveQueries(SearchExecutionContext context) {
+        if (context.allowExpensiveQueries() == false) {
+            throw new ElasticsearchException(
+                "queries cannot be executed against runtime fields while [" + ALLOW_EXPENSIVE_QUERIES.getKey() + "] is set to [false]."
+            );
+        }
+    }
+
+    @Override
+    public final ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
+        return new DocValueFetcher(docValueFormat(format, null), context.getForField(this));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/runtimefields/mapper/BooleanScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/runtimefields/mapper/BooleanScriptFieldType.java
@@ -12,11 +12,10 @@ import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Booleans;
-import org.elasticsearch.common.CheckedBiConsumer;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.time.DateMathParser;
-import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.index.mapper.BooleanFieldMapper;
 import org.elasticsearch.index.mapper.RuntimeFieldType;
 import org.elasticsearch.index.query.SearchExecutionContext;
@@ -27,7 +26,6 @@ import org.elasticsearch.script.Script;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.lookup.SearchLookup;
 
-import java.io.IOException;
 import java.time.ZoneId;
 import java.util.Collection;
 import java.util.Collections;
@@ -38,21 +36,17 @@ public final class BooleanScriptFieldType extends AbstractScriptFieldType<Boolea
 
     public static final RuntimeFieldType.Parser PARSER = new RuntimeFieldType.Parser((name, parserContext) -> new Builder(name) {
         @Override
-        protected AbstractScriptFieldType<?> buildFieldType() {
+        protected RuntimeFieldType buildFieldType() {
             if (script.get() == null) {
-                return new BooleanScriptFieldType(name, BooleanFieldScript.PARSE_FROM_SOURCE, this);
+                return new BooleanScriptFieldType(name, BooleanFieldScript.PARSE_FROM_SOURCE, getScript(), meta(), this);
             }
             BooleanFieldScript.Factory factory = parserContext.scriptCompiler().compile(script.getValue(), BooleanFieldScript.CONTEXT);
-            return new BooleanScriptFieldType(name, factory, this);
+            return new BooleanScriptFieldType(name, factory, getScript(), meta(), this);
         }
     });
 
-    private BooleanScriptFieldType(String name, BooleanFieldScript.Factory scriptFactory, Builder builder) {
-        super(name, scriptFactory::newFactory, builder);
-    }
-
     public BooleanScriptFieldType(String name) {
-        this(name, BooleanFieldScript.PARSE_FROM_SOURCE, null, Collections.emptyMap(), (builder, includeDefaults) -> {});
+        this(name, BooleanFieldScript.PARSE_FROM_SOURCE, null, Collections.emptyMap(), (builder, params) -> builder);
     }
 
     BooleanScriptFieldType(
@@ -60,7 +54,7 @@ public final class BooleanScriptFieldType extends AbstractScriptFieldType<Boolea
         BooleanFieldScript.Factory scriptFactory,
         Script script,
         Map<String, String> meta,
-        CheckedBiConsumer<XContentBuilder, Boolean, IOException> toXContent
+        ToXContent toXContent
     ) {
         super(name, scriptFactory::newFactory, script, meta, toXContent);
     }

--- a/server/src/main/java/org/elasticsearch/runtimefields/mapper/DateScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/runtimefields/mapper/DateScriptFieldType.java
@@ -11,14 +11,13 @@ package org.elasticsearch.runtimefields.mapper;
 import com.carrotsearch.hppc.LongHashSet;
 import com.carrotsearch.hppc.LongSet;
 import org.apache.lucene.search.Query;
-import org.elasticsearch.common.CheckedBiConsumer;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.time.DateMathParser;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.LocaleUtils;
-import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.DateFieldMapper.DateFieldType;
 import org.elasticsearch.index.mapper.DateFieldMapper.Resolution;
@@ -35,7 +34,6 @@ import org.elasticsearch.script.Script;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.lookup.SearchLookup;
 
-import java.io.IOException;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
@@ -81,30 +79,26 @@ public class DateScriptFieldType extends AbstractScriptFieldType<DateFieldScript
         }
 
         @Override
-        protected AbstractScriptFieldType<?> buildFieldType() {
+        protected RuntimeFieldType buildFieldType() {
             String pattern = format.getValue() == null ? DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.pattern() : format.getValue();
             Locale locale = this.locale.getValue() == null ? Locale.ROOT : this.locale.getValue();
             DateFormatter dateTimeFormatter = DateFormatter.forPattern(pattern).withLocale(locale);
             if (script.get() == null) {
-                return new DateScriptFieldType(name, DateFieldScript.PARSE_FROM_SOURCE, dateTimeFormatter, this);
+                return new DateScriptFieldType(name, DateFieldScript.PARSE_FROM_SOURCE, dateTimeFormatter, getScript(), meta(), this);
             }
             DateFieldScript.Factory factory = parserContext.scriptCompiler().compile(script.getValue(), DateFieldScript.CONTEXT);
-            return new DateScriptFieldType(name, factory, dateTimeFormatter, this);
+            return new DateScriptFieldType(name, factory, dateTimeFormatter, getScript(), meta(), this);
         }
     });
 
     private final DateFormatter dateTimeFormatter;
 
-    private DateScriptFieldType(String name, DateFieldScript.Factory scriptFactory, DateFormatter dateTimeFormatter, Builder builder) {
-        super(name, (n, params, ctx) -> scriptFactory.newFactory(n, params, ctx, dateTimeFormatter), builder);
-        this.dateTimeFormatter = dateTimeFormatter;
-    }
-
     public DateScriptFieldType(String name, DateFormatter dateTimeFormatter) {
-        this(name, DateFieldScript.PARSE_FROM_SOURCE, dateTimeFormatter, null, Collections.emptyMap(), (builder, includeDefaults) -> {
+        this(name, DateFieldScript.PARSE_FROM_SOURCE, dateTimeFormatter, null, Collections.emptyMap(), (builder, params) -> {
             if (DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.pattern().equals(dateTimeFormatter.pattern()) == false) {
                 builder.field("format", dateTimeFormatter.pattern());
             }
+            return builder;
         });
     }
 
@@ -114,7 +108,7 @@ public class DateScriptFieldType extends AbstractScriptFieldType<DateFieldScript
         DateFormatter dateTimeFormatter,
         Script script,
         Map<String, String> meta,
-        CheckedBiConsumer<XContentBuilder, Boolean, IOException> toXContent
+        ToXContent toXContent
     ) {
         super(name, (n, params, ctx) -> scriptFactory.newFactory(n, params, ctx, dateTimeFormatter), script, meta, toXContent);
         this.dateTimeFormatter = dateTimeFormatter;

--- a/server/src/main/java/org/elasticsearch/runtimefields/mapper/DoubleScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/runtimefields/mapper/DoubleScriptFieldType.java
@@ -11,10 +11,9 @@ package org.elasticsearch.runtimefields.mapper;
 import com.carrotsearch.hppc.LongHashSet;
 import com.carrotsearch.hppc.LongSet;
 import org.apache.lucene.search.Query;
-import org.elasticsearch.common.CheckedBiConsumer;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.time.DateMathParser;
-import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.index.mapper.NumberFieldMapper.NumberType;
 import org.elasticsearch.index.mapper.RuntimeFieldType;
 import org.elasticsearch.index.query.SearchExecutionContext;
@@ -27,7 +26,6 @@ import org.elasticsearch.script.Script;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.lookup.SearchLookup;
 
-import java.io.IOException;
 import java.time.ZoneId;
 import java.util.Collection;
 import java.util.Collections;
@@ -38,21 +36,17 @@ public final class DoubleScriptFieldType extends AbstractScriptFieldType<DoubleF
 
     public static final RuntimeFieldType.Parser PARSER = new RuntimeFieldType.Parser((name, parserContext) -> new Builder(name) {
         @Override
-        protected AbstractScriptFieldType<?> buildFieldType() {
+        protected RuntimeFieldType buildFieldType() {
             if (script.get() == null) {
-                return new DoubleScriptFieldType(name, DoubleFieldScript.PARSE_FROM_SOURCE, this);
+                return new DoubleScriptFieldType(name, DoubleFieldScript.PARSE_FROM_SOURCE, getScript(), meta(), this);
             }
             DoubleFieldScript.Factory factory = parserContext.scriptCompiler().compile(script.getValue(), DoubleFieldScript.CONTEXT);
-            return new DoubleScriptFieldType(name, factory, this);
+            return new DoubleScriptFieldType(name, factory, getScript(), meta(), this);
         }
     });
 
-    private DoubleScriptFieldType(String name, DoubleFieldScript.Factory scriptFactory, Builder builder) {
-        super(name, scriptFactory::newFactory, builder);
-    }
-
     public DoubleScriptFieldType(String name) {
-        this(name, DoubleFieldScript.PARSE_FROM_SOURCE, null, Collections.emptyMap(), (builder, includeDefaults) -> {});
+        this(name, DoubleFieldScript.PARSE_FROM_SOURCE, null, Collections.emptyMap(), (builder, params) -> builder);
     }
 
     DoubleScriptFieldType(
@@ -60,7 +54,7 @@ public final class DoubleScriptFieldType extends AbstractScriptFieldType<DoubleF
         DoubleFieldScript.Factory scriptFactory,
         Script script,
         Map<String, String> meta,
-        CheckedBiConsumer<XContentBuilder, Boolean, IOException> toXContent
+        ToXContent toXContent
     ) {
         super(name, scriptFactory::newFactory, script, meta, toXContent);
     }

--- a/server/src/main/java/org/elasticsearch/runtimefields/mapper/GeoPointScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/runtimefields/mapper/GeoPointScriptFieldType.java
@@ -12,14 +12,13 @@ import org.apache.lucene.geo.LatLonGeometry;
 import org.apache.lucene.geo.Point;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
-import org.elasticsearch.common.CheckedBiConsumer;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.GeoShapeUtils;
 import org.elasticsearch.common.geo.GeoUtils;
 import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.time.DateMathParser;
 import org.elasticsearch.common.unit.DistanceUnit;
-import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.index.mapper.GeoPointFieldMapper;
 import org.elasticsearch.index.mapper.GeoShapeQueryable;
@@ -32,7 +31,6 @@ import org.elasticsearch.runtimefields.query.GeoPointScriptFieldGeoShapeQuery;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.search.lookup.SearchLookup;
 
-import java.io.IOException;
 import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.Map;
@@ -42,25 +40,21 @@ public final class GeoPointScriptFieldType extends AbstractScriptFieldType<GeoPo
 
     public static final RuntimeFieldType.Parser PARSER = new RuntimeFieldType.Parser((name, parserContext) -> new Builder(name) {
         @Override
-        protected AbstractScriptFieldType<?> buildFieldType() {
+        protected RuntimeFieldType buildFieldType() {
             if (script.get() == null) {
-                return new GeoPointScriptFieldType(name, GeoPointFieldScript.PARSE_FROM_SOURCE, this);
+                return new GeoPointScriptFieldType(name, GeoPointFieldScript.PARSE_FROM_SOURCE, getScript(), meta(), this);
             }
             GeoPointFieldScript.Factory factory = parserContext.scriptCompiler().compile(script.getValue(), GeoPointFieldScript.CONTEXT);
-            return new GeoPointScriptFieldType(name, factory, this);
+            return new GeoPointScriptFieldType(name, factory, getScript(), meta(), this);
         }
     });
-
-    private GeoPointScriptFieldType(String name, GeoPointFieldScript.Factory scriptFactory, Builder builder) {
-        super(name, scriptFactory::newFactory, builder);
-    }
 
     GeoPointScriptFieldType(
         String name,
         GeoPointFieldScript.Factory scriptFactory,
         Script script,
         Map<String, String> meta,
-        CheckedBiConsumer<XContentBuilder, Boolean, IOException> toXContent
+        ToXContent toXContent
     ) {
         super(name, scriptFactory::newFactory, script, meta, toXContent);
     }

--- a/server/src/main/java/org/elasticsearch/runtimefields/mapper/IpScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/runtimefields/mapper/IpScriptFieldType.java
@@ -13,14 +13,13 @@ import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.CheckedBiConsumer;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.time.DateMathParser;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BytesRefHash;
-import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.index.mapper.IpFieldMapper;
 import org.elasticsearch.index.mapper.RuntimeFieldType;
 import org.elasticsearch.index.query.SearchExecutionContext;
@@ -33,7 +32,6 @@ import org.elasticsearch.script.Script;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.lookup.SearchLookup;
 
-import java.io.IOException;
 import java.net.InetAddress;
 import java.time.ZoneId;
 import java.util.ArrayList;
@@ -47,25 +45,21 @@ public final class IpScriptFieldType extends AbstractScriptFieldType<IpFieldScri
 
     public static final RuntimeFieldType.Parser PARSER = new RuntimeFieldType.Parser((name, parserContext) -> new Builder(name) {
         @Override
-        protected AbstractScriptFieldType<?> buildFieldType() {
+        protected RuntimeFieldType buildFieldType() {
             if (script.get() == null) {
-                return new IpScriptFieldType(name, IpFieldScript.PARSE_FROM_SOURCE, this);
+                return new IpScriptFieldType(name, IpFieldScript.PARSE_FROM_SOURCE, getScript(), meta(), this);
             }
             IpFieldScript.Factory factory = parserContext.scriptCompiler().compile(script.getValue(), IpFieldScript.CONTEXT);
-            return new IpScriptFieldType(name, factory, this);
+            return new IpScriptFieldType(name, factory, getScript(), meta(), this);
         }
     });
-
-    private IpScriptFieldType(String name, IpFieldScript.Factory scriptFactory, Builder builder) {
-        super(name, scriptFactory::newFactory, builder);
-    }
 
     IpScriptFieldType(
         String name,
         IpFieldScript.Factory scriptFactory,
         Script script,
         Map<String, String> meta,
-        CheckedBiConsumer<XContentBuilder, Boolean, IOException> toXContent
+        ToXContent toXContent
     ) {
         super(name, scriptFactory::newFactory, script, meta, toXContent);
     }

--- a/server/src/main/java/org/elasticsearch/runtimefields/mapper/KeywordScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/runtimefields/mapper/KeywordScriptFieldType.java
@@ -11,11 +11,10 @@ package org.elasticsearch.runtimefields.mapper;
 import org.apache.lucene.search.MultiTermQuery.RewriteMethod;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.CheckedBiConsumer;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.time.DateMathParser;
 import org.elasticsearch.common.unit.Fuzziness;
-import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.RuntimeFieldType;
 import org.elasticsearch.index.query.SearchExecutionContext;
@@ -31,7 +30,6 @@ import org.elasticsearch.runtimefields.query.StringScriptFieldWildcardQuery;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.search.lookup.SearchLookup;
 
-import java.io.IOException;
 import java.time.ZoneId;
 import java.util.Collection;
 import java.util.Collections;
@@ -46,21 +44,17 @@ public final class KeywordScriptFieldType extends AbstractScriptFieldType<String
 
     public static final RuntimeFieldType.Parser PARSER = new RuntimeFieldType.Parser((name, parserContext) -> new Builder(name) {
         @Override
-        protected AbstractScriptFieldType<?> buildFieldType() {
+        protected RuntimeFieldType buildFieldType() {
             if (script.get() == null) {
-                return new KeywordScriptFieldType(name, StringFieldScript.PARSE_FROM_SOURCE, this);
+                return new KeywordScriptFieldType(name, StringFieldScript.PARSE_FROM_SOURCE, getScript(), meta(), this);
             }
             StringFieldScript.Factory factory = parserContext.scriptCompiler().compile(script.getValue(), StringFieldScript.CONTEXT);
-            return new KeywordScriptFieldType(name, factory, this);
+            return new KeywordScriptFieldType(name, factory, getScript(), meta(), this);
         }
     });
 
     public KeywordScriptFieldType(String name) {
-        this(name, StringFieldScript.PARSE_FROM_SOURCE, null, Collections.emptyMap(), (builder, includeDefaults) -> {});
-    }
-
-    private KeywordScriptFieldType(String name, StringFieldScript.Factory scriptFactory, Builder builder) {
-        super(name, scriptFactory::newFactory, builder);
+        this(name, StringFieldScript.PARSE_FROM_SOURCE, null, Collections.emptyMap(), (builder, params) -> builder);
     }
 
     KeywordScriptFieldType(
@@ -68,7 +62,7 @@ public final class KeywordScriptFieldType extends AbstractScriptFieldType<String
         StringFieldScript.Factory scriptFactory,
         Script script,
         Map<String, String> meta,
-        CheckedBiConsumer<XContentBuilder, Boolean, IOException> toXContent
+        ToXContent toXContent
     ) {
         super(name, scriptFactory::newFactory, script, meta, toXContent);
     }

--- a/server/src/main/java/org/elasticsearch/runtimefields/mapper/LongScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/runtimefields/mapper/LongScriptFieldType.java
@@ -11,10 +11,9 @@ package org.elasticsearch.runtimefields.mapper;
 import com.carrotsearch.hppc.LongHashSet;
 import com.carrotsearch.hppc.LongSet;
 import org.apache.lucene.search.Query;
-import org.elasticsearch.common.CheckedBiConsumer;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.time.DateMathParser;
-import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.index.mapper.NumberFieldMapper.NumberType;
 import org.elasticsearch.index.mapper.RuntimeFieldType;
 import org.elasticsearch.index.query.SearchExecutionContext;
@@ -27,7 +26,6 @@ import org.elasticsearch.script.Script;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.lookup.SearchLookup;
 
-import java.io.IOException;
 import java.time.ZoneId;
 import java.util.Collection;
 import java.util.Collections;
@@ -38,21 +36,17 @@ public final class LongScriptFieldType extends AbstractScriptFieldType<LongField
 
     public static final RuntimeFieldType.Parser PARSER = new RuntimeFieldType.Parser((name, parserContext) -> new Builder(name) {
         @Override
-        protected AbstractScriptFieldType<?> buildFieldType() {
+        protected RuntimeFieldType buildFieldType() {
             if (script.get() == null) {
-                return new LongScriptFieldType(name, LongFieldScript.PARSE_FROM_SOURCE, this);
+                return new LongScriptFieldType(name, LongFieldScript.PARSE_FROM_SOURCE, getScript(), meta(), this);
             }
             LongFieldScript.Factory factory = parserContext.scriptCompiler().compile(script.getValue(), LongFieldScript.CONTEXT);
-            return new LongScriptFieldType(name, factory, this);
+            return new LongScriptFieldType(name, factory, getScript(), meta(), this);
         }
     });
 
     public LongScriptFieldType(String name) {
-        this(name, LongFieldScript.PARSE_FROM_SOURCE, null, Collections.emptyMap(), (builder, includeDefaults) -> {});
-    }
-
-    private LongScriptFieldType(String name, LongFieldScript.Factory scriptFactory, Builder builder) {
-        super(name, scriptFactory::newFactory, builder);
+        this(name, LongFieldScript.PARSE_FROM_SOURCE, null, Collections.emptyMap(), (builder, params) -> builder);
     }
 
     LongScriptFieldType(
@@ -60,7 +54,7 @@ public final class LongScriptFieldType extends AbstractScriptFieldType<LongField
         LongFieldScript.Factory scriptFactory,
         Script script,
         Map<String, String> meta,
-        CheckedBiConsumer<XContentBuilder, Boolean, IOException> toXContent
+        ToXContent toXContent
     ) {
         super(name, scriptFactory::newFactory, script, meta, toXContent);
     }

--- a/server/src/test/java/org/elasticsearch/index/IndexSortSettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexSortSettingsTests.java
@@ -10,11 +10,11 @@ package org.elasticsearch.index;
 
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.time.DateMathParser;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldDataService;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.mapper.RuntimeFieldType;
+import org.elasticsearch.index.mapper.TextSearchInfo;
+import org.elasticsearch.index.mapper.ValueFetcher;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.indices.fielddata.cache.IndicesFieldDataCache;
@@ -23,7 +23,6 @@ import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.test.ESTestCase;
 
-import java.time.ZoneId;
 import java.util.Collections;
 import java.util.function.Supplier;
 
@@ -141,13 +140,7 @@ public class IndexSortSettingsTests extends ESTestCase {
         IndicesFieldDataCache cache = new IndicesFieldDataCache(Settings.EMPTY, null);
         NoneCircuitBreakerService circuitBreakerService = new NoneCircuitBreakerService();
         final IndexFieldDataService indexFieldDataService = new IndexFieldDataService(indexSettings, cache, circuitBreakerService, null);
-        MappedFieldType fieldType = new RuntimeFieldType("field", Collections.emptyMap(), null) {
-            @Override
-            protected Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, ZoneId timeZone,
-                                       DateMathParser parser, SearchExecutionContext context) {
-                throw new UnsupportedOperationException();
-            }
-
+        MappedFieldType fieldType = new MappedFieldType("field", false, false, false, TextSearchInfo.NONE, Collections.emptyMap()) {
             @Override
             public String typeName() {
                 return null;
@@ -157,6 +150,11 @@ public class IndexSortSettingsTests extends ESTestCase {
             public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName, Supplier<SearchLookup> searchLookup) {
                 searchLookup.get();
                 return null;
+            }
+
+            @Override
+            public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
+                throw new UnsupportedOperationException();
             }
 
             @Override

--- a/server/src/test/java/org/elasticsearch/index/mapper/FieldAliasMapperValidationTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FieldAliasMapperValidationTests.java
@@ -197,7 +197,7 @@ public class FieldAliasMapperValidationTests extends ESTestCase {
                                                      List<FieldAliasMapper> fieldAliasMappers,
                                                      List<RuntimeFieldType> runtimeFields) {
         RootObjectMapper.Builder builder = new RootObjectMapper.Builder("_doc", Version.CURRENT);
-        Map<String, RuntimeFieldType> runtimeFieldTypes = runtimeFields.stream().collect(Collectors.toMap(MappedFieldType::name, r -> r));
+        Map<String, RuntimeFieldType> runtimeFieldTypes = runtimeFields.stream().collect(Collectors.toMap(RuntimeFieldType::name, r -> r));
         builder.setRuntime(runtimeFieldTypes);
         Mapping mapping = new Mapping(builder.build(new ContentPath()), new MetadataFieldMapper[0], Collections.emptyMap());
         return new MappingLookup(mapping, fieldMappers, objectMappers, fieldAliasMappers, null, null, null);

--- a/server/src/test/java/org/elasticsearch/index/mapper/MappingLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/MappingLookupTests.java
@@ -36,7 +36,7 @@ public class MappingLookupTests extends ESTestCase {
                                                      List<ObjectMapper> objectMappers,
                                                      List<RuntimeFieldType> runtimeFields) {
         RootObjectMapper.Builder builder = new RootObjectMapper.Builder("_doc", Version.CURRENT);
-        Map<String, RuntimeFieldType> runtimeFieldTypes = runtimeFields.stream().collect(Collectors.toMap(MappedFieldType::name, r -> r));
+        Map<String, RuntimeFieldType> runtimeFieldTypes = runtimeFields.stream().collect(Collectors.toMap(RuntimeFieldType::name, r -> r));
         builder.setRuntime(runtimeFieldTypes);
         Mapping mapping = new Mapping(builder.build(new ContentPath()), new MetadataFieldMapper[0], Collections.emptyMap());
         return new MappingLookup(mapping, fieldMappers, objectMappers, emptyList(), null, null, null);

--- a/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldMapperTests.java
@@ -21,6 +21,7 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 
 import java.io.IOException;
 import java.net.InetAddress;
+import java.util.Collections;
 import java.util.Locale;
 import java.util.Set;
 
@@ -339,7 +340,8 @@ public class RangeFieldMapperTests extends AbstractNumericFieldMapperTestCase {
             DocumentMapper docMapper = createDocumentMapper(fieldMapping(b -> b.field("type", type)));
             RangeFieldMapper mapper = (RangeFieldMapper) docMapper.mapping().getRoot().getMapper("field");
             XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
-            mapper.doXContentBody(builder, true, ToXContent.EMPTY_PARAMS);
+            ToXContent.MapParams params = new ToXContent.MapParams(Collections.singletonMap("include_defaults", "true"));
+            mapper.doXContentBody(builder, params);
             String got = Strings.toString(builder.endObject());
 
             // if type is date_range we check that the mapper contains the default format and locale

--- a/server/src/test/java/org/elasticsearch/index/mapper/TestRuntimeField.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TestRuntimeField.java
@@ -9,18 +9,18 @@
 package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.search.Query;
-import org.elasticsearch.common.time.DateMathParser;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.query.SearchExecutionContext;
 
-import java.time.ZoneId;
+import java.io.IOException;
 import java.util.Collections;
 
-public class TestRuntimeField extends RuntimeFieldType {
+public class TestRuntimeField extends MappedFieldType implements RuntimeFieldType {
 
     private final String type;
 
     public TestRuntimeField(String name, String type) {
-        super(name, Collections.emptyMap(), null);
+        super(name, false, false, false, TextSearchInfo.NONE, Collections.emptyMap());
         this.type = type;
     }
 
@@ -30,13 +30,22 @@ public class TestRuntimeField extends RuntimeFieldType {
     }
 
     @Override
+    public MappedFieldType asMappedFieldType() {
+        return this;
+    }
+
+    @Override
+    public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Query termQuery(Object value, SearchExecutionContext context) {
         return null;
     }
 
     @Override
-    protected Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper,
-                               ZoneId timeZone, DateMathParser parser, SearchExecutionContext context) {
-        throw new UnsupportedOperationException();
+    public void doXContentBody(XContentBuilder builder, Params params) throws IOException {
+
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/query/SearchExecutionContextTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/SearchExecutionContextTests.java
@@ -324,7 +324,7 @@ public class SearchExecutionContextTests extends ESTestCase {
     private static MappingLookup createMappingLookup(List<MappedFieldType> concreteFields, List<RuntimeFieldType> runtimeFields) {
         List<FieldMapper> mappers = concreteFields.stream().map(MockFieldMapper::new).collect(Collectors.toList());
         RootObjectMapper.Builder builder = new RootObjectMapper.Builder("_doc", Version.CURRENT);
-        Map<String, RuntimeFieldType> runtimeFieldTypes = runtimeFields.stream().collect(Collectors.toMap(MappedFieldType::name, r -> r));
+        Map<String, RuntimeFieldType> runtimeFieldTypes = runtimeFields.stream().collect(Collectors.toMap(RuntimeFieldType::name, r -> r));
         builder.setRuntime(runtimeFieldTypes);
         Mapping mapping = new Mapping(builder.build(new ContentPath()), new MetadataFieldMapper[0], Collections.emptyMap());
         return new MappingLookup(mapping, mappers, Collections.emptyList(), Collections.emptyList(), null, null, null);

--- a/server/src/test/java/org/elasticsearch/runtimefields/mapper/BooleanScriptFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/runtimefields/mapper/BooleanScriptFieldTypeTests.java
@@ -479,6 +479,6 @@ public class BooleanScriptFieldTypeTests extends AbstractNonTextScriptFieldTypeT
     }
 
     private static BooleanScriptFieldType build(Script script) {
-        return new BooleanScriptFieldType("test", factory(script), script, emptyMap(), (b, d) -> {});
+        return new BooleanScriptFieldType("test", factory(script), script, emptyMap(), (builder, params) -> builder);
     }
 }

--- a/server/src/test/java/org/elasticsearch/runtimefields/mapper/DateScriptFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/runtimefields/mapper/DateScriptFieldTypeTests.java
@@ -567,7 +567,7 @@ public class DateScriptFieldTypeTests extends AbstractNonTextScriptFieldTypeTest
     }
 
     private static DateScriptFieldType build(Script script, DateFormatter dateTimeFormatter) {
-        return new DateScriptFieldType("test", factory(script), dateTimeFormatter, script, emptyMap(), (b, d) -> {});
+        return new DateScriptFieldType("test", factory(script), dateTimeFormatter, script, emptyMap(), (builder, params) -> builder);
     }
 
     private static long randomDate() {

--- a/server/src/test/java/org/elasticsearch/runtimefields/mapper/DoubleScriptFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/runtimefields/mapper/DoubleScriptFieldTypeTests.java
@@ -290,6 +290,6 @@ public class DoubleScriptFieldTypeTests extends AbstractNonTextScriptFieldTypeTe
     }
 
     private static DoubleScriptFieldType build(Script script) {
-        return new DoubleScriptFieldType("test", factory(script), script, emptyMap(), (b, d) -> {});
+        return new DoubleScriptFieldType("test", factory(script), script, emptyMap(), (builder, params) -> builder);
     }
 }

--- a/server/src/test/java/org/elasticsearch/runtimefields/mapper/GeoPointScriptFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/runtimefields/mapper/GeoPointScriptFieldTypeTests.java
@@ -256,6 +256,6 @@ public class GeoPointScriptFieldTypeTests extends AbstractNonTextScriptFieldType
     }
 
     private static GeoPointScriptFieldType build(Script script) {
-        return new GeoPointScriptFieldType("test", factory(script), script, emptyMap(), (b, d) -> {});
+        return new GeoPointScriptFieldType("test", factory(script), script, emptyMap(), (builder, params) -> builder);
     }
 }

--- a/server/src/test/java/org/elasticsearch/runtimefields/mapper/IpScriptFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/runtimefields/mapper/IpScriptFieldTypeTests.java
@@ -333,6 +333,6 @@ public class IpScriptFieldTypeTests extends AbstractScriptFieldTypeTestCase {
     }
 
     private static IpScriptFieldType build(Script script) {
-        return new IpScriptFieldType("test", factory(script), script, emptyMap(), (b, d) -> {});
+        return new IpScriptFieldType("test", factory(script), script, emptyMap(), (builder, params) -> builder);
     }
 }

--- a/server/src/test/java/org/elasticsearch/runtimefields/mapper/KeywordScriptFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/runtimefields/mapper/KeywordScriptFieldTypeTests.java
@@ -412,6 +412,6 @@ public class KeywordScriptFieldTypeTests extends AbstractScriptFieldTypeTestCase
     }
 
     private static KeywordScriptFieldType build(Script script) {
-        return new KeywordScriptFieldType("test", factory(script), script, emptyMap(), (b, d) -> {});
+        return new KeywordScriptFieldType("test", factory(script), script, emptyMap(), (builder, params) -> builder);
     }
 }

--- a/server/src/test/java/org/elasticsearch/runtimefields/mapper/LongScriptFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/runtimefields/mapper/LongScriptFieldTypeTests.java
@@ -342,6 +342,6 @@ public class LongScriptFieldTypeTests extends AbstractNonTextScriptFieldTypeTest
     }
 
     private static LongScriptFieldType build(Script script) {
-        return new LongScriptFieldType("test", factory(script), script, emptyMap(), (b, d) -> {});
+        return new LongScriptFieldType("test", factory(script), script, emptyMap(), (builder, params) -> builder);
     }
 }


### PR DESCRIPTION
So far the runtime section supports only leaf field types, hence the internal representation is based on `RuntimeFieldType` that extends directly `MappedFieldType`. This is straightforward but it is limiting for e.g. an alias field that points to another field, or for object fields that are not queryable directly, hence should not be a MappedFieldType, yet their subfields do.

This commit makes `RuntimeFieldType` an interface, effectively splitting the definition of a runtime fields as defined and returned in the mappings, from its internal representation in terms of `MappedFieldType`.

The existing runtime script field types still extend `MappedFieldType` and now also implement the new interface, which makes the change rather simple.
