### PR TITLE
[7.12] [DOCS] Adds source index privileges required for Explain DFA API docs. (#70978)

### DIFF
--- a/docs/reference/ml/df-analytics/apis/explain-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/explain-dfanalytics.asciidoc
@@ -31,8 +31,10 @@ beta::[]
 If the {es} {security-features} are enabled, you must have the following privileges:
 
 * cluster: `monitor_ml`
+* source indices: `read`, `view_index_metadata`
   
-For more information, see <<security-privileges>> and {ml-docs-setup-privileges}.
+For more information, see <<security-privileges>> and 
+{ml-docs-setup-privileges}.
 
 
 [[ml-explain-dfanalytics-desc]]


### PR DESCRIPTION
Backports the following commits to 7.12:
 - [DOCS] Adds source index privileges required for Explain DFA API docs. (#70978)