### PR TITLE
[DOCS] Expands DFA and TM API docs with required privileges info

### DIFF
--- a/docs/reference/ml/df-analytics/apis/delete-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/delete-dfanalytics.asciidoc
@@ -19,13 +19,8 @@ Deletes an existing {dfanalytics-job}.
 [[ml-delete-dfanalytics-prereq]]
 == {api-prereq-title}
 
-If the {es} {security-features} are enabled, you must have the following 
-built-in roles or equivalent privileges:
-
-* `machine_learning_admin`
-* cluster: `manage_ml` or `manage`
-
-For more information, see <<built-in-roles>> and {ml-docs-setup-privileges}.
+You must have the `manage_ml` cluster privilege to use this API. This privilege 
+is included in the `machine_learning_admin` built-in role.
 
 
 [[ml-delete-dfanalytics-path-params]]

--- a/docs/reference/ml/df-analytics/apis/delete-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/delete-dfanalytics.asciidoc
@@ -23,6 +23,7 @@ If the {es} {security-features} are enabled, you must have the following
 built-in roles or equivalent privileges:
 
 * `machine_learning_admin`
+* cluster: `manage_ml` or `manage`
 
 For more information, see <<built-in-roles>> and {ml-docs-setup-privileges}.
 

--- a/docs/reference/ml/df-analytics/apis/delete-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/delete-dfanalytics.asciidoc
@@ -19,8 +19,8 @@ Deletes an existing {dfanalytics-job}.
 [[ml-delete-dfanalytics-prereq]]
 == {api-prereq-title}
 
-You must have the `manage_ml` cluster privilege to use this API. This privilege 
-is included in the `machine_learning_admin` built-in role.
+It is required to have the `manage_ml` cluster privilege to use this API. This 
+privilege is included in the `machine_learning_admin` built-in role.
 
 
 [[ml-delete-dfanalytics-path-params]]

--- a/docs/reference/ml/df-analytics/apis/delete-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/delete-dfanalytics.asciidoc
@@ -19,8 +19,8 @@ Deletes an existing {dfanalytics-job}.
 [[ml-delete-dfanalytics-prereq]]
 == {api-prereq-title}
 
-It is required to have the `manage_ml` cluster privilege to use this API. This 
-privilege is included in the `machine_learning_admin` built-in role.
+Requires the `manage_ml` cluster privilege. This privilege is included in the 
+`machine_learning_admin` built-in role.
 
 
 [[ml-delete-dfanalytics-path-params]]

--- a/docs/reference/ml/df-analytics/apis/delete-trained-models-aliases.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/delete-trained-models-aliases.asciidoc
@@ -19,8 +19,8 @@ Deletes a trained model alias.
 [[ml-delete-trained-models-aliases-prereq]]
 == {api-prereq-title}
 
-It is required to have the `manage_ml` cluster privilege to use this API. This 
-privilege is included in the `machine_learning_admin` built-in role.
+Requires the `manage_ml` cluster privilege. This privilege is included in the 
+`machine_learning_admin` built-in role.
 
 
 [[ml-delete-trained-models-aliases-desc]]

--- a/docs/reference/ml/df-analytics/apis/delete-trained-models-aliases.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/delete-trained-models-aliases.asciidoc
@@ -19,13 +19,9 @@ Deletes a trained model alias.
 [[ml-delete-trained-models-aliases-prereq]]
 == {api-prereq-title}
 
-If the {es} {security-features} are enabled, you must have the following
-built-in roles and privileges:
+You must have the `manage_ml` cluster privilege to use this API. This privilege 
+is included in the `machine_learning_admin` built-in role.
 
-* `machine_learning_admin`
-
-For more information, see <<built-in-roles>>, <<security-privileges>>, and
-{ml-docs-setup-privileges}.
 
 [[ml-delete-trained-models-aliases-desc]]
 == {api-description-title}

--- a/docs/reference/ml/df-analytics/apis/delete-trained-models-aliases.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/delete-trained-models-aliases.asciidoc
@@ -19,8 +19,8 @@ Deletes a trained model alias.
 [[ml-delete-trained-models-aliases-prereq]]
 == {api-prereq-title}
 
-You must have the `manage_ml` cluster privilege to use this API. This privilege 
-is included in the `machine_learning_admin` built-in role.
+It is required to have the `manage_ml` cluster privilege to use this API. This 
+privilege is included in the `machine_learning_admin` built-in role.
 
 
 [[ml-delete-trained-models-aliases-desc]]

