### PR TITLE
QL: Polish optimizer expression rule declaration

### DIFF
--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/optimizer/Optimizer.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/optimizer/Optimizer.java
@@ -37,12 +37,13 @@ import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.NotEq
 import org.elasticsearch.xpack.ql.expression.predicate.regex.Like;
 import org.elasticsearch.xpack.ql.expression.predicate.regex.RegexMatch;
 import org.elasticsearch.xpack.ql.optimizer.OptimizerRules;
+import org.elasticsearch.xpack.ql.optimizer.OptimizerRules.BinaryComparisonSimplification;
 import org.elasticsearch.xpack.ql.optimizer.OptimizerRules.BooleanFunctionEqualsElimination;
-import org.elasticsearch.xpack.ql.optimizer.OptimizerRules.BooleanLiteralsOnTheRight;
 import org.elasticsearch.xpack.ql.optimizer.OptimizerRules.BooleanSimplification;
 import org.elasticsearch.xpack.ql.optimizer.OptimizerRules.CombineBinaryComparisons;
 import org.elasticsearch.xpack.ql.optimizer.OptimizerRules.CombineDisjunctionsToIn;
 import org.elasticsearch.xpack.ql.optimizer.OptimizerRules.ConstantFolding;
+import org.elasticsearch.xpack.ql.optimizer.OptimizerRules.LiteralsOnTheRight;
 import org.elasticsearch.xpack.ql.optimizer.OptimizerRules.OptimizerRule;
 import org.elasticsearch.xpack.ql.optimizer.OptimizerRules.PropagateEquals;
 import org.elasticsearch.xpack.ql.optimizer.OptimizerRules.PruneLiteralsInOrderBy;
@@ -86,7 +87,8 @@ public class Optimizer extends RuleExecutor<LogicalPlan> {
                 new ConstantFolding(),
                 // boolean
                 new BooleanSimplification(),
-                new BooleanLiteralsOnTheRight(),
+                new LiteralsOnTheRight(),
+                new BinaryComparisonSimplification(),
                 new BooleanFunctionEqualsElimination(),
                 // needs to occur before BinaryComparison combinations
                 new PropagateEquals(),

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/util/ReflectionUtils.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/util/ReflectionUtils.java
@@ -30,7 +30,7 @@ public class ReflectionUtils {
                 if (tp instanceof Class<?>) {
                     return (Class<E>) tp;
                 } else if (tp instanceof ParameterizedType) {
-                    Type rawType = ((ParameterizedType) type).getRawType();
+                    Type rawType = ((ParameterizedType) tp).getRawType();
                     if (rawType instanceof Class<?>) {
                         return (Class<E>) rawType;
                     }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/optimizer/OptimizerRunTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/optimizer/OptimizerRunTests.java
@@ -23,7 +23,7 @@ import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.NotEq
 import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.NullEquals;
 import org.elasticsearch.xpack.ql.index.EsIndex;
 import org.elasticsearch.xpack.ql.index.IndexResolution;
-import org.elasticsearch.xpack.ql.optimizer.OptimizerRules.BooleanLiteralsOnTheRight;
+import org.elasticsearch.xpack.ql.optimizer.OptimizerRules.LiteralsOnTheRight;
 import org.elasticsearch.xpack.ql.plan.logical.Filter;
 import org.elasticsearch.xpack.ql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.ql.plan.logical.UnaryPlan;
@@ -67,7 +67,7 @@ public class OptimizerRunTests extends ESTestCase {
             put(LTE.symbol(), LessThanOrEqual.class);
         }
     };
-    private static final BooleanLiteralsOnTheRight LITERALS_ON_THE_RIGHT = new BooleanLiteralsOnTheRight();
+    private static final LiteralsOnTheRight LITERALS_ON_THE_RIGHT = new LiteralsOnTheRight();
 
     public OptimizerRunTests() {
         parser = new SqlParser();
@@ -214,6 +214,7 @@ public class OptimizerRunTests extends ESTestCase {
 
     private void doTestSimplifyComparisonArithmetics(String expression, String fieldName, String compSymbol, Object bound) {
         BinaryComparison bc = extractPlannedBinaryComparison(expression);
+        assertEquals(compSymbol, bc.symbol());
         assertTrue(COMPARISONS.get(compSymbol).isInstance(bc));
 
         assertTrue(bc.left() instanceof FieldAttribute);
@@ -252,7 +253,7 @@ public class OptimizerRunTests extends ESTestCase {
 
     private static void assertSemanticMatching(Expression fieldAttributeExp, Expression unresolvedAttributeExp) {
         Expression unresolvedUpdated = unresolvedAttributeExp
-            .transformUp(LITERALS_ON_THE_RIGHT::rule)
+            .transformUp(LITERALS_ON_THE_RIGHT.expressionToken(), LITERALS_ON_THE_RIGHT::rule)
             .transformUp(x -> x.foldable() ? new Literal(x.source(), x.fold(), x.dataType()) : x);
 
         List<Expression> resolvedFields = fieldAttributeExp.collectFirstChildren(x -> x instanceof FieldAttribute);


### PR DESCRIPTION
Introduce generics to optimizer expression rules to remove some of the
instanceof classes.
While at it, move BinaryComparisonSimplification into QL project and
make use of it inside EQL as well.
Additionally fix an old, obscure bug in ReflectionUtils
