### PR TITLE
[7.x] [DOCS] Fix 'How To' title (#70772)

### DIFF
--- a/docs/reference/how-to.asciidoc
+++ b/docs/reference/how-to.asciidoc
@@ -1,5 +1,5 @@
 [[how-to]]
-= How To
+= How to
 
 [partintro]
 --


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Fix 'How To' title (#70772)