### PR TITLE
[DOCS] Fix create enrich policy API title

### DIFF
--- a/docs/java-rest/high-level/enrich/put_policy.asciidoc
+++ b/docs/java-rest/high-level/enrich/put_policy.asciidoc
@@ -5,12 +5,12 @@
 --
 
 [id="{upid}-{api}"]
-=== Create or update enrich policy API
+=== Create enrich policy API
 
 [id="{upid}-{api}-request"]
 ==== Request
 
-Creates or updates an enrich policy.
+Creates an enrich policy.
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------

--- a/docs/reference/ingest/apis/enrich/put-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/put-enrich-policy.asciidoc
@@ -1,12 +1,12 @@
 [role="xpack"]
 [testenv="basic"]
 [[put-enrich-policy-api]]
-=== Create or update enrich policy API
+=== Create enrich policy API
 ++++
-<titleabbrev>Create or update enrich policy</titleabbrev>
+<titleabbrev>Create enrich policy</titleabbrev>
 ++++
 
-Creates or updates an enrich policy.
+Creates an enrich policy.
 
 ////
 [source,console]

--- a/docs/reference/ingest/geo-match-enrich-policy-type-ex.asciidoc
+++ b/docs/reference/ingest/geo-match-enrich-policy-type-ex.asciidoc
@@ -46,7 +46,7 @@ PUT /postal_codes/_doc/1?refresh=wait_for
 ----
 // TEST[continued]
 
-Use the <<put-enrich-policy-api,create or update enrich policy API>> to create
+Use the <<put-enrich-policy-api,create enrich policy API>> to create
 an enrich policy with the `geo_match` policy type. This policy must include:
 
 * One or more source indices

--- a/docs/reference/ingest/match-enrich-policy-type-ex.asciidoc
+++ b/docs/reference/ingest/match-enrich-policy-type-ex.asciidoc
@@ -32,7 +32,7 @@ PUT /users/_doc/1?refresh=wait_for
 }
 ----
 
-Use the create or update enrich policy API to create an enrich policy with the
+Use the create enrich policy API to create an enrich policy with the
 `match` policy type. This policy must include:
 
 * One or more source indices


### PR DESCRIPTION
#70330 introduced a bug in the enrich policy API title.

You can only use the API to create an enrich policy, not update one. This fixes the bug.