### PR TITLE
Fix testHealthOnMasterFailover on Mac OS

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterHealthIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterHealthIT.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.cluster;
 
+import org.apache.lucene.util.Constants;
 import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest;
@@ -317,9 +318,11 @@ public class ClusterHealthIT extends ESIntegTestCase {
         // Run a few health requests concurrent to master fail-overs against a data-node to make sure master failover is handled
         // without exceptions
         final int iterations = withIndex ? 10 : 20;
+        // CI darwin workers are sometimes very slow, give them extra time.
+        int timeoutMinutes = Constants.MAC_OS_X ? 2 : 1;
         for (int i = 0; i < iterations; ++i) {
             responseFutures.add(client(node).admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID)
-                .setWaitForGreenStatus().setMasterNodeTimeout(TimeValue.timeValueMinutes(1)).execute());
+                .setWaitForGreenStatus().setMasterNodeTimeout(TimeValue.timeValueMinutes(timeoutMinutes)).execute());
             internalCluster().restartNode(internalCluster().getMasterName(), InternalTestCluster.EMPTY_CALLBACK);
         }
         if (withIndex) {


### PR DESCRIPTION
Give a bit more time to complete test on mac since darwin CI workers are
(sometimes?) slow.

Closes #62690