### PR TITLE
Refactor how fields tell aggs about ords (backport of #70693)

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/TermsValuesSourceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/TermsValuesSourceBuilder.java
@@ -158,7 +158,7 @@ public class TermsValuesSourceBuilder extends CompositeValuesSourceBuilder<Terms
                     LongConsumer addRequestCircuitBreakerBytes,
                     CompositeValuesSourceConfig compositeValuesSourceConfig) -> {
 
-                    if (valuesSourceConfig.hasGlobalOrdinals() && reader instanceof DirectoryReader) {
+                    if (valuesSourceConfig.hasOrdinals() && reader instanceof DirectoryReader) {
                         ValuesSource.Bytes.WithOrdinals vs = (ValuesSource.Bytes.WithOrdinals) compositeValuesSourceConfig
                             .valuesSource();
                         return new GlobalOrdinalValuesSource(

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedAggregatorFactory.java
@@ -76,7 +76,7 @@ public class DiversifiedAggregatorFactory extends ValuesSourceAggregatorFactory 
                 if (execution == null) {
                     execution = ExecutionMode.GLOBAL_ORDINALS;
                 }
-                if ((execution.needsGlobalOrdinals()) && (valuesSourceConfig.hasGlobalOrdinals() == false)) {
+                if ((execution.needsGlobalOrdinals()) && (valuesSourceConfig.hasOrdinals() == false)) {
                     execution = ExecutionMode.MAP;
                 }
                 return execution.create(name, factories, shardSize, maxDocsPerValue, valuesSourceConfig, context, parent, metadata);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSource.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSource.java
@@ -68,9 +68,9 @@ public abstract class ValuesSource {
     protected abstract Function<Rounding, Rounding.Prepared> roundingPreparer() throws IOException;
 
     /**
-     * Check if this values source supports using global ordinals
+     * Check if this values source supports using global and segment ordinals.
      */
-    public boolean hasGlobalOrdinals() {
+    public boolean hasOrdinals() {
         return false;
     }
 
@@ -163,7 +163,7 @@ public abstract class ValuesSource {
             }
 
             @Override
-            public boolean hasGlobalOrdinals() {
+            public boolean hasOrdinals() {
                 return true;
             }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceConfig.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceConfig.java
@@ -360,8 +360,11 @@ public class ValuesSourceConfig {
         return valuesSource.roundingPreparer();
     }
 
-    public boolean hasGlobalOrdinals() {
-        return valuesSource.hasGlobalOrdinals();
+    /**
+     * Check if this values source supports using global and segment ordinals.
+     */
+    public boolean hasOrdinals() {
+        return valuesSource.hasOrdinals();
     }
 
     /**

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/TopMetricsAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/TopMetricsAggregator.java
@@ -415,14 +415,12 @@ class TopMetricsAggregator extends NumericMetricsAggregator.MultiValue {
 
         SegmentOrdsValues(int size, BigArrays bigArrays, String name, ValuesSourceConfig config) {
             super(bigArrays, name, config);
-            try {
-                valuesSource = (ValuesSource.Bytes.WithOrdinals) config.getValuesSource();
-            } catch (ClassCastException e) {
+            if (false == config.hasOrdinals()) {
                 throw new IllegalArgumentException(
-                    "top_metrics can only collect bytes that have segment ordinals but " + config.getDescription() + " does not",
-                    e
+                    "top_metrics can only collect bytes that have segment ordinals but " + config.getDescription() + " does not"
                 );
             }
+            valuesSource = (ValuesSource.Bytes.WithOrdinals) config.getValuesSource();
             segmentResolve = bigArrays.newObjectArray(size);
             segmentOrds = bigArrays.newLongArray(size, false);
         }

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/topmetrics/TopMetricsAggregatorMetricsTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/topmetrics/TopMetricsAggregatorMetricsTests.java
@@ -229,7 +229,7 @@ public class TopMetricsAggregatorMetricsTests extends ESTestCase {
         ValuesSource.Bytes.WithOrdinals source = mock(ValuesSource.Bytes.WithOrdinals.class);
         when(source.ordinalsValues(null)).thenReturn(values);
         ValuesSourceConfig config = toConfig(source, CoreValuesSourceType.KEYWORD, DocValueFormat.RAW, true);
-        when(config.hasGlobalOrdinals()).thenReturn(false); // We don't need global orindals. Only segment ordinals.
+        when(config.hasOrdinals()).thenReturn(true);
         return config;
     }
 


### PR DESCRIPTION
This just renamed `hasGlobalOrdinals` to `hasOrginals` and changes the
documentation to say that it returns true when there are segment or
global ordinals. There isn't any case when we supported global ordinals
that we don't also support segment ordinals. I mean, global ordinals are
*built* from segment ordinals.
