### PR TITLE
Service Accounts - Get service account API

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/service/GetServiceAccountAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/service/GetServiceAccountAction.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.security.action.service;
+
+import org.elasticsearch.action.ActionType;
+
+public class GetServiceAccountAction extends ActionType<GetServiceAccountResponse> {
+
+    public static final String NAME = "cluster:admin/xpack/security/service_account/get";
+    public static final GetServiceAccountAction INSTANCE = new GetServiceAccountAction();
+
+    public GetServiceAccountAction() {
+        super(NAME, GetServiceAccountResponse::new);
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/service/GetServiceAccountRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/service/GetServiceAccountRequest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.security.action.service;
+
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+import java.util.Objects;
+
+public class GetServiceAccountRequest extends ActionRequest {
+
+    @Nullable
+    private final String namespace;
+    @Nullable
+    private final String serviceName;
+
+    public GetServiceAccountRequest(@Nullable String namespace, @Nullable String serviceName) {
+        this.namespace = namespace;
+        this.serviceName = serviceName;
+    }
+
+    public GetServiceAccountRequest(StreamInput in) throws IOException {
+        super(in);
+        this.namespace = in.readOptionalString();
+        this.serviceName = in.readOptionalString();
+    }
+
+    public String getNamespace() {
+        return namespace;
+    }
+
+    public String getServiceName() {
+        return serviceName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        GetServiceAccountRequest that = (GetServiceAccountRequest) o;
+        return Objects.equals(namespace, that.namespace) && Objects.equals(serviceName, that.serviceName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(namespace, serviceName);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeOptionalString(namespace);
+        out.writeOptionalString(serviceName);
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        return null;
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/service/GetServiceAccountResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/service/GetServiceAccountResponse.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.security.action.service;
+
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+
+public class GetServiceAccountResponse extends ActionResponse implements ToXContentObject {
+
+    private final Map<String, RoleDescriptor> serviceAccounts;
+
+    public GetServiceAccountResponse(Map<String, RoleDescriptor> serviceAccounts) {
+        this.serviceAccounts = Objects.requireNonNull(serviceAccounts);
+    }
+
+    public GetServiceAccountResponse(StreamInput in) throws IOException {
+        super(in);
+        this.serviceAccounts = in.readMap(StreamInput::readString, RoleDescriptor::new);
+    }
+
+    public Map<String, RoleDescriptor> getServiceAccounts() {
+        return serviceAccounts;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeMap(serviceAccounts, StreamOutput::writeString, (o, v) -> v.writeTo(o));
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        for (Map.Entry<String, RoleDescriptor> entry: serviceAccounts.entrySet()) {
+            builder.startObject(entry.getKey());
+            builder.field("role_descriptor");
+            entry.getValue().toXContent(builder, params);
+            builder.endObject();
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        GetServiceAccountResponse that = (GetServiceAccountResponse) o;
+        return serviceAccounts.equals(that.serviceAccounts);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(serviceAccounts);
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/service/GetServiceAccountResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/service/GetServiceAccountResponse.java
@@ -12,45 +12,46 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
 
 import java.io.IOException;
-import java.util.Map;
+import java.util.Arrays;
 import java.util.Objects;
 
 public class GetServiceAccountResponse extends ActionResponse implements ToXContentObject {
 
-    private final Map<String, RoleDescriptor> serviceAccounts;
+    private final ServiceAccountInfo[] serviceAccountInfos;
 
-    public GetServiceAccountResponse(Map<String, RoleDescriptor> serviceAccounts) {
-        this.serviceAccounts = Objects.requireNonNull(serviceAccounts);
+    public GetServiceAccountResponse(ServiceAccountInfo[] serviceAccountInfos) {
+        this.serviceAccountInfos = Objects.requireNonNull(serviceAccountInfos);
     }
 
     public GetServiceAccountResponse(StreamInput in) throws IOException {
         super(in);
-        this.serviceAccounts = in.readMap(StreamInput::readString, RoleDescriptor::new);
+        this.serviceAccountInfos = in.readArray(ServiceAccountInfo::new, ServiceAccountInfo[]::new);
     }
 
-    public Map<String, RoleDescriptor> getServiceAccounts() {
-        return serviceAccounts;
+    public ServiceAccountInfo[] getServiceAccountInfos() {
+        return serviceAccountInfos;
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(serviceAccounts, StreamOutput::writeString, (o, v) -> v.writeTo(o));
+        out.writeArray(serviceAccountInfos);
     }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        for (Map.Entry<String, RoleDescriptor> entry: serviceAccounts.entrySet()) {
-            builder.startObject(entry.getKey());
-            builder.field("role_descriptor");
-            entry.getValue().toXContent(builder, params);
-            builder.endObject();
+        for (ServiceAccountInfo info : serviceAccountInfos) {
+            info.toXContent(builder, params);
         }
         builder.endObject();
         return builder;
+    }
+
+    @Override
+    public String toString() {
+        return "GetServiceAccountResponse{" + "serviceAccountInfos=" + Arrays.toString(serviceAccountInfos) + '}';
     }
 
     @Override
@@ -60,11 +61,11 @@ public class GetServiceAccountResponse extends ActionResponse implements ToXCont
         if (o == null || getClass() != o.getClass())
             return false;
         GetServiceAccountResponse that = (GetServiceAccountResponse) o;
-        return serviceAccounts.equals(that.serviceAccounts);
+        return Arrays.equals(serviceAccountInfos, that.serviceAccountInfos);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(serviceAccounts);
+        return Arrays.hashCode(serviceAccountInfos);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/service/ServiceAccountInfo.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/service/ServiceAccountInfo.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.security.action.service;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
+
+import java.io.IOException;
+import java.util.Objects;
+
+public class ServiceAccountInfo implements Writeable, ToXContent {
+
+    private final String principal;
+    private final RoleDescriptor roleDescriptor;
+
+    public ServiceAccountInfo(String principal, RoleDescriptor roleDescriptor) {
+        this.principal = Objects.requireNonNull(principal, "service account principal cannot be null");
+        this.roleDescriptor = Objects.requireNonNull(roleDescriptor, "service account descriptor cannot be null");
+    }
+
+    public ServiceAccountInfo(StreamInput in) throws IOException {
+        this.principal = in.readString();
+        this.roleDescriptor = new RoleDescriptor(in);
+    }
+
+    public String getPrincipal() {
+        return principal;
+    }
+
+    public RoleDescriptor getRoleDescriptor() {
+        return roleDescriptor;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(principal);
+        roleDescriptor.writeTo(out);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(principal);
+        builder.field("role_descriptor");
+        roleDescriptor.toXContent(builder, params);
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public String toString() {
+        return "ServiceAccountInfo{" + "principal='" + principal + '\'' + ", roleDescriptor=" + roleDescriptor + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        ServiceAccountInfo that = (ServiceAccountInfo) o;
+        return principal.equals(that.principal) && roleDescriptor.equals(that.roleDescriptor);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(principal, roleDescriptor);
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/service/GetServiceAccountRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/service/GetServiceAccountRequestTests.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.security.action.service;
+
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+
+import java.io.IOException;
+
+public class GetServiceAccountRequestTests extends AbstractWireSerializingTestCase<GetServiceAccountRequest> {
+
+    @Override
+    protected Writeable.Reader<GetServiceAccountRequest> instanceReader() {
+        return GetServiceAccountRequest::new;
+    }
+
+    @Override
+    protected GetServiceAccountRequest createTestInstance() {
+        return new GetServiceAccountRequest(randomFrom(randomAlphaOfLengthBetween(3, 8), null),
+            randomFrom(randomAlphaOfLengthBetween(3, 8), null));
+    }
+
+    @Override
+    protected GetServiceAccountRequest mutateInstance(GetServiceAccountRequest instance) throws IOException {
+        if (randomBoolean()) {
+            return new GetServiceAccountRequest(
+                randomValueOtherThan(instance.getNamespace(), () -> randomFrom(randomAlphaOfLengthBetween(3, 8), null)),
+                instance.getServiceName());
+        } else {
+            return new GetServiceAccountRequest(
+                instance.getNamespace(),
+                randomValueOtherThan(instance.getServiceName(), () -> randomFrom(randomAlphaOfLengthBetween(3, 8), null)));
+        }
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/service/GetServiceAccountResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/service/GetServiceAccountResponseTests.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.security.action.service;
+
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.test.XContentTestUtils;
+import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.equalTo;
+
+public class GetServiceAccountResponseTests extends AbstractWireSerializingTestCase<GetServiceAccountResponse> {
+
+    @Override
+    protected Writeable.Reader<GetServiceAccountResponse> instanceReader() {
+        return GetServiceAccountResponse::new;
+    }
+
+    @Override
+    protected GetServiceAccountResponse createTestInstance() {
+        final String principal = randomPrincipal();
+        return new GetServiceAccountResponse(randomBoolean() ? Map.of(principal, getRoleDescriptorFor(principal)) : Map.of());
+    }
+
+    @Override
+    protected GetServiceAccountResponse mutateInstance(GetServiceAccountResponse instance) throws IOException {
+        if (instance.getServiceAccounts().isEmpty()) {
+            final String principal = randomPrincipal();
+            return new GetServiceAccountResponse(Map.of(principal, getRoleDescriptorFor(principal)));
+        } else {
+            return new GetServiceAccountResponse(Map.of());
+        }
+    }
+
+    public void testToXContent() throws IOException {
+        final GetServiceAccountResponse response = createTestInstance();
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        response.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        final Map<String, Object> responseMap = XContentHelper.convertToMap(
+            BytesReference.bytes(builder),
+            false, builder.contentType()).v2();
+        final Map<String, RoleDescriptor> serviceAccounts = response.getServiceAccounts();
+        if (serviceAccounts.isEmpty()) {
+            assertThat(responseMap, anEmptyMap());
+        } else {
+            assertThat(responseMap.size(), equalTo(serviceAccounts.size()));
+            assertThat(responseMap.keySet(), equalTo(serviceAccounts.keySet()));
+            for (String key : responseMap.keySet()) {
+                //noinspection unchecked
+                assertRoleDescriptorEquals((Map<String, Object>) responseMap.get(key), serviceAccounts.get(key));
+            }
+        }
+    }
+
+    private String randomPrincipal() {
+        return randomAlphaOfLengthBetween(3, 8) + "/" + randomAlphaOfLengthBetween(3, 8);
+    }
+
+    private RoleDescriptor getRoleDescriptorFor(String name) {
+        return new RoleDescriptor(name,
+            new String[] { "monitor", "manage_own_api_key" },
+            new RoleDescriptor.IndicesPrivileges[] {
+            RoleDescriptor.IndicesPrivileges.builder()
+                .indices("logs-*", "metrics-*", "traces-*")
+                .privileges("write", "create_index", "auto_configure").build() },
+            null,
+            null,
+            null,
+            null,
+            null);
+    }
+
+    private void assertRoleDescriptorEquals(Map<String, Object> responseFragment, RoleDescriptor roleDescriptor) throws IOException {
+        @SuppressWarnings("unchecked")
+        final Map<String, Object> descriptorMap = (Map<String, Object>) responseFragment.get("role_descriptor");
+        assertThat(RoleDescriptor.parse(roleDescriptor.getName(),
+            XContentTestUtils.convertToXContent(descriptorMap, XContentType.JSON), false, XContentType.JSON),
+            equalTo(roleDescriptor));
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/service/GetServiceAccountResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/service/GetServiceAccountResponseTests.java
@@ -47,6 +47,7 @@ public class GetServiceAccountResponseTests extends AbstractWireSerializingTestC
         }
     }
 
+    @SuppressWarnings("unchecked")
     public void testToXContent() throws IOException {
         final GetServiceAccountResponse response = createTestInstance();
         XContentBuilder builder = XContentFactory.jsonBuilder();
@@ -61,7 +62,6 @@ public class GetServiceAccountResponseTests extends AbstractWireSerializingTestC
             assertThat(responseMap.size(), equalTo(serviceAccounts.size()));
             assertThat(responseMap.keySet(), equalTo(serviceAccounts.keySet()));
             for (String key : responseMap.keySet()) {
-                //noinspection unchecked
                 assertRoleDescriptorEquals((Map<String, Object>) responseMap.get(key), serviceAccounts.get(key));
             }
         }

--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
@@ -191,6 +191,7 @@ public class Constants {
         "cluster:admin/xpack/security/saml/invalidate",
         "cluster:admin/xpack/security/saml/logout",
         "cluster:admin/xpack/security/saml/prepare",
+        "cluster:admin/xpack/security/service_account/get",
         "cluster:admin/xpack/security/service_account/token/create",
         "cluster:admin/xpack/security/service_account/token/get",
         "cluster:admin/xpack/security/token/create",

--- a/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
+++ b/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.basicAuthHeaderValue;
+import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
@@ -61,6 +62,36 @@ public class ServiceAccountIT extends ESRestTestCase {
         + "  \"authentication_type\": \"token\"\n"
         + "}\n";
 
+    private static final String ELASTIC_FLEET_ROLE_DESCRIPTOR = ""
+        + "{\n"
+        + "      \"cluster\": [\n"
+        + "        \"monitor\",\n"
+        + "        \"manage_own_api_key\"\n"
+        + "      ],\n"
+        + "      \"indices\": [\n"
+        + "        {\n"
+        + "          \"names\": [\n"
+        + "            \"logs-*\",\n"
+        + "            \"metrics-*\",\n"
+        + "            \"traces-*\"\n"
+        + "          ],\n"
+        + "          \"privileges\": [\n"
+        + "            \"write\",\n"
+        + "            \"create_index\",\n"
+        + "            \"auto_configure\"\n"
+        + "          ],\n"
+        + "          \"allow_restricted_indices\": false\n"
+        + "        }\n"
+        + "      ],\n"
+        + "      \"applications\": [],\n"
+        + "      \"run_as\": [],\n"
+        + "      \"metadata\": {},\n"
+        + "      \"transient_metadata\": {\n"
+        + "        \"enabled\": true\n"
+        + "      }\n"
+        + "    }\n"
+        + "  }";
+
     @BeforeClass
     public static void init() throws URISyntaxException, FileNotFoundException {
         URL resource = ServiceAccountIT.class.getResource("/ssl/ca.crt");
@@ -82,6 +113,32 @@ public class ServiceAccountIT extends ESRestTestCase {
         return Settings.builder().put(ThreadContext.PREFIX + ".Authorization", token)
             .put(CERTIFICATE_AUTHORITIES, caPath)
             .build();
+    }
+
+    public void testGetServiceAccount() throws IOException {
+        final Request getServiceAccountRequest1 = new Request("GET", "_security/service");
+        final Response getServiceAccountResponse1 = client().performRequest(getServiceAccountRequest1);
+        assertOK(getServiceAccountResponse1);
+        assertServiceAccountRoleDescriptor(getServiceAccountResponse1,
+            "elastic/fleet-server", ELASTIC_FLEET_ROLE_DESCRIPTOR);
+
+        final Request getServiceAccountRequest2 = new Request("GET", "_security/service/elastic");
+        final Response getServiceAccountResponse2 = client().performRequest(getServiceAccountRequest2);
+        assertOK(getServiceAccountResponse2);
+        assertServiceAccountRoleDescriptor(getServiceAccountResponse2,
+            "elastic/fleet-server", ELASTIC_FLEET_ROLE_DESCRIPTOR);
+
+        final Request getServiceAccountRequest3 = new Request("GET", "_security/service/elastic/fleet-server");
+        final Response getServiceAccountResponse3 = client().performRequest(getServiceAccountRequest3);
+        assertOK(getServiceAccountResponse3);
+        assertServiceAccountRoleDescriptor(getServiceAccountResponse3,
+            "elastic/fleet-server", ELASTIC_FLEET_ROLE_DESCRIPTOR);
+
+        final String requestPath = "_security/service/" + randomFrom("foo", "elastic/foo", "foo/bar");
+        final Request getServiceAccountRequest4 = new Request("GET", requestPath);
+        final Response getServiceAccountResponse4 = client().performRequest(getServiceAccountRequest4);
+        assertOK(getServiceAccountResponse4);
+        assertThat(responseAsMap(getServiceAccountResponse4), anEmptyMap());
     }
 
     public void testAuthenticate() throws IOException {
@@ -289,5 +346,13 @@ public class ServiceAccountIT extends ESRestTestCase {
         assertThat(apiKey.get("username"), equalTo("elastic/fleet-server"));
         assertThat(apiKey.get("realm"), equalTo("service_account"));
         assertThat(apiKey.get("invalidated"), is(invalidated));
+    }
+
+    private void assertServiceAccountRoleDescriptor(Response response,
+                                                    String serviceAccountPrincipal,
+                                                    String roleDescriptorString) throws IOException {
+        final Map<String, Object> responseMap = responseAsMap(response);
+        assertThat(responseMap, hasEntry(serviceAccountPrincipal, Map.of("role_descriptor",
+            XContentHelper.convertToMap(new BytesArray(roleDescriptorString), false, XContentType.JSON).v2())));
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -113,6 +113,7 @@ import org.elasticsearch.xpack.core.security.action.saml.SamlLogoutAction;
 import org.elasticsearch.xpack.core.security.action.saml.SamlPrepareAuthenticationAction;
 import org.elasticsearch.xpack.core.security.action.saml.SamlSpMetadataAction;
 import org.elasticsearch.xpack.core.security.action.service.CreateServiceAccountTokenAction;
+import org.elasticsearch.xpack.core.security.action.service.GetServiceAccountAction;
 import org.elasticsearch.xpack.core.security.action.service.GetServiceAccountTokensAction;
 import org.elasticsearch.xpack.core.security.action.token.CreateTokenAction;
 import org.elasticsearch.xpack.core.security.action.token.InvalidateTokenAction;
@@ -182,6 +183,7 @@ import org.elasticsearch.xpack.security.action.saml.TransportSamlLogoutAction;
 import org.elasticsearch.xpack.security.action.saml.TransportSamlPrepareAuthenticationAction;
 import org.elasticsearch.xpack.security.action.saml.TransportSamlSpMetadataAction;
 import org.elasticsearch.xpack.security.action.service.TransportCreateServiceAccountTokenAction;
+import org.elasticsearch.xpack.security.action.service.TransportGetServiceAccountAction;
 import org.elasticsearch.xpack.security.action.service.TransportGetServiceAccountTokensAction;
 import org.elasticsearch.xpack.security.action.token.TransportCreateTokenAction;
 import org.elasticsearch.xpack.security.action.token.TransportInvalidateTokenAction;
@@ -264,6 +266,7 @@ import org.elasticsearch.xpack.security.rest.action.saml.RestSamlLogoutAction;
 import org.elasticsearch.xpack.security.rest.action.saml.RestSamlPrepareAuthenticationAction;
 import org.elasticsearch.xpack.security.rest.action.saml.RestSamlSpMetadataAction;
 import org.elasticsearch.xpack.security.rest.action.service.RestCreateServiceAccountTokenAction;
+import org.elasticsearch.xpack.security.rest.action.service.RestGetServiceAccountAction;
 import org.elasticsearch.xpack.security.rest.action.service.RestGetServiceAccountTokensAction;
 import org.elasticsearch.xpack.security.rest.action.user.RestChangePasswordAction;
 import org.elasticsearch.xpack.security.rest.action.user.RestDeleteUserAction;
@@ -872,6 +875,7 @@ public class Security extends Plugin implements SystemIndexPlugin, IngestPlugin,
                 new ActionHandler<>(DelegatePkiAuthenticationAction.INSTANCE, TransportDelegatePkiAuthenticationAction.class),
                 new ActionHandler<>(CreateServiceAccountTokenAction.INSTANCE, TransportCreateServiceAccountTokenAction.class),
                 new ActionHandler<>(GetServiceAccountTokensAction.INSTANCE, TransportGetServiceAccountTokensAction.class),
+                new ActionHandler<>(GetServiceAccountAction.INSTANCE, TransportGetServiceAccountAction.class),
                 usageAction,
                 infoAction);
     }
@@ -933,7 +937,8 @@ public class Security extends Plugin implements SystemIndexPlugin, IngestPlugin,
                 new RestGetApiKeyAction(settings, getLicenseState()),
                 new RestDelegatePkiAuthenticationAction(settings, getLicenseState()),
                 new RestCreateServiceAccountTokenAction(settings, getLicenseState()),
-                new RestGetServiceAccountTokensAction(settings, getLicenseState())
+                new RestGetServiceAccountTokensAction(settings, getLicenseState()),
+                new RestGetServiceAccountAction(settings, getLicenseState())
         );
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/service/TransportGetServiceAccountAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/service/TransportGetServiceAccountAction.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.security.action.service;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.security.action.service.GetServiceAccountAction;
+import org.elasticsearch.xpack.core.security.action.service.GetServiceAccountRequest;
+import org.elasticsearch.xpack.core.security.action.service.GetServiceAccountResponse;
+import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
+import org.elasticsearch.xpack.security.authc.service.ServiceAccount;
+import org.elasticsearch.xpack.security.authc.service.ServiceAccountService;
+import org.elasticsearch.xpack.security.authc.support.HttpTlsRuntimeCheck;
+
+import java.util.Map;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+public class TransportGetServiceAccountAction extends HandledTransportAction<GetServiceAccountRequest, GetServiceAccountResponse> {
+
+    private final HttpTlsRuntimeCheck httpTlsRuntimeCheck;
+
+    @Inject
+    public TransportGetServiceAccountAction(TransportService transportService, ActionFilters actionFilters,
+                                            HttpTlsRuntimeCheck httpTlsRuntimeCheck) {
+        super(GetServiceAccountAction.NAME, transportService, actionFilters, GetServiceAccountRequest::new);
+        this.httpTlsRuntimeCheck = httpTlsRuntimeCheck;
+    }
+
+    @Override
+    protected void doExecute(Task task, GetServiceAccountRequest request, ActionListener<GetServiceAccountResponse> listener) {
+        httpTlsRuntimeCheck.checkTlsThenExecute(listener::onFailure, "get service accounts", () -> {
+            final Predicate<ServiceAccount> filter;
+            if (request.getNamespace() == null && request.getServiceName() == null) {
+                filter = v -> true;
+            } else if (request.getServiceName() == null) {
+                filter = v -> v.id().namespace().equals(request.getNamespace());
+            } else {
+                filter = v -> v.id().namespace().equals(request.getNamespace()) && v.id().serviceName().equals(request.getServiceName());
+            }
+            final Map<String, RoleDescriptor> results = ServiceAccountService.getServiceAccounts()
+                .values()
+                .stream()
+                .filter(filter)
+                .collect(Collectors.toMap(v -> v.id().asPrincipal(), ServiceAccount::roleDescriptor));
+            listener.onResponse(new GetServiceAccountResponse(results));
+        });
+    }
+}

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/service/TransportGetServiceAccountAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/service/TransportGetServiceAccountAction.java
@@ -39,13 +39,12 @@ public class TransportGetServiceAccountAction extends HandledTransportAction<Get
     @Override
     protected void doExecute(Task task, GetServiceAccountRequest request, ActionListener<GetServiceAccountResponse> listener) {
         httpTlsRuntimeCheck.checkTlsThenExecute(listener::onFailure, "get service accounts", () -> {
-            final Predicate<ServiceAccount> filter;
-            if (request.getNamespace() == null && request.getServiceName() == null) {
-                filter = v -> true;
-            } else if (request.getServiceName() == null) {
-                filter = v -> v.id().namespace().equals(request.getNamespace());
-            } else {
-                filter = v -> v.id().namespace().equals(request.getNamespace()) && v.id().serviceName().equals(request.getServiceName());
+            Predicate<ServiceAccount> filter = v -> true;
+            if (request.getNamespace() != null) {
+                filter = filter.and( v -> v.id().namespace().equals(request.getNamespace()) );
+            } 
+            if (request.getServiceName() != null) {
+                filter = filter.and( v -> v.id().serviceName().equals(request.getServiceName()) );
             }
             final Map<String, RoleDescriptor> results = ServiceAccountService.getServiceAccounts()
                 .values()

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountService.java
@@ -53,6 +53,10 @@ public class ServiceAccountService {
         return ACCOUNTS.keySet();
     }
 
+    public static Map<String, ServiceAccount> getServiceAccounts() {
+        return Map.copyOf(ACCOUNTS);
+    }
+
     /**
      * Parses a token object from the content of a {@link ServiceAccountToken#asBearerString()} bearer string}.
      * This bearer string would typically be

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/service/RestGetServiceAccountAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/service/RestGetServiceAccountAction.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.security.rest.action.service;
+
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.xpack.core.security.action.service.GetServiceAccountAction;
+import org.elasticsearch.xpack.core.security.action.service.GetServiceAccountRequest;
+import org.elasticsearch.xpack.security.rest.action.SecurityBaseRestHandler;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.elasticsearch.rest.RestRequest.Method.GET;
+
+public class RestGetServiceAccountAction extends SecurityBaseRestHandler {
+
+    public RestGetServiceAccountAction(Settings settings, XPackLicenseState licenseState) {
+        super(settings, licenseState);
+    }
+
+    @Override
+    public List<Route> routes() {
+        return List.of(
+            new Route(GET, "/_security/service"),
+            new Route(GET, "/_security/service/{namespace}"),
+            new Route(GET, "/_security/service/{namespace}/{service}")
+        );
+    }
+
+    @Override
+    public String getName() {
+        return "xpack_security_get_service_account";
+    }
+
+    @Override
+    protected RestChannelConsumer innerPrepareRequest(RestRequest request, NodeClient client) throws IOException {
+        final String namespace = request.param("namespace");
+        final String serviceName = request.param("service");
+        final GetServiceAccountRequest getServiceAccountRequest = new GetServiceAccountRequest(namespace, serviceName);
+        return channel -> client.execute(GetServiceAccountAction.INSTANCE, getServiceAccountRequest,
+            new RestToXContentListener<>(channel));
+    }
+}

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/service/TransportGetServiceAccountActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/service/TransportGetServiceAccountActionTests.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.security.action.service;
+
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.security.action.service.GetServiceAccountRequest;
+import org.elasticsearch.xpack.core.security.action.service.GetServiceAccountResponse;
+import org.elasticsearch.xpack.security.authc.support.HttpTlsRuntimeCheck;
+import org.junit.Before;
+
+import java.util.Collections;
+
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+public class TransportGetServiceAccountActionTests extends ESTestCase {
+
+    private HttpTlsRuntimeCheck httpTlsRuntimeCheck;
+    private TransportGetServiceAccountAction transportGetServiceAccountAction;
+
+    @Before
+    public void init() {
+        httpTlsRuntimeCheck = mock(HttpTlsRuntimeCheck.class);
+        transportGetServiceAccountAction = new TransportGetServiceAccountAction(
+            mock(TransportService.class), new ActionFilters(Collections.emptySet()), httpTlsRuntimeCheck);
+
+        doAnswer(invocationOnMock -> {
+            final Object[] arguments = invocationOnMock.getArguments();
+            ((Runnable) arguments[2]).run();
+            return null;
+        }).when(httpTlsRuntimeCheck).checkTlsThenExecute(any(), any(), any());
+    }
+
+    public void testDoExecute() {
+        final GetServiceAccountRequest request1 = randomFrom(
+            new GetServiceAccountRequest(null, null),
+            new GetServiceAccountRequest("elastic", null),
+            new GetServiceAccountRequest("elastic", "fleet-server"));
+        final PlainActionFuture<GetServiceAccountResponse> future1 = new PlainActionFuture<>();
+        transportGetServiceAccountAction.doExecute(mock(Task.class), request1, future1);
+        final GetServiceAccountResponse getServiceAccountResponse1 = future1.actionGet();
+        assertThat(getServiceAccountResponse1.getServiceAccounts().size(), equalTo(1));
+        assertThat(getServiceAccountResponse1.getServiceAccounts(), hasKey("elastic/fleet-server"));
+
+        final GetServiceAccountRequest request2 = randomFrom(
+            new GetServiceAccountRequest("foo", null),
+            new GetServiceAccountRequest("elastic", "foo"),
+            new GetServiceAccountRequest("foo", "bar"));
+        final PlainActionFuture<GetServiceAccountResponse> future2 = new PlainActionFuture<>();
+        transportGetServiceAccountAction.doExecute(mock(Task.class), request2, future2);
+        final GetServiceAccountResponse getServiceAccountResponse2 = future2.actionGet();
+        assertThat(getServiceAccountResponse2.getServiceAccounts(), anEmptyMap());
+    }
+}

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/service/TransportGetServiceAccountActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/service/TransportGetServiceAccountActionTests.java
@@ -19,9 +19,7 @@ import org.junit.Before;
 
 import java.util.Collections;
 
-import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasKey;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -52,8 +50,8 @@ public class TransportGetServiceAccountActionTests extends ESTestCase {
         final PlainActionFuture<GetServiceAccountResponse> future1 = new PlainActionFuture<>();
         transportGetServiceAccountAction.doExecute(mock(Task.class), request1, future1);
         final GetServiceAccountResponse getServiceAccountResponse1 = future1.actionGet();
-        assertThat(getServiceAccountResponse1.getServiceAccounts().size(), equalTo(1));
-        assertThat(getServiceAccountResponse1.getServiceAccounts(), hasKey("elastic/fleet-server"));
+        assertThat(getServiceAccountResponse1.getServiceAccountInfos().length, equalTo(1));
+        assertThat(getServiceAccountResponse1.getServiceAccountInfos()[0].getPrincipal(), equalTo("elastic/fleet-server"));
 
         final GetServiceAccountRequest request2 = randomFrom(
             new GetServiceAccountRequest("foo", null),
@@ -62,6 +60,6 @@ public class TransportGetServiceAccountActionTests extends ESTestCase {
         final PlainActionFuture<GetServiceAccountResponse> future2 = new PlainActionFuture<>();
         transportGetServiceAccountAction.doExecute(mock(Task.class), request2, future2);
         final GetServiceAccountResponse getServiceAccountResponse2 = future2.actionGet();
-        assertThat(getServiceAccountResponse2.getServiceAccounts(), anEmptyMap());
+        assertThat(getServiceAccountResponse2.getServiceAccountInfos().length, equalTo(0));
     }
 }


### PR DESCRIPTION
This PR adds a new API endpoint to retrieve service accounts. Depends on the request parameter, it returns either all accounts, accounts belong to a namespace, a specific account, or an empty map if nothing is found.