### PR TITLE
Stop Blocking Snapshot Deletes Due to Concurrency Limits (#71050)

### DIFF
--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -2280,10 +2280,8 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                         reusedExistingDelete = true;
                         return currentState;
                     }
-                    final List<SnapshotId> toDelete = Collections.unmodifiableList(new ArrayList<>(snapshotIdsRequiringCleanup));
-                    ensureBelowConcurrencyLimit(repoName, toDelete.get(0).getName(), snapshots, deletionsInProgress);
                     newDelete = new SnapshotDeletionsInProgress.Entry(
-                        toDelete,
+                        Collections.unmodifiableList(new ArrayList<>(snapshotIdsRequiringCleanup)),
                         repoName,
                         threadPool.absoluteTimeInMillis(),
                         repositoryData.getGenId(),


### PR DESCRIPTION
Limiting the number of concurrent snapshots is useful in preventing excessive memory use.
For deletes that aren't actively executing memory use is negligible. We also only have
at the most two delete snapshot entries per repository (a currently executing one and a queued
up one that that new delete requests get batched into). Thus there is no good reason to prevent
snapshot deletes via the concurrent operations limit to limit memory use. On the other hand though,
not allowing deletes and specifically aborts to exceed the concurrency limits makes it impossible for
a user that already has the maximum number of snapshot create operations running to abort any of them.

backport of #71050