### PR TITLE
[7.x] Fix flakiness in testRetryPolicy (#70769)

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/ILMDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/ILMDocumentationIT.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.client.documentation;
 
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.LatchedActionListener;
 import org.elasticsearch.action.admin.cluster.repositories.put.PutRepositoryRequest;
@@ -80,6 +81,7 @@ import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import static org.hamcrest.Matchers.containsStringIgnoringCase;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
@@ -596,7 +598,6 @@ public class ILMDocumentationIT extends ESRestHighLevelClientTestCase {
         assertTrue(latch.await(30L, TimeUnit.SECONDS));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/70594")
     public void testRetryPolicy() throws Exception {
         RestHighLevelClient client = highLevelClient();
 
@@ -622,7 +623,7 @@ public class ILMDocumentationIT extends ESRestHighLevelClientTestCase {
             client.indices().create(createIndexRequest, RequestOptions.DEFAULT);
             assertBusy(() -> assertNotNull(client.indexLifecycle()
                 .explainLifecycle(new ExplainLifecycleRequest("my_index"), RequestOptions.DEFAULT)
-                .getIndexResponses().get("my_index").getFailedStep()), 15, TimeUnit.SECONDS);
+                .getIndexResponses().get("my_index").getFailedStep()), 30, TimeUnit.SECONDS);
         }
 
         // tag::ilm-retry-lifecycle-policy-request
@@ -631,16 +632,24 @@ public class ILMDocumentationIT extends ESRestHighLevelClientTestCase {
         // end::ilm-retry-lifecycle-policy-request
 
 
-        // tag::ilm-retry-lifecycle-policy-execute
-        AcknowledgedResponse response = client.indexLifecycle()
-            .retryLifecyclePolicy(request, RequestOptions.DEFAULT);
-        // end::ilm-retry-lifecycle-policy-execute
+        try {
+            // tag::ilm-retry-lifecycle-policy-execute
+            AcknowledgedResponse response = client.indexLifecycle()
+                .retryLifecyclePolicy(request, RequestOptions.DEFAULT);
+            // end::ilm-retry-lifecycle-policy-execute
 
-        // tag::ilm-retry-lifecycle-policy-response
-        boolean acknowledged = response.isAcknowledged(); // <1>
-        // end::ilm-retry-lifecycle-policy-response
+            // tag::ilm-retry-lifecycle-policy-response
+            boolean acknowledged = response.isAcknowledged(); // <1>
+            // end::ilm-retry-lifecycle-policy-response
 
-        assertTrue(acknowledged);
+            assertTrue(acknowledged);
+        } catch (ElasticsearchException e) {
+            // the retry API might fail as the shrink action steps are retryable (so if the retry API reaches ES when ILM is retrying the
+            // failed `shrink` step, the retry API will fail)
+            // assert that's the exception we encountered (we want to test to fail if there is an actual error with the retry api)
+            assertThat(e.getMessage(), containsStringIgnoringCase("reason=cannot retry an action for an index [my_index] that has not " +
+                "encountered an error when running a Lifecycle Policy"));
+        }
 
         // tag::ilm-retry-lifecycle-policy-execute-listener
         ActionListener<AcknowledgedResponse> listener =


### PR DESCRIPTION
Retrying a retryable step when the ILM loop is configured to `1s` (as we do in
the integration tests) is a recipe for flakiness - as ILM keeps moving a failed
step from `ERROR` back into the failed step for it to be retried, and the retry
step API fails if executed when ILM is not in the `ERROR` step.

This makes the documentation integration test more lenient.

(cherry picked from commit 03e2cec5a2edf2d99f66acd9881c4694dfad2dd7)
Signed-off-by: Andrei Dan <andrei.dan@elastic.co>

Backport of #70769
