### PR TITLE
[7.x] [DOCS] Fix duplication in allocation command test. (#71028)

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationCommandsTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationCommandsTests.java
@@ -232,7 +232,7 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
         } catch (IllegalArgumentException e) {
         }
 
-        logger.info("--> allocate the replica shard on on the second node");
+        logger.info("--> allocate the replica shard on the second node");
         newState = allocation.reroute(clusterState,
             new AllocationCommands(new AllocateReplicaAllocationCommand("test", 0, "node2")), false, false).getClusterState();
         assertThat(newState, not(equalTo(clusterState)));


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Fix duplication in allocation commond test. (#71028)