### PR TITLE
[DOCS] Removes beta labels from DFA related docs

### DIFF
--- a/docs/java-rest/high-level/ml/delete-data-frame-analytics.asciidoc
+++ b/docs/java-rest/high-level/ml/delete-data-frame-analytics.asciidoc
@@ -7,7 +7,6 @@
 [id="{upid}-{api}"]
 === Delete {dfanalytics-jobs} API
 
-beta::[]
 
 Delete an existing {dfanalytics-job}.
 The API accepts a +{request}+ object as a request and returns a +{response}+.

--- a/docs/java-rest/high-level/ml/delete-trained-model-alias.asciidoc
+++ b/docs/java-rest/high-level/ml/delete-trained-model-alias.asciidoc
@@ -7,7 +7,6 @@
 [id="{upid}-{api}"]
 === Delete trained model alias API
 
-beta::[]
 
 Deletes a trained model alias.
 The API accepts a +{request}+ object as a request and returns a +{response}+.

--- a/docs/java-rest/high-level/ml/delete-trained-models.asciidoc
+++ b/docs/java-rest/high-level/ml/delete-trained-models.asciidoc
@@ -7,7 +7,6 @@
 [id="{upid}-{api}"]
 === Delete trained models API
 
-beta::[]
 
 Deletes a previously saved trained model.
 The API accepts a +{request}+ object and returns a +{response}+.

--- a/docs/java-rest/high-level/ml/evaluate-data-frame.asciidoc
+++ b/docs/java-rest/high-level/ml/evaluate-data-frame.asciidoc
@@ -7,7 +7,6 @@
 [id="{upid}-{api}"]
 === Evaluate {dfanalytics} API
 
-beta::[]
 
 Evaluates the {dfanalytics} for an annotated index.
 The API accepts an +{request}+ object and returns an +{response}+.

--- a/docs/java-rest/high-level/ml/explain-data-frame-analytics.asciidoc
+++ b/docs/java-rest/high-level/ml/explain-data-frame-analytics.asciidoc
@@ -7,7 +7,6 @@
 [id="{upid}-{api}"]
 === Explain {dfanalytics} API
 
-beta::[]
 
 Explains the following about a {dataframe-analytics-config}:
 

--- a/docs/java-rest/high-level/ml/get-data-frame-analytics-stats.asciidoc
+++ b/docs/java-rest/high-level/ml/get-data-frame-analytics-stats.asciidoc
@@ -7,7 +7,6 @@
 [id="{upid}-{api}"]
 === Get {dfanalytics-jobs} stats API
 
-beta::[]
 
 Retrieves the operational statistics of one or more {dfanalytics-jobs}.
 The API accepts a +{request}+ object and returns a +{response}+.

--- a/docs/java-rest/high-level/ml/get-data-frame-analytics.asciidoc
+++ b/docs/java-rest/high-level/ml/get-data-frame-analytics.asciidoc
@@ -7,7 +7,6 @@
 [id="{upid}-{api}"]
 === Get {dfanalytics-jobs} API
 
-beta::[]
 
 Retrieves one or more {dfanalytics-jobs}.
 The API accepts a +{request}+ object and returns a +{response}+.

--- a/docs/java-rest/high-level/ml/get-trained-models-stats.asciidoc
+++ b/docs/java-rest/high-level/ml/get-trained-models-stats.asciidoc
@@ -7,7 +7,6 @@
 [id="{upid}-{api}"]
 === Get trained models stats API
 
-beta::[]
 
 Retrieves one or more trained model statistics.
 The API accepts a +{request}+ object and returns a +{response}+.

--- a/docs/java-rest/high-level/ml/get-trained-models.asciidoc
+++ b/docs/java-rest/high-level/ml/get-trained-models.asciidoc
@@ -7,7 +7,6 @@
 [id="{upid}-{api}"]
 === Get trained models API
 
-beta::[]
 
 Retrieves one or more trained models.
 The API accepts a +{request}+ object and returns a +{response}+.

--- a/docs/java-rest/high-level/ml/put-data-frame-analytics.asciidoc
+++ b/docs/java-rest/high-level/ml/put-data-frame-analytics.asciidoc
@@ -7,7 +7,6 @@
 [id="{upid}-{api}"]
 === Create {dfanalytics-jobs} API
 
