### PR TITLE
Make sure _tier field handles missing setting

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/routing/allocation/mapper/DataTierFieldMapper.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/routing/allocation/mapper/DataTierFieldMapper.java
@@ -53,7 +53,7 @@ public class DataTierFieldMapper extends MetadataFieldMapper {
                 pattern = Strings.toLowercaseAscii(pattern);
             }
             String tierPreference = DataTierAllocationDecider.INDEX_ROUTING_PREFER_SETTING.get(context.getIndexSettings().getSettings());
-            if (tierPreference == null) {
+            if (Strings.hasText(tierPreference) == false) {
                 return false;
             }
             // Tier preference can be a comma-delimited list of tiers, ordered by preference
@@ -65,7 +65,7 @@ public class DataTierFieldMapper extends MetadataFieldMapper {
         @Override
         public Query existsQuery(SearchExecutionContext context) {
             String tierPreference = DataTierAllocationDecider.INDEX_ROUTING_PREFER_SETTING.get(context.getIndexSettings().getSettings());
-            if (tierPreference == null) {
+            if (Strings.hasText(tierPreference) == false) {
                 return new MatchNoDocsQuery();
             }
             return new MatchAllDocsQuery();

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/cluster/routing/allocation/mapper/DataTierFieldTypeTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/cluster/routing/allocation/mapper/DataTierFieldTypeTests.java
@@ -42,6 +42,9 @@ public class DataTierFieldTypeTests extends MapperServiceTestCase {
         assertEquals(new MatchAllDocsQuery(), ft.wildcardQuery("Data_Warm", null, true, createContext()));
         assertEquals(new MatchNoDocsQuery(), ft.wildcardQuery("Data_Warm", null, false, createContext()));
         assertEquals(new MatchNoDocsQuery(), ft.wildcardQuery("noSuchRole", null, createContext()));
+
+        assertEquals(new MatchNoDocsQuery(), ft.wildcardQuery("data_*", null, createContextWithoutSetting()));
+        assertEquals(new MatchNoDocsQuery(), ft.wildcardQuery("*", null, createContextWithoutSetting()));
     }
 
     public void testTermQuery() {
@@ -49,12 +52,24 @@ public class DataTierFieldTypeTests extends MapperServiceTestCase {
         assertEquals(new MatchAllDocsQuery(), ft.termQuery("data_warm", createContext()));
         assertEquals(new MatchNoDocsQuery(), ft.termQuery("data_hot", createContext()));
         assertEquals(new MatchNoDocsQuery(), ft.termQuery("noSuchRole", createContext()));
+
+        assertEquals(new MatchNoDocsQuery(), ft.termQuery("data_warm", createContextWithoutSetting()));
+        assertEquals(new MatchNoDocsQuery(), ft.termQuery("", createContextWithoutSetting()));
     }
 
     public void testTermsQuery() {
         MappedFieldType ft = DataTierFieldMapper.DataTierFieldType.INSTANCE;
         assertEquals(new MatchAllDocsQuery(), ft.termsQuery(Arrays.asList("data_warm"), createContext()));
         assertEquals(new MatchNoDocsQuery(), ft.termsQuery(Arrays.asList("data_cold", "data_frozen"), createContext()));
+
+        assertEquals(new MatchNoDocsQuery(), ft.termsQuery(Arrays.asList("data_warm"), createContextWithoutSetting()));
+        assertEquals(new MatchNoDocsQuery(), ft.termsQuery(Arrays.asList(""), createContextWithoutSetting()));
+    }
+
+    public void testExistsQuery() {
+        MappedFieldType ft = DataTierFieldMapper.DataTierFieldType.INSTANCE;
+        assertEquals(new MatchAllDocsQuery(), ft.existsQuery(createContext()));
+        assertEquals(new MatchNoDocsQuery(), ft.existsQuery(createContextWithoutSetting()));
     }
 
     public void testRegexpQuery() {
@@ -101,5 +116,19 @@ public class DataTierFieldTypeTests extends MapperServiceTestCase {
             null,
             emptyMap()
         );
+    }
+
+    private SearchExecutionContext createContextWithoutSetting() {
+        IndexMetadata indexMetadata = IndexMetadata.builder("index")
+            .settings(Settings.builder()
+                .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                .build())
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
+        IndexSettings indexSettings = new IndexSettings(indexMetadata, Settings.EMPTY);
+        return new SearchExecutionContext(0, 0, indexSettings, null, null, null, null, null, null,
+            xContentRegistry(), writableRegistry(), null, null, System::currentTimeMillis, null,
+            value -> true, () -> true, null, emptyMap());
     }
 }


### PR DESCRIPTION
When `_tier_preference` isn't set, getting it returns an empty string "". This
PR updates the _tier metadata field to detect this case correctly.

Relates to #68135.