### PR TITLE
Improve error message for invalid field name

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -173,6 +173,9 @@ final class DocumentParser {
     private static String[] splitAndValidatePath(String fullFieldPath) {
         if (fullFieldPath.contains(".")) {
             String[] parts = fullFieldPath.split("\\.");
+            if (parts.length == 0) {
+                throw new IllegalArgumentException("field name cannot contain only dots");
+            }
             for (String part : parts) {
                 if (Strings.hasText(part) == false) {
                     // check if the field name contains only whitespace

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
@@ -1656,6 +1656,16 @@ public class DocumentParserTests extends MapperServiceTestCase {
         assertThat(err.getCause().getMessage(), containsString("field name cannot be an empty string"));
     }
 
+    public void testDotsOnlyFieldNames() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(mapping(b -> {}));
+        MapperParsingException err = expectThrows(
+            MapperParsingException.class,
+            () -> mapper.parse(source(b -> b.field(randomFrom(".", "..", "..."), "bar")))
+        );
+        assertThat(err.getCause(), notNullValue());
+        assertThat(err.getCause().getMessage(), containsString("field name cannot contain only dots"));
+    }
+
     public void testWriteToFieldAlias() throws Exception {
         DocumentMapper mapper = createDocumentMapper(mapping(b -> {
             b.startObject("alias-field");


### PR DESCRIPTION
The current error when a field name consists only of path separator dots is not
very user friendly. Instead of throwing an array_index_out_of_bounds_exception
we can detect this case and throw a more useful IAE.

Closes #70960