### PR TITLE
Deprecate multiple path.data entries (#71207)

### DIFF
--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -326,6 +326,13 @@ public class Node implements Closeable {
                     Build.CURRENT.getQualifiedVersion());
             }
 
+            if (initialEnvironment.dataFiles().length > 1) {
+                // NOTE: we use initialEnvironment here, but assertEquivalent below ensures the data paths do not change
+                deprecationLogger.deprecate(DeprecationCategory.SETTINGS, "multiple-data-paths",
+                    "Configuring multiple [path.data] paths is deprecated. Use RAID or other system level features for utilizing " +
+                        "multiple disks. This feature will be removed in 8.0.");
+            }
+
             if (logger.isDebugEnabled()) {
                 logger.debug("using config [{}], data [{}], logs [{}], plugins [{}]",
                     initialEnvironment.configFile(), Arrays.toString(initialEnvironment.dataFiles()),

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractMultiClustersTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractMultiClustersTestCase.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.elasticsearch.discovery.DiscoveryModule.DISCOVERY_SEED_PROVIDERS_SETTING;
 import static org.elasticsearch.discovery.SettingsBasedSeedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING;
@@ -101,6 +102,13 @@ public abstract class AbstractMultiClustersTestCase extends ESTestCase {
         }
         clusterGroup = new ClusterGroup(clusters);
         configureAndConnectsToRemoteClusters();
+    }
+
+    @Override
+    public List<String> filteredWarnings() {
+        return Stream.concat(super.filteredWarnings().stream(),
+            Stream.of("Configuring multiple [path.data] paths is deprecated. Use RAID or other system level features for utilizing " +
+            "multiple disks. This feature will be removed in 8.0.")).collect(Collectors.toList());
     }
 
     @After

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -494,11 +494,17 @@ public abstract class ESTestCase extends LuceneTestCase {
         }
         try {
 
-            final List<String> actualWarnings = threadContext.getResponseHeaders().get("Warning").stream()
-                .filter(k -> filteredWarnings().stream().noneMatch(s -> s.contains(k)))
-                .collect(Collectors.toList());
+            final List<String> rawWarnings = threadContext.getResponseHeaders().get("Warning");
+            final List<String> actualWarnings;
+            if (rawWarnings == null) {
+                actualWarnings = Collections.emptyList();
+            } else {
+                actualWarnings = rawWarnings.stream()
+                    .filter(k -> filteredWarnings().stream().noneMatch(s -> s.contains(k)))
+                    .collect(Collectors.toList());
+            }
             if ((expectedWarnings == null || expectedWarnings.length == 0)) {
-                assertNull("expected 0 warnings, actual: " + actualWarnings, actualWarnings);
+                assertThat("expected 0 warnings, actual: " + actualWarnings, actualWarnings, empty());
             } else {
                 assertWarnings(stripXContentPosition, actualWarnings, expectedWarnings);
             }

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -411,19 +411,11 @@ public abstract class ESTestCase extends LuceneTestCase {
         try {
             final List<String> warnings = threadContext.getResponseHeaders().get("Warning");
             if (warnings != null) {
-                List<String> filteredWarnings = new ArrayList<>(warnings);
-                if (enableJodaDeprecationWarningsCheck() == false) {
-                    filteredWarnings = filterJodaDeprecationWarnings(filteredWarnings);
-                }
-                if (JvmInfo.jvmInfo().getBundledJdk() == false) {
-                    // unit tests do not run with the bundled JDK, if there are warnings we need to filter the no-jdk deprecation warning
-                    filteredWarnings = filteredWarnings
-                        .stream()
-                        .filter(k -> k.contains(
-                            "no-jdk distributions that do not bundle a JDK are deprecated and will be removed in a future release"
-                        ) == false)
-                        .collect(Collectors.toList());
-                }
+                // unit tests do not run with the bundled JDK, if there are warnings we need to filter the no-jdk deprecation warning
+                final List<String> filteredWarnings = warnings
+                    .stream()
+                    .filter(k -> filteredWarnings().stream().anyMatch(s -> s.contains(k)))
+                    .collect(Collectors.toList());
                 assertThat("unexpected warning headers", filteredWarnings, empty());
             } else {
                 assertNull("unexpected warning headers", warnings);
@@ -431,6 +423,17 @@ public abstract class ESTestCase extends LuceneTestCase {
         } finally {
             resetDeprecationLogger();
         }
+    }
+
+    protected List<String> filteredWarnings() {
+        List<String> filtered = new ArrayList<>();
+        if (enableJodaDeprecationWarningsCheck()) {
+            filtered.add(JodaDeprecationPatterns.USE_NEW_FORMAT_SPECIFIERS);
+        }
+        if (JvmInfo.jvmInfo().getBundledJdk() == false) {
+            filtered.add("no-jdk distributions that do not bundle a JDK are deprecated and will be removed in a future release");
+        }
+        return filtered;
     }
 
     /**
@@ -490,24 +493,18 @@ public abstract class ESTestCase extends LuceneTestCase {
             throw new IllegalStateException("unable to check warning headers if the test is not set to do so");
         }
         try {
-            final List<String> actualWarnings = threadContext.getResponseHeaders().get("Warning");
+
+            final List<String> actualWarnings = threadContext.getResponseHeaders().get("Warning").stream()
+                .filter(k -> filteredWarnings().stream().anyMatch(s -> s.contains(k)))
+                .collect(Collectors.toList());
             if ((expectedWarnings == null || expectedWarnings.length == 0)) {
                 assertNull("expected 0 warnings, actual: " + actualWarnings, actualWarnings);
-            } else if (actualWarnings != null && enableJodaDeprecationWarningsCheck() == false) {
-                List<String> filteredWarnings = filterJodaDeprecationWarnings(actualWarnings);
-                assertWarnings(stripXContentPosition, filteredWarnings, expectedWarnings);
             } else {
                 assertWarnings(stripXContentPosition, actualWarnings, expectedWarnings);
             }
         } finally {
             resetDeprecationLogger();
         }
-    }
-
-    private List<String> filterJodaDeprecationWarnings(List<String> actualWarnings) {
-        return actualWarnings.stream()
-                             .filter(m -> m.contains(JodaDeprecationPatterns.USE_NEW_FORMAT_SPECIFIERS) == false)
-                             .collect(Collectors.toList());
     }
 
     private void assertWarnings(boolean stripXContentPosition, List<String> actualWarnings, String[] expectedWarnings) {

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -495,7 +495,7 @@ public abstract class ESTestCase extends LuceneTestCase {
         try {
 
             final List<String> actualWarnings = threadContext.getResponseHeaders().get("Warning").stream()
-                .filter(k -> filteredWarnings().stream().anyMatch(s -> s.contains(k)))
+                .filter(k -> filteredWarnings().stream().noneMatch(s -> s.contains(k)))
                 .collect(Collectors.toList());
             if ((expectedWarnings == null || expectedWarnings.length == 0)) {
                 assertNull("expected 0 warnings, actual: " + actualWarnings, actualWarnings);

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -493,7 +493,6 @@ public abstract class ESTestCase extends LuceneTestCase {
             throw new IllegalStateException("unable to check warning headers if the test is not set to do so");
         }
         try {
-
             final List<String> rawWarnings = threadContext.getResponseHeaders().get("Warning");
             final List<String> actualWarnings;
             if (rawWarnings == null) {

--- a/test/framework/src/test/java/org/elasticsearch/test/test/InternalTestClusterTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/test/InternalTestClusterTests.java
@@ -42,6 +42,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.elasticsearch.discovery.DiscoveryModule.DISCOVERY_SEED_PROVIDERS_SETTING;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertFileExists;
@@ -58,6 +59,13 @@ public class InternalTestClusterTests extends ESTestCase {
 
     private static Collection<Class<? extends Plugin>> mockPlugins() {
         return Arrays.asList(getTestTransportPlugin(), MockHttpTransport.TestPlugin.class);
+    }
+
+    @Override
+    protected List<String> filteredWarnings() {
+        return Stream.concat(super.filteredWarnings().stream(),
+            Stream.of("Configuring multiple [path.data] paths is deprecated. Use RAID or other system level features for utilizing " +
+            "multiple disks. This feature will be removed in 8.0.")).collect(Collectors.toList());
     }
 
     public void testInitializiationIsConsistent() {

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/CcrIntegTestCase.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/CcrIntegTestCase.java
@@ -320,6 +320,13 @@ public abstract class CcrIntegTestCase extends ESTestCase {
         };
     }
 
+    @Override
+    public List<String> filteredWarnings() {
+        return Stream.concat(super.filteredWarnings().stream(),
+            Stream.of("Configuring multiple [path.data] paths is deprecated. Use RAID or other system level features for utilizing " +
+            "multiple disks. This feature will be removed in 8.0.")).collect(Collectors.toList());
+    }
+
     @AfterClass
     public static void stopClusters() throws IOException {
         IOUtils.close(clusterGroup);


### PR DESCRIPTION
This commit adds a node level deprecation log message when multiple
data paths are specified.

relates #71205