### PR TITLE
[7.x] Relax backing index name assertions in ccr tests

### DIFF
--- a/x-pack/plugin/ccr/qa/src/main/java/org/elasticsearch/xpack/ccr/ESCCRRestTestCase.java
+++ b/x-pack/plugin/ccr/qa/src/main/java/org/elasticsearch/xpack/ccr/ESCCRRestTestCase.java
@@ -311,12 +311,20 @@ public class ESCCRRestTestCase extends ESRestTestCase {
         Map<String, ?> response = toMap(client.performRequest(request));
         List<?> retrievedDataStreams = (List<?>) response.get("data_streams");
         assertThat(retrievedDataStreams, hasSize(1));
-        List<?> actualBackingIndices = (List<?>) ((Map<?, ?>) retrievedDataStreams.get(0)).get("indices");
-        assertThat(actualBackingIndices, hasSize(expectedBackingIndices.length));
+        List<?> actualBackingIndexItems = (List<?>) ((Map<?, ?>) retrievedDataStreams.get(0)).get("indices");
+        assertThat(actualBackingIndexItems, hasSize(expectedBackingIndices.length));
         for (int i = 0; i < expectedBackingIndices.length; i++) {
-            Map<?, ?> actualBackingIndex = (Map<?, ?>) actualBackingIndices.get(i);
+            Map<?, ?> actualBackingIndexItem = (Map<?, ?>) actualBackingIndexItems.get(i);
+            String actualBackingIndex = (String) actualBackingIndexItem.get("index_name");
             String expectedBackingIndex = expectedBackingIndices[i];
-            assertThat(actualBackingIndex.get("index_name"), equalTo(expectedBackingIndex));
+
+            String actualDataStreamName = actualBackingIndex.substring(5, actualBackingIndex.indexOf('-', 5));
+            String expectedDataStreamName = expectedBackingIndex.substring(5, expectedBackingIndex.indexOf('-', 5));
+            assertThat(actualDataStreamName, equalTo(expectedDataStreamName));
+
+            int actualGeneration = Integer.parseInt(actualBackingIndex.substring(actualBackingIndex.lastIndexOf('-')));
+            int expectedGeneration = Integer.parseInt(expectedBackingIndex.substring(expectedBackingIndex.lastIndexOf('-')));
+            assertThat(actualGeneration, equalTo(expectedGeneration));
         }
     }
 


### PR DESCRIPTION
Backport of #71419 to 7.x branch.

Assert data stream name and generation instead of the complete backing index name.
The backing index also contains a date snippet and when this tests
using this assertion are ran around midnight then tests may fail.
By just comparing the data stream name and generation the tests are resilient to
timing issues (expected backing index name is generated before midnight and
actual backing index is created after midnight).

Closes #71226