### PR TITLE
[7.12] [DOCS] Document `on_failure` param for create pipeline API (#70679)

### DIFF
--- a/docs/reference/ingest.asciidoc
+++ b/docs/reference/ingest.asciidoc
@@ -510,7 +510,9 @@ PUT _ingest/pipeline/my-pipeline
 }
 ----
 
-You can also specify `on_failure` for a pipeline.
+You can also specify `on_failure` for a pipeline. If a processor without an
+`on_failure` value fails, {es} uses this pipeline-level parameter as a fallback.
+{es} will not attempt to run the pipeline's remaining processors.
 
 [source,console]
 ----

--- a/docs/reference/ingest/apis/put-pipeline.asciidoc
+++ b/docs/reference/ingest/apis/put-pipeline.asciidoc
@@ -57,6 +57,15 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 (Optional, string)
 Description of the ingest pipeline.
 
+`on_failure`::
+(Optional, array of <<processors,processor>> objects)
+Processors to run immediately after a processor failure.
++
+Each processor supports a processor-level `on_failure` value. If a processor
+without an `on_failure` value fails, {es} uses this pipeline-level parameter as
+a fallback. The processors in this parameter run sequentially in the order
+specified. {es} will not attempt to run the pipeline's remaining processors.
+
 `processors`::
 (Required, array of <<processors,processor>> objects)
 Processors used to preform transformations on documents before indexing.


### PR DESCRIPTION
Backports the following commits to 7.12:
 - [DOCS] Document `on_failure` param for create pipeline API (#70679)