### PR TITLE
Remove MappedFieldType#setEagerGlobalOrdinals

### DIFF
--- a/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentIdFieldMapper.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentIdFieldMapper.java
@@ -47,14 +47,22 @@ public final class ParentIdFieldMapper extends FieldMapper {
     }
 
     public static final class ParentIdFieldType extends StringFieldType {
+
+        private final boolean eagerGlobalOrdinals;
+
         public ParentIdFieldType(String name, boolean eagerGlobalOrdinals) {
             super(name, true, false, true, TextSearchInfo.SIMPLE_MATCH_ONLY, Collections.emptyMap());
-            setEagerGlobalOrdinals(eagerGlobalOrdinals);
+            this.eagerGlobalOrdinals = eagerGlobalOrdinals;
         }
 
         @Override
         public String typeName() {
             return CONTENT_TYPE;
+        }
+
+        @Override
+        public boolean eagerGlobalOrdinals() {
+            return eagerGlobalOrdinals;
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -168,6 +168,7 @@ public final class KeywordFieldMapper extends FieldMapper {
         private final int ignoreAbove;
         private final String nullValue;
         private final NamedAnalyzer normalizer;
+        private final boolean eagerGlobalOrdinals;
 
         public KeywordFieldType(String name, FieldType fieldType,
                                 NamedAnalyzer normalizer, NamedAnalyzer searchAnalyzer, NamedAnalyzer quoteAnalyzer,
@@ -178,7 +179,7 @@ public final class KeywordFieldMapper extends FieldMapper {
                 builder.hasDocValues.getValue(),
                 new TextSearchInfo(fieldType, builder.similarity.getValue(), searchAnalyzer, quoteAnalyzer),
                 builder.meta.getValue());
-            setEagerGlobalOrdinals(builder.eagerGlobalOrdinals.getValue());
+            this.eagerGlobalOrdinals = builder.eagerGlobalOrdinals.getValue();
             this.normalizer = normalizer;
             this.ignoreAbove = builder.ignoreAbove.getValue();
             this.nullValue = builder.nullValue.getValue();
@@ -189,6 +190,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             this.normalizer = Lucene.KEYWORD_ANALYZER;
             this.ignoreAbove = Integer.MAX_VALUE;
             this.nullValue = null;
+            this.eagerGlobalOrdinals = false;
         }
 
         public KeywordFieldType(String name) {
@@ -203,6 +205,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             this.normalizer = Lucene.KEYWORD_ANALYZER;
             this.ignoreAbove = Integer.MAX_VALUE;
             this.nullValue = null;
+            this.eagerGlobalOrdinals = false;
         }
 
         public KeywordFieldType(String name, NamedAnalyzer analyzer) {
@@ -210,11 +213,17 @@ public final class KeywordFieldMapper extends FieldMapper {
             this.normalizer = Lucene.KEYWORD_ANALYZER;
             this.ignoreAbove = Integer.MAX_VALUE;
             this.nullValue = null;
+            this.eagerGlobalOrdinals = false;
         }
 
         @Override
         public String typeName() {
             return CONTENT_TYPE;
+        }
+
+        @Override
+        public boolean eagerGlobalOrdinals() {
+            return eagerGlobalOrdinals;
         }
 
         NamedAnalyzer normalizer() {

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
@@ -61,7 +61,6 @@ public abstract class MappedFieldType {
     private final boolean isStored;
     private final TextSearchInfo textSearchInfo;
     private final Map<String, String> meta;
-    private boolean eagerGlobalOrdinals;
 
     public MappedFieldType(String name, boolean isIndexed, boolean isStored,
                            boolean hasDocValues, TextSearchInfo textSearchInfo, Map<String, String> meta) {
@@ -329,12 +328,11 @@ public abstract class MappedFieldType {
         }
     }
 
+    /**
+     * @return if this field type should load global ordinals eagerly
+     */
     public boolean eagerGlobalOrdinals() {
-        return eagerGlobalOrdinals;
-    }
-
-    public void setEagerGlobalOrdinals(boolean eagerGlobalOrdinals) {
-        this.eagerGlobalOrdinals = eagerGlobalOrdinals;
+        return false;
     }
 
     /** Return a {@link DocValueFormat} that can be used to display and parse

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -311,8 +311,9 @@ public class TextFieldMapper extends FieldMapper {
                 }
             }
             TextSearchInfo tsi = new TextSearchInfo(fieldType, similarity.getValue(), searchAnalyzer, searchQuoteAnalyzer);
-            TextFieldType ft = new TextFieldType(buildFullName(contentPath), index.getValue(), store.getValue(), tsi, meta.getValue());
-            ft.setEagerGlobalOrdinals(eagerGlobalOrdinals.getValue());
+            TextFieldType ft = new TextFieldType(
+                buildFullName(contentPath), index.getValue(), store.getValue(), tsi, meta.getValue());
+            ft.eagerGlobalOrdinals = eagerGlobalOrdinals.getValue();
             if (fieldData.getValue()) {
                 ft.setFielddata(true, freqFilter.getValue());
             }
@@ -572,6 +573,7 @@ public class TextFieldMapper extends FieldMapper {
         private FielddataFrequencyFilter filter;
         private PrefixFieldType prefixFieldType;
         private boolean indexPhrases = false;
+        private boolean eagerGlobalOrdinals = false;
 
         public TextFieldType(String name, boolean indexed, boolean stored, TextSearchInfo tsi, Map<String, String> meta) {
             super(name, indexed, stored, false, tsi, meta);
@@ -592,6 +594,11 @@ public class TextFieldMapper extends FieldMapper {
 
         public boolean fielddata() {
             return fielddata;
+        }
+
+        @Override
+        public boolean eagerGlobalOrdinals() {
+            return eagerGlobalOrdinals;
         }
 
         public void setFielddata(boolean fielddata, FielddataFrequencyFilter filter) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
@@ -147,10 +147,12 @@ public final class FlattenedFieldMapper extends DynamicKeyFieldMapper {
                 throw new IllegalArgumentException(CONTENT_TYPE + " field [" + name + "] does not support [copy_to]");
             }
             MappedFieldType ft = new RootFlattenedFieldType(
-                buildFullName(contentPath), indexed.get(), hasDocValues.get(), meta.get(), splitQueriesOnWhitespace.get());
-            if (eagerGlobalOrdinals.get()) {
-                ft.setEagerGlobalOrdinals(true);
-            }
+                buildFullName(contentPath),
+                indexed.get(),
+                hasDocValues.get(),
+                meta.get(),
+                splitQueriesOnWhitespace.get(),
+                eagerGlobalOrdinals.get());
             return new FlattenedFieldMapper(name, ft, this);
         }
     }
@@ -375,17 +377,24 @@ public final class FlattenedFieldMapper extends DynamicKeyFieldMapper {
      */
     public static final class RootFlattenedFieldType extends StringFieldType {
         private final boolean splitQueriesOnWhitespace;
+        private final boolean eagerGlobalOrdinals;
 
         public RootFlattenedFieldType(String name, boolean indexed, boolean hasDocValues, Map<String, String> meta,
-                                      boolean splitQueriesOnWhitespace) {
+                                      boolean splitQueriesOnWhitespace, boolean eagerGlobalOrdinals) {
             super(name, indexed, false, hasDocValues,
                 splitQueriesOnWhitespace ? TextSearchInfo.WHITESPACE_MATCH_ONLY : TextSearchInfo.SIMPLE_MATCH_ONLY, meta);
             this.splitQueriesOnWhitespace = splitQueriesOnWhitespace;
+            this.eagerGlobalOrdinals = eagerGlobalOrdinals;
         }
 
         @Override
         public String typeName() {
             return CONTENT_TYPE;
+        }
+
+        @Override
+        public boolean eagerGlobalOrdinals() {
+            return eagerGlobalOrdinals;
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/index/mapper/flattened/RootFlattenedFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/flattened/RootFlattenedFieldTypeTests.java
@@ -32,7 +32,7 @@ import java.util.Map;
 public class RootFlattenedFieldTypeTests extends FieldTypeTestCase {
 
     private static RootFlattenedFieldType createDefaultFieldType() {
-        return new RootFlattenedFieldType("field", true, true, Collections.emptyMap(), false);
+        return new RootFlattenedFieldType("field", true, true, Collections.emptyMap(), false, false);
     }
 
     public void testValueForDisplay() {
@@ -54,19 +54,19 @@ public class RootFlattenedFieldTypeTests extends FieldTypeTestCase {
 
 
         RootFlattenedFieldType unsearchable = new RootFlattenedFieldType("field", false, true,
-            Collections.emptyMap(), false);
+            Collections.emptyMap(), false, false);
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
             () -> unsearchable.termQuery("field", null));
         assertEquals("Cannot search on field [field] since it is not indexed.", e.getMessage());
     }
 
     public void testExistsQuery() {
-        RootFlattenedFieldType ft = new RootFlattenedFieldType("field", true, false, Collections.emptyMap(), false);
+        RootFlattenedFieldType ft = new RootFlattenedFieldType("field", true, false, Collections.emptyMap(), false, false);
         assertEquals(
             new TermQuery(new Term(FieldNamesFieldMapper.NAME, new BytesRef("field"))),
             ft.existsQuery(null));
 
-        RootFlattenedFieldType withDv = new RootFlattenedFieldType("field", true, true, Collections.emptyMap(), false);
+        RootFlattenedFieldType withDv = new RootFlattenedFieldType("field", true, true, Collections.emptyMap(), false, false);
         assertEquals(new DocValuesFieldExistsQuery("field"), withDv.existsQuery(null));
     }
 


### PR DESCRIPTION
This is the only remaining setter on MappedFieldType, and removing
it makes the base class entirely final.  We now only override the
`eagerGlobalOrdinals` method on types that actually support it.