### PR TITLE
Rename data stream unit test to better describe function

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
@@ -959,7 +959,7 @@ public class MetadataTests extends ESTestCase {
                 "]) conflicts with data stream]"));
     }
 
-    public void testBuilderRejectsDataStreamWithConflictingBackingAlias() {
+    public void testBuilderRejectsAliasThatRefersToDataStreamBackingIndex() {
         final String dataStreamName = "my-data-stream";
         final String conflictingName = DataStream.getDefaultBackingIndexName(dataStreamName, 2);
         IndexMetadata idx = createFirstBackingIndex(dataStreamName)


### PR DESCRIPTION
After the removal of some validation logic in #70934, the focus of this unit test is different and its name should reflect that.