### PR TITLE
Optimize BytesReferenceStreamInput Number Reads

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/Numbers.java
+++ b/server/src/main/java/org/elasticsearch/common/Numbers.java
@@ -24,12 +24,24 @@ public final class Numbers {
     private Numbers() {
     }
 
+    public static short bytesToShort(byte[] bytes, int offset) {
+        return (short) (((bytes[offset] & 0xFF) << 8) | (bytes[offset + 1] & 0xFF));
+    }
+
+    public static int bytesToInt(byte[] bytes, int offset) {
+        return ((bytes[offset] & 0xFF) << 24) | ((bytes[offset + 1] & 0xFF) << 16) | ((bytes[offset + 2] & 0xFF) << 8)
+                | (bytes[offset + 3] & 0xFF);
+    }
+
+    public static long bytesToLong(byte[] bytes, int offset) {
+        return (((long) (((bytes[offset] & 0xFF) << 24) | ((bytes[offset + 1] & 0xFF) << 16) | ((bytes[offset + 2] & 0xFF) << 8)
+                | (bytes[offset + 3] & 0xFF))) << 32)
+                | ((((bytes[offset + 4] & 0xFF) << 24) | ((bytes[offset + 5] & 0xFF) << 16) | ((bytes[offset + 6] & 0xFF) << 8)
+                | (bytes[offset + 7] & 0xFF)) & 0xFFFFFFFFL);
+    }
+
     public static long bytesToLong(BytesRef bytes) {
-        int high = (bytes.bytes[bytes.offset + 0] << 24) | ((bytes.bytes[bytes.offset + 1] & 0xff) << 16) |
-            ((bytes.bytes[bytes.offset + 2] & 0xff) << 8) | (bytes.bytes[bytes.offset + 3] & 0xff);
-        int low = (bytes.bytes[bytes.offset + 4] << 24) | ((bytes.bytes[bytes.offset + 5] & 0xff) << 16) |
-            ((bytes.bytes[bytes.offset + 6] & 0xff) << 8) | (bytes.bytes[bytes.offset + 7] & 0xff);
-        return (((long) high) << 32) | (low & 0x0ffffffffL);
+        return bytesToLong(bytes.bytes, bytes.offset);
     }
 
     public static byte[] intToBytes(int val) {

--- a/server/src/main/java/org/elasticsearch/common/bytes/BytesReferenceStreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/BytesReferenceStreamInput.java
@@ -10,6 +10,7 @@ package org.elasticsearch.common.bytes;
 
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefIterator;
+import org.elasticsearch.common.Numbers;
 import org.elasticsearch.common.io.stream.StreamInput;
 
 import java.io.EOFException;
@@ -40,11 +41,41 @@ class BytesReferenceStreamInput extends StreamInput {
 
     @Override
     public byte readByte() throws IOException {
-        if (offset() >= bytesReference.length()) {
-            throw new EOFException();
-        }
         maybeNextSlice();
         return slice.bytes[slice.offset + (sliceIndex++)];
+    }
+
+    @Override
+    public short readShort() throws IOException {
+        if (slice.length - sliceIndex >= 2) {
+            sliceIndex += 2;
+            return Numbers.bytesToShort(slice.bytes, slice.offset + sliceIndex - 2);
+        } else {
+            // slow path
+            return super.readShort();
+        }
+    }
+
+    @Override
+    public int readInt() throws IOException {
+        if (slice.length - sliceIndex >= 4) {
+            sliceIndex += 4;
+            return Numbers.bytesToInt(slice.bytes, slice.offset + sliceIndex - 4);
+        } else {
+            // slow path
+            return super.readInt();
+        }
+    }
+
+    @Override
+    public long readLong() throws IOException {
+        if (slice.length - sliceIndex >= 8) {
+            sliceIndex += 8;
+            return Numbers.bytesToLong(slice.bytes, slice.offset + sliceIndex - 8);
+        } else {
+            // slow path
+            return super.readLong();
+        }
     }
 
     protected int offset() {
@@ -52,14 +83,22 @@ class BytesReferenceStreamInput extends StreamInput {
     }
 
     private void maybeNextSlice() throws IOException {
-        while (sliceIndex == slice.length) {
-            sliceStartOffset += sliceIndex;
-            slice = iterator.next();
-            sliceIndex = 0;
-            if (slice == null) {
-                throw new EOFException();
-            }
+        if (sliceIndex == slice.length) {
+            moveToNextSlice();
         }
+    }
+
+    private void moveToNextSlice() throws IOException {
+        slice = iterator.next();
+        while (slice != null && slice.length == 0) {
+            // rare corner case of a bytes reference that has a 0-length component
+            slice = iterator.next();
+        }
+        if (slice == null) {
+            throw new EOFException();
+        }
+        sliceStartOffset += sliceIndex;
+        sliceIndex = 0;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/common/bytes/BytesReferenceStreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/BytesReferenceStreamInput.java
@@ -84,6 +84,7 @@ class BytesReferenceStreamInput extends StreamInput {
 
     private void maybeNextSlice() throws IOException {
         if (sliceIndex == slice.length) {
+            // moveToNextSlice is intentionally extracted to another method since it's the assumed cold-path
             moveToNextSlice();
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/translog/BufferedChecksumStreamInput.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/BufferedChecksumStreamInput.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.index.translog;
 
 import org.apache.lucene.store.BufferedChecksum;
+import org.elasticsearch.common.Numbers;
 import org.elasticsearch.common.io.stream.FilterStreamInput;
 import org.elasticsearch.common.io.stream.StreamInput;
 
@@ -65,22 +66,21 @@ public final class BufferedChecksumStreamInput extends FilterStreamInput {
     public short readShort() throws IOException {
         final byte[] buf = buffer.get();
         readBytes(buf, 0, 2);
-        return (short) (((buf[0] & 0xFF) << 8) | (buf[1] & 0xFF));
+        return Numbers.bytesToShort(buf, 0);
     }
 
     @Override
     public int readInt() throws IOException {
         final byte[] buf = buffer.get();
         readBytes(buf, 0, 4);
-        return ((buf[0] & 0xFF) << 24) | ((buf[1] & 0xFF) << 16) | ((buf[2] & 0xFF) << 8) | (buf[3] & 0xFF);
+        return Numbers.bytesToInt(buf, 0);
     }
 
     @Override
     public long readLong() throws IOException {
         final byte[] buf = buffer.get();
         readBytes(buf, 0, 8);
-        return (((long) (((buf[0] & 0xFF) << 24) | ((buf[1] & 0xFF) << 16) | ((buf[2] & 0xFF) << 8) | (buf[3] & 0xFF))) << 32)
-            | ((((buf[4] & 0xFF) << 24) | ((buf[5] & 0xFF) << 16) | ((buf[6] & 0xFF) << 8) | (buf[7] & 0xFF)) & 0xFFFFFFFFL);
+        return Numbers.bytesToLong(buf, 0);
     }
 
     @Override


### PR DESCRIPTION
`readByte` was used for all primitive reads which via the expensive `maybeNextSlice`
which did not inline well caused slowness when reading large aggregate messages.

This commit makes these reads do bulk operations on the underlying `byte[]` where possible
instead. Also, it extracts cold path from `maybeNextSlice` so that we get a fast bounds check
branch instead of the loop with a large body for the hot case.

closes #70800
