### PR TITLE
[DOCS] Add redirect for missing geoIP stats API docs

### DIFF
--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -1513,3 +1513,8 @@ See <<put-enrich-policy-api>>.
 === Rollup API
 
 See <<rollup-apis>>.
+
+[role="exclude",id="geoip-stats-api"]
+=== GeoIP stats API
+
+coming::[7.x]


### PR DESCRIPTION
The REST spec for the [geoIP stat API](https://github.com/elastic/elasticsearch/blob/master/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.geo_ip_stats.json) lists https://www.elastic.co/guide/en/elasticsearch/reference/master/geoip-stats-api.html as the docs URL. However, this URL does not yet exist.

ElasticsearchJS, a downstream client, uses the REST specs to create its docs. Those docs included this broken link, causing a docs build failure.

This adds a redirect to fix the docs build failure. I'll document the geoIP stats API and remove this redirect in a separate PR.