### PR TITLE
[7.x] Include URLHttpClientIOException on URLBlobContainerRetriesTests testReadBlobWithReadTimeouts

### DIFF
--- a/modules/repository-url/src/test/java/org/elasticsearch/common/blobstore/url/URLBlobContainerRetriesTests.java
+++ b/modules/repository-url/src/test/java/org/elasticsearch/common/blobstore/url/URLBlobContainerRetriesTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.common.blobstore.url;
 
+import org.apache.http.ConnectionClosedException;
 import org.elasticsearch.common.SuppressForbidden;
 import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.common.blobstore.BlobPath;
@@ -19,13 +20,18 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.repositories.blobstore.AbstractBlobContainerRetriesTestCase;
+import org.hamcrest.Matcher;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
+import java.net.SocketTimeoutException;
 import java.net.URL;
+
+import static org.hamcrest.Matchers.either;
+import static org.hamcrest.Matchers.instanceOf;
 
 @SuppressForbidden(reason = "use a http server")
 public class URLBlobContainerRetriesTests extends AbstractBlobContainerRetriesTestCase {
@@ -55,6 +61,14 @@ public class URLBlobContainerRetriesTests extends AbstractBlobContainerRetriesTe
     @Override
     protected Class<? extends Exception> unresponsiveExceptionType() {
         return URLHttpClientIOException.class;
+    }
+
+    @Override
+    protected Matcher<Object> readTimeoutExceptionMatcher() {
+        // If the timeout is too tight it's possible that an URLHttpClientIOException is thrown as that
+        // exception is thrown before reading data from the response body.
+        return either(instanceOf(SocketTimeoutException.class)).or(instanceOf(ConnectionClosedException.class))
+            .or(instanceOf(RuntimeException.class)).or(instanceOf(URLHttpClientIOException.class));
     }
 
     @Override

--- a/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/AbstractBlobContainerRetriesTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/AbstractBlobContainerRetriesTestCase.java
@@ -79,6 +79,11 @@ public abstract class AbstractBlobContainerRetriesTestCase extends ESTestCase {
         @Nullable Boolean disableChunkedEncoding,
         @Nullable ByteSizeValue bufferSize);
 
+    protected org.hamcrest.Matcher<Object> readTimeoutExceptionMatcher() {
+        return either(instanceOf(SocketTimeoutException.class)).or(instanceOf(ConnectionClosedException.class))
+            .or(instanceOf(RuntimeException.class));
+    }
+
     public void testReadNonexistentBlobThrowsNoSuchFileException() {
         final BlobContainer blobContainer = createBlobContainer(between(1, 5), null, null, null);
         final long position = randomLongBetween(0, MAX_RANGE_VAL);
@@ -236,8 +241,7 @@ public abstract class AbstractBlobContainerRetriesTestCase extends ESTestCase {
                 Streams.readFully(stream);
             }
         });
-        assertThat(exception, either(instanceOf(SocketTimeoutException.class)).or(instanceOf(ConnectionClosedException.class))
-            .or(instanceOf(RuntimeException.class)));
+        assertThat(exception, readTimeoutExceptionMatcher());
         assertThat(exception.getMessage().toLowerCase(Locale.ROOT), either(containsString("read timed out")).or(
             containsString("premature end of chunk coded message body: closing chunk expected")).or(containsString("Read timed out"))
             .or(containsString("unexpected end of file from server")));


### PR DESCRIPTION
In some scenarios where the read timeout is too tight it's possible
that the http request times out before the response headers have
been received, in that case an URLHttpClientIOException is thrown.
This commit adds that exception type to the expected set of read timeout
exceptions.

Closes #70931
Backport of #71318
