### PR TITLE
Setting to permit disabling of HTTP client stats

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -270,6 +270,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
             HttpTransportSettings.SETTING_HTTP_TCP_RECEIVE_BUFFER_SIZE,
             HttpTransportSettings.SETTING_HTTP_TRACE_LOG_INCLUDE,
             HttpTransportSettings.SETTING_HTTP_TRACE_LOG_EXCLUDE,
+            HttpTransportSettings.SETTING_HTTP_CLIENT_STATS_ENABLED,
             HierarchyCircuitBreakerService.USE_REAL_MEMORY_USAGE_SETTING,
             HierarchyCircuitBreakerService.TOTAL_CIRCUIT_BREAKER_LIMIT_SETTING,
             HierarchyCircuitBreakerService.FIELDDATA_CIRCUIT_BREAKER_LIMIT_SETTING,

--- a/server/src/main/java/org/elasticsearch/http/AbstractHttpServerTransport.java
+++ b/server/src/main/java/org/elasticsearch/http/AbstractHttpServerTransport.java
@@ -89,6 +89,7 @@ public abstract class AbstractHttpServerTransport extends AbstractLifecycleCompo
 
     private volatile long slowLogThresholdMs;
     protected volatile long lastClientStatsPruneTime;
+    private volatile boolean clientStatsEnabled;
 
     protected AbstractHttpServerTransport(Settings settings, NetworkService networkService, BigArrays bigArrays, ThreadPool threadPool,
                                           NamedXContentRegistry xContentRegistry, Dispatcher dispatcher, ClusterSettings clusterSettings) {
@@ -117,6 +118,8 @@ public abstract class AbstractHttpServerTransport extends AbstractLifecycleCompo
         clusterSettings.addSettingsUpdateConsumer(TransportSettings.SLOW_OPERATION_THRESHOLD_SETTING,
                 slowLogThreshold -> this.slowLogThresholdMs = slowLogThreshold.getMillis());
         slowLogThresholdMs = TransportSettings.SLOW_OPERATION_THRESHOLD_SETTING.get(settings).getMillis();
+        clusterSettings.addSettingsUpdateConsumer(HttpTransportSettings.SETTING_HTTP_CLIENT_STATS_ENABLED, this::enableClientStats);
+        clientStatsEnabled = HttpTransportSettings.SETTING_HTTP_CLIENT_STATS_ENABLED.get(settings);
     }
 
     @Override
@@ -145,7 +148,7 @@ public abstract class AbstractHttpServerTransport extends AbstractLifecycleCompo
      * @param throttled When true, executes the prune process only if more than 60 seconds has elapsed since the last execution.
      */
     void pruneClientStats(boolean throttled) {
-        if (throttled == false || (threadPool.relativeTimeInMillis() - lastClientStatsPruneTime > PRUNE_THROTTLE_INTERVAL)) {
+        if (clientStatsEnabled && throttled == false || (threadPool.relativeTimeInMillis() - lastClientStatsPruneTime > PRUNE_THROTTLE_INTERVAL)) {
             long nowMillis = threadPool.absoluteTimeInMillis();
             for (var statsEntry : httpChannelStats.entrySet()) {
                 long closedTimeMillis = statsEntry.getValue().closedTimeMillis;
@@ -154,6 +157,17 @@ public abstract class AbstractHttpServerTransport extends AbstractLifecycleCompo
                 }
             }
             lastClientStatsPruneTime = threadPool.relativeTimeInMillis();
+        }
+    }
+
+    /**
+     * Enables or disables collection of HTTP client stats.
+     */
+    void enableClientStats(boolean enabled) {
+        this.clientStatsEnabled = enabled;
+        if (enabled == false) {
+            // when disabling, immediately clear client stats
+            httpChannelStats.clear();
         }
     }
 
