### PR TITLE
Wait for blob cache fills to complete before stopping the service

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/blobstore/cache/BlobStoreCacheService.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/blobstore/cache/BlobStoreCacheService.java
@@ -28,9 +28,11 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.cache.Cache;
 import org.elasticsearch.common.cache.CacheBuilder;
+import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.util.concurrent.RunOnce;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -42,12 +44,15 @@ import org.elasticsearch.xpack.searchablesnapshots.cache.ByteRange;
 import java.time.Instant;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.xpack.core.ClientHelper.SEARCHABLE_SNAPSHOTS_ORIGIN;
 
-public class BlobStoreCacheService {
+public class BlobStoreCacheService extends AbstractLifecycleComponent {
 
     private static final Logger logger = LogManager.getLogger(BlobStoreCacheService.class);
 
@@ -61,17 +66,58 @@ public class BlobStoreCacheService {
         .setExpireAfterAccess(TimeValue.timeValueMinutes(60L))
         .build();
 
+    static final int MAX_IN_FLIGHT_CACHE_FILLS = Integer.MAX_VALUE;
+
     private final ClusterService clusterService;
-    private final ThreadPool threadPool;
+    private final Semaphore inFlightCacheFills;
+    private final Supplier<Long> timeSupplier;
+    private final AtomicBoolean closed;
     private final Client client;
     private final String index;
 
-    public BlobStoreCacheService(ClusterService clusterService, ThreadPool threadPool, Client client, String index) {
+    public BlobStoreCacheService(ClusterService clusterService, Client client, String index, Supplier<Long> timeSupplier) {
         this.client = new OriginSettingClient(client, SEARCHABLE_SNAPSHOTS_ORIGIN);
+        this.inFlightCacheFills = new Semaphore(MAX_IN_FLIGHT_CACHE_FILLS);
+        this.closed = new AtomicBoolean(false);
         this.clusterService = clusterService;
-        this.threadPool = threadPool;
+        this.timeSupplier = timeSupplier;
         this.index = index;
     }
+
+    @Override
+    protected void doStart() {}
+
+    @Override
+    protected void doStop() {
+        if (closed.compareAndSet(false, true)) {
+            logger.debug("blob cache service is stopped");
+        }
+    }
+
+    // public for tests
+    public boolean waitForInFlightCacheFillsToComplete(long timeout, TimeUnit unit) {
+        boolean acquired = false;
+        try {
+            logger.debug("waiting for in-flight blob cache fills to complete");
+            acquired = inFlightCacheFills.tryAcquire(MAX_IN_FLIGHT_CACHE_FILLS, timeout, unit);
+        } catch (InterruptedException e) {
+            logger.warn("interrupted while waiting for in-flight blob cache fills to complete", e);
+            Thread.currentThread().interrupt();
+        } finally {
+            if (acquired) {
+                inFlightCacheFills.release(MAX_IN_FLIGHT_CACHE_FILLS);
+            }
+        }
+        return acquired;
+    }
+
+    // pkg private for tests
+    int getInFlightCacheFills() {
+        return MAX_IN_FLIGHT_CACHE_FILLS - inFlightCacheFills.availablePermits();
+    }
+
+    @Override
+    protected void doClose() {}
 
     public CachedBlob get(String repository, String name, String path, long offset) {
         assert Thread.currentThread().getName().contains('[' + ThreadPool.Names.SYSTEM_READ + ']') == false : "must not block ["
@@ -84,7 +130,7 @@ public class BlobStoreCacheService {
             return future.actionGet(5, TimeUnit.SECONDS);
         } catch (ElasticsearchTimeoutException e) {
             if (logger.isDebugEnabled()) {
-                logger.warn(
+                logger.debug(
                     () -> new ParameterizedMessage(
                         "get from cache index timed out after [5s], retrieving from blob store instead [id={}]",
                         CachedBlob.generateId(repository, name, path, offset)
@@ -99,6 +145,11 @@ public class BlobStoreCacheService {
     }
 
     protected void getAsync(String repository, String name, String path, long offset, ActionListener<CachedBlob> listener) {
+        if (closed.get()) {
+            logger.debug("failed to retrieve cached blob from system index [{}], service is closed", index);
+            listener.onResponse(CachedBlob.CACHE_NOT_READY);
+            return;
+        }
         final GetRequest request = new GetRequest(index).id(CachedBlob.generateId(repository, name, path, offset));
         client.get(request, new ActionListener<GetResponse>() {
             @Override
@@ -144,7 +195,7 @@ public class BlobStoreCacheService {
     public void putAsync(String repository, String name, String path, long offset, BytesReference content, ActionListener<Void> listener) {
         try {
             final CachedBlob cachedBlob = new CachedBlob(
-                Instant.ofEpochMilli(threadPool.absoluteTimeInMillis()),
+                Instant.ofEpochMilli(timeSupplier.get()),
                 Version.CURRENT,
                 repository,
                 name,
@@ -157,19 +208,39 @@ public class BlobStoreCacheService {
                 request.source(cachedBlob.toXContent(builder, ToXContent.EMPTY_PARAMS));
             }
 
-            client.index(request, new ActionListener<IndexResponse>() {
-                @Override
-                public void onResponse(IndexResponse indexResponse) {
-                    logger.trace("cache fill ({}): [{}]", indexResponse.status(), request.id());
-                    listener.onResponse(null);
-                }
-
-                @Override
-                public void onFailure(Exception e) {
-                    logger.debug(new ParameterizedMessage("failure in cache fill: [{}]", request.id()), e);
-                    listener.onFailure(e);
-                }
+            final RunOnce release = new RunOnce(() -> {
+                final int availablePermits = inFlightCacheFills.availablePermits();
+                assert availablePermits > 0 : "in-flight available permits should be greater than 0 but got: " + availablePermits;
+                inFlightCacheFills.release();
             });
+
+            boolean submitted = false;
+            inFlightCacheFills.acquire();
+            try {
+                if (closed.get()) {
+                    listener.onFailure(new IllegalStateException("Blob cache service is closed"));
+                    return;
+                }
+                final ActionListener<Void> wrappedListener = ActionListener.runAfter(listener, release);
+                client.index(request, new ActionListener<IndexResponse>() {
+                    @Override
+                    public void onResponse(IndexResponse indexResponse) {
+                        logger.trace("cache fill ({}): [{}]", indexResponse.status(), request.id());
+                        wrappedListener.onResponse(null);
+                    }
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        logger.debug(new ParameterizedMessage("failure in cache fill: [{}]", request.id()), e);
+                        wrappedListener.onFailure(e);
+                    }
+                });
+                submitted = true;
+            } finally {
+                if (submitted == false) {
+                    release.run();
+                }
+            }
         } catch (Exception e) {
             logger.warn(new ParameterizedMessage("cache fill failure: [{}]", CachedBlob.generateId(repository, name, path, offset)), e);
             listener.onFailure(e);

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
@@ -336,9 +336,9 @@ public class SearchableSnapshots extends Plugin implements IndexStorePlugin, Eng
             components.add(cacheService);
             final BlobStoreCacheService blobStoreCacheService = new BlobStoreCacheService(
                 clusterService,
-                threadPool,
                 client,
-                SNAPSHOT_BLOB_CACHE_INDEX
+                SNAPSHOT_BLOB_CACHE_INDEX,
+                threadPool::absoluteTimeInMillis
             );
             this.blobStoreCacheService.set(blobStoreCacheService);
             components.add(blobStoreCacheService);

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/blobstore/cache/BlobStoreCacheServiceTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/blobstore/cache/BlobStoreCacheServiceTests.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.blobstore.cache;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.get.GetAction;
+import org.elasticsearch.action.get.GetRequest;
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.action.index.IndexAction;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.get.GetResult;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.Collections.emptyMap;
+import static org.elasticsearch.index.mapper.MapperService.SINGLE_MAPPING_NAME;
+import static org.elasticsearch.index.seqno.SequenceNumbers.UNASSIGNED_PRIMARY_TERM;
+import static org.elasticsearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
+import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsConstants.SNAPSHOT_BLOB_CACHE_INDEX;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class BlobStoreCacheServiceTests extends ESTestCase {
+
+    private TestThreadPool threadPool;
+    private Client mockClient;
+
+    @Before
+    public void createThreadPool() {
+        mockClient = mock(Client.class);
+        threadPool = new TestThreadPool(getClass().getSimpleName());
+        when(mockClient.threadPool()).thenReturn(threadPool);
+        when(mockClient.settings()).thenReturn(Settings.EMPTY);
+    }
+
+    @After
+    public void shutdownThreadPool() {
+        threadPool.shutdown();
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testGetWhenServiceNotStarted() {
+        doAnswer(invocation -> {
+            final GetRequest request = (GetRequest) invocation.getArguments()[1];
+            final ActionListener<GetResponse> listener = (ActionListener<GetResponse>) invocation.getArguments()[2];
+            listener.onResponse(
+                new GetResponse(
+                    new GetResult(
+                        request.index(),
+                        SINGLE_MAPPING_NAME,
+                        request.id(),
+                        UNASSIGNED_SEQ_NO,
+                        UNASSIGNED_PRIMARY_TERM,
+                        request.version(),
+                        false,
+                        BytesArray.EMPTY,
+                        emptyMap(),
+                        emptyMap()
+                    )
+                )
+            );
+            return null;
+        }).when(mockClient).execute(eq(GetAction.INSTANCE), any(GetRequest.class), any(ActionListener.class));
+
+        BlobStoreCacheService blobCacheService = new BlobStoreCacheService(null, mockClient, SNAPSHOT_BLOB_CACHE_INDEX, () -> 0L);
+        blobCacheService.start();
+
+        PlainActionFuture<CachedBlob> future = PlainActionFuture.newFuture();
+        blobCacheService.getAsync("_repository", "_file", "/path", 0L, future);
+        assertThat(future.actionGet(), equalTo(CachedBlob.CACHE_MISS));
+
+        blobCacheService.stop();
+
+        future = PlainActionFuture.newFuture();
+        blobCacheService.getAsync("_repository", "_file", "/path", 0L, future);
+        assertThat(future.actionGet(), equalTo(CachedBlob.CACHE_NOT_READY));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testPutWhenServiceNotStarted() {
+        doAnswer(invocation -> {
+            final IndexRequest request = (IndexRequest) invocation.getArguments()[1];
+            final ActionListener<IndexResponse> listener = (ActionListener<IndexResponse>) invocation.getArguments()[2];
+            listener.onResponse(
+                new IndexResponse(
+                    new ShardId(request.index(), "_uuid", 0),
+                    SINGLE_MAPPING_NAME,
+                    request.id(),
+                    UNASSIGNED_SEQ_NO,
+                    UNASSIGNED_PRIMARY_TERM,
+                    request.version(),
+                    true
+                )
+            );
+            return null;
+        }).when(mockClient).execute(eq(IndexAction.INSTANCE), any(IndexRequest.class), any(ActionListener.class));
+
+        BlobStoreCacheService blobCacheService = new BlobStoreCacheService(null, mockClient, SNAPSHOT_BLOB_CACHE_INDEX, () -> 0L);
+        blobCacheService.start();
+
+        PlainActionFuture<Void> future = PlainActionFuture.newFuture();
+        blobCacheService.putAsync("_repository", "_file", "/path", 0L, BytesArray.EMPTY, future);
+        assertThat(future.actionGet(), nullValue());
+
+        blobCacheService.stop();
+
+        future = PlainActionFuture.newFuture();
+        blobCacheService.putAsync("_repository", "_file", "/path", 0L, BytesArray.EMPTY, future);
+        IllegalStateException exception = expectThrows(IllegalStateException.class, future::actionGet);
+        assertThat(exception.getMessage(), containsString("Blob cache service is closed"));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testWaitForInFlightCacheFillsToComplete() throws Exception {
+        final int nbThreads = randomIntBetween(1, 5);
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        doAnswer(invocation -> {
+            final IndexRequest request = (IndexRequest) invocation.getArguments()[1];
+            final ActionListener<IndexResponse> listener = (ActionListener<IndexResponse>) invocation.getArguments()[2];
+            latch.await();
+            Thread.sleep(randomLongBetween(100L, 3000L));
+            listener.onResponse(
+                new IndexResponse(
+                    new ShardId(request.index(), "_uuid", 0),
+                    SINGLE_MAPPING_NAME,
+                    request.id(),
+                    UNASSIGNED_SEQ_NO,
+                    UNASSIGNED_PRIMARY_TERM,
+                    request.version(),
+                    true
+                )
+            );
+            return null;
+        }).when(mockClient).execute(eq(IndexAction.INSTANCE), any(IndexRequest.class), any(ActionListener.class));
+
+        final BlobStoreCacheService blobCacheService = new BlobStoreCacheService(null, mockClient, SNAPSHOT_BLOB_CACHE_INDEX, () -> 0L);
+        blobCacheService.start();
+
+        assertThat(blobCacheService.getInFlightCacheFills(), equalTo(0));
+
+        final List<PlainActionFuture<Void>> futures = new ArrayList<>(nbThreads);
+        for (int i = 0; i < nbThreads; i++) {
+            final PlainActionFuture<Void> future = PlainActionFuture.newFuture();
+            threadPool.generic()
+                .execute(
+                    () -> { blobCacheService.putAsync("_repository", randomAlphaOfLength(3), "/path", 0L, BytesArray.EMPTY, future); }
+                );
+            futures.add(future);
+        }
+
+        assertBusy(() -> assertThat(blobCacheService.getInFlightCacheFills(), equalTo(nbThreads)));
+        assertFalse(blobCacheService.waitForInFlightCacheFillsToComplete(0L, TimeUnit.SECONDS));
+        assertTrue(futures.stream().noneMatch(Future::isDone));
+
+        latch.countDown();
+
+        assertTrue(blobCacheService.waitForInFlightCacheFillsToComplete(30L, TimeUnit.SECONDS));
+        assertTrue(futures.stream().allMatch(Future::isDone));
+    }
+}

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/TestUtils.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/TestUtils.java
@@ -314,7 +314,7 @@ public final class TestUtils {
     public static class NoopBlobStoreCacheService extends BlobStoreCacheService {
 
         public NoopBlobStoreCacheService() {
-            super(null, null, mockClient(), null);
+            super(null, mockClient(), null, () -> 0L);
         }
 
         @Override
@@ -345,13 +345,7 @@ public final class TestUtils {
         private final ConcurrentHashMap<String, CachedBlob> blobs = new ConcurrentHashMap<>();
 
         public SimpleBlobStoreCacheService() {
-            super(null, null, mockClient(), null);
-        }
-
-        private static Client mockClient() {
-            final Client client = mock(Client.class);
-            when(client.settings()).thenReturn(Settings.EMPTY);
-            return client;
+            super(null, mockClient(), null, () -> 0L);
         }
 
         @Override


### PR DESCRIPTION
Today nothing prevents to use the BlobStoreCacheService after the component
is stopped. It sometimes happens because the shards are one of the very last
resources to be closed when a node stops, after components are stopped, and
the closing of shards also releases more resources that are likely to trigger more
blobs to be cached by the BlobStoreCacheService.

On CI we can notice this behavior by seeing the blob cache index re-created
while the after-test clean up logic is running (see #69735). This committ changes
integration tests so that at stop time they now waits for in-flight index operations
to be completed. It also prevents any new blob to be cached after the service
has been stopped.

Closes #69735

Backport of #70220 for 7.12