### PR TITLE
[Transform] Simplify transform role default

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeRole.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeRole.java
@@ -14,7 +14,6 @@ import org.elasticsearch.common.util.set.Sets;
 import java.util.Objects;
 import java.util.Set;
 import java.util.SortedSet;
-import java.util.function.Predicate;
 
 /**
  * Represents a node role.
@@ -176,19 +175,7 @@ public class DiscoveryNodeRole implements Comparable<DiscoveryNodeRole> {
 
     public static final DiscoveryNodeRole ML_ROLE = new DiscoveryNodeRole("ml", "l");
 
-    public static final DiscoveryNodeRole TRANSFORM_ROLE = new DiscoveryNodeRole("transform", "t") {
-
-        @Override
-        public boolean isEnabledByDefault(final Settings settings) {
-            // transform is enabled by default on any non-frozen data node
-            final Predicate<DiscoveryNodeRole> notFrozen = Predicate.not(s -> Objects.equals(DiscoveryNodeRole.DATA_FROZEN_NODE_ROLE, s));
-            return DiscoveryNode.getPossibleRoles()
-                .stream()
-                .filter(notFrozen.and(DiscoveryNodeRole::canContainData))
-                .anyMatch(r -> DiscoveryNode.hasRole(settings, r));
-        }
-
-    };
+    public static final DiscoveryNodeRole TRANSFORM_ROLE = new DiscoveryNodeRole("transform", "t");
 
     /**
      * The built-in node roles.


### PR DESCRIPTION
The old `node.data: true` setting implied
`node.transform: true` unless `node.transform` was
explicitly set to `false`. However, with the new
`node.roles` setting, if it is set to _anything_
then those are the precise roles of the node, with
no extra defaults. Therefore, in 8.0 and above there
is no need for the transform role to have any special
logic for when it's enabled. Like most roles, if
`node.roles` isn't specified at all then it's enabled
and otherwise it's enabled if and only if `transform`
is present in `node.roles`.

Followup to #71412