### PR TITLE
Always use CacheService for caching metadata blobs (#70668)

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/blobstore/cache/SearchableSnapshotsBlobStoreCacheIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/blobstore/cache/SearchableSnapshotsBlobStoreCacheIntegTests.java
@@ -157,11 +157,11 @@ public class SearchableSnapshotsBlobStoreCacheIntegTests extends BaseSearchableS
             () -> systemClient().admin().indices().prepareGetIndex().addIndices(SNAPSHOT_BLOB_CACHE_INDEX).get()
         );
 
-        final Storage storage = randomFrom(Storage.values());
+        final Storage storage1 = randomFrom(Storage.values());
         logger.info(
             "--> mount snapshot [{}] as an index for the first time [storage={}, max length={}]",
             snapshot,
-            storage,
+            storage1,
             blobCacheMaxLength.getStringRep()
         );
         final String restoredIndex = randomBoolean() ? indexName : randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
@@ -175,7 +175,7 @@ public class SearchableSnapshotsBlobStoreCacheIntegTests extends BaseSearchableS
                 .put(SearchableSnapshots.SNAPSHOT_CACHE_PREWARM_ENABLED_SETTING.getKey(), false)
                 .put(SearchableSnapshots.SNAPSHOT_BLOB_CACHE_METADATA_FILES_MAX_LENGTH, blobCacheMaxLength)
                 .build(),
-            storage
+            storage1
         );
         ensureGreen(restoredIndex);
 
@@ -244,7 +244,8 @@ public class SearchableSnapshotsBlobStoreCacheIntegTests extends BaseSearchableS
             );
         });
 
-        logger.info("--> mount snapshot [{}] as an index for the second time [storage={}]", snapshot, storage);
+        final Storage storage2 = randomFrom(Storage.values());
+        logger.info("--> mount snapshot [{}] as an index for the second time [storage={}]", snapshot, storage2);
         final String restoredAgainIndex = randomBoolean() ? indexName : randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
         mountSnapshot(
             repositoryName,
@@ -256,7 +257,7 @@ public class SearchableSnapshotsBlobStoreCacheIntegTests extends BaseSearchableS
                 .put(SearchableSnapshots.SNAPSHOT_CACHE_PREWARM_ENABLED_SETTING.getKey(), false)
                 .put(SearchableSnapshots.SNAPSHOT_BLOB_CACHE_METADATA_FILES_MAX_LENGTH, blobCacheMaxLength)
                 .build(),
-            storage
+            storage2
         );
         ensureGreen(restoredAgainIndex);
 

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsPrewarmingIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsPrewarmingIntegTests.java
@@ -49,6 +49,7 @@ import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.searchablesnapshots.MountSearchableSnapshotAction;
 import org.elasticsearch.xpack.core.searchablesnapshots.MountSearchableSnapshotRequest;
+import org.junit.After;
 
 import java.io.FilterInputStream;
 import java.io.IOException;
@@ -180,14 +181,7 @@ public class SearchableSnapshotsPrewarmingIntegTests extends ESSingleNodeTestCas
                 .setSettings(repositorySettings.build())
         );
 
-        TrackingRepositoryPlugin tracker = null;
-        for (RepositoryPlugin plugin : getInstanceFromNode(PluginsService.class).filterPlugins(RepositoryPlugin.class)) {
-            if (plugin instanceof TrackingRepositoryPlugin) {
-                tracker = ((TrackingRepositoryPlugin) plugin);
-            }
-        }
-
-        assertThat(tracker, notNullValue());
+        TrackingRepositoryPlugin tracker = getTrackingRepositoryPlugin();
         assertThat(tracker.totalFilesRead(), equalTo(0L));
         assertThat(tracker.totalBytesRead(), equalTo(0L));
 
@@ -305,6 +299,20 @@ public class SearchableSnapshotsPrewarmingIntegTests extends ESSingleNodeTestCas
         }
     }
 
+    @After
+    public void resetTracker() {
+        getTrackingRepositoryPlugin().clear();
+    }
+
+    private TrackingRepositoryPlugin getTrackingRepositoryPlugin() {
+        for (RepositoryPlugin plugin : getInstanceFromNode(PluginsService.class).filterPlugins(RepositoryPlugin.class)) {
+            if (plugin instanceof TrackingRepositoryPlugin) {
+                return ((TrackingRepositoryPlugin) plugin);
+            }
+        }
+        throw new IllegalStateException("tracking repository missing");
+    }
+
     /**
      * A plugin that allows to track the read operations on blobs
      */
@@ -312,6 +320,11 @@ public class SearchableSnapshotsPrewarmingIntegTests extends ESSingleNodeTestCas
 
         private final ConcurrentHashMap<String, Long> files = new ConcurrentHashMap<>();
         private final AtomicBoolean enabled = new AtomicBoolean(true);