--- a/docs/reference/ml/df-analytics/apis/delete-trained-models.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/delete-trained-models.asciidoc
@@ -20,12 +20,8 @@ ingest pipeline.
 [[ml-delete-trained-models-prereq]]
 == {api-prereq-title}
 
-If the {es} {security-features} are enabled, you must have the following
-built-in roles or equivalent privileges:
-
-* `machine_learning_admin`
-
-For more information, see <<built-in-roles>> and {ml-docs-setup-privileges}.
+You must have the `manage_ml` cluster privilege to use this API. This privilege 
+is included in the `machine_learning_admin` built-in role.
 
 
 [[ml-delete-trained-models-path-params]]

--- a/docs/reference/ml/df-analytics/apis/delete-trained-models.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/delete-trained-models.asciidoc
@@ -20,8 +20,8 @@ ingest pipeline.
 [[ml-delete-trained-models-prereq]]
 == {api-prereq-title}
 
-You must have the `manage_ml` cluster privilege to use this API. This privilege 
-is included in the `machine_learning_admin` built-in role.
+It is required to have the `manage_ml` cluster privilege to use this API. This 
+privilege is included in the `machine_learning_admin` built-in role.
 
 
 [[ml-delete-trained-models-path-params]]

--- a/docs/reference/ml/df-analytics/apis/delete-trained-models.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/delete-trained-models.asciidoc
@@ -20,8 +20,8 @@ ingest pipeline.
 [[ml-delete-trained-models-prereq]]
 == {api-prereq-title}
 
-It is required to have the `manage_ml` cluster privilege to use this API. This 
-privilege is included in the `machine_learning_admin` built-in role.
+Requires the `manage_ml` cluster privilege. This privilege is included in the 
+`machine_learning_admin` built-in role.
 
 
 [[ml-delete-trained-models-path-params]]

--- a/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
@@ -20,14 +20,9 @@ Evaluates the {dfanalytics} for an annotated index.
 [[ml-evaluate-dfanalytics-prereq]]
 == {api-prereq-title}
 
-If the {es} {security-features} are enabled, you must have the following 
-privileges:
-
-* cluster: `monitor_ml` or `monitor`
-* index: `read`, `write`
-  
-For more information, see <<security-privileges>> and 
-{ml-docs-setup-privileges}.
+You must have the `monitor_ml` cluster privilege and `read` privilege on the 
+destination index to use this API. The required cluster privilege is included in 
+the `machine_learning_user` built-in role.
 
 
 [[ml-evaluate-dfanalytics-desc]]

--- a/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
@@ -20,9 +20,11 @@ Evaluates the {dfanalytics} for an annotated index.
 [[ml-evaluate-dfanalytics-prereq]]
 == {api-prereq-title}
 
-You must have the `monitor_ml` cluster privilege and `read` privilege on the 
-destination index to use this API. The required cluster privilege is included in 
-the `machine_learning_user` built-in role.
+It is required to have the following privileges to use this API:
+
+* cluster: `monitor_ml` (the `machine_learning_user` built-in role grants this 
+  privilege)
+* destination index: `read`
 
 
 [[ml-evaluate-dfanalytics-desc]]

--- a/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
@@ -20,7 +20,7 @@ Evaluates the {dfanalytics} for an annotated index.
 [[ml-evaluate-dfanalytics-prereq]]
 == {api-prereq-title}
 
-It is required to have the following privileges to use this API:
+Requires the following privileges:
 
 * cluster: `monitor_ml` (the `machine_learning_user` built-in role grants this 
   privilege)

--- a/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
@@ -23,7 +23,8 @@ Evaluates the {dfanalytics} for an annotated index.
 If the {es} {security-features} are enabled, you must have the following 
 privileges:
 
-* cluster: `monitor_ml`
+* cluster: `monitor_ml` or `monitor`
+* index: `read`, `write`
   
 For more information, see <<security-privileges>> and 
 {ml-docs-setup-privileges}.

--- a/docs/reference/ml/df-analytics/apis/explain-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/explain-dfanalytics.asciidoc
@@ -26,14 +26,10 @@ Explains a {dataframe-analytics-config}.
 [[ml-explain-dfanalytics-prereq]]
 == {api-prereq-title}
 
-If the {es} {security-features} are enabled, you must have the following 
-privileges:
-
-* cluster: `monitor_ml`
-* source indices: `read`, `view_index_metadata`
-  
-For more information, see <<security-privileges>> and 
-{ml-docs-setup-privileges}.
+You must have the `monitor_ml` cluster privilege and the `read` and 
+`view_index_metadata` privileges on the source indices to use this API. The 
+required cluster privilege is included in the `machine_learning_user` built-in 
+role.
 
 
 [[ml-explain-dfanalytics-desc]]

