### PR TITLE
Fix search states of CCS requests in mixed cluster

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchCluster.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchCluster.java
@@ -133,8 +133,14 @@ public class ElasticsearchCluster implements TestClusterConfiguration, Named {
     }
 
     @Internal
-    ElasticsearchNode getFirstNode() {
+    public ElasticsearchNode getFirstNode() {
         return nodes.getAt(clusterName + "-0");
+    }
+
+    @Internal
+    public ElasticsearchNode getLastNode() {
+        int index = nodes.size() - 1;
+        return nodes.getAt(clusterName + "-" + index);
     }
 
     @Internal

--- a/qa/ccs-rolling-upgrade-remote-cluster/build.gradle
+++ b/qa/ccs-rolling-upgrade-remote-cluster/build.gradle
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import org.elasticsearch.gradle.Version
+import org.elasticsearch.gradle.info.BuildParams
+import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
+
+apply plugin: 'elasticsearch.testclusters'
+apply plugin: 'elasticsearch.standalone-test'
+apply from: "$rootDir/gradle/bwc-test.gradle"
+apply plugin: 'elasticsearch.rest-resources'
+
+dependencies {
+  testImplementation project(':client:rest-high-level')
+}
+
+for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
+  String baseName = "v${bwcVersion}"
+  String bwcVersionStr = "${bwcVersion}"
+
+  /**
+   * We execute tests 3 times.
+   * - The local cluster is unchanged and it consists of an old version node and a new version node.
+   * - Nodes in the remote cluster are upgraded one by one in three steps.
+   * - Only node-0 and node-2 of the remote cluster can accept remote connections. This can creates a test
+   *   scenario where a query request and fetch request are sent via **proxy nodes** that have different version.
+   */
+  testClusters {
+    "${baseName}-local" {
+      numberOfNodes = 2
+      versions = [bwcVersionStr, project.version]
+      setting 'cluster.remote.node.attr', 'gateway'
+    }
+    "${baseName}-remote" {
+      numberOfNodes = 3
+      versions = [bwcVersionStr, project.version]
+      firstNode.setting 'node.attr.gateway', 'true'
+      lastNode.setting 'node.attr.gateway', 'true'
+    }
+  }
+
+  tasks.withType(StandaloneRestIntegTestTask).matching { it.name.startsWith("${baseName}#") }.configureEach {
+    useCluster testClusters."${baseName}-local"
+    useCluster testClusters."${baseName}-remote"
+    systemProperty 'tests.upgrade_from_version', bwcVersionStr.replace('-SNAPSHOT', '')
+
+    doFirst {
+      nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}-local".allHttpSocketURI.join(",")}")
+      nonInputProperties.systemProperty('tests.rest.remote_cluster', "${-> testClusters."${baseName}-remote".allHttpSocketURI.join(",")}")
+    }
+  }
+
+  tasks.register("${baseName}#oneThirdUpgraded", StandaloneRestIntegTestTask) {
+    dependsOn "processTestResources"
+    mustRunAfter("precommit")
+    doFirst {
+      testClusters."${baseName}-local".nextNodeToNextVersion()
+      testClusters."${baseName}-remote".nextNodeToNextVersion()
+    }
+  }
+
+  tasks.register("${baseName}#twoThirdUpgraded", StandaloneRestIntegTestTask) {
+    dependsOn "${baseName}#oneThirdUpgraded"
+    doFirst {
+      testClusters."${baseName}-remote".nextNodeToNextVersion()
+    }
+  }
+
+  tasks.register("${baseName}#fullUpgraded", StandaloneRestIntegTestTask) {
+    dependsOn "${baseName}#twoThirdUpgraded"
+    doFirst {
+      testClusters."${baseName}-remote".nextNodeToNextVersion()
+    }
+  }
+
+  tasks.register(bwcTaskName(bwcVersion)) {
+    dependsOn tasks.named("${baseName}#fullUpgraded")
+  }
+}

