### PR TITLE
[DOCS] [7.x] Fix typo in "handing" (missing "l") (#71383)

### DIFF
--- a/docs/reference/ingest.asciidoc
+++ b/docs/reference/ingest.asciidoc
@@ -578,7 +578,7 @@ PUT _ingest/pipeline/my-pipeline
 
 [discrete]
 [[handling-pipeline-failures]]
-=== Handing pipeline failures
+=== Handling pipeline failures
 
 A pipeline's processors run sequentially. By default, pipeline processing stops
 when one of these processors fails or encounters an error.


### PR DESCRIPTION
7.x backport for #71383