### PR TITLE
[ML] fix test failure from issue #71150

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlNativeIntegTestCase.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlNativeIntegTestCase.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.ml.integration;
 
 import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksRequest;
+import org.elasticsearch.action.support.DestructiveOperations;
 import org.elasticsearch.cluster.NamedDiff;
 import org.elasticsearch.xpack.autoscaling.Autoscaling;
 import org.elasticsearch.xpack.autoscaling.AutoscalingMetadata;
@@ -165,6 +166,7 @@ abstract class MlNativeIntegTestCase extends ESIntegTestCase {
 
         Settings.Builder builder = Settings.builder();
         builder.putList("node.roles", Collections.emptyList());
+        builder.put(DestructiveOperations.REQUIRES_NAME_SETTING.getKey(), false);
         builder.put(NetworkModule.TRANSPORT_TYPE_KEY, SecurityField.NAME4);
         builder.put(XPackSettings.MACHINE_LEARNING_ENABLED.getKey(), true);
         builder.put(XPackSettings.SECURITY_ENABLED.getKey(), true);

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/TestFeatureResetIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/TestFeatureResetIT.java
@@ -61,7 +61,6 @@ public class TestFeatureResetIT extends MlNativeAutodetectIntegTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/71150")
     public void testMLFeatureReset() throws Exception {
         startRealtime("feature_reset_anomaly_job");
         startDataFrameJob("feature_reset_data_frame_analytics_job");


### PR DESCRIPTION
Recently merged was a change that modified the default value of: `action.destructive_requires_name` to `true`.

The original merge was fairly careful to adjust all the test clusters to account for the default value change.

However, the machine learning test runner was missed. We create custom node settings and thus require
the handling of the default value change.

relates to https://github.com/elastic/elasticsearch/issues/71150