-beta::[]
 
 Creates a new {dfanalytics-job}.
 The API accepts a +{request}+ object as a request and returns a +{response}+.

--- a/docs/java-rest/high-level/ml/put-trained-model-alias.asciidoc
+++ b/docs/java-rest/high-level/ml/put-trained-model-alias.asciidoc
@@ -7,7 +7,6 @@
 [id="{upid}-{api}"]
 === Create or update trained model alias API
 
-beta::[]
 
 Creates or reassigns a trained model alias.
 The API accepts a +{request}+ object as a request and returns a +{response}+.

--- a/docs/java-rest/high-level/ml/put-trained-model.asciidoc
+++ b/docs/java-rest/high-level/ml/put-trained-model.asciidoc
@@ -7,7 +7,6 @@
 [id="{upid}-{api}"]
 === Create trained models API
 
-beta::[]
 
 Creates a new trained model for inference.
 The API accepts a +{request}+ object as a request and returns a +{response}+.

--- a/docs/java-rest/high-level/ml/start-data-frame-analytics.asciidoc
+++ b/docs/java-rest/high-level/ml/start-data-frame-analytics.asciidoc
@@ -7,7 +7,6 @@
 [id="{upid}-{api}"]
 === Start {dfanalytics-jobs} API
 
-beta::[]
 
 Starts an existing {dfanalytics-job}.
 It accepts a +{request}+ object and responds with a +{response}+ object.

--- a/docs/java-rest/high-level/ml/stop-data-frame-analytics.asciidoc
+++ b/docs/java-rest/high-level/ml/stop-data-frame-analytics.asciidoc
@@ -7,7 +7,6 @@
 [id="{upid}-{api}"]
 === Stop {dfanalytics-jobs} API
 
-beta::[]
 
 Stops a running {dfanalytics-job}.
 It accepts a +{request}+ object and responds with a +{response}+ object.

--- a/docs/java-rest/high-level/ml/update-data-frame-analytics.asciidoc
+++ b/docs/java-rest/high-level/ml/update-data-frame-analytics.asciidoc
@@ -7,7 +7,6 @@
 [id="{upid}-{api}"]
 === Update {dfanalytics-jobs} API
 
-beta::[]
 
 Updates an existing {dfanalytics-job}.
 The API accepts an +{request}+ object as a request and returns an +{response}+.

--- a/docs/reference/aggregations/pipeline/inference-bucket-aggregation.asciidoc
+++ b/docs/reference/aggregations/pipeline/inference-bucket-aggregation.asciidoc
@@ -6,13 +6,13 @@
 <titleabbrev>{infer-cap} bucket</titleabbrev>
 ++++
 
-beta::[]
 
 A parent pipeline aggregation which loads a pre-trained model and performs 
 {infer} on the collated result fields from the parent bucket aggregation.
 
 To use the {infer} bucket aggregation, you need to have the same security
-privileges that are required for using the <<get-trained-models,get trained models API>>.
+privileges that are required for using the 
+<<get-trained-models,get trained models API>>.
 
 [[inference-bucket-agg-syntax]]
 ==== Syntax

--- a/docs/reference/ingest/processors/inference.asciidoc
+++ b/docs/reference/ingest/processors/inference.asciidoc
@@ -6,7 +6,6 @@
 <titleabbrev>{infer-cap}</titleabbrev>
 ++++
 
-beta::[]
 
 Uses a pre-trained {dfanalytics} model to infer against the data that is being
 ingested in the pipeline.

--- a/docs/reference/ml/df-analytics/apis/delete-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/delete-dfanalytics.asciidoc
@@ -9,8 +9,6 @@
 
 Deletes an existing {dfanalytics-job}.
 
-beta::[]
-
 
 [[ml-delete-dfanalytics-request]]
 == {api-request-title}

--- a/docs/reference/ml/df-analytics/apis/delete-trained-models-aliases.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/delete-trained-models-aliases.asciidoc
@@ -9,7 +9,6 @@
 
 Deletes a trained model alias.
 
-beta::[]
 
 [[ml-delete-trained-models-aliases-request]]
 == {api-request-title}

