### PR TITLE
Wait on relocation in UpdateSettingsIT#testNoopUpdate

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/settings/UpdateSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/settings/UpdateSettingsIT.java
@@ -692,6 +692,7 @@ public class UpdateSettingsIT extends ESIntegTestCase {
         client().admin().cluster().prepareHealth()
             .setWaitForGreenStatus()
             .setWaitForNoInitializingShards(true)
+            .setWaitForNoRelocatingShards(true)
             .setWaitForEvents(Priority.LANGUID)
             .setTimeout(TimeValue.MAX_VALUE)
             .get();


### PR DESCRIPTION
This test works by capturing the applied cluster state and verifying
that it does not change as no-op updates are applied. However the
captured cluster state might contain some ongoing relocations which
subsequently finish, causing an unexpected cluster state update. This
commit fixes that by waiting for any ongoing relocations too.

Relates #61348
Closes #70961