### PR TITLE
[7.12] [DOCS] Fix typos for Elasticsearch Service and Elastic Agent (#71076)

### DIFF
--- a/docs/reference/getting-started.asciidoc
+++ b/docs/reference/getting-started.asciidoc
@@ -32,10 +32,9 @@ trial of {ess}] in the cloud.
 [[getting-started-install]]
 == Get {es} up and running
 
-To take {es} for a test drive, you can create a 
-{ess-trial}[hosted deployment]  on 
-the {ess} or set up a multi-node {es} cluster on your own
-Linux, macOS, or Windows machine.
+To take {es} for a test drive, you can create a {ess-trial}[hosted deployment]
+on {ess} or set up a multi-node {es} cluster on your own Linux, macOS, or
+Windows machine.
 
 [discrete]
 [[run-elasticsearch-hosted]]
@@ -57,10 +56,10 @@ Once you've created a deployment, you're ready to <<getting-started-index>>.
 [[run-elasticsearch-local]]
 === Run {es} locally on Linux, macOS, or Windows
 
-When you create a deployment on the {ess}, a master node and
-two data nodes are provisioned automatically. By installing from the tar or zip 
-archive, you can start multiple instances of {es} locally to see how a multi-node 
-cluster behaves.
+When you create a deployment on {ess}, a master node and two data nodes are
+provisioned automatically. By installing from the tar or zip archive, you can
+start multiple instances of {es} locally to see how a multi-node cluster
+behaves.
 
 To run a three-node {es} cluster locally:
 

--- a/docs/reference/ilm/example-index-lifecycle-policy.asciidoc
+++ b/docs/reference/ilm/example-index-lifecycle-policy.asciidoc
@@ -12,7 +12,7 @@
 - `metrics`
 - `synthetics`
 
-The {agent} uses these policies to manage backing indices for its data streams.
+{agent} uses these policies to manage backing indices for its data streams.
 This tutorial shows you how to use {kib}’s **Index Lifecycle Policies** to
 customize these policies based on your application's performance, resilience,
 and retention requirements.
@@ -44,9 +44,8 @@ To complete this tutorial, you'll need:
 * An {es} cluster with hot and warm data tiers.
 
 ** {ess}:
-Elastic Stack deployments on the {ess} include a hot tier by default. To add a
-warm tier, edit your deployment and click **Add capacity** for the warm data
-tier.
+Elastic Stack deployments on {ess} include a hot tier by default. To add a warm
+tier, edit your deployment and click **Add capacity** for the warm data tier.
 +
 [role="screenshot"]
 image::images/ilm/tutorial-ilm-ess-add-warm-data-tier.png[Add a warm data tier to your deployment]
@@ -63,14 +62,14 @@ of each node in the warm tier:
 node.roles: [ data_warm ]
 ----
 
-* A host with the {agent} installed and configured to send logs to your {es}
+* A host with {agent} installed and configured to send logs to your {es}
 cluster.
 
 [discrete]
 [[example-using-index-lifecycle-policy-view-ilm-policy]]
 ==== View the policy
 
-The {agent} uses data streams with an index pattern of `logs-*-*` to store log
+{agent} uses data streams with an index pattern of `logs-*-*` to store log
 monitoring data. The built-in `logs` {ilm-init} policy automatically manages
 backing indices for these data streams.
 

--- a/docs/reference/indices/index-templates.asciidoc
+++ b/docs/reference/indices/index-templates.asciidoc
@@ -49,9 +49,9 @@ The {fleet-guide}/fleet-overview.html[{agent}] uses these templates to create
 data streams. Index templates created by {fleet} integrations use similar
 overlapping index patterns and have a priority up to `200`.
 
-If you use {fleet} or the {agent}, assign your index templates a priority
-lower than `100` to avoid overriding these templates. Otherwise, to avoid
-accidentally applying the templates, do one or more of the following:
+If you use {fleet} or {agent}, assign your index templates a priority lower than
+`100` to avoid overriding these templates. Otherwise, to avoid accidentally
+applying the templates, do one or more of the following:
 
 - To disable all built-in index and component templates, set
 <<stack-templates-enabled,`stack.templates.enabled`>> to `false` using the
@@ -60,10 +60,10 @@ accidentally applying the templates, do one or more of the following:
 - Use a non-overlapping index pattern.
 
 - Assign templates with an overlapping pattern a `priority` higher than `200`.
-For example, if you don't use {fleet} or the {agent} and want to create a
-template for the `logs-*` index pattern, assign your template a priority of
-`500`. This ensures your template is applied instead of the built-in template
-for `logs-*-*`.
+For example, if you don't use {fleet} or {agent} and want to create a template
+for the `logs-*` index pattern, assign your template a priority of `500`. This
+ensures your template is applied instead of the built-in template for
+`logs-*-*`.
 ====
 // end::built-in-index-templates[]
 ****

--- a/docs/reference/indices/put-component-template.asciidoc
+++ b/docs/reference/indices/put-component-template.asciidoc
@@ -100,13 +100,13 @@ Name of the component template to create.
 // end::built-in-component-templates[]
 
 The {fleet-guide}/fleet-overview.html[{agent}] uses these templates to configure
-backing indices for its data streams. If you use the {agent} and want to
-overwrite one of these templates, set the `version` for your replacement
-template higher than the current version.
+backing indices for its data streams. If you use {agent} and want to overwrite
+one of these templates, set the `version` for your replacement template higher
+than the current version.
 
-If you don't use the {agent} and want to disable all built-in component and
-index templates, set <<stack-templates-enabled,`stack.templates.enabled`>> to
-`false` using the <<cluster-update-settings,cluster update settings API>>.
+If you don't use {agent} and want to disable all built-in component and index
+templates, set <<stack-templates-enabled,`stack.templates.enabled`>> to `false`
+using the <<cluster-update-settings,cluster update settings API>>.
 ====
 
 [[put-component-template-api-query-params]]

--- a/docs/reference/searchable-snapshots/index.asciidoc
+++ b/docs/reference/searchable-snapshots/index.asciidoc
@@ -219,7 +219,7 @@ repository storage then you are responsible for its reliability.
 
 [discrete]
 [[searchable-snapshots-frozen-tier-on-cloud]]
-=== Configure a frozen tier on the {ess}
+=== Configure a frozen tier on {ess}
 
 The frozen data tier is not yet available on the {ess-trial}[{ess}]. However,
 you can configure another tier to use <<shared-cache,shared snapshot caches>>.


### PR DESCRIPTION
Backports the following commits to 7.12:
 - [DOCS] Fix typos for Elasticsearch Service and Elastic Agent (#71076)