### PR TITLE
[ML] Fix error on data frame analytics using a dest index without mappings

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RunDataFrameAnalyticsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RunDataFrameAnalyticsIT.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.ml.integration;
 
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequestBuilder;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsRequest;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
@@ -455,9 +456,13 @@ public class RunDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsIntegTest
             .addMapping("_doc", "numeric_1", "type=double", "numeric_2", "type=float", "categorical_1", "type=keyword")
             .get();
 
-        client().admin().indices().prepareCreate(destIndex)
-            .addMapping("_doc", "numeric_1", "type=double", "numeric_2", "type=float", "categorical_1", "type=keyword")
-            .get();
+        CreateIndexRequestBuilder createDestIndexBuilder = client().admin().indices().prepareCreate(destIndex);
+        // Test with and without mappings in the dest index
+        if (randomBoolean()) {
+            createDestIndexBuilder.addMapping("_doc",
+                "numeric_1", "type=double", "numeric_2", "type=float", "categorical_1", "type=keyword");
+        }
+        createDestIndexBuilder.get();
 
         BulkRequestBuilder bulkRequestBuilder = client().prepareBulk();
         bulkRequestBuilder.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DestinationIndex.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DestinationIndex.java
@@ -313,7 +313,8 @@ public final class DestinationIndex {
         try {
             singleDocEmptyMetadata = new MappingMetadata(MapperService.SINGLE_MAPPING_NAME, Collections.emptyMap());
         } catch (IOException e) {
-            throw new IllegalStateException("we should never fail to create empty mapping_metadata");
+            // we should never fail to create empty mapping_metadata
+            throw new IllegalStateException("failed to create empty mapping_metadata");
         }
         return ImmutableOpenMap.<String, MappingMetadata>builder()
             .fPut(MapperService.SINGLE_MAPPING_NAME, singleDocEmptyMetadata)

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DestinationIndex.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DestinationIndex.java
@@ -31,6 +31,7 @@ import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.ml.action.StartDataFrameAnalyticsAction;
@@ -39,6 +40,7 @@ import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsDest;
 import org.elasticsearch.xpack.core.ml.dataframe.analyses.RequiredField;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 
+import java.io.IOException;
 import java.time.Clock;
 import java.util.Collections;
 import java.util.HashMap;
@@ -269,6 +271,9 @@ public final class DestinationIndex {
 
         // Fetch mappings from destination index
         ImmutableOpenMap<String, MappingMetadata> mappings = getIndexResponse.getMappings().get(getIndexResponse.indices()[0]);
+        if (mappings.isEmpty()) {
+           mappings = createEmptyMappings();
+        }
         String type = mappings.keysIt().next();
         Map<String, Object> destMappingsAsMap = mappings.valuesIt().next().sourceAsMap();
         Map<String, Object> destPropertiesAsMap =
@@ -303,6 +308,18 @@ public final class DestinationIndex {
         getFieldCapsForRequiredFields(client, config, fieldCapabilitiesListener);
     }
 
+    private static ImmutableOpenMap<String, MappingMetadata> createEmptyMappings() {
+        MappingMetadata singleDocEmptyMetadata;
+        try {
+            singleDocEmptyMetadata = new MappingMetadata(MapperService.SINGLE_MAPPING_NAME, Collections.emptyMap());
+        } catch (IOException e) {
+            throw new IllegalStateException("we should never fail to create empty mapping_metadata");
+        }
+        return ImmutableOpenMap.<String, MappingMetadata>builder()
+            .fPut(MapperService.SINGLE_MAPPING_NAME, singleDocEmptyMetadata)
+            .build();
+    }
+
     private static void checkResultsFieldIsNotPresentInProperties(DataFrameAnalyticsConfig config, Map<String, Object> properties) {
         String resultsField = config.getDest().getResultsField();
         if (properties.containsKey(resultsField)) {
@@ -316,7 +333,10 @@ public final class DestinationIndex {
     }
 
     @SuppressWarnings("unchecked")
-    public static Metadata readMetadata(String jobId, MappingMetadata mappingMetadata) {
+    public static Metadata readMetadata(String jobId, @Nullable MappingMetadata mappingMetadata) {
+        if (mappingMetadata == null) {
+            return new NoMetadata();
+        }
         Map<String, Object> mappings = mappingMetadata.getSourceAsMap();
         Map<String, Object> meta = (Map<String, Object>) mappings.get(META);
         if ((meta == null) || (DFA_CREATOR.equals(meta.get(CREATED_BY)) == false)) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/DestinationIndexTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/DestinationIndexTests.java
@@ -404,6 +404,14 @@ public class DestinationIndexTests extends ESTestCase {
         verifyZeroInteractions(client);
     }
 
+    public void testReadMetadata_GivenNull() {
+        DestinationIndex.Metadata metadata = DestinationIndex.readMetadata("test_id", null);
+
+        assertThat(metadata.hasMetadata(), is(false));
+        expectThrows(UnsupportedOperationException.class, () -> metadata.isCompatible());
+        expectThrows(UnsupportedOperationException.class, () -> metadata.getVersion());
+    }
+
     public void testReadMetadata_GivenNoMeta() {
         Map<String, Object> mappings = new HashMap<>();
         MappingMetadata mappingMetadata = mock(MappingMetadata.class);


### PR DESCRIPTION
…t mappings

This commit fixes a failure to update the mappings of the destination index
of a data frame analytics job during startup. The failure only occurs in `7.x`.
In particular, the bug occurs when the destination index contains no mappings
at all. The code used to assume there will at least be mappings for the single
type in the dest index. This assumption doesn't hold. The fix checks whether
the mappings are empty and if so creates an empty map for the `_doc` type.

Closes #60457
