### PR TITLE
[DOCS] Fix sidebar for built-in index templates

### DIFF
--- a/docs/reference/indices/index-templates.asciidoc
+++ b/docs/reference/indices/index-templates.asciidoc
@@ -31,7 +31,7 @@ templates.
 * If a new data stream or index matches more than one index template, the index
 template with the highest priority is used.
 
-.Using index templates with {fleet} or {agent}
+.Avoid index pattern collisions
 ****
 // tag::built-in-index-templates[]
 [IMPORTANT]


### PR DESCRIPTION
#70172 added a sidebar and title to an admon about built-in index templates.

While the built-in templates are for Fleet/Elastic Agent, **all** ES users need to be aware of their index patterns to avoid accidentally applying the wrong template. The current title implies that the content is only relevant to Fleet/Elastic Agent users.

This PR updates the sidebar title.