### PR TITLE
REST API compat testing - remove the requirement for default distro

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -189,7 +189,7 @@ tasks.register("verifyVersions") {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = false
+boolean bwc_tests_enabled = true //Jake - don't commit this !...only here to run tests via CI
 // place a PR link here when committing bwc changes:
 String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/70625"
 /*

--- a/build.gradle
+++ b/build.gradle
@@ -189,7 +189,7 @@ tasks.register("verifyVersions") {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = true //Jake - don't commit this !...only here to run tests via CI
+boolean bwc_tests_enabled = false
 // place a PR link here when committing bwc changes:
 String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/70625"
 /*

--- a/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/YamlRestCompatTestPluginFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/YamlRestCompatTestPluginFuncTest.groovy
@@ -73,9 +73,6 @@ class YamlRestCompatTestPluginFuncTest extends AbstractRestResourcesFuncTest {
 
             // avoids a dependency problem in this test, the distribution in use here is inconsequential to the test
             import org.elasticsearch.gradle.testclusters.TestDistribution;
-            testClusters {
-              yamlRestCompatTest.setTestDistribution(TestDistribution.INTEG_TEST)
-            }
 
             dependencies {
                yamlRestTestImplementation "junit:junit:4.12"
@@ -198,10 +195,7 @@ class YamlRestCompatTestPluginFuncTest extends AbstractRestResourcesFuncTest {
 
             // avoids a dependency problem in this test, the distribution in use here is inconsequential to the test
             import org.elasticsearch.gradle.testclusters.TestDistribution;
-            testClusters {
-              yamlRestCompatTest.setTestDistribution(TestDistribution.INTEG_TEST)
-            }
-
+     
             dependencies {
                yamlRestTestImplementation "junit:junit:4.12"
             }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/internal/rest/compat/YamlRestCompatTestPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/internal/rest/compat/YamlRestCompatTestPlugin.java
@@ -75,10 +75,6 @@ public class YamlRestCompatTestPlugin implements Plugin<Project> {
         SourceSet yamlTestSourceSet = sourceSets.getByName(YamlRestTestPlugin.SOURCE_SET_NAME);
         GradleUtils.extendSourceSet(project, YamlRestTestPlugin.SOURCE_SET_NAME, SOURCE_SET_NAME);
 
-        // create the test cluster container, and always use the default distribution
-        ElasticsearchCluster testCluster = createTestCluster(project, yamlCompatTestSourceSet);
-        testCluster.setTestDistribution(TestDistribution.DEFAULT);
-
         // copy compatible rest specs
         Configuration bwcMinorConfig = project.getConfigurations().create("bwcMinor");
         Dependency bwcMinor = project.getDependencies().project(Map.of("path", ":distribution:bwc:minor", "configuration", "checkout"));

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/internal/rest/compat/YamlRestCompatTestPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/internal/rest/compat/YamlRestCompatTestPlugin.java
@@ -19,9 +19,7 @@ import org.elasticsearch.gradle.test.rest.RestResourcesExtension;
 import org.elasticsearch.gradle.test.rest.RestResourcesPlugin;
 import org.elasticsearch.gradle.test.rest.RestTestUtil;
 import org.elasticsearch.gradle.test.rest.YamlRestTestPlugin;
-import org.elasticsearch.gradle.testclusters.ElasticsearchCluster;
 import org.elasticsearch.gradle.testclusters.TestClustersPlugin;
-import org.elasticsearch.gradle.testclusters.TestDistribution;
 import org.elasticsearch.gradle.util.GradleUtils;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -39,7 +37,6 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.Map;
 
-import static org.elasticsearch.gradle.test.rest.RestTestUtil.createTestCluster;
 import static org.elasticsearch.gradle.test.rest.RestTestUtil.setupDependencies;
 
 /**


### PR DESCRIPTION
Originally much of the REST API compatibility code was to live in 
x-pack. However, some design changes has removed this requirements 
and there is no longer a need to explicitly use the default distribution
for REST API compatibility testing. 

----
If using the default distribution AND applying the modules for test clusters (as is the default) then there can be server errors such as mapping types already registered. If we had kept with the original design we would need to figure out how to conditionally add modules...but now we can simply remove this special requirement. 