### PR TITLE
Deprecate xpack.searchable.snapshot.cache.size setting

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/BaseSearchableSnapshotsIntegTestCase.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/BaseSearchableSnapshotsIntegTestCase.java
@@ -67,16 +67,6 @@ public abstract class BaseSearchableSnapshotsIntegTestCase extends AbstractSnaps
         builder.put(XPackSettings.SECURITY_ENABLED.getKey(), false);
         if (randomBoolean()) {
             builder.put(
-                CacheService.SNAPSHOT_CACHE_SIZE_SETTING.getKey(),
-                rarely()
-                    ? randomBoolean()
-                        ? new ByteSizeValue(randomIntBetween(0, 10), ByteSizeUnit.KB)
-                        : new ByteSizeValue(randomIntBetween(0, 1000), ByteSizeUnit.BYTES)
-                    : new ByteSizeValue(randomIntBetween(1, 10), ByteSizeUnit.MB)
-            );
-        }
-        if (randomBoolean()) {
-            builder.put(
                 CacheService.SNAPSHOT_CACHE_RANGE_SIZE_SETTING.getKey(),
                 rarely()
                     ? new ByteSizeValue(randomIntBetween(4, 1024), ByteSizeUnit.KB)

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsCanMatchOnCoordinatorIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsCanMatchOnCoordinatorIntegTests.java
@@ -17,7 +17,6 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.List;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.Index;
@@ -35,7 +34,6 @@ import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.xpack.core.searchablesnapshots.MountSearchableSnapshotAction;
 import org.elasticsearch.xpack.core.searchablesnapshots.MountSearchableSnapshotRequest;
-import org.elasticsearch.xpack.searchablesnapshots.cache.full.CacheService;
 import org.elasticsearch.xpack.searchablesnapshots.cache.shared.FrozenCacheService;
 
 import java.io.IOException;
@@ -67,8 +65,6 @@ public class SearchableSnapshotsCanMatchOnCoordinatorIntegTests extends BaseSear
     protected Settings nodeSettings(int nodeOrdinal, Settings nodeSettings) {
         return Settings.builder()
             .put(super.nodeSettings(nodeOrdinal, nodeSettings))
-            // Use an unbound cache so we can recover the searchable snapshot completely all the times
-            .put(CacheService.SNAPSHOT_CACHE_SIZE_SETTING.getKey(), new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES))
             // Have a shared cache of reasonable size available on each node because tests randomize over frozen and cold allocation
             .put(FrozenCacheService.SNAPSHOT_CACHE_SIZE_SETTING.getKey(), ByteSizeValue.ofMb(randomLongBetween(1, 10)))
             .build();

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.xpack.searchablesnapshots;
 
-import com.carrotsearch.hppc.cursors.ObjectCursor;
 import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.store.AlreadyClosedException;
 import org.elasticsearch.ExceptionsHelper;
@@ -73,7 +72,6 @@ import org.elasticsearch.xpack.core.searchablesnapshots.SearchableSnapshotShardS
 import org.elasticsearch.xpack.searchablesnapshots.action.SearchableSnapshotsStatsAction;
 import org.elasticsearch.xpack.searchablesnapshots.action.SearchableSnapshotsStatsRequest;
 import org.elasticsearch.xpack.searchablesnapshots.action.SearchableSnapshotsStatsResponse;
-import org.elasticsearch.xpack.searchablesnapshots.cache.full.CacheService;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -83,11 +81,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
@@ -109,7 +105,6 @@ import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshots.ge
 import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsConstants.SNAPSHOT_DIRECTORY_FACTORY_KEY;
 import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsConstants.SNAPSHOT_RECOVERY_STATE_FACTORY_KEY;
 import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -1452,23 +1447,13 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
 
             for (List<RecoveryState> recoveryStates : recoveryResponse.shardRecoveryStates().values()) {
                 for (RecoveryState recoveryState : recoveryStates) {
-                    ByteSizeValue cacheSize = getCacheSizeForNode(recoveryState.getTargetNode().getName());
-                    boolean unboundedCache = cacheSize.equals(new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES));
                     RecoveryState.Index index = recoveryState.getIndex();
                     assertThat(
                         Strings.toString(recoveryState, true, true),
                         index.recoveredFileCount(),
-                        preWarmEnabled && unboundedCache ? equalTo(index.totalRecoverFiles()) : greaterThanOrEqualTo(0)
+                        preWarmEnabled ? equalTo(index.totalRecoverFiles()) : greaterThanOrEqualTo(0)
                     );
-
-                    // Since the cache size is variable, the pre-warm phase might fail as some of the files can be evicted
-                    // while a part is pre-fetched, in that case the recovery state stage is left as FINALIZE.
-                    assertThat(
-                        recoveryState.getStage(),
-                        unboundedCache
-                            ? equalTo(RecoveryState.Stage.DONE)
-                            : anyOf(equalTo(RecoveryState.Stage.DONE), equalTo(RecoveryState.Stage.FINALIZE))
-                    );
+                    assertThat(recoveryState.getStage(), equalTo(RecoveryState.Stage.DONE));
                 }
             }
         }, 30L, TimeUnit.SECONDS);
