### PR TITLE
[ML] adding logging and unmuting test failure #67756

### DIFF
--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlDistributedFailureIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlDistributedFailureIT.java
@@ -38,6 +38,7 @@ import org.elasticsearch.persistent.PersistentTasksClusterService;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata.PersistentTask;
 import org.elasticsearch.persistent.UpdatePersistentTaskStatusAction;
+import org.elasticsearch.test.junit.annotations.TestIssueLogging;
 import org.elasticsearch.xpack.core.action.util.QueryPage;
 import org.elasticsearch.xpack.core.ml.MlTasks;
 import org.elasticsearch.xpack.core.ml.action.CloseJobAction;
@@ -452,7 +453,12 @@ public class MlDistributedFailureIT extends BaseMlIntegTestCase {
         });
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/67756")
+    @TestIssueLogging(
+        value = "org.elasticsearch.xpack.ml.action:TRACE,"
+            + "org.elasticsearch.xpack.ml.job.process.autodetect.AutodetectProcessManager:TRACE"
+            + "org.elasticsearch.xpack.ml.datafeed:TRACE",
+        issueUrl = "https://github.com/elastic/elasticsearch/issues/67756"
+    )
     public void testClusterWithTwoMlNodes_RunsDatafeed_GivenOriginalNodeGoesDown() throws Exception {
         internalCluster().ensureAtMostNumDataNodes(0);
         logger.info("Starting dedicated master node...");

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlDistributedFailureIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlDistributedFailureIT.java
@@ -455,7 +455,7 @@ public class MlDistributedFailureIT extends BaseMlIntegTestCase {
 
     @TestIssueLogging(
         value = "org.elasticsearch.xpack.ml.action:TRACE,"
-            + "org.elasticsearch.xpack.ml.job.process.autodetect.AutodetectProcessManager:TRACE"
+            + "org.elasticsearch.xpack.ml.job.process.autodetect.AutodetectProcessManager:TRACE,"
             + "org.elasticsearch.xpack.ml.datafeed:TRACE",
         issueUrl = "https://github.com/elastic/elasticsearch/issues/67756"
     )


### PR DESCRIPTION
This test has been muted for some time, and some bugs have been fixed relating to `_close` and race conditions.

But, since we are not 100% the test is now fixed, adding logging to capture data in potential failures.

relates: #67756