### PR TITLE
[7.12] [DOCS] Remove dupe `wait_for_completion` def (#71012)

### DIFF
--- a/docs/reference/cluster/tasks.asciidoc
+++ b/docs/reference/cluster/tasks.asciidoc
@@ -238,11 +238,6 @@ list tasks command, so multiple tasks can be cancelled at the same time. For
 example, the following command will cancel all reindex tasks running on the 
 nodes `nodeId1` and `nodeId2`.
 
-`wait_for_completion`::
-(Optional, Boolean) If `true`, the request blocks until the cancellation of the
-task and its descendant tasks is completed. Otherwise, the request can return soon
-after the cancellation is started. Defaults to `false`.
-
 [source,console]
 --------------------------------------------------
 POST _tasks/_cancel?nodes=nodeId1,nodeId2&actions=*reindex


### PR DESCRIPTION
Backports the following commits to 7.12:
 - [DOCS] Remove dupe `wait_for_completion` def (#71012)