### PR TITLE
[7.x] [ML] fix composite extractor test (#71108)

### DIFF
--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/CompositeAggregationDataExtractorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/CompositeAggregationDataExtractorTests.java
@@ -277,7 +277,7 @@ public class CompositeAggregationDataExtractorTests extends ESTestCase {
                     timestamp,
                     "time_bucket",
                     3,
-                    Arrays.asList(createMax("time", randomLongBetween(timestamp, timestamp + 1000)), createAvg("responsetime", 32.0)),
+                    Arrays.asList(createMax("time", randomLongBetween(timestamp, timestamp + 999)), createAvg("responsetime", 32.0)),
                     Collections.singletonList(Tuple.tuple("airline", "c"))
                 )
             );
@@ -304,7 +304,7 @@ public class CompositeAggregationDataExtractorTests extends ESTestCase {
                     timestamp,
                     "time_bucket",
                     3,
-                    Arrays.asList(createMax("time", randomLongBetween(timestamp, timestamp + 1000)), createAvg("responsetime", 32.0)),
+                    Arrays.asList(createMax("time", randomLongBetween(timestamp, timestamp + 999)), createAvg("responsetime", 32.0)),
                     Collections.singletonList(Tuple.tuple("airline", "c"))
                 )
             );
@@ -316,7 +316,7 @@ public class CompositeAggregationDataExtractorTests extends ESTestCase {
                     timestamp,
                     "time_bucket",
                     3,
-                    Arrays.asList(createMax("time", randomLongBetween(timestamp, timestamp + 1000)),
+                    Arrays.asList(createMax("time", randomLongBetween(timestamp, timestamp + 999)),
                         createAvg("responsetime", 32.0)),
                     Collections.singletonList(Tuple.tuple("airline", "c"))
                 )


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ML] fix composite extractor test (#71108)