### PR TITLE
[DOCS] Fix heading for ILM shrink example

### DIFF
--- a/docs/reference/ilm/actions/ilm-shrink.asciidoc
+++ b/docs/reference/ilm/actions/ilm-shrink.asciidoc
@@ -75,7 +75,7 @@ PUT _ilm/policy/my_policy
 
 The following policy uses the `max_primary_shard_size` parameter to
 automatically calculate the new shrunken index's primary shard count based on
-source index's storage size.
+the source index's storage size.
 
 [source,console]
 --------------------------------------------------

--- a/docs/reference/ilm/actions/ilm-shrink.asciidoc
+++ b/docs/reference/ilm/actions/ilm-shrink.asciidoc
@@ -71,8 +71,11 @@ PUT _ilm/policy/my_policy
 --------------------------------------------------
 
 [[ilm-shrink-size-ex]]
-===== Calculate the number of shards of the new shrunken index based on the storage of the
-source index and the `max_primary_shard_size` parameter
+===== Calculate optimal number of primary shards for a shrunken index
+
+The following policy uses the `max_primary_shard_size` parameter to
+automatically calculate the new shrunken index's primary shard count based on
+source index's storage size.
 
 [source,console]
 --------------------------------------------------

--- a/docs/reference/ilm/actions/ilm-shrink.asciidoc
+++ b/docs/reference/ilm/actions/ilm-shrink.asciidoc
@@ -71,7 +71,7 @@ PUT _ilm/policy/my_policy
 --------------------------------------------------
 
 [[ilm-shrink-size-ex]]
-===== Calculate optimal number of primary shards for a shrunken index
+===== Calculate the optimal number of primary shards for a shrunken index
 
 The following policy uses the `max_primary_shard_size` parameter to
 automatically calculate the new shrunken index's primary shard count based on


### PR DESCRIPTION
The current heading contains a line break, which messes up the HTML display:

<img width="753" alt="Screen Shot 2021-03-23 at 9 05 04 AM" src="https://user-images.githubusercontent.com/40268737/112150787-de9be700-8bb6-11eb-9b69-ddaed9ee2f96.PNG">

This shortens the heading and moves some of the content to an intro sentence.

<img width="763" alt="Screen Shot 2021-03-23 at 9 12 10 AM" src="https://user-images.githubusercontent.com/40268737/112151676-e0b27580-8bb7-11eb-8470-6b86a7a73101.PNG">


Any feedback welcome!

### Preview
https://elasticsearch_70733.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ilm-shrink.html#ilm-shrink-size-ex