### PR TITLE
[DOC] Clarify how to remove stack templates

### DIFF
--- a/docs/reference/indices/index-templates.asciidoc
+++ b/docs/reference/indices/index-templates.asciidoc
@@ -1,8 +1,8 @@
 [[index-templates]]
 = Index templates
 
-NOTE: This topic describes the composable index templates introduced in {es} 7.8. 
-For information about how index templates worked previously, 
+NOTE: This topic describes the composable index templates introduced in {es} 7.8.
+For information about how index templates worked previously,
 see the <<indices-templates-v1,legacy template documentation>>.
 
 [[getting]]
@@ -23,16 +23,27 @@ If a new data stream or index matches more than one index template, the index te
 // tag::built-in-index-templates[]
 [IMPORTANT]
 ====
-{es} has built-in index templates for the `metrics-*-*`, `logs-*-*`, and
-`synthetics-*-*` index patterns, each with a priority of `100`. The
-{fleet-guide}/fleet-overview.html[{agent}] uses these templates to create data
-streams. If you use the {agent}, assign your index templates a priority lower
-than `100` to avoid overriding the built-in templates.
+{es} has built-in index templates, each with a priority of `100`, for the
+following index patterns:
 
-Otherwise, to avoid accidentally applying the built-in templates, use a
-non-overlapping index pattern or assign templates with an overlapping pattern a
-`priority` higher than `100`.
+// tag::built-in-index-template-patterns[]
+- `logs-*-*`
+- `metrics-*-*`
+- `synthetics-*-*`
+// end::built-in-index-template-patterns[]
 
+The {fleet-guide}/fleet-overview.html[{agent}] uses these templates to create
+data streams. If you use the {agent}, assign your index templates a priority
+lower than `100` to avoid overriding the built-in templates.Otherwise, to avoid
+accidentally applying the built-in templates, do one or more of the following:
+
+- To disable all built-in index and component templates, set
+<<stack-templates-enabled,`stack.templates.enabled`>> to `false` in the
+<<config-files-location,`elasticsearch.yml`>>.
+
+- Use a non-overlapping index pattern.
+
+- Assign templates with an overlapping pattern a `priority` higher than `100`.
 For example, if you don't use the {agent} and want to create a template for the
 `logs-*` index pattern, assign your template a priority of `200`. This ensures
 your template is applied instead of the built-in template for `logs-*-*`.

--- a/docs/reference/indices/index-templates.asciidoc
+++ b/docs/reference/indices/index-templates.asciidoc
@@ -32,13 +32,13 @@ following index patterns:
 - `synthetics-*-*`
 // end::built-in-index-template-patterns[]
 
-The {fleet-guide}/fleet-overview.html[{agent}] uses these templates to create
+{fleet-guide}/fleet-overview.html[{agent}] uses these templates to create
 data streams. If you use the {agent}, assign your index templates a priority
 lower than `100` to avoid overriding the built-in templates.Otherwise, to avoid
 accidentally applying the built-in templates, do one or more of the following:
 
 - To disable all built-in index and component templates, set
-<<stack-templates-enabled,`stack.templates.enabled`>> to `false` in the
+<<stack-templates-enabled,`stack.templates.enabled`>> to `false` in
 <<config-files-location,`elasticsearch.yml`>>.
 
 - Use a non-overlapping index pattern.

--- a/docs/reference/indices/put-component-template.asciidoc
+++ b/docs/reference/indices/put-component-template.asciidoc
@@ -99,7 +99,7 @@ Name of the component template to create.
 - `synthetics-settings`
 // end::built-in-component-templates[]
 
-The {fleet-guide}/fleet-overview.html[{agent}] uses these templates to configure
+{fleet-guide}/fleet-overview.html[{agent}] uses these templates to configure
 backing indices for its data streams. If you use {agent} and want to overwrite
 one of these templates, set the `version` for your replacement template higher
 than the current version.

--- a/docs/reference/indices/put-component-template.asciidoc
+++ b/docs/reference/indices/put-component-template.asciidoc
@@ -85,7 +85,29 @@ except before the opening curly bracket.
 `<component-template>`::
 (Required, string)
 Name of the component template to create.
++
+[IMPORTANT]
+====
+{es} includes the following built-in component templates:
 
