### PR TITLE
Optimize InternalAggregations Reduce

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/InternalAggregations.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/InternalAggregations.java
@@ -137,12 +137,16 @@ public final class InternalAggregations extends Aggregations implements Writeabl
         InternalAggregation[] reducedAggregations = new InternalAggregation[colSize];
         InternalAggregation[] aggregations = new InternalAggregation[rowSize];
         for (int col = 0; col < colSize; col++) {
+            boolean hasUnmapped = false;
             for (int row = 0; row < aggregationsList.size(); row++) {
                 aggregations[row] = (InternalAggregation) aggregationsList.get(row).aggregations.get(col);
+                hasUnmapped = hasUnmapped || (aggregations[row].isMapped() == false);
             }
             // Sort aggregations so that unmapped aggs come last in the list
             // If all aggs are unmapped, the agg that leads the reduction will just return itself
-            Arrays.sort(aggregations, INTERNAL_AGG_COMPARATOR);
+            if (hasUnmapped) {
+                Arrays.sort(aggregations, INTERNAL_AGG_COMPARATOR);
+            }
             InternalAggregation first = aggregations[0]; // the list can't be empty as it's created on demand
             if (first.mustReduceOnSingleInternalAgg() || aggregations.length > 1) {
                 reducedAggregations[col] = first.reduce(Arrays.asList(aggregations), context);


### PR DESCRIPTION
Today, in `InternalAggregations#Reduce`, we always collect all aggregations with the same name and list them together with a `map`. I'm not sure if this is necessary but for all the cases i can think of, aggregations with a same name always have a same index in `InternalAggregations`. So maybe all we need to do is just to convert the aggregations with the same index into a list and reduce them, as the code shows.

Here is the took of a query whose terms agg needs to reduce 2,600,000 buckets to 630,000 on the coodinator and sum 8 metric in each bucket, and we can see a great improvement.
| baseline | candidate |
| ---- | ---- |
|  7100 ms | 4687 ms |

