### PR TITLE
[REST Compatible API] 'template' parameter and field on PUT index template

### DIFF
--- a/rest-api-spec/src/yamlRestCompatTest/resources/rest-api-spec/api/indices.put_template_with_param.json
+++ b/rest-api-spec/src/yamlRestCompatTest/resources/rest-api-spec/api/indices.put_template_with_param.json
@@ -1,0 +1,54 @@
+{
+  "indices.put_template_with_param":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html",
+      "description":"Creates or updates an index template."
+    },
+    "stability":"stable",
+    "visibility":"public",
+    "headers":{
+      "accept": [ "application/vnd.elasticsearch+json;compatible-with=7"],
+      "content_type": ["application/vnd.elasticsearch+json;compatible-with=7"]
+    },
+    "url":{
+      "paths":[
+        {
+          "path":"/_template/{name}",
+          "methods":[
+            "PUT",
+            "POST"
+          ],
+          "parts":{
+            "name":{
+              "type":"string",
+              "description":"The name of the template"
+            }
+          }
+        }
+      ]
+    },
+    "params":{
+      "template":{
+        "type":"string",
+        "description":"The indices that this template should apply to, replaced by index_patterns within the template definition."
+      },
+      "order":{
+        "type":"number",
+        "description":"The order for this template when merging multiple matching ones (higher numbers are merged later, overriding the lower numbers)"
+      },
+      "create":{
+        "type":"boolean",
+        "description":"Whether the index template should only be added if new or can also replace an existing one",
+        "default":false
+      },
+      "master_timeout":{
+        "type":"time",
+        "description":"Specify timeout for connection to master"
+      }
+    },
+    "body":{
+      "description":"The template definition",
+      "required":true
+    }
+  }
+}

--- a/rest-api-spec/src/yamlRestCompatTest/resources/rest-api-spec/test/v7compat/indices.put_template/10_basic_compat.yml
+++ b/rest-api-spec/src/yamlRestCompatTest/resources/rest-api-spec/test/v7compat/indices.put_template/10_basic_compat.yml
@@ -1,0 +1,68 @@
+---
+setup:
+  - skip:
+      version: "9.0.0 - "
+      reason: "compatible from 8.x to 7.x"
+      features:
+        - "headers"
+        - "warnings"
+
+---
+"Put template":
+
+  - do:
+      headers:
+        Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
+        Accept: "application/vnd.elasticsearch+json;compatible-with=7"
+      warnings:
+        - "Deprecated field [template] used, replaced by [index_patterns]"
+      indices.put_template:
+        name: test
+        body:
+          template: test-*
+          settings:
+            number_of_shards:   1
+            number_of_replicas: 0
+          mappings:
+            properties:
+              field:
+                type: keyword
+
+  - do:
+      indices.get_template:
+        name: test
+        flat_settings: true
+
+  - match: {test.index_patterns: ["test-*"]}
+  - match: {test.settings: {index.number_of_shards: '1', index.number_of_replicas: '0'}}
+  - match: {test.mappings: {properties: {field: {type: keyword}}}}
+
+---
+"Put template (with template parameter)":
+
+  - do:
+      headers:
+        Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
+        Accept: "application/vnd.elasticsearch+json;compatible-with=7"
+      warnings:
+        - "Deprecated parameter [template] used, replaced by [index_patterns]"
+      indices.put_template_with_param:
+        name: test
+        template: "test-*"
+        body:
+          settings:
+            number_of_shards:   1
+            number_of_replicas: 0
+          mappings:
+            properties:
+              field:
+                type: keyword
+
+  - do:
+      indices.get_template:
+        name: test
+        flat_settings: true
+
+  - match: {test.index_patterns: ["test-*"]}
+  - match: {test.settings: {index.number_of_shards: '1', index.number_of_replicas: '0'}}
+  - match: {test.mappings: {properties: {field: {type: keyword}}}}


### PR DESCRIPTION
Related to #51816 / #68905. See also especially #49460 -- this adds back the index template parameter and field (via rest compatibility).