### PR TITLE
Remove obsolete wire BWC for pre-7.10 node roles

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
@@ -230,12 +230,7 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
         for (int i = 0; i < rolesSize; i++) {
             final String roleName = in.readString();
             final String roleNameAbbreviation = in.readString();
-            final boolean canContainData;
-            if (in.getVersion().onOrAfter(Version.V_7_10_0)) {
-                canContainData = in.readBoolean();
-            } else {
-                canContainData = roleName.equals(DiscoveryNodeRole.DATA_ROLE.roleName());
-            }
+            final boolean canContainData = in.readBoolean();
             final DiscoveryNodeRole role = roleMap.get(roleName);
             if (role == null) {
                 roles.add(new DiscoveryNodeRole.UnknownRole(roleName, roleNameAbbreviation, canContainData));
@@ -263,9 +258,7 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
         for (final DiscoveryNodeRole role : roles) {
             out.writeString(role.roleName());
             out.writeString(role.roleNameAbbreviation());
-            if (out.getVersion().onOrAfter(Version.V_7_10_0)) {
-                out.writeBoolean(role.canContainData());
-            }
+            out.writeBoolean(role.canContainData());
         }
         Version.writeVersion(version, out);
     }


### PR DESCRIPTION
In `master` we still have code to handle serializing node roles without
the `canContainData` flag that was introduced in 7.10, but we will never
be talking to such an old node over the wire. This commit removes this
obsolete BWC code.