### PR TITLE
[Text Structure][ML] adjust spec to reflect accurate stability

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/text_structure.find_structure.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/text_structure.find_structure.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/find-structure.html",
       "description":"Finds the structure of a text file. The text file must contain data that is suitable to be ingested into Elasticsearch."
     },
-    "stability":"experimental",
+    "stability":"stable",
     "visibility":"public",
     "headers":{
       "accept": [ "application/json"],


### PR DESCRIPTION
the text_structure/find_structure API is stable and GA as of 7.12.

This commit adjusts the spec to reflect that.