### PR TITLE
[7.x] Add read permissions for apm_user role to APM fleet indices (#68749)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -192,17 +192,44 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                         },
                     null, MetadataUtils.DEFAULT_RESERVED_METADATA))
                 .put("apm_user", new RoleDescriptor("apm_user",
-                    null, new RoleDescriptor.IndicesPrivileges[] {
+                    null,
+                    new RoleDescriptor.IndicesPrivileges[] {
+                        // Self managed APM Server
+                        // Can be removed in 8.0
                         RoleDescriptor.IndicesPrivileges.builder().indices("apm-*")
                             .privileges("read", "view_index_metadata").build(),
-                        RoleDescriptor.IndicesPrivileges.builder().indices(".ml-anomalies*")
+
+                            // APM Server under fleet (data streams)
+                            RoleDescriptor.IndicesPrivileges.builder().indices("logs-apm.*")
                             .privileges("read", "view_index_metadata").build(),
-                        RoleDescriptor.IndicesPrivileges.builder().indices("observability-annotations")
+                            RoleDescriptor.IndicesPrivileges.builder().indices("metrics-apm.*")
+                            .privileges("read", "view_index_metadata").build(),
+                            RoleDescriptor.IndicesPrivileges.builder().indices("traces-apm.*")
+                            .privileges("read", "view_index_metadata").build(),
+
+                            // Machine Learning indices. Only needed for legacy reasons
+                            // Can be removed in 8.0
+                            RoleDescriptor.IndicesPrivileges.builder().indices(".ml-anomalies*")
+                            .privileges("read", "view_index_metadata").build(),
+
+                            // Annotations
+                            RoleDescriptor.IndicesPrivileges.builder().indices("observability-annotations")
                             .privileges("read", "view_index_metadata").build()
-                    }, new RoleDescriptor.ApplicationResourcePrivileges[] {
-                            RoleDescriptor.ApplicationResourcePrivileges.builder()
-                                .application("kibana-*").resources("*").privileges("reserved_ml_apm_user").build()
-                        }, null, null, MetadataUtils.DEFAULT_RESERVED_METADATA, null))
+                    },
+                    new RoleDescriptor.ApplicationResourcePrivileges[] {
+                        RoleDescriptor
+                                .ApplicationResourcePrivileges
+                                .builder()
+                                .application("kibana-*")
+                                .resources("*")
+                                .privileges("reserved_ml_apm_user")
+                                .build()
+                    },
+                    null,
+                    null,
+                    MetadataUtils.getDeprecatedReservedMetadata("This role will be removed in 8.0"),
+                    null
+                ))
                 .put("machine_learning_user", new RoleDescriptor("machine_learning_user", new String[] { "monitor_ml" },
                         new RoleDescriptor.IndicesPrivileges[] {
                                 RoleDescriptor.IndicesPrivileges.builder().indices(".ml-anomalies*", ".ml-notifications*")

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -1263,7 +1263,14 @@ public class ReservedRolesStoreTests extends ESTestCase {
         assertThat(role.runAs().check(randomAlphaOfLengthBetween(1, 12)), is(false));
 
         assertNoAccessAllowed(role, "foo");
+        assertNoAccessAllowed(role, "foo-apm");
+        assertNoAccessAllowed(role, "foo-logs-apm.bar");
+        assertNoAccessAllowed(role, "foo-traces-apm.bar");
+        assertNoAccessAllowed(role, "foo-metrics-apm.bar");
 
+        assertOnlyReadAllowed(role, "logs-apm." + randomIntBetween(0, 5));
+        assertOnlyReadAllowed(role, "traces-apm." + randomIntBetween(0, 5));
+        assertOnlyReadAllowed(role, "metrics-apm." + randomIntBetween(0, 5));
         assertOnlyReadAllowed(role, "apm-" + randomIntBetween(0, 5));
         assertOnlyReadAllowed(role, AnomalyDetectorsIndexFields.RESULTS_INDEX_PREFIX + AnomalyDetectorsIndexFields.RESULTS_INDEX_DEFAULT);
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add read permissions for apm_user role to APM fleet indices (#68749)