### PR TITLE
Use latest busybox musl binaries for Docker distribution

### DIFF
--- a/distribution/docker/src/docker/Dockerfile
+++ b/distribution/docker/src/docker/Dockerfile
@@ -112,7 +112,6 @@ RUN tar xfJ "\${TARBALL_PATH}" && \\
 ################################################################################
 FROM ${base_image} AS rootfs
 
-ENV BUSYBOX_VERSION 1.31.0
 ENV TINI_VERSION 0.19.0
 
 # Start off with an up-to-date system
@@ -151,14 +150,14 @@ RUN ${package_manager} --installroot=/rootfs --releasever=/ --setopt=tsflags=nod
 # all kinds of stuff we don't want.
 RUN set -e ; \\
     TINI_BIN="" ; \\
-    BUSYBOX_ARCH="" ; \\
+    BUSYBOX_COMMIT="" ; \\
     case "\$(arch)" in \\
         aarch64) \\
-            BUSYBOX_ARCH='armv8l' ; \\
+            BUSYBOX_COMMIT='8a500845daeaeb926b25f73089c0668cac676e97' ; \\
             TINI_BIN='tini-arm64' ; \\
             ;; \\
         x86_64) \\
-            BUSYBOX_ARCH='x86_64' ; \\
+            BUSYBOX_COMMIT='cc81bf8a3c979f596af2d811a3910aeaa230e8ef' ; \\
             TINI_BIN='tini-amd64' ; \\
             ;; \\
         *) echo >&2 "Unsupported architecture \$(arch)" ; exit 1 ;; \\
@@ -169,15 +168,10 @@ RUN set -e ; \\
     rm "\${TINI_BIN}.sha256sum" ; \\
     mv "\${TINI_BIN}" /rootfs/bin/tini ; \\
     chmod +x /rootfs/bin/tini ; \\
-    curl --retry 10 -L -o /rootfs/bin/busybox \\
-      "https://busybox.net/downloads/binaries/\${BUSYBOX_VERSION}-defconfig-multiarch-musl/busybox-\${BUSYBOX_ARCH}" ; \\
-    chmod +x /rootfs/bin/busybox
-
-# Add links for most of the Busybox utilities
-RUN set -e ; \\
-    for path in \$( /rootfs/bin/busybox --list-full | grep -v bin/sh | grep -v telnet | grep -v unzip); do \\
-      ln /rootfs/bin/busybox /rootfs/\$path ; \\
-    done
+    curl --retry 10 -L -O \\
+      "https://github.com/docker-library/busybox/raw/\${BUSYBOX_COMMIT}/stable/musl/busybox.tar.xz" ; \\
+    tar -xf busybox.tar.xz -C /rootfs/bin --strip=2 ./bin ; \\
+    rm busybox.tar.xz ;
 
 # Curl needs files under here. More importantly, we change Elasticsearch's
 # bundled JDK to use /etc/pki/ca-trust/extracted/java/cacerts instead of

--- a/distribution/docker/src/docker/Dockerfile
+++ b/distribution/docker/src/docker/Dockerfile
@@ -169,6 +169,7 @@ RUN set -e ; \\
     mv "\${TINI_BIN}" /rootfs/bin/tini ; \\
     chmod +x /rootfs/bin/tini ; \\
     curl --retry 10 -L -O \\
+      # Here we're fetching the same binaries used for the official busybox docker image from their GtiHub repository
       "https://github.com/docker-library/busybox/raw/\${BUSYBOX_COMMIT}/stable/musl/busybox.tar.xz" ; \\
     tar -xf busybox.tar.xz -C /rootfs/bin --strip=2 ./bin ; \\
     rm busybox.tar.xz ;

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/PackagingTestCase.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/PackagingTestCase.java
@@ -231,7 +231,7 @@ public abstract class PackagingTestCase extends Assert {
 
     protected static void cleanup() throws Exception {
         installation = null;
-        cleanEverything();
+        //cleanEverything();
     }
 
     /**

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/PackagingTestCase.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/PackagingTestCase.java
@@ -231,7 +231,7 @@ public abstract class PackagingTestCase extends Assert {
 
     protected static void cleanup() throws Exception {
         installation = null;
-        //cleanEverything();
+        cleanEverything();
     }
 
     /**

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Docker.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Docker.java
@@ -487,7 +487,7 @@ public class Docker {
             .forEach(
                 cliBinary -> assertTrue(
                     cliBinary + " ought to be available.",
-                    dockerShell.runIgnoreExitCode("hash " + cliBinary).isSuccess()
+                    dockerShell.runIgnoreExitCode("bash -c  'hash " + cliBinary + "'").isSuccess()
                 )
             );
     }


### PR DESCRIPTION
The busybox binaries we were using for our Docker distribution were slightly out of date, and didn't play nice with older kernel versions on aarch64. This pull request updates our Docker build to use  the same static binaries used in the busybox Docker image itself.

Closes https://github.com/elastic/elasticsearch/issues/71138