### PR TITLE
Adjust the docs for template-v1 API

### DIFF
--- a/docs/reference/indices/delete-index-template-v1.asciidoc
+++ b/docs/reference/indices/delete-index-template-v1.asciidoc
@@ -48,7 +48,7 @@ privilege>> to use this API.
 
 `<legacy-index-template>`::
 (Required, string)
-Comma-separated list of legacy index templates to delete. Wildcard (`*`)
+The name of the legacy index template to delete. Wildcard (`*`)
 expressions are supported.
 
 


### PR DESCRIPTION
The delete legacy template API doesn't support comma-separated list of names in any version.

Forward-port of #70649