### PR TITLE
Reenable bwc tests after backport

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -189,9 +189,9 @@ tasks.register("verifyVersions") {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = false
+boolean bwc_tests_enabled = true
 // place a PR link here when committing bwc changes:
-String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/71047"
+String bwc_tests_disabled_issue = ""
 /*
  * FIPS 140-2 behavior was fixed in 7.11.0. Before that there is no way to run elasticsearch in a
  * JVM that is properly configured to be in fips mode with BCFIPS. For now we need to disable

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilities.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilities.java
@@ -96,7 +96,7 @@ public class FieldCapabilities implements Writeable, ToXContentObject {
     FieldCapabilities(StreamInput in) throws IOException {
         this.name = in.readString();
         this.type = in.readString();
-        this.isMetadataField = in.getVersion().onOrAfter(Version.V_8_0_0) ? in.readBoolean() : false;
+        this.isMetadataField = in.getVersion().onOrAfter(Version.V_7_13_0) ? in.readBoolean() : false;
         this.isSearchable = in.readBoolean();
         this.isAggregatable = in.readBoolean();
         this.indices = in.readOptionalStringArray();
@@ -113,7 +113,7 @@ public class FieldCapabilities implements Writeable, ToXContentObject {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(name);
         out.writeString(type);
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_13_0)) {
             out.writeBoolean(isMetadataField);
         }
         out.writeBoolean(isSearchable);

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/IndexFieldCapabilities.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/IndexFieldCapabilities.java
@@ -55,7 +55,7 @@ public class IndexFieldCapabilities implements Writeable {
         if (in.getVersion().onOrAfter(Version.V_7_7_0)) {
             this.name = in.readString();
             this.type = in.readString();
-            this.isMetadatafield = in.getVersion().onOrAfter(Version.V_8_0_0) ? in.readBoolean() : false;
+            this.isMetadatafield = in.getVersion().onOrAfter(Version.V_7_13_0) ? in.readBoolean() : false;
             this.isSearchable = in.readBoolean();
             this.isAggregatable = in.readBoolean();
             this.meta = in.readMap(StreamInput::readString, StreamInput::readString);
@@ -78,7 +78,7 @@ public class IndexFieldCapabilities implements Writeable {
         if (out.getVersion().onOrAfter(Version.V_7_7_0)) {
             out.writeString(name);
             out.writeString(type);
-            if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+            if (out.getVersion().onOrAfter(Version.V_7_13_0)) {
                 out.writeBoolean(isMetadatafield);
             }
             out.writeBoolean(isSearchable);

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
@@ -202,7 +202,7 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
         for (Map.Entry<String, IndexFieldCapabilities> entry : response.get().entrySet()) {
             final String field = entry.getKey();
             // best effort to detect metadata field coming from older nodes
-            final boolean isMetadataField = response.getOriginVersion().onOrAfter(Version.V_8_0_0) ?
+            final boolean isMetadataField = response.getOriginVersion().onOrAfter(Version.V_7_13_0) ?
                 entry.getValue().isMetadatafield() : metadataFieldPred.test(field);
             final IndexFieldCapabilities fieldCap = entry.getValue();
             Map<String, FieldCapabilities.Builder> typeMap = responseMapBuilder.computeIfAbsent(field, f -> new HashMap<>());


### PR DESCRIPTION
This change adapts the version checks for #69977 and reenables bwc tests now that the [backport](https://github.com/elastic/elasticsearch/pull/71047) is done.