### PR TITLE
Include URLHttpClientIOException on URLBlobContainerRetriesTests testReadBlobWithReadTimeouts

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/AbstractBlobContainerRetriesTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/AbstractBlobContainerRetriesTestCase.java
@@ -79,6 +79,11 @@ public abstract class AbstractBlobContainerRetriesTestCase extends ESTestCase {
         @Nullable Boolean disableChunkedEncoding,
         @Nullable ByteSizeValue bufferSize);
 
+    protected org.hamcrest.Matcher<Object> readTimeoutExceptionMatcher() {
+        return either(instanceOf(SocketTimeoutException.class)).or(instanceOf(ConnectionClosedException.class))
+            .or(instanceOf(RuntimeException.class));
+    }
+
     public void testReadNonexistentBlobThrowsNoSuchFileException() {
         final BlobContainer blobContainer = createBlobContainer(between(1, 5), null, null, null);
         final long position = randomLongBetween(0, MAX_RANGE_VAL);
@@ -236,8 +241,7 @@ public abstract class AbstractBlobContainerRetriesTestCase extends ESTestCase {
                 Streams.readFully(stream);
             }
         });
-        assertThat(exception, either(instanceOf(SocketTimeoutException.class)).or(instanceOf(ConnectionClosedException.class))
-            .or(instanceOf(RuntimeException.class)));
+        assertThat(exception, readTimeoutExceptionMatcher());
         assertThat(exception.getMessage().toLowerCase(Locale.ROOT), either(containsString("read timed out")).or(
             containsString("premature end of chunk coded message body: closing chunk expected")).or(containsString("Read timed out"))
             .or(containsString("unexpected end of file from server")));


### PR DESCRIPTION
In some scenarios where the read timeout is too tight it's possible
that the http request times out before the response headers have
been received, in that case an URLHttpClientIOException is thrown.
This commit adds that exception type to the expected set of read timeout
exceptions.

Closes #70931