### PR TITLE
[DOCS] Adds source index privileges required for Explain DFA API docs

### DIFF
--- a/docs/reference/ml/df-analytics/apis/explain-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/explain-dfanalytics.asciidoc
@@ -30,8 +30,10 @@ If the {es} {security-features} are enabled, you must have the following
 privileges:
 
 * cluster: `monitor_ml`
+* source indices: `read`, `view_index_metadata`
   
-For more information, see <<security-privileges>> and {ml-docs-setup-privileges}.
+For more information, see <<security-privileges>> and 
+{ml-docs-setup-privileges}.
 
 
 [[ml-explain-dfanalytics-desc]]


### PR DESCRIPTION
## Overview

This PR adds the privileges on the source index that required for using the Explain DFA API to the reference docs.


### Preview

[Explain DFA API docs](https://elasticsearch_70978.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/explain-dfanalytics.html#ml-explain-dfanalytics-prereq)