### PR TITLE
[DOCS] Rename ES Reference to ES Guide

### DIFF
--- a/docs/reference/index.asciidoc
+++ b/docs/reference/index.asciidoc
@@ -1,5 +1,5 @@
 [[elasticsearch-reference]]
-= Elasticsearch Reference
+= Elasticsearch Guide
 
 :include-xpack:         true
 :es-test-dir:           {elasticsearch-root}/docs/src/test

--- a/docs/reference/links.asciidoc
+++ b/docs/reference/links.asciidoc
@@ -1,4 +1,4 @@
-// These attributes define common links in the Elasticsearch Reference
+// These attributes define common links in the Elasticsearch Guide
 
 :ml-docs-setup:            {ml-docs}/setup.html[Set up {ml-features}]
 :ml-docs-setup-privileges: {ml-docs}/setup.html#setup-privileges[{ml-cap} security privileges]

--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -807,7 +807,7 @@ See:
 
 This page was deleted.
 Information about the Java testing framework was removed
-({es-issue}55257[#55257]) from the {es} Reference
+({es-issue}55257[#55257]) from the {es} Guide
 because it was out of date and erroneously implied that it should be used by application developers.
 There is an issue ({es-issue}55258[#55258])
 for providing general testing guidance for applications that communicate with {es}.
@@ -817,7 +817,7 @@ for providing general testing guidance for applications that communicate with {e
 
 This page was deleted.
 Information about the Java testing framework was removed
-({es-issue}55257[55257]) from the {es} Reference because it was out of date and
+({es-issue}55257[55257]) from the {es} Guide because it was out of date and
 erroneously implied that it should be used by application developers.
 
 There is an issue ({es-issue}55258[#55258]) for providing general testing
@@ -829,7 +829,7 @@ guidance for applications that communicate with {es}.
 
 This page was deleted.
 Information about the Java testing framework was removed
-({es-issue}55257[55257]) from the {es} Reference
+({es-issue}55257[55257]) from the {es} Guide
 because it was out of date and erroneously implied that it should be used by application developers.
 There is an issue ({es-issue}[#55258])
 for providing general testing guidance for applications that communicate with {es}.
@@ -840,7 +840,7 @@ for providing general testing guidance for applications that communicate with {e
 
 This page was deleted.
 Information about the Java testing framework was removed
-({es-issue}55257[55257]) from the {es} Reference
+({es-issue}55257[55257]) from the {es} Guide
 because it was out of date and erroneously implied that it should be used by application developers.
 There is an issue ({es-issue}55258[#55258])
 for providing general testing guidance for applications that communicate with {es}.
@@ -851,7 +851,7 @@ for providing general testing guidance for applications that communicate with {e
 
 This page was deleted.
 Information about the Java testing framework was removed
-({es-issue}55257[55257]) from the {es} Reference
+({es-issue}55257[55257]) from the {es} Guide
 because it was out of date and erroneously implied that it should be used by application developers.
 There is an issue ({es-issue}55258[#55258])
 for providing general testing guidance for applications that communicate with {es}.
@@ -862,7 +862,7 @@ for providing general testing guidance for applications that communicate with {e
 
 This page was deleted.
 Information about the Java testing framework was removed
-({es-issue}55257[55257]) from the {es} Reference
+({es-issue}55257[55257]) from the {es} Guide
 because it was out of date and erroneously implied that it should be used by application developers.
 There is an issue ({es-issue}55258[#55258])
 for providing general testing guidance for applications that communicate with {es}.


### PR DESCRIPTION
The ES docs team recently agreed to rename the `Elasticsearch Reference` docs to the `Elasticsearch Guide`.

This will help avoid the confusion and highlight that the ES docs contain more than reference material.

! This PR does **not** change the ES docs' URL structure or any links. !

Relates to https://github.com/elastic/docs/pull/2098