@@ -322,27 +336,32 @@ public abstract class AbstractHttpServerTransport extends AbstractLifecycleCompo
     }
 
     private HttpStats.ClientStats addClientStats(final HttpChannel httpChannel) {
-        final HttpStats.ClientStats clientStats;
-        if (httpChannel != null) {
-            clientStats = new HttpStats.ClientStats(threadPool.absoluteTimeInMillis());
-            httpChannelStats.put(HttpStats.ClientStats.getChannelKey(httpChannel), clientStats);
-            httpChannel.addCloseListener(ActionListener.wrap(() -> {
-                try {
-                    httpChannels.remove(httpChannel);
-                    HttpStats.ClientStats disconnectedClientStats = httpChannelStats.get(HttpStats.ClientStats.getChannelKey(httpChannel));
-                    if (disconnectedClientStats != null) {
-                        disconnectedClientStats.closedTimeMillis = threadPool.absoluteTimeInMillis();
+        if (clientStatsEnabled) {
+            final HttpStats.ClientStats clientStats;
+            if (httpChannel != null) {
+                clientStats = new HttpStats.ClientStats(threadPool.absoluteTimeInMillis());
+                httpChannelStats.put(HttpStats.ClientStats.getChannelKey(httpChannel), clientStats);
+                httpChannel.addCloseListener(ActionListener.wrap(() -> {
+                    try {
+                        httpChannels.remove(httpChannel);
+                        HttpStats.ClientStats disconnectedClientStats =
+                            httpChannelStats.get(HttpStats.ClientStats.getChannelKey(httpChannel));
+                        if (disconnectedClientStats != null) {
+                            disconnectedClientStats.closedTimeMillis = threadPool.absoluteTimeInMillis();
+                        }
+                    } catch (Exception e) {
+                        // the listener code above should never throw
+                        logger.trace("error removing HTTP channel listener", e);
                     }
-                } catch (Exception e) {
-                    // the listener code above should never throw
-                    logger.trace("error removing HTTP channel listener", e);
-                }
-            }));
+                }));
+            } else {
+                clientStats = null;
+            }
+            pruneClientStats(true);
+            return clientStats;
         } else {
-            clientStats = null;
+            return null;
         }
-        pruneClientStats(true);
-        return clientStats;
     }
 
     /**
@@ -367,7 +386,7 @@ public abstract class AbstractHttpServerTransport extends AbstractLifecycleCompo
     }
 
     void updateClientStats(final HttpRequest httpRequest, final HttpChannel httpChannel) {
-        if (httpChannel != null) {
+        if (clientStatsEnabled && httpChannel != null) {
             HttpStats.ClientStats clientStats = httpChannelStats.get(HttpStats.ClientStats.getChannelKey(httpChannel));
             if (clientStats == null) {
                 // will always return a non-null value when httpChannel is non-null

--- a/server/src/main/java/org/elasticsearch/http/AbstractHttpServerTransport.java
+++ b/server/src/main/java/org/elasticsearch/http/AbstractHttpServerTransport.java
@@ -148,7 +148,8 @@ public abstract class AbstractHttpServerTransport extends AbstractLifecycleCompo
      * @param throttled When true, executes the prune process only if more than 60 seconds has elapsed since the last execution.
      */
     void pruneClientStats(boolean throttled) {
-        if (clientStatsEnabled && throttled == false || (threadPool.relativeTimeInMillis() - lastClientStatsPruneTime > PRUNE_THROTTLE_INTERVAL)) {
+        if (clientStatsEnabled && throttled == false ||
+            (threadPool.relativeTimeInMillis() - lastClientStatsPruneTime > PRUNE_THROTTLE_INTERVAL)) {
             long nowMillis = threadPool.absoluteTimeInMillis();
             for (var statsEntry : httpChannelStats.entrySet()) {
                 long closedTimeMillis = statsEntry.getValue().closedTimeMillis;

--- a/server/src/main/java/org/elasticsearch/http/HttpTransportSettings.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpTransportSettings.java
@@ -112,6 +112,9 @@ public final class HttpTransportSettings {
         Setting.listSetting("http.tracer.exclude",
             Collections.emptyList(), Function.identity(), Setting.Property.Dynamic, Setting.Property.NodeScope);
 
+    public static final Setting<Boolean> SETTING_HTTP_CLIENT_STATS_ENABLED =
+        boolSetting("http.client_stats.enabled", true, Property.Dynamic, Property.NodeScope);
+
     private HttpTransportSettings() {
     }
 }

--- a/server/src/test/java/org/elasticsearch/http/AbstractHttpServerTransportTests.java
+++ b/server/src/test/java/org/elasticsearch/http/AbstractHttpServerTransportTests.java
@@ -493,7 +493,91 @@ public class AbstractHttpServerTransportTests extends ESTestCase {
         }
     }
 
+    public void testDisablingHttpClientStats() {
+        final ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        try (
+            AbstractHttpServerTransport transport = new AbstractHttpServerTransport(Settings.EMPTY,
+                networkService,
+                bigArrays,
+                threadPool,
+                xContentRegistry(),
+                new HttpServerTransport.Dispatcher() {
+                    @Override public void dispatchRequest(RestRequest request, RestChannel channel, ThreadContext threadContext) {
+                        channel.sendResponse(emptyResponse(RestStatus.OK));
+                    }
 
+                    @Override public void dispatchBadRequest(RestChannel channel, ThreadContext threadContext, Throwable cause) {
+                        channel.sendResponse(emptyResponse(RestStatus.BAD_REQUEST));
+                    }
+                },
+                clusterSettings) {
+
+                @Override protected HttpServerChannel bind(InetSocketAddress hostAddress) {
+                    return null;
+                }
+
+                @Override protected void doStart() {
+                }
+
+                @Override protected void stopInternal() {
+                }
+            }) {
+
+            InetSocketAddress remoteAddress = new InetSocketAddress(randomIp(randomBoolean()), randomIntBetween(1, 65535));
+            String opaqueId = UUIDs.randomBase64UUID(random());
+            FakeRestRequest
+                fakeRestRequest =
+                new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withRemoteAddress(remoteAddress)
+                    .withMethod(RestRequest.Method.GET)
+                    .withPath("/internal/stats_test")
+                    .withHeaders(Map.of(Task.X_OPAQUE_ID, Collections.singletonList(opaqueId)))
+                    .build();
+            transport.incomingRequest(fakeRestRequest.getHttpRequest(), fakeRestRequest.getHttpChannel());
+
+            // HTTP client stats should default to enabled
+            HttpStats httpStats = transport.stats();
+            assertThat(httpStats.getClientStats().size(), equalTo(1));
+            assertThat(httpStats.getClientStats().get(0).opaqueId, equalTo(opaqueId));
+
+            clusterSettings.applySettings(Settings.builder()
+                .put(HttpTransportSettings.SETTING_HTTP_CLIENT_STATS_ENABLED.getKey(), false)
+                .build());
+
+            // After disabling, HTTP client stats should be cleared immediately
+            httpStats = transport.stats();
+            assertThat(httpStats.getClientStats().size(), equalTo(0));
+
+            // After disabling, HTTP client stats should not track new clients
+            remoteAddress = new InetSocketAddress(randomIp(randomBoolean()), randomIntBetween(1, 65535));
+            opaqueId = UUIDs.randomBase64UUID(random());
+            fakeRestRequest =
+                new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withRemoteAddress(remoteAddress)
+                    .withMethod(RestRequest.Method.GET)
+                    .withPath("/internal/stats_test")
+                    .withHeaders(Map.of(Task.X_OPAQUE_ID, Collections.singletonList(opaqueId)))
+                    .build();
+            transport.incomingRequest(fakeRestRequest.getHttpRequest(), fakeRestRequest.getHttpChannel());
+            httpStats = transport.stats();
+            assertThat(httpStats.getClientStats().size(), equalTo(0));
+
+            clusterSettings.applySettings(Settings.builder()
+                .put(HttpTransportSettings.SETTING_HTTP_CLIENT_STATS_ENABLED.getKey(), true)
+                .build());
+
+            // After re-enabling, HTTP client stats should now track new clients
+            remoteAddress = new InetSocketAddress(randomIp(randomBoolean()), randomIntBetween(1, 65535));
+            opaqueId = UUIDs.randomBase64UUID(random());
+            fakeRestRequest =
+                new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withRemoteAddress(remoteAddress)
+                    .withMethod(RestRequest.Method.GET)
+                    .withPath("/internal/stats_test")
+                    .withHeaders(Map.of(Task.X_OPAQUE_ID, Collections.singletonList(opaqueId)))
+                    .build();
+            transport.incomingRequest(fakeRestRequest.getHttpRequest(), fakeRestRequest.getHttpChannel());
+            httpStats = transport.stats();
+            assertThat(httpStats.getClientStats().size(), equalTo(1));
+        }
+    }
 
     private static RestResponse emptyResponse(RestStatus status) {
         return new RestResponse() {


### PR DESCRIPTION
In scenarios with high HTTP client churn, it could be beneficial to disable collection of HTTP client stats to reduce load.

`Non-issue` as this improves a not-yet-released feature.

Relates to https://github.com/elastic/elasticsearch/pull/64561