### PR TITLE
[DOCS] Fixes deprecation message for Geo-polygon query

### DIFF
--- a/docs/reference/query-dsl/geo-polygon-query.asciidoc
+++ b/docs/reference/query-dsl/geo-polygon-query.asciidoc
@@ -4,8 +4,7 @@
 <titleabbrev>Geo-polygon</titleabbrev>
 ++++
 
-deprecated[7.12.0,"Use <<query-dsl-geo-shape-query>> instead,
-where polygons are defined in geojson or wkt."]
+deprecated:[7.12.0] Use <<query-dsl-geo-shape-query>> instead, where polygons are defined in GeoJSON or http://docs.opengeospatial.org/is/18-010r7/18-010r7.html[Well-Known Text (WKT)].
 
 A query returning hits that only fall within a polygon of
 points. Here is an example:

--- a/docs/reference/query-dsl/geo-polygon-query.asciidoc
+++ b/docs/reference/query-dsl/geo-polygon-query.asciidoc
@@ -3,8 +3,7 @@
 ++++
 <titleabbrev>Geo-polygon</titleabbrev>
 ++++
-
-deprecated:[7.12.0] Use <<query-dsl-geo-shape-query>> instead, where polygons are defined in GeoJSON or http://docs.opengeospatial.org/is/18-010r7/18-010r7.html[Well-Known Text (WKT)].
+deprecated::[7.12,Use <<query-dsl-geo-shape-query>> instead where polygons are defined in GeoJSON or http://docs.opengeospatial.org/is/18-010r7/18-010r7.html[Well-Known Text (WKT)].]
 
 A query returning hits that only fall within a polygon of
 points. Here is an example:


### PR DESCRIPTION
The deprecation message for Geo-polygon query was not formatted correctly, causing it to display incorrectly. This PR fixes the formatting error.
![image](https://user-images.githubusercontent.com/25848033/113195756-a50b5180-9230-11eb-81aa-087775cb9354.png)

Preview link: https://elasticsearch_71141.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/query-dsl-geo-polygon-query.html