### PR TITLE
[7.x] QL: Propagate nullability constraints across conjunctions (#71187)

### DIFF
--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/optimizer/Optimizer.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/optimizer/Optimizer.java
@@ -66,6 +66,7 @@ import java.util.Objects;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
+import static org.elasticsearch.xpack.ql.optimizer.OptimizerRules.PropagateNullable;
 
 public class Optimizer extends RuleExecutor<LogicalPlan> {
 
@@ -89,6 +90,7 @@ public class Optimizer extends RuleExecutor<LogicalPlan> {
                 new BooleanFunctionEqualsElimination(),
                 // needs to occur before BinaryComparison combinations
                 new PropagateEquals(),
+                new PropagateNullable(),
                 new CombineBinaryComparisons(),
                 new CombineDisjunctionsToIn(),
                 new PushDownAndCombineFilters(),

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/Expressions.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/Expressions.java
@@ -93,8 +93,29 @@ public final class Expressions {
         return false;
     }
 
+    /**
+     * Return the logical AND of a list of {@code Nullability}
+     * <pre>
+     *  UNKNOWN AND TRUE/FALSE/UNKNOWN = UNKNOWN
+     *  FALSE AND FALSE = FALSE
+     *  TRUE AND FALSE/TRUE = TRUE
+     * </pre>
+     */
     public static Nullability nullable(List<? extends Expression> exps) {
-        return Nullability.and(exps.stream().map(Expression::nullable).toArray(Nullability[]::new));
+        Nullability value = Nullability.FALSE;
+        for (Expression exp : exps) {
+            switch (exp.nullable()) {
+                case UNKNOWN:
+                    return Nullability.UNKNOWN;
+                case TRUE:
+                    value = Nullability.TRUE;
+                    break;
+                default:
+                    // not nullable
+                    break;
+            }
+        }
+        return value;
     }
 
     public static boolean foldable(List<? extends Expression> exps) {

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/Nullability.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/Nullability.java
@@ -9,31 +9,5 @@ package org.elasticsearch.xpack.ql.expression;
 public enum Nullability {
     TRUE,    // Whether the expression can become null
     FALSE,   // The expression can never become null
-    UNKNOWN; // Cannot determine if the expression supports possible null folding
-
-    /**
-     * Return the logical AND of a list of {@code Nullability}
-     * <pre>
-     *  UNKNOWN AND TRUE/FALSE/UNKNOWN = UNKNOWN
-     *  FALSE AND FALSE = FALSE
-     *  TRUE AND FALSE/TRUE = TRUE
-     * </pre>
-     */
-    public static Nullability and(Nullability... nullabilities) {
-        Nullability value = null;
-        for (Nullability n: nullabilities) {
-            switch (n) {
-                case UNKNOWN:
-                    return UNKNOWN;
-                case TRUE:
-                    value = TRUE;
-                    break;
-                case FALSE:
-                    if (value == null) {
-                        value = FALSE;
-                    }
-            }
-        }
-        return value != null ? value : FALSE;
-    }
+    UNKNOWN // Cannot determine if the expression supports possible null folding
 }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/Range.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/Range.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.ql.expression.predicate;
 
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.Expressions;
-import org.elasticsearch.xpack.ql.expression.Nullability;
 import org.elasticsearch.xpack.ql.expression.function.scalar.ScalarFunction;
 import org.elasticsearch.xpack.ql.expression.gen.pipeline.Pipe;
 import org.elasticsearch.xpack.ql.expression.gen.script.Params;
@@ -115,11 +114,6 @@ public class Range extends ScalarFunction {
         Integer compare = BinaryComparison.compare(lower.fold(), upper.fold());
         // upper < lower OR upper == lower and the range doesn't contain any equals
         return compare != null && (compare > 0 || (compare == 0 && (includeLower == false || includeUpper == false)));
-    }
-
-    @Override
-    public Nullability nullable() {
-        return Nullability.and(value.nullable(), lower.nullable(), upper.nullable());
     }
 
     @Override

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/logical/And.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/logical/And.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.ql.expression.predicate.logical;
 
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.predicate.Negatable;
+import org.elasticsearch.xpack.ql.expression.predicate.Predicates;
 import org.elasticsearch.xpack.ql.expression.predicate.logical.BinaryLogicProcessor.BinaryLogicOperation;
 import org.elasticsearch.xpack.ql.tree.NodeInfo;
 import org.elasticsearch.xpack.ql.tree.Source;
@@ -36,5 +37,11 @@ public class And extends BinaryLogic implements Negatable<BinaryLogic> {
     @Override
     public Or negate() {
         return new Or(source(), new Not(source(), left()), new Not(source(), right()));
+    }
+
+    @Override
+    protected Expression canonicalize() {
+        // NB: this add a circular dependency between Predicates / Logical package
+        return Predicates.combineAnd(Predicates.splitAnd(super.canonicalize()));
     }
 }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/logical/Or.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/logical/Or.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.ql.expression.predicate.logical;
 
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.predicate.Negatable;
+import org.elasticsearch.xpack.ql.expression.predicate.Predicates;
 import org.elasticsearch.xpack.ql.expression.predicate.logical.BinaryLogicProcessor.BinaryLogicOperation;
 import org.elasticsearch.xpack.ql.tree.NodeInfo;
 import org.elasticsearch.xpack.ql.tree.Source;
@@ -36,5 +37,11 @@ public class Or extends BinaryLogic implements Negatable<BinaryLogic> {
     @Override
     public And negate() {
         return new And(source(), new Not(source(), left()), new Not(source(), right()));
+    }
+
+    @Override
+    protected Expression canonicalize() {
+        // NB: this add a circular dependency between Predicates / Logical package
+        return Predicates.combineOr(Predicates.splitOr(super.canonicalize()));
     }
 }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/optimizer/OptimizerRules.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/optimizer/OptimizerRules.java
@@ -6,9 +6,11 @@
  */
 package org.elasticsearch.xpack.ql.optimizer;
 
+import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.Expressions;
 import org.elasticsearch.xpack.ql.expression.Literal;
+import org.elasticsearch.xpack.ql.expression.Nullability;
 import org.elasticsearch.xpack.ql.expression.Order;
 import org.elasticsearch.xpack.ql.expression.function.Function;
 import org.elasticsearch.xpack.ql.expression.function.scalar.SurrogateFunction;
@@ -18,9 +20,11 @@ import org.elasticsearch.xpack.ql.expression.predicate.Negatable;
 import org.elasticsearch.xpack.ql.expression.predicate.Predicates;
 import org.elasticsearch.xpack.ql.expression.predicate.Range;
 import org.elasticsearch.xpack.ql.expression.predicate.logical.And;
+import org.elasticsearch.xpack.ql.expression.predicate.logical.BinaryLogic;
 import org.elasticsearch.xpack.ql.expression.predicate.logical.Not;
 import org.elasticsearch.xpack.ql.expression.predicate.logical.Or;
 import org.elasticsearch.xpack.ql.expression.predicate.nulls.IsNotNull;
+import org.elasticsearch.xpack.ql.expression.predicate.nulls.IsNull;
 import org.elasticsearch.xpack.ql.expression.predicate.operator.arithmetic.ArithmeticOperation;
 import org.elasticsearch.xpack.ql.expression.predicate.operator.arithmetic.BinaryComparisonInversible;
 import org.elasticsearch.xpack.ql.expression.predicate.operator.arithmetic.Neg;
@@ -1369,7 +1373,7 @@ public final class OptimizerRules {
 
         @Override
         protected LogicalPlan rule(Filter filter) {
-            Expression condition = filter.condition().transformUp(PruneFilters::foldBinaryLogic);
+            Expression condition = filter.condition().transformUp(BinaryLogic.class, PruneFilters::foldBinaryLogic);
 
             if (condition instanceof Literal) {
                 if (TRUE.equals(condition)) {
@@ -1388,13 +1392,13 @@ public final class OptimizerRules {
 
         protected abstract LogicalPlan skipPlan(Filter filter);
 
-        private static Expression foldBinaryLogic(Expression expression) {
-            if (expression instanceof Or) {
-                Or or = (Or) expression;
+        private static Expression foldBinaryLogic(BinaryLogic binaryLogic) {
+            if (binaryLogic instanceof Or) {
+                Or or = (Or) binaryLogic;
                 boolean nullLeft = Expressions.isNull(or.left());
                 boolean nullRight = Expressions.isNull(or.right());
                 if (nullLeft && nullRight) {
-                    return new Literal(expression.source(), null, DataTypes.NULL);
+                    return new Literal(binaryLogic.source(), null, DataTypes.NULL);
                 }
                 if (nullLeft) {
                     return or.right();
@@ -1403,13 +1407,13 @@ public final class OptimizerRules {
                     return or.left();
                 }
             }
-            if (expression instanceof And) {
-                And and = (And) expression;
+            if (binaryLogic instanceof And) {
+                And and = (And) binaryLogic;
                 if (Expressions.isNull(and.left()) || Expressions.isNull(and.right())) {
-                    return new Literal(expression.source(), null, DataTypes.NULL);
+                    return new Literal(binaryLogic.source(), null, DataTypes.NULL);
                 }
             }
-            return expression;
+            return binaryLogic;
         }
     }
 
@@ -1502,6 +1506,97 @@ public final class OptimizerRules {
 
         protected Expression regexToEquals(RegexMatch<?> regexMatch, Literal literal) {
             return new Equals(regexMatch.source(), regexMatch.field(), literal);
+        }
+    }
+
+    // a IS NULL AND a IS NOT NULL -> FALSE
+    // a IS NULL AND a > 10 -> a IS NULL and FALSE
+    // can be extended to handle null conditions where available
+    public static class PropagateNullable extends OptimizerExpressionRule {
+
+        public PropagateNullable() {
+            super(TransformDirection.DOWN);
+        }
+
+        @Override
+        protected Expression rule(Expression e) {
+            if (e instanceof And) {
+                List<Expression> splits = Predicates.splitAnd(e);
+
+                Set<Expression> nullExpressions = new LinkedHashSet<>();
+                Set<Expression> notNullExpressions = new LinkedHashSet<>();
+                List<Expression> others = new LinkedList<>();
+
+                // first find isNull/isNotNull
+                for (Expression ex : splits) {
+                    if (ex instanceof IsNull) {
+                        nullExpressions.add(((IsNull) ex).field());
+                    } else if (ex instanceof IsNotNull) {
+                        notNullExpressions.add(((IsNotNull) ex).field());
+                    }
+                    // the rest
+                    else {
+                        others.add(ex);
+                    }
+                }
+
+                // check for is isNull and isNotNull --> FALSE
+                if (Sets.haveNonEmptyIntersection(nullExpressions, notNullExpressions)) {
+                    return Literal.of(e, Boolean.FALSE);
+                }
+
+                // apply nullability across relevant/matching expressions
+
+                // first against all nullable expressions
+                // followed by all not-nullable expressions
+                boolean modified = replace(nullExpressions, others, splits, this::nullify);
+                modified |= replace(notNullExpressions, others, splits, this::nonNullify);
+                if (modified) {
+                    // reconstruct the expression
+                    return Predicates.combineAnd(splits);
+                }
+            }
+            return e;
+        }
+
+        /**
+         * Replace the given 'pattern' expressions against the target expression.
+         * If a match is found, the matching expression will be replaced by the replacer result
+         * or removed if null is returned.
+         */
+        private static boolean replace(
+            Iterable<Expression> pattern,
+            List<Expression> target,
+            List<Expression> originalExpressions,
+            BiFunction<Expression, Expression, Expression> replacer
+        ) {
+            boolean modified = false;
+            for (Expression s : pattern) {
+                for (int i = 0; i < target.size(); i++) {
+                    Expression t = target.get(i);
+                    // identify matching expressions
+                    if (t.anyMatch(s::semanticEquals)) {
+                        Expression replacement = replacer.apply(t, s);
+                        // if the expression has changed, replace it
+                        if (replacement != t) {
+                            modified = true;
+                            target.set(i, replacement);
+                            originalExpressions.replaceAll(e -> t.semanticEquals(e) ? replacement : e);
+                        }
+                    }
+                }
+            }
+            return modified;
+        }
+
+        // default implementation nullifies all nullable expressions
+        protected Expression nullify(Expression exp, Expression nullExp) {
+            return exp.nullable() == Nullability.TRUE ? new Literal(exp.source(), null, DataTypes.NULL) : exp;
+        }
+
+        // placeholder for non-null
+        protected Expression nonNullify(Expression exp, Expression nonNullExp) {
+            return exp;
         }
     }
 

--- a/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/expression/NullabilityTests.java
+++ b/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/expression/NullabilityTests.java
@@ -7,30 +7,63 @@
 package org.elasticsearch.xpack.ql.expression;
 
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.ql.tree.NodeInfo;
+import org.elasticsearch.xpack.ql.tree.Source;
+import org.elasticsearch.xpack.ql.type.DataType;
+import org.elasticsearch.xpack.ql.type.DataTypes;
 
+import static java.util.Arrays.asList;
 import static org.elasticsearch.xpack.ql.expression.Nullability.FALSE;
 import static org.elasticsearch.xpack.ql.expression.Nullability.TRUE;
 import static org.elasticsearch.xpack.ql.expression.Nullability.UNKNOWN;
+import static org.elasticsearch.xpack.ql.tree.Source.EMPTY;
 
 public class NullabilityTests extends ESTestCase {
 
+    public static class Nullable extends LeafExpression {
+
+        private final Nullability nullability;
+
+        public Nullable(Source source, Nullability nullability) {
+            super(source);
+            this.nullability = nullability;
+        }
+
+        @Override
+        public Nullability nullable() {
+            return nullability;
+        }
+
+        @Override
+        public DataType dataType() {
+            return DataTypes.BOOLEAN;
+        }
+
+        @Override
+        protected NodeInfo<? extends Expression> info() {
+            return NodeInfo.create(this, Nullable::new, nullability);
+        }
+    }
+
+    private Nullable YES = new Nullable(EMPTY, TRUE);
+    private Nullable NO = new Nullable(EMPTY, FALSE);
+    private Nullable MAYBE = new Nullable(EMPTY, UNKNOWN);
+
     public void testLogicalAndOfNullabilities() {
-        assertEquals(FALSE, Nullability.and());
+        assertEquals(TRUE, Expressions.nullable(asList(YES)));
+        assertEquals(FALSE, Expressions.nullable(asList(NO)));
+        assertEquals(UNKNOWN, Expressions.nullable(asList(MAYBE)));
 
-        assertEquals(TRUE, Nullability.and(TRUE));
-        assertEquals(FALSE, Nullability.and(FALSE));
-        assertEquals(UNKNOWN, Nullability.and(UNKNOWN));
+        assertEquals(UNKNOWN, Expressions.nullable(asList(MAYBE, MAYBE)));
+        assertEquals(UNKNOWN, Expressions.nullable(asList(MAYBE, YES)));
+        assertEquals(UNKNOWN, Expressions.nullable(asList(MAYBE, NO)));
 
-        assertEquals(UNKNOWN, Nullability.and(UNKNOWN, UNKNOWN));
-        assertEquals(UNKNOWN, Nullability.and(UNKNOWN, TRUE));
-        assertEquals(UNKNOWN, Nullability.and(UNKNOWN, FALSE));
+        assertEquals(FALSE, Expressions.nullable(asList(NO, NO)));
+        assertEquals(TRUE, Expressions.nullable(asList(NO, YES)));
+        assertEquals(UNKNOWN, Expressions.nullable(asList(NO, MAYBE)));
 
-        assertEquals(FALSE, Nullability.and(FALSE, FALSE));
-        assertEquals(TRUE, Nullability.and(FALSE, TRUE));
-        assertEquals(UNKNOWN, Nullability.and(FALSE, UNKNOWN));
-
-        assertEquals(TRUE, Nullability.and(TRUE, TRUE));
-        assertEquals(TRUE, Nullability.and(TRUE, FALSE));
-        assertEquals(UNKNOWN, Nullability.and(TRUE, UNKNOWN));
+        assertEquals(TRUE, Expressions.nullable(asList(YES, YES)));
+        assertEquals(TRUE, Expressions.nullable(asList(YES, NO)));
+        assertEquals(UNKNOWN, Expressions.nullable(asList(YES, MAYBE)));
     }
 }

--- a/x-pack/plugin/sql/qa/server/src/main/resources/null.sql-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/null.sql-spec
@@ -69,3 +69,23 @@ SELECT LEAST(10098, ABS(MAX(emp_no)) + 1) AS lt FROM test_emp GROUP BY languages
 
 leastOrderBy
 SELECT LEAST(10096, ABS(emp_no + 1)) AS lt FROM test_emp ORDER BY lt LIMIT 10;
+
+
+//
+// IS NULL/IS NOT NULL propagation
+//
+
+isNullAndComparisonOnTheSameField
+SELECT emp_no IS NULL AS e FROM "test_emp" WHERE emp_no IS NULL AND emp_no > 10;
+
+isNotNullAndComparisonOnTheSameField
+SELECT emp_no IS NULL AS e FROM "test_emp" WHERE emp_no IS NOT NULL AND emp_no IS NULL;
+
+nullifyFieldExpression
+SELECT emp_no + 1 AS e FROM "test_emp" WHERE (emp_no + 2) / 1 + 10 % 3 > 100 AND emp_no IS NULL;
+
+nullifyCoalesceInSelectAndFilter
+SELECT COALESCE(null, ABS(emp_no) + 1, 123) AS c FROM test_emp WHERE emp_no IS NULL ORDER BY c NULLS FIRST LIMIT 5;
+
+
+

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/SqlFunctionRegistry.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/SqlFunctionRegistry.java
@@ -183,7 +183,7 @@ public class SqlFunctionRegistry extends FunctionRegistry {
                 def(Case.class, Case::new, "CASE"),
                 def(Coalesce.class, Coalesce::new, "COALESCE"),
                 def(Iif.class, Iif::new, "IIF"),
-                def(IfNull.class, IfNull::new, "IFNULL", "ISNULL", "NVL"),
+                def(IfNull.class, (BinaryBuilder<IfNull>) IfNull::new, "IFNULL", "ISNULL", "NVL"),
                 def(NullIf.class, NullIf::new, "NULLIF"),
                 def(Greatest.class, Greatest::new, "GREATEST"),
                 def(Least.class, Least::new, "LEAST")

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/conditional/IfNull.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/conditional/IfNull.java
@@ -14,6 +14,8 @@ import org.elasticsearch.xpack.ql.tree.Source;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.elasticsearch.xpack.ql.expression.Literal.NULL;
+
 /**
  * Variant of {@link Coalesce} with two args used by MySQL and ODBC.
  */
@@ -34,6 +36,9 @@ public class IfNull extends Coalesce {
 
     @Override
     protected NodeInfo<IfNull> info() {
-        return NodeInfo.create(this, IfNull::new, children().get(0), children().get(1));
+        List<Expression> children = children();
+        Expression first = children.size() > 0 ? children.get(0) : NULL;
+        Expression second = children.size() > 0 ? children.get(1) : NULL;
+        return NodeInfo.create(this, IfNull::new, first, second);
     }
 }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - QL: Propagate nullability constraints across conjunctions (#71187)