--- a/docs/reference/ml/df-analytics/apis/explain-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/explain-dfanalytics.asciidoc
@@ -26,10 +26,11 @@ Explains a {dataframe-analytics-config}.
 [[ml-explain-dfanalytics-prereq]]
 == {api-prereq-title}
 
-You must have the `monitor_ml` cluster privilege and the `read` and 
-`view_index_metadata` privileges on the source indices to use this API. The 
-required cluster privilege is included in the `machine_learning_user` built-in 
-role.
+It is required to have the following privileges to use this API:
+
+* cluster: `monitor_ml` (the `machine_learning_user` built-in role grants this 
+  privilege)
+* source indices: `read`, `view_index_metadata`
 
 
 [[ml-explain-dfanalytics-desc]]

--- a/docs/reference/ml/df-analytics/apis/explain-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/explain-dfanalytics.asciidoc
@@ -26,7 +26,7 @@ Explains a {dataframe-analytics-config}.
 [[ml-explain-dfanalytics-prereq]]
 == {api-prereq-title}
 
-It is required to have the following privileges to use this API:
+Requires the following privileges:
 
 * cluster: `monitor_ml` (the `machine_learning_user` built-in role grants this 
   privilege)

--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
@@ -27,8 +27,9 @@ Retrieves usage information for {dfanalytics-jobs}.
 [[ml-get-dfanalytics-stats-prereq]]
 == {api-prereq-title}
 
-You must have the `monitor_ml` cluster privilege to use this API. The required 
-cluster privilege is included in the `machine_learning_user` built-in role.
+It is required to have the `monitor_ml` cluster privilege to use this API. The 
+required cluster privilege is included in the `machine_learning_user` built-in 
+role.
 
 
 [[ml-get-dfanalytics-stats-path-params]]

--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
@@ -27,9 +27,8 @@ Retrieves usage information for {dfanalytics-jobs}.
 [[ml-get-dfanalytics-stats-prereq]]
 == {api-prereq-title}
 
-It is required to have the `monitor_ml` cluster privilege to use this API. The 
-required cluster privilege is included in the `machine_learning_user` built-in 
-role.
+Requires the `monitor_ml` cluster privilege. This privilege is included in the 
+`machine_learning_user` built-in role.
 
 
 [[ml-get-dfanalytics-stats-path-params]]

--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
@@ -27,12 +27,9 @@ Retrieves usage information for {dfanalytics-jobs}.
 [[ml-get-dfanalytics-stats-prereq]]
 == {api-prereq-title}
 
-If the {es} {security-features} are enabled, you must have the following 
-privileges:
+You must have the `monitor_ml` cluster privilege to use this API. The required 
+cluster privilege is included in the `machine_learning_user` built-in role.
 
-* cluster: `monitor_ml` or `monitor`, `manage_ml` or `manage`
-  
-For more information, see <<security-privileges>> and {ml-docs-setup-privileges}.
 
 [[ml-get-dfanalytics-stats-path-params]]
 == {api-path-parms-title}

--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
@@ -30,7 +30,7 @@ Retrieves usage information for {dfanalytics-jobs}.
 If the {es} {security-features} are enabled, you must have the following 
 privileges:
 
-* cluster: `monitor_ml`
+* cluster: `monitor_ml` or `monitor`, `manage_ml` or `manage`
   
 For more information, see <<security-privileges>> and {ml-docs-setup-privileges}.
 

--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics.asciidoc
@@ -25,9 +25,8 @@ Retrieves configuration information for {dfanalytics-jobs}.
 [[ml-get-dfanalytics-prereq]]
 == {api-prereq-title}
 
-It is required to have the `monitor_ml` cluster privilege to use this API. The 
-required cluster privilege is included in the `machine_learning_user` built-in 
-role.
+Requires the `monitor_ml` cluster privilege. This privilege is included in the 
+`machine_learning_user` built-in role.
 
 
 [[ml-get-dfanalytics-desc]]

--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics.asciidoc
@@ -28,7 +28,7 @@ Retrieves configuration information for {dfanalytics-jobs}.
 If the {es} {security-features} are enabled, you must have the following
 privileges:
 
-* cluster: `monitor_ml`
+* cluster: `monitor_ml` or `monitor`, `manage_ml` or `manage`
 
 For more information, see <<security-privileges>> and {ml-docs-setup-privileges}.
 

