### PR TITLE
[7.x] [ML] Allow datafeed and job configs for datafeed preview API (#70836)

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/MLRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/MLRequestConverters.java
@@ -326,14 +326,18 @@ final class MLRequestConverters {
         return request;
     }
 
-    static Request previewDatafeed(PreviewDatafeedRequest previewDatafeedRequest) {
-        String endpoint = new EndpointBuilder()
+    static Request previewDatafeed(PreviewDatafeedRequest previewDatafeedRequest) throws IOException {
+        EndpointBuilder builder = new EndpointBuilder()
             .addPathPartAsIs("_ml")
-            .addPathPartAsIs("datafeeds")
-            .addPathPart(previewDatafeedRequest.getDatafeedId())
-            .addPathPartAsIs("_preview")
-            .build();
-        return new Request(HttpGet.METHOD_NAME, endpoint);
+            .addPathPartAsIs("datafeeds");
+        String endpoint = previewDatafeedRequest.getDatafeedId() != null ?
+            builder.addPathPart(previewDatafeedRequest.getDatafeedId()).addPathPartAsIs("_preview").build() :
+            builder.addPathPartAsIs("_preview").build();
+        Request request = new Request(HttpPost.METHOD_NAME, endpoint);
+        if (previewDatafeedRequest.getDatafeedId() == null) {
+            request.setEntity(createEntity(previewDatafeedRequest, REQUEST_BODY_CONTENT_TYPE));
+        }
+        return request;
     }
 
     static Request deleteForecast(DeleteForecastRequest deleteForecastRequest) {

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/PreviewDatafeedRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/PreviewDatafeedRequest.java
@@ -10,6 +10,9 @@ package org.elasticsearch.client.ml;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.client.ml.datafeed.DatafeedConfig;
+import org.elasticsearch.client.ml.job.config.Job;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.ToXContentObject;
@@ -24,11 +27,17 @@ import java.util.Objects;
  */
 public class PreviewDatafeedRequest extends ActionRequest implements ToXContentObject {
 
+    private static final ParseField DATAFEED_CONFIG = new ParseField("datafeed_config");
+    private static final ParseField JOB_CONFIG = new ParseField("job_config");
+
     public static final ConstructingObjectParser<PreviewDatafeedRequest, Void> PARSER = new ConstructingObjectParser<>(
-        "open_datafeed_request", true, a -> new PreviewDatafeedRequest((String) a[0]));
+        "preview_datafeed_request",
+        a -> new PreviewDatafeedRequest((String) a[0], (DatafeedConfig.Builder) a[1], (Job.Builder) a[2]));
 
     static {
-        PARSER.declareString(ConstructingObjectParser.constructorArg(), DatafeedConfig.ID);
+        PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), DatafeedConfig.ID);
+        PARSER.declareObject(ConstructingObjectParser.optionalConstructorArg(), DatafeedConfig.PARSER, DATAFEED_CONFIG);
+        PARSER.declareObject(ConstructingObjectParser.optionalConstructorArg(), Job.PARSER, JOB_CONFIG);
     }
 
     public static PreviewDatafeedRequest fromXContent(XContentParser parser) throws IOException {
@@ -36,6 +45,16 @@ public class PreviewDatafeedRequest extends ActionRequest implements ToXContentO
     }
 
     private final String datafeedId;
+    private final DatafeedConfig datafeedConfig;
+    private final Job jobConfig;
+
+    private PreviewDatafeedRequest(@Nullable String datafeedId,
+                                   @Nullable DatafeedConfig.Builder datafeedConfig,
+                                   @Nullable Job.Builder jobConfig) {
+        this.datafeedId = datafeedId;
+        this.datafeedConfig = datafeedConfig == null ? null : datafeedConfig.build();
+        this.jobConfig = jobConfig == null ? null : jobConfig.build();
+    }
 
     /**
      * Create a new request with the desired datafeedId
@@ -44,10 +63,31 @@ public class PreviewDatafeedRequest extends ActionRequest implements ToXContentO
      */
     public PreviewDatafeedRequest(String datafeedId) {
         this.datafeedId = Objects.requireNonNull(datafeedId, "[datafeed_id] must not be null");
+        this.datafeedConfig = null;
+        this.jobConfig = null;
+    }
+
+    /**
+     * Create a new request to preview the provided datafeed config and optional job config
+     * @param datafeedConfig The datafeed to preview
+     * @param jobConfig The associated job config (required if the datafeed does not refer to an existing job)
+     */
+    public PreviewDatafeedRequest(DatafeedConfig datafeedConfig, Job jobConfig) {
+        this.datafeedId = null;
+        this.datafeedConfig = datafeedConfig;
+        this.jobConfig = jobConfig;
     }
 
     public String getDatafeedId() {
         return datafeedId;
+    }
+
+    public DatafeedConfig getDatafeedConfig() {
+        return datafeedConfig;
+    }
+
+    public Job getJobConfig() {
+        return jobConfig;
     }
 
     @Override
@@ -58,7 +98,15 @@ public class PreviewDatafeedRequest extends ActionRequest implements ToXContentO
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.field(DatafeedConfig.ID.getPreferredName(), datafeedId);
+        if (datafeedId != null) {
+            builder.field(DatafeedConfig.ID.getPreferredName(), datafeedId);
+        }
+        if (datafeedConfig != null) {
+            builder.field(DATAFEED_CONFIG.getPreferredName(), datafeedConfig);
+        }
+        if (jobConfig != null) {
+            builder.field(JOB_CONFIG.getPreferredName(), jobConfig);
+        }
         builder.endObject();
         return builder;
     }
