### PR TITLE
[DOCS] Fix collapsible properties role

### DIFF
--- a/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
@@ -102,7 +102,7 @@ Name of the repository to restore a snapshot from.
 (Required, string)
 Name of the snapshot to restore.
 
-[role="child-attributes"]
+[role="child_attributes"]
 [[restore-snapshot-api-request-body]]
 ==== {api-request-body-title}
 


### PR DESCRIPTION
This is a no-op as the snapshot restore API does not currently use nested request body parameters.