### PR TITLE
[7.x][ML] Mute testClusterWithTwoMlNodes_RunsDatafeed_GivenOriginalNo…

### DIFF
--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlDistributedFailureIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlDistributedFailureIT.java
@@ -482,12 +482,7 @@ public class MlDistributedFailureIT extends BaseMlIntegTestCase {
         });
     }
 
-    @TestIssueLogging(
-        value = "org.elasticsearch.xpack.ml.action:TRACE,"
-            + "org.elasticsearch.xpack.ml.job.process.autodetect.AutodetectProcessManager:TRACE,"
-            + "org.elasticsearch.xpack.ml.datafeed:TRACE",
-        issueUrl = "https://github.com/elastic/elasticsearch/issues/67756"
-    )
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/67756")
     public void testClusterWithTwoMlNodes_RunsDatafeed_GivenOriginalNodeGoesDown() throws Exception {
         internalCluster().ensureAtMostNumDataNodes(0);
         logger.info("Starting dedicated master node...");


### PR DESCRIPTION
…deGoesDown (#70979)

Relates #67756

Backport of #70979