@@ -70,7 +118,7 @@ public class PreviewDatafeedRequest extends ActionRequest implements ToXContentO
 
     @Override
     public int hashCode() {
-        return Objects.hash(datafeedId);
+        return Objects.hash(datafeedId, datafeedConfig, jobConfig);
     }
 
     @Override
@@ -84,6 +132,8 @@ public class PreviewDatafeedRequest extends ActionRequest implements ToXContentO
         }
 
         PreviewDatafeedRequest that = (PreviewDatafeedRequest) other;
-        return Objects.equals(datafeedId, that.datafeedId);
+        return Objects.equals(datafeedId, that.datafeedId)
+            && Objects.equals(datafeedConfig, that.datafeedConfig)
+            && Objects.equals(jobConfig, that.jobConfig);
     }
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/MLRequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/MLRequestConvertersTests.java
@@ -91,6 +91,7 @@ import org.elasticsearch.client.ml.inference.TrainedModelConfigTests;
 import org.elasticsearch.client.ml.job.config.AnalysisConfig;
 import org.elasticsearch.client.ml.job.config.Detector;
 import org.elasticsearch.client.ml.job.config.Job;
+import org.elasticsearch.client.ml.job.config.JobTests;
 import org.elasticsearch.client.ml.job.config.JobUpdate;
 import org.elasticsearch.client.ml.job.config.JobUpdateTests;
 import org.elasticsearch.client.ml.job.config.MlFilter;
@@ -390,11 +391,24 @@ public class MLRequestConvertersTests extends ESTestCase {
         assertEquals(Boolean.toString(true), request.getParameters().get("allow_no_match"));
     }
 
-    public void testPreviewDatafeed() {
+    public void testPreviewDatafeed() throws IOException {
         PreviewDatafeedRequest datafeedRequest = new PreviewDatafeedRequest("datafeed_1");
         Request request = MLRequestConverters.previewDatafeed(datafeedRequest);
-        assertEquals(HttpGet.METHOD_NAME, request.getMethod());
+        assertEquals(HttpPost.METHOD_NAME, request.getMethod());
         assertEquals("/_ml/datafeeds/" + datafeedRequest.getDatafeedId() + "/_preview", request.getEndpoint());
+        assertThat(request.getEntity(), is(nullValue()));
+
+        datafeedRequest = new PreviewDatafeedRequest(
+            DatafeedConfigTests.createRandom(),
+            randomBoolean() ? null : JobTests.createRandomizedJob()
+        );
+        request = MLRequestConverters.previewDatafeed(datafeedRequest);
+        assertEquals(HttpPost.METHOD_NAME, request.getMethod());
+        assertEquals("/_ml/datafeeds/_preview", request.getEndpoint());
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, request.getEntity().getContent())) {
+            PreviewDatafeedRequest parsedDatafeedRequest = PreviewDatafeedRequest.PARSER.apply(parser, null);
+            assertThat(parsedDatafeedRequest, equalTo(datafeedRequest));
+        }
     }
 
     public void testDeleteForecast() {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/PreviewDatafeedRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/PreviewDatafeedRequestTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.client.ml;
 
 import org.elasticsearch.client.ml.datafeed.DatafeedConfigTests;
+import org.elasticsearch.client.ml.job.config.JobTests;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.test.AbstractXContentTestCase;
 
@@ -17,7 +18,9 @@ public class PreviewDatafeedRequestTests extends AbstractXContentTestCase<Previe
 
     @Override
     protected PreviewDatafeedRequest createTestInstance() {
-        return new PreviewDatafeedRequest(DatafeedConfigTests.randomValidDatafeedId());
+        return randomBoolean() ?
+            new PreviewDatafeedRequest(DatafeedConfigTests.randomValidDatafeedId()) :
+            new PreviewDatafeedRequest(DatafeedConfigTests.createRandom(), randomBoolean() ? null : JobTests.createRandomizedJob());
     }
 
     @Override
@@ -27,6 +30,6 @@ public class PreviewDatafeedRequestTests extends AbstractXContentTestCase<Previe
 
     @Override
     protected boolean supportsUnknownFields() {
-        return true;
+        return false;
     }
 }

