### PR TITLE
Change script context names for run time fields to type_field

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/script/StoredScriptsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/script/StoredScriptsIT.java
@@ -70,6 +70,16 @@ public class StoredScriptsIT extends ESIntegTestCase {
         assertEquals("exceeded max allowed stored script size in bytes [64] with size [65] for script [foobar]", e.getMessage());
     }
 
+    public void testDisallowedContext() {
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> client().admin().cluster().preparePutStoredScript()
+                .setId("foobar")
+                .setContext("double_field")
+                .setContent(new BytesArray("{\"script\": {\"lang\": \"" + LANG + "\", \"source\": \"1\"} }"), XContentType.JSON)
+                .get()
+        );
+        assertEquals("cannot store a script for context [double_field]", e.getCause().getMessage());
+    }
+
     public static class CustomScriptPlugin extends MockScriptPlugin {
 
         @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/storedscripts/PutStoredScriptRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/storedscripts/PutStoredScriptRequestBuilder.java
@@ -26,6 +26,11 @@ public class PutStoredScriptRequestBuilder extends AcknowledgedRequestBuilder<Pu
         return this;
     }
 
+    public PutStoredScriptRequestBuilder setContext(String context) {
+        request.context(context);
+        return this;
+    }
+
     /**
      * Set the source of the script along with the content type of the source
      */