@@ -1487,22 +1472,6 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
             .flatMap(s -> s.getStats().stream())
             .mapToLong(stat -> stat.getTotalSize().getBytes())
             .sum();
-        final Set<String> nodeIdsWithLargeEnoughCache = new HashSet<>();
-        for (ObjectCursor<DiscoveryNode> nodeCursor : client().admin()
-            .cluster()
-            .prepareState()
-            .clear()
-            .setNodes(true)
-            .get()
-            .getState()
-            .nodes()
-            .getDataNodes()
-            .values()) {
-            final Settings nodeSettings = internalCluster().getInstance(Environment.class, nodeCursor.value.getName()).settings();
-            if (totalSize <= CacheService.SNAPSHOT_CACHE_SIZE_SETTING.get(nodeSettings).getBytes()) {
-                nodeIdsWithLargeEnoughCache.add(nodeCursor.value.getId());
-            }
-        }
         assertThat("Expecting stats to exist for at least one Lucene file", totalSize, greaterThan(0L));
 
         for (SearchableSnapshotShardStats stats : statsResponse.getStats()) {
@@ -1558,7 +1527,7 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
                             max(indexInputStats.getCachedBytesRead().getCount(), indexInputStats.getCachedBytesWritten().getCount()),
                             equalTo(0L)
                         );
-                    } else if (nodeIdsWithLargeEnoughCache.contains(stats.getShardRouting().currentNodeId())) {
+                    } else {
                         assertThat(
                             "Expected at least 1 cache read or write for " + fileExt + " of shard " + shardRouting,
                             max(
@@ -1578,18 +1547,6 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
                             indexInputStats.getDirectBytesRead().getCount(),
                             equalTo(0L)
                         );
-                    } else {
-                        assertThat(
-                            "Expected at least 1 read or write of any kind for " + fileExt + " of shard " + shardRouting,
-                            max(
-                                indexInputStats.getCachedBytesRead().getCount(),
-                                indexInputStats.getCachedBytesWritten().getCount(),
-                                indexInputStats.getOptimizedBytesRead().getCount(),
-                                indexInputStats.getDirectBytesRead().getCount(),
-                                indexInputStats.getIndexCacheBytesRead().getCount()
-                            ),
-                            greaterThan(0L)
-                        );
                     }
                 }
             }
