### PR TITLE
StoreStats update serialization version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -189,9 +189,9 @@ tasks.register("verifyVersions") {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = false
+boolean bwc_tests_enabled = true
 // place a PR link here when committing bwc changes:
-String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/70625"
+String bwc_tests_disabled_issue = ""
 /*
  * FIPS 140-2 behavior was fixed in 7.11.0. Before that there is no way to run elasticsearch in a
  * JVM that is properly configured to be in fips mode with BCFIPS. For now we need to disable

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/nodes.stats/40_store_stats.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/nodes.stats/40_store_stats.yml
@@ -2,8 +2,7 @@
 "Store stats":
   - skip:
       features: [arbitrary_key]
-      # todo change after backport
-      version: " - 7.99.99"
+      version: " - 7.12.99"
       reason:  "total_data_set_size added in 7.13"
 
   - do:

--- a/server/src/main/java/org/elasticsearch/index/store/StoreStats.java
+++ b/server/src/main/java/org/elasticsearch/index/store/StoreStats.java
@@ -27,7 +27,7 @@ public class StoreStats implements Writeable, ToXContentFragment {
     public static final long UNKNOWN_RESERVED_BYTES = -1L;
 
     public static final Version RESERVED_BYTES_VERSION = Version.V_7_9_0;
-    public static final Version TOTAL_DATA_SET_SIZE_SIZE_VERSION = Version.V_8_0_0; // todo: Version.V_7_13_0;
+    public static final Version TOTAL_DATA_SET_SIZE_SIZE_VERSION = Version.V_7_13_0;
 
     private long sizeInBytes;
     private long totalDataSetSizeInBytes;


### PR DESCRIPTION
Reenable bwc and serialize new field `totalDataSetSizeInBytes` to 7.13+ now that the [backport](#71057) is done.