### PR TITLE
SQL: Fix test to not run as a jdbc driver newer than the server (backport of #70674)

### DIFF
--- a/x-pack/plugin/sql/qa/mixed-node/src/test/java/org/elasticsearch/xpack/sql/qa/mixed_node/SqlSearchIT.java
+++ b/x-pack/plugin/sql/qa/mixed-node/src/test/java/org/elasticsearch/xpack/sql/qa/mixed_node/SqlSearchIT.java
@@ -20,7 +20,6 @@ import org.elasticsearch.test.NotEqualMessageBuilder;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xpack.ql.TestNode;
 import org.elasticsearch.xpack.ql.TestNodes;
-import org.elasticsearch.xpack.sql.type.SqlDataTypes;
 import org.junit.After;
 import org.junit.Before;
 
@@ -225,19 +224,15 @@ public class SqlSearchIT extends ESRestTestCase {
         Map<String, Object> column = new HashMap<>();
         column.put("name", name);
         column.put("type", type);
-        column.put("display_size", SqlDataTypes.displaySize(SqlDataTypes.fromTypeName(type)));
         return unmodifiableMap(column);
     }
 
-    private void assertAllTypesWithNodes(Map<String, Object> expectedResponse, List<TestNode> nodesList) throws Exception {
+    private void assertAllTypesWithNodes(Map<String, Object> expectedResponse, List<TestNode> nodesList)
+        throws Exception {
         try (
             RestClient client = buildClient(restClientSettings(),
                 nodesList.stream().map(TestNode::getPublishAddress).toArray(HttpHost[]::new))
         ) {
-            Request request = new Request("POST", "_sql");
-            String version = ",\"version\":\"" + newVersion.toString() + "\"";
-            String binaryFormat = ",\"binary_format\":\"false\"";
-
             @SuppressWarnings("unchecked")
             List<Map<String, Object>> columns = (List<Map<String, Object>>) expectedResponse.get("columns");
             String intervalYearMonth = "INTERVAL '150' YEAR AS interval_year, ";
@@ -248,9 +243,8 @@ public class SqlSearchIT extends ESRestTestCase {
             String fieldsList = columns.stream().map(m -> (String) m.get("name")).filter(str -> str.startsWith("interval") == false)
                 .collect(Collectors.toList()).stream().collect(Collectors.joining(", "));
             String query = "SELECT " + intervalYearMonth + intervalDayTime + fieldsList + " FROM " + index + " ORDER BY id";
-            request.setJsonEntity(
-                "{\"mode\":\"jdbc\"" + version + binaryFormat + ",\"query\":\"" + query + "\"}"
-            );
+            Request request = new Request("POST", "_sql");
+            request.setJsonEntity("{\"query\":\"" + query + "\"}");
             assertBusy(() -> { assertResponse(expectedResponse, runSql(client, request)); });
         }
     }


### PR DESCRIPTION
Fix test simulating running an newer JDBC driver against an older
server. This scenario's no longer supported.

Fixes #70630.

(cherry picked from commit e6c4ce58b96cebc122b10a2b3cd6148e0e845216)