--- a/docs/reference/ml/anomaly-detection/apis/preview-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/preview-datafeed.asciidoc
@@ -13,7 +13,13 @@ Previews a {dfeed}.
 [[ml-preview-datafeed-request]]
 == {api-request-title}
 
-`GET _ml/datafeeds/<datafeed_id>/_preview`
+`GET _ml/datafeeds/<datafeed_id>/_preview` +
+
+`POST _ml/datafeeds/<datafeed_id>/_preview` +
+
+`GET _ml/datafeeds/_preview` +
+
+`POST _ml/datafeeds/_preview`
 
 [[ml-preview-datafeed-prereqs]]
 == {api-prereq-title}
@@ -25,9 +31,10 @@ Previews a {dfeed}.
 [[ml-preview-datafeed-desc]]
 == {api-description-title}
 
-The preview {dfeeds} API returns the first "page" of results from the `search`
-that is created by using the current {dfeed} settings. This preview shows the
-structure of the data that will be passed to the anomaly detection engine.
+The preview {dfeeds} API returns the first "page" of search results from a 
+{dfeed}. You can preview an existing {dfeed} or provide configuration details
+for the {dfeed} and {anomaly-job} in the API. The preview shows the structure of 
+the data that will be passed to the anomaly detection engine.
 
 IMPORTANT: When {es} {security-features} are enabled, the {dfeed} query is
 previewed using the credentials of the user calling the preview {dfeed} API.
@@ -43,11 +50,31 @@ supply the credentials.
 == {api-path-parms-title}
 
 `<datafeed_id>`::
-(Required, string)
+(Optional, string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=datafeed-id]
++
+NOTE: If you provide the `<datafeed_id>` as a path parameter, you cannot
+provide {dfeed} or {anomaly-job} configuration details in the request body.
+
+[[ml-preview-datafeed-request-body]]
+== {api-request-body-title}
+
+`datafeed_config`::
+(Optional, object) The {dfeed} definition to preview. For valid definitions, see
+the <<ml-put-datafeed-request-body,create {dfeeds} API>>.
+
+`job_config`::
+(Optional, object) The configuration details for the {anomaly-job} that is
+associated with the {dfeed}. If the `datafeed_config` object does not include a
+`job_id` that references an existing {anomaly-job}, you must supply this
+`job_config` object. If you include both a `job_id` and a `job_config`, the
+latter information is used. You cannot specify a `job_config` object unless you also supply a `datafeed_config` object. For valid definitions, see the
+<<ml-put-job-request-body,create {anomaly-jobs} API>>.
 
 [[ml-preview-datafeed-example]]
 == {api-examples-title}
+
+This is an example of providing the ID of an existing {dfeed}:
 
 [source,console]
 --------------------------------------------------
@@ -85,5 +112,90 @@ The data that is returned for this example is as follows:
     "taxful_total_price" : 72.0
   },
   ...
