### PR TITLE
[ML] Make ML memory tracker more robust to flipping on/off master

### DIFF
--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/EstablishedMemUsageIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/EstablishedMemUsageIT.java
@@ -41,7 +41,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 
 public class EstablishedMemUsageIT extends BaseMlIntegTestCase {
 
-    private long bucketSpan = AnalysisConfig.Builder.DEFAULT_BUCKET_SPAN.getMillis();
+    private final long bucketSpan = AnalysisConfig.Builder.DEFAULT_BUCKET_SPAN.getMillis();
 
     private JobResultsProvider jobResultsProvider;
     private JobResultsPersister jobResultsPersister;

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlDistributedFailureIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlDistributedFailureIT.java
@@ -38,7 +38,6 @@ import org.elasticsearch.persistent.PersistentTasksClusterService;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata.PersistentTask;
 import org.elasticsearch.persistent.UpdatePersistentTaskStatusAction;
-import org.elasticsearch.test.junit.annotations.TestIssueLogging;
 import org.elasticsearch.xpack.core.action.util.QueryPage;
 import org.elasticsearch.xpack.core.ml.MlTasks;
 import org.elasticsearch.xpack.core.ml.action.CloseJobAction;
@@ -408,10 +407,6 @@ public class MlDistributedFailureIT extends BaseMlIntegTestCase {
         assertTrue(closeJobResponse.isClosed());
     }
 
-    @TestIssueLogging(issueUrl = "https://github.com/elastic/elasticsearch/issues/68685",
-        value = "org.elasticsearch.xpack.ml.process:TRACE,"
-            + "org.elasticsearch.xpack.ml.job:TRACE,"
-            + "org.elasticsearch.persistent.PersistentTasksClusterService:TRACE")
     public void testJobRelocationIsMemoryAware() throws Exception {
 
         // see: https://github.com/elastic/elasticsearch/issues/66885#issuecomment-758790179

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/process/MlMemoryTrackerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/process/MlMemoryTrackerTests.java
@@ -119,7 +119,14 @@ public class MlMemoryTrackerTests extends ESTestCase {
             return null;
         }).when(jobResultsProvider).getEstablishedMemoryUsage(anyString(), any(), any(), any(), any());
 
-        memoryTracker.refresh(persistentTasks, ActionListener.wrap(aVoid -> {}, ESTestCase::assertNull));
+        if (isMaster) {
+            memoryTracker.refresh(persistentTasks, ActionListener.wrap(aVoid -> {}, ESTestCase::assertNull));
+        } else {
+            AtomicReference<Exception> exception = new AtomicReference<>();
+            memoryTracker.refresh(persistentTasks,
+                ActionListener.wrap(e -> fail("Expected failure response"), exception::set));
+            assertEquals("Request to refresh anomaly detector memory requirement on non-master node", exception.get().getMessage());
+        }
 
         if (isMaster) {
             for (int i = 1; i <= numAnomalyDetectorJobTasks; ++i) {
@@ -186,10 +193,10 @@ public class MlMemoryTrackerTests extends ESTestCase {
             return null;
         }).when(configProvider).getConfigsForJobsWithTasksLeniently(any(), any());
 
-        AtomicBoolean gotSuccessResponse = new AtomicBoolean(false);
+        AtomicReference<Exception> exception = new AtomicReference<>();
         memoryTracker.refresh(persistentTasks,
-            ActionListener.wrap(aVoid -> gotSuccessResponse.set(true), e -> fail("Expected success response")));
-        assertTrue(gotSuccessResponse.get());
+            ActionListener.wrap(e -> fail("Expected failure response"), exception::set));
+        assertEquals("Request to refresh anomaly detector memory requirement on non-master node", exception.get().getMessage());
     }
 
     public void testRefreshOneAnomalyDetectorJob() {
@@ -223,10 +230,10 @@ public class MlMemoryTrackerTests extends ESTestCase {
             return null;
         }).when(jobManager).getJob(eq(jobId), any());
 
-        AtomicReference<Long> refreshedMemoryRequirement = new AtomicReference<>();
-        memoryTracker.refreshAnomalyDetectorJobMemory(jobId, ActionListener.wrap(refreshedMemoryRequirement::set, ESTestCase::assertNull));
-
         if (isMaster) {
+            AtomicReference<Long> refreshedMemoryRequirement = new AtomicReference<>();
+            memoryTracker.refreshAnomalyDetectorJobMemory(jobId,
+                ActionListener.wrap(refreshedMemoryRequirement::set, ESTestCase::assertNull));
             if (haveEstablishedModelMemory) {
                 assertEquals(Long.valueOf(modelBytes + Job.PROCESS_MEMORY_OVERHEAD.getBytes()),
                     memoryTracker.getAnomalyDetectorJobMemoryRequirement(jobId));
@@ -236,11 +243,14 @@ public class MlMemoryTrackerTests extends ESTestCase {
                 assertEquals(Long.valueOf(ByteSizeValue.ofMb(expectedModelMemoryLimit).getBytes() + Job.PROCESS_MEMORY_OVERHEAD.getBytes()),
                     memoryTracker.getAnomalyDetectorJobMemoryRequirement(jobId));
             }
+            assertEquals(memoryTracker.getAnomalyDetectorJobMemoryRequirement(jobId), refreshedMemoryRequirement.get());
         } else {
+            AtomicReference<Exception> exception = new AtomicReference<>();
+            memoryTracker.refreshAnomalyDetectorJobMemory(jobId,
+                ActionListener.wrap(e -> fail("Expected failure response"), exception::set));
+            assertEquals("Request to refresh anomaly detector memory requirement on non-master node", exception.get().getMessage());
             assertNull(memoryTracker.getAnomalyDetectorJobMemoryRequirement(jobId));
         }
-
-        assertEquals(memoryTracker.getAnomalyDetectorJobMemoryRequirement(jobId), refreshedMemoryRequirement.get());
 
         memoryTracker.removeAnomalyDetectorJob(jobId);
         assertNull(memoryTracker.getAnomalyDetectorJobMemoryRequirement(jobId));


### PR DESCRIPTION
Testing has shown that during cluster formation it is possible for
a node to flip backwards and forwards between being master/not
being master a couple of times. The ML memory tracker is not
completely robust to this.

This change improves the situation in a low-risk way, by aborting
refreshes if the node ceases to be master during the refresh, and
not updating the last update time when this happens. This helps
because then the "is recently refreshed?" question will return
false if the node briefly became master, then ceased to be master
before the refresh was complete, then later became master again.

There is still a race condition after this change: it is possible
that the "is recently refreshed?" question is asked after a
refresh is complete and while the node is still master, but then
the node ceases to be master before the memory information is used.
Fixing this is a much more major change, so too dangerous for a
patch. Since the refresh is a longer operation than a simple
boolean accessor, the change in this PR should still help a lot.

Backport of #71067