### PR TITLE
SSL/TLS certificates cannot be issued for longer than 13 months

### DIFF
--- a/x-pack/plugin/security/cli/src/main/java/org/elasticsearch/xpack/security/cli/CertificateTool.java
+++ b/x-pack/plugin/security/cli/src/main/java/org/elasticsearch/xpack/security/cli/CertificateTool.java
@@ -101,7 +101,7 @@ public class CertificateTool extends LoggingAwareMultiCommand {
      */
     private static final CharsetEncoder ASCII_ENCODER = StandardCharsets.US_ASCII.newEncoder();
 
-    private static final int DEFAULT_DAYS = 3 * 365;
+    private static final int DEFAULT_DAYS = 397;
     private static final int FILE_EXTENSION_LENGTH = 4;
     static final int MAX_FILENAME_LENGTH = 255 - FILE_EXTENSION_LENGTH;
     private static final Pattern ALLOWED_FILENAME_CHAR_PATTERN =


### PR DESCRIPTION
Starting on September 1st (2020), SSL/TLS certificates cannot be issued for longer than 13 months (397 days).
More info [NET::ERR_CERT_VALIDITY_TOO_LONG - The server certificate has a validity period that is too long](https://stackoverflow.com/questions/64597721/neterr-cert-validity-too-long-the-server-certificate-has-a-validity-period-t).

Currently generated certificate show `NET::ERR_CERT_VALIDITY_TOO_LONG` warning.
![Screenshot 2021-03-28 at 12 53 26 am](https://user-images.githubusercontent.com/114551/112814961-b9f0b500-9077-11eb-95b1-44b3523e8baa.png)




<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