+]
+----
+
+The following example provides {dfeed} and {anomaly-job} configuration 
+details in the API:
+
+[source,console]
+--------------------------------------------------
+POST _ml/datafeeds/_preview
+{
+  "datafeed_config": {
+    "indices" : [
+      "kibana_sample_data_ecommerce"
+    ],
+    "query" : {
+      "bool" : {
+        "filter" : [
+          {
+            "term" : {
+              "_index" : "kibana_sample_data_ecommerce"
+            }
+          }
+        ]
+      }
+    },
+    "scroll_size" : 1000
+  },
+  "job_config": {
+    "description" : "Find customers spending an unusually high amount in an hour",
+    "analysis_config" : {
+      "bucket_span" : "1h",
+      "detectors" : [
+        {
+          "detector_description" : "High total sales",
+          "function" : "high_sum",
+          "field_name" : "taxful_total_price",
+          "over_field_name" : "customer_full_name.keyword"
+        }
+      ],
+      "influencers" : [
+        "customer_full_name.keyword",
+        "category.keyword"
+      ]
+    },
+    "analysis_limits" : {
+      "model_memory_limit" : "10mb"
+    },
+    "data_description" : {
+      "time_field" : "order_date",
+      "time_format" : "epoch_ms"
+    }
+  }
+}
+--------------------------------------------------
+// TEST[skip:set up Kibana sample data]
+
+The data that is returned for this example is as follows:
+
+[source,console-result]
+----
+[
+  {
+    "order_date" : 1574294659000,
+    "category.keyword" : "Men's Clothing",
+    "customer_full_name.keyword" : "Sultan Al Benson",
+    "taxful_total_price" : 35.96875
+  },
+  {
+    "order_date" : 1574294918000,
+    "category.keyword" : [
+      "Women's Accessories",
+      "Women's Clothing"
+    ],
+    "customer_full_name.keyword" : "Pia Webb",
+    "taxful_total_price" : 83.0
+  },
+  {
+    "order_date" : 1574295782000,
+    "category.keyword" : [
+      "Women's Accessories",
+      "Women's Shoes"
+    ],
+    "customer_full_name.keyword" : "Brigitte Graham",
+    "taxful_total_price" : 72.0
+  }
 ]
 ----

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PreviewDatafeedAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PreviewDatafeedAction.java
@@ -6,20 +6,25 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.client.ElasticsearchClient;
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
+import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 
 import java.io.IOException;
@@ -37,26 +42,68 @@ public class PreviewDatafeedAction extends ActionType<PreviewDatafeedAction.Resp
 
     public static class Request extends ActionRequest implements ToXContentObject {
 
-        private String datafeedId;
+        private static final String BLANK_ID = "";
 
-        public Request() {
+        public static final ParseField DATAFEED_CONFIG = new ParseField("datafeed_config");
+        public static final ParseField JOB_CONFIG = new ParseField("job_config");
+
+        private static final ObjectParser<Builder, Void> PARSER = new ObjectParser<>(
+            "preview_datafeed_action",
+            Request.Builder::new
+        );
+        static {
+            PARSER.declareObject(Builder::setDatafeedBuilder, DatafeedConfig.STRICT_PARSER, DATAFEED_CONFIG);
+            PARSER.declareObject(Builder::setJobBuilder, Job.STRICT_PARSER, JOB_CONFIG);
+        }
+
+        public static Request fromXContent(XContentParser parser) {
+            return PARSER.apply(parser, null).build();
+        }
+
+        private final String datafeedId;
+        private final DatafeedConfig datafeedConfig;
+        private final Job.Builder jobConfig;
+
+        private Request() {
+            this.datafeedId = null;
+            this.datafeedConfig = null;
+            this.jobConfig = null;
         }
 
         public Request(StreamInput in) throws IOException {
             super(in);
             datafeedId = in.readString();
+            if (in.getVersion().onOrAfter(Version.V_7_13_0)) {
+                datafeedConfig = in.readOptionalWriteable(DatafeedConfig::new);
+                jobConfig = in.readOptionalWriteable(Job.Builder::new);
+            } else {
+                datafeedConfig = null;
+                jobConfig = null;
+            }
         }
 
         public Request(String datafeedId) {
-            setDatafeedId(datafeedId);
+            this.datafeedId = ExceptionsHelper.requireNonNull(datafeedId, DatafeedConfig.ID);
+            this.datafeedConfig = null;
+            this.jobConfig = null;
+        }
+
+        public Request(DatafeedConfig datafeedConfig, Job.Builder jobConfig) {
+            this.datafeedId = BLANK_ID;
+            this.datafeedConfig = ExceptionsHelper.requireNonNull(datafeedConfig, DATAFEED_CONFIG.getPreferredName());
+            this.jobConfig = jobConfig;
         }
 
         public String getDatafeedId() {
             return datafeedId;
         }
 
-        public final void setDatafeedId(String datafeedId) {
-            this.datafeedId = ExceptionsHelper.requireNonNull(datafeedId, DatafeedConfig.ID.getPreferredName());
+        public DatafeedConfig getDatafeedConfig() {
+            return datafeedConfig;
+        }
+
+        public Job.Builder getJobConfig() {
+            return jobConfig;
         }
 
         @Override
@@ -68,19 +115,31 @@ public class PreviewDatafeedAction extends ActionType<PreviewDatafeedAction.Resp
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
             out.writeString(datafeedId);
+            if (out.getVersion().onOrAfter(Version.V_7_13_0)) {
+                out.writeOptionalWriteable(datafeedConfig);
+                out.writeOptionalWriteable(jobConfig);
+            }
         }
 
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject();
-            builder.field(DatafeedConfig.ID.getPreferredName(), datafeedId);
+            if (datafeedId.equals("") == false) {
+                builder.field(DatafeedConfig.ID.getPreferredName(), datafeedId);
+            }
+            if (datafeedConfig != null) {
+                builder.field(DATAFEED_CONFIG.getPreferredName(), datafeedConfig);
+            }
+            if (jobConfig != null) {
+                builder.field(JOB_CONFIG.getPreferredName(), jobConfig);
+            }
             builder.endObject();
             return builder;
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(datafeedId);
+            return Objects.hash(datafeedId, datafeedConfig, jobConfig);
         }
 
         @Override
@@ -92,7 +151,56 @@ public class PreviewDatafeedAction extends ActionType<PreviewDatafeedAction.Resp
                 return false;
             }
             Request other = (Request) obj;
