### PR TITLE
[7.12] [DOCS] Document REST API uses UTF-8 encoding (#71474)

### DIFF
--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -1,7 +1,9 @@
 [[api-conventions]]
 == API conventions
 
-The *Elasticsearch* REST APIs are exposed using JSON over HTTP.
+The {es} REST APIs are exposed using JSON over HTTP. The JSON request body must
+be UTF-8 encoded. {es} ignores any other encoding headings sent with a request.
+Responses are also UTF-8 encoded.
 
 The conventions listed in this chapter can be applied throughout the REST
 API, unless otherwise specified.


### PR DESCRIPTION
Backports the following commits to 7.12:
 - [DOCS] Document REST API uses UTF-8 encoding (#71474)