--- a/docs/reference/ml/df-analytics/apis/delete-trained-models.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/delete-trained-models.asciidoc
@@ -10,8 +10,6 @@
 Deletes an existing trained {infer} model that is currently not referenced by an
 ingest pipeline.
 
-beta::[]
-
 
 [[ml-delete-trained-models-request]]
 == {api-request-title}

--- a/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
@@ -10,8 +10,6 @@
 
 Evaluates the {dfanalytics} for an annotated index.
 
-beta::[]
-
 
 [[ml-evaluate-dfanalytics-request]]
 == {api-request-title}

--- a/docs/reference/ml/df-analytics/apis/explain-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/explain-dfanalytics.asciidoc
@@ -10,8 +10,6 @@
 
 Explains a {dataframe-analytics-config}.
 
-beta::[]
-
 
 [[ml-explain-dfanalytics-request]]
 == {api-request-title}

--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
@@ -9,7 +9,6 @@
 
 Retrieves usage information for {dfanalytics-jobs}.
 
-beta::[]
 
 [[ml-get-dfanalytics-stats-request]]
 == {api-request-title}

--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics.asciidoc
@@ -9,8 +9,6 @@
 
 Retrieves configuration information for {dfanalytics-jobs}.
 
-beta::[]
-
 
 [[ml-get-dfanalytics-request]]
 == {api-request-title}

--- a/docs/reference/ml/df-analytics/apis/get-trained-models-stats.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-trained-models-stats.asciidoc
@@ -9,8 +9,6 @@
 
 Retrieves usage information for trained models.
 
-beta::[]
-
 
 [[ml-get-trained-models-stats-request]]
 == {api-request-title}

--- a/docs/reference/ml/df-analytics/apis/get-trained-models.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-trained-models.asciidoc
@@ -9,8 +9,6 @@
 
 Retrieves configuration information for a trained model.
 
-beta::[]
-
 
 [[ml-get-trained-models-request]]
 == {api-request-title}

--- a/docs/reference/ml/df-analytics/apis/preview-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/preview-dfanalytics.asciidoc
@@ -10,8 +10,6 @@
 
 Previews the features used by a {dataframe-analytics-config}.
 
-beta::[]
-
 
 [[ml-preview-dfanalytics-request]]
 == {api-request-title}

--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -9,7 +9,6 @@
 
 Instantiates a {dfanalytics-job}.
 
-beta::[]
 
 [[ml-put-dfanalytics-request]]
 == {api-request-title}

--- a/docs/reference/ml/df-analytics/apis/put-trained-models-aliases.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-trained-models-aliases.asciidoc
@@ -7,7 +7,6 @@
 <titleabbrev>Create or update trained model aliases</titleabbrev>
 ++++
 
-beta::[]
 
 Creates or updates a trained model alias.
 

--- a/docs/reference/ml/df-analytics/apis/put-trained-models.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-trained-models.asciidoc
@@ -15,9 +15,6 @@ WARNING: Models created in version 7.8.0 are not backwards compatible
          a 7.8.0 node.
 
 
-beta::[]
-
-
 [[ml-put-trained-models-request]]
 == {api-request-title}
 

--- a/docs/reference/ml/df-analytics/apis/start-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/start-dfanalytics.asciidoc
@@ -10,7 +10,6 @@
 
 Starts a {dfanalytics-job}.
 
-beta::[]
 
 [[ml-start-dfanalytics-request]]
 == {api-request-title}

--- a/docs/reference/ml/df-analytics/apis/stop-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/stop-dfanalytics.asciidoc
@@ -10,7 +10,6 @@
 
 Stops one or more {dfanalytics-jobs}.
 
-beta::[]
 
 [[ml-stop-dfanalytics-request]]
 == {api-request-title}

--- a/docs/reference/ml/df-analytics/apis/update-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/update-dfanalytics.asciidoc
@@ -9,7 +9,6 @@
 
 Updates an existing {dfanalytics-job}.
 
-beta::[]
 
 [[ml-update-dfanalytics-request]]
 == {api-request-title}


### PR DESCRIPTION
## Overview

As the data frame analytics feature goes GA in 7.13, this PR removes the `beta` label from the:
* DFA API doc pages (including trained model APIs),
* DFA HLRC doc pages (including trained model APIs),
* Inference bucket aggregation doc page,
* Inference ingest processor doc page.