### PR TITLE
Preserve half_float's precision in fields API (backport of #70653)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -125,6 +125,18 @@ public class NumberFieldMapper extends FieldMapper {
         HALF_FLOAT("half_float", NumericType.HALF_FLOAT) {
             @Override
             public Float parse(Object value, boolean coerce) {
+                final float result = parseToFloat(value);
+                // Reduce the precision to what we actually index
+                return HalfFloatPoint.sortableShortToHalfFloat(HalfFloatPoint.halfFloatToSortableShort(result));
+            }
+
+            /**
+             * Parse a query parameter or {@code _source} value to a float,
+             * keeping float precision. Used by queries which need more
+             * precise control over their rounding behavior that
+             * {@link #parse(Object, boolean)} provides.
+             */
+            private float parseToFloat(Object value) {
                 final float result;
 
                 if (value instanceof Number) {
@@ -153,7 +165,7 @@ public class NumberFieldMapper extends FieldMapper {
 
             @Override
             public Query termQuery(String field, Object value) {
-                float v = parse(value, false);
+                float v = parseToFloat(value);
                 return HalfFloatPoint.newExactQuery(field, v);
             }
 
@@ -162,7 +174,7 @@ public class NumberFieldMapper extends FieldMapper {
                 float[] v = new float[values.size()];
                 int pos = 0;
                 for (Object value: values) {
-                    v[pos++] = parse(value, false);
+                    v[pos++] = parseToFloat(value);
                 }
                 return HalfFloatPoint.newSetQuery(field, v);
             }
@@ -174,14 +186,14 @@ public class NumberFieldMapper extends FieldMapper {
                 float l = Float.NEGATIVE_INFINITY;
                 float u = Float.POSITIVE_INFINITY;
                 if (lowerTerm != null) {
-                    l = parse(lowerTerm, false);
+                    l = parseToFloat(lowerTerm);
                     if (includeLower) {
                         l = HalfFloatPoint.nextDown(l);
                     }
                     l = HalfFloatPoint.nextUp(l);
                 }
                 if (upperTerm != null) {
-                    u = parse(upperTerm, false);
+                    u = parseToFloat(upperTerm);
                     if (includeUpper) {
                         u = HalfFloatPoint.nextUp(u);
                     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldTypeTests.java
@@ -277,7 +277,7 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
         assertEquals("Value [2147483648] is out of range for an integer", e.getMessage());
         e = expectThrows(IllegalArgumentException.class, () -> NumberType.LONG.parse(10000000000000000000d, true));
         assertEquals("Value [1.0E19] is out of range for a long", e.getMessage());
-        assertEquals(1.1f, NumberType.HALF_FLOAT.parse(1.1, true));
+        assertEquals(1.0996094f, NumberType.HALF_FLOAT.parse(1.1, true));  // Half float loses a bit of precision even on 1.1....
         assertEquals(1.1f, NumberType.FLOAT.parse(1.1, true));
         assertEquals(1.1d, NumberType.DOUBLE.parse(1.1, true));
     }
@@ -647,5 +647,23 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
             .fieldType();
         assertEquals(Collections.singletonList(2.71f), fetchSourceValue(nullValueMapper, ""));
         assertEquals(Collections.singletonList(2.71f), fetchSourceValue(nullValueMapper, null));
+    }
+
+    public void testFetchHalfFloatFromSource() throws IOException {
+        MappedFieldType mapper = new NumberFieldMapper.Builder("field", NumberType.HALF_FLOAT, false, true)
+            .build(new ContentPath())
+            .fieldType();
+        /*
+         * Half float loses a fair bit of precision compared to float but
+         * we still do floating point comparisons. The "funny" trailing
+         * {@code .000625} is, for example, the precision loss of using
+         * a half float reflected back into a float.
+         */
+        assertEquals(org.elasticsearch.common.collect.List.of(3.140625F), fetchSourceValue(mapper, 3.14));
+        assertEquals(org.elasticsearch.common.collect.List.of(3.140625F), fetchSourceValue(mapper, 3.14F));
+        assertEquals(org.elasticsearch.common.collect.List.of(3.0F), fetchSourceValue(mapper, 3));
+        assertEquals(org.elasticsearch.common.collect.List.of(42.90625F), fetchSourceValue(mapper, "42.9"));
+        assertEquals(org.elasticsearch.common.collect.List.of(47.125F), fetchSourceValue(mapper, 47.1231234));
+        assertEquals(org.elasticsearch.common.collect.List.of(3.140625F, 42.90625F), fetchSourceValues(mapper, 3.14, "foo", "42.9"));
     }
 }

--- a/x-pack/plugin/sql/qa/mixed-node/src/test/java/org/elasticsearch/xpack/sql/qa/mixed_node/SqlSearchIT.java
+++ b/x-pack/plugin/sql/qa/mixed-node/src/test/java/org/elasticsearch/xpack/sql/qa/mixed_node/SqlSearchIT.java
@@ -72,7 +72,7 @@ public class SqlSearchIT extends ESRestTestCase {
         newVersion = nodes.getNewNodes().get(0).getVersion();
         isBwcNodeBeforeFieldsApiInQL = bwcVersion.before(FIELDS_API_QL_INTRODUCTION);
         isBwcNodeBeforeFieldsApiInES = bwcVersion.before(SWITCH_TO_FIELDS_API_VERSION);
-        halfFloatMightReturnFullFloatPrecision = false == isBwcNodeBeforeFieldsApiInQL && bwcVersion.before(Version.V_7_13_0);
+        halfFloatMightReturnFullFloatPrecision = bwcVersion.before(Version.V_7_13_0);
 
         String mappings = readResource(SqlSearchIT.class.getResourceAsStream("/all_field_types.json"));
         createIndex(
@@ -103,7 +103,7 @@ public class SqlSearchIT extends ESRestTestCase {
                  * that version we don't fetch the half float because we
                  * can't make any assertions about it.
                  */
-                if (false == halfFloatMightReturnFullFloatPrecision) {
+                if (isBwcNodeBeforeFieldsApiInQL || false == halfFloatMightReturnFullFloatPrecision) {
                     columns.add(columnInfo("half_float_field", "half_float"));
                 }
             },
@@ -153,7 +153,7 @@ public class SqlSearchIT extends ESRestTestCase {
                  * that version we don't fetch the half float because we
                  * can't make any assertions about it.
                  */
-                if (false == halfFloatMightReturnFullFloatPrecision) {
+                if (isBwcNodeBeforeFieldsApiInQL && isBwcNodeBeforeFieldsApiInES || false == halfFloatMightReturnFullFloatPrecision) {
                     columns.add(columnInfo("half_float_field", "half_float"));
                 }
             },

--- a/x-pack/plugin/sql/qa/mixed-node/src/test/java/org/elasticsearch/xpack/sql/qa/mixed_node/SqlSearchIT.java
+++ b/x-pack/plugin/sql/qa/mixed-node/src/test/java/org/elasticsearch/xpack/sql/qa/mixed_node/SqlSearchIT.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.sql.qa.mixed_node;
 
 import org.apache.http.HttpHost;
+import org.apache.lucene.document.HalfFloatPoint;
 import org.elasticsearch.Version;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
@@ -58,6 +59,7 @@ public class SqlSearchIT extends ESRestTestCase {
     private static Version newVersion;
     private static boolean isBwcNodeBeforeFieldsApiInQL;
     private static boolean isBwcNodeBeforeFieldsApiInES;
+    private static boolean halfFloatMightReturnFullFloatPrecision;
 
     @Before
     public void createIndex() throws IOException {
@@ -70,6 +72,7 @@ public class SqlSearchIT extends ESRestTestCase {
         newVersion = nodes.getNewNodes().get(0).getVersion();
         isBwcNodeBeforeFieldsApiInQL = bwcVersion.before(FIELDS_API_QL_INTRODUCTION);
         isBwcNodeBeforeFieldsApiInES = bwcVersion.before(SWITCH_TO_FIELDS_API_VERSION);
+        halfFloatMightReturnFullFloatPrecision = false == isBwcNodeBeforeFieldsApiInQL && bwcVersion.before(Version.V_7_13_0);
 
         String mappings = readResource(SqlSearchIT.class.getResourceAsStream("/all_field_types.json"));
         createIndex(
@@ -94,7 +97,15 @@ public class SqlSearchIT extends ESRestTestCase {
             columns -> {
                 columns.add(columnInfo("geo_point_field", "geo_point"));
                 columns.add(columnInfo("float_field", "float"));
-                columns.add(columnInfo("half_float_field", "half_float"));
+                /*
+                 * In 7.12.x we got full float precision from half floats
+                 * back from the fields API. When the cluster is mixed with
+                 * that version we don't fetch the half float because we
+                 * can't make any assertions about it.
+                 */
+                if (false == halfFloatMightReturnFullFloatPrecision) {
+                    columns.add(columnInfo("half_float_field", "half_float"));
+                }
             },
             (builder, fieldValues) -> {
                 Float randomFloat = randomFloat();
@@ -114,7 +125,17 @@ public class SqlSearchIT extends ESRestTestCase {
                     fieldValues.put("geo_point_field", "POINT (-122.083843 37.386483)");
                     builder.append("\"float_field\":" + randomFloat + ",");
                     fieldValues.put("float_field", Double.valueOf(Float.valueOf(randomFloat).toString()));
-                    builder.append("\"half_float_field\":" + fieldValues.computeIfAbsent("half_float_field", v -> 123.456));
+                    /*
+                     * In 7.12.x we got full float precision from half floats
+                     * back from the fields API. When the cluster is mixed with
+                     * that version we don't fetch the half float because we
+                     * can't make any assertions about it.
+                     */
+                    float roundedHalfFloat = HalfFloatPoint.sortableShortToHalfFloat(HalfFloatPoint.halfFloatToSortableShort(randomFloat));
+                    builder.append("\"half_float_field\":\"" + randomFloat + "\"");
+                    if (false == halfFloatMightReturnFullFloatPrecision) {
+                        fieldValues.put("half_float_field", roundedHalfFloat);
+                    }
                 }
             }
         );
@@ -126,7 +147,15 @@ public class SqlSearchIT extends ESRestTestCase {
             columns -> {
                 columns.add(columnInfo("geo_point_field", "geo_point"));
                 columns.add(columnInfo("float_field", "float"));
-                columns.add(columnInfo("half_float_field", "half_float"));
+                /*
+                 * In 7.12.x we got full float precision from half floats
+                 * back from the fields API. When the cluster is mixed with
+                 * that version we don't fetch the half float because we
+                 * can't make any assertions about it.
+                 */
+                if (false == halfFloatMightReturnFullFloatPrecision) {
+                    columns.add(columnInfo("half_float_field", "half_float"));
+                }
             },
             (builder, fieldValues) -> {
                 Float randomFloat = randomFloat();
@@ -143,7 +172,17 @@ public class SqlSearchIT extends ESRestTestCase {
                     fieldValues.put("geo_point_field", "POINT (-122.083843 37.386483)");
                     builder.append("\"float_field\":" + randomFloat + ",");
                     fieldValues.put("float_field", Double.valueOf(Float.valueOf(randomFloat).toString()));
-                    builder.append("\"half_float_field\":" + fieldValues.computeIfAbsent("half_float_field", v -> 123.456));
+                    /*
+                     * In 7.12.x we got full float precision from half floats
+                     * back from the fields API. When the cluster is mixed with
+                     * that version we don't fetch the half float because we
+                     * can't make any assertions about it.
+                     */
+                    float roundedHalfFloat = HalfFloatPoint.sortableShortToHalfFloat(HalfFloatPoint.halfFloatToSortableShort(randomFloat));
+                    builder.append("\"half_float_field\":\"" + randomFloat + "\"");
+                    if (false == halfFloatMightReturnFullFloatPrecision) {
+                        fieldValues.put("half_float_field", roundedHalfFloat);
+                    }
                 }
             }
         );

--- a/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/FieldExtractorTestCase.java
+++ b/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/FieldExtractorTestCase.java
@@ -230,7 +230,7 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
         // because "coerce" is true, a "123.456" floating point number STRING should be converted to 123.456 as number
         // and converted to 123.5 for "scaled_float" type
         // and 123.4375 for "half_float" because that is all it stores.
-        double expectedNumber = isScaledFloat ? 123.5 : fieldType.equals("half_float") ? 123.4375 : 1234.56;
+        double expectedNumber = isScaledFloat ? 123.5 : fieldType.equals("half_float") ? 123.4375 : 123.456;
         expected.put("rows", singletonList(singletonList(expectedNumber)));
         assertResponse(expected, runSql("SELECT " + fieldType + "_field FROM test"));
     }

--- a/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/FieldExtractorTestCase.java
+++ b/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/FieldExtractorTestCase.java
@@ -229,7 +229,9 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
 
         // because "coerce" is true, a "123.456" floating point number STRING should be converted to 123.456 as number
         // and converted to 123.5 for "scaled_float" type
-        expected.put("rows", singletonList(singletonList(isScaledFloat ? 123.5 : 123.456d)));
+        // and 123.4375 for "half_float" because that is all it stores.
+        double expectedNumber = isScaledFloat ? 123.5 : fieldType.equals("half_float") ? 123.4375 : 1234.56;
+        expected.put("rows", singletonList(singletonList(expectedNumber)));
         assertResponse(expected, runSql("SELECT " + fieldType + "_field FROM test"));
     }
 


### PR DESCRIPTION
This modifies the fields API to return values with half_float's
precision. This makes the fields API better reflect what we've indexed
which we'd like to to do in general. It does make the values that come
back "uglier" because things like `3.14` end up becoming `3.140625`. But
that is what is actually in the index so itsmore "real".

Closes #70260
