### PR TITLE
[7.x] Change tier preference for shared_cache searchable snapshots to frozen only (#70786)

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
@@ -227,14 +227,14 @@ public class SearchableSnapshots extends Plugin implements IndexStorePlugin, Eng
     /**
      * Returns the preference for new searchable snapshot indices. When
      * performing a full mount the preference is cold - warm - hot. When
-     * performing a partial mount the preference is frozen - cold - warm - hot.
+     * performing a partial mount the preference is only frozen
      */
     public static String getDataTiersPreference(MountSearchableSnapshotRequest.Storage type) {
         switch (type) {
             case FULL_COPY:
                 return String.join(",", DataTier.DATA_COLD, DataTier.DATA_WARM, DataTier.DATA_HOT);
             case SHARED_CACHE:
-                return String.join(",", DataTier.DATA_FROZEN, DataTier.DATA_COLD, DataTier.DATA_WARM, DataTier.DATA_HOT);
+                return DataTier.DATA_FROZEN;
             default:
                 throw new IllegalArgumentException("unknown searchable snapshot type [" + type + "]");
         }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Change tier preference for shared_cache searchable snapshots to frozen only (#70786)