### PR TITLE
[7.x] Document CCR auto-follow patterns and searchable snapshots indices

### DIFF
--- a/docs/reference/ccr/auto-follow.asciidoc
+++ b/docs/reference/ccr/auto-follow.asciidoc
@@ -7,6 +7,13 @@ each new index in the series is replicated automatically. Whenever the name of
 a new index on the remote cluster matches the auto-follow pattern, a
 corresponding follower index is added to the local cluster.
 
+NOTE: Auto-follow patterns only match open indices on the remote cluster that
+have all primary shards started. Auto-follow patterns do not match indices that
+can't be used for {ccr-init} such as <<open-index-api-desc,closed indices>> or
+<<searchable-snapshots,{search-snaps}>>. Avoid using an auto-follow pattern
+that matches indices with a <<index-block-settings, read or write block>>. These
+blocks prevent follower indices from replicating such indices.
+
 You can also create auto-follow patterns for data streams. When a new backing
 index is generated on a remote cluster, that index and its data stream are
 automatically followed if the data stream name matches an auto-follow


### PR DESCRIPTION
This commit adds a note in CCR document about auto-follow 
patterns that should not match searchable snapshots indices.

Relates #70580 (comment)
Backport of #70863