### PR TITLE
[ML] fix composite extractor test

### DIFF
--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/CompositeAggregationDataExtractorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/CompositeAggregationDataExtractorTests.java
@@ -277,7 +277,7 @@ public class CompositeAggregationDataExtractorTests extends ESTestCase {
                     timestamp,
                     "time_bucket",
                     3,
-                    Arrays.asList(createMax("time", randomLongBetween(timestamp, timestamp + 1000)), createAvg("responsetime", 32.0)),
+                    Arrays.asList(createMax("time", randomLongBetween(timestamp, timestamp + 999)), createAvg("responsetime", 32.0)),
                     Collections.singletonList(Tuple.tuple("airline", "c"))
                 )
             );
@@ -304,7 +304,7 @@ public class CompositeAggregationDataExtractorTests extends ESTestCase {
                     timestamp,
                     "time_bucket",
                     3,
-                    Arrays.asList(createMax("time", randomLongBetween(timestamp, timestamp + 1000)), createAvg("responsetime", 32.0)),
+                    Arrays.asList(createMax("time", randomLongBetween(timestamp, timestamp + 999)), createAvg("responsetime", 32.0)),
                     Collections.singletonList(Tuple.tuple("airline", "c"))
                 )
             );
@@ -316,7 +316,7 @@ public class CompositeAggregationDataExtractorTests extends ESTestCase {
                     timestamp,
                     "time_bucket",
                     3,
-                    Arrays.asList(createMax("time", randomLongBetween(timestamp, timestamp + 1000)),
+                    Arrays.asList(createMax("time", randomLongBetween(timestamp, timestamp + 999)),
                         createAvg("responsetime", 32.0)),
                     Collections.singletonList(Tuple.tuple("airline", "c"))
                 )


### PR DESCRIPTION
`randomLongBetween` is inclusive. The assumption is that the aggregating date_histogram bucket length is
`1000`, but the test `max` timestamp aggregation would return a timestamp between `[0, 1000]`, Consequently
the maximum possible value of `1000` was actually outside the bucket interval.

This commit fixes that.

closes: https://github.com/elastic/elasticsearch/issues/71087