### PR TITLE
[DOCS] Adding note about TLS-related files being reloaded

### DIFF
--- a/x-pack/docs/en/security/securing-communications/security-basic-setup.asciidoc
+++ b/x-pack/docs/en/security/securing-communications/security-basic-setup.asciidoc
@@ -113,7 +113,14 @@ ensure that communication between the nodes is encrypted.
 Now that you've generated a certificate authority and certificates, you'll
 update your cluster to use these files.
 
-NOTE: Complete the following steps for each node in your cluster. To join the
+NOTE: {es} monitors all files such as certificates, keys, keystores, or
+truststores that are configured as values of TLS-related node settings. If
+you update any of these files, such as when your hostnames change or your
+certificates are due to expire, {es} reloads them. The files are polled for
+changes at a frequency determined by the global {es}
+`resource.reload.interval.high` setting, which defaults to 5 seconds.
+
+Complete the following steps *for each node in your cluster*. To join the
 same cluster, all nodes must share the same `cluster.name` value.
 
 . Open the `ES_PATH_CONF/elasticsearch.yml` file and make the following


### PR DESCRIPTION
#68946 removed a note indicating that Elasticsearch reloads TLS-related settings on a polled interval. Adding the missing note back to the security documentation.

Closes #71234