--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics.asciidoc
@@ -25,8 +25,9 @@ Retrieves configuration information for {dfanalytics-jobs}.
 [[ml-get-dfanalytics-prereq]]
 == {api-prereq-title}
 
-You must have the `monitor_ml` cluster privilege to use this API. The required 
-cluster privilege is included in the `machine_learning_user` built-in role.
+It is required to have the `monitor_ml` cluster privilege to use this API. The 
+required cluster privilege is included in the `machine_learning_user` built-in 
+role.
 
 
 [[ml-get-dfanalytics-desc]]

--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics.asciidoc
@@ -25,12 +25,8 @@ Retrieves configuration information for {dfanalytics-jobs}.
 [[ml-get-dfanalytics-prereq]]
 == {api-prereq-title}
 
-If the {es} {security-features} are enabled, you must have the following
-privileges:
-
-* cluster: `monitor_ml` or `monitor`, `manage_ml` or `manage`
-
-For more information, see <<security-privileges>> and {ml-docs-setup-privileges}.
+You must have the `monitor_ml` cluster privilege to use this API. The required 
+cluster privilege is included in the `machine_learning_user` built-in role.
 
 
 [[ml-get-dfanalytics-desc]]

--- a/docs/reference/ml/df-analytics/apis/get-trained-models-stats.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-trained-models-stats.asciidoc
@@ -30,7 +30,7 @@ Retrieves usage information for trained models.
 If the {es} {security-features} are enabled, you must have the following
 privileges:
 
-* cluster: `monitor_ml`
+* cluster: `monitor_ml` or `monitor`, `manage_ml` or `manage`
 
 For more information, see <<security-privileges>> and {ml-docs-setup-privileges}.
 

--- a/docs/reference/ml/df-analytics/apis/get-trained-models-stats.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-trained-models-stats.asciidoc
@@ -27,9 +27,8 @@ Retrieves usage information for trained models.
 [[ml-get-trained-models-stats-prereq]]
 == {api-prereq-title}
 
-It is required to have the `monitor_ml` cluster privilege to use this API. The 
-required cluster privilege is included in the `machine_learning_user` built-in 
-role.
+Requires the `monitor_ml` cluster privilege. This privilege is included in the 
+`machine_learning_user` built-in role.
 
 
 [[ml-get-trained-models-stats-desc]]

--- a/docs/reference/ml/df-analytics/apis/get-trained-models-stats.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-trained-models-stats.asciidoc
@@ -27,8 +27,9 @@ Retrieves usage information for trained models.
 [[ml-get-trained-models-stats-prereq]]
 == {api-prereq-title}
 
-You must have the `monitor_ml` cluster privilege to use this API. The required 
-cluster privilege is included in the `machine_learning_user` built-in role.
+It is required to have the `monitor_ml` cluster privilege to use this API. The 
+required cluster privilege is included in the `machine_learning_user` built-in 
+role.
 
 
 [[ml-get-trained-models-stats-desc]]

--- a/docs/reference/ml/df-analytics/apis/get-trained-models-stats.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-trained-models-stats.asciidoc
@@ -27,12 +27,9 @@ Retrieves usage information for trained models.
 [[ml-get-trained-models-stats-prereq]]
 == {api-prereq-title}
 
-If the {es} {security-features} are enabled, you must have the following
-privileges:
+You must have the `monitor_ml` cluster privilege to use this API. The required 
+cluster privilege is included in the `machine_learning_user` built-in role.
 
-* cluster: `monitor_ml` or `monitor`, `manage_ml` or `manage`
-
-For more information, see <<security-privileges>> and {ml-docs-setup-privileges}.
 
 [[ml-get-trained-models-stats-desc]]
 == {api-description-title}

--- a/docs/reference/ml/df-analytics/apis/get-trained-models.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-trained-models.asciidoc
@@ -27,13 +27,8 @@ Retrieves configuration information for a trained model.
 [[ml-get-trained-models-prereq]]
 == {api-prereq-title}
 
-If the {es} {security-features} are enabled, you must have the following
-privileges:
-
-* cluster: `monitor_ml` or `monitor`, `manage_ml` or `manage`
-
-For more information, see <<security-privileges>> and
-{ml-docs-setup-privileges}.
+You must have the `monitor_ml` cluster privilege to use this API. The required 
+cluster privilege is included in the `machine_learning_user` built-in role.
 
 
 [[ml-get-trained-models-desc]]

