### PR TITLE
[ML] do not write audit messages for already deleted jobs if DELETE fails

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteJobAction.java
@@ -176,7 +176,9 @@ public class TransportDeleteJobAction extends AcknowledgedTransportMasterNodeAct
                 ack -> notifyListeners(request.getJobId(), ack, null),
                 e -> {
                     notifyListeners(request.getJobId(), null, e);
-                    auditor.error(request.getJobId(), Messages.getMessage(Messages.JOB_AUDIT_DELETING_FAILED, e.getMessage()));
+                    if ((ExceptionsHelper.unwrapCause(e) instanceof ResourceNotFoundException) == false) {
+                        auditor.error(request.getJobId(), Messages.getMessage(Messages.JOB_AUDIT_DELETING_FAILED, e.getMessage()));
+                    }
                 }
         );
 


### PR DESCRIPTION
Audit messages are written on job deletion failure. 

This makes sense unless the failure is caused by the job not being found

closes: https://github.com/elastic/elasticsearch/issues/71414