### PR TITLE
Remove the beta flag from 'fields' option.

### DIFF
--- a/docs/reference/search/search-your-data/retrieve-selected-fields.asciidoc
+++ b/docs/reference/search/search-your-data/retrieve-selected-fields.asciidoc
@@ -58,7 +58,6 @@ following sections:
 [discrete]
 [[search-fields-param]]
 === Fields
-beta::[]
 
 // tag::fields-param-desc[]
 The `fields` parameter allows for retrieving a list of document fields in


### PR DESCRIPTION
Now that we've addressed the open issues, the 'fields' option can be considered GA.

Relates to #60985.