--- a/docs/reference/ml/df-analytics/apis/get-trained-models.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-trained-models.asciidoc
@@ -27,9 +27,8 @@ Retrieves configuration information for a trained model.
 [[ml-get-trained-models-prereq]]
 == {api-prereq-title}
 
-It is required to have the `monitor_ml` cluster privilege to use this API. The 
-required cluster privilege is included in the `machine_learning_user` built-in 
-role.
+Requires the `monitor_ml` cluster privilege. This privilege is included in the 
+`machine_learning_user` built-in role.
 
 
 [[ml-get-trained-models-desc]]

--- a/docs/reference/ml/df-analytics/apis/get-trained-models.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-trained-models.asciidoc
@@ -30,7 +30,7 @@ Retrieves configuration information for a trained model.
 If the {es} {security-features} are enabled, you must have the following
 privileges:
 
-* cluster: `monitor_ml`
+* cluster: `monitor_ml` or `monitor`, `manage_ml` or `manage`
 
 For more information, see <<security-privileges>> and
 {ml-docs-setup-privileges}.

--- a/docs/reference/ml/df-analytics/apis/get-trained-models.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-trained-models.asciidoc
@@ -27,8 +27,9 @@ Retrieves configuration information for a trained model.
 [[ml-get-trained-models-prereq]]
 == {api-prereq-title}
 
-You must have the `monitor_ml` cluster privilege to use this API. The required 
-cluster privilege is included in the `machine_learning_user` built-in role.
+It is required to have the `monitor_ml` cluster privilege to use this API. The 
+required cluster privilege is included in the `machine_learning_user` built-in 
+role.
 
 
 [[ml-get-trained-models-desc]]

--- a/docs/reference/ml/df-analytics/apis/preview-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/preview-dfanalytics.asciidoc
@@ -26,9 +26,8 @@ Previews the features used by a {dataframe-analytics-config}.
 [[ml-preview-dfanalytics-prereq]]
 == {api-prereq-title}
 
-It is required to have the `monitor_ml` cluster privilege to use this API. The 
-required cluster privilege is included in the `machine_learning_user` built-in 
-role.
+Requires the `monitor_ml` cluster privilege. This privilege is included in the 
+`machine_learning_user` built-in role.
 
 
 [[ml-preview-dfanalytics-desc]]

--- a/docs/reference/ml/df-analytics/apis/preview-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/preview-dfanalytics.asciidoc
@@ -29,7 +29,7 @@ Previews the features used by a {dataframe-analytics-config}.
 If the {es} {security-features} are enabled, you must have the following
 privileges:
 
-* cluster: `monitor_ml`
+* cluster: `monitor_ml` or `monitor`, `manage_ml` or `manage`
 
 For more information, see <<security-privileges>> and {ml-docs-setup-privileges}.
 

--- a/docs/reference/ml/df-analytics/apis/preview-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/preview-dfanalytics.asciidoc
@@ -26,8 +26,9 @@ Previews the features used by a {dataframe-analytics-config}.
 [[ml-preview-dfanalytics-prereq]]
 == {api-prereq-title}
 
-You must have the `monitor_ml` cluster privilege to use this API. The required 
-cluster privilege is included in the `machine_learning_user` built-in role.
+It is required to have the `monitor_ml` cluster privilege to use this API. The 
+required cluster privilege is included in the `machine_learning_user` built-in 
+role.
 
 
 [[ml-preview-dfanalytics-desc]]

--- a/docs/reference/ml/df-analytics/apis/preview-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/preview-dfanalytics.asciidoc
@@ -26,12 +26,8 @@ Previews the features used by a {dataframe-analytics-config}.
 [[ml-preview-dfanalytics-prereq]]
 == {api-prereq-title}
 
-If the {es} {security-features} are enabled, you must have the following
-privileges:
-
-* cluster: `monitor_ml` or `monitor`, `manage_ml` or `manage`
-
-For more information, see <<security-privileges>> and {ml-docs-setup-privileges}.
+You must have the `monitor_ml` cluster privilege to use this API. The required 
+cluster privilege is included in the `machine_learning_user` built-in role.
 
 
 [[ml-preview-dfanalytics-desc]]

--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -20,11 +20,12 @@ Instantiates a {dfanalytics-job}.
 == {api-prereq-title}
 
 
-You must have the `manage_ml` cluster privilege, the `read` and 
-`view_index_metadata` privileges on the source indices, and the `read`, 
-`create_index`, `manage`, `index` privileges on the destination index to use 
-this API. The required cluster privilege is included in the 
-`machine_learning_admin` built-in role.
+It is required to have the following privileges to use this API:
+
+* cluster: `manage_ml` (the `machine_learning_admin` built-in role grants this 
+  privilege)
+* source indices: `read`, `view_index_metadata`
+* destination index: `read`, `create_index`, `manage` and `index`
 
 NOTE: The {dfanalytics-job} remembers which roles the user who created it had at
 the time of creation. When you start the job, it performs the analysis using

