### PR TITLE
[7.x] [DOCS] Fix 'Register a snapshot repo' title (#71224)

### DIFF
--- a/docs/reference/snapshot-restore/register-repository.asciidoc
+++ b/docs/reference/snapshot-restore/register-repository.asciidoc
@@ -1,11 +1,9 @@
 [[snapshots-register-repository]]
 == Register a snapshot repository
+++++
+<titleabbrev>Register a repository</titleabbrev>
+++++
 
-++++
-<titleabbrev>Register repository</titleabbrev>
-++++
-[[snapshots-register-repository-description]]
-// tag::snapshots-register-repository-tag[]
 You must register a snapshot repository before you can perform snapshot and
 restore operations. Use the <<put-snapshot-repo-api,create or update snapshot
 repository API>> to register or update a snapshot repository. We recommend
@@ -15,7 +13,6 @@ settings depend on the repository type.
 If you register the same snapshot repository with multiple clusters, only
 one cluster should have write access to the repository. All other clusters
 connected to that repository should set the repository to `readonly` mode.
-// end::snapshots-register-repository-tag[]
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Fix 'Register a snapshot repo' title (#71224)