### PR TITLE
Legacy geo-shape mapper not detecting [points_only] parameter

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/LegacyGeoShapeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/LegacyGeoShapeFieldMapper.java
@@ -73,7 +73,7 @@ public class LegacyGeoShapeFieldMapper extends AbstractShapeGeometryFieldMapper<
     public static final String CONTENT_TYPE = "geo_shape";
 
     public static final Set<String> DEPRECATED_PARAMETERS
-        = Set.of("strategy", "tree", "tree_levels", "precision", "distance_error_pct", "points only");
+        = Set.of("strategy", "tree", "tree_levels", "precision", "distance_error_pct", "points_only");
 
     public static boolean containsDeprecatedParameter(Set<String> paramKeys) {
         return DEPRECATED_PARAMETERS.stream().anyMatch(paramKeys::contains);


### PR DESCRIPTION
We have two `geo_shape` mapper implementations, and the type parser
will select which one to use by examining the other fields used in the mapper
definition.  This commit fixes a bug in the list of legacy parameters that was 
causing a `geo_shape` mapper with only a `points_only` field to throw an 
exception when parsed.

Fixes #70751