### PR TITLE
[7.12] [DOCS] Fix sidebar for built-in index patterns (#70788)

### DIFF
--- a/docs/reference/indices/index-templates.asciidoc
+++ b/docs/reference/indices/index-templates.asciidoc
@@ -31,7 +31,7 @@ templates.
 * If a new data stream or index matches more than one index template, the index
 template with the highest priority is used.
 
-.Using index templates with {fleet} or {agent}
+.Avoid index pattern collisions
 ****
 // tag::built-in-index-templates[]
 [IMPORTANT]


### PR DESCRIPTION
Backports the following commits to 7.12:
 - [DOCS] Fix sidebar for built-in index patterns (#70788)