### PR TITLE
[7.x] [ML] do not write audit messages for already deleted jobs (#71420)

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteJobAction.java
@@ -181,7 +181,9 @@ public class TransportDeleteJobAction extends AcknowledgedTransportMasterNodeAct
                 ack -> notifyListeners(request.getJobId(), ack, null),
                 e -> {
                     notifyListeners(request.getJobId(), null, e);
-                    auditor.error(request.getJobId(), Messages.getMessage(Messages.JOB_AUDIT_DELETING_FAILED, e.getMessage()));
+                    if ((ExceptionsHelper.unwrapCause(e) instanceof ResourceNotFoundException) == false) {
+                        auditor.error(request.getJobId(), Messages.getMessage(Messages.JOB_AUDIT_DELETING_FAILED, e.getMessage()));
+                    }
                 }
         );
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ML] do not write audit messages for already deleted jobs (#71420)