--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -19,16 +19,12 @@ Instantiates a {dfanalytics-job}.
 [[ml-put-dfanalytics-prereq]]
 == {api-prereq-title}
 
-If the {es} {security-features} are enabled, you must have the following
-built-in roles and privileges:
 
-* `machine_learning_admin`
-* source indices: `read`, `view_index_metadata`
-* destination index: `read`, `create_index`, `manage` and `index`
-
-For more information, see <<built-in-roles>>, <<security-privileges>>, and
-{ml-docs-setup-privileges}.
-
+You must have the `manage_ml` cluster privilege, the `read` and 
+`view_index_metadata` privileges on the source indices, and the `read`, 
+`create_index`, `manage`, `index` privileges on the destination index to use 
+this API. The required cluster privilege is included in the 
+`machine_learning_admin` built-in role.
 
 NOTE: The {dfanalytics-job} remembers which roles the user who created it had at
 the time of creation. When you start the job, it performs the analysis using

--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -20,7 +20,7 @@ Instantiates a {dfanalytics-job}.
 == {api-prereq-title}
 
 
-It is required to have the following privileges to use this API:
+Requires the following privileges:
 
 * cluster: `manage_ml` (the `machine_learning_admin` built-in role grants this 
   privilege)

--- a/docs/reference/ml/df-analytics/apis/put-trained-models-aliases.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-trained-models-aliases.asciidoc
@@ -21,13 +21,9 @@ A trained model alias is a logical name used to reference a single trained model
 [[ml-put-trained-models-aliases-prereq]]
 == {api-prereq-title}
 
-If the {es} {security-features} are enabled, you must have the following
-built-in role:
+You must have the `manage_ml` cluster privilege to use this API. This privilege 
+is included in the `machine_learning_admin` built-in role.
 
-* `machine_learning_admin`
-
-For more information, see <<built-in-roles>>, <<security-privileges>>, and
-{ml-docs-setup-privileges}.
 
 [[ml-put-trained-models-aliases-desc]]
 == {api-description-title}

--- a/docs/reference/ml/df-analytics/apis/put-trained-models-aliases.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-trained-models-aliases.asciidoc
@@ -21,8 +21,8 @@ A trained model alias is a logical name used to reference a single trained model
 [[ml-put-trained-models-aliases-prereq]]
 == {api-prereq-title}
 
-You must have the `manage_ml` cluster privilege to use this API. This privilege 
-is included in the `machine_learning_admin` built-in role.
+It is required to have the `manage_ml` cluster privilege to use this API. This 
+privilege is included in the `machine_learning_admin` built-in role.
 
 
 [[ml-put-trained-models-aliases-desc]]

--- a/docs/reference/ml/df-analytics/apis/put-trained-models-aliases.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-trained-models-aliases.asciidoc
@@ -21,8 +21,8 @@ A trained model alias is a logical name used to reference a single trained model
 [[ml-put-trained-models-aliases-prereq]]
 == {api-prereq-title}
 
-It is required to have the `manage_ml` cluster privilege to use this API. This 
-privilege is included in the `machine_learning_admin` built-in role.
+Requires the `manage_ml` cluster privilege. This privilege is included in the 
+`machine_learning_admin` built-in role.
 
 
 [[ml-put-trained-models-aliases-desc]]

--- a/docs/reference/ml/df-analytics/apis/put-trained-models.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-trained-models.asciidoc
@@ -24,12 +24,8 @@ WARNING: Models created in version 7.8.0 are not backwards compatible
 [[ml-put-trained-models-prereq]]
 == {api-prereq-title}
 
-If the {es} {security-features} are enabled, you must have the following
-built-in roles or equivalent privileges:
-
-* `machine_learning_admin`
-
-For more information, see <<built-in-roles>> and {ml-docs-setup-privileges}.
+You must have the `manage_ml` cluster privilege to use this API. This privilege 
+is included in the `machine_learning_admin` built-in role.
 
 
 [[ml-put-trained-models-desc]]

--- a/docs/reference/ml/df-analytics/apis/put-trained-models.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-trained-models.asciidoc
@@ -24,8 +24,8 @@ WARNING: Models created in version 7.8.0 are not backwards compatible
 [[ml-put-trained-models-prereq]]
 == {api-prereq-title}
 
