### PR TITLE
Convert date_nanos example script to runtime field

### DIFF
--- a/docs/reference/mapping/types/date_nanos.asciidoc
+++ b/docs/reference/mapping/types/date_nanos.asciidoc
@@ -47,7 +47,7 @@ GET my-index-000001/_search
 {
   "sort": { "date": "asc"}, <5>
   "runtime_mappings": {
-    "date.has_nanos": {
+    "date_has_nanos": {
       "type": "boolean",
       "script": "emit(doc['date'].value.nano != 0)" <6>
     }
@@ -58,7 +58,7 @@ GET my-index-000001/_search
       "format": "strict_date_optional_time_nanos" <7>
     },
     {
-      "field": "date.has_nanos"
+      "field": "date_has_nanos"
     }
   ]
 }
@@ -87,7 +87,7 @@ it includes `nanos` or you'll get a rounded result.
         "_source": {"date": "2015-01-01"},
         "fields": {
           "date": ["2015-01-01T00:00:00.000Z"],
-          "date.has_nanos": [false]
+          "date_has_nanos": [false]
         },
         "sort": [1420070400000000000]
       },
@@ -98,7 +98,7 @@ it includes `nanos` or you'll get a rounded result.
         "_source": {"date": 1420070400000},
         "fields": {
           "date": ["2015-01-01T00:00:00.000Z"],
-          "date.has_nanos": [false]
+          "date_has_nanos": [false]
         },
         "sort": [1420070400000000000]
       },
@@ -109,7 +109,7 @@ it includes `nanos` or you'll get a rounded result.
         "_source": {"date": "2015-01-01T12:10:30.123456789Z"},
         "fields": {
           "date": ["2015-01-01T12:10:30.123456789Z"],
-          "date.has_nanos": [true]
+          "date_has_nanos": [true]
         },
         "sort": [1420114230123456789]
       }

--- a/docs/reference/mapping/types/date_nanos.asciidoc
+++ b/docs/reference/mapping/types/date_nanos.asciidoc
@@ -23,7 +23,7 @@ the default:
 For instance:
 
 [source,console]
---------------------------------------------------
+----
 PUT my-index-000001
 {
   "mappings": {
@@ -35,52 +35,89 @@ PUT my-index-000001
   }
 }
 
-PUT my-index-000001/_doc/1
+PUT my-index-000001/_bulk?refresh
+{ "index" : { "_id" : "1" } }
 { "date": "2015-01-01" } <2>
-
-PUT my-index-000001/_doc/2
+{ "index" : { "_id" : "2" } }
 { "date": "2015-01-01T12:10:30.123456789Z" } <3>
-
-PUT my-index-000001/_doc/3
-{ "date": 1420070400 } <4>
-
-GET my-index-000001/_search
-{
-  "sort": { "date": "asc"} <5>
-}
+{ "index" : { "_id" : "3" } }
+{ "date": 1420070400000 } <4>
 
 GET my-index-000001/_search
 {
-  "script_fields" : {
-    "my_field" : {
-      "script" : {
-        "lang" : "painless",
-        "source" : "doc['date'].value.nano" <6>
-      }
+  "sort": { "date": "asc"}, <5>
+  "runtime_mappings": {
+    "date.has_nanos": {
+      "type": "boolean",
+      "script": "emit(doc['date'].value.nano != 0)" <6>
     }
-  }
-}
-
-GET my-index-000001/_search
-{
-  "docvalue_fields" : [
+  },
+  "fields": [
     {
-      "field" : "date",
+      "field": "date",
       "format": "strict_date_optional_time_nanos" <7>
+    },
+    {
+      "field": "date.has_nanos"
     }
   ]
 }
---------------------------------------------------
-
+----
+// TEST[s/_search/_search?filter_path=hits.hits/]
 <1> The `date` field uses the default `format`.
 <2> This document uses a plain date.
 <3> This document includes a time.
 <4> This document uses milliseconds-since-the-epoch.
 <5> Note that the `sort` values that are returned are all in
 nanoseconds-since-the-epoch.
-<6> Access the nanosecond part of the date in a script
-<7> Use doc value fields, which can be formatted in nanosecond
-resolution
+<6> In scripts use `.nano` gets the nanosecond component of the date.
+<7> When fetching using fields you can specify the format. Make sure
+it includes `nanos` or you'll get a rounded result.
+
+////
+[source,console-result]
+----
+{
+  "hits": {
+    "hits": [
+      {
+        "_id": "1",
+        "_index": "my-index-000001",
+        "_score": null,
+        "_source": {"date": "2015-01-01"},
+        "fields": {
+          "date": ["2015-01-01T00:00:00.000Z"],
+          "date.has_nanos": [false]
+        },
+        "sort": [1420070400000000000]
+      },
+      {
+        "_id": "3",
+        "_index": "my-index-000001",
+        "_score": null,
+        "_source": {"date": 1420070400000},
+        "fields": {
+          "date": ["2015-01-01T00:00:00.000Z"],
+          "date.has_nanos": [false]
+        },
+        "sort": [1420070400000000000]
+      },
+      {
+        "_id": "2",
+        "_index": "my-index-000001",
+        "_score": null,
+        "_source": {"date": "2015-01-01T12:10:30.123456789Z"},
+        "fields": {
+          "date": ["2015-01-01T12:10:30.123456789Z"],
+          "date.has_nanos": [true]
+        },
+        "sort": [1420114230123456789]
+      }
+    ]
+  }
+}
+----
+////
 
 You can also specify multiple date formats separated by `||`. The
 same mapping parameters than with the `date` field can be used.

--- a/docs/reference/mapping/types/date_nanos.asciidoc
+++ b/docs/reference/mapping/types/date_nanos.asciidoc
@@ -71,8 +71,8 @@ GET my-index-000001/_search
 <5> Note that the `sort` values that are returned are all in
 nanoseconds-since-the-epoch.
 <6> Use `.nano` in scripts to return the nanosecond component of the date.
-<7> When fetching using fields you can specify the format. Make sure
-it includes `nanos` or you'll get a rounded result.
+<7> You can specify the format when fetching data using the <<search-fields-param,`fields` parameter>>.  
+Use <<strict-date-time-nanos,`strict_date_optional_time_nanos`>> or you'll get a rounded result.
 
 ////
 [source,console-result]

--- a/docs/reference/mapping/types/date_nanos.asciidoc
+++ b/docs/reference/mapping/types/date_nanos.asciidoc
@@ -70,7 +70,7 @@ GET my-index-000001/_search
 <4> This document uses milliseconds-since-the-epoch.
 <5> Note that the `sort` values that are returned are all in
 nanoseconds-since-the-epoch.
-<6> In scripts use `.nano` gets the nanosecond component of the date.
+<6> Use `.nano` in scripts to return the nanosecond component of the date.
 <7> When fetching using fields you can specify the format. Make sure
 it includes `nanos` or you'll get a rounded result.
 


### PR DESCRIPTION
Runtime fields are much more flexible than script_fields because you
can filter and aggregate on them so we hope folks use them! This
converts the example of using a `date_nanos` field in a script to a
runtime field so folks get used to seeing them and hopefully using them.

While I was editing this I took the opportunity to replace the script
with a real-ish example. Scripts that just load the field value are nice
and short but I hope no one uses them in real life because they just add
overhead when compared to accessing the field directly. So I made the
script do something.

Relates to #69291
