### PR TITLE
[ML] fixing test related to #67756

### DIFF
--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlDistributedFailureIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlDistributedFailureIT.java
@@ -85,7 +85,9 @@ import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 
 public class MlDistributedFailureIT extends BaseMlIntegTestCase {
 
@@ -467,7 +469,6 @@ public class MlDistributedFailureIT extends BaseMlIntegTestCase {
         });
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/67756")
     public void testClusterWithTwoMlNodes_RunsDatafeed_GivenOriginalNodeGoesDown() throws Exception {
         internalCluster().ensureAtMostNumDataNodes(0);
         logger.info("Starting dedicated master node...");
@@ -513,18 +514,24 @@ public class MlDistributedFailureIT extends BaseMlIntegTestCase {
         setMlIndicesDelayedNodeLeftTimeoutToZero();
 
         StartDatafeedAction.Request startDatafeedRequest = new StartDatafeedAction.Request(config.getId(), 0L);
-        startDatafeedRequest.getParams().setEndTime("now");
         client().execute(StartDatafeedAction.INSTANCE, startDatafeedRequest).get();
 
         waitForJobToHaveProcessedAtLeast(jobId, 1000);
 
         internalCluster().stopNode(nodeRunningJob.getName());
 
-        waitForJobClosed(jobId);
+        // Wait for job and datafeed to get reassigned
+        assertBusy(() -> {
+            assertThat(getJobStats(jobId).getNode(), is(not(nullValue())));
+            assertThat(getDatafeedStats(datafeedId).getNode(), is(not(nullValue())));
+        }, 30, TimeUnit.SECONDS);
 
-        DataCounts dataCounts = getJobStats(jobId).getDataCounts();
-        assertThat(dataCounts.getProcessedRecordCount(), greaterThanOrEqualTo(numDocs));
-        assertThat(dataCounts.getOutOfOrderTimeStampCount(), equalTo(0L));
+        assertBusy(() -> {
+            DataCounts dataCounts = getJobStats(jobId).getDataCounts();
+            assertThat(dataCounts.getProcessedRecordCount(), greaterThanOrEqualTo(numDocs));
+            assertThat(dataCounts.getOutOfOrderTimeStampCount(), equalTo(0L));
+        });
+
     }
 
     private void setupJobWithoutDatafeed(String jobId, ByteSizeValue modelMemoryLimit) throws Exception {


### PR DESCRIPTION
The test was originally waiting on a lookback only datafeed to complete and autoclose the job

But, there were times where the lookback completed right when the node was shutting down.
Consequently, the job never closed, but the datafeed did. So, the job never autoclosed.

This commit makes the test's datafeed a realtime datafeed so it always gets reassigned.

closes: https://github.com/elastic/elasticsearch/issues/67756