### PR TITLE
Fix isDedicatedVotingOnlyNode

### DIFF
--- a/server/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
@@ -381,8 +381,9 @@ public class RepositoriesService extends AbstractLifecycleComponent implements C
     }
 
     public static boolean isDedicatedVotingOnlyNode(Set<DiscoveryNodeRole> roles) {
-        return roles.contains(DiscoveryNodeRole.MASTER_ROLE) && roles.contains(DiscoveryNodeRole.DATA_ROLE) == false &&
-            roles.stream().anyMatch(role -> role.roleName().equals("voting_only"));
+        return roles.contains(DiscoveryNodeRole.MASTER_ROLE)
+                && roles.stream().noneMatch(DiscoveryNodeRole::canContainData)
+                && roles.stream().anyMatch(role -> role.roleName().equals("voting_only"));
     }
 
     /**

--- a/x-pack/plugin/voting-only-node/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/VotingOnlyNodePluginTests.java
+++ b/x-pack/plugin/voting-only-node/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/VotingOnlyNodePluginTests.java
@@ -44,6 +44,7 @@ import java.util.Set;
 import static org.elasticsearch.test.NodeRoles.addRoles;
 import static org.elasticsearch.test.NodeRoles.onlyRole;
 import static org.elasticsearch.test.NodeRoles.onlyRoles;
+import static org.elasticsearch.test.NodeRoles.removeRoles;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -150,8 +151,11 @@ public class VotingOnlyNodePluginTests extends ESIntegTestCase {
         final String dedicatedVotingOnlyNode = internalCluster().startNode(
             onlyRoles(Set.of(DiscoveryNodeRole.MASTER_ROLE, VotingOnlyNodePlugin.VOTING_ONLY_NODE_ROLE)));
         // voting-only master node that also has data
-        final String nonDedicatedVotingOnlyNode = internalCluster().startNode(
-            addRoles(Set.of(VotingOnlyNodePlugin.VOTING_ONLY_NODE_ROLE)));
+        Settings dataContainingVotingOnlyNodeSettings = addRoles(Set.of(VotingOnlyNodePlugin.VOTING_ONLY_NODE_ROLE));
+        if (randomBoolean()) {
+            dataContainingVotingOnlyNodeSettings = removeRoles(dataContainingVotingOnlyNodeSettings, Set.of(DiscoveryNodeRole.DATA_ROLE));
+        }
+        final String nonDedicatedVotingOnlyNode = internalCluster().startNode(dataContainingVotingOnlyNodeSettings);
 
         assertAcked(client().admin().cluster().preparePutRepository("test-repo")
             .setType("verifyaccess-fs").setSettings(Settings.builder().put("location", randomRepoPath())


### PR DESCRIPTION
Today we incorrectly consider a data-containing voting-only node as a
dedicated voting-only node if it does not have the `data` role, because
we check specifically for the `data` role rather than using
`DiscoveryNodeRole::canContainData`. This means that such nodes don't
get involved with snapshots, but they should. This commit fixes that.

Closes #71352