### PR TITLE
Refactor empty role marker in autoscaling

### DIFF
--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingCalculateCapacityService.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingCalculateCapacityService.java
@@ -39,8 +39,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-import static org.elasticsearch.xpack.autoscaling.capacity.AutoscalingDeciderService.EMPTY_ROLES;
-
 public class AutoscalingCalculateCapacityService implements PolicyValidator {
     private final Map<String, AutoscalingDeciderService> deciderByName;
 
@@ -174,7 +172,7 @@ public class AutoscalingCalculateCapacityService implements PolicyValidator {
 
     private boolean appliesToPolicy(AutoscalingDeciderService deciderService, SortedSet<String> roles) {
         if (roles.isEmpty()) {
-            return deciderService.roles().contains(EMPTY_ROLES);
+            return deciderService.appliesToEmptyRoles();
         } else {
             return deciderService.roles().stream().map(DiscoveryNodeRole::roleName).anyMatch(roles::contains);
         }

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingDeciderService.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingDeciderService.java
@@ -19,13 +19,6 @@ import java.util.List;
 public interface AutoscalingDeciderService {
 
     /**
-     * A marker role to use to also match policies having an empty set of roles.
-     */
-    DiscoveryNodeRole EMPTY_ROLES = new DiscoveryNodeRole("_empty", "_empty") {
-
-    };
-
-    /**
      * The name of the autoscaling decider.
      *
      * @return the name
@@ -51,6 +44,18 @@ public interface AutoscalingDeciderService {
      * has no restrictions on the roles it applies to. This is intended only for supplying deciders useful for testing.
      */
     List<DiscoveryNodeRole> roles();
+
+    /**
+     * Whether or not the decider applies to a policy that specifies an empty set of roles.
+     *
+     * The default implementation is false, as it is expected that most deciders will apply to specific roles. The application of a policy
+     * that specifies an empty set of roles is useful for testing.
+     *
+     * @return true if the decider applies to a policy that specifies an empty set of roles, otherwise false.
+     */
+    default boolean appliesToEmptyRoles() {
+        return false;
+    }
 
     /**
      * Is the decider default on for policies matching the roles() of this decider service?

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/FixedAutoscalingDeciderService.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/FixedAutoscalingDeciderService.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 public class FixedAutoscalingDeciderService implements AutoscalingDeciderService {
 
@@ -30,13 +31,10 @@ public class FixedAutoscalingDeciderService implements AutoscalingDeciderService
     public static final Setting<ByteSizeValue> STORAGE = Setting.byteSizeSetting("storage", ByteSizeValue.ofBytes(-1));
     public static final Setting<ByteSizeValue> MEMORY = Setting.byteSizeSetting("memory", ByteSizeValue.ofBytes(-1));
     public static final Setting<Integer> NODES = Setting.intSetting("nodes", 1, 0);
-    private final List<DiscoveryNodeRole> appliesToRoles;
 
     @Inject
     public FixedAutoscalingDeciderService() {
-        ArrayList<DiscoveryNodeRole> appliesToRoles = new ArrayList<>(DiscoveryNode.getPossibleRoles());
-        appliesToRoles.add(EMPTY_ROLES);
-        this.appliesToRoles = Collections.unmodifiableList(appliesToRoles);
+
     }
 
     @Override
@@ -77,7 +75,12 @@ public class FixedAutoscalingDeciderService implements AutoscalingDeciderService
 
     @Override
     public List<DiscoveryNodeRole> roles() {
-        return appliesToRoles;
+        return DiscoveryNode.getPossibleRoles().stream().collect(Collectors.toUnmodifiableList());
+    }
+
+    @Override
+    public boolean appliesToEmptyRoles() {
+        return true;
     }
 
     @Override

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/FixedAutoscalingDeciderService.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/FixedAutoscalingDeciderService.java
@@ -18,8 +18,6 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;


### PR DESCRIPTION
Some autoscaling deciders can apply to policies that specify an empty a set of roles. This is useful for testing. Today this is done by a special empty marker role which can be included in the list of roles that the decider supports. That marker is checked for when a policy that specifies an empty set of roles is encountered. This commit refactors this so that there is an interface method for answering the same question that implementors can override.

We make this change to support removing the ability to plugin roles.

