### PR TITLE
[DOCS] Move enrich policy object def to API docs

### DIFF
--- a/docs/reference/ingest/apis/enrich/put-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/put-enrich-policy.asciidoc
@@ -73,24 +73,55 @@ include::../../enrich.asciidoc[tag=update-enrich-policy]
 ====
 
 
-
 [[put-enrich-policy-api-path-params]]
 ==== {api-path-parms-title}
 
 `<enrich-policy>`::
 (Required, string)
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=enrich-policy]
+Name of the enrich policy to create or update.
 
-
+[role="child_attributes"]
 [[put-enrich-policy-api-request-body]]
 ==== {api-request-body-title}
 
 `<policy-type>`::
+(Required, object)
+Configures the enrich policy. The field key is the enrich policy type. Valid key
+values are:
 +
 --
-(Required, <<enrich-policy-definition,enrich policy>> object)
-Enrich policy used to match and add the right enrich data to
-the right incoming documents.
+`geo_match`:::
+Matches enrich data to incoming documents based on a
+<<query-dsl-geo-shape-query,`geo_shape` query>>. For an example, see
+<<geo-match-enrich-policy-type>>.
 
-See <<enrich-policy-definition>> for object definition and parameters.
+`match`:::
+Matches enrich data to incoming documents based on a
+<<query-dsl-term-query,`term` query>>. For an example, see
+<<match-enrich-policy-type>>.
 --
++
+.Properties of `<policy-type>`
+[%collapsible%open]
+====
+`indices`::
+(Required, String or array of strings)
+One or more source indices used to create the enrich index.
++
+If multiple indices are specified, they must share a common `match_field`.
+
+`match_field`::
+(Required, string)
+Field in source indices used to match incoming documents.
+
+`enrich_fields`::
+(Required, Array of strings)
+Fields to add to matching incoming documents. These fields must be present in
+the source indices.
+
+`query`::
+(Optional, <<query-dsl,Query DSL query object>>)
+Query used to filter documents in the enrich index. The policy only uses
+documents matching this query to enrich incoming documents. Defaults to a
+<<query-dsl-match-all-query,`match_all`>> query.
+====

--- a/docs/reference/ingest/enrich.asciidoc
+++ b/docs/reference/ingest/enrich.asciidoc
@@ -50,9 +50,6 @@ Before it can be used with an enrich processor, an enrich policy must be
 enrich data from the policy's source indices to create a streamlined system
 index called the _enrich index_. The processor uses this index to match and
 enrich incoming documents.
-
-See <<enrich-policy-definition>> for a full list of enrich policy types and
-configuration options.
 --
 
 [[source-index]]
@@ -136,14 +133,8 @@ automatically send and index documents to your source indices. See
 [[create-enrich-policy]]
 ==== Create an enrich policy
 
-After adding enrich data to your source indices, you can
-<<enrich-policy-definition,define an enrich policy>>. When defining the enrich
-policy, you should include at least the following:
-
-include::enrich.asciidoc[tag=enrich-policy-fields]
-
-You can use this definition to create the enrich policy with the
-<<put-enrich-policy-api,create or update enrich policy API>>.
+After adding enrich data to your source indices, use the
+<<put-enrich-policy-api,create enrich policy API>> to create an enrich policy.
 
 [WARNING]
 ====
@@ -226,74 +217,6 @@ Instead, you can:
 .   Use the <<delete-enrich-policy-api, delete enrich policy>> API
     to delete the previous enrich policy.
 // end::update-enrich-policy[]
