### PR TITLE
[DOCS] Rename glossary

### DIFF
--- a/docs/reference/glossary.asciidoc
+++ b/docs/reference/glossary.asciidoc
@@ -8,7 +8,7 @@ https://github.com/elastic/stack-docs/tree/master/docs/en/glossary
 
 [glossary]
 [[glossary]]
-= Glossary of terms
+= Glossary
 
 [glossary]
 [[glossary-analysis]] analysis::


### PR DESCRIPTION
Changes title from "Glossary of terms" to "Glossary."
"Glossary of terms" is redundant.