### PR TITLE
[ML] restore old ml.find_file_structure.json spec

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.find_file_structure.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.find_file_structure.json
@@ -1,0 +1,101 @@
+{
+  "ml.find_file_structure":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/find-structure.html",
+      "description":"Finds the structure of a text file. The text file must contain data that is suitable to be ingested into Elasticsearch."
+    },
+    "stability":"experimental",
+    "visibility":"public",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/x-ndjson"]
+    },
+    "url":{
+      "paths":[
+        {
+          "path":"/_ml/find_file_structure",
+          "methods":[
+            "POST"
+          ],
+          "deprecated":{
+            "version":"7.12.0",
+            "description":"This endpoint has changed to _text_structure/find_structure, please use that API instead"
+          }
+        }
+      ]
+    },
+    "params":{
+      "lines_to_sample":{
+        "type":"int",
+        "description":"How many lines of the file should be included in the analysis",
+        "default":1000
+      },
+      "line_merge_size_limit":{
+        "type":"int",
+        "description":"Maximum number of characters permitted in a single message when lines are merged to create messages.",
+        "default":10000
+      },
+      "timeout":{
+        "type":"time",
+        "description":"Timeout after which the analysis will be aborted",
+        "default":"25s"
+      },
+      "charset":{
+        "type":"string",
+        "description":"Optional parameter to specify the character set of the file"
+      },
+      "format":{
+        "type":"enum",
+        "options":[
+          "ndjson",
+          "xml",
+          "delimited",
+          "semi_structured_text"
+        ],
+        "description":"Optional parameter to specify the high level file format"
+      },
+      "has_header_row":{
+        "type":"boolean",
+        "description":"Optional parameter to specify whether a delimited file includes the column names in its first row"
+      },
+      "column_names":{
+        "type":"list",
+        "description":"Optional parameter containing a comma separated list of the column names for a delimited file"
+      },
+      "delimiter":{
+        "type":"string",
+        "description":"Optional parameter to specify the delimiter character for a delimited file - must be a single character"
+      },
+      "quote":{
+        "type":"string",
+        "description":"Optional parameter to specify the quote character for a delimited file - must be a single character"
+      },
+      "should_trim_fields":{
+        "type":"boolean",
+        "description":"Optional parameter to specify whether the values between delimiters in a delimited file should have whitespace trimmed from them"
+      },
+      "grok_pattern":{
+        "type":"string",
+        "description":"Optional parameter to specify the Grok pattern that should be used to extract fields from messages in a semi-structured text file"
+      },
+      "timestamp_field":{
+        "type":"string",
+        "description":"Optional parameter to specify the timestamp field in the file"
+      },
+      "timestamp_format":{
+        "type":"string",
+        "description":"Optional parameter to specify the timestamp format in the file - may be either a Joda or Java time format"
+      },
+      "explain":{
+        "type":"boolean",
+        "description":"Whether to include a commentary on how the structure was derived",
+        "default":false
+      }
+    },
+    "body":{
+      "description":"The contents of the file to be analyzed",
+      "required":true,
+      "serialize":"bulk"
+    }
+  }
+}


### PR DESCRIPTION
We should keep specs in line with APIs that actually exist. Since the old endpoint is still around (even though experimental), the spec should remain.

relates to: https://github.com/elastic/elasticsearch/issues/70862