### PR TITLE
[7.x] [DOCS] Fix typo comment in `SpecialPermission` (#70945)

### DIFF
--- a/server/src/main/java/org/elasticsearch/SpecialPermission.java
+++ b/server/src/main/java/org/elasticsearch/SpecialPermission.java
@@ -50,7 +50,7 @@ public final class SpecialPermission extends BasicPermission {
     public static final SpecialPermission INSTANCE = new SpecialPermission();
 
     /**
-     * Creates a new SpecialPermision object.
+     * Creates a new SpecialPermission object.
      */
     public SpecialPermission() {
         // TODO: if we really need we can break out name (e.g. "hack" or "scriptEngineService" or whatever).


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Fix typo comment in `SpecialPermission` (#70945)