### PR TITLE
Separate free and x-pack tests in rest resources artifact

### DIFF
--- a/x-pack/rest-resources-zip/build.gradle
+++ b/x-pack/rest-resources-zip/build.gradle
@@ -5,26 +5,34 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
+apply plugin: 'base'
 
-apply plugin: 'java'
-apply plugin: 'elasticsearch.rest-resources'
+configurations {
+  apis
+  freeTests
+  platinumTests
+}
 
-restResources {
-  restApi {
-    includeCore '*'
-    includeXpack '*'
-  }
-  restTests {
-    includeCore '*'
-    includeXpack '*'
-  }
+dependencies {
+  apis project(path: ':rest-api-spec', configuration: 'restSpecs')
+  apis project(path: ':x-pack:plugin', configuration: 'restXpackSpecs')
+  freeTests project(path: ':rest-api-spec', configuration: 'restTests')
+  platinumTests project(path: ':x-pack:plugin', configuration: 'restXpackTests')
 }
 
 tasks.register('restResourcesZip', Zip).configure {
   description = 'Build archive containing all REST API specifications and YAML tests'
 
   destinationDirectory = layout.buildDirectory.dir('distributions')
-  from sourceSets.test.output
+  from(configurations.apis) {
+    into 'rest-api-spec/api'
+  }
+  from(configurations.freeTests) {
+    into 'rest-api-spec/test/free'
+  }
+  from(configurations.platinumTests) {
+    into 'rest-api-spec/test/platinum'
+  }
 }
 
 tasks.named("assemble").configure { dependsOn 'restResourcesZip' }


### PR DESCRIPTION
Per https://github.com/elastic/clients-team/issues/388#issuecomment-808180092, the clients team needs to be able to differentiate between tests for "free" vs "x-pack" environments. These tests make certain assumptions about the cluster configuration so we need to be able to tailor for each. This change creates `free` and `platinum` directories in the archive to separate the two.