### PR TITLE
Convert `boolean` field example to runtime fields (backport of #71341)

### DIFF
--- a/docs/reference/mapping/types/boolean.asciidoc
+++ b/docs/reference/mapping/types/boolean.asciidoc
@@ -19,7 +19,7 @@ True values::
 For example:
 
 [source,console]
---------------------------------------------------
+----
 PUT my-index-000001
 {
   "mappings": {
@@ -31,7 +31,7 @@ PUT my-index-000001
   }
 }
 
-POST my-index-000001/_doc/1
+POST my-index-000001/_doc/1?refresh
 {
   "is_published": "true" <1>
 }
@@ -44,24 +44,45 @@ GET my-index-000001/_search
     }
   }
 }
---------------------------------------------------
-
+----
+// TEST[s/_search/_search?filter_path=hits.hits/]
 <1> Indexing a document with `"true"`, which is interpreted as `true`.
 <2> Searching for documents with a JSON `true`.
+
+////
+[source,console-result]
+----
+{
+  "hits": {
+    "hits": [
+      {
+        "_id": "1",
+        "_index": "my-index-000001",
+        "_type": "_doc",
+        "_score": "$body.hits.hits.0._score",
+        "_source": {
+          "is_published": "true"
+        }
+      }
+    ]
+  }
+}
+----
+////
 
 Aggregations like the <<search-aggregations-bucket-terms-aggregation,`terms`
 aggregation>>  use `1` and `0` for the `key`, and the strings `"true"` and
 `"false"` for the `key_as_string`. Boolean fields when used in scripts,
-return `1` and `0`:
+return `true` and `false`:
 
 [source,console]
---------------------------------------------------
-POST my-index-000001/_doc/1
+----
+POST my-index-000001/_doc/1?refresh
 {
   "is_published": true
 }
 
-POST my-index-000001/_doc/2
+POST my-index-000001/_doc/2?refresh
 {
   "is_published": false
 }
@@ -75,16 +96,71 @@ GET my-index-000001/_search
       }
     }
   },
-  "script_fields": {
-    "is_published": {
-      "script": {
-        "lang": "painless",
-        "source": "doc['is_published'].value"
-      }
+  "sort": [ "is_published" ],
+  "fields": [
+    {"field": "weight"}
+  ],
+  "runtime_mappings": {
+    "weight": {
+      "type": "long",
+      "script": "emit(doc['is_published'].value ? 10 : 0)"
     }
   }
 }
---------------------------------------------------
+----
+// TEST[s/_search/_search?filter_path=aggregations,hits.hits/]
+
+////
+[source,console-result]
+----
+{
+  "aggregations": {
+    "publish_state": {
+      "doc_count_error_upper_bound": 0,
+      "sum_other_doc_count": 0,
+      "buckets": [
+        {
+          "key": 0,
+          "key_as_string": "false",
+          "doc_count": 1
+        },
+        {
+          "key": 1,
+          "key_as_string": "true",
+          "doc_count": 1
+        }
+      ]
+    }
+  },
+  "hits": {
+    "hits": [
+      {
+        "_id": "2",
+        "_index": "my-index-000001",
+        "_type": "_doc",
+        "_score": null,
+        "_source": {
+          "is_published": false
+        },
+        "sort": [0],
+        "fields": {"weight": [0]}
+      },
+      {
+        "_id": "1",
+        "_index": "my-index-000001",
+        "_type": "_doc",
+        "_score": null,
+        "_source": {
+          "is_published": true
+        },
+        "sort": [1],
+        "fields": {"weight": [10]}
+      }
+    ]
+  }
+}
+----
+////
 
 [[boolean-params]]
 ==== Parameters for `boolean` fields


### PR DESCRIPTION
Runtime fields are much more flexible than `script_fields` because you
can filter and aggregate on them so we hope folks use them! This
converts the example of using a `boolean` field in a script to a runtime
field so folks get used to seeing them and hopefully using them.

While I was editing this I took the opportunity to replace the script
with a real-ish example. Scripts that just load the field value are nice
and short but I hope no one uses them in real life because they just add
overhead when compared to accessing the field directly. So I made the
script do *something*.

Relates to #69291
