### PR TITLE
[ML] Do not create ML annotations index in upgrade mode

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/SetUpgradeModeAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/SetUpgradeModeAction.java
@@ -31,7 +31,7 @@ public class SetUpgradeModeAction extends ActionType<AcknowledgedResponse> {
 
     public static class Request extends AcknowledgedRequest<Request> implements ToXContentObject {
 
-        private boolean enabled;
+        private final boolean enabled;
 
         private static final ParseField ENABLED = new ParseField("enabled");
         public static final ConstructingObjectParser<Request, Void> PARSER =

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/AnnotationIndexIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/AnnotationIndexIT.java
@@ -7,18 +7,27 @@
 package org.elasticsearch.xpack.ml.integration;
 
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.action.search.SearchPhaseExecutionException;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.xpack.core.XPackSettings;
+import org.elasticsearch.xpack.core.ml.action.SetResetModeAction;
+import org.elasticsearch.xpack.core.ml.action.SetUpgradeModeAction;
 import org.elasticsearch.xpack.core.ml.annotations.AnnotationIndex;
 import org.elasticsearch.xpack.ml.MlSingleNodeTestCase;
 import org.elasticsearch.xpack.ml.notifications.AnomalyDetectionAuditor;
 import org.junit.Before;
 
+import java.util.Collections;
 import java.util.List;
 
 import static org.hamcrest.Matchers.is;
@@ -59,6 +68,57 @@ public class AnnotationIndexIT extends MlSingleNodeTestCase {
             assertTrue(annotationsIndexExists());
             assertEquals(2, numberOfAnnotationsAliases());
         });
+    }
+
+    public void testNotCreatedWhenAfterOtherMlIndexAndUpgradeInProgress() throws Exception {
+
+        client().execute(SetUpgradeModeAction.INSTANCE, new SetUpgradeModeAction.Request(true)).actionGet();
+
+        try {
+            AnomalyDetectionAuditor auditor = new AnomalyDetectionAuditor(client(), getInstanceFromNode(ClusterService.class));
+            auditor.info("whatever", "blah");
+
+            // Creating a document in the .ml-notifications-000001 index would normally cause .ml-annotations
+            // to be created, but in this case it shouldn't as we're doing an upgrade
+
+            assertBusy(() -> {
+                try {
+                    SearchResponse response = client().search(new SearchRequest(".ml-notifications*")).actionGet();
+                    assertEquals(1, response.getHits().getHits().length);
+                } catch (SearchPhaseExecutionException e) {
+                    throw new AssertionError("Notifications index exists but shards not yet ready - continuing busy wait", e);
+                }
+                assertFalse(annotationsIndexExists());
+                assertEquals(0, numberOfAnnotationsAliases());
+            });
+        } finally {
+            client().execute(SetUpgradeModeAction.INSTANCE, new SetUpgradeModeAction.Request(false)).actionGet();
+        }
+    }
+
+    public void testNotCreatedWhenAfterOtherMlIndexAndResetInProgress() throws Exception {
+
+        client().execute(SetResetModeAction.INSTANCE, SetResetModeAction.Request.enabled()).actionGet();
+
+        try {
+
+            IndexRequest stateDoc = new IndexRequest(".ml-state");
+            stateDoc.source(Collections.singletonMap("state", "blah"));
+            IndexResponse indexResponse = client().index(stateDoc).actionGet();
+            assertEquals(RestStatus.CREATED, indexResponse.status());
+
+            // Creating the .ml-state index would normally cause .ml-annotations
+            // to be created, but in this case it shouldn't as we're doing a reset
+
+            assertBusy(() -> {
+                SearchResponse response = client().search(new SearchRequest(".ml-state")).actionGet();
+                assertEquals(1, response.getHits().getHits().length);
+                assertFalse(annotationsIndexExists());
+                assertEquals(0, numberOfAnnotationsAliases());
+            });
+        } finally {
+            client().execute(SetResetModeAction.INSTANCE, SetResetModeAction.Request.disabled()).actionGet();
+        }
     }
 
     private boolean annotationsIndexExists() {


### PR DESCRIPTION
The ML annotations index is created automatically as soon as
any other ML index is created. It's done this way so that the
ML UI can index into it as soon as ML is being used, but the
index is owned by the backend.

However, if it's detected that the annotations index needs to
be created when upgrade mode is enabled then we shouldn't
instantly create it, as we may be fighting against a user
trying to repair the index in some way.

Additionally, the annotations index should not be created
during a feature reset. Doing this could fight against the
reset process if the annotations index happened to get removed
before some other ML index but then immediately got added back.
(We get away with this at the moment as there is custom test
cleanup code to ensure .ml-annotations is deleted after other
ML indices, but we want ML feature reset to completely and
robustly replace custom ML test cleanup.)