### PR TITLE
[DOCS] How to migrate to node roles from node attrs. Closes #65855

### DIFF
--- a/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
+++ b/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
@@ -155,4 +155,4 @@ PUT my-index-000001/_settings
 }
 ----
 
-For an index already in the cold tier, include the cold, warm, and hot tiers.
+If an index is already in the cold phase, include the cold, warm, and hot tiers.

--- a/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
+++ b/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
@@ -36,8 +36,8 @@ A node can also have other <<modules-node,roles>>. By default, new nodes are
 configured with all roles.
 
 When you add a data tier to an {ess} deployment,
-new nodes are automatically assigned to the tier.
-To change the role of an existing node in an {ess} deployment, use the
+one or more nodes are automatically configured with the corresponding role.
+To explicitly change the role of a node in an {ess} deployment, use the
 {cloud}/ec-api-deployment-crud.html#ec_update_a_deployment[Update deployment API].
 Replace the node's `node_type` configuration with the appropriate `node_roles`.
 For example, the following configuration adds the node to the hot and content
@@ -99,6 +99,7 @@ that set the hot shard allocation attribute on all indices.
 ----
 DELETE _template/.cloud-hot-warm-allocation-0
 ----
+// TEST[skip:no cloud template]
 
 If you're using a custom index template, update it to remove the <<shard-allocation-filtering, attribute-based allocation filters>> you used to assign new indices to the hot tier.
 

--- a/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
+++ b/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
@@ -4,9 +4,10 @@
 
 If you currently use custom node attributes and
 <<shard-allocation-filtering, attribute-based allocation filters>> to
-move indices through <<data-tiers, data tiers>> in a hot-warm-cold architecture,
+move indices through <<data-tiers, data tiers>> in a
+https://www.elastic.co/blog/implementing-hot-warm-cold-in-elasticsearch-with-index-lifecycle-management[hot-warm-cold architecture],
 we recommend that you switch to using the built-in node roles
-and automatic <<data-tier-shard-filtering, data tier allocation>>.
+and automatic <<data-tier-allocation, data tier allocation>>.
 Using node roles enables {ilm-init} to automatically
 move indices between data tiers.
 
@@ -65,19 +66,22 @@ node.roles [ data_hot, data_content ]
 
 [discrete]
 [[remove-custom-allocation-settings]]
-=== Remove custom allocation settings from your {ilm-init} policy
+=== Remove custom allocation settings from existing {ilm-init} policies
 
-Update the allocate action for each phase to remove the attribute-based
-allocation settings. If the allocate action does not set the number of replicas,
+Update the allocate action for each lifecycle phase to remove the attribute-based
+allocation settings. This enables {ilm-init} to inject the
+<<ilm-migrate,migrate>> action into each phase
+to automatically transition the indices through the data tiers.
+
+If the allocate action does not set the number of replicas,
 remove the allocate action entirely. (An empty allocate action is invalid.)
 
 IMPORTANT: The policy must specify the corresponding phase for each data tier in
-your architecture.
-For example, if you enable the warm and cold data tiers for a deployment, your
-policy must include the hot, warm, and cold phases.
-This is necessary for {ilm-init} to automatically inject the <<ilm-migrate,
-migrate>> action to move indices through the data tiers,
-even if you don't need to perform any other actions and the phase is empty.
+your architecture. Each phase must be present so {ilm-init} can inject the
+migrate action to move indices through the data tiers.
+If you don't need to perform any other actions, the phase can be empty.
+For example, if you enable the warm and cold data tiers for a deployment,
+your policy must include the hot, warm, and cold phases.
 
 [discrete]
 [[stop-setting-custom-hot-attribute]]
@@ -110,7 +114,7 @@ To enable {ilm-init} to move an _existing_ managed index
 through the data tiers, update the index settings to:
 
 . Remove the custom allocation filter by setting it to `null`.
-. Set the `_tier_preference`.
+. Set the <<data-tier-shard-filtering,tier preference>>.
 
 For example, if your old template set the `data` attribute to `hot`
 to allocate shards to the hot tier, set the `data` attribute to `null`
@@ -134,3 +138,21 @@ PUT my-index-000001/_settings
   "index.routing.allocation.include._tier_preference": "data_hot"
 }
 ----
