### PR TITLE
Point script query docs at runtime fields (backport of #71291)

### DIFF
--- a/docs/reference/query-dsl/script-query.asciidoc
+++ b/docs/reference/query-dsl/script-query.asciidoc
@@ -4,6 +4,12 @@
 <titleabbrev>Script</titleabbrev>
 ++++
 
+NOTE: <<runtime,Runtime fields>> provide a very similar feature that is
+      more flexible. You write a script to create field values and they
+      are available everywhere, such as <<search-fields, `fields`>>,
+      <<query-dsl, all queries>>, and <<search-aggregations, aggregations>>.
+
+
 Filters documents based on a provided <<modules-scripting-using,script>>. The
 `script` query is typically used in a <<query-filter-context,filter context>>.
 
@@ -22,17 +28,113 @@ GET /_search
     "bool": {
       "filter": {
         "script": {
-          "script": {
-            "source": "doc['num1'].value > 1",
-            "lang": "painless"
-          }
+          "script": """
+            double amount = doc['amount'].value;
+            if (doc['type'].value == 'expense') {
+              amount *= -1;
+            }
+            return amount < 10;
+          """
         }
       }
     }
   }
 }
 ----
+// TEST[setup:ledger]
+// TEST[s/_search/_search?filter_path=hits.hits&sort=amount/]
 
+////
+[source,console-result]
+----
+{
+  "hits": {
+    "hits": [
+      {
+        "_id": $body.hits.hits.0._id,
+        "_index": $body.hits.hits.0._index,
+        "_score": null,
+        "_source": $body.hits.hits.0._source,
+        "sort": [10.0]
+      },
+      {
+        "_id": $body.hits.hits.1._id,
+        "_index": $body.hits.hits.1._index,
+        "_score": null,
+        "_source": $body.hits.hits.1._source,
+        "sort": [50.0]
+      },
+      {
+        "_id": $body.hits.hits.2._id,
+        "_index": $body.hits.hits.2._index,
+        "_score": null,
+        "_source": $body.hits.hits.2._source,
+        "sort": [50.0]
+      }
+    ]
+  }
+}
+----
+////
+
+
+[NOTE]
+====
+Doing this with runtime fields would looke like:
+
+[source,console]
+----
+GET /_search
+{
+  "runtime_mappings": {
+    "amount.signed": {
+      "type": "double",
+      "script": """
+        double amount = doc['amount'].value;
+        if (doc['type'].value == 'expense') {
+          amount *= -1;
+        }
+        emit(amount);
+      """
+    }
+  },
+  "query": {
+    "bool": {
+      "filter": {
+        "range": {
+          "amount.signed": { "lt": 10 }
+        }
+      }
+    }
+  },
+  "fields": [{"field": "amount.signed"}] <1>
+}
+----
+// TEST[setup:ledger]
+// TEST[s/_search/_search?filter_path=hits.hits.fields&sort=amount.signed:desc/]
+<1> You can fetch the values too!
+====
+
+////
+[source,console-result]
+----
+{
+  "hits": {
+    "hits": [
+      {
+        "fields": {"amount.signed": [-10.0]}
+      },
+      {
+        "fields": {"amount.signed": [-50.0]}
+      },
+      {
+        "fields": {"amount.signed": [-50.0]}
+      }
+    ]
+  }
+}
+----
+////
 
 [[script-top-level-params]]
 ==== Top-level parameters for `script`

--- a/docs/reference/query-dsl/script-query.asciidoc
+++ b/docs/reference/query-dsl/script-query.asciidoc
@@ -52,6 +52,7 @@ GET /_search
     "hits": [
       {
         "_id": $body.hits.hits.0._id,
+        "_type": "_doc",
         "_index": $body.hits.hits.0._index,
         "_score": null,
         "_source": $body.hits.hits.0._source,
@@ -59,6 +60,7 @@ GET /_search
       },
       {
         "_id": $body.hits.hits.1._id,
+        "_type": "_doc",
         "_index": $body.hits.hits.1._index,
         "_score": null,
         "_source": $body.hits.hits.1._source,
@@ -66,6 +68,7 @@ GET /_search
       },
       {
         "_id": $body.hits.hits.2._id,
+        "_type": "_doc",
         "_index": $body.hits.hits.2._index,
         "_score": null,
         "_source": $body.hits.hits.2._source,


### PR DESCRIPTION
This adds a "note" on the docs for the script query pointing folks to
runtime fields because they are more flexible. It also translates the
request example into runtime fields.

Relates to #69291

Co-authored-by: Adam Locke <adam.locke@elastic.co>
