### PR TITLE
[Test] Service Accounts - handle token names with leading hyphen

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountTokenTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountTokenTests.java
@@ -101,7 +101,7 @@ public class ServiceAccountTokenTests extends ESTestCase {
             Character[]::new,
             () -> randomFrom(VALID_TOKEN_NAME_CHARS));
         final String name = Arrays.stream(chars).map(String::valueOf).collect(Collectors.joining());
-        return name.startsWith("_") ? "-" + name.substring(1) : name;
+        return name.startsWith("_") ? randomAlphaOfLength(1) + name.substring(1) : name;
     }
 
     public static String randomInvalidTokenName() {

--- a/x-pack/qa/security-tools-tests/src/test/java/org/elasticsearch/xpack/security/authc/service/FileTokensToolTests.java
+++ b/x-pack/qa/security-tools-tests/src/test/java/org/elasticsearch/xpack/security/authc/service/FileTokensToolTests.java
@@ -142,7 +142,7 @@ public class FileTokensToolTests extends CommandTestCase {
     }
 
     public void testCreateTokenWithInvalidTokenName() throws Exception {
-        final String tokenName = randomValueOtherThanMany(n -> n.startsWith("-"), ServiceAccountTokenTests::randomTokenName);
+        final String tokenName = randomValueOtherThanMany(n -> n.startsWith("-"), ServiceAccountTokenTests::randomInvalidTokenName);
         final UserException e = expectThrows(UserException.class,
             () -> execute("create", pathHomeParameter, "elastic/fleet", tokenName));
         assertServiceTokenNotExists("elastic/fleet/" + tokenName);

--- a/x-pack/qa/security-tools-tests/src/test/java/org/elasticsearch/xpack/security/authc/service/FileTokensToolTests.java
+++ b/x-pack/qa/security-tools-tests/src/test/java/org/elasticsearch/xpack/security/authc/service/FileTokensToolTests.java
@@ -127,12 +127,13 @@ public class FileTokensToolTests extends CommandTestCase {
             "Expected two arguments, service-account-principal and token-name, found extra:"));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/70959")
     public void testCreateToken() throws Exception {
-        final String tokenName1 = ServiceAccountTokenTests.randomTokenName();
+        // The CLI test infra does not like names begin with a hyphen
+        final String tokenName1 = randomValueOtherThanMany(n -> n.startsWith("-"), ServiceAccountTokenTests::randomTokenName);
         execute("create", pathHomeParameter, "elastic/fleet", tokenName1);
         assertServiceTokenExists("elastic/fleet/" + tokenName1);
-        final String tokenName2 = ServiceAccountTokenTests.randomTokenName();
+        final String tokenName2 = randomValueOtherThanMany(n -> n.startsWith("-") || n.equals(tokenName1),
+            ServiceAccountTokenTests::randomTokenName);
         execute("create", pathHomeParameter, "elastic/fleet", tokenName2);
         assertServiceTokenExists("elastic/fleet/" + tokenName2);
         final String output = terminal.getOutput();
@@ -140,9 +141,8 @@ public class FileTokensToolTests extends CommandTestCase {
         assertThat(output, containsString("SERVICE_TOKEN elastic/fleet/" + tokenName2 + " = "));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/70959")
     public void testCreateTokenWithInvalidTokenName() throws Exception {
-        final String tokenName = ServiceAccountTokenTests.randomInvalidTokenName();
+        final String tokenName = randomValueOtherThanMany(n -> n.startsWith("-"), ServiceAccountTokenTests::randomTokenName);
         final UserException e = expectThrows(UserException.class,
             () -> execute("create", pathHomeParameter, "elastic/fleet", tokenName));
         assertServiceTokenNotExists("elastic/fleet/" + tokenName);

--- a/x-pack/qa/security-tools-tests/src/test/java/org/elasticsearch/xpack/security/authc/service/FileTokensToolTests.java
+++ b/x-pack/qa/security-tools-tests/src/test/java/org/elasticsearch/xpack/security/authc/service/FileTokensToolTests.java
@@ -128,7 +128,6 @@ public class FileTokensToolTests extends CommandTestCase {
     }
 
     public void testCreateToken() throws Exception {
-        // The CLI test infra does not like names begin with a hyphen
         final String tokenName1 = randomValueOtherThanMany(n -> n.startsWith("-"), ServiceAccountTokenTests::randomTokenName);
         execute("create", pathHomeParameter, "elastic/fleet", tokenName1);
         assertServiceTokenExists("elastic/fleet/" + tokenName1);
@@ -136,15 +135,22 @@ public class FileTokensToolTests extends CommandTestCase {
             ServiceAccountTokenTests::randomTokenName);
         execute("create", pathHomeParameter, "elastic/fleet", tokenName2);
         assertServiceTokenExists("elastic/fleet/" + tokenName2);
+        // token name with a leading hyphen requires an option terminator
+        final String tokenName3 = "-" + ServiceAccountTokenTests.randomTokenName().substring(1);
+        execute("create", pathHomeParameter, "elastic/fleet", "--", tokenName3);
+        assertServiceTokenExists("elastic/fleet/" + tokenName3);
         final String output = terminal.getOutput();
         assertThat(output, containsString("SERVICE_TOKEN elastic/fleet/" + tokenName1 + " = "));
         assertThat(output, containsString("SERVICE_TOKEN elastic/fleet/" + tokenName2 + " = "));
+        assertThat(output, containsString("SERVICE_TOKEN elastic/fleet/" + tokenName3 + " = "));
     }
 
     public void testCreateTokenWithInvalidTokenName() throws Exception {
-        final String tokenName = randomValueOtherThanMany(n -> n.startsWith("-"), ServiceAccountTokenTests::randomInvalidTokenName);
-        final UserException e = expectThrows(UserException.class,
-            () -> execute("create", pathHomeParameter, "elastic/fleet", tokenName));
+        final String tokenName = ServiceAccountTokenTests.randomInvalidTokenName();
+        final String[] args = tokenName.startsWith("-") ?
+            new String[] { "create", pathHomeParameter, "elastic/fleet", "--", tokenName } :
+            new String[] { "create", pathHomeParameter, "elastic/fleet", tokenName };
+        final UserException e = expectThrows(UserException.class, () -> execute(args));
         assertServiceTokenNotExists("elastic/fleet/" + tokenName);
         assertThat(e.getMessage(), containsString(ServiceAccountToken.INVALID_TOKEN_NAME_MESSAGE));
     }


### PR DESCRIPTION
The CLI tool needs an option terminator (`--`) for another option names that begin with a hyphen. Otherwise it errors out with message of "not recognized option". The service account token name can begin with a hyphen.  Hence we need to use `--` when it is the case. An example of equivalent command line is `./bin/elasticsearch-service-tokens create elastic/fleet -- -lead-with-hyphen`.

Resolves: #70959