### PR TITLE
Remove bogus assertion in CacheFile

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/common/CacheFile.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/common/CacheFile.java
@@ -365,7 +365,6 @@ public class CacheFile {
                     @Override
                     protected void doRun() throws Exception {
                         if (reference.tryIncRef() == false) {
-                            assert false : "expected a non-closed channel reference";
                             throw new AlreadyClosedException("Cache file channel has been released and closed");
                         }
                         try {

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/FrozenCacheService.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/FrozenCacheService.java
@@ -667,7 +667,6 @@ public class FrozenCacheService implements Releasable {
                         @Override
                         protected void doRun() throws Exception {
                             if (CacheFileRegion.this.tryIncRef() == false) {
-                                // assert false : "expected a non-closed channel reference";
                                 throw new AlreadyClosedException("Cache file channel has been released and closed");
                             }
                             try {


### PR DESCRIPTION
There's a bogus assertion in CacheFile that expects a channel to be available whenever we continue writing to it. In case where the range listener does not care about the write anymore (i.e. all reads are ok), it does not continues to hold onto the file, however, which is ok. 

Closes #71083