### PR TITLE
Fixing Query to retrieve watches

### DIFF
--- a/x-pack/docs/en/watcher/managing-watches.asciidoc
+++ b/x-pack/docs/en/watcher/managing-watches.asciidoc
@@ -28,8 +28,8 @@ For example, the following returns the first 100 watches:
 
 [source,console]
 --------------------------------------------------
-GET /_watcher/_query/watches
+GET /.watches/_search
 {
-  "size" : 100
+  "size": 100
 }
 --------------------------------------------------


### PR DESCRIPTION
As there is no index with the name _watches, the right index would be to query .watches.

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