@@ -1598,9 +1555,5 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
 
     private static long max(long... values) {
         return Arrays.stream(values).max().orElseThrow(() -> new AssertionError("no values"));
-    }
-
-    private ByteSizeValue getCacheSizeForNode(String nodeName) {
-        return CacheService.SNAPSHOT_CACHE_SIZE_SETTING.get(internalCluster().getInstance(Environment.class, nodeName).settings());
     }
 }

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotAllocationIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotAllocationIntegTests.java
@@ -11,8 +11,6 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.unit.ByteSizeUnit;
-import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.xpack.searchablesnapshots.BaseSearchableSnapshotsIntegTestCase;
@@ -28,15 +26,6 @@ import static org.hamcrest.Matchers.is;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0)
 public class SearchableSnapshotAllocationIntegTests extends BaseSearchableSnapshotsIntegTestCase {
-
-    @Override
-    protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
-        return Settings.builder()
-            .put(super.nodeSettings(nodeOrdinal, otherSettings))
-            // ensure the cache is definitely used
-            .put(CacheService.SNAPSHOT_CACHE_SIZE_SETTING.getKey(), new ByteSizeValue(1L, ByteSizeUnit.GB))
-            .build();
-    }
 
     public void testAllocatesToBestAvailableNodeOnRestart() throws Exception {
         internalCluster().startMasterOnlyNode();

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotEnableAllocationDeciderIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotEnableAllocationDeciderIntegTests.java
@@ -12,15 +12,12 @@ import org.elasticsearch.client.Requests;
 import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.unit.ByteSizeUnit;
-import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.snapshots.mockstore.MockRepository;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.xpack.searchablesnapshots.BaseSearchableSnapshotsIntegTestCase;
 import org.elasticsearch.xpack.searchablesnapshots.allocation.decider.SearchableSnapshotEnableAllocationDecider;
-import org.elasticsearch.xpack.searchablesnapshots.cache.full.CacheService;
 import org.hamcrest.Matchers;
 
 import java.util.ArrayList;
@@ -39,15 +36,6 @@ public class SearchableSnapshotEnableAllocationDeciderIntegTests extends BaseSea
         List<Class<? extends Plugin>> plugins = new ArrayList<>(super.nodePlugins());
         plugins.add(MockRepository.Plugin.class);
         return plugins;
-    }
-
-    @Override
-    protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
-        return Settings.builder()
-            .put(super.nodeSettings(nodeOrdinal, otherSettings))
-            // Use an unbound cache so we can recover the searchable snapshot completely all the times
-            .put(CacheService.SNAPSHOT_CACHE_SIZE_SETTING.getKey(), new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES))
-            .build();
     }
 
     public void testAllocationDisabled() throws Exception {

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/blob/SearchableSnapshotsBlobStoreCacheIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/blob/SearchableSnapshotsBlobStoreCacheIntegTests.java
@@ -76,8 +76,6 @@ public class SearchableSnapshotsBlobStoreCacheIntegTests extends BaseSearchableS
         blobCacheMaxLength = pageAligned(new ByteSizeValue(randomLongBetween(64L, 128L), ByteSizeUnit.KB));
 
         final Settings.Builder builder = Settings.builder();
-        // Cold (full copy) cache should be unlimited to not cause evictions
-        builder.put(CacheService.SNAPSHOT_CACHE_SIZE_SETTING.getKey(), new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES));
         // Align ranges to match the blob cache max length
         builder.put(CacheService.SNAPSHOT_CACHE_RANGE_SIZE_SETTING.getKey(), blobCacheMaxLength);
         builder.put(CacheService.SNAPSHOT_CACHE_RECOVERY_RANGE_SIZE_SETTING.getKey(), blobCacheMaxLength);

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/full/SearchableSnapshotsPersistentCacheIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/full/SearchableSnapshotsPersistentCacheIntegTests.java
@@ -12,8 +12,6 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.unit.ByteSizeUnit;
-import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexService;
@@ -46,8 +44,6 @@ public class SearchableSnapshotsPersistentCacheIntegTests extends BaseSearchable
     protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
         return Settings.builder()
             .put(super.nodeSettings(nodeOrdinal, otherSettings))