--- a/qa/ccs-rolling-upgrade-remote-cluster/src/test/java/org/elasticsearch/upgrades/SearchStatesIT.java
+++ b/qa/ccs-rolling-upgrade-remote-cluster/src/test/java/org/elasticsearch/upgrades/SearchStatesIT.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.upgrades;
+
+import org.apache.http.HttpHost;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.Version;
+import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
+import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.indices.CreateIndexRequest;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.DeprecationHandler;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.rest.action.document.RestIndexAction;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
+import org.elasticsearch.test.rest.ESRestTestCase;
+import org.elasticsearch.test.rest.yaml.ObjectPath;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * This test ensure that we keep the search states of a CCS request correctly when the local and remote clusters
+ * have different but compatible versions. See SearchService#createAndPutReaderContext
+ */
+public class SearchStatesIT extends ESRestTestCase {
+
+    private static final Logger LOGGER = LogManager.getLogger(SearchStatesIT.class);
+    private static final Version UPGRADE_FROM_VERSION = Version.fromString(System.getProperty("tests.upgrade_from_version"));
+    private static final String CLUSTER_ALIAS = "remote_cluster";
+
+    static class Node {
+        final String id;
+        final String name;
+        final Version version;
+        final String transportAddress;
+        final String httpAddress;
+        final Map<String, Object> attributes;
+
+        Node(String id, String name, Version version, String transportAddress, String httpAddress, Map<String, Object> attributes) {
+            this.id = id;
+            this.name = name;
+            this.version = version;
+            this.transportAddress = transportAddress;
+            this.httpAddress = httpAddress;
+            this.attributes = attributes;
+        }
+
+        @Override
+        public String toString() {
+            return "Node{" +
+                "id='" + id + '\'' +
+                ", name='" + name + '\'' +
+                ", version=" + version +
+                ", transportAddress='" + transportAddress + '\'' +
+                ", httpAddress='" + httpAddress + '\'' +
+                ", attributes=" + attributes +
+                '}';
+        }
+    }
+
+    static List<Node> getNodes(RestClient restClient) throws IOException {
+        Response response = restClient.performRequest(new Request("GET", "_nodes"));
+        ObjectPath objectPath = ObjectPath.createFromResponse(response);
+        final Map<String, Object> nodeMap = objectPath.evaluate("nodes");
+        final List<Node> nodes = new ArrayList<>();
+        for (String id : nodeMap.keySet()) {
+            final String name = objectPath.evaluate("nodes." + id + ".name");
+            final Version version = Version.fromString(objectPath.evaluate("nodes." + id + ".version"));
+            final String transportAddress = objectPath.evaluate("nodes." + id + ".transport.publish_address");
+            final String httpAddress = objectPath.evaluate("nodes." + id + ".http.publish_address");
+            final Map<String, Object> attributes = objectPath.evaluate("nodes." + id + ".attributes");
+            nodes.add(new Node(id, name, version, transportAddress, httpAddress, attributes));
+        }
+        return nodes;
+    }
+
+    static List<HttpHost> parseHosts(String props) {
+        final String address = System.getProperty(props);
+        assertNotNull("[" + props + "] is not configured", address);
+        String[] stringUrls = address.split(",");
+        List<HttpHost> hosts = new ArrayList<>(stringUrls.length);
+        for (String stringUrl : stringUrls) {
+            int portSeparator = stringUrl.lastIndexOf(':');
+            if (portSeparator < 0) {
+                throw new IllegalArgumentException("Illegal cluster url [" + stringUrl + "]");
+            }
+            String host = stringUrl.substring(0, portSeparator);
+            int port = Integer.parseInt(stringUrl.substring(portSeparator + 1));
+            hosts.add(new HttpHost(host, port, "http"));
+        }
+        assertThat("[" + props + "] is empty", hosts, not(empty()));
+        return hosts;
+    }
+
+    public static void configureRemoteClusters(List<Node> remoteNodes) throws Exception {
+        assertThat(remoteNodes, hasSize(3));
+        final String remoteClusterSettingPrefix = "cluster.remote." + CLUSTER_ALIAS + ".";
+        try (RestHighLevelClient localClient = newLocalClient()) {
+            final Settings remoteConnectionSettings;
+            if (UPGRADE_FROM_VERSION.before(Version.V_7_6_0) || randomBoolean()) {
+                final List<String> seeds = remoteNodes.stream()
+                    .filter(n -> n.attributes.containsKey("gateway"))
+                    .map(n -> n.transportAddress)
+                    .collect(Collectors.toList());
+                assertThat(seeds, hasSize(2));
+                LOGGER.info("--> use sniff mode with seed [{}], remote nodes [{}]", seeds, remoteNodes);
+                if (UPGRADE_FROM_VERSION.before(Version.V_7_6_0)) {
+                    remoteConnectionSettings = Settings.builder()
+                        .putList(remoteClusterSettingPrefix + "seeds", seeds)
+                        .build();
+                } else {
+                    remoteConnectionSettings = Settings.builder()
+                        .putNull(remoteClusterSettingPrefix + "proxy_address")
+                        .put(remoteClusterSettingPrefix + "mode", "sniff")
+                        .putList(remoteClusterSettingPrefix + "seeds", seeds)
+                        .build();
+                }
+            } else {
+                final Node proxyNode = randomFrom(remoteNodes);
+                LOGGER.info("--> use proxy node [{}], remote nodes [{}]", proxyNode, remoteNodes);
+                remoteConnectionSettings = Settings.builder()
+                    .putNull(remoteClusterSettingPrefix + "seeds")
+                    .put(remoteClusterSettingPrefix + "mode", "proxy")
+                    .put(remoteClusterSettingPrefix + "proxy_address", proxyNode.transportAddress)
+                    .build();
+            }
+            assertTrue(
+                localClient.cluster()
+                    .putSettings(new ClusterUpdateSettingsRequest().persistentSettings(remoteConnectionSettings), RequestOptions.DEFAULT)
+                    .isAcknowledged()
+            );
+            assertBusy(() -> {
+                final Response resp = localClient.getLowLevelClient().performRequest(new Request("GET", "/_remote/info"));
+                assertOK(resp);
+                final ObjectPath objectPath = ObjectPath.createFromResponse(resp);
+                assertNotNull(objectPath.evaluate(CLUSTER_ALIAS));
+                assertTrue(objectPath.evaluate(CLUSTER_ALIAS + ".connected"));
+            }, 60, TimeUnit.SECONDS);
+        }
+    }
+
+    static RestHighLevelClient newLocalClient() {
+        final List<HttpHost> hosts = parseHosts("tests.rest.cluster");
+        final int index = random().nextInt(hosts.size());
+        LOGGER.info("Using client node {}", index);
+        return new RestHighLevelClient(RestClient.builder(hosts.get(index)));
+    }
+
+    static RestHighLevelClient newRemoteClient() {
+        return new RestHighLevelClient(RestClient.builder(randomFrom(parseHosts("tests.rest.remote_cluster"))));
+    }
+
+    static int indexDocs(RestHighLevelClient client, String index, int numDocs) throws IOException {
+        for (int i = 0; i < numDocs; i++) {
+            Request indexDoc = new Request("PUT", index + "/type/" + i);
+            indexDoc.setJsonEntity("{\"f\":" + i + "}");
+            indexDoc.setOptions(expectWarnings(RestIndexAction.TYPES_DEPRECATION_MESSAGE));
+            client.getLowLevelClient().performRequest(indexDoc);
+        }
+        client.indices().refresh(new RefreshRequest(index), RequestOptions.DEFAULT);
+        return numDocs;
+    }
+
+    void verifySearch(String localIndex, int localNumDocs, String remoteIndex, int remoteNumDocs) {
+        try (RestHighLevelClient localClient = newLocalClient()) {
+            Request request = new Request("POST", "/_search");
+            final int expectedDocs;
+            if (randomBoolean()) {
+                request.addParameter("index", remoteIndex);
+                expectedDocs = remoteNumDocs;
+            } else {
+                request.addParameter("index", localIndex + "," + remoteIndex);
+                expectedDocs = localNumDocs + remoteNumDocs;
+            }
+            if (UPGRADE_FROM_VERSION.onOrAfter(Version.V_7_0_0)) {
+                request.addParameter("ccs_minimize_roundtrips", Boolean.toString(randomBoolean()));
+            }
+            int size = between(1, 100);
+            request.setJsonEntity("{\"sort\": \"f\", \"size\": " + size + "}");
+            Response response = localClient.getLowLevelClient().performRequest(request);
+            try (XContentParser parser = JsonXContent.jsonXContent.createParser(
+                NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                response.getEntity().getContent())) {
+                SearchResponse searchResponse = SearchResponse.fromXContent(parser);
+                ElasticsearchAssertions.assertNoFailures(searchResponse);
+                ElasticsearchAssertions.assertHitCount(searchResponse, expectedDocs);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    public void testBWCSearchStates() throws Exception {
+        String localIndex = "test_bwc_search_states_index";
+        String remoteIndex = "test_bwc_search_states_remote_index";
+        try (RestHighLevelClient localClient = newLocalClient();
+             RestHighLevelClient remoteClient = newRemoteClient()) {
+            localClient.indices().create(new CreateIndexRequest(localIndex)
+                    .settings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, between(1, 5))),
+                RequestOptions.DEFAULT);
+            int localNumDocs = indexDocs(localClient, localIndex, between(10, 100));
+
+            remoteClient.indices().create(new CreateIndexRequest(remoteIndex)
+                    .settings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, between(1, 5))),
+                RequestOptions.DEFAULT);
+            int remoteNumDocs = indexDocs(remoteClient, remoteIndex, between(10, 100));
+
+            configureRemoteClusters(getNodes(remoteClient.getLowLevelClient()));
+            int iterations = between(1, 20);
+            for (int i = 0; i < iterations; i++) {
+                verifySearch(localIndex, localNumDocs, CLUSTER_ALIAS + ":" + remoteIndex, remoteNumDocs);
+            }
+            localClient.indices().delete(new DeleteIndexRequest(localIndex), RequestOptions.DEFAULT);
+            remoteClient.indices().delete(new DeleteIndexRequest(remoteIndex), RequestOptions.DEFAULT);
+        }
+    }
+}

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CrossClusterSearchIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CrossClusterSearchIT.java
@@ -26,6 +26,8 @@ import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.shard.SearchOperationListener;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.internal.LegacyReaderContext;
+import org.elasticsearch.search.internal.ReaderContext;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.TaskInfo;
@@ -45,6 +47,8 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
 
 public class CrossClusterSearchIT extends AbstractMultiClustersTestCase {
 
@@ -207,6 +211,11 @@ public class CrossClusterSearchIT extends AbstractMultiClustersTestCase {
         public void onIndexModule(IndexModule indexModule) {
             indexModule.addSearchOperationListener(new SearchOperationListener() {
                 @Override
+                public void onNewReaderContext(ReaderContext readerContext) {
+                    assertThat(readerContext, not(instanceOf(LegacyReaderContext.class)));
+                }
+
+                @Override
                 public void onPreQueryPhase(SearchContext searchContext) {
                     startedLatch.get().countDown();
                     final CountDownLatch latch = queryLatch.get();
@@ -222,4 +231,5 @@ public class CrossClusterSearchIT extends AbstractMultiClustersTestCase {
             super.onIndexModule(indexModule);
         }
     }
+
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/simple/SimpleSearchIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/simple/SimpleSearchIT.java
@@ -14,19 +14,27 @@ import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.WriteRequest.RefreshPolicy;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.TermQueryBuilder;
+import org.elasticsearch.index.shard.SearchOperationListener;
+import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.search.internal.LegacyReaderContext;
+import org.elasticsearch.search.internal.ReaderContext;
+import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.rescore.QueryRescorerBuilder;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.test.ESIntegTestCase;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
@@ -43,8 +51,15 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitC
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
 
 public class SimpleSearchIT extends ESIntegTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return CollectionUtils.appendToCopy(super.nodePlugins(), VerifyReaderContextPlugin.class);
+    }
 
     public void testSearchNullIndex() {
         expectThrows(NullPointerException.class,
@@ -516,5 +531,28 @@ public class SimpleSearchIT extends ESIntegTestCase {
                 + "be less than [" + IndexSettings.MAX_RESCORE_WINDOW_SETTING.get(Settings.EMPTY)));
         assertThat(e.toString(), containsString(
                 "This limit can be set by changing the [" + IndexSettings.MAX_RESCORE_WINDOW_SETTING.getKey() + "] index level setting."));
+    }
+
+    public static class VerifyReaderContextPlugin extends Plugin {
+        @Override
+        public void onIndexModule(IndexModule indexModule) {
+            super.onIndexModule(indexModule);
+            indexModule.addSearchOperationListener(new SearchOperationListener() {
+                @Override
+                public void onNewReaderContext(ReaderContext readerContext) {
+                    assertThat(readerContext, not(instanceOf(LegacyReaderContext.class)));
+                }
+
+                @Override
+                public void onQueryPhase(SearchContext searchContext, long tookInNanos) {
+                    assertThat(searchContext.readerContext(), not(instanceOf(LegacyReaderContext.class)));
+                }
+
+                @Override
+                public void onFetchPhase(SearchContext searchContext, long tookInNanos) {
+                    assertThat(searchContext.readerContext(), not(instanceOf(LegacyReaderContext.class)));
+                }
+            });
+        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/search/SearchTransportService.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchTransportService.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.action.search;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionListenerResponseHandler;
 import org.elasticsearch.action.IndicesRequest;
@@ -277,10 +276,6 @@ public class SearchTransportService {
         }
     }
 
-    static boolean keepStatesInContext(Version version) {
-        return version.before(Version.V_7_10_0);
-    }
-
     public static void registerRequestHandler(TransportService transportService, SearchService searchService) {
         transportService.registerRequestHandler(FREE_CONTEXT_SCROLL_ACTION_NAME, ThreadPool.Names.SAME, ScrollFreeContextRequest::new,
             (request, channel, task) -> {
@@ -305,17 +300,17 @@ public class SearchTransportService {
 
         transportService.registerRequestHandler(DFS_ACTION_NAME, ThreadPool.Names.SAME, ShardSearchRequest::new,
             (request, channel, task) ->
-                searchService.executeDfsPhase(request, keepStatesInContext(channel.getVersion()), (SearchShardTask) task,
+                searchService.executeDfsPhase(request, (SearchShardTask) task,
                     new ChannelActionListener<>(channel, DFS_ACTION_NAME, request))
         );
 
         TransportActionProxy.registerProxyAction(transportService, DFS_ACTION_NAME, true, DfsSearchResult::new);
 
         transportService.registerRequestHandler(QUERY_ACTION_NAME, ThreadPool.Names.SAME, ShardSearchRequest::new,
-            (request, channel, task) -> {
-                searchService.executeQueryPhase(request, keepStatesInContext(channel.getVersion()), (SearchShardTask) task,
-                    new ChannelActionListener<>(channel, QUERY_ACTION_NAME, request));
-            });
+            (request, channel, task) ->
+                searchService.executeQueryPhase(request, (SearchShardTask) task,
+                    new ChannelActionListener<>(channel, QUERY_ACTION_NAME, request))
+        );
         TransportActionProxy.registerProxyActionWithDynamicResponseType(transportService, QUERY_ACTION_NAME, true,
             (request) -> ((ShardSearchRequest)request).numberOfShards() == 1 ? QueryFetchSearchResult::new : QuerySearchResult::new);
 

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -670,8 +670,8 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
             // Note that it's ok to keep the search states in ReaderContext even when the coordinating node also sends
             // them back in the fetch phase and it only happens in a mixed cluster.
             if (request.scroll() != null ||
-                request.getChannelVersion().before(Version.V_7_13_0) ||
-                clusterService.state().nodes().getMinNodeVersion().before(Version.V_7_13_0)) {
+                request.getChannelVersion().before(Version.V_7_12_1) ||
+                clusterService.state().nodes().getMinNodeVersion().before(Version.V_7_12_1)) {
                 readerContext = new LegacyReaderContext(id, indexService, shard, reader, request, keepAliveInMillis);
                 if (request.scroll() != null) {
                     readerContext.addOnClose(decreaseScrollContexts);

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -322,14 +322,13 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         keepAliveReaper.cancel();
     }
 
-    public void executeDfsPhase(ShardSearchRequest request, boolean keepStatesInContext,
-                                SearchShardTask task, ActionListener<SearchPhaseResult> listener) {
+    public void executeDfsPhase(ShardSearchRequest request, SearchShardTask task, ActionListener<SearchPhaseResult> listener) {
         final IndexShard shard = getShard(request);
         rewriteAndFetchShardRequest(shard, request, new ActionListener<ShardSearchRequest>() {
             @Override
             public void onResponse(ShardSearchRequest rewritten) {
                 // fork the execution in the search thread pool
-                runAsync(getExecutor(shard), () -> executeDfsPhase(request, task, keepStatesInContext), listener);
+                runAsync(getExecutor(shard), () -> executeDfsPhase(request, task), listener);
             }
 
             @Override
@@ -339,10 +338,8 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         });
     }
 
-    private DfsSearchResult executeDfsPhase(ShardSearchRequest request,
-                                            SearchShardTask task,
-                                            boolean keepStatesInContext) throws IOException {
-        ReaderContext readerContext = createOrGetReaderContext(request, keepStatesInContext);
+    private DfsSearchResult executeDfsPhase(ShardSearchRequest request, SearchShardTask task) throws IOException {
+        ReaderContext readerContext = createOrGetReaderContext(request);
         try (Releasable ignored = readerContext.markAsUsed(getKeepAlive(request));
                 SearchContext context = createContext(readerContext, request, task, true)) {
             dfsPhase.execute(context);
@@ -367,8 +364,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         }
     }
 
-    public void executeQueryPhase(ShardSearchRequest request, boolean keepStatesInContext,
-                                  SearchShardTask task, ActionListener<SearchPhaseResult> listener) {
+    public void executeQueryPhase(ShardSearchRequest request, SearchShardTask task, ActionListener<SearchPhaseResult> listener) {
         assert request.canReturnNullResponseIfMatchNoDocs() == false || request.numberOfShards() > 1
             : "empty responses require more than one shard";
         final IndexShard shard = getShard(request);
@@ -392,7 +388,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
                     }
                 }
                 // fork the execution in the search thread pool
-                runAsync(getExecutor(shard), () -> executeQueryPhase(orig, task, keepStatesInContext), listener);
+                runAsync(getExecutor(shard), () -> executeQueryPhase(orig, task), listener);
             }
 
             @Override
@@ -420,10 +416,8 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         executor.execute(ActionRunnable.supply(listener, executable::get));
     }
 
-    private SearchPhaseResult executeQueryPhase(ShardSearchRequest request,
-                                                SearchShardTask task,
-                                                boolean keepStatesInContext) throws Exception {
-        final ReaderContext readerContext = createOrGetReaderContext(request, keepStatesInContext);
+    private SearchPhaseResult executeQueryPhase(ShardSearchRequest request, SearchShardTask task) throws Exception {
+        final ReaderContext readerContext = createOrGetReaderContext(request);
         try (Releasable ignored = readerContext.markAsUsed(getKeepAlive(request));
                 SearchContext context = createContext(readerContext, request, task, true)) {
             final long afterQueryTime;
@@ -618,9 +612,9 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         return reader;
     }
 
-    final ReaderContext createOrGetReaderContext(ShardSearchRequest request, boolean keepStatesInContext) {
+    final ReaderContext createOrGetReaderContext(ShardSearchRequest request) {
         if (request.readerId() != null) {
-            assert keepStatesInContext == false;
+            assert request.scroll() == null : "scroll can't be used with pit";
             try {
                 return findReaderContext(request.readerId(), request);
             } catch (SearchContextMissingException e) {
@@ -635,19 +629,19 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
                     searcherSupplier.close();
                     throw e;
                 }
-                return createAndPutReaderContext(request, indexService, shard, searcherSupplier, false, defaultKeepAlive);
+                return createAndPutReaderContext(request, indexService, shard, searcherSupplier, defaultKeepAlive);
             }
         } else {
             final long keepAliveInMillis = getKeepAlive(request);
             final IndexService indexService = indicesService.indexServiceSafe(request.shardId().getIndex());
             final IndexShard shard = indexService.getShard(request.shardId().id());
             final Engine.SearcherSupplier searcherSupplier = shard.acquireSearcherSupplier();
-            return createAndPutReaderContext(request, indexService, shard, searcherSupplier, keepStatesInContext, keepAliveInMillis);
+            return createAndPutReaderContext(request, indexService, shard, searcherSupplier, keepAliveInMillis);
         }
     }
 
     final ReaderContext createAndPutReaderContext(ShardSearchRequest request, IndexService indexService, IndexShard shard,
-                                                  Engine.SearcherSupplier reader, boolean keepStatesInContext, long keepAliveInMillis) {
+                                                  Engine.SearcherSupplier reader, long keepAliveInMillis) {
         ReaderContext readerContext = null;
         Releasable decreaseScrollContexts = null;
         try {
@@ -661,7 +655,23 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
                 }
             }
             final ShardSearchContextId id = new ShardSearchContextId(sessionId, idGenerator.incrementAndGet());
-            if (keepStatesInContext || request.scroll() != null) {
+            // Previously, the search states are stored in ReaderContext on data nodes. Since 7.10, they are now
+            // sent to the coordinating node in QuerySearchResult and the coordinating node then sends them back
+            // in ShardFetchSearchRequest. We must keep the search states in ReaderContext unless the coordinating
+            // node is guaranteed to send them back in the fetch phase.
+            // Three cases that we have to keep the search states in ReaderContext:
+            // 1. Scroll requests
+            // 2. The coordinating node or a proxy node (i.e. CCS) is on the old version. The `channelVersion`
+            //    of ShardSearchRequest, which is the minimum version of nodes that the request has been passed,
+            //    can be used to determine this.
+            // 3. Any node on the cluster is on the old version. This extra check is to avoid a situation where a
+            //    ShardSearchRequest is sent via a new proxy node, but a ShardFetchSearchRequest on an old proxy node.
+            //
+            // Note that it's ok to keep the search states in ReaderContext even when the coordinating node also sends
+            // them back in the fetch phase and it only happens in a mixed cluster.
+            if (request.scroll() != null ||
+                request.getChannelVersion().before(Version.V_7_13_0) ||
+                clusterService.state().nodes().getMinNodeVersion().before(Version.V_7_13_0)) {
                 readerContext = new LegacyReaderContext(id, indexService, shard, reader, request, keepAliveInMillis);
                 if (request.scroll() != null) {
                     readerContext.addOnClose(decreaseScrollContexts);

--- a/server/src/main/java/org/elasticsearch/search/internal/LegacyReaderContext.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/LegacyReaderContext.java
@@ -30,7 +30,7 @@ public class LegacyReaderContext extends ReaderContext {
         assert shardSearchRequest.readerId() == null;
         assert shardSearchRequest.keepAlive() == null;
         assert id.getSearcherId() == null : "Legacy reader context must not have searcher id";
-        this.shardSearchRequest = Objects.requireNonNull(shardSearchRequest);
+        this.shardSearchRequest = Objects.requireNonNull(shardSearchRequest, "ShardSearchRequest must be provided");
         if (shardSearchRequest.scroll() != null) {
             // Search scroll requests are special, they don't hold indices names so we have
             // to reuse the searcher created on the request that initialized the scroll.

--- a/server/src/main/java/org/elasticsearch/search/internal/ReaderContext.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/ReaderContext.java
@@ -140,7 +140,7 @@ public class ReaderContext implements Releasable {
 
     // BWC
     public ShardSearchRequest getShardSearchRequest(ShardSearchRequest other) {
-        return Objects.requireNonNull(other);
+        return Objects.requireNonNull(other, "ShardSearchRequest must be sent back in a fetch request");
     }
 
     public ScrollContext scrollContext() {
@@ -156,7 +156,7 @@ public class ReaderContext implements Releasable {
     }
 
     public RescoreDocIds getRescoreDocIds(RescoreDocIds other) {
-        return Objects.requireNonNull(other);
+        return Objects.requireNonNull(other, "RescoreDocIds must be sent back in a fetch request");
     }
 
     public void setRescoreDocIds(RescoreDocIds rescoreDocIds) {

--- a/server/src/main/java/org/elasticsearch/search/internal/ShardSearchRequest.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/ShardSearchRequest.java
@@ -211,7 +211,7 @@ public class ShardSearchRequest extends TransportRequest implements IndicesReque
             this.keepAlive = null;
         }
         assert keepAlive == null || readerId != null : "readerId: " + readerId + " keepAlive: " + keepAlive;
-        if (in.getVersion().onOrAfter(Version.V_7_13_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_12_1)) {
             channelVersion = Version.min(Version.readVersion(in), in.getVersion());
         } else {
             channelVersion = in.getVersion();
@@ -284,7 +284,7 @@ public class ShardSearchRequest extends TransportRequest implements IndicesReque
             out.writeOptionalWriteable(readerId);
             out.writeOptionalTimeValue(keepAlive);
         }
-        if (out.getVersion().onOrAfter(Version.V_7_13_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_12_1)) {
             Version.writeVersion(channelVersion, out);
         }
     }

--- a/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
@@ -118,6 +118,7 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.Matchers.not;
 
 public class SearchServiceTests extends ESSingleNodeTestCase {
 
@@ -961,7 +962,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
             searchService.freeReaderContext(readerContext.id());
         }
         if (randomBoolean()) {
-            final Version version = VersionUtils.randomVersionBetween(random(), Version.V_7_13_0, Version.CURRENT);
+            final Version version = VersionUtils.randomVersionBetween(random(), Version.V_7_12_1, Version.CURRENT);
             request = serialize(request, version);
             assertThat(request.getChannelVersion(), equalTo(version));
             ReaderContext readerContext = searchService.createOrGetReaderContext(request);
@@ -971,7 +972,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
             searchService.freeReaderContext(readerContext.id());
         } else {
             final Version version = VersionUtils.randomVersionBetween(
-                random(), Version.V_7_0_0, VersionUtils.getPreviousVersion(Version.V_7_13_0));
+                random(), Version.V_7_0_0, VersionUtils.getPreviousVersion(Version.V_7_12_1));
             request = serialize(request, version);
             assertThat(request.getChannelVersion(), equalTo(version));
             ReaderContext readerContext = searchService.createOrGetReaderContext(request);

--- a/server/src/test/java/org/elasticsearch/search/internal/ShardSearchRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/search/internal/ShardSearchRequestTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.collect.Map;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
@@ -196,5 +197,57 @@ public class ShardSearchRequestTests extends AbstractSearchTestCase {
                 return parseInnerQueryBuilder(parser);
             }
         }, indexMetadata, aliasNames);
+    }
+
+    ShardSearchRequest serialize(ShardSearchRequest request, Version version) throws IOException {
+        if (version.before(Version.V_7_11_0)) {
+            if (request.source() != null) {
+                request.source().runtimeMappings(Map.of());
+            }
+        }
+        return copyWriteable(request, namedWriteableRegistry, ShardSearchRequest::new, version);
+    }
+
+    public void testChannelVersion() throws Exception {
+        ShardSearchRequest request = createShardSearchRequest();
+        Version channelVersion = Version.CURRENT;
+        assertThat(request.getChannelVersion(), equalTo(channelVersion));
+        int iterations = between(0, 5);
+        // New version
+        for (int i = 0; i < iterations; i++) {
+            Version newVersion = VersionUtils.randomVersionBetween(random(), Version.V_7_13_0, Version.CURRENT);
+            request = serialize(request, newVersion);
+            channelVersion = Version.min(newVersion, channelVersion);
+            assertThat(request.getChannelVersion(), equalTo(channelVersion));
+            if (randomBoolean()) {
+                request = new ShardSearchRequest(request);
+            }
+        }
+        // Old version
+        iterations = between(1, 5);
+        for (int i = 0; i < iterations; i++) {
+            channelVersion = VersionUtils.randomVersionBetween(random(),
+                Version.V_7_0_0, VersionUtils.getPreviousVersion(Version.V_7_13_0));
+            request = serialize(request, channelVersion);
+            assertThat(request.getChannelVersion(), equalTo(channelVersion));
+            if (randomBoolean()) {
+                request = new ShardSearchRequest(request);
+            }
+        }
+        // Any version
+        iterations = between(1, 5);
+        for (int i = 0; i < iterations; i++) {
+            Version version = VersionUtils.randomVersion(random());
+            request = serialize(request, version);
+            if (version.onOrAfter(Version.V_7_13_0)) {
+                channelVersion = Version.min(channelVersion, version);
+            } else {
+                channelVersion = version;
+            }
+            assertThat(request.getChannelVersion(), equalTo(channelVersion));
+            if (randomBoolean()) {
+                request = new ShardSearchRequest(request);
+            }
+        }
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/internal/ShardSearchRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/search/internal/ShardSearchRequestTests.java
@@ -215,7 +215,7 @@ public class ShardSearchRequestTests extends AbstractSearchTestCase {
         int iterations = between(0, 5);
         // New version
         for (int i = 0; i < iterations; i++) {
-            Version newVersion = VersionUtils.randomVersionBetween(random(), Version.V_7_13_0, Version.CURRENT);
+            Version newVersion = VersionUtils.randomVersionBetween(random(), Version.V_7_12_1, Version.CURRENT);
             request = serialize(request, newVersion);
             channelVersion = Version.min(newVersion, channelVersion);
             assertThat(request.getChannelVersion(), equalTo(channelVersion));
@@ -227,7 +227,7 @@ public class ShardSearchRequestTests extends AbstractSearchTestCase {
         iterations = between(1, 5);
         for (int i = 0; i < iterations; i++) {
             channelVersion = VersionUtils.randomVersionBetween(random(),
-                Version.V_7_0_0, VersionUtils.getPreviousVersion(Version.V_7_13_0));
+                Version.V_7_0_0, VersionUtils.getPreviousVersion(Version.V_7_12_1));
             request = serialize(request, channelVersion);
             assertThat(request.getChannelVersion(), equalTo(channelVersion));
             if (randomBoolean()) {
@@ -239,7 +239,7 @@ public class ShardSearchRequestTests extends AbstractSearchTestCase {
         for (int i = 0; i < iterations; i++) {
             Version version = VersionUtils.randomVersion(random());
             request = serialize(request, version);
-            if (version.onOrAfter(Version.V_7_13_0)) {
+            if (version.onOrAfter(Version.V_7_12_1)) {
                 channelVersion = Version.min(channelVersion, version);
             } else {
                 channelVersion = version;


### PR DESCRIPTION
Backport of #70948 to 7.12

Previously, the search states are stored in ReaderContext on data nodes. Since 7.10, we send them to the coordinating node in a QuerySearchResult of a `ShardSearchRequest and the coordinating node then sends them back in ShardFetchSearchRequest. We must keep the search states in data nodes unless they are sent back in the fetch phase. We used the channel version to determine this guarantee. However, it's not correct in CCS requests in mixed clusters.

1. The coordinating node of the local cluster on the old version sends a ShardSearchRequest to a proxy node of the remote cluster on the new version. That proxy node delivers the request to the data node. In this case, the channel version between the data node and the proxy node is >= 7.10, but we won't receive the search states in the fetch phase as they are stripped out in the channel between the old coordinating node and the new proxy.
```
[coordinating node v7.9] --> [proxy node v7.10] --> [data node on v7.10]
```

2. The coordinating node of the local on the new version sends a ShardSearchRequest to a proxy node of the remote cluster on the new version. However, the coordinating node sends a ShardFetchSearchRequest to another proxy node of the remote cluster that is still on an old version. The search states then are stripped out and never reach the data node.
```
- query phase: [coordinating node v7.10] --> [proxy node v7.10] --> [data node on v7.10]
- fetch phase: [coordinating node v7.10] --> [proxy node v7.9] --> [data node on v7.10]
```

This commit fixes the first issue by adding an explicit flag `keepSearchStatesInContext` to ShardSearchRequest and the second by continue storing the search states in ReaderContext unless all nodes are upgraded.

Relates #52741