+
+        void clear() {
+            files.clear();
+            enabled.set(true);
+        }
 
         long totalFilesRead() {
             return files.size();

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsUuidValidationIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsUuidValidationIntegTests.java
@@ -21,6 +21,7 @@ import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.plugins.ActionPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.snapshots.SnapshotRestoreException;
+import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.xpack.core.searchablesnapshots.MountSearchableSnapshotAction;
 import org.elasticsearch.xpack.core.searchablesnapshots.MountSearchableSnapshotRequest;
 
@@ -33,6 +34,7 @@ import static org.elasticsearch.index.IndexSettings.INDEX_SOFT_DELETES_SETTING;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.containsString;
 
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST)
 public class SearchableSnapshotsUuidValidationIntegTests extends BaseSearchableSnapshotsIntegTestCase {
 
     public static class TestPlugin extends Plugin implements ActionPlugin {

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/BaseSearchableSnapshotIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/BaseSearchableSnapshotIndexInput.java
@@ -152,7 +152,7 @@ public abstract class BaseSearchableSnapshotIndexInput extends BufferedIndexInpu
         return success;
     }
 
-    protected ByteRange maybeReadFromBlobCache(long position, int length) {
+    protected ByteRange rangeToReadFromBlobCache(long position, int length) {
         final long end = position + length;
         if (headerBlobCacheByteRange.contains(position, end)) {
             return headerBlobCacheByteRange;

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/CachedBlobContainerIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/CachedBlobContainerIndexInput.java
@@ -9,44 +9,26 @@ package org.elasticsearch.index.store.cache;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.index.IndexFileNames;
-import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
-import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.BytesRefIterator;
-import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.blobstore.cache.BlobStoreCacheService;
-import org.elasticsearch.blobstore.cache.CachedBlob;
-import org.elasticsearch.common.SuppressForbidden;
-import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.collect.Tuple;
-import org.elasticsearch.common.io.Channels;
-import org.elasticsearch.common.lease.Releasable;
-import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot.FileInfo;
-import org.elasticsearch.index.store.BaseSearchableSnapshotIndexInput;
 import org.elasticsearch.index.store.IndexInputStats;
 import org.elasticsearch.index.store.SearchableSnapshotDirectory;
 import org.elasticsearch.xpack.searchablesnapshots.cache.ByteRange;
 
-import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
-import java.nio.channels.FileChannel;
-import java.util.Locale;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Consumer;
 import java.util.stream.IntStream;
 
 import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsUtils.toIntBytes;
 
-public class CachedBlobContainerIndexInput extends BaseSearchableSnapshotIndexInput {
+public class CachedBlobContainerIndexInput extends MetadataCachingIndexInput {
 
     /**
      * Specific IOContext used for prewarming the cache. This context allows to write
@@ -56,22 +38,6 @@ public class CachedBlobContainerIndexInput extends BaseSearchableSnapshotIndexIn
     public static final IOContext CACHE_WARMING_CONTEXT = new IOContext();
 
     private static final Logger logger = LogManager.getLogger(CachedBlobContainerIndexInput.class);
-    private static final int COPY_BUFFER_SIZE = ByteSizeUnit.KB.toIntBytes(8);
-
-    private final CacheFileReference cacheFileReference;
-    private final int defaultRangeSize;
-    private final int recoveryRangeSize;
-
-    /**
-     * If > 0, represents a logical file within a compound (CFS) file or is a slice thereof represents the offset of the logical
-     * compound file within the physical CFS file
-     */
-    private final long compoundFileOffset;
-
-    // last read position is kept around in order to detect (non)contiguous reads for stats
-    private long lastReadPosition;
-    // last seek position is kept around in order to detect forward/backward seeks for stats
-    private long lastSeekPosition;
 
     public CachedBlobContainerIndexInput(
         String name,
@@ -97,7 +63,6 @@ public class CachedBlobContainerIndexInput extends BaseSearchableSnapshotIndexIn
             directory.getBlobCacheByteRange(name, fileInfo.length()),
             ByteRange.EMPTY
         );
-        assert getBufferSize() <= BlobStoreCacheService.DEFAULT_CACHED_BLOB_SIZE; // must be able to cache at least one buffer's worth
         stats.incrementOpenCount();
     }
 
@@ -111,286 +76,63 @@ public class CachedBlobContainerIndexInput extends BaseSearchableSnapshotIndexIn
         long compoundFileOffset,
         long length,
         CacheFileReference cacheFileReference,
-        int rangeSize,
+        int defaultRangeSize,
         int recoveryRangeSize,
         ByteRange headerBlobCacheByteRange,
         ByteRange footerBlobCacheByteRange
     ) {
-        super(logger, name, directory, fileInfo, context, stats, offset, length, headerBlobCacheByteRange, footerBlobCacheByteRange);
-        this.cacheFileReference = cacheFileReference;
-        this.lastReadPosition = this.offset;
-        this.lastSeekPosition = this.offset;
-        this.defaultRangeSize = rangeSize;
-        this.recoveryRangeSize = recoveryRangeSize;
-        this.compoundFileOffset = compoundFileOffset;
+        super(
+            logger,
+            name,
+            directory,
+            fileInfo,
+            context,
+            stats,
+            offset,
+            compoundFileOffset,
+            length,
+            cacheFileReference,
+            defaultRangeSize,
+            recoveryRangeSize,
+            headerBlobCacheByteRange,
+            footerBlobCacheByteRange
+        );
     }
 
     @Override
-    public void doClose() {
-        if (isClone == false) {
-            cacheFileReference.releaseOnClose();
-        }
-    }
-
-    private long getDefaultRangeSize() {
+    protected long getDefaultRangeSize() {
         return (context != CACHE_WARMING_CONTEXT)
             ? (directory.isRecoveryFinalized() ? defaultRangeSize : recoveryRangeSize)
             : fileInfo.partSize().getBytes();
     }
 
-    private ByteRange computeRange(long position) {
-        final long rangeSize = getDefaultRangeSize();
-        long start = (position / rangeSize) * rangeSize;
-        long end = Math.min(start + rangeSize, fileInfo.length());
-        return ByteRange.of(start, end);
-    }
-
     @Override
-    protected void doReadInternal(ByteBuffer b) throws IOException {
+    protected void readWithoutBlobCache(ByteBuffer b) throws Exception {
         ensureContext(ctx -> ctx != CACHE_WARMING_CONTEXT);
         final long position = getAbsolutePosition();
         final int length = b.remaining();
 
-        logger.trace("readInternal: read [{}-{}] ([{}] bytes) from [{}]", position, position + length, length, this);
-        try {
-            final CacheFile cacheFile = cacheFileReference.get();
+        final CacheFile cacheFile = cacheFileReference.get();
 
-            // Can we serve the read directly from disk? If so, do so and don't worry about anything else.
+        final ByteRange startRangeToWrite = computeRange(position);
+        final ByteRange endRangeToWrite = computeRange(position + length - 1);
+        assert startRangeToWrite.end() <= endRangeToWrite.end() : startRangeToWrite + " vs " + endRangeToWrite;
+        final ByteRange rangeToWrite = startRangeToWrite.minEnvelope(endRangeToWrite);
 
-            final Future<Integer> waitingForRead = cacheFile.readIfAvailableOrPending(ByteRange.of(position, position + length), chan -> {
-                final int read = readCacheFile(chan, position, b);
-                assert read == length : read + " vs " + length;
-                return read;
-            });
+        final ByteRange rangeToRead = ByteRange.of(position, position + length);
+        assert rangeToRead.isSubRangeOf(rangeToWrite) : rangeToRead + " vs " + rangeToWrite;
+        assert rangeToRead.length() == b.remaining() : b.remaining() + " vs " + rangeToRead;
 
-            if (waitingForRead != null) {
-                final Integer read = waitingForRead.get();
-                assert read == length;
-                readComplete(position, length);
-                return;
-            }
+        final Future<Integer> populateCacheFuture = cacheFile.populateAndRead(
+            rangeToWrite,
+            rangeToRead,
+            channel -> readCacheFile(channel, position, b),
+            this::writeCacheFile,
+            directory.cacheFetchAsyncExecutor()
+        );
 
-            // Requested data is not on disk, so try the cache index next.
-            final ByteRange indexCacheMiss; // null if not a miss
-
-            final ByteRange blobCacheByteRange = maybeReadFromBlobCache(position, length);
-            if (blobCacheByteRange.isEmpty() == false) {
-                final CachedBlob cachedBlob = directory.getCachedBlob(fileInfo.physicalName(), blobCacheByteRange);
-                assert cachedBlob == CachedBlob.CACHE_MISS || cachedBlob == CachedBlob.CACHE_NOT_READY || cachedBlob.from() <= position;
-                assert cachedBlob == CachedBlob.CACHE_MISS || cachedBlob == CachedBlob.CACHE_NOT_READY || length <= cachedBlob.length();
-
-                if (cachedBlob == CachedBlob.CACHE_MISS || cachedBlob == CachedBlob.CACHE_NOT_READY) {
-                    // We would have liked to find a cached entry but we did not find anything: the cache on the disk will be requested
-                    // so we compute the region of the file we would like to have the next time. The region is expressed as a tuple of
-                    // {start, end} where positions are relative to the whole file.
-                    indexCacheMiss = blobCacheByteRange;
-
-                    // We must fill in a cache miss even if CACHE_NOT_READY since the cache index is only created on the first put.
-                    // TODO TBD use a different trigger for creating the cache index and avoid a put in the CACHE_NOT_READY case.
-                } else {
-                    logger.trace(
-                        "reading [{}] bytes of file [{}] at position [{}] using cache index",
-                        length,
-                        fileInfo.physicalName(),
-                        position
-                    );
-                    stats.addIndexCacheBytesRead(cachedBlob.length());
-                    try {
-                        final int sliceOffset = toIntBytes(position - cachedBlob.from());
-                        final BytesRefIterator cachedBytesIterator = cachedBlob.bytes().slice(sliceOffset, length).iterator();
-                        BytesRef bytesRef;
-                        while ((bytesRef = cachedBytesIterator.next()) != null) {
-                            b.put(bytesRef.bytes, bytesRef.offset, bytesRef.length);
-                        }
-                        assert b.position() == length : "copied " + b.position() + " but expected " + length;
-
-                        final ByteRange cachedRange = ByteRange.of(cachedBlob.from(), cachedBlob.to());
-                        cacheFile.populateAndRead(
-                            cachedRange,
-                            cachedRange,
-                            channel -> cachedBlob.length(),
-                            (channel, from, to, progressUpdater) -> {
-                                final long startTimeNanos = stats.currentTimeNanos();
-                                final BytesRefIterator iterator = cachedBlob.bytes()
-                                    .slice(toIntBytes(from - cachedBlob.from()), toIntBytes(to - from))
-                                    .iterator();
-                                long writePosition = from;
-                                BytesRef current;
-                                while ((current = iterator.next()) != null) {
-                                    final ByteBuffer byteBuffer = ByteBuffer.wrap(current.bytes, current.offset, current.length);
-                                    while (byteBuffer.remaining() > 0) {
-                                        writePosition += positionalWrite(channel, writePosition, byteBuffer);
-                                        progressUpdater.accept(writePosition);
-                                    }
-                                }
-                                assert writePosition == to : writePosition + " vs " + to;
-                                final long endTimeNanos = stats.currentTimeNanos();
-                                stats.addCachedBytesWritten(to - from, endTimeNanos - startTimeNanos);
-                                logger.trace("copied bytes [{}-{}] of file [{}] from cache index to disk", from, to, fileInfo);
-                            },
-                            directory.cacheFetchAsyncExecutor()
-                        );
-                    } catch (Exception e) {
-                        logger.debug(
-                            new ParameterizedMessage(
-                                "failed to store bytes [{}-{}] of file [{}] obtained from index cache",
-                                cachedBlob.from(),
-                                cachedBlob.to(),
-                                fileInfo
-                            ),
-                            e
-                        );
-                        // oh well, no big deal, at least we can return them to the caller.
-                    }
-
-                    readComplete(position, length);
-
-                    return;
-                }
-            } else {
-                // requested range is not eligible for caching
-                indexCacheMiss = null;
-            }
-
-            // Requested data is also not in the cache index, so we must visit the blob store to satisfy both the target range and any
-            // miss in the cache index.
-
-            final ByteRange startRangeToWrite = computeRange(position);
-            final ByteRange endRangeToWrite = computeRange(position + length - 1);
-            assert startRangeToWrite.end() <= endRangeToWrite.end() : startRangeToWrite + " vs " + endRangeToWrite;
-
-            // only request what's needed to fill the cache to make sure the cache is always fully populated during recovery
-            final ByteRange rangeToWrite = indexCacheMiss != null && directory.isRecoveryFinalized() == false
-                ? indexCacheMiss
-                : startRangeToWrite.minEnvelope(endRangeToWrite);
-
-            final ByteRange rangeToRead = ByteRange.of(position, position + length);
-            assert rangeToRead.isSubRangeOf(rangeToWrite) : rangeToRead + " vs " + rangeToWrite;
-            assert rangeToRead.length() == b.remaining() : b.remaining() + " vs " + rangeToRead;
-
-            final Future<Integer> populateCacheFuture = cacheFile.populateAndRead(
-                rangeToWrite,
-                rangeToRead,
-                channel -> readCacheFile(channel, position, b),
-                this::writeCacheFile,
-                directory.cacheFetchAsyncExecutor()
-            );
-
-            if (indexCacheMiss != null) {
-                fillIndexCache(cacheFile, indexCacheMiss);
-                if (compoundFileOffset > 0L
-                    && indexCacheMiss.equals(headerBlobCacheByteRange)
-                    && footerBlobCacheByteRange.isEmpty() == false) {
-                    fillIndexCache(cacheFile, footerBlobCacheByteRange);
-                }
-            }
-
-            final int bytesRead = populateCacheFuture.get();
-            assert bytesRead == length : bytesRead + " vs " + length;
-        } catch (final Exception e) {
-            // may have partially filled the buffer before the exception was thrown, so try and get the remainder directly.
-            final int alreadyRead = length - b.remaining();
-            final int bytesRead = readDirectlyIfAlreadyClosed(position + alreadyRead, b, e);
-            assert alreadyRead + bytesRead == length : alreadyRead + " + " + bytesRead + " vs " + length;
-
-            // In principle we could handle an index cache miss here too, ensuring that the direct read was large enough, but this is
-            // already a rare case caused by an overfull/undersized cache.
-        }
-
-        readComplete(position, length);
-    }
-
-    private void fillIndexCache(CacheFile cacheFile, ByteRange indexCacheMiss) {
-        final Releasable onCacheFillComplete = stats.addIndexCacheFill();
-        final Future<Integer> readFuture = cacheFile.readIfAvailableOrPending(indexCacheMiss, channel -> {
-            final int indexCacheMissLength = toIntBytes(indexCacheMiss.length());
-
-            // We assume that we only cache small portions of blobs so that we do not need to:
-            // - use a BigArrays for allocation
-            // - use an intermediate copy buffer to read the file in sensibly-sized chunks
-            // - release the buffer once the indexing operation is complete
-
-            final ByteBuffer byteBuffer = ByteBuffer.allocate(indexCacheMissLength);
-            Channels.readFromFileChannelWithEofException(channel, indexCacheMiss.start(), byteBuffer);
-            // NB use Channels.readFromFileChannelWithEofException not readCacheFile() to avoid counting this in the stats
-            byteBuffer.flip();
-            final BytesReference content = BytesReference.fromByteBuffer(byteBuffer);
-            directory.putCachedBlob(fileInfo.physicalName(), indexCacheMiss.start(), content, new ActionListener<Void>() {
-                @Override
-                public void onResponse(Void response) {
-                    onCacheFillComplete.close();
-                }
-
-                @Override
-                public void onFailure(Exception e1) {
-                    onCacheFillComplete.close();
-                }
-            });
-            return indexCacheMissLength;
-        });
-
-        if (readFuture == null) {
-            // Normally doesn't happen, we're already obtaining a range covering all cache misses above, but theoretically
-            // possible in the case that the real populateAndRead call already failed to obtain this range of the file. In that
-            // case, simply move on.
-            onCacheFillComplete.close();
-        }
-    }
-
-    private void readComplete(long position, int length) {
-        stats.incrementBytesRead(lastReadPosition, position, length);
-        lastReadPosition = position + length;
-        lastSeekPosition = lastReadPosition;
-    }
-
-    private int readDirectlyIfAlreadyClosed(long position, ByteBuffer b, Exception e) throws IOException {
-        if (e instanceof AlreadyClosedException || (e.getCause() != null && e.getCause() instanceof AlreadyClosedException)) {
-            try {
-                // cache file was evicted during the range fetching, read bytes directly from blob container
-                final long length = b.remaining();
-                final byte[] copyBuffer = new byte[toIntBytes(Math.min(COPY_BUFFER_SIZE, length))];
-                logger.trace(
-                    () -> new ParameterizedMessage(
-                        "direct reading of range [{}-{}] for cache file [{}]",
-                        position,
-                        position + length,
-                        cacheFileReference
-                    )
-                );
-
-                int bytesCopied = 0;
-                final long startTimeNanos = stats.currentTimeNanos();
-                try (InputStream input = openInputStreamFromBlobStore(position, length)) {
-                    long remaining = length;
-                    while (remaining > 0) {
-                        final int len = (remaining < copyBuffer.length) ? (int) remaining : copyBuffer.length;
-                        int bytesRead = input.read(copyBuffer, 0, len);
-                        if (bytesRead == -1) {
-                            throw new EOFException(
-                                String.format(
-                                    Locale.ROOT,
-                                    "unexpected EOF reading [%d-%d] ([%d] bytes remaining) from %s",
-                                    position,
-                                    position + length,
-                                    remaining,
-                                    cacheFileReference
-                                )
-                            );
-                        }
-                        b.put(copyBuffer, 0, bytesRead);
-                        bytesCopied += bytesRead;
-                        remaining -= bytesRead;
-                        assert remaining == b.remaining() : remaining + " vs " + b.remaining();
-                    }
-                    final long endTimeNanos = stats.currentTimeNanos();
-                    stats.addDirectBytesRead(bytesCopied, endTimeNanos - startTimeNanos);
-                }
-                return bytesCopied;
-            } catch (Exception inner) {
-                e.addSuppressed(inner);
-            }
-        }
-        throw new IOException("failed to read data from cache", e);
+        final int bytesRead = populateCacheFuture.get();
+        assert bytesRead == length : bytesRead + " vs " + length;
     }
 
     /**
@@ -474,44 +216,6 @@ public class CachedBlobContainerIndexInput extends BaseSearchableSnapshotIndexIn
         }
     }
 
-    @SuppressForbidden(reason = "Use positional writes on purpose")
-    private static int positionalWrite(FileChannel fc, long start, ByteBuffer byteBuffer) throws IOException {
-        assert assertCurrentThreadMayWriteCacheFile();
-        return fc.write(byteBuffer, start);
-    }
-
-    /**
-     * Perform a single {@code read()} from {@code inputStream} into {@code copyBuffer}, handling an EOF by throwing an {@link EOFException}
-     * rather than returning {@code -1}. Returns the number of bytes read, which is always positive.
-     *
-     * Most of its arguments are there simply to make the message of the {@link EOFException} more informative.
-     */
-    private static int readSafe(
-        InputStream inputStream,
-        byte[] copyBuffer,
-        long rangeStart,
-        long rangeEnd,
-        long remaining,
-        CacheFileReference cacheFileReference
-    ) throws IOException {
-        final int len = (remaining < copyBuffer.length) ? toIntBytes(remaining) : copyBuffer.length;
-        final int bytesRead = inputStream.read(copyBuffer, 0, len);
-        if (bytesRead == -1) {
-            throw new EOFException(
-                String.format(
-                    Locale.ROOT,
-                    "unexpected EOF reading [%d-%d] ([%d] bytes remaining) from %s",
-                    rangeStart,
-                    rangeEnd,
-                    remaining,
-                    cacheFileReference
-                )
-            );
-        }
-        assert bytesRead > 0 : bytesRead;
-        return bytesRead;
-    }
-
     /**
      * Asserts that the range of bytes to warm in cache is aligned with {@link #fileInfo}'s part size.
      */
@@ -528,60 +232,6 @@ public class CachedBlobContainerIndexInput extends BaseSearchableSnapshotIndexIn
                 + "] is not aligned with part end or with file length";
         }
         return true;
-    }
-
-    private int readCacheFile(final FileChannel fc, final long position, final ByteBuffer buffer) throws IOException {
-        assert assertFileChannelOpen(fc);
-        final int bytesRead = Channels.readFromFileChannel(fc, position, buffer);
-        if (bytesRead == -1) {
-            throw new EOFException(
-                String.format(
-                    Locale.ROOT,
-                    "unexpected EOF reading [%d-%d] from %s",
-                    position,
-                    position + buffer.remaining(),
-                    cacheFileReference
-                )
-            );
-        }
-        stats.addCachedBytesRead(bytesRead);
-        return bytesRead;
-    }
-
-    private void writeCacheFile(final FileChannel fc, final long start, final long end, final Consumer<Long> progressUpdater)
-        throws IOException {
-        assert assertFileChannelOpen(fc);
-        assert assertCurrentThreadMayWriteCacheFile();
-        final long length = end - start;
-        final byte[] copyBuffer = new byte[toIntBytes(Math.min(COPY_BUFFER_SIZE, length))];
-        logger.trace(() -> new ParameterizedMessage("writing range [{}-{}] to cache file [{}]", start, end, cacheFileReference));
-
-        long bytesCopied = 0L;
-        long remaining = end - start;
-        final long startTimeNanos = stats.currentTimeNanos();
-        try (InputStream input = openInputStreamFromBlobStore(start, length)) {
-            while (remaining > 0L) {
-                final int bytesRead = readSafe(input, copyBuffer, start, end, remaining, cacheFileReference);
-                positionalWrite(fc, start + bytesCopied, ByteBuffer.wrap(copyBuffer, 0, bytesRead));
-                bytesCopied += bytesRead;
-                remaining -= bytesRead;
-                progressUpdater.accept(start + bytesCopied);
-            }
-            final long endTimeNanos = stats.currentTimeNanos();
-            stats.addCachedBytesWritten(bytesCopied, endTimeNanos - startTimeNanos);
-        }
-    }
-
-    @Override
-    protected void seekInternal(long pos) throws IOException {
-        if (pos > length()) {
-            throw new EOFException("Reading past end of file [position=" + pos + ", length=" + length() + "] for " + toString());
-        } else if (pos < 0L) {
-            throw new IOException("Seeking to negative position [" + pos + "] for " + toString());
-        }
-        final long position = pos + this.offset;
-        stats.incrementSeeks(lastSeekPosition, position);
-        lastSeekPosition = position;
     }
 
     @Override
@@ -619,7 +269,7 @@ public class CachedBlobContainerIndexInput extends BaseSearchableSnapshotIndexIn
         if (sliceCompoundFile) {
             sliceCompoundFileOffset = this.offset + sliceOffset;
             sliceHeaderByteRange = directory.getBlobCacheByteRange(sliceName, sliceLength).shift(sliceCompoundFileOffset);
-            if (sliceHeaderByteRange.length() < sliceLength) {
+            if (sliceHeaderByteRange.isEmpty() == false && sliceHeaderByteRange.length() < sliceLength) {
                 sliceFooterByteRange = ByteRange.of(sliceLength - CodecUtil.footerLength(), sliceLength).shift(sliceCompoundFileOffset);
             } else {
                 sliceFooterByteRange = ByteRange.EMPTY;
@@ -665,83 +315,5 @@ public class CachedBlobContainerIndexInput extends BaseSearchableSnapshotIndexIn
                 )
                 : null)
             + ']';
-    }
-
-    private static class CacheFileReference implements CacheFile.EvictionListener {
-
-        private final long fileLength;
-        private final CacheKey cacheKey;
-        private final SearchableSnapshotDirectory directory;
-        private final AtomicReference<CacheFile> cacheFile = new AtomicReference<>(); // null if evicted or not yet acquired
-
-        private CacheFileReference(SearchableSnapshotDirectory directory, String fileName, long fileLength) {
-            this.cacheKey = directory.createCacheKey(fileName);
-            this.fileLength = fileLength;
-            this.directory = directory;
-        }
-
-        CacheFile get() throws Exception {
-            CacheFile currentCacheFile = cacheFile.get();
-            if (currentCacheFile != null) {
-                return currentCacheFile;
-            }
-
-            final CacheFile newCacheFile = directory.getCacheFile(cacheKey, fileLength);
-            synchronized (this) {
-                currentCacheFile = cacheFile.get();
-                if (currentCacheFile != null) {
-                    return currentCacheFile;
-                }
-                newCacheFile.acquire(this);
-                final CacheFile previousCacheFile = cacheFile.getAndSet(newCacheFile);
-                assert previousCacheFile == null;
-                return newCacheFile;
-            }
-        }
-
-        @Override
-        public void onEviction(final CacheFile evictedCacheFile) {
-            synchronized (this) {
-                if (cacheFile.compareAndSet(evictedCacheFile, null)) {
-                    evictedCacheFile.release(this);
-                }
-            }
-        }
-
-        void releaseOnClose() {
-            synchronized (this) {
-                final CacheFile currentCacheFile = cacheFile.getAndSet(null);
-                if (currentCacheFile != null) {
-                    currentCacheFile.release(this);
-                }
-            }
-        }
-
-        @Override
-        public String toString() {
-            return "CacheFileReference{"
-                + "cacheKey='"
-                + cacheKey
-                + '\''
-                + ", fileLength="
-                + fileLength
-                + ", acquired="
-                + (cacheFile.get() != null)
-                + '}';
-        }
-    }
-
-    private static boolean assertFileChannelOpen(FileChannel fileChannel) {
-        assert fileChannel != null;
-        assert fileChannel.isOpen();
-        return true;
-    }
-
-    private static boolean assertCurrentThreadMayWriteCacheFile() {
-        final String threadName = Thread.currentThread().getName();
-        assert isCacheFetchAsyncThread(threadName) : "expected the current thread ["
-            + threadName
-            + "] to belong to the cache fetch async thread pool";
-        return true;
     }
 }

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/FrozenIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/FrozenIndexInput.java
@@ -12,20 +12,10 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.index.IndexFileNames;
-import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
-import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.BytesRefIterator;
-import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.StepListener;
-import org.elasticsearch.blobstore.cache.BlobStoreCacheService;
-import org.elasticsearch.blobstore.cache.CachedBlob;
-import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.lease.Releasable;
-import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot.FileInfo;
-import org.elasticsearch.index.store.BaseSearchableSnapshotIndexInput;
 import org.elasticsearch.index.store.IndexInputStats;
 import org.elasticsearch.index.store.SearchableSnapshotDirectory;
 import org.elasticsearch.xpack.searchablesnapshots.cache.ByteRange;
@@ -43,27 +33,11 @@ import java.util.function.Consumer;
 
 import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsUtils.toIntBytes;
 
-public class FrozenIndexInput extends BaseSearchableSnapshotIndexInput {
-
-    public static final IOContext CACHE_WARMING_CONTEXT = new IOContext();
+public class FrozenIndexInput extends MetadataCachingIndexInput {
 
     private static final Logger logger = LogManager.getLogger(FrozenIndexInput.class);
-    private static final int COPY_BUFFER_SIZE = ByteSizeUnit.KB.toIntBytes(8);
 
     private final FrozenCacheFile frozenCacheFile;
-    private final int defaultRangeSize;
-    private final int recoveryRangeSize;
-
-    /**
-     * If > 0, represents a logical file within a compound (CFS) file or is a slice thereof represents the offset of the logical
-     * compound file within the physical CFS file
-     */
-    private final long compoundFileOffset;
-
-    // last read position is kept around in order to detect (non)contiguous reads for stats
-    private long lastReadPosition;
-    // last seek position is kept around in order to detect forward/backward seeks for stats
-    private long lastSeekPosition;
 
     public FrozenIndexInput(
         String name,
@@ -83,13 +57,13 @@ public class FrozenIndexInput extends BaseSearchableSnapshotIndexInput {
             0L,
             0L,
             fileInfo.length(),
+            new CacheFileReference(directory, fileInfo.physicalName(), fileInfo.length()),
             directory.getFrozenCacheFile(name, fileInfo.length()),
             rangeSize,
             recoveryRangeSize,
             directory.getBlobCacheByteRange(name, fileInfo.length()),
             ByteRange.EMPTY
         );
-        assert getBufferSize() <= BlobStoreCacheService.DEFAULT_CACHED_BLOB_SIZE; // must be able to cache at least one buffer's worth
         stats.incrementOpenCount();
     }
 
@@ -102,48 +76,46 @@ public class FrozenIndexInput extends BaseSearchableSnapshotIndexInput {
         long offset,
         long compoundFileOffset,
         long length,
+        CacheFileReference cacheFileReference,
         FrozenCacheFile frozenCacheFile,
-        int rangeSize,
+        int defaultRangeSize,
         int recoveryRangeSize,
         ByteRange headerBlobCacheByteRange,
         ByteRange footerBlobCacheByteRange
     ) {
-        super(logger, name, directory, fileInfo, context, stats, offset, length, headerBlobCacheByteRange, footerBlobCacheByteRange);
+        super(
+            logger,
+            name,
+            directory,
+            fileInfo,
+            context,
+            stats,
+            offset,
+            compoundFileOffset,
+            length,
+            cacheFileReference,
+            defaultRangeSize,
+            recoveryRangeSize,
+            headerBlobCacheByteRange,
+            footerBlobCacheByteRange
+        );
         this.frozenCacheFile = frozenCacheFile;
-        this.lastReadPosition = this.offset;
-        this.lastSeekPosition = this.offset;
-        this.defaultRangeSize = rangeSize;
-        this.recoveryRangeSize = recoveryRangeSize;
-        this.compoundFileOffset = compoundFileOffset;
-        assert offset >= compoundFileOffset;
     }
 
     @Override
-    public void doClose() {
-        // nothing needed to be done here
-    }
-
-    private long getDefaultRangeSize() {
+    protected long getDefaultRangeSize() {
         return directory.isRecoveryFinalized() ? defaultRangeSize : recoveryRangeSize;
     }
 
-    private ByteRange computeRange(long position) {
-        final long rangeSize = getDefaultRangeSize();
-        long start = (position / rangeSize) * rangeSize;
-        long end = Math.min(start + rangeSize, frozenCacheFile.getLength());
-        return ByteRange.of(start, end);
-    }
-
     @Override
-    protected void doReadInternal(ByteBuffer b) throws IOException {
-        ensureContext(ctx -> ctx != CACHE_WARMING_CONTEXT);
-        final long position = getAbsolutePosition() - compoundFileOffset;
+    protected void readWithoutBlobCache(ByteBuffer b) throws Exception {
+        final long position = getAbsolutePosition();
         final int length = b.remaining();
 
         final ReentrantReadWriteLock luceneByteBufLock = new ReentrantReadWriteLock();
         final AtomicBoolean stopAsyncReads = new AtomicBoolean();
         // Runnable that, when called, ensures that async callbacks (such as those used by readCacheFile) are not
-        // accessing the byte buffer anymore that was passed to readInternal
+        // accessing the byte buffer anymore that was passed to readWithoutBlobCache
         // In particular, it's important to call this method before adapting the ByteBuffer's offset
         final Runnable preventAsyncBufferChanges = () -> {
             luceneByteBufLock.writeLock().lock();
@@ -154,113 +126,13 @@ public class FrozenIndexInput extends BaseSearchableSnapshotIndexInput {
             }
         };
 
-        final String fileName = frozenCacheFile.getCacheKey().getFileName();
         logger.trace("readInternal: read [{}-{}] ([{}] bytes) from [{}]", position, position + length, length, this);
 
         try {
-            // Can we serve the read directly from disk? If so, do so and don't worry about anything else.
-
-            final StepListener<Integer> waitingForRead = frozenCacheFile.readIfAvailableOrPending(
-                ByteRange.of(position, position + length),
-                (channel, pos, relativePos, len) -> {
-                    final int read = readCacheFile(channel, pos, relativePos, len, b, position, true, luceneByteBufLock, stopAsyncReads);
-                    assert read <= length : read + " vs " + length;
-                    return read;
-                }
-            );
-
-            if (waitingForRead != null) {
-                final Integer read = waitingForRead.asFuture().get();
-                assert read == length;
-                assert luceneByteBufLock.getReadHoldCount() == 0;
-                preventAsyncBufferChanges.run();
-                b.position(read); // mark all bytes as accounted for
-                readComplete(position, length);
-                return;
-            }
-
-            // Requested data is not on disk, so try the cache index next.
-            final ByteRange indexCacheMiss; // null if not a miss
-
-            final ByteRange blobCacheByteRange = maybeReadFromBlobCache(position, length);
-            if (blobCacheByteRange != ByteRange.EMPTY) {
-                final CachedBlob cachedBlob = directory.getCachedBlob(fileName, blobCacheByteRange);
-                assert cachedBlob == CachedBlob.CACHE_MISS || cachedBlob == CachedBlob.CACHE_NOT_READY || cachedBlob.from() <= position;
-                assert cachedBlob == CachedBlob.CACHE_MISS || cachedBlob == CachedBlob.CACHE_NOT_READY || length <= cachedBlob.length();
-
-                if (cachedBlob == CachedBlob.CACHE_MISS || cachedBlob == CachedBlob.CACHE_NOT_READY) {
-                    // We would have liked to find a cached entry but we did not find anything: the cache on the disk will be requested
-                    // so we compute the region of the file we would like to have the next time. The region is expressed as a tuple of
-                    // {start, end} where positions are relative to the whole file.
-                    indexCacheMiss = blobCacheByteRange;
-
-                    // We must fill in a cache miss even if CACHE_NOT_READY since the cache index is only created on the first put.
-                    // TODO TBD use a different trigger for creating the cache index and avoid a put in the CACHE_NOT_READY case.
-                } else {
-                    logger.trace("reading [{}] bytes of file [{}] at position [{}] using cache index", length, fileName, position);
-                    stats.addIndexCacheBytesRead(cachedBlob.length());
-
-                    preventAsyncBufferChanges.run();
-                    try {
-                        final int sliceOffset = toIntBytes(position - cachedBlob.from());
-                        final BytesRefIterator cachedBytesIterator = cachedBlob.bytes().slice(sliceOffset, length).iterator();
-                        int copiedBytes = 0;
-                        BytesRef bytesRef;
-                        while ((bytesRef = cachedBytesIterator.next()) != null) {
-                            b.put(bytesRef.bytes, bytesRef.offset, bytesRef.length);
-                            copiedBytes += bytesRef.length;
-                        }
-                        assert copiedBytes == length : "copied " + copiedBytes + " but expected " + length;
-
-                        final ByteRange cachedRange = ByteRange.of(cachedBlob.from(), cachedBlob.to());
-                        frozenCacheFile.populateAndRead(
-                            cachedRange,
-                            cachedRange,
-                            (channel, channelPos, relativePos, len) -> Math.toIntExact(len),
-                            (channel, channelPos, relativePos, len, progressUpdater) -> {
-                                assert len <= cachedBlob.to() - cachedBlob.from();
-                                final long startTimeNanos = stats.currentTimeNanos();
-                                writeCacheFile(
-                                    channel,
-                                    cachedBlob.bytes().slice(toIntBytes(relativePos), toIntBytes(len)).streamInput(),
-                                    channelPos,
-                                    relativePos,
-                                    len,
-                                    progressUpdater,
-                                    startTimeNanos
-                                );
-                            },
-                            directory.cacheFetchAsyncExecutor()
-                        );
-                    } catch (Exception e) {
-                        logger.debug(
-                            new ParameterizedMessage(
-                                "failed to store bytes [{}-{}] of file [{}] obtained from index cache",
-                                cachedBlob.from(),
-                                cachedBlob.to(),
-                                fileName
-                            ),
-                            e
-                        );
-                        // oh well, no big deal, at least we can return them to the caller.
-                    }
-
-                    readComplete(position, length);
-
-                    return;
-                }
-            } else {
-                // requested range is not eligible for caching
-                indexCacheMiss = null;
-            }
-
-            // Requested data is also not in the cache index, so we must visit the blob store to satisfy both the target range and any
-            // miss in the cache index.
-
             final ByteRange startRangeToWrite = computeRange(position);
             final ByteRange endRangeToWrite = computeRange(position + length - 1);
             assert startRangeToWrite.end() <= endRangeToWrite.end() : startRangeToWrite + " vs " + endRangeToWrite;
-            final ByteRange rangeToWrite = startRangeToWrite.minEnvelope(endRangeToWrite).minEnvelope(indexCacheMiss);
+            final ByteRange rangeToWrite = startRangeToWrite.minEnvelope(endRangeToWrite);
 
             assert rangeToWrite.start() <= position && position + length <= rangeToWrite.end() : "["
                 + position
@@ -286,7 +158,7 @@ public class FrozenIndexInput extends BaseSearchableSnapshotIndexInput {
                 ),
                 (channel, channelPos, relativePos, len, progressUpdater) -> {
                     final long startTimeNanos = stats.currentTimeNanos();
-                    final long streamStartPosition = rangeToWrite.start() + relativePos + compoundFileOffset;
+                    final long streamStartPosition = rangeToWrite.start() + relativePos;
 
                     try (InputStream input = openInputStreamFromBlobStore(streamStartPosition, len)) {
                         this.writeCacheFile(channel, input, channelPos, relativePos, len, progressUpdater, startTimeNanos);
@@ -295,154 +167,15 @@ public class FrozenIndexInput extends BaseSearchableSnapshotIndexInput {
                 directory.cacheFetchAsyncExecutor()
             );
 
-            if (indexCacheMiss != null) {
-
-                fillIndexCache(fileName, indexCacheMiss);
-                if (compoundFileOffset > 0L
-                    && indexCacheMiss.equals(headerBlobCacheByteRange)
-                    && footerBlobCacheByteRange != ByteRange.EMPTY) {
-                    fillIndexCache(fileName, footerBlobCacheByteRange);
-                }
-            }
-
             final int bytesRead = populateCacheFuture.asFuture().get();
             assert bytesRead == length : bytesRead + " vs " + length;
             assert luceneByteBufLock.getReadHoldCount() == 0;
 
             preventAsyncBufferChanges.run();
             b.position(bytesRead); // mark all bytes as accounted for
-        } catch (final Exception e) {
+        } finally {
             preventAsyncBufferChanges.run();
-
-            // may have partially filled the buffer before the exception was thrown, so try and get the remainder directly.
-            final int alreadyRead = length - b.remaining();
-            final int bytesRead = readDirectlyIfAlreadyClosed(position + alreadyRead, b, e);
-            assert alreadyRead + bytesRead == length : alreadyRead + " + " + bytesRead + " vs " + length;
-
-            // In principle we could handle an index cache miss here too, ensuring that the direct read was large enough, but this is
-            // already a rare case caused by an overfull/undersized cache.
         }
-
-        readComplete(position, length);
-    }
-
-    private void fillIndexCache(String fileName, ByteRange indexCacheMiss) {
-        final Releasable onCacheFillComplete = stats.addIndexCacheFill();
-        final int indexCacheMissLength = toIntBytes(indexCacheMiss.length());
-
-        // We assume that we only cache small portions of blobs so that we do not need to:
-        // - use a BigArrays for allocation
-        // - use an intermediate copy buffer to read the file in sensibly-sized chunks
-        // - release the buffer once the indexing operation is complete
-        final ByteBuffer byteBuffer = ByteBuffer.allocate(indexCacheMissLength);
-
-        final StepListener<Integer> readListener = frozenCacheFile.readIfAvailableOrPending(
-            indexCacheMiss,
-            (channel, channelPos, relativePos, len) -> {
-                assert len <= indexCacheMissLength;
-
-                if (len == 0) {
-                    return 0;
-                }
-
-                // create slice that is positioned to read the given values
-                final ByteBuffer dup = byteBuffer.duplicate();
-                final int newPosition = dup.position() + Math.toIntExact(relativePos);
-                assert newPosition <= dup.limit() : "newpos " + newPosition + " limit " + dup.limit();
-                assert newPosition + len <= byteBuffer.limit();
-                dup.position(newPosition);
-                dup.limit(newPosition + Math.toIntExact(len));
-
-                final int read = channel.read(dup, channelPos);
-                if (read < 0) {
-                    throw new EOFException("read past EOF. pos [" + relativePos + "] length: [" + len + "]");
-                }
-                // NB use Channels.readFromFileChannelWithEofException not readCacheFile() to avoid counting this in the stats
-                assert read == len;
-                return read;
-            }
-        );
-
-        if (readListener == null) {
-            // Normally doesn't happen, we're already obtaining a range covering all cache misses above, but theoretically
-            // possible in the case that the real populateAndRead call already failed to obtain this range of the file. In that
-            // case, simply move on.
-            onCacheFillComplete.close();
-        } else {
-            readListener.whenComplete(read -> {
-                assert read == indexCacheMissLength;
-                byteBuffer.position(read); // mark all bytes as accounted for
-                byteBuffer.flip();
-                final BytesReference content = BytesReference.fromByteBuffer(byteBuffer);
-                directory.putCachedBlob(fileName, indexCacheMiss.start(), content, new ActionListener<Void>() {
-                    @Override
-                    public void onResponse(Void response) {
-                        onCacheFillComplete.close();
-                    }
-
-                    @Override
-                    public void onFailure(Exception e1) {
-                        onCacheFillComplete.close();
-                    }
-                });
-            }, e -> onCacheFillComplete.close());
-        }
-    }
-
-    private void readComplete(long position, int length) {
-        stats.incrementBytesRead(lastReadPosition, position, length);
-        lastReadPosition = position + length;
-        lastSeekPosition = lastReadPosition;
-    }
-
-    private int readDirectlyIfAlreadyClosed(long position, ByteBuffer b, Exception e) throws IOException {
-        if (e instanceof AlreadyClosedException || (e.getCause() != null && e.getCause() instanceof AlreadyClosedException)) {
-            try {
-                // cache file was evicted during the range fetching, read bytes directly from blob container
-                final long length = b.remaining();
-                final byte[] copyBuffer = new byte[toIntBytes(Math.min(COPY_BUFFER_SIZE, length))];
-                logger.trace(
-                    () -> new ParameterizedMessage(
-                        "direct reading of range [{}-{}] for cache file [{}]",
-                        position,
-                        position + length,
-                        frozenCacheFile
-                    )
-                );
-
-                int bytesCopied = 0;
-                final long startTimeNanos = stats.currentTimeNanos();
-                try (InputStream input = openInputStreamFromBlobStore(position + compoundFileOffset, length)) {
-                    long remaining = length;
-                    while (remaining > 0) {
-                        final int len = (remaining < copyBuffer.length) ? (int) remaining : copyBuffer.length;
-                        int bytesRead = input.read(copyBuffer, 0, len);
-                        if (bytesRead == -1) {
-                            throw new EOFException(
-                                String.format(
-                                    Locale.ROOT,
-                                    "unexpected EOF reading [%d-%d] ([%d] bytes remaining) from %s",
-                                    position,
-                                    position + length,
-                                    remaining,
-                                    frozenCacheFile
-                                )
-                            );
-                        }
-                        b.put(copyBuffer, 0, bytesRead);
-                        bytesCopied += bytesRead;
-                        remaining -= bytesRead;
-                        assert remaining == b.remaining() : remaining + " vs " + b.remaining();
-                    }
-                    final long endTimeNanos = stats.currentTimeNanos();
-                    stats.addDirectBytesRead(bytesCopied, endTimeNanos - startTimeNanos);
-                }
-                return bytesCopied;
-            } catch (Exception inner) {
-                e.addSuppressed(inner);
-            }
-        }
-        throw new IOException("failed to read data from cache", e);
     }
 
     private static int positionalWrite(SharedBytes.IO fc, long start, ByteBuffer byteBuffer) throws IOException {
@@ -591,31 +324,31 @@ public class FrozenIndexInput extends BaseSearchableSnapshotIndexInput {
         while (remaining > 0L) {
             final int bytesRead = readSafe(input, copyBuffer, relativePos, end, remaining, frozenCacheFile);
             if (bytesRead > buf.remaining()) {
+                // always fill up buf to the max
+                final int bytesToAdd = buf.remaining();
+                buf.put(copyBuffer, 0, bytesToAdd);
+                assert buf.remaining() == 0;
                 long bytesWritten = positionalWrite(fc, fileChannelPos + bytesCopied, buf);
                 bytesCopied += bytesWritten;
                 progressUpdater.accept(bytesCopied);
+                // add the remaining bytes to buf
+                buf.put(copyBuffer, bytesToAdd, bytesRead - bytesToAdd);
+            } else {
+                buf.put(copyBuffer, 0, bytesRead);
             }
-            buf.put(copyBuffer, 0, bytesRead);
             remaining -= bytesRead;
         }
+        // ensure that last write is aligned on 4k boundaries (= page size)
+        final int remainder = buf.position() % SharedBytes.PAGE_SIZE;
+        final int adjustment = remainder == 0 ? 0 : SharedBytes.PAGE_SIZE - remainder;
+        buf.position(buf.position() + adjustment);
         long bytesWritten = positionalWrite(fc, fileChannelPos + bytesCopied, buf);
         bytesCopied += bytesWritten;
-        progressUpdater.accept(bytesCopied);
+        final long adjustedBytesCopied = bytesCopied - adjustment; // adjust to not break RangeFileTracker
+        assert adjustedBytesCopied == length;
+        progressUpdater.accept(adjustedBytesCopied);
         final long endTimeNanos = stats.currentTimeNanos();
-        assert bytesCopied == length;
-        stats.addCachedBytesWritten(bytesCopied, endTimeNanos - startTimeNanos);
-    }
-
-    @Override
-    protected void seekInternal(long pos) throws IOException {
-        if (pos > length()) {
-            throw new EOFException("Reading past end of file [position=" + pos + ", length=" + length() + "] for " + toString());
-        } else if (pos < 0L) {
-            throw new IOException("Seeking to negative position [" + pos + "] for " + toString());
-        }
-        final long position = pos + this.offset - compoundFileOffset;
-        stats.incrementSeeks(lastSeekPosition, position);
-        lastSeekPosition = position;
+        stats.addCachedBytesWritten(adjustedBytesCopied, endTimeNanos - startTimeNanos);
     }
 
     @Override
@@ -646,23 +379,20 @@ public class FrozenIndexInput extends BaseSearchableSnapshotIndexInput {
             && compoundFileOffset == 0L // not already a compound file
             && isClone == false; // tests aggressively clone and slice
 
-        final FrozenCacheFile sliceFrozenCacheFile;
         final ByteRange sliceHeaderByteRange;
         final ByteRange sliceFooterByteRange;
         final long sliceCompoundFileOffset;
 
         if (sliceCompoundFile) {
             sliceCompoundFileOffset = this.offset + sliceOffset;
-            sliceFrozenCacheFile = directory.getFrozenCacheFile(sliceName, sliceLength);
-            sliceHeaderByteRange = directory.getBlobCacheByteRange(sliceName, sliceLength);
-            if (sliceHeaderByteRange.length() < sliceLength) {
-                sliceFooterByteRange = ByteRange.of(sliceLength - CodecUtil.footerLength(), sliceLength);
+            sliceHeaderByteRange = directory.getBlobCacheByteRange(sliceName, sliceLength).shift(sliceCompoundFileOffset);
+            if (sliceHeaderByteRange.isEmpty() == false && sliceHeaderByteRange.length() < sliceLength) {
+                sliceFooterByteRange = ByteRange.of(sliceLength - CodecUtil.footerLength(), sliceLength).shift(sliceCompoundFileOffset);
             } else {
                 sliceFooterByteRange = ByteRange.EMPTY;
             }
         } else {
             sliceCompoundFileOffset = this.compoundFileOffset;
-            sliceFrozenCacheFile = this.frozenCacheFile;
             sliceHeaderByteRange = ByteRange.EMPTY;
             sliceFooterByteRange = ByteRange.EMPTY;
         }
@@ -676,7 +406,8 @@ public class FrozenIndexInput extends BaseSearchableSnapshotIndexInput {
             this.offset + sliceOffset,
             sliceCompoundFileOffset,
             sliceLength,
-            sliceFrozenCacheFile,
+            cacheFileReference,
+            frozenCacheFile,
             defaultRangeSize,
             recoveryRangeSize,
             sliceHeaderByteRange,
@@ -686,11 +417,4 @@ public class FrozenIndexInput extends BaseSearchableSnapshotIndexInput {
         return slice;
     }
 
-    private static boolean assertCurrentThreadMayWriteCacheFile() {
-        final String threadName = Thread.currentThread().getName();
-        assert isCacheFetchAsyncThread(threadName) : "expected the current thread ["
-            + threadName
-            + "] to belong to the cache fetch async thread pool";
-        return true;
-    }
 }

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/MetadataCachingIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/MetadataCachingIndexInput.java
@@ -1,0 +1,504 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.index.store.cache;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.apache.lucene.store.AlreadyClosedException;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefIterator;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.blobstore.cache.BlobStoreCacheService;
+import org.elasticsearch.blobstore.cache.CachedBlob;
+import org.elasticsearch.common.SuppressForbidden;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.Channels;
+import org.elasticsearch.common.lease.Releasable;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot;
+import org.elasticsearch.index.store.BaseSearchableSnapshotIndexInput;
+import org.elasticsearch.index.store.IndexInputStats;
+import org.elasticsearch.index.store.SearchableSnapshotDirectory;
+import org.elasticsearch.xpack.searchablesnapshots.cache.ByteRange;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.util.Locale;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsUtils.toIntBytes;
+
+/**
+ * Searchable snapshots index input that supports fully caching metadata files as well as header/footer information for each file,
+ * consisting of a two-level cache (BlobStoreCacheService and CacheService).
+ */
+public abstract class MetadataCachingIndexInput extends BaseSearchableSnapshotIndexInput {
+
+    protected static final int COPY_BUFFER_SIZE = ByteSizeUnit.KB.toIntBytes(8);
+
+    protected final CacheFileReference cacheFileReference;
+
+    /**
+     * If > 0, represents a logical file within a compound (CFS) file or is a slice thereof represents the offset of the logical
+     * compound file within the physical CFS file
+     */
+    protected final long compoundFileOffset;
+
+    protected final int defaultRangeSize;
+    protected final int recoveryRangeSize;
+
+    // last read position is kept around in order to detect (non)contiguous reads for stats
+    protected long lastReadPosition;
+    // last seek position is kept around in order to detect forward/backward seeks for stats
+    protected long lastSeekPosition;
+
+    public MetadataCachingIndexInput(
+        Logger logger,
+        String name,
+        SearchableSnapshotDirectory directory,
+        BlobStoreIndexShardSnapshot.FileInfo fileInfo,
+        IOContext context,
+        IndexInputStats stats,
+        long offset,
+        long compoundFileOffset,
+        long length,
+        CacheFileReference cacheFileReference,
+        int defaultRangeSize,
+        int recoveryRangeSize,
+        ByteRange headerBlobCacheByteRange,
+        ByteRange footerBlobCacheByteRange
+    ) {
+        super(logger, name, directory, fileInfo, context, stats, offset, length, headerBlobCacheByteRange, footerBlobCacheByteRange);
+        this.cacheFileReference = cacheFileReference;
+        this.compoundFileOffset = compoundFileOffset;
+        this.defaultRangeSize = defaultRangeSize;
+        this.recoveryRangeSize = recoveryRangeSize;
+        this.lastReadPosition = offset;
+        this.lastSeekPosition = offset;
+        assert offset >= compoundFileOffset;
+        assert getBufferSize() <= BlobStoreCacheService.DEFAULT_CACHED_BLOB_SIZE; // must be able to cache at least one buffer's worth
+    }
+
+    @Override
+    protected void doReadInternal(ByteBuffer b) throws IOException {
+        final long position = getAbsolutePosition();
+        final int length = b.remaining();
+
+        logger.trace("readInternal: read [{}-{}] ([{}] bytes) from [{}]", position, position + length, length, this);
+
+        try {
+            final ByteRange blobCacheByteRange = rangeToReadFromBlobCache(position, length);
+            if (blobCacheByteRange.isEmpty()) {
+                readWithoutBlobCache(b);
+            } else {
+                readWithBlobCache(b, blobCacheByteRange);
+            }
+        } catch (final Exception e) {
+            // may have partially filled the buffer before the exception was thrown, so try and get the remainder directly.
+            final int alreadyRead = length - b.remaining();
+            final int bytesRead = readDirectlyIfAlreadyClosed(position + alreadyRead, b, e);
+            assert alreadyRead + bytesRead == length : alreadyRead + " + " + bytesRead + " vs " + length;
+        }
+
+        readComplete(position, length);
+    }
+
+    protected abstract void readWithoutBlobCache(ByteBuffer b) throws Exception;
+
+    private void readWithBlobCache(ByteBuffer b, ByteRange blobCacheByteRange) throws Exception {
+        final long position = getAbsolutePosition();
+        final int length = b.remaining();
+
+        final CacheFile cacheFile = cacheFileReference.get();
+
+        // Can we serve the read directly from disk? If so, do so and don't worry about anything else.
+        final Future<Integer> waitingForRead = cacheFile.readIfAvailableOrPending(ByteRange.of(position, position + length), chan -> {
+            final int read = readCacheFile(chan, position, b);
+            assert read == length : read + " vs " + length;
+            return read;
+        });
+
+        if (waitingForRead != null) {
+            final Integer read = waitingForRead.get();
+            assert read == length;
+            return;
+        }
+
+        final CachedBlob cachedBlob = directory.getCachedBlob(fileInfo.physicalName(), blobCacheByteRange);
+        assert cachedBlob == CachedBlob.CACHE_MISS || cachedBlob == CachedBlob.CACHE_NOT_READY || cachedBlob.from() <= position;
+        assert cachedBlob == CachedBlob.CACHE_MISS || cachedBlob == CachedBlob.CACHE_NOT_READY || length <= cachedBlob.length();
+
+        if (cachedBlob == CachedBlob.CACHE_MISS || cachedBlob == CachedBlob.CACHE_NOT_READY) {
+            // We would have liked to find a cached entry but we did not find anything: the cache on the disk will be requested
+            // so we compute the region of the file we would like to have the next time. The region is expressed as a tuple of
+            // {start, end} where positions are relative to the whole file.
+
+            // We must fill in a cache miss even if CACHE_NOT_READY since the cache index is only created on the first put.
+            // TODO TBD use a different trigger for creating the cache index and avoid a put in the CACHE_NOT_READY case.
+            final ByteRange rangeToWrite = blobCacheByteRange;
+            final ByteRange rangeToRead = ByteRange.of(position, position + length);
+            assert rangeToRead.isSubRangeOf(rangeToWrite) : rangeToRead + " vs " + rangeToWrite;
+            assert rangeToRead.length() == b.remaining() : b.remaining() + " vs " + rangeToRead;
+
+            final Future<Integer> populateCacheFuture = cacheFile.populateAndRead(
+                rangeToWrite,
+                rangeToRead,
+                channel -> readCacheFile(channel, position, b),
+                this::writeCacheFile,
+                directory.cacheFetchAsyncExecutor()
+            );
+
+            fillIndexCache(cacheFile, blobCacheByteRange);
+            if (compoundFileOffset > 0L
+                && blobCacheByteRange.equals(headerBlobCacheByteRange)
+                && footerBlobCacheByteRange.isEmpty() == false) {
+                fillIndexCache(cacheFile, footerBlobCacheByteRange);
+            }
+
+            final int bytesRead = populateCacheFuture.get();
+            assert bytesRead == length : bytesRead + " vs " + length;
+        } else {
+            logger.trace("reading [{}] bytes of file [{}] at position [{}] using cache index", length, fileInfo.physicalName(), position);
+            final int sliceOffset = toIntBytes(position - cachedBlob.from());
+            final BytesRefIterator cachedBytesIterator = cachedBlob.bytes().slice(sliceOffset, length).iterator();
+            BytesRef bytesRef;
+            int copiedBytes = 0;
+            while ((bytesRef = cachedBytesIterator.next()) != null) {
+                b.put(bytesRef.bytes, bytesRef.offset, bytesRef.length);
+                copiedBytes += bytesRef.length;
+            }
+            assert copiedBytes == length : "copied " + copiedBytes + " but expected " + length;
+            stats.addIndexCacheBytesRead(cachedBlob.length());
+
+            try {
+                final ByteRange cachedRange = ByteRange.of(cachedBlob.from(), cachedBlob.to());
+                cacheFile.populateAndRead(
+                    cachedRange,
+                    cachedRange,
+                    channel -> cachedBlob.length(),
+                    (channel, from, to, progressUpdater) -> {
+                        final long startTimeNanos = stats.currentTimeNanos();
+                        final BytesRefIterator iterator = cachedBlob.bytes()
+                            .slice(toIntBytes(from - cachedBlob.from()), toIntBytes(to - from))
+                            .iterator();
+                        long writePosition = from;
+                        BytesRef current;
+                        while ((current = iterator.next()) != null) {
+                            final ByteBuffer byteBuffer = ByteBuffer.wrap(current.bytes, current.offset, current.length);
+                            while (byteBuffer.remaining() > 0) {
+                                writePosition += positionalWrite(channel, writePosition, byteBuffer);
+                                progressUpdater.accept(writePosition);
+                            }
+                        }
+                        assert writePosition == to : writePosition + " vs " + to;
+                        final long endTimeNanos = stats.currentTimeNanos();
+                        stats.addCachedBytesWritten(to - from, endTimeNanos - startTimeNanos);
+                        logger.trace("copied bytes [{}-{}] of file [{}] from cache index to disk", from, to, fileInfo);
+                    },
+                    directory.cacheFetchAsyncExecutor()
+                );
+            } catch (Exception e) {
+                logger.debug(
+                    new ParameterizedMessage(
+                        "failed to store bytes [{}-{}] of file [{}] obtained from index cache",
+                        cachedBlob.from(),
+                        cachedBlob.to(),
+                        fileInfo
+                    ),
+                    e
+                );
+                // oh well, no big deal, at least we can return them to the caller.
+            }
+        }
+    }
+
+    private void readComplete(long position, int length) {
+        stats.incrementBytesRead(lastReadPosition, position, length);
+        lastReadPosition = position + length;
+        lastSeekPosition = lastReadPosition;
+    }
+
+    protected int readCacheFile(final FileChannel fc, final long position, final ByteBuffer buffer) throws IOException {
+        assert assertFileChannelOpen(fc);
+        final int bytesRead = Channels.readFromFileChannel(fc, position, buffer);
+        if (bytesRead == -1) {
+            throw new EOFException(
+                String.format(
+                    Locale.ROOT,
+                    "unexpected EOF reading [%d-%d] from %s",
+                    position,
+                    position + buffer.remaining(),
+                    cacheFileReference
+                )
+            );
+        }
+        stats.addCachedBytesRead(bytesRead);
+        return bytesRead;
+    }
+
+    protected void writeCacheFile(final FileChannel fc, final long start, final long end, final Consumer<Long> progressUpdater)
+        throws IOException {
+        assert assertFileChannelOpen(fc);
+        assert assertCurrentThreadMayWriteCacheFile();
+        final long length = end - start;
+        final byte[] copyBuffer = new byte[toIntBytes(Math.min(COPY_BUFFER_SIZE, length))];
+        logger.trace(() -> new ParameterizedMessage("writing range [{}-{}] to cache file [{}]", start, end, cacheFileReference));
+
+        long bytesCopied = 0L;
+        long remaining = end - start;
+        final long startTimeNanos = stats.currentTimeNanos();
+        try (InputStream input = openInputStreamFromBlobStore(start, length)) {
+            while (remaining > 0L) {
+                final int bytesRead = readSafe(input, copyBuffer, start, end, remaining, cacheFileReference);
+                positionalWrite(fc, start + bytesCopied, ByteBuffer.wrap(copyBuffer, 0, bytesRead));
+                bytesCopied += bytesRead;
+                remaining -= bytesRead;
+                progressUpdater.accept(start + bytesCopied);
+            }
+            final long endTimeNanos = stats.currentTimeNanos();
+            stats.addCachedBytesWritten(bytesCopied, endTimeNanos - startTimeNanos);
+        }
+    }
+
+    private void fillIndexCache(CacheFile cacheFile, ByteRange indexCacheMiss) {
+        final Releasable onCacheFillComplete = stats.addIndexCacheFill();
+        final Future<Integer> readFuture = cacheFile.readIfAvailableOrPending(indexCacheMiss, channel -> {
+            final int indexCacheMissLength = toIntBytes(indexCacheMiss.length());
+
+            // We assume that we only cache small portions of blobs so that we do not need to:
+            // - use a BigArrays for allocation
+            // - use an intermediate copy buffer to read the file in sensibly-sized chunks
+            // - release the buffer once the indexing operation is complete
+
+            final ByteBuffer byteBuffer = ByteBuffer.allocate(indexCacheMissLength);
+            Channels.readFromFileChannelWithEofException(channel, indexCacheMiss.start(), byteBuffer);
+            // NB use Channels.readFromFileChannelWithEofException not readCacheFile() to avoid counting this in the stats
+            byteBuffer.flip();
+            final BytesReference content = BytesReference.fromByteBuffer(byteBuffer);
+            directory.putCachedBlob(fileInfo.physicalName(), indexCacheMiss.start(), content, new ActionListener<Void>() {
+                @Override
+                public void onResponse(Void response) {
+                    onCacheFillComplete.close();
+                }
+
+                @Override
+                public void onFailure(Exception e1) {
+                    onCacheFillComplete.close();
+                }
+            });
+            return indexCacheMissLength;
+        });
+
+        if (readFuture == null) {
+            // Normally doesn't happen, we're already obtaining a range covering all cache misses above, but theoretically
+            // possible in the case that the real populateAndRead call already failed to obtain this range of the file. In that
+            // case, simply move on.
+            onCacheFillComplete.close();
+        }
+    }
+
+    /**
+     * Perform a single {@code read()} from {@code inputStream} into {@code copyBuffer}, handling an EOF by throwing an {@link EOFException}
+     * rather than returning {@code -1}. Returns the number of bytes read, which is always positive.
+     *
+     * Most of its arguments are there simply to make the message of the {@link EOFException} more informative.
+     */
+    protected static int readSafe(
+        InputStream inputStream,
+        byte[] copyBuffer,
+        long rangeStart,
+        long rangeEnd,
+        long remaining,
+        CacheFileReference cacheFileReference
+    ) throws IOException {
+        final int len = (remaining < copyBuffer.length) ? toIntBytes(remaining) : copyBuffer.length;
+        final int bytesRead = inputStream.read(copyBuffer, 0, len);
+        if (bytesRead == -1) {
+            throw new EOFException(
+                String.format(
+                    Locale.ROOT,
+                    "unexpected EOF reading [%d-%d] ([%d] bytes remaining) from %s",
+                    rangeStart,
+                    rangeEnd,
+                    remaining,
+                    cacheFileReference
+                )
+            );
+        }
+        assert bytesRead > 0 : bytesRead;
+        return bytesRead;
+    }
+
+    protected static boolean assertFileChannelOpen(FileChannel fileChannel) {
+        assert fileChannel != null;
+        assert fileChannel.isOpen();
+        return true;
+    }
+
+    @SuppressForbidden(reason = "Use positional writes on purpose")
+    protected static int positionalWrite(FileChannel fc, long start, ByteBuffer byteBuffer) throws IOException {
+        assert assertCurrentThreadMayWriteCacheFile();
+        return fc.write(byteBuffer, start);
+    }
+
+    protected static boolean assertCurrentThreadMayWriteCacheFile() {
+        final String threadName = Thread.currentThread().getName();
+        assert isCacheFetchAsyncThread(threadName) : "expected the current thread ["
+            + threadName
+            + "] to belong to the cache fetch async thread pool";
+        return true;
+    }
+
+    protected int readDirectlyIfAlreadyClosed(long position, ByteBuffer b, Exception e) throws IOException {
+        if (e instanceof AlreadyClosedException || (e.getCause() != null && e.getCause() instanceof AlreadyClosedException)) {
+            try {
+                // cache file was evicted during the range fetching, read bytes directly from blob container
+                final long length = b.remaining();
+                final byte[] copyBuffer = new byte[toIntBytes(Math.min(COPY_BUFFER_SIZE, length))];
+                logger.trace(
+                    () -> new ParameterizedMessage(
+                        "direct reading of range [{}-{}] for cache file [{}]",
+                        position,
+                        position + length,
+                        cacheFileReference
+                    )
+                );
+
+                int bytesCopied = 0;
+                final long startTimeNanos = stats.currentTimeNanos();
+                try (InputStream input = openInputStreamFromBlobStore(position, length)) {
+                    long remaining = length;
+                    while (remaining > 0) {
+                        final int len = (remaining < copyBuffer.length) ? (int) remaining : copyBuffer.length;
+                        int bytesRead = input.read(copyBuffer, 0, len);
+                        if (bytesRead == -1) {
+                            throw new EOFException(
+                                String.format(
+                                    Locale.ROOT,
+                                    "unexpected EOF reading [%d-%d] ([%d] bytes remaining) from %s",
+                                    position,
+                                    position + length,
+                                    remaining,
+                                    cacheFileReference
+                                )
+                            );
+                        }
+                        b.put(copyBuffer, 0, bytesRead);
+                        bytesCopied += bytesRead;
+                        remaining -= bytesRead;
+                        assert remaining == b.remaining() : remaining + " vs " + b.remaining();
+                    }
+                    final long endTimeNanos = stats.currentTimeNanos();
+                    stats.addDirectBytesRead(bytesCopied, endTimeNanos - startTimeNanos);
+                }
+                return bytesCopied;
+            } catch (Exception inner) {
+                e.addSuppressed(inner);
+            }
+        }
+        throw new IOException("failed to read data from cache", e);
+    }
+
+    protected abstract long getDefaultRangeSize();
+
+    protected ByteRange computeRange(long position) {
+        final long rangeSize = getDefaultRangeSize();
+        long start = (position / rangeSize) * rangeSize;
+        long end = Math.min(start + rangeSize, fileInfo.length());
+        return ByteRange.of(start, end);
+    }
+
+    @Override
+    protected void seekInternal(long pos) throws IOException {
+        if (pos > length()) {
+            throw new EOFException("Reading past end of file [position=" + pos + ", length=" + length() + "] for " + toString());
+        } else if (pos < 0L) {
+            throw new IOException("Seeking to negative position [" + pos + "] for " + toString());
+        }
+        final long position = pos + this.offset;
+        stats.incrementSeeks(lastSeekPosition, position);
+        lastSeekPosition = position;
+    }
+
+    @Override
+    public void doClose() {
+        if (isClone == false) {
+            cacheFileReference.releaseOnClose();
+        }
+    }
+
+    static class CacheFileReference implements CacheFile.EvictionListener {
+
+        private final long fileLength;
+        private final CacheKey cacheKey;
+        private final SearchableSnapshotDirectory directory;
+        final AtomicReference<CacheFile> cacheFile = new AtomicReference<>(); // null if evicted or not yet acquired
+
+        CacheFileReference(SearchableSnapshotDirectory directory, String fileName, long fileLength) {
+            this.cacheKey = directory.createCacheKey(fileName);
+            this.fileLength = fileLength;
+            this.directory = directory;
+        }
+
+        CacheFile get() throws Exception {
+            CacheFile currentCacheFile = cacheFile.get();
+            if (currentCacheFile != null) {
+                return currentCacheFile;
+            }
+
+            final CacheFile newCacheFile = directory.getCacheFile(cacheKey, fileLength);
+            synchronized (this) {
+                currentCacheFile = cacheFile.get();
+                if (currentCacheFile != null) {
+                    return currentCacheFile;
+                }
+                newCacheFile.acquire(this);
+                final CacheFile previousCacheFile = cacheFile.getAndSet(newCacheFile);
+                assert previousCacheFile == null;
+                return newCacheFile;
+            }
+        }
+
+        @Override
+        public void onEviction(final CacheFile evictedCacheFile) {
+            synchronized (this) {
+                if (cacheFile.compareAndSet(evictedCacheFile, null)) {
+                    evictedCacheFile.release(this);
+                }
+            }
+        }
+
+        void releaseOnClose() {
+            synchronized (this) {
+                final CacheFile currentCacheFile = cacheFile.getAndSet(null);
+                if (currentCacheFile != null) {
+                    currentCacheFile.release(this);
+                }
+            }
+        }
+
+        @Override
+        public String toString() {
+            return "CacheFileReference{"
+                + "cacheKey='"
+                + cacheKey
+                + '\''
+                + ", fileLength="
+                + fileLength
+                + ", acquired="
+                + (cacheFile.get() != null)
+                + '}';
+        }
+    }
+}

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/FrozenCacheService.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/FrozenCacheService.java
@@ -14,7 +14,6 @@ import org.elasticsearch.Assertions;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.StepListener;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.logging.DeprecationCategory;
@@ -29,7 +28,6 @@ import org.elasticsearch.common.util.concurrent.AbstractAsyncTask;
 import org.elasticsearch.common.util.concurrent.AbstractRefCounted;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.KeyedLock;
-import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.store.cache.CacheKey;
@@ -72,6 +70,7 @@ public class FrozenCacheService implements Releasable {
         Setting.Property.NodeScope
     );
 
+    // TODO: require range size to be multiple of 4kb
     public static final Setting<ByteSizeValue> SNAPSHOT_CACHE_REGION_SIZE_SETTING = Setting.byteSizeSetting(
         SHARED_CACHE_SETTINGS_PREFIX + "region_size",
         SHARED_CACHE_RANGE_SIZE_SETTING,
@@ -689,31 +688,6 @@ public class FrozenCacheService implements Releasable {
             return listener;
         }
 
-        @Nullable
-        public StepListener<Integer> readIfAvailableOrPending(final ByteRange rangeToRead, final RangeAvailableHandler reader) {
-            final StepListener<Integer> listener = new StepListener<>();
-            Releasable decrementRef = null;
-            try {
-                ensureOpen();
-                incRef();
-                decrementRef = Releasables.releaseOnce(this::decRef);
-                ensureOpen();
-                final Releasable finalDecrementRef = decrementRef;
-                listener.whenComplete(integer -> finalDecrementRef.close(), throwable -> finalDecrementRef.close());
-                final SharedBytes.IO fileChannel = sharedBytes.getFileChannel(sharedBytesPos);
-                listener.whenComplete(integer -> fileChannel.decRef(), e -> fileChannel.decRef());
-                if (tracker.waitForRangeIfPending(rangeToRead, rangeListener(rangeToRead, reader, listener, fileChannel))) {
-                    return listener;
-                } else {
-                    IOUtils.close(decrementRef, fileChannel::decRef);
-                    return null;
-                }
-            } catch (Exception e) {
-                releaseAndFail(listener, decrementRef, e);
-                return listener;
-            }
-        }
-
         private ActionListener<Void> rangeListener(
             ByteRange rangeToRead,
             RangeAvailableHandler reader,
@@ -820,35 +794,6 @@ public class FrozenCacheService implements Releasable {
                     stepListener = stepListener.thenCombine(lis, Math::addExact);
                 }
 
-            }
-            return stepListener;
-        }
-
-        @Nullable
-        public StepListener<Integer> readIfAvailableOrPending(final ByteRange rangeToRead, final RangeAvailableHandler reader) {
-            StepListener<Integer> stepListener = null;
-            final long start = rangeToRead.start();
-            for (int region = getRegion(start); region <= getEndingRegion(rangeToRead.end()); region++) {
-                final ByteRange subRangeToRead = mapSubRangeToRegion(rangeToRead, region);
-                final CacheFileRegion fileRegion = get(cacheKey, length, region);
-                final long readOffset = start - getRegionStart(region);
-                final StepListener<Integer> lis = fileRegion.readIfAvailableOrPending(
-                    subRangeToRead,
-                    (channel, channelPos, relativePos, length) -> reader.onRangeAvailable(
-                        channel,
-                        channelPos,
-                        relativePos - readOffset,
-                        length
-                    )
-                );
-                if (lis == null) {
-                    return null;
-                }
-                if (stepListener == null) {
-                    stepListener = lis;
-                } else {
-                    stepListener = stepListener.thenCombine(lis, Math::addExact);
-                }
             }
             return stepListener;
         }

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/SharedBytes.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/SharedBytes.java
@@ -31,6 +31,8 @@ public class SharedBytes extends AbstractRefCounted {
 
     private static final Logger logger = LogManager.getLogger(SharedBytes.class);
 
+    public static int PAGE_SIZE = 4096;
+
     private static final String CACHE_FILE_NAME = "shared_snapshot_cache";
 
     private static final StandardOpenOption[] OPEN_OPTIONS = new StandardOpenOption[] {
@@ -171,6 +173,9 @@ public class SharedBytes extends AbstractRefCounted {
 
         @SuppressForbidden(reason = "Use positional writes on purpose")
         public int write(ByteBuffer src, long position) throws IOException {
+            // check if writes are page size aligned for optimal performance
+            assert position % PAGE_SIZE == 0;
+            assert src.remaining() % PAGE_SIZE == 0;
             checkOffsets(position, src.remaining());
             return fileChannel.write(src, position);
         }

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/SearchableSnapshotDirectoryStatsTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/SearchableSnapshotDirectoryStatsTests.java
@@ -39,6 +39,7 @@ import org.elasticsearch.xpack.searchablesnapshots.AbstractSearchableSnapshotsTe
 import org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsConstants;
 import org.elasticsearch.xpack.searchablesnapshots.cache.CacheService;
 import org.elasticsearch.xpack.searchablesnapshots.cache.FrozenCacheService;
+import org.elasticsearch.xpack.searchablesnapshots.cache.SharedBytes;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -112,7 +113,7 @@ public class SearchableSnapshotDirectoryStatsTests extends AbstractSearchableSna
 
     public void testCachedBytesReadsAndWrites() throws Exception {
         // a cache service with a low range size but enough space to not evict the cache file
-        final ByteSizeValue rangeSize = new ByteSizeValue(randomLongBetween(MAX_FILE_LENGTH, MAX_FILE_LENGTH * 2), ByteSizeUnit.BYTES);
+        final ByteSizeValue rangeSize = new ByteSizeValue(SharedBytes.PAGE_SIZE * randomLongBetween(3, 6), ByteSizeUnit.BYTES);
         final ByteSizeValue cacheSize = new ByteSizeValue(10, ByteSizeUnit.MB);
 
         executeTestCaseWithCache(cacheSize, rangeSize, (fileName, fileContent, directory) -> {
@@ -571,7 +572,7 @@ public class SearchableSnapshotDirectoryStatsTests extends AbstractSearchableSna
             defaultCacheService(),
             createFrozenCacheService(
                 ByteSizeValue.ofMb(10),
-                new ByteSizeValue(randomLongBetween(MAX_FILE_LENGTH, MAX_FILE_LENGTH * 2), ByteSizeUnit.BYTES)
+                new ByteSizeValue(SharedBytes.PAGE_SIZE * randomLongBetween(3, 6), ByteSizeUnit.BYTES)
             ),
             Settings.builder()
                 .put(SNAPSHOT_CACHE_ENABLED_SETTING.getKey(), true)

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/FrozenIndexInputTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/FrozenIndexInputTests.java
@@ -30,14 +30,15 @@ import org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshots;
 import org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsConstants;
 import org.elasticsearch.xpack.searchablesnapshots.cache.CacheService;
 import org.elasticsearch.xpack.searchablesnapshots.cache.FrozenCacheService;
+import org.elasticsearch.xpack.searchablesnapshots.cache.SharedBytes;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 
+import static org.elasticsearch.xpack.searchablesnapshots.cache.CacheService.resolveSnapshotCache;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.mockito.Mockito.mock;
 
 public class FrozenIndexInputTests extends AbstractSearchableSnapshotsTestCase {
 
@@ -50,7 +51,6 @@ public class FrozenIndexInputTests extends AbstractSearchableSnapshotsTestCase {
         final byte[] fileData = bytes.v2();
         final String checksum = bytes.v1();
 
-        final Path tempDir = createTempDir().resolve(SHARD_ID.getIndex().getUUID()).resolve(String.valueOf(SHARD_ID.getId()));
         final FileInfo fileInfo = new FileInfo(
             randomAlphaOfLength(10),
             new StoreFileMetadata(fileName, fileData.length, checksum, Version.CURRENT.luceneVersion),
@@ -61,22 +61,16 @@ public class FrozenIndexInputTests extends AbstractSearchableSnapshotsTestCase {
         if (rarely()) {
             rangeSize = FrozenCacheService.SHARED_CACHE_RANGE_SIZE_SETTING.get(Settings.EMPTY);
         } else if (randomBoolean()) {
-            rangeSize = new ByteSizeValue(
-                randomLongBetween(CacheService.MIN_SNAPSHOT_CACHE_RANGE_SIZE.getBytes(), ByteSizeValue.ofKb(8L).getBytes())
-            );
+            rangeSize = new ByteSizeValue(randomIntBetween(1, 16) * SharedBytes.PAGE_SIZE);
         } else {
-            rangeSize = new ByteSizeValue(
-                randomLongBetween(CacheService.MIN_SNAPSHOT_CACHE_RANGE_SIZE.getBytes(), ByteSizeValue.ofMb(64L).getBytes())
-            );
+            rangeSize = new ByteSizeValue(randomIntBetween(1, 16000) * SharedBytes.PAGE_SIZE);
         }
 
         final ByteSizeValue regionSize;
         if (rarely()) {
             regionSize = FrozenCacheService.SNAPSHOT_CACHE_REGION_SIZE_SETTING.get(Settings.EMPTY);
-        } else if (randomBoolean()) {
-            regionSize = new ByteSizeValue(randomLongBetween(ByteSizeValue.ofKb(1L).getBytes(), ByteSizeValue.ofKb(8L).getBytes()));
         } else {
-            regionSize = new ByteSizeValue(randomLongBetween(ByteSizeValue.ofKb(1L).getBytes(), ByteSizeValue.ofMb(64L).getBytes()));
+            regionSize = new ByteSizeValue(randomIntBetween(1, 16) * SharedBytes.PAGE_SIZE);
         }
 
         final ByteSizeValue cacheSize;
@@ -96,11 +90,25 @@ public class FrozenIndexInputTests extends AbstractSearchableSnapshotsTestCase {
         for (Path path : environment.dataFiles()) {
             Files.createDirectories(path);
         }
+        SnapshotId snapshotId = new SnapshotId("_name", "_uuid");
+        final Path shardDir = randomShardPath(SHARD_ID);
+        final ShardPath shardPath = new ShardPath(false, shardDir, shardDir, SHARD_ID);
+        final Path cacheDir = Files.createDirectories(resolveSnapshotCache(shardDir).resolve(snapshotId.getUUID()));
         try (
             NodeEnvironment nodeEnvironment = new NodeEnvironment(settings, environment);
-            FrozenCacheService cacheService = new FrozenCacheService(nodeEnvironment, settings, threadPool);
-            TestSearchableSnapshotDirectory directory = new TestSearchableSnapshotDirectory(cacheService, tempDir, fileInfo, fileData)
+            FrozenCacheService frozenCacheService = new FrozenCacheService(nodeEnvironment, settings, threadPool);
+            CacheService cacheService = randomCacheService();
+            TestSearchableSnapshotDirectory directory = new TestSearchableSnapshotDirectory(
+                frozenCacheService,
+                cacheService,
+                fileInfo,
+                snapshotId,
+                fileData,
+                shardPath,
+                cacheDir
+            )
         ) {
+            cacheService.start();
             directory.loadSnapshot(createRecoveryState(true), ActionListener.wrap(() -> {}));
 
             // TODO does not test using the recovery range size
@@ -117,13 +125,21 @@ public class FrozenIndexInputTests extends AbstractSearchableSnapshotsTestCase {
 
     private class TestSearchableSnapshotDirectory extends SearchableSnapshotDirectory {
 
-        TestSearchableSnapshotDirectory(FrozenCacheService service, Path tempDir, FileInfo fileInfo, byte[] fileData) {
+        TestSearchableSnapshotDirectory(
+            FrozenCacheService service,
+            CacheService cacheService,
+            FileInfo fileInfo,
+            SnapshotId snapshotId,
+            byte[] fileData,
+            ShardPath shardPath,
+            Path cacheDir
+        ) {
             super(
                 () -> TestUtils.singleBlobContainer(fileInfo.partName(0), fileData),
                 () -> new BlobStoreIndexShardSnapshot("_snapshot_id", 0L, Collections.singletonList(fileInfo), 0L, 0L, 0, 0L),
                 new TestUtils.SimpleBlobStoreCacheService(),
                 "_repository",
-                new SnapshotId("_snapshot_name", "_snapshot_id"),
+                snapshotId,
                 new IndexId(SHARD_ID.getIndex().getName(), SHARD_ID.getIndex().getUUID()),
                 SHARD_ID,
                 Settings.builder()
@@ -131,9 +147,9 @@ public class FrozenIndexInputTests extends AbstractSearchableSnapshotsTestCase {
                     .put(SearchableSnapshots.SNAPSHOT_CACHE_ENABLED_SETTING.getKey(), true)
                     .build(),
                 System::currentTimeMillis,
-                mock(CacheService.class),
-                tempDir,
-                new ShardPath(false, tempDir, tempDir, SHARD_ID),
+                cacheService,
+                cacheDir,
+                shardPath,
                 threadPool,
                 service
             );

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/TestUtils.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/TestUtils.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.PathUtilsForTesting;
 import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.index.store.IndexInputStats;
 import org.elasticsearch.xpack.searchablesnapshots.cache.ByteRange;
 
@@ -325,6 +326,11 @@ public final class TestUtils {
         @Override
         protected void getAsync(String repository, String name, String path, long offset, ActionListener<CachedBlob> listener) {
             listener.onResponse(CachedBlob.CACHE_NOT_READY);
+        }
+
+        @Override
+        public ByteRange computeBlobCacheByteRange(String fileName, long fileLength, ByteSizeValue maxMetadataLength) {
+            return ByteRange.EMPTY;
         }
 
         @Override

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsTestCase.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsTestCase.java
@@ -14,7 +14,6 @@ import org.apache.lucene.store.ByteBuffersIndexOutput;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
-import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
@@ -72,7 +71,6 @@ import java.util.concurrent.TimeUnit;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.randomAsciiLettersOfLengthBetween;
 import static org.elasticsearch.index.store.cache.TestUtils.randomPopulateAndReads;
 
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/70763")
 public abstract class AbstractSearchableSnapshotsTestCase extends ESIndexInputTestCase {
 
     private static final ClusterSettings CLUSTER_SETTINGS = new ClusterSettings(


### PR DESCRIPTION
This PR unifies CachedBlobContainerIndexInput and FrozenIndexInput so that they share the same infrastructure for
caching metadata blobs as well as header and footer ranges for data blobs. The idea is to always use CacheService for
this, which does not evict the metadata, and which efficiently stores the information on disk (using sparse file support).

This also allows us to align writes in FrozenCacheService to 4KB block sizes in this PR, which addresses an issue when
reusing regions from the shared cache, as writes that are not aligned on page cache boundaries causes the existing data
(which we don't care about) to be loaded from disk, which comes with a dramatic performance penalty.

Closes #70728
Closes #70763