### PR TITLE
Fix ML preview datafeed rest API spec

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.preview_datafeed.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.preview_datafeed.json
@@ -14,8 +14,7 @@
         {
           "path":"/_ml/datafeeds/{datafeed_id}/_preview",
           "methods":[
-            "GET",
-            "POST"
+            "GET"
           ],
           "parts":{
             "datafeed_id":{
@@ -27,8 +26,7 @@
         {
           "path":"/_ml/datafeeds/_preview",
           "methods":[
-            "GET",
-            "POST"
+            "GET"
           ]
         }
       ]


### PR DESCRIPTION
I noticed that the .NET client YAML tests for 7.x were failing when our test runner picked `POST` from the API spec as the method to use. This is rejected by the server as not supported and recommends `GET`. This aligns with the documentation that only lists `GET` for this endpoint.

I believe this will also need a backport to `7.x`.