### PR TITLE
Disable check for ML notice file in integ-test distribution

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionArchiveCheckPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionArchiveCheckPlugin.java
@@ -63,7 +63,7 @@ public class InternalDistributionArchiveCheckPlugin implements InternalPlugin {
         });
 
         String projectName = project.getName();
-        if (projectName.contains("oss") == false && (projectName.contains("zip") || projectName.contains("tar"))) {
+        if (projectName.equalsIgnoreCase("integ-test-zip") == false && (projectName.contains("zip") || projectName.contains("tar"))) {
             project.getExtensions()
                 .add(
                     "projectLicenses",


### PR DESCRIPTION
The integ-test distribution is a minimal distribution meant for testing only. By default, it includes no modules except for the netty transport. Checking for the ML notice file doesn't make sense here and causes build failures, so disable this.

Closes #69993