### PR TITLE
[DOCS] Add 6.8.15 release notes

### DIFF
--- a/docs/reference/release-notes/6.8.asciidoc
+++ b/docs/reference/release-notes/6.8.asciidoc
@@ -5,6 +5,20 @@ Also see <<breaking-changes-6.8,Breaking changes in 6.8>>.
 
 coming::[6.8.15]
 
+[[enhancement-6.8.15]]
+[discrete]
+=== Enhancements
+
+Authorization::
+* Improve shard level request cache efficiency {es-pull}69505[#69505]
+
+[[upgrade-6.8.15]]
+[discrete]
+=== Upgrades
+
+Packaging::
+* Upgrade to JNA 5.7.0-1 {es-pull}69653[#69653]
+
 [[release-notes-6.8.14]]
 == {es} version 6.8.14
 

--- a/docs/reference/release-notes/6.8.asciidoc
+++ b/docs/reference/release-notes/6.8.asciidoc
@@ -10,14 +10,14 @@ coming::[6.8.15]
 === Enhancements
 
 Authorization::
-* Improve shard level request cache efficiency {es-pull}69505[#69505]
+* Improve shard-level request cache efficiency {es-pull}69505[#69505]
 
 [[upgrade-6.8.15]]
 [discrete]
 === Upgrades
 
 Packaging::
-* Upgrade to JNA 5.7.0-1 {es-pull}69653[#69653]
+* Upgrade to Java Native Access (JNA) 5.7.0-1 {es-pull}69653[#69653]
 
 [[release-notes-6.8.14]]
 == {es} version 6.8.14


### PR DESCRIPTION
Adds release notes for 6.8.15.

### Preview
https://elasticsearch_70729.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/6.8/release-notes-6.8.15.html