-            return Objects.equals(datafeedId, other.datafeedId);
+            return Objects.equals(datafeedId, other.datafeedId)
+                && Objects.equals(datafeedConfig, other.datafeedConfig)
+                && Objects.equals(jobConfig, other.jobConfig);
+        }
+
+        public static class Builder {
+            private String datafeedId;
+            private DatafeedConfig.Builder datafeedBuilder;
+            private Job.Builder jobBuilder;
+
+            public Builder setDatafeedId(String datafeedId) {
+                this.datafeedId = datafeedId;
+                return this;
+            }
+
+            public Builder setDatafeedBuilder(DatafeedConfig.Builder datafeedBuilder) {
+                this.datafeedBuilder = datafeedBuilder;
+                return this;
+            }
+
+            public Builder setJobBuilder(Job.Builder jobBuilder) {
+                this.jobBuilder = jobBuilder;
+                return this;
+            }
+
+            public Request build() {
+                if (datafeedBuilder != null) {
+                    datafeedBuilder.setId("preview_id");
+                    if (datafeedBuilder.getJobId() == null && jobBuilder == null) {
+                        throw new IllegalArgumentException("[datafeed_config.job_id] must be set or a [job_config] must be provided");
+                    }
+                    if (datafeedBuilder.getJobId() == null) {
+                        datafeedBuilder.setJobId("preview_job_id");
+                    }
+                }
+                if (jobBuilder != null) {
+                    jobBuilder.setId("preview_job_id");
+                    if (datafeedBuilder == null) {
+                        throw new IllegalArgumentException("[datafeed_config] must be present when a [job_config] is provided");
+                    }
+                }
+                if (datafeedId != null && (datafeedBuilder != null || jobBuilder != null)) {
+                    throw new IllegalArgumentException(
+                        "[datafeed_id] cannot be supplied when either [job_config] or [datafeed_config] is present"
+                    );
+                }
+                return datafeedId != null ?
+                    new Request(datafeedId) :
+                    new Request(datafeedBuilder == null ? null : datafeedBuilder.build(), jobBuilder);
+            }
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java
@@ -744,6 +744,10 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
             return this;
         }
 
