### PR TITLE
SQL: Improve the test coverage of the Verifier (#70474)

### DIFF
--- a/x-pack/plugin/ql/src/test/resources/mapping-multi-field-with-nested.json
+++ b/x-pack/plugin/ql/src/test/resources/mapping-multi-field-with-nested.json
@@ -7,7 +7,8 @@
         "unsupported" : { "type" : "ip_range" },
         "date" : { "type" : "date" },
         "date_nanos" : { "type" : "date_nanos" },
-        "shape": { "type" : "geo_shape" },
+        "shape": { "type" : "shape" },
+        "geo_shape": { "type" : "geo_shape" },
         "binary": {"type" : "binary", "doc_values": false },
         "binary_stored": {"type" : "binary", "doc_values": true },
         "x" : {

--- a/x-pack/plugin/sql/qa/jdbc/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/JdbcErrorsTestCase.java
+++ b/x-pack/plugin/sql/qa/jdbc/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/JdbcErrorsTestCase.java
@@ -123,14 +123,6 @@ public abstract class JdbcErrorsTestCase extends JdbcIntegrationTestCase {
         }
     }
 
-    public void testSelectScoreInScalar() throws IOException, SQLException {
-        index("test", body -> body.field("foo", 1));
-        try (Connection c = esJdbc()) {
-            SQLException e = expectThrows(SQLException.class, () -> c.prepareStatement("SELECT SIN(SCORE()) FROM test").executeQuery());
-            assertThat(e.getMessage(), startsWith("Found 1 problem\nline 1:12: [SCORE()] cannot be an argument to a function"));
-        }
-    }
-
     public void testHardLimitForSortOnAggregate() throws IOException, SQLException {
         index("test", body -> body.field("a", 1).field("b", 2));
         try (Connection c = esJdbc()) {

--- a/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/ErrorsTestCase.java
+++ b/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/ErrorsTestCase.java
@@ -34,7 +34,5 @@ public interface ErrorsTestCase {
 
     void testSelectScoreSubField() throws Exception;
 
-    void testSelectScoreInScalar() throws Exception;
-
     void testHardLimitForSortOnAggregate() throws Exception;
 }

--- a/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/cli/ErrorsTestCase.java
+++ b/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/cli/ErrorsTestCase.java
@@ -109,13 +109,6 @@ public abstract class ErrorsTestCase extends CliIntegrationTestCase implements o
     }
 
     @Override
-    public void testSelectScoreInScalar() throws Exception {
-        index("test", body -> body.field("foo", 1));
-        assertFoundOneProblem(command("SELECT SIN(SCORE()) FROM test"));
-        assertEquals("line 1:12: [SCORE()] cannot be an argument to a function" + END, readLine());
-    }
-
-    @Override
     public void testHardLimitForSortOnAggregate() throws Exception {
         index("test", body -> body.field("a", 1).field("b", 2));
         String commandResult = command("SELECT max(a) max FROM test GROUP BY b ORDER BY max LIMIT 120000");

--- a/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/rest/RestSqlTestCase.java
+++ b/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/rest/RestSqlTestCase.java
@@ -317,27 +317,11 @@ public abstract class RestSqlTestCase extends BaseRestSqlTestCase implements Err
         );
     }
 
-    public void testSelectDistinctFails() throws Exception {
-        index("{\"name\":\"test\"}");
-        expectBadRequest(
-            () -> runSql(randomMode(), "SELECT DISTINCT name FROM test"),
-            containsString("line 1:8: SELECT DISTINCT is not yet supported")
-        );
-    }
-
     public void testSelectGroupByAllFails() throws Exception {
         index("{\"foo\":1}", "{\"foo\":2}");
         expectBadRequest(
             () -> runSql(randomMode(), "SELECT foo FROM test GROUP BY ALL foo"),
             containsString("line 1:32: GROUP BY ALL is not supported")
-        );
-    }
-
-    public void testSelectWhereExistsFails() throws Exception {
-        index("{\"foo\":1}", "{\"foo\":2}");
-        expectBadRequest(
-            () -> runSql(randomMode(), "SELECT foo FROM test WHERE EXISTS (SELECT * FROM test t WHERE t.foo = test.foo)", randomBoolean()),
-            containsString("line 1:28: EXISTS is not yet supported")
         );
     }
 
@@ -468,15 +452,6 @@ public abstract class RestSqlTestCase extends BaseRestSqlTestCase implements Err
         expectBadRequest(
             () -> runSql(randomMode(), "SELECT SCORE().bar FROM test"),
             containsString("line 1:15: extraneous input '.' expecting {<EOF>, ','")
-        );
-    }
-
-    @Override
-    public void testSelectScoreInScalar() throws Exception {
-        index("{\"foo\":1}");
-        expectBadRequest(
-            () -> runSql(randomMode(), "SELECT SIN(SCORE()) FROM test"),
-            containsString("line 1:12: [SCORE()] cannot be an argument to a function")
         );
     }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Verifier.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Verifier.java
