### PR TITLE
Avoid running core rest yaml tests twice

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/RestResourcesPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/RestResourcesPlugin.java
@@ -115,7 +115,10 @@ public class RestResourcesPlugin implements Plugin<Project> {
                     task.setCoreConfig(testConfig);
                     task.setXpackConfig(xpackTestConfig);
                 }
-                task.getIncludeCore().set(extension.getRestTests().getIncludeCore());
+                // If this is the rest spec project, don't copy the tests again
+                if (project.getPath().equals(":rest-api-spec") == false) {
+                    task.getIncludeCore().set(extension.getRestTests().getIncludeCore());
+                }
                 task.getIncludeXpack().set(extension.getRestTests().getIncludeXpack());
                 task.getOutputResourceDir().set(project.getLayout().getBuildDirectory().dir("restResources/yamlTests"));
             });


### PR DESCRIPTION
Some fallout from the changes in https://github.com/elastic/elasticsearch/pull/70036 is that we started running the YAML tests in the `:rest-api-spec` project **twice**. The reason for this is that when we moved the tests to the conventional location of `src/yamlRestTest/resources` we effectively are adding them to the classpath twice. Once because they are now in the "right" place, and second when we copy them using the `RestResourcesPlugin`. We can't eliminate the latter, since that is used for compatibility testing, so we just account for this edge case in the plugin itself. Essentially, if we are the project from which we are sourcing the tests from, don't bother.