+        public String getJobId() {
+            return jobId;
+        }
+
         public Builder setHeaders(Map<String, String> headers) {
             this.headers = ExceptionsHelper.requireNonNull(headers, HEADERS.getPreferredName());
             return this;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/PreviewDatafeedActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/PreviewDatafeedActionRequestTests.java
@@ -6,19 +6,73 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.action.PreviewDatafeedAction.Request;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfigTests;
+import org.elasticsearch.xpack.core.ml.job.config.JobTests;
+
+import java.util.Collections;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 
 public class PreviewDatafeedActionRequestTests extends AbstractWireSerializingTestCase<Request> {
 
     @Override
     protected Request createTestInstance() {
-        return new Request(randomAlphaOfLength(10));
+        String jobId = randomAlphaOfLength(10);
+        return randomBoolean() ?
+            new Request(randomAlphaOfLength(10)) :
+            new Request(
+                DatafeedConfigTests.createRandomizedDatafeedConfig(jobId),
+                randomBoolean() ? JobTests.buildJobBuilder(jobId) : null
+            );
     }
 
     @Override
     protected Writeable.Reader<Request> instanceReader() {
         return Request::new;
+    }
+
+    public void testCtor() {
+        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> new Request((String) null));
+        assertThat(ex.getMessage(), equalTo("[datafeed_id] must not be null."));
+    }
+
+    public void testValidation() {
+        String jobId = randomAlphaOfLength(10);
+        Request.Builder requestBuilder = new Request.Builder()
+            .setDatafeedId(randomAlphaOfLength(10))
+            .setDatafeedBuilder(new DatafeedConfig.Builder(DatafeedConfigTests.createRandomizedDatafeedConfig(jobId)))
+            .setJobBuilder(randomBoolean() ? JobTests.buildJobBuilder(jobId) : null);
+        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, requestBuilder::build);
+        assertThat(ex.getMessage(),
+            containsString("[datafeed_id] cannot be supplied when either [job_config] or [datafeed_config] is present"));
+
+        requestBuilder.setJobBuilder(null)
+            .setDatafeedId(null)
+            .setDatafeedBuilder(new DatafeedConfig.Builder());
+
+        ex = expectThrows(IllegalArgumentException.class, requestBuilder::build);
+        assertThat(ex.getMessage(),
+            containsString("[datafeed_config.job_id] must be set or a [job_config] must be provided"));
+    }
+
+    @Override
+    protected NamedWriteableRegistry getNamedWriteableRegistry() {
+        SearchModule searchModule = new SearchModule(Settings.EMPTY, false, Collections.emptyList());
+        return new NamedWriteableRegistry(searchModule.getNamedWriteables());
+    }
+
+    @Override
+    protected NamedXContentRegistry xContentRegistry() {
+        SearchModule searchModule = new SearchModule(Settings.EMPTY, false, Collections.emptyList());
+        return new NamedXContentRegistry(searchModule.getNamedXContents());
     }
 }

