### PR TITLE
Add script parameter to long and double field mappers (#69531)

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/script/ScriptScoreBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/script/ScriptScoreBenchmark.java
@@ -81,7 +81,7 @@ public class ScriptScoreBenchmark {
     private final Map<String, MappedFieldType> fieldTypes = org.elasticsearch.common.collect.Map.ofEntries(
         org.elasticsearch.common.collect.Map.entry(
             "n",
-            new NumberFieldType("n", NumberType.LONG, false, false, true, true, null, org.elasticsearch.common.collect.Map.of())
+            new NumberFieldType("n", NumberType.LONG, false, false, true, true, null, org.elasticsearch.common.collect.Map.of(), null)
         )
     );
     private final IndexFieldDataCache fieldDataCache = new IndexFieldDataCache.None();

--- a/docs/reference/mapping/types/numeric.asciidoc
+++ b/docs/reference/mapping/types/numeric.asciidoc
@@ -117,6 +117,7 @@ The following parameters are accepted by numeric types:
 
     Try to convert strings to numbers and truncate fractions for integers.
     Accepts `true` (default) and `false`. Not applicable for `unsigned_long`.
+    Note that this cannot be set if the `script` parameter is used.
 
 <<mapping-boost,`boost`>>::
 
@@ -132,7 +133,8 @@ The following parameters are accepted by numeric types:
 <<ignore-malformed,`ignore_malformed`>>::
 
     If `true`, malformed numbers are ignored. If `false` (default), malformed
-    numbers throw an exception and reject the whole document.
+    numbers throw an exception and reject the whole document.  Note that this
+    cannot be set if the `script` parameter is used.
 
 <<mapping-index,`index`>>::
 
@@ -142,7 +144,26 @@ The following parameters are accepted by numeric types:
 
     Accepts a numeric value of the same `type` as the field which is
     substituted for any explicit `null` values.  Defaults to `null`, which
-    means the field is treated as missing.
+    means the field is treated as missing.  Note that this cannot be set
+    if the `script` parameter is used.
+
+`on_script_error`::
+
+    Defines what to do if the script defined by the `script` parameter
+    throws an error at indexing time.  Accepts `reject` (default), which
+    will cause the entire document to be rejected, and `ignore`, which
+    will register the field in the document's
+    <<mapping-ignored-field,`_ignored`>> metadata field and continue
+    indexing.  This parameter can only be set if the `script` field is
+    also set.
+
+`script`::
+
+    If this parameter is set, then the field will index values generated
+    by this script, rather than reading the values directly from the
+    source.  Scripts are in the same format as their
+    <<runtime-mapping-fields,runtime equivalent>>. Scripts can only be
+    configured on `long` and `double` field types.
 
 <<mapping-store,`store`>>::
 

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/TokenCountFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/TokenCountFieldMapper.java
@@ -77,7 +77,7 @@ public class TokenCountFieldMapper extends FieldMapper {
 
         TokenCountFieldType(String name, boolean isSearchable, boolean isStored,
                             boolean hasDocValues, Number nullValue, Map<String, String> meta) {
-            super(name, NumberFieldMapper.NumberType.INTEGER, isSearchable, isStored, hasDocValues, false, nullValue, meta);
+            super(name, NumberFieldMapper.NumberType.INTEGER, isSearchable, isStored, hasDocValues, false, nullValue, meta, null);
         }
 
         @Override

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/RankFeatureFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/RankFeatureFieldMapperTests.java
@@ -57,6 +57,11 @@ public class RankFeatureFieldMapperTests extends MapperTestCase {
         return List.of(new MapperExtrasPlugin());
     }
 
+    @Override
+    protected boolean allowsStore() {
+        return false;
+    }
+
     static int getFrequency(TokenStream tk) throws IOException {
         TermFrequencyAttribute freqAttribute = tk.addAttribute(TermFrequencyAttribute.class);
         tk.reset();

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/RankFeaturesFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/RankFeaturesFieldMapperTests.java
@@ -53,6 +53,11 @@ public class RankFeaturesFieldMapperTests extends MapperTestCase {
         return false;
     }
 
+    @Override
+    protected boolean allowsStore() {
+        return false;
+    }
+
     public void testDefaults() throws Exception {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
         assertEquals(Strings.toString(fieldMapping(this::minimalMapping)), mapper.mappingSource().toString());

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/23_long_calculated_at_index.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/23_long_calculated_at_index.yml
@@ -1,0 +1,152 @@
+---
+setup:
+  - do:
+      indices.create:
+        index: sensor
+        body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
+          mappings:
+            properties:
+              timestamp:
+                type: date
+              temperature:
+                type: long
+              voltage:
+                type: double
+              node:
+                type: keyword
+              voltage_times_ten:
+                type: long
+                script:
+                  source: |
+                   for (double v : doc['voltage']) {
+                     emit((long)(v * params.multiplier));
+                   }
+                  params:
+                    multiplier: 10
+              voltage_times_ten_no_dv:
+                type: long
+                doc_values: false
+                script:
+                  source: |
+                    for (double v : doc['voltage']) {
+                      emit((long)(v * params.multiplier));
+                    }
+                  params:
+                    multiplier: 10
+              # test multiple values
+              temperature_digits:
+                type: long
+                script:
+                  source: |
+                    for (long temperature : doc['temperature']) {
+                      long t = temperature;
+                      while (t != 0) {
+                        emit(t % 10);
+                        t /= 10;
+                      }
+                    }
+
+  - do:
+      bulk:
+        index: sensor
+        refresh: true
+        body: |
+          {"index":{}}
+          {"timestamp": 1516729294000, "temperature": 200, "voltage": 5.2, "node": "a"}
+          {"index":{}}
+          {"timestamp": 1516642894000, "temperature": 201, "voltage": 5.8, "node": "b"}
+          {"index":{}}
+          {"timestamp": 1516556494000, "temperature": 202, "voltage": 5.1, "node": "a"}
+          {"index":{}}
+          {"timestamp": 1516470094000, "temperature": 198, "voltage": 5.6, "node": "b"}
+          {"index":{}}
+          {"timestamp": 1516383694000, "temperature": 200, "voltage": 4.2, "node": "c"}
+          {"index":{}}
+          {"timestamp": 1516297294000, "temperature": 202, "voltage": 4.0, "node": "c"}
+
+---
+"get mapping":
+  - do:
+      indices.get_mapping:
+        index: sensor
+  - match: {sensor.mappings.properties.voltage_times_ten.type: long }
+  - match:
+      sensor.mappings.properties.voltage_times_ten.script.source: |
+        for (double v : doc['voltage']) {
+          emit((long)(v * params.multiplier));
+        }
+  - match: {sensor.mappings.properties.voltage_times_ten.script.params: {multiplier: 10} }
+  - match: {sensor.mappings.properties.voltage_times_ten.script.lang: painless }
+
+---
+"fetch fields":
+  - do:
+      search:
+        index: sensor
+        body:
+          sort: timestamp
+          fields:
+            - voltage_times_ten
+            - voltage_times_ten_no_dv
+            - temperature_digits
+  - match: {hits.total.value: 6}
+  - match: {hits.hits.0.fields.voltage_times_ten: [40] }
+  - match: {hits.hits.0.fields.temperature_digits: [2, 0, 2] }
+  - match: {hits.hits.0.fields.voltage_times_ten: [40] }
+  - match: {hits.hits.0.fields.voltage_times_ten_no_dv: [40] }
+  - match: {hits.hits.1.fields.voltage_times_ten: [42] }
+  - match: {hits.hits.2.fields.voltage_times_ten: [56] }
+  - match: {hits.hits.3.fields.voltage_times_ten: [51] }
+  - match: {hits.hits.4.fields.voltage_times_ten: [58] }
+  - match: {hits.hits.5.fields.voltage_times_ten: [52] }
+
+---
+"docvalue_fields":
+  - do:
+      search:
+        index: sensor
+        body:
+          sort: timestamp
+          docvalue_fields:
+            - voltage_times_ten
+            - temperature_digits
+  - match: {hits.total.value: 6}
+  - match: {hits.hits.0.fields.voltage_times_ten: [40] }
+  - match: {hits.hits.0.fields.temperature_digits: [0, 2, 2] }
+  - match: {hits.hits.0.fields.voltage_times_ten: [40] }
+  - match: {hits.hits.1.fields.voltage_times_ten: [42] }
+  - match: {hits.hits.2.fields.voltage_times_ten: [56] }
+  - match: {hits.hits.3.fields.voltage_times_ten: [51] }
+  - match: {hits.hits.4.fields.voltage_times_ten: [58] }
+  - match: {hits.hits.5.fields.voltage_times_ten: [52] }
+
+---
+"terms agg":
+  - do:
+      search:
+        index: sensor
+        body:
+          aggs:
+            v10:
+              terms:
+                field: voltage_times_ten
+  - match: {hits.total.value: 6}
+  - match: {aggregations.v10.buckets.0.key: 40.0}
+  - match: {aggregations.v10.buckets.0.doc_count: 1}
+  - match: {aggregations.v10.buckets.1.key: 42.0}
+  - match: {aggregations.v10.buckets.1.doc_count: 1}
+
+---
+"term query":
+  - do:
+      search:
+        index: sensor
+        body:
+          query:
+            term:
+              voltage_times_ten: 58
+  - match: {hits.total.value: 1}
+  - match: {hits.hits.0._source.voltage: 5.8}

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/33_double_calculated_at_index.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/33_double_calculated_at_index.yml
@@ -1,0 +1,193 @@
+---
+setup:
+  - do:
+      indices.create:
+        index: sensor
+        body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
+          mappings:
+            properties:
+              timestamp:
+                type: date
+              temperature:
+                type: long
+              voltage:
+                type: double
+              node:
+                type: keyword
+              voltage_percent:
+                type: double
+                script:
+                  source: |
+                    for (double v : doc['voltage']) {
+                      emit(v / params.max);
+                    }
+                  params:
+                    max: 5.8
+              voltage_percent_no_dv:
+                type: double
+                doc_values: false
+                script:
+                  source: |
+                    for (double v : doc['voltage']) {
+                      emit(v / params.max);
+                    }
+                  params:
+                    max: 5.8
+              # Test fetching many values
+              voltage_sqrts:
+                type: double
+                script:
+                  source: |
+                    for (double voltage : doc['voltage']) {
+                      double v = voltage;
+                      while (v > 1.2) {
+                        emit(v);
+                        v = Math.sqrt(v);
+                      }
+                    }
+
+  - do:
+      bulk:
+        index: sensor
+        refresh: true
+        body: |
+          {"index":{}}
+          {"timestamp": 1516729294000, "temperature": 200, "voltage": 5.2, "node": "a"}
+          {"index":{}}
+          {"timestamp": 1516642894000, "temperature": 201, "voltage": 5.8, "node": "b"}
+          {"index":{}}
+          {"timestamp": 1516556494000, "temperature": 202, "voltage": 5.1, "node": "a"}
+          {"index":{}}
+          {"timestamp": 1516470094000, "temperature": 198, "voltage": 5.6, "node": "b"}
+          {"index":{}}
+          {"timestamp": 1516383694000, "temperature": 200, "voltage": 4.2, "node": "c"}
+          {"index":{}}
+          {"timestamp": 1516297294000, "temperature": 202, "voltage": 4.0, "node": "c"}
+
+---
+"get mapping":
+  - do:
+      indices.get_mapping:
+        index: sensor
+  - match: {sensor.mappings.properties.voltage_percent.type: double }
+  - match:
+      sensor.mappings.properties.voltage_percent.script.source: |
+        for (double v : doc['voltage']) {
+          emit(v / params.max);
+        }
+  - match: {sensor.mappings.properties.voltage_percent.script.params: {max: 5.8} }
+  - match: {sensor.mappings.properties.voltage_percent.script.lang: painless }
+
+---
+"fetch fields":
+  - do:
+      search:
+        index: sensor
+        body:
+          sort: timestamp
+          fields: [voltage_percent, voltage_percent_no_dv, voltage_sqrts]
+  - match: {hits.total.value: 6}
+  - match: {hits.hits.0.fields.voltage_percent: [0.6896551724137931] }
+  # Scripts that scripts that emit multiple values are supported
+  - match: {hits.hits.0.fields.voltage_sqrts: [4.0, 2.0, 1.4142135623730951] }
+  - match: {hits.hits.1.fields.voltage_percent: [0.7241379310344828] }
+  - match: {hits.hits.1.fields.voltage_percent_no_dv: [0.7241379310344828] }
+  - match: {hits.hits.2.fields.voltage_percent: [0.9655172413793103] }
+  - match: {hits.hits.3.fields.voltage_percent: [0.8793103448275862] }
+  - match: {hits.hits.4.fields.voltage_percent: [1.0] }
+  - match: {hits.hits.5.fields.voltage_percent: [0.896551724137931] }
+
+---
+"docvalue_fields":
+  - do:
+      search:
+        index: sensor
+        body:
+          sort: timestamp
+          docvalue_fields: [voltage_percent, voltage_sqrts]
+  - match: {hits.total.value: 6}
+  - match: {hits.hits.0.fields.voltage_percent: [0.6896551724137931] }
+  # Scripts that scripts that emit multiple values are supported and their results are sorted
+  - match: {hits.hits.0.fields.voltage_sqrts: [1.4142135623730951, 2.0, 4.0] }
+  - match: {hits.hits.1.fields.voltage_percent: [0.7241379310344828] }
+  - match: {hits.hits.2.fields.voltage_percent: [0.9655172413793103] }
+  - match: {hits.hits.3.fields.voltage_percent: [0.8793103448275862] }
+  - match: {hits.hits.4.fields.voltage_percent: [1.0] }
+  - match: {hits.hits.5.fields.voltage_percent: [0.896551724137931] }
+
+---
+"terms agg":
+  - do:
+      search:
+        index: sensor
+        body:
+          aggs:
+            v10:
+              terms:
+                field: voltage_percent
+  - match: {hits.total.value: 6}
+  - match: {aggregations.v10.buckets.0.key: 0.6896551724137931}
+  - match: {aggregations.v10.buckets.0.doc_count: 1}
+  - match: {aggregations.v10.buckets.1.key: 0.7241379310344828}
+  - match: {aggregations.v10.buckets.1.doc_count: 1}
+
+---
+"range query":
+  - do:
+      search:
+        index: sensor
+        body:
+          query:
+            range:
+              voltage_percent:
+                lt: .7
+  - match: {hits.total.value: 1}
+  - match: {hits.hits.0._source.voltage: 4.0}
+
+  - do:
+      search:
+        index: sensor
+        body:
+          query:
+            range:
+              voltage_percent:
+                gt: 1
+  - match: {hits.total.value: 0}
+
+  - do:
+      search:
+        index: sensor
+        body:
+          query:
+            range:
+              voltage_percent:
+                gte: 1
+  - match: {hits.total.value: 1}
+  - match: {hits.hits.0._source.voltage: 5.8}
+
+  - do:
+      search:
+        index: sensor
+        body:
+          query:
+            range:
+              voltage_percent:
+                gte: .7
+                lte: .8
+  - match: {hits.total.value: 1}
+  - match: {hits.hits.0._source.voltage: 4.2}
+
+---
+"term query":
+  - do:
+      search:
+        index: sensor
+        body:
+          query:
+            term:
+              voltage_percent: 1.0
+  - match: {hits.total.value: 1}
+  - match: {hits.hits.0._source.voltage: 5.8}

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentLeafReader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentLeafReader.java
@@ -1,0 +1,486 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.Fields;
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.index.LeafMetaData;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.PointValues;
+import org.apache.lucene.index.SortedDocValues;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.index.StoredFieldVisitor;
+import org.apache.lucene.index.Terms;
+import org.apache.lucene.index.memory.MemoryIndex;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.BytesRef;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+/**
+ * A {@link LeafReader} over a lucene document that exposes doc values and stored fields.
+ * Note that unlike lucene's {@link MemoryIndex} implementation, this holds no state and
+ * does not attempt to do any analysis on text fields.  It also supports stored
+ * fields where MemoryIndex does not.  It is used to back index-time scripts that
+ * reference field data and stored fields from a document that has not yet been
+ * indexed.
+ */
+class DocumentLeafReader extends LeafReader {
+
+    private final ParseContext.Document document;
+    private final Map<String, Consumer<LeafReaderContext>> calculatedFields;
+    private final Set<String> fieldPath = new LinkedHashSet<>();
+
+    DocumentLeafReader(ParseContext.Document document, Map<String, Consumer<LeafReaderContext>> calculatedFields) {
+        this.document = document;
+        this.calculatedFields = calculatedFields;
+    }
+
+    private void checkField(String field) {
+        if (calculatedFields.containsKey(field)) {
+            // this means that a mapper script is referring to another calculated field;
+            // in which case we need to execute that field first. We also check for loops here
+            if (fieldPath.add(field) == false) {
+                throw new IllegalArgumentException(
+                    "Loop in field resolution detected: " + String.join("->", fieldPath) + "->" + field
+                );
+            }
+            calculatedFields.get(field).accept(this.getContext());
+            fieldPath.remove(field);
+        }
+    }
+
+    @Override
+    public NumericDocValues getNumericDocValues(String field) throws IOException {
+        checkField(field);
+        List<Number> values = document.getFields().stream()
+            .filter(f -> Objects.equals(f.name(), field))
+            .filter(f -> f.fieldType().docValuesType() == DocValuesType.NUMERIC)
+            .map(IndexableField::numericValue)
+            .sorted()
+            .collect(Collectors.toList());
+        return numericDocValues(values);
+    }
+
+    @Override
+    public BinaryDocValues getBinaryDocValues(String field) throws IOException {
+        checkField(field);
+        List<BytesRef> values = document.getFields().stream()
+            .filter(f -> Objects.equals(f.name(), field))
+            .filter(f -> f.fieldType().docValuesType() == DocValuesType.BINARY)
+            .map(IndexableField::binaryValue)
+            .sorted()
+            .collect(Collectors.toList());
+        return binaryDocValues(values);
+    }
+
+    @Override
+    public SortedDocValues getSortedDocValues(String field) throws IOException {
+        checkField(field);
+        List<BytesRef> values = document.getFields().stream()
+            .filter(f -> Objects.equals(f.name(), field))
+            .filter(f -> f.fieldType().docValuesType() == DocValuesType.SORTED)
+            .map(IndexableField::binaryValue)
+            .sorted()
+            .collect(Collectors.toList());
+        return sortedDocValues(values);
+    }
+
+    @Override
+    public SortedNumericDocValues getSortedNumericDocValues(String field) throws IOException {
+        checkField(field);
+        List<Number> values = document.getFields().stream()
+            .filter(f -> Objects.equals(f.name(), field))
+            .filter(f -> f.fieldType().docValuesType() == DocValuesType.SORTED_NUMERIC)
+            .map(IndexableField::numericValue)
+            .sorted()
+            .collect(Collectors.toList());
+        return sortedNumericDocValues(values);
+    }
+
+    @Override
+    public SortedSetDocValues getSortedSetDocValues(String field) throws IOException {
+        List<BytesRef> values = document.getFields().stream()
+            .filter(f -> Objects.equals(f.name(), field))
+            .filter(f -> f.fieldType().docValuesType() == DocValuesType.SORTED_SET)
+            .map(IndexableField::binaryValue)
+            .sorted()
+            .collect(Collectors.toList());
+        return sortedSetDocValues(values);
+    }
+
+    @Override
+    public FieldInfos getFieldInfos() {
+        return new FieldInfos(new FieldInfo[0]);
+    }
+
+    @Override
+    public void document(int docID, StoredFieldVisitor visitor) throws IOException {
+        List<IndexableField> fields = document.getFields().stream()
+            .filter(f -> f.fieldType().stored())
+            .collect(Collectors.toList());
+        for (IndexableField field : fields) {
+            FieldInfo fieldInfo = fieldInfo(field.name());
+            if (visitor.needsField(fieldInfo) != StoredFieldVisitor.Status.YES) {
+                continue;
+            }
+            if (field.numericValue() != null) {
+                Number v = field.numericValue();
+                if (v instanceof Integer) {
+                    visitor.intField(fieldInfo, v.intValue());
+                } else if (v instanceof Long) {
+                    visitor.longField(fieldInfo, v.longValue());
+                } else if (v instanceof Float) {
+                    visitor.floatField(fieldInfo, v.floatValue());
+                } else if (v instanceof Double) {
+                    visitor.doubleField(fieldInfo, v.doubleValue());
+                }
+            } else if (field.stringValue() != null) {
+                visitor.stringField(fieldInfo, field.stringValue().getBytes(StandardCharsets.UTF_8));
+            } else if (field.binaryValue() != null) {
+                // We can't just pass field.binaryValue().bytes here as there may be offset/length
+                // considerations
+                byte[] data = new byte[field.binaryValue().length];
+                System.arraycopy(field.binaryValue().bytes, field.binaryValue().offset, data, 0, data.length);
+                visitor.binaryField(fieldInfo, data);
+            }
+        }
+    }
+
+    @Override
+    public CacheHelper getCoreCacheHelper() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Terms terms(String field) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public NumericDocValues getNormValues(String field) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Bits getLiveDocs() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public PointValues getPointValues(String field) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void checkIntegrity() throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public LeafMetaData getMetaData() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Fields getTermVectors(int docID) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int numDocs() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int maxDoc() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected void doClose() throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CacheHelper getReaderCacheHelper() {
+        throw new UnsupportedOperationException();
+    }
+
+    // Our StoredFieldsVisitor implementations only check the name of the passed-in
+    // FieldInfo, so that's the only value we need to set here.
+    private static FieldInfo fieldInfo(String name) {
+        return new FieldInfo(
+            name,
+            0,
+            false,
+            false,
+            false,
+            IndexOptions.NONE,
+            DocValuesType.NONE,
+            -1,
+            Collections.emptyMap(),
+            0,
+            0,
+            0,
+            false
+        );
+    }
+
+    private static NumericDocValues numericDocValues(List<Number> values) {
+        if (values.size() == 0) {
+            return null;
+        }
+        DocIdSetIterator disi = DocIdSetIterator.all(1);
+        return new NumericDocValues() {
+            @Override
+            public long longValue() {
+                return values.get(0).longValue();
+            }
+
+            @Override
+            public boolean advanceExact(int target) throws IOException {
+                return disi.advance(target) == target;
+            }
+
+            @Override
+            public int docID() {
+                return disi.docID();
+            }
+
+            @Override
+            public int nextDoc() throws IOException {
+                return disi.nextDoc();
+            }
+
+            @Override
+            public int advance(int target) throws IOException {
+                return disi.advance(target);
+            }
+
+            @Override
+            public long cost() {
+                return disi.cost();
+            }
+        };
+    }
+
+    private static SortedNumericDocValues sortedNumericDocValues(List<Number> values) {
+        if (values.size() == 0) {
+            return null;
+        }
+        DocIdSetIterator disi = DocIdSetIterator.all(1);
+        return new SortedNumericDocValues() {
+
+            int i = -1;
+
+            @Override
+            public long nextValue() {
+                i++;
+                return values.get(i).longValue();
+            }
+
+            @Override
+            public int docValueCount() {
+                return values.size();
+            }
+
+            @Override
+            public boolean advanceExact(int target) throws IOException {
+                i = -1;
+                return disi.advance(target) == target;
+            }
+
+            @Override
+            public int docID() {
+                return disi.docID();
+            }
+
+            @Override
+            public int nextDoc() throws IOException {
+                i = -1;
+                return disi.nextDoc();
+            }
+
+            @Override
+            public int advance(int target) throws IOException {
+                i = -1;
+                return disi.advance(target);
+            }
+
+            @Override
+            public long cost() {
+                return disi.cost();
+            }
+        };
+    }
+
+    private static BinaryDocValues binaryDocValues(List<BytesRef> values) {
+        if (values.size() == 0) {
+            return null;
+        }
+        DocIdSetIterator disi = DocIdSetIterator.all(1);
+        return new BinaryDocValues() {
+            @Override
+            public BytesRef binaryValue() {
+                return values.get(0);
+            }
+
+            @Override
+            public boolean advanceExact(int target) throws IOException {
+                return disi.advance(target) == target;
+            }
+
+            @Override
+            public int docID() {
+                return disi.docID();
+            }
+
+            @Override
+            public int nextDoc() throws IOException {
+                return disi.nextDoc();
+            }
+
+            @Override
+            public int advance(int target) throws IOException {
+                return disi.advance(target);
+            }
+
+            @Override
+            public long cost() {
+                return disi.cost();
+            }
+        };
+    }
+
+    private static SortedDocValues sortedDocValues(List<BytesRef> values) {
+        if (values.size() == 0) {
+            return null;
+        }
+        DocIdSetIterator disi = DocIdSetIterator.all(1);
+        return new SortedDocValues() {
+
+            @Override
+            public int ordValue() {
+                return 0;
+            }
+
+            @Override
+            public BytesRef lookupOrd(int ord) {
+                return values.get(0);
+            }
+
+            @Override
+            public int getValueCount() {
+                return values.size();
+            }
+
+            @Override
+            public boolean advanceExact(int target) throws IOException {
+                return disi.advance(target) == target;
+            }
+
+            @Override
+            public int docID() {
+                return disi.docID();
+            }
+
+            @Override
+            public int nextDoc() throws IOException {
+                return disi.nextDoc();
+            }
+
+            @Override
+            public int advance(int target) throws IOException {
+                return disi.advance(target);
+            }
+
+            @Override
+            public long cost() {
+                return disi.cost();
+            }
+        };
+    }
+
+    private static SortedSetDocValues sortedSetDocValues(List<BytesRef> values) {
+        if (values.size() == 0) {
+            return null;
+        }
+        DocIdSetIterator disi = DocIdSetIterator.all(1);
+        return new SortedSetDocValues() {
+
+            int i = -1;
+
+            @Override
+            public long nextOrd() {
+                i++;
+                if (i >= values.size()) {
+                    return NO_MORE_ORDS;
+                }
+                return i;
+            }
+
+            @Override
+            public BytesRef lookupOrd(long ord) {
+                return values.get((int)ord);
+            }
+
+            @Override
+            public long getValueCount() {
+                return values.size();
+            }
+
+            @Override
+            public boolean advanceExact(int target) throws IOException {
+                i = -1;
+                return disi.advance(target) == target;
+            }
+
+            @Override
+            public int docID() {
+                return disi.docID();
+            }
+
+            @Override
+            public int nextDoc() throws IOException {
+                i = -1;
+                return disi.nextDoc();
+            }
+
+            @Override
+            public int advance(int target) throws IOException {
+                i = -1;
+                return disi.advance(target);
+            }
+
+            @Override
+            public long cost() {
+                return disi.cost();
+            }
+        };
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -8,17 +8,9 @@
 
 package org.elasticsearch.index.mapper;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Objects;
-import java.util.function.Function;
-
 import org.apache.lucene.document.Field;
 import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.Tuple;
@@ -29,7 +21,22 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.fielddata.IndexFieldDataCache;
 import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
+import org.elasticsearch.search.lookup.SearchLookup;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 /** A parser for documents, given mappings from a DocumentMapper */
 final class DocumentParser {
@@ -94,6 +101,7 @@ final class DocumentParser {
 
     private static void internalParseDocument(RootObjectMapper root, MetadataFieldMapper[] metadataFieldsMappers,
                                               ParseContext context, XContentParser parser) throws IOException {
+
         final boolean emptyDoc = isEmptyDoc(root, parser);
 
         for (MetadataFieldMapper metadataMapper : metadataFieldsMappers) {
@@ -107,6 +115,8 @@ final class DocumentParser {
             parseObjectOrNested(context, root);
         }
 
+        executeIndexTimeScripts(context);
+
         for (MetadataFieldMapper metadataMapper : metadataFieldsMappers) {
             metadataMapper.postParse(context);
         }
@@ -118,8 +128,41 @@ final class DocumentParser {
         }
 
         if (Objects.equals(source.type(), type) == false &&
-                MapperService.SINGLE_MAPPING_NAME.equals(source.type()) == false) { // used by typeless APIs
+            MapperService.SINGLE_MAPPING_NAME.equals(source.type()) == false) { // used by typeless APIs
             throw new MapperParsingException("Type mismatch, provide type [" + source.type() + "] but mapper is of type [" + type + "]");
+        }
+    }
+
+    private static void executeIndexTimeScripts(ParseContext context) {
+        List<FieldMapper> indexTimeScriptMappers = context.mappingLookup().indexTimeScriptMappers();
+        if (indexTimeScriptMappers.isEmpty()) {
+            return;
+        }
+        SearchLookup searchLookup = new SearchLookup(
+            context.mappingLookup().indexTimeLookup()::get,
+            (ft, lookup) -> ft.fielddataBuilder(context.indexSettings().getIndex().getName(), lookup).build(
+                new IndexFieldDataCache.None(),
+                new NoneCircuitBreakerService())
+        );
+        // field scripts can be called both by the loop at the end of this method and via
+        // the document reader, so to ensure that we don't run them multiple times we
+        // guard them with an 'executed' boolean
+        Map<String, Consumer<LeafReaderContext>> fieldScripts = new HashMap<>();
+        indexTimeScriptMappers.forEach(mapper -> fieldScripts.put(mapper.name(), new Consumer<LeafReaderContext>() {
+            boolean executed = false;
+            @Override
+            public void accept(LeafReaderContext leafReaderContext) {
+                if (executed == false) {
+                    mapper.executeScript(searchLookup, leafReaderContext, 0, context);
+                    executed = true;
+                }
+            }
+        }));
+
+        // call the index script on all field mappers configured with one
+        DocumentLeafReader reader = new DocumentLeafReader(context.rootDoc(), fieldScripts);
+        for (Consumer<LeafReaderContext> script : fieldScripts.values()) {
+            script.accept(reader.getContext());
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/DoubleScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DoubleScriptFieldType.java
@@ -34,7 +34,7 @@ import java.util.function.Supplier;
 
 public final class DoubleScriptFieldType extends AbstractScriptFieldType<DoubleFieldScript.LeafFactory> {
 
-    private static final DoubleFieldScript.Factory PARSE_FROM_SOURCE
+    static final DoubleFieldScript.Factory PARSE_FROM_SOURCE
         = (field, params, lookup) -> (DoubleFieldScript.LeafFactory) ctx -> new DoubleFieldScript
         (
             field,

--- a/server/src/main/java/org/elasticsearch/index/mapper/DynamicFieldsBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DynamicFieldsBuilder.java
@@ -271,7 +271,12 @@ final class DynamicFieldsBuilder {
         @Override
         public void newDynamicLongField(ParseContext context, String name) throws IOException {
             createDynamicField(
-                new NumberFieldMapper.Builder(name, NumberFieldMapper.NumberType.LONG, context.indexSettings().getSettings()), context);
+                new NumberFieldMapper.Builder(
+                    name,
+                    NumberFieldMapper.NumberType.LONG,
+                    null,
+                    context.indexSettings().getSettings()
+                ), context);
         }
 
         @Override
@@ -279,8 +284,11 @@ final class DynamicFieldsBuilder {
             // no templates are defined, we use float by default instead of double
             // since this is much more space-efficient and should be enough most of
             // the time
-            createDynamicField(new NumberFieldMapper.Builder(name,
-                NumberFieldMapper.NumberType.FLOAT, context.indexSettings().getSettings()), context);
+            createDynamicField(new NumberFieldMapper.Builder(
+                name,
+                NumberFieldMapper.NumberType.FLOAT,
+                null,
+                context.indexSettings().getSettings()), context);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.document.Field;
+import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.Explicit;
 import org.elasticsearch.common.TriFunction;
@@ -25,6 +26,9 @@ import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.mapper.FieldNamesFieldMapper.FieldNamesFieldType;
 import org.elasticsearch.index.mapper.Mapper.TypeParser.ParserContext;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptType;
+import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -167,6 +171,25 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
                 context.sourceToParse().id(), valuePreview);
         }
         multiFields.parse(this, context);
+    }
+
+    /**
+     * @return whether this field mapper uses a script to generate its values
+     */
+    public boolean hasScript() {
+        return false;
+    }
+
+    /**
+     * Execute the index-time script associated with this field mapper.
+     *
+     * This method should only be called if {@link #hasScript()} has returned {@code true}
+     * @param searchLookup  a SearchLookup to be passed the script
+     * @param ctx           a LeafReaderContext exposing values from an incoming document
+     * @param pc            the ParseContext over the incoming document
+     */
+    public void executeScript(SearchLookup searchLookup, LeafReaderContext ctx, int doc, ParseContext pc) {
+        throw new UnsupportedOperationException("FieldMapper " + name() + " does not have an index-time script");
     }
 
     /**
@@ -510,6 +533,8 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
         private MergeValidator<T> mergeValidator;
         private T value;
         private boolean isSet;
+        private List<Parameter<?>> requires = new ArrayList<>();
+        private List<Parameter<?>> precludes = new ArrayList<>();
 
         /**
          * Creates a new Parameter
@@ -640,9 +665,31 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
             return this;
         }
 
+        public Parameter<T> requiresParameters(Parameter<?>... ps) {
+            this.requires.addAll(Arrays.asList(ps));
+            return this;
+        }
+
+        public Parameter<T> precludesParameters(Parameter<?>... ps) {
+            this.precludes.addAll(Arrays.asList(ps));
+            return this;
+        }
+
         private void validate() {
             if (validator != null) {
                 validator.accept(getValue());
+            }
+            if (this.isConfigured()) {
+                for (Parameter<?> p : requires) {
+                    if (p.isConfigured() == false) {
+                        throw new IllegalArgumentException("Field [" + name + "] requires field [" + p.name + "] to be configured");
+                    }
+                }
+                for (Parameter<?> p : precludes) {
+                    if (p.isConfigured()) {
+                        throw new IllegalArgumentException("Field [" + p.name + "] cannot be set in conjunction with field [" + name + "]");
+                    }
+                }
             }
         }
 
@@ -826,6 +873,32 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
 
         public static Parameter<Boolean> docValuesParam(Function<FieldMapper, Boolean> initializer, boolean defaultValue) {
             return Parameter.boolParam("doc_values", false, initializer, defaultValue);
+        }
+
+        /**
+         * Defines a script parameter
+         * @param initializer   retrieves the equivalent parameter from an existing FieldMapper for use in merges
+         * @return a script parameter
+         */
+        public static FieldMapper.Parameter<Script> scriptParam(
+            Function<FieldMapper, Script> initializer
+        ) {
+            return new FieldMapper.Parameter<>(
+                "script",
+                false,
+                () -> null,
+                (n, c, o) -> {
+                    if (o == null) {
+                        return null;
+                    }
+                    Script script = Script.parse(o);
+                    if (script.getType() == ScriptType.STORED) {
+                        throw new IllegalArgumentException("stored scripts are not supported on field [" + n + "]");
+                    }
+                    return script;
+                },
+                initializer
+            ).acceptsNull();
         }
 
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/LongScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/LongScriptFieldType.java
@@ -34,7 +34,7 @@ import java.util.function.Supplier;
 
 public final class LongScriptFieldType extends AbstractScriptFieldType<LongFieldScript.LeafFactory> {
 
-    private static final LongFieldScript.Factory PARSE_FROM_SOURCE
+    static final LongFieldScript.Factory PARSE_FROM_SOURCE
         = (field, params, lookup) -> (LongFieldScript.LeafFactory) ctx -> new LongFieldScript
         (
             field,

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
@@ -54,7 +54,9 @@ public final class MappingLookup {
     private final Map<String, ObjectMapper> objectMappers;
     private final boolean hasNested;
     private final FieldTypeLookup fieldTypeLookup;
+    private final FieldTypeLookup indexTimeLookup;  // for index-time scripts, a lookup that does not include runtime fields
     private final Map<String, NamedAnalyzer> indexAnalyzersMap = new HashMap<>();
+    private final List<FieldMapper> indexTimeScriptMappers = new ArrayList<>();
     private final DocumentParser documentParser;
     private final Mapping mapping;
     private final IndexSettings indexSettings;
@@ -137,6 +139,9 @@ public final class MappingLookup {
                 throw new MapperParsingException("Field [" + mapper.name() + "] is defined more than once");
             }
             indexAnalyzersMap.putAll(mapper.indexAnalyzers());
+            if (mapper.hasScript()) {
+                indexTimeScriptMappers.add(mapper);
+            }
         }
 
         for (FieldAliasMapper aliasMapper : aliasMappers) {
@@ -149,6 +154,9 @@ public final class MappingLookup {
         }
 
         this.fieldTypeLookup = new FieldTypeLookup(mapping.type(), mappers, aliasMappers, mapping.getRoot().runtimeFields());
+        this.indexTimeLookup = indexTimeScriptMappers.isEmpty()
+            ? null
+            : new FieldTypeLookup(mapping.type(), mappers, aliasMappers, Collections.emptyList());
         this.fieldMappers = Collections.unmodifiableMap(fieldMappers);
         this.objectMappers = Collections.unmodifiableMap(objects);
     }
@@ -165,6 +173,14 @@ public final class MappingLookup {
 
     FieldTypeLookup fieldTypesLookup() {
         return fieldTypeLookup;
+    }
+
+    FieldTypeLookup indexTimeLookup() {
+        return indexTimeLookup;
+    }
+
+    List<FieldMapper> indexTimeScriptMappers() {
+        return indexTimeScriptMappers;
     }
 
     public NamedAnalyzer indexAnalyzer(String field, Function<String, NamedAnalyzer> unmappedFieldAnalyzer) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -18,6 +18,7 @@ import org.apache.lucene.document.IntPoint;
 import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.document.StoredField;
+import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.IndexSortSortedNumericDocValuesRangeQuery;
@@ -37,8 +38,14 @@ import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData.NumericType;
 import org.elasticsearch.index.fielddata.plain.SortedNumericIndexFieldData;
 import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.script.DoubleFieldScript;
+import org.elasticsearch.script.LongFieldScript;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptCompiler;
 import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.lookup.FieldValues;
 import org.elasticsearch.search.lookup.SearchLookup;
+import org.elasticsearch.search.lookup.SourceLookup;
 
 import java.io.IOException;
 import java.time.ZoneId;
@@ -74,29 +81,43 @@ public class NumberFieldMapper extends FieldMapper {
 
         private final Parameter<Number> nullValue;
 
+        private final Parameter<Script> script = Parameter.scriptParam(m -> toType(m).builder.script.get());
+        private final Parameter<String> onScriptError = Parameter.restrictedStringParam(
+            "on_script_error",
+            true,
+            m -> toType(m).onScriptError,
+            "reject", "ignore"
+        );
+
         private final Parameter<Map<String, String>> meta = Parameter.metaParam();
 
         private final NumberType type;
+        private final ScriptCompiler compiler;
 
-        public Builder(String name, NumberType type, Settings settings) {
-            this(name, type, IGNORE_MALFORMED_SETTING.get(settings), COERCE_SETTING.get(settings));
+        public Builder(String name, NumberType type, ScriptCompiler compiler, Settings settings) {
+            this(name, type, compiler, IGNORE_MALFORMED_SETTING.get(settings), COERCE_SETTING.get(settings));
         }
 
         public static Builder docValuesOnly(String name, NumberType type) {
-            Builder builder = new Builder(name, type, false, false);
+            Builder builder = new Builder(name, type, null, false, false);
             builder.indexed.setValue(false);
             return builder;
         }
 
-        public Builder(String name, NumberType type, boolean ignoreMalformedByDefault, boolean coerceByDefault) {
+        public Builder(String name, NumberType type, ScriptCompiler compiler, boolean ignoreMalformedByDefault, boolean coerceByDefault) {
             super(name);
             this.type = type;
+            this.compiler = compiler;
+
             this.ignoreMalformed
                 = Parameter.explicitBoolParam("ignore_malformed", true, m -> toType(m).ignoreMalformed, ignoreMalformedByDefault);
             this.coerce
                 = Parameter.explicitBoolParam("coerce", true, m -> toType(m).coerce, coerceByDefault);
             this.nullValue = new Parameter<>("null_value", false, () -> null,
                 (n, c, o) -> o == null ? null : type.parse(o, false), m -> toType(m).nullValue).acceptsNull();
+
+            this.onScriptError.requiresParameters(this.script);
+            this.script.precludesParameters(ignoreMalformed, coerce, nullValue);
         }
 
         Builder nullValue(Number number) {
@@ -109,9 +130,17 @@ public class NumberFieldMapper extends FieldMapper {
             return this;
         }
 
+        private FieldValues<Number> scriptValues() {
+            if (this.script.get() == null) {
+                return null;
+            }
+            assert compiler != null;
+            return type.compile(name, script.get(), compiler);
+        }
+
         @Override
         protected List<Parameter<?>> getParameters() {
-            return Arrays.asList(indexed, hasDocValues, stored, ignoreMalformed, coerce, nullValue, meta);
+            return Arrays.asList(indexed, hasDocValues, stored, ignoreMalformed, coerce, nullValue, script, onScriptError, meta);
         }
 
         @Override
@@ -345,6 +374,15 @@ public class NumberFieldMapper extends FieldMapper {
                 double parsed = parser.doubleValue(coerce);
                 validateParsed(parsed);
                 return parsed;
+            }
+
+            @Override
+            public FieldValues<Number> compile(String fieldName, Script script, ScriptCompiler compiler) {
+                DoubleFieldScript.Factory scriptFactory = compiler.compile(script, DoubleFieldScript.CONTEXT);
+                return (lookup, ctx, doc, consumer) -> scriptFactory
+                    .newFactory(fieldName, script.getParams(), lookup)
+                    .newInstance(ctx)
+                    .runForDoc(doc, consumer::accept);
             }
 
             @Override
@@ -651,6 +689,15 @@ public class NumberFieldMapper extends FieldMapper {
             }
 
             @Override
+            public FieldValues<Number> compile(String fieldName, Script script, ScriptCompiler compiler) {
+                final LongFieldScript.Factory scriptFactory = compiler.compile(script, LongFieldScript.CONTEXT);
+                return (lookup, ctx, doc, consumer) -> scriptFactory
+                    .newFactory(fieldName, script.getParams(), lookup)
+                    .newInstance(ctx)
+                    .runForDoc(doc, consumer::accept);
+            }
+
+            @Override
             public Query termQuery(String field, Object value) {
                 if (hasDecimalPart(value)) {
                     return Queries.newMatchNoDocsQuery("Value [" + value + "] has a decimal part");
@@ -720,7 +767,7 @@ public class NumberFieldMapper extends FieldMapper {
         NumberType(String name, NumericType numericType) {
             this.name = name;
             this.numericType = numericType;
-            this.parser = new TypeParser((n, c) -> new Builder(n, this, c.getSettings()));
+            this.parser = new TypeParser((n, c) -> new Builder(n, this, c.scriptCompiler(), c.getSettings()));
         }
 
         /** Get the associated type name. */
@@ -744,6 +791,12 @@ public class NumberFieldMapper extends FieldMapper {
         public abstract Number parsePoint(byte[] value);
         public abstract List<Field> createFields(String name, Number value, boolean indexed,
                                                  boolean docValued, boolean stored);
+
+        public FieldValues<Number> compile(String fieldName, Script script, ScriptCompiler compiler) {
+            // only implemented for long and double fields
+            throw new IllegalArgumentException("Unknown parameter [script] for mapper [" + fieldName + "]");
+        }
+
         Number valueForSearch(Number value) {
             return value;
         }
@@ -897,22 +950,26 @@ public class NumberFieldMapper extends FieldMapper {
         private final NumberType type;
         private final boolean coerce;
         private final Number nullValue;
+        private final FieldValues<Number> scriptValues;
 
         public NumberFieldType(String name, NumberType type, boolean isSearchable, boolean isStored,
-                               boolean hasDocValues, boolean coerce, Number nullValue, Map<String, String> meta) {
+                               boolean hasDocValues, boolean coerce, Number nullValue, Map<String, String> meta,
+                               FieldValues<Number> script) {
             super(name, isSearchable, isStored, hasDocValues, TextSearchInfo.SIMPLE_MATCH_WITHOUT_TERMS, meta);
             this.type = Objects.requireNonNull(type);
             this.coerce = coerce;
             this.nullValue = nullValue;
+            this.scriptValues = script;
         }
 
         NumberFieldType(String name, Builder builder) {
             this(name, builder.type, builder.indexed.getValue(), builder.stored.getValue(), builder.hasDocValues.getValue(),
-                builder.coerce.getValue().value(), builder.nullValue.getValue(), builder.meta.getValue());
+                builder.coerce.getValue().value(), builder.nullValue.getValue(), builder.meta.getValue(),
+                builder.scriptValues());
         }
 
         public NumberFieldType(String name, NumberType type) {
-            this(name, type, true, false, true, true, null, Collections.emptyMap());
+            this(name, type, true, false, true, true, null, Collections.emptyMap(), null);
         }
 
         @Override
@@ -982,6 +1039,28 @@ public class NumberFieldMapper extends FieldMapper {
             if (format != null) {
                 throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
             }
+            if (this.scriptValues != null) {
+                return new ValueFetcher() {
+                    LeafReaderContext ctx;
+
+                    @Override
+                    public void setNextReader(LeafReaderContext context) {
+                        this.ctx = context;
+                    }
+
+                    @Override
+                    public List<Object> fetchValues(SourceLookup lookup) {
+                        List<Object> values = new ArrayList<>();
+                        try {
+                            scriptValues.valuesForDoc(context.lookup(), ctx, lookup.docId(), values::add);
+                        } catch (Exception e) {
+                            // ignore errors - if they exist here then they existed at index time
+                            // and so on_script_error must have been set to `ignore`
+                        }
+                        return values;
+                    }
+                };
+            }
 
             return new SourceValueFetcher(name(), context, nullValue) {
                 @Override
@@ -1017,6 +1096,7 @@ public class NumberFieldMapper extends FieldMapper {
         }
     }
 
+    private final Builder builder;
     private final NumberType type;
 
     private final boolean indexed;
@@ -1025,6 +1105,8 @@ public class NumberFieldMapper extends FieldMapper {
     private final Explicit<Boolean> ignoreMalformed;
     private final Explicit<Boolean> coerce;
     private final Number nullValue;
+    private final FieldValues<Number> scriptValues;
+    private final String onScriptError;
 
     private final boolean ignoreMalformedByDefault;
     private final boolean coerceByDefault;
@@ -1045,6 +1127,9 @@ public class NumberFieldMapper extends FieldMapper {
         this.nullValue = builder.nullValue.getValue();
         this.ignoreMalformedByDefault = builder.ignoreMalformed.getDefaultValue().value();
         this.coerceByDefault = builder.coerce.getDefaultValue().value();
+        this.scriptValues = builder.scriptValues();
+        this.onScriptError = builder.onScriptError.get();
+        this.builder = builder;
     }
 
     boolean coerce() {
@@ -1053,6 +1138,10 @@ public class NumberFieldMapper extends FieldMapper {
 
     boolean ignoreMalformed() {
         return ignoreMalformed.value();
+    }
+
+    String onScriptError() {
+        return onScriptError;
     }
 
     @Override
@@ -1067,6 +1156,11 @@ public class NumberFieldMapper extends FieldMapper {
 
     @Override
     protected void parseCreateField(ParseContext context) throws IOException {
+
+        if (this.scriptValues != null) {
+            throw new IllegalArgumentException("Cannot index data directly into a field with a [script] parameter");
+        }
+
         XContentParser parser = context.parser();
         Object value;
         Number numericValue = null;
@@ -1104,6 +1198,10 @@ public class NumberFieldMapper extends FieldMapper {
             numericValue = fieldType().type.parse(value, coerce.value());
         }
 
+        indexValue(context, numericValue);
+    }
+
+    private void indexValue(ParseContext context, Number numericValue) {
         context.doc().addAll(fieldType().type.createFields(fieldType().name(), numericValue,
             indexed, hasDocValues, stored));
 
@@ -1113,7 +1211,26 @@ public class NumberFieldMapper extends FieldMapper {
     }
 
     @Override
+    public boolean hasScript() {
+        return this.scriptValues != null;
+    }
+
+    @Override
+    public void executeScript(SearchLookup searchLookup, LeafReaderContext readerContext, int doc, ParseContext parseContext) {
+        assert this.scriptValues != null;
+        try {
+            this.scriptValues.valuesForDoc(searchLookup, readerContext, doc, value -> indexValue(parseContext, value));
+        } catch (Exception e) {
+            if ("ignore".equals(onScriptError)) {
+                parseContext.addIgnoredField(name());
+            } else {
+                throw new MapperParsingException("Error executing script on field [" + name() + "]", e);
+            }
+        }
+    }
+
+    @Override
     public FieldMapper.Builder getMergeBuilder() {
-        return new Builder(simpleName(), type, ignoreMalformedByDefault, coerceByDefault).init(this);
+        return new Builder(simpleName(), type, builder.compiler, ignoreMalformedByDefault, coerceByDefault).init(this);
     }
 }

--- a/server/src/main/java/org/elasticsearch/script/AbstractLongFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/AbstractLongFieldScript.java
@@ -13,6 +13,7 @@ import org.apache.lucene.util.ArrayUtil;
 import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.util.Map;
+import java.util.function.LongConsumer;
 
 /**
  * Common base class for script field scripts that return long values.
@@ -32,6 +33,16 @@ public abstract class AbstractLongFieldScript extends AbstractFieldScript {
         count = 0;
         setDocument(docId);
         execute();
+    }
+
+    /**
+     * Execute the script for the provided {@code docId}, passing results to the {@code consumer}
+     */
+    public final void runForDoc(int docId, LongConsumer consumer) {
+        runForDoc(docId);
+        for (int i = 0; i < count; i++) {
+            consumer.accept(values[i]);
+        }
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/script/DoubleFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/DoubleFieldScript.java
@@ -13,6 +13,7 @@ import org.apache.lucene.util.ArrayUtil;
 import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.util.Map;
+import java.util.function.DoubleConsumer;
 
 public abstract class DoubleFieldScript extends AbstractFieldScript {
     public static final ScriptContext<Factory> CONTEXT = newContext("double_script_field", Factory.class);
@@ -44,6 +45,16 @@ public abstract class DoubleFieldScript extends AbstractFieldScript {
         count = 0;
         setDocument(docId);
         execute();
+    }
+
+    /**
+     * Execute the script for the provided {@code docId}, passing results to the {@code consumer}
+     */
+    public final void runForDoc(int docId, DoubleConsumer consumer) {
+        runForDoc(docId);
+        for (int i = 0; i < count; i++) {
+            consumer.accept(values[i]);
+        }
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/search/lookup/FieldValues.java
+++ b/server/src/main/java/org/elasticsearch/search/lookup/FieldValues.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.search.lookup;
+
+import org.apache.lucene.index.LeafReaderContext;
+
+import java.util.function.Consumer;
+
+/**
+ * Represents values for a given document
+ */
+public interface FieldValues<T> {
+
+    /**
+     * Loads the values for the given document and passes them to the consumer
+     * @param lookup    a search lookup to access values from
+     * @param ctx       the LeafReaderContext containing the document
+     * @param doc       the docid
+     * @param consumer  called with each document value
+     */
+    void valuesForDoc(SearchLookup lookup, LeafReaderContext ctx, int doc, Consumer<T> consumer);
+}

--- a/server/src/test/java/org/elasticsearch/index/fielddata/AbstractFieldDataTestCase.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/AbstractFieldDataTestCase.java
@@ -92,22 +92,22 @@ public abstract class AbstractFieldDataTestCase extends ESSingleNodeTestCase {
                     .fielddata(true).build(contentPath).fieldType();
             }
         } else if (type.equals("float")) {
-            fieldType = new NumberFieldMapper.Builder(fieldName, NumberFieldMapper.NumberType.FLOAT, false, true)
+            fieldType = new NumberFieldMapper.Builder(fieldName, NumberFieldMapper.NumberType.FLOAT, null, false, true)
                     .docValues(docValues).build(contentPath).fieldType();
         } else if (type.equals("double")) {
-            fieldType = new NumberFieldMapper.Builder(fieldName, NumberFieldMapper.NumberType.DOUBLE, false, true)
+            fieldType = new NumberFieldMapper.Builder(fieldName, NumberFieldMapper.NumberType.DOUBLE, null, false, true)
                     .docValues(docValues).build(contentPath).fieldType();
         } else if (type.equals("long")) {
-            fieldType = new NumberFieldMapper.Builder(fieldName, NumberFieldMapper.NumberType.LONG, false, true)
+            fieldType = new NumberFieldMapper.Builder(fieldName, NumberFieldMapper.NumberType.LONG, null, false, true)
                     .docValues(docValues).build(contentPath).fieldType();
         } else if (type.equals("int")) {
-            fieldType = new NumberFieldMapper.Builder(fieldName, NumberFieldMapper.NumberType.INTEGER, false, true)
+            fieldType = new NumberFieldMapper.Builder(fieldName, NumberFieldMapper.NumberType.INTEGER, null, false, true)
                     .docValues(docValues).build(contentPath).fieldType();
         } else if (type.equals("short")) {
-            fieldType = new NumberFieldMapper.Builder(fieldName, NumberFieldMapper.NumberType.SHORT, false, true)
+            fieldType = new NumberFieldMapper.Builder(fieldName, NumberFieldMapper.NumberType.SHORT, null, false, true)
                     .docValues(docValues).build(contentPath).fieldType();
         } else if (type.equals("byte")) {
-            fieldType = new NumberFieldMapper.Builder(fieldName, NumberFieldMapper.NumberType.BYTE, false, true)
+            fieldType = new NumberFieldMapper.Builder(fieldName, NumberFieldMapper.NumberType.BYTE, null, false, true)
                     .docValues(docValues).build(contentPath).fieldType();
         } else if (type.equals("geo_point")) {
             fieldType = new GeoPointFieldMapper.Builder(fieldName, false).docValues(docValues).build(contentPath).fieldType();

--- a/server/src/test/java/org/elasticsearch/index/fielddata/IndexFieldDataServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/IndexFieldDataServiceTests.java
@@ -30,6 +30,7 @@ import org.elasticsearch.index.mapper.ContentPath;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
+import org.elasticsearch.index.mapper.NumberFieldMapper.NumberType;
 import org.elasticsearch.index.mapper.TextFieldMapper;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.IndicesService;
@@ -49,6 +50,11 @@ import java.util.Collections;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
+import static org.elasticsearch.index.mapper.NumberFieldMapper.NumberType.BYTE;
+import static org.elasticsearch.index.mapper.NumberFieldMapper.NumberType.DOUBLE;
+import static org.elasticsearch.index.mapper.NumberFieldMapper.NumberType.INTEGER;
+import static org.elasticsearch.index.mapper.NumberFieldMapper.NumberType.LONG;
+import static org.elasticsearch.index.mapper.NumberFieldMapper.NumberType.SHORT;
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -74,10 +80,10 @@ public class IndexFieldDataServiceTests extends ESSingleNodeTestCase {
         assertTrue(fd instanceof SortedSetOrdinalsIndexFieldData);
 
         for (MappedFieldType mapper : Arrays.asList(
-                new NumberFieldMapper.Builder("int", NumberFieldMapper.NumberType.BYTE, false, true).build(contentPath).fieldType(),
-                new NumberFieldMapper.Builder("int", NumberFieldMapper.NumberType.SHORT, false, true).build(contentPath).fieldType(),
-                new NumberFieldMapper.Builder("int", NumberFieldMapper.NumberType.INTEGER, false, true).build(contentPath).fieldType(),
-                new NumberFieldMapper.Builder("long", NumberFieldMapper.NumberType.LONG, false, true).build(contentPath).fieldType()
+                new NumberFieldMapper.Builder("int", BYTE, null, false, true).build(contentPath).fieldType(),
+                new NumberFieldMapper.Builder("int", SHORT, null, false, true).build(contentPath).fieldType(),
+                new NumberFieldMapper.Builder("int", INTEGER, null, false, true).build(contentPath).fieldType(),
+                new NumberFieldMapper.Builder("long", LONG, null, false, true).build(contentPath).fieldType()
                 )) {
             ifdService.clear();
             fd = ifdService.getForField(mapper, "test", () -> {
@@ -86,7 +92,7 @@ public class IndexFieldDataServiceTests extends ESSingleNodeTestCase {
             assertTrue(fd instanceof SortedNumericIndexFieldData);
         }
 
-        final MappedFieldType floatMapper = new NumberFieldMapper.Builder("float", NumberFieldMapper.NumberType.FLOAT, false, true)
+        final MappedFieldType floatMapper = new NumberFieldMapper.Builder("float", NumberType.FLOAT, null, false, true)
                 .build(contentPath).fieldType();
         ifdService.clear();
         fd = ifdService.getForField(floatMapper, "test", () -> {
@@ -94,7 +100,8 @@ public class IndexFieldDataServiceTests extends ESSingleNodeTestCase {
         });
         assertTrue(fd instanceof SortedNumericIndexFieldData);
 
-        final MappedFieldType doubleMapper = new NumberFieldMapper.Builder("double", NumberFieldMapper.NumberType.DOUBLE, false, true)
+        final MappedFieldType doubleMapper
+            = new NumberFieldMapper.Builder("double", DOUBLE, null, false, true)
                 .build(contentPath).fieldType();
         ifdService.clear();
         fd = ifdService.getForField(doubleMapper, "test", () -> {
@@ -301,15 +308,15 @@ public class IndexFieldDataServiceTests extends ESSingleNodeTestCase {
     }
 
     public void testRequireDocValuesOnLongs() {
-        doTestRequireDocValues(new NumberFieldMapper.NumberFieldType("field", NumberFieldMapper.NumberType.LONG));
-        doTestRequireDocValues(new NumberFieldMapper.NumberFieldType("field", NumberFieldMapper.NumberType.LONG,
-            true, false, false, false, null, Collections.emptyMap()));
+        doTestRequireDocValues(new NumberFieldMapper.NumberFieldType("field", LONG));
+        doTestRequireDocValues(new NumberFieldMapper.NumberFieldType("field", LONG,
+            true, false, false, false, null, Collections.emptyMap(), null));
     }
 
     public void testRequireDocValuesOnDoubles() {
-        doTestRequireDocValues(new NumberFieldMapper.NumberFieldType("field", NumberFieldMapper.NumberType.DOUBLE));
-        doTestRequireDocValues(new NumberFieldMapper.NumberFieldType("field", NumberFieldMapper.NumberType.DOUBLE,
-            true, false, false, false, null, Collections.emptyMap()));
+        doTestRequireDocValues(new NumberFieldMapper.NumberFieldType("field", NumberType.DOUBLE));
+        doTestRequireDocValues(new NumberFieldMapper.NumberFieldType("field", NumberType.DOUBLE,
+            true, false, false, false, null, Collections.emptyMap(), null));
     }
 
     public void testRequireDocValuesOnBools() {

--- a/server/src/test/java/org/elasticsearch/index/mapper/CompletionFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/CompletionFieldMapperTests.java
@@ -106,6 +106,11 @@ public class CompletionFieldMapperTests extends MapperTestCase {
         return new IndexAnalyzers(analyzers, Collections.emptyMap(), Collections.emptyMap());
     }
 
+    @Override
+    protected boolean allowsStore() {
+        return false;
+    }
+
     public void testDefaultConfiguration() throws IOException {
 
         DocumentMapper defaultMapper = createDocumentMapper(fieldMapping(this::minimalMapping));

--- a/server/src/test/java/org/elasticsearch/index/mapper/DoubleFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DoubleFieldMapperTests.java
@@ -39,6 +39,11 @@ public class DoubleFieldMapperTests extends NumberFieldMapperTests {
     }
 
     @Override
+    protected boolean allowsIndexTimeScript() {
+        return true;
+    }
+
+    @Override
     protected Number randomNumber() {
         /*
          * The source parser and doc values round trip will both increase

--- a/server/src/test/java/org/elasticsearch/index/mapper/GeoShapeFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/GeoShapeFieldMapperTests.java
@@ -61,6 +61,11 @@ public class GeoShapeFieldMapperTests extends MapperTestCase {
         return "POINT (14.0 15.0)";
     }
 
+    @Override
+    protected boolean allowsStore() {
+        return false;
+    }
+
     public void testDefaultConfiguration() throws IOException {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
         Mapper fieldMapper = mapper.mappers().getMapper("field");

--- a/server/src/test/java/org/elasticsearch/index/mapper/IndexTimeScriptTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IndexTimeScriptTests.java
@@ -1,0 +1,338 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.index.LeafReaderContext;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.script.DoubleFieldScript;
+import org.elasticsearch.script.LongFieldScript;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptContext;
+import org.elasticsearch.search.lookup.SearchLookup;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+public class IndexTimeScriptTests extends MapperServiceTestCase {
+
+    public void testSimpleFieldReference() throws IOException {
+        DocumentMapper mapper = createDocumentMapper(mapping(b -> {
+            b.startObject("message").field("type", "text").endObject();
+            b.startObject("message_length");
+            b.field("type", "long");
+            b.field("script", "message_length");
+            b.endObject();
+        }));
+
+        ParsedDocument doc = mapper.parse(source(b -> b.field("message", "this is some text")));
+        IndexableField[] lengthFields = doc.rootDoc().getFields("message_length");
+        assertEquals(2, lengthFields.length);
+        assertEquals("LongPoint <message_length:17>", lengthFields[0].toString());
+        assertEquals("docValuesType=SORTED_NUMERIC<message_length:17>", lengthFields[1].toString());
+    }
+
+    public void testDocAccess() throws IOException {
+        DocumentMapper mapper = createDocumentMapper(mapping(b -> {
+            b.startObject("long_field").field("type", "long").endObject();
+            b.startObject("long_field_plus_two");
+            b.field("type", "long");
+            b.field("script", "long_field_plus_two");
+            b.endObject();
+        }));
+
+        ParsedDocument doc = mapper.parse(source(b -> b.field("long_field", 4)));
+        assertEquals(doc.rootDoc().getField("long_field_plus_two").numericValue(), 6L);
+    }
+
+    public void testDoublesAccess() throws IOException {
+        DocumentMapper mapper = createDocumentMapper(mapping(b -> {
+            b.startObject("double_field").field("type", "double").endObject();
+            b.startObject("double_field_plus_two");
+            b.field("type", "double");
+            b.field("script", "double_field_plus_two");
+            b.endObject();
+        }));
+
+        ParsedDocument doc = mapper.parse(source(b -> b.field("double_field", 4.5)));
+        assertEquals(doc.rootDoc().getField("double_field_plus_two").numericValue(), 6.5);
+    }
+
+    public void testSerialization() throws IOException {
+        DocumentMapper mapper = createDocumentMapper(mapping(b -> {
+            b.startObject("message").field("type", "text").endObject();
+            b.startObject("message_length");
+            b.field("type", "long");
+            b.field("script", "message_length");
+            b.endObject();
+        }));
+        assertEquals(
+            "{\"_doc\":{\"properties\":{\"message\":{\"type\":\"text\"}," +
+                "\"message_length\":{\"type\":\"long\",\"script\":{\"source\":\"message_length\",\"lang\":\"painless\"}}}}}",
+            Strings.toString(mapper.mapping()));
+    }
+
+    public void testCrossReferences() throws IOException {
+        DocumentMapper mapper = createDocumentMapper(mapping(b -> {
+            b.startObject("message").field("type", "text").endObject();
+            b.startObject("message_length_plus_two");
+            b.field("type", "long");
+            b.field("script", "message_length_plus_two");
+            b.endObject();
+            b.startObject("message_length");
+            b.field("type", "long");
+            b.field("script", "message_length");
+            b.endObject();
+            b.startObject("message_length_plus_four");
+            b.field("type", "double");
+            b.field("script", "message_length_plus_two_plus_two");
+            b.endObject();
+        }));
+        ParsedDocument doc = mapper.parse(source(b -> b.field("message", "this is a message")));
+        assertEquals(doc.rootDoc().getField("message_length_plus_two").numericValue(), 19L);
+        assertEquals(doc.rootDoc().getField("message_length").numericValue(), 17L);
+        assertEquals(doc.rootDoc().getField("message_length_plus_four").numericValue(), 21d);
+    }
+
+    public void testCannotIndexDirectlyIntoScriptMapper() throws IOException {
+        DocumentMapper mapper = createDocumentMapper(mapping(b -> {
+            b.startObject("message").field("type", "text").endObject();
+            b.startObject("message_length");
+            b.field("type", "long");
+            b.field("script", "length");
+            b.endObject();
+        }));
+
+        Exception e = expectThrows(MapperParsingException.class, () -> mapper.parse(source(b -> {
+            b.field("message", "foo");
+            b.field("message_length", 3);
+        })));
+        assertEquals("failed to parse field [message_length] of type [long] in document with id '1'. Preview of field's value: '3'",
+            e.getMessage());
+        Throwable original = e.getCause();
+        assertEquals("Cannot index data directly into a field with a [script] parameter", original.getMessage());
+    }
+
+    public void testLoopDetection() throws IOException {
+        DocumentMapper mapper = createDocumentMapper(mapping(b -> {
+            b.startObject("field1").field("type", "long").field("script", "field2_plus_two").endObject();
+            b.startObject("field2").field("type", "long").field("script", "field1_plus_two").endObject();
+        }));
+
+        Exception e = expectThrows(MapperParsingException.class, () -> mapper.parse(source(b -> {})));
+        assertEquals("Error executing script on field [field1]", e.getMessage());
+
+        Throwable root = e.getCause();
+        while (root.getCause() != null) {
+            root = root.getCause();
+        }
+        assertThat(root.getMessage(), containsString("Loop in field resolution detected"));
+        // Can be either field1->field2->field1 or field2->field1->field2 because
+        // post-phase executor order is not deterministic
+        assertThat(root.getMessage(), containsString("field1->field2"));
+    }
+
+    public void testStoredScriptsNotPermitted() {
+        Exception e = expectThrows(MapperParsingException.class, () -> createDocumentMapper(fieldMapping(b -> {
+            b.field("type", "long");
+            b.startObject("script").field("id", "foo").endObject();
+        })));
+        assertThat(e.getMessage(), equalTo("Failed to parse mapping [_doc]: stored scripts are not supported on field [field]"));
+    }
+
+    public void testCannotReferToRuntimeFields() throws IOException {
+        DocumentMapper mapper = createDocumentMapper(topMapping(b -> {
+            b.startObject("runtime");
+            b.startObject("runtime-field").field("type", "long").endObject();
+            b.endObject();
+            b.startObject("properties");
+            b.startObject("index-field").field("type", "long").field("script", "refer-to-runtime").endObject();
+            b.endObject();
+        }));
+
+        Exception e = expectThrows(MapperParsingException.class, () -> mapper.parse(source(b -> {})));
+        assertEquals("Error executing script on field [index-field]", e.getMessage());
+        assertEquals("No field found for [runtime-field] in mapping", e.getCause().getMessage());
+    }
+
+    public void testScriptErrorParameterRequiresScript() {
+        Exception e = expectThrows(MapperParsingException.class, () -> createDocumentMapper(fieldMapping(b -> {
+            b.field("type", "long");
+            b.field("on_script_error", "ignore");
+        })));
+        assertThat(e.getMessage(),
+            equalTo("Failed to parse mapping [_doc]: Field [on_script_error] requires field [script] to be configured"));
+    }
+
+    public void testIgnoreScriptErrors() throws IOException {
+        DocumentMapper mapper = createDocumentMapper(mapping(b -> {
+            b.startObject("message").field("type", "keyword").endObject();
+            b.startObject("message_length");
+            {
+                b.field("type", "long");
+                b.field("script", "message_length");
+            }
+            b.endObject();
+            b.startObject("message_error");
+            {
+                b.field("type", "long");
+                b.field("script", "throws");
+                b.field("on_script_error", "ignore");
+            }
+            b.endObject();
+        }));
+
+        ParsedDocument doc = mapper.parse(source(b -> b.field("message", "this is some text")));
+        assertThat(doc.rootDoc().getFields("message_length"), arrayWithSize(2));
+        assertThat(doc.rootDoc().getFields("message_error"), arrayWithSize(0));
+        assertThat(doc.rootDoc().getField("_ignored").stringValue(), equalTo("message_error"));
+    }
+
+    public void testRejectScriptErrors() throws IOException {
+        DocumentMapper mapper = createDocumentMapper(mapping(b -> {
+            b.startObject("message").field("type", "keyword").endObject();
+            b.startObject("message_length");
+            {
+                b.field("type", "long");
+                b.field("script", "message_length");
+            }
+            b.endObject();
+            b.startObject("message_error");
+            {
+                b.field("type", "long");
+                b.field("script", "throws");
+            }
+            b.endObject();
+        }));
+
+        Exception e = expectThrows(MapperParsingException.class, () -> mapper.parse(source(b -> b.field("message", "foo"))));
+        assertThat(e.getMessage(), equalTo("Error executing script on field [message_error]"));
+        assertThat(e.getCause().getMessage(), equalTo("Oops!"));
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected <T> T compileScript(Script script, ScriptContext<T> context) {
+        if (context.factoryClazz == LongFieldScript.Factory.class) {
+            return (T) (LongFieldScript.Factory) (n, p, l) -> ctx -> new TestLongFieldScript(
+                n, p, l, ctx, getLongScript(script.getIdOrCode())
+            );
+        }
+        if (context.factoryClazz == DoubleFieldScript.Factory.class) {
+            return (T) (DoubleFieldScript.Factory) (n, p, l) -> ctx -> new TestDoubleFieldScript(
+                n, p, l, ctx, getDoubleScript(script.getIdOrCode())
+            );
+        }
+        throw new IllegalArgumentException("Unknown factory type " + context.factoryClazz + " for code " + script.getIdOrCode());
+    }
+
+    private static Consumer<TestLongFieldScript> getLongScript(String name) {
+        if ("refer-to-runtime".equals(name)) {
+            return s -> {
+                s.emitValue((long) s.getDoc().get("runtime-field").get(0));
+            };
+        }
+        if ("throws".equals(name)) {
+            return s -> { throw new RuntimeException("Oops!"); };
+        }
+        if (name.endsWith("_length")) {
+            String field = name.substring(0, name.lastIndexOf("_length"));
+            return s -> {
+                for (Object v : s.extractValuesFromSource(field)) {
+                    s.emitValue(Objects.toString(v).length());
+                }
+            };
+        }
+        if (name.endsWith("_plus_two")) {
+            String field = name.substring(0, name.lastIndexOf("_plus_two"));
+            return s -> {
+                long input = (long) s.getDoc().get(field).get(0);
+                s.emitValue(input + 2);
+            };
+        }
+        throw new UnsupportedOperationException("Unknown script [" + name + "]");
+    }
+
+    private static Consumer<TestDoubleFieldScript> getDoubleScript(String name) {
+        if (name.endsWith("_plus_two")) {
+            String field = name.substring(0, name.lastIndexOf("_plus_two"));
+            return s -> {
+                Number input = (Number) s.getDoc().get(field).get(0);
+                s.emitValue(input.doubleValue() + 2);
+            };
+        }
+        throw new UnsupportedOperationException("Unknown script [" + name + "]");
+    }
+
+    private static class TestLongFieldScript extends LongFieldScript {
+
+        final Consumer<TestLongFieldScript> executor;
+
+        TestLongFieldScript(
+            String fieldName,
+            Map<String, Object> params,
+            SearchLookup searchLookup,
+            LeafReaderContext ctx,
+            Consumer<TestLongFieldScript> executor
+        ) {
+            super(fieldName, params, searchLookup, ctx);
+            this.executor = executor;
+        }
+
+        @Override
+        public void execute() {
+            executor.accept(this);
+        }
+
+        public void emitValue(long v) {
+            super.emit(v);
+        }
+
+        public List<Object> extractValuesFromSource(String path) {
+            return super.extractFromSource(path);
+        }
+    }
+
+    private static class TestDoubleFieldScript extends DoubleFieldScript {
+
+        final Consumer<TestDoubleFieldScript> executor;
+
+        TestDoubleFieldScript(
+            String fieldName,
+            Map<String, Object> params,
+            SearchLookup searchLookup,
+            LeafReaderContext ctx,
+            Consumer<TestDoubleFieldScript> executor
+        ) {
+            super(fieldName, params, searchLookup, ctx);
+            this.executor = executor;
+        }
+
+        @Override
+        public void execute() {
+            executor.accept(this);
+        }
+
+        public void emitValue(double v) {
+            super.emit(v);
+        }
+
+        public List<Object> extractValuesFromSource(String path) {
+            return super.extractFromSource(path);
+        }
+    }
+
+}

--- a/server/src/test/java/org/elasticsearch/index/mapper/LegacyGeoShapeFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/LegacyGeoShapeFieldMapperTests.java
@@ -98,6 +98,11 @@ public class LegacyGeoShapeFieldMapperTests extends MapperTestCase {
         return false;
     }
 
+    @Override
+    protected boolean allowsStore() {
+        return false;
+    }
+
     public void testLegacySwitches() throws IOException {
         // if one of the legacy parameters is added to a 'type':'geo_shape' config then
         // that will select the legacy field mapper

--- a/server/src/test/java/org/elasticsearch/index/mapper/LongFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/LongFieldMapperTests.java
@@ -58,7 +58,7 @@ public class LongFieldMapperTests extends WholeNumberFieldMapperTests {
                 b.field("coerce", "true");
             })));
             assertThat(e.getMessage(),
-                equalTo("Failed to parse mapping: Field [coerce] cannot be set in conjunction with field [script]"));
+                equalTo("Failed to parse mapping [_doc]: Field [coerce] cannot be set in conjunction with field [script]"));
         }
         {
             Exception e = expectThrows(MapperParsingException.class, () -> createDocumentMapper(fieldMapping(b -> {
@@ -67,7 +67,7 @@ public class LongFieldMapperTests extends WholeNumberFieldMapperTests {
                 b.field("null_value", 7);
             })));
             assertThat(e.getMessage(),
-                equalTo("Failed to parse mapping: Field [null_value] cannot be set in conjunction with field [script]"));
+                equalTo("Failed to parse mapping [_doc]: Field [null_value] cannot be set in conjunction with field [script]"));
         }
         {
             Exception e = expectThrows(MapperParsingException.class, () -> createDocumentMapper(fieldMapping(b -> {
@@ -76,7 +76,7 @@ public class LongFieldMapperTests extends WholeNumberFieldMapperTests {
                 b.field("ignore_malformed", "true");
             })));
             assertThat(e.getMessage(),
-                equalTo("Failed to parse mapping: Field [ignore_malformed] cannot be set in conjunction with field [script]"));
+                equalTo("Failed to parse mapping [_doc]: Field [ignore_malformed] cannot be set in conjunction with field [script]"));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/LongFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/LongFieldMapperTests.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.equalTo;
 
 public class LongFieldMapperTests extends WholeNumberFieldMapperTests {
 
@@ -42,6 +43,41 @@ public class LongFieldMapperTests extends WholeNumberFieldMapperTests {
     @Override
     protected void minimalMapping(XContentBuilder b) throws IOException {
         b.field("type", "long");
+    }
+
+    @Override
+    protected boolean allowsIndexTimeScript() {
+        return true;
+    }
+
+    public void testScriptAndPrecludedParameters() {
+        {
+            Exception e = expectThrows(MapperParsingException.class, () -> createDocumentMapper(fieldMapping(b -> {
+                b.field("type", "long");
+                b.field("script", "test");
+                b.field("coerce", "true");
+            })));
+            assertThat(e.getMessage(),
+                equalTo("Failed to parse mapping: Field [coerce] cannot be set in conjunction with field [script]"));
+        }
+        {
+            Exception e = expectThrows(MapperParsingException.class, () -> createDocumentMapper(fieldMapping(b -> {
+                b.field("type", "long");
+                b.field("script", "test");
+                b.field("null_value", 7);
+            })));
+            assertThat(e.getMessage(),
+                equalTo("Failed to parse mapping: Field [null_value] cannot be set in conjunction with field [script]"));
+        }
+        {
+            Exception e = expectThrows(MapperParsingException.class, () -> createDocumentMapper(fieldMapping(b -> {
+                b.field("type", "long");
+                b.field("script", "test");
+                b.field("ignore_malformed", "true");
+            })));
+            assertThat(e.getMessage(),
+                equalTo("Failed to parse mapping: Field [ignore_malformed] cannot be set in conjunction with field [script]"));
+        }
     }
 
     public void testLongIndexingOutOfRange() throws Exception {

--- a/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldMapperTests.java
@@ -14,11 +14,16 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.mapper.NumberFieldTypeTests.OutOfRangeSpec;
 import org.elasticsearch.index.termvectors.TermVectorsService;
+import org.elasticsearch.script.DoubleFieldScript;
+import org.elasticsearch.script.LongFieldScript;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptContext;
 
 import java.io.IOException;
 import java.util.List;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 
 public abstract class NumberFieldMapperTests extends MapperTestCase {
 
@@ -32,6 +37,13 @@ public abstract class NumberFieldMapperTests extends MapperTestCase {
      */
     protected abstract Number missingValue();
 
+    /**
+     * @return does this mapper allow index time scripts
+     */
+    protected boolean allowsIndexTimeScript() {
+        return false;
+    }
+
     @Override
     protected void registerParameters(ParameterChecker checker) throws IOException {
         checker.registerConflictCheck("doc_values", b -> b.field("doc_values", false));
@@ -42,6 +54,22 @@ public abstract class NumberFieldMapperTests extends MapperTestCase {
             m -> assertFalse(((NumberFieldMapper) m).coerce()));
         checker.registerUpdateCheck(b -> b.field("ignore_malformed", true),
             m -> assertTrue(((NumberFieldMapper) m).ignoreMalformed()));
+
+        if (allowsIndexTimeScript()) {
+            checker.registerConflictCheck("script", b -> b.field("script", "foo"));
+            checker.registerUpdateCheck(
+                b -> {
+                    minimalMapping(b);
+                    b.field("script", "test");
+                    b.field("on_script_error", "reject");
+                },
+                b -> {
+                    minimalMapping(b);
+                    b.field("script", "test");
+                    b.field("on_script_error", "ignore");
+                },
+                m -> assertThat(((NumberFieldMapper)m).onScriptError(), equalTo("ignore")));
+        }
     }
 
     @Override
@@ -226,5 +254,33 @@ public abstract class NumberFieldMapperTests extends MapperTestCase {
         return randomBoolean() ? n : n.toString();
     }
 
+    @Override
+    @SuppressWarnings("unchecked")
+    protected <T> T compileScript(Script script, ScriptContext<T> context) {
+        if (context == LongFieldScript.CONTEXT) {
+            return (T) LongScriptFieldType.PARSE_FROM_SOURCE;
+        }
+        if (context == DoubleFieldScript.CONTEXT) {
+            return (T) DoubleScriptFieldType.PARSE_FROM_SOURCE;
+        }
+        throw new UnsupportedOperationException("Unknown script " + script.getIdOrCode());
+    }
+
+    public void testScriptableTypes() throws IOException {
+        if (allowsIndexTimeScript()) {
+            createDocumentMapper(fieldMapping(b -> {
+                minimalMapping(b);
+                b.field("script", "foo");
+            }));
+        } else {
+            Exception e = expectThrows(MapperParsingException.class, () -> createDocumentMapper(fieldMapping(b -> {
+                minimalMapping(b);
+                b.field("script", "foo");
+            })));
+            assertEquals("Failed to parse mapping [_doc]: Unknown parameter [script] for mapper [field]", e.getMessage());
+        }
+    }
+
     protected abstract Number randomNumber();
+
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldTypeTests.java
@@ -122,7 +122,7 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
     }
 
     private static MappedFieldType unsearchable() {
-        return new NumberFieldType("field", NumberType.LONG, false, false, true, true, null, Collections.emptyMap());
+        return new NumberFieldType("field", NumberType.LONG, false, false, true, true, null, Collections.emptyMap(), null);
     }
 
     public void testTermQuery() {
@@ -634,14 +634,14 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
     }
 
     public void testFetchSourceValue() throws IOException {
-        MappedFieldType mapper = new NumberFieldMapper.Builder("field", NumberType.INTEGER, false, true)
+        MappedFieldType mapper = new NumberFieldMapper.Builder("field", NumberType.INTEGER, null, false, true)
             .build(new ContentPath())
             .fieldType();
         assertEquals(Collections.singletonList(3), fetchSourceValue(mapper, 3.14));
         assertEquals(Collections.singletonList(42), fetchSourceValue(mapper, "42.9"));
         assertEquals(org.elasticsearch.common.collect.List.of(3, 42), fetchSourceValues(mapper, 3.14, "foo", "42.9"));
 
-        MappedFieldType nullValueMapper = new NumberFieldMapper.Builder("field", NumberType.FLOAT, false, true)
+        MappedFieldType nullValueMapper = new NumberFieldMapper.Builder("field", NumberType.FLOAT, null, false, true)
             .nullValue(2.71f)
             .build(new ContentPath())
             .fieldType();
@@ -650,7 +650,7 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
     }
 
     public void testFetchHalfFloatFromSource() throws IOException {
-        MappedFieldType mapper = new NumberFieldMapper.Builder("field", NumberType.HALF_FLOAT, false, true)
+        MappedFieldType mapper = new NumberFieldMapper.Builder("field", NumberType.HALF_FLOAT, null, false, true)
             .build(new ContentPath())
             .fieldType();
         /*

--- a/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldMapperTests.java
@@ -76,6 +76,11 @@ public class RangeFieldMapperTests extends AbstractNumericFieldMapperTestCase {
         return 6;
     }
 
+    @Override
+    protected boolean supportsSearchLookup() {
+        return false;
+    }
+
     public void testExistsQueryDocValuesDisabled() throws IOException {
         MapperService mapperService = createMapperService(fieldMapping(b -> {
             minimalMapping(b);

--- a/server/src/test/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapperTests.java
@@ -65,6 +65,11 @@ public class FlattenedFieldMapperTests extends MapperTestCase {
             m -> assertEquals(10, ((FlattenedFieldMapper)m).depthLimit()));
     }
 
+    @Override
+    protected boolean allowsStore() {
+        return false;
+    }
+
     public void testDefaults() throws Exception {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
         ParsedDocument parsedDoc = mapper.parse(source(b -> b.startObject("field").field("key", "value").endObject()));

--- a/server/src/test/java/org/elasticsearch/search/aggregations/AggregatorBaseTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/AggregatorBaseTests.java
@@ -85,7 +85,7 @@ public class AggregatorBaseTests extends MapperServiceTestCase {
         AggregationContext context
     ) {
         MappedFieldType ft
-            = new NumberFieldMapper.NumberFieldType(fieldName, numType, indexed, false, true, false, null, Collections.emptyMap());
+            = new NumberFieldMapper.NumberFieldType(fieldName, numType, indexed, false, true, false, null, Collections.emptyMap(), null);
         return ValuesSourceConfig.resolveFieldOnly(ft, context);
     }
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregatorTests.java
@@ -177,7 +177,8 @@ public class RangeAggregatorTests extends AggregatorTestCase {
                 true,
                 false,
                 null,
-                Collections.emptyMap()
+                Collections.emptyMap(),
+                null
             )
         );
     }
@@ -280,7 +281,8 @@ public class RangeAggregatorTests extends AggregatorTestCase {
             true,
             false,
             null,
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            null
         );
 
         long start = 2L << 54; // Double stores 53 bits of mantissa, so we aggregate a bunch of bigger values
@@ -476,7 +478,8 @@ public class RangeAggregatorTests extends AggregatorTestCase {
             true,
             false,
             null,
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            null
         );
         RangeAggregationBuilder aggregationBuilder = new RangeAggregationBuilder("test_range_agg");
         aggregationBuilder.field(NUMBER_FIELD_NAME);

--- a/server/src/test/java/org/elasticsearch/search/collapse/CollapseBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/collapse/CollapseBuilderTests.java
@@ -145,14 +145,14 @@ public class CollapseBuilderTests extends AbstractSerializingTestCase<CollapseBu
 
             numberFieldType =
                 new NumberFieldMapper.NumberFieldType("field", NumberFieldMapper.NumberType.LONG, true, false,
-                    false, false, null, Collections.emptyMap());
+                    false, false, null, Collections.emptyMap(), null);
             when(searchExecutionContext.getFieldType("field")).thenReturn(numberFieldType);
             IllegalArgumentException exc = expectThrows(IllegalArgumentException.class, () -> builder.build(searchExecutionContext));
             assertEquals(exc.getMessage(), "cannot collapse on field `field` without `doc_values`");
 
             numberFieldType =
                 new NumberFieldMapper.NumberFieldType("field", NumberFieldMapper.NumberType.LONG, false, false,
-                    true, false, null, Collections.emptyMap());
+                    true, false, null, Collections.emptyMap(), null);
             when(searchExecutionContext.getFieldType("field")).thenReturn(numberFieldType);
             builder.setInnerHits(new InnerHitBuilder());
             exc = expectThrows(IllegalArgumentException.class, () -> builder.build(searchExecutionContext));

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
@@ -28,9 +28,11 @@ import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldDataCache;
+import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.lookup.LeafStoredFieldsLookup;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.search.lookup.SourceLookup;
 
@@ -48,6 +50,7 @@ import static java.util.stream.Collectors.toList;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -563,6 +566,103 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
              * difference. But we have to convince the test we're ok with it.
              */
             assertThat("fetching " + value, fromNative, containsInAnyOrder(fromDocValues.toArray()));
+        });
+    }
+
+    /**
+     * @return whether or not this field type supports access to its values from a SearchLookup
+     */
+    protected boolean supportsSearchLookup() {
+        return true;
+    }
+
+    /**
+     * Checks that field data from this field produces the same values for query-time
+     * scripts and for index-time scripts
+     */
+    public final void testIndexTimeFieldData() throws IOException {
+        assumeTrue("Field type does not support access via search lookup", supportsSearchLookup());
+        MapperService mapperService = createMapperService(fieldMapping(this::minimalMapping));
+        assertParseMinimalWarnings();
+        MappedFieldType fieldType = mapperService.fieldType("field");
+        if (fieldType.isAggregatable() == false) {
+            return; // No field data available, so we ignore
+        }
+        SourceToParse source = source(this::writeField);
+        ParsedDocument doc = mapperService.documentMapper().parse(source);
+
+        withLuceneIndex(mapperService, iw -> iw.addDocument(doc.rootDoc()), ir -> {
+
+            LeafReaderContext ctx = ir.leaves().get(0);
+
+            ScriptDocValues<?> fieldData = fieldType
+                .fielddataBuilder("test", () -> { throw new UnsupportedOperationException(); })
+                .build(new IndexFieldDataCache.None(), new NoneCircuitBreakerService())
+                .load(ctx)
+                .getScriptValues();
+
+            fieldData.setNextDocId(0);
+
+            DocumentLeafReader reader = new DocumentLeafReader(doc.rootDoc(), Collections.emptyMap());
+            ScriptDocValues<?> indexData = fieldType
+                .fielddataBuilder("test", () -> {
+                    throw new UnsupportedOperationException();
+                })
+                .build(new IndexFieldDataCache.None(), new NoneCircuitBreakerService())
+                .load(reader.getContext())
+                .getScriptValues();
+            indexData.setNextDocId(0);
+
+            // compare index and search time fielddata
+            assertThat(fieldData, equalTo(indexData));
+        });
+    }
+
+    protected boolean allowsStore() {
+        return true;
+    }
+
+    /**
+     * Checks that loading stored fields for this field produces the same set of values
+     * for query time scripts and index time scripts
+     */
+    public final void testIndexTimeStoredFieldsAccess() throws IOException {
+
+        assumeTrue("FieldMapper implementation does not allow stored fields", allowsStore());
+        MapperService mapperService;
+        try {
+            mapperService = createMapperService(fieldMapping(b -> {
+                minimalMapping(b);
+                b.field("store", true);
+            }));
+            assertParseMinimalWarnings();
+        } catch (MapperParsingException e) {
+            assertParseMinimalWarnings();
+            assumeFalse("Field type does not support stored fields", true);
+            return;
+        }
+
+        MappedFieldType fieldType = mapperService.fieldType("field");
+        SourceToParse source = source(this::writeField);
+        ParsedDocument doc = mapperService.documentMapper().parse(source);
+
+        SearchLookup lookup = new SearchLookup(f -> fieldType, (f, s) -> {
+            throw new UnsupportedOperationException();
+        });
+
+        withLuceneIndex(mapperService, iw -> iw.addDocument(doc.rootDoc()), ir -> {
+
+            LeafReaderContext ctx = ir.leaves().get(0);
+            LeafStoredFieldsLookup storedFields = lookup.getLeafSearchLookup(ctx).fields();
+            storedFields.setDocument(0);
+
+            DocumentLeafReader reader = new DocumentLeafReader(doc.rootDoc(), Collections.emptyMap());
+
+            LeafStoredFieldsLookup indexStoredFields = lookup.getLeafSearchLookup(reader.getContext()).fields();
+            indexStoredFields.setDocument(0);
+
+            // compare index and search time stored fields
+            assertThat(storedFields.get("field").getValues(), equalTo(indexStoredFields.get("field").getValues()));
         });
     }
 

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapperTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapperTests.java
@@ -49,6 +49,11 @@ public class HistogramFieldMapperTests extends MapperTestCase {
             m -> assertTrue(((HistogramFieldMapper)m).ignoreMalformed()));
     }
 
+    @Override
+    protected boolean supportsSearchLookup() {
+        return false;
+    }
+
     public void testParseValue() throws Exception {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
         ParsedDocument doc = mapper.parse(

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapperTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapperTests.java
@@ -54,6 +54,11 @@ public class HistogramFieldMapperTests extends MapperTestCase {
         return false;
     }
 
+    @Override
+    protected boolean allowsStore() {
+        return false;
+    }
+
     public void testParseValue() throws Exception {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
         ParsedDocument doc = mapper.parse(

--- a/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateDoubleMetricFieldMapper.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateDoubleMetricFieldMapper.java
@@ -184,9 +184,9 @@ public class AggregateDoubleMetricFieldMapper extends FieldMapper {
 
                 if (m == Metric.value_count) {
                     // value_count metric can only be an integer and not a double
-                    builder = new NumberFieldMapper.Builder(fieldName, NumberFieldMapper.NumberType.INTEGER, false, false);
+                    builder = new NumberFieldMapper.Builder(fieldName, NumberFieldMapper.NumberType.INTEGER, null, false, false);
                 } else {
-                    builder = new NumberFieldMapper.Builder(fieldName, NumberFieldMapper.NumberType.DOUBLE, false, true);
+                    builder = new NumberFieldMapper.Builder(fieldName, NumberFieldMapper.NumberType.DOUBLE, null, false, true);
                 }
                 NumberFieldMapper fieldMapper = builder.build(context);
                 metricMappers.put(m, fieldMapper);

--- a/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateDoubleMetricFieldMapperTests.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateDoubleMetricFieldMapperTests.java
@@ -99,6 +99,11 @@ public class AggregateDoubleMetricFieldMapperTests extends MapperTestCase {
         return 50.0;
     }
 
+    @Override
+    protected boolean allowsStore() {
+        return false;
+    }
+
     /**
      * Test parsing field mapping and adding simple field
      */

--- a/x-pack/plugin/mapper-constant-keyword/src/internalClusterTest/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapperTests.java
+++ b/x-pack/plugin/mapper-constant-keyword/src/internalClusterTest/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapperTests.java
@@ -58,6 +58,11 @@ public class ConstantKeywordFieldMapperTests extends MapperTestCase {
         return singleton(new ConstantKeywordMapperPlugin());
     }
 
+    @Override
+    protected boolean allowsStore() {
+        return false;
+    }
+
     public void testDefaults() throws Exception {
         XContentBuilder mapping = fieldMapping(b -> b.field("type", "constant_keyword").field("value", "foo"));
         DocumentMapper mapper = createDocumentMapper(mapping);

--- a/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapperTests.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapperTests.java
@@ -50,6 +50,11 @@ public class UnsignedLongFieldMapperTests extends MapperTestCase {
     }
 
     @Override
+    protected boolean supportsSearchLookup() {
+        return false;
+    }
+
+    @Override
     protected void registerParameters(ParameterChecker checker) throws IOException {
         checker.registerConflictCheck("doc_values", b -> b.field("doc_values", false));
         checker.registerConflictCheck("index", b -> b.field("index", false));

--- a/x-pack/plugin/mapper-version/src/test/java/org/elasticsearch/xpack/versionfield/VersionStringFieldMapperTests.java
+++ b/x-pack/plugin/mapper-version/src/test/java/org/elasticsearch/xpack/versionfield/VersionStringFieldMapperTests.java
@@ -52,6 +52,11 @@ public class VersionStringFieldMapperTests extends MapperTestCase {
         // no configurable parameters
     }
 
+    @Override
+    protected boolean allowsStore() {
+        return false;
+    }
+
     public void testDefaults() throws Exception {
         XContentBuilder mapping = fieldMapping(this::minimalMapping);
         DocumentMapper mapper = createDocumentMapper(mapping);

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerIndexingTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerIndexingTests.java
@@ -39,6 +39,7 @@ import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
+import org.elasticsearch.index.mapper.NumberFieldMapper.NumberType;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.elasticsearch.search.aggregations.Aggregations;
@@ -551,7 +552,7 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
 
         if (job.getGroupConfig().getHistogram() != null) {
             for (String field : job.getGroupConfig().getHistogram().getFields()) {
-                MappedFieldType ft = new NumberFieldMapper.Builder(field, NumberFieldMapper.NumberType.LONG, false, false)
+                MappedFieldType ft = new NumberFieldMapper.Builder(field, NumberType.LONG, null, false, false)
                         .build(new ContentPath(0))
                         .fieldType();
                 fieldTypes.put(ft.name(), ft);
@@ -569,7 +570,7 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
 
         if (job.getMetricsConfig() != null) {
             for (MetricConfig metric : job.getMetricsConfig()) {
-                MappedFieldType ft = new NumberFieldMapper.Builder(metric.getField(), NumberFieldMapper.NumberType.LONG, false, false)
+                MappedFieldType ft = new NumberFieldMapper.Builder(metric.getField(), NumberType.LONG, null, false, false)
                         .build(new ContentPath(0))
                         .fieldType();
                 fieldTypes.put(ft.name(), ft);

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapperTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapperTests.java
@@ -55,6 +55,11 @@ public class GeoShapeWithDocValuesFieldMapperTests extends MapperTestCase {
     }
 
     @Override
+    protected boolean supportsSearchLookup() {
+        return false;
+    }
+
+    @Override
     protected void registerParameters(ParameterChecker checker) throws IOException {
         checker.registerConflictCheck("doc_values", b -> b.field("doc_values", false));
         checker.registerConflictCheck("index", b -> b.field("index", false));

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapperTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapperTests.java
@@ -82,6 +82,11 @@ public class GeoShapeWithDocValuesFieldMapperTests extends MapperTestCase {
     }
 
     @Override
+    protected boolean allowsStore() {
+        return false;
+    }
+
+    @Override
     protected Collection<Plugin> getPlugins() {
         return Collections.singletonList(new LocalStateSpatialPlugin());
     }

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldMapperTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldMapperTests.java
@@ -53,6 +53,11 @@ public class ShapeFieldMapperTests extends CartesianFieldMapperTests {
         });
     }
 
+    @Override
+    protected boolean allowsStore() {
+        return false;
+    }
+
     public void testDefaultConfiguration() throws IOException {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
         Mapper fieldMapper = mapper.mappers().getMapper(FIELD_NAME);

--- a/x-pack/plugin/vectors/src/test/java/org/elasticsearch/xpack/vectors/mapper/DenseVectorFieldMapperTests.java
+++ b/x-pack/plugin/vectors/src/test/java/org/elasticsearch/xpack/vectors/mapper/DenseVectorFieldMapperTests.java
@@ -54,6 +54,11 @@ public class DenseVectorFieldMapperTests extends MapperTestCase {
             fieldMapping(b -> b.field("type", "dense_vector").field("dims", 5)));
     }
 
+    @Override
+    protected boolean allowsStore() {
+        return false;
+    }
+
     public void testDims() {
         {
             Exception e = expectThrows(MapperParsingException.class, () -> createMapperService(fieldMapping(b -> {

--- a/x-pack/plugin/vectors/src/test/java/org/elasticsearch/xpack/vectors/mapper/SparseVectorFieldMapperTests.java
+++ b/x-pack/plugin/vectors/src/test/java/org/elasticsearch/xpack/vectors/mapper/SparseVectorFieldMapperTests.java
@@ -57,6 +57,11 @@ public class SparseVectorFieldMapperTests extends MapperTestCase {
     }
 
     @Override
+    protected boolean allowsStore() {
+        return false;
+    }
+
+    @Override
     protected Object getSampleValueForDocument() {
         return Collections.singletonMap("1", 1);
     }

--- a/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
+++ b/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
@@ -98,6 +98,11 @@ public class WildcardFieldMapperTests extends MapperTestCase {
     static KeywordFieldMapper keywordFieldType;
 
     @Override
+    protected boolean allowsStore() {
+        return false;
+    }
+
+    @Override
     protected Collection<? extends Plugin> getPlugins() {
         return Collections.singleton(new Wildcard());
     }
@@ -565,7 +570,7 @@ public class WildcardFieldMapperTests extends MapperTestCase {
         }
 
     }
-    
+
     public void testQueryCachingEquality() throws IOException, ParseException {
         String pattern = "A*b*B?a";
         // Case sensitivity matters when it comes to caching
@@ -742,7 +747,7 @@ public class WildcardFieldMapperTests extends MapperTestCase {
         Query expectedAccelerationQuery = qsp.parse(expectedAccelerationQueryString);
         testExpectedAccelerationQuery(regex, combinedQuery, expectedAccelerationQuery);
     }
-    
+
     private Query unwrapAnyConstantScore(Query q) {
         if (q instanceof ConstantScoreQuery) {
             ConstantScoreQuery csq = (ConstantScoreQuery) q;


### PR DESCRIPTION
This commit adds a script parameter to long and double fields that makes
it possible to calculate a value for these fields at index time. It uses the same
script context as the equivalent runtime fields, and allows for multiple index-time
scripted fields to cross-refer while still checking for indirection loops.