### PR TITLE
[7.x] [DOCS] Add reusable tests to ingest docs (#70990)

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -172,6 +172,38 @@ setupMyIndex('my_index_huge', 1200)
 
 tasks.named("buildRestTests").configure {buildRestTests ->
 
+setups['my_data_stream_template'] = '''
+  - do:
+      indices.put_index_template:
+        name: my-data-stream-template
+        body: |
+          {
+            "index_patterns": [ "my-data-stream*" ],
+            "data_stream": { },
+            "priority": 500
+          }
+'''
+
+setups['my_data_stream'] = setups['my_data_stream_template'] + '''
+  - do:
+      raw:
+        method: PUT
+        path: '_data_stream/my-data-stream'
+'''
+
+teardowns['data_stream_cleanup'] = '''
+  - do:
+      raw:
+        method: DELETE
+        path: '_data_stream/*'
+  - is_true: acknowledged
+  - do:
+      raw:
+        method: DELETE
+        path: '_index_template/*'
+  - is_true: acknowledged
+'''
+
 // Used for several full-text search and agg examples
 buildRestTests.setups['messages'] = '''
   - do:
@@ -198,16 +230,7 @@ buildRestTests.setups['messages'] = '''
             {"message": "some message with the number 4"}'''
 
 // Used for EQL
-buildRestTests.setups['sec_logs'] = '''
-  - do:
-      indices.put_index_template:
-        name: my-data-stream-template
-        body: |
-          {
-            "index_patterns": [ "my-data-stream*" ],
-            "data_stream": { },
-            "priority": 500
-          }
+setups['sec_logs'] = setups['my_data_stream'] + '''
   - do:
         bulk:
           index: my-data-stream
@@ -1525,16 +1548,7 @@ setups['setup-repository'] = '''
 '''
 
 // Fake sec logs data used by EQL search
-  setups['atomic_red_regsvr32'] = '''
-  - do:
-      indices.put_index_template:
-        name: my-data-stream-template
-        body: |
-          {
-            "index_patterns": [ "my-data-stream*" ],
-            "data_stream": { },
-            "priority": 500
-          }
+  setups['atomic_red_regsvr32'] = setups['my_data_stream'] + '''
   - do:
         bulk:
           index: my-data-stream

--- a/docs/reference/ingest.asciidoc
+++ b/docs/reference/ingest.asciidoc
@@ -232,6 +232,8 @@ PUT my-data-stream/_bulk?pipeline=my-pipeline
 { "create":{ } }
 { "@timestamp": "2099-03-07T11:04:07.000Z", "my-keyword-field": "bar" }
 ----
+// TEST[setup:my_data_stream]
+// TEST[teardown:data_stream_cleanup]
 
 You can also use the `pipeline` parameter with the <<docs-update-by-query,update
 by query>> or <<docs-reindex,reindex>> APIs.
@@ -252,7 +254,8 @@ POST _reindex
   }
 }
 ----
-// TEST[continued]
+// TEST[setup:my_data_stream]
+// TEST[teardown:data_stream_cleanup]
 
 [discrete]
 [[set-default-pipeline]]

--- a/docs/reference/tab-widgets/data-tiers-widget.asciidoc
+++ b/docs/reference/tab-widgets/data-tiers-widget.asciidoc
@@ -1,0 +1,40 @@
+++++
+<div class="tabs" data-tab-group="host">
+  <div role="tablist" aria-label="Data tiers configuration">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="cloud-tab"
+            id="cloud">
+      Elasticsearch Service
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="self-managed-tab"
+            id="self-managed"
+            tabindex="-1">
+      Self-managed
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="cloud-tab"
+       aria-labelledby="cloud">
+++++
+
+include::data-tiers.asciidoc[tag=cloud]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="self-managed-tab"
+       aria-labelledby="self-managed"
+       hidden="">
+++++
+
+include::data-tiers.asciidoc[tag=self-managed]
+
+++++
+  </div>
+</div>
+++++

--- a/docs/reference/tab-widgets/data-tiers.asciidoc
+++ b/docs/reference/tab-widgets/data-tiers.asciidoc
@@ -1,0 +1,93 @@
+// tag::cloud[]
+
+. Log in to the {ess-trial}[{ess} Console].
+
+. Add or select your deployment from the {ess} home page or the deployments
+page.
+
+. From your deployment menu, select **Edit deployment**.
+
+. To enable a data tier, click **Add capacity**.
+
+**Frozen tier**
+
+The frozen tier is not yet available on {ess}. However, you can follow these
+steps to effectively recreate a frozen tier in your {ess} deployment:
+
+. Choose an existing tier to use. Typically, you'll use the cold tier, but the
+hot and warm tiers are also supported. You can use this tier as a shared tier,
+or use it exclusively as a frozen tier.
+
+. On the **Edit deployment** page, click **Edit elasticsearch.yml** for your
+chosen tier.
+
+. In the `elasticsearch.yml` configuration, set
+<<searchable-snapshots-shared-cache,`xpack.searchable.snapshot.shared_cache.size`>>
+to any size between a couple of gigabytes up to 90% of available disk space. The
+tier will use reserve this space for a <<shared-cache,shared cache>> for
+<<searchable-snapshots,searchable snapshots>>. We only recommend larger sizes if
+you use the node exclusively for a frozen tier.
++
+[source,yaml]
+----
+xpack.searchable.snapshot.shared_cache.size: 50GB
+----
+
+. Click **Save** and **Confirm** to apply your configuration changes.
+
+**Enable autoscaling**
+
+{cloud}/ec-autoscaling.html[Autoscaling] automatically adjusts your deployment's
+capacity to meet your storage needs. To enable autoscaling, select **Autoscale
+this deployment** on **Edit deployment** page. Autoscaling is only available for
+{ess}.
+
+// end::cloud[]
+
+// tag::self-managed[]
+
+To add a node to a data tier, add one of the respective `data_hot`, `data_warm`,
+`data_cold`, or `data_frozen` <<node-roles,node roles>> to
+<<node-roles,`node.roles`>> in the node's `elasticsearch.yml` file.
+
+For nodes with the `data_frozen` role, set
+<<searchable-snapshots-shared-cache,`xpack.searchable.snapshot.shared_cache.size`>>
+to any size between a couple of gigabytes up to 90% of available disk space. The
+tier will use reserve this space for a <<shared-cache,shared cache>> for
+<<searchable-snapshots,searchable snapshots>>. We only recommend larger sizes if
+you use the node exclusively for a frozen tier.
+
+[source,yaml]
+----
+# On hot nodes 
+node.roles: [ data_hot ] 
+
+# On warm nodes 
+node.roles: [ data_warm ] 
+
+# On cold nodes 
+node.roles: [ data_cold ]
+
+# On frozen nodes 
+node.roles: [ data_frozen ]
+xpack.searchable.snapshot.shared_cache.size: 50GB
+----
+
+If needed, you can assign a node to more than one data tier.
+
+[source,yaml]
+----
+node.roles: [ data_hot, data_warm ] 
+----
+
+Assign your data nodes any other roles needed for your cluster. For example, a
+small cluster may have a node configured with multiple roles:
+
+[source,yaml]
+----
+node.roles: [ master, ingest, ml, data_hot, transform ]
+----
+
+For more information about node roles, see <<node-roles>>.
+
+// end::self-managed[]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Add reusable tests to ingest docs (#70990)