### PR TITLE
[DOCS] Add ECS and runtime fields tip to data stream tutorial

### DIFF
--- a/docs/reference/data-streams/set-up-a-data-stream.asciidoc
+++ b/docs/reference/data-streams/set-up-a-data-stream.asciidoc
@@ -102,6 +102,7 @@ with default options.
 ====
 Use the {ecs-ref}[Elastic Common Schema (ECS)] when mapping your fields. ECS
 fields integrate with several {stack} features by default.
+
 If you're unsure how to map your fields, use <<runtime-search-request,runtime
 fields>> to extract fields from <<mapping-unstructured-content,unstructured
 content>> at a search time. For example, you can index a log message to a

--- a/docs/reference/data-streams/set-up-a-data-stream.asciidoc
+++ b/docs/reference/data-streams/set-up-a-data-stream.asciidoc
@@ -105,7 +105,7 @@ fields integrate with several {stack} features by default.
 
 If you're unsure how to map your fields, use <<runtime-search-request,runtime
 fields>> to extract fields from <<mapping-unstructured-content,unstructured
-content>> at a search time. For example, you can index a log message to a
+content>> at search time. For example, you can index a log message to a
 `wildcard` field and later extract IP addresses and other data from this field
 during a search.
 ====

--- a/docs/reference/data-streams/set-up-a-data-stream.asciidoc
+++ b/docs/reference/data-streams/set-up-a-data-stream.asciidoc
@@ -98,6 +98,18 @@ with default options.
 
 * Your lifecycle policy in the `index.lifecycle.name` index setting.
 
+[TIP]
+====
+Use the {ecs-ref}[Elastic Common Schema (ECS)] when mapping your fields. ECS
+fields integrate with several {stack} features by default.
+
+If you're unsure how to map your fields, use <<runtime-search-request,runtime
+fields>> to extract fields from <<mapping-unstructured-content,unstructured
+content>> at a search time. For example, you can index a log message to a
+`wildcard` field and later extract IP addresses and other data from this field
+during a search.
+====
+
 To create a component template in {kib}, open the main menu and go to *Stack
 Management > Index Management*. In the *Index Templates* view, click *Create a
 component template*.
@@ -189,11 +201,11 @@ PUT _index_template/my-index-template
 [[create-data-stream]]
 === Step 4. Create the data stream
 
-To automatically create the data stream, submit an
-<<add-documents-to-a-data-stream,indexing request>> that targets the stream's
-name. This name must match one of your index template's index patterns. The
-request must use an `op_type` of `create`. Documents must include a `@timestamp`
-field.
+<<add-documents-to-a-data-stream,Indexing requests>> add documents to a data
+stream. To automatically create the data stream, submit an indexing request that
+targets the stream's name. This name must match one of your index template's
+index patterns. The request must use an `op_type` of `create`. Documents must
+include a `@timestamp` field.
 
 [source,console]
 ----

--- a/docs/reference/data-streams/set-up-a-data-stream.asciidoc
+++ b/docs/reference/data-streams/set-up-a-data-stream.asciidoc
@@ -14,8 +14,8 @@ You can also <<convert-index-alias-to-data-stream,convert an index alias to
 a data stream>>.
 
 IMPORTANT: If you use {fleet} or {agent}, skip this tutorial. {fleet} and
-{agent} set up data streams for you. See {fleet-guide}/data-streams.html[Data
-streams] in the {fleet} Guide.
+{agent} set up data streams for you. See {fleet}'s
+{fleet-guide}/data-streams.html[data streams] documentation.
 
 [discrete]
 [[create-index-lifecycle-policy]]
@@ -102,7 +102,6 @@ with default options.
 ====
 Use the {ecs-ref}[Elastic Common Schema (ECS)] when mapping your fields. ECS
 fields integrate with several {stack} features by default.
-
 If you're unsure how to map your fields, use <<runtime-search-request,runtime
 fields>> to extract fields from <<mapping-unstructured-content,unstructured
 content>> at a search time. For example, you can index a log message to a
@@ -202,10 +201,12 @@ PUT _index_template/my-index-template
 === Step 4. Create the data stream
 
 <<add-documents-to-a-data-stream,Indexing requests>> add documents to a data
-stream. To automatically create the data stream, submit an indexing request that
+stream. These requests must use an `op_type` of `create`. Documents must include
+a `@timestamp` field.
+
+To automatically create your data stream, submit an indexing request that
 targets the stream's name. This name must match one of your index template's
-index patterns. The request must use an `op_type` of `create`. Documents must
-include a `@timestamp` field.
+index patterns.
 
 [source,console]
 ----


### PR DESCRIPTION
Adds a tip for ECS and runtime fields to the "Set up a data stream" tutorial.

At a later point, we can replace the tip with a link to a "How to map time series data" page that's yet to be written. 

### Preview
https://elasticsearch_71183.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/set-up-a-data-stream.html#create-component-templates