### PR TITLE
[7.12] [DOCS] Use HTML-unescaped Mustache variables in ingest pipelines (#71360)

### DIFF
--- a/docs/reference/ingest.asciidoc
+++ b/docs/reference/ingest.asciidoc
@@ -491,9 +491,10 @@ PUT _ingest/pipeline/my-pipeline
 ----
 
 [[template-snippets]]
-To access field values, enclose the field name in double curly brackets `{{ }}`
-to create a https://mustache.github.io[Mustache] template snippet. You can use
-template snippets to dynamically set field names.
+Several processor parameters support https://mustache.github.io[Mustache]
+template snippets. To access field values in a template snippet, enclose the
+field name in triple curly brackets:`{{{field-name}}}`. You can use template
+snippets to dynamically set field names.
 
 [source,console]
 ----
@@ -503,8 +504,8 @@ PUT _ingest/pipeline/my-pipeline
     {
       "set": {
         "description": "Set dynamic '<service>' field to 'code' value",
-        "field": "{{service}}",
-        "value": "{{code}}"
+        "field": "{{{service}}}",
+        "value": "{{{code}}}"
       }
     }
   ]
@@ -530,7 +531,7 @@ PUT _ingest/pipeline/my-pipeline
       "set": {
         "description": "Set '_routing' to 'geoip.country_iso_code' value",
         "field": "_routing",
-        "value": "{{geoip.country_iso_code}}"
+        "value": "{{{geoip.country_iso_code}}}"
       }
     }
   ]
@@ -538,10 +539,10 @@ PUT _ingest/pipeline/my-pipeline
 ----
 
 Use a Mustache template snippet to access metadata field values. For example,
-`{{_routing}}` retrieves a document's routing value.
+`{{{_routing}}}` retrieves a document's routing value.
 
 WARNING: If you <<create-document-ids-automatically,automatically generate>>
-document IDs, you cannot use `{{_id}}` in a processor. {es} assigns
+document IDs, you cannot use `{{{_id}}}` in a processor. {es} assigns
 auto-generated `_id` values after ingest.
 
 [discrete]
@@ -568,7 +569,7 @@ PUT _ingest/pipeline/my-pipeline
       "set": {
         "description": "Index the ingest timestamp as 'event.ingested'",
         "field": "event.ingested",
-        "value": "{{_ingest.timestamp}}"
+        "value": "{{{_ingest.timestamp}}}"
       }
     }
   ]
@@ -685,7 +686,7 @@ PUT _ingest/pipeline/my-pipeline
       "set": {
         "description": "Index document to 'failed-<index>'",
         "field": "_index",
-        "value": "failed-{{ _index }}"
+        "value": "failed-{{{ _index }}}"
       }
     }
   ]

--- a/docs/reference/ingest/processors/append.asciidoc
+++ b/docs/reference/ingest/processors/append.asciidoc
@@ -27,7 +27,7 @@ include::common-options.asciidoc[]
 {
   "append": {
     "field": "tags",
-    "value": ["production", "{{app}}", "{{owner}}"]
+    "value": ["production", "{{{app}}}", "{{{owner}}}"]
   }
 }
 --------------------------------------------------

--- a/docs/reference/ingest/processors/date.asciidoc
+++ b/docs/reference/ingest/processors/date.asciidoc
@@ -59,8 +59,8 @@ the timezone and locale values.
         "field" : "initial_date",
         "target_field" : "timestamp",
         "formats" : ["ISO8601"],
-        "timezone" : "{{my_timezone}}",
-        "locale" : "{{my_locale}}"
+        "timezone" : "{{{my_timezone}}}",
+        "locale" : "{{{my_locale}}}"
       }
     }
   ]

--- a/docs/reference/ingest/processors/fail.asciidoc
+++ b/docs/reference/ingest/processors/fail.asciidoc
@@ -22,7 +22,7 @@ include::common-options.asciidoc[]
 {
   "fail": {
     "if" : "ctx.tags.contains('production') != true",
-    "message": "The production tag is not present, found tags: {{tags}}"
+    "message": "The production tag is not present, found tags: {{{tags}}}"
   }
 }
 --------------------------------------------------

--- a/docs/reference/ingest/processors/set.asciidoc
+++ b/docs/reference/ingest/processors/set.asciidoc
@@ -44,7 +44,7 @@ PUT _ingest/pipeline/set_os
     {
       "set": {
         "field": "host.os.name",
-        "value": "{{os}}"
+        "value": "{{{os}}}"
       }
     }
   ]


### PR DESCRIPTION
Backports the following commits to 7.12:
 - [DOCS] Use HTML-unescaped Mustache variables in ingest pipelines (#71360)