### PR TITLE
[ML] Avoid assignment timeouts in MlDistributedFailureIT

### DIFF
--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlDistributedFailureIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlDistributedFailureIT.java
@@ -398,8 +398,9 @@ public class MlDistributedFailureIT extends BaseMlIntegTestCase {
     }
 
     @TestIssueLogging(issueUrl = "https://github.com/elastic/elasticsearch/issues/68685",
-        value = "org.elasticsearch.xpack.ml.process:TRACE,org.elasticsearch.xpack.ml.job:TRACE")
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/68685")
+        value = "org.elasticsearch.xpack.ml.process:TRACE,"
+            + "org.elasticsearch.xpack.ml.job:TRACE,"
+            + "org.elasticsearch.persistent.PersistentTasksClusterService:TRACE")
     public void testJobRelocationIsMemoryAware() throws Exception {
         internalCluster().ensureAtLeastNumDataNodes(1);
         ensureStableCluster();
@@ -429,6 +430,16 @@ public class MlDistributedFailureIT extends BaseMlIntegTestCase {
 
         internalCluster().stopCurrentMasterNode();
         ensureStableCluster();
+
+        PersistentTasksClusterService persistentTasksClusterService =
+            internalCluster().getInstance(PersistentTasksClusterService.class, internalCluster().getMasterName());
+        // Speed up rechecks to a rate that is quicker than what settings would allow.
+        // The tests would work eventually without doing this, but the assertBusy() below
+        // would need to wait 30 seconds, which would make the suite run very slowly.
+        // The 200ms refresh puts a greater burden on the master node to recheck
+        // persistent tasks, but it will cope in these tests as it's not doing anything
+        // else.
+        persistentTasksClusterService.setRecheckInterval(TimeValue.timeValueMillis(200));
 
         // If memory requirements are used to reallocate the 4 small jobs (as we expect) then they should
         // all reallocate to the same node, that being the one that doesn't have the big job on.  If job counts

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/process/MlMemoryTracker.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/process/MlMemoryTracker.java
@@ -302,13 +302,14 @@ public class MlMemoryTracker implements LocalNodeMasterListener {
         }
 
         ActionListener<Void> refreshComplete = ActionListener.wrap(aVoid -> {
-            lastUpdateTime = Instant.now();
             synchronized (fullRefreshCompletionListeners) {
+                lastUpdateTime = Instant.now();
                 assert fullRefreshCompletionListeners.isEmpty() == false;
                 for (ActionListener<Void> listener : fullRefreshCompletionListeners) {
                     listener.onResponse(null);
                 }
                 fullRefreshCompletionListeners.clear();
+                logger.trace("ML memory tracker last update time now [{}] and listeners called", lastUpdateTime);
             }
         },
         e -> {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/support/BaseMlIntegTestCase.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/support/BaseMlIntegTestCase.java
@@ -469,7 +469,7 @@ public abstract class BaseMlIntegTestCase extends ESIntegTestCase {
 
     /**
      * Sets delayed allocation to 0 to make sure we have tests are not delayed
-      */
+     */
     protected void setMlIndicesDelayedNodeLeftTimeoutToZero() {
         OriginSettingClient originSettingClient = new OriginSettingClient(client(), ClientHelper.ML_ORIGIN);
         originSettingClient.admin().indices().updateSettings(new UpdateSettingsRequest(".ml-*")


### PR DESCRIPTION
This change should fix the problem of #68685 where
MlDistributedFailureIT.testJobRelocationIsMemoryAware
can fail with "expected:<4> but was:<0>" because
persistent task assignment for the small jobs that
need reassigning after the simulated failure is
not checked often enough.

It also adds even more test logging for the other
failure covered by #68685, "expected:<1> but was:<2>".