### PR TITLE
[ML] Rename autodetect flush id counter

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/writer/AutodetectControlMsgWriter.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/writer/AutodetectControlMsgWriter.java
@@ -82,7 +82,7 @@ public class AutodetectControlMsgWriter extends AbstractControlMsgWriter {
      * An number to uniquely identify each flush so that subsequent code can
      * wait for acknowledgement of the correct flush.
      */
-    private static AtomicLong ms_FlushNumber = new AtomicLong(1);
+    private static AtomicLong flushIdCounter = new AtomicLong(1);
 
     /**
      * This field name must match that in the api::CAnomalyJobConfig C++ class.
@@ -155,7 +155,7 @@ public class AutodetectControlMsgWriter extends AbstractControlMsgWriter {
      * autodetect process once it is complete.
      */
     public String writeFlushMessage() throws IOException {
-        String flushId = Long.toString(ms_FlushNumber.getAndIncrement());
+        String flushId = Long.toString(flushIdCounter.getAndIncrement());
         writeMessage(FLUSH_MESSAGE_CODE + flushId);
 
         fillCommandBuffer();


### PR DESCRIPTION
Renames `AutodetectControlMsgWriter` static member
for counting flush ids from the legacy `ms_FlushNumber`
to `flushIdCounter`.