-It is required to have the `manage_ml` cluster privilege to use this API. This 
-privilege is included in the `machine_learning_admin` built-in role.
+Requires the `manage_ml` cluster privilege. This privilege is included in the 
+`machine_learning_admin` built-in role.
 
 
 [[ml-put-trained-models-desc]]

--- a/docs/reference/ml/df-analytics/apis/put-trained-models.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-trained-models.asciidoc
@@ -24,8 +24,8 @@ WARNING: Models created in version 7.8.0 are not backwards compatible
 [[ml-put-trained-models-prereq]]
 == {api-prereq-title}
 
-You must have the `manage_ml` cluster privilege to use this API. This privilege 
-is included in the `machine_learning_admin` built-in role.
+It is required to have the `manage_ml` cluster privilege to use this API. This 
+privilege is included in the `machine_learning_admin` built-in role.
 
 
 [[ml-put-trained-models-desc]]

--- a/docs/reference/ml/df-analytics/apis/start-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/start-dfanalytics.asciidoc
@@ -19,7 +19,7 @@ Starts a {dfanalytics-job}.
 [[ml-start-dfanalytics-prereq]]
 == {api-prereq-title}
 
-You must have the following privileges to use this API:
+It is required to have the following privileges to use this API:
 
 * cluster: `manage_ml` (the `machine_learning_admin` built-in role grants this 
   privilege)

--- a/docs/reference/ml/df-analytics/apis/start-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/start-dfanalytics.asciidoc
@@ -19,15 +19,13 @@ Starts a {dfanalytics-job}.
 [[ml-start-dfanalytics-prereq]]
 == {api-prereq-title}
 
-If the {es} {security-features} are enabled, you must have the following 
-built-in roles and privileges:
+You must have the following privileges to use this API:
 
-* `machine_learning_admin`
+* cluster: `manage_ml` (the `machine_learning_admin` built-in role grants this 
+  privilege)
 * source indices: `read`, `view_index_metadata`
 * destination index: `read`, `create_index`, `manage` and `index`
 
-For more information, see <<built-in-roles>>, <<security-privileges>>, and
-{ml-docs-setup-privileges}.
 
 [[ml-start-dfanalytics-desc]]
 == {api-description-title}

--- a/docs/reference/ml/df-analytics/apis/start-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/start-dfanalytics.asciidoc
@@ -19,7 +19,7 @@ Starts a {dfanalytics-job}.
 [[ml-start-dfanalytics-prereq]]
 == {api-prereq-title}
 
-It is required to have the following privileges to use this API:
+Requires the following privileges:
 
 * cluster: `manage_ml` (the `machine_learning_admin` built-in role grants this 
   privilege)

--- a/docs/reference/ml/df-analytics/apis/stop-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/stop-dfanalytics.asciidoc
@@ -23,8 +23,8 @@ Stops one or more {dfanalytics-jobs}.
 [[ml-stop-dfanalytics-prereq]]
 == {api-prereq-title}
 
-It is required to have the `manage_ml` cluster privilege to use this API. This 
-privilege is included in the `machine_learning_admin` built-in role.
+Requires the `manage_ml` cluster privilege. This privilege is included in the 
+`machine_learning_admin` built-in role.
 
 
 [[ml-stop-dfanalytics-desc]]

--- a/docs/reference/ml/df-analytics/apis/stop-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/stop-dfanalytics.asciidoc
@@ -27,6 +27,7 @@ If the {es} {security-features} are enabled, you must have the following
 built-in roles or equivalent privileges:
 
 * `machine_learning_admin`
+* cluster: `manage_ml` or `manage`
   
 For more information, see <<built-in-roles>> and {ml-docs-setup-privileges}.
 

--- a/docs/reference/ml/df-analytics/apis/stop-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/stop-dfanalytics.asciidoc
@@ -23,8 +23,8 @@ Stops one or more {dfanalytics-jobs}.
 [[ml-stop-dfanalytics-prereq]]
 == {api-prereq-title}
 
-You must have the `manage_ml` cluster privilege to use this API. This privilege 
-is included in the `machine_learning_admin` built-in role.
+It is required to have the `manage_ml` cluster privilege to use this API. This 
+privilege is included in the `machine_learning_admin` built-in role.
 
 
 [[ml-stop-dfanalytics-desc]]

--- a/docs/reference/ml/df-analytics/apis/stop-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/stop-dfanalytics.asciidoc
@@ -23,13 +23,8 @@ Stops one or more {dfanalytics-jobs}.
 [[ml-stop-dfanalytics-prereq]]
 == {api-prereq-title}
 
