### PR TITLE
Disable Docker test fixtures that don't support aarch64

### DIFF
--- a/x-pack/qa/oidc-op-tests/build.gradle
+++ b/x-pack/qa/oidc-op-tests/build.gradle
@@ -1,3 +1,5 @@
+import org.elasticsearch.gradle.Architecture
+
 Project idpFixtureProject = xpackProject("test:idp-fixture")
 
 apply plugin: 'elasticsearch.testclusters'
@@ -20,4 +22,9 @@ tasks.named("processTestResources").configure {
           .files(
                   'src/test/resources/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode_ec.crt'
           )
+}
+
+tasks.named("integTest").configure {
+  // OpenID Connect fixture does not support aarm64
+  onlyIf { Architecture.current() == Architecture.X64 }
 }

--- a/x-pack/qa/saml-idp-tests/build.gradle
+++ b/x-pack/qa/saml-idp-tests/build.gradle
@@ -1,3 +1,5 @@
+import org.elasticsearch.gradle.Architecture
+
 Project idpFixtureProject = xpackProject("test:idp-fixture")
 
 apply plugin: 'elasticsearch.testclusters'
@@ -9,8 +11,8 @@ dependencies {
   testImplementation(testArtifact(project(xpackModule('core'))))
   testImplementation "com.google.jimfs:jimfs:${versions.jimfs}"
 }
-testFixtures.useFixture ":x-pack:test:idp-fixture"
 
+testFixtures.useFixture ":x-pack:test:idp-fixture"
 
 String outputDir = "${project.buildDir}/generated-resources/${project.name}"
 def copyIdpFiles = tasks.register("copyIdpFiles", Copy) {
@@ -18,12 +20,12 @@ def copyIdpFiles = tasks.register("copyIdpFiles", Copy) {
     'idp/shibboleth-idp/credentials/sp-signing.key', 'idp/shibboleth-idp/credentials/sp-signing.crt');
   into outputDir
 }
-project.sourceSets.test.output.dir(outputDir, builtBy: copyIdpFiles)
 
-tasks.register("setupPorts") {
+def setupPorts = tasks.register("setupPorts") {
   dependsOn copyIdpFiles, idpFixtureProject.postProcessFixture
   // Don't attempt to get ephemeral ports when Docker is not available
-  onlyIf { idpFixtureProject.postProcessFixture.state.skipped == false }
+  // Also, shibboleth fixture is not available on aarch64
+  onlyIf { idpFixtureProject.postProcessFixture.state.skipped == false && Architecture.current() == Architecture.X64 }
   doLast {
     String portString = idpFixtureProject.postProcessFixture.ext."test.fixtures.shibboleth-idp.tcp.4443"
     int ephemeralPort = Integer.valueOf(portString)
@@ -39,7 +41,11 @@ tasks.register("setupPorts") {
   }
 }
 
-tasks.named("integTest").configure {dependsOn "setupPorts" }
+project.sourceSets.test.output.dir(outputDir, builtBy: [copyIdpFiles, setupPorts])
+
+tasks.named("integTest").configure {
+  onlyIf { idpFixtureProject.postProcessFixture.state.skipped == false && Architecture.current() == Architecture.X64 }
+}
 
 testClusters.matching { it.name == "integTest" }.configureEach {
   testDistribution = 'DEFAULT'


### PR DESCRIPTION
We have a few Docker-based test fixtures used for testing various identity providers. A couple of these (openid connect and shibboleth) don't provide Docker images for aarch64, and therefore these tests cannot be run on ARM. This pull request disables these tests on ARM until we can find suitable fixtures.