### PR TITLE
[Tests] Ignore all indices when testing global state for snapshot and restore

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/snapshot/20_operator_privileges_disabled.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/snapshot/20_operator_privileges_disabled.yml
@@ -42,13 +42,14 @@ teardown:
         snapshot: test_snapshot_2
         wait_for_completion: true
         body: |
-          { "include_global_state": true }
+          { "include_global_state": true, "indices": "-*" }
 
   - match: { snapshot.snapshot: test_snapshot_2 }
   - match: { snapshot.state : SUCCESS }
   - is_true: snapshot.include_global_state
   - is_true: snapshot.version
   - gt: { snapshot.version_id: 0}
+  - length: { snapshot.indices: 0 }
 
   - do:
       cluster.put_settings:


### PR DESCRIPTION
The failed test is to ensure opreator-only settings can be snapshot and restored by regular users when the operator privileges feature is disabled. It only cares about cluster settings, not any indices. But it currently includes every index into its snapshot. This creates a problem because the indices cannot be restored unless the original ones are deleted or closed and this results in a 500 error. 

This PR fixes the issue by excluding all indices from the snapshot/restore process. It is the simplest viable fix since the test only cares about cluster settings.

Resolves: #71321