@@ -705,11 +705,12 @@ public final class Verifier {
 
 
     private static void checkForScoreInsideFunctions(LogicalPlan p, Set<Failure> localFailures) {
-        // Make sure that SCORE is only used in "top level" functions
+        // Make sure that SCORE is only used as a "top level" function
         p.forEachExpression(Function.class, f ->
             f.arguments().stream()
                 .filter(exp -> exp.anyMatch(Score.class::isInstance))
-                .forEach(exp -> localFailures.add(fail(exp, "[SCORE()] cannot be an argument to a function")))
+                .forEach(exp -> localFailures.add(fail(exp,
+                    "[SCORE()] cannot be used in expressions, does not support further processing")))
         );
     }
 

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/VerifierErrorMessagesTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/VerifierErrorMessagesTests.java
@@ -577,8 +577,8 @@ public class VerifierErrorMessagesTests extends ESTestCase {
         accept("SELECT int FROM test WHERE dep.start_date > '2020-01-30'::date AND (int > 10 OR dep.end_date IS NULL) " +
                "OR NOT(dep.start_date >= '2020-01-01')");
         String operator = randomFrom("<", "<=");
-        assertEquals("1:42: WHERE isn't (yet) compatible with scalar functions on nested fields [dep.location]",
-            error("SELECT shape FROM test " +
+        assertEquals("1:46: WHERE isn't (yet) compatible with scalar functions on nested fields [dep.location]",
+            error("SELECT geo_shape FROM test " +
                 "WHERE ST_Distance(dep.location, ST_WKTToSQL('point (10 20)')) " + operator + " 25"));
     }
 
@@ -1146,26 +1146,27 @@ public class VerifierErrorMessagesTests extends ESTestCase {
     }
 
     public void testGeoShapeInWhereClause() {
-        assertEquals("1:49: geo shapes cannot be used for filtering",
-            error("SELECT ST_AsWKT(shape) FROM test WHERE ST_AsWKT(shape) = 'point (10 20)'"));
+        assertEquals("1:53: geo shapes cannot be used for filtering",
+            error("SELECT ST_AsWKT(geo_shape) FROM test WHERE ST_AsWKT(geo_shape) = 'point (10 20)'"));
 
         // We get only one message back because the messages are grouped by the node that caused the issue
-        assertEquals("1:46: geo shapes cannot be used for filtering",
-            error("SELECT MAX(ST_X(shape)) FROM test WHERE ST_Y(shape) > 10 GROUP BY ST_GEOMETRYTYPE(shape) ORDER BY ST_ASWKT(shape)"));
+        assertEquals("1:50: geo shapes cannot be used for filtering",
+            error("SELECT MAX(ST_X(geo_shape)) FROM test WHERE ST_Y(geo_shape) > 10 " +
+                "GROUP BY ST_GEOMETRYTYPE(geo_shape) ORDER BY ST_ASWKT(geo_shape)"));
     }
 
     public void testGeoShapeInGroupBy() {
-        assertEquals("1:44: geo shapes cannot be used in grouping",
-            error("SELECT ST_X(shape) FROM test GROUP BY ST_X(shape)"));
+        assertEquals("1:48: geo shapes cannot be used in grouping",
+            error("SELECT ST_X(geo_shape) FROM test GROUP BY ST_X(geo_shape)"));
     }
 
     public void testGeoShapeInOrderBy() {
-        assertEquals("1:44: geo shapes cannot be used for sorting",
-            error("SELECT ST_X(shape) FROM test ORDER BY ST_Z(shape)"));
+        assertEquals("1:48: geo shapes cannot be used for sorting",
+            error("SELECT ST_X(geo_shape) FROM test ORDER BY ST_Z(geo_shape)"));
     }
 
     public void testGeoShapeInSelect() {
-        accept("SELECT ST_X(shape) FROM test");
+        accept("SELECT ST_X(geo_shape) FROM test");
     }
 
     //
@@ -1254,5 +1255,68 @@ public class VerifierErrorMessagesTests extends ESTestCase {
             error("SELECT count(binary) FROM test HAVING count(binary) > 1"));
         assertEquals("1:34: Binary field [binary] cannot be used for ordering unless it has the doc_values setting enabled",
             error("SELECT binary FROM test ORDER BY binary"));
+    }
+
+    public void testDistinctIsNotSupported() {
+        assertEquals("1:8: SELECT DISTINCT is not yet supported", error("SELECT DISTINCT int FROM test"));
+    }
+
+    public void testExistsIsNotSupported() {
+        assertEquals("1:33: EXISTS is not yet supported", error("SELECT test.int FROM test WHERE EXISTS (SELECT 1)"));
+    }
+
+    public void testScoreCannotBeUsedInExpressions() {
+        assertEquals("1:12: [SCORE()] cannot be used in expressions, does not support further processing",
+            error("SELECT SIN(SCORE()) FROM test"));
+    }
+
+    public void testScoreIsNotInHaving() {
+        assertEquals("1:54: HAVING filter is unsupported for function [SCORE()]\n" +
+                "line 1:54: [SCORE()] cannot be used in expressions, does not support further processing",
+            error("SELECT bool, AVG(int) FROM test GROUP BY bool HAVING SCORE() > 0.5"));
+    }
+
+    public void testScoreCannotBeUsedForGrouping() {
+        assertEquals("1:42: Cannot use [SCORE()] for grouping",
+            error("SELECT bool, AVG(int) FROM test GROUP BY SCORE()"));
+    }
+
+    public void testScoreCannotBeAnAggregateFunction() {
+        assertEquals("1:14: Cannot use non-grouped column [SCORE()], expected [bool]",
+            error("SELECT bool, SCORE() FROM test GROUP BY bool"));
+    }
+
+    public void testScalarFunctionInAggregateAndGrouping() {
+        accept("SELECT bool, SQRT(int) FROM test GROUP BY bool, SQRT(int)");
+        accept("SELECT bool, SQRT(int) FROM test GROUP BY bool, int");
+    }
+
+    public void testFunctionInAggregateAndGroupingAsReference() {
+        accept("SELECT b, s FROM (SELECT bool b, int, SQRT(int) s FROM test) GROUP BY b, SQRT(int)");
+    }
+
+    public void testLiteralAsAggregate() {
+        accept("SELECT bool, AVG(int), 2 as lit FROM test GROUP BY bool");
+    }
+
+    public void testShapeInWhereClause() {
+        assertEquals("1:49: shapes cannot be used for filtering",
+            error("SELECT ST_AsWKT(shape) FROM test WHERE ST_AsWKT(shape) = 'point (10 20)'"));
+        assertEquals("1:46: shapes cannot be used for filtering",
+            error("SELECT MAX(ST_X(shape)) FROM test WHERE ST_Y(shape) > 10 GROUP BY ST_GEOMETRYTYPE(shape) ORDER BY ST_ASWKT(shape)"));
+    }
+
+    public void testShapeInGroupBy() {
+        assertEquals("1:44: shapes cannot be used in grouping",
+            error("SELECT ST_X(shape) FROM test GROUP BY ST_X(shape)"));
+    }
+
+    public void testShapeInOrderBy() {
+        assertEquals("1:44: shapes cannot be used for sorting",
+            error("SELECT ST_X(shape) FROM test ORDER BY ST_Z(shape)"));
+    }
+
+    public void testShapeInSelect() {
+        accept("SELECT ST_X(shape) FROM test");
     }
 }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysColumnsTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysColumnsTests.java
@@ -55,7 +55,7 @@ public class SysColumnsTests extends ESTestCase {
     private static final String CLUSTER_NAME = "cluster";
     private static final Map<String, EsField> MAPPING1 = loadMapping("mapping-multi-field-with-nested.json", true);
     private static final Map<String, EsField> MAPPING2 = loadMapping("mapping-multi-field-variation.json", true);
-    private static final int FIELD_COUNT1 = 18;
+    private static final int FIELD_COUNT1 = 19;
     private static final int FIELD_COUNT2 = 17;
 
     private final SqlParser parser = new SqlParser();


### PR DESCRIPTION
The reason for increasing the test coverage on the Verifier
is to gain extra confidence that later moving rules between the
Analyzer and Optimizer won't break any current functionality,
won't turn current checks effectively noop.