### PR TITLE
Enable logging for proxy connection test

### DIFF
--- a/server/src/test/java/org/elasticsearch/transport/ProxyConnectionStrategyTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/ProxyConnectionStrategyTests.java
@@ -19,6 +19,8 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.junit.annotations.TestIssueLogging;
+import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -98,6 +100,9 @@ public class ProxyConnectionStrategyTests extends ESTestCase {
         }
     }
 
+    @TestLogging(
+        value = "org.elasticsearch.transport.ClusterConnectionManager:TRACE,org.elasticsearch.transport.ProxyConnectionStrategy:TRACE",
+        reason = "to ensure that connections are logged")
     public void testProxyStrategyWillOpenNewConnectionsOnDisconnect() throws Exception {
         try (MockTransportService transport1 = startTransport("node1", Version.CURRENT);
              MockTransportService transport2 = startTransport("node2", Version.CURRENT)) {

--- a/server/src/test/java/org/elasticsearch/transport/ProxyConnectionStrategyTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/ProxyConnectionStrategyTests.java
@@ -19,7 +19,6 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.junit.annotations.TestIssueLogging;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.threadpool.TestThreadPool;

--- a/server/src/test/java/org/elasticsearch/transport/ProxyConnectionStrategyTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/ProxyConnectionStrategyTests.java
@@ -100,6 +100,7 @@ public class ProxyConnectionStrategyTests extends ESTestCase {
         }
     }
 
+    // This test has failed once or twice in the past. This is enabled in case it were to fail again.
     @TestLogging(
         value = "org.elasticsearch.transport.ClusterConnectionManager:TRACE,org.elasticsearch.transport.ProxyConnectionStrategy:TRACE",
         reason = "to ensure that connections are logged")


### PR DESCRIPTION
This commit enables logging for a remote proxy connection test which
failed once. After observation, the test has not consistently failed and
no clear explanation has been identified. This logging will add
additional information in case the test were to fail again.

Closes #68108.