### PR TITLE
Add multiple data paths deprecation to docs

### DIFF
--- a/docs/reference/setup/important-settings/path-settings.asciidoc
+++ b/docs/reference/setup/important-settings/path-settings.asciidoc
@@ -24,14 +24,18 @@ include::{es-repo-dir}/tab-widgets/code.asciidoc[]
 
 include::{es-repo-dir}/tab-widgets/customize-data-log-path-widget.asciidoc[]
 
+[discrete]
+==== Multiple data paths
+deprecated::[7.13.0]
+
 If needed, you can specify multiple paths in `path.data`. {es} stores the node's
 data across all provided paths but keeps each shard's data on the same path.
 
-WARNING: {es} does not balance shards across a node's data paths. High disk
+{es} does not balance shards across a node's data paths. High disk
 usage in a single path can trigger a <<disk-based-shard-allocation,high disk
 usage watermark>> for the entire node. If triggered, {es} will not add shards to
 the node, even if the node’s other paths have available disk space. If you need
 additional disk space, we recommend you add a new node rather than additional
-data paths. 
+data paths.
 
 include::{es-repo-dir}/tab-widgets/multi-data-path-widget.asciidoc[]

--- a/docs/reference/setup/install/brew.asciidoc
+++ b/docs/reference/setup/install/brew.asciidoc
@@ -49,7 +49,7 @@ and data directory are stored in the following locations.
 
 | data
   | The location of the data files of each index / shard allocated
-    on the node. Can hold multiple locations.
+    on the node.
   | /usr/local/var/lib/elasticsearch
   | path.data
 

--- a/docs/reference/setup/install/deb.asciidoc
+++ b/docs/reference/setup/install/deb.asciidoc
@@ -192,7 +192,7 @@ locations for a Debian-based system:
 
 | data
   | The location of the data files of each index / shard allocated
-    on the node. Can hold multiple locations.
+    on the node.
   | /var/lib/elasticsearch
   | path.data
 

--- a/docs/reference/setup/install/rpm.asciidoc
+++ b/docs/reference/setup/install/rpm.asciidoc
@@ -185,7 +185,7 @@ locations for an RPM-based system:
 
 | data
   | The location of the data files of each index / shard allocated
-    on the node. Can hold multiple locations.
+    on the node.
   | /var/lib/elasticsearch
   | path.data
 

--- a/docs/reference/setup/install/targz.asciidoc
+++ b/docs/reference/setup/install/targz.asciidoc
@@ -142,7 +142,7 @@ directory so that you do not delete important data later on.
 
 | data
   | The location of the data files of each index / shard allocated
-    on the node. Can hold multiple locations.
+    on the node.
   | $ES_HOME/data
   | path.data
 

--- a/docs/reference/setup/install/zip-windows.asciidoc
+++ b/docs/reference/setup/install/zip-windows.asciidoc
@@ -263,7 +263,7 @@ directory so that you do not delete important data later on.
 
 | data
   | The location of the data files of each index / shard allocated
-    on the node. Can hold multiple locations.
+    on the node.
   | %ES_HOME%\data
   | path.data
 


### PR DESCRIPTION
This commit adds a deprecation note to the multiple data paths doc. It also removes mention of multiple paths support in the setup settings table.

relates #71205