### PR TITLE
[Test] Service Accounts - Remove colon from invalid token name generator

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountToken.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountToken.java
@@ -131,6 +131,11 @@ public class ServiceAccountToken implements AuthenticationToken, Closeable {
     }
 
     @Override
+    public String toString() {
+        return getQualifiedName();
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o)
             return true;

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountTokenTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountTokenTests.java
@@ -33,7 +33,7 @@ public class ServiceAccountTokenTests extends ESTestCase {
     );
 
     private static final Set<Character> INVALID_TOKEN_NAME_CHARS = Set.of(
-        '!', '"', '#', '$', '%', '&', '\'', '(', ')', '*', '+', ',', '.', '/', ':', ';', '<', '=', '>', '?', '@', '[',
+        '!', '"', '#', '$', '%', '&', '\'', '(', ')', '*', '+', ',', '.', '/', ';', '<', '=', '>', '?', '@', '[',
         '\\', ']', '^', '`', '{', '|', '}', '~', ' ', '\t', '\n', '\r');
 
     public void testIsValidTokenName() {


### PR DESCRIPTION
The colon character is interpreted as the separate between token name and token secret. So if a token name contains a colon, it is in theory invalid. But the parser takes only the part before the colon as the token name and thus consider it as a valid token name. Subsequent authentication will still fail. But for tests, this generates a different exception and fails the expectation. This PR removes the colon char from being used to generate invalid token names for simplicity.

Resolves: #71094