### PR TITLE
[ML] fixes bug with composite agg datafeed extraction

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/CompositeAggregationDataExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/CompositeAggregationDataExtractor.java
@@ -182,14 +182,10 @@ class CompositeAggregationDataExtractor implements DataExtractor {
                     // by max timestamp, our iteration of the page results is. So, once we cross over to the next bucket within
                     // a given page, we know the previous bucket has been exhausted.
                     if (nextBucketOnCancel == 0L) {
-                        if (timestamp.equals(afterKeyTimeBucket)) {
-                            // If the timestamp is the current floor, this means we need to keep processing until the next timebucket
-                            // This is because the order of these timestamps in the middle of the page is not guaranteed.
-                            nextBucketOnCancel = afterKeyTimeBucket + interval;
-                        } else {
-                            // If we are not matching the current bucket floor, then simply align to the next bucket
-                            nextBucketOnCancel = Intervals.alignToCeil(timestamp, interval);
-                        }
+                        // This simple equation handles two unique scenarios:
+                        //   If the timestamp is the current floor, this means we need to keep processing until the next timebucket
+                        //   If we are not matching the current bucket floor, then this simply aligns to the next bucket
+                        nextBucketOnCancel = Intervals.alignToFloor(timestamp + interval, interval);
                         LOGGER.debug(() -> new ParameterizedMessage(
                             "[{}] set future timestamp cancel to [{}] via timestamp [{}]",
                             context.jobId,

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/CompositeAggregationDataExtractorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/CompositeAggregationDataExtractorTests.java
@@ -267,7 +267,6 @@ public class CompositeAggregationDataExtractorTests extends ESTestCase {
         assertThat(extractor.hasNext(), is(false));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/71212")
     public void testExtractionGivenCancelHalfWay() throws IOException {
         int numBuckets = 10;
         List<CompositeAggregation.Bucket> buckets = new ArrayList<>(numBuckets);


### PR DESCRIPTION
If a `max` value in a given composite aggregation bucket is the same as the current after page floor, the datafeed could cancel processing composite aggregation pages too early.

It will see that `max` timestamp aligned with the interval and stop processing. This is a bug. There may be still other terms
to process within that `date_histogram` bucket in subsequent pages as the order of the buckets are done by term NOT by max timestamp.

This commit corrects this to verify that if the process is canceled, the datafeed continues to finish out the current date_histogram bucket, regardless if the first timestamp seen after cancelling aligns with the current page or not.

closes https://github.com/elastic/elasticsearch/issues/71212