### PR TITLE
Indicate that the quota-aware-fs plugin is for cloud-only use in docs

### DIFF
--- a/docs/plugins/quota-aware-fs.asciidoc
+++ b/docs/plugins/quota-aware-fs.asciidoc
@@ -1,6 +1,11 @@
 [[quota-aware-fs]]
 === Quota-aware Filesystem Plugin
 
+[NOTE]
+The Quota-aware Filesystem plugin is designed for indirect use by {ess-trial}[{ess}],
+{ece-ref}[{ece}], and {eck-ref}[Elastic Cloud on Kubernetes]. Direct use is not
+supported.
+
 The Quota-aware Filesystem plugin adds an interface for telling
 Elasticsearch the disk-quota limits under which it is operating.
 


### PR DESCRIPTION
As per discussions in https://github.com/elastic/elasticsearch/issues/70583#issuecomment-805634892 we are updating the documentation for the quota-aware filesystem plugin to indicate it's not support outside of cloud use cases. This is similar to the note used for operator privileges and autoscaling docs.