### PR TITLE
[DOCS] [7.12] Update mapping API to require index name (#71489)

### DIFF
--- a/docs/reference/indices/put-mapping.asciidoc
+++ b/docs/reference/indices/put-mapping.asciidoc
@@ -33,8 +33,6 @@ please see <<removal-of-types>>.
 
 `PUT /<target>/_mapping`
 
-`PUT /_mapping`
-
 [[put-mapping-api-prereqs]]
 ==== {api-prereq-title}
 
@@ -51,7 +49,7 @@ privilege.
 ==== {api-path-parms-title}
 
 `<target>`::
-(Optional, string)
+(Required, string)
 Comma-separated list of data streams, indices, and index aliases used to limit
 the request. Wildcard expressions (`*`) are supported.
 +


### PR DESCRIPTION
7.12 backport for #71489