--- a/x-pack/plugin/ml/qa/ml-with-security/build.gradle
+++ b/x-pack/plugin/ml/qa/ml-with-security/build.gradle
@@ -191,6 +191,8 @@ tasks.named("yamlRestTest").configure {
     'ml/post_data/Test open and close with non-existent job id',
     'ml/post_data/Test POST data with invalid parameters',
     'ml/preview_datafeed/Test preview missing datafeed',
+    'ml/preview_datafeed/Test preview with datafeed_id and job config',
+    'ml/preview_datafeed/Test preview with datafeed id and config',
     'ml/revert_model_snapshot/Test revert model with invalid snapshotId',
     'ml/start_data_frame_analytics/Test start given missing source index',
     'ml/start_data_frame_analytics/Test start outlier_detection given source index has no fields',

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPreviewDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPreviewDatafeedAction.java
@@ -23,6 +23,7 @@ import org.elasticsearch.xpack.core.ml.datafeed.ChunkingConfig;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedTimingStats;
 import org.elasticsearch.xpack.core.ml.datafeed.extractor.DataExtractor;
+import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.security.SecurityContext;
 import org.elasticsearch.xpack.ml.datafeed.DatafeedTimingStatsReporter;
 import org.elasticsearch.xpack.ml.datafeed.extractor.DataExtractorFactory;
@@ -33,6 +34,7 @@ import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.util.Date;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -65,35 +67,50 @@ public class TransportPreviewDatafeedAction extends HandledTransportAction<Previ
 
     @Override
     protected void doExecute(Task task, PreviewDatafeedAction.Request request, ActionListener<PreviewDatafeedAction.Response> listener) {
-        datafeedConfigProvider.getDatafeedConfig(request.getDatafeedId(), ActionListener.wrap(
-            datafeedConfigBuilder -> {
-                DatafeedConfig datafeedConfig = datafeedConfigBuilder.build();
+        ActionListener<DatafeedConfig> datafeedConfigActionListener = ActionListener.wrap(
+            datafeedConfig -> {
+                if (request.getJobConfig() != null) {
+                    previewDatafeed(datafeedConfig, request.getJobConfig().build(new Date()), listener);
+                    return;
+                }
                 jobConfigProvider.getJob(datafeedConfig.getJobId(), ActionListener.wrap(
-                    jobBuilder -> {
-                        DatafeedConfig.Builder previewDatafeed = buildPreviewDatafeed(datafeedConfig);
-                        useSecondaryAuthIfAvailable(securityContext, () -> {
-                            previewDatafeed.setHeaders(filterSecurityHeaders(threadPool.getThreadContext().getHeaders()));
-
-                            // NB: this is using the client from the transport layer, NOT the internal client.
-                            // This is important because it means the datafeed search will fail if the user
-                            // requesting the preview doesn't have permission to search the relevant indices.
-                            DataExtractorFactory.create(
-                                client,
-                                previewDatafeed.build(),
-                                jobBuilder.build(),
-                                xContentRegistry,
-                                // Fake DatafeedTimingStatsReporter that does not have access to results index
-                                new DatafeedTimingStatsReporter(new DatafeedTimingStats(datafeedConfig.getJobId()), (ts, refreshPolicy) -> {
-                                }),
-                                listener.delegateFailure((l, dataExtractorFactory) -> {
-                                    DataExtractor dataExtractor = dataExtractorFactory.newExtractor(0, Long.MAX_VALUE);
-                                    threadPool.generic().execute(() -> previewDatafeed(dataExtractor, l));
-                                }));
-                        });
-                    },
+                    jobBuilder -> previewDatafeed(datafeedConfig, jobBuilder.build(), listener),
                     listener::onFailure));
             },
-            listener::onFailure));
+            listener::onFailure
+        );
+        if (request.getDatafeedConfig() != null) {
+            datafeedConfigActionListener.onResponse(request.getDatafeedConfig());
+        } else {
+            datafeedConfigProvider.getDatafeedConfig(
+                request.getDatafeedId(),
+                ActionListener.wrap(builder -> datafeedConfigActionListener.onResponse(builder.build()), listener::onFailure));
+        }
+    }
+
+    private void previewDatafeed(
+        DatafeedConfig datafeedConfig,
+        Job job,
+        ActionListener<PreviewDatafeedAction.Response> listener
+    ) {
+        DatafeedConfig.Builder previewDatafeed = buildPreviewDatafeed(datafeedConfig);
+        useSecondaryAuthIfAvailable(securityContext, () -> {
+            previewDatafeed.setHeaders(filterSecurityHeaders(threadPool.getThreadContext().getHeaders()));
+            // NB: this is using the client from the transport layer, NOT the internal client.
+            // This is important because it means the datafeed search will fail if the user
+            // requesting the preview doesn't have permission to search the relevant indices.
+            DataExtractorFactory.create(
+                client,
+                previewDatafeed.build(),
+                job,
+                xContentRegistry,
+                // Fake DatafeedTimingStatsReporter that does not have access to results index
+                new DatafeedTimingStatsReporter(new DatafeedTimingStats(datafeedConfig.getJobId()), (ts, refreshPolicy) -> {}),
+                listener.delegateFailure((l, dataExtractorFactory) -> {
+                    DataExtractor dataExtractor = dataExtractorFactory.newExtractor(0, Long.MAX_VALUE);
+                    threadPool.generic().execute(() -> previewDatafeed(dataExtractor, l));
+                }));
+        });
     }
 
     /** Visible for testing */

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.preview_datafeed.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.preview_datafeed.json
@@ -14,7 +14,8 @@
         {
           "path":"/_ml/datafeeds/{datafeed_id}/_preview",
           "methods":[
-            "GET"
+            "GET",
+            "POST"
           ],
           "parts":{
             "datafeed_id":{
@@ -22,8 +23,19 @@
               "description":"The ID of the datafeed to preview"
             }
           }
+        },
+        {
+          "path":"/_ml/datafeeds/_preview",
+          "methods":[
+            "GET",
+            "POST"
+          ]
         }
       ]
+    },
+    "body":{
+      "description":"The datafeed config and job config with which to execute the preview",
+      "required":false
     }
   }
 }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/preview_datafeed.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/preview_datafeed.yml
@@ -109,6 +109,60 @@ setup:
   - match: { 3.airline: foo }
   - match: { 3.responsetime: 42.0 }
 
