### PR TITLE
[DOCS]  Clarify language for supported APIs with CCS and older clusters

### DIFF
--- a/docs/reference/search/search-your-data/search-across-clusters.asciidoc
+++ b/docs/reference/search/search-your-data/search-across-clusters.asciidoc
@@ -14,9 +14,11 @@ IMPORTANT: {ccs-cap} requires <<modules-remote-clusters, remote clusters>>.
 The following APIs support {ccs}:
 
 * <<search-search,Search>>
+* <<async-search,Async search>>
 * <<search-multi-search,Multi search>>
 * <<search-template,Search template>>
 * <<multi-search-template,Multi search template>>
+* <<search-field-caps,Field capabilities>>
 
 [discrete]
 [[ccs-example]]
@@ -421,16 +423,6 @@ cluster.
 WARNING: Running multiple versions of {es} in the same cluster beyond the
 duration of an upgrade is not supported.
 
-.Searching across clusters with older versions
-****
-{es} only supports the following APIs when searching across clusters that are
-running an earlier {es} version:
-
-* <<search-search,`_search`>>
-* <<async-search,`_async_search`>>
-* <<search-field-caps,`_field_caps`>>
-
 Only features that exist across all searched clusters are supported. Using
 a recent feature with a remote cluster where the feature is not supported
 will result in undefined behavior.
-****

--- a/docs/reference/search/search-your-data/search-across-clusters.asciidoc
+++ b/docs/reference/search/search-your-data/search-across-clusters.asciidoc
@@ -421,7 +421,10 @@ cluster.
 WARNING: Running multiple versions of {es} in the same cluster beyond the
 duration of an upgrade is not supported.
 
-{es} only supports the following APIs via cross-cluster search:
+.Searching across clusters with older versions
+****
+{es} only supports the following APIs when searching across clusters that are
+running an earlier {es} version:
 
 * <<search-search,`_search`>>
 * <<async-search,`_async_search`>>
@@ -430,3 +433,4 @@ duration of an upgrade is not supported.
 Only features that exist across all searched clusters are supported. Using
 a recent feature with a remote cluster where the feature is not supported
 will result in undefined behavior.
+****

--- a/docs/reference/search/search-your-data/search-across-clusters.asciidoc
+++ b/docs/reference/search/search-your-data/search-across-clusters.asciidoc
@@ -420,3 +420,13 @@ cluster.
 
 WARNING: Running multiple versions of {es} in the same cluster beyond the
 duration of an upgrade is not supported.
+
+{es} only supports the following APIs via cross-cluster search:
+
+* <<search-search,`_search`>>
+* <<async-search,`_async_search`>>
+* <<search-field-caps,`_field_caps`>>
+
+Only features that exist across all searched clusters are supported. Using
+a recent feature with a remote cluster where the feature is not supported
+will result in undefined behavior.


### PR DESCRIPTION
Clarifies language around supported APIs when searching across clusters when calls are made to a cluster running an older version of Elasticsearch.

Preview link: https://elasticsearch_70734.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/modules-cross-cluster-search.html#ccs-supported-configurations