### PR TITLE
[7.x] [DOCS] Rename Glossary (#71222)

### DIFF
--- a/docs/reference/glossary.asciidoc
+++ b/docs/reference/glossary.asciidoc
@@ -8,7 +8,7 @@ https://github.com/elastic/stack-docs/tree/master/docs/en/glossary
 
 [glossary]
 [[glossary]]
-= Glossary of terms
+= Glossary
 
 [glossary]
 [[glossary-analysis]] analysis::


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Rename Glossary (#71222)