### PR TITLE
Add MapperScriptTestCase (#71322)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -118,6 +118,11 @@ public class NumberFieldMapper extends FieldMapper {
 
             this.onScriptError.requiresParameters(this.script);
             this.script.precludesParameters(ignoreMalformed, coerce, nullValue);
+            this.script.setValidator(s -> {
+                if (s != null && indexed.get() == false && hasDocValues.get() == false) {
+                    throw new MapperParsingException("Cannot define script on field with index:false and doc_values:false");
+                }
+            });
         }
 
         Builder nullValue(Number number) {

--- a/server/src/main/java/org/elasticsearch/script/AbstractLongFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/AbstractLongFieldScript.java
@@ -62,7 +62,7 @@ public abstract class AbstractLongFieldScript extends AbstractFieldScript {
         return count;
     }
 
-    protected final void emit(long v) {
+    public final void emit(long v) {
         checkMaxSize(count);
         if (values.length < count + 1) {
             values = ArrayUtil.grow(values, count + 1);

--- a/server/src/main/java/org/elasticsearch/script/DoubleFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/DoubleFieldScript.java
@@ -29,8 +29,6 @@ public abstract class DoubleFieldScript extends AbstractFieldScript {
         DoubleFieldScript newInstance(LeafReaderContext ctx);
     }
 
-
-
     private double[] values = new double[1];
     private int count;
 
@@ -74,7 +72,7 @@ public abstract class DoubleFieldScript extends AbstractFieldScript {
         return count;
     }
 
-    protected final void emit(double v) {
+    public final void emit(double v) {
         checkMaxSize(count);
         if (values.length < count + 1) {
             values = ArrayUtil.grow(values, count + 1);

--- a/server/src/test/java/org/elasticsearch/index/mapper/DoubleFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DoubleFieldMapperTests.java
@@ -64,7 +64,7 @@ public class DoubleFieldMapperTests extends NumberFieldMapperTests {
                 b.field("coerce", "true");
             })));
             assertThat(e.getMessage(),
-                equalTo("Failed to parse mapping: Field [coerce] cannot be set in conjunction with field [script]"));
+                equalTo("Failed to parse mapping [_doc]: Field [coerce] cannot be set in conjunction with field [script]"));
         }
         {
             Exception e = expectThrows(MapperParsingException.class, () -> createDocumentMapper(fieldMapping(b -> {

--- a/server/src/test/java/org/elasticsearch/index/mapper/DoubleFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DoubleFieldMapperTests.java
@@ -73,7 +73,7 @@ public class DoubleFieldMapperTests extends NumberFieldMapperTests {
                 b.field("null_value", 7);
             })));
             assertThat(e.getMessage(),
-                equalTo("Failed to parse mapping: Field [null_value] cannot be set in conjunction with field [script]"));
+                equalTo("Failed to parse mapping [_doc]: Field [null_value] cannot be set in conjunction with field [script]"));
         }
         {
             Exception e = expectThrows(MapperParsingException.class, () -> createDocumentMapper(fieldMapping(b -> {
@@ -82,7 +82,7 @@ public class DoubleFieldMapperTests extends NumberFieldMapperTests {
                 b.field("ignore_malformed", "true");
             })));
             assertThat(e.getMessage(),
-                equalTo("Failed to parse mapping: Field [ignore_malformed] cannot be set in conjunction with field [script]"));
+                equalTo("Failed to parse mapping [_doc]: Field [ignore_malformed] cannot be set in conjunction with field [script]"));
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/DoubleFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DoubleFieldMapperTests.java
@@ -15,6 +15,8 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.hamcrest.Matchers.equalTo;
+
 public class DoubleFieldMapperTests extends NumberFieldMapperTests {
 
     @Override
@@ -52,5 +54,35 @@ public class DoubleFieldMapperTests extends NumberFieldMapperTests {
          * range of valid values.
          */
         return randomBoolean() ? randomDoubleBetween(-Double.MAX_VALUE, Double.MAX_VALUE, true) : randomFloat();
+    }
+
+    public void testScriptAndPrecludedParameters() {
+        {
+            Exception e = expectThrows(MapperParsingException.class, () -> createDocumentMapper(fieldMapping(b -> {
+                b.field("type", "double");
+                b.field("script", "test");
+                b.field("coerce", "true");
+            })));
+            assertThat(e.getMessage(),
+                equalTo("Failed to parse mapping: Field [coerce] cannot be set in conjunction with field [script]"));
+        }
+        {
+            Exception e = expectThrows(MapperParsingException.class, () -> createDocumentMapper(fieldMapping(b -> {
+                b.field("type", "double");
+                b.field("script", "test");
+                b.field("null_value", 7);
+            })));
+            assertThat(e.getMessage(),
+                equalTo("Failed to parse mapping: Field [null_value] cannot be set in conjunction with field [script]"));
+        }
+        {
+            Exception e = expectThrows(MapperParsingException.class, () -> createDocumentMapper(fieldMapping(b -> {
+                b.field("type", "double");
+                b.field("script", "test");
+                b.field("ignore_malformed", "true");
+            })));
+            assertThat(e.getMessage(),
+                equalTo("Failed to parse mapping: Field [ignore_malformed] cannot be set in conjunction with field [script]"));
+        }
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/DoubleScriptMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DoubleScriptMapperTests.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.index.LeafReaderContext;
+import org.elasticsearch.script.DoubleFieldScript;
+import org.elasticsearch.search.lookup.SearchLookup;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class DoubleScriptMapperTests extends MapperScriptTestCase<DoubleFieldScript.Factory> {
+
+    private static DoubleFieldScript.Factory factory(Consumer<DoubleFieldScript> executor) {
+        return new DoubleFieldScript.Factory() {
+            @Override
+            public DoubleFieldScript.LeafFactory newFactory(String fieldName, Map<String, Object> params, SearchLookup searchLookup) {
+                return new DoubleFieldScript.LeafFactory() {
+                    @Override
+                    public DoubleFieldScript newInstance(LeafReaderContext ctx) {
+                        return new DoubleFieldScript(fieldName, params, searchLookup, ctx) {
+                            @Override
+                            public void execute() {
+                                executor.accept(this);
+                            }
+                        };
+                    }
+                };
+            }
+        };
+    }
+
+    @Override
+    protected String type() {
+        return "double";
+    }
+
+    @Override
+    protected DoubleFieldScript.Factory serializableScript() {
+        return factory(s -> {});
+    }
+
+    @Override
+    protected DoubleFieldScript.Factory errorThrowingScript() {
+        return factory(s -> {
+            throw new UnsupportedOperationException("Oops");
+        });
+    }
+
+    @Override
+    protected DoubleFieldScript.Factory compileScript(String name) {
+        if ("single-valued".equals(name)) {
+            return factory(s -> s.emit(3.14));
+        }
+        if ("multi-valued".equals(name)) {
+            return factory(s -> {
+                s.emit(3.14);
+                s.emit(2.78);
+            });
+        }
+        return super.compileScript(name);
+    }
+
+    public void testMultipleValues() throws IOException {
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
+            b.field("type", "double");
+            b.field("script", "multi-valued");
+        }));
+        ParsedDocument doc = mapper.parse(source(b -> {}));
+        IndexableField[] fields = doc.rootDoc().getFields("field");
+        assertEquals(4, fields.length);
+        assertEquals("DoublePoint <field:3.14>", fields[0].toString());
+        assertEquals("docValuesType=SORTED_NUMERIC<field:4614253070214989087>", fields[1].toString());
+        assertEquals("DoublePoint <field:2.78>", fields[2].toString());
+        assertEquals("docValuesType=SORTED_NUMERIC<field:4613442422282062397>", fields[3].toString());
+    }
+
+    public void testDocValuesDisabled() throws IOException {
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
+            b.field("type", "double");
+            b.field("script", "single-valued");
+            b.field("doc_values", false);
+        }));
+        ParsedDocument doc = mapper.parse(source(b -> {}));
+        IndexableField[] fields = doc.rootDoc().getFields("field");
+        assertEquals(1, fields.length);
+        assertEquals("DoublePoint <field:3.14>", fields[0].toString());
+    }
+
+    public void testIndexDisabled() throws IOException {
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
+            b.field("type", "double");
+            b.field("script", "single-valued");
+            b.field("index", false);
+        }));
+        ParsedDocument doc = mapper.parse(source(b -> {}));
+        IndexableField[] fields = doc.rootDoc().getFields("field");
+        assertEquals(1, fields.length);
+        assertEquals("docValuesType=SORTED_NUMERIC<field:4614253070214989087>", fields[0].toString());
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/mapper/IndexTimeScriptTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IndexTimeScriptTests.java
@@ -10,7 +10,6 @@ package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.LeafReaderContext;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.script.DoubleFieldScript;
 import org.elasticsearch.script.LongFieldScript;
 import org.elasticsearch.script.Script;
