### PR TITLE
Update docs that closing a data stream's write index is allowed

### DIFF
--- a/docs/reference/indices/open-close.asciidoc
+++ b/docs/reference/indices/open-close.asciidoc
@@ -64,11 +64,6 @@ Closed indices consume a significant amount of disk-space which can cause
 problems in managed environments. Closing indices can be disabled via the cluster settings
 API by setting `cluster.indices.close.enable` to `false`. The default is `true`.
 
-The current write index on a data stream cannot be closed. In order to close
-the current write index, the data stream must first be
-<<data-streams-rollover,rolled over>> so that a new write index is created
-and then the previous write index can be closed.
-
 // end::closed-index[]
 
 [[open-index-api-wait-for-active-shards]]

--- a/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
@@ -72,9 +72,6 @@ POST /_snapshot/my_repository/my_snapshot/_restore
 
 Use the restore snapshot API to restore a snapshot of a cluster, including all data streams and indices in the snapshot. If you do not want to restore the entire snapshot, you can select specific data streams or indices to restore.
 
-NOTE: You cannot restore a data stream if a stream with the same name already
-exists.
-
 You can run the restore operation on a cluster that contains an elected
 <<master-node,master node>> and has data nodes with enough capacity to accommodate the snapshot
 you are restoring. Existing indices can only be restored if they are

--- a/docs/reference/snapshot-restore/restore-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/restore-snapshot.asciidoc
@@ -107,9 +107,6 @@ new indices if they didn't exist in the cluster.
 If a data stream is restored, its backing indices are also restored. The restore
 operation automatically opens restored backing indices if they were closed.
 
-NOTE: You cannot restore a data stream if a stream with the same name already
-exists.
-
 In addition to entire data streams, you can restore only specific backing
 indices from a snapshot. However, restored backing indices are not automatically
 added to any existing data streams. For example, if only the


### PR DESCRIPTION
This was forgotten as part of #70908
The backport does include the doc change.