--- a/server/src/main/java/org/elasticsearch/script/AbstractFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/AbstractFieldScript.java
@@ -35,7 +35,7 @@ public abstract class AbstractFieldScript {
 
     static <F> ScriptContext<F> newContext(String name, Class<F> factoryClass) {
         return new ScriptContext<>(
-            name + "_script_field",
+            name,
             factoryClass,
             /*
              * We rely on the script cache in two ways:
@@ -54,7 +54,12 @@ public abstract class AbstractFieldScript {
              * source of runaway script compilations. We think folks will
              * mostly reuse scripts though.
              */
-            ScriptCache.UNLIMITED_COMPILATION_RATE.asTuple()
+            ScriptCache.UNLIMITED_COMPILATION_RATE.asTuple(),
+            /*
+             * Disable runtime fields scripts from being allowed
+             * to be stored as part of the script meta data.
+             */
+            false
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/script/BooleanFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/BooleanFieldScript.java
@@ -15,7 +15,7 @@ import java.util.Map;
 
 public abstract class BooleanFieldScript extends AbstractFieldScript {
 
-    public static final ScriptContext<Factory> CONTEXT = newContext("boolean_script_field", Factory.class);
+    public static final ScriptContext<Factory> CONTEXT = newContext("boolean_field", Factory.class);
 
     @SuppressWarnings("unused")
     public static final String[] PARAMETERS = {};

--- a/server/src/main/java/org/elasticsearch/script/DateFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/DateFieldScript.java
@@ -15,7 +15,7 @@ import org.elasticsearch.search.lookup.SearchLookup;
 import java.util.Map;
 
 public abstract class DateFieldScript extends AbstractLongFieldScript {
-    public static final ScriptContext<Factory> CONTEXT = newContext("date", Factory.class);
+    public static final ScriptContext<Factory> CONTEXT = newContext("date_field", Factory.class);
 
     @SuppressWarnings("unused")
     public static final String[] PARAMETERS = {};

--- a/server/src/main/java/org/elasticsearch/script/DoubleFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/DoubleFieldScript.java
@@ -16,7 +16,7 @@ import java.util.Map;
 import java.util.function.DoubleConsumer;
 
 public abstract class DoubleFieldScript extends AbstractFieldScript {
-    public static final ScriptContext<Factory> CONTEXT = newContext("double_script_field", Factory.class);
+    public static final ScriptContext<Factory> CONTEXT = newContext("double_field", Factory.class);
 
     @SuppressWarnings("unused")
     public static final String[] PARAMETERS = {};

--- a/server/src/main/java/org/elasticsearch/script/GeoPointFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/GeoPointFieldScript.java
@@ -22,7 +22,7 @@ import static org.apache.lucene.geo.GeoEncodingUtils.encodeLongitude;
  * it encodes the points as a long value.
  */
 public abstract class GeoPointFieldScript extends AbstractLongFieldScript {
-    public static final ScriptContext<Factory> CONTEXT = newContext("geo_point_script_field", Factory.class);
+    public static final ScriptContext<Factory> CONTEXT = newContext("geo_point_field", Factory.class);
 
     @SuppressWarnings("unused")
     public static final String[] PARAMETERS = {};

--- a/server/src/main/java/org/elasticsearch/script/IpFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/IpFieldScript.java
@@ -36,7 +36,7 @@ import java.util.Map;
  * </ul>
  */
 public abstract class IpFieldScript extends AbstractFieldScript {
-    public static final ScriptContext<Factory> CONTEXT = newContext("ip_script_field", Factory.class);
+    public static final ScriptContext<Factory> CONTEXT = newContext("ip_field", Factory.class);
 
     @SuppressWarnings("unused")
     public static final String[] PARAMETERS = {};

--- a/server/src/main/java/org/elasticsearch/script/LongFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/LongFieldScript.java
@@ -14,7 +14,7 @@ import org.elasticsearch.search.lookup.SearchLookup;
 import java.util.Map;
 
 public abstract class LongFieldScript extends AbstractLongFieldScript {
-    public static final ScriptContext<Factory> CONTEXT = newContext("long_script_field", Factory.class);
+    public static final ScriptContext<Factory> CONTEXT = newContext("long_field", Factory.class);
 
     @SuppressWarnings("unused")
     public static final String[] PARAMETERS = {};

--- a/server/src/main/java/org/elasticsearch/script/ScriptContext.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptContext.java
@@ -69,9 +69,12 @@ public final class ScriptContext<FactoryType> {
     /** The default max compilation rate for scripts in this context.  Script compilation is throttled if this is exceeded */
     public final Tuple<Integer, TimeValue> maxCompilationRateDefault;
 
+    /** Determines if the script can be stored as part of the cluster state. */
+    public final boolean allowStoredScript;
+
     /** Construct a context with the related instance and compiled classes with caller provided cache defaults */
     public ScriptContext(String name, Class<FactoryType> factoryClazz, int cacheSizeDefault, TimeValue cacheExpireDefault,
-                        Tuple<Integer, TimeValue> maxCompilationRateDefault) {
+                        Tuple<Integer, TimeValue> maxCompilationRateDefault, boolean allowStoredScript) {
         this.name = name;
         this.factoryClazz = factoryClazz;
         Method newInstanceMethod = findMethod("FactoryType", factoryClazz, "newInstance");
@@ -96,13 +99,21 @@ public final class ScriptContext<FactoryType> {
         this.cacheSizeDefault = cacheSizeDefault;
         this.cacheExpireDefault = cacheExpireDefault;
         this.maxCompilationRateDefault = maxCompilationRateDefault;
+        this.allowStoredScript = allowStoredScript;
+    }
+
+    /** Construct a context with the related instance and compiled classes with caller provided cache defaults and allow
+     * scripts of this context to be stored scripts */
+    public ScriptContext(String name, Class<FactoryType> factoryClazz, int cacheSizeDefault, TimeValue cacheExpireDefault,
+            Tuple<Integer, TimeValue> maxCompilationRateDefault) {
+        this(name, factoryClazz, cacheSizeDefault, cacheExpireDefault, maxCompilationRateDefault, true);
     }
 
     /** Construct a context with the related instance and compiled classes with defaults for cacheSizeDefault, cacheExpireDefault and
-     *  maxCompilationRateDefault */
+     *  maxCompilationRateDefault and allow scripts of this context to be stored scripts */
     public ScriptContext(String name, Class<FactoryType> factoryClazz) {
         // cache size default, cache expire default, max compilation rate are defaults from ScriptService.
-        this(name, factoryClazz, 100, TimeValue.timeValueMillis(0), new Tuple<>(75, TimeValue.timeValueMinutes(5)));
+        this(name, factoryClazz, 100, TimeValue.timeValueMillis(0), new Tuple<>(75, TimeValue.timeValueMinutes(5)), true);
     }
 
     /** Returns a method with the given name, or throws an exception if multiple are found. */

--- a/server/src/main/java/org/elasticsearch/script/ScriptService.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptService.java
@@ -409,6 +409,9 @@ public class ScriptService implements Closeable, ClusterStateApplier, ScriptComp
                 if (context == null) {
                     throw new IllegalArgumentException("Unknown context [" + request.context() + "]");
                 }
+                if (context.allowStoredScript == false) {
+                    throw new IllegalArgumentException("cannot store a script for context [" + request.context() + "]");
+                }
                 scriptEngine.compile(request.id(), source.getSource(), context, Collections.emptyMap());
             }
         } catch (ScriptException good) {

--- a/server/src/main/java/org/elasticsearch/script/StringFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/StringFieldScript.java
@@ -22,7 +22,7 @@ public abstract class StringFieldScript extends AbstractFieldScript {
      */
     public static final long MAX_CHARS = 1024 * 1024;
 
-    public static final ScriptContext<Factory> CONTEXT = newContext("string_script_field", Factory.class);
+    public static final ScriptContext<Factory> CONTEXT = newContext("string_field", Factory.class);
 
     @SuppressWarnings("unused")
     public static final String[] PARAMETERS = {};


### PR DESCRIPTION
This change does two things:
1. renames all script contexts for runtime fields to type_field such as `long_field` or `geo_point_field`
2. disallows runtime fields scripts to be stored when a runtime fields context is specified as part of the stored script; this does not change a user's ability delete any stored script as context is only used during a put

Note that change 2 adds a boolean value to contexts to determine whether or not they are allowed to be stored. I added a new constructor for this and only changed it for runtime fields.
