### PR TITLE
Make sure forbidPrivateIndexSettings is kept during an internal cluster full restarter full restart

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -944,7 +944,7 @@ public final class InternalTestCluster extends TestCluster {
                     .put(NodeEnvironment.NODE_ID_SEED_SETTING.getKey(), newIdSeed)
                     .build();
             Collection<Class<? extends Plugin>> plugins = node.getClasspathPlugins();
-            node = new MockNode(finalSettings, plugins);
+            node = new MockNode(finalSettings, plugins, forbidPrivateIndexSettings);
             node.injector().getInstance(TransportService.class).addLifecycleListener(new LifecycleListener() {
                 @Override
                 public void afterStart() {

--- a/test/framework/src/test/java/org/elasticsearch/test/test/InternalClusterForbiddenSettingIT.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/test/InternalClusterForbiddenSettingIT.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+package org.elasticsearch.test.test;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.test.ESIntegTestCase;
+
+import org.elasticsearch.test.InternalTestCluster;
+import org.elasticsearch.test.VersionUtils;
+
+/**
+ * This test ensures that after a cluster restart, the forbidPrivateIndexSettings value
+ * is kept
+ */
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.SUITE)
+public class InternalClusterForbiddenSettingIT extends ESIntegTestCase {
+
+    @Override
+    protected boolean forbidPrivateIndexSettings() {
+        return false;
+    }
+
+    public void testRestart() throws Exception {
+        final Version version = VersionUtils.randomPreviousCompatibleVersion(random(), Version.CURRENT);
+        // create / delete an index with forbidden setting
+        prepareCreate("test").setSettings(settings(version).build()).get();
+        client().admin().indices().prepareDelete("test").get();
+        // full restart
+        internalCluster().fullRestart();
+        // create / delete an index with forbidden setting
+        prepareCreate("test").setSettings(settings(version).build()).get();
+        client().admin().indices().prepareDelete("test").get();
+    }
+
+
+    public void testRollingRestart() throws Exception {
+        final Version version = VersionUtils.randomPreviousCompatibleVersion(random(), Version.CURRENT);
+        // create / delete an index with forbidden setting
+        prepareCreate("test").setSettings(settings(version).build()).get();
+        client().admin().indices().prepareDelete("test").get();
+        // rolling restart
+        internalCluster().rollingRestart(new InternalTestCluster.RestartCallback());
+        // create / delete an index with forbidden setting
+        prepareCreate("test").setSettings(settings(version).build()).get();
+        client().admin().indices().prepareDelete("test").get();
+    }
+}


### PR DESCRIPTION
`forbidPrivateIndexSettings` is a test tool to add internal setting to indexes, for example faking the version when they were created. The setting is controlled by overrides a method on `ESIntegTestCase`.

Currently if we do a cluster restart in one method, the setting is always set to true. This PR makes sure we keep honouring the value provided in the test.