-
-[role="xpack"]
-[testenv="basic"]
-[[enrich-policy-definition]]
-=== Enrich policy definition
-
-<<enrich-policy,Enrich policies>> are defined as JSON objects like the
-following:
-
-[source,js]
-----
-{
-  "<enrich_policy_type>": {
-    "indices": [ "..." ],
-    "match_field": "...",
-    "enrich_fields": [ "..." ],
-    "query": {... }
-  }
-}
-----
-// NOTCONSOLE
-
-[[enrich-policy-parms]]
-==== Parameters
-
-`<enrich_policy_type>`::
-+
---
-(Required, enrich policy object)
-The enrich policy type determines how enrich data is matched to incoming
-documents.
-
-Supported enrich policy types include:
-
-<<geo-match-enrich-policy-type,`geo_match`>>:::
-Matches enrich data to incoming documents based on a geographic location using
-a <<query-dsl-geo-shape-query,`geo_shape` query>>. For an example, see
-<<geo-match-enrich-policy-type>>.
-
-<<match-enrich-policy-type,`match`>>:::
-Matches enrich data to incoming documents based on a precise value, such as an
-email address or ID, using a <<query-dsl-term-query,`term` query>>. For an
-example, see <<match-enrich-policy-type>>.
---
-
-`indices`::
-+
---
-(Required, String or array of strings)
-Source indices used to create the enrich index.
-
-If multiple indices are provided, they must share a common `match_field`, which
-the enrich processor can use to match incoming documents.
---
-
-`match_field`::
-(Required, string)
-Field in the source indices used to match incoming documents.
-
-`enrich_fields`::
-(Required, Array of strings)
-Fields to add to matching incoming documents. These fields must be present in
-the source indices.
-
-`query`::
-(Optional, <<query-dsl,Query DSL query object>>)
-Query used to filter documents in the enrich index for matching. Defaults to
-a <<query-dsl-match-all-query,`match_all`>> query.
 
 [role="xpack"]
 [testenv="basic"]

--- a/docs/reference/ingest/processors/enrich.asciidoc
+++ b/docs/reference/ingest/processors/enrich.asciidoc
@@ -16,7 +16,7 @@ See <<ingest-enriching-data,enrich data>> section for more information about how
 | Name               | Required  | Default              | Description
 | `policy_name`      | yes       | -                    | The name of the enrich policy to use.
 | `field`            | yes       | -                    | The field in the input document that matches the policies match_field used to retrieve the enrichment data. Supports <<template-snippets,template snippets>>.
-| `target_field`     | yes       | -                    | Field added to incoming documents to contain enrich data. This field contains both the `match_field` and `enrich_fields` specified in the <<enrich-policy-definition,enrich policy>>. Supports <<template-snippets,template snippets>>.
+| `target_field`     | yes       | -                    | Field added to incoming documents to contain enrich data. This field contains both the `match_field` and `enrich_fields` specified in the <<put-enrich-policy-api,enrich policy>>. Supports <<template-snippets,template snippets>>.
 | `ignore_missing`   | no        | false                | If `true` and `field` does not exist, the processor quietly exits without modifying the document
 | `override`         | no        | true                 | If processor will update fields with pre-existing non-null-valued field. When set to `false`, such fields will not be touched.
 | `max_matches`      | no        | 1                    | The maximum number of matched documents to include under the configured target field. The `target_field` will be turned into a json array if `max_matches` is higher than 1, otherwise `target_field` will become a json object. In order to avoid documents getting too large, the maximum allowed value is 128.

--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -1443,3 +1443,8 @@ See <<handling-pipeline-failures>>.
 === Ingest processors
 
 See <<processors>>.
+
+[role="exclude",id="enrich-policy-definition"]
+=== Enrich policy definition
+
+See <<put-enrich-policy-api>>.

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -215,11 +215,6 @@ The number of documents that have been processed from the source index of
 the {transform}.
 end::docs-processed[]
 
-tag::enrich-policy[]
-Enrich policy name
-used to limit the request.
-end::enrich-policy[]
-
 tag::ds-expand-wildcards[]
 `expand_wildcards`::
 +


### PR DESCRIPTION
Relocates the enrich policy object definition to the create/update enrich policy API docs.

When these docs were introduced, separate object defs were the norm. However, now have better support for nested param objects.


### Preview
- Create or update enrich policy API: https://elasticsearch_70825.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/put-enrich-policy-api.html
- Redirect: https://elasticsearch_70825.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/enrich-policy-definition.html