+
+For indices that have already transitioned out of the hot phase,
+the tier preference should include the appropriate fallback tiers
+to ensure index shards can be allocated if the preferred tier
+is unavailable.
+For example, specify the hot tier as the fallback for indices
+already in the warm phase.
+
+[source,console]
+----
+PUT my-index-000001/_settings
+{
+  "index.routing.allocation.require.data": null,
+  "index.routing.allocation.include._tier_preference": "data_warm,data_hot"
+}
+----
+
+For an index already in the cold tier, include the cold, warm, and hot tiers.

--- a/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
+++ b/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
@@ -96,8 +96,7 @@ that set the hot shard allocation attribute on all indices.
 DELETE _template/.cloud-hot-warm-allocation-0
 ----
 
-If you're using a custom index template, update it to remove the node attribute
-you used to assign new indices to the hot tier.
+If you're using a custom index template, update it to remove the <<shard-allocation-filtering, attribute-based allocation filters>> you used to assign new indices to the hot tier.
 
 [discrete]
 [[set-tier-preference]]

--- a/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
+++ b/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
@@ -141,6 +141,7 @@ PUT my-index/_settings
   "index.routing.allocation.include._tier_preference": "data_hot"
 }
 ----
+// TEST[continued]
 
 For indices that have already transitioned out of the hot phase,
 the tier preference should include the appropriate fallback tiers
@@ -157,5 +158,6 @@ PUT my-index/_settings
   "index.routing.allocation.include._tier_preference": "data_warm,data_hot"
 }
 ----
+// TEST[continued]
 
 If an index is already in the cold phase, include the cold, warm, and hot tiers.

--- a/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
+++ b/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
@@ -42,15 +42,15 @@ The same nodes can serve both the `data_hot` and `data_content` roles.
 
 To enable {ilm} to automatically move _existing_ managed indices through the data tiers,
 remove the routing allocation filters from the indices and set the `_tier_preference`.
-For example, if your old template set a `node-type` attribute to assign new indices to `hot-nodes`,
-set the value to `null` to remove the filter:
+For example, if your old template set the `data` attribute to `hot` to allocate shards to the hot tier,
+set the `data` attribute to `null` to remove the filter and set the `_tier_preference` instead.
 
 ////
 [source,console]
 --------------------------------------------------
 PUT /my-index-000001/_settings
 {
-  "index.routing.allocation.require.node-type": "hot-nodes"
+  "index.routing.allocation.require.data": "hot"
 }
 --------------------------------------------------
 // TEST[setup:my_index]
@@ -61,7 +61,7 @@ PUT /my-index-000001/_settings
 --------------------------------------------------
 PUT my-index-000001/_settings
 {
-  "index.routing.allocation.require.node-type": null,
+  "index.routing.allocation.require.data": null,
   "index.routing.allocation.include._tier_preference": "data_hot"
 
 }

--- a/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
+++ b/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
@@ -3,67 +3,137 @@
 == Migrate index allocation filters to node roles
 
 If you currently use custom node attributes and
-<<<<shard-allocation-filtering, attribute-based allocation filters>> to move indices
-through data tiers in a hot-warm-cold architecture, we recommend that you switch to using
-the built-in node roles and automatic <<data-tier-shard-filtering, data tier allocation>>.
-Using node roles enables {ilm-init} to automatically move indices between data tiers.
-To modify the number of replicas as the index moves between tiers,
-you can specify an allocate action with no allocation filters.
+<<shard-allocation-filtering, attribute-based allocation filters>> to
+move indices through <<data-tiers, data tiers>> in a hot-warm-cold architecture,
+we recommend that you switch to using the built-in node roles
+and automatic <<data-tier-shard-filtering, data tier allocation>>.
+Using node roles enables {ilm-init} to automatically
+move indices between data tiers.
 
-NOTE: While we recommend relying on automatic data tier allocation to manage your data
-in a hot-warm-cold architecture,
-you can still use attribute-based allocation filters to control shard allocation for other purposes.
+NOTE: While we recommend relying on automatic data tier allocation to manage
+your data in a hot-warm-cold architecture,
+you can still use attribute-based allocation filters to
+control shard allocation for other purposes.
 
 To switch to using node roles:
 
