### PR TITLE
Update node shutdown metadata serialization version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -189,9 +189,9 @@ tasks.register("verifyVersions") {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = false
+boolean bwc_tests_enabled = true
 // place a PR link here when committing bwc changes:
-String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/70887"
+String bwc_tests_disabled_issue = ""
 /*
  * FIPS 140-2 behavior was fixed in 7.11.0. Before that there is no way to run elasticsearch in a
  * JVM that is properly configured to be in fips mode with BCFIPS. For now we need to disable

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/NodesShutdownMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/NodesShutdownMetadata.java
@@ -37,7 +37,7 @@ import java.util.stream.Collectors;
  */
 public class NodesShutdownMetadata implements Metadata.Custom {
     public static final String TYPE = "node_shutdown";
-    public static final Version NODE_SHUTDOWN_VERSION = Version.V_8_0_0;
+    public static final Version NODE_SHUTDOWN_VERSION = Version.V_7_13_0;
 
     private static final ParseField NODES_FIELD = new ParseField("nodes");
 


### PR DESCRIPTION
This commit updates the serialization verion used for node shutdown
metadata following the backport of #70044.

Also re-enables BWC tests.