### PR TITLE
Fix Tripped Assertion on Resync Failure during Node Shutdown

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -597,7 +597,11 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                                         if (state == IndexShardState.CLOSED) {
                                             // ignore, shutting down
                                         } else {
-                                            failShard("exception during primary-replica resync", e);
+                                            try {
+                                                failShard("exception during primary-replica resync", e);
+                                            } catch (AlreadyClosedException ace) {
+                                                // okay, the index was deleted
+                                            }
                                         }
                                     }
                                 });


### PR DESCRIPTION
We can have a race here where the closed check passes and then we concurrently to
a shard close try to fail the shard also. Previously this was covered by the catch below
the changed code that would just ignore the already-closed exception but with #69949 we're
now forking to the generic pool for this logic and thus have to handle the exception in the
callback as well.

Failed in https://gradle-enterprise.elastic.co/s/5i55v7oeoekxc/tests/:server:internalClusterTest/org.elasticsearch.cluster.routing.PrimaryAllocationIT/testForceStaleReplicaToBePromotedToPrimary?expanded-stacktrace=WyIwLTEiLCIwLTEtMiIsIjAtMS0yLTMiXQ#1 and could fail elsewhere (though it's very unlikely)