-. Assign your nodes to the appropriate <<data-tiers, data tier>> using the
-`data_hot`, `data_content`, `data_warm`, `data_cold`, and `data_frozen` roles.
-When you add a data tier to an {ess} deployment,
-nodes are automatically assigned to the tier.
-You can change the role of an existing node in an {ess} deployment with the
-{cloud}/ec-api-deployment-crud.html#ec_update_a_deployment[Update deployment API].
-If you are directly managing your own cluster,
-configure the appropriate data role for each node in `elasticsearch.yml`.
-. Update your {ilm-init} policy to:
-.. Remove the attribute-based allocation settings From the {ilm-init}
-allocate action in each phase, or remove the allocate action entirely
-if it does not set the number of replicas. (An empty allocate action is invalid.)
-.. Ensure the policy specifies the corresponding phase for each data tier in your architecture.
-For example, if you enable the warm and cold data tiers for a deployment, your policy must
-include the hot, warm, and cold phases.
-This is necessary for {ilm-init} to automatically inject the <<ilm-migrate, migrate>> action
-to move indices through the data tiers,
-even if you don't need to perform any other actions and the phase is empty.
-. Update your index template to remove the custom node attribute you used to assign new indices
-to the hot tier. Going forward, when you create a data stream, its first backing index is automatically
-assigned to `data_hot` nodes. Similarly, when you directly create an index, it
-is automatically assigned to `data_content` nodes.
-The same nodes can serve both the `data_hot` and `data_content` roles.
+. <<assign-data-tier, Assign data nodes>> to the appropriate data tier.
+. <<remove-custom-allocation-settings, Remove the attribute-based allocation
+settings>> from your {ilm} policy.
+. <<stop-setting-custom-hot-attribute, Stop setting the custom hot attribute>>
+on new indices.
+. Update existing indices to <<set-tier-preference, set a tier preference>>.
 
-To enable {ilm} to automatically move _existing_ managed indices through the data tiers,
-remove the routing allocation filters from the indices and set the `_tier_preference`.
-For example, if your old template set the `data` attribute to `hot` to allocate shards to the hot tier,
-set the `data` attribute to `null` to remove the filter and set the `_tier_preference` instead.
+
+[discrete]
+[[assign-data-tier]]
+=== Assign data nodes to a data tier
+
+Configure the appropriate roles for each data node to assign it to one or more
+data tiers: `data_hot`, `data_content`, `data_warm`, `data_cold`, or `data_frozen`.
+A node can also have other <<modules-node,roles>>. By default, new nodes are
+configured with all roles.
+
+When you add a data tier to an {ess} deployment,
+new nodes are automatically assigned to the tier.
+To change the role of an existing node in an {ess} deployment, use the
+{cloud}/ec-api-deployment-crud.html#ec_update_a_deployment[Update deployment API].
+Replace the node's `node_type` configuration with the appropriate `node_roles`.
+For example, the following configuration adds the node to the hot and content
+tiers, and enables it to act as an ingest node, remote, and transform node.
+
+[source,yaml]
+----
+"node_roles": [
+  "data_hot",
+  "data_content",
+  "ingest",
+  "remote_cluster_client",
+  "transform"
+],
+----
+
+If you are directly managing your own cluster,
+configure the appropriate roles for each node in `elasticsearch.yml`.
+For example, the following setting configures a node to be a data-only
+node in the hot and content tiers.
+
+[source,yaml]
+----
+node.roles [ data_hot, data_content ]
+----
+
+[discrete]
+[[remove-custom-allocation-settings]]
+=== Remove custom allocation settings from your {ilm-init} policy
+
+Update the allocate action for each phase to remove the attribute-based
+allocation settings. If the allocate action does not set the number of replicas,
+remove the allocate action entirely. (An empty allocate action is invalid.)
+
+IMPORTANT: The policy must specify the corresponding phase for each data tier in
+your architecture.
+For example, if you enable the warm and cold data tiers for a deployment, your
+policy must include the hot, warm, and cold phases.
+This is necessary for {ilm-init} to automatically inject the <<ilm-migrate,
+migrate>> action to move indices through the data tiers,
+even if you don't need to perform any other actions and the phase is empty.
+
+[discrete]
+[[stop-setting-custom-hot-attribute]]
+=== Stop setting the custom hot attribute on new indices
+
+When you create a data stream, its first backing index
+is now automatically assigned to `data_hot` nodes.
+Similarly, when you directly create an index, it
+is automatically assigned to `data_content` nodes.
+
+On {ess} deployments, remove the `cloud-hot-warm-allocation-0` index template
+that set the hot shard allocation attribute on all indices.
+
+[source,console]
+----
+DELETE _template/.cloud-hot-warm-allocation-0
+----
+
+If you're using a custom index template, update it to remove the node attribute
+you used to assign new indices to the hot tier.
+
+[discrete]
+[[set-tier-preference]]
+=== Set a tier preference for existing indices.
+
+{ilm-init} automatically transitions managed indices through the available
+data tiers by automatically injecting a <<ilm-migrate,migrate action>>
+into each phase.
+
+To enable {ilm-init} to move an _existing_ managed index
+through the data tiers, update the index settings to:
+
+. Remove the custom allocation filter by setting it to `null`.
+. Set the `_tier_preference`.
+
+For example, if your old template set the `data` attribute to `hot`
+to allocate shards to the hot tier, set the `data` attribute to `null`
+and set the `_tier_preference` to `data_hot`.
 
 ////
 [source,console]