+// tag::built-in-component-templates[]
+- `logs-mappings`
+- `logs-settings`
+- `metrics-mappings`
+- `metrics-settings`
+- `synthetics-mapping`
+- `synthetics-settings`
+// end::built-in-component-templates[]
+
+The {fleet-guide}/fleet-overview.html[{agent}] uses these templates to configure
+backing indices for its data streams. If you use {agent} and want to overwrite
+one of these templates, set the `version` for your replacement template higher
+than the current version.
+
+If you don't use {agent} and want to disable all built-in component and index
+templates, set <<stack-templates-enabled,`stack.templates.enabled`>> to `false`
+in <<config-files-location,`elasticsearch.yml`>>.
+====
 
 [[put-component-template-api-query-params]]
 ==== {api-query-parms-title}

--- a/docs/reference/migration/migrate_7_9.asciidoc
+++ b/docs/reference/migration/migrate_7_9.asciidoc
@@ -43,10 +43,10 @@ For example, if you don't use {agent} and want to use a template for the
 your template is applied instead of the built-in template for `logs-*-*`.
 
 To disable all built-in index and component templates, set
-<<stack-templates-enabled,`stack.templates.enabled`>> to `false` in the
+<<stack-templates-enabled,`stack.templates.enabled`>> to `false` in
 <<config-files-location,`elasticsearch.yml`>> before start up. If the templates
-already exist, then setting this property will ensure the templates will not be
-recreated when they are deleted.
+already exist, this setting ensures {es} does not recreate the built-in
+templates after deletion.
 ====
 //end::notable-breaking-changes[]
 

--- a/docs/reference/migration/migrate_7_9.asciidoc
+++ b/docs/reference/migration/migrate_7_9.asciidoc
@@ -41,6 +41,12 @@ non-overlapping index pattern or assign templates with an overlapping pattern a
 For example, if you don't use {agent} and want to use a template for the
 `logs-*` index pattern, assign your template a priority of `200`. This ensures
 your template is applied instead of the built-in template for `logs-*-*`.
+
+To disable all built-in index and component templates, set
+<<stack-templates-enabled,`stack.templates.enabled`>> to `false` in the
+<<config-files-location,`elasticsearch.yml`>> before start up. If the templates
+already exist, then setting this property will ensure the templates will not be
+recreated when they are deleted.
 ====
 //end::notable-breaking-changes[]
 
@@ -114,7 +120,7 @@ explicitly update the mapping of an index:
 * `write`
 
 Additionally, in {es} 8.0.0, the following privileges will no longer allow users to
-{ref}/dynamic-mapping.html[dynamically update the mapping] of an index 
+{ref}/dynamic-mapping.html[dynamically update the mapping] of an index
 during indexing or ingest:
 
 * `create_doc`

--- a/docs/reference/modules/indices/index_management.asciidoc
+++ b/docs/reference/modules/indices/index_management.asciidoc
@@ -38,7 +38,7 @@ Specifies the hosts that can be <<reindex-from-remote,reindexed from remotely>>.
 +
 --
 (<<static-cluster-setting,Static>>)
-If `true`, enables built-in index and component templates. The
+If `true`, enables built-in index and component templates.
 {fleet-guide}/fleet-overview.html[{agent}] uses these templates to create data
 streams. If `false`, {es} disables these index and component templates. Defaults
 to `true`.

--- a/docs/reference/modules/indices/index_management.asciidoc
+++ b/docs/reference/modules/indices/index_management.asciidoc
@@ -32,3 +32,22 @@ IMPORTANT: Closed indices are a data loss risk because they are not included whe
 (<<static-cluster-setting,Static>>)
 Specifies the hosts that can be <<reindex-from-remote,reindexed from remotely>>. Expects a YAML array of `host:port` strings. Consists of a comma-delimited list of `host:port` entries. Defaults to `["\*.io:*", "\*.com:*"]`.
 // end::reindex-remote-whitelist[]
+
+[[stack-templates-enabled]]
+`stack.templates.enabled` {ess-icon}::
++
+--
+(<<static-cluster-setting,Static>>)
+If `true`, enables built-in index and component templates. The
+{fleet-guide}/fleet-overview.html[{agent}] uses these templates to create data
+streams. If `false`, {es} disables these index and component templates. Defaults
+to `true`.
+
+This setting affects the following built-in index templates:
+
+include::{es-repo-dir}/indices/index-templates.asciidoc[tag=built-in-index-template-patterns]
+
+This setting also affects the following built-in component templates:
+
+include::{es-repo-dir}/indices/put-component-template.asciidoc[tag=built-in-component-templates]
+--


### PR DESCRIPTION
Clarify in 7.10 docs how to disable the automatic (re)creation of stack templates.

This will be back-ported to 7.9 with edits (synthetics-*-* did not exist in that version)
Note that the contents differ from the 7.11 pages because the stack template setting was made dynamic in that version.