### PR TITLE
[7.12] [DOCS] Update data stream rollover references (#70993)

### DIFF
--- a/docs/reference/data-streams/data-streams.asciidoc
+++ b/docs/reference/data-streams/data-streams.asciidoc
@@ -84,7 +84,6 @@ roll over data streams when the write index reaches a specified age or size.
 If needed, you can also <<manually-roll-over-a-data-stream,manually roll over>>
 a data stream.
 
-
 [discrete]
 [[data-streams-generation]]
 == Generation

--- a/docs/reference/data-streams/set-up-a-data-stream.asciidoc
+++ b/docs/reference/data-streams/set-up-a-data-stream.asciidoc
@@ -9,8 +9,8 @@ To set up a data stream, follow these steps:
 . <<create-a-data-stream>>.
 . <<secure-a-data-stream>>.
 
-You can also <<convert-an-index-alias-to-a-data-stream,convert an existing index
-alias to a data stream>>.
+You can also <<convert-an-index-alias-to-a-data-stream,convert an index alias to
+a data stream>>.
 
 [discrete]
 [[configure-a-data-stream-ilm-policy]]
@@ -189,9 +189,12 @@ the stream. This index also acts as the stream's first write index.
 [[convert-an-index-alias-to-a-data-stream]]
 === Convert an index alias to a data stream
 
+// tag::time-series-alias-tip[]
 Prior to {es} 7.9, you would typically use an <<indices-aliases,index alias>>
-with a write index to manage time series data. Data streams replace most of
-this functionality and usually require less maintenance.
+with a write index to manage time series data. Data streams replace this
+functionality, require less maintenance, and automatically integrate with
+<<data-tiers,data tiers>>.
+// end::time-series-alias-tip[]
 
 To convert an index alias with a write index to a new data stream with the same
 name, use the <<indices-migrate-to-data-stream,migrate to data stream API>>.

--- a/docs/reference/indices/apis/freeze.asciidoc
+++ b/docs/reference/indices/apis/freeze.asciidoc
@@ -29,7 +29,7 @@ merges>>. See <<frozen-indices>> and <<unfreeze-index-api>>.
 
 The current write index on a data stream cannot be frozen. In order to freeze
 the current write index, the data stream must first be
-<<rollover-data-stream-ex,rolled over>> so that a new write index is created
+<<data-streams-rollover,rolled over>> so that a new write index is created
 and then the previous write index can be frozen.
 
 IMPORTANT: Freezing an index will close the index and reopen it within the same

--- a/docs/reference/indices/clone-index.asciidoc
+++ b/docs/reference/indices/clone-index.asciidoc
@@ -47,7 +47,7 @@ PUT /my_source_index/_settings
 
 The current write index on a data stream cannot be cloned. In order to clone
 the current write index, the data stream must first be
-<<rollover-data-stream-ex,rolled over>> so that a new write index is created
+<<data-streams-rollover,rolled over>> so that a new write index is created
 and then the previous write index can be cloned.
 
 [[clone-index-api-desc]]

--- a/docs/reference/indices/delete-index.asciidoc
+++ b/docs/reference/indices/delete-index.asciidoc
@@ -43,7 +43,7 @@ this setting in the `elasticsearch.yml` file or using the
 <<cluster-update-settings,cluster update settings>> API.
 
 NOTE: You cannot delete the current write index of a data stream. To delete the
-index, you must <<rollover-data-stream-ex,roll over>> the data stream so a new
+index, you must <<data-streams-rollover,roll over>> the data stream so a new
 write index is created. You can then use the delete index API to delete the
 previous write index.
 --

--- a/docs/reference/indices/open-close.asciidoc
+++ b/docs/reference/indices/open-close.asciidoc
@@ -66,7 +66,7 @@ API by setting `cluster.indices.close.enable` to `false`. The default is `true`.
 
 The current write index on a data stream cannot be closed. In order to close
 the current write index, the data stream must first be
-<<rollover-data-stream-ex,rolled over>> so that a new write index is created
+<<data-streams-rollover,rolled over>> so that a new write index is created
 and then the previous write index can be closed.
 
 // end::closed-index[]

--- a/docs/reference/indices/shrink-index.asciidoc
+++ b/docs/reference/indices/shrink-index.asciidoc
@@ -82,7 +82,7 @@ in the index must be present on the same node.
 
 The current write index on a data stream cannot be shrunk. In order to shrink
 the current write index, the data stream must first be
-<<rollover-data-stream-ex,rolled over>> so that a new write index is created
+<<data-streams-rollover,rolled over>> so that a new write index is created
 and then the previous write index can be shrunk.
 
 [[how-shrink-works]]

--- a/docs/reference/indices/split-index.asciidoc
+++ b/docs/reference/indices/split-index.asciidoc
@@ -56,7 +56,7 @@ PUT /my_source_index/_settings
 
 The current write index on a data stream cannot be split. In order to split
 the current write index, the data stream must first be
-<<rollover-data-stream-ex,rolled over>> so that a new write index is created
+<<data-streams-rollover,rolled over>> so that a new write index is created
 and then the previous write index can be split.
 
 [[split-index-api-desc]]


### PR DESCRIPTION
Backports the following commits to 7.12:
 - [DOCS] Update data stream rollover references (#70993)