---------------------------------------------------
+----
 PUT /my-index-000001/_settings
 {
   "index.routing.allocation.require.data": "hot"
 }
---------------------------------------------------
-// TEST[setup:my_index]
-
+----
 ////
 
 [source,console]
---------------------------------------------------
+----
 PUT my-index-000001/_settings
 {
   "index.routing.allocation.require.data": null,
   "index.routing.allocation.include._tier_preference": "data_hot"
 
 }
---------------------------------------------------
+----
 // TEST[continued]

--- a/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
+++ b/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
@@ -133,7 +133,5 @@ PUT my-index-000001/_settings
 {
   "index.routing.allocation.require.data": null,
   "index.routing.allocation.include._tier_preference": "data_hot"
-
 }
 ----
-// TEST[continued]

--- a/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
+++ b/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
@@ -2,13 +2,17 @@
 [[migrate-index-allocation-filters]]
 == Migrate index allocation filters to node roles
 
-If you currently use custom node attributes and routing allocation filters to move indices
-through data tiers in a hot-warm-cold architecture, we recommend that you switch to using node roles.
-The built-in node roles enable {ilm-init} to automatically migrate indices between data tiers.
-You no longer need to explicitly invoke the allocate action in your {ilm-init} policies.
+If you currently use custom node attributes and
+<<<<shard-allocation-filtering, attribute-based allocation filters>> to move indices
+through data tiers in a hot-warm-cold architecture, we recommend that you switch to using
+the built-in node roles and automatic <<data-tier-shard-filtering, data tier allocation>>.
+Using node roles enables {ilm-init} to automatically move indices between data tiers.
+To modify the number of replicas as the index moves between tiers,
+you can specify an allocate action with no allocation filters.
 
-NOTE: While index allocation filters are no longer the best way to manage your data
-in a hot-warm-cold architecture, you can still use them to control shard allocation for other purposes.
+NOTE: While we recommend relying on automatic data tier allocation to manage your data
+in a hot-warm-cold architecture,
+you can still use attribute-based allocation filters to control shard allocation for other purposes.
 
 To switch to using node roles:
 
@@ -37,7 +41,7 @@ is automatically assigned to `data_content` nodes.
 The same nodes can serve both the `data_hot` and `data_content` roles.
 
 To enable {ilm} to automatically move _existing_ managed indices through the data tiers,
-you must remove the routing allocation filters from the indices.
+remove the routing allocation filters from the indices and set the `_tier_preference`.
 For example, if your old template set a `node-type` attribute to assign new indices to `hot-nodes`,
 set the value to `null` to remove the filter:
 
@@ -57,7 +61,9 @@ PUT /my-index-000001/_settings
 --------------------------------------------------
 PUT my-index-000001/_settings
 {
-  "index.routing.allocation.require.node-type": null
+  "index.routing.allocation.require.node-type": null,
+  "index.routing.allocation.include._tier_preference": "data_hot"
+
 }
 --------------------------------------------------
 // TEST[continued]

--- a/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
+++ b/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
@@ -124,9 +124,9 @@ and set the `_tier_preference` to `data_hot`.
 ////
 [source,console]
 ----
-PUT /my-index-000001
+PUT /my-index
 