@@ -71,20 +70,6 @@ public class IndexTimeScriptTests extends MapperServiceTestCase {
         assertEquals(doc.rootDoc().getField("double_field_plus_two").numericValue(), 6.5);
     }
 
-    public void testSerialization() throws IOException {
-        DocumentMapper mapper = createDocumentMapper(mapping(b -> {
-            b.startObject("message").field("type", "text").endObject();
-            b.startObject("message_length");
-            b.field("type", "long");
-            b.field("script", "message_length");
-            b.endObject();
-        }));
-        assertEquals(
-            "{\"_doc\":{\"properties\":{\"message\":{\"type\":\"text\"}," +
-                "\"message_length\":{\"type\":\"long\",\"script\":{\"source\":\"message_length\",\"lang\":\"painless\"}}}}}",
-            Strings.toString(mapper.mapping()));
-    }
-
     public void testCrossReferences() throws IOException {
         DocumentMapper mapper = createDocumentMapper(mapping(b -> {
             b.startObject("message").field("type", "text").endObject();
@@ -105,25 +90,6 @@ public class IndexTimeScriptTests extends MapperServiceTestCase {
         assertEquals(doc.rootDoc().getField("message_length_plus_two").numericValue(), 19L);
         assertEquals(doc.rootDoc().getField("message_length").numericValue(), 17L);
         assertEquals(doc.rootDoc().getField("message_length_plus_four").numericValue(), 21d);
-    }
-
-    public void testCannotIndexDirectlyIntoScriptMapper() throws IOException {
-        DocumentMapper mapper = createDocumentMapper(mapping(b -> {
-            b.startObject("message").field("type", "text").endObject();
-            b.startObject("message_length");
-            b.field("type", "long");
-            b.field("script", "length");
-            b.endObject();
-        }));
-
-        Exception e = expectThrows(MapperParsingException.class, () -> mapper.parse(source(b -> {
-            b.field("message", "foo");
-            b.field("message_length", 3);
-        })));
-        assertEquals("failed to parse field [message_length] of type [long] in document with id '1'. Preview of field's value: '3'",
-            e.getMessage());
-        Throwable original = e.getCause();
-        assertEquals("Cannot index data directly into a field with a [script] parameter", original.getMessage());
     }
 
     public void testLoopDetection() throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/mapper/LongScriptMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/LongScriptMapperTests.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.index.LeafReaderContext;
+import org.elasticsearch.script.LongFieldScript;
+import org.elasticsearch.search.lookup.SearchLookup;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class LongScriptMapperTests extends MapperScriptTestCase<LongFieldScript.Factory> {
+
+    private static LongFieldScript.Factory factory(Consumer<LongFieldScript> executor) {
+        return new LongFieldScript.Factory() {
+            @Override
+            public LongFieldScript.LeafFactory newFactory(String fieldName, Map<String, Object> params, SearchLookup searchLookup) {
+                return new LongFieldScript.LeafFactory() {
+                    @Override
+                    public LongFieldScript newInstance(LeafReaderContext ctx) {
+                        return new LongFieldScript(fieldName, params, searchLookup, ctx) {
+                            @Override
+                            public void execute() {
+                                executor.accept(this);
+                            }
+                        };
+                    }
+                };
+            }
+        };
+    }
+
+    @Override
+    protected String type() {
+        return "long";
+    }
+
+    @Override
+    protected LongFieldScript.Factory serializableScript() {
+        return factory(s -> {});
+    }
+
+    @Override
+    protected LongFieldScript.Factory errorThrowingScript() {
+        return factory(s -> {
+            throw new UnsupportedOperationException("Oops");
+        });
+    }
+
+    @Override
+    protected LongFieldScript.Factory compileScript(String name) {
+        if ("single-valued".equals(name)) {
+            return factory(s -> s.emit(4));
+        }
+        if ("multi-valued".equals(name)) {
+            return factory(s -> {
+                s.emit(1);
+                s.emit(2);
+            });
+        }
+        return super.compileScript(name);
+    }
+
+    public void testMultipleValues() throws IOException {
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
+            b.field("type", "long");
+            b.field("script", "multi-valued");
+        }));
+        ParsedDocument doc = mapper.parse(source(b -> {}));
+        IndexableField[] fields = doc.rootDoc().getFields("field");
+        assertEquals(4, fields.length);
+        assertEquals("LongPoint <field:1>", fields[0].toString());
+        assertEquals("docValuesType=SORTED_NUMERIC<field:1>", fields[1].toString());
+        assertEquals("LongPoint <field:2>", fields[2].toString());
+        assertEquals("docValuesType=SORTED_NUMERIC<field:2>", fields[3].toString());
+    }
+
+    public void testDocValuesDisabled() throws IOException {
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
+            b.field("type", "long");
+            b.field("script", "single-valued");
+            b.field("doc_values", false);
+        }));
+        ParsedDocument doc = mapper.parse(source(b -> {}));
+        IndexableField[] fields = doc.rootDoc().getFields("field");
+        assertEquals(1, fields.length);
+        assertEquals("LongPoint <field:4>", fields[0].toString());
+    }
+
+    public void testIndexDisabled() throws IOException {
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
+            b.field("type", "long");
+            b.field("script", "single-valued");
+            b.field("index", false);
+        }));
+        ParsedDocument doc = mapper.parse(source(b -> {}));
+        IndexableField[] fields = doc.rootDoc().getFields("field");
+        assertEquals(1, fields.length);
+        assertEquals("docValuesType=SORTED_NUMERIC<field:4>", fields[0].toString());
+    }
+
+}

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperScriptTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperScriptTestCase.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptContext;
+
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.equalTo;
+
+public abstract class MapperScriptTestCase<FactoryType> extends MapperServiceTestCase {
+
+    protected abstract String type();
+
+    protected abstract FactoryType serializableScript();
+
+    protected abstract FactoryType errorThrowingScript();
+
+    protected FactoryType compileScript(String name) {
+        throw new UnsupportedOperationException("Unknown script " + name);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected final <T> T compileScript(Script script, ScriptContext<T> context) {
+        if (script.getIdOrCode().equals("serializer_test")) {
+            return (T) serializableScript();
+        }
+        if (script.getIdOrCode().equals("throws")) {
+            return (T) errorThrowingScript();
+        }
+        return (T) compileScript(script.getIdOrCode());
+    }
+
+    public void testSerialization() throws IOException {
+        DocumentMapper mapper = createDocumentMapper(mapping(b -> {
+            b.startObject("scripted");
+            b.field("type", type());
+            b.field("script", "serializer_test");
+            b.endObject();
+        }));
+        assertThat(
+            Strings.toString(mapper.mapping()),
+            containsString("\"script\":{\"source\":\"serializer_test\",\"lang\":\"painless\"}")
+        );
+    }
+
+    public void testCannotIndexDirectlyIntoScriptMapper() throws IOException {
+        DocumentMapper mapper = createDocumentMapper(mapping(b -> {
+            b.startObject("scripted");
+            b.field("type", type());
+            b.field("script", "serializer_test");
+            b.endObject();
+        }));
+
+        Exception e = expectThrows(MapperParsingException.class, () -> mapper.parse(source(b -> {
+            b.field("scripted", "foo");
+        })));
+        assertThat(e.getMessage(), containsString("failed to parse field [scripted]"));
+        assertEquals("Cannot index data directly into a field with a [script] parameter", e.getCause().getMessage());
+    }
+
+    public void testStoredScriptsNotPermitted() {
+        Exception e = expectThrows(MapperParsingException.class, () -> createDocumentMapper(fieldMapping(b -> {
+            b.field("type", type());
+            b.startObject("script").field("id", "foo").endObject();
+        })));
+        assertThat(e.getMessage(), equalTo("Failed to parse mapping: stored scripts are not supported on field [field]"));
+    }
+
+    public void testIndexAndDocValuesFalseNotPermitted() {
+        Exception e = expectThrows(MapperParsingException.class, () -> createDocumentMapper(fieldMapping(b -> {
+            b.field("type", type());
+            b.field("index", false);
+            b.field("doc_values", false);
+            b.field("script", "serializer_test");
+        })));
+        assertThat(e.getMessage(), containsString("Cannot define script on field with index:false and doc_values:false"));
+    }
+
+    public void testScriptErrorParameterRequiresScript() {
+        Exception e = expectThrows(MapperParsingException.class, () -> createDocumentMapper(fieldMapping(b -> {
+            b.field("type", type());
+            b.field("on_script_error", "ignore");
+        })));
+        assertThat(e.getMessage(),
+            equalTo("Failed to parse mapping: Field [on_script_error] requires field [script] to be configured"));
+    }
+
+    public void testIgnoreScriptErrors() throws IOException {
+        DocumentMapper mapper = createDocumentMapper(mapping(b -> {
+            b.startObject("message").field("type", "keyword").endObject();
+            b.startObject("message_error");
+            {
+                b.field("type", type());
+                b.field("script", "throws");
+                b.field("on_script_error", "ignore");
+            }
+            b.endObject();
+        }));
+
+        ParsedDocument doc = mapper.parse(source(b -> b.field("message", "this is some text")));
+        assertThat(doc.rootDoc().getFields("message_error"), arrayWithSize(0));
+        assertThat(doc.rootDoc().getField("_ignored").stringValue(), equalTo("message_error"));
+    }
+
+    public void testRejectScriptErrors() throws IOException {
+        DocumentMapper mapper = createDocumentMapper(mapping(b -> {
+            b.startObject("message").field("type", "keyword").endObject();
+            b.startObject("message_error");
+            {
+                b.field("type", type());
+                b.field("script", "throws");
+            }
+            b.endObject();
+        }));
+
+        Exception e = expectThrows(MapperParsingException.class, () -> mapper.parse(source(b -> b.field("message", "foo"))));
+        assertThat(e.getMessage(), equalTo("Error executing script on field [message_error]"));
+    }
+}

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperScriptTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperScriptTestCase.java
@@ -75,7 +75,7 @@ public abstract class MapperScriptTestCase<FactoryType> extends MapperServiceTes
             b.field("type", type());
             b.startObject("script").field("id", "foo").endObject();
         })));
-        assertThat(e.getMessage(), equalTo("Failed to parse mapping: stored scripts are not supported on field [field]"));
+        assertThat(e.getMessage(), equalTo("Failed to parse mapping [_doc]: stored scripts are not supported on field [field]"));
     }
 
     public void testIndexAndDocValuesFalseNotPermitted() {
@@ -94,7 +94,7 @@ public abstract class MapperScriptTestCase<FactoryType> extends MapperServiceTes
             b.field("on_script_error", "ignore");
         })));
         assertThat(e.getMessage(),
-            equalTo("Failed to parse mapping: Field [on_script_error] requires field [script] to be configured"));
+            equalTo("Failed to parse mapping [_doc]: Field [on_script_error] requires field [script] to be configured"));
     }
 
     public void testIgnoreScriptErrors() throws IOException {


### PR DESCRIPTION
When we added scripts to long and double mapped fields, we added tests
for the general scripting infrastructure, and also specific tests for those two
field types. This commit extracts those type-specific tests out into a new base
test class that we can use when adding scripts to more field mappers.