### PR TITLE
SQL: Improve the optimization of null conditionals

### DIFF
--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/conditional/NullIf.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/conditional/NullIf.java
@@ -26,8 +26,12 @@ import static org.elasticsearch.xpack.ql.expression.gen.script.ParamsBuilder.par
  */
 public class NullIf extends ConditionalFunction {
 
+    private final Expression left, right;
+
     public NullIf(Source source, Expression left, Expression right) {
         super(source, Arrays.asList(left, right));
+        this.left = left;
+        this.right = right;
     }
 
     @Override
@@ -40,9 +44,25 @@ public class NullIf extends ConditionalFunction {
         return new NullIf(source(), newChildren.get(0), newChildren.get(1));
     }
 
+    public Expression left() {
+        return left;
+    }
+
+    public Expression right() {
+        return right;
+    }
+
+    @Override
+    public boolean foldable() {
+        return left.semanticEquals(right) || super.foldable();
+    }
+
     @Override
     public Object fold() {
-        return NullIfProcessor.apply(children().get(0).fold(), children().get(1).fold());
+        if (left.semanticEquals(right)) {
+            return null;
+        }
+        return NullIfProcessor.apply(left.fold(), right.fold());
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/optimizer/Optimizer.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/optimizer/Optimizer.java
@@ -708,10 +708,19 @@ public class Optimizer extends RuleExecutor<LogicalPlan> {
                 if (e instanceof ArbitraryConditionalFunction) {
                     ArbitraryConditionalFunction c = (ArbitraryConditionalFunction) e;
 
-                    // there's no need for a conditional with only one child
-                    if (c instanceof Coalesce) {
-                        if (children.size() == 1) {
-                            return c.children().get(0);
+                    // there's no need for a conditional if all the children are the same (this includes the case of just one value)
+                    if (c instanceof Coalesce && children.size() > 0) {
+                        Expression firstChild = children.get(0);
+                        boolean sameChild = true;
+                        for (int i = 1; i < children.size(); i++) {
+                            Expression child =  children.get(i);
+                            if (firstChild.semanticEquals(child) == false) {
+                                sameChild = false;
+                                break;
+                            }
+                        }
+                        if (sameChild) {
+                            return firstChild;
                         }
                     }
 

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/optimizer/OptimizerTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/optimizer/OptimizerTests.java
@@ -443,26 +443,19 @@ public class OptimizerTests extends ESTestCase {
         assertEquals(conditionalFunction, rule.rule(conditionalFunction));
     }
 
-    public void testSimplifyCoalesceNulls() {
-        Expression e = new SimplifyConditional().rule(new Coalesce(EMPTY, asList(NULL, NULL)));
-        assertEquals(Coalesce.class, e.getClass());
-        assertEquals(0, e.children().size());
-    }
-
     public void testSimplifyCoalesceRandomNulls() {
-        List<Expression> nulls = randomListOfNulls();
-        Expression e = new SimplifyConditional().rule(new Coalesce(EMPTY, nulls));
-        if (nulls.size() == 1) {
-            assertEquals(NULL, e);
-        } else {
-            assertEquals(Coalesce.class, e.getClass());
-            assertEquals(0, e.children().size());
-        }
+        Expression e = new SimplifyConditional().rule(new Coalesce(EMPTY, randomListOfNulls()));
+        assertEquals(NULL, e);
     }
 
     public void testSimplifyCoalesceWithOnlyOneChild() {
         Expression fa = fieldAttribute();
         assertSame(fa, new SimplifyConditional().rule(new Coalesce(EMPTY, singletonList(fa))));
+    }
+
+    public void testSimplifyCoalesceSameExpression() {
+        Expression fa = fieldAttribute();
+        assertSame(fa, new SimplifyConditional().rule(new Coalesce(EMPTY, randomList(2, 10, () -> fa))));
     }
 
     public void testSimplifyCoalesceRandomNullsWithValue() {
@@ -491,8 +484,7 @@ public class OptimizerTests extends ESTestCase {
 
     public void testSimplifyIfNullNulls() {
         Expression e = new SimplifyConditional().rule(new IfNull(EMPTY, NULL, NULL));
-        assertEquals(IfNull.class, e.getClass());
-        assertEquals(0, e.children().size());
+        assertEquals(NULL, e);
     }
 
     public void testSimplifyIfNullWithNullAndValue() {


### PR DESCRIPTION
Enhance the existing rules so that
Coalesce(ex) -> ex
NullIf(a, a) -> null
NullIf(null, a) -> null
NullIf(a, null) -> a
