### PR TITLE
[7.12] [DOCS] Remove 7.12.0 coming tags (#70666)

### DIFF
--- a/docs/reference/release-notes/7.12.asciidoc
+++ b/docs/reference/release-notes/7.12.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-7.12.0]]
 == {es} version 7.12.0
 
-coming[7.12.0]
-
 Also see <<breaking-changes-7.12,Breaking changes in 7.12>>.
 
 [[breaking-7.12.0]]

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -1,8 +1,6 @@
 [[release-highlights]]
 == What's new in {minor-version}
 
-coming[{minor-version}]
-
 Here are the highlights of what's new and improved in {es} {minor-version}!
 
 For detailed information about this release, see the <<es-release-notes>> and


### PR DESCRIPTION
Backports the following commits to 7.12:
 - [DOCS] Remove 7.12.0 coming tags (#70666)