### PR TITLE
[7.x] Mark Step#isRetryable abstract (#70716)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/AllocationRoutedStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/AllocationRoutedStep.java
@@ -41,6 +41,11 @@ public class AllocationRoutedStep extends ClusterStateWaitStep {
     }
 
     @Override
+    public boolean isRetryable() {
+        return true;
+    }
+
+    @Override
     public Result isConditionMet(Index index, ClusterState clusterState) {
         IndexMetadata idxMeta = clusterState.metadata().index(index);
         if (idxMeta == null) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ErrorStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ErrorStep.java
@@ -18,4 +18,10 @@ public class ErrorStep extends Step {
             throw new IllegalArgumentException("An error step must have a step key whose step name is " + NAME);
         }
     }
+
+    @Override
+    public boolean isRetryable() {
+        // this is marker step so it doesn't make sense to be retryable
+        return false;
+    }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/GenerateSnapshotNameStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/GenerateSnapshotNameStep.java
@@ -89,6 +89,11 @@ public class GenerateSnapshotNameStep extends ClusterStateActionStep {
     }
 
     @Override
+    public boolean isRetryable() {
+        return true;
+    }
+
+    @Override
     public int hashCode() {
         return Objects.hash(super.hashCode(), snapshotRepository);
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/PhaseCompleteStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/PhaseCompleteStep.java
@@ -20,4 +20,10 @@ public class PhaseCompleteStep extends Step {
     public static PhaseCompleteStep finalStep(String phase) {
         return new PhaseCompleteStep(new StepKey(phase, NAME, NAME), null);
     }
+
+    @Override
+    public boolean isRetryable() {
+        // this is marker step so it doesn't make sense to be retryable
+        return false;
+    }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/Step.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/Step.java
@@ -42,9 +42,7 @@ public abstract class Step {
     /**
      * Indicates if the step can be automatically retried when it encounters an execution error.
      */
-    public boolean isRetryable() {
-        return false;
-    }
+    public abstract boolean isRetryable();
 
     @Override
     public int hashCode() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/TerminalPolicyStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/TerminalPolicyStep.java
@@ -17,4 +17,10 @@ public class TerminalPolicyStep extends Step {
     TerminalPolicyStep(StepKey key, StepKey nextStepKey) {
         super(key, nextStepKey);
     }
+
+    @Override
+    public boolean isRetryable() {
+        // this is marker step so it doesn't make sense to be retryable
+        return false;
+    }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitForIndexingCompleteStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitForIndexingCompleteStep.java
@@ -31,6 +31,11 @@ final class WaitForIndexingCompleteStep extends ClusterStateWaitStep {
     }
 
     @Override
+    public boolean isRetryable() {
+        return true;
+    }
+
+    @Override
     public Result isConditionMet(Index index, ClusterState clusterState) {
         IndexMetadata followerIndex = clusterState.metadata().index(index);
         if (followerIndex == null) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/AsyncActionBranchingStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/AsyncActionBranchingStepTests.java
@@ -54,6 +54,11 @@ public class AsyncActionBranchingStepTests extends AbstractStepMasterTimeoutTest
     public void testBranchStepKeyIsTheWrappedStepKey() {
         AsyncActionStep stepToExecute = new AsyncActionStep(randomStepKey(), randomStepKey(), client) {
             @Override
+            public boolean isRetryable() {
+                return true;
+            }
+
+            @Override
             public void performAction(IndexMetadata indexMetadata, ClusterState currentClusterState, ClusterStateObserver observer,
                                       Listener listener) {
             }
@@ -65,6 +70,11 @@ public class AsyncActionBranchingStepTests extends AbstractStepMasterTimeoutTest
 
     public void testBranchStepNextKeyOnCompleteResponse() {
         AsyncActionStep stepToExecute = new AsyncActionStep(randomStepKey(), randomStepKey(), client) {
+            @Override
+            public boolean isRetryable() {
+                return true;
+            }
+
             @Override
             public void performAction(IndexMetadata indexMetadata, ClusterState currentClusterState, ClusterStateObserver observer,
                                       Listener listener) {
@@ -91,6 +101,11 @@ public class AsyncActionBranchingStepTests extends AbstractStepMasterTimeoutTest
 
     public void testBranchStepNextKeyOnInCompleteResponse() {
         AsyncActionStep stepToExecute = new AsyncActionStep(randomStepKey(), randomStepKey(), client) {
+            @Override
+            public boolean isRetryable() {
+                return true;
+            }
+
             @Override
             public void performAction(IndexMetadata indexMetadata, ClusterState currentClusterState, ClusterStateObserver observer,
                                       Listener listener) {
@@ -120,6 +135,11 @@ public class AsyncActionBranchingStepTests extends AbstractStepMasterTimeoutTest
     public void testBranchStepPropagatesFailure() {
         NullPointerException failException = new NullPointerException("fail");
         AsyncActionStep stepToExecute = new AsyncActionStep(randomStepKey(), randomStepKey(), client) {
+            @Override
+            public boolean isRetryable() {
+                return true;
+            }
+
             @Override
             public void performAction(IndexMetadata indexMetadata, ClusterState currentClusterState, ClusterStateObserver observer,
                                       Listener listener) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/MockStep.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/MockStep.java
@@ -19,6 +19,11 @@ public class MockStep extends Step implements Writeable {
         super(stepKey, nextStepKey);
     }
 
+    @Override
+    public boolean isRetryable() {
+        return false;
+    }
+
     public MockStep(Step other) {
         super(other.getKey(), other.getNextStepKey());
     }

--- a/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/IndexLifecycleInitialisationTests.java
+++ b/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/IndexLifecycleInitialisationTests.java
@@ -491,6 +491,11 @@ public class IndexLifecycleInitialisationTests extends ESIntegTestCase {
             super(current, next);
         }
 
+        @Override
+        public boolean isRetryable() {
+            return false;
+        }
+
         public ObservableClusterStateWaitStep(StreamInput in) throws IOException {
             this(new StepKey(in.readString(), in.readString(), in.readString()), readOptionalNextStepKey(in));
         }

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunnerTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunnerTests.java
@@ -888,6 +888,11 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
             super(key, nextStepKey, null);
         }
 
+        @Override
+        public boolean isRetryable() {
+            return false;
+        }
+
         void setException(Exception exception) {
             this.exception = exception;
         }
@@ -937,6 +942,11 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
             super(key, nextStepKey, null);
         }
 
+        @Override
+        public boolean isRetryable() {
+            return false;
+        }
+
         void setException(Exception exception) {
             this.exception = exception;
         }
@@ -974,6 +984,11 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
             super(key, nextStepKey);
         }
 
+        @Override
+        public boolean isRetryable() {
+            return false;
+        }
+
         public void setException(RuntimeException exception) {
             this.exception = exception;
         }
@@ -1008,6 +1023,11 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
 
         MockClusterStateWaitStep(StepKey key, StepKey nextStepKey) {
             super(key, nextStepKey);
+        }
+
+        @Override
+        public boolean isRetryable() {
+            return false;
         }
 
         public void setException(RuntimeException exception) {


### PR DESCRIPTION
This marks isRetryable and implements it in the remaining places.

(cherry picked from commit b039b8077eacb1db87607ad95c0e7ce8178772a5)
Signed-off-by: Andrei Dan <andrei.dan@elastic.co>

Backport of #70716