### PR TITLE
Fix CanMatchPreFilterSearchPhaseTests#testSortShards

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhaseTests.java
@@ -48,6 +48,7 @@ import org.elasticsearch.transport.Transport;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -356,7 +357,10 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
                 .sorted(Comparator.comparing(minAndMaxes::get, MinAndMax.getComparator(order)).thenComparing(shardIds::get))
                 .map(shardIds::get)
                 .toArray(ShardId[]::new);
-
+            if (shardToSkip.size() == expected.length) {
+                // we need at least one shard to produce the empty result for aggs
+                shardToSkip.remove(new ShardId("logs", "_na_", 0));
+            }
             int pos = 0;
             for (SearchShardIterator i : result.get()) {
                 assertEquals(shardToSkip.contains(i.shardId()), i.skip());

--- a/server/src/test/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhaseTests.java
@@ -48,7 +48,6 @@ import org.elasticsearch.transport.Transport;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;


### PR DESCRIPTION
Fix test to handle the case where all shards are skipped.
We ensure that we don't skip all shards in the can match phase
in order to be able to produce an empty result for aggs.

Closes #70933