### PR TITLE
Fix Snapshot Cleanup Tool Base Path for 3rd Party Tests

### DIFF
--- a/x-pack/snapshot-tool/qa/google-cloud-storage/build.gradle
+++ b/x-pack/snapshot-tool/qa/google-cloud-storage/build.gradle
@@ -31,7 +31,7 @@ if (!gcsServiceAccount && !gcsBucket && !gcsBasePath) {
   gcsServiceAccount = new File(project(':plugins:repository-gcs').buildDir,
     'generated-resources/service_account_test.json').path
   gcsBucket = 'bucket_test'
-  gcsBasePath = 'integration_test'
+  gcsBasePath = null
 
   useGCSFixture = true
 } else if (!gcsServiceAccount || !gcsBucket || !gcsBasePath) {
@@ -48,7 +48,7 @@ task gcsThirdPartyTest(type: Test) {
   systemProperty 'tests.security.manager', false
 
   systemProperty 'test.google.bucket', gcsBucket
-  systemProperty 'test.google.base', gcsBasePath
+  nonInputProperties.systemProperty 'test.google.base', gcsBasePath ? gcsBasePath + "_snapshot_tool_tests" + BuildParams.testSeed : 'base_path'
   nonInputProperties.systemProperty 'test.google.account', "${-> encodedCredentials.call()}"
 }
 

--- a/x-pack/snapshot-tool/qa/s3/build.gradle
+++ b/x-pack/snapshot-tool/qa/s3/build.gradle
@@ -4,6 +4,8 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import org.elasticsearch.gradle.info.BuildParams
+
 apply plugin: 'elasticsearch.build'
 
 dependencies {
@@ -26,7 +28,7 @@ if (!s3PermanentAccessKey && !s3PermanentSecretKey && !s3PermanentBucket && !s3P
   s3PermanentAccessKey = 'sn_tool_access_key'
   s3PermanentSecretKey = 'sn_tool_secret_key'
   s3PermanentBucket = 'bucket'
-  s3PermanentBasePath = 'integration_test'
+  s3PermanentBasePath = null
 
   useS3Fixture = true
 } else if (!s3PermanentAccessKey || !s3PermanentSecretKey || !s3PermanentBucket || !s3PermanentBasePath) {
@@ -41,7 +43,7 @@ task s3ThirdPartyTest(type: Test) {
   systemProperty 'test.s3.account', s3PermanentAccessKey
   systemProperty 'test.s3.key', s3PermanentSecretKey
   systemProperty 'test.s3.bucket', s3PermanentBucket
-  systemProperty 'test.s3.base', s3PermanentBasePath
+  nonInputProperties.systemProperty 'test.s3.base', s3PermanentBasePath ? s3PermanentBasePath + "_snapshot_tool_tests" + BuildParams.testSeed : 'base_path'
 }
 
 if (useS3Fixture) {


### PR DESCRIPTION
We were not randomizing these paths for the cleanup tool like we do for the repo plugins
and repo test kit tests. This commit aligns the behavior with the other two third party
tests to avoid collisions on CI.

Closes #70941
