### PR TITLE
[DOCS] Fix 'How To' title

### DIFF
--- a/docs/reference/how-to.asciidoc
+++ b/docs/reference/how-to.asciidoc
@@ -1,5 +1,5 @@
 [[how-to]]
-= How To
+= How to
 
 [partintro]
 --


### PR DESCRIPTION
Changes the title to sentence case