-If the {es} {security-features} are enabled, you must have the following 
-built-in roles or equivalent privileges:
-
-* `machine_learning_admin`
-* cluster: `manage_ml` or `manage`
-  
-For more information, see <<built-in-roles>> and {ml-docs-setup-privileges}.
+You must have the `manage_ml` cluster privilege to use this API. This privilege 
+is included in the `machine_learning_admin` built-in role.
 
 
 [[ml-stop-dfanalytics-desc]]

--- a/docs/reference/ml/df-analytics/apis/update-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/update-dfanalytics.asciidoc
@@ -19,7 +19,7 @@ Updates an existing {dfanalytics-job}.
 [[ml-update-dfanalytics-prereq]]
 == {api-prereq-title}
 
-You must have the following privileges to use this API:
+It is required to have the following privileges to use this API:
 
 * cluster: `manage_ml` (the `machine_learning_admin` built-in role grants this 
   privilege)

--- a/docs/reference/ml/df-analytics/apis/update-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/update-dfanalytics.asciidoc
@@ -19,7 +19,7 @@ Updates an existing {dfanalytics-job}.
 [[ml-update-dfanalytics-prereq]]
 == {api-prereq-title}
 
-It is required to have the following privileges to use this API:
+Requires the following privileges:
 
 * cluster: `manage_ml` (the `machine_learning_admin` built-in role grants this 
   privilege)

--- a/docs/reference/ml/df-analytics/apis/update-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/update-dfanalytics.asciidoc
@@ -19,21 +19,19 @@ Updates an existing {dfanalytics-job}.
 [[ml-update-dfanalytics-prereq]]
 == {api-prereq-title}
 
-If the {es} {security-features} are enabled, you must have the following 
-built-in roles and privileges:
+You must have the following privileges to use this API:
 
-* `machine_learning_admin`
+* cluster: `manage_ml` (the `machine_learning_admin` built-in role grants this 
+  privilege)
 * source indices: `read`, `view_index_metadata`
 * destination index: `read`, `create_index`, `manage` and `index`
-  
-For more information, see <<built-in-roles>>, <<security-privileges>>, and
-{ml-docs-setup-privileges}.
 
 NOTE: The {dfanalytics-job} remembers which roles the user who updated it had at
 the time of the update. When you start the job, it performs the analysis using
 those same roles. If you provide
 <<http-clients-secondary-authorization,secondary authorization headers>>, 
 those credentials are used instead.
+
 
 [[ml-update-dfanalytics-desc]]
 == {api-description-title}


### PR DESCRIPTION
## Overview

This PR edits the required security privileges in the data frame analytics and the trained models API docs. It also removes links that point to sec privileges, built-in roles, and ML security setup pages from the prereq section.

Related to https://github.com/elastic/ml-team/issues/525

**Applied principles:**
* document the least privilege
* always mention cluster privilege
* mention the built-in role that grants the respective cluster privilege
* mention index privileges when it is necessary
* use flowing-text if there is only one privilege
* use bullet points if there are more privileges

### Preview

[Delete DFA](https://elasticsearch_71335.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/delete-dfanalytics.html)
[Delete TM aliases](https://elasticsearch_71335.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/delete-trained-models-aliases.html)
[Delete TM](https://elasticsearch_71335.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/delete-trained-models.html)
[Evaluate DFA](https://elasticsearch_71335.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/evaluate-dfanalytics.html)
[Explain DFA](https://elasticsearch_71335.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/explain-dfanalytics.html)
[GET DFA stats](https://elasticsearch_71335.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/get-dfanalytics-stats.html)
[GET DFA](https://elasticsearch_71335.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/get-dfanalytics.html)
[GET TM starts](https://elasticsearch_71335.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/get-trained-models-stats.html)
[GET TM](https://elasticsearch_71335.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/get-trained-models.html)
[Preview DFA](https://elasticsearch_71335.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/preview-dfanalytics.html)
[PUT DFA](https://elasticsearch_71335.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/put-dfanalytics.html)
[PUT TM aliases](https://elasticsearch_71335.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/put-trained-models-aliases.html)
[PUT TM](https://elasticsearch_71335.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/put-trained-models.html)
[Start DFA](https://elasticsearch_71335.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/start-dfanalytics.html)
[Stop DFA](https://elasticsearch_71335.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/stop-dfanalytics.html)
[Update DFA](https://elasticsearch_71335.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/update-dfanalytics.html)