### PR TITLE
Script: whitelist CIDR api (#71258)

### DIFF
--- a/modules/lang-painless/spi/src/main/java/org/elasticsearch/painless/spi/Whitelist.java
+++ b/modules/lang-painless/spi/src/main/java/org/elasticsearch/painless/spi/Whitelist.java
@@ -28,6 +28,7 @@ public final class Whitelist {
 
     private static final String[] BASE_WHITELIST_FILES = new String[] {
         "org.elasticsearch.txt",
+        "org.elasticsearch.net.txt",
         "java.lang.txt",
         "java.math.txt",
         "java.text.txt",

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/api/CIDR.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/api/CIDR.java
@@ -43,7 +43,7 @@ public class CIDR {
      * @return whether the IP is in the object's range or not.
      */
     public boolean contains(String addressToCheck) {
-        if (addressToCheck == null) {
+        if (addressToCheck == null || "".equals(addressToCheck)) {
             return false;
         }
 

--- a/modules/lang-painless/src/main/resources/org/elasticsearch/painless/spi/org.elasticsearch.net.txt
+++ b/modules/lang-painless/src/main/resources/org/elasticsearch/painless/spi/org.elasticsearch.net.txt
@@ -1,0 +1,12 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0 and the Server Side Public License, v 1; you may not use this file except
+# in compliance with, at your election, the Elastic License 2.0 or the Server
+# Side Public License, v 1.
+#
+
+class org.elasticsearch.painless.api.CIDR {
+    (String)
+    boolean contains(String)
+}

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/CidrTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/CidrTests.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.painless;
+
+public class CidrTests extends ScriptTestCase {
+    public void testContains() {
+        Object bool = exec("CIDR c = new CIDR('10.1.1.0/23'); c.contains('10.1.1.128') && c.contains('10.1.0.255')");
+        assertEquals(Boolean.TRUE, bool);
+
+
+        bool = exec("CIDR c = new CIDR('10.1.1.0/25'); c.contains('10.1.1.127')");
+        assertEquals(Boolean.TRUE, bool);
+
+        bool = exec("CIDR c = new CIDR('10.1.1.0/25'); c.contains('10.1.1.129')");
+        assertEquals(Boolean.FALSE, bool);
+
+        bool = exec("new CIDR('192.168.3.5').contains('192.168.3.5')");
+        assertEquals(Boolean.TRUE, bool);
+
+        bool = exec("new CIDR('192.168.3.5').contains('')");
+        assertEquals(Boolean.FALSE, bool);
+
+        bool = exec("new CIDR('2001:0db8:85a3::/64').contains('2001:0db8:85a3:0000:0000:8a2e:0370:7334')");
+        assertEquals(Boolean.TRUE, bool);
+
+        bool = exec("new CIDR('2001:0db8:85a3::/64').contains('2001:0db8:85a3:0001:0000:8a2e:0370:7334')");
+        assertEquals(Boolean.FALSE, bool);
+
+    }
+
+    public void testInvalidIPs() {
+        IllegalArgumentException e = expectScriptThrows(IllegalArgumentException.class, () -> exec("new CIDR('abc')"));
+        assertEquals("'abc' is not an IP string literal.", e.getMessage());
+
+        e = expectScriptThrows(IllegalArgumentException.class, () -> exec("new CIDR('10.257.3.5')"));
+        assertEquals("'10.257.3.5' is not an IP string literal.", e.getMessage());
+
+        e = expectScriptThrows(IllegalArgumentException.class, () -> exec("new CIDR('2001:0db8:85a3:0000:0000:8a2e:0370:733g')"));
+        assertEquals("'2001:0db8:85a3:0000:0000:8a2e:0370:733g' is not an IP string literal.", e.getMessage());
+
+        e = expectScriptThrows(IllegalArgumentException.class,
+            () -> exec("new CIDR('2001:0db8:85a3::/64').contains('2001:0db8:85a3:0000:0000:8a2g:0370:7334')")
+        );
+        assertEquals("'2001:0db8:85a3:0000:0000:8a2g:0370:7334' is not an IP string literal.", e.getMessage());
+    }
+}

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/api/CIDRTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/api/CIDRTests.java
@@ -18,6 +18,7 @@ public class CIDRTests extends ESTestCase {
         assertFalse(cidr.contains("192.168.9.0"));
         assertFalse(cidr.contains("192.168.7.255"));
         assertFalse(cidr.contains(null));
+        assertFalse(cidr.contains(""));
 
         CIDR cidrNoRange = new CIDR("169.254.0.0");
         assertTrue(cidrNoRange.contains("169.254.0.0"));


### PR DESCRIPTION
Exposes the CIDR convenience class in painless.

API:
```
class CIDR {
  CIDR(String)
  boolean contains(String)
}
```

```
CIDR c = new CIDR('10.1.1.0/25');
c.contains('10.1.1.127'); // true
c.contains('10.1.1.129'); // false

c = new CIDR('2001:0db8:85a3::/64');
c.contains('2001:0db8:85a3:0000:0000:8a2e:0370:7334'); // true
c.contains('2001:0db8:85a3:0001:0000:8a2e:0370:7334'); // false

c.contains(null); // false
c.contains(''); // false
```

Closes: #60668
Backport: 44dc1af04b2156cfae9a79ba33a8d9e736c969f0, #71258