+  - do:
+      ml.preview_datafeed:
+        body: >
+          {
+            "datafeed_config": {
+              "job_id":"preview-datafeed-job",
+              "indexes":"airline-data"
+            }
+          }
+  - length: { $body: 4 }
+  - match: { 0.time: 1487376000000 }
+  - match: { 0.airline: foo }
+  - match: { 0.responsetime: 1.0 }
+  - match: { 1.time: 1487377800000 }
+  - match: { 1.airline: foo }
+  - match: { 1.responsetime: 1.0 }
+  - match: { 2.time: 1487379600000 }
+  - match: { 2.airline: bar }
+  - match: { 2.responsetime: 42.0 }
+  - match: { 3.time: 1487379660000 }
+  - match: { 3.airline: foo }
+  - match: { 3.responsetime: 42.0 }
+
+  - do:
+      ml.preview_datafeed:
+        body: >
+          {
+            "datafeed_config": {
+              "job_id":"preview-datafeed-job",
+              "indexes":"airline-data"
+            },
+            "job_config": {
+              "analysis_config": {
+                "bucket_span": "1h",
+                "detectors": [{"function":"sum","field_name":"responsetime","by_field_name":"airline"}]
+              },
+              "data_description": {
+                "time_field":"time"
+              }
+            }
+          }
+  - length: { $body: 4 }
+  - match: { 0.time: 1487376000000 }
+  - match: { 0.airline: foo }
+  - match: { 0.responsetime: 1.0 }
+  - match: { 1.time: 1487377800000 }
+  - match: { 1.airline: foo }
+  - match: { 1.responsetime: 1.0 }
+  - match: { 2.time: 1487379600000 }
+  - match: { 2.airline: bar }
+  - match: { 2.responsetime: 42.0 }
+  - match: { 3.time: 1487379660000 }
+  - match: { 3.airline: foo }
+  - match: { 3.responsetime: 42.0 }
 ---
 "Test preview aggregation datafeed with doc_count":
 
@@ -167,6 +221,65 @@ setup:
   - do:
       ml.preview_datafeed:
         datafeed_id: aggregation-doc-count-feed
+  - length: { $body: 3 }
+  - match: { 0.time: 1487377800000 }
+  - match: { 0.airline: foo }
+  - match: { 0.responsetime: 2.0 }
+  - match: { 0.doc_count: 2 }
+  - match: { 1.time: 1487379660000 }
+  - match: { 1.airline: bar }
+  - match: { 1.responsetime: 42.0 }
+  - match: { 1.doc_count: 1 }
+  - match: { 1.time: 1487379660000 }
+  - match: { 2.airline: foo }
+  - match: { 2.responsetime: 42.0 }
+  - match: { 2.doc_count: 1 }
+  - do:
+      ml.preview_datafeed:
+        body: >
+          {
+            "datafeed_config": {
+              "indexes":"airline-data",
+              "aggregations": {
+                "buckets": {
+                  "histogram": {
+                    "field": "time",
+                    "interval": 3600000
+                  },
+                  "aggregations": {
+                    "time": {
+                      "max": {
+                        "field": "time"
+                      }
+                    },
+                    "airline": {
+                      "terms": {
+                        "field": "airline",
+                        "size": 100
+                      },
+                      "aggregations": {
+                        "responsetime": {
+                          "sum": {
+                             "field": "responsetime"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "job_config": {
+              "analysis_config" : {
+                  "bucket_span": "1h",
+                  "summary_count_field_name": "doc_count",
+                  "detectors" :[{"function":"sum","field_name":"responsetime","by_field_name":"airline"}]
+              },
+              "data_description" : {
+                  "time_field":"time"
+              }
+            }
+          }
   - length: { $body: 3 }
   - match: { 0.time: 1487377800000 }
   - match: { 0.airline: foo }
@@ -326,6 +439,43 @@ setup:
       ml.preview_datafeed:
         datafeed_id: missing-feed
 
+---
+"Test preview with datafeed_id and job config":
+
+  - do:
+      catch: bad_request
+      ml.preview_datafeed:
+        datafeed_id: some_datafeed_id
+        body: >
+          {
+             "job_config": {
+               "analysis_config" : {
+                 "bucket_span": "1h",
+                 "detectors" :[{"function":"sum","field_name":"responsetime","by_field_name":"airline"}]
+               },
+               "data_description" : {
+                 "time_field":"time"
+               }
+             }
+          }
+---
+"Test preview with datafeed id and config":
+
+  - do:
+      catch: bad_request
+      ml.preview_datafeed:
+        body: >
+          {
+             "job_config": {
+               "analysis_config" : {
+                 "bucket_span": "1h",
+                 "detectors" :[{"function":"sum","field_name":"responsetime","by_field_name":"airline"}]
+               },
+               "data_description" : {
+                 "time_field":"time"
+               }
+             }
+          }
 ---
 "Test preview datafeed with unavailable index":
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ML] Allow datafeed and job configs for datafeed preview API (#70836)