-            // ensure the cache is definitely used
-            .put(CacheService.SNAPSHOT_CACHE_SIZE_SETTING.getKey(), new ByteSizeValue(1L, ByteSizeUnit.GB))
             // to make cache synchronization predictable
             .put(CacheService.SNAPSHOT_CACHE_SYNC_INTERVAL_SETTING.getKey(), TimeValue.timeValueHours(1L))
             .build();

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/recovery/SearchableSnapshotRecoveryStateIntegrationTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/recovery/SearchableSnapshotRecoveryStateIntegrationTests.java
@@ -15,8 +15,6 @@ import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.SuppressForbidden;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.unit.ByteSizeUnit;
-import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
@@ -65,14 +63,6 @@ public class SearchableSnapshotRecoveryStateIntegrationTests extends BaseSearcha
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
         return CollectionUtils.appendToCopy(super.nodePlugins(), TestRepositoryPlugin.class);
-    }
-
-    @Override
-    protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
-        final Settings.Builder builder = Settings.builder().put(super.nodeSettings(nodeOrdinal, otherSettings));
-        builder.put(CacheService.SNAPSHOT_CACHE_SIZE_SETTING.getKey(), new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES));
-
-        return builder.build();
     }
 
     public void testRecoveryStateRecoveredBytesMatchPhysicalCacheState() throws Exception {

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/full/CacheService.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/full/CacheService.java
@@ -28,12 +28,12 @@ import org.elasticsearch.common.util.concurrent.FutureUtils;
 import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.ShardPath;
-import org.elasticsearch.xpack.searchablesnapshots.cache.common.CacheFile;
-import org.elasticsearch.xpack.searchablesnapshots.cache.common.CacheKey;
 import org.elasticsearch.repositories.IndexId;
 import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.searchablesnapshots.cache.common.ByteRange;
+import org.elasticsearch.xpack.searchablesnapshots.cache.common.CacheFile;
+import org.elasticsearch.xpack.searchablesnapshots.cache.common.CacheKey;
 import org.elasticsearch.xpack.searchablesnapshots.store.SearchableSnapshotDirectory;
 
 import java.io.FileNotFoundException;
@@ -71,10 +71,11 @@ public class CacheService extends AbstractLifecycleComponent {
 
     public static final Setting<ByteSizeValue> SNAPSHOT_CACHE_SIZE_SETTING = Setting.byteSizeSetting(
         SETTINGS_PREFIX + "size",
-        new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES),  // TODO: size the default value according to disk space
+        new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES),
         new ByteSizeValue(0, ByteSizeUnit.BYTES),               // min
         new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES),  // max
-        Setting.Property.NodeScope
+        Setting.Property.NodeScope,
+        Setting.Property.Deprecated
     );
 
     public static final ByteSizeValue MIN_SNAPSHOT_CACHE_RANGE_SIZE = new ByteSizeValue(4, ByteSizeUnit.KB);
@@ -144,7 +145,6 @@ public class CacheService extends AbstractLifecycleComponent {
     private final ReentrantLock cacheSyncLock;
     private final PersistentCache persistentCache;
     private final Cache<CacheKey, CacheFile> cache;
-    private final ByteSizeValue cacheSize;
     private final ByteSizeValue rangeSize;
     private final ByteSizeValue recoveryRangeSize;
     private final Map<ShardEviction, Future<?>> pendingShardsEvictions;
@@ -161,11 +161,9 @@ public class CacheService extends AbstractLifecycleComponent {
         final PersistentCache persistentCache
     ) {
         this.threadPool = Objects.requireNonNull(threadPool);
-        this.cacheSize = SNAPSHOT_CACHE_SIZE_SETTING.get(settings);
         this.rangeSize = SNAPSHOT_CACHE_RANGE_SIZE_SETTING.get(settings);
         this.recoveryRangeSize = SNAPSHOT_CACHE_RECOVERY_RANGE_SIZE_SETTING.get(settings);
         this.cache = CacheBuilder.<CacheKey, CacheFile>builder()
-            .setMaximumWeight(cacheSize.getBytes())
             .weigher((key, entry) -> entry.getLength())
             // NORELEASE This does not immediately free space on disk, as cache file are only deleted when all index inputs
             // are done with reading/writing the cache file
@@ -250,13 +248,6 @@ public class CacheService extends AbstractLifecycleComponent {
         if (state != Lifecycle.State.STARTED) {
             throw new IllegalStateException("Failed to read data from cache: cache service is not started [" + state + "]");
         }
-    }
-
-    /**
-     * @return the cache size (in bytes)
-     */
-    public long getCacheSize() {
-        return cacheSize.getBytes();
     }
 
     /**

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsTestCase.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsTestCase.java
@@ -32,7 +32,6 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.core.internal.io.IOUtils;
-import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.store.Store;
@@ -79,7 +78,6 @@ public abstract class AbstractSearchableSnapshotsTestCase extends ESIndexInputTe
         Sets.union(
             ClusterSettings.BUILT_IN_CLUSTER_SETTINGS,
             Set.of(
-                CacheService.SNAPSHOT_CACHE_SIZE_SETTING,
                 CacheService.SNAPSHOT_CACHE_RANGE_SIZE_SETTING,
                 CacheService.SNAPSHOT_CACHE_SYNC_INTERVAL_SETTING,
                 CacheService.SNAPSHOT_CACHE_MAX_FILES_TO_SYNC_AT_ONCE_SETTING
@@ -90,7 +88,6 @@ public abstract class AbstractSearchableSnapshotsTestCase extends ESIndexInputTe
     protected ThreadPool threadPool;
     protected ClusterService clusterService;
     protected NodeEnvironment nodeEnvironment;
-    protected Environment environment;
 
     @Before
     public void setUpTest() throws Exception {
@@ -124,9 +121,6 @@ public abstract class AbstractSearchableSnapshotsTestCase extends ESIndexInputTe
      */
     protected CacheService randomCacheService() {
         final Settings.Builder cacheSettings = Settings.builder();
-        if (randomBoolean()) {
-            cacheSettings.put(CacheService.SNAPSHOT_CACHE_SIZE_SETTING.getKey(), randomCacheSize());
-        }
         if (randomBoolean()) {
             cacheSettings.put(CacheService.SNAPSHOT_CACHE_RANGE_SIZE_SETTING.getKey(), randomCacheRangeSize());
         }
@@ -167,14 +161,11 @@ public abstract class AbstractSearchableSnapshotsTestCase extends ESIndexInputTe
     }
 
     /**
-     * @return a new {@link CacheService} instance configured with the given cache size and cache range size settings
+     * @return a new {@link CacheService} instance configured with the given cache range size setting
      */
-    protected CacheService createCacheService(final ByteSizeValue cacheSize, final ByteSizeValue cacheRangeSize) {
+    protected CacheService createCacheService(final ByteSizeValue cacheRangeSize) {
         return new CacheService(
-            Settings.builder()
-                .put(CacheService.SNAPSHOT_CACHE_SIZE_SETTING.getKey(), cacheSize)
-                .put(CacheService.SNAPSHOT_CACHE_RANGE_SIZE_SETTING.getKey(), cacheRangeSize)
-                .build(),
+            Settings.builder().put(CacheService.SNAPSHOT_CACHE_RANGE_SIZE_SETTING.getKey(), cacheRangeSize).build(),
             clusterService,
             threadPool,
             new PersistentCache(nodeEnvironment)
@@ -197,14 +188,6 @@ public abstract class AbstractSearchableSnapshotsTestCase extends ESIndexInputTe
      */
     protected Path randomShardPath(ShardId shardId) {
         return randomFrom(nodeEnvironment.availableShardPaths(shardId));
-    }
-
-    /**
-     * @return a random {@link ByteSizeValue} that can be used to set {@link CacheService#SNAPSHOT_CACHE_SIZE_SETTING}.
-     * Note that it can return a cache size of 0.
-     */
-    protected static ByteSizeValue randomCacheSize() {
-        return new ByteSizeValue(randomNonNegativeLong());
     }
 
     protected static ByteSizeValue randomFrozenCacheSize() {

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryStatsTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryStatsTests.java
@@ -192,56 +192,64 @@ public class SearchableSnapshotDirectoryStatsTests extends AbstractSearchableSna
     }
 
     public void testDirectBytesReadsWithCache() throws Exception {
-        // Cache service always evicts files
-        executeTestCaseWithCache(ByteSizeValue.ZERO, randomFrozenCacheRangeSize(), (fileName, fileContent, directory) -> {
-            assertThat(directory.getStats(fileName), nullValue());
+        // Cache on cold tier is unbounded, making it difficult to cause evictions and direct reads so only frozen cache is tested here
+        executeTestCase(
+            defaultCacheService(), // unused
+            createFrozenCacheService(ByteSizeValue.ZERO, randomFrozenCacheRangeSize()),
+            Settings.builder()
+                .put(SNAPSHOT_CACHE_ENABLED_SETTING.getKey(), true)
+                .put(SearchableSnapshotsConstants.SNAPSHOT_PARTIAL_SETTING.getKey(), true)
+                .build(),
+            (fileName, fileContent, directory) -> {
+                assertThat(directory.getStats(fileName), nullValue());
 
-            final IOContext ioContext = randomIOContext();
-            try {
-                IndexInput input = directory.openInput(fileName, ioContext);
-                if (randomBoolean()) {
-                    input = input.slice("test", 0L, input.length());
-                }
-                if (randomBoolean()) {
-                    input = input.clone();
-                }
-                final IndexInputStats inputStats = directory.getStats(fileName);
-
-                // account for internal buffered reads
-                final long bufferSize = BufferedIndexInput.bufferSize(ioContext);
-                final long remaining = input.length() % bufferSize;
-                final long expectedTotal = input.length();
-                final long expectedCount = input.length() / bufferSize + (remaining > 0L ? 1L : 0L);
-                final long minRead = remaining > 0L ? remaining : bufferSize;
-                final long maxRead = Math.min(input.length(), bufferSize);
-
-                // read all index input sequentially as it simplifies testing
-                final byte[] readBuffer = new byte[512];
-                for (long i = 0L; i < input.length();) {
-                    int size = between(1, toIntBytes(Math.min(readBuffer.length, input.length() - input.getFilePointer())));
-                    input.readBytes(readBuffer, 0, size);
-                    i += size;
-
-                    // direct cache file reads are aligned with the internal buffer
-                    long currentCount = i / bufferSize + (i % bufferSize > 0L ? 1L : 0L);
-                    if (currentCount < expectedCount) {
-                        assertCounter(inputStats.getDirectBytesRead(), currentCount * bufferSize, currentCount, bufferSize, bufferSize);
-                    } else {
-                        assertCounter(inputStats.getDirectBytesRead(), expectedTotal, expectedCount, minRead, maxRead);
+                final IOContext ioContext = randomIOContext();
+                try {
+                    IndexInput input = directory.openInput(fileName, ioContext);
+                    if (randomBoolean()) {
+                        input = input.slice("test", 0L, input.length());
                     }
-                    assertThat(inputStats.getDirectBytesRead().totalNanoseconds(), equalTo(currentCount * FAKE_CLOCK_ADVANCE_NANOS));
+                    if (randomBoolean()) {
+                        input = input.clone();
+                    }
+                    final IndexInputStats inputStats = directory.getStats(fileName);
+
+                    // account for internal buffered reads
+                    final long bufferSize = BufferedIndexInput.bufferSize(ioContext);
+                    final long remaining = input.length() % bufferSize;
+                    final long expectedTotal = input.length();
+                    final long expectedCount = input.length() / bufferSize + (remaining > 0L ? 1L : 0L);
+                    final long minRead = remaining > 0L ? remaining : bufferSize;
+                    final long maxRead = Math.min(input.length(), bufferSize);
+
+                    // read all index input sequentially as it simplifies testing
+                    final byte[] readBuffer = new byte[512];
+                    for (long i = 0L; i < input.length();) {
+                        int size = between(1, toIntBytes(Math.min(readBuffer.length, input.length() - input.getFilePointer())));
+                        input.readBytes(readBuffer, 0, size);
+                        i += size;
+
+                        // direct cache file reads are aligned with the internal buffer
+                        long currentCount = i / bufferSize + (i % bufferSize > 0L ? 1L : 0L);
+                        if (currentCount < expectedCount) {
+                            assertCounter(inputStats.getDirectBytesRead(), currentCount * bufferSize, currentCount, bufferSize, bufferSize);
+                        } else {
+                            assertCounter(inputStats.getDirectBytesRead(), expectedTotal, expectedCount, minRead, maxRead);
+                        }
+                        assertThat(inputStats.getDirectBytesRead().totalNanoseconds(), equalTo(currentCount * FAKE_CLOCK_ADVANCE_NANOS));
+                    }
+
+                    // cache file has never been written nor read
+                    assertCounter(inputStats.getCachedBytesWritten(), 0L, 0L, 0L, 0L);
+                    assertCounter(inputStats.getCachedBytesRead(), 0L, 0L, 0L, 0L);
+                    assertThat(inputStats.getCachedBytesWritten().totalNanoseconds(), equalTo(0L));
+
+                    input.close();
+                } catch (IOException e) {
+                    throw new AssertionError(e);
                 }
-
-                // cache file has never been written nor read
-                assertCounter(inputStats.getCachedBytesWritten(), 0L, 0L, 0L, 0L);
-                assertCounter(inputStats.getCachedBytesRead(), 0L, 0L, 0L, 0L);
-                assertThat(inputStats.getCachedBytesWritten().totalNanoseconds(), equalTo(0L));
-
-                input.close();
-            } catch (IOException e) {
-                throw new AssertionError(e);
             }
-        });
+        );
     }
 
     public void testDirectBytesReadsWithoutCache() throws Exception {
@@ -590,7 +598,7 @@ public class SearchableSnapshotDirectoryStatsTests extends AbstractSearchableSna
         final TriConsumer<String, byte[], SearchableSnapshotDirectory> test
     ) throws Exception {
         executeTestCase(
-            createCacheService(cacheSize, cacheRangeSize),
+            createCacheService(cacheRangeSize),
             createFrozenCacheService(cacheSize, cacheRangeSize),
             Settings.builder()
                 .put(SNAPSHOT_CACHE_ENABLED_SETTING.getKey(), true)

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/input/CachedBlobContainerIndexInputTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/input/CachedBlobContainerIndexInputTests.java
@@ -87,7 +87,7 @@ public class CachedBlobContainerIndexInputTests extends AbstractSearchableSnapsh
                 final boolean prewarmEnabled = randomBoolean();
                 final BlobContainer singleBlobContainer = singleSplitBlobContainer(blobName, input, partSize);
                 final BlobContainer blobContainer;
-                if (input.length == partSize && input.length <= cacheService.getCacheSize() && prewarmEnabled == false) {
+                if (input.length == partSize && prewarmEnabled == false) {
                     blobContainer = new CountingBlobContainer(singleBlobContainer);
                 } else {
                     blobContainer = singleBlobContainer;


### PR DESCRIPTION
This change deprecates the `xpack.searchable.snapshot.cache.size` that has been removed in 8.0 (#71334).

The setting is now deprecated and should therefore emit a warning starting 7.13.0. Randomization in tests is removed too.