### PR TITLE
[7.x] [DOCS] Replace hard-coded admons with cloud-only attribute (#70864)

### DIFF
--- a/docs/plugins/quota-aware-fs.asciidoc
+++ b/docs/plugins/quota-aware-fs.asciidoc
@@ -1,10 +1,7 @@
 [[quota-aware-fs]]
 === Quota-aware Filesystem Plugin
 
-[NOTE]
-The Quota-aware Filesystem plugin is designed for indirect use by {ess-trial}[{ess}],
-{ece-ref}[{ece}], and {eck-ref}[Elastic Cloud on Kubernetes]. Direct use is not
-supported.
+NOTE: {cloud-only}
 
 The Quota-aware Filesystem plugin adds an interface for telling
 Elasticsearch the disk-quota limits under which it is operating.

--- a/docs/reference/autoscaling/apis/autoscaling-apis.asciidoc
+++ b/docs/reference/autoscaling/apis/autoscaling-apis.asciidoc
@@ -3,7 +3,7 @@
 [[autoscaling-apis]]
 == Autoscaling APIs
 
-include::../autoscaling-designed-for-note.asciidoc[]
+NOTE: {cloud-only}
 
 You can use the following APIs to perform autoscaling operations.
 

--- a/docs/reference/autoscaling/apis/delete-autoscaling-policy.asciidoc
+++ b/docs/reference/autoscaling/apis/delete-autoscaling-policy.asciidoc
@@ -6,7 +6,7 @@
 <titleabbrev>Delete autoscaling policy</titleabbrev>
 ++++
 
-include::../autoscaling-designed-for-note.asciidoc[]
+NOTE: {cloud-only}
 
 Delete autoscaling policy.
 

--- a/docs/reference/autoscaling/apis/get-autoscaling-capacity.asciidoc
+++ b/docs/reference/autoscaling/apis/get-autoscaling-capacity.asciidoc
@@ -6,7 +6,7 @@
 <titleabbrev>Get autoscaling capacity</titleabbrev>
 ++++
 
-include::../autoscaling-designed-for-note.asciidoc[]
+NOTE: {cloud-only}
 
 Get autoscaling capacity.
 

--- a/docs/reference/autoscaling/apis/get-autoscaling-policy.asciidoc
+++ b/docs/reference/autoscaling/apis/get-autoscaling-policy.asciidoc
@@ -6,7 +6,7 @@
 <titleabbrev>Get autoscaling policy</titleabbrev>
 ++++
 
-include::../autoscaling-designed-for-note.asciidoc[]
+NOTE: {cloud-only}
 
 Get autoscaling policy.
 

--- a/docs/reference/autoscaling/apis/put-autoscaling-policy.asciidoc
+++ b/docs/reference/autoscaling/apis/put-autoscaling-policy.asciidoc
@@ -6,7 +6,7 @@
 <titleabbrev>Create or update autoscaling policy</titleabbrev>
 ++++
 
-include::../autoscaling-designed-for-note.asciidoc[]
+NOTE: {cloud-only}
 
 Creates or updates an autoscaling policy.
 

--- a/docs/reference/autoscaling/autoscaling-designed-for-note.asciidoc
+++ b/docs/reference/autoscaling/autoscaling-designed-for-note.asciidoc
@@ -1,4 +1,0 @@
-[NOTE]
-Autoscaling is designed for indirect use by {ess-trial}[{ess}],
-{ece-ref}[{ece}], and {eck-ref}[Elastic Cloud on Kubernetes]. Direct use is not
-supported.

--- a/docs/reference/autoscaling/index.asciidoc
+++ b/docs/reference/autoscaling/index.asciidoc
@@ -3,7 +3,7 @@
 [[xpack-autoscaling]]
 = Autoscaling
 
-include::autoscaling-designed-for-note.asciidoc[]
+NOTE: {cloud-only}
 
 The autoscaling feature enables an operator to configure tiers of nodes that
 self-monitor whether or not they need to scale based on an operator-defined

--- a/x-pack/docs/en/security/operator-privileges/configure-operator-privileges.asciidoc
+++ b/x-pack/docs/en/security/operator-privileges/configure-operator-privileges.asciidoc
@@ -3,7 +3,7 @@
 [[configure-operator-privileges]]
 === Configure operator privileges
 
-include::operator-privileges-designed-for-note.asciidoc[]
+NOTE: {cloud-only}
 
 Before you can use operator privileges, you must
 <<enable-operator-privileges, enable the feature>> on all nodes in the cluster

--- a/x-pack/docs/en/security/operator-privileges/index.asciidoc
+++ b/x-pack/docs/en/security/operator-privileges/index.asciidoc
@@ -3,7 +3,7 @@
 [[operator-privileges]]
 == Operator privileges
 
-include::operator-privileges-designed-for-note.asciidoc[]
+NOTE: {cloud-only}
 
 With a typical {es} deployment, people who administer the cluster also operate
 the cluster at the infrastructure level. User authorization based on

--- a/x-pack/docs/en/security/operator-privileges/operator-only-functionality.asciidoc
+++ b/x-pack/docs/en/security/operator-privileges/operator-only-functionality.asciidoc
@@ -3,7 +3,7 @@
 [[operator-only-functionality]]
 === Operator-only functionality
 
-include::operator-privileges-designed-for-note.asciidoc[]
+NOTE: {cloud-only}
 
 Operator privileges provide protection for APIs and dynamic cluster settings.
 Any API or cluster setting that is protected by operator privileges is known as 

--- a/x-pack/docs/en/security/operator-privileges/operator-only-snapshot-and-restore.asciidoc
+++ b/x-pack/docs/en/security/operator-privileges/operator-only-snapshot-and-restore.asciidoc
@@ -3,7 +3,7 @@
 [[operator-only-snapshot-and-restore]]
 === Operator privileges for snapshot and restore
 
-include::operator-privileges-designed-for-note.asciidoc[]
+NOTE: {cloud-only}
 
 Invoking <<operator-only-apis,operator-only APIs>> or updating
 <<operator-only-dynamic-cluster-settings,operator-only dynamic cluster settings>>

--- a/x-pack/docs/en/security/operator-privileges/operator-privileges-designed-for-note.asciidoc
+++ b/x-pack/docs/en/security/operator-privileges/operator-privileges-designed-for-note.asciidoc
@@ -1,4 +1,0 @@
-[NOTE]
-The operator privileges feature is designed for indirect use by {ess-trial}[{ess}],
-{ece-ref}[{ece}], and {eck-ref}[Elastic Cloud on Kubernetes]. Direct use is not
-supported.


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Replace hard-coded admons with cloud-only attribute (#70864)