### PR TITLE
Simplify runtime field parser and builder

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
@@ -28,7 +28,7 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
 
     public abstract static class Builder {
 
-        public String name;
+        protected final String name;
 
         protected Builder(String name) {
             this.name = name;

--- a/server/src/main/java/org/elasticsearch/index/mapper/RuntimeField.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RuntimeField.java
@@ -17,7 +17,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.function.BiFunction;
+import java.util.function.Function;
 
 /**
  * Definition of a runtime field that can be defined as part of the runtime section of the index mappings
@@ -90,7 +90,7 @@ public interface RuntimeField extends ToXContentFragment {
             throw new UnsupportedOperationException();
         }
 
-        protected abstract RuntimeField buildFieldType();
+        protected abstract RuntimeField createRuntimeField(Mapper.TypeParser.ParserContext parserContext);
 
         private void validate() {
             ContentPath contentPath = parentPath(name());
@@ -110,19 +110,19 @@ public interface RuntimeField extends ToXContentFragment {
      * as defined in the runtime section of the index mappings.
      */
     final class Parser {
-        private final BiFunction<String, Mapper.TypeParser.ParserContext, RuntimeField.Builder> builderFunction;
+        private final Function<String, Builder> builderFunction;
 
-        public Parser(BiFunction<String, Mapper.TypeParser.ParserContext, RuntimeField.Builder> builderFunction) {
+        public Parser(Function<String, RuntimeField.Builder> builderFunction) {
             this.builderFunction = builderFunction;
         }
 
         RuntimeField parse(String name, Map<String, Object> node, Mapper.TypeParser.ParserContext parserContext)
             throws MapperParsingException {
 
-            RuntimeField.Builder builder = builderFunction.apply(name, parserContext);
+            RuntimeField.Builder builder = builderFunction.apply(name);
             builder.parse(name, parserContext, node);
             builder.validate();
-            return builder.buildFieldType();
+            return builder.createRuntimeField(parserContext);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/runtimefields/mapper/BooleanFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/runtimefields/mapper/BooleanFieldScript.java
@@ -31,7 +31,7 @@ public abstract class BooleanFieldScript extends AbstractFieldScript {
         BooleanFieldScript newInstance(LeafReaderContext ctx);
     }
 
-    public static final Factory PARSE_FROM_SOURCE = (field, params, lookup) -> (LeafFactory) ctx -> new BooleanFieldScript(
+    static final Factory PARSE_FROM_SOURCE = (field, params, lookup) -> (LeafFactory) ctx -> new BooleanFieldScript(
         field,
         params,
         lookup,

--- a/server/src/main/java/org/elasticsearch/runtimefields/mapper/BooleanScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/runtimefields/mapper/BooleanScriptFieldType.java
@@ -34,16 +34,13 @@ import java.util.function.Supplier;
 
 public final class BooleanScriptFieldType extends AbstractScriptFieldType<BooleanFieldScript.LeafFactory> {
 
-    public static final RuntimeField.Parser PARSER = new RuntimeField.Parser((name, parserContext) -> new Builder(name) {
-        @Override
-        protected RuntimeField buildFieldType() {
-            if (script.get() == null) {
-                return new BooleanScriptFieldType(name, BooleanFieldScript.PARSE_FROM_SOURCE, getScript(), meta(), this);
+    public static final RuntimeField.Parser PARSER = new RuntimeField.Parser(name ->
+        new Builder<>(name, BooleanFieldScript.CONTEXT, BooleanFieldScript.PARSE_FROM_SOURCE) {
+            @Override
+            RuntimeField newRuntimeField(BooleanFieldScript.Factory scriptFactory) {
+                return new BooleanScriptFieldType(name, scriptFactory, getScript(), meta(), this);
             }
-            BooleanFieldScript.Factory factory = parserContext.scriptCompiler().compile(script.getValue(), BooleanFieldScript.CONTEXT);
-            return new BooleanScriptFieldType(name, factory, getScript(), meta(), this);
-        }
-    });
+        });
 
     public BooleanScriptFieldType(String name) {
         this(name, BooleanFieldScript.PARSE_FROM_SOURCE, null, Collections.emptyMap(), (builder, params) -> builder);

--- a/server/src/main/java/org/elasticsearch/runtimefields/mapper/DateFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/runtimefields/mapper/DateFieldScript.java
@@ -31,7 +31,7 @@ public abstract class DateFieldScript extends AbstractLongFieldScript {
         DateFieldScript newInstance(LeafReaderContext ctx);
     }
 
-    public static final Factory PARSE_FROM_SOURCE = (field, params, lookup, formatter) -> (LeafFactory) ctx -> new DateFieldScript(
+    static final Factory PARSE_FROM_SOURCE = (field, params, lookup, formatter) -> (LeafFactory) ctx -> new DateFieldScript(
         field,
         params,
         lookup,

--- a/server/src/main/java/org/elasticsearch/runtimefields/mapper/DoubleFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/runtimefields/mapper/DoubleFieldScript.java
@@ -30,7 +30,7 @@ public abstract class DoubleFieldScript extends AbstractFieldScript {
         DoubleFieldScript newInstance(LeafReaderContext ctx);
     }
 
-    public static final Factory PARSE_FROM_SOURCE = (field, params, lookup) -> (LeafFactory) ctx -> new DoubleFieldScript(
+    static final Factory PARSE_FROM_SOURCE = (field, params, lookup) -> (LeafFactory) ctx -> new DoubleFieldScript(
         field,
         params,
         lookup,

--- a/server/src/main/java/org/elasticsearch/runtimefields/mapper/DoubleScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/runtimefields/mapper/DoubleScriptFieldType.java
@@ -34,16 +34,13 @@ import java.util.function.Supplier;
 
 public final class DoubleScriptFieldType extends AbstractScriptFieldType<DoubleFieldScript.LeafFactory> {
 
-    public static final RuntimeField.Parser PARSER = new RuntimeField.Parser((name, parserContext) -> new Builder(name) {
-        @Override
-        protected RuntimeField buildFieldType() {
-            if (script.get() == null) {
-                return new DoubleScriptFieldType(name, DoubleFieldScript.PARSE_FROM_SOURCE, getScript(), meta(), this);
+    public static final RuntimeField.Parser PARSER = new RuntimeField.Parser(name ->
+        new Builder<>(name, DoubleFieldScript.CONTEXT, DoubleFieldScript.PARSE_FROM_SOURCE) {
+            @Override
+            RuntimeField newRuntimeField(DoubleFieldScript.Factory scriptFactory) {
+                return new DoubleScriptFieldType(name, scriptFactory, getScript(), meta(), this);
             }
-            DoubleFieldScript.Factory factory = parserContext.scriptCompiler().compile(script.getValue(), DoubleFieldScript.CONTEXT);
-            return new DoubleScriptFieldType(name, factory, getScript(), meta(), this);
-        }
-    });
+        });
 
     public DoubleScriptFieldType(String name) {
         this(name, DoubleFieldScript.PARSE_FROM_SOURCE, null, Collections.emptyMap(), (builder, params) -> builder);

--- a/server/src/main/java/org/elasticsearch/runtimefields/mapper/GeoPointFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/runtimefields/mapper/GeoPointFieldScript.java
@@ -41,7 +41,7 @@ public abstract class GeoPointFieldScript extends AbstractLongFieldScript {
         GeoPointFieldScript newInstance(LeafReaderContext ctx);
     }
 
-    public static final Factory PARSE_FROM_SOURCE = (field, params, lookup) -> (LeafFactory) ctx -> new GeoPointFieldScript(
+    static final Factory PARSE_FROM_SOURCE = (field, params, lookup) -> (LeafFactory) ctx -> new GeoPointFieldScript(
         field,
         params,
         lookup,

--- a/server/src/main/java/org/elasticsearch/runtimefields/mapper/GeoPointScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/runtimefields/mapper/GeoPointScriptFieldType.java
@@ -38,16 +38,13 @@ import java.util.function.Supplier;
 
 public final class GeoPointScriptFieldType extends AbstractScriptFieldType<GeoPointFieldScript.LeafFactory> implements GeoShapeQueryable {
 
-    public static final RuntimeField.Parser PARSER = new RuntimeField.Parser((name, parserContext) -> new Builder(name) {
-        @Override
-        protected RuntimeField buildFieldType() {
-            if (script.get() == null) {
-                return new GeoPointScriptFieldType(name, GeoPointFieldScript.PARSE_FROM_SOURCE, getScript(), meta(), this);
+    public static final RuntimeField.Parser PARSER = new RuntimeField.Parser(name ->
+        new Builder<>(name, GeoPointFieldScript.CONTEXT, GeoPointFieldScript.PARSE_FROM_SOURCE) {
+            @Override
+            RuntimeField newRuntimeField(GeoPointFieldScript.Factory scriptFactory) {
+                return new GeoPointScriptFieldType(name, scriptFactory, getScript(), meta(), this);
             }
-            GeoPointFieldScript.Factory factory = parserContext.scriptCompiler().compile(script.getValue(), GeoPointFieldScript.CONTEXT);
-            return new GeoPointScriptFieldType(name, factory, getScript(), meta(), this);
-        }
-    });
+        });
 
     GeoPointScriptFieldType(
         String name,

--- a/server/src/main/java/org/elasticsearch/runtimefields/mapper/IpFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/runtimefields/mapper/IpFieldScript.java
@@ -51,7 +51,7 @@ public abstract class IpFieldScript extends AbstractFieldScript {
         IpFieldScript newInstance(LeafReaderContext ctx);
     }
 
-    public static final Factory PARSE_FROM_SOURCE = (field, params, lookup) -> (LeafFactory) ctx -> new IpFieldScript(
+    static final Factory PARSE_FROM_SOURCE = (field, params, lookup) -> (LeafFactory) ctx -> new IpFieldScript(
         field,
         params,
         lookup,

--- a/server/src/main/java/org/elasticsearch/runtimefields/mapper/IpScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/runtimefields/mapper/IpScriptFieldType.java
@@ -43,16 +43,13 @@ import java.util.function.Supplier;
 
 public final class IpScriptFieldType extends AbstractScriptFieldType<IpFieldScript.LeafFactory> {
 
-    public static final RuntimeField.Parser PARSER = new RuntimeField.Parser((name, parserContext) -> new Builder(name) {
-        @Override
-        protected RuntimeField buildFieldType() {
-            if (script.get() == null) {
-                return new IpScriptFieldType(name, IpFieldScript.PARSE_FROM_SOURCE, getScript(), meta(), this);
+    public static final RuntimeField.Parser PARSER = new RuntimeField.Parser(name ->
+        new Builder<>(name, IpFieldScript.CONTEXT, IpFieldScript.PARSE_FROM_SOURCE) {
+            @Override
+            RuntimeField newRuntimeField(IpFieldScript.Factory scriptFactory) {
+                return new IpScriptFieldType(name, scriptFactory, getScript(), meta(), this);
             }
-            IpFieldScript.Factory factory = parserContext.scriptCompiler().compile(script.getValue(), IpFieldScript.CONTEXT);
-            return new IpScriptFieldType(name, factory, getScript(), meta(), this);
-        }
-    });
+        });
 
     IpScriptFieldType(
         String name,

--- a/server/src/main/java/org/elasticsearch/runtimefields/mapper/KeywordScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/runtimefields/mapper/KeywordScriptFieldType.java
@@ -42,16 +42,13 @@ import static java.util.stream.Collectors.toSet;
 
 public final class KeywordScriptFieldType extends AbstractScriptFieldType<StringFieldScript.LeafFactory> {
 
-    public static final RuntimeField.Parser PARSER = new RuntimeField.Parser((name, parserContext) -> new Builder(name) {
-        @Override
-        protected RuntimeField buildFieldType() {
-            if (script.get() == null) {
-                return new KeywordScriptFieldType(name, StringFieldScript.PARSE_FROM_SOURCE, getScript(), meta(), this);
+    public static final RuntimeField.Parser PARSER = new RuntimeField.Parser(name ->
+        new Builder<>(name, StringFieldScript.CONTEXT, StringFieldScript.PARSE_FROM_SOURCE) {
+            @Override
+            RuntimeField newRuntimeField(StringFieldScript.Factory scriptFactory) {
+                return new KeywordScriptFieldType(name, scriptFactory, getScript(), meta(), this);
             }
-            StringFieldScript.Factory factory = parserContext.scriptCompiler().compile(script.getValue(), StringFieldScript.CONTEXT);
-            return new KeywordScriptFieldType(name, factory, getScript(), meta(), this);
-        }
-    });
+        });
 
     public KeywordScriptFieldType(String name) {
         this(name, StringFieldScript.PARSE_FROM_SOURCE, null, Collections.emptyMap(), (builder, params) -> builder);

--- a/server/src/main/java/org/elasticsearch/runtimefields/mapper/LongFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/runtimefields/mapper/LongFieldScript.java
@@ -30,7 +30,7 @@ public abstract class LongFieldScript extends AbstractLongFieldScript {
         LongFieldScript newInstance(LeafReaderContext ctx);
     }
 
-    public static final Factory PARSE_FROM_SOURCE = (field, params, lookup) -> (LeafFactory) ctx -> new LongFieldScript(
+    static final Factory PARSE_FROM_SOURCE = (field, params, lookup) -> (LeafFactory) ctx -> new LongFieldScript(
         field,
         params,
         lookup,

--- a/server/src/main/java/org/elasticsearch/runtimefields/mapper/LongScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/runtimefields/mapper/LongScriptFieldType.java
@@ -34,16 +34,13 @@ import java.util.function.Supplier;
 
 public final class LongScriptFieldType extends AbstractScriptFieldType<LongFieldScript.LeafFactory> {
 
-    public static final RuntimeField.Parser PARSER = new RuntimeField.Parser((name, parserContext) -> new Builder(name) {
-        @Override
-        protected RuntimeField buildFieldType() {
-            if (script.get() == null) {
-                return new LongScriptFieldType(name, LongFieldScript.PARSE_FROM_SOURCE, getScript(), meta(), this);
+    public static final RuntimeField.Parser PARSER = new RuntimeField.Parser(name ->
+        new Builder<>(name, LongFieldScript.CONTEXT, LongFieldScript.PARSE_FROM_SOURCE) {
+            @Override
+            RuntimeField newRuntimeField(LongFieldScript.Factory scriptFactory) {
+                return new LongScriptFieldType(name, scriptFactory, getScript(), meta(), this);
             }
-            LongFieldScript.Factory factory = parserContext.scriptCompiler().compile(script.getValue(), LongFieldScript.CONTEXT);
-            return new LongScriptFieldType(name, factory, getScript(), meta(), this);
-        }
-    });
+        });
 
     public LongScriptFieldType(String name) {
         this(name, LongFieldScript.PARSE_FROM_SOURCE, null, Collections.emptyMap(), (builder, params) -> builder);

--- a/server/src/main/java/org/elasticsearch/runtimefields/mapper/StringFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/runtimefields/mapper/StringFieldScript.java
@@ -37,7 +37,7 @@ public abstract class StringFieldScript extends AbstractFieldScript {
         StringFieldScript newInstance(LeafReaderContext ctx);
     }
 
-    public static final Factory PARSE_FROM_SOURCE = (field, params, lookup) -> (LeafFactory) ctx -> new StringFieldScript(
+    static final Factory PARSE_FROM_SOURCE = (field, params, lookup) -> (LeafFactory) ctx -> new StringFieldScript(
         field,
         params,
         lookup,

--- a/server/src/test/java/org/elasticsearch/indices/IndicesModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndicesModuleTests.java
@@ -173,7 +173,7 @@ public class IndicesModuleTests extends ESTestCase {
         MapperPlugin plugin = new MapperPlugin() {
             @Override
             public Map<String, RuntimeField.Parser> getRuntimeFields() {
-                return Map.of("test", new RuntimeField.Parser((s, parserContext) -> null));
+                return Map.of("test", new RuntimeField.Parser(name -> null));
             }
         };
         List<MapperPlugin> plugins = Arrays.asList(plugin, plugin);
@@ -186,7 +186,7 @@ public class IndicesModuleTests extends ESTestCase {
         MapperPlugin plugin = new MapperPlugin() {
             @Override
             public Map<String, RuntimeField.Parser> getRuntimeFields() {
-                return Map.of(KeywordFieldMapper.CONTENT_TYPE, new RuntimeField.Parser((s, parserContext) -> null));
+                return Map.of(KeywordFieldMapper.CONTENT_TYPE, new RuntimeField.Parser(name -> null));
             }
         };
         List<MapperPlugin> plugins = Collections.singletonList(plugin);


### PR DESCRIPTION
RuntimeField.Parser currently requires a BiFunction <String, ParserContext, Builder> but in reality ParserContext can be made an argument to the method that creates the runtime field itself, so that the BiFunction becomes a Function. At the same time, buildFieldType can be renamed to createRuntimeField (following the split between RuntimeField and the corresponding MappedFieldType.

Additionally, the creation logic for all of the currently supported runtime fields is the same: if the script is not provided, initialize the script factory with the predefined script that extract values from source, otherwise compile the script and create the runtime field. This logic can be shared by refactoring the RuntimeField.Builder.

These steps simplify things, and will help with the creation of the runtime object field. In fact, more logic will be introduced around the creation of a runtime field that can this way be shared instead of repeated for each field type.