-PUT /my-index-000001/_settings
+PUT /my-index/_settings
 {
   "index.routing.allocation.require.data": "hot"
 }
@@ -135,7 +135,7 @@ PUT /my-index-000001/_settings
 
 [source,console]
 ----
-PUT my-index-000001/_settings
+PUT my-index/_settings
 {
   "index.routing.allocation.require.data": null,
   "index.routing.allocation.include._tier_preference": "data_hot"
@@ -151,7 +151,7 @@ already in the warm phase.
 
 [source,console]
 ----
-PUT my-index-000001/_settings
+PUT my-index/_settings
 {
   "index.routing.allocation.require.data": null,
   "index.routing.allocation.include._tier_preference": "data_warm,data_hot"

--- a/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
+++ b/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
@@ -12,22 +12,52 @@ in a hot-warm-cold architecture, you can still use them to control shard allocat
 
 To switch to using node roles:
 
-. Assign your nodes to the appropriate data tier using the `data_hot`, `data_warm`,
-`data_cold`, and `data_frozen` roles.
-When you add a data tier to an {ess} deployment, this is done automatically.
+. Assign your nodes to the appropriate <<data-tiers, data tier>> using the
+`data_hot`, `data_content`, `data_warm`, `data_cold`, and `data_frozen` roles.
+When you add a data tier to an {ess} deployment,
+nodes are automatically assigned to the tier.
 You can change the role of an existing node in an {ess} deployment with the
 {cloud}/ec-api-deployment-crud.html#ec_update_a_deployment[Update deployment API].
 If you are directly managing your own cluster,
 configure the appropriate data role for each node in `elasticsearch.yml`.
 . Update your {ilm-init} policy to:
-.. Remove the {ilm-init} allocate action from each phase in your index lifecycle policy.
+.. Remove the attribute-based allocation settings From the {ilm-init}
+allocate action in each phase, or remove the allocate action entirely
+if it does not set the number of replicas. (An empty allocate action is invalid.)
 .. Ensure the policy specifies the corresponding phase for each data tier in your architecture.
 For example, if you enable the warm and cold data tiers for a deployment, your policy must
 include the hot, warm, and cold phases.
-This is necessary for {ilm-init} to automatically move indices through the data tiers,
+This is necessary for {ilm-init} to automatically inject the <<ilm-migrate, migrate>> action
+to move indices through the data tiers,
 even if you don't need to perform any other actions and the phase is empty.
 . Update your index template to remove the custom node attribute you used to assign new indices
-to the hot tier. New indices are automatically assigned to `data_content` nodes, and new backing
-indices for data streams are automatically assigned to `data_hot` nodes.
-. To enable {ilm} to automatically move existing managed indices through the data tiers,
-remove your routing allocation filters from those indices.
+to the hot tier. Going forward, when you create a data stream, its first backing index is automatically
+assigned to `data_hot` nodes. Similarly, when you directly create an index, it
+is automatically assigned to `data_content` nodes.
+The same nodes can serve both the `data_hot` and `data_content` roles.
+
+To enable {ilm} to automatically move _existing_ managed indices through the data tiers,
+you must remove the routing allocation filters from the indices.
+For example, if your old template set a `node-type` attribute to assign new indices to `hot-nodes`,
+set the value to `null` to remove the filter:
+
+////
+[source,console]
+--------------------------------------------------
+PUT /my-index-000001/_settings
+{
+  "index.routing.allocation.require.node-type": "hot-nodes"
+}
+--------------------------------------------------
+// TEST[setup:my_index]
+
+////
+
+[source,console]
+--------------------------------------------------
+PUT my-index-000001/_settings
+{
+  "index.routing.allocation.require.node-type": null
+}
+--------------------------------------------------
+// TEST[continued]

--- a/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
+++ b/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
@@ -124,6 +124,8 @@ and set the `_tier_preference` to `data_hot`.
 ////
 [source,console]
 ----
+PUT /my-index-000001
+
 PUT /my-index-000001/_settings
 {
   "index.routing.allocation.require.data": "hot"

--- a/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
+++ b/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
@@ -1,0 +1,33 @@
+[role="xpack"]
+[[migrate-index-allocation-filters]]
+== Migrate index allocation filters to node roles
+
+If you currently use custom node attributes and routing allocation filters to move indices
+through data tiers in a hot-warm-cold architecture, we recommend that you switch to using node roles.
+The built-in node roles enable {ilm-init} to automatically migrate indices between data tiers.
+You no longer need to explicitly invoke the allocate action in your {ilm-init} policies.
+
+NOTE: While index allocation filters are no longer the best way to manage your data
+in a hot-warm-cold architecture, you can still use them to control shard allocation for other purposes.
+
+To switch to using node roles:
+
+. Assign your nodes to the appropriate data tier using the `data_hot`, `data_warm`,
+`data_cold`, and `data_frozen` roles.
+When you add a data tier to an {ess} deployment, this is done automatically.
+You can change the role of an existing node in an {ess} deployment with the
+{cloud}/ec-api-deployment-crud.html#ec_update_a_deployment[Update deployment API].
+If you are directly managing your own cluster,
+configure the appropriate data role for each node in `elasticsearch.yml`.
+. Update your {ilm-init} policy to:
+.. Remove the {ilm-init} allocate action from each phase in your index lifecycle policy.
+.. Ensure the policy specifies the corresponding phase for each data tier in your architecture.
+For example, if you enable the warm and cold data tiers for a deployment, your policy must
+include the hot, warm, and cold phases.
+This is necessary for {ilm-init} to automatically move indices through the data tiers,
+even if you don't need to perform any other actions and the phase is empty.
+. Update your index template to remove the custom node attribute you used to assign new indices
+to the hot tier. New indices are automatically assigned to `data_content` nodes, and new backing
+indices for data streams are automatically assigned to `data_hot` nodes.
+. To enable {ilm} to automatically move existing managed indices through the data tiers,
+remove your routing allocation filters from those indices.

--- a/docs/reference/ilm/index.asciidoc
+++ b/docs/reference/ilm/index.asciidoc
@@ -5,23 +5,23 @@
 
 [partintro]
 --
-You can configure {ilm} ({ilm-init}) policies to automatically manage indices 
-according to your performance, resiliency, and retention requirements. 
+You can configure {ilm} ({ilm-init}) policies to automatically manage indices
+according to your performance, resiliency, and retention requirements.
 For example, you could use {ilm-init} to:
 
 * Spin up a new index when an index reaches a certain size or number of documents
 * Create a new index each day, week, or month and archive previous ones
 * Delete stale indices to enforce data retention standards
- 
+
 You can create and manage index lifecycle policies through {kib} Management or the {ilm-init} APIs.
-When you enable {ilm} for {beats} or the {ls} {es} output plugin, 
+When you enable {ilm} for {beats} or the {ls} {es} output plugin,
 default policies are configured automatically.
 
 [role="screenshot"]
 image:images/ilm/index-lifecycle-policies.png[]
 
 [TIP]
-To automatically back up your indices and manage snapshots, 
+To automatically back up your indices and manage snapshots,
 use <<getting-started-snapshot-lifecycle-management,snapshot lifecycle policies>>.
 
 * <<overview-index-lifecycle-management>>
@@ -29,6 +29,7 @@ use <<getting-started-snapshot-lifecycle-management,snapshot lifecycle policies>
 * <<getting-started-index-lifecycle-management>>
 * <<example-using-index-lifecycle-policy>>
 * <<set-up-lifecycle-policy>>
+* <<migrate-index-allocation-filters>>
 * <<index-lifecycle-error-handling>>
 * <<start-stop-ilm>>
 * <<ilm-with-existing-indices>>
@@ -49,6 +50,8 @@ include::example-index-lifecycle-policy.asciidoc[leveloffset=-1]
 include::ilm-actions.asciidoc[]
 
 include::set-up-lifecycle-policy.asciidoc[]
+
+include::../data-management/migrate-index-allocation-filters.asciidoc[]
 
 include::error-handling.asciidoc[]
 


### PR DESCRIPTION
Closes https://github.com/elastic/elasticsearch/issues/65855

Preview: https://elasticsearch_71160.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/migrate-index-allocation-filters.html

In addition to the basic steps outlined here:

- Are there upgrade/order implications that need to be called out, other than you should complete the upgrade before modifying the node roles, policies, and templates?

- What is necessary on cloud deployments wrt template changes? Do they need to remove the old default template?

- Are there any interactions with autoscaling or restores that need to be called out?