### PR TITLE
Rename RuntimeFieldType to RuntimeField

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/MappingStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/MappingStats.java
@@ -125,26 +125,26 @@ public final class MappingStats implements ToXContentFragment, Writeable {
     }
 
     private final Set<IndexFeatureStats> fieldTypeStats;
-    private final Set<RuntimeFieldStats> runtimeFieldTypeStats;
+    private final Set<RuntimeFieldStats> runtimeFieldStats;
 
-    MappingStats(Collection<IndexFeatureStats> fieldTypeStats, Collection<RuntimeFieldStats> runtimeFieldTypeStats) {
+    MappingStats(Collection<IndexFeatureStats> fieldTypeStats, Collection<RuntimeFieldStats> runtimeFieldStats) {
         List<IndexFeatureStats> stats = new ArrayList<>(fieldTypeStats);
         stats.sort(Comparator.comparing(IndexFeatureStats::getName));
         this.fieldTypeStats = Collections.unmodifiableSet(new LinkedHashSet<IndexFeatureStats>(stats));
-        List<RuntimeFieldStats> runtimeStats = new ArrayList<>(runtimeFieldTypeStats);
+        List<RuntimeFieldStats> runtimeStats = new ArrayList<>(runtimeFieldStats);
         runtimeStats.sort(Comparator.comparing(RuntimeFieldStats::type));
-        this.runtimeFieldTypeStats = Collections.unmodifiableSet(new LinkedHashSet<>(runtimeStats));
+        this.runtimeFieldStats = Collections.unmodifiableSet(new LinkedHashSet<>(runtimeStats));
     }
 
     MappingStats(StreamInput in) throws IOException {
         fieldTypeStats = Collections.unmodifiableSet(new LinkedHashSet<>(in.readList(IndexFeatureStats::new)));
-        runtimeFieldTypeStats = Collections.unmodifiableSet(new LinkedHashSet<>(in.readList(RuntimeFieldStats::new)));
+        runtimeFieldStats = Collections.unmodifiableSet(new LinkedHashSet<>(in.readList(RuntimeFieldStats::new)));
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeCollection(fieldTypeStats);
-        out.writeCollection(runtimeFieldTypeStats);
+        out.writeCollection(runtimeFieldStats);
     }
 
     /**
@@ -157,8 +157,8 @@ public final class MappingStats implements ToXContentFragment, Writeable {
     /**
      * Return stats about runtime field types.
      */
-    public Set<RuntimeFieldStats> getRuntimeFieldTypeStats() {
-        return runtimeFieldTypeStats;
+    public Set<RuntimeFieldStats> getRuntimeFieldStats() {
+        return runtimeFieldStats;
     }
 
     @Override
@@ -170,7 +170,7 @@ public final class MappingStats implements ToXContentFragment, Writeable {
         }
         builder.endArray();
         builder.startArray("runtime_field_types");
-        for (RuntimeFieldStats st : runtimeFieldTypeStats) {
+        for (RuntimeFieldStats st : runtimeFieldStats) {
             st.toXContent(builder, params);
         }
         builder.endArray();
@@ -190,11 +190,11 @@ public final class MappingStats implements ToXContentFragment, Writeable {
         }
         MappingStats that = (MappingStats) o;
         return fieldTypeStats.equals(that.fieldTypeStats) &&
-            runtimeFieldTypeStats.equals(that.runtimeFieldTypeStats);
+            runtimeFieldStats.equals(that.runtimeFieldStats);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(fieldTypeStats, runtimeFieldTypeStats);
+        return Objects.hash(fieldTypeStats, runtimeFieldStats);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesIndexAction.java
@@ -34,7 +34,7 @@ import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.ObjectMapper;
-import org.elasticsearch.index.mapper.RuntimeFieldType;
+import org.elasticsearch.index.mapper.RuntimeField;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.shard.IndexShard;
@@ -129,7 +129,7 @@ public class TransportFieldCapabilitiesIndexAction
                     // Check the ancestor of the field to find nested and object fields.
                     // Runtime fields are excluded since they can override any path.
                     //TODO find a way to do this that does not require an instanceof check
-                    if (ft instanceof RuntimeFieldType == false) {
+                    if (ft instanceof RuntimeField == false) {
                         int dotIndex = ft.name().lastIndexOf('.');
                         while (dotIndex > -1) {
                             String parentField = ft.name().substring(0, dotIndex);

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -196,7 +196,7 @@ final class DocumentParser {
     /** Creates a Mapping containing any dynamically added fields, or returns null if there were no dynamic mappings. */
     static Mapping createDynamicUpdate(MappingLookup mappingLookup,
                                        List<Mapper> dynamicMappers,
-                                       List<RuntimeFieldType> dynamicRuntimeFields) {
+                                       List<RuntimeField> dynamicRuntimeFields) {
         if (dynamicMappers.isEmpty() && dynamicRuntimeFields.isEmpty()) {
             return null;
         }
@@ -799,9 +799,9 @@ final class DocumentParser {
         // if a leaf field is not mapped, and is defined as a runtime field, then we
         // don't create a dynamic mapping for it and don't index it.
         String fieldPath = context.path().pathAsText(fieldName);
-        RuntimeFieldType runtimeFieldType = context.root().getRuntimeFieldType(fieldPath);
-        if (runtimeFieldType != null) {
-            return new NoOpFieldMapper(subfields[subfields.length - 1], runtimeFieldType.asMappedFieldType().name());
+        RuntimeField runtimeField = context.root().getRuntimeFieldType(fieldPath);
+        if (runtimeField != null) {
+            return new NoOpFieldMapper(subfields[subfields.length - 1], runtimeField.asMappedFieldType().name());
         }
         return null;
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -799,7 +799,7 @@ final class DocumentParser {
         // if a leaf field is not mapped, and is defined as a runtime field, then we
         // don't create a dynamic mapping for it and don't index it.
         String fieldPath = context.path().pathAsText(fieldName);
-        RuntimeField runtimeField = context.root().getRuntimeFieldType(fieldPath);
+        RuntimeField runtimeField = context.root().getRuntimeField(fieldPath);
         if (runtimeField != null) {
             return new NoOpFieldMapper(subfields[subfields.length - 1], runtimeField.asMappedFieldType().name());
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/DynamicFieldsBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DynamicFieldsBuilder.java
@@ -198,7 +198,7 @@ final class DynamicFieldsBuilder {
         Map<String, Object> mapping = dynamicTemplate.mappingForName(name, dynamicType);
         if (dynamicTemplate.isRuntimeMapping()) {
             Mapper.TypeParser.ParserContext parserContext = context.parserContext(dateFormatter);
-            RuntimeField.Parser parser = parserContext.runtimeFieldTypeParser(mappingType);
+            RuntimeField.Parser parser = parserContext.runtimeFieldParser(mappingType);
             String fullName = context.path().pathAsText(name);
             if (parser == null) {
                 throw new MapperParsingException("failed to find type parsed [" + mappingType + "] for [" + fullName + "]");

--- a/server/src/main/java/org/elasticsearch/index/mapper/DynamicFieldsBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DynamicFieldsBuilder.java
@@ -198,13 +198,13 @@ final class DynamicFieldsBuilder {
         Map<String, Object> mapping = dynamicTemplate.mappingForName(name, dynamicType);
         if (dynamicTemplate.isRuntimeMapping()) {
             Mapper.TypeParser.ParserContext parserContext = context.parserContext(dateFormatter);
-            RuntimeFieldType.Parser parser = parserContext.runtimeFieldTypeParser(mappingType);
+            RuntimeField.Parser parser = parserContext.runtimeFieldTypeParser(mappingType);
             String fullName = context.path().pathAsText(name);
             if (parser == null) {
                 throw new MapperParsingException("failed to find type parsed [" + mappingType + "] for [" + fullName + "]");
             }
-            RuntimeFieldType runtimeFieldType = parser.parse(fullName, mapping, parserContext);
-            Runtime.createDynamicField(runtimeFieldType, context);
+            RuntimeField runtimeField = parser.parse(fullName, mapping, parserContext);
+            Runtime.createDynamicField(runtimeField, context);
         } else {
             Mapper.Builder builder = parseDynamicTemplateMapping(name, mappingType, mapping, dateFormatter, context);
             CONCRETE.createDynamicField(builder, context);
@@ -312,8 +312,8 @@ final class DynamicFieldsBuilder {
      * @see Dynamic
      */
     private static final class Runtime implements Strategy {
-        static void createDynamicField(RuntimeFieldType runtimeFieldType, ParseContext context) {
-            context.addDynamicRuntimeField(runtimeFieldType);
+        static void createDynamicField(RuntimeField runtimeField, ParseContext context) {
+            context.addDynamicRuntimeField(runtimeField);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
@@ -38,7 +38,7 @@ final class FieldTypeLookup {
     FieldTypeLookup(
         Collection<FieldMapper> fieldMappers,
         Collection<FieldAliasMapper> fieldAliasMappers,
-        Collection<RuntimeFieldType> runtimeFieldTypes
+        Collection<RuntimeField> runtimeFields
     ) {
         Map<String, DynamicKeyFieldMapper> dynamicKeyMappers = new HashMap<>();
 
@@ -69,7 +69,7 @@ final class FieldTypeLookup {
             fullNameToFieldType.put(aliasName, fullNameToFieldType.get(path));
         }
 
-        for (RuntimeFieldType runtimeField : runtimeFieldTypes) {
+        for (RuntimeField runtimeField : runtimeFields) {
             MappedFieldType runtimeFieldType = runtimeField.asMappedFieldType();
             //this will override concrete fields with runtime fields that have the same name
             fullNameToFieldType.put(runtimeFieldType.name(), runtimeFieldType);

--- a/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
@@ -48,7 +48,7 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
 
             private final Function<String, SimilarityProvider> similarityLookupService;
             private final Function<String, TypeParser> typeParsers;
-            private final Function<String, RuntimeFieldType.Parser> runtimeTypeParsers;
+            private final Function<String, RuntimeField.Parser> runtimeTypeParsers;
             private final Version indexVersionCreated;
             private final Supplier<SearchExecutionContext> searchExecutionContextSupplier;
             private final DateFormatter dateFormatter;
@@ -59,7 +59,7 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
 
             public ParserContext(Function<String, SimilarityProvider> similarityLookupService,
                                  Function<String, TypeParser> typeParsers,
-                                 Function<String, RuntimeFieldType.Parser> runtimeTypeParsers,
+                                 Function<String, RuntimeField.Parser> runtimeTypeParsers,
                                  Version indexVersionCreated,
                                  Supplier<SearchExecutionContext> searchExecutionContextSupplier,
                                  DateFormatter dateFormatter,
@@ -103,7 +103,7 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
                 return typeParsers.apply(type);
             }
 
-            public RuntimeFieldType.Parser runtimeFieldTypeParser(String type) {
+            public RuntimeField.Parser runtimeFieldTypeParser(String type) {
                 return runtimeTypeParsers.apply(type);
             }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
@@ -48,7 +48,7 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
 
             private final Function<String, SimilarityProvider> similarityLookupService;
             private final Function<String, TypeParser> typeParsers;
-            private final Function<String, RuntimeField.Parser> runtimeTypeParsers;
+            private final Function<String, RuntimeField.Parser> runtimeFieldParsers;
             private final Version indexVersionCreated;
             private final Supplier<SearchExecutionContext> searchExecutionContextSupplier;
             private final DateFormatter dateFormatter;
@@ -59,7 +59,7 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
 
             public ParserContext(Function<String, SimilarityProvider> similarityLookupService,
                                  Function<String, TypeParser> typeParsers,
-                                 Function<String, RuntimeField.Parser> runtimeTypeParsers,
+                                 Function<String, RuntimeField.Parser> runtimeFieldParsers,
                                  Version indexVersionCreated,
                                  Supplier<SearchExecutionContext> searchExecutionContextSupplier,
                                  DateFormatter dateFormatter,
@@ -69,7 +69,7 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
                                  BooleanSupplier idFieldDataEnabled) {
                 this.similarityLookupService = similarityLookupService;
                 this.typeParsers = typeParsers;
-                this.runtimeTypeParsers = runtimeTypeParsers;
+                this.runtimeFieldParsers = runtimeFieldParsers;
                 this.indexVersionCreated = indexVersionCreated;
                 this.searchExecutionContextSupplier = searchExecutionContextSupplier;
                 this.dateFormatter = dateFormatter;
@@ -103,8 +103,8 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
                 return typeParsers.apply(type);
             }
 
-            public RuntimeField.Parser runtimeFieldTypeParser(String type) {
-                return runtimeTypeParsers.apply(type);
+            public RuntimeField.Parser runtimeFieldParser(String type) {
+                return runtimeFieldParsers.apply(type);
             }
 
             public Version indexVersionCreated() {
@@ -150,7 +150,7 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
 
             private static class MultiFieldParserContext extends ParserContext {
                 MultiFieldParserContext(ParserContext in) {
-                    super(in.similarityLookupService, in.typeParsers, in.runtimeTypeParsers, in.indexVersionCreated,
+                    super(in.similarityLookupService, in.typeParsers, in.runtimeFieldParsers, in.indexVersionCreated,
                         in.searchExecutionContextSupplier, in.dateFormatter, in.scriptCompiler, in.indexAnalyzers, in.indexSettings,
                         in.idFieldDataEnabled);
                 }
@@ -161,7 +161,7 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
 
             private static class DynamicTemplateParserContext extends ParserContext {
                 DynamicTemplateParserContext(ParserContext in) {
-                    super(in.similarityLookupService, in.typeParsers, in.runtimeTypeParsers, in.indexVersionCreated,
+                    super(in.similarityLookupService, in.typeParsers, in.runtimeFieldParsers, in.indexVersionCreated,
                         in.searchExecutionContextSupplier, in.dateFormatter, in.scriptCompiler, in.indexAnalyzers, in.indexSettings,
                         in.idFieldDataEnabled);
                 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperRegistry.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperRegistry.java
@@ -23,17 +23,17 @@ import java.util.function.Predicate;
 public final class MapperRegistry {
 
     private final Map<String, Mapper.TypeParser> mapperParsers;
-    private final Map<String, RuntimeField.Parser> runtimeFieldTypeParsers;
+    private final Map<String, RuntimeField.Parser> runtimeFieldParsers;
     private final Map<String, MetadataFieldMapper.TypeParser> metadataMapperParsers;
     private final Map<String, MetadataFieldMapper.TypeParser> metadataMapperParsers7x;
     private final Function<String, Predicate<String>> fieldFilter;
 
 
-    public MapperRegistry(Map<String, Mapper.TypeParser> mapperParsers, Map<String, RuntimeField.Parser> runtimeFieldTypeParsers,
+    public MapperRegistry(Map<String, Mapper.TypeParser> mapperParsers, Map<String, RuntimeField.Parser> runtimeFieldParsers,
                           Map<String, MetadataFieldMapper.TypeParser> metadataMapperParsers,
                           Function<String, Predicate<String>> fieldFilter) {
         this.mapperParsers = Collections.unmodifiableMap(new LinkedHashMap<>(mapperParsers));
-        this.runtimeFieldTypeParsers = runtimeFieldTypeParsers;
+        this.runtimeFieldParsers = runtimeFieldParsers;
         this.metadataMapperParsers = Collections.unmodifiableMap(new LinkedHashMap<>(metadataMapperParsers));
         Map<String, MetadataFieldMapper.TypeParser> metadata7x = new LinkedHashMap<>(metadataMapperParsers);
         metadata7x.remove(NestedPathFieldMapper.NAME);
@@ -49,8 +49,8 @@ public final class MapperRegistry {
         return mapperParsers;
     }
 
-    public Map<String, RuntimeField.Parser> getRuntimeFieldTypeParsers() {
-        return runtimeFieldTypeParsers;
+    public Map<String, RuntimeField.Parser> getRuntimeFieldParsers() {
+        return runtimeFieldParsers;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperRegistry.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperRegistry.java
@@ -23,13 +23,13 @@ import java.util.function.Predicate;
 public final class MapperRegistry {
 
     private final Map<String, Mapper.TypeParser> mapperParsers;
-    private final Map<String, RuntimeFieldType.Parser> runtimeFieldTypeParsers;
+    private final Map<String, RuntimeField.Parser> runtimeFieldTypeParsers;
     private final Map<String, MetadataFieldMapper.TypeParser> metadataMapperParsers;
     private final Map<String, MetadataFieldMapper.TypeParser> metadataMapperParsers7x;
     private final Function<String, Predicate<String>> fieldFilter;
 
 
-    public MapperRegistry(Map<String, Mapper.TypeParser> mapperParsers, Map<String, RuntimeFieldType.Parser> runtimeFieldTypeParsers,
+    public MapperRegistry(Map<String, Mapper.TypeParser> mapperParsers, Map<String, RuntimeField.Parser> runtimeFieldTypeParsers,
                           Map<String, MetadataFieldMapper.TypeParser> metadataMapperParsers,
                           Function<String, Predicate<String>> fieldFilter) {
         this.mapperParsers = Collections.unmodifiableMap(new LinkedHashMap<>(mapperParsers));
@@ -49,7 +49,7 @@ public final class MapperRegistry {
         return mapperParsers;
     }
 
-    public Map<String, RuntimeFieldType.Parser> getRuntimeFieldTypeParsers() {
+    public Map<String, RuntimeField.Parser> getRuntimeFieldTypeParsers() {
         return runtimeFieldTypeParsers;
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -108,7 +108,7 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
         this.mapperRegistry = mapperRegistry;
         Function<DateFormatter, Mapper.TypeParser.ParserContext> parserContextFunction =
             dateFormatter -> new Mapper.TypeParser.ParserContext(similarityService::getSimilarity, mapperRegistry.getMapperParsers()::get,
-                mapperRegistry.getRuntimeFieldTypeParsers()::get, indexVersionCreated, searchExecutionContextSupplier, dateFormatter,
+                mapperRegistry.getRuntimeFieldParsers()::get, indexVersionCreated, searchExecutionContextSupplier, dateFormatter,
                 scriptCompiler, indexAnalyzers, indexSettings, idFieldDataEnabled);
         this.documentParser = new DocumentParser(xContentRegistry, parserContextFunction);
         Map<String, MetadataFieldMapper.TypeParser> metadataMapperParsers =

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
@@ -148,7 +148,7 @@ public final class MappingLookup {
             }
         }
 
-        this.fieldTypeLookup = new FieldTypeLookup(mappers, aliasMappers, mapping.getRoot().runtimeFieldTypes());
+        this.fieldTypeLookup = new FieldTypeLookup(mappers, aliasMappers, mapping.getRoot().runtimeFields());
         this.fieldMappers = Collections.unmodifiableMap(fieldMappers);
         this.objectMappers = Collections.unmodifiableMap(objects);
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/ParseContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ParseContext.java
@@ -274,12 +274,12 @@ public abstract class ParseContext {
         }
 
         @Override
-        public void addDynamicRuntimeField(RuntimeFieldType runtimeField) {
+        public void addDynamicRuntimeField(RuntimeField runtimeField) {
             in.addDynamicRuntimeField(runtimeField);
         }
 
         @Override
-        public List<RuntimeFieldType> getDynamicRuntimeFields() {
+        public List<RuntimeField> getDynamicRuntimeFields() {
             return in.getDynamicRuntimeFields();
         }
 
@@ -305,7 +305,7 @@ public abstract class ParseContext {
         private final long maxAllowedNumNestedDocs;
         private final List<Mapper> dynamicMappers = new ArrayList<>();
         private final Map<String, ObjectMapper> dynamicObjectMappers = new HashMap<>();
-        private final List<RuntimeFieldType> dynamicRuntimeFields = new ArrayList<>();
+        private final List<RuntimeField> dynamicRuntimeFields = new ArrayList<>();
         private final Set<String> ignoredFields = new HashSet<>();
         private Field version;
         private SeqNoFieldMapper.SequenceIDFields seqID;
@@ -437,12 +437,12 @@ public abstract class ParseContext {
         }
 
         @Override
-        public void addDynamicRuntimeField(RuntimeFieldType runtimeField) {
+        public void addDynamicRuntimeField(RuntimeField runtimeField) {
             dynamicRuntimeFields.add(runtimeField);
         }
 
         @Override
-        public List<RuntimeFieldType> getDynamicRuntimeFields() {
+        public List<RuntimeField> getDynamicRuntimeFields() {
             return Collections.unmodifiableList(dynamicRuntimeFields);
         }
 
@@ -662,10 +662,10 @@ public abstract class ParseContext {
     /**
      * Add a new runtime field dynamically created while parsing.
      */
-    public abstract void addDynamicRuntimeField(RuntimeFieldType runtimeField);
+    public abstract void addDynamicRuntimeField(RuntimeField runtimeField);
 
     /**
      * Get dynamic runtime fields created while parsing.
      */
-    public abstract List<RuntimeFieldType> getDynamicRuntimeFields();
+    public abstract List<RuntimeField> getDynamicRuntimeFields();
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/RuntimeField.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RuntimeField.java
@@ -22,7 +22,7 @@ import java.util.function.BiFunction;
 /**
  * Definition of a runtime field that can be defined as part of the runtime section of the index mappings
  */
-public interface RuntimeFieldType extends ToXContentFragment {
+public interface RuntimeField extends ToXContentFragment {
 
     @Override
     default XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
@@ -57,11 +57,11 @@ public interface RuntimeFieldType extends ToXContentFragment {
     MappedFieldType asMappedFieldType();
 
     /**
-     *  For runtime fields the {@link RuntimeFieldType.Parser} returns directly the {@link MappedFieldType}.
-     *  Internally we still create a {@link RuntimeFieldType.Builder} so we reuse the {@link FieldMapper.Parameter} infrastructure,
-     *  but {@link RuntimeFieldType.Builder#init(FieldMapper)} and {@link RuntimeFieldType.Builder#build(ContentPath)} are never called as
-     *  {@link RuntimeFieldType.Parser#parse(String, Map, Mapper.TypeParser.ParserContext)} calls
-     *  {@link RuntimeFieldType.Builder#parse(String, Mapper.TypeParser.ParserContext, Map)} and returns the corresponding
+     *  For runtime fields the {@link RuntimeField.Parser} returns directly the {@link MappedFieldType}.
+     *  Internally we still create a {@link RuntimeField.Builder} so we reuse the {@link FieldMapper.Parameter} infrastructure,
+     *  but {@link RuntimeField.Builder#init(FieldMapper)} and {@link RuntimeField.Builder#build(ContentPath)} are never called as
+     *  {@link RuntimeField.Parser#parse(String, Map, Mapper.TypeParser.ParserContext)} calls
+     *  {@link RuntimeField.Builder#parse(String, Mapper.TypeParser.ParserContext, Map)} and returns the corresponding
      *  {@link MappedFieldType}.
      */
     abstract class Builder extends FieldMapper.Builder {
@@ -90,7 +90,7 @@ public interface RuntimeFieldType extends ToXContentFragment {
             throw new UnsupportedOperationException();
         }
 
-        protected abstract RuntimeFieldType buildFieldType();
+        protected abstract RuntimeField buildFieldType();
 
         private void validate() {
             ContentPath contentPath = parentPath(name());
@@ -106,20 +106,20 @@ public interface RuntimeFieldType extends ToXContentFragment {
     }
 
     /**
-     * Parser for a runtime field. Creates the appropriate {@link RuntimeFieldType} for a runtime field,
+     * Parser for a runtime field. Creates the appropriate {@link RuntimeField} for a runtime field,
      * as defined in the runtime section of the index mappings.
      */
     final class Parser {
-        private final BiFunction<String, Mapper.TypeParser.ParserContext, RuntimeFieldType.Builder> builderFunction;
+        private final BiFunction<String, Mapper.TypeParser.ParserContext, RuntimeField.Builder> builderFunction;
 
-        public Parser(BiFunction<String, Mapper.TypeParser.ParserContext, RuntimeFieldType.Builder> builderFunction) {
+        public Parser(BiFunction<String, Mapper.TypeParser.ParserContext, RuntimeField.Builder> builderFunction) {
             this.builderFunction = builderFunction;
         }
 
-        RuntimeFieldType parse(String name, Map<String, Object> node, Mapper.TypeParser.ParserContext parserContext)
+        RuntimeField parse(String name, Map<String, Object> node, Mapper.TypeParser.ParserContext parserContext)
             throws MapperParsingException {
 
-            RuntimeFieldType.Builder builder = builderFunction.apply(name, parserContext);
+            RuntimeField.Builder builder = builderFunction.apply(name, parserContext);
             builder.parse(name, parserContext, node);
             builder.validate();
             return builder.buildFieldType();
@@ -134,10 +134,10 @@ public interface RuntimeFieldType extends ToXContentFragment {
      *                        translated to the removal of such runtime field
      * @return the parsed runtime fields
      */
-    static Map<String, RuntimeFieldType> parseRuntimeFields(Map<String, Object> node,
-                                                            Mapper.TypeParser.ParserContext parserContext,
-                                                            boolean supportsRemoval) {
-        Map<String, RuntimeFieldType> runtimeFields = new HashMap<>();
+    static Map<String, RuntimeField> parseRuntimeFields(Map<String, Object> node,
+                                                        Mapper.TypeParser.ParserContext parserContext,
+                                                        boolean supportsRemoval) {
+        Map<String, RuntimeField> runtimeFields = new HashMap<>();
         Iterator<Map.Entry<String, Object>> iterator = node.entrySet().iterator();
         while (iterator.hasNext()) {
             Map.Entry<String, Object> entry = iterator.next();

--- a/server/src/main/java/org/elasticsearch/index/mapper/RuntimeField.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RuntimeField.java
@@ -159,7 +159,7 @@ public interface RuntimeField extends ToXContentFragment {
                 } else {
                     type = typeNode.toString();
                 }
-                Parser typeParser = parserContext.runtimeFieldTypeParser(type);
+                Parser typeParser = parserContext.runtimeFieldParser(type);
                 if (typeParser == null) {
                     throw new MapperParsingException("No handler for type [" + type +
                         "] declared on runtime field [" + fieldName + "]");

--- a/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
@@ -43,7 +43,7 @@ import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MappingLookup;
 import org.elasticsearch.index.mapper.ObjectMapper;
 import org.elasticsearch.index.mapper.ParsedDocument;
-import org.elasticsearch.index.mapper.RuntimeFieldType;
+import org.elasticsearch.index.mapper.RuntimeField;
 import org.elasticsearch.index.mapper.SourceToParse;
 import org.elasticsearch.index.mapper.TextFieldMapper;
 import org.elasticsearch.index.query.support.NestedScope;
@@ -612,11 +612,11 @@ public class SearchExecutionContext extends QueryRewriteContext {
         if (runtimeMappings.isEmpty()) {
             return Collections.emptyMap();
         }
-        Map<String, RuntimeFieldType> runtimeFields = RuntimeFieldType.parseRuntimeFields(new HashMap<>(runtimeMappings),
+        Map<String, RuntimeField> runtimeFields = RuntimeField.parseRuntimeFields(new HashMap<>(runtimeMappings),
             mapperService.parserContext(), false);
         Map<String, MappedFieldType> runtimeFieldTypes = new HashMap<>();
-        for (RuntimeFieldType runtimeFieldType : runtimeFields.values()) {
-            MappedFieldType fieldType = runtimeFieldType.asMappedFieldType();
+        for (RuntimeField runtimeField : runtimeFields.values()) {
+            MappedFieldType fieldType = runtimeField.asMappedFieldType();
             runtimeFieldTypes.put(fieldType.name(), fieldType);
         }
         return Collections.unmodifiableMap(runtimeFieldTypes);

--- a/server/src/main/java/org/elasticsearch/indices/IndicesModule.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesModule.java
@@ -39,7 +39,7 @@ import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.mapper.ObjectMapper;
 import org.elasticsearch.index.mapper.RangeType;
 import org.elasticsearch.index.mapper.RoutingFieldMapper;
-import org.elasticsearch.index.mapper.RuntimeFieldType;
+import org.elasticsearch.index.mapper.RuntimeField;
 import org.elasticsearch.index.mapper.SeqNoFieldMapper;
 import org.elasticsearch.index.mapper.SourceFieldMapper;
 import org.elasticsearch.index.mapper.TextFieldMapper;
@@ -140,8 +140,8 @@ public class IndicesModule extends AbstractModule {
         return Collections.unmodifiableMap(mappers);
     }
 
-    private static Map<String, RuntimeFieldType.Parser> getRuntimeFieldTypes(List<MapperPlugin> mapperPlugins) {
-        Map<String, RuntimeFieldType.Parser> runtimeParsers = new LinkedHashMap<>();
+    private static Map<String, RuntimeField.Parser> getRuntimeFieldTypes(List<MapperPlugin> mapperPlugins) {
+        Map<String, RuntimeField.Parser> runtimeParsers = new LinkedHashMap<>();
         runtimeParsers.put(BooleanFieldMapper.CONTENT_TYPE, BooleanScriptFieldType.PARSER);
         runtimeParsers.put(NumberFieldMapper.NumberType.LONG.typeName(), LongScriptFieldType.PARSER);
         runtimeParsers.put(NumberFieldMapper.NumberType.DOUBLE.typeName(), DoubleScriptFieldType.PARSER);
@@ -151,7 +151,7 @@ public class IndicesModule extends AbstractModule {
         runtimeParsers.put(GeoPointFieldMapper.CONTENT_TYPE, GeoPointScriptFieldType.PARSER);
 
         for (MapperPlugin mapperPlugin : mapperPlugins) {
-            for (Map.Entry<String, RuntimeFieldType.Parser> entry : mapperPlugin.getRuntimeFieldTypes().entrySet()) {
+            for (Map.Entry<String, RuntimeField.Parser> entry : mapperPlugin.getRuntimeFieldTypes().entrySet()) {
                 if (runtimeParsers.put(entry.getKey(), entry.getValue()) != null) {
                     throw new IllegalArgumentException("Runtime field type [" + entry.getKey() + "] is already registered");
                 }

--- a/server/src/main/java/org/elasticsearch/indices/IndicesModule.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesModule.java
@@ -76,7 +76,7 @@ public class IndicesModule extends AbstractModule {
     private final MapperRegistry mapperRegistry;
 
     public IndicesModule(List<MapperPlugin> mapperPlugins) {
-        this.mapperRegistry = new MapperRegistry(getMappers(mapperPlugins), getRuntimeFieldTypes(mapperPlugins),
+        this.mapperRegistry = new MapperRegistry(getMappers(mapperPlugins), getRuntimeFields(mapperPlugins),
             getMetadataMappers(mapperPlugins), getFieldFilter(mapperPlugins));
     }
 
@@ -140,7 +140,7 @@ public class IndicesModule extends AbstractModule {
         return Collections.unmodifiableMap(mappers);
     }
 
-    private static Map<String, RuntimeField.Parser> getRuntimeFieldTypes(List<MapperPlugin> mapperPlugins) {
+    private static Map<String, RuntimeField.Parser> getRuntimeFields(List<MapperPlugin> mapperPlugins) {
         Map<String, RuntimeField.Parser> runtimeParsers = new LinkedHashMap<>();
         runtimeParsers.put(BooleanFieldMapper.CONTENT_TYPE, BooleanScriptFieldType.PARSER);
         runtimeParsers.put(NumberFieldMapper.NumberType.LONG.typeName(), LongScriptFieldType.PARSER);
@@ -151,7 +151,7 @@ public class IndicesModule extends AbstractModule {
         runtimeParsers.put(GeoPointFieldMapper.CONTENT_TYPE, GeoPointScriptFieldType.PARSER);
 
         for (MapperPlugin mapperPlugin : mapperPlugins) {
-            for (Map.Entry<String, RuntimeField.Parser> entry : mapperPlugin.getRuntimeFieldTypes().entrySet()) {
+            for (Map.Entry<String, RuntimeField.Parser> entry : mapperPlugin.getRuntimeFields().entrySet()) {
                 if (runtimeParsers.put(entry.getKey(), entry.getValue()) != null) {
                     throw new IllegalArgumentException("Runtime field type [" + entry.getKey() + "] is already registered");
                 }

--- a/server/src/main/java/org/elasticsearch/plugins/MapperPlugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/MapperPlugin.java
@@ -40,7 +40,7 @@ public interface MapperPlugin {
      * as the mapping {@code type}, and the value is a {@link RuntimeField.Parser} to parse the
      * field type settings into a {@link RuntimeField}.
      */
-    default Map<String, RuntimeField.Parser> getRuntimeFieldTypes() {
+    default Map<String, RuntimeField.Parser> getRuntimeFields() {
         return Collections.emptyMap();
     }
 

--- a/server/src/main/java/org/elasticsearch/plugins/MapperPlugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/MapperPlugin.java
@@ -10,7 +10,7 @@ package org.elasticsearch.plugins;
 
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MetadataFieldMapper;
-import org.elasticsearch.index.mapper.RuntimeFieldType;
+import org.elasticsearch.index.mapper.RuntimeField;
 
 import java.util.Collections;
 import java.util.Map;
@@ -37,10 +37,10 @@ public interface MapperPlugin {
      * Returns the runtime field implementations added by this plugin.
      * <p>
      * The key of the returned {@link Map} is the unique name for the field type which will be used
-     * as the mapping {@code type}, and the value is a {@link RuntimeFieldType.Parser} to parse the
-     * field type settings into a {@link RuntimeFieldType}.
+     * as the mapping {@code type}, and the value is a {@link RuntimeField.Parser} to parse the
+     * field type settings into a {@link RuntimeField}.
      */
-    default Map<String, RuntimeFieldType.Parser> getRuntimeFieldTypes() {
+    default Map<String, RuntimeField.Parser> getRuntimeFieldTypes() {
         return Collections.emptyMap();
     }
 

--- a/server/src/main/java/org/elasticsearch/runtimefields/mapper/AbstractScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/runtimefields/mapper/AbstractScriptFieldType.java
@@ -24,7 +24,7 @@ import org.elasticsearch.index.mapper.DocValueFetcher;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
-import org.elasticsearch.index.mapper.RuntimeFieldType;
+import org.elasticsearch.index.mapper.RuntimeField;
 import org.elasticsearch.index.mapper.TextSearchInfo;
 import org.elasticsearch.index.mapper.ValueFetcher;
 import org.elasticsearch.index.query.SearchExecutionContext;
@@ -46,7 +46,7 @@ import static org.elasticsearch.search.SearchService.ALLOW_EXPENSIVE_QUERIES;
 /**
  * Abstract base {@linkplain MappedFieldType} for runtime fields based on a script.
  */
-abstract class AbstractScriptFieldType<LeafFactory> extends MappedFieldType implements RuntimeFieldType {
+abstract class AbstractScriptFieldType<LeafFactory> extends MappedFieldType implements RuntimeField {
     protected final Script script;
     private final TriFunction<String, Map<String, Object>, SearchLookup, LeafFactory> factory;
     private final ToXContent toXContent;
@@ -213,7 +213,7 @@ abstract class AbstractScriptFieldType<LeafFactory> extends MappedFieldType impl
     // TODO rework things so that we don't need this
     private static final Script DEFAULT_SCRIPT = new Script("");
 
-    abstract static class Builder extends RuntimeFieldType.Builder {
+    abstract static class Builder extends RuntimeField.Builder {
         final FieldMapper.Parameter<Script> script = new FieldMapper.Parameter<>(
             "script",
             true,

--- a/server/src/main/java/org/elasticsearch/runtimefields/mapper/BooleanScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/runtimefields/mapper/BooleanScriptFieldType.java
@@ -17,7 +17,7 @@ import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.time.DateMathParser;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.index.mapper.BooleanFieldMapper;
-import org.elasticsearch.index.mapper.RuntimeFieldType;
+import org.elasticsearch.index.mapper.RuntimeField;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.runtimefields.fielddata.BooleanScriptFieldData;
 import org.elasticsearch.runtimefields.query.BooleanScriptFieldExistsQuery;
@@ -34,9 +34,9 @@ import java.util.function.Supplier;
 
 public final class BooleanScriptFieldType extends AbstractScriptFieldType<BooleanFieldScript.LeafFactory> {
 
-    public static final RuntimeFieldType.Parser PARSER = new RuntimeFieldType.Parser((name, parserContext) -> new Builder(name) {
+    public static final RuntimeField.Parser PARSER = new RuntimeField.Parser((name, parserContext) -> new Builder(name) {
         @Override
-        protected RuntimeFieldType buildFieldType() {
+        protected RuntimeField buildFieldType() {
             if (script.get() == null) {
                 return new BooleanScriptFieldType(name, BooleanFieldScript.PARSE_FROM_SOURCE, getScript(), meta(), this);
             }

--- a/server/src/main/java/org/elasticsearch/runtimefields/mapper/DateScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/runtimefields/mapper/DateScriptFieldType.java
@@ -22,7 +22,7 @@ import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.DateFieldMapper.DateFieldType;
 import org.elasticsearch.index.mapper.DateFieldMapper.Resolution;
 import org.elasticsearch.index.mapper.FieldMapper;
-import org.elasticsearch.index.mapper.RuntimeFieldType;
+import org.elasticsearch.index.mapper.RuntimeField;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.runtimefields.fielddata.DateScriptFieldData;
 import org.elasticsearch.runtimefields.query.LongScriptFieldDistanceFeatureQuery;
@@ -46,7 +46,7 @@ import java.util.function.Supplier;
 
 public class DateScriptFieldType extends AbstractScriptFieldType<DateFieldScript.LeafFactory> {
 
-    public static final RuntimeFieldType.Parser PARSER = new RuntimeFieldType.Parser((name, parserContext) -> new Builder(name) {
+    public static final RuntimeField.Parser PARSER = new RuntimeField.Parser((name, parserContext) -> new Builder(name) {
         private final FieldMapper.Parameter<String> format = FieldMapper.Parameter.stringParam(
             "format",
             true,
@@ -79,7 +79,7 @@ public class DateScriptFieldType extends AbstractScriptFieldType<DateFieldScript
         }
 
         @Override
-        protected RuntimeFieldType buildFieldType() {
+        protected RuntimeField buildFieldType() {
             String pattern = format.getValue() == null ? DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.pattern() : format.getValue();
             Locale locale = this.locale.getValue() == null ? Locale.ROOT : this.locale.getValue();
             DateFormatter dateTimeFormatter = DateFormatter.forPattern(pattern).withLocale(locale);

--- a/server/src/main/java/org/elasticsearch/runtimefields/mapper/DoubleScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/runtimefields/mapper/DoubleScriptFieldType.java
@@ -15,7 +15,7 @@ import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.time.DateMathParser;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.index.mapper.NumberFieldMapper.NumberType;
-import org.elasticsearch.index.mapper.RuntimeFieldType;
+import org.elasticsearch.index.mapper.RuntimeField;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.runtimefields.fielddata.DoubleScriptFieldData;
 import org.elasticsearch.runtimefields.query.DoubleScriptFieldExistsQuery;
@@ -34,9 +34,9 @@ import java.util.function.Supplier;
 
 public final class DoubleScriptFieldType extends AbstractScriptFieldType<DoubleFieldScript.LeafFactory> {
 
-    public static final RuntimeFieldType.Parser PARSER = new RuntimeFieldType.Parser((name, parserContext) -> new Builder(name) {
+    public static final RuntimeField.Parser PARSER = new RuntimeField.Parser((name, parserContext) -> new Builder(name) {
         @Override
-        protected RuntimeFieldType buildFieldType() {
+        protected RuntimeField buildFieldType() {
             if (script.get() == null) {
                 return new DoubleScriptFieldType(name, DoubleFieldScript.PARSE_FROM_SOURCE, getScript(), meta(), this);
             }

--- a/server/src/main/java/org/elasticsearch/runtimefields/mapper/GeoPointScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/runtimefields/mapper/GeoPointScriptFieldType.java
@@ -22,7 +22,7 @@ import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.index.mapper.GeoPointFieldMapper;
 import org.elasticsearch.index.mapper.GeoShapeQueryable;
-import org.elasticsearch.index.mapper.RuntimeFieldType;
+import org.elasticsearch.index.mapper.RuntimeField;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.runtimefields.fielddata.GeoPointScriptFieldData;
 import org.elasticsearch.runtimefields.query.GeoPointScriptFieldDistanceFeatureQuery;
@@ -38,9 +38,9 @@ import java.util.function.Supplier;
 
 public final class GeoPointScriptFieldType extends AbstractScriptFieldType<GeoPointFieldScript.LeafFactory> implements GeoShapeQueryable {
 
-    public static final RuntimeFieldType.Parser PARSER = new RuntimeFieldType.Parser((name, parserContext) -> new Builder(name) {
+    public static final RuntimeField.Parser PARSER = new RuntimeField.Parser((name, parserContext) -> new Builder(name) {
         @Override
-        protected RuntimeFieldType buildFieldType() {
+        protected RuntimeField buildFieldType() {
             if (script.get() == null) {
                 return new GeoPointScriptFieldType(name, GeoPointFieldScript.PARSE_FROM_SOURCE, getScript(), meta(), this);
             }

--- a/server/src/main/java/org/elasticsearch/runtimefields/mapper/IpScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/runtimefields/mapper/IpScriptFieldType.java
@@ -21,7 +21,7 @@ import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BytesRefHash;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.index.mapper.IpFieldMapper;
-import org.elasticsearch.index.mapper.RuntimeFieldType;
+import org.elasticsearch.index.mapper.RuntimeField;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.runtimefields.fielddata.IpScriptFieldData;
 import org.elasticsearch.runtimefields.query.IpScriptFieldExistsQuery;
@@ -43,9 +43,9 @@ import java.util.function.Supplier;
 
 public final class IpScriptFieldType extends AbstractScriptFieldType<IpFieldScript.LeafFactory> {
 
-    public static final RuntimeFieldType.Parser PARSER = new RuntimeFieldType.Parser((name, parserContext) -> new Builder(name) {
+    public static final RuntimeField.Parser PARSER = new RuntimeField.Parser((name, parserContext) -> new Builder(name) {
         @Override
-        protected RuntimeFieldType buildFieldType() {
+        protected RuntimeField buildFieldType() {
             if (script.get() == null) {
                 return new IpScriptFieldType(name, IpFieldScript.PARSE_FROM_SOURCE, getScript(), meta(), this);
             }

--- a/server/src/main/java/org/elasticsearch/runtimefields/mapper/KeywordScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/runtimefields/mapper/KeywordScriptFieldType.java
@@ -16,7 +16,7 @@ import org.elasticsearch.common.time.DateMathParser;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
-import org.elasticsearch.index.mapper.RuntimeFieldType;
+import org.elasticsearch.index.mapper.RuntimeField;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.runtimefields.fielddata.StringScriptFieldData;
 import org.elasticsearch.runtimefields.query.StringScriptFieldExistsQuery;
@@ -42,9 +42,9 @@ import static java.util.stream.Collectors.toSet;
 
 public final class KeywordScriptFieldType extends AbstractScriptFieldType<StringFieldScript.LeafFactory> {
 
-    public static final RuntimeFieldType.Parser PARSER = new RuntimeFieldType.Parser((name, parserContext) -> new Builder(name) {
+    public static final RuntimeField.Parser PARSER = new RuntimeField.Parser((name, parserContext) -> new Builder(name) {
         @Override
-        protected RuntimeFieldType buildFieldType() {
+        protected RuntimeField buildFieldType() {
             if (script.get() == null) {
                 return new KeywordScriptFieldType(name, StringFieldScript.PARSE_FROM_SOURCE, getScript(), meta(), this);
             }

--- a/server/src/main/java/org/elasticsearch/runtimefields/mapper/LongScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/runtimefields/mapper/LongScriptFieldType.java
@@ -15,7 +15,7 @@ import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.time.DateMathParser;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.index.mapper.NumberFieldMapper.NumberType;
-import org.elasticsearch.index.mapper.RuntimeFieldType;
+import org.elasticsearch.index.mapper.RuntimeField;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.runtimefields.fielddata.LongScriptFieldData;
 import org.elasticsearch.runtimefields.query.LongScriptFieldExistsQuery;
@@ -34,9 +34,9 @@ import java.util.function.Supplier;
 
 public final class LongScriptFieldType extends AbstractScriptFieldType<LongFieldScript.LeafFactory> {
 
-    public static final RuntimeFieldType.Parser PARSER = new RuntimeFieldType.Parser((name, parserContext) -> new Builder(name) {
+    public static final RuntimeField.Parser PARSER = new RuntimeField.Parser((name, parserContext) -> new Builder(name) {
         @Override
-        protected RuntimeFieldType buildFieldType() {
+        protected RuntimeField buildFieldType() {
             if (script.get() == null) {
                 return new LongScriptFieldType(name, LongFieldScript.PARSE_FROM_SOURCE, getScript(), meta(), this);
             }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/MappingStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/MappingStatsTests.java
@@ -170,7 +170,7 @@ public class MappingStatsTests extends AbstractWireSerializingTestCase<MappingSt
     @Override
     protected MappingStats mutateInstance(MappingStats instance) throws IOException {
         List<IndexFeatureStats> fieldTypes = new ArrayList<>(instance.getFieldTypeStats());
-        List<RuntimeFieldStats> runtimeFieldTypes = new ArrayList<>(instance.getRuntimeFieldTypeStats());
+        List<RuntimeFieldStats> runtimeFieldTypes = new ArrayList<>(instance.getRuntimeFieldStats());
         if (randomBoolean()) {
             boolean remove = fieldTypes.size() > 0 && randomBoolean();
             if (remove) {

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
@@ -635,7 +635,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         Mapping mapping = DocumentParser.createDynamicUpdate(docMapper.mappers(), Collections.emptyList(), updates);
         assertNotNull(mapping);
         assertNull(mapping.getRoot().getMapper("foo"));
-        assertNotNull(mapping.getRoot().getRuntimeFieldType("foo"));
+        assertNotNull(mapping.getRoot().getRuntimeField("foo"));
     }
 
     public void testSubfieldMappingUpdate() throws Exception {
@@ -657,7 +657,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         assertNotNull(mapping);
         Mapper xMapper = mapping.getRoot().getMapper("x");
         assertNull(xMapper);
-        assertNotNull(mapping.getRoot().getRuntimeFieldType("x.foo"));
+        assertNotNull(mapping.getRoot().getRuntimeField("x.foo"));
     }
 
     public void testMultipleSubfieldMappingUpdate() throws Exception {
@@ -803,7 +803,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         DocumentMapper mapper = createDocumentMapper(topMapping(b -> b.field("dynamic", "runtime")));
         ParsedDocument doc = mapper.parse(source(b -> b.startArray("foo").value(0).value(1).endArray()));
         assertEquals(0, doc.rootDoc().getFields("foo").length);
-        RuntimeField foo = doc.dynamicMappingsUpdate().getRoot().getRuntimeFieldType("foo");
+        RuntimeField foo = doc.dynamicMappingsUpdate().getRoot().getRuntimeField("foo");
         assertEquals("long", foo.typeName());
     }
 
@@ -811,7 +811,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         DocumentMapper mapper = createDocumentMapper(topMapping(b -> b.field("dynamic", "runtime")));
         ParsedDocument doc = mapper.parse(source(b -> b.startArray("foo").value(0.25).value(1.43).endArray()));
         assertEquals(0, doc.rootDoc().getFields("foo").length);
-        RuntimeField foo = doc.dynamicMappingsUpdate().getRoot().getRuntimeFieldType("foo");
+        RuntimeField foo = doc.dynamicMappingsUpdate().getRoot().getRuntimeField("foo");
         assertEquals("double", foo.typeName());
     }
 
@@ -819,7 +819,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         DocumentMapper mapper = createDocumentMapper(topMapping(b -> b.field("dynamic", "runtime")));
         ParsedDocument doc = mapper.parse(source(b -> b.startArray("foo").value("test1").value("test2").endArray()));
         assertEquals(0, doc.rootDoc().getFields("foo").length);
-        RuntimeField foo = doc.dynamicMappingsUpdate().getRoot().getRuntimeFieldType("foo");
+        RuntimeField foo = doc.dynamicMappingsUpdate().getRoot().getRuntimeField("foo");
         assertEquals("keyword", foo.typeName());
     }
 
@@ -827,7 +827,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         DocumentMapper mapper = createDocumentMapper(topMapping(b -> b.field("dynamic", "runtime")));
         ParsedDocument doc = mapper.parse(source(b -> b.startArray("foo").value(true).value(false).endArray()));
         assertEquals(0, doc.rootDoc().getFields("foo").length);
-        RuntimeField foo = doc.dynamicMappingsUpdate().getRoot().getRuntimeFieldType("foo");
+        RuntimeField foo = doc.dynamicMappingsUpdate().getRoot().getRuntimeField("foo");
         assertEquals("boolean", foo.typeName());
     }
 
@@ -835,7 +835,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         DocumentMapper mapper = createDocumentMapper(topMapping(b -> b.field("dynamic", "runtime")));
         ParsedDocument doc = mapper.parse(source(b -> b.startArray("foo").value("2020-12-15").value("2020-12-09").endArray()));
         assertEquals(0, doc.rootDoc().getFields("foo").length);
-        RuntimeField foo = doc.dynamicMappingsUpdate().getRoot().getRuntimeFieldType("foo");
+        RuntimeField foo = doc.dynamicMappingsUpdate().getRoot().getRuntimeField("foo");
         assertEquals("date", foo.typeName());
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
@@ -631,7 +631,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
 
     public void testSingleRuntimeFieldMappingUpdate() throws Exception {
         DocumentMapper docMapper = createDummyMapping();
-        List<RuntimeFieldType> updates = Collections.singletonList(new TestRuntimeField("foo", "any"));
+        List<RuntimeField> updates = Collections.singletonList(new TestRuntimeField("foo", "any"));
         Mapping mapping = DocumentParser.createDynamicUpdate(docMapper.mappers(), Collections.emptyList(), updates);
         assertNotNull(mapping);
         assertNull(mapping.getRoot().getMapper("foo"));
@@ -652,7 +652,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
 
     public void testRuntimeSubfieldMappingUpdate() throws Exception {
         DocumentMapper docMapper = createDummyMapping();
-        List<RuntimeFieldType> updates = Collections.singletonList(new TestRuntimeField("x.foo", "any"));
+        List<RuntimeField> updates = Collections.singletonList(new TestRuntimeField("x.foo", "any"));
         Mapping mapping = DocumentParser.createDynamicUpdate(docMapper.mappers(), Collections.emptyList(), updates);
         assertNotNull(mapping);
         Mapper xMapper = mapping.getRoot().getMapper("x");
@@ -803,7 +803,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         DocumentMapper mapper = createDocumentMapper(topMapping(b -> b.field("dynamic", "runtime")));
         ParsedDocument doc = mapper.parse(source(b -> b.startArray("foo").value(0).value(1).endArray()));
         assertEquals(0, doc.rootDoc().getFields("foo").length);
-        RuntimeFieldType foo = doc.dynamicMappingsUpdate().getRoot().getRuntimeFieldType("foo");
+        RuntimeField foo = doc.dynamicMappingsUpdate().getRoot().getRuntimeFieldType("foo");
         assertEquals("long", foo.typeName());
     }
 
@@ -811,7 +811,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         DocumentMapper mapper = createDocumentMapper(topMapping(b -> b.field("dynamic", "runtime")));
         ParsedDocument doc = mapper.parse(source(b -> b.startArray("foo").value(0.25).value(1.43).endArray()));
         assertEquals(0, doc.rootDoc().getFields("foo").length);
-        RuntimeFieldType foo = doc.dynamicMappingsUpdate().getRoot().getRuntimeFieldType("foo");
+        RuntimeField foo = doc.dynamicMappingsUpdate().getRoot().getRuntimeFieldType("foo");
         assertEquals("double", foo.typeName());
     }
 
@@ -819,7 +819,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         DocumentMapper mapper = createDocumentMapper(topMapping(b -> b.field("dynamic", "runtime")));
         ParsedDocument doc = mapper.parse(source(b -> b.startArray("foo").value("test1").value("test2").endArray()));
         assertEquals(0, doc.rootDoc().getFields("foo").length);
-        RuntimeFieldType foo = doc.dynamicMappingsUpdate().getRoot().getRuntimeFieldType("foo");
+        RuntimeField foo = doc.dynamicMappingsUpdate().getRoot().getRuntimeFieldType("foo");
         assertEquals("keyword", foo.typeName());
     }
 
@@ -827,7 +827,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         DocumentMapper mapper = createDocumentMapper(topMapping(b -> b.field("dynamic", "runtime")));
         ParsedDocument doc = mapper.parse(source(b -> b.startArray("foo").value(true).value(false).endArray()));
         assertEquals(0, doc.rootDoc().getFields("foo").length);
-        RuntimeFieldType foo = doc.dynamicMappingsUpdate().getRoot().getRuntimeFieldType("foo");
+        RuntimeField foo = doc.dynamicMappingsUpdate().getRoot().getRuntimeFieldType("foo");
         assertEquals("boolean", foo.typeName());
     }
 
@@ -835,7 +835,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         DocumentMapper mapper = createDocumentMapper(topMapping(b -> b.field("dynamic", "runtime")));
         ParsedDocument doc = mapper.parse(source(b -> b.startArray("foo").value("2020-12-15").value("2020-12-09").endArray()));
         assertEquals(0, doc.rootDoc().getFields("foo").length);
-        RuntimeFieldType foo = doc.dynamicMappingsUpdate().getRoot().getRuntimeFieldType("foo");
+        RuntimeField foo = doc.dynamicMappingsUpdate().getRoot().getRuntimeFieldType("foo");
         assertEquals("date", foo.typeName());
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/DynamicMappingTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DynamicMappingTests.java
@@ -197,8 +197,8 @@ public class DynamicMappingTests extends MapperServiceTestCase {
         merge(mapperService, dynamicMapping(doc.dynamicMappingsUpdate()));
         Mapping merged = mapperService.documentMapper().mapping();
         assertNotNull(merged.getRoot().getMapper("test"));
-        assertEquals(1, merged.getRoot().runtimeFieldTypes().size());
-        assertNotNull(merged.getRoot().getRuntimeFieldType("field"));
+        assertEquals(1, merged.getRoot().runtimeFields().size());
+        assertNotNull(merged.getRoot().getRuntimeField("field"));
     }
 
     public void testDynamicUpdateWithRuntimeFieldDottedName() throws Exception {
@@ -210,7 +210,7 @@ public class DynamicMappingTests extends MapperServiceTestCase {
             b.endObject().endObject().endObject();
         }));
         RootObjectMapper root = doc.dynamicMappingsUpdate().getRoot();
-        assertEquals(0, root.runtimeFieldTypes().size());
+        assertEquals(0, root.runtimeFields().size());
         {
             //the runtime field is defined but the object structure is not, hence it is defined under properties
             Mapper path1 = root.getMapper("path1");
@@ -233,8 +233,8 @@ public class DynamicMappingTests extends MapperServiceTestCase {
             assertThat(path3, instanceOf(ObjectMapper.class));
             assertFalse(path3.iterator().hasNext());
         }
-        assertEquals(1, merged.getRoot().runtimeFieldTypes().size());
-        assertNotNull(merged.getRoot().getRuntimeFieldType("path1.path2.path3.field"));
+        assertEquals(1, merged.getRoot().runtimeFields().size());
+        assertNotNull(merged.getRoot().getRuntimeField("path1.path2.path3.field"));
     }
 
     public void testIncremental() throws Exception {

--- a/server/src/test/java/org/elasticsearch/index/mapper/FieldAliasMapperValidationTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FieldAliasMapperValidationTests.java
@@ -197,9 +197,9 @@ public class FieldAliasMapperValidationTests extends ESTestCase {
     private static MappingLookup createMappingLookup(List<FieldMapper> fieldMappers,
                                                      List<ObjectMapper> objectMappers,
                                                      List<FieldAliasMapper> fieldAliasMappers,
-                                                     List<RuntimeFieldType> runtimeFields) {
+                                                     List<RuntimeField> runtimeFields) {
         RootObjectMapper.Builder builder = new RootObjectMapper.Builder("_doc", Version.CURRENT);
-        Map<String, RuntimeFieldType> runtimeFieldTypes = runtimeFields.stream().collect(Collectors.toMap(RuntimeFieldType::name, r -> r));
+        Map<String, RuntimeField> runtimeFieldTypes = runtimeFields.stream().collect(Collectors.toMap(RuntimeField::name, r -> r));
         builder.setRuntime(runtimeFieldTypes);
         Mapping mapping = new Mapping(builder.build(new ContentPath()), new MetadataFieldMapper[0], Collections.emptyMap());
         return new MappingLookup(mapping, fieldMappers, objectMappers, fieldAliasMappers, null, null, null);

--- a/server/src/test/java/org/elasticsearch/index/mapper/FieldTypeLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FieldTypeLookupTests.java
@@ -41,7 +41,7 @@ public class FieldTypeLookupTests extends ESTestCase {
     public void testFilter() {
         Collection<FieldMapper> fieldMappers = List.of(new MockFieldMapper("field"), new MockFieldMapper("test"));
         Collection<FieldAliasMapper> fieldAliases = singletonList(new FieldAliasMapper("alias", "alias", "test"));
-        Collection<RuntimeFieldType> runtimeFields = List.of(
+        Collection<RuntimeField> runtimeFields = List.of(
             new TestRuntimeField("runtime", "type"), new TestRuntimeField("field", "type"));
         FieldTypeLookup fieldTypeLookup = new FieldTypeLookup(fieldMappers, fieldAliases, runtimeFields);
         assertEquals(3, size(fieldTypeLookup.filter(ft -> true)));

--- a/server/src/test/java/org/elasticsearch/index/mapper/MappingLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/MappingLookupTests.java
@@ -34,9 +34,9 @@ public class MappingLookupTests extends ESTestCase {
 
     private static MappingLookup createMappingLookup(List<FieldMapper> fieldMappers,
                                                      List<ObjectMapper> objectMappers,
-                                                     List<RuntimeFieldType> runtimeFields) {
+                                                     List<RuntimeField> runtimeFields) {
         RootObjectMapper.Builder builder = new RootObjectMapper.Builder("_doc", Version.CURRENT);
-        Map<String, RuntimeFieldType> runtimeFieldTypes = runtimeFields.stream().collect(Collectors.toMap(RuntimeFieldType::name, r -> r));
+        Map<String, RuntimeField> runtimeFieldTypes = runtimeFields.stream().collect(Collectors.toMap(RuntimeField::name, r -> r));
         builder.setRuntime(runtimeFieldTypes);
         Mapping mapping = new Mapping(builder.build(new ContentPath()), new MetadataFieldMapper[0], Collections.emptyMap());
         return new MappingLookup(mapping, fieldMappers, objectMappers, emptyList(), null, null, null);

--- a/server/src/test/java/org/elasticsearch/index/mapper/MappingParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/MappingParserTests.java
@@ -36,7 +36,7 @@ public class MappingParserTests extends MapperServiceTestCase {
         MapperRegistry mapperRegistry = new IndicesModule(Collections.emptyList()).getMapperRegistry();
         Supplier<Mapper.TypeParser.ParserContext> parserContextSupplier =
             () -> new Mapper.TypeParser.ParserContext(similarityService::getSimilarity, mapperRegistry.getMapperParsers()::get,
-                mapperRegistry.getRuntimeFieldTypeParsers()::get, indexSettings.getIndexVersionCreated(),
+                mapperRegistry.getRuntimeFieldParsers()::get, indexSettings.getIndexVersionCreated(),
                 () -> { throw new UnsupportedOperationException(); }, null,
                 scriptService, indexAnalyzers, indexSettings, () -> false);
         Map<String, MetadataFieldMapper.TypeParser> metadataMapperParsers =

--- a/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperMergeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperMergeTests.java
@@ -108,8 +108,8 @@ public class ObjectMapperMergeTests extends ESTestCase {
 
         RootObjectMapper merged = (RootObjectMapper) rootObjectMapper.merge(mergeWith);
         assertFalse(merged.isEnabled());
-        assertEquals(1, merged.runtimeFieldTypes().size());
-        assertEquals("test", merged.runtimeFieldTypes().iterator().next().name());
+        assertEquals(1, merged.runtimeFields().size());
+        assertEquals("test", merged.runtimeFields().iterator().next().name());
     }
 
     public void testMergeNested() {

--- a/server/src/test/java/org/elasticsearch/index/mapper/RootObjectMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RootObjectMapperTests.java
@@ -296,7 +296,7 @@ public class RootObjectMapperTests extends MapperServiceTestCase {
         assertThat(e.getRootCause().getMessage(), equalTo("No mapper found for type [string]"));
     }
 
-    public void testIllegalDynamicTemplateUnknownRuntimeFieldType() throws Exception {
+    public void testIllegalDynamicTemplateUnknownRuntimeField() throws Exception {
         XContentBuilder mapping = XContentFactory.jsonBuilder();
         mapping.startObject();
         {

--- a/server/src/test/java/org/elasticsearch/index/mapper/TestRuntimeField.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TestRuntimeField.java
@@ -15,7 +15,7 @@ import org.elasticsearch.index.query.SearchExecutionContext;
 import java.io.IOException;
 import java.util.Collections;
 
-public class TestRuntimeField extends MappedFieldType implements RuntimeFieldType {
+public class TestRuntimeField extends MappedFieldType implements RuntimeField {
 
     private final String type;
 

--- a/server/src/test/java/org/elasticsearch/index/query/SearchExecutionContextTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/SearchExecutionContextTests.java
@@ -447,7 +447,7 @@ public class SearchExecutionContextTests extends ESTestCase {
         when(mapperService.parserContext()).thenReturn(new Mapper.TypeParser.ParserContext(
             null,
             mapperRegistry.getMapperParsers()::get,
-            mapperRegistry.getRuntimeFieldTypeParsers()::get,
+            mapperRegistry.getRuntimeFieldParsers()::get,
             indexSettings.getIndexVersionCreated(),
             searchExecutionContextSupplier,
             null,

--- a/server/src/test/java/org/elasticsearch/index/query/SearchExecutionContextTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/SearchExecutionContextTests.java
@@ -55,7 +55,7 @@ import org.elasticsearch.index.mapper.MetadataFieldMapper;
 import org.elasticsearch.index.mapper.MockFieldMapper;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.mapper.RootObjectMapper;
-import org.elasticsearch.index.mapper.RuntimeFieldType;
+import org.elasticsearch.index.mapper.RuntimeField;
 import org.elasticsearch.index.mapper.TestRuntimeField;
 import org.elasticsearch.index.mapper.TextFieldMapper;
 import org.elasticsearch.indices.IndicesModule;
@@ -301,7 +301,7 @@ public class SearchExecutionContextTests extends ESTestCase {
 
     public void testFielddataLookupOneFieldManyReferences() throws IOException {
         int numFields = randomIntBetween(5, 20);
-        List<RuntimeFieldType> fields = new ArrayList<>(numFields + 1);
+        List<RuntimeField> fields = new ArrayList<>(numFields + 1);
         fields.add(runtimeField("root", leafLookup -> {
             StringBuilder value = new StringBuilder();
             for (int i = 0; i < numFields; i++) {
@@ -321,10 +321,10 @@ public class SearchExecutionContextTests extends ESTestCase {
         );
     }
 
-    private static MappingLookup createMappingLookup(List<MappedFieldType> concreteFields, List<RuntimeFieldType> runtimeFields) {
+    private static MappingLookup createMappingLookup(List<MappedFieldType> concreteFields, List<RuntimeField> runtimeFields) {
         List<FieldMapper> mappers = concreteFields.stream().map(MockFieldMapper::new).collect(Collectors.toList());
         RootObjectMapper.Builder builder = new RootObjectMapper.Builder("_doc", Version.CURRENT);
-        Map<String, RuntimeFieldType> runtimeFieldTypes = runtimeFields.stream().collect(Collectors.toMap(RuntimeFieldType::name, r -> r));
+        Map<String, RuntimeField> runtimeFieldTypes = runtimeFields.stream().collect(Collectors.toMap(RuntimeField::name, r -> r));
         builder.setRuntime(runtimeFieldTypes);
         Mapping mapping = new Mapping(builder.build(new ContentPath()), new MetadataFieldMapper[0], Collections.emptyMap());
         return new MappingLookup(mapping, mappers, Collections.emptyList(), Collections.emptyList(), null, null, null);
@@ -383,7 +383,7 @@ public class SearchExecutionContextTests extends ESTestCase {
         return createSearchExecutionContext(indexUuid, clusterAlias, MappingLookup.EMPTY, Map.of());
     }
 
-    private static SearchExecutionContext createSearchExecutionContext(RuntimeFieldType... fieldTypes) {
+    private static SearchExecutionContext createSearchExecutionContext(RuntimeField... fieldTypes) {
         return createSearchExecutionContext(
             "uuid",
             null,
@@ -459,11 +459,11 @@ public class SearchExecutionContextTests extends ESTestCase {
         return mapperService;
     }
 
-    private static RuntimeFieldType runtimeField(String name, Function<LeafSearchLookup, String> runtimeDocValues) {
+    private static RuntimeField runtimeField(String name, Function<LeafSearchLookup, String> runtimeDocValues) {
         return runtimeField(name, (leafLookup, docId) -> runtimeDocValues.apply(leafLookup));
     }
 
-    private static RuntimeFieldType runtimeField(String name, BiFunction<LeafSearchLookup, Integer, String> runtimeDocValues) {
+    private static RuntimeField runtimeField(String name, BiFunction<LeafSearchLookup, Integer, String> runtimeDocValues) {
         return new TestRuntimeField(name, null) {
             @Override
             public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName,

--- a/server/src/test/java/org/elasticsearch/indices/IndicesModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndicesModuleTests.java
@@ -172,7 +172,7 @@ public class IndicesModuleTests extends ESTestCase {
     public void testDuplicateRuntimeFieldPlugin() {
         MapperPlugin plugin = new MapperPlugin() {
             @Override
-            public Map<String, RuntimeField.Parser> getRuntimeFieldTypes() {
+            public Map<String, RuntimeField.Parser> getRuntimeFields() {
                 return Map.of("test", new RuntimeField.Parser((s, parserContext) -> null));
             }
         };
@@ -185,7 +185,7 @@ public class IndicesModuleTests extends ESTestCase {
     public void testRuntimeFieldPluginWithBuiltinFieldType() {
         MapperPlugin plugin = new MapperPlugin() {
             @Override
-            public Map<String, RuntimeField.Parser> getRuntimeFieldTypes() {
+            public Map<String, RuntimeField.Parser> getRuntimeFields() {
                 return Map.of(KeywordFieldMapper.CONTENT_TYPE, new RuntimeField.Parser((s, parserContext) -> null));
             }
         };

--- a/server/src/test/java/org/elasticsearch/indices/IndicesModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndicesModuleTests.java
@@ -21,7 +21,7 @@ import org.elasticsearch.index.mapper.MapperRegistry;
 import org.elasticsearch.index.mapper.MetadataFieldMapper;
 import org.elasticsearch.index.mapper.NestedPathFieldMapper;
 import org.elasticsearch.index.mapper.RoutingFieldMapper;
-import org.elasticsearch.index.mapper.RuntimeFieldType;
+import org.elasticsearch.index.mapper.RuntimeField;
 import org.elasticsearch.index.mapper.SeqNoFieldMapper;
 import org.elasticsearch.index.mapper.SourceFieldMapper;
 import org.elasticsearch.index.mapper.TextFieldMapper;
@@ -172,8 +172,8 @@ public class IndicesModuleTests extends ESTestCase {
     public void testDuplicateRuntimeFieldPlugin() {
         MapperPlugin plugin = new MapperPlugin() {
             @Override
-            public Map<String, RuntimeFieldType.Parser> getRuntimeFieldTypes() {
-                return Map.of("test", new RuntimeFieldType.Parser((s, parserContext) -> null));
+            public Map<String, RuntimeField.Parser> getRuntimeFieldTypes() {
+                return Map.of("test", new RuntimeField.Parser((s, parserContext) -> null));
             }
         };
         List<MapperPlugin> plugins = Arrays.asList(plugin, plugin);
@@ -185,8 +185,8 @@ public class IndicesModuleTests extends ESTestCase {
     public void testRuntimeFieldPluginWithBuiltinFieldType() {
         MapperPlugin plugin = new MapperPlugin() {
             @Override
-            public Map<String, RuntimeFieldType.Parser> getRuntimeFieldTypes() {
-                return Map.of(KeywordFieldMapper.CONTENT_TYPE, new RuntimeFieldType.Parser((s, parserContext) -> null));
+            public Map<String, RuntimeField.Parser> getRuntimeFieldTypes() {
+                return Map.of(KeywordFieldMapper.CONTENT_TYPE, new RuntimeField.Parser((s, parserContext) -> null));
             }
         };
         List<MapperPlugin> plugins = Collections.singletonList(plugin);


### PR DESCRIPTION
RuntimeFieldType was recently made an interface, hence it no longer extends MappedFieldType. It makes sense then to rename it to RuntimeField.