### PR TITLE
[ML][Text Structure] add ability to find the structure of a field in an index

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/text_structure.find_field_structure.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/text_structure.find_field_structure.json
@@ -1,0 +1,102 @@
+{
+  "text_structure.find_field_structure":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/find-structure.html",
+      "description":"Finds the structure of a text field in an index (or set of indices). The field must contain data that is suitable to be ingested into Elasticsearch."
+    },
+    "stability":"experimental",
+    "visibility":"public",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
+    "url":{
+      "paths":[
+        {
+          "path":"/_text_structure/{index}/find_field_structure",
+          "methods":[
+            "POST"
+          ],
+          "parts":{
+            "index":{
+              "type":"string",
+              "description":"The index or comma delimited list of index expressions of the indices to search"
+            }
+          }
+        }
+      ]
+    },
+    "params":{
+      "lines_to_sample":{
+        "type":"int",
+        "description":"How many lines of the file should be included in the analysis",
+        "default":1000
+      },
+      "line_merge_size_limit":{
+        "type":"int",
+        "description":"Maximum number of characters permitted in a single message when lines are merged to create messages.",
+        "default":10000
+      },
+      "timeout":{
+        "type":"time",
+        "description":"Timeout after which the analysis will be aborted",
+        "default":"25s"
+      },
+      "charset":{
+        "type":"string",
+        "description":"Optional parameter to specify the character set of the file"
+      },
+      "format":{
+        "type":"enum",
+        "options":[
+          "ndjson",
+          "xml",
+          "delimited",
+          "semi_structured_text"
+        ],
+        "description":"Optional parameter to specify the high level file format"
+      },
+      "has_header_row":{
+        "type":"boolean",
+        "description":"Optional parameter to specify whether a delimited file includes the column names in its first row"
+      },
+      "column_names":{
+        "type":"list",
+        "description":"Optional parameter containing a comma separated list of the column names for a delimited file"
+      },
+      "delimiter":{
+        "type":"string",
+        "description":"Optional parameter to specify the delimiter character for a delimited file - must be a single character"
+      },
+      "quote":{
+        "type":"string",
+        "description":"Optional parameter to specify the quote character for a delimited file - must be a single character"
+      },
+      "should_trim_fields":{
+        "type":"boolean",
+        "description":"Optional parameter to specify whether the values between delimiters in a delimited file should have whitespace trimmed from them"
+      },
+      "grok_pattern":{
+        "type":"string",
+        "description":"Optional parameter to specify the Grok pattern that should be used to extract fields from messages in a semi-structured text file"
+      },
+      "timestamp_field":{
+        "type":"string",
+        "description":"Optional parameter to specify the timestamp field in the file"
+      },
+      "timestamp_format":{
+        "type":"string",
+        "description":"Optional parameter to specify the timestamp format in the file - may be either a Joda or Java time format"
+      },
+      "explain":{
+        "type":"boolean",
+        "description":"Whether to include a commentary on how the structure was derived",
+        "default":false
+      }
+    },
+    "body":{
+      "description":"The field name to be analyzed with an optional query and runtime_mappings",
+      "required":true
+    }
+  }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ClientHelper.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ClientHelper.java
@@ -82,6 +82,7 @@ public final class ClientHelper {
     public static final String SECURITY_ORIGIN = "security";
     public static final String WATCHER_ORIGIN = "watcher";
     public static final String ML_ORIGIN = "ml";
+    public static final String TEXT_STRUCTURE_ORIGIN = "text_structure";
     public static final String INDEX_LIFECYCLE_ORIGIN = "index_lifecycle";
     public static final String MONITORING_ORIGIN = "monitoring";
     public static final String DEPRECATION_ORIGIN = "deprecation";

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/textstructure/action/AbstractFindStructureRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/textstructure/action/AbstractFindStructureRequest.java
@@ -1,0 +1,296 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.textstructure.action;
+
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.xpack.core.textstructure.structurefinder.TextStructure;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+
+import static org.elasticsearch.action.ValidateActions.addValidationError;
+
+public class AbstractFindStructureRequest extends ActionRequest {
+
+    public static final int MIN_SAMPLE_LINE_COUNT = 2;
+
+    public static final ParseField LINES_TO_SAMPLE = new ParseField("lines_to_sample");
+    public static final ParseField LINE_MERGE_SIZE_LIMIT = new ParseField("line_merge_size_limit");
+    public static final ParseField TIMEOUT = new ParseField("timeout");
+    public static final ParseField CHARSET = TextStructure.CHARSET;
+    public static final ParseField FORMAT = TextStructure.FORMAT;
+    public static final ParseField COLUMN_NAMES = TextStructure.COLUMN_NAMES;
+    public static final ParseField HAS_HEADER_ROW = TextStructure.HAS_HEADER_ROW;
+    public static final ParseField DELIMITER = TextStructure.DELIMITER;
+    public static final ParseField QUOTE = TextStructure.QUOTE;
+    public static final ParseField SHOULD_TRIM_FIELDS = TextStructure.SHOULD_TRIM_FIELDS;
+    public static final ParseField GROK_PATTERN = TextStructure.GROK_PATTERN;
+    // This one is plural in FileStructure, but singular in FileStructureOverrides
+    public static final ParseField TIMESTAMP_FORMAT = new ParseField("timestamp_format");
+    public static final ParseField TIMESTAMP_FIELD = TextStructure.TIMESTAMP_FIELD;
+
+    private static final String ARG_INCOMPATIBLE_WITH_FORMAT_TEMPLATE =
+        "[%s] may only be specified if [" + FORMAT.getPreferredName() + "] is [%s]";
+
+    protected Integer linesToSample;
+    protected Integer lineMergeSizeLimit;
+    protected TimeValue timeout;
+    protected String charset;
+    protected TextStructure.Format format;
+    protected List<String> columnNames;
+    protected Boolean hasHeaderRow;
+    protected Character delimiter;
+    protected Character quote;
+    protected Boolean shouldTrimFields;
+    protected String grokPattern;
+    protected String timestampFormat;
+    protected String timestampField;
+
+    public AbstractFindStructureRequest() {
+    }
+
+    public AbstractFindStructureRequest(StreamInput in) throws IOException {
+        super(in);
+        linesToSample = in.readOptionalVInt();
+        lineMergeSizeLimit = in.readOptionalVInt();
+        timeout = in.readOptionalTimeValue();
+        charset = in.readOptionalString();
+        format = in.readBoolean() ? in.readEnum(TextStructure.Format.class) : null;
+        columnNames = in.readBoolean() ? in.readStringList() : null;
+        hasHeaderRow = in.readOptionalBoolean();
+        delimiter = in.readBoolean() ? (char) in.readVInt() : null;
+        quote = in.readBoolean() ? (char) in.readVInt() : null;
+        shouldTrimFields = in.readOptionalBoolean();
+        grokPattern = in.readOptionalString();
+        timestampFormat = in.readOptionalString();
+        timestampField = in.readOptionalString();
+    }
+
+
+    public Integer getLinesToSample() {
+        return linesToSample;
+    }
+
+    public void setLinesToSample(Integer linesToSample) {
+        this.linesToSample = linesToSample;
+    }
+
+    public Integer getLineMergeSizeLimit() {
+        return lineMergeSizeLimit;
+    }
+
+    public void setLineMergeSizeLimit(Integer lineMergeSizeLimit) {
+        this.lineMergeSizeLimit = lineMergeSizeLimit;
+    }
+
+    public TimeValue getTimeout() {
+        return timeout;
+    }
+
+    public void setTimeout(TimeValue timeout) {
+        this.timeout = timeout;
+    }
+
+    public String getCharset() {
+        return charset;
+    }
+
+    public void setCharset(String charset) {
+        this.charset = (charset == null || charset.isEmpty()) ? null : charset;
+    }
+
+    public TextStructure.Format getFormat() {
+        return format;
+    }
+
+    public void setFormat(TextStructure.Format format) {
+        this.format = format;
+    }
+
+    public void setFormat(String format) {
+        this.format = (format == null || format.isEmpty()) ? null : TextStructure.Format.fromString(format);
+    }
+
+    public List<String> getColumnNames() {
+        return columnNames;
+    }
+
+    public void setColumnNames(List<String> columnNames) {
+        this.columnNames = (columnNames == null || columnNames.isEmpty()) ? null : columnNames;
+    }
+
+    public void setColumnNames(String[] columnNames) {
+        this.columnNames = (columnNames == null || columnNames.length == 0) ? null : Arrays.asList(columnNames);
+    }
+
+    public Boolean getHasHeaderRow() {
+        return hasHeaderRow;
+    }
+
+    public void setHasHeaderRow(Boolean hasHeaderRow) {
+        this.hasHeaderRow = hasHeaderRow;
+    }
+
+    public Character getDelimiter() {
+        return delimiter;
+    }
+
+    public void setDelimiter(Character delimiter) {
+        this.delimiter = delimiter;
+    }
+
+    public void setDelimiter(String delimiter) {
+        if (delimiter == null || delimiter.isEmpty()) {
+            this.delimiter = null;
+        } else if (delimiter.length() == 1) {
+            this.delimiter = delimiter.charAt(0);
+        } else {
+            throw new IllegalArgumentException(DELIMITER.getPreferredName() + " must be a single character");
+        }
+    }
+
+    public Character getQuote() {
+        return quote;
+    }
+
+    public void setQuote(Character quote) {
+        this.quote = quote;
+    }
+
+    public void setQuote(String quote) {
+        if (quote == null || quote.isEmpty()) {
+            this.quote = null;
+        } else if (quote.length() == 1) {
+            this.quote = quote.charAt(0);
+        } else {
+            throw new IllegalArgumentException(QUOTE.getPreferredName() + " must be a single character");
+        }
+    }
+
+    public Boolean getShouldTrimFields() {
+        return shouldTrimFields;
+    }
+
+    public void setShouldTrimFields(Boolean shouldTrimFields) {
+        this.shouldTrimFields = shouldTrimFields;
+    }
+
+    public String getGrokPattern() {
+        return grokPattern;
+    }
+
+    public void setGrokPattern(String grokPattern) {
+        this.grokPattern = (grokPattern == null || grokPattern.isEmpty()) ? null : grokPattern;
+    }
+
+    public String getTimestampFormat() {
+        return timestampFormat;
+    }
+
+    public void setTimestampFormat(String timestampFormat) {
+        this.timestampFormat = (timestampFormat == null || timestampFormat.isEmpty()) ? null : timestampFormat;
+    }
+
+    public String getTimestampField() {
+        return timestampField;
+    }
+
+    public void setTimestampField(String timestampField) {
+        this.timestampField = (timestampField == null || timestampField.isEmpty()) ? null : timestampField;
+    }
+
+    private static ActionRequestValidationException addIncompatibleArgError(ParseField arg, TextStructure.Format format,
+                                                                            ActionRequestValidationException validationException) {
+        return addValidationError(String.format(Locale.ROOT, ARG_INCOMPATIBLE_WITH_FORMAT_TEMPLATE, arg.getPreferredName(), format),
+            validationException);
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        ActionRequestValidationException validationException = null;
+        if (linesToSample != null && linesToSample < MIN_SAMPLE_LINE_COUNT) {
+            validationException = addValidationError(
+                "[" + LINES_TO_SAMPLE.getPreferredName() + "] must be at least [" + MIN_SAMPLE_LINE_COUNT + "] if specified",
+                validationException);
+        }
+        if (lineMergeSizeLimit != null && lineMergeSizeLimit <= 0) {
+            validationException = addValidationError("[" + LINE_MERGE_SIZE_LIMIT.getPreferredName() + "] must be positive if specified",
+                validationException);
+        }
+        if (format != TextStructure.Format.DELIMITED) {
+            if (columnNames != null) {
+                validationException = addIncompatibleArgError(COLUMN_NAMES, TextStructure.Format.DELIMITED, validationException);
+            }
+            if (hasHeaderRow != null) {
+                validationException = addIncompatibleArgError(HAS_HEADER_ROW, TextStructure.Format.DELIMITED, validationException);
+            }
+            if (delimiter != null) {
+                validationException = addIncompatibleArgError(DELIMITER, TextStructure.Format.DELIMITED, validationException);
+            }
+            if (quote != null) {
+                validationException = addIncompatibleArgError(QUOTE, TextStructure.Format.DELIMITED, validationException);
+            }
+            if (shouldTrimFields != null) {
+                validationException = addIncompatibleArgError(SHOULD_TRIM_FIELDS, TextStructure.Format.DELIMITED, validationException);
+            }
+        }
+        if (format != TextStructure.Format.SEMI_STRUCTURED_TEXT) {
+            if (grokPattern != null) {
+                validationException =
+                    addIncompatibleArgError(GROK_PATTERN, TextStructure.Format.SEMI_STRUCTURED_TEXT, validationException);
+            }
+        }
+        return validationException;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeOptionalVInt(linesToSample);
+        out.writeOptionalVInt(lineMergeSizeLimit);
+        out.writeOptionalTimeValue(timeout);
+        out.writeOptionalString(charset);
+        if (format == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            out.writeEnum(format);
+        }
+        if (columnNames == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            out.writeCollection(columnNames, StreamOutput::writeString);
+        }
+        out.writeOptionalBoolean(hasHeaderRow);
+        if (delimiter == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            out.writeVInt(delimiter);
+        }
+        if (quote == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            out.writeVInt(quote);
+        }
+        out.writeOptionalBoolean(shouldTrimFields);
+        out.writeOptionalString(grokPattern);
+        out.writeOptionalString(timestampFormat);
+        out.writeOptionalString(timestampField);
+    }
+
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/textstructure/action/FindFieldStructureAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/textstructure/action/FindFieldStructureAction.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.core.textstructure.action;
+
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.query.AbstractQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.elasticsearch.action.ValidateActions.addValidationError;
+
+public class FindFieldStructureAction extends ActionType<TextStructureResponse> {
+
+    public static final FindFieldStructureAction INSTANCE = new FindFieldStructureAction();
+    public static final String NAME = "cluster:monitor/text_structure/find_field_structure";
+
+    private FindFieldStructureAction() {
+        super(NAME, TextStructureResponse::new);
+    }
+
+    public static class Request extends AbstractFindStructureRequest {
+        public static final ParseField INDEX = new ParseField("index");
+        public static final ParseField FIELD_NAME = new ParseField("field_name");
+        public static final ParseField QUERY = new ParseField("query");
+
+        private static final ObjectParser<Request, Void> PARSER = new ObjectParser<>(
+            "find_field_structure_action",
+            Request::new
+        );
+
+        static {
+            PARSER.declareStringArray(Request::setIndices, INDEX);
+            PARSER.declareString(Request::setFieldName, FIELD_NAME);
+            PARSER.declareObject(Request::setQueryBuilder, (p, c) -> AbstractQueryBuilder.parseInnerQueryBuilder(p), QUERY);
+            PARSER.declareObject(Request::setRuntimeMappings, (p, c) -> p.map(), SearchSourceBuilder.RUNTIME_MAPPINGS_FIELD);
+        }
+
+        public static Request fromXContent(XContentParser parser) {
+            return PARSER.apply(parser, null);
+        }
+
+        private String[] indices;
+        private String fieldName;
+        private QueryBuilder queryBuilder;
+        private Map<String, Object> runtimeMappings = Collections.emptyMap();
+
+        public Request() {
+        }
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            indices = in.readStringArray();
+            fieldName = in.readString();
+            queryBuilder = in.readOptionalNamedWriteable(QueryBuilder.class);
+            runtimeMappings = in.readMap();
+        }
+
+        public String[] getIndices() {
+            return indices;
+        }
+
+        private void setIndices(List<String> indices) {
+            setIndices(indices.toArray(String[]::new));
+        }
+
+        public Request setIndices(String[] indices) {
+            this.indices = indices;
+            return this;
+        }
+
+        public QueryBuilder getQueryBuilder() {
+            return queryBuilder;
+        }
+
+        public Request setQueryBuilder(QueryBuilder queryBuilder) {
+            this.queryBuilder = queryBuilder;
+            return this;
+        }
+
+        public Map<String, Object> getRuntimeMappings() {
+            return runtimeMappings;
+        }
+
+        public Request setRuntimeMappings(Map<String, Object> runtimeMappings) {
+            this.runtimeMappings = runtimeMappings;
+            return this;
+        }
+
+        public String getFieldName() {
+            return fieldName;
+        }
+
+        public Request setFieldName(String fieldName) {
+            this.fieldName = fieldName;
+            return this;
+        }
+
+        @Override
+        public ActionRequestValidationException validate() {
+            ActionRequestValidationException validationException = super.validate();
+            if (indices == null || indices.length == 0) {
+                validationException = addValidationError("valid indices must be provided", validationException);
+            }
+            if (fieldName == null) {
+                validationException = addValidationError("valid non-null field_name must be provided", validationException);
+            }
+            return validationException;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeStringArray(indices);
+            out.writeString(fieldName);
+            out.writeOptionalNamedWriteable(queryBuilder);
+            out.writeMap(runtimeMappings);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(linesToSample, lineMergeSizeLimit, timeout, charset, format, columnNames, hasHeaderRow, delimiter,
+                grokPattern, timestampFormat, timestampField, Arrays.hashCode(indices), fieldName, queryBuilder, runtimeMappings);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+
+            if (this == other) {
+                return true;
+            }
+
+            if (other == null || getClass() != other.getClass()) {
+                return false;
+            }
+
+            Request that = (Request) other;
+            return Objects.equals(this.linesToSample, that.linesToSample) &&
+                Objects.equals(this.lineMergeSizeLimit, that.lineMergeSizeLimit) &&
+                Objects.equals(this.timeout, that.timeout) &&
+                Objects.equals(this.charset, that.charset) &&
+                Objects.equals(this.format, that.format) &&
+                Objects.equals(this.columnNames, that.columnNames) &&
+                Objects.equals(this.hasHeaderRow, that.hasHeaderRow) &&
+                Objects.equals(this.delimiter, that.delimiter) &&
+                Objects.equals(this.grokPattern, that.grokPattern) &&
+                Objects.equals(this.timestampFormat, that.timestampFormat) &&
+                Objects.equals(this.timestampField, that.timestampField) &&
+                Arrays.equals(this.indices, that.indices) &&
+                Objects.equals(this.fieldName, that.fieldName) &&
+                Objects.equals(this.queryBuilder, that.queryBuilder) &&
+                Objects.equals(this.runtimeMappings, that.runtimeMappings);
+        }
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/textstructure/action/FindStructureAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/textstructure/action/FindStructureAction.java
@@ -6,123 +6,28 @@
  */
 package org.elasticsearch.xpack.core.textstructure.action;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
-import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
-import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.common.xcontent.StatusToXContentObject;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.rest.RestStatus;
-import org.elasticsearch.xpack.core.textstructure.structurefinder.TextStructure;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Locale;
 import java.util.Objects;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
-public class FindStructureAction extends ActionType<FindStructureAction.Response> {
+public class FindStructureAction extends ActionType<TextStructureResponse> {
 
     public static final FindStructureAction INSTANCE = new FindStructureAction();
     public static final String NAME = "cluster:monitor/text_structure/findstructure";
 
-    public static final int MIN_SAMPLE_LINE_COUNT = 2;
-
     private FindStructureAction() {
-        super(NAME, Response::new);
+        super(NAME, TextStructureResponse::new);
     }
 
-    public static class Response extends ActionResponse implements StatusToXContentObject, Writeable {
+    public static class Request extends AbstractFindStructureRequest {
 
-        private final TextStructure textStructure;
-
-        public Response(TextStructure textStructure) {
-            this.textStructure = textStructure;
-        }
-
-        Response(StreamInput in) throws IOException {
-            super(in);
-            textStructure = new TextStructure(in);
-        }
-
-        @Override
-        public void writeTo(StreamOutput out) throws IOException {
-            textStructure.writeTo(out);
-        }
-
-        @Override
-        public RestStatus status() {
-            return RestStatus.OK;
-        }
-
-        @Override
-        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-            textStructure.toXContent(builder, params);
-            return builder;
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(textStructure);
-        }
-
-        @Override
-        public boolean equals(Object other) {
-
-            if (this == other) {
-                return true;
-            }
-
-            if (other == null || getClass() != other.getClass()) {
-                return false;
-            }
-
-            FindStructureAction.Response that = (FindStructureAction.Response) other;
-            return Objects.equals(textStructure, that.textStructure);
-        }
-    }
-
-    public static class Request extends ActionRequest {
-
-        public static final ParseField LINES_TO_SAMPLE = new ParseField("lines_to_sample");
-        public static final ParseField LINE_MERGE_SIZE_LIMIT = new ParseField("line_merge_size_limit");
-        public static final ParseField TIMEOUT = new ParseField("timeout");
-        public static final ParseField CHARSET = TextStructure.CHARSET;
-        public static final ParseField FORMAT = TextStructure.FORMAT;
-        public static final ParseField COLUMN_NAMES = TextStructure.COLUMN_NAMES;
-        public static final ParseField HAS_HEADER_ROW = TextStructure.HAS_HEADER_ROW;
-        public static final ParseField DELIMITER = TextStructure.DELIMITER;
-        public static final ParseField QUOTE = TextStructure.QUOTE;
-        public static final ParseField SHOULD_TRIM_FIELDS = TextStructure.SHOULD_TRIM_FIELDS;
-        public static final ParseField GROK_PATTERN = TextStructure.GROK_PATTERN;
-        // This one is plural in FileStructure, but singular in FileStructureOverrides
-        public static final ParseField TIMESTAMP_FORMAT = new ParseField("timestamp_format");
-        public static final ParseField TIMESTAMP_FIELD = TextStructure.TIMESTAMP_FIELD;
-
-        private static final String ARG_INCOMPATIBLE_WITH_FORMAT_TEMPLATE =
-            "[%s] may only be specified if [" + FORMAT.getPreferredName() + "] is [%s]";
-
-        private Integer linesToSample;
-        private Integer lineMergeSizeLimit;
-        private TimeValue timeout;
-        private String charset;
-        private TextStructure.Format format;
-        private List<String> columnNames;
-        private Boolean hasHeaderRow;
-        private Character delimiter;
-        private Character quote;
-        private Boolean shouldTrimFields;
-        private String grokPattern;
-        private String timestampFormat;
-        private String timestampField;
         private BytesReference sample;
 
         public Request() {
@@ -130,153 +35,7 @@ public class FindStructureAction extends ActionType<FindStructureAction.Response
 
         public Request(StreamInput in) throws IOException {
             super(in);
-            linesToSample = in.readOptionalVInt();
-            lineMergeSizeLimit = in.readOptionalVInt();
-            timeout = in.readOptionalTimeValue();
-            charset = in.readOptionalString();
-            format = in.readBoolean() ? in.readEnum(TextStructure.Format.class) : null;
-            columnNames = in.readBoolean() ? in.readStringList() : null;
-            hasHeaderRow = in.readOptionalBoolean();
-            delimiter = in.readBoolean() ? (char) in.readVInt() : null;
-            quote = in.readBoolean() ? (char) in.readVInt() : null;
-            shouldTrimFields = in.readOptionalBoolean();
-            grokPattern = in.readOptionalString();
-            timestampFormat = in.readOptionalString();
-            timestampField = in.readOptionalString();
             sample = in.readBytesReference();
-        }
-
-
-        public Integer getLinesToSample() {
-            return linesToSample;
-        }
-
-        public void setLinesToSample(Integer linesToSample) {
-            this.linesToSample = linesToSample;
-        }
-
-        public Integer getLineMergeSizeLimit() {
-            return lineMergeSizeLimit;
-        }
-
-        public void setLineMergeSizeLimit(Integer lineMergeSizeLimit) {
-            this.lineMergeSizeLimit = lineMergeSizeLimit;
-        }
-
-        public TimeValue getTimeout() {
-            return timeout;
-        }
-
-        public void setTimeout(TimeValue timeout) {
-            this.timeout = timeout;
-        }
-
-        public String getCharset() {
-            return charset;
-        }
-
-        public void setCharset(String charset) {
-            this.charset = (charset == null || charset.isEmpty()) ? null : charset;
-        }
-
-        public TextStructure.Format getFormat() {
-            return format;
-        }
-
-        public void setFormat(TextStructure.Format format) {
-            this.format = format;
-        }
-
-        public void setFormat(String format) {
-            this.format = (format == null || format.isEmpty()) ? null : TextStructure.Format.fromString(format);
-        }
-
-        public List<String> getColumnNames() {
-            return columnNames;
-        }
-
-        public void setColumnNames(List<String> columnNames) {
-            this.columnNames = (columnNames == null || columnNames.isEmpty()) ? null : columnNames;
-        }
-
-        public void setColumnNames(String[] columnNames) {
-            this.columnNames = (columnNames == null || columnNames.length == 0) ? null : Arrays.asList(columnNames);
-        }
-
-        public Boolean getHasHeaderRow() {
-            return hasHeaderRow;
-        }
-
-        public void setHasHeaderRow(Boolean hasHeaderRow) {
-            this.hasHeaderRow = hasHeaderRow;
-        }
-
-        public Character getDelimiter() {
-            return delimiter;
-        }
-
-        public void setDelimiter(Character delimiter) {
-            this.delimiter = delimiter;
-        }
-
-        public void setDelimiter(String delimiter) {
-            if (delimiter == null || delimiter.isEmpty()) {
-                this.delimiter = null;
-            } else if (delimiter.length() == 1) {
-                this.delimiter = delimiter.charAt(0);
-            } else {
-                throw new IllegalArgumentException(DELIMITER.getPreferredName() + " must be a single character");
-            }
-        }
-
-        public Character getQuote() {
-            return quote;
-        }
-
-        public void setQuote(Character quote) {
-            this.quote = quote;
-        }
-
-        public void setQuote(String quote) {
-            if (quote == null || quote.isEmpty()) {
-                this.quote = null;
-            } else if (quote.length() == 1) {
-                this.quote = quote.charAt(0);
-            } else {
-                throw new IllegalArgumentException(QUOTE.getPreferredName() + " must be a single character");
-            }
-        }
-
-        public Boolean getShouldTrimFields() {
-            return shouldTrimFields;
-        }
-
-        public void setShouldTrimFields(Boolean shouldTrimFields) {
-            this.shouldTrimFields = shouldTrimFields;
-        }
-
-        public String getGrokPattern() {
-            return grokPattern;
-        }
-
-        public void setGrokPattern(String grokPattern) {
-            this.grokPattern = (grokPattern == null || grokPattern.isEmpty()) ? null : grokPattern;
-        }
-
-        public String getTimestampFormat() {
-            return timestampFormat;
-        }
-
-        public void setTimestampFormat(String timestampFormat) {
-            this.timestampFormat = (timestampFormat == null || timestampFormat.isEmpty()) ? null : timestampFormat;
-        }
-
-        public String getTimestampField() {
-            return timestampField;
-        }
-
-        public void setTimestampField(String timestampField) {
-            this.timestampField = (timestampField == null || timestampField.isEmpty()) ? null : timestampField;
         }
 
         public BytesReference getSample() {
@@ -287,47 +46,9 @@ public class FindStructureAction extends ActionType<FindStructureAction.Response
             this.sample = sample;
         }
 
-        private static ActionRequestValidationException addIncompatibleArgError(ParseField arg, TextStructure.Format format,
-                                                                                ActionRequestValidationException validationException) {
-            return addValidationError(String.format(Locale.ROOT, ARG_INCOMPATIBLE_WITH_FORMAT_TEMPLATE, arg.getPreferredName(), format),
-                validationException);
-        }
-
         @Override
         public ActionRequestValidationException validate() {
-            ActionRequestValidationException validationException = null;
-            if (linesToSample != null && linesToSample < MIN_SAMPLE_LINE_COUNT) {
-                validationException = addValidationError(
-                    "[" + LINES_TO_SAMPLE.getPreferredName() + "] must be at least [" + MIN_SAMPLE_LINE_COUNT + "] if specified",
-                    validationException);
-            }
-            if (lineMergeSizeLimit != null && lineMergeSizeLimit <= 0) {
-                validationException = addValidationError("[" + LINE_MERGE_SIZE_LIMIT.getPreferredName() + "] must be positive if specified",
-                    validationException);
-            }
-            if (format != TextStructure.Format.DELIMITED) {
-                if (columnNames != null) {
-                    validationException = addIncompatibleArgError(COLUMN_NAMES, TextStructure.Format.DELIMITED, validationException);
-                }
-                if (hasHeaderRow != null) {
-                    validationException = addIncompatibleArgError(HAS_HEADER_ROW, TextStructure.Format.DELIMITED, validationException);
-                }
-                if (delimiter != null) {
-                    validationException = addIncompatibleArgError(DELIMITER, TextStructure.Format.DELIMITED, validationException);
-                }
-                if (quote != null) {
-                    validationException = addIncompatibleArgError(QUOTE, TextStructure.Format.DELIMITED, validationException);
-                }
-                if (shouldTrimFields != null) {
-                    validationException = addIncompatibleArgError(SHOULD_TRIM_FIELDS, TextStructure.Format.DELIMITED, validationException);
-                }
-            }
-            if (format != TextStructure.Format.SEMI_STRUCTURED_TEXT) {
-                if (grokPattern != null) {
-                    validationException =
-                        addIncompatibleArgError(GROK_PATTERN, TextStructure.Format.SEMI_STRUCTURED_TEXT, validationException);
-                }
-            }
+            ActionRequestValidationException validationException = super.validate();
             if (sample == null || sample.length() == 0) {
                 validationException = addValidationError("sample must be specified", validationException);
             }
@@ -337,39 +58,6 @@ public class FindStructureAction extends ActionType<FindStructureAction.Response
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
-            out.writeOptionalVInt(linesToSample);
-            out.writeOptionalVInt(lineMergeSizeLimit);
-            out.writeOptionalTimeValue(timeout);
-            out.writeOptionalString(charset);
-            if (format == null) {
-                out.writeBoolean(false);
-            } else {
-                out.writeBoolean(true);
-                out.writeEnum(format);
-            }
-            if (columnNames == null) {
-                out.writeBoolean(false);
-            } else {
-                out.writeBoolean(true);
-                out.writeCollection(columnNames, StreamOutput::writeString);
-            }
-            out.writeOptionalBoolean(hasHeaderRow);
-            if (delimiter == null) {
-                out.writeBoolean(false);
-            } else {
-                out.writeBoolean(true);
-                out.writeVInt(delimiter);
-            }
-            if (quote == null) {
-                out.writeBoolean(false);
-            } else {
-                out.writeBoolean(true);
-                out.writeVInt(quote);
-            }
-            out.writeOptionalBoolean(shouldTrimFields);
-            out.writeOptionalString(grokPattern);
-            out.writeOptionalString(timestampFormat);
-            out.writeOptionalString(timestampField);
             out.writeBytesReference(sample);
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/textstructure/action/TextStructureResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/textstructure/action/TextStructureResponse.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.textstructure.action;
+
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.StatusToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.xpack.core.textstructure.structurefinder.TextStructure;
+
+import java.io.IOException;
+import java.util.Objects;
+
+public class TextStructureResponse extends ActionResponse implements StatusToXContentObject, Writeable {
+
+    private final TextStructure textStructure;
+
+    public TextStructureResponse(TextStructure textStructure) {
+        this.textStructure = textStructure;
+    }
+
+    TextStructureResponse(StreamInput in) throws IOException {
+        super(in);
+        textStructure = new TextStructure(in);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        textStructure.writeTo(out);
+    }
+
+    @Override
+    public RestStatus status() {
+        return RestStatus.OK;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        textStructure.toXContent(builder, params);
+        return builder;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(textStructure);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+
+        if (this == other) {
+            return true;
+        }
+
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+
+        TextStructureResponse that = (TextStructureResponse) other;
+        return Objects.equals(textStructure, that.textStructure);
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/textstructure/action/FindFieldStructureActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/textstructure/action/FindFieldStructureActionRequestTests.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.core.textstructure.action;
+
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.xpack.core.textstructure.structurefinder.TextStructure;
+
+import java.util.HashMap;
+import java.util.Map;
+
+
+public class FindFieldStructureActionRequestTests extends AbstractWireSerializingTestCase<FindFieldStructureAction.Request> {
+
+    @Override
+    protected FindFieldStructureAction.Request createTestInstance() {
+
+        FindFieldStructureAction.Request request = new FindFieldStructureAction.Request();
+
+        if (randomBoolean()) {
+            request.setLinesToSample(randomIntBetween(10, 2000));
+        }
+
+        if (randomBoolean()) {
+            request.setLineMergeSizeLimit(randomIntBetween(1000, 20000));
+        }
+
+        if (randomBoolean()) {
+            request.setCharset(randomAlphaOfLength(10));
+        }
+
+        if (randomBoolean()) {
+            TextStructure.Format format = randomFrom(TextStructure.Format.values());
+            request.setFormat(format);
+            if (format == TextStructure.Format.DELIMITED) {
+                if (randomBoolean()) {
+                    request.setColumnNames(generateRandomStringArray(10, 15, false, false));
+                }
+                if (randomBoolean()) {
+                    request.setHasHeaderRow(randomBoolean());
+                }
+                if (randomBoolean()) {
+                    request.setDelimiter(randomFrom(',', '\t', ';', '|'));
+                }
+                if (randomBoolean()) {
+                    request.setQuote(randomFrom('"', '\''));
+                }
+                if (randomBoolean()) {
+                    request.setShouldTrimFields(randomBoolean());
+                }
+            } else if (format == TextStructure.Format.SEMI_STRUCTURED_TEXT) {
+                if (randomBoolean()) {
+                    request.setGrokPattern(randomAlphaOfLength(80));
+                }
+            }
+        }
+
+        if (randomBoolean()) {
+            request.setTimestampFormat(randomAlphaOfLength(20));
+        }
+        if (randomBoolean()) {
+            request.setTimestampField(randomAlphaOfLength(15));
+        }
+
+        request.setIndices(randomArray(1, 10, String[]::new, () -> randomAlphaOfLength(10)));
+        request.setFieldName(randomAlphaOfLength(10));
+        if (randomBoolean()) {
+            request.setQueryBuilder(QueryBuilders.boolQuery().filter(QueryBuilders.termQuery("foo", "bar")));
+        }
+        if (randomBoolean()) {
+            Map<String, Object> settings = new HashMap<>();
+            settings.put("type", "keyword");
+            settings.put("script", "");
+            Map<String, Object> field = new HashMap<>();
+            field.put("runtime_field_foo", settings);
+            request.setRuntimeMappings(field);
+        }
+
+        return request;
+    }
+
+    @Override
+    protected Writeable.Reader<FindFieldStructureAction.Request> instanceReader() {
+        return FindFieldStructureAction.Request::new;
+    }
+
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/textstructure/action/TextStructureResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/textstructure/action/TextStructureResponseTests.java
@@ -10,15 +10,15 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.textstructure.structurefinder.TextStructureTests;
 
-public class FindTextStructureActionResponseTests extends AbstractWireSerializingTestCase<FindStructureAction.Response> {
+public class TextStructureResponseTests extends AbstractWireSerializingTestCase<TextStructureResponse> {
 
     @Override
-    protected FindStructureAction.Response createTestInstance() {
-        return new FindStructureAction.Response(TextStructureTests.createTestFileStructure());
+    protected TextStructureResponse createTestInstance() {
+        return new TextStructureResponse(TextStructureTests.createTestFileStructure());
     }
 
     @Override
-    protected Writeable.Reader<FindStructureAction.Response> instanceReader() {
-        return FindStructureAction.Response::new;
+    protected Writeable.Reader<TextStructureResponse> instanceReader() {
+        return TextStructureResponse::new;
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationUtils.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationUtils.java
@@ -36,6 +36,7 @@ import static org.elasticsearch.xpack.core.ClientHelper.ROLLUP_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.SEARCHABLE_SNAPSHOTS_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.SECURITY_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.STACK_ORIGIN;
+import static org.elasticsearch.xpack.core.ClientHelper.TEXT_STRUCTURE_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.TRANSFORM_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.WATCHER_ORIGIN;
 
@@ -116,6 +117,7 @@ public final class AuthorizationUtils {
             case WATCHER_ORIGIN:
             case ML_ORIGIN:
             case MONITORING_ORIGIN:
+            case TEXT_STRUCTURE_ORIGIN:
             case TRANSFORM_ORIGIN:
             case DEPRECATION_ORIGIN:
             case PERSISTENT_TASK_ORIGIN:

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/text_structure/find_field_structure.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/text_structure/find_field_structure.yml
@@ -1,0 +1,73 @@
+setup:
+  - skip:
+      features: headers
+  - do:
+      indices.create:
+        index: raw-log-data
+        body:
+          mappings:
+            properties:
+              log:
+                type: text
+
+  - do:
+      index:
+        index: raw-log-data
+        body: >
+          {
+            "log": "2017-02-18T00:00:00Z foo 1.0 5"
+          }
+  - do:
+      index:
+        index: raw-log-data
+        body: >
+          {
+            "log": "2018-02-18T00:00:00Z foo 1.0 5"
+          }
+  - do:
+      index:
+        index: raw-log-data
+        body: >
+          {
+            "log": "2020-02-18T12:00:00Z bar 12038.0 2"
+          }
+  - do:
+      index:
+        index: raw-log-data
+        body: >
+          {
+            "log": "2019-04-11T00:00:20Z foo 5.0 1"
+          }
+  - do:
+      index:
+        index: raw-log-data
+        body: >
+          {
+            "log": "2014-01-11T10:01:00Z bar 1235.1 50"
+          }
+  - do:
+      indices.refresh:
+        index: raw-log-data
+---
+"Test raw log field structure analysis without overrides":
+  - do:
+      headers:
+        Content-Type: "application/json"
+      text_structure.find_field_structure:
+        index: raw-log-data
+        lines_to_sample: 5
+        line_merge_size_limit: 1234
+        timeout: 10s
+        body: >
+          {
+            "field_name": "log"
+          }
+
+  - match: { num_lines_analyzed: 4 }
+  - match: { num_messages_analyzed: 4 }
+  - match: { grok_pattern: "%{TIMESTAMP_ISO8601:timestamp} .*? %{NUMBER:field2} %{INT:field}" }
+  - match: { joda_timestamp_formats.0: ISO8601 }
+  - match: { java_timestamp_formats.0: ISO8601 }
+  - match: { mappings.properties.field.type: long }
+  - match: { mappings.properties.field2.type: double }
+  - match: { mappings.properties.@timestamp.type: date }

--- a/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/TextStructurePlugin.java
+++ b/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/TextStructurePlugin.java
@@ -19,8 +19,11 @@ import org.elasticsearch.plugins.ActionPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestHandler;
+import org.elasticsearch.xpack.core.textstructure.action.FindFieldStructureAction;
 import org.elasticsearch.xpack.core.textstructure.action.FindStructureAction;
+import org.elasticsearch.xpack.textstructure.rest.RestFindFieldStructureAction;
 import org.elasticsearch.xpack.textstructure.rest.RestFindStructureAction;
+import org.elasticsearch.xpack.textstructure.transport.TransportFindFieldStructureAction;
 import org.elasticsearch.xpack.textstructure.transport.TransportFindStructureAction;
 
 import java.util.Arrays;
@@ -45,12 +48,15 @@ public class TextStructurePlugin extends Plugin implements ActionPlugin {
         IndexNameExpressionResolver indexNameExpressionResolver,
         Supplier<DiscoveryNodes> nodesInCluster
     ) {
-        return Arrays.asList(new RestFindStructureAction());
+        return Arrays.asList(new RestFindStructureAction(), new RestFindFieldStructureAction());
     }
 
     @Override
     public List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
-        return Arrays.asList(new ActionHandler<>(FindStructureAction.INSTANCE, TransportFindStructureAction.class));
+        return Arrays.asList(
+            new ActionHandler<>(FindStructureAction.INSTANCE, TransportFindStructureAction.class),
+            new ActionHandler<>(FindFieldStructureAction.INSTANCE, TransportFindFieldStructureAction.class)
+        );
     }
 
 }

--- a/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/rest/RestFindFieldStructureAction.java
+++ b/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/rest/RestFindFieldStructureAction.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.textstructure.rest;
+
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.xpack.core.textstructure.action.AbstractFindStructureRequest;
+import org.elasticsearch.xpack.core.textstructure.action.FindFieldStructureAction;
+import org.elasticsearch.xpack.core.textstructure.structurefinder.TextStructure;
+import org.elasticsearch.xpack.textstructure.structurefinder.TextStructureFinderManager;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static org.elasticsearch.rest.RestRequest.Method.POST;
+import static org.elasticsearch.xpack.textstructure.TextStructurePlugin.BASE_PATH;
+
+public class RestFindFieldStructureAction extends BaseRestHandler {
+
+    private static final TimeValue DEFAULT_TIMEOUT = new TimeValue(25, TimeUnit.SECONDS);
+
+    @Override
+    public List<Route> routes() {
+        return List.of(
+            Route.builder(POST, BASE_PATH + "{" + FindFieldStructureAction.Request.INDEX.getPreferredName() + "}/find_field_structure")
+                .build()
+        );
+    }
+
+    @Override
+    public String getName() {
+        return "text_structure_find_field_structure_action";
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
+
+        FindFieldStructureAction.Request request = FindFieldStructureAction.Request.fromXContent(restRequest.contentOrSourceParamParser());
+        request.setIndices(restRequest.paramAsStringArray(FindFieldStructureAction.Request.INDEX.getPreferredName(), new String[0]));
+        request.setLinesToSample(
+            restRequest.paramAsInt(
+                AbstractFindStructureRequest.LINES_TO_SAMPLE.getPreferredName(),
+                TextStructureFinderManager.DEFAULT_IDEAL_SAMPLE_LINE_COUNT
+            )
+        );
+        request.setLineMergeSizeLimit(
+            restRequest.paramAsInt(
+                AbstractFindStructureRequest.LINE_MERGE_SIZE_LIMIT.getPreferredName(),
+                TextStructureFinderManager.DEFAULT_LINE_MERGE_SIZE_LIMIT
+            )
+        );
+        request.setTimeout(
+            TimeValue.parseTimeValue(
+                restRequest.param(AbstractFindStructureRequest.TIMEOUT.getPreferredName()),
+                DEFAULT_TIMEOUT,
+                AbstractFindStructureRequest.TIMEOUT.getPreferredName()
+            )
+        );
+        request.setCharset(restRequest.param(AbstractFindStructureRequest.CHARSET.getPreferredName()));
+        request.setFormat(restRequest.param(AbstractFindStructureRequest.FORMAT.getPreferredName()));
+        request.setColumnNames(restRequest.paramAsStringArray(AbstractFindStructureRequest.COLUMN_NAMES.getPreferredName(), null));
+        request.setHasHeaderRow(restRequest.paramAsBoolean(AbstractFindStructureRequest.HAS_HEADER_ROW.getPreferredName(), null));
+        request.setDelimiter(restRequest.param(AbstractFindStructureRequest.DELIMITER.getPreferredName()));
+        request.setQuote(restRequest.param(AbstractFindStructureRequest.QUOTE.getPreferredName()));
+        request.setShouldTrimFields(restRequest.paramAsBoolean(AbstractFindStructureRequest.SHOULD_TRIM_FIELDS.getPreferredName(), null));
+        request.setGrokPattern(restRequest.param(AbstractFindStructureRequest.GROK_PATTERN.getPreferredName()));
+        request.setTimestampFormat(restRequest.param(AbstractFindStructureRequest.TIMESTAMP_FORMAT.getPreferredName()));
+        request.setTimestampField(restRequest.param(AbstractFindStructureRequest.TIMESTAMP_FIELD.getPreferredName()));
+
+        return channel -> client.execute(FindFieldStructureAction.INSTANCE, request, new RestToXContentListener<>(channel));
+    }
+
+    @Override
+    protected Set<String> responseParams() {
+        return Collections.singleton(TextStructure.EXPLAIN);
+    }
+}

--- a/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/TextStructureFinderManager.java
+++ b/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/TextStructureFinderManager.java
@@ -12,7 +12,7 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.xpack.core.textstructure.action.FindStructureAction;
+import org.elasticsearch.xpack.core.textstructure.action.AbstractFindStructureRequest;
 import org.elasticsearch.xpack.core.textstructure.structurefinder.TextStructure;
 
 import java.io.BufferedInputStream;
@@ -34,6 +34,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
+
+import static org.elasticsearch.xpack.core.textstructure.action.AbstractFindStructureRequest.MIN_SAMPLE_LINE_COUNT;
 
 /**
  * Runs the high-level steps needed to create ingest configs for some text.  In order:
@@ -309,7 +311,7 @@ public final class TextStructureFinderManager {
      * Given a stream of text data, determine its structure.
      * @param idealSampleLineCount Ideally, how many lines from the stream will be read to determine the structure?
      *                             If the stream has fewer lines then an attempt will still be made, providing at
-     *                             least {@link FindStructureAction#MIN_SAMPLE_LINE_COUNT} lines can be read.  If
+     *                             least {@link AbstractFindStructureRequest#MIN_SAMPLE_LINE_COUNT} lines can be read.  If
      *                             <code>null</code> the value of {@link #DEFAULT_IDEAL_SAMPLE_LINE_COUNT} will be used.
      * @param lineMergeSizeLimit Maximum number of characters permitted when lines are merged to create messages.
      *                           If <code>null</code> the value of {@link #DEFAULT_LINE_MERGE_SIZE_LIMIT} will be used.
@@ -382,11 +384,11 @@ public final class TextStructureFinderManager {
                 sampleReader = charsetMatch.getReader();
             }
 
-            assert idealSampleLineCount >= FindStructureAction.MIN_SAMPLE_LINE_COUNT;
+            assert idealSampleLineCount >= MIN_SAMPLE_LINE_COUNT;
             Tuple<String, Boolean> sampleInfo = sampleText(
                 sampleReader,
                 charsetName,
-                FindStructureAction.MIN_SAMPLE_LINE_COUNT,
+                MIN_SAMPLE_LINE_COUNT,
                 idealSampleLineCount,
                 timeoutChecker
             );

--- a/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/TextStructureOverrides.java
+++ b/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/TextStructureOverrides.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.textstructure.structurefinder;
 
+import org.elasticsearch.xpack.core.textstructure.action.AbstractFindStructureRequest;
 import org.elasticsearch.xpack.core.textstructure.action.FindStructureAction;
 import org.elasticsearch.xpack.core.textstructure.structurefinder.TextStructure;
 
@@ -35,7 +36,7 @@ public class TextStructureOverrides {
     private final String timestampFormat;
     private final String timestampField;
 
-    public TextStructureOverrides(FindStructureAction.Request request) {
+    public TextStructureOverrides(AbstractFindStructureRequest request) {
 
         this(
             request.getCharset(),

--- a/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/transport/TransportFindFieldStructureAction.java
+++ b/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/transport/TransportFindFieldStructureAction.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.textstructure.transport;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.search.SearchAction;
+import org.elasticsearch.action.search.SearchRequestBuilder;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.document.DocumentField;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.query.functionscore.FunctionScoreQueryBuilder;
+import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilders;
+import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.ClientHelper;
+import org.elasticsearch.xpack.core.XPackSettings;
+import org.elasticsearch.xpack.core.ml.utils.MapHelper;
+import org.elasticsearch.xpack.core.security.SecurityContext;
+import org.elasticsearch.xpack.core.security.action.user.HasPrivilegesAction;
+import org.elasticsearch.xpack.core.security.action.user.HasPrivilegesRequest;
+import org.elasticsearch.xpack.core.security.action.user.HasPrivilegesResponse;
+import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
+import org.elasticsearch.xpack.core.security.authz.permission.ResourcePrivileges;
+import org.elasticsearch.xpack.core.security.support.Exceptions;
+import org.elasticsearch.xpack.core.textstructure.action.FindFieldStructureAction;
+import org.elasticsearch.xpack.core.textstructure.action.TextStructureResponse;
+import org.elasticsearch.xpack.textstructure.structurefinder.TextStructureFinder;
+import org.elasticsearch.xpack.textstructure.structurefinder.TextStructureFinderManager;
+import org.elasticsearch.xpack.textstructure.structurefinder.TextStructureOverrides;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.elasticsearch.threadpool.ThreadPool.Names.GENERIC;
+
+public class TransportFindFieldStructureAction extends HandledTransportAction<FindFieldStructureAction.Request, TextStructureResponse> {
+
+    private final ThreadPool threadPool;
+    private final XPackLicenseState licenseState;
+    private final Client client;
+    private final SecurityContext securityContext;
+
+    @Inject
+    public TransportFindFieldStructureAction(
+        TransportService transportService,
+        ActionFilters actionFilters,
+        ThreadPool threadPool,
+        XPackLicenseState licenseState,
+        Client client,
+        Settings settings
+    ) {
+        super(FindFieldStructureAction.NAME, transportService, actionFilters, FindFieldStructureAction.Request::new);
+        this.threadPool = threadPool;
+        this.licenseState = licenseState;
+        this.client = client;
+        this.securityContext = XPackSettings.SECURITY_ENABLED.get(settings)
+            ? new SecurityContext(settings, threadPool.getThreadContext())
+            : null;
+    }
+
+    @Override
+    protected void doExecute(Task task, FindFieldStructureAction.Request request, ActionListener<TextStructureResponse> listener) {
+
+        if (licenseState.isSecurityEnabled()) {
+            final String[] indices = request.getIndices();
+
+            final String username = securityContext.getUser().principal();
+            final HasPrivilegesRequest privRequest = new HasPrivilegesRequest();
+            privRequest.applicationPrivileges(new RoleDescriptor.ApplicationResourcePrivileges[0]);
+            privRequest.username(username);
+            privRequest.clusterPrivileges(Strings.EMPTY_ARRAY);
+            privRequest.indexPrivileges(RoleDescriptor.IndicesPrivileges.builder().indices(indices).privileges(SearchAction.NAME).build());
+
+            ActionListener<HasPrivilegesResponse> privResponseListener = ActionListener.wrap(
+                r -> handlePrivsResponse(username, request, r, listener),
+                listener::onFailure
+            );
+            client.execute(HasPrivilegesAction.INSTANCE, privRequest, privResponseListener);
+
+        } else {
+            searchAndBuildTextStructureResponse(request, threadPool.getThreadContext().getHeaders(), listener);
+        }
+
+    }
+
+    private void handlePrivsResponse(
+        String username,
+        FindFieldStructureAction.Request request,
+        HasPrivilegesResponse response,
+        ActionListener<TextStructureResponse> listener
+    ) throws IOException {
+        if (response.isCompleteMatch()) {
+            searchAndBuildTextStructureResponse(request, threadPool.getThreadContext().getHeaders(), listener);
+        } else {
+            XContentBuilder builder = JsonXContent.contentBuilder();
+            builder.startObject();
+            for (ResourcePrivileges index : response.getIndexPrivileges()) {
+                builder.field(index.getResource());
+                builder.map(index.getPrivileges());
+            }
+            builder.endObject();
+
+            listener.onFailure(
+                Exceptions.authorizationError(
+                    "Cannot determine field structure because user {} lacks permissions on the indices: {}",
+                    username,
+                    Strings.toString(builder)
+                )
+            );
+        }
+    }
+
+    private void searchAndBuildTextStructureResponse(
+        FindFieldStructureAction.Request request,
+        Map<String, String> headers,
+        ActionListener<TextStructureResponse> listener
+    ) {
+
+        ActionListener<SearchResponse> searchResponseActionListener = ActionListener.wrap(searchResponse -> {
+            // TODO could we just feed the doc fields as "lines" to the field structure finder?
+            StringBuilder stringBuilder = new StringBuilder();
+            for (SearchHit hit : searchResponse.getHits().getHits()) {
+                if (request.getRuntimeMappings().isEmpty()) {
+                    Object value = MapHelper.dig(request.getFieldName(), Objects.requireNonNull(hit.getSourceAsMap()));
+                    if (value instanceof String) {
+                        stringBuilder.append(value.toString()).append("\n");
+                    } else if (value instanceof List<?>) {
+                        @SuppressWarnings("unchecked")
+                        List<Object> values = (List<Object>) value;
+                        for (Object v : values) {
+                            if (v instanceof String) {
+                                stringBuilder.append(v.toString()).append("\n");
+                            }
+                        }
+                    }
+                } else {
+                    DocumentField field = hit.field(request.getFieldName());
+                    for (Object v : field.getValues()) {
+                        if (v instanceof String) {
+                            stringBuilder.append(v.toString()).append("\n");
+                        }
+                    }
+                }
+            }
+            threadPool.executor(GENERIC).execute(() -> {
+                try {
+                    listener.onResponse(buildTextStructureResponse(request, new BytesArray(stringBuilder.toString())));
+                } catch (Exception e) {
+                    listener.onFailure(e);
+                }
+            });
+        }, listener::onFailure);
+        FunctionScoreQueryBuilder functionBuilder = request.getQueryBuilder() != null
+            ? QueryBuilders.functionScoreQuery(request.getQueryBuilder(), ScoreFunctionBuilders.randomFunction())
+            : QueryBuilders.functionScoreQuery(ScoreFunctionBuilders.randomFunction());
+
+        SearchRequestBuilder searchRequest = client.prepareSearch(request.getIndices())
+            .setQuery(functionBuilder)
+            .setSize(request.getLinesToSample())
+            .setTrackTotalHits(false);
+        // If we have a runtime mapping, that means we have to fetch via the fields
+        // But, don't do that unless we have to so that the user could query older remote clusters
+        if (request.getRuntimeMappings().isEmpty() == false) {
+            searchRequest.addFetchField(request.getFieldName()).setFetchSource(false).setRuntimeMappings(request.getRuntimeMappings());
+        } else {
+            searchRequest.setFetchSource(new String[] { request.getFieldName() }, null);
+        }
+
+        ClientHelper.executeWithHeadersAsync(
+            headers,
+            ClientHelper.TEXT_STRUCTURE_ORIGIN,
+            client,
+            SearchAction.INSTANCE,
+            searchRequest.request(),
+            searchResponseActionListener
+        );
+    }
+
+    private TextStructureResponse buildTextStructureResponse(FindFieldStructureAction.Request request, BytesReference sample)
+        throws Exception {
+
+        TextStructureFinderManager structureFinderManager = new TextStructureFinderManager(threadPool.scheduler());
+        try (InputStream sampleStream = sample.streamInput()) {
+            TextStructureFinder textStructureFinder = structureFinderManager.findTextStructure(
+                request.getLinesToSample(),
+                request.getLineMergeSizeLimit(),
+                sampleStream,
+                new TextStructureOverrides(request),
+                request.getTimeout()
+            );
+            return new TextStructureResponse(textStructureFinder.getStructure());
+        }
+    }
+}

--- a/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/transport/TransportFindStructureAction.java
+++ b/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/transport/TransportFindStructureAction.java
@@ -14,6 +14,7 @@ import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.textstructure.action.FindStructureAction;
+import org.elasticsearch.xpack.core.textstructure.action.TextStructureResponse;
 import org.elasticsearch.xpack.textstructure.structurefinder.TextStructureFinder;
 import org.elasticsearch.xpack.textstructure.structurefinder.TextStructureFinderManager;
 import org.elasticsearch.xpack.textstructure.structurefinder.TextStructureOverrides;
@@ -22,7 +23,7 @@ import java.io.InputStream;
 
 import static org.elasticsearch.threadpool.ThreadPool.Names.GENERIC;
 
-public class TransportFindStructureAction extends HandledTransportAction<FindStructureAction.Request, FindStructureAction.Response> {
+public class TransportFindStructureAction extends HandledTransportAction<FindStructureAction.Request, TextStructureResponse> {
 
     private final ThreadPool threadPool;
 
@@ -33,7 +34,7 @@ public class TransportFindStructureAction extends HandledTransportAction<FindStr
     }
 
     @Override
-    protected void doExecute(Task task, FindStructureAction.Request request, ActionListener<FindStructureAction.Response> listener) {
+    protected void doExecute(Task task, FindStructureAction.Request request, ActionListener<TextStructureResponse> listener) {
 
         // As determining the text structure might take a while, we run
         // in a different thread to avoid blocking the network thread.
@@ -46,7 +47,7 @@ public class TransportFindStructureAction extends HandledTransportAction<FindStr
         });
     }
 
-    private FindStructureAction.Response buildTextStructureResponse(FindStructureAction.Request request) throws Exception {
+    private TextStructureResponse buildTextStructureResponse(FindStructureAction.Request request) throws Exception {
 
         TextStructureFinderManager structureFinderManager = new TextStructureFinderManager(threadPool.scheduler());
 
@@ -59,7 +60,7 @@ public class TransportFindStructureAction extends HandledTransportAction<FindStr
                 request.getTimeout()
             );
 
-            return new FindStructureAction.Response(textStructureFinder.getStructure());
+            return new TextStructureResponse(textStructureFinder.getStructure());
         }
     }
 }


### PR DESCRIPTION
This commit adds the ability to run text structure analysis on a text field in an index (or indices). 

We accept a query, a field_name, set of indices, and runtime_mappings. From those configuration options
the text is gathered from the field. Each individual field value is considered a "line".