### PR TITLE
Fix scroll contexts counter in SearchService

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -33,6 +33,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.settings.Setting;
@@ -574,6 +575,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
     }
 
     final SearchContext createAndPutContext(ShardSearchRequest request) throws IOException {
+        final Releasable decreaseScrollContexts;
         if (request.scroll() != null) {
             if (maxOpenScrollContext == Integer.MAX_VALUE && openScrollContexts.get() > 500) {
                 /**
@@ -593,14 +595,17 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
                         maxOpenScrollContext + "]. " + "This limit can be set by changing the ["
                         + MAX_OPEN_SCROLL_CONTEXT.getKey() + "] setting.");
             }
+            decreaseScrollContexts = openScrollContexts::decrementAndGet;
+        } else {
+            decreaseScrollContexts = () -> {};
         }
         SearchContext context = null;
         try {
             context = createContext(request);
-            context.addReleasable(openScrollContexts::decrementAndGet, Lifetime.CONTEXT);
+            context.addReleasable(decreaseScrollContexts, Lifetime.CONTEXT);
         } finally {
             if (context == null) {
-                openScrollContexts.decrementAndGet();
+                decreaseScrollContexts.close();
             }
         }
         onNewContext(context);
@@ -1021,6 +1026,13 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
      */
     public int getActiveContexts() {
         return this.activeContexts.size();
+    }
+
+    /**
+     * Returns the number of opening scroll contexts.
+     */
+    public int getOpenScrollContexts() {
+        return openScrollContexts.get();
     }
 
     public ResponseCollectorService getResponseCollectorService() {

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -1029,7 +1029,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
     }
 
     /**
-     * Returns the number of opening scroll contexts.
+     * Returns the number of scroll contexts opened on the node
      */
     public int getOpenScrollContexts() {
         return openScrollContexts.get();

--- a/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
@@ -796,5 +796,6 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
         assertSame(searchShardTarget, searchContext.dfsResult().getSearchShardTarget());
         assertSame(searchShardTarget, searchContext.queryResult().getSearchShardTarget());
         assertSame(searchShardTarget, searchContext.fetchResult().getSearchShardTarget());
+        assertThat(service.getOpenScrollContexts(), equalTo(0));
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/ESSingleNodeTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESSingleNodeTestCase.java
@@ -50,6 +50,7 @@ import org.elasticsearch.node.Node;
 import org.elasticsearch.node.NodeValidationException;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.search.SearchService;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.test.discovery.TestZenDiscovery;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -121,6 +122,9 @@ public abstract class ESSingleNodeTestCase extends ESTestCase {
     @Override
     public void tearDown() throws Exception {
         logger.info("[{}#{}]: cleaning up after test", getTestClass().getSimpleName(), getTestName());
+        SearchService searchService = getInstanceFromNode(SearchService.class);
+        assertThat(searchService.getActiveContexts(), equalTo(0));
+        assertThat(searchService.getOpenScrollContexts(), equalTo(0));
         super.tearDown();
         assertAcked(client().admin().indices().prepareDelete("*").get());
         MetaData metaData = client().admin().cluster().prepareState().get().getState().getMetaData();


### PR DESCRIPTION
Unfortunately, the backport of #53449 to 6.8 and 7.6.2 weren't correct. The scroll context counter can be negative even become `Integer.MAX_VALUE` after handling many search requests. This bug causes two issues:

- Disable the limit of open scroll contexts when the counter is negative
- Prevent opening new scroll contexts when the counter is greater than the limit of open scroll contexts

This bug was already fixed in 7.7 and later. I will add the assertions in this PR to 7.x and master.

Kudos to @jerryjune for this finding.

Closes #56202