### PR TITLE
Update mapping version check assertion to allow for representation changes

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/mapper/MapperServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/MapperServiceTests.java
@@ -287,4 +287,41 @@ public class MapperServiceTests extends MapperServiceTestCase {
         }
     }
 
+    public void testMappingUpdateChecks() throws IOException {
+        MapperService mapperService = createMapperService(fieldMapping(b -> b.field("type", "text")));
+
+        {
+            IndexMetadata.Builder builder = new IndexMetadata.Builder("test");
+            Settings settings = Settings.builder()
+                .put("index.number_of_replicas", 0)
+                .put("index.number_of_shards", 1)
+                .put("index.version.created", Version.CURRENT)
+                .build();
+            builder.settings(settings);
+
+            // Text fields are not stored by default, so an incoming update that is identical but
+            // just has `stored:false` should not require an update
+            builder.putMapping("_doc", "{\"properties\":{\"field\":{\"type\":\"text\",\"store\":\"false\"}}}");
+            assertTrue(mapperService.assertNoUpdateRequired(builder.build()));
+        }
+
+        {
+            IndexMetadata.Builder builder = new IndexMetadata.Builder("test");
+            Settings settings = Settings.builder()
+                .put("index.number_of_replicas", 0)
+                .put("index.number_of_shards", 1)
+                .put("index.version.created", Version.CURRENT)
+                .build();
+            builder.settings(settings);
+
+            // However, an update that really does need a rebuild will throw an exception
+            builder.putMapping("_doc", "{\"properties\":{\"field\":{\"type\":\"text\",\"store\":\"true\"}}}");
+            Exception e = expectThrows(IllegalStateException.class,
+                () -> mapperService.assertNoUpdateRequired(builder.build()));
+
+            assertThat(e.getMessage(), containsString("expected current mapping ["));
+            assertThat(e.getMessage(), containsString("to be the same as new mapping"));
+        }
+    }
+
 }


### PR DESCRIPTION
When a mapping update is received on a node, we currently check to see if it has the
same version as the node's current mappings, allowing us to skip applying the update
if the versions are equal. We also do a more expensive check, hidden behind an
assertion, that the incoming mapping has the same json representation as the current
mapper. This check unfortunately means that it is not possible to ever change the
serialized form of a field mapper, because the index metadata of an index created on
an older version may contain the older representation and the equality check would
then fail.

This commit alters this equality check to instead build a new mapper from the old
mapping, and then check that its serialization is equal to that of the current mapper;
this way we ensure that the mappings have not changed while still allowing for
changes in representation.

Fixes #59427