### PR TITLE
SQL: Introduce dedicated node for HAVING declaration

### DIFF
--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/analyzer/AnalyzerRules.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/analyzer/AnalyzerRules.java
@@ -38,7 +38,7 @@ public final class AnalyzerRules {
             }
 
             if (condition != filter.condition()) {
-                filter = new Filter(filter.source(), filter.child(), condition);
+                filter = filter.with(condition);
             }
             return filter;
         }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/plan/logical/Filter.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/plan/logical/Filter.java
@@ -64,4 +64,12 @@ public class Filter extends UnaryPlan {
         return Objects.equals(condition, other.condition)
                 && Objects.equals(child(), other.child());
     }
+
+    public Filter with(Expression condition) {
+        return new Filter(source(), child(), condition);
+    }
+
+    public Filter with(LogicalPlan child, Expression condition) {
+        return new Filter(source(), child, condition);
+    }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Verifier.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Verifier.java
@@ -53,6 +53,7 @@ import org.elasticsearch.xpack.sql.expression.function.aggregate.Skewness;
 import org.elasticsearch.xpack.sql.expression.function.aggregate.TopHits;
 import org.elasticsearch.xpack.sql.expression.function.scalar.Cast;
 import org.elasticsearch.xpack.sql.plan.logical.Distinct;
+import org.elasticsearch.xpack.sql.plan.logical.Having;
 import org.elasticsearch.xpack.sql.plan.logical.LocalRelation;
 import org.elasticsearch.xpack.sql.plan.logical.Pivot;
 import org.elasticsearch.xpack.sql.plan.logical.command.Command;
@@ -372,14 +373,14 @@ public final class Verifier {
 
     private static boolean checkGroupByHaving(LogicalPlan p, Set<Failure> localFailures,
             Set<LogicalPlan> groupingFailures, AttributeMap<Expression> attributeRefs) {
-        if (p instanceof Filter) {
-            Filter f = (Filter) p;
-            if (f.child() instanceof Aggregate) {
-                Aggregate a = (Aggregate) f.child();
+        if (p instanceof Having) {
+            Having h = (Having) p;
+            if (h.child() instanceof Aggregate) {
+                Aggregate a = (Aggregate) h.child();
 
                 Set<Expression> missing = new LinkedHashSet<>();
                 Set<Expression> unsupported = new LinkedHashSet<>();
-                Expression condition = f.condition();
+                Expression condition = h.condition();
                 // variation of checkGroupMatch customized for HAVING, which requires just aggregations
                 condition.collectFirstChildren(c -> checkGroupByHavingHasOnlyAggs(c, missing, unsupported, attributeRefs));
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/LogicalPlanBuilder.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/LogicalPlanBuilder.java
@@ -47,6 +47,7 @@ import org.elasticsearch.xpack.sql.parser.SqlBaseParser.SetQuantifierContext;
 import org.elasticsearch.xpack.sql.parser.SqlBaseParser.SubqueryContext;
 import org.elasticsearch.xpack.sql.parser.SqlBaseParser.TableNameContext;
 import org.elasticsearch.xpack.sql.plan.logical.Distinct;
+import org.elasticsearch.xpack.sql.plan.logical.Having;
 import org.elasticsearch.xpack.sql.plan.logical.Join;
 import org.elasticsearch.xpack.sql.plan.logical.LocalRelation;
 import org.elasticsearch.xpack.sql.plan.logical.Pivot;
@@ -154,7 +155,7 @@ abstract class LogicalPlanBuilder extends ExpressionBuilder {
 
         // HAVING
         if (ctx.having != null) {
-            query = new Filter(source(ctx.having), query, expression(ctx.having));
+            query = new Having(source(ctx.having), query, expression(ctx.having));
         }
 
         if (ctx.setQuantifier() != null && ctx.setQuantifier().DISTINCT() != null) {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/Having.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/Having.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.sql.plan.logical;
+
+import org.elasticsearch.xpack.ql.expression.Expression;
+import org.elasticsearch.xpack.ql.plan.logical.Filter;
+import org.elasticsearch.xpack.ql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.ql.tree.NodeInfo;
+import org.elasticsearch.xpack.ql.tree.Source;
+
+/**
+ * Dedicated class for SQL HAVING.
+ * It doesn't add any functionality and itself, acts as a marker.
+ */
+public class Having extends Filter {
+
+    public Having(Source source, LogicalPlan child, Expression condition) {
+        super(source, child, condition);
+    }
+
+    @Override
+    protected NodeInfo<Filter> info() {
+        return NodeInfo.create(this, Having::new, child(), condition());
+    }
+
+    @Override
+    protected Having replaceChild(LogicalPlan newChild) {
+        return new Having(source(), newChild, condition());
+    }
+
+    @Override
+    public Filter with(Expression condition) {
+        return new Having(source(), child(), condition);
+    }
+
+    @Override
+    public Filter with(LogicalPlan child, Expression condition) {
+        return new Having(source(), child, condition);
+    }
+}

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/VerifierErrorMessagesTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/VerifierErrorMessagesTests.java
@@ -522,8 +522,7 @@ public class VerifierErrorMessagesTests extends ESTestCase {
             error("SELECT AVG(int) FROM test GROUP BY bool HAVING int > 10"));
         accept("SELECT AVG(int) FROM test GROUP BY bool HAVING AVG(int) > 2");
     }
-    
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/69758")
+
     public void testGroupByWhereSubselect() {
         accept("SELECT b, a FROM (SELECT bool as b, AVG(int) as a FROM test GROUP BY bool) WHERE b = false");
         accept("SELECT b, a FROM (SELECT bool as b, AVG(int) as a FROM test GROUP BY bool HAVING AVG(int) > 2) WHERE b = false");


### PR DESCRIPTION
Currently HAVING is modeled as a Filter - while this works well
conceptually, it leads to false positives when validation correct usage
of HAVING (only on aggregate functions or grouped expressions).
This occurs because there's no way to detect whether a filter was
declared as a WHERE or HAVING call - the existing heuristic works in
basic queries but fails when dealing with subqueries.

This PR addresses the issue by introducing a dedicated HAVING node that,
through its definition, clearly disambiguate between regular Filter
(WHERE) and aggregated one (HAVING).

Fix #69758