### PR TITLE
Fix GeoIpDownloaderStatsIT.testStats

### DIFF
--- a/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderStatsIT.java
+++ b/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderStatsIT.java
@@ -33,6 +33,7 @@ import static org.elasticsearch.common.xcontent.ToXContent.EMPTY_PARAMS;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, maxNumDataNodes = 1)
@@ -92,6 +93,7 @@ public class GeoIpDownloaderStatsIT extends AbstractGeoIpIT {
             Map<String, Map<String, List<Map<String, Object>>>> nodes = view.get("nodes");
             assertThat(nodes.values(), hasSize(greaterThan(0)));
             for (Map<String, List<Map<String, Object>>> value : nodes.values()) {
+                assertThat(value, hasKey("databases"));
                 assertThat(value.get("databases").stream().map(m -> m.get("name")).collect(Collectors.toSet()),
                     containsInAnyOrder("GeoLite2-City.mmdb", "GeoLite2-ASN.mmdb", "GeoLite2-Country.mmdb"));
             }


### PR DESCRIPTION
Node in GeoIpStats response can have no `databases` field if there are no databases yet downloaded to that node. We have to check if the key is there before processing it to avoid NPE.

Fixes https://github.com/elastic/elasticsearch/issues/70789