### PR TITLE
Change bool string to true bool value in watcher.stats test

### DIFF
--- a/x-pack/plugin/watcher/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/watcher/stats/10_basic.yml
+++ b/x-pack/plugin/watcher/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/watcher/stats/10_basic.yml
@@ -9,7 +9,7 @@
   - do:
       watcher.stats:
         metric: "all"
-        emit_stacktraces: "true"
+        emit_stacktraces: true
   - match: { "manually_stopped": false }
   - match: { "stats.0.watcher_state": "started" }
 


### PR DESCRIPTION
The type of `emit_stacktraces` is defined as boolean [spec](https://github.com/elastic/elasticsearch/blob/master/rest-api-spec/src/main/resources/rest-api-spec/api/watcher.stats.json#L51), but the test used the string value `"true"